### PR TITLE
feat: detect write-only config keys

### DIFF
--- a/docs/commands/audit-rules.md
+++ b/docs/commands/audit-rules.md
@@ -35,3 +35,48 @@ Use one of:
 - severity: warning
 
 These findings participate in baseline comparisons like any other audit finding.
+
+## Config Key Usage Rules
+
+`audit.config_key_usage.rules` lets a component provide language/framework-specific regexes for config keys that are written, migrated, or exposed by accessors. Homeboy core only correlates configured captures across fingerprints; it does not know what a given key means.
+
+Example:
+
+```json
+{
+  "audit": {
+    "config_key_usage": {
+      "rules": [
+        {
+          "id": "workflow-config",
+          "exclude_path_contains": ["fixtures/", "vendor/"],
+          "write_patterns": [
+            {
+              "pattern": "set_config\\(\\s*['\"](?P<key>[a-z_]+)['\"]"
+            }
+          ],
+          "accessor_patterns": [
+            {
+              "pattern": "function\\s+(?P<symbol>[a-z_]+)\\(.*get_config\\(\\s*['\"](?P<key>[a-z_]+)['\"]",
+              "symbol_capture": "symbol"
+            }
+          ],
+          "read_patterns": [
+            {
+              "pattern": "read_config\\(\\s*['\"](?P<key>[a-z_]+)['\"]"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+Finding output:
+
+- `convention`: `config_key_usage:<rule id>`
+- `kind`: `write_only_config_key`
+- severity: warning
+
+Reads in test paths do not satisfy the rule. If an accessor pattern captures `symbol_capture`, a non-test reference to that symbol outside the accessor definition file counts as a production read.

--- a/src/core/code_audit/config_key_usage.rs
+++ b/src/core/code_audit/config_key_usage.rs
@@ -1,0 +1,279 @@
+//! Config-key usage correlation for component-owned rule packs.
+//!
+//! Core is intentionally language/framework agnostic here: configured regexes
+//! capture opaque key and symbol strings, then core correlates write/accessor
+//! evidence with non-test read evidence.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use regex::Regex;
+
+use crate::core::component::{ConfigKeyUsagePattern, ConfigKeyUsageRule};
+
+use super::conventions::AuditFinding;
+use super::findings::{Finding, Severity};
+use super::fingerprint::FileFingerprint;
+use super::source_locations::line_of_offset;
+use super::walker::is_test_path;
+
+#[derive(Debug, Default)]
+struct KeyEvidence {
+    writes: Vec<EvidenceSite>,
+    accessors: Vec<EvidenceSite>,
+    reads: Vec<EvidenceSite>,
+    accessor_symbols: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone)]
+struct EvidenceSite {
+    file: String,
+    line: usize,
+}
+
+pub(super) fn run(fingerprints: &[&FileFingerprint], rules: &[ConfigKeyUsageRule]) -> Vec<Finding> {
+    if rules.is_empty() {
+        return Vec::new();
+    }
+
+    let mut findings = Vec::new();
+    for rule in rules {
+        findings.extend(run_rule(fingerprints, rule));
+    }
+    findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
+    findings
+}
+
+fn run_rule(fingerprints: &[&FileFingerprint], rule: &ConfigKeyUsageRule) -> Vec<Finding> {
+    let mut evidence_by_key: BTreeMap<String, KeyEvidence> = BTreeMap::new();
+    let eligible = fingerprints
+        .iter()
+        .copied()
+        .filter(|fp| is_eligible_path(&fp.relative_path, rule))
+        .collect::<Vec<_>>();
+
+    for fp in &eligible {
+        collect_pattern_evidence(fp, &rule.write_patterns, |key, site, _symbol| {
+            evidence_by_key.entry(key).or_default().writes.push(site);
+        });
+        collect_pattern_evidence(fp, &rule.accessor_patterns, |key, site, symbol| {
+            let evidence = evidence_by_key.entry(key).or_default();
+            evidence.accessors.push(site);
+            if let Some(symbol) = symbol {
+                evidence.accessor_symbols.insert(symbol);
+            }
+        });
+    }
+
+    for fp in eligible
+        .iter()
+        .filter(|fp| !is_test_path(&fp.relative_path))
+    {
+        collect_pattern_evidence(fp, &rule.read_patterns, |key, site, _symbol| {
+            evidence_by_key.entry(key).or_default().reads.push(site);
+        });
+    }
+
+    collect_accessor_symbol_reads(&eligible, &mut evidence_by_key);
+
+    evidence_by_key
+        .into_iter()
+        .filter(|(_, evidence)| {
+            (!evidence.writes.is_empty() || !evidence.accessors.is_empty())
+                && evidence.reads.is_empty()
+        })
+        .filter_map(|(key, evidence)| finding_for(rule, &key, &evidence))
+        .collect()
+}
+
+fn is_eligible_path(path: &str, rule: &ConfigKeyUsageRule) -> bool {
+    !rule
+        .exclude_path_contains
+        .iter()
+        .any(|needle| path.contains(needle))
+}
+
+fn collect_pattern_evidence(
+    fp: &FileFingerprint,
+    patterns: &[ConfigKeyUsagePattern],
+    mut record: impl FnMut(String, EvidenceSite, Option<String>),
+) {
+    for pattern in patterns {
+        let Ok(regex) = Regex::new(&pattern.pattern) else {
+            continue;
+        };
+        for captures in regex.captures_iter(&fp.content) {
+            let Some(key) = captures.name(&pattern.key_capture) else {
+                continue;
+            };
+            let symbol = pattern
+                .symbol_capture
+                .as_ref()
+                .and_then(|capture| captures.name(capture))
+                .map(|value| value.as_str().to_string())
+                .filter(|value| !value.trim().is_empty());
+            let line = captures
+                .get(0)
+                .map(|m| line_of_offset(&fp.content, m.start()))
+                .unwrap_or(1);
+            record(
+                key.as_str().to_string(),
+                EvidenceSite {
+                    file: fp.relative_path.clone(),
+                    line,
+                },
+                symbol,
+            );
+        }
+    }
+}
+
+fn collect_accessor_symbol_reads(
+    fingerprints: &[&FileFingerprint],
+    evidence_by_key: &mut BTreeMap<String, KeyEvidence>,
+) {
+    for evidence in evidence_by_key.values_mut() {
+        let definition_files = evidence
+            .accessors
+            .iter()
+            .chain(evidence.writes.iter())
+            .map(|site| site.file.as_str())
+            .collect::<BTreeSet<_>>();
+        for symbol in evidence.accessor_symbols.clone() {
+            if symbol.len() < 3 {
+                continue;
+            }
+            for fp in fingerprints
+                .iter()
+                .filter(|fp| !is_test_path(&fp.relative_path))
+            {
+                if definition_files.contains(fp.relative_path.as_str()) {
+                    continue;
+                }
+                if let Some(offset) = fp.content.find(&symbol) {
+                    evidence.reads.push(EvidenceSite {
+                        file: fp.relative_path.clone(),
+                        line: line_of_offset(&fp.content, offset),
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn finding_for(rule: &ConfigKeyUsageRule, key: &str, evidence: &KeyEvidence) -> Option<Finding> {
+    let primary = evidence
+        .writes
+        .first()
+        .or_else(|| evidence.accessors.first())?;
+    let write_count = evidence.writes.len();
+    let accessor_count = evidence.accessors.len();
+    let first_site = format!("{}:{}", primary.file, primary.line);
+    Some(Finding {
+        convention: format!("config_key_usage:{}", rule.id),
+        severity: Severity::Warning,
+        file: primary.file.clone(),
+        description: format!(
+            "Config key '{}' has {} write/migration site(s) and {} accessor site(s), but no non-test read matched this rule; first evidence at {}",
+            key, write_count, accessor_count, first_site
+        ),
+        suggestion: "Either consume the key in production code or remove the stale write/accessor path".to_string(),
+        kind: AuditFinding::WriteOnlyConfigKey,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::component::ConfigKeyUsagePattern;
+
+    use super::*;
+
+    fn fp(path: &str, content: &str) -> FileFingerprint {
+        FileFingerprint {
+            relative_path: path.to_string(),
+            content: content.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn rule() -> ConfigKeyUsageRule {
+        ConfigKeyUsageRule {
+            id: "generic-config".to_string(),
+            exclude_path_contains: vec!["fixtures/".to_string()],
+            write_patterns: vec![ConfigKeyUsagePattern {
+                pattern: r#"set_config\(\s*['\"](?P<key>[a-z_]+)['\"]"#.to_string(),
+                key_capture: "key".to_string(),
+                symbol_capture: None,
+            }],
+            accessor_patterns: vec![ConfigKeyUsagePattern {
+                pattern:
+                    r#"fn\s+(?P<symbol>[a-z_]+)\(\).*get_config\(\s*['\"](?P<key>[a-z_]+)['\"]"#
+                        .to_string(),
+                key_capture: "key".to_string(),
+                symbol_capture: Some("symbol".to_string()),
+            }],
+            read_patterns: vec![ConfigKeyUsagePattern {
+                pattern: r#"read_config\(\s*['\"](?P<key>[a-z_]+)['\"]"#.to_string(),
+                key_capture: "key".to_string(),
+                symbol_capture: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn flags_written_accessor_backed_key_without_production_read() {
+        let files = vec![
+            fp("src/builder.rs", "set_config('enabled_items', values);"),
+            fp(
+                "src/config.rs",
+                "fn enabled_items() { get_config('enabled_items') }",
+            ),
+            fp("tests/config_test.rs", "read_config('enabled_items');"),
+        ];
+        let refs = files.iter().collect::<Vec<_>>();
+
+        let findings = run(&refs, &[rule()]);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, AuditFinding::WriteOnlyConfigKey);
+        assert!(findings[0].description.contains("enabled_items"));
+    }
+
+    #[test]
+    fn production_read_satisfies_written_key() {
+        let files = vec![
+            fp("src/builder.rs", "set_config('enabled_items', values);"),
+            fp(
+                "src/runtime.rs",
+                "let items = read_config('enabled_items');",
+            ),
+        ];
+        let refs = files.iter().collect::<Vec<_>>();
+
+        assert!(run(&refs, &[rule()]).is_empty());
+    }
+
+    #[test]
+    fn production_accessor_symbol_call_satisfies_key() {
+        let files = vec![
+            fp(
+                "src/config.rs",
+                "fn enabled_items() { get_config('enabled_items') }",
+            ),
+            fp("src/runtime.rs", "let items = enabled_items();"),
+        ];
+        let refs = files.iter().collect::<Vec<_>>();
+
+        assert!(run(&refs, &[rule()]).is_empty());
+    }
+
+    #[test]
+    fn fixture_only_writes_are_excluded() {
+        let files = vec![fp(
+            "fixtures/builder.rs",
+            "set_config('enabled_items', values);",
+        )];
+        let refs = files.iter().collect::<Vec<_>>();
+
+        assert!(run(&refs, &[rule()]).is_empty());
+    }
+}

--- a/src/core/code_audit/config_key_usage.rs
+++ b/src/core/code_audit/config_key_usage.rs
@@ -220,7 +220,7 @@ mod tests {
     }
 
     #[test]
-    fn flags_written_accessor_backed_key_without_production_read() {
+    fn test_run() {
         let files = vec![
             fp("src/builder.rs", "set_config('enabled_items', values);"),
             fp(
@@ -236,6 +236,92 @@ mod tests {
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].kind, AuditFinding::WriteOnlyConfigKey);
         assert!(findings[0].description.contains("enabled_items"));
+    }
+
+    #[test]
+    fn test_run_rule() {
+        let files = vec![fp("src/builder.rs", "set_config('enabled_items', values);")];
+        let refs = files.iter().collect::<Vec<_>>();
+
+        let findings = run_rule(&refs, &rule());
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].file, "src/builder.rs");
+    }
+
+    #[test]
+    fn test_is_eligible_path() {
+        let rule = rule();
+
+        assert!(is_eligible_path("src/builder.rs", &rule));
+        assert!(!is_eligible_path("fixtures/builder.rs", &rule));
+    }
+
+    #[test]
+    fn test_collect_pattern_evidence() {
+        let file = fp(
+            "src/builder.rs",
+            "first\nset_config('enabled_items', values);",
+        );
+        let mut records = Vec::new();
+
+        collect_pattern_evidence(&file, &rule().write_patterns, |key, site, symbol| {
+            records.push((key, site.file, site.line, symbol));
+        });
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].0, "enabled_items");
+        assert_eq!(records[0].1, "src/builder.rs");
+        assert_eq!(records[0].2, 2);
+        assert_eq!(records[0].3, None);
+    }
+
+    #[test]
+    fn test_collect_accessor_symbol_reads() {
+        let files = vec![
+            fp(
+                "src/config.rs",
+                "fn enabled_items() { get_config('enabled_items') }",
+            ),
+            fp("src/runtime.rs", "let items = enabled_items();"),
+        ];
+        let refs = files.iter().collect::<Vec<_>>();
+        let mut evidence_by_key = BTreeMap::new();
+        evidence_by_key.insert(
+            "enabled_items".to_string(),
+            KeyEvidence {
+                accessors: vec![EvidenceSite {
+                    file: "src/config.rs".to_string(),
+                    line: 1,
+                }],
+                accessor_symbols: BTreeSet::from(["enabled_items".to_string()]),
+                ..Default::default()
+            },
+        );
+
+        collect_accessor_symbol_reads(&refs, &mut evidence_by_key);
+
+        let evidence = evidence_by_key.get("enabled_items").unwrap();
+        assert_eq!(evidence.reads.len(), 1);
+        assert_eq!(evidence.reads[0].file, "src/runtime.rs");
+    }
+
+    #[test]
+    fn test_finding_for() {
+        let evidence = KeyEvidence {
+            writes: vec![EvidenceSite {
+                file: "src/builder.rs".to_string(),
+                line: 3,
+            }],
+            ..Default::default()
+        };
+
+        let finding = finding_for(&rule(), "enabled_items", &evidence).unwrap();
+
+        assert_eq!(finding.kind, AuditFinding::WriteOnlyConfigKey);
+        assert_eq!(finding.severity, Severity::Warning);
+        assert!(finding.description.contains("enabled_items"));
+        assert!(finding.description.contains("src/builder.rs:3"));
     }
 
     #[test]

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -240,6 +240,8 @@ pub enum AuditFinding {
     /// Direct aggregate/struct literals are repeated even though a canonical
     /// construction seam exists for the same type.
     DirectAggregateConstruction,
+    /// Configured key has write/migration/accessor evidence but no non-test read.
+    WriteOnlyConfigKey,
     /// Configured ecosystem/language/framework term appears in core-owned source.
     CoreBoundaryLeak,
 }
@@ -299,6 +301,7 @@ impl AuditFinding {
             "parallel_runner_setup",
             "repeated_enum_dispatch_contract",
             "direct_aggregate_construction",
+            "write_only_config_key",
             "core_boundary_leak",
         ]
     }

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -479,6 +479,7 @@ pub fn discover_conventions_with_config(
         });
         let utility_like = helper_like && is_utility_like_file(fp, audit_config);
         let convention_exempt = is_convention_exception(fp, audit_config);
+        let skip_member_requirements = helper_like || convention_exempt;
 
         let mut deviations = Vec::new();
 
@@ -502,52 +503,52 @@ pub fn discover_conventions_with_config(
 
         // Check missing methods
         for expected in &expected_methods {
-            if helper_like || convention_exempt {
+            if skip_member_requirements {
                 continue;
             }
             if !fp.methods.contains(expected) {
-                deviations.push(Deviation {
-                    kind: AuditFinding::MissingMethod,
-                    description: format!("Missing method: {}", expected),
-                    suggestion: format!(
-                        "Add {}() to match the convention in {}",
-                        expected, group_name
-                    ),
-                });
+                deviations.push(member_requirement_deviation(
+                    AuditFinding::MissingMethod,
+                    "Missing method",
+                    "Add",
+                    expected,
+                    "()",
+                    group_name,
+                ));
             }
         }
 
         // Check missing registrations
         for expected in &expected_registrations {
-            if helper_like || convention_exempt {
+            if skip_member_requirements {
                 continue;
             }
             if !fp.registrations.contains(expected) {
-                deviations.push(Deviation {
-                    kind: AuditFinding::MissingRegistration,
-                    description: format!("Missing registration: {}", expected),
-                    suggestion: format!(
-                        "Add {} call to match the convention in {}",
-                        expected, group_name
-                    ),
-                });
+                deviations.push(member_requirement_deviation(
+                    AuditFinding::MissingRegistration,
+                    "Missing registration",
+                    "Add",
+                    expected,
+                    " call",
+                    group_name,
+                ));
             }
         }
 
         // Check missing interfaces/traits
         for expected in &expected_interfaces {
-            if helper_like || convention_exempt {
+            if skip_member_requirements {
                 continue;
             }
             if !fp.implements.contains(expected) {
-                deviations.push(Deviation {
-                    kind: AuditFinding::MissingInterface,
-                    description: format!("Missing interface: {}", expected),
-                    suggestion: format!(
-                        "Implement {} to match the convention in {}",
-                        expected, group_name
-                    ),
-                });
+                deviations.push(member_requirement_deviation(
+                    AuditFinding::MissingInterface,
+                    "Missing interface",
+                    "Implement",
+                    expected,
+                    "",
+                    group_name,
+                ));
             }
         }
 
@@ -636,6 +637,24 @@ pub fn discover_conventions_with_config(
         total_files: total,
         confidence,
     })
+}
+
+fn member_requirement_deviation(
+    kind: AuditFinding,
+    description_label: &str,
+    suggestion_verb: &str,
+    expected: &str,
+    expected_suffix: &str,
+    group_name: &str,
+) -> Deviation {
+    Deviation {
+        kind,
+        description: format!("{}: {}", description_label, expected),
+        suggestion: format!(
+            "{} {}{} to match the convention in {}",
+            suggestion_verb, expected, expected_suffix, group_name
+        ),
+    }
 }
 
 fn declared_trait_name(fp: &FileFingerprint) -> Option<String> {
@@ -1000,6 +1019,96 @@ mod tests {
         assert_eq!(Language::from_extension("ts"), Language::TypeScript);
         assert_eq!(Language::from_extension("jsx"), Language::JavaScript);
         assert_eq!(Language::from_extension("txt"), Language::Unknown);
+    }
+
+    #[test]
+    fn test_from_path() {
+        assert_eq!(Language::from_path(Path::new("src/lib.rs")), Language::Rust);
+        assert_eq!(
+            Language::from_path(Path::new("src/app.tsx")),
+            Language::TypeScript
+        );
+        assert_eq!(Language::from_path(Path::new("README")), Language::Unknown);
+    }
+
+    #[test]
+    fn test_all_names() {
+        assert!(AuditFinding::all_names().contains(&"write_only_config_key"));
+        assert!(AuditFinding::all_names().contains(&"core_boundary_leak"));
+    }
+
+    #[test]
+    fn test_discover_conventions_with_config() {
+        let fingerprints = vec![
+            FileFingerprint {
+                relative_path: "abilities/CreateAbility.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string(), "register".to_string()],
+                type_name: Some("CreateAbility".to_string()),
+                ..Default::default()
+            },
+            FileFingerprint {
+                relative_path: "abilities/UpdateAbility.php".to_string(),
+                language: Language::Php,
+                methods: vec!["execute".to_string(), "register".to_string()],
+                type_name: Some("UpdateAbility".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        let convention = discover_conventions_with_config(
+            "Abilities",
+            "abilities/*.php",
+            &fingerprints,
+            &AuditConfig::default(),
+        )
+        .unwrap();
+
+        let mut expected_methods = convention.expected_methods.clone();
+        expected_methods.sort();
+        assert_eq!(expected_methods, vec!["execute", "register"]);
+        assert_eq!(convention.conforming.len(), 2);
+        assert!(convention.outliers.is_empty());
+    }
+
+    #[test]
+    fn test_check_signature_consistency() {
+        let mut conventions = vec![Convention {
+            name: "No Methods".to_string(),
+            glob: "src/*.rs".to_string(),
+            expected_methods: Vec::new(),
+            expected_registrations: Vec::new(),
+            expected_interfaces: Vec::new(),
+            expected_namespace: None,
+            expected_imports: Vec::new(),
+            conforming: vec!["src/a.rs".to_string()],
+            outliers: Vec::new(),
+            total_files: 1,
+            confidence: 1.0,
+        }];
+
+        check_signature_consistency(&mut conventions, Path::new("."), &AuditConfig::default());
+
+        assert!(conventions[0].outliers.is_empty());
+    }
+
+    #[test]
+    fn test_member_requirement_deviation() {
+        let deviation = member_requirement_deviation(
+            AuditFinding::MissingMethod,
+            "Missing method",
+            "Add",
+            "execute",
+            "()",
+            "Abilities",
+        );
+
+        assert_eq!(deviation.kind, AuditFinding::MissingMethod);
+        assert_eq!(deviation.description, "Missing method: execute");
+        assert_eq!(
+            deviation.suggestion,
+            "Add execute() to match the convention in Abilities"
+        );
     }
 
     #[test]

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -19,6 +19,7 @@ mod comment_blocks;
 mod comment_hygiene;
 pub mod compare;
 mod compiler_warnings;
+mod config_key_usage;
 pub(crate) mod conventions;
 mod core_boundary_leak;
 pub(crate) mod core_fingerprint;
@@ -158,6 +159,7 @@ pub(crate) struct AuditExecutionPlan {
     pub(crate) run_parallel_runner_setup: bool,
     pub(crate) run_enum_dispatch_contracts: bool,
     pub(crate) run_aggregate_construction: bool,
+    pub(crate) run_config_key_usage: bool,
 }
 
 impl AuditExecutionPlan {
@@ -191,6 +193,7 @@ impl AuditExecutionPlan {
                 run_parallel_runner_setup: true,
                 run_enum_dispatch_contracts: true,
                 run_aggregate_construction: true,
+                run_config_key_usage: true,
             },
         )
     }
@@ -367,6 +370,11 @@ impl AuditExecutionPlan {
                     exclude,
                     &[AuditFinding::DirectAggregateConstruction],
                 ),
+                run_config_key_usage: Self::family_enabled(
+                    only,
+                    exclude,
+                    &[AuditFinding::WriteOnlyConfigKey],
+                ),
             },
         )
     }
@@ -407,6 +415,7 @@ impl AuditExecutionPlan {
             ("parallel_runner_setup", self.run_parallel_runner_setup),
             ("enum_dispatch_contracts", self.run_enum_dispatch_contracts),
             ("aggregate_construction", self.run_aggregate_construction),
+            ("config_key_usage", self.run_config_key_usage),
         ]
         .into_iter()
         .map(|(name, enabled)| {
@@ -461,6 +470,7 @@ impl AuditExecutionPlan {
             || self.run_parallel_runner_setup
             || self.run_enum_dispatch_contracts
             || self.run_aggregate_construction
+            || self.run_config_key_usage
     }
 }
 
@@ -1149,6 +1159,21 @@ fn audit_internal(
             requested_findings.len()
         );
         all_findings.extend(requested_findings);
+    }
+
+    // Phase 4t1: Component-owned config-key write/accessor/read correlation.
+    let config_key_findings = if plan.run_config_key_usage {
+        config_key_usage::run(&all_fingerprints, &audit_config.config_key_usage.rules)
+    } else {
+        Vec::new()
+    };
+    if !config_key_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Config key usage: {} finding(s) (write/accessor evidence without production reads)",
+            config_key_findings.len()
+        );
+        all_findings.extend(config_key_findings);
     }
 
     // Phase 4t2: Configured core-boundary ecosystem leak detection.

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -44,6 +44,63 @@ pub struct AuditConfig {
     /// are merged with the built-in generic floor lists.
     #[serde(default, skip_serializing_if = "DuplicationDetectorConfig::is_empty")]
     pub duplication_detector: DuplicationDetectorConfig,
+    /// Component-owned regexes that correlate config-key writes, accessors, and
+    /// reads. Core only matches configured captures; components own semantics.
+    #[serde(default, skip_serializing_if = "ConfigKeyUsageConfig::is_empty")]
+    pub config_key_usage: ConfigKeyUsageConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ConfigKeyUsageConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<ConfigKeyUsageRule>,
+}
+
+impl ConfigKeyUsageConfig {
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    fn merge(&mut self, other: &ConfigKeyUsageConfig) {
+        for rule in &other.rules {
+            if !self.rules.iter().any(|existing| existing.id == rule.id) {
+                self.rules.push(rule.clone());
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConfigKeyUsageRule {
+    /// Stable rule label used in finding descriptions and merge de-duplication.
+    pub id: String,
+    /// Optional path substrings excluded from all evidence collection.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exclude_path_contains: Vec<String>,
+    /// Regexes that capture keys written or migrated into storage/builders.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub write_patterns: Vec<ConfigKeyUsagePattern>,
+    /// Regexes that capture accessors/backing helpers for keys.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub accessor_patterns: Vec<ConfigKeyUsagePattern>,
+    /// Regexes that capture non-test runtime/display reads of keys.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub read_patterns: Vec<ConfigKeyUsagePattern>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConfigKeyUsagePattern {
+    pub pattern: String,
+    #[serde(default = "default_config_key_capture")]
+    pub key_capture: String,
+    /// Optional symbol capture for accessor definitions. If present, core also
+    /// treats non-test references to that symbol outside the definition file as reads.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbol_capture: Option<String>,
+}
+
+fn default_config_key_capture() -> String {
+    "key".to_string()
 }
 
 /// Extension-supplied call-name lists for the parallel-implementation /
@@ -280,6 +337,7 @@ impl AuditConfig {
             && self.requested_detectors.is_empty()
             && self.core_boundary_leaks.is_empty()
             && self.duplication_detector.is_empty()
+            && self.config_key_usage.is_empty()
     }
 
     pub fn merge(&mut self, other: &AuditConfig) {
@@ -305,6 +363,7 @@ impl AuditConfig {
         self.known_symbols.merge(&other.known_symbols);
         self.core_boundary_leaks.merge(&other.core_boundary_leaks);
         self.duplication_detector.merge(&other.duplication_detector);
+        self.config_key_usage.merge(&other.config_key_usage);
         for rule in &other.requested_detectors {
             if !self
                 .requested_detectors

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -12,8 +12,9 @@ pub mod scope;
 pub mod versioning;
 
 pub use audit::{
-    AuditConfig, ConventionTagGlob, CoreBoundaryLeakConfig, DuplicationDetectorConfig,
-    KnownSymbolEntry, KnownSymbolHeaderVersionProvider, KnownSymbolKind, KnownSymbolVersionedEntry,
+    AuditConfig, ConfigKeyUsageConfig, ConfigKeyUsagePattern, ConfigKeyUsageRule,
+    ConventionTagGlob, CoreBoundaryLeakConfig, DuplicationDetectorConfig, KnownSymbolEntry,
+    KnownSymbolHeaderVersionProvider, KnownSymbolKind, KnownSymbolVersionedEntry,
     RequestedDetectorRule, RequestedDetectorRuleBody,
 };
 pub use inventory::{

--- a/tests/core/component/audit_test.rs
+++ b/tests/core/component/audit_test.rs
@@ -1,4 +1,6 @@
-use homeboy::core::component::AuditConfig;
+use homeboy::core::component::{
+    AuditConfig, ConfigKeyUsageConfig, ConfigKeyUsagePattern, ConfigKeyUsageRule,
+};
 
 #[test]
 fn is_empty_reports_only_empty_rule_sets() {
@@ -19,6 +21,19 @@ fn test_merge() {
         runtime_entrypoint_markers: vec!["@runtime-entrypoint".to_string()],
         lifecycle_path_globs: vec!["lifecycle/*.php".to_string()],
         utility_suffixes: vec!["Verifier".to_string()],
+        config_key_usage: ConfigKeyUsageConfig {
+            rules: vec![ConfigKeyUsageRule {
+                id: "generic-config".to_string(),
+                exclude_path_contains: vec!["fixtures/".to_string()],
+                write_patterns: vec![ConfigKeyUsagePattern {
+                    pattern: "set_config".to_string(),
+                    key_capture: "key".to_string(),
+                    symbol_capture: None,
+                }],
+                accessor_patterns: vec![],
+                read_patterns: vec![],
+            }],
+        },
         convention_exception_globs: vec!["generated/**".to_string()],
         ..Default::default()
     };
@@ -28,6 +43,24 @@ fn test_merge() {
         runtime_entrypoint_markers: vec!["@runtime-entrypoint".to_string(), "@queued".to_string()],
         lifecycle_path_globs: vec!["lifecycle/*.php".to_string(), "bin/*".to_string()],
         utility_suffixes: vec!["Verifier".to_string(), "Resolver".to_string()],
+        config_key_usage: ConfigKeyUsageConfig {
+            rules: vec![
+                ConfigKeyUsageRule {
+                    id: "generic-config".to_string(),
+                    exclude_path_contains: vec![],
+                    write_patterns: vec![],
+                    accessor_patterns: vec![],
+                    read_patterns: vec![],
+                },
+                ConfigKeyUsageRule {
+                    id: "state-config".to_string(),
+                    exclude_path_contains: vec![],
+                    write_patterns: vec![],
+                    accessor_patterns: vec![],
+                    read_patterns: vec![],
+                },
+            ],
+        },
         convention_exception_globs: vec!["generated/**".to_string(), "fixtures/**".to_string()],
         ..Default::default()
     });
@@ -45,6 +78,7 @@ fn test_merge() {
         vec!["lifecycle/*.php", "bin/*"]
     );
     assert_eq!(config.utility_suffixes, vec!["Verifier", "Resolver"]);
+    assert_eq!(config.config_key_usage.rules.len(), 2);
     assert_eq!(
         config.convention_exception_globs,
         vec!["generated/**", "fixtures/**"]


### PR DESCRIPTION
## Summary
- Add a component-owned, core-agnostic config-key usage audit detector that correlates configured write, accessor, and read regex evidence across fingerprints.
- Flag keys with write/migration/accessor evidence but no non-test production read as `write_only_config_key` warnings.
- Document the rule configuration shape and cover write-only, production-read, accessor-symbol, fixture-exclusion, and config-merge behavior with tests.

Closes #1553.

## Tests
- `cargo test config_key_usage`
- `cargo test audit_test`
- `cargo check`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the audit detector/config/docs/tests, ran verification, and drafted this PR description for Chris to review.