### PR TITLE
fix: reduce intra-method duplicate blocks

### DIFF
--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -18,7 +18,8 @@
 use std::fmt::Write as _;
 
 use homeboy::core::ci_profile::CiRunOutput;
-use homeboy::core::code_audit::{AuditCommandOutput, AuditFinding, Severity};
+use homeboy::core::code_audit::report::AuditSummaryFinding;
+use homeboy::core::code_audit::{AuditCommandOutput, AuditFinding, Finding, Severity};
 use homeboy::core::extension::lint::LintCommandOutput;
 use homeboy::core::extension::test::{FailedTest, TestCommandOutput};
 use homeboy::core::top_n::top_n_by;
@@ -234,42 +235,44 @@ struct AuditFindingLine {
     suggestion: String,
 }
 
+impl From<&Finding> for AuditFindingLine {
+    fn from(finding: &Finding) -> Self {
+        Self {
+            file: finding.file.clone(),
+            kind: finding.kind.clone(),
+            severity: finding.severity.clone(),
+            description: finding.description.clone(),
+            suggestion: finding.suggestion.clone(),
+        }
+    }
+}
+
+impl From<&AuditSummaryFinding> for AuditFindingLine {
+    fn from(finding: &AuditSummaryFinding) -> Self {
+        Self {
+            file: finding.file.clone(),
+            kind: finding.kind.clone(),
+            severity: finding.severity.clone(),
+            description: finding.description.clone(),
+            suggestion: finding.suggestion.clone(),
+        }
+    }
+}
+
 /// Pull actionable audit finding details. PR comments should answer "where and
 /// why?" without forcing the reviewer to run the deep-dive command first.
 fn audit_findings(output: &AuditCommandOutput) -> Vec<AuditFindingLine> {
     match output {
-        AuditCommandOutput::Full { result, .. } => result
-            .findings
-            .iter()
-            .map(|f| AuditFindingLine {
-                file: f.file.clone(),
-                kind: f.kind.clone(),
-                severity: f.severity.clone(),
-                description: f.description.clone(),
-                suggestion: f.suggestion.clone(),
-            })
-            .collect(),
-        AuditCommandOutput::Compared { result, .. } => result
-            .findings
-            .iter()
-            .map(|f| AuditFindingLine {
-                file: f.file.clone(),
-                kind: f.kind.clone(),
-                severity: f.severity.clone(),
-                description: f.description.clone(),
-                suggestion: f.suggestion.clone(),
-            })
-            .collect(),
+        AuditCommandOutput::Full { result, .. } => {
+            result.findings.iter().map(AuditFindingLine::from).collect()
+        }
+        AuditCommandOutput::Compared { result, .. } => {
+            result.findings.iter().map(AuditFindingLine::from).collect()
+        }
         AuditCommandOutput::Summary(summary) => summary
             .top_findings
             .iter()
-            .map(|f| AuditFindingLine {
-                file: f.file.clone(),
-                kind: f.kind.clone(),
-                severity: f.severity.clone(),
-                description: f.description.clone(),
-                suggestion: f.suggestion.clone(),
-            })
+            .map(AuditFindingLine::from)
             .collect(),
         AuditCommandOutput::BaselineSaved { .. } => Vec::new(),
         AuditCommandOutput::Conventions { .. } => Vec::new(),

--- a/src/commands/runs/remote_artifact.rs
+++ b/src/commands/runs/remote_artifact.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 
 use homeboy::core::observation::ArtifactRecord;
@@ -153,24 +154,8 @@ fn collect_runner_download_cleanup(
 
     if metadata.is_dir() && !metadata.file_type().is_symlink() {
         plan.directory_count += usize::from(path != root);
-        for entry in fs::read_dir(path).map_err(|err| {
-            crate::core::Error::internal_io(
-                err.to_string(),
-                Some(format!(
-                    "read runner artifact cache directory {}",
-                    path.display()
-                )),
-            )
-        })? {
-            let entry = entry.map_err(|err| {
-                crate::core::Error::internal_io(
-                    err.to_string(),
-                    Some(format!(
-                        "read runner artifact cache directory {}",
-                        path.display()
-                    )),
-                )
-            })?;
+        for entry in fs::read_dir(path).map_err(|err| runner_cache_directory_error(path, err))? {
+            let entry = entry.map_err(|err| runner_cache_directory_error(path, err))?;
             collect_runner_download_cleanup(root, &entry.path(), plan)?;
         }
     } else {
@@ -179,6 +164,16 @@ fn collect_runner_download_cleanup(
     }
 
     Ok(())
+}
+
+fn runner_cache_directory_error(path: &Path, err: io::Error) -> crate::core::Error {
+    crate::core::Error::internal_io(
+        err.to_string(),
+        Some(format!(
+            "read runner artifact cache directory {}",
+            path.display()
+        )),
+    )
 }
 
 fn remove_runner_download_root(root: &Path) -> crate::core::Result<()> {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -365,24 +365,10 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
                     if d.is_behind() {
                         ProjectComponentDashboardStatus::BehindUpstream
                     } else {
-                        // Not behind upstream — check deployed version
-                        match (&local_ver, &remote_ver) {
-                            (Some(local), Some(remote)) if local != remote => {
-                                ProjectComponentDashboardStatus::Outdated
-                            }
-                            (Some(_), None) => ProjectComponentDashboardStatus::Outdated,
-                            _ => ProjectComponentDashboardStatus::Current,
-                        }
+                        deployed_version_dashboard_status(&local_ver, &remote_ver)
                     }
                 } else {
-                    // No upstream data — check deployed version
-                    match (&local_ver, &remote_ver) {
-                        (Some(local), Some(remote)) if local != remote => {
-                            ProjectComponentDashboardStatus::Outdated
-                        }
-                        (Some(_), None) => ProjectComponentDashboardStatus::Outdated,
-                        _ => ProjectComponentDashboardStatus::Current,
-                    }
+                    deployed_version_dashboard_status(&local_ver, &remote_ver)
                 }
             }
             ReleaseStateStatus::Unknown => ProjectComponentDashboardStatus::Unknown,
@@ -442,6 +428,17 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
         }),
         0,
     ))
