### PR TITLE
fix: back release plan compatibility with HomeboyPlan

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -43,7 +43,10 @@ pub(super) fn execute_release_plan_step(
         "version" => executor::run_version(
             context.component,
             &mut context.state,
-            &context.options.bump_type,
+            step.inputs
+                .get("bump")
+                .and_then(|value| value.as_str())
+                .unwrap_or(&context.options.bump_type),
         )
         .map(Some),
         "release.prepare" => Ok(Some(
@@ -410,7 +413,7 @@ mod tests {
         execute_release_plan_step, release_step_is_plan_only, release_step_is_show_stopper,
         ReleaseExecutionContext,
     };
-    use crate::core::component::Component;
+    use crate::core::component::{Component, VersionTarget};
     use crate::core::plan::PlanStep;
     use crate::core::release::types::{
         ReleaseOptions, ReleaseState, ReleaseStepResult, ReleaseStepStatus,
@@ -755,6 +758,62 @@ mod tests {
 
         assert_eq!(result.status, ReleaseStepStatus::Success);
         assert!(changelog_path.exists());
+    }
+
+    #[test]
+    fn version_step_uses_planned_bump_input() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            temp.path().join("plugin.php"),
+            "<?php\n/*\nPlugin Name: Fixture\nVersion: 0.6.12\n*/\n",
+        )
+        .expect("write plugin");
+        std::fs::write(
+            temp.path().join("CHANGELOG.md"),
+            "# Changelog\n\n## Unreleased\n\n- Planned bump fixture\n",
+        )
+        .expect("write changelog");
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: temp.path().to_string_lossy().to_string(),
+            changelog_target: Some("CHANGELOG.md".to_string()),
+            version_targets: Some(vec![VersionTarget {
+                file: "plugin.php".to_string(),
+                pattern: Some(r"(?:Version|version)[:=]\s+([0-9]+\.[0-9]+\.[0-9]+)".to_string()),
+            }]),
+            ..Default::default()
+        };
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            ..Default::default()
+        };
+        let mut context = ReleaseExecutionContext {
+            component: &component,
+            extensions: &[],
+            component_id: "fixture",
+            options: &options,
+            state: ReleaseState::default(),
+            publish_failed: false,
+        };
+        let mut step = plan_step("version");
+        step.inputs
+            .insert("bump".to_string(), serde_json::json!("minor"));
+
+        let result = execute_release_plan_step(&step, &mut context)
+            .expect("dispatch")
+            .expect("result");
+
+        assert_eq!(result.status, ReleaseStepStatus::Success);
+        assert_eq!(
+            result
+                .data
+                .as_ref()
+                .and_then(|data| data.get("new_version"))
+                .and_then(|value| value.as_str()),
+            Some("0.7.0")
+        );
+        let plugin = std::fs::read_to_string(temp.path().join("plugin.php")).expect("read plugin");
+        assert!(plugin.contains("Version: 0.7.0"));
     }
 
     #[test]

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -2,7 +2,7 @@ use serde::ser::Error as SerializeError;
 use serde::{Deserialize, Serialize, Serializer};
 use std::collections::HashMap;
 
-use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep};
+use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
 use crate::is_zero_u32;
 
 /// Ordered release plan shared by dry-run output and release execution.
