### PR TITLE
Make SSH runners server capabilities

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -6,7 +6,7 @@
 homeboy runner <COMMAND>
 ```
 
-`runner` manages durable execution backends. It records where Homeboy workflows can run and can execute explicit commands through a connected runner daemon or an opt-in SSH diagnostic path.
+`runner` manages durable execution backends. SSH runners are a capability on a `homeboy server` record, so the common Lab flow uses one ID for the machine and its runner. Local runners remain standalone because they describe this machine rather than an SSH server.
 
 ## Subcommands
 
@@ -14,19 +14,36 @@ homeboy runner <COMMAND>
 
 ```sh
 homeboy runner add <id> --workspace-root <path>
-homeboy runner add <id> --server <server-id> --workspace-root <path>
+homeboy runner add <server-id> --server <server-id> --workspace-root <path>
 homeboy runner add --json <spec>
 ```
 
 Options:
 
 - `--kind local|ssh`: explicit runner kind. Defaults to `ssh` when `--server` is set, otherwise `local`.
-- `--server <server-id>`: existing `homeboy server` record for SSH runners.
+- `--server <server-id>`: existing `homeboy server` record for SSH runners. For SSH runners, `<id>` must match `<server-id>`.
 - `--workspace-root <path>`: workspace root on the runner machine.
 - `--homeboy-path <path>`: Homeboy binary path on the runner machine.
 - `--daemon`: marks the runner as daemon-preferred for future commands.
 - `--concurrency-limit <n>`: maximum concurrent workflows this runner should accept.
 - `--artifact-policy <label>`: artifact policy label reserved for future execution commands.
+
+### `enable`
+
+```sh
+homeboy runner enable <server-id> --workspace-root <path>
+homeboy runner enable <server-id> --workspace-root <path> --concurrency-limit 4 --artifact-policy copy
+```
+
+Enables runner capability on an existing SSH server. This is the recommended Homeboy Lab onboarding path:
+
+```sh
+homeboy server create homeboy-lab --host 192.168.86.63 --user chubes --port 22
+homeboy runner enable homeboy-lab --workspace-root /home/chubes/Developer --concurrency-limit 4 --artifact-policy copy
+homeboy runner connect homeboy-lab
+```
+
+After this, `homeboy-lab` is both the server ID and the runner ID.
 
 ### `list`
 
@@ -48,7 +65,7 @@ homeboy runner set <id> workspace_root=/srv/homeboy
 homeboy runner set <id> -- --concurrency_limit 4
 ```
 
-Updates a runner by merging a JSON object into `runners/<id>.json`.
+Updates a runner by merging a JSON object into the runner config. SSH runner settings live under `servers/<id>.json` as the server's `runner` capability; local runners live under `runners/<id>.json`.
 
 ### `remove`
 
@@ -151,7 +168,27 @@ Delta form is also accepted for explicit file replacement/deletion:
 
 ## Runner Shape
 
-Runner records are stored as JSON config entities under `~/.config/homeboy/runners/`.
+SSH runner records are stored on their server as `runner` capability config under `~/.config/homeboy/servers/<id>.json`.
+
+```json
+{
+  "id": "homeboy-lab",
+  "host": "192.168.86.63",
+  "user": "chubes",
+  "port": 22,
+  "runner": {
+    "workspace_root": "/home/chubes/Developer",
+    "homeboy_path": "/usr/local/bin/homeboy",
+    "daemon": false,
+    "concurrency_limit": 4,
+    "artifact_policy": "copy",
+    "env": {},
+    "resources": {}
+  }
+}
+```
+
+Standalone local runner records are still stored under `~/.config/homeboy/runners/`.
 
 ```json
 {
@@ -171,7 +208,7 @@ Runner records are stored as JSON config entities under `~/.config/homeboy/runne
 Rules:
 
 - `kind` is `local` or `ssh`.
-- `ssh` runners require `server_id` to reference an existing `homeboy server` record.
+- `ssh` runner IDs are server IDs; a single SSH machine does not need a separate runner ID.
 - `concurrency_limit`, when set, must be greater than zero.
 - `env` and `resources` are metadata maps for future `connect`, `doctor`, `exec`, and Desktop workflows.
 

--- a/docs/commands/server.md
+++ b/docs/commands/server.md
@@ -8,6 +8,18 @@ homeboy server <COMMAND>
 
 ## Subcommands
 
+## Homeboy Lab Onboarding
+
+For a normal Lab machine, use one ID for the machine and its runner capability:
+
+```sh
+homeboy server create homeboy-lab --host 192.168.86.63 --user chubes --port 22
+homeboy runner enable homeboy-lab --workspace-root /home/chubes/Developer --concurrency-limit 4 --artifact-policy copy
+homeboy runner connect homeboy-lab
+```
+
+This records `homeboy-lab` as the SSH server and enables runner settings on the same server record.
+
 ### `create`
 
 ```sh
@@ -35,7 +47,7 @@ homeboy server set <server_id> auth.mode=key_plus_password_controlmaster
 homeboy server set --json <JSON>   # server_id may be provided in JSON body
 ```
 