+}
+
+fn deployed_version_dashboard_status(
+    local_ver: &Option<String>,
+    remote_ver: &Option<String>,
+) -> ProjectComponentDashboardStatus {
+    match (local_ver, remote_ver) {
+        (Some(local), Some(remote)) if local != remote => ProjectComponentDashboardStatus::Outdated,
+        (Some(_), None) => ProjectComponentDashboardStatus::Outdated,
+        _ => ProjectComponentDashboardStatus::Current,
+    }
 }
 
 /// Fetch from origin and compute upstream drift for a component.
@@ -540,59 +537,35 @@ fn log_dashboard_table(rows: &[ProjectStatusRow]) {
     }
 
     // Calculate column widths
-    let id_width = rows
-        .iter()
-        .map(|r| r.component_id.len())
-        .max()
-        .unwrap_or(9)
-        .max(9);
-    let local_width = rows
-        .iter()
-        .map(|r| r.local_version.as_deref().unwrap_or("-").len())
-        .max()
-        .unwrap_or(5)
-        .max(5);
-    let remote_width = rows
-        .iter()
-        .map(|r| r.remote_version.as_deref().unwrap_or("-").len())
-        .max()
-        .unwrap_or(6)
-        .max(6);
-    let origin_width = rows
-        .iter()
-        .map(|r| r.origin_version.as_deref().unwrap_or("-").len())
-        .max()
-        .unwrap_or(6)
-        .max(6);
+    let widths = DashboardColumnWidths {
+        id: rows
+            .iter()
+            .map(|r| r.component_id.len())
+            .max()
+            .unwrap_or(9)
+            .max(9),
+        local: rows
+            .iter()
+            .map(|r| r.local_version.as_deref().unwrap_or("-").len())
+            .max()
+            .unwrap_or(5)
+            .max(5),
+        remote: rows
+            .iter()
+            .map(|r| r.remote_version.as_deref().unwrap_or("-").len())
+            .max()
+            .unwrap_or(6)
+            .max(6),
+        origin: rows
+            .iter()
+            .map(|r| r.origin_version.as_deref().unwrap_or("-").len())
+            .max()
+            .unwrap_or(6)
+            .max(6),
+    };
 
-    // Header
-    eprintln!(
-        "{:<id_w$}  {:<local_w$}  {:<remote_w$}  {:<origin_w$}  {:>10}  {:>8}  Status",
-        "Component",
-        "Local",
-        "Remote",
-        "Origin",
-        "Unreleased",
-        "Upstream",
-        id_w = id_width,
-        local_w = local_width,
-        remote_w = remote_width,
-        origin_w = origin_width,
-    );
-    eprintln!(
-        "{:-<id_w$}  {:-<local_w$}  {:-<remote_w$}  {:-<origin_w$}  {:->10}  {:->8}  {:-<10}",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        id_w = id_width,
-        local_w = local_width,
-        remote_w = remote_width,
-        origin_w = origin_width,
-    );
+    log_dashboard_header(&widths);
+    log_dashboard_separator(&widths);
 
     for row in rows {
         let local = row.local_version.as_deref().unwrap_or("-");
@@ -618,12 +591,52 @@ fn log_dashboard_table(rows: &[ProjectStatusRow]) {
             row.unreleased_commits,
             upstream,
             status_icon,
-            id_w = id_width,
-            local_w = local_width,
-            remote_w = remote_width,
-            origin_w = origin_width,
+            id_w = widths.id,
+            local_w = widths.local,
+            remote_w = widths.remote,
+            origin_w = widths.origin,
         );
     }
