### PR TITLE
Warn on request redirect validation gaps

### DIFF
--- a/docs/commands/audit-rules.md
+++ b/docs/commands/audit-rules.md
@@ -224,3 +224,26 @@ config keys and import/export schema drift checks.
 
 Templates support regex capture names and `{line}`. `derived_absence` also exposes
 `{value}` and `{label}`.
+
+## Redirect Validation Dominance
+
+`audit.redirect_validation` configures a warning-level security-adjacent detector for request-derived redirect destinations. Core stays framework-agnostic: components or extensions provide the request parameter markers, request source markers or regex patterns, redirect sink markers, and validation/allowlist markers for their runtime.
+
+Example:
+
+```json
+{
+  "audit": {
+    "redirect_validation": {
+      "request_names": ["'redirect_uri'", "'return_to'", "'callback_url'"],
+      "request_source_markers": ["query.", "body.", "$_GET[", "$_POST["],
+      "request_source_patterns": ["\\brequest\\.(query|body)\\."],
+      "redirect_sinks": ["redirect_to(", "Location:"],
+      "validation_markers": ["allow_redirect_destination", "validate_redirect_destination"],
+      "file_extensions": ["php"]
+    }
+  }
+}
+```
+
+The detector tracks variables assigned from configured request-name markers on lines that also include configured request source markers or patterns, then reports `redirect_validation` when a configured redirect sink uses the variable before a configured validation marker dominates that sink by line order and block depth. This is a heuristic line/block-depth check, not CFG evidence, so findings require reviewer judgment.

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -266,6 +266,9 @@ pub enum AuditFinding {
     FactorySeamBypass,
     /// Internal REST/API proxy call lacks a configured namespace or scope guard.
     InternalProxyScopeMissing,
+    /// Request-derived redirect destination reaches a configured redirect sink
+    /// before configured URL validation dominates the sink path.
+    RedirectValidation,
 }
 
 impl AuditFinding {
@@ -334,6 +337,7 @@ impl AuditFinding {
             "undominated_redirect_param",
             "factory_seam_bypass",
             "internal_proxy_scope_missing",
+            "redirect_validation",
         ]
     }
 }

--- a/src/core/code_audit/findings.rs
+++ b/src/core/code_audit/findings.rs
@@ -302,6 +302,10 @@ mod tests {
             AuditFinding::OrphanedTest.confidence(),
             FindingConfidence::Heuristic
         );
+        assert_eq!(
+            AuditFinding::RedirectValidation.confidence(),
+            FindingConfidence::Heuristic
+        );
         assert!(AuditFinding::CompilerWarning
             .confidence()
             .allows_automated_refactor());

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -42,6 +42,7 @@ mod layer_ownership;
 mod mutating_resource_access;
 pub(crate) mod naming;
 mod parallel_runner_setup;
+mod redirect_validation;
 mod repeated_literal_shape;
 pub mod report;
 mod requested_detectors;
