### PR TITLE
fix: derive trace run identity from plans

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -619,7 +619,7 @@ fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
     let run_order = plan_trace_run_order(repeat, args.schedule, &["run"]);
 
     for plan_entry in &run_order {
-        let index = plan_entry.index;
+        let index = plan_entry.index();
         let mut run_args = args.clone();
         run_args.repeat = 1;
         match execute_trace_run(run_args) {
@@ -755,9 +755,9 @@ fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
         run_order: run_order
             .into_iter()
             .map(|entry| extension_trace::TraceRunOrderEntryOutput {
-                index: entry.index,
-                group: entry.group,
-                iteration: entry.iteration,
+                index: entry.index(),
+                group: entry.group().to_string(),
+                iteration: entry.iteration(),
             })
             .collect(),
         rig_state,

--- a/src/commands/trace/compare_variant.rs
+++ b/src/commands/trace/compare_variant.rs
@@ -139,14 +139,14 @@ fn run_compare_variant_pair(
     let mut variant = TraceCompareVariantAggregateBuilder::new("variant", &args);
 
     for entry in &plan {
-        let mut run_args = if entry.group == "baseline" {
+        let mut run_args = if entry.group() == "baseline" {
             baseline_args.clone()
         } else {
             args.clone()
         };
         run_args.repeat = 1;
         let single = run_repeat_output(run_args)?;
-        if entry.group == "baseline" {
+        if entry.group() == "baseline" {
             baseline.push(entry, single);
         } else {
             variant.push(entry, single);
@@ -164,9 +164,9 @@ fn trace_run_order_entry_output(
     entry: TraceRunPlanEntry,
 ) -> extension_trace::TraceRunOrderEntryOutput {
     extension_trace::TraceRunOrderEntryOutput {
-        index: entry.index,
-        group: entry.group,
-        iteration: entry.iteration,
+        index: entry.index(),
+        group: entry.group().to_string(),
+        iteration: entry.iteration(),
     }
 }
 
@@ -215,13 +215,13 @@ impl TraceCompareVariantAggregateBuilder {
         self.guardrails.extend(aggregate.guardrails.clone());
         self.run_order
             .push(extension_trace::TraceRunOrderEntryOutput {
-                index: plan.index,
+                index: plan.index(),
                 group: self.group.to_string(),
-                iteration: plan.iteration,
+                iteration: plan.iteration(),
             });
 
         for mut run in aggregate.runs {
-            run.index = plan.index;
+            run.index = plan.index();
             self.runs.push(run);
         }
 
@@ -231,7 +231,7 @@ impl TraceCompareVariantAggregateBuilder {
                 self.span_samples.entry(span.id.clone()).or_default().push(
                     TraceAggregateSpanSample {
                         duration_ms: duration,
-                        run_index: plan.index,
+                        run_index: plan.index(),
                         artifact_path: span.max_artifact_path.clone().unwrap_or_default(),
                     },
                 );

--- a/src/commands/trace/experiment.rs
+++ b/src/commands/trace/experiment.rs
@@ -12,9 +12,31 @@ use super::{TraceArgs, TraceRigContext};
 
 pub(super) struct TraceExperimentRunPlan<'a> {
     plan: HomeboyPlan,
-    name: String,
+    execution: TraceExperimentExecutionContext<'a>,
+}
+
+struct TraceExperimentExecutionContext<'a> {
     spec: &'a rig::TraceExperimentSpec,
     context: &'a TraceRigContext,
+}
+
+impl TraceExperimentRunPlan<'_> {
+    fn experiment_name(&self) -> &str {
+        self.plan
+            .inputs
+            .get("experiment")
+            .and_then(|value| value.as_str())
+            .expect("trace experiment plan missing experiment input")
+    }
+
+    fn phase_steps(&self, phase: &str) -> Vec<&PlanStep> {
+        let kind = format!("trace.experiment.{phase}");
+        self.plan
+            .steps
+            .iter()
+            .filter(|step| step.kind == kind && trace_experiment_step_phase(step) == Some(phase))
+            .collect()
+    }
 }
 
 pub(super) fn trace_experiment_plan_for_args<'a>(
@@ -62,9 +84,10 @@ pub(super) fn trace_experiment_plan_for_args<'a>(
         })?;
     Ok(Some(TraceExperimentRunPlan {
         plan: trace_experiment_plan(&context.rig_spec.id, name, experiment),
-        name: name.to_string(),
-        spec: experiment,
-        context,
+        execution: TraceExperimentExecutionContext {
+            spec: experiment,
+            context,
+        },
     }))
 }
 
@@ -111,6 +134,7 @@ fn trace_experiment_step(phase: &str, name: &str, index: usize, command: &str) -
     .inputs(
         PlanValues::new()
             .string("experiment", name)
+            .number("index", index as u64)
             .string("phase", phase)
             .string("command", command),
     )
@@ -123,7 +147,8 @@ pub(super) fn trace_experiment_settings(
     let Some(plan) = plan else {
         return Ok(Vec::new());
     };
-    plan.spec
+    plan.execution
+        .spec
         .settings
         .iter()
         .map(|(key, value)| {
@@ -131,7 +156,7 @@ pub(super) fn trace_experiment_settings(
                 key.clone(),
                 match value {
                     serde_json::Value::String(value) => serde_json::Value::String(
-                        resolve_trace_experiment_string(plan.context, value),
+                        resolve_trace_experiment_string(plan.execution.context, value),
                     ),
                     other => other.clone(),
                 },
@@ -146,13 +171,14 @@ pub(super) fn trace_experiment_env(
     let Some(plan) = plan else {
         return Ok(Vec::new());
     };
-    plan.spec
+    plan.execution
+        .spec
         .env
         .iter()
         .map(|(key, value)| {
             Ok((
                 key.clone(),
-                resolve_trace_experiment_string(plan.context, value),
+                resolve_trace_experiment_string(plan.execution.context, value),
             ))
         })
         .collect()
@@ -165,13 +191,12 @@ pub(super) fn run_trace_experiment_setup_for_plan(
     let Some(plan) = plan else {
         return Ok(());
     };
-    validate_trace_experiment_plan_phase(&plan.plan, &plan.name, "setup", plan.spec.setup.len())?;
+    validate_trace_experiment_plan_phase(plan, "setup", plan.execution.spec.setup.len())?;
     run_trace_experiment_commands(
-        plan.context,
-        &plan.name,
+        plan,
         "setup",
-        &plan.spec.setup,
-        &plan.spec.env,
+        &plan.execution.spec.setup,
+        &plan.execution.spec.env,
         run_dir,
     )
 }
@@ -183,56 +208,47 @@ pub(super) fn run_trace_experiment_teardown_for_plan(
     let Some(plan) = plan else {
         return Ok(());
     };
-    validate_trace_experiment_plan_phase(
-        &plan.plan,
-        &plan.name,
-        "teardown",
-        plan.spec.teardown.len(),
-    )?;
+    validate_trace_experiment_plan_phase(plan, "teardown", plan.execution.spec.teardown.len())?;
     run_trace_experiment_commands(
-        plan.context,
-        &plan.name,
+        plan,
         "teardown",
-        &plan.spec.teardown,
-        &plan.spec.env,
+        &plan.execution.spec.teardown,
+        &plan.execution.spec.env,
         run_dir,
     )
 }
 
 fn validate_trace_experiment_plan_phase(
-    plan: &HomeboyPlan,
-    experiment_name: &str,
+    plan: &TraceExperimentRunPlan,
     phase: &str,
     command_count: usize,
 ) -> homeboy::core::Result<()> {
-    let planned_count = plan
-        .steps
-        .iter()
-        .filter(|step| {
-            step.kind == format!("trace.experiment.{phase}")
-                && step.inputs.get("phase").and_then(|value| value.as_str()) == Some(phase)
-        })
-        .count();
+    let planned_count = plan.phase_steps(phase).len();
     if planned_count == command_count {
         return Ok(());
     }
 
     Err(homeboy::core::Error::internal_unexpected(format!(
         "trace experiment '{}' {} plan has {} steps for {} commands",
-        experiment_name, phase, planned_count, command_count
+        plan.experiment_name(),
+        phase,
+        planned_count,
+        command_count
     )))
 }
 
 fn run_trace_experiment_commands(
-    context: &TraceRigContext,
-    experiment_name: &str,
+    plan: &TraceExperimentRunPlan,
     phase: &str,
     commands: &[rig::TraceExperimentCommandSpec],
     experiment_env: &BTreeMap<String, String>,
     run_dir: &RunDir,
 ) -> homeboy::core::Result<()> {
-    for command_spec in commands {
-        let command_text = resolve_trace_experiment_string(context, &command_spec.command);
+    let context = plan.execution.context;
+    let experiment_name = plan.experiment_name();
+    for (step, command_spec) in plan.phase_steps(phase).into_iter().zip(commands) {
+        let command_text =
+            resolve_trace_experiment_string(context, trace_experiment_step_command(step));
         let mut command = Command::new(trace_experiment_shell());
         command.arg("-c").arg(&command_text);
         command.env("HOMEBOY_TRACE_EXPERIMENT", experiment_name);
@@ -287,7 +303,24 @@ pub(super) fn collect_trace_experiment_artifacts_for_plan(
     let Some(plan) = plan else {
         return Ok(());
     };
-    collect_trace_experiment_artifacts(plan.context, &plan.name, plan.spec, run_dir, workflow)
+    collect_trace_experiment_artifacts(
+        plan.execution.context,
+        plan.experiment_name(),
+        plan.execution.spec,
+        run_dir,
+        workflow,
+    )
+}
+
+fn trace_experiment_step_phase(step: &PlanStep) -> Option<&str> {
+    step.inputs.get("phase").and_then(|value| value.as_str())
+}
+
+fn trace_experiment_step_command(step: &PlanStep) -> &str {
+    step.inputs
+        .get("command")
+        .and_then(|value| value.as_str())
+        .expect("trace experiment plan step missing command input")
 }
 
 fn collect_trace_experiment_artifacts(

--- a/src/commands/trace/schedule.rs
+++ b/src/commands/trace/schedule.rs
@@ -20,9 +20,26 @@ impl TraceSchedule {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct TraceRunPlanEntry {
     pub(super) plan: HomeboyPlan,
-    pub(super) index: usize,
-    pub(super) group: String,
-    pub(super) iteration: usize,
+}
+
+impl TraceRunPlanEntry {
+    fn new(index: usize, group: &str, iteration: usize) -> Self {
+        Self {
+            plan: trace_run_entry_plan(index, group, iteration),
+        }
+    }
+
+    pub(super) fn index(&self) -> usize {
+        plan_usize_input(&self.plan, "index")
+    }
+
+    pub(super) fn group(&self) -> &str {
+        plan_str_input(&self.plan, "group")
+    }
+
+    pub(super) fn iteration(&self) -> usize {
+        plan_usize_input(&self.plan, "iteration")
+    }
 }
 
 pub(crate) fn plan_trace_run_order(
@@ -32,12 +49,7 @@ pub(crate) fn plan_trace_run_order(
 ) -> Vec<TraceRunPlanEntry> {
     let mut entries = Vec::new();
     let mut push_entry = |group: &str, iteration: usize| {
-        entries.push(TraceRunPlanEntry {
-            plan: trace_run_entry_plan(entries.len() + 1, group, iteration),
-            index: entries.len() + 1,
-            group: group.to_string(),
-            iteration,
-        });
+        entries.push(TraceRunPlanEntry::new(entries.len() + 1, group, iteration));
     };
     match schedule {
         TraceSchedule::Grouped => {
@@ -60,6 +72,7 @@ pub(crate) fn plan_trace_run_order(
 
 fn trace_run_entry_plan(index: usize, group: &str, iteration: usize) -> HomeboyPlan {
     let inputs = PlanValues::new()
+        .number("index", index as u64)
         .string("group", group)
         .number("iteration", iteration as u64);
 
@@ -76,6 +89,21 @@ fn trace_run_entry_plan(index: usize, group: &str, iteration: usize) -> HomeboyP
         .build()])
         .summarize()
         .build()
+}
+
+fn plan_usize_input(plan: &HomeboyPlan, key: &str) -> usize {
+    plan.inputs
+        .get(key)
+        .and_then(|value| value.as_u64())
+        .and_then(|value| usize::try_from(value).ok())
+        .unwrap_or_else(|| panic!("trace plan missing numeric {key}"))
+}
+
+fn plan_str_input<'a>(plan: &'a HomeboyPlan, key: &str) -> &'a str {
+    plan.inputs
+        .get(key)
+        .and_then(|value| value.as_str())
+        .unwrap_or_else(|| panic!("trace plan missing string {key}"))
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, ValueEnum)]

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -759,7 +759,7 @@ fn trace_run_order_planner_supports_grouped_and_interleaved_variants() {
     assert_eq!(
         grouped
             .iter()
-            .map(|entry| (entry.index, entry.group.as_str(), entry.iteration))
+            .map(|entry| (entry.index(), entry.group(), entry.iteration()))
             .collect::<Vec<_>>(),
         vec![
             (1, "baseline", 1),
@@ -773,7 +773,7 @@ fn trace_run_order_planner_supports_grouped_and_interleaved_variants() {
     assert_eq!(
         interleaved
             .iter()
-            .map(|entry| (entry.index, entry.group.as_str(), entry.iteration))
+            .map(|entry| (entry.index(), entry.group(), entry.iteration()))
             .collect::<Vec<_>>(),
         vec![
             (1, "baseline", 1),


### PR DESCRIPTION
## Summary
- Derive trace run `index`, `group`, and `iteration` from each `TraceRunPlanEntry`'s `HomeboyPlan` instead of storing duplicate authoritative wrapper fields.
- Route trace repeat and compare-variant run-order/output construction through plan-derived accessors.
- Keep trace experiment metadata on the serialized plan while isolating rig spec/context as execution-only state.

Closes #2697.

## Tests
- `cargo test trace --lib`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the trace planning normalization, updated call sites/tests, and ran local verification. Chris remains responsible for review and merge.