### PR TITLE
Extract shared source command plumbing

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -1,7 +1,6 @@
 use clap::Args;
 
-use homeboy::core::ci_profile::{self, CiResolvedJob};
-use homeboy::core::engine::execution_context::{self, ResolveOptions};
+use homeboy::core::ci_profile;
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::lint::{
     report, run_main_lint_workflow, run_self_check_lint_workflow, LintCommandOutput,
@@ -16,6 +15,9 @@ use homeboy::core::refactor::plan::{
     collect_refactor_sources, lint_refactor_request, LintSourceOptions,
 };
 
+use super::source_command::{
+    finish_observed_workflow, resolve_ci_job_for_command, SourceContextRequest,
+};
 use super::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
 };
@@ -105,14 +107,11 @@ impl LintArgs {
 }
 
 pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput> {
-    let source_ctx = execution_context::resolve(&ResolveOptions {
-        component_id: args.comp.component.clone(),
-        path_override: args.comp.path.clone(),
-        capability: None,
-        settings_overrides: args.setting_args.setting.clone(),
-        settings_json_overrides: Vec::new(),
-        extension_overrides: args.extension_override.extensions.clone(),
-    })?;
+    let source_request =
+        SourceContextRequest::new(args.comp.component.clone(), args.comp.path.clone())
+            .with_settings(args.setting_args.setting.clone())
+            .with_extension_overrides(args.extension_override.extensions.clone());
+    let source_ctx = source_request.resolve(None)?;
 
     if !args.fix
         && args.ci_job.is_none()
@@ -136,16 +135,9 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
         return Ok(report::from_main_workflow(workflow));
     }
 
-    let ctx = execution_context::resolve(&ResolveOptions {
-        component_id: args.comp.component.clone(),
-        path_override: args.comp.path.clone(),
-        capability: Some(ExtensionCapability::Lint),
-        settings_overrides: args.setting_args.setting.clone(),
-        settings_json_overrides: Vec::new(),
-        extension_overrides: args.extension_override.extensions.clone(),
-    })?;
+    let ctx = source_request.resolve(Some(ExtensionCapability::Lint))?;
     let effective_id = ctx.component_id.clone();
-    let ci_job = resolve_ci_job(args.ci_job.as_deref(), &ctx.component)?;
+    let ci_job = resolve_ci_job_for_command(args.ci_job.as_deref(), &ctx.component, "lint")?;
 
     let stringified_settings = ctx.resolved_settings().string_lossy_overrides();
 
@@ -204,46 +196,16 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
     ))
 }
 
-fn resolve_ci_job(
-    job_id: Option<&str>,
-    component: &homeboy::core::component::Component,
-) -> homeboy::core::Result<Option<CiResolvedJob>> {
-    let Some(job_id) = job_id else {
-        return Ok(None);
-    };
-    let extension_ids = component
-        .extensions
-        .as_ref()
-        .map(|extensions| {
-            let mut ids: Vec<String> = extensions.keys().cloned().collect();
-            ids.sort();
-            ids
-        })
-        .unwrap_or_default();
-    let extension_id = ci_profile::select_extension_id(&extension_ids)?;
-    let job = ci_profile::resolve_job_for_extension(&extension_id, job_id)?;
-    ci_profile::validate_job_command(&job, "lint")?;
-    Ok(Some(job))
-}
-
 fn finish_lint_workflow(
     observation: Option<LintObservation>,
     workflow: homeboy::core::Result<homeboy::core::extension::lint::LintRunWorkflowResult>,
 ) -> homeboy::core::Result<homeboy::core::extension::lint::LintRunWorkflowResult> {
-    match workflow {
-        Ok(workflow) => {
-            if let Some(observation) = observation {
-                observation.finish_workflow(&workflow);
-            }
-            Ok(workflow)
-        }
-        Err(error) => {
-            if let Some(observation) = observation {
-                observation.finish_error();
-            }
-            Err(error)
-        }
-    }
+    finish_observed_workflow(
+        observation,
+        workflow,
+        |observation, workflow| observation.finish_workflow(workflow),
+        |observation, _error| observation.finish_error(),
+    )
 }
 
 struct LintObservation(ActiveObservation);

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -16,7 +16,7 @@ use homeboy::core::refactor::plan::{
 };
 
 use super::source_command::{
-    finish_observed_workflow, resolve_ci_job_for_command, SourceContextRequest,
+    finish_observed_workflow, resolve_ci_job_for_command, resolve_source_context,
 };
 use super::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