-Updates a server by merging a JSON object into `servers/<id>.json`.
+Updates a server by merging a JSON object into `servers/<id>.json`. Runner-capable servers store their runner settings under the nested `runner` object; `homeboy runner enable <server_id>` is the preferred CLI for adding that capability.
 
 `key=value` arguments support dotted paths, so `auth.mode=value` is equivalent to `{"auth":{"mode":"value"}}`.
 

--- a/docs/schemas/server-schema.md
+++ b/docs/schemas/server-schema.md
@@ -18,6 +18,15 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
     "control_path": "string",
     "persist": "string"
   },
+  "runner": {
+    "workspace_root": "string",
+    "homeboy_path": "string",
+    "daemon": boolean,
+    "concurrency_limit": number,
+    "artifact_policy": "string",
+    "env": {},
+    "resources": {}
+  },
   "forward_agent": boolean
 }
 ```
@@ -37,6 +46,7 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
 - **`identity_file`** (string): Path to SSH private key file for authentication
 - **`kind`** (string): Optional server classification for extensions and project-specific behavior
 - **`auth`** (object): Optional SSH authentication/session policy
+- **`runner`** (object): Optional runner capability for Homeboy Lab execution on this server
 - **`forward_agent`** (boolean): Enable SSH agent forwarding (default: false)
 
 ## Example
@@ -55,9 +65,22 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
     "control_path": "~/.ssh/controlmasters/%h-%p-%r",
     "persist": "4h"
   },
+  "runner": {
+    "workspace_root": "/home/deploy/Developer",
+    "homeboy_path": "/usr/local/bin/homeboy",
+    "daemon": false,
+    "concurrency_limit": 4,
+    "artifact_policy": "copy",
+    "env": {},
+    "resources": {}
+  },
   "forward_agent": true
 }
 ```
+
+## Runner Capability
+
+Use `homeboy runner enable <server_id>` to make an SSH server runner-capable. The server ID is also the runner ID, matching the common Homeboy Lab model: one machine, one server, one runner-capable server.
 
 ## Managed SSH Sessions
 

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -102,6 +102,31 @@ enum RunnerCommand {
         #[arg(long)]
         artifact_policy: Option<String>,
     },
+    /// Enable runner capability on an existing SSH server
+    Enable {
+        /// Server ID to make runner-capable
+        server_id: String,
+
+        /// Root directory where this server checks out or owns workspaces
+        #[arg(long)]
+        workspace_root: Option<String>,
+
+        /// Homeboy binary path on the server machine
+        #[arg(long)]
+        homeboy_path: Option<String>,
+
+        /// Prefer daemon-backed execution for future runner commands
+        #[arg(long)]
+        daemon: bool,
+
+        /// Maximum concurrent workflows this server should accept
+        #[arg(long)]
+        concurrency_limit: Option<usize>,
+
+        /// Artifact retention/copying policy label for future execution commands
+        #[arg(long)]
+        artifact_policy: Option<String>,
+    },
     /// List all configured runners
     List,
     /// Display runner configuration
@@ -256,6 +281,23 @@ pub fn run(
             concurrency_limit,
             artifact_policy,
         })),
+        RunnerCommand::Enable {
+            server_id,
+            workspace_root,
+            homeboy_path,
+            daemon,
+            concurrency_limit,
+            artifact_policy,
+        } => map_registry(enable(
+            &server_id,
+            RunnerEnableInput {
+                workspace_root,
+                homeboy_path,
+                daemon,
+                concurrency_limit,
+                artifact_policy,
+            },
+        )),
         RunnerCommand::List => map_registry(list()),
         RunnerCommand::Show { id } => map_registry(show(&id)),
         RunnerCommand::Set { args } => map_registry(set(args)),
@@ -334,6 +376,14 @@ struct RunnerAddInput {
     artifact_policy: Option<String>,
 }
 
