### PR TITLE
feat: detect config roundtrip key asymmetry

### DIFF
--- a/docs/commands/audit-rules.md
+++ b/docs/commands/audit-rules.md
@@ -142,3 +142,44 @@ config keys and import/export schema drift checks.
 
 Templates support regex capture names and `{line}`. `derived_absence` also exposes
 `{value}` and `{label}`.
+
+## Requested Config Round-Trip Key Detector
+
+Extensions and components can configure a generic requested detector that compares
+config-object key sets across export/import/copy allowlists and behavior-bearing
+read/write sites. Homeboy core only evaluates the configured regexes and compares
+captured key strings; framework-specific semantics and intentional runtime-only key
+exclusions belong in the extension or component config.
+
+```json
+{
+  "audit_rules": {
+    "requested_detectors": [
+      {
+        "id": "flow-step-config-roundtrip",
+        "kind": "config_roundtrip_asymmetry",
+        "severity": "warning",
+        "convention": "requested_detectors",
+        "language": "php",
+        "file_extensions": ["php"],
+        "type": "config_roundtrip_keys",
+        "object": "flow step config",
+        "export_pattern": "'(?P<key>[a-z_]+)'\\s*=>\\s*\\$config\\[",
+        "import_pattern": "\\$config\\['(?P<key>[a-z_]+)'\\]\\s*=",
+        "copy_patterns": ["\\$copy\\['(?P<key>[a-z_]+)'\\]\\s*="],
+        "behavior_pattern": "\\$config\\['(?P<key>[a-z_]+)'\\]",
+        "exclude_key_patterns": ["^runtime_"],
+        "description": "{object} key `{key}` is missing from {missing} round-trip side(s)",
+        "suggestion": "Review `{key}` and add it to the missing allowlist, or exclude it as runtime-only."
+      }
+    ]
+  }
+}
+```
+
+The detector emits `config_roundtrip_asymmetry` when a behavior-bearing key is
+absent from export or import, or when export/import key allowlists disagree for a
+key not excluded by `exclude_key_patterns`. When `copy_patterns` is configured,
+copy allowlists participate in the same comparison. Template variables include
+`object`, `key`, `missing`, `line`, `export_count`, `import_count`, `copy_count`,
+and `behavior_count`.

--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -8,7 +8,7 @@ homeboy audit <component-id|path> [options]
 
 ## Description
 
-Audit a component's codebase for convention drift, structural complexity, dead code, duplication, and test coverage gaps. The audit engine fingerprints source files, discovers conventions (patterns most files follow), detects outliers, and produces actionable findings.
+Audit a component's codebase for convention drift, structural complexity, dead code, duplication, configured detector drift, and test coverage gaps. The audit engine fingerprints source files, discovers conventions (patterns most files follow), detects outliers, and produces actionable findings.
 
 Works with registered components (by ID) or raw filesystem paths.
 
@@ -40,6 +40,7 @@ The audit runs in 6 phases:
    - **4e: Dead code** — Unused params, unreferenced exports, orphaned internals
    - **4f: Test coverage gaps** — Missing test files, uncovered methods, orphaned tests (requires extension `test_mapping` config)
    - **4h: Layer ownership** — Optional architecture/layer ownership rule violations (`layer_ownership_violation`)
