### PR TITLE
feat: detect scoped proxy audit drift

### DIFF
--- a/docs/commands/audit-rules.md
+++ b/docs/commands/audit-rules.md
@@ -35,3 +35,49 @@ Use one of:
 - severity: warning
 
 These findings participate in baseline comparisons like any other audit finding.
+
+## Requested Detectors
+
+`audit_rules.requested_detectors` lets an extension provide generic text detectors
+without baking ecosystem terms into Homeboy core. Core owns the matching primitive;
+the component supplies the sink, scope, and allowlist markers.
+
+### Scoped Proxy Drift
+
+Use `type: "scoped_proxy"` when docs/schema describe a helper as scoped to an
+internal namespace but the implementation forwards request-controlled paths to a
+local proxy sink. The detector flags files that match all of:
+
+- `claim_pattern`: docs/schema text that claims an internal namespace or scoped API
+- `target_pattern`: request input used as the forwarded target/path
+- `sink_pattern`: the local forwarding call
+- no `allowlist_pattern`: prefix/allowlist validation for the documented scope
+
+Example:
+
+```json
+{
+  "requested_detectors": [
+    {
+      "id": "internal-proxy-scope",
+      "kind": "proxy_scope_drift",
+      "severity": "warning",
+      "language": "php",
+      "file_extensions": ["php"],
+      "type": "scoped_proxy",
+      "claim_pattern": "(?i)\\b(internal API|/acme/v1)\\b",
+      "target_pattern": "\\$input\\s*\\[\\s*['\"]path['\"]\\s*\\]",
+      "sink_pattern": "\\b(?P<sink>forward_internal_request)\\s*\\(",
+      "allowlist_pattern": "(?i)(str_starts_with|preg_match)\\s*\\([^;]*(/acme/v1|allowed_prefixes|allowlist)",
+      "description": "Proxy scope drift at line {line}: scoped docs feed `{sink}` from request input without a matching allowlist",
+      "suggestion": "Add an allowlist/prefix check for the documented scope or document the proxy as general-purpose."
+    }
+  ]
+}
+```
+
+Finding output:
+
+- `convention`: defaults to `requested_detectors`
+- `kind`: `proxy_scope_drift`
+- severity: configured by the rule, usually warning

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -225,6 +225,9 @@ pub enum AuditFinding {
     /// Comments/docblocks promise network/site-option storage while nearby code
     /// uses single-site get_option/update_option calls.
     OptionScopeDrift,
+    /// Docs/schema claim a scoped internal proxy while implementation forwards
+    /// request-controlled targets without an explicit allowlist/prefix marker.
+    ProxyScopeDrift,
     /// Tests mutate process-global environment variables without using the
     /// shared guard for that variable.
     GlobalEnvMutationGuard,
@@ -294,6 +297,7 @@ impl AuditFinding {
             "json_like_exact_match",
             "constant_backed_slug_literal",
             "option_scope_drift",
+            "proxy_scope_drift",
             "global_env_mutation_guard",
             "unwired_nested_rust_test",
             "parallel_runner_setup",

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -335,6 +335,7 @@ impl AuditExecutionPlan {
                         AuditFinding::JsonLikeExactMatch,
                         AuditFinding::ConstantBackedSlugLiteral,
                         AuditFinding::OptionScopeDrift,
+                        AuditFinding::ProxyScopeDrift,
                     ],
                 ),
                 run_core_boundary_leaks: Self::family_enabled(

--- a/src/core/code_audit/requested_detectors.rs
+++ b/src/core/code_audit/requested_detectors.rs
@@ -82,6 +82,23 @@ fn run_rule(rule: &RequestedDetectorRule, fingerprints: &[&FileFingerprint]) -> 
             description,
             suggestion,
         ),
+        RequestedDetectorRuleBody::ScopedProxy {
+            claim_pattern,
+            sink_pattern,
+            target_pattern,
+            allowlist_pattern,
+            description,
+            suggestion,
+        } => run_scoped_proxy_rule(
+            rule,
+            fingerprints,
+            claim_pattern,
+            sink_pattern,
+            target_pattern,
+            allowlist_pattern,
+            description,
+            suggestion,
+        ),
     }
 }
 
@@ -267,6 +284,51 @@ fn collect_derived_values(
         }
     }
     values
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_scoped_proxy_rule(
+    rule: &RequestedDetectorRule,
+    fingerprints: &[&FileFingerprint],
+    claim_pattern: &str,
+    sink_pattern: &str,
+    target_pattern: &str,
+    allowlist_pattern: &str,
+    description: &str,
+    suggestion: &str,
+) -> Vec<Finding> {
+    let Ok(claim_regex) = Regex::new(claim_pattern) else {
+        return Vec::new();
+    };
+    let Ok(sink_regex) = Regex::new(sink_pattern) else {
+        return Vec::new();
+    };
+    let Ok(target_regex) = Regex::new(target_pattern) else {
+        return Vec::new();
+    };
+    let Ok(allowlist_regex) = Regex::new(allowlist_pattern) else {
+        return Vec::new();
+    };
+
+    let mut findings = Vec::new();
+    for fp in eligible_files(rule, fingerprints) {
+        if !claim_regex.is_match(&fp.content)
+            || !target_regex.is_match(&fp.content)
+            || allowlist_regex.is_match(&fp.content)
+        {
+            continue;
+        }
+        for captures in sink_regex.captures_iter(&fp.content) {
+            findings.push(finding_from_captures(
+                rule,
+                fp,
+                &captures,
+                description,
+                suggestion,
+            ));
+        }
+    }
+    findings
 }
 
 fn eligible_files<'a>(
