### PR TITLE
docs: define headless daemon API contract

### DIFF
--- a/docs/architecture/headless-daemon-api.md
+++ b/docs/architecture/headless-daemon-api.md
@@ -1,0 +1,161 @@
+# Headless Daemon API Contract
+
+Homeboy is CLI-first, but the daemon is the stable local UI and automation
+surface for clients that should not shell out and parse terminal output. The
+daemon remains a local Homeboy engine, not a hosted control plane.
+
+## Scope
+
+The daemon owns a loopback-only HTTP contract for:
+
+- local client discovery and health checks
+- read-only component, rig, stack, run, artifact, and finding inspection
+- long-running lint, test, audit, and bench jobs
+- structured job events and final results
+- future mutating operations behind explicit capabilities and confirmations
+
+The CLI remains usable without the daemon. Daemon routes reuse Homeboy core and
+command adapters so desktop, web, agent, and CLI workflows do not fork product
+logic.
+
+## Discovery
+
+Clients discover a local daemon through the CLI-managed state file instead of a
+hardcoded public port.
+
+```text
+homeboy daemon start
+        |
+        +-- binds 127.0.0.1:<port>
+        +-- writes pid/address/token metadata to the daemon state file
+        |
+homeboy daemon status --format=json
+        |
+        +-- returns the current loopback address and process state
+```
+
+Remote runner clients use `homeboy runner connect <runner-id>` to create an SSH
+loopback tunnel to a runner daemon. The client still talks to a local loopback
+URL; Homeboy owns the SSH tunnel and rejects non-loopback daemon addresses.
+
+## Minimum Dashboard Surface
+
+A useful headless UI can be built from this read/query surface:
+
+- `GET /health` and `GET /version` for connectivity and compatibility
+- `GET /config/paths` for local configuration discovery
+- `GET /components`, `GET /components/:id`, `GET /components/:id/status`, and
+  `GET /components/:id/changes` for source checkout selection
+- `GET /rigs`, `GET /rigs/:id`, and `POST /rigs/:id/check` for environment
+  readiness
+- `GET /stacks`, `GET /stacks/:id`, and `POST /stacks/:id/status` for stacked
+  branch inspection
+- `GET /runs`, `GET /runs/:id`, `GET /runs/:id/artifacts`,
+  `GET /runs/:id/artifacts/:artifact_id/content`, and `GET /runs/:id/findings`
+  for persisted evidence
+- `GET /audit/runs` and `GET /bench/runs` for analysis-specific run history
+- `GET /jobs`, `GET /jobs/:id`, `GET /jobs/:id/events`, and
+  `POST /jobs/:id/cancel` for long-running work
+
+This is enough for a dashboard that lists components, shows selected checkout
+state, displays rigs/stacks, starts analysis jobs, streams progress, and renders
+structured final results.
+
+## Job/Event Contract
+
+Long-running analysis routes return immediately with a job record. Clients poll
+job state and events instead of holding a request open.
+
+```text
+POST /lint|/test|/audit|/bench
+        |
+        v
+{ "job": { "id": "...", "status": "queued" } }
+        |
+        +--> GET /jobs/:id
+        +--> GET /jobs/:id/events
+        +--> POST /jobs/:id/cancel
+```
+
+Events are append-only records. They are safe for UIs to render incrementally and
+safe for runners to mirror as evidence. The final result event carries the same
+structured result shape as the corresponding CLI command, including artifacts,
+findings, summaries, and CI context when a CI profile/job selector was used.
+
+## Client Replacement Order
+
+Headless clients should replace shell-out flows in low-risk order:
+
+1. Discovery: `daemon status`, `health`, and `version`.
+2. Dashboard reads: components, status, changes, rigs, stacks, runs, artifacts,
+   and findings.
+3. Analysis jobs: lint, test, audit, and bench with event polling.
+4. Safe cancellation: `POST /jobs/:id/cancel` for daemon-owned queued/running
+   jobs.
+5. Mutating actions only after the capability and confirmation model below is
+   implemented.
+
+## Mutating Endpoint Model
+
+The daemon defaults to no write/operator capabilities. Future mutating endpoints
+must declare capability requirements before they are routed.
+
+Suggested capability names:
+
+- `read:components`
+- `read:runs`
+- `run:lint`
+- `run:test`
+- `run:audit`
+- `run:bench`
+- `write:files`
+- `write:git`
+- `write:rig`
+- `write:stack`
+- `operator:ssh`
+- `operator:deploy`
+- `operator:release`
+
+Risk categories:
+
+- Read-only: status, inventory, persisted runs, artifacts, findings.
+- Bounded local run: lint, test, audit, bench, rig check, stack status.
+- Local write: file edits, refactor fixes, generated patches.
+- Git write: commit, tag, push, stack apply/sync/push.
+- Environment write: rig up/down/service operations.
+- Operator write: SSH execution, deploy, release, transfer, DB operations.
+
+High-risk operations use a preview/apply contract:
+
+```text
+POST /operations/preview
+        |
+        +-- validates capability
+        +-- returns operation_id, required_capabilities, risk, and plan/diff
+
+POST /operations/:id/apply
+        |
+        +-- validates the same capabilities
+        +-- applies exactly the previewed plan
+        +-- runs as a job and emits events/results
+```
+
+The apply request must not accept a new free-form plan body. It applies the
+stored preview by id so clients cannot accidentally confirm one plan and execute
+another.
+
+## Default-Deny Rules
+
+- Bind to loopback by default.
+- Treat daemon tokens/capabilities as local secrets.
+- Reject mutating routes until they declare required capabilities.
+- Require preview/apply for high-risk writes.
+- Run long writes as jobs with event trails and artifacts.
+- Return enough structured data for review or undo where Homeboy has an undo
+  primitive.
+
+## Related Issues
+
+- [#1759](https://github.com/Extra-Chill/homeboy/issues/1759)
+- [#1761](https://github.com/Extra-Chill/homeboy/issues/1761)
+- [#1762](https://github.com/Extra-Chill/homeboy/issues/1762)

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -48,9 +48,14 @@ contract and return the same JSON envelope shape as other daemon responses.
 - `GET /runs?kind=bench|audit&component=<id>&rig=<id>&status=<status>&limit=<n>`
 - `GET /runs/:id`
 - `GET /runs/:id/artifacts`
+- `GET /runs/:id/artifacts/:artifact_id/content`
 - `GET /runs/:id/findings?tool=<tool>&file=<path>&fingerprint=<id>&limit=<n>`
 - `GET /audit/runs?component=<id>&rig=<id>&status=<status>&limit=<n>`
 - `GET /bench/runs?component=<id>&rig=<id>&status=<status>&limit=<n>`
+- `GET /jobs`
+- `GET /jobs/:id`
+- `GET /jobs/:id/events`
+- `POST /jobs/:id/cancel`
 
 The run readers expose persisted observation-store evidence from previous
 analysis runs. They do not start audit, lint, test, bench, rig, or stack work.
@@ -62,12 +67,15 @@ endpoint should reuse that implementation rather than duplicating comparison
 logic in the HTTP API contract.
 
 The analysis entry points `POST /audit`, `POST /lint`, `POST /test`, and
-`POST /bench` are reserved by the contract, but intentionally return a daemon
-HTTP analysis-enqueue blocker until the existing `src/core/api_jobs.rs` job
-model is wired into daemon routes.
+`POST /bench` enqueue daemon jobs. Clients inspect those jobs through
+`GET /jobs/:id` and `GET /jobs/:id/events` instead of parsing terminal output.
 
 Mutating operations such as deploy, release, rig up/down, stack apply, git
 writes, and SSH execution are not exposed by this daemon slice.
+
+See [Headless Daemon API Contract](../architecture/headless-daemon-api.md) for
+the headless client contract, job/event shape, mutating capability model, and
+preview/apply rules for future write endpoints.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Documents the headless daemon API contract for local UI clients, including discovery, dashboard endpoints, job/event polling, and client migration order.
- Defines default-deny mutating endpoint rules, capability names, risk classes, and preview/apply semantics for future write routes.
- Updates `homeboy daemon` docs to reflect the current job and artifact-content endpoints.

Closes #1759.
Closes #1761.
Closes #1762.

## Verification
- `cargo test --test architecture_core_agnostic_test`
- `cargo test --test core_agnostic_test`
- `cargo test http_api`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the focused daemon contract documentation and verifying it against the current Homeboy daemon, job, and core-agnostic test surfaces.