+   - **4t: Requested detectors** — Extension/component-owned regex detector packs, including generic config round-trip key asymmetry (`config_roundtrip_asymmetry`)
 5. **Report** — Aggregate findings, compute alignment score
 6. **Cross-directory conventions** — Detect patterns shared by sibling subdirectories
 

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -336,6 +336,7 @@ impl AuditExecutionPlan {
                         AuditFinding::ConstantBackedSlugLiteral,
                         AuditFinding::OptionScopeDrift,
                         AuditFinding::ProxyScopeDrift,
+                        AuditFinding::ConfigRoundtripAsymmetry,
                     ],
                 ),
                 run_core_boundary_leaks: Self::family_enabled(

--- a/src/core/code_audit/requested_detectors.rs
+++ b/src/core/code_audit/requested_detectors.rs
@@ -1,7 +1,7 @@
 //! Extension-owned requested detector rule-pack execution.
 
 use regex::{Captures, Regex};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::str::FromStr;
 
 use crate::core::component::{
@@ -37,6 +37,21 @@ struct DerivedLiteralSite {
     value: String,
     captures: HashMap<String, String>,
     labels: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ConfigKeySite {
+    file: String,
+    line: usize,
+}
+
+#[derive(Debug, Default)]
+struct ConfigRoundtripKeySets {
+    exported: BTreeMap<String, Vec<ConfigKeySite>>,
+    imported: BTreeMap<String, Vec<ConfigKeySite>>,
+    copied: BTreeMap<String, Vec<ConfigKeySite>>,
+    copy_enabled: bool,
+    behavior: BTreeMap<String, Vec<ConfigKeySite>>,
 }
 
 pub(super) fn run(fingerprints: &[&FileFingerprint], audit_config: &AuditConfig) -> Vec<Finding> {
@@ -141,6 +156,29 @@ fn run_rule(rule: &RequestedDetectorRule, fingerprints: &[&FileFingerprint]) -> 
             label,
             required_pattern,
             exclude_required_path_contains,
+            description,
+            suggestion,
+        ),
+        RequestedDetectorRuleBody::ConfigRoundtripKeys {
+            object,
+            export_pattern,
+            import_pattern,
+            copy_patterns,
+            behavior_pattern,
+            key_capture,
+            exclude_key_patterns,
+            description,
+            suggestion,
+        } => run_config_roundtrip_keys_rule(
+            rule,
+            fingerprints,
+            object,
+            export_pattern,
+            import_pattern,
+            copy_patterns,
+            behavior_pattern,
+            key_capture,
+            exclude_key_patterns,
             description,
             suggestion,
         ),
@@ -520,6 +558,187 @@ fn collect_derived_values_with_captures(
         }
     }
     values
+}
+
+fn run_config_roundtrip_keys_rule(
+    rule: &RequestedDetectorRule,
+    fingerprints: &[&FileFingerprint],
+    object: &str,
+    export_pattern: &str,
+    import_pattern: &str,
+    copy_patterns: &[String],
+    behavior_pattern: &str,
+    key_capture: &str,
+    exclude_key_patterns: &[String],
+    description: &str,
+    suggestion: &str,
+) -> Vec<Finding> {
+    let Ok(export_regex) = Regex::new(export_pattern) else {
+        return Vec::new();
+    };
+    let Ok(import_regex) = Regex::new(import_pattern) else {
+        return Vec::new();
+    };
+    let Ok(behavior_regex) = Regex::new(behavior_pattern) else {
+        return Vec::new();
+    };
+    let copy_regexes = copy_patterns
+        .iter()
+        .filter_map(|pattern| Regex::new(pattern).ok())
+        .collect::<Vec<_>>();
+    let exclude_regexes = exclude_key_patterns
+        .iter()
+        .filter_map(|pattern| Regex::new(pattern).ok())
+        .collect::<Vec<_>>();
+
+    let files = eligible_files(rule, fingerprints);
+    let key_sets = ConfigRoundtripKeySets {
+        exported: collect_config_key_sites(&files, &export_regex, key_capture, &exclude_regexes),
+        imported: collect_config_key_sites(&files, &import_regex, key_capture, &exclude_regexes),
+        copied: collect_config_key_sites_from_many(
+            &files,
+            &copy_regexes,
+            key_capture,
+            &exclude_regexes,
+        ),
+        copy_enabled: !copy_regexes.is_empty(),
+        behavior: collect_config_key_sites(&files, &behavior_regex, key_capture, &exclude_regexes),
+    };
+
+    config_roundtrip_findings(rule, object, &key_sets, description, suggestion)
+}
+
+fn collect_config_key_sites(
+    files: &[&FileFingerprint],
+    regex: &Regex,
+    key_capture: &str,
+    exclude_regexes: &[Regex],
+) -> BTreeMap<String, Vec<ConfigKeySite>> {
+    let mut sites: BTreeMap<String, Vec<ConfigKeySite>> = BTreeMap::new();
+    for fp in files {
+        for captures in regex.captures_iter(&fp.content) {
+            let key = capture_value(&captures, key_capture);
+            if key.is_empty() || exclude_regexes.iter().any(|regex| regex.is_match(&key)) {
+                continue;
+            }
+            let offset = captures.get(0).map(|m| m.start()).unwrap_or(0);
+            sites.entry(key).or_default().push(ConfigKeySite {
+                file: fp.relative_path.clone(),
+                line: line_of_offset(&fp.content, offset),
+            });
+        }
+    }
+    sites
+}
+
+fn config_roundtrip_findings(
+    rule: &RequestedDetectorRule,
+    object: &str,
+    key_sets: &ConfigRoundtripKeySets,
+    description: &str,
+    suggestion: &str,
+) -> Vec<Finding> {
+    let mut candidate_keys = BTreeSet::new();
+    candidate_keys.extend(key_sets.behavior.keys().cloned());
+    candidate_keys.extend(key_sets.exported.keys().cloned());
+    candidate_keys.extend(key_sets.imported.keys().cloned());
+    candidate_keys.extend(key_sets.copied.keys().cloned());
+
+    let mut findings = Vec::new();
+    for key in candidate_keys {
+        let missing = missing_roundtrip_sides(&key, key_sets);
+        if missing.is_empty() {
+            continue;
+        }
+
+        let Some(site) = representative_config_key_site(&key, key_sets) else {
+            continue;
+        };
+        let missing_text = missing.join(", ");
+        let render_value = |name: &str| match name {
+            "object" => object.to_string(),
+            "key" => key.clone(),
+            "missing" => missing_text.clone(),
+            "line" => site.line.to_string(),
+            "export_count" => key_sets.exported.get(&key).map_or(0, Vec::len).to_string(),
+            "import_count" => key_sets.imported.get(&key).map_or(0, Vec::len).to_string(),
+            "behavior_count" => key_sets.behavior.get(&key).map_or(0, Vec::len).to_string(),
+            "copy_count" => key_sets.copied.get(&key).map_or(0, Vec::len).to_string(),
+            _ => String::new(),
+        };
+        findings.push(Finding {
+            convention: rule.convention.clone(),
+            severity: severity_from_config(&rule.severity),
+            file: site.file.clone(),
+            description: render_template(description, None, &render_value),
+            suggestion: render_template(suggestion, None, &render_value),
+            kind: AuditFinding::from_str(&rule.kind).unwrap_or(AuditFinding::LegacyComment),
+        });
+    }
+
+    findings
+}
+
+fn missing_roundtrip_sides(key: &str, key_sets: &ConfigRoundtripKeySets) -> Vec<&'static str> {
+    let behavior_bearing = key_sets.behavior.contains_key(key);
+    let exported = key_sets.exported.contains_key(key);
+    let imported = key_sets.imported.contains_key(key);
+    let copied = key_sets.copied.contains_key(key);
+    let mut missing = Vec::new();
+
+    if behavior_bearing {
+        if !exported {
+            missing.push("export");
+        }
+        if !imported {
+            missing.push("import");
+        }
+        if key_sets.copy_enabled && !copied {
+            missing.push("copy");
+        }
+    } else if exported != imported
+        || (key_sets.copy_enabled && (copied != exported || copied != imported))
+    {
+        if !exported {
+            missing.push("export");
+        }
+        if !imported {
+            missing.push("import");
+        }
+        if key_sets.copy_enabled && !copied {
+            missing.push("copy");
+        }
+    }
+
+    missing
+}
+
+fn representative_config_key_site<'a>(
+    key: &str,
+    key_sets: &'a ConfigRoundtripKeySets,
+) -> Option<&'a ConfigKeySite> {
+    key_sets
+        .behavior
+        .get(key)
+        .or_else(|| key_sets.exported.get(key))
+        .or_else(|| key_sets.imported.get(key))
+        .or_else(|| key_sets.copied.get(key))
+        .and_then(|sites| sites.first())
+}
+
+fn collect_config_key_sites_from_many(
+    files: &[&FileFingerprint],
+    regexes: &[Regex],
+    key_capture: &str,
+    exclude_regexes: &[Regex],
+) -> BTreeMap<String, Vec<ConfigKeySite>> {
+    let mut all_sites: BTreeMap<String, Vec<ConfigKeySite>> = BTreeMap::new();
+    for regex in regexes {
+        for (key, sites) in collect_config_key_sites(files, regex, key_capture, exclude_regexes) {
+            all_sites.entry(key).or_default().extend(sites);
+        }
+    }
+    all_sites
 }
 
 fn eligible_files<'a>(
