### PR TITLE
Block release planning on orphaned current-version tags

### DIFF
--- a/src/core/release/planner.rs
+++ b/src/core/release/planner.rs
@@ -9,7 +9,10 @@ use super::context::{load_component, resolve_extensions};
 use super::plan_steps::{build_preflight_steps, build_release_steps};
 use super::planning_changelog::{build_changelog_plan, generate_changelog_entries};
 use super::planning_policy::release_skip_plan;
-use super::planning_semver::{build_semver_recommendation, validate_release_version_floor};
+use super::planning_semver::{
+    build_semver_recommendation, current_version_tag_name, validate_current_version_tag_reachable,
+    validate_release_version_floor,
+};
 use super::planning_worktree::validate_release_worktree;
 use super::types::{ReleaseOptions, ReleasePlan};
 
@@ -25,6 +28,36 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     let mut v = ValidationCollector::new();
 
     let monorepo = git::MonorepoContext::detect(&component.local_path, component_id);
+    let version_info = v.capture(version::read_component_version(&component), "version");
+    if let Some(ref info) = version_info {
+        if let Some(message) = v
+            .capture(
+                validate_current_version_tag_reachable(
+                    &component.local_path,
+                    monorepo.as_ref(),
+                    &info.version,
+                ),
+                "tag",
+            )
+            .flatten()
+        {
+            let tag_name = current_version_tag_name(monorepo.as_ref(), &info.version);
+            v.push(
+                "tag",
+                &message,
+                Some(serde_json::json!({
+                    "version": &info.version,
+                    "tag": &tag_name,
+                    "recovery": [
+                        format!("Inspect the existing tag: git show --no-patch --decorate {}", tag_name),
+                        format!("If the orphaned tag is abandoned, delete it locally and remotely: git tag -d {} && git push origin :refs/tags/{}", tag_name, tag_name),
+                        format!("Then rerun recovery: homeboy release {} --recover", component_id),
+                        format!("If the tag is valid, check out or merge the tagged release commit before releasing {}", component_id),
+                    ]
+                })),
+            );
+        }
+    }
     let semver_recommendation = if options.pipeline.head {
         None
     } else {
@@ -49,7 +82,6 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
         .unwrap_or_default()
     };
 
-    let version_info = v.capture(version::read_component_version(&component), "version");
     let new_version = if let Some(ref info) = version_info {
         if options.pipeline.head {
             Some(info.version.clone())

--- a/src/core/release/planning_semver.rs
+++ b/src/core/release/planning_semver.rs
@@ -88,6 +88,45 @@ pub(super) fn validate_release_version_floor(
     None
 }
 
+pub(super) fn validate_current_version_tag_reachable(
+    local_path: &str,
+    monorepo: Option<&git::MonorepoContext>,
+    current_version: &str,
+) -> Result<Option<String>> {
+    let git_root = monorepo
+        .map(|ctx| ctx.git_root.as_str())
+        .unwrap_or(local_path);
+    let tag_name = current_version_tag_name(monorepo, current_version);
+
+    if !git::tag_exists_locally(git_root, &tag_name)? {
+        return Ok(None);
+    }
+
+    let tag_commit = git::get_tag_commit(git_root, &tag_name)?;
+    let output = git::execute_git_for_release(
+        git_root,
+        &["merge-base", "--is-ancestor", &tag_commit, "HEAD"],
+    )
+    .map_err(|err| Error::git_command_failed(format!("git merge-base failed: {}", err)))?;
+    if output.status.success() {
+        return Ok(None);
+    }
+
+    Ok(Some(format!(
+        "Release tag {} exists for current source version {} but is not reachable from HEAD. Refusing to plan the next release until the orphaned tag is recovered or removed.",
+        tag_name, current_version
+    )))
+}
+
+pub(super) fn current_version_tag_name(
+    monorepo: Option<&git::MonorepoContext>,
+    current_version: &str,
+) -> String {
+    monorepo
+        .map(|ctx| ctx.format_tag(current_version))
+        .unwrap_or_else(|| format!("v{}", current_version))
+}
+
 /// Resolve the latest tag and commits since that tag for a component.
 ///
 /// In a monorepo, uses component-prefixed tags and path-scoped commits.
@@ -181,7 +220,8 @@ fn commit_range(latest_tag: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_semver_recommendation, resolve_tag_and_commits, validate_release_version_floor,
+        build_semver_recommendation, resolve_tag_and_commits,
+        validate_current_version_tag_reachable, validate_release_version_floor,
     };
     use crate::core::component::Component;
 
@@ -297,5 +337,44 @@ mod tests {
         assert!(message.contains(
             "Next release version 0.125.0 is not greater than latest release tag v0.125.0"
         ));
+    }
+
+    #[test]
+    fn current_version_tag_reachability_blocks_orphaned_tag() {
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        run_git(dir, &["tag", "v0.1.0"]);
+        commit_file(dir, "fix.txt", "fix", "fix: patch bug");
+        commit_file(dir, "VERSION", "0.1.1", "release: v0.1.1");
+        run_git(dir, &["branch", "-M", "main"]);
+
+        run_git(dir, &["checkout", "--orphan", "orphan-release"]);
+        run_git(dir, &["rm", "-qrf", "."]);
+        commit_file(dir, "VERSION", "0.1.1", "release: v0.1.1");
+        run_git(dir, &["tag", "v0.1.1"]);
+        run_git(dir, &["checkout", "main"]);
+
+        let message = validate_current_version_tag_reachable(&dir.to_string_lossy(), None, "0.1.1")
+            .expect("validation should run")
+            .expect("orphaned current-version tag should block release");
+
+        assert!(message.contains("Release tag v0.1.1 exists"));
+        assert!(message.contains("not reachable from HEAD"));
+        assert!(message.contains("Refusing to plan the next release"));
+    }
+
+    #[test]
+    fn current_version_tag_reachability_allows_reachable_tag() {
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        commit_file(dir, "VERSION", "0.1.1", "release: v0.1.1");
+        run_git(dir, &["tag", "v0.1.1"]);
+
+        let message = validate_current_version_tag_reachable(&dir.to_string_lossy(), None, "0.1.1")
+            .expect("validation should run");
+
+        assert!(message.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Detect when the current source version already has a release tag that is not reachable from `HEAD`.
- Refuse release planning before Homeboy advances to the next version and surface recovery commands for the orphaned tag state.
- Add regression coverage for orphaned and reachable current-version tags.

Fixes https://github.com/Extra-Chill/homeboy/issues/2693

## Verification
- `cargo test current_version_tag_reachability --lib`
- `cargo test core::release::planning_semver --lib`
- `cargo check`
- `cargo fmt --check`
- `git diff --check`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-release-orphaned-tag-recovery --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the release planning guard, regression tests, and PR description; Chris remains responsible for review and merge.