@@ -107,11 +107,12 @@ impl LintArgs {
 }
 
 pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput> {
-    let source_request =
-        SourceContextRequest::new(args.comp.component.clone(), args.comp.path.clone())
-            .with_settings(args.setting_args.setting.clone())
-            .with_extension_overrides(args.extension_override.extensions.clone());
-    let source_ctx = source_request.resolve(None)?;
+    let source_ctx = resolve_source_context(
+        &args.comp,
+        &args.setting_args,
+        &args.extension_override,
+        None,
+    )?;
 
     if !args.fix
         && args.ci_job.is_none()
@@ -135,7 +136,12 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
         return Ok(report::from_main_workflow(workflow));
     }
 
-    let ctx = source_request.resolve(Some(ExtensionCapability::Lint))?;
+    let ctx = resolve_source_context(
+        &args.comp,
+        &args.setting_args,
+        &args.extension_override,
+        Some(ExtensionCapability::Lint),
+    )?;
     let effective_id = ctx.component_id.clone();
     let ci_job = resolve_ci_job_for_command(args.ci_job.as_deref(), &ctx.component, "lint")?;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -368,6 +368,7 @@ pub mod runner;
 pub mod runs;
 pub mod self_cmd;
 pub mod server;
+pub mod source_command;
 pub mod ssh;
 pub mod stack;
 pub mod status;

--- a/src/commands/source_command.rs
+++ b/src/commands/source_command.rs
@@ -3,57 +3,22 @@ use homeboy::core::component::Component;
 use homeboy::core::engine::execution_context::{self, ExecutionContext, ResolveOptions};
 use homeboy::core::extension::ExtensionCapability;
 
-#[derive(Clone, Debug)]
-pub(crate) struct SourceContextRequest {
-    component_id: Option<String>,
-    path_override: Option<String>,
-    settings_overrides: Vec<(String, String)>,
-    settings_json_overrides: Vec<(String, serde_json::Value)>,
-    extension_overrides: Vec<String>,
-}
+use super::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs};
 