@@ -1152,5 +1371,149 @@ $this->assertSame( array(), $config['enabled_tools'] );
         assert_eq!(findings[0].kind, AuditFinding::ConfigKeyWriteOnly);
         assert!(findings[0].description.contains("enabled_tools"));
         assert!(!findings[0].description.contains("user_message"));
+    }
+
+    #[test]
+    fn config_roundtrip_keys_flags_behavior_key_missing_from_export() {
+        let exporter = php_fp(
+            "src/export.php",
+            r#"<?php
+$payload = array(
+    'handler_slugs' => $config['handler_slugs'],
+    'handler_configs' => $config['handler_configs'],
+);
+"#,
+        );
+        let importer = php_fp(
+            "src/import.php",
+            r#"<?php
+$config['handler_slugs'] = $payload['handler_slugs'];
+$config['handler_configs'] = $payload['handler_configs'];
+$config['enabled_tools'] = $payload['enabled_tools'];
+"#,
+        );
+        let behavior = php_fp(
+            "src/runtime.php",
+            r#"<?php
+if ( ! empty( $config['enabled_tools'] ) ) {
+    enable_tools( $config['enabled_tools'] );
+}
+"#,
+        );
+        let rule = RequestedDetectorRule {
+            id: "config-roundtrip".to_string(),
+            kind: "config_roundtrip_asymmetry".to_string(),
+            severity: "warning".to_string(),
+            convention: "requested_detectors".to_string(),
+            language: Some("php".to_string()),
+            file_extensions: vec!["php".to_string()],
+            exclude_path_contains: vec![],
+            rule: RequestedDetectorRuleBody::ConfigRoundtripKeys {
+                object: "flow step config".to_string(),
+                export_pattern: r#"'(?P<key>[a-z_]+)'\s*=>\s*\$config\["#.to_string(),
+                import_pattern: r#"\$config\['(?P<key>[a-z_]+)'\]\s*="#.to_string(),
+                copy_patterns: vec![],
+                behavior_pattern: r#"enable_tools\(\s*\$config\['(?P<key>[a-z_]+)'\]"#.to_string(),
+                key_capture: "key".to_string(),
+                exclude_key_patterns: vec![],
+                description: "{object} key `{key}` is missing from {missing} round-trip side(s)".to_string(),
+                suggestion: "Review `{key}` and add it to the missing config round-trip allowlist or exclude it as runtime-only.".to_string(),
+            },
+        };
+
+        let findings = run(&[&exporter, &importer, &behavior], &config(rule));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, AuditFinding::ConfigRoundtripAsymmetry);
+        assert_eq!(findings[0].file, "src/runtime.php");
+        assert!(findings[0].description.contains("enabled_tools"));
+        assert!(findings[0].description.contains("export"));
+    }
+
+    #[test]
+    fn config_roundtrip_keys_respects_runtime_key_exclusions() {
+        let exporter = php_fp(
+            "src/export.php",
+            r#"<?php
+$payload = array(
+    'handler_slugs' => $config['handler_slugs'],
+    'runtime_only' => $config['runtime_only'],
+);
+"#,
+        );
+        let importer = php_fp(
+            "src/import.php",
+            r#"<?php
+$config['handler_slugs'] = $payload['handler_slugs'];
+"#,
+        );
+        let rule = RequestedDetectorRule {
+            id: "config-roundtrip".to_string(),
+            kind: "config_roundtrip_asymmetry".to_string(),
+            severity: "info".to_string(),
+            convention: "requested_detectors".to_string(),
+            language: Some("php".to_string()),
+            file_extensions: vec!["php".to_string()],
+            exclude_path_contains: vec![],
+            rule: RequestedDetectorRuleBody::ConfigRoundtripKeys {
+                object: "generic config".to_string(),
+                export_pattern: r#"'(?P<key>[a-z_]+)'\s*=>\s*\$config\["#.to_string(),
+                import_pattern: r#"\$config\['(?P<key>[a-z_]+)'\]\s*="#.to_string(),
+                copy_patterns: vec![],
+                behavior_pattern: r#"behavior_get\('(?P<key>[a-z_]+)'\)"#.to_string(),
+                key_capture: "key".to_string(),
+                exclude_key_patterns: vec!["^runtime_".to_string()],
+                description: "{object} key `{key}` is missing from {missing}".to_string(),
+                suggestion: "Keep import/export key allowlists symmetric or exclude intentional runtime-only keys.".to_string(),
+            },
+        };
+
+        let findings = run(&[&exporter, &importer], &config(rule));
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn config_roundtrip_keys_compares_configured_copy_allowlists() {
+        let exporter = php_fp(
+            "src/export.php",
+            r#"<?php
+$payload = array( 'user_message' => $config['user_message'] );
+"#,
+        );
+        let importer = php_fp(
+            "src/import.php",
+            r#"<?php
+$config['user_message'] = $payload['user_message'];
+"#,
+        );
+        let behavior = php_fp(
+            "src/runtime.php",
+            r#"<?php
+send_message( $config['user_message'] );
+"#,
+        );
+        let rule = RequestedDetectorRule {
+            id: "config-roundtrip".to_string(),
+            kind: "config_roundtrip_asymmetry".to_string(),
+            severity: "warning".to_string(),
+            convention: "requested_detectors".to_string(),
+            language: Some("php".to_string()),
+            file_extensions: vec!["php".to_string()],
+            exclude_path_contains: vec![],
+            rule: RequestedDetectorRuleBody::ConfigRoundtripKeys {
+                object: "message config".to_string(),
+                export_pattern: r#"'(?P<key>[a-z_]+)'\s*=>\s*\$config\["#.to_string(),
+                import_pattern: r#"\$config\['(?P<key>[a-z_]+)'\]\s*="#.to_string(),
+                copy_patterns: vec![r#"\$copy\['(?P<key>[a-z_]+)'\]\s*="#.to_string()],
+                behavior_pattern: r#"send_message\(\s*\$config\['(?P<key>[a-z_]+)'\]"#.to_string(),
+                key_capture: "key".to_string(),
+                exclude_key_patterns: vec![],
+                description: "{object} key `{key}` is missing from {missing}".to_string(),
+                suggestion: "Keep configured round-trip key allowlists symmetric.".to_string(),
+            },
+        };
+
+        let findings = run(&[&exporter, &importer, &behavior], &config(rule));
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].description.contains("copy"));
     }
 }

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -290,6 +290,23 @@ pub enum RequestedDetectorRuleBody {
         description: String,
         suggestion: String,
     },
