### PR TITLE
Simplify command output routing

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -155,7 +155,14 @@ pub enum CommandRawOutputMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CommandOutputArtifactPolicy {
+pub enum CommandStdoutMode {
+    JsonEnvelope,
+    Raw(CommandRawOutputMode),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandOutputFileMode {
+    None,
     GenericEnvelope,
     ReviewStableArtifact,
     TraceJsonSummaryArtifact,
@@ -163,9 +170,8 @@ pub enum CommandOutputArtifactPolicy {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CommandResponsePlan {
-    pub mode: CommandResponseMode,
-    pub output_artifact_policy: CommandOutputArtifactPolicy,
-    pub print_json: bool,
+    pub stdout: CommandStdoutMode,
+    pub output_file: CommandOutputFileMode,
 }
 
 impl Commands {
@@ -173,9 +179,11 @@ impl Commands {
         let mode = self.response_mode(has_output_file);
 
         CommandResponsePlan {
-            mode,
-            output_artifact_policy: self.output_artifact_policy(has_output_file),
-            print_json: matches!(mode, CommandResponseMode::Json),
+            stdout: match mode {
+                CommandResponseMode::Json => CommandStdoutMode::JsonEnvelope,
+                CommandResponseMode::Raw(raw_mode) => CommandStdoutMode::Raw(raw_mode),
+            },
+            output_file: self.output_file_mode(has_output_file),
         }
     }
 
@@ -237,13 +245,17 @@ impl Commands {
         }
     }
 
-    pub fn output_artifact_policy(&self, has_output_file: bool) -> CommandOutputArtifactPolicy {
+    pub fn output_file_mode(&self, has_output_file: bool) -> CommandOutputFileMode {
+        if !has_output_file {
+            return CommandOutputFileMode::None;
+        }
+
         match self {
-            Commands::Review(_) => CommandOutputArtifactPolicy::ReviewStableArtifact,
-            Commands::Trace(args) if has_output_file && args.json_summary => {
-                CommandOutputArtifactPolicy::TraceJsonSummaryArtifact
+            Commands::Review(_) => CommandOutputFileMode::ReviewStableArtifact,
+            Commands::Trace(args) if args.json_summary => {
+                CommandOutputFileMode::TraceJsonSummaryArtifact
             }
-            _ => CommandOutputArtifactPolicy::GenericEnvelope,
+            _ => CommandOutputFileMode::GenericEnvelope,
         }
     }
 }
@@ -382,18 +394,33 @@ mod tests {
         assert_eq!(
             parsed_command(&["homeboy", "status"]).response_plan(false),
             CommandResponsePlan {
-                mode: CommandResponseMode::Json,
-                output_artifact_policy: CommandOutputArtifactPolicy::GenericEnvelope,
-                print_json: true,
+                stdout: CommandStdoutMode::JsonEnvelope,
+                output_file: CommandOutputFileMode::None,
             }
         );
 
         assert_eq!(
             parsed_command(&["homeboy", "review", "--report", "pr-comment"]).response_plan(false),
             CommandResponsePlan {
-                mode: CommandResponseMode::Raw(CommandRawOutputMode::Markdown),
-                output_artifact_policy: CommandOutputArtifactPolicy::ReviewStableArtifact,
-                print_json: false,
+                stdout: CommandStdoutMode::Raw(CommandRawOutputMode::Markdown),
+                output_file: CommandOutputFileMode::None,
+            }
+        );
+
+        assert_eq!(
+            parsed_command(&["homeboy", "review", "--report", "pr-comment"]).response_plan(true),
+            CommandResponsePlan {
+                stdout: CommandStdoutMode::Raw(CommandRawOutputMode::Markdown),
+                output_file: CommandOutputFileMode::ReviewStableArtifact,
+            }
+        );
+
+        assert_eq!(
+            parsed_command(&["homeboy", "trace", "--report", "markdown", "--json-summary",])
+                .response_plan(true),
+            CommandResponsePlan {
+                stdout: CommandStdoutMode::Raw(CommandRawOutputMode::Markdown),
+                output_file: CommandOutputFileMode::TraceJsonSummaryArtifact,
             }
         );
     }
@@ -440,20 +467,20 @@ mod tests {
     #[test]
     fn test_output_artifact_policy() {
         assert_eq!(
-            parsed_command(&["homeboy", "status"]).output_artifact_policy(true),
-            CommandOutputArtifactPolicy::GenericEnvelope
+            parsed_command(&["homeboy", "status"]).output_file_mode(true),
+            CommandOutputFileMode::GenericEnvelope
         );
         assert_eq!(
-            parsed_command(&["homeboy", "review"]).output_artifact_policy(true),
-            CommandOutputArtifactPolicy::ReviewStableArtifact
+            parsed_command(&["homeboy", "review"]).output_file_mode(true),
+            CommandOutputFileMode::ReviewStableArtifact
         );
         assert_eq!(
-            parsed_command(&["homeboy", "trace", "--json-summary"]).output_artifact_policy(true),
-            CommandOutputArtifactPolicy::TraceJsonSummaryArtifact
+            parsed_command(&["homeboy", "trace", "--json-summary"]).output_file_mode(true),
+            CommandOutputFileMode::TraceJsonSummaryArtifact
         );
         assert_eq!(
-            parsed_command(&["homeboy", "trace", "--json-summary"]).output_artifact_policy(false),
-            CommandOutputArtifactPolicy::GenericEnvelope
+            parsed_command(&["homeboy", "trace", "--json-summary"]).output_file_mode(false),
+            CommandOutputFileMode::None
         );
     }
 }

--- a/src/commands/output_artifact/mod.rs
+++ b/src/commands/output_artifact/mod.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use crate::cli_surface::{CommandOutputArtifactPolicy, Commands};
+use crate::cli_surface::{CommandOutputFileMode, Commands};
 
 use super::utils::response as output;
 use super::{review, trace, GlobalArgs};
@@ -11,22 +11,29 @@ pub struct JsonCommandRun {
     pub output_file_result: Option<homeboy::core::Result<Value>>,
 }
 
+impl JsonCommandRun {
+    pub fn from_stdout_result(stdout_result: homeboy::core::Result<Value>, exit_code: i32) -> Self {
+        Self {
+            stdout_result,
+            exit_code,
+            output_file_result: None,
+        }
+    }
+}
+
 pub fn run_and_print(
     command: Commands,
     global: &GlobalArgs,
-    policy: CommandOutputArtifactPolicy,
+    mode: CommandOutputFileMode,
     output_file: Option<&str>,
-    print_json: bool,
 ) -> i32 {
-    let json_run = run_json(command, global, policy);
+    let json_run = run_json(command, global, mode);
 
     if let Some(path) = output_file {
-        write_to_file(&json_run, policy, path);
+        write_to_file(&json_run, mode, path);
     }
 
-    if print_json {
-        output::print_json_result(json_run.stdout_result, json_run.exit_code).ok();
-    }
+    output::print_json_result(json_run.stdout_result, json_run.exit_code).ok();
 
     json_run.exit_code
 }
@@ -34,10 +41,10 @@ pub fn run_and_print(
 pub fn run_json(
     command: Commands,
     global: &GlobalArgs,
-    policy: CommandOutputArtifactPolicy,
+    mode: CommandOutputFileMode,
 ) -> JsonCommandRun {
-    match (policy, command) {
-        (CommandOutputArtifactPolicy::TraceJsonSummaryArtifact, Commands::Trace(args)) => {
+    match (mode, command) {
+        (CommandOutputFileMode::TraceJsonSummaryArtifact, Commands::Trace(args)) => {
             let (stdout_result, exit_code, output_file_result) =
                 trace::run_json_with_output_artifact(args, global);
 
@@ -50,26 +57,23 @@ pub fn run_json(
         (_, command) => {
             let (stdout_result, exit_code) = super::json_output::run(command, global);
 
-            JsonCommandRun {
-                stdout_result,
-                exit_code,
-                output_file_result: None,
-            }
+            JsonCommandRun::from_stdout_result(stdout_result, exit_code)
         }
     }
 }
 
-pub fn write_to_file(run: &JsonCommandRun, policy: CommandOutputArtifactPolicy, path: &str) {
-    match policy {
-        CommandOutputArtifactPolicy::ReviewStableArtifact => {
+pub fn write_to_file(run: &JsonCommandRun, mode: CommandOutputFileMode, path: &str) {
+    match mode {
+        CommandOutputFileMode::None => {}
+        CommandOutputFileMode::ReviewStableArtifact => {
             if !review::write_artifact_to_file(&run.stdout_result, path, run.exit_code) {
                 output::write_json_to_file(&run.stdout_result, path, run.exit_code);
             }
         }
-        CommandOutputArtifactPolicy::TraceJsonSummaryArtifact => {
-            output::write_json_to_file(select_output_file_result(run, policy), path, run.exit_code);
+        CommandOutputFileMode::TraceJsonSummaryArtifact => {
+            output::write_json_to_file(select_output_file_result(run, mode), path, run.exit_code);
         }
-        CommandOutputArtifactPolicy::GenericEnvelope => {
+        CommandOutputFileMode::GenericEnvelope => {
             output::write_json_to_file(&run.stdout_result, path, run.exit_code);
         }
     }
@@ -77,15 +81,16 @@ pub fn write_to_file(run: &JsonCommandRun, policy: CommandOutputArtifactPolicy, 
 
 fn select_output_file_result(
     run: &JsonCommandRun,
-    policy: CommandOutputArtifactPolicy,
+    mode: CommandOutputFileMode,
 ) -> &homeboy::core::Result<Value> {
-    match policy {
-        CommandOutputArtifactPolicy::TraceJsonSummaryArtifact => run
+    match mode {
+        CommandOutputFileMode::TraceJsonSummaryArtifact => run
             .output_file_result
             .as_ref()
             .unwrap_or(&run.stdout_result),
-        CommandOutputArtifactPolicy::ReviewStableArtifact
-        | CommandOutputArtifactPolicy::GenericEnvelope => &run.stdout_result,
+        CommandOutputFileMode::None
+        | CommandOutputFileMode::ReviewStableArtifact
+        | CommandOutputFileMode::GenericEnvelope => &run.stdout_result,
     }
 }
 
@@ -109,7 +114,7 @@ mod tests {
         let run = run_with_output_file_result(Some(Ok(json!({ "kind": "summary" }))));
 
         assert_eq!(
-            select_output_file_result(&run, CommandOutputArtifactPolicy::TraceJsonSummaryArtifact)
+            select_output_file_result(&run, CommandOutputFileMode::TraceJsonSummaryArtifact)
                 .as_ref()
                 .unwrap(),
             &json!({ "kind": "summary" })
@@ -121,7 +126,7 @@ mod tests {
         let run = run_with_output_file_result(None);
 
         assert_eq!(
-            select_output_file_result(&run, CommandOutputArtifactPolicy::TraceJsonSummaryArtifact)
+            select_output_file_result(&run, CommandOutputFileMode::TraceJsonSummaryArtifact)
                 .as_ref()
                 .unwrap(),
             &json!({ "kind": "stdout" })
@@ -133,10 +138,56 @@ mod tests {
         let run = run_with_output_file_result(Some(Ok(json!({ "kind": "summary" }))));
 
         assert_eq!(
-            select_output_file_result(&run, CommandOutputArtifactPolicy::GenericEnvelope)
+            select_output_file_result(&run, CommandOutputFileMode::GenericEnvelope)
                 .as_ref()
                 .unwrap(),
             &json!({ "kind": "stdout" })
         );
+    }
+
+    #[test]
+    fn generic_output_file_writes_cli_envelope() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("status.json");
+        let run = run_with_output_file_result(None);
+
+        write_to_file(
+            &run,
+            CommandOutputFileMode::GenericEnvelope,
+            path.to_str().expect("utf8 path"),
+        );
+
+        let written = std::fs::read_to_string(path).expect("artifact written");
+        let json: Value = serde_json::from_str(&written).expect("valid json");
+        assert_eq!(json["success"], true);
+        assert_eq!(json["data"], json!({ "kind": "stdout" }));
+    }
+
+    #[test]
+    fn review_output_file_writes_stable_artifact_without_envelope() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("review.json");
+        let run = JsonCommandRun::from_stdout_result(
+            Ok(json!({
+                "command": "review",
+                "artifact": {
+                    "schema": "homeboy/review/v1",
+                    "status": "passed",
+                    "commands": []
+                }
+            })),
+            0,
+        );
+
+        write_to_file(
+            &run,
+            CommandOutputFileMode::ReviewStableArtifact,
+            path.to_str().expect("utf8 path"),
+        );
+
+        let written = std::fs::read_to_string(path).expect("artifact written");
+        let json: Value = serde_json::from_str(&written).expect("valid json");
+        assert_eq!(json["schema"], "homeboy/review/v1");
+        assert!(json.get("success").is_none());
     }
 }

--- a/src/commands/raw_output/mod.rs
+++ b/src/commands/raw_output/mod.rs
@@ -83,7 +83,7 @@ fn run_markdown(command: Commands, global: &GlobalArgs) -> RawCommandRun {
     match command {
         Commands::Docs(args) => raw_stdout_only(docs::run_markdown(args)),
         Commands::Changelog(args) => raw_stdout_only(changelog::run_markdown(args)),
-        Commands::Review(args) => review::run_markdown_with_json(args, global),
+        Commands::Review(args) => review::raw_output::run_markdown_with_json(args, global),
         Commands::Trace(args) => trace::run_markdown_with_json_artifact(args, global),
         Commands::Runs(args) => raw_stdout_only(runs::run_markdown(args, global)),
         Commands::Report(args) => raw_stdout_only(report::run_markdown(args)),

--- a/src/commands/raw_output/mod.rs
+++ b/src/commands/raw_output/mod.rs
@@ -1,4 +1,6 @@
-use crate::cli_surface::{CommandRawOutputMode, CommandResponseMode, Commands};
+use serde_json::Value;
+
+use crate::cli_surface::{CommandRawOutputMode, CommandStdoutMode, Commands};
 
 use super::utils::{response as output, tty};
 use super::{changelog, docs, file, report, review, runs, trace, GlobalArgs};
@@ -8,22 +10,36 @@ pub enum RawExecution {
     Continue(Box<Commands>),
 }
 
-pub enum JsonCommandPreparation {
+pub enum CommandRunPreparation {
     Handled(i32),
-    Continue(Box<Commands>),
+    Json(Box<Commands>),
+    Raw(RawCommandRun),
 }
 
-pub fn prepare_json_command(
+pub struct RawCommandRun {
+    pub stdout_result: homeboy::core::Result<String>,
+    pub exit_code: i32,
+    pub output_file_result: Option<homeboy::core::Result<Value>>,
+}
+
+pub fn prepare_command_run(
     command: Commands,
     global: &GlobalArgs,
-    mode: CommandResponseMode,
-) -> JsonCommandPreparation {
+    mode: CommandStdoutMode,
+) -> CommandRunPreparation {
     match mode {
-        CommandResponseMode::Json => JsonCommandPreparation::Continue(Box::new(command)),
-        CommandResponseMode::Raw(raw_mode) => match run_and_print(command, global, raw_mode) {
-            RawExecution::Handled(exit_code) => JsonCommandPreparation::Handled(exit_code),
-            RawExecution::Continue(command) => JsonCommandPreparation::Continue(command),
-        },
+        CommandStdoutMode::JsonEnvelope => CommandRunPreparation::Json(Box::new(command)),
+        CommandStdoutMode::Raw(CommandRawOutputMode::InteractivePassthrough) => {
+            match validate_interactive_tty(command) {
+                RawExecution::Handled(exit_code) => CommandRunPreparation::Handled(exit_code),
+                RawExecution::Continue(command) => CommandRunPreparation::Json(command),
+            }
+        }
+        CommandStdoutMode::Raw(raw_mode) => {
+            let raw_run = run(command, global, raw_mode)
+                .expect("markdown and plain-text modes should return raw output");
+            CommandRunPreparation::Raw(raw_run)
+        }
     }
 }
 
@@ -34,15 +50,15 @@ pub fn run_and_print(
 ) -> RawExecution {
     if let CommandRawOutputMode::InteractivePassthrough = mode {
         return validate_interactive_tty(command);
-    };
+    }
 
-    let raw_result =
+    let raw_run =
         run(command, global, mode).expect("markdown and plain-text modes should return raw output");
 
-    RawExecution::Handled(match raw_result {
-        Ok((content, exit_code)) => {
+    RawExecution::Handled(match raw_run.stdout_result {
+        Ok(content) => {
             print!("{}", content);
-            exit_code
+            raw_run.exit_code
         }
         Err(err) => {
             output::print_result::<serde_json::Value>(Err(err)).ok();
@@ -55,7 +71,7 @@ pub fn run(
     command: Commands,
     global: &GlobalArgs,
     mode: CommandRawOutputMode,
-) -> Option<homeboy::core::Result<(String, i32)>> {
+) -> Option<RawCommandRun> {
     match mode {
         CommandRawOutputMode::InteractivePassthrough => None,
         CommandRawOutputMode::Markdown => Some(run_markdown(command, global)),
@@ -63,27 +79,43 @@ pub fn run(
     }
 }
 
-fn run_markdown(command: Commands, global: &GlobalArgs) -> homeboy::core::Result<(String, i32)> {
+fn run_markdown(command: Commands, global: &GlobalArgs) -> RawCommandRun {
     match command {
-        Commands::Docs(args) => docs::run_markdown(args),
-        Commands::Changelog(args) => changelog::run_markdown(args),
-        Commands::Review(args) => review::run_markdown(args, global),
-        Commands::Trace(args) => trace::run_markdown(args, global),
-        Commands::Runs(args) => runs::run_markdown(args, global),
-        Commands::Report(args) => report::run_markdown(args),
-        _ => unsupported_output("markdown"),
+        Commands::Docs(args) => raw_stdout_only(docs::run_markdown(args)),
+        Commands::Changelog(args) => raw_stdout_only(changelog::run_markdown(args)),
+        Commands::Review(args) => review::run_markdown_with_json(args, global),
+        Commands::Trace(args) => trace::run_markdown_with_json_artifact(args, global),
+        Commands::Runs(args) => raw_stdout_only(runs::run_markdown(args, global)),
+        Commands::Report(args) => raw_stdout_only(report::run_markdown(args)),
+        _ => raw_stdout_only(unsupported_output("markdown")),
     }
 }
 
-fn run_plain_text(command: Commands, global: &GlobalArgs) -> homeboy::core::Result<(String, i32)> {
+fn run_plain_text(command: Commands, global: &GlobalArgs) -> RawCommandRun {
     match command {
-        Commands::File(args) => match file::run(args, global)? {
-            (file::FileCommandOutput::Raw(content), exit_code) => Ok((content, exit_code)),
-            _ => Err(homeboy::core::Error::internal_unexpected(
+        Commands::File(args) => raw_stdout_only(match file::run(args, global) {
+            Ok((file::FileCommandOutput::Raw(content), exit_code)) => Ok((content, exit_code)),
+            Ok(_) => Err(homeboy::core::Error::internal_unexpected(
                 "Unexpected output type for raw mode",
             )),
+            Err(err) => Err(err),
+        }),
+        _ => raw_stdout_only(unsupported_output("plain text")),
+    }
+}
+
+pub fn raw_stdout_only(result: homeboy::core::Result<(String, i32)>) -> RawCommandRun {
+    match result {
+        Ok((content, exit_code)) => RawCommandRun {
+            stdout_result: Ok(content),
+            exit_code,
+            output_file_result: None,
         },
-        _ => unsupported_output("plain text"),
+        Err(err) => RawCommandRun {
+            stdout_result: Err(err),
+            exit_code: 1,
+            output_file_result: None,
+        },
     }
 }
 
@@ -134,6 +166,7 @@ mod tests {
             CommandRawOutputMode::PlainText,
         )
         .expect("plain text mode should return a result")
+        .stdout_result
         .expect_err("list does not support plain text output");
 
         assert!(result.to_string().contains("plain text output"));

--- a/src/commands/response.rs
+++ b/src/commands/response.rs
@@ -5,16 +5,38 @@ use super::GlobalArgs;
 pub fn run(command: Commands, global: &GlobalArgs, output_file: Option<&str>) -> i32 {
     let plan = command.response_plan(output_file.is_some());
 
-    let command = match super::raw_output::prepare_json_command(command, global, plan.mode) {
-        super::raw_output::JsonCommandPreparation::Handled(exit_code) => return exit_code,
-        super::raw_output::JsonCommandPreparation::Continue(command) => *command,
-    };
+    match super::raw_output::prepare_command_run(command, global, plan.stdout) {
+        super::raw_output::CommandRunPreparation::Handled(exit_code) => exit_code,
+        super::raw_output::CommandRunPreparation::Json(command) => {
+            super::output_artifact::run_and_print(*command, global, plan.output_file, output_file)
+        }
+        super::raw_output::CommandRunPreparation::Raw(raw_run) => {
+            let exit_code = raw_run.exit_code;
+            let output_file_result = match raw_run.output_file_result {
+                Some(result) => result,
+                None => match raw_run.stdout_result.as_ref() {
+                    Ok(content) => Ok(serde_json::Value::String(content.clone())),
+                    Err(err) => Err(err.clone()),
+                },
+            };
+            let json_run = super::output_artifact::JsonCommandRun {
+                stdout_result: output_file_result,
+                exit_code,
+                output_file_result: None,
+            };
 
-    super::output_artifact::run_and_print(
-        command,
-        global,
-        plan.output_artifact_policy,
-        output_file,
-        plan.print_json,
-    )
+            if let Some(path) = output_file {
+                super::output_artifact::write_to_file(&json_run, plan.output_file, path);
+            }
+
+            match raw_run.stdout_result {
+                Ok(content) => print!("{}", content),
+                Err(err) => {
+                    super::utils::response::print_result::<serde_json::Value>(Err(err)).ok();
+                }
+            }
+
+            exit_code
+        }
+    }
 }

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -34,6 +34,7 @@ use super::utils::args::{BaselineArgs, ExtensionOverrideArgs, PositionalComponen
 use super::{audit, lint, test, CmdResult, GlobalArgs};
 
 mod observation;
+pub(super) mod raw_output;
 mod render;
 
 #[derive(Args, Debug, Clone)]
@@ -563,38 +564,6 @@ pub fn run_markdown(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<String> 
         render::render_pr_comment_with_banners(&output, &banners)
     };
     Ok((md, exit_code))
-}
-
-pub fn run_markdown_with_json(
-    args: ReviewArgs,
-    global: &GlobalArgs,
-) -> super::raw_output::RawCommandRun {
-    let banners = args.banner.clone();
-    match run(args, global) {
-        Ok((output, exit_code)) => {
-            let md = if banners.is_empty() {
-                render::render_pr_comment(&output)
-            } else {
-                render::render_pr_comment_with_banners(&output, &banners)
-            };
-
-            super::raw_output::RawCommandRun {
-                stdout_result: Ok(md),
-                exit_code,
-                output_file_result: Some(serde_json::to_value(output).map_err(|err| {
-                    homeboy::core::Error::internal_json(
-                        err.to_string(),
-                        Some("serialize response".to_string()),
-                    )
-                })),
-            }
-        }
-        Err(err) => super::raw_output::RawCommandRun {
-            stdout_result: Err(err),
-            exit_code: 1,
-            output_file_result: None,
-        },
-    }
 }
 
 /// Write the stable review artifact to `--output` for automated consumers.

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -565,6 +565,38 @@ pub fn run_markdown(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<String> 
     Ok((md, exit_code))
 }
 
+pub fn run_markdown_with_json(
+    args: ReviewArgs,
+    global: &GlobalArgs,
+) -> super::raw_output::RawCommandRun {
+    let banners = args.banner.clone();
+    match run(args, global) {
+        Ok((output, exit_code)) => {
+            let md = if banners.is_empty() {
+                render::render_pr_comment(&output)
+            } else {
+                render::render_pr_comment_with_banners(&output, &banners)
+            };
+
+            super::raw_output::RawCommandRun {
+                stdout_result: Ok(md),
+                exit_code,
+                output_file_result: Some(serde_json::to_value(output).map_err(|err| {
+                    homeboy::core::Error::internal_json(
+                        err.to_string(),
+                        Some("serialize response".to_string()),
+                    )
+                })),
+            }
+        }
+        Err(err) => super::raw_output::RawCommandRun {
+            stdout_result: Err(err),
+            exit_code: 1,
+            output_file_result: None,
+        },
+    }
+}
+
 /// Write the stable review artifact to `--output` for automated consumers.
 /// Falls back to the generic JSON envelope if the review command failed before
 /// producing an artifact.

--- a/src/commands/review/raw_output.rs
+++ b/src/commands/review/raw_output.rs
@@ -1,0 +1,33 @@
+use crate::commands::raw_output::RawCommandRun;
+use crate::commands::GlobalArgs;
+
+use super::{render, run, ReviewArgs};
+
+pub fn run_markdown_with_json(args: ReviewArgs, global: &GlobalArgs) -> RawCommandRun {
+    let banners = args.banner.clone();
+    match run(args, global) {
+        Ok((output, exit_code)) => {
+            let md = if banners.is_empty() {
+                render::render_pr_comment(&output)
+            } else {
+                render::render_pr_comment_with_banners(&output, &banners)
+            };
+
+            RawCommandRun {
+                stdout_result: Ok(md),
+                exit_code,
+                output_file_result: Some(serde_json::to_value(output).map_err(|err| {
+                    homeboy::core::Error::internal_json(
+                        err.to_string(),
+                        Some("serialize response".to_string()),
+                    )
+                })),
+            }
+        }
+        Err(err) => RawCommandRun {
+            stdout_result: Err(err),
+            exit_code: 1,
+            output_file_result: None,
+        },
+    }
+}

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -173,57 +173,88 @@ pub fn is_markdown_mode(args: &TraceArgs) -> bool {
 
 pub fn run_markdown(args: TraceArgs, global: &GlobalArgs) -> CmdResult<String> {
     let (output, exit_code) = run(args, global)?;
+    Ok((render_markdown_output(&output), exit_code))
+}
+
+pub fn run_markdown_with_json_artifact(
+    args: TraceArgs,
+    _global: &GlobalArgs,
+) -> super::raw_output::RawCommandRun {
+    let output_to_json = |output: &TraceCommandOutput| {
+        serde_json::to_value(output).map_err(|err| {
+            homeboy::core::Error::internal_json(
+                err.to_string(),
+                Some("serialize response".to_string()),
+            )
+        })
+    };
+
+    match run_outputs(args) {
+        Ok(((stdout_output, artifact_output), exit_code)) => {
+            let markdown = render_markdown_output(&stdout_output);
+            super::raw_output::RawCommandRun {
+                stdout_result: Ok(markdown),
+                exit_code,
+                output_file_result: Some(match artifact_output {
+                    Some(ref output) => output_to_json(output),
+                    None => output_to_json(&stdout_output),
+                }),
+            }
+        }
+        Err(err) => super::raw_output::RawCommandRun {
+            stdout_result: Err(err),
+            exit_code: 1,
+            output_file_result: None,
+        },
+    }
+}
+
+fn render_markdown_output(output: &TraceCommandOutput) -> String {
     match output {
         TraceCommandOutput::Run(run_output) => {
-            let Some(results) = run_output.results else {
-                return Ok(("# Trace\n\nNo trace results were produced.\n".to_string(), exit_code));
+            let Some(results) = run_output.results.as_ref() else {
+                return "# Trace\n\nNo trace results were produced.\n".to_string();
             };
-            Ok((
-                extension_trace::render_markdown(&results, &run_output.overlays),
-                exit_code,
-            ))
+            extension_trace::render_markdown(&results, &run_output.overlays)
         }
-        TraceCommandOutput::Summary(summary) => Ok((
+        TraceCommandOutput::Summary(summary) => {
             format!(
                 "# Trace Summary\n\n- **Component:** `{}`\n- **Status:** `{}`\n- **Exit code:** `{}`\n",
                 summary.component, summary.status, summary.exit_code
-            ),
-            exit_code,
-        )),
-        TraceCommandOutput::Aggregate(aggregate) => {
-            Ok((render_aggregate_markdown(&aggregate), exit_code))
+            )
         }
-        TraceCommandOutput::Compare(compare) => Ok((render_compare_markdown(&compare), exit_code)),
-        TraceCommandOutput::Matrix(matrix) => Ok((render_matrix_markdown(&matrix), exit_code)),
+        TraceCommandOutput::Aggregate(aggregate) => render_aggregate_markdown(&aggregate),
+        TraceCommandOutput::Compare(compare) => render_compare_markdown(&compare),
+        TraceCommandOutput::Matrix(matrix) => render_matrix_markdown(&matrix),
         TraceCommandOutput::List(list) => {
             if !list.profiles.is_empty() || list.command == "trace.list.profiles" {
                 let mut markdown = "# Trace Profiles\n\n".to_string();
-                for profile in list.profiles {
+                for profile in &list.profiles {
                     markdown.push_str(&format!("- `{}`", profile.id));
                     markdown.push_str(&format!(" in rig `{}`", profile.rig_id));
-                    if let Some(scenario) = profile.scenario {
+                    if let Some(scenario) = profile.scenario.as_deref() {
                         markdown.push_str(&format!(": `{}`", scenario));
                     }
                     markdown.push('\n');
                 }
-                return Ok((markdown, exit_code));
+                return markdown;
             }
             let mut markdown = format!("# Trace Scenarios: `{}`\n\n", list.component_id);
-            for scenario in list.scenarios {
+            for scenario in &list.scenarios {
                 markdown.push_str(&format!("- `{}`", scenario.id));
-                if let Some(summary) = scenario.summary {
+                if let Some(summary) = scenario.summary.as_deref() {
                     markdown.push_str(&format!(": {}", summary));
                 }
                 markdown.push('\n');
             }
-            Ok((markdown, exit_code))
+            markdown
         }
         TraceCommandOutput::OverlayLocks(locks) => {
             let mut markdown = format!("# Trace Overlay Locks\n\n- **Count:** `{}`\n- **Active:** `{}`\n- **Stale:** `{}`\n- **Unknown:** `{}`\n\n", locks.count, locks.active_count, locks.stale_count, locks.unknown_count);
-            for lock in locks.locks {
+            for lock in &locks.locks {
                 markdown.push_str(&format!("- `{}`: `{:?}`\n", lock.lock_path, lock.status));
             }
-            Ok((markdown, exit_code))
+            markdown
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replaces the split command response policy with one `CommandResponsePlan` covering stdout mode and output-file mode.
- Routes raw markdown/plaintext and JSON commands through a shared run result so `--output` can be written consistently without bypassing raw stdout.
- Adds coverage for markdown stdout with output files, generic JSON envelopes, and review/trace special artifact behavior.

## Tests
- `cargo test cli_surface --lib`
- `cargo test raw_output --lib`
- `cargo test output_artifact --lib`
- `cargo test commands::utils::response --lib`
- `cargo test --lib -- --test-threads=1`

Closes #2700.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the command response routing refactor, added targeted tests, and ran verification; Chris remains responsible for review and merge.