+}
+
+struct DashboardColumnWidths {
+    id: usize,
+    local: usize,
+    remote: usize,
+    origin: usize,
+}
+
+fn log_dashboard_header(widths: &DashboardColumnWidths) {
+    eprintln!(
+        "{:<id_w$}  {:<local_w$}  {:<remote_w$}  {:<origin_w$}  {:>10}  {:>8}  Status",
+        "Component",
+        "Local",
+        "Remote",
+        "Origin",
+        "Unreleased",
+        "Upstream",
+        id_w = widths.id,
+        local_w = widths.local,
+        remote_w = widths.remote,
+        origin_w = widths.origin,
+    );
+}
+
+fn log_dashboard_separator(widths: &DashboardColumnWidths) {
+    eprintln!(
+        "{:-<id_w$}  {:-<local_w$}  {:-<remote_w$}  {:-<origin_w$}  {:->10}  {:->8}  {:-<10}",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        id_w = widths.id,
+        local_w = widths.local,
+        remote_w = widths.remote,
+        origin_w = widths.origin,
+    );
 }
 
 /// Format upstream ahead/behind as a compact string like "↓3" or "↑1↓2" or "=".

--- a/src/core/fleet/exec.rs
+++ b/src/core/fleet/exec.rs
@@ -84,16 +84,14 @@ pub fn collect_exec(
         }) {
             Ok(r) => r,
             Err(e) => {
-                summary.failed += 1;
-                results.push(FleetExecProjectResult {
-                    project_id: proj.id.clone(),
-                    server_id: server_id.clone(),
-                    base_path: proj.base_path.clone(),
-                    command: command_string.clone(),
-                    status: "failed".to_string(),
-                    error: Some(e.to_string()),
-                    ..Default::default()
-                });
+                record_failed_project_result(
+                    &mut results,
+                    &mut summary,
+                    proj,
+                    &server_id,
+                    &command_string,
+                    &e,
+                );
                 continue;
             }
         };
@@ -102,16 +100,14 @@ pub fn collect_exec(
             match SshClient::from_server(&resolve_result.server, &resolve_result.server_id) {
                 Ok(c) => c,
                 Err(e) => {
-                    summary.failed += 1;
-                    results.push(FleetExecProjectResult {
-                        project_id: proj.id.clone(),
-                        server_id: server_id.clone(),
-                        base_path: proj.base_path.clone(),
-                        command: command_string.clone(),
-                        status: "failed".to_string(),
-                        error: Some(e.to_string()),
-                        ..Default::default()
-                    });
+                    record_failed_project_result(
+                        &mut results,
+                        &mut summary,
+                        proj,
+                        &server_id,
+                        &command_string,
+                        &e,
+                    );
                     continue;
                 }
             };
@@ -163,4 +159,33 @@ fn planned_command(project: &Project, command_string: &str) -> String {
         Some(bp) => format!("cd {} && {}", shell::quote_path(bp), command_string),
         None => command_string.to_string(),
     }
+}
+
+fn failed_project_result(
+    project: &Project,
+    server_id: &Option<String>,
+    command: &str,
+    error: &crate::core::Error,
+) -> FleetExecProjectResult {
+    FleetExecProjectResult {
+        project_id: project.id.clone(),
+        server_id: server_id.clone(),
+        base_path: project.base_path.clone(),
+        command: command.to_string(),
+        status: "failed".to_string(),
+        error: Some(error.to_string()),
+        ..Default::default()
+    }
+}
+
+fn record_failed_project_result(
+    results: &mut Vec<FleetExecProjectResult>,
+    summary: &mut FleetExecSummary,
+    project: &Project,
+    server_id: &Option<String>,
+    command: &str,
+    error: &crate::core::Error,
+) {
+    summary.failed += 1;
+    results.push(failed_project_result(project, server_id, command, error));
 }


### PR DESCRIPTION
## Summary
- Extract shared audit finding conversion, runner cache directory error mapping, dashboard version status selection, dashboard table header/separator formatting, and fleet exec failure result recording.
- Keeps the cleanup mechanical and local to the high-confidence duplicate blocks called out in #2703.

## Verification
- `cargo check`
- `cargo test commands::review::render::tests`
- `cargo test commands::runs::remote_artifact::tests`
- `cargo test commands::status::tests`
- `cargo test core::fleet::tests`
- `homeboy audit homeboy --only intra_method_duplicate --json-summary --force-hot` reduced findings from 28 to 23 in this worktree

Closes #2703

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the mechanical duplicate-block cleanup and ran targeted verification; Chris remains responsible for review and merge.