+    /// Compare configured import/export/copy key allowlists against keys that
+    /// appear in behavior-bearing read/write sites. Core only compares captured
+    /// strings; the component owns the regexes and runtime-key exclusions.
+    ConfigRoundtripKeys {
+        object: String,
+        export_pattern: String,
+        import_pattern: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        copy_patterns: Vec<String>,
+        behavior_pattern: String,
+        #[serde(default = "default_config_roundtrip_key_capture")]
+        key_capture: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        exclude_key_patterns: Vec<String>,
+        description: String,
+        suggestion: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -312,6 +329,10 @@ fn default_requested_detector_severity() -> String {
 
 fn default_requested_detector_convention() -> String {
     "requested_detectors".to_string()
+}
+
+fn default_config_roundtrip_key_capture() -> String {
+    "key".to_string()
 }
 
 impl AuditConfig {


### PR DESCRIPTION
## Summary
- Adds a generic requested detector rule for comparing config object export/import/copy key allowlists against configured behavior-bearing key sites.
- Reports `config_roundtrip_asymmetry` findings with configurable templates, runtime-key exclusions, and representative key sites.
- Documents the detector configuration and covers export/import/copy and exclusion behavior with focused tests.

Fixes #1554.

## Tests
- `cargo test requested_detectors`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic detector primitive, focused tests, documentation updates, and verification commands; Chris remains responsible for review and merge.