+struct RunnerEnableInput {
+    workspace_root: Option<String>,
+    homeboy_path: Option<String>,
+    daemon: bool,
+    concurrency_limit: Option<usize>,
+    artifact_policy: Option<String>,
+}
+
 fn add(input: RunnerAddInput) -> CmdResult<RunnerOutput> {
     let json_spec = if let Some(spec) = input.json {
         spec
@@ -399,6 +449,36 @@ fn list() -> CmdResult<RunnerOutput> {
         RunnerOutput {
             command: "runner.list".to_string(),
             entities: runner::list()?,
+            ..Default::default()
+        },
+        0,
+    ))
+}
+
+fn enable(server_id: &str, input: RunnerEnableInput) -> CmdResult<RunnerOutput> {
+    let mut spec = serde_json::Map::new();
+    if let Some(workspace_root) = input.workspace_root {
+        spec.insert("workspace_root".to_string(), workspace_root.into());
+    }
+    if let Some(homeboy_path) = input.homeboy_path {
+        spec.insert("homeboy_path".to_string(), homeboy_path.into());
+    }
+    if input.daemon {
+        spec.insert("daemon".to_string(), true.into());
+    }
+    if let Some(concurrency_limit) = input.concurrency_limit {
+        spec.insert("concurrency_limit".to_string(), concurrency_limit.into());
+    }
+    if let Some(artifact_policy) = input.artifact_policy {
+        spec.insert("artifact_policy".to_string(), artifact_policy.into());
+    }
+    let runner = runner::enable_server_runner(server_id, Value::Object(spec))?;
+    Ok((
+        RunnerOutput {
+            command: "runner.enable".to_string(),
+            id: Some(runner.id.clone()),
+            entity: Some(runner),
+            updated_fields: vec!["runner".to_string()],
             ..Default::default()
         },
         0,

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -9,6 +9,7 @@ use homeboy::core::runner::{
     RunnerStatusReport, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode,
     RunnerWorkspaceSyncOutput,
 };
+use homeboy::core::server::RunnerSettings;
 use homeboy::core::{EntityCrudOutput, MergeOutput};
 
 use super::{CmdResult, DynamicSetArgs};
@@ -31,12 +32,6 @@ pub enum RunnerConnectionOutput {
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
-pub enum RunnerExecutionOutput {
-    Exec(RunnerExecOutput),
-}
-
-#[derive(Debug, Serialize)]
-#[serde(tag = "action", rename_all = "snake_case")]
 pub enum RunnerWorkspaceOutput {
     Sync(RunnerWorkspaceSyncOutput),
     Apply(RunnerWorkspaceApplyOutput),
@@ -49,7 +44,7 @@ pub type RunnerOutput = EntityCrudOutput<Runner, RunnerExtra>;
 pub enum RunnerCommandOutput {
     Registry(RunnerOutput),
     Doctor(doctor::RunnerDoctorOutput),
-    Execution(RunnerExecutionOutput),
+    Execution(RunnerExecOutput),
     Workspace(RunnerWorkspaceOutput),
 }
 
@@ -276,10 +271,12 @@ pub fn run(
             kind,
             server,
             workspace_root,
-            homeboy_path,
-            daemon,
-            concurrency_limit,
-            artifact_policy,
+            settings: RunnerSettings {
+                homeboy_path,
+                daemon,
+                concurrency_limit,
+                artifact_policy,
+            },
         })),
         RunnerCommand::Enable {
             server_id,
@@ -290,8 +287,8 @@ pub fn run(
             artifact_policy,
         } => map_registry(enable(
             &server_id,
-            RunnerEnableInput {
-                workspace_root,
+            workspace_root,
+            RunnerSettings {
                 homeboy_path,
                 daemon,
                 concurrency_limit,
@@ -335,12 +332,7 @@ fn map_doctor(result: CmdResult<doctor::RunnerDoctorOutput>) -> CmdResult<Runner
 }
 
 fn map_execution(result: CmdResult<RunnerExecOutput>) -> CmdResult<RunnerCommandOutput> {
-    result.map(|(output, exit_code)| {
-        (
-            RunnerCommandOutput::Execution(RunnerExecutionOutput::Exec(output)),
-            exit_code,
-        )
-    })
+    result.map(|(output, exit_code)| (RunnerCommandOutput::Execution(output), exit_code))
 }
 
 fn map_workspace(result: CmdResult<RunnerWorkspaceSyncOutput>) -> CmdResult<RunnerCommandOutput> {
@@ -370,18 +362,7 @@ struct RunnerAddInput {
     kind: Option<RunnerKindArg>,
     server: Option<String>,
     workspace_root: Option<String>,
-    homeboy_path: Option<String>,
-    daemon: bool,
-    concurrency_limit: Option<usize>,
-    artifact_policy: Option<String>,
-}
-
-struct RunnerEnableInput {
-    workspace_root: Option<String>,
-    homeboy_path: Option<String>,
-    daemon: bool,
-    concurrency_limit: Option<usize>,
-    artifact_policy: Option<String>,
+    settings: RunnerSettings,
 }
 
 fn add(input: RunnerAddInput) -> CmdResult<RunnerOutput> {
@@ -408,10 +389,7 @@ fn add(input: RunnerAddInput) -> CmdResult<RunnerOutput> {
             kind,
             server_id: input.server,
             workspace_root: input.workspace_root,
-            homeboy_path: input.homeboy_path,
-            daemon: input.daemon,
-            concurrency_limit: input.concurrency_limit,
-            artifact_policy: input.artifact_policy,
+            settings: input.settings,
             env: HashMap::new(),
             resources: HashMap::<String, Value>::new(),
         };
@@ -455,21 +433,25 @@ fn list() -> CmdResult<RunnerOutput> {
     ))
 }
 
-fn enable(server_id: &str, input: RunnerEnableInput) -> CmdResult<RunnerOutput> {
+fn enable(
+    server_id: &str,
+    workspace_root: Option<String>,
+    settings: RunnerSettings,
+) -> CmdResult<RunnerOutput> {
     let mut spec = serde_json::Map::new();
-    if let Some(workspace_root) = input.workspace_root {
+    if let Some(workspace_root) = workspace_root {
         spec.insert("workspace_root".to_string(), workspace_root.into());
     }
-    if let Some(homeboy_path) = input.homeboy_path {
+    if let Some(homeboy_path) = settings.homeboy_path {
         spec.insert("homeboy_path".to_string(), homeboy_path.into());
     }
-    if input.daemon {
+    if settings.daemon {
         spec.insert("daemon".to_string(), true.into());
     }
-    if let Some(concurrency_limit) = input.concurrency_limit {
+    if let Some(concurrency_limit) = settings.concurrency_limit {
         spec.insert("concurrency_limit".to_string(), concurrency_limit.into());
     }
-    if let Some(artifact_policy) = input.artifact_policy {
+    if let Some(artifact_policy) = settings.artifact_policy {
         spec.insert("artifact_policy".to_string(), artifact_policy.into());
     }
     let runner = runner::enable_server_runner(server_id, Value::Object(spec))?;

--- a/src/commands/runner/doctor.rs
+++ b/src/commands/runner/doctor.rs
@@ -237,7 +237,7 @@ mod local {
         let homeboy = HomeboyProbe {
             version: env!("CARGO_PKG_VERSION").to_string(),
             path: runner
-                .and_then(|runner| runner.homeboy_path.clone())
+                .and_then(|runner| runner.settings.homeboy_path.clone())
                 .or_else(|| env::current_exe().ok().map(common::display_path)),
         };
         checks.push(checks::ok(
@@ -386,7 +386,7 @@ mod remote {
             ),
         });
 
-        let homeboy_command = runner.homeboy_path.as_deref().unwrap_or("homeboy");
+        let homeboy_command = runner.settings.homeboy_path.as_deref().unwrap_or("homeboy");
         let homeboy = HomeboyProbe {
             version: common::remote_line(
                 client,
@@ -397,6 +397,7 @@ mod remote {
             )
             .unwrap_or_else(|| "unknown".to_string()),
             path: runner
+                .settings
                 .homeboy_path
                 .clone()
                 .or_else(|| common::remote_line(client, "command -v homeboy")),

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -194,6 +194,7 @@ pub fn run(args: ServerArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
                     kind: None,
                     auth: None,
                     env: std::collections::HashMap::new(),
+                    runner: None,
                 };
 
                 homeboy::core::config::to_json_string(&new_server)?

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -630,6 +630,7 @@ mod tests {
             kind: None,
             auth: None,
             env: HashMap::new(),
+            runner: None,
         };
 
         let tunnel = open_loopback_tunnel(&server, 49100, "127.0.0.1", 49200);

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -86,7 +86,7 @@ struct CliEnvelope {
 pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
     let runner = load(runner_id)?;
     let session_path = session_path(runner_id)?;
-    let homeboy = runner.homeboy_path.as_deref().unwrap_or("homeboy");
+    let homeboy = runner.settings.homeboy_path.as_deref().unwrap_or("homeboy");
 
     let Some((server_id, server, client)) = resolve_ssh_runner(&runner)? else {
         return Ok(failed_connect(

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -368,9 +368,9 @@ fn runner_metadata(runner: &Runner) -> Value {
         "kind": runner.kind,
         "server_id": runner.server_id,
         "workspace_root": runner.workspace_root,
-        "homeboy_path": runner.homeboy_path,
-        "daemon": runner.daemon,
-        "artifact_policy": runner.artifact_policy,
+        "homeboy_path": runner.settings.homeboy_path,
+        "daemon": runner.settings.daemon,
+        "artifact_policy": runner.settings.artifact_policy,
     })
 }
 
@@ -490,6 +490,7 @@ fn decode_component(value: &str) -> String {
 mod tests {
     use super::*;
     use crate::core::runner::RunnerKind;
+    use crate::core::server::RunnerSettings;
     use uuid::Uuid;
 
     fn ssh_runner() -> Runner {
@@ -498,10 +499,10 @@ mod tests {
             kind: RunnerKind::Ssh,
             server_id: Some("srv".to_string()),
             workspace_root: Some("/srv/homeboy".to_string()),
-            homeboy_path: None,
-            daemon: true,
-            concurrency_limit: None,
-            artifact_policy: None,
+            settings: RunnerSettings {
+                daemon: true,
+                ..Default::default()
+            },
             env: Default::default(),
             resources: Default::default(),
         }

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -454,6 +454,7 @@ fn string_field(value: &Value, key: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::server::RunnerSettings;
 
     fn ssh_runner() -> Runner {
         Runner {
@@ -461,10 +462,10 @@ mod tests {
             kind: RunnerKind::Ssh,
             server_id: Some("srv".to_string()),
             workspace_root: Some("/srv/homeboy".to_string()),
-            homeboy_path: None,
-            daemon: true,
-            concurrency_limit: None,
-            artifact_policy: None,
+            settings: RunnerSettings {
+                daemon: true,
+                ..Default::default()
+            },
             env: Default::default(),
             resources: Default::default(),
         }

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -5,8 +5,8 @@ use serde_json::Value;
 
 use crate::core::config::{self, ConfigEntity};
 use crate::core::error::{Error, Result};
-use crate::core::output::{CreateOutput, MergeOutput, RemoveResult};
-use crate::core::server;
+use crate::core::output::{BatchResult, CreateOutput, CreateResult, MergeOutput, MergeResult};
+use crate::core::server::{self, ServerRunner};
 
 mod apply;
 mod connection;
@@ -107,7 +107,233 @@ impl ConfigEntity for Runner {
     }
 }
 
-entity_crud!(Runner; merge);
+pub fn load(id: &str) -> Result<Runner> {
+    if config::exists::<Runner>(id) {
+        return config::load::<Runner>(id);
+    }
+
+    load_server_runner(id)
+}
+
+pub fn list() -> Result<Vec<Runner>> {
+    let mut runners = config::list::<Runner>()?;
+    runners.extend(
+        server::list()?
+            .into_iter()
+            .filter(|server| server.runner.is_some())
+            .map(|server| runner_from_server(&server.id, server.runner.expect("checked above"))),
+    );
+    runners.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(runners)
+}
+
+pub fn create(json_spec: &str, skip_existing: bool) -> Result<CreateOutput<Runner>> {
+    let raw = config::read_json_spec_to_string(json_spec)?;
+    let value: Value = config::from_str(&raw)?;
+
+    if let Some(items) = value.as_array() {
+        let mut summary = BatchResult::new();
+        for item in items {
+            let id = item
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .to_string();
+            if skip_existing && load(&id).is_ok() {
+                summary.record_skipped(id);
+                continue;
+            }
+
+            match create_single_value(item.clone()) {
+                Ok(result) => summary.record_created(result.id),
+                Err(err) => summary.record_error(id, err.message),
+            }
+        }
+        return Ok(CreateOutput::Bulk(summary));
+    }
+
+    Ok(CreateOutput::Single(create_single_value(value)?))
+}
+
+pub fn merge(id: Option<&str>, json_spec: &str, replace_fields: &[String]) -> Result<MergeOutput> {
+    let raw = config::read_json_spec_to_string(json_spec)?;
+    let parsed: Value = config::from_str(&raw)?;
+
+    if parsed.is_array() {
+        return Ok(MergeOutput::Bulk(config::merge_batch_from_json::<Runner>(
+            &raw,
+        )?));
+    }
+
+    let effective_id = id
+        .map(String::from)
+        .or_else(|| parsed.get("id").and_then(Value::as_str).map(String::from))
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "id",
+                "Provide runner ID as argument or in JSON body",
+                None,
+                None,
+            )
+        })?;
+
+    if config::exists::<Runner>(&effective_id) {
+        return Ok(MergeOutput::Single(config::merge_from_json::<Runner>(
+            Some(&effective_id),
+            &raw,
+            replace_fields,
+        )?));
+    }
+
+    Ok(MergeOutput::Single(merge_server_runner(
+        &effective_id,
+        parsed,
+        replace_fields,
+    )?))
+}
+
+pub fn delete_safe(id: &str) -> Result<()> {
+    if config::exists::<Runner>(id) {
+        return config::delete_safe::<Runner>(id);
+    }
+
+    let mut server = server::load(id)?;
+    if server.runner.is_none() {
+        return Err(Error::runner_not_found(id.to_string(), vec![]));
+    }
+    server.runner = None;
+    server::save(&server)
+}
+
+pub fn exists(id: &str) -> bool {
+    config::exists::<Runner>(id) || load_server_runner(id).is_ok()
+}
+
+pub fn enable_server_runner(server_id: &str, patch: Value) -> Result<Runner> {
+    let mut server = server::load(server_id)?;
+    let mut runner = server.runner.unwrap_or_default();
+    let patch = strip_runner_identity_fields(patch);
+    if !matches!(patch.as_object(), Some(obj) if obj.is_empty()) {
+        config::merge_config(&mut runner, patch, &[])?;
+    }
+    validate_server_runner(server_id, &runner)?;
+    server.runner = Some(runner.clone());
+    server::save(&server)?;
+    Ok(runner_from_server(server_id, runner))
+}
+
+fn create_single_value(value: Value) -> Result<CreateResult<Runner>> {
+    let id = value
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument("id", "Missing required field: id", None, None)
+        })?
+        .to_string();
+    let mut runner: Runner = serde_json::from_value(value.clone())
+        .map_err(|err| Error::validation_invalid_argument("json", err.to_string(), None, None))?;
+    runner.set_id(id.clone());
+
+    match runner.kind {
+        RunnerKind::Local => {
+            if config::exists::<Runner>(&id) {
+                return Err(Error::validation_invalid_argument(
+                    "runner.id",
+                    format!("runner '{}' already exists", id),
+                    Some(id),
+                    None,
+                ));
+            }
+            runner.validate()?;
+            config::save(&runner)?;
+            Ok(CreateResult {
+                id: runner.id.clone(),
+                entity: runner,
+            })
+        }
+        RunnerKind::Ssh => {
+            let server_id = runner.server_id.as_deref().unwrap_or(&id);
+            if server_id != id {
+                return Err(Error::validation_invalid_argument(
+                    "server_id",
+                    "SSH runner IDs are server IDs; use the server ID as the runner ID",
+                    Some(server_id.to_string()),
+                    Some(vec![format!(
+                        "Run `homeboy runner enable {server_id}` to make server '{server_id}' runner-capable."
+                    )]),
+                ));
+            }
+            let entity = enable_server_runner(&id, value)?;
+            Ok(CreateResult { id, entity })
+        }
+    }
+}
+
+fn load_server_runner(id: &str) -> Result<Runner> {
+    let server = server::load(id)?;
+    let runner = server
+        .runner
+        .ok_or_else(|| Error::runner_not_found(id.to_string(), vec![]))?;
+    Ok(runner_from_server(id, runner))
+}
+
+fn runner_from_server(server_id: &str, runner: ServerRunner) -> Runner {
+    Runner {
+        id: server_id.to_string(),
+        kind: RunnerKind::Ssh,
+        server_id: Some(server_id.to_string()),
+        workspace_root: runner.workspace_root,
+        homeboy_path: runner.homeboy_path,
+        daemon: runner.daemon,
+        concurrency_limit: runner.concurrency_limit,
+        artifact_policy: runner.artifact_policy,
+        env: runner.env,
+        resources: runner.resources,
+    }
+}
+
+fn merge_server_runner(
+    id: &str,
+    mut patch: Value,
+    replace_fields: &[String],
+) -> Result<MergeResult> {
+    let mut server = server::load(id)?;
+    let mut runner = server.runner.unwrap_or_default();
+    if let Some(obj) = patch.as_object_mut() {
+        obj.remove("id");
+        obj.remove("kind");
+        obj.remove("server_id");
+    }
+    let result = config::merge_config(&mut runner, patch, replace_fields)?;
+    validate_server_runner(id, &runner)?;
+    server.runner = Some(runner);
+    server::save(&server)?;
+    Ok(MergeResult {
+        id: id.to_string(),
+        updated_fields: result.updated_fields,
+    })
+}
+
+fn strip_runner_identity_fields(mut value: Value) -> Value {
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("id");
+        obj.remove("kind");
+        obj.remove("server_id");
+    }
+    value
+}
+
+fn validate_server_runner(server_id: &str, runner: &ServerRunner) -> Result<()> {
+    if runner.concurrency_limit == Some(0) {
+        return Err(Error::validation_invalid_argument(
+            "concurrency_limit",
+            "concurrency_limit must be greater than zero",
+            Some(server_id.to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
 
 #[cfg(test)]
 mod tests {
@@ -151,12 +377,74 @@ mod tests {
             let spec = r#"{
                 "id": "remote-lab",
                 "kind": "ssh",
-                "server_id": "missing",
+                "server_id": "remote-lab",
                 "workspace_root": "/srv/homeboy"
             }"#;
 
             let err = create(spec, false).expect_err("missing server rejects ssh runner");
             assert_eq!(err.code.as_str(), "server.not_found");
+        });
+    }
+
+    #[test]
+    fn ssh_runner_is_server_capability() {
+        test_support::with_isolated_home(|_| {
+            server::create(
+                r#"{"id":"homeboy-lab","host":"192.168.86.63","user":"chubes"}"#,
+                false,
+            )
+            .expect("create server");
+
+            create(
+                r#"{
+                    "id":"homeboy-lab",
+                    "kind":"ssh",
+                    "server_id":"homeboy-lab",
+                    "workspace_root":"/home/chubes/Developer",
+                    "concurrency_limit":4,
+                    "artifact_policy":"copy"
+                }"#,
+                false,
+            )
+            .expect("enable runner capability");
+
+            let runner = load("homeboy-lab").expect("load server runner");
+            assert_eq!(runner.id, "homeboy-lab");
+            assert_eq!(runner.kind, RunnerKind::Ssh);
+            assert_eq!(runner.server_id.as_deref(), Some("homeboy-lab"));
+            assert_eq!(
+                runner.workspace_root.as_deref(),
+                Some("/home/chubes/Developer")
+            );
+            assert_eq!(runner.concurrency_limit, Some(4));
+
+            let stored_server = server::load("homeboy-lab").expect("load server");
+            assert!(stored_server.runner.is_some());
+        });
+    }
+
+    #[test]
+    fn ssh_runner_id_must_match_server_id() {
+        test_support::with_isolated_home(|_| {
+            server::create(
+                r#"{"id":"homeboy-lab","host":"192.168.86.63","user":"chubes"}"#,
+                false,
+            )
+            .expect("create server");
+
+            let err = create(
+                r#"{
+                    "id":"lab",
+                    "kind":"ssh",
+                    "server_id":"homeboy-lab",
+                    "workspace_root":"/home/chubes/Developer"
+                }"#,
+                false,
+            )
+            .expect_err("ssh runner cannot use a second ID");
+
+            assert_eq!(err.code.as_str(), "validation.invalid_argument");
+            assert!(err.message.contains("SSH runner IDs are server IDs"));
         });
     }
 

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use crate::core::config::{self, ConfigEntity};
 use crate::core::error::{Error, Result};
 use crate::core::output::{BatchResult, CreateOutput, CreateResult, MergeOutput, MergeResult};
-use crate::core::server::{self, ServerRunner};
+use crate::core::server::{self, RunnerSettings, ServerRunner};
 
 mod apply;
 mod connection;
@@ -47,14 +47,8 @@ pub struct Runner {
     pub server_id: Option<String>,
     #[serde(default)]
     pub workspace_root: Option<String>,
-    #[serde(default)]
-    pub homeboy_path: Option<String>,
-    #[serde(default)]
-    pub daemon: bool,
-    #[serde(default)]
-    pub concurrency_limit: Option<usize>,
-    #[serde(default)]
-    pub artifact_policy: Option<String>,
+    #[serde(flatten)]
+    pub settings: RunnerSettings,
     #[serde(default)]
     pub env: HashMap<String, String>,
     #[serde(default)]
@@ -90,7 +84,7 @@ impl ConfigEntity for Runner {
             server::load(server_id)?;
         }
 
-        if self.concurrency_limit == Some(0) {
+        if self.settings.concurrency_limit == Some(0) {
             return Err(Error::validation_invalid_argument(
                 "concurrency_limit",
                 "concurrency_limit must be greater than zero",
@@ -283,10 +277,7 @@ fn runner_from_server(server_id: &str, runner: ServerRunner) -> Runner {
         kind: RunnerKind::Ssh,
         server_id: Some(server_id.to_string()),
         workspace_root: runner.workspace_root,
-        homeboy_path: runner.homeboy_path,
-        daemon: runner.daemon,
-        concurrency_limit: runner.concurrency_limit,
-        artifact_policy: runner.artifact_policy,
+        settings: runner.settings,
         env: runner.env,
         resources: runner.resources,
     }
@@ -324,7 +315,7 @@ fn strip_runner_identity_fields(mut value: Value) -> Value {
 }
 
 fn validate_server_runner(server_id: &str, runner: &ServerRunner) -> Result<()> {
-    if runner.concurrency_limit == Some(0) {
+    if runner.settings.concurrency_limit == Some(0) {
         return Err(Error::validation_invalid_argument(
             "concurrency_limit",
             "concurrency_limit must be greater than zero",
@@ -365,7 +356,7 @@ mod tests {
                 runner.workspace_root.as_deref(),
                 Some("/Users/chubes/Developer")
             );
-            assert_eq!(runner.concurrency_limit, Some(2));
+            assert_eq!(runner.settings.concurrency_limit, Some(2));
             assert_eq!(runner.env.get("RUST_LOG").map(String::as_str), Some("info"));
             assert_eq!(runner.resources.get("cpu"), Some(&Value::from(8)));
         });
@@ -416,7 +407,7 @@ mod tests {
                 runner.workspace_root.as_deref(),
                 Some("/home/chubes/Developer")
             );
-            assert_eq!(runner.concurrency_limit, Some(4));
+            assert_eq!(runner.settings.concurrency_limit, Some(4));
 
             let stored_server = server::load("homeboy-lab").expect("load server");
             assert!(stored_server.runner.is_some());
@@ -479,7 +470,7 @@ mod tests {
 
             let runner = load("lab-local").expect("load runner");
             assert_eq!(runner.workspace_root.as_deref(), Some("/tmp/b"));
-            assert_eq!(runner.concurrency_limit, Some(3));
+            assert_eq!(runner.settings.concurrency_limit, Some(3));
         });
     }
 }

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -462,12 +462,9 @@ pub fn execute_local_command(command: &str) -> CommandOutput {
 
 /// Run a local command, capturing stdout/stderr.
 ///
-/// All locally-spawned commands run in their own process group with
-/// guaranteed teardown of every descendant on exit, panic, or signal.
-/// There is no "leak the children" mode — verbs that genuinely want a
-/// process to outlive the command (e.g. `homeboy daemon`) build their
-/// own background spawn directly with `std::process::Command` and
-/// manage the pid themselves.
+/// All locally-spawned commands run in their own process group with guaranteed
+/// descendant teardown on exit, panic, or signal. Verbs that genuinely need a
+/// background process use `std::process::Command` directly and manage the pid.
 pub fn execute_local_command_in_dir(
     command: &str,
     current_dir: Option<&str>,

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -1266,6 +1266,7 @@ mod tests {
                 },
             }),
             env: HashMap::new(),
+            runner: None,
         };
 
         let client = SshClient::from_server(&server, "bastion").expect("client");
@@ -1326,6 +1327,7 @@ mod tests {
                 },
             }),
             env: HashMap::new(),
+            runner: None,
         };
 
         let client = SshClient::from_server(&server, "local").expect("client");

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -51,6 +51,26 @@ pub struct Server {
     /// Values support `$PATH`-style expansion — the shell handles it.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub env: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner: Option<ServerRunner>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServerRunner {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_root: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub homeboy_path: Option<String>,
+    #[serde(default)]
+    pub daemon: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub concurrency_limit: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_policy: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub resources: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -107,6 +127,24 @@ impl ConfigEntity for Server {
             .filter(|p| p.server_id.as_deref() == Some(id))
             .map(|p| p.id.clone())
             .collect())
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self
+            .runner
+            .as_ref()
+            .and_then(|runner| runner.concurrency_limit)
+            == Some(0)
+        {
+            return Err(Error::validation_invalid_argument(
+                "runner.concurrency_limit",
+                "runner.concurrency_limit must be greater than zero",
+                None,
+                None,
+            ));
+        }
+
+        Ok(())
     }
 }
 

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -56,9 +56,7 @@ pub struct Server {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ServerRunner {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workspace_root: Option<String>,
+pub struct RunnerSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub homeboy_path: Option<String>,
     #[serde(default)]
@@ -67,6 +65,14 @@ pub struct ServerRunner {
     pub concurrency_limit: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifact_policy: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServerRunner {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_root: Option<String>,
+    #[serde(flatten)]
+    pub settings: RunnerSettings,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub env: HashMap<String, String>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -133,7 +139,7 @@ impl ConfigEntity for Server {
         if self
             .runner
             .as_ref()
-            .and_then(|runner| runner.concurrency_limit)
+            .and_then(|runner| runner.settings.concurrency_limit)
             == Some(0)
         {
             return Err(Error::validation_invalid_argument(

--- a/src/core/server/transfer.rs
+++ b/src/core/server/transfer.rs
@@ -497,6 +497,7 @@ mod tests {
             kind: None,
             auth: None,
             env: HashMap::new(),
+            runner: None,
         })
         .expect("save server");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,7 +326,7 @@ fn run_lab_offload_inner(
         Some(&remote_cwd),
         "lab_offload",
     );
-    let homeboy_path = runner.homeboy_path.as_deref().unwrap_or("homeboy");
+    let homeboy_path = runner.settings.homeboy_path.as_deref().unwrap_or("homeboy");
     let mut command = vec![homeboy_path.to_string()];
     command.extend(strip_runner_flag(normalized_args).into_iter().skip(1));
 


### PR DESCRIPTION
## Summary
- Store SSH runner settings as a `runner` capability on the existing server record so one Lab machine uses one ID.
- Add `homeboy runner enable <server-id>` as the first-class Lab onboarding path while preserving standalone local runners.
- Update runner/server docs and server schema docs for the new model.

Fixes https://github.com/Extra-Chill/homeboy/issues/2691

## Verification
- `cargo test core::runner::tests --lib`
- `cargo test command_surface`
- `cargo check`
- CLI smoke: `server create homeboy-lab`, `runner enable homeboy-lab`, `runner show homeboy-lab` with isolated `HOME`
- `git diff --check`

## Notes
- No legacy migration path is included because this runner model has not shipped yet.
- Local runners remain standalone because they describe the current machine and do not map to an SSH server record.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the server-capability runner implementation, updated CLI/docs/tests, and ran verification; Chris remains responsible for review and merge.