-impl SourceContextRequest {
-    pub(crate) fn new(component_id: Option<String>, path_override: Option<String>) -> Self {
-        Self {
-            component_id,
-            path_override,
-            settings_overrides: Vec::new(),
-            settings_json_overrides: Vec::new(),
-            extension_overrides: Vec::new(),
-        }
-    }
-
-    pub(crate) fn with_settings(mut self, settings: Vec<(String, String)>) -> Self {
-        self.settings_overrides = settings;
-        self
-    }
-
-    pub(crate) fn with_json_settings(
-        mut self,
-        settings_json: Vec<(String, serde_json::Value)>,
-    ) -> Self {
-        self.settings_json_overrides = settings_json;
-        self
-    }
-
-    pub(crate) fn with_extension_overrides(mut self, extension_overrides: Vec<String>) -> Self {
-        self.extension_overrides = extension_overrides;
-        self
-    }
-
-    pub(crate) fn resolve(
-        &self,
-        capability: Option<ExtensionCapability>,
-    ) -> homeboy::core::Result<ExecutionContext> {
-        execution_context::resolve(&ResolveOptions {
-            component_id: self.component_id.clone(),
-            path_override: self.path_override.clone(),
-            capability,
-            settings_overrides: self.settings_overrides.clone(),
-            settings_json_overrides: self.settings_json_overrides.clone(),
-            extension_overrides: self.extension_overrides.clone(),
-        })
-    }
+pub(crate) fn resolve_source_context(
+    comp: &PositionalComponentArgs,
+    settings: &SettingArgs,
+    extension_override: &ExtensionOverrideArgs,
+    capability: Option<ExtensionCapability>,
+) -> homeboy::core::Result<ExecutionContext> {
+    execution_context::resolve(&ResolveOptions {
+        component_id: comp.component.clone(),
+        path_override: comp.path.clone(),
+        capability,
+        settings_overrides: settings.setting.clone(),
+        settings_json_overrides: settings.setting_json.clone(),
+        extension_overrides: extension_override.extensions.clone(),
+    })
 }
 
 pub(crate) fn resolve_ci_job_for_command(

--- a/src/commands/source_command.rs
+++ b/src/commands/source_command.rs
@@ -1,0 +1,134 @@
+use homeboy::core::ci_profile::{self, CiResolvedJob};
+use homeboy::core::component::Component;
+use homeboy::core::engine::execution_context::{self, ExecutionContext, ResolveOptions};
+use homeboy::core::extension::ExtensionCapability;
+
+#[derive(Clone, Debug)]
+pub(crate) struct SourceContextRequest {
+    component_id: Option<String>,
+    path_override: Option<String>,
+    settings_overrides: Vec<(String, String)>,
+    settings_json_overrides: Vec<(String, serde_json::Value)>,
+    extension_overrides: Vec<String>,
+}
+
+impl SourceContextRequest {
+    pub(crate) fn new(component_id: Option<String>, path_override: Option<String>) -> Self {
+        Self {
+            component_id,
+            path_override,
+            settings_overrides: Vec::new(),
+            settings_json_overrides: Vec::new(),
+            extension_overrides: Vec::new(),
+        }
+    }
+
+    pub(crate) fn with_settings(mut self, settings: Vec<(String, String)>) -> Self {
+        self.settings_overrides = settings;
+        self
+    }
+
+    pub(crate) fn with_json_settings(
+        mut self,
+        settings_json: Vec<(String, serde_json::Value)>,
+    ) -> Self {
+        self.settings_json_overrides = settings_json;
+        self
+    }
+
+    pub(crate) fn with_extension_overrides(mut self, extension_overrides: Vec<String>) -> Self {
+        self.extension_overrides = extension_overrides;
+        self
+    }
+
+    pub(crate) fn resolve(
+        &self,
+        capability: Option<ExtensionCapability>,
+    ) -> homeboy::core::Result<ExecutionContext> {
+        execution_context::resolve(&ResolveOptions {
+            component_id: self.component_id.clone(),
+            path_override: self.path_override.clone(),
+            capability,
+            settings_overrides: self.settings_overrides.clone(),
+            settings_json_overrides: self.settings_json_overrides.clone(),
+            extension_overrides: self.extension_overrides.clone(),
+        })
+    }
+}
+
+pub(crate) fn resolve_ci_job_for_command(
+    job_id: Option<&str>,
+    component: &Component,
+    command: &'static str,
+) -> homeboy::core::Result<Option<CiResolvedJob>> {
+    let Some(job_id) = job_id else {
+        return Ok(None);
+    };
+    let extension_ids = component_extension_ids(component);
+    let extension_id = ci_profile::select_extension_id(&extension_ids)?;
+    let job = ci_profile::resolve_job_for_extension(&extension_id, job_id)?;
+    ci_profile::validate_job_command(&job, command)?;
+    Ok(Some(job))
+}
+
+pub(crate) fn finish_observed_workflow<O, T, F, E>(
+    observation: Option<O>,
+    workflow: homeboy::core::Result<T>,
+    finish_success: F,
+    finish_error: E,
+) -> homeboy::core::Result<T>
+where
+    F: FnOnce(O, &T),
+    E: FnOnce(O, &homeboy::core::Error),
+{
+    match workflow {
+        Ok(workflow) => {
+            if let Some(observation) = observation {
+                finish_success(observation, &workflow);
+            }
+            Ok(workflow)
+        }
+        Err(error) => {
+            if let Some(observation) = observation {
+                finish_error(observation, &error);
+            }
+            Err(error)
+        }
+    }
+}
+
+fn component_extension_ids(component: &Component) -> Vec<String> {
+    let mut ids: Vec<String> = component
+        .extensions
+        .as_ref()
+        .map(|extensions| extensions.keys().cloned().collect())
+        .unwrap_or_default();
+    ids.sort();
+    ids
+}
+
+#[cfg(test)]
+mod tests {
+    use super::component_extension_ids;
+    use homeboy::core::component::{Component, ScopedExtensionConfig};
+    use std::collections::HashMap;
+
+    #[test]
+    fn component_extension_ids_are_sorted() {
+        let mut extensions = HashMap::new();
+        extensions.insert("wordpress".to_string(), ScopedExtensionConfig::default());
+        extensions.insert("nodejs".to_string(), ScopedExtensionConfig::default());
+        let mut component = Component::new(
+            "demo".to_string(),
+            "/tmp/demo".to_string(),
+            String::new(),
+            None,
+        );
+        component.extensions = Some(extensions);
+
+        assert_eq!(
+            component_extension_ids(&component),
+            vec!["nodejs", "wordpress"]
+        );
+    }
+}

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -1,7 +1,6 @@
 use clap::Args;
 
 use homeboy::core::ci_profile::{self, CiResolvedJob};
-use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::test as extension_test;
 use homeboy::core::extension::test::{
@@ -17,6 +16,9 @@ use homeboy::core::observation::{
 };
 use std::path::Path;
 
+use super::source_command::{
+    finish_observed_workflow, resolve_ci_job_for_command, SourceContextRequest,
+};
 use super::utils::args::{
     filter_passthrough_args, BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs,
     PassthroughCommand, PositionalComponentArgs, SettingArgs,
@@ -100,14 +102,12 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
 }
 
 pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput> {
-    let source_ctx = execution_context::resolve(&ResolveOptions {
-        component_id: args.comp.component.clone(),
-        path_override: args.comp.path.clone(),
-        capability: None,
-        settings_overrides: args.setting_args.setting.clone(),
-        settings_json_overrides: args.setting_args.setting_json.clone(),
-        extension_overrides: args.extension_override.extensions.clone(),
-    })?;
+    let source_request =
+        SourceContextRequest::new(args.comp.component.clone(), args.comp.path.clone())
+            .with_settings(args.setting_args.setting.clone())
+            .with_json_settings(args.setting_args.setting_json.clone())
+            .with_extension_overrides(args.extension_override.extensions.clone());
+    let source_ctx = source_request.resolve(None)?;
 
     if !args.drift
         && args.ci_job.is_none()
@@ -132,16 +132,9 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
         return Ok(report::from_main_workflow(workflow));
     }
 
-    let ctx = execution_context::resolve(&ResolveOptions {
-        component_id: args.comp.component.clone(),
-        path_override: args.comp.path.clone(),
-        capability: Some(ExtensionCapability::Test),
-        settings_overrides: args.setting_args.setting.clone(),
-        settings_json_overrides: args.setting_args.setting_json.clone(),
-        extension_overrides: args.extension_override.extensions.clone(),
-    })?;
+    let ctx = source_request.resolve(Some(ExtensionCapability::Test))?;
     let effective_id = ctx.component_id.clone();
-    let ci_job = resolve_ci_job(args.ci_job.as_deref(), &ctx.component)?;
+    let ci_job = resolve_ci_job_for_command(args.ci_job.as_deref(), &ctx.component, "test")?;
 
     // Drift detection mode — delegate to core drift workflow (read-only)
     // Fixes are owned by `homeboy refactor --from test --write`.
@@ -210,28 +203,6 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
     ))
 }
 