@@ -683,5 +745,69 @@ write_local_option( 'local_setting', true );
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].kind, AuditFinding::OptionScopeDrift);
         assert!(findings[0].description.contains("write_local_option"));
+    }
+
+    #[test]
+    fn scoped_proxy_rules_flag_scoped_claim_without_allowlist() {
+        let unsafe_proxy = php_fp(
+            "src/internal_proxy.php",
+            r#"<?php
+/** Query the Acme internal API namespace. */
+function run( $input ) {
+    $target = $input['path'];
+    return forward_internal_request( $target );
+}
+"#,
+        );
+        let allowed_proxy = php_fp(
+            "src/allowed_proxy.php",
+            r#"<?php
+/** Query the Acme internal API namespace. */
+function run( $input ) {
+    $target = $input['path'];
+    if ( ! str_starts_with( $target, '/acme/v1/' ) ) {
+        return null;
+    }
+    return forward_internal_request( $target );
+}
+"#,
+        );
+        let general_proxy = php_fp(
+            "src/general_proxy.php",
+            r#"<?php
+/** Query any local API path. */
+function run( $input ) {
+    $target = $input['path'];
+    return forward_internal_request( $target );
+}
+"#,
+        );
+        let rule = RequestedDetectorRule {
+            id: "internal-proxy-scope".to_string(),
+            kind: "proxy_scope_drift".to_string(),
+            severity: "warning".to_string(),
+            convention: "requested_detectors".to_string(),
+            language: Some("php".to_string()),
+            file_extensions: vec!["php".to_string()],
+            exclude_path_contains: vec![],
+            rule: RequestedDetectorRuleBody::ScopedProxy {
+                claim_pattern: r#"(?i)\b(internal API|internal API namespace|/acme/v1)\b"#.to_string(),
+                sink_pattern: r#"\b(?P<sink>forward_internal_request)\s*\("#.to_string(),
+                target_pattern: r#"\$input\s*\[\s*['\"]path['\"]\s*\]"#.to_string(),
+                allowlist_pattern: r#"(?i)(str_starts_with|preg_match)\s*\([^;]*(/acme/v1|allowed_prefixes|allowlist)"#.to_string(),
+                description: "Proxy scope drift at line {line}: scoped docs feed `{sink}` from request input without a matching allowlist".to_string(),
+                suggestion: "Add an allowlist/prefix check for the documented scope or document the proxy as general-purpose.".to_string(),
+            },
+        };
+
+        let findings = run(
+            &[&unsafe_proxy, &allowed_proxy, &general_proxy],
+            &config(rule),
+        );
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, AuditFinding::ProxyScopeDrift);
+        assert_eq!(findings[0].file, "src/internal_proxy.php");
+        assert!(findings[0].description.contains("forward_internal_request"));
     }
 }

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -257,6 +257,17 @@ pub enum RequestedDetectorRuleBody {
         description: String,
         suggestion: String,
     },
+    /// Flag files whose docs/schema claim a scoped internal proxy but whose
+    /// implementation forwards request-controlled targets without an explicit
+    /// allowlist/prefix marker. All markers are extension-owned regexes.
+    ScopedProxy {
+        claim_pattern: String,
+        sink_pattern: String,
+        target_pattern: String,
+        allowlist_pattern: String,
+        description: String,
+        suggestion: String,
+    },
 }
 
 fn default_requested_detector_severity() -> String {


### PR DESCRIPTION
## Summary
- Add a generic `scoped_proxy` requested-detector primitive for docs/schema claims that promise a scoped internal API while implementation forwards request-controlled targets.
- Add the `proxy_scope_drift` finding kind, focused detector coverage, and audit-rule docs for configurable claim/sink/target/allowlist markers.

## Tests
- `cargo test core::code_audit::requested_detectors::tests::scoped_proxy_rules_flag_scoped_claim_without_allowlist`
- `cargo test core::code_audit::requested_detectors`
- `cargo test` (one transient failure in `core::http_probe::tests::get_status_marks_connection_failures`; reran that exact test and it passed)
- `cargo test core::http_probe::tests::get_status_marks_connection_failures`

Closes #1562.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic requested-detector primitive, added focused Rust tests and documentation, ran verification, and prepared the PR body for Chris to review.