@@ -12,11 +12,12 @@ use crate::is_zero_u32;
 #[derive(Debug, Clone)]
 pub struct ReleasePlan {
     pub plan: HomeboyPlan,
-    enabled: bool,
-    semver_recommendation: Option<ReleaseSemverRecommendation>,
 }
 
 impl ReleasePlan {
+    const ENABLED_POLICY_KEY: &'static str = "enabled";
+    const SEMVER_RECOMMENDATION_POLICY_KEY: &'static str = "semver_recommendation";
+
     pub fn new(
         component_id: impl Into<String>,
         enabled: bool,
@@ -30,12 +31,29 @@ impl ReleasePlan {
         plan.steps = steps;
         plan.warnings = warnings;
         plan.hints = hints;
-
-        Self {
-            plan,
-            enabled,
-            semver_recommendation,
+        plan.policy.insert(
+            Self::ENABLED_POLICY_KEY.to_string(),
+            serde_json::Value::Bool(enabled),
+        );
+        if let Some(semver_recommendation) = semver_recommendation {
+            plan.policy.insert(
+                Self::SEMVER_RECOMMENDATION_POLICY_KEY.to_string(),
+                serde_json::to_value(semver_recommendation).unwrap_or(serde_json::Value::Null),
+            );
         }
+
+        Self::from_plan(plan)
+    }
+
+    /// Wrap a generic Homeboy plan in the release compatibility contract.
+    ///
+    /// Release execution consumes `plan.steps` directly. The legacy top-level
+    /// JSON fields (`component_id`, `enabled`, and `semver_recommendation`) are
+    /// projected from the generic plan subject/policy during serialization so
+    /// existing release JSON consumers keep the same shape without creating a
+    /// second authoritative release data store.
+    pub fn from_plan(plan: HomeboyPlan) -> Self {
+        Self { plan }
     }
 
     pub fn component_id(&self) -> Option<&str> {
@@ -43,11 +61,27 @@ impl ReleasePlan {
     }
 
     pub fn enabled(&self) -> bool {
-        self.enabled
+        if let Some(enabled) = self
+            .plan
+            .policy
+            .get(Self::ENABLED_POLICY_KEY)
+            .and_then(|value| value.as_bool())
+        {
+            return enabled;
+        }
+
+        self.plan
+            .steps
+            .iter()
+            .any(|step| matches!(step.status, PlanStepStatus::Ready | PlanStepStatus::Running))
     }
 
-    pub fn semver_recommendation(&self) -> Option<&ReleaseSemverRecommendation> {
-        self.semver_recommendation.as_ref()
+    pub fn semver_recommendation(&self) -> Option<ReleaseSemverRecommendation> {
+        self.plan
+            .policy
+            .get(Self::SEMVER_RECOMMENDATION_POLICY_KEY)
+            .cloned()
+            .and_then(|value| serde_json::from_value(value).ok())
     }
 }
 
@@ -67,8 +101,11 @@ impl Serialize for ReleasePlan {
                 serde_json::Value::String(component_id.to_string()),
             );
         }
-        object.insert("enabled".to_string(), serde_json::Value::Bool(self.enabled));
-        if let Some(semver_recommendation) = self.semver_recommendation.as_ref() {
+        object.insert(
+            "enabled".to_string(),
+            serde_json::Value::Bool(self.enabled()),
+        );
+        if let Some(semver_recommendation) = self.semver_recommendation() {
             object.insert(
                 "semver_recommendation".to_string(),
                 serde_json::to_value(semver_recommendation).map_err(S::Error::custom)?,
@@ -384,6 +421,19 @@ mod tests {
     }
 
     #[test]
+    fn enabled_falls_back_to_plan_step_state_when_policy_is_absent() {
+        let mut plan = HomeboyPlan::for_component(PlanKind::Release, "demo");
+        plan.steps = vec![PlanStep::ready("version", "version").build()];
+
+        assert!(ReleasePlan::from_plan(plan).enabled());
+
+        let mut disabled_plan = HomeboyPlan::for_component(PlanKind::Release, "demo");
+        disabled_plan.steps = vec![PlanStep::disabled("release.skip", "release.skip").build()];
+
+        assert!(!ReleasePlan::from_plan(disabled_plan).enabled());
+    }
+
+    #[test]
     fn test_semver_recommendation() {
         let recommendation = ReleaseSemverRecommendation {
             latest_tag: Some("v1.0.0".to_string()),
@@ -405,8 +455,8 @@ mod tests {
 
         assert_eq!(
             plan.semver_recommendation()
-                .and_then(|recommendation| recommendation.recommended_bump.as_deref()),
-            Some("minor")
+                .and_then(|recommendation| recommendation.recommended_bump),
+            Some("minor".to_string())
         );
     }
 
@@ -421,6 +471,7 @@ mod tests {
         assert_eq!(serialized["subject"]["component_id"], "demo");
         assert_eq!(serialized["component_id"], "demo");
         assert_eq!(serialized["enabled"], true);
+        assert_eq!(serialized["policy"]["enabled"], true);
         assert!(serialized.get("semver_recommendation").is_none());
     }
 


### PR DESCRIPTION
## Summary
- Makes `ReleasePlan` a compatibility wrapper over `HomeboyPlan`, projecting legacy `component_id`, `enabled`, and `semver_recommendation` JSON fields from the generic plan subject/policy.
- Keeps release JSON compatibility while making `enabled` derive from plan policy or step state instead of a parallel wrapper field.
- Executes the version step from the planned `version.inputs.bump`, so real release execution consumes the same plan data shown in dry-run output.

Closes #2698.

## Tests
- `cargo test core::release`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the ReleasePlan/HomeboyPlan boundary tightening, added targeted tests, and ran release test verification. Chris remains responsible for review and merge.