### PR TITLE
fix: explain divergent release tag recovery

### DIFF
--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -29,10 +29,11 @@ pub use operations::{
     changes_project_filtered, cherry_pick, cherry_pick_at, commit, commit_at, commit_from_json,
     detect_baseline_with_version, execute_git_for_release, fetch_and_fast_forward,
     fetch_and_get_behind_count, get_head_commit, get_repo_snapshot, get_tag_commit, pull, pull_at,
-    pull_bulk, push, push_at, push_bulk, rebase, rebase_at, short_head_revision_at, status,
-    status_at, status_bulk, tag, tag_at, tag_exists_locally, tag_exists_on_remote, BaselineInfo,
-    BaselineSource, ChangelogInfo, ChangesOutput, CherryPickOptions, CommitJsonOutput,
-    CommitOptions, GitOutput, PushOptions, RebaseOptions, RepoBaselineSnapshot, RepoSnapshot,
+    pull_bulk, push, push_at, push_bulk, rebase, rebase_at, remote_tag_commit,
+    short_head_revision_at, status, status_at, status_bulk, tag, tag_at, tag_exists_locally,
+    tag_exists_on_remote, BaselineInfo, BaselineSource, ChangelogInfo, ChangesOutput,
+    CherryPickOptions, CommitJsonOutput, CommitOptions, GitOutput, PushOptions, RebaseOptions,
+    RepoBaselineSnapshot, RepoSnapshot,
 };
 pub use pr_policy::{
     evaluate_merge_policy, evaluate_open_policy, PrPolicyContext, PrPolicyDecision, PrPolicyFile,

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -1131,18 +1131,30 @@ pub fn tag_at(
 
 /// Check if a tag exists on the remote.
 pub fn tag_exists_on_remote(path: &str, tag_name: &str) -> Result<bool> {
-    Ok(crate::core::engine::command::run_in_optional(
+    Ok(remote_tag_commit(path, tag_name)?.is_some())
+}
+
+/// Get the commit SHA a remote tag points to, if it exists.
+pub fn remote_tag_commit(path: &str, tag_name: &str) -> Result<Option<String>> {
+    let peeled_ref = format!("refs/tags/{}^{{}}", tag_name);
+    if let Some(commit) = remote_ref_commit(path, &peeled_ref) {
+        return Ok(Some(commit));
+    }
+
+    Ok(remote_ref_commit(path, &format!("refs/tags/{}", tag_name)))
+}
+
+fn remote_ref_commit(path: &str, ref_name: &str) -> Option<String> {
+    crate::core::engine::command::run_in_optional(
         path,
         "git",
-        &[
-            "ls-remote",
-            "--tags",
-            "origin",
-            &format!("refs/tags/{}", tag_name),
-        ],
+        &["ls-remote", "--tags", "origin", ref_name],
     )
-    .map(|s| !s.is_empty())
-    .unwrap_or(false))
+    .and_then(|output| {
+        output
+            .lines()
+            .find_map(|line| line.split_whitespace().next().map(str::to_string))
+    })
 }
 
 /// Check if a tag exists locally.

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -1613,6 +1613,44 @@ mod tests {
     }
 
     #[test]
+    fn test_remote_tag_commit() {
+        let (_dir, path) = init_repo_with_initial_commit();
+        let remote = tempfile::TempDir::new().expect("remote tempdir");
+
+        Command::new("git")
+            .args(["init", "--bare", "-q"])
+            .current_dir(remote.path())
+            .output()
+            .expect("git init bare remote");
+        Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                remote.path().to_str().expect("remote path"),
+            ])
+            .current_dir(&path)
+            .output()
+            .expect("git remote add");
+        Command::new("git")
+            .args(["tag", "v1.2.3"])
+            .current_dir(&path)
+            .output()
+            .expect("git tag");
+        Command::new("git")
+            .args(["push", "origin", "v1.2.3"])
+            .current_dir(&path)
+            .output()
+            .expect("git push tag");
+
+        let head = get_head_commit(&path).expect("head commit");
+        let remote_tag = remote_tag_commit(&path, "v1.2.3").expect("remote tag lookup");
+
+        assert_eq!(remote_tag.as_deref(), Some(head.as_str()));
+        assert_eq!(remote_tag_commit(&path, "v9.9.9").unwrap(), None);
+    }
+
+    #[test]
     fn rebase_against_self_is_a_noop_success() {
         let (_dir, path) = init_repo_with_initial_commit();
 

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -458,10 +458,10 @@ pub(crate) fn run_git_tag(
     }
 
     if local_tag_commit.is_some() || remote_tag_commit.is_some() {
-        let short_sha = |commit: &str| &commit[..8.min(commit.len())];
+        let short_sha = |commit: &str| commit[..8.min(commit.len())].to_string();
         let tag_state = |commit: Option<&str>| {
             commit
-                .map(|sha| short_sha(sha).to_string())
+                .map(&short_sha)
                 .unwrap_or_else(|| "absent".to_string())
         };
         let github_release = component

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -424,38 +424,47 @@ pub(crate) fn run_git_tag(
         }
     }
 
-    if crate::core::git::tag_exists_locally(&component.local_path, tag_name).unwrap_or(false) {
-        let tag_commit = crate::core::git::get_tag_commit(&component.local_path, tag_name)?;
-        let head_commit = crate::core::git::get_head_commit(&component.local_path)?;
+    let head_commit = crate::core::git::get_head_commit(&component.local_path)?;
+    let local_tag_commit =
+        if crate::core::git::tag_exists_locally(&component.local_path, tag_name).unwrap_or(false) {
+            Some(crate::core::git::get_tag_commit(
+                &component.local_path,
+                tag_name,
+            )?)
+        } else {
+            None
+        };
+    let remote_tag_commit = crate::core::git::remote_tag_commit(&component.local_path, tag_name)?;
 
-        if tag_commit == head_commit {
-            state.tag = Some(tag_name.to_string());
-            return Ok(step_success(
-                "git.tag",
-                "git.tag",
-                Some(serde_json::json!({
-                    "action": "tag",
-                    "component_id": component_id,
-                    "tag": tag_name,
-                    "skipped": true,
-                    "reason": "tag already exists and points to HEAD"
-                })),
-                Vec::new(),
-            ));
-        }
+    if local_tag_commit.as_deref() == Some(head_commit.as_str())
+        || remote_tag_commit.as_deref() == Some(head_commit.as_str())
+    {
+        state.tag = Some(tag_name.to_string());
+        return Ok(step_success(
+            "git.tag",
+            "git.tag",
+            Some(serde_json::json!({
+                "action": "tag",
+                "component_id": component_id,
+                "tag": tag_name,
+                "skipped": true,
+                "reason": "tag already exists and points to HEAD",
+                "head": head_commit,
+                "local_tag": local_tag_commit,
+                "remote_tag": remote_tag_commit,
+            })),
+            Vec::new(),
+        ));
+    }
 
-        return Err(Error::validation_invalid_argument(
-            "tag",
-            format!("Tag '{}' exists but points to different commit", tag_name),
-            Some(format!(
-                "Tag points to {}, HEAD is {}",
-                &tag_commit[..8.min(tag_commit.len())],
-                &head_commit[..8.min(head_commit.len())]
-            )),
-            Some(vec![
-                format!("Delete stale tag: git tag -d {}", tag_name),
-                format!("Then retry: homeboy release {}", component_id),
-            ]),
+    if local_tag_commit.is_some() || remote_tag_commit.is_some() {
+        return Ok(divergent_release_tag_result(
+            component,
+            component_id,
+            tag_name,
+            &head_commit,
+            local_tag_commit.as_deref(),
+            remote_tag_commit.as_deref(),
         ));
     }
 
@@ -508,6 +517,109 @@ pub(crate) fn run_git_tag(
 
     state.tag = Some(tag_name.to_string());
     Ok(step_success("git.tag", "git.tag", Some(data), Vec::new()))
+}
+
+fn divergent_release_tag_result(
+    component: &Component,
+    component_id: &str,
+    tag_name: &str,
+    head_commit: &str,
+    local_tag_commit: Option<&str>,
+    remote_tag_commit: Option<&str>,
+) -> ReleaseStepResult {
+    let github_release = github_release_probe(component, tag_name);
+    let github_release_label = match github_release {
+        Some(true) => "exists".to_string(),
+        Some(false) => "not found".to_string(),
+        None => "not checked".to_string(),
+    };
+    let error_msg = format!(
+        "Release tag {} already exists but does not point at HEAD ({}). Local tag: {}; origin tag: {}; GitHub Release: {}. Refusing to move or overwrite the tag.",
+        tag_name,
+        short_sha(head_commit),
+        tag_state(local_tag_commit),
+        tag_state(remote_tag_commit),
+        github_release_label,
+    );
+
+    let mut hints = vec![crate::core::error::Hint {
+        message: format!(
+            "If {} is a previous successful release, bump the component version and rerun `homeboy release {}` so Homeboy creates the next tag.",
+            tag_name, component_id
+        ),
+    }];
+
+    if github_release == Some(true) {
+        hints.push(crate::core::error::Hint {
+            message: format!(
+                "If {} is an abandoned pre-release tag with a GitHub Release, delete both deliberately: `gh release delete {} --cleanup-tag --yes`.",
+                tag_name, tag_name
+            ),
+        });
+    } else if remote_tag_commit.is_some() {
+        hints.push(crate::core::error::Hint {
+            message: format!(
+                "If {} is an abandoned pre-release tag without a GitHub Release, delete the remote tag deliberately: `git push origin :refs/tags/{}`.",
+                tag_name, tag_name
+            ),
+        });
+    }
+
+    if local_tag_commit.is_some() {
+        hints.push(crate::core::error::Hint {
+            message: format!(
+                "After confirming the remote state, remove the stale local tag with `git tag -d {}`.",
+                tag_name
+            ),
+        });
+    }
+
+    hints.push(crate::core::error::Hint {
+        message: format!(
+            "Retry with `homeboy release {}` after cleanup.",
+            component_id
+        ),
+    });
+
+    step_failed(
+        "git.tag",
+        "git.tag",
+        Some(serde_json::json!({
+            "action": "tag",
+            "component_id": component_id,
+            "tag": tag_name,
+            "head": head_commit,
+            "local_tag": local_tag_commit,
+            "remote_tag": remote_tag_commit,
+            "github_release": github_release,
+        })),
+        Some(error_msg),
+        hints,
+    )
+}
+
+fn tag_state(commit: Option<&str>) -> String {
+    commit.map(short_sha).unwrap_or("absent").to_string()
+}
+
+fn short_sha(commit: &str) -> &str {
+    &commit[..8.min(commit.len())]
+}
+
+fn github_release_probe(component: &Component, tag_name: &str) -> Option<bool> {
+    let remote_url = component.remote_url.clone().or_else(|| {
+        crate::core::deploy::release_download::detect_remote_url(std::path::Path::new(
+            &component.local_path,
+        ))
+    })?;
+    let github = crate::core::deploy::release_download::parse_github_url(&remote_url)?;
+
+    if !gh_is_available() || !gh_is_authenticated() {
+        return None;
+    }
+
+    let repo_flag = format!("{}/{}", github.owner, github.repo);
+    Some(gh_release_exists(tag_name, &repo_flag))
 }
 
 /// Push commits (and tags) to the remote.
@@ -1683,6 +1795,122 @@ mod tests {
         assert!(
             crate::core::git::tag_exists_locally(&component.local_path, "v0.6.13").unwrap_or(false),
             "tag should have been created on HEAD"
+        );
+    }
+
+    #[test]
+    fn git_tag_step_explains_existing_tag_on_different_commit() {
+        let (_temp, component) = plugin_repo_at("0.6.12");
+        let component_path = std::path::Path::new(&component.local_path);
+        run_in(component_path, &["git", "tag", "v0.6.13"]);
+
+        std::fs::write(
+            component_path.join("plugin.php"),
+            "<?php\n/*\nPlugin Name: Fixture\nVersion: 0.6.13\n*/\n",
+        )
+        .expect("write bumped plugin");
+        run_in(component_path, &["git", "add", "plugin.php"]);
+        run_in(
+            component_path,
+            &["git", "commit", "-q", "-m", "release: v0.6.13"],
+        );
+
+        let mut state = ReleaseState {
+            version: Some("0.6.13".to_string()),
+            tag: Some("v0.6.13".to_string()),
+            ..ReleaseState::default()
+        };
+
+        let result = run_git_tag(&component, "fixture", &mut state, "v0.6.13")
+            .expect("existing tag on older commit should return a failed step");
+
+        assert_eq!(result.status, ReleaseStepStatus::Failed);
+        let err = result.error.expect("expected tag divergence error");
+        assert!(
+            err.contains("does not point at HEAD"),
+            "expected tag divergence message, got: {}",
+            err
+        );
+        assert!(err.contains("Local tag:"), "expected local tag state");
+        assert!(err.contains("origin tag:"), "expected remote tag state");
+        assert!(
+            result
+                .data
+                .as_ref()
+                .and_then(|data| data.get("local_tag"))
+                .and_then(serde_json::Value::as_str)
+                .is_some(),
+            "expected local tag commit in structured data"
+        );
+        assert!(
+            result
+                .hints
+                .iter()
+                .any(|hint| hint.message.contains("previous successful release")),
+            "expected next-version recovery guidance"
+        );
+    }
+
+    #[test]
+    fn git_tag_step_catches_remote_only_tag_on_different_commit() {
+        let (_temp, component) = plugin_repo_at("0.6.12");
+        let component_path = std::path::Path::new(&component.local_path);
+        let remote = tempfile::tempdir().expect("remote tempdir");
+        run_in(remote.path(), &["git", "init", "--bare", "-q"]);
+        run_in(
+            component_path,
+            &[
+                "git",
+                "remote",
+                "add",
+                "origin",
+                remote.path().to_str().expect("remote path"),
+            ],
+        );
+        run_in(component_path, &["git", "tag", "v0.6.13"]);
+        run_in(component_path, &["git", "push", "origin", "v0.6.13"]);
+        run_in(component_path, &["git", "tag", "-d", "v0.6.13"]);
+
+        std::fs::write(
+            component_path.join("plugin.php"),
+            "<?php\n/*\nPlugin Name: Fixture\nVersion: 0.6.13\n*/\n",
+        )
+        .expect("write bumped plugin");
+        run_in(component_path, &["git", "add", "plugin.php"]);
+        run_in(
+            component_path,
+            &["git", "commit", "-q", "-m", "release: v0.6.13"],
+        );
+
+        let mut state = ReleaseState {
+            version: Some("0.6.13".to_string()),
+            tag: Some("v0.6.13".to_string()),
+            ..ReleaseState::default()
+        };
+
+        let result = run_git_tag(&component, "fixture", &mut state, "v0.6.13")
+            .expect("remote-only divergent tag should return a failed step");
+
+        assert_eq!(result.status, ReleaseStepStatus::Failed);
+        assert!(
+            !crate::core::git::tag_exists_locally(&component.local_path, "v0.6.13").unwrap(),
+            "remote-only divergent tag must not be recreated locally"
+        );
+        assert!(
+            result
+                .data
+                .as_ref()
+                .and_then(|data| data.get("remote_tag"))
+                .and_then(serde_json::Value::as_str)
+                .is_some(),
+            "expected remote tag commit in structured data"
+        );
+        assert!(
+            result
+                .hints
+                .iter()
+                .any(|hint| hint.message.contains("git push origin :refs/tags/v0.6.13")),
+            "expected deliberate remote tag cleanup guidance"
         );
     }
 }

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -458,13 +458,96 @@ pub(crate) fn run_git_tag(
     }
 
     if local_tag_commit.is_some() || remote_tag_commit.is_some() {
-        return Ok(divergent_release_tag_result(
-            component,
-            component_id,
-            tag_name,
-            &head_commit,
-            local_tag_commit.as_deref(),
-            remote_tag_commit.as_deref(),
+        let short_sha = |commit: &str| &commit[..8.min(commit.len())];
+        let tag_state = |commit: Option<&str>| {
+            commit
+                .map(|sha| short_sha(sha).to_string())
+                .unwrap_or_else(|| "absent".to_string())
+        };
+        let github_release = component
+            .remote_url
+            .clone()
+            .or_else(|| {
+                crate::core::deploy::release_download::detect_remote_url(std::path::Path::new(
+                    &component.local_path,
+                ))
+            })
+            .and_then(|remote_url| {
+                crate::core::deploy::release_download::parse_github_url(&remote_url)
+            })
+            .and_then(|github| {
+                if !gh_is_available() || !gh_is_authenticated() {
+                    return None;
+                }
+
+                let repo_flag = format!("{}/{}", github.owner, github.repo);
+                Some(gh_release_exists(tag_name, &repo_flag))
+            });
+        let github_release_label = match github_release {
+            Some(true) => "exists".to_string(),
+            Some(false) => "not found".to_string(),
+            None => "not checked".to_string(),
+        };
+        let mut hints = vec![crate::core::error::Hint {
+            message: format!(
+                "If {} is a previous successful release, bump the component version and rerun `homeboy release {}` so Homeboy creates the next tag.",
+                tag_name, component_id
+            ),
+        }];
+
+        if github_release == Some(true) {
+            hints.push(crate::core::error::Hint {
+                message: format!(
+                    "If {} is an abandoned pre-release tag with a GitHub Release, delete both deliberately: `gh release delete {} --cleanup-tag --yes`.",
+                    tag_name, tag_name
+                ),
+            });
+        } else if remote_tag_commit.is_some() {
+            hints.push(crate::core::error::Hint {
+                message: format!(
+                    "If {} is an abandoned pre-release tag without a GitHub Release, delete the remote tag deliberately: `git push origin :refs/tags/{}`.",
+                    tag_name, tag_name
+                ),
+            });
+        }
+
+        if local_tag_commit.is_some() {
+            hints.push(crate::core::error::Hint {
+                message: format!(
+                    "After confirming the remote state, remove the stale local tag with `git tag -d {}`.",
+                    tag_name
+                ),
+            });
+        }
+
+        hints.push(crate::core::error::Hint {
+            message: format!(
+                "Retry with `homeboy release {}` after cleanup.",
+                component_id
+            ),
+        });
+
+        return Ok(step_failed(
+            "git.tag",
+            "git.tag",
+            Some(serde_json::json!({
+                "action": "tag",
+                "component_id": component_id,
+                "tag": tag_name,
+                "head": head_commit,
+                "local_tag": local_tag_commit,
+                "remote_tag": remote_tag_commit,
+                "github_release": github_release,
+            })),
+            Some(format!(
+                "Release tag {} already exists but does not point at HEAD ({}). Local tag: {}; origin tag: {}; GitHub Release: {}. Refusing to move or overwrite the tag.",
+                tag_name,
+                short_sha(&head_commit),
+                tag_state(local_tag_commit.as_deref()),
+                tag_state(remote_tag_commit.as_deref()),
+                github_release_label,
+            )),
+            hints,
         ));
     }
 
@@ -517,109 +600,6 @@ pub(crate) fn run_git_tag(
 
     state.tag = Some(tag_name.to_string());
     Ok(step_success("git.tag", "git.tag", Some(data), Vec::new()))
-}
-
-fn divergent_release_tag_result(
-    component: &Component,
-    component_id: &str,
-    tag_name: &str,
-    head_commit: &str,
-    local_tag_commit: Option<&str>,
-    remote_tag_commit: Option<&str>,
-) -> ReleaseStepResult {
-    let github_release = github_release_probe(component, tag_name);
-    let github_release_label = match github_release {
-        Some(true) => "exists".to_string(),
-        Some(false) => "not found".to_string(),
-        None => "not checked".to_string(),
-    };
-    let error_msg = format!(
-        "Release tag {} already exists but does not point at HEAD ({}). Local tag: {}; origin tag: {}; GitHub Release: {}. Refusing to move or overwrite the tag.",
-        tag_name,
-        short_sha(head_commit),
-        tag_state(local_tag_commit),
-        tag_state(remote_tag_commit),
-        github_release_label,
-    );
-
-    let mut hints = vec![crate::core::error::Hint {
-        message: format!(
-            "If {} is a previous successful release, bump the component version and rerun `homeboy release {}` so Homeboy creates the next tag.",
-            tag_name, component_id
-        ),
-    }];
-
-    if github_release == Some(true) {
-        hints.push(crate::core::error::Hint {
-            message: format!(
-                "If {} is an abandoned pre-release tag with a GitHub Release, delete both deliberately: `gh release delete {} --cleanup-tag --yes`.",
-                tag_name, tag_name
-            ),
-        });
-    } else if remote_tag_commit.is_some() {
-        hints.push(crate::core::error::Hint {
-            message: format!(
-                "If {} is an abandoned pre-release tag without a GitHub Release, delete the remote tag deliberately: `git push origin :refs/tags/{}`.",
-                tag_name, tag_name
-            ),
-        });
-    }
-
-    if local_tag_commit.is_some() {
-        hints.push(crate::core::error::Hint {
-            message: format!(
-                "After confirming the remote state, remove the stale local tag with `git tag -d {}`.",
-                tag_name
-            ),
-        });
-    }
-
-    hints.push(crate::core::error::Hint {
-        message: format!(
-            "Retry with `homeboy release {}` after cleanup.",
-            component_id
-        ),
-    });
-
-    step_failed(
-        "git.tag",
-        "git.tag",
-        Some(serde_json::json!({
-            "action": "tag",
-            "component_id": component_id,
-            "tag": tag_name,
-            "head": head_commit,
-            "local_tag": local_tag_commit,
-            "remote_tag": remote_tag_commit,
-            "github_release": github_release,
-        })),
-        Some(error_msg),
-        hints,
-    )
-}
-
-fn tag_state(commit: Option<&str>) -> String {
-    commit.map(short_sha).unwrap_or("absent").to_string()
-}
-
-fn short_sha(commit: &str) -> &str {
-    &commit[..8.min(commit.len())]
-}
-
-fn github_release_probe(component: &Component, tag_name: &str) -> Option<bool> {
-    let remote_url = component.remote_url.clone().or_else(|| {
-        crate::core::deploy::release_download::detect_remote_url(std::path::Path::new(
-            &component.local_path,
-        ))
-    })?;
-    let github = crate::core::deploy::release_download::parse_github_url(&remote_url)?;
-
-    if !gh_is_available() || !gh_is_authenticated() {
-        return None;
-    }
-
-    let repo_flag = format!("{}/{}", github.owner, github.repo);
-    Some(gh_release_exists(tag_name, &repo_flag))
 }
 
 /// Push commits (and tags) to the remote.
@@ -1751,7 +1731,7 @@ mod tests {
     }
 
     #[test]
-    fn git_tag_step_refuses_to_tag_when_head_lacks_new_version() {
+    fn git_tag_step_refuses_invalid_release_tags() {
         // The orphan-tag scenario from issue #2234: the in-memory state.version
         // says 0.6.13, but HEAD's plugin.php still reads 0.6.12. Without the
         // invariant check this would happily push a tag onto the wrong commit.
@@ -1777,29 +1757,7 @@ mod tests {
             !crate::core::git::tag_exists_locally(&component.local_path, "v0.6.13").unwrap_or(true),
             "tag must NOT have been created when invariant fails"
         );
-    }
 
-    #[test]
-    fn git_tag_step_creates_tag_when_head_matches_state_version() {
-        let (_temp, component) = plugin_repo_at("0.6.13");
-        let mut state = ReleaseState {
-            version: Some("0.6.13".to_string()),
-            tag: Some("v0.6.13".to_string()),
-            ..ReleaseState::default()
-        };
-
-        let result = run_git_tag(&component, "fixture", &mut state, "v0.6.13")
-            .expect("step should succeed when HEAD shows the bumped version");
-
-        assert_eq!(result.status, ReleaseStepStatus::Success);
-        assert!(
-            crate::core::git::tag_exists_locally(&component.local_path, "v0.6.13").unwrap_or(false),
-            "tag should have been created on HEAD"
-        );
-    }
-
-    #[test]
-    fn git_tag_step_explains_existing_tag_on_different_commit() {
         let (_temp, component) = plugin_repo_at("0.6.12");
         let component_path = std::path::Path::new(&component.local_path);
         run_in(component_path, &["git", "tag", "v0.6.13"]);
@@ -1849,10 +1807,7 @@ mod tests {
                 .any(|hint| hint.message.contains("previous successful release")),
             "expected next-version recovery guidance"
         );
-    }
 
-    #[test]
-    fn git_tag_step_catches_remote_only_tag_on_different_commit() {
         let (_temp, component) = plugin_repo_at("0.6.12");
         let component_path = std::path::Path::new(&component.local_path);
         let remote = tempfile::tempdir().expect("remote tempdir");
@@ -1911,6 +1866,25 @@ mod tests {
                 .iter()
                 .any(|hint| hint.message.contains("git push origin :refs/tags/v0.6.13")),
             "expected deliberate remote tag cleanup guidance"
+        );
+    }
+
+    #[test]
+    fn git_tag_step_creates_tag_when_head_matches_state_version() {
+        let (_temp, component) = plugin_repo_at("0.6.13");
+        let mut state = ReleaseState {
+            version: Some("0.6.13".to_string()),
+            tag: Some("v0.6.13".to_string()),
+            ..ReleaseState::default()
+        };
+
+        let result = run_git_tag(&component, "fixture", &mut state, "v0.6.13")
+            .expect("step should succeed when HEAD shows the bumped version");
+
+        assert_eq!(result.status, ReleaseStepStatus::Success);
+        assert!(
+            crate::core::git::tag_exists_locally(&component.local_path, "v0.6.13").unwrap_or(false),
+            "tag should have been created on HEAD"
         );
     }
 }

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -282,6 +282,10 @@ fn format_tag(version: &str, monorepo: Option<&git::MonorepoContext>) -> String 
     }
 }
 
+fn short_sha(commit: &str) -> &str {
+    &commit[..8.min(commit.len())]
+}
+
 fn extract_new_version_from_plan(plan: &ReleasePlan) -> Option<String> {
     plan.plan
         .steps
@@ -385,6 +389,53 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
         git::tag_exists_locally(&component.local_path, &tag_name).unwrap_or(false);
     let tag_exists_remote =
         git::tag_exists_on_remote(&component.local_path, &tag_name).unwrap_or(false);
+    let head_commit = git::get_head_commit(&component.local_path)?;
+    let local_tag_commit = if tag_exists_local {
+        Some(git::get_tag_commit(&component.local_path, &tag_name)?)
+    } else {
+        None
+    };
+    let remote_tag_commit = git::remote_tag_commit(&component.local_path, &tag_name)?;
+
+    if local_tag_commit
+        .as_deref()
+        .is_some_and(|commit| commit != head_commit)
+        || remote_tag_commit
+            .as_deref()
+            .is_some_and(|commit| commit != head_commit)
+    {
+        return Err(Error::validation_invalid_argument(
+            "tag",
+            format!("Tag '{}' exists but does not point to HEAD", tag_name),
+            Some(format!(
+                "local tag points to {}, origin tag points to {}, HEAD is {}",
+                local_tag_commit
+                    .as_deref()
+                    .map(short_sha)
+                    .unwrap_or("<missing>"),
+                remote_tag_commit
+                    .as_deref()
+                    .map(short_sha)
+                    .unwrap_or("<missing>"),
+                short_sha(&head_commit)
+            )),
+            Some(vec![
+                format!(
+                    "Inspect the existing tag before recovery: git show --no-patch --decorate {}",
+                    tag_name
+                ),
+                format!(
+                    "If the existing tag is valid, create a new releasable commit and run: homeboy release {}",
+                    input.component_id
+                ),
+                format!(
+                    "If the tag is an abandoned partial release, delete the GitHub release/tag explicitly, then run: homeboy release {} --recover",
+                    input.component_id
+                ),
+            ]),
+        ));
+    }
+
     let uncommitted = git::get_uncommitted_changes(&component.local_path)?;
 
     let mut actions = Vec::new();


### PR DESCRIPTION
## Summary
- Detect local and remote release tags that already exist but do not point at release HEAD before trying to create or recover a tag.
- Return a structured failed release step with local/remote/GitHub Release state instead of a generic invalid-argument abort.
- Guard `homeboy release --recover` from claiming success when the existing tag points at a different commit.

Fixes #2674.

## Tests
- `cargo fmt --check`
- `cargo test core::release::executor::tests::git_tag_step --lib`
- `cargo test core::release::workflow::tests --lib`
- `cargo test --lib`
- `cargo test`
- `homeboy audit --path . --changed-since 7d69e738800d89412991d48dab34920919dbcb8e`
- `cargo clippy --all-targets -- -D warnings` (fails on pre-existing repository-wide Clippy debt unrelated to this PR)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing release-tag divergence diagnostics, recovery guardrails, and targeted Rust tests; Chris directed the issue and reviewed the desired behavior.