### PR TITLE
fix: share rig json config loaders

### DIFF
--- a/src/core/rig/json_config.rs
+++ b/src/core/rig/json_config.rs
@@ -1,0 +1,101 @@
+use crate::core::error::{Error, Result};
+use serde::de::DeserializeOwned;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub(crate) struct JsonConfigEntry {
+    pub(crate) id: String,
+    pub(crate) path: PathBuf,
+}
+
+#[derive(Debug)]
+pub(crate) struct ParsedJsonConfig<T> {
+    pub(crate) id: String,
+    pub(crate) value: T,
+}
+
+#[derive(Debug)]
+pub(crate) struct InvalidJsonConfig {
+    pub(crate) id: String,
+    pub(crate) path: PathBuf,
+    pub(crate) error: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct ParsedJsonConfigs<T> {
+    pub(crate) valid: Vec<ParsedJsonConfig<T>>,
+    pub(crate) invalid: Vec<InvalidJsonConfig>,
+}
+
+pub(crate) fn sorted_json_config_entries(
+    dir: &Path,
+    read_dir_context: &'static str,
+    read_entry_context: &'static str,
+    map_error: impl Fn(std::io::Error, &'static str) -> Error,
+) -> Result<Vec<JsonConfigEntry>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(dir).map_err(|e| map_error(e, read_dir_context))? {
+        let entry = entry.map_err(|e| map_error(e, read_entry_context))?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(id) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        entries.push(JsonConfigEntry {
+            id: id.to_string(),
+            path,
+        });
+    }
+    entries.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(entries)
+}
+
+pub(crate) fn read_json_configs<T>(
+    dir: &Path,
+    read_dir_context: &'static str,
+    read_entry_context: &'static str,
+) -> Result<ParsedJsonConfigs<T>>
+where
+    T: DeserializeOwned,
+{
+    let mut valid = Vec::new();
+    let mut invalid = Vec::new();
+    for entry in
+        sorted_json_config_entries(dir, read_dir_context, read_entry_context, |e, context| {
+            Error::internal_io(e.to_string(), Some(context.into()))
+        })?
+    {
+        let content = match fs::read_to_string(&entry.path) {
+            Ok(content) => content,
+            Err(err) => {
+                invalid.push(InvalidJsonConfig {
+                    id: entry.id,
+                    path: entry.path,
+                    error: err.to_string(),
+                });
+                continue;
+            }
+        };
+
+        match serde_json::from_str::<T>(&content) {
+            Ok(value) => valid.push(ParsedJsonConfig {
+                id: entry.id,
+                value,
+            }),
+            Err(err) => invalid.push(InvalidJsonConfig {
+                id: entry.id,
+                path: entry.path,
+                error: err.to_string(),
+            }),
+        }
+    }
+    invalid.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(ParsedJsonConfigs { valid, invalid })
+}

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -21,6 +21,7 @@ pub mod app;
 pub mod check;
 pub mod expand;
 pub mod install;
+mod json_config;
 pub mod lease;
 pub mod pipeline;
 pub mod runner;
@@ -122,28 +123,17 @@ pub fn declared_id(id: &str) -> Result<Option<String>> {
 /// List all rig specs in `~/.config/homeboy/rigs/`.
 pub fn list() -> Result<Vec<RigSpec>> {
     let dir = paths::rigs()?;
-    if !dir.exists() {
-        return Ok(Vec::new());
-    }
     let mut rigs = Vec::new();
-    for entry in fs::read_dir(&dir)
-        .map_err(|e| Error::internal_unexpected(format!("Failed to list rigs: {}", e)))?
-    {
-        let entry = entry
-            .map_err(|e| Error::internal_unexpected(format!("Failed to read rig entry: {}", e)))?;
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
-            continue;
-        }
-        let stem = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(s) => s.to_string(),
-            None => continue,
-        };
-        if let Ok(spec) = load(&stem) {
+    for entry in json_config::sorted_json_config_entries(
+        &dir,
+        "list rigs",
+        "read rig entry",
+        |e, context| Error::internal_unexpected(format!("Failed to {}: {}", context, e)),
+    )? {
+        if let Ok(spec) = load(&entry.id) {
             rigs.push(spec);
         }
     }
-    rigs.sort_by(|a, b| a.id.cmp(&b.id));
     Ok(rigs)
 }
 
@@ -151,23 +141,8 @@ pub fn list() -> Result<Vec<RigSpec>> {
 /// e.g. for error suggestions).
 pub fn list_ids() -> Result<Vec<String>> {
     let dir = paths::rigs()?;
-    if !dir.exists() {
-        return Ok(Vec::new());
-    }
-    let mut ids = Vec::new();
-    for entry in fs::read_dir(&dir)
-        .map_err(|e| Error::internal_unexpected(format!("Failed to list rigs: {}", e)))?
-    {
-        let entry = entry
-            .map_err(|e| Error::internal_unexpected(format!("Failed to read rig entry: {}", e)))?;
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
-            continue;
-        }
-        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-            ids.push(stem.to_string());
-        }
-    }
-    ids.sort();
-    Ok(ids)
+    json_config::sorted_json_config_entries(&dir, "list rigs", "read rig entry", |e, context| {
+        Error::internal_unexpected(format!("Failed to {}: {}", context, e))
+    })
+    .map(|entries| entries.into_iter().map(|entry| entry.id).collect())
 }

--- a/src/core/rig/source.rs
+++ b/src/core/rig/source.rs
@@ -358,53 +358,26 @@ struct StackSourceEntry {
 
 fn read_source_entries() -> Result<SourceEntries> {
     let dir = paths::rig_sources()?;
-    let mut invalid = Vec::new();
-    if !dir.exists() {
-        let valid_stacks = read_stack_source_entries(&mut invalid)?;
-        return Ok(SourceEntries {
-            valid: Vec::new(),
-            valid_stacks,
-            invalid,
-        });
-    }
-
-    let mut valid = Vec::new();
-    for entry in fs::read_dir(&dir)
-        .map_err(|e| Error::internal_io(e.to_string(), Some("read rig sources dir".into())))?
-    {
-        let entry = entry
-            .map_err(|e| Error::internal_io(e.to_string(), Some("read rig source entry".into())))?;
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
-            continue;
-        }
-        let id = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(id) => id.to_string(),
-            None => continue,
-        };
-        let content = match fs::read_to_string(&path) {
-            Ok(content) => content,
-            Err(err) => {
-                invalid.push(InvalidRigSourceMetadata {
-                    id,
-                    metadata_path: path.to_string_lossy().to_string(),
-                    error: err.to_string(),
-                });
-                continue;
-            }
-        };
-        match serde_json::from_str::<RigSourceMetadata>(&content) {
-            Ok(metadata) => valid.push(RigSourceEntry { id, metadata }),
-            Err(err) => invalid.push(InvalidRigSourceMetadata {
-                id,
-                metadata_path: path.to_string_lossy().to_string(),
-                error: err.to_string(),
-            }),
-        }
-    }
+    let rig_entries = super::json_config::read_json_configs::<RigSourceMetadata>(
+        &dir,
+        "read rig sources dir",
+        "read rig source entry",
+    )?;
+    let mut invalid = rig_entries
+        .invalid
+        .into_iter()
+        .map(invalid_source_metadata)
+        .collect::<Vec<_>>();
+    let valid = rig_entries
+        .valid
+        .into_iter()
+        .map(|entry| RigSourceEntry {
+            id: entry.id,
+            metadata: entry.value,
+        })
+        .collect::<Vec<_>>();
 
     let valid_stacks = read_stack_source_entries(&mut invalid)?;
-    valid.sort_by(|a, b| a.id.cmp(&b.id));
     invalid.sort_by(|a, b| a.id.cmp(&b.id));
     Ok(SourceEntries {
         valid,
@@ -417,47 +390,30 @@ fn read_stack_source_entries(
     invalid: &mut Vec<InvalidRigSourceMetadata>,
 ) -> Result<Vec<StackSourceEntry>> {
     let dir = paths::stack_sources()?;
-    if !dir.exists() {
-        return Ok(Vec::new());
-    }
+    let entries = super::json_config::read_json_configs::<StackSourceMetadata>(
+        &dir,
+        "read stack sources dir",
+        "read stack source entry",
+    )?;
+    invalid.extend(entries.invalid.into_iter().map(invalid_source_metadata));
+    Ok(entries
+        .valid
+        .into_iter()
+        .map(|entry| StackSourceEntry {
+            id: entry.id,
+            metadata: entry.value,
+        })
+        .collect())
+}
 
-    let mut valid = Vec::new();
-    for entry in fs::read_dir(&dir)
-        .map_err(|e| Error::internal_io(e.to_string(), Some("read stack sources dir".into())))?
-    {
-        let entry = entry.map_err(|e| {
-            Error::internal_io(e.to_string(), Some("read stack source entry".into()))
-        })?;
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
-            continue;
-        }
-        let id = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(id) => id.to_string(),
-            None => continue,
-        };
-        let content = match fs::read_to_string(&path) {
-            Ok(content) => content,
-            Err(err) => {
-                invalid.push(InvalidRigSourceMetadata {
-                    id,
-                    metadata_path: path.to_string_lossy().to_string(),
-                    error: err.to_string(),
-                });
-                continue;
-            }
-        };
-        match serde_json::from_str::<StackSourceMetadata>(&content) {
-            Ok(metadata) => valid.push(StackSourceEntry { id, metadata }),
-            Err(err) => invalid.push(InvalidRigSourceMetadata {
-                id,
-                metadata_path: path.to_string_lossy().to_string(),
-                error: err.to_string(),
-            }),
-        }
+fn invalid_source_metadata(
+    entry: super::json_config::InvalidJsonConfig,
+) -> InvalidRigSourceMetadata {
+    InvalidRigSourceMetadata {
+        id: entry.id,
+        metadata_path: entry.path.to_string_lossy().to_string(),
+        error: entry.error,
     }
-    valid.sort_by(|a, b| a.id.cmp(&b.id));
-    Ok(valid)
 }
 
 fn group_source_entries(entries: SourceEntries) -> RigSourceListResult {

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -297,6 +297,27 @@ fn installed_filename_is_runtime_identity_when_declared_id_differs() {
 }
 
 #[test]
+fn rig_list_ids_skip_non_json_files() {
+    let _home = HomeGuard::new();
+    fs::create_dir_all(crate::core::paths::rigs().expect("rigs dir")).expect("rigs dir");
+    fs::write(
+        crate::core::paths::rig_config("alpha").expect("alpha rig path"),
+        minimal_rig("alpha"),
+    )
+    .expect("alpha rig");
+    fs::write(
+        crate::core::paths::rigs()
+            .expect("rigs dir")
+            .join("ignore.txt"),
+        "not json",
+    )
+    .expect("non-json rig sidecar");
+
+    assert_eq!(list_ids().expect("list ids"), vec!["alpha"]);
+    assert_eq!(list().expect("list rigs").len(), 1);
+}
+
+#[test]
 fn git_url_installs_clone_package_and_config_link() {
     let _home = HomeGuard::new();
     let package = tempfile::tempdir().expect("package");

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -187,6 +187,36 @@ fn sources_list_reports_corrupt_metadata_and_missing_configs() {
 }
 
 #[test]
+fn sources_list_skips_non_json_and_collects_invalid_stack_metadata() {
+    let _home = HomeGuard::new();
+    fs::create_dir_all(crate::core::paths::rig_sources().expect("rig sources dir"))
+        .expect("rig sources dir");
+    fs::create_dir_all(crate::core::paths::stack_sources().expect("stack sources dir"))
+        .expect("stack sources dir");
+    fs::write(
+        crate::core::paths::rig_sources()
+            .expect("rig sources dir")
+            .join("ignored.txt"),
+        "not json",
+    )
+    .expect("non-json metadata");
+    fs::write(
+        crate::core::paths::stack_source_metadata("broken-stack").expect("stack metadata"),
+        "not json",
+    )
+    .expect("broken stack metadata");
+
+    let result = list_sources().expect("sources");
+
+    assert!(result.sources.is_empty());
+    assert_eq!(result.invalid.len(), 1);
+    assert_eq!(result.invalid[0].id, "broken-stack");
+    assert!(result.invalid[0]
+        .metadata_path
+        .ends_with("stack-sources/broken-stack.json"));
+}
+
+#[test]
 fn update_git_source_fast_forwards_package_and_refreshes_metadata() {
     let _home = HomeGuard::new();
     let package = tempfile::tempdir().expect("package");


### PR DESCRIPTION
## Summary
- Add a shared private JSON config directory helper for sorted `.json` stem traversal and typed read/parse collection.
- Reuse the helper for rig `list`/`list_ids` plus rig and stack source metadata loading while keeping strict errors and invalid metadata collection explicit at call sites.
- Add focused coverage for non-JSON skips and invalid stack metadata collection.

## Tests
- `cargo fmt`
- `cargo test core::rig::install::install_test`
- `cargo test core::rig::source::source_test`

Closes #2702.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the shared helper/refactor and focused tests; Chris remains responsible for review and validation.