### PR TITLE
Derive stack sync preview from HomeboyPlan

### DIFF
--- a/src/core/rig/stack.rs
+++ b/src/core/rig/stack.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use super::expand::expand_vars;
 use super::spec::RigSpec;
 use crate::core::error::{ErrorCode, Result};
+use crate::core::plan::HomeboyPlan;
 use crate::core::stack::{self, StackSpec, SyncOutput};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -36,6 +37,9 @@ pub struct RigStackSyncEntry {
     pub base: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<String>,
+    /// Stack sync plan reused from the underlying stack sync contract.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan: Option<HomeboyPlan>,
     #[serde(default, skip_serializing_if = "is_zero")]
     pub picked_count: usize,
     #[serde(default, skip_serializing_if = "is_zero")]
@@ -181,6 +185,7 @@ where
                 branch: None,
                 base: None,
                 target: None,
+                plan: None,
                 picked_count: 0,
                 skipped_count: 0,
                 dropped_count: 0,
@@ -249,17 +254,25 @@ fn comparable_path(path: &str) -> PathBuf {
 }
 
 fn entry_from_output(component_id: &str, output: SyncOutput) -> RigStackSyncEntry {
-    let changed = output.picked_count > 0 || output.preview.dropped_count > 0;
+    let SyncOutput {
+        preview,
+        picked_count,
+        skipped_count,
+        ..
+    } = output;
+    let changed = stack::sync::sync_plan_would_mutate(&preview.plan);
+    let dropped_count = preview.dropped_count;
     RigStackSyncEntry {
         component_id: component_id.to_string(),
-        stack_id: output.preview.stack_id,
+        stack_id: preview.stack_id,
         status: if changed { "changed" } else { "no-op" }.to_string(),
-        branch: Some(output.preview.branch),
-        base: Some(output.preview.base),
-        target: Some(output.preview.target),
-        picked_count: output.picked_count,
-        skipped_count: output.skipped_count,
-        dropped_count: output.preview.dropped_count,
+        branch: Some(preview.branch),
+        base: Some(preview.base),
+        target: Some(preview.target),
+        plan: Some(preview.plan),
+        picked_count,
+        skipped_count,
+        dropped_count,
         error: None,
     }
 }

--- a/src/core/stack/sync.rs
+++ b/src/core/stack/sync.rs
@@ -199,32 +199,29 @@ pub(crate) fn plan_sync(spec: &StackSpec) -> Result<SyncPlan> {
     let mut kept_metas = Vec::new();
 
     for pr in &spec.prs {
-        let meta = match fetch_pr_meta(pr) {
-            Ok(meta) => meta,
-            Err(e) => {
-                uncertain.push(uncertain_pr(pr, e.to_string()));
-                continue;
-            }
+        let Some(meta) = record_uncertain(&mut uncertain, pr, fetch_pr_meta(pr)) else {
+            continue;
         };
 
-        let head = match meta.require_head(pr) {
-            Ok(head) => head,
-            Err(e) => {
-                uncertain.push(uncertain_pr(pr, e.to_string()));
-                continue;
-            }
+        let Some(head) = record_uncertain(&mut uncertain, pr, meta.require_head(pr)) else {
+            continue;
         };
 
-        let head_remote = match ensure_head_remote(&path, pr, &head, &mut ensured_remotes) {
-            Ok(remote) => remote,
-            Err(e) => {
-                uncertain.push(uncertain_pr(pr, e.to_string()));
-                continue;
-            }
+        let Some(head_remote) = record_uncertain(
+            &mut uncertain,
+            pr,
+            ensure_head_remote(&path, pr, &head, &mut ensured_remotes),
+        ) else {
+            continue;
         };
 
-        if let Err(e) = fetch_sha(&path, &head_remote, &meta.head_sha) {
-            uncertain.push(uncertain_pr(pr, e.to_string()));
+        if record_uncertain(
+            &mut uncertain,
+            pr,
+            fetch_sha(&path, &head_remote, &meta.head_sha),
+        )
+        .is_none()
+        {
             continue;
         }
 
@@ -261,14 +258,15 @@ pub(crate) fn plan_sync(spec: &StackSpec) -> Result<SyncPlan> {
         target_ahead,
         target_behind,
     );
-    let dropped = sync_dropped_prs(&plan);
-    let replayed = sync_replayed_prs(&plan);
-    let uncertain = sync_uncertain_prs(&plan);
-    let dropped_count = sync_plan_action_count(&plan, STACK_SYNC_DROP_KIND);
-    let replayed_count = sync_plan_action_count(&plan, STACK_SYNC_REPLAY_KIND);
-    let uncertain_count = sync_plan_action_count(&plan, STACK_SYNC_UNCERTAIN_KIND);
-    let would_mutate = sync_plan_would_mutate(&plan);
-    let blocked = sync_plan_blocked(&plan);
+    let view = SyncPlanView::new(&plan);
+    let dropped = view.dropped_prs();
+    let replayed = view.replayed_prs();
+    let uncertain = view.uncertain_prs();
+    let dropped_count = view.action_count(STACK_SYNC_DROP_KIND);
+    let replayed_count = view.action_count(STACK_SYNC_REPLAY_KIND);
+    let uncertain_count = view.action_count(STACK_SYNC_UNCERTAIN_KIND);
+    let would_mutate = view.would_mutate();
+    let blocked = view.blocked();
 
     Ok(SyncPlan {
         preview: SyncPreview {
@@ -438,109 +436,128 @@ fn sync_pr_step(
     }
 }
 
-fn sync_dropped_prs(plan: &HomeboyPlan) -> Vec<DroppedPr> {
-    plan.steps
-        .iter()
-        .filter(|step| step.kind == STACK_SYNC_DROP_KIND)
-        .map(|step| DroppedPr {
-            repo: step_string_input(step, "repo"),
-            number: step_u64_input(step, "number"),
-            title: step_optional_string_input(step, "title"),
-            merged_at: step_optional_string_input(step, "merged_at"),
-            reason: step_string_input(step, "reason"),
-        })
-        .collect()
-}
-
-fn sync_replayed_prs(plan: &HomeboyPlan) -> Vec<ReplayedPr> {
-    plan.steps
-        .iter()
-        .filter(|step| step.kind == STACK_SYNC_REPLAY_KIND)
-        .map(|step| ReplayedPr {
-            repo: step_string_input(step, "repo"),
-            number: step_u64_input(step, "number"),
-            sha: step_string_input(step, "sha"),
-            title: step_optional_string_input(step, "title"),
-            url: step_optional_string_input(step, "url"),
-            upstream_state: step_optional_string_input(step, "upstream_state"),
-            note: step_optional_string_input(step, "note"),
-            reason: step_string_input(step, "reason"),
-        })
-        .collect()
-}
-
-fn sync_uncertain_prs(plan: &HomeboyPlan) -> Vec<UncertainPr> {
-    plan.steps
-        .iter()
-        .filter(|step| step.kind == STACK_SYNC_UNCERTAIN_KIND)
-        .map(|step| UncertainPr {
-            repo: step_string_input(step, "repo"),
-            number: step_u64_input(step, "number"),
-            note: step_optional_string_input(step, "note"),
-            error: step_string_input(step, "error"),
-        })
-        .collect()
-}
-
-fn sync_plan_action_count(plan: &HomeboyPlan, kind: &str) -> usize {
-    plan.steps.iter().filter(|step| step.kind == kind).count()
-}
-
 pub(crate) fn sync_plan_would_mutate(plan: &HomeboyPlan) -> bool {
-    plan_bool_policy(plan, "would_mutate").unwrap_or_else(|| {
-        sync_would_mutate_from_parts(
-            plan.inputs
-                .get("target_exists")
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or(true),
-            plan_usize_input(plan, "target_ahead"),
-            plan_usize_input(plan, "target_behind"),
-            sync_plan_action_count(plan, STACK_SYNC_DROP_KIND),
-            sync_plan_action_count(plan, STACK_SYNC_REPLAY_KIND),
-        )
-    })
+    SyncPlanView::new(plan).would_mutate()
 }
 
-pub(crate) fn sync_plan_blocked(plan: &HomeboyPlan) -> bool {
-    plan_bool_policy(plan, "blocked").unwrap_or_else(|| {
-        plan.summary
-            .as_ref()
-            .map(|summary| summary.blocked > 0)
-            .unwrap_or_else(|| {
-                plan.steps
-                    .iter()
-                    .any(|step| step.blocking && step.status == PlanStepStatus::Missing)
+struct SyncPlanView<'a> {
+    plan: &'a HomeboyPlan,
+}
+
+impl<'a> SyncPlanView<'a> {
+    fn new(plan: &'a HomeboyPlan) -> Self {
+        Self { plan }
+    }
+
+    fn dropped_prs(&self) -> Vec<DroppedPr> {
+        self.steps(STACK_SYNC_DROP_KIND)
+            .map(|step| DroppedPr {
+                repo: self.string_input(step, "repo"),
+                number: self.u64_input(step, "number"),
+                title: self.optional_string_input(step, "title"),
+                merged_at: self.optional_string_input(step, "merged_at"),
+                reason: self.string_input(step, "reason"),
             })
-    })
-}
+            .collect()
+    }
 
-fn plan_bool_policy(plan: &HomeboyPlan, key: &str) -> Option<bool> {
-    plan.policy.get(key).and_then(serde_json::Value::as_bool)
-}
+    fn replayed_prs(&self) -> Vec<ReplayedPr> {
+        self.steps(STACK_SYNC_REPLAY_KIND)
+            .map(|step| ReplayedPr {
+                repo: self.string_input(step, "repo"),
+                number: self.u64_input(step, "number"),
+                sha: self.string_input(step, "sha"),
+                title: self.optional_string_input(step, "title"),
+                url: self.optional_string_input(step, "url"),
+                upstream_state: self.optional_string_input(step, "upstream_state"),
+                note: self.optional_string_input(step, "note"),
+                reason: self.string_input(step, "reason"),
+            })
+            .collect()
+    }
 
-fn plan_usize_input(plan: &HomeboyPlan, key: &str) -> Option<usize> {
-    plan.inputs
-        .get(key)
-        .and_then(serde_json::Value::as_u64)
-        .and_then(|value| usize::try_from(value).ok())
-}
+    fn uncertain_prs(&self) -> Vec<UncertainPr> {
+        self.steps(STACK_SYNC_UNCERTAIN_KIND)
+            .map(|step| UncertainPr {
+                repo: self.string_input(step, "repo"),
+                number: self.u64_input(step, "number"),
+                note: self.optional_string_input(step, "note"),
+                error: self.string_input(step, "error"),
+            })
+            .collect()
+    }
 
-fn step_string_input(step: &PlanStep, key: &str) -> String {
-    step_optional_string_input(step, key).unwrap_or_default()
-}
+    fn action_count(&self, kind: &str) -> usize {
+        self.steps(kind).count()
+    }
 
-fn step_optional_string_input(step: &PlanStep, key: &str) -> Option<String> {
-    step.inputs
-        .get(key)
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_string)
-}
+    fn would_mutate(&self) -> bool {
+        self.bool_policy("would_mutate").unwrap_or_else(|| {
+            sync_would_mutate_from_parts(
+                self.plan
+                    .inputs
+                    .get("target_exists")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(true),
+                self.usize_input("target_ahead"),
+                self.usize_input("target_behind"),
+                self.action_count(STACK_SYNC_DROP_KIND),
+                self.action_count(STACK_SYNC_REPLAY_KIND),
+            )
+        })
+    }
 
-fn step_u64_input(step: &PlanStep, key: &str) -> u64 {
-    step.inputs
-        .get(key)
-        .and_then(serde_json::Value::as_u64)
-        .unwrap_or_default()
+    fn blocked(&self) -> bool {
+        self.bool_policy("blocked").unwrap_or_else(|| {
+            self.plan
+                .summary
+                .as_ref()
+                .map(|summary| summary.blocked > 0)
+                .unwrap_or_else(|| {
+                    self.plan
+                        .steps
+                        .iter()
+                        .any(|step| step.blocking && step.status == PlanStepStatus::Missing)
+                })
+        })
+    }
+
+    fn steps(&self, kind: &'a str) -> impl Iterator<Item = &'a PlanStep> {
+        self.plan.steps.iter().filter(move |step| step.kind == kind)
+    }
+
+    fn bool_policy(&self, key: &str) -> Option<bool> {
+        self.plan
+            .policy
+            .get(key)
+            .and_then(serde_json::Value::as_bool)
+    }
+
+    fn usize_input(&self, key: &str) -> Option<usize> {
+        self.plan
+            .inputs
+            .get(key)
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|value| usize::try_from(value).ok())
+    }
+
+    fn string_input(&self, step: &PlanStep, key: &str) -> String {
+        self.optional_string_input(step, key).unwrap_or_default()
+    }
+
+    fn optional_string_input(&self, step: &PlanStep, key: &str) -> Option<String> {
+        step.inputs
+            .get(key)
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+    }
+
+    fn u64_input(&self, step: &PlanStep, key: &str) -> u64 {
+        step.inputs
+            .get(key)
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or_default()
+    }
 }
 
 /// Read-only preview for `homeboy stack diff`.
@@ -658,6 +675,20 @@ fn sync_output(
         picked_count,
         skipped_count,
         success: true,
+    }
+}
+
+fn record_uncertain<T>(
+    uncertain: &mut Vec<UncertainPr>,
+    pr: &StackPrEntry,
+    result: Result<T>,
+) -> Option<T> {
+    match result {
+        Ok(value) => Some(value),
+        Err(error) => {
+            uncertain.push(uncertain_pr(pr, error.to_string()));
+            None
+        }
     }
 }
 

--- a/src/core/stack/sync.rs
+++ b/src/core/stack/sync.rs
@@ -34,6 +34,10 @@ use std::collections::HashSet;
 use crate::core::error::{Error, Result};
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
 
+const STACK_SYNC_DROP_KIND: &str = "stack.sync.drop";
+const STACK_SYNC_REPLAY_KIND: &str = "stack.sync.replay";
+const STACK_SYNC_UNCERTAIN_KIND: &str = "stack.sync.uncertain";
+
 use super::apply::{
     checkout_force, cherry_pick, ensure_head_remote, fetch_remote_branch, fetch_sha, AppliedPr,
     CherryPickResult, PickOutcome,
@@ -248,27 +252,23 @@ pub(crate) fn plan_sync(spec: &StackSpec) -> Result<SyncPlan> {
         }
     }
 
-    let dropped_count = dropped.len();
-    let replayed_count = replayed.len();
-    let uncertain_count = uncertain.len();
-    let blocked = uncertain_count > 0;
-    let would_mutate = sync_would_mutate(
-        target_exists,
-        target_ahead,
-        target_behind,
-        dropped_count,
-        replayed_count,
-    );
-
     let plan = sync_homeboy_plan(
         spec,
         &dropped,
         &replayed,
         &uncertain,
         target_exists,
-        would_mutate,
-        blocked,
+        target_ahead,
+        target_behind,
     );
+    let dropped = sync_dropped_prs(&plan);
+    let replayed = sync_replayed_prs(&plan);
+    let uncertain = sync_uncertain_prs(&plan);
+    let dropped_count = sync_plan_action_count(&plan, STACK_SYNC_DROP_KIND);
+    let replayed_count = sync_plan_action_count(&plan, STACK_SYNC_REPLAY_KIND);
+    let uncertain_count = sync_plan_action_count(&plan, STACK_SYNC_UNCERTAIN_KIND);
+    let would_mutate = sync_plan_would_mutate(&plan);
+    let blocked = sync_plan_blocked(&plan);
 
     Ok(SyncPlan {
         preview: SyncPreview {
@@ -302,43 +302,108 @@ fn sync_homeboy_plan(
     replayed: &[ReplayedPr],
     uncertain: &[UncertainPr],
     target_exists: bool,
-    would_mutate: bool,
-    blocked: bool,
+    target_ahead: Option<usize>,
+    target_behind: Option<usize>,
 ) -> HomeboyPlan {
     let mut steps = Vec::new();
     for pr in dropped {
+        let mut inputs = PlanValues::new()
+            .string("repo", pr.repo.clone())
+            .number("number", pr.number)
+            .string("reason", pr.reason.clone());
+        if let Some(title) = &pr.title {
+            inputs = inputs.string("title", title.clone());
+        }
+        if let Some(merged_at) = &pr.merged_at {
+            inputs = inputs.string("merged_at", merged_at.clone());
+        }
+
         steps.push(sync_pr_step(
+            STACK_SYNC_DROP_KIND,
             "drop",
             &pr.repo,
             pr.number,
             PlanStepStatus::Skipped,
             &pr.reason,
+            inputs,
         ));
     }
     for pr in replayed {
+        let mut inputs = PlanValues::new()
+            .string("repo", pr.repo.clone())
+            .number("number", pr.number)
+            .string("sha", pr.sha.clone())
+            .string("reason", pr.reason.clone());
+        if let Some(title) = &pr.title {
+            inputs = inputs.string("title", title.clone());
+        }
+        if let Some(url) = &pr.url {
+            inputs = inputs.string("url", url.clone());
+        }
+        if let Some(upstream_state) = &pr.upstream_state {
+            inputs = inputs.string("upstream_state", upstream_state.clone());
+        }
+        if let Some(note) = &pr.note {
+            inputs = inputs.string("note", note.clone());
+        }
+
         steps.push(sync_pr_step(
+            STACK_SYNC_REPLAY_KIND,
             "replay",
             &pr.repo,
             pr.number,
             PlanStepStatus::Ready,
             &pr.reason,
+            inputs,
         ));
     }
     for pr in uncertain {
+        let mut inputs = PlanValues::new()
+            .string("repo", pr.repo.clone())
+            .number("number", pr.number)
+            .string("error", pr.error.clone())
+            .string("reason", pr.error.clone());
+        if let Some(note) = &pr.note {
+            inputs = inputs.string("note", note.clone());
+        }
+
         steps.push(sync_pr_step(
+            STACK_SYNC_UNCERTAIN_KIND,
             "uncertain",
             &pr.repo,
             pr.number,
             PlanStepStatus::Missing,
             &pr.error,
+            inputs,
         ));
     }
+
+    let dropped_count = steps
+        .iter()
+        .filter(|step| step.kind == STACK_SYNC_DROP_KIND)
+        .count();
+    let replayed_count = steps
+        .iter()
+        .filter(|step| step.kind == STACK_SYNC_REPLAY_KIND)
+        .count();
+    let blocked = steps
+        .iter()
+        .any(|step| step.blocking && step.status == PlanStepStatus::Missing);
+    let would_mutate = sync_would_mutate_from_parts(
+        target_exists,
+        target_ahead,
+        target_behind,
+        dropped_count,
+        replayed_count,
+    );
 
     HomeboyPlan::builder_for_description(PlanKind::StackSync, spec.id.clone())
         .inputs(
             PlanValues::new()
                 .string("stack_id", spec.id.clone())
-                .bool("target_exists", target_exists),
+                .bool("target_exists", target_exists)
+                .json("target_ahead", target_ahead)
+                .json("target_behind", target_behind),
         )
         .policy_value("would_mutate", serde_json::Value::Bool(would_mutate))
         .policy_value("blocked", serde_json::Value::Bool(blocked))
@@ -348,27 +413,134 @@ fn sync_homeboy_plan(
 }
 
 fn sync_pr_step(
+    kind: &str,
     action: &str,
     repo: &str,
     number: u64,
     status: PlanStepStatus,
     reason: &str,
+    inputs: PlanValues,
 ) -> PlanStep {
-    PlanStep::builder(
+    let builder = PlanStep::builder(
         format!("stack.sync.{action}.{repo}#{number}"),
-        format!("stack.sync.{action}"),
+        kind.to_string(),
         status.clone(),
     )
     .label(format!("{action} {repo}#{number}"))
     .blocking(status == PlanStepStatus::Missing)
     .scope(vec![format!("{repo}#{number}")])
-    .inputs(
-        PlanValues::new()
-            .string("repo", repo)
-            .number("number", number)
-            .string("reason", reason),
-    )
-    .build()
+    .inputs(inputs);
+
+    if status == PlanStepStatus::Skipped {
+        builder.skip_reason(reason.to_string()).build()
+    } else {
+        builder.build()
+    }
+}
+
+fn sync_dropped_prs(plan: &HomeboyPlan) -> Vec<DroppedPr> {
+    plan.steps
+        .iter()
+        .filter(|step| step.kind == STACK_SYNC_DROP_KIND)
+        .map(|step| DroppedPr {
+            repo: step_string_input(step, "repo"),
+            number: step_u64_input(step, "number"),
+            title: step_optional_string_input(step, "title"),
+            merged_at: step_optional_string_input(step, "merged_at"),
+            reason: step_string_input(step, "reason"),
+        })
+        .collect()
+}
+
+fn sync_replayed_prs(plan: &HomeboyPlan) -> Vec<ReplayedPr> {
+    plan.steps
+        .iter()
+        .filter(|step| step.kind == STACK_SYNC_REPLAY_KIND)
+        .map(|step| ReplayedPr {
+            repo: step_string_input(step, "repo"),
+            number: step_u64_input(step, "number"),
+            sha: step_string_input(step, "sha"),
+            title: step_optional_string_input(step, "title"),
+            url: step_optional_string_input(step, "url"),
+            upstream_state: step_optional_string_input(step, "upstream_state"),
+            note: step_optional_string_input(step, "note"),
+            reason: step_string_input(step, "reason"),
+        })
+        .collect()
+}
+
+fn sync_uncertain_prs(plan: &HomeboyPlan) -> Vec<UncertainPr> {
+    plan.steps
+        .iter()
+        .filter(|step| step.kind == STACK_SYNC_UNCERTAIN_KIND)
+        .map(|step| UncertainPr {
+            repo: step_string_input(step, "repo"),
+            number: step_u64_input(step, "number"),
+            note: step_optional_string_input(step, "note"),
+            error: step_string_input(step, "error"),
+        })
+        .collect()
+}
+
+fn sync_plan_action_count(plan: &HomeboyPlan, kind: &str) -> usize {
+    plan.steps.iter().filter(|step| step.kind == kind).count()
+}
+
+pub(crate) fn sync_plan_would_mutate(plan: &HomeboyPlan) -> bool {
+    plan_bool_policy(plan, "would_mutate").unwrap_or_else(|| {
+        sync_would_mutate_from_parts(
+            plan.inputs
+                .get("target_exists")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(true),
+            plan_usize_input(plan, "target_ahead"),
+            plan_usize_input(plan, "target_behind"),
+            sync_plan_action_count(plan, STACK_SYNC_DROP_KIND),
+            sync_plan_action_count(plan, STACK_SYNC_REPLAY_KIND),
+        )
+    })
+}
+
+pub(crate) fn sync_plan_blocked(plan: &HomeboyPlan) -> bool {
+    plan_bool_policy(plan, "blocked").unwrap_or_else(|| {
+        plan.summary
+            .as_ref()
+            .map(|summary| summary.blocked > 0)
+            .unwrap_or_else(|| {
+                plan.steps
+                    .iter()
+                    .any(|step| step.blocking && step.status == PlanStepStatus::Missing)
+            })
+    })
+}
+
+fn plan_bool_policy(plan: &HomeboyPlan, key: &str) -> Option<bool> {
+    plan.policy.get(key).and_then(serde_json::Value::as_bool)
+}
+
+fn plan_usize_input(plan: &HomeboyPlan, key: &str) -> Option<usize> {
+    plan.inputs
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+}
+
+fn step_string_input(step: &PlanStep, key: &str) -> String {
+    step_optional_string_input(step, key).unwrap_or_default()
+}
+
+fn step_optional_string_input(step: &PlanStep, key: &str) -> Option<String> {
+    step.inputs
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+fn step_u64_input(step: &PlanStep, key: &str) -> u64 {
+    step.inputs
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or_default()
 }
 
 /// Read-only preview for `homeboy stack diff`.
@@ -506,7 +678,7 @@ fn replay_reason(meta: &PrMeta) -> &'static str {
     }
 }
 
-pub(crate) fn sync_would_mutate(
+pub(crate) fn sync_would_mutate_from_parts(
     target_exists: bool,
     target_ahead: Option<usize>,
     target_behind: Option<usize>,

--- a/tests/core/rig/stack_test.rs
+++ b/tests/core/rig/stack_test.rs
@@ -43,9 +43,10 @@ fn rig_with_components(components: HashMap<String, ComponentSpec>) -> RigSpec {
 }
 
 fn sync_output(stack_id: &str, picked: usize, skipped: usize, dropped: usize) -> SyncOutput {
+    let would_mutate = picked > 0 || skipped > 0 || dropped > 0;
     SyncOutput {
         preview: SyncPreview {
-            plan: HomeboyPlan::for_description(PlanKind::StackSync, stack_id),
+            plan: stack_sync_plan(stack_id, would_mutate),
             stack_id: stack_id.to_string(),
             component_path: "/tmp/component".to_string(),
             branch: "dev/combined-fixes".to_string(),
@@ -60,7 +61,7 @@ fn sync_output(stack_id: &str, picked: usize, skipped: usize, dropped: usize) ->
             dropped_count: dropped,
             replayed_count: picked + skipped,
             uncertain_count: 0,
-            would_mutate: picked > 0 || dropped > 0,
+            would_mutate,
             blocked: false,
             success: true,
         },
@@ -70,6 +71,17 @@ fn sync_output(stack_id: &str, picked: usize, skipped: usize, dropped: usize) ->
         skipped_count: skipped,
         success: true,
     }
+}
+
+fn stack_sync_plan(stack_id: &str, would_mutate: bool) -> HomeboyPlan {
+    let mut plan = HomeboyPlan::for_description(PlanKind::StackSync, stack_id);
+    plan.policy.insert(
+        "would_mutate".to_string(),
+        serde_json::Value::Bool(would_mutate),
+    );
+    plan.policy
+        .insert("blocked".to_string(), serde_json::Value::Bool(false));
+    plan
 }
 
 fn stack_spec(id: &str, component_path: &str) -> StackSpec {
@@ -196,7 +208,7 @@ fn test_sync_entry_serializes_counts_and_refs() {
     let report = run_sync_with(&rig, false, |_component_id, stack_id, _dry_run| {
         Ok(SyncOutput {
             preview: SyncPreview {
-                plan: HomeboyPlan::for_description(PlanKind::StackSync, stack_id),
+                plan: stack_sync_plan(stack_id, true),
                 stack_id: stack_id.to_string(),
                 component_path: "/tmp/component".to_string(),
                 branch: "dev/combined-fixes".to_string(),

--- a/tests/core/stack/sync_test.rs
+++ b/tests/core/stack/sync_test.rs
@@ -11,7 +11,7 @@
 //! from the spec. The cherry-pick orchestration after that decision is
 //! the same machinery `apply` uses (already tested in `apply_test.rs`).
 
-use crate::core::stack::sync::{is_droppable, sync_would_mutate, PrMeta};
+use crate::core::stack::sync::{is_droppable, sync_would_mutate_from_parts, PrMeta};
 use std::fs;
 
 mod support;
@@ -173,7 +173,7 @@ fn is_droppable_state_check_is_case_sensitive() {
 #[test]
 fn sync_would_mutate_false_for_clean_materialized_target() {
     assert!(
-        !sync_would_mutate(true, Some(0), Some(0), 0, 0),
+        !sync_would_mutate_from_parts(true, Some(0), Some(0), 0, 0),
         "existing target at base with no drops or replays is a no-op"
     );
 }
@@ -181,7 +181,7 @@ fn sync_would_mutate_false_for_clean_materialized_target() {
 #[test]
 fn sync_would_mutate_true_when_target_missing() {
     assert!(
-        sync_would_mutate(false, None, None, 0, 0),
+        sync_would_mutate_from_parts(false, None, None, 0, 0),
         "sync would create the target branch"
     );
 }
@@ -189,11 +189,11 @@ fn sync_would_mutate_true_when_target_missing() {
 #[test]
 fn sync_would_mutate_true_when_target_diverged_from_base() {
     assert!(
-        sync_would_mutate(true, Some(1), Some(0), 0, 0),
+        sync_would_mutate_from_parts(true, Some(1), Some(0), 0, 0),
         "sync would drop target-only commits by recreating target from base"
     );
     assert!(
-        sync_would_mutate(true, Some(0), Some(1), 0, 0),
+        sync_would_mutate_from_parts(true, Some(0), Some(1), 0, 0),
         "sync would move target forward to the newer base"
     );
 }
@@ -201,11 +201,11 @@ fn sync_would_mutate_true_when_target_diverged_from_base() {
 #[test]
 fn sync_would_mutate_true_for_drop_or_replay_plan() {
     assert!(
-        sync_would_mutate(true, Some(0), Some(0), 1, 0),
+        sync_would_mutate_from_parts(true, Some(0), Some(0), 1, 0),
         "sync would mutate the stack spec by dropping merged PRs"
     );
     assert!(
-        sync_would_mutate(true, Some(0), Some(0), 0, 1),
+        sync_would_mutate_from_parts(true, Some(0), Some(0), 0, 1),
         "sync would replay PRs onto the rebuilt target"
     );
 }


### PR DESCRIPTION
## Summary
- Make stack sync build one authoritative `HomeboyPlan` for drop/replay/uncertain classification, then derive compatibility preview arrays, counts, `blocked`, and `would_mutate` from the plan.
- Reuse the stack sync plan in rig stack sync output and derive rig changed/no-op status from the plan policy.
- Preserve existing stable JSON preview fields while sourcing their values from plan steps/policy/summary.

Closes #2695.

## Tests
- `cargo test core::stack`
- `cargo test core::rig::stack`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the stack sync preview refactor, updated tests, and ran verification; Chris remains responsible for review and merge.