-fn resolve_ci_job(
-    job_id: Option<&str>,
-    component: &homeboy::core::component::Component,
-) -> homeboy::core::Result<Option<CiResolvedJob>> {
-    let Some(job_id) = job_id else {
-        return Ok(None);
-    };
-    let extension_ids = component
-        .extensions
-        .as_ref()
-        .map(|extensions| {
-            let mut ids: Vec<String> = extensions.keys().cloned().collect();
-            ids.sort();
-            ids
-        })
-        .unwrap_or_default();
-    let extension_id = ci_profile::select_extension_id(&extension_ids)?;
-    let job = ci_profile::resolve_job_for_extension(&extension_id, job_id)?;
-    ci_profile::validate_job_command(&job, "test")?;
-    Ok(Some(job))
-}
-
 fn ci_job_passthrough_args(job: Option<&CiResolvedJob>) -> Vec<String> {
     job.map(|job| job.spec.args.clone()).unwrap_or_default()
 }
@@ -263,16 +234,12 @@ fn finish_test_workflow_observation(
     observation: Option<TestObservation>,
     workflow: homeboy::core::Result<extension_test::TestRunWorkflowResult>,
 ) -> homeboy::core::Result<extension_test::TestRunWorkflowResult> {
-    match workflow {
-        Ok(workflow) => {
-            finish_test_observation(observation, &workflow);
-            Ok(workflow)
-        }
-        Err(error) => {
-            finish_test_observation_error(observation, &error);
-            Err(error)
-        }
-    }
+    finish_observed_workflow(
+        observation,
+        workflow,
+        |observation, workflow| finish_test_observation(Some(observation), workflow),
+        |observation, error| finish_test_observation_error(Some(observation), error),
+    )
 }
 
 fn finish_test_observation(

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -17,7 +17,7 @@ use homeboy::core::observation::{
 use std::path::Path;
 
 use super::source_command::{
-    finish_observed_workflow, resolve_ci_job_for_command, SourceContextRequest,
+    finish_observed_workflow, resolve_ci_job_for_command, resolve_source_context,
 };
 use super::utils::args::{
     filter_passthrough_args, BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs,
@@ -102,12 +102,12 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
 }
 
 pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput> {
-    let source_request =
-        SourceContextRequest::new(args.comp.component.clone(), args.comp.path.clone())
-            .with_settings(args.setting_args.setting.clone())
-            .with_json_settings(args.setting_args.setting_json.clone())
-            .with_extension_overrides(args.extension_override.extensions.clone());
-    let source_ctx = source_request.resolve(None)?;
+    let source_ctx = resolve_source_context(
+        &args.comp,
+        &args.setting_args,
+        &args.extension_override,
+        None,
+    )?;
 
     if !args.drift
         && args.ci_job.is_none()
@@ -132,7 +132,12 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
         return Ok(report::from_main_workflow(workflow));
     }
 
-    let ctx = source_request.resolve(Some(ExtensionCapability::Test))?;
+    let ctx = resolve_source_context(
+        &args.comp,
+        &args.setting_args,
+        &args.extension_override,
+        Some(ExtensionCapability::Test),
+    )?;
     let effective_id = ctx.component_id.clone();
     let ci_job = resolve_ci_job_for_command(args.ci_job.as_deref(), &ctx.component, "test")?;
 


### PR DESCRIPTION
## Summary
- Add a small shared source command helper for lint/test source context resolution and CI job lookup/command validation.
- Reuse shared observed-workflow finish/error plumbing for lint/test without changing command-specific metadata or reporting.
- Keep audit/bench behavior untouched while preserving their existing test coverage for this issue.

Fixes #2701

## Tests
- `cargo check`
- `cargo test commands::lint`
- `cargo test commands::test`
- `cargo test commands::audit`
- `cargo test commands::bench`
- `cargo test`
- `homeboy lint --path /Users/chubes/Developer/homeboy@source-command-plumbing --extension rust --changed-since origin/main --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the shared command helper refactor, updated lint/test call sites, and ran local verification. Chris remains responsible for review and merge.