@@ -156,6 +157,7 @@ pub(crate) struct AuditExecutionPlan {
     pub(crate) run_requested_detectors: bool,
     pub(crate) run_core_boundary_leaks: bool,
     pub(crate) run_mutating_resource_access: bool,
+    pub(crate) run_redirect_validation: bool,
     pub(crate) run_global_env_guard: bool,
     pub(crate) run_shared_scaffolding: bool,
     pub(crate) run_parallel_runner_setup: bool,
@@ -191,6 +193,7 @@ impl AuditExecutionPlan {
                 run_requested_detectors: true,
                 run_core_boundary_leaks: true,
                 run_mutating_resource_access: true,
+                run_redirect_validation: true,
                 run_global_env_guard: true,
                 run_shared_scaffolding: true,
                 run_parallel_runner_setup: true,
@@ -354,6 +357,11 @@ impl AuditExecutionPlan {
                     exclude,
                     &[AuditFinding::MutatingResourceAccess],
                 ),
+                run_redirect_validation: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::RedirectValidation],
+                ),
                 run_global_env_guard: Self::family_enabled(
                     only,
                     exclude,
@@ -423,6 +431,7 @@ impl AuditExecutionPlan {
                 "mutating_resource_access",
                 self.run_mutating_resource_access,
             ),
+            ("redirect_validation", self.run_redirect_validation),
             ("global_env_guard", self.run_global_env_guard),
             ("shared_scaffolding", self.run_shared_scaffolding),
             ("parallel_runner_setup", self.run_parallel_runner_setup),
@@ -479,6 +488,7 @@ impl AuditExecutionPlan {
             || self.run_requested_detectors
             || self.run_core_boundary_leaks
             || self.run_mutating_resource_access
+            || self.run_redirect_validation
             || self.run_global_env_guard
             || self.run_shared_scaffolding
             || self.run_parallel_runner_setup
@@ -1218,6 +1228,21 @@ fn audit_internal(
             mutating_access_findings.len()
         );
         all_findings.extend(mutating_access_findings);
+    }
+
+    // Phase 4t4: Configured redirect-destination dominance checks.
+    let redirect_validation_findings = if plan.run_redirect_validation {
+        redirect_validation::run(&all_fingerprints, &audit_config.redirect_validation)
+    } else {
+        Vec::new()
+    };
+    if !redirect_validation_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Redirect validation: {} finding(s) (request-derived redirects without dominating validation)",
+            redirect_validation_findings.len()
+        );
+        all_findings.extend(redirect_validation_findings);
     }
 
     // Phase 4v: Process-global environment mutation guard consistency in tests.

--- a/src/core/code_audit/redirect_validation.rs
+++ b/src/core/code_audit/redirect_validation.rs
@@ -1,0 +1,310 @@
+//! Configurable detector for request-derived redirect destinations without
+//! dominating URL validation.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+use crate::core::component::RedirectValidationConfig;
+
+use super::conventions::AuditFinding;
+use super::findings::{Finding, Severity};
+use super::fingerprint::FileFingerprint;
+
+static ASSIGNMENT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?:(?:\$|let\s+|const\s+|var\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=|([A-Za-z_][A-Za-z0-9_]*)\s*:=)"#)
+        .expect("request assignment regex compiles")
+});
+static PHP_REQUEST_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"\$_(?:GET|POST|REQUEST|SERVER)\s*\["#).expect("php request regex compiles")
+});
+static GENERIC_REQUEST_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"\b(?:request|req|params|query|body|form|search_params|url_search_params)\b"#)
+        .expect("generic request regex compiles")
+});
+
+#[derive(Debug, Clone)]
+struct TrackedRedirectValue {
+    variable: String,
+    request_name: String,
+    source_line: usize,
+}
+
+#[derive(Debug, Clone)]
+struct ValidationSite {
+    line: usize,
+    block_path: Vec<usize>,
+}
+
+pub(super) fn run(
+    fingerprints: &[&FileFingerprint],
+    config: &RedirectValidationConfig,
+) -> Vec<Finding> {
+    if config.request_names.is_empty()
+        || config.redirect_sinks.is_empty()
+        || config.validation_markers.is_empty()
+    {
+        return Vec::new();
+    }
+
+    let mut findings = Vec::new();
+    for fp in fingerprints {
+        if !eligible_file(fp, config) {
+            continue;
+        }
+        findings.extend(scan_file(fp, config));
+    }
+    findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
+    findings
+}
+
+fn scan_file(fp: &FileFingerprint, config: &RedirectValidationConfig) -> Vec<Finding> {
+    let lines = fp.content.lines().collect::<Vec<_>>();
+    let mut tracked = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        if let Some(value) = tracked_value_from_line(line, index + 1, config) {
+            tracked.push(value);
+        }
+    }
+    if tracked.is_empty() {
+        return Vec::new();
+    }
+
+    let mut findings = Vec::new();
+    for value in tracked {
+        let validations = validation_sites_for(&lines, &value, config);
+        let block_paths = block_paths_for(&lines);
+        for (index, line) in lines.iter().enumerate() {
+            let line_number = index + 1;
+            if redirect_uses_value(line, &value.variable, config)
+                && !validation_dominates(line_number, &block_paths[index], &validations)
+            {
+                findings.push(Finding {
+                    convention: "redirect_validation".to_string(),
+                    severity: Severity::Warning,
+                    file: fp.relative_path.clone(),
+                    description: format!(
+                        "Request-derived redirect destination `{}` from `{}` is used at line {} without dominating URL validation",
+                        value.variable, value.request_name, line_number
+                    ),
+                    suggestion: format!(
+                        "Validate and allowlist `{}` on every control-flow path before passing it to a configured redirect sink.",
+                        value.variable
+                    ),
+                    kind: AuditFinding::RedirectValidation,
+                });
+            }
+        }
+    }
+    findings
+}
+
+fn tracked_value_from_line(
+    line: &str,
+    line_number: usize,
+    config: &RedirectValidationConfig,
+) -> Option<TrackedRedirectValue> {
+    let request_name = config
+        .request_names
+        .iter()
+        .find(|name| line_contains_name(line, name))?;
+    if !looks_request_derived(line) {
+        return None;
+    }
+    let captures = ASSIGNMENT_RE.captures(line)?;
+    let variable = captures
+        .get(1)
+        .or_else(|| captures.get(2))
+        .map(|m| m.as_str().trim_start_matches('$').to_string())?;
+    Some(TrackedRedirectValue {
+        variable,
+        request_name: request_name.clone(),
+        source_line: line_number,
+    })
+}
+
+fn validation_sites_for(
+    lines: &[&str],
+    value: &TrackedRedirectValue,
+    config: &RedirectValidationConfig,
+) -> Vec<ValidationSite> {
+    let mut sites = Vec::new();
+    let block_paths = block_paths_for(lines);
+    for (index, line) in lines.iter().enumerate() {
+        let line_number = index + 1;
+        if line_number > value.source_line
+            && line_mentions_variable(line, &value.variable)
+            && marker_matches(line, &config.validation_markers)
+        {
+            sites.push(ValidationSite {
+                line: line_number,
+                block_path: block_paths[index].clone(),
+            });
+        }
+    }
+    sites
+}
+
+fn validation_dominates(
+    line_number: usize,
+    block_path: &[usize],
+    validations: &[ValidationSite],
+) -> bool {
+    validations.iter().any(|site| {
+        site.line < line_number
+            && site.block_path.len() <= block_path.len()
+            && block_path.starts_with(&site.block_path)
+    })
+}
+
+fn eligible_file(fp: &FileFingerprint, config: &RedirectValidationConfig) -> bool {
+    if config
+        .exclude_path_contains
+        .iter()
+        .any(|needle| fp.relative_path.contains(needle))
+    {
+        return false;
+    }
+    if config.file_extensions.is_empty() {
+        return true;
+    }
+    let Some(extension) = fp.relative_path.rsplit('.').next() else {
+        return false;
+    };
+    config
+        .file_extensions
+        .iter()
+        .any(|allowed| allowed == extension)
+}
+
+fn looks_request_derived(line: &str) -> bool {
+    PHP_REQUEST_RE.is_match(line) || GENERIC_REQUEST_RE.is_match(line)
+}
+
+fn redirect_uses_value(line: &str, variable: &str, config: &RedirectValidationConfig) -> bool {
+    line_mentions_variable(line, variable) && marker_matches(line, &config.redirect_sinks)
+}
+
+fn marker_matches(line: &str, markers: &[String]) -> bool {
+    markers
+        .iter()
+        .any(|marker| !marker.is_empty() && line.contains(marker))
+}
+
+fn line_contains_name(line: &str, name: &str) -> bool {
+    line.contains(&format!("'{name}'"))
+        || line.contains(&format!("\"{name}\""))
+        || line.contains(&format!("[{name}]"))
+        || line.contains(&format!(".{name}"))
+}
+
+fn line_mentions_variable(line: &str, variable: &str) -> bool {
+    line.contains(&format!("${variable}"))
+        || Regex::new(&format!(r"\b{}\b", regex::escape(variable)))
+            .ok()
+            .is_some_and(|regex| regex.is_match(line))
+}
+
+fn block_paths_for(lines: &[&str]) -> Vec<Vec<usize>> {
+    let mut paths = Vec::with_capacity(lines.len());
+    let mut path = Vec::new();
+    let mut next_block_id = 1usize;
+    for line in lines {
+        let leading_closes = line
+            .chars()
+            .take_while(|ch| ch.is_whitespace() || *ch == '}')
+            .filter(|ch| *ch == '}')
+            .count();
+        for _ in 0..leading_closes {
+            path.pop();
+        }
+
+        paths.push(path.clone());
+
+        let opens = line.chars().filter(|ch| *ch == '{').count();
+        let closes = line.chars().filter(|ch| *ch == '}').count();
+        for _ in 0..opens {
+            path.push(next_block_id);
+            next_block_id += 1;
+        }
+        for _ in leading_closes..closes {
+            path.pop();
+        }
+    }
+    paths
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::code_audit::Language;
+
+    fn php_fp(path: &str, content: &str) -> FileFingerprint {
+        FileFingerprint {
+            relative_path: path.to_string(),
+            language: Language::Php,
+            content: content.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn config() -> RedirectValidationConfig {
+        RedirectValidationConfig {
+            request_names: vec!["redirect_uri".to_string(), "return_to".to_string()],
+            redirect_sinks: vec!["redirect_to(".to_string(), "Location:".to_string()],
+            validation_markers: vec!["allow_redirect_destination".to_string()],
+            file_extensions: vec!["php".to_string()],
+            exclude_path_contains: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn flags_redirect_when_validation_is_conditional_and_not_dominating() {
+        let fp = php_fp(
+            "src/Auth.php",
+            r#"<?php
+$redirect_uri = $_GET['redirect_uri'];
+if ($agent) {
+    allow_redirect_destination($redirect_uri);
+}
+if (! $agent) {
+    redirect_to($redirect_uri);
+}
+"#,
+        );
+
+        let findings = run(&[&fp], &config());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, AuditFinding::RedirectValidation);
+        assert!(findings[0].description.contains("redirect_uri"));
+    }
+
+    #[test]
+    fn accepts_validation_that_dominates_redirect_sink() {
+        let fp = php_fp(
+            "src/Auth.php",
+            r#"<?php
+$return_to = $_REQUEST['return_to'];
+allow_redirect_destination($return_to);
+if ($failed) {
+    redirect_to($return_to);
+}
+"#,
+        );
+
+        assert!(run(&[&fp], &config()).is_empty());
+    }
+
+    #[test]
+    fn ignores_request_values_not_used_by_configured_redirect_sinks() {
+        let fp = php_fp(
+            "src/Auth.php",
+            r#"<?php
+$redirect_uri = $_GET['redirect_uri'];
+render_link($redirect_uri);
+"#,
+        );
+
+        assert!(run(&[&fp], &config()).is_empty());
+    }
+}

--- a/src/core/code_audit/redirect_validation.rs
+++ b/src/core/code_audit/redirect_validation.rs
@@ -349,6 +349,20 @@ redirect_to($redirect_uri);
     }
 
     #[test]
+    fn test_patterns_match() {
+        let patterns = vec![r#"\bcontext\.input\."#.to_string(), "(".to_string()];
+
+        assert!(patterns_match(
+            "const url = context.input.return_to;",
+            &patterns
+        ));
+        assert!(!patterns_match(
+            "const url = context.output.return_to;",
+            &patterns
+        ));
+    }
+
+    #[test]
     fn test_redirect_uses_value() {
         let config = config();
 
@@ -380,14 +394,6 @@ redirect_to($redirect_uri);
             "render($url);",
             &["redirect_to(".to_string()]
         ));
-    }
-
-    #[test]
-    fn test_patterns_match() {
-        let patterns = vec![r#"\bcontext\.input\."#.to_string(), "(".to_string()];
-
-        assert!(patterns_match("const url = context.input.return_to;", &patterns));
-        assert!(!patterns_match("const url = context.output.return_to;", &patterns));
     }
 
     #[test]

--- a/src/core/code_audit/redirect_validation.rs
+++ b/src/core/code_audit/redirect_validation.rs
@@ -14,14 +14,6 @@ static ASSIGNMENT_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(?:(?:\$|let\s+|const\s+|var\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=|([A-Za-z_][A-Za-z0-9_]*)\s*:=)"#)
         .expect("request assignment regex compiles")
 });
-static PHP_REQUEST_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"\$_(?:GET|POST|REQUEST|SERVER)\s*\["#).expect("php request regex compiles")
-});
-static GENERIC_REQUEST_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"\b(?:request|req|params|query|body|form|search_params|url_search_params)\b"#)
-        .expect("generic request regex compiles")
-});
-
 #[derive(Debug, Clone)]
 struct TrackedRedirectValue {
     variable: String,
@@ -40,6 +32,7 @@ pub(super) fn run(
     config: &RedirectValidationConfig,
 ) -> Vec<Finding> {
     if config.request_names.is_empty()
+        || (config.request_source_markers.is_empty() && config.request_source_patterns.is_empty())
         || config.redirect_sinks.is_empty()
         || config.validation_markers.is_empty()
     {
@@ -106,8 +99,8 @@ fn tracked_value_from_line(
     let request_name = config
         .request_names
         .iter()
-        .find(|name| line_contains_name(line, name))?;
-    if !looks_request_derived(line) {
+        .find(|name| marker_matches(line, std::slice::from_ref(name)))?;
+    if !looks_request_derived(line, config) {
         return None;
     }
     let captures = ASSIGNMENT_RE.captures(line)?;
@@ -176,8 +169,9 @@ fn eligible_file(fp: &FileFingerprint, config: &RedirectValidationConfig) -> boo
         .any(|allowed| allowed == extension)
 }
 
-fn looks_request_derived(line: &str) -> bool {
-    PHP_REQUEST_RE.is_match(line) || GENERIC_REQUEST_RE.is_match(line)
+fn looks_request_derived(line: &str, config: &RedirectValidationConfig) -> bool {
+    marker_matches(line, &config.request_source_markers)
+        || patterns_match(line, &config.request_source_patterns)
 }
 
 fn redirect_uses_value(line: &str, variable: &str, config: &RedirectValidationConfig) -> bool {
@@ -190,11 +184,13 @@ fn marker_matches(line: &str, markers: &[String]) -> bool {
         .any(|marker| !marker.is_empty() && line.contains(marker))
 }
 
-fn line_contains_name(line: &str, name: &str) -> bool {
-    line.contains(&format!("'{name}'"))
-        || line.contains(&format!("\"{name}\""))
-        || line.contains(&format!("[{name}]"))
-        || line.contains(&format!(".{name}"))
+fn patterns_match(line: &str, patterns: &[String]) -> bool {
+    patterns.iter().any(|pattern| {
+        !pattern.is_empty()
+            && Regex::new(pattern)
+                .ok()
+                .is_some_and(|regex| regex.is_match(line))
+    })
 }
 
 fn line_mentions_variable(line: &str, variable: &str) -> bool {
@@ -249,12 +245,196 @@ mod tests {
 
     fn config() -> RedirectValidationConfig {
         RedirectValidationConfig {
-            request_names: vec!["redirect_uri".to_string(), "return_to".to_string()],
+            request_names: vec!["'redirect_uri'".to_string(), "'return_to'".to_string()],
+            request_source_markers: vec![
+                "$_GET[".to_string(),
+                "$_REQUEST[".to_string(),
+                "$_POST[".to_string(),
+            ],
+            request_source_patterns: vec![r#"\brequest\.(query|body)\."#.to_string()],
             redirect_sinks: vec!["redirect_to(".to_string(), "Location:".to_string()],
             validation_markers: vec!["allow_redirect_destination".to_string()],
             file_extensions: vec!["php".to_string()],
             exclude_path_contains: Vec::new(),
         }
+    }
+
+    #[test]
+    fn test_run() {
+        let fp = php_fp(
+            "src/Auth.php",
+            r#"<?php
+$redirect_uri = $_GET['redirect_uri'];
+redirect_to($redirect_uri);
+"#,
+        );
+
+        let findings = run(&[&fp], &config());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, AuditFinding::RedirectValidation);
+        assert_eq!(findings[0].severity, Severity::Warning);
+    }
+
+    #[test]
+    fn test_tracked_value_from_line() {
+        let value = tracked_value_from_line("$return_to = $_REQUEST['return_to'];", 12, &config())
+            .expect("request assignment should be tracked");
+
+        assert_eq!(value.variable, "return_to");
+        assert_eq!(value.request_name, "'return_to'");
+        assert_eq!(value.source_line, 12);
+        assert!(tracked_value_from_line("$safe = get_default_url();", 13, &config()).is_none());
+    }
+
+    #[test]
+    fn test_validation_sites_for() {
+        let lines = [
+            "$redirect_uri = $_GET['redirect_uri'];",
+            "if ($ok) {",
+            "    allow_redirect_destination($redirect_uri);",
+            "}",
+        ];
+        let value = TrackedRedirectValue {
+            variable: "redirect_uri".to_string(),
+            request_name: "redirect_uri".to_string(),
+            source_line: 1,
+        };
+
+        let sites = validation_sites_for(&lines, &value, &config());
+
+        assert_eq!(sites.len(), 1);
+        assert_eq!(sites[0].line, 3);
+        assert_eq!(sites[0].block_path, vec![1]);
+    }
+
+    #[test]
+    fn test_validation_dominates() {
+        let validations = vec![ValidationSite {
+            line: 3,
+            block_path: vec![1],
+        }];
+
+        assert!(validation_dominates(4, &[1, 2], &validations));
+        assert!(!validation_dominates(4, &[2], &validations));
+        assert!(!validation_dominates(3, &[1], &validations));
+    }
+
+    #[test]
+    fn test_eligible_file() {
+        let mut config = config();
+        config.exclude_path_contains = vec!["vendor/".to_string()];
+
+        assert!(eligible_file(&php_fp("src/Auth.php", ""), &config));
+        assert!(!eligible_file(&php_fp("vendor/Auth.php", ""), &config));
+        assert!(!eligible_file(&php_fp("src/Auth.rs", ""), &config));
+    }
+
+    #[test]
+    fn test_looks_request_derived() {
+        let config = config();
+
+        assert!(looks_request_derived(
+            "$url = $_POST['redirect_uri'];",
+            &config
+        ));
+        assert!(looks_request_derived(
+            "const url = request.query.redirect_uri;",
+            &config
+        ));
+        assert!(!looks_request_derived(
+            "const url = configuredRedirect;",
+            &config
+        ));
+    }
+
+    #[test]
+    fn test_redirect_uses_value() {
+        let config = config();
+
+        assert!(redirect_uses_value(
+            "redirect_to($redirect_uri);",
+            "redirect_uri",
+            &config
+        ));
+        assert!(redirect_uses_value(
+            "redirect_to(redirect_uri);",
+            "redirect_uri",
+            &config
+        ));
+        assert!(!redirect_uses_value(
+            "render($redirect_uri);",
+            "redirect_uri",
+            &config
+        ));
+    }
+
+    #[test]
+    fn test_marker_matches() {
+        assert!(marker_matches(
+            "redirect_to($url);",
+            &["redirect_to(".to_string()]
+        ));
+        assert!(!marker_matches("redirect_to($url);", &[String::new()]));
+        assert!(!marker_matches(
+            "render($url);",
+            &["redirect_to(".to_string()]
+        ));
+    }
+
+    #[test]
+    fn test_patterns_match() {
+        let patterns = vec![r#"\bcontext\.input\."#.to_string(), "(".to_string()];
+
+        assert!(patterns_match("const url = context.input.return_to;", &patterns));
+        assert!(!patterns_match("const url = context.output.return_to;", &patterns));
+    }
+
+    #[test]
+    fn test_marker_matches_request_names_only_as_configured_substrings() {
+        let names = vec!["['redirect_uri']".to_string(), ".return_to".to_string()];
+
+        assert!(marker_matches("$_GET['redirect_uri']", &names));
+        assert!(marker_matches("request.query.return_to", &names));
+        assert!(!marker_matches("redirect_uri_backup", &names));
+    }
+
+    #[test]
+    fn test_line_mentions_variable() {
+        assert!(line_mentions_variable(
+            "redirect_to($redirect_uri);",
+            "redirect_uri"
+        ));
+        assert!(line_mentions_variable(
+            "redirect_to(redirect_uri);",
+            "redirect_uri"
+        ));
+        assert!(!line_mentions_variable(
+            "redirect_to(redirect_uri_backup);",
+            "redirect_uri"
+        ));
+    }
+
+    #[test]
+    fn test_block_paths_for() {
+        let lines = [
+            "if ($ok) {",
+            "    while ($next) {",
+            "        run();",
+            "    }",
+            "}",
+        ];
+
+        assert_eq!(
+            block_paths_for(&lines),
+            vec![
+                Vec::<usize>::new(),
+                vec![1],
+                vec![1, 2],
+                vec![1],
+                Vec::new()
+            ]
+        );
     }
 
     #[test]

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -45,6 +45,10 @@ pub struct AuditConfig {
         skip_serializing_if = "MutatingResourceAccessConfig::is_empty"
     )]
     pub mutating_resource_access: MutatingResourceAccessConfig,
+    /// Configurable checks for request-derived redirect destinations that are
+    /// used before URL validation dominates the redirect sink.
+    #[serde(default, skip_serializing_if = "RedirectValidationConfig::is_empty")]
+    pub redirect_validation: RedirectValidationConfig,
     /// Extension-owned call-name lists used by the duplication /
     /// parallel-implementation detector to filter out language- and
     /// framework-specific noise. Core never interprets these strings; they
@@ -112,6 +116,67 @@ pub struct ConfigKeyUsagePattern {
 
 fn default_config_key_capture() -> String {
     "key".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct RedirectValidationConfig {
+    /// Line substrings that identify configured request parameter names whose
+    /// values may become redirect destinations.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub request_names: Vec<String>,
+    /// Line substrings that identify reads from request/user-input sources.
+    /// Components or extensions own ecosystem-specific source syntax; core only
+    /// matches configured markers.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub request_source_markers: Vec<String>,
+    /// Regex patterns that identify reads from request/user-input sources.
+    /// Invalid patterns are ignored by the detector.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub request_source_patterns: Vec<String>,
+    /// Function names, method names, or line substrings that perform redirects.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub redirect_sinks: Vec<String>,
+    /// Function names, method names, or line substrings that validate/allowlist
+    /// redirect destinations.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub validation_markers: Vec<String>,
+    /// Optional path-extension filter, without leading dots.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_extensions: Vec<String>,
+    /// Path substrings that opt files out of this detector.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exclude_path_contains: Vec<String>,
+}
+
+impl RedirectValidationConfig {
+    pub fn is_empty(&self) -> bool {
+        self.request_names.is_empty()
+            && self.request_source_markers.is_empty()
+            && self.request_source_patterns.is_empty()
+            && self.redirect_sinks.is_empty()
+            && self.validation_markers.is_empty()
+            && self.file_extensions.is_empty()
+            && self.exclude_path_contains.is_empty()
+    }
+
+    fn merge(&mut self, other: &RedirectValidationConfig) {
+        extend_unique(&mut self.request_names, &other.request_names);
+        extend_unique(
+            &mut self.request_source_markers,
+            &other.request_source_markers,
+        );
+        extend_unique(
+            &mut self.request_source_patterns,
+            &other.request_source_patterns,
+        );
+        extend_unique(&mut self.redirect_sinks, &other.redirect_sinks);
+        extend_unique(&mut self.validation_markers, &other.validation_markers);
+        extend_unique(&mut self.file_extensions, &other.file_extensions);
+        extend_unique(
+            &mut self.exclude_path_contains,
+            &other.exclude_path_contains,
+        );
+    }
 }
 
 /// Extension-supplied call-name lists for the parallel-implementation /
@@ -457,6 +522,7 @@ impl AuditConfig {
             && self.requested_detectors.is_empty()
             && self.core_boundary_leaks.is_empty()
             && self.mutating_resource_access.is_empty()
+            && self.redirect_validation.is_empty()
             && self.duplication_detector.is_empty()
             && self.config_key_usage.is_empty()
     }
@@ -485,6 +551,7 @@ impl AuditConfig {
         self.core_boundary_leaks.merge(&other.core_boundary_leaks);
         self.mutating_resource_access
             .merge(&other.mutating_resource_access);
+        self.redirect_validation.merge(&other.redirect_validation);
         self.duplication_detector.merge(&other.duplication_detector);
         self.config_key_usage.merge(&other.config_key_usage);
         for rule in &other.requested_detectors {

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -15,8 +15,8 @@ pub use audit::{
     AuditConfig, ConfigKeyUsageConfig, ConfigKeyUsagePattern, ConfigKeyUsageRule,
     ConventionTagGlob, CoreBoundaryLeakConfig, DuplicationDetectorConfig, KnownSymbolEntry,
     KnownSymbolHeaderVersionProvider, KnownSymbolKind, KnownSymbolVersionedEntry,
-    MutatingResourceAccessConfig, RequestedDetectorRule, RequestedDetectorRuleBody,
-    RequiredRegexScope,
+    MutatingResourceAccessConfig, RedirectValidationConfig, RequestedDetectorRule,
+    RequestedDetectorRuleBody, RequiredRegexScope,
 };
 pub use inventory::{
     exists, extension_provides_artifact_pattern, inventory, list, list_ids, load,

--- a/tests/core/component/audit_test.rs
+++ b/tests/core/component/audit_test.rs
@@ -1,6 +1,6 @@
 use homeboy::core::component::{
     AuditConfig, ConfigKeyUsageConfig, ConfigKeyUsagePattern, ConfigKeyUsageRule,
-    MutatingResourceAccessConfig,
+    MutatingResourceAccessConfig, RedirectValidationConfig,
 };
 
 #[test]
@@ -42,6 +42,14 @@ fn test_merge() {
             access_helper_markers: vec!["owns_resource".to_string()],
             ..Default::default()
         },
+        redirect_validation: RedirectValidationConfig {
+            request_names: vec!["return_to".to_string()],
+            request_source_markers: vec!["query.".to_string()],
+            request_source_patterns: vec!["input\\.".to_string()],
+            redirect_sinks: vec!["redirect(".to_string()],
+            validation_markers: vec!["validate_redirect".to_string()],
+            ..Default::default()
+        },
         ..Default::default()
     };
 
@@ -77,6 +85,15 @@ fn test_merge() {
             mutator_markers: vec!["delete(".to_string()],
             ..Default::default()
         },
+        redirect_validation: RedirectValidationConfig {
+            request_names: vec!["return_to".to_string(), "callback_url".to_string()],
+            request_source_markers: vec!["query.".to_string(), "body.".to_string()],
+            request_source_patterns: vec!["input\\.".to_string(), "form\\.".to_string()],
+            redirect_sinks: vec!["redirect(".to_string(), "Location:".to_string()],
+            validation_markers: vec!["validate_redirect".to_string()],
+            file_extensions: vec!["php".to_string()],
+            ..Default::default()
+        },
         ..Default::default()
     });
 
@@ -110,4 +127,21 @@ fn test_merge() {
         config.mutating_resource_access.mutator_markers,
         vec!["delete("]
     );
+    assert_eq!(
+        config.redirect_validation.request_names,
+        vec!["return_to", "callback_url"]
+    );
+    assert_eq!(
+        config.redirect_validation.request_source_markers,
+        vec!["query.", "body."]
+    );
+    assert_eq!(
+        config.redirect_validation.request_source_patterns,
+        vec!["input\\.", "form\\."]
+    );
+    assert_eq!(
+        config.redirect_validation.redirect_sinks,
+        vec!["redirect(", "Location:"]
+    );
+    assert_eq!(config.redirect_validation.file_extensions, vec!["php"]);
 }


### PR DESCRIPTION
## Summary
- Adds a configurable, core-agnostic `redirect_validation` audit detector for request-derived redirect destinations.
- Tracks configured request names through local variables and warns when configured redirect sinks use them without dominating validation/allowlist markers.
- Documents the rule config and covers conditional-validation, dominating-validation, and non-sink cases with focused tests.

Fixes #1557.

## Tests
- `cargo test redirect_validation --lib`
- `cargo test test_merge --lib`
- `cargo check`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the configurable audit detector, tests, docs, verification commands, and PR preparation for Chris to review.