### PR TITLE
Reduce duplicate audit blocks

### DIFF
--- a/src/core/code_audit/dead_code.rs
+++ b/src/core/code_audit/dead_code.rs
@@ -81,31 +81,28 @@ pub(crate) fn analyze_dead_code_with_config(
         for unused in &fp.unused_parameters {
             let (kind, description, suggestion) = classify_unused_param(unused, &caller_map);
 
-            findings.push(Finding {
-                convention: "dead_code".to_string(),
-                severity: Severity::Warning,
-                file: fp.relative_path.clone(),
+            findings.push(dead_code_finding(
+                fp,
+                Severity::Warning,
                 description,
                 suggestion,
                 kind,
-            });
+            ));
         }
 
         // Check 2: Dead code markers
         for marker in &fp.dead_code_markers {
-            findings.push(Finding {
-                convention: "dead_code".to_string(),
-                severity: Severity::Info,
-                file: fp.relative_path.clone(),
-                description: format!(
+            findings.push(dead_code_finding(
+                fp,
+                Severity::Info,
+                format!(
                     "Dead code marker on '{}' (line {}, type: {})",
                     marker.item, marker.line, marker.marker_type
                 ),
-                suggestion:
-                    "Remove the dead code instead of suppressing the warning, or document why it must stay"
+                "Remove the dead code instead of suppressing the warning, or document why it must stay"
                         .to_string(),
-                kind: AuditFinding::DeadCodeMarker,
-            });
+                AuditFinding::DeadCodeMarker,
+            ));
         }
 
         // Check 3: Unreferenced exports
@@ -181,19 +178,17 @@ pub(crate) fn analyze_dead_code_with_config(
                         continue;
                     }
 
-                    findings.push(Finding {
-                    convention: "dead_code".to_string(),
-                    severity: Severity::Info,
-                    file: fp.relative_path.clone(),
-                    description: format!(
-                        "Public function '{}' is not referenced by any other file",
-                        export
-                    ),
-                    suggestion:
+                    findings.push(dead_code_finding(
+                        fp,
+                        Severity::Info,
+                        format!(
+                            "Public function '{}' is not referenced by any other file",
+                            export
+                        ),
                         "Consider making it private/pub(crate), removing it, or verifying it's used externally"
                             .to_string(),
-                    kind: AuditFinding::UnreferencedExport,
-                });
+                        AuditFinding::UnreferencedExport,
+                    ));
                 }
             }
         } // end if !is_test_path
@@ -248,6 +243,23 @@ pub(crate) fn analyze_dead_code_with_config(
     // Sort by file path for deterministic output
     findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
     findings
+}
+
+fn dead_code_finding(
+    fp: &FileFingerprint,
+    severity: Severity,
+    description: String,
+    suggestion: String,
+    kind: AuditFinding,
+) -> Finding {
+    Finding {
+        convention: "dead_code".to_string(),
+        severity,
+        file: fp.relative_path.clone(),
+        description,
+        suggestion,
+        kind,
+    }
 }
 
 /// Check if a function name is a framework entry point that's expected to be

--- a/src/core/code_audit/detectors/repeated_literal_shape.rs
+++ b/src/core/code_audit/detectors/repeated_literal_shape.rs
@@ -225,10 +225,7 @@ fn extract_literal_shapes(content: &str) -> Vec<Shape> {
 
         // `[` → short array literal candidate.
         if bytes[i] == b'[' && !looks_like_subscript(bytes, i) {
-            if let Some((shape, end)) = parse_array_literal(bytes, i + 1, b']') {
-                if !shape.is_empty() {
-                    results.push(shape);
-                }
+            if let Some(end) = parse_and_push_shape(bytes, i + 1, b']', &mut results) {
                 i = end;
                 continue;
             }
@@ -243,10 +240,7 @@ fn extract_literal_shapes(content: &str) -> Vec<Shape> {
                 j += 1;
             }
             if j < bytes.len() && bytes[j] == b'(' && is_ident_boundary(bytes, i) {
-                if let Some((shape, end)) = parse_array_literal(bytes, j + 1, b')') {
-                    if !shape.is_empty() {
-                        results.push(shape);
-                    }
+                if let Some(end) = parse_and_push_shape(bytes, j + 1, b')', &mut results) {
                     i = end;
                     continue;
                 }
@@ -257,6 +251,23 @@ fn extract_literal_shapes(content: &str) -> Vec<Shape> {
     }
 
     results
+}
+
+fn parse_and_push_shape(
+    bytes: &[u8],
+    start: usize,
+    closer: u8,
+    results: &mut Vec<Shape>,
+) -> Option<usize> {
+    let (shape, end) = parse_array_literal(bytes, start, closer)?;
+    push_shape_if_present(results, shape);
+    Some(end)
+}
+
+fn push_shape_if_present(results: &mut Vec<Shape>, shape: Shape) {
+    if !shape.is_empty() {
+        results.push(shape);
+    }
 }
 
 /// Starting just after the opening delimiter, read until the matching closer

--- a/src/core/code_audit/docs_audit/claims.rs
+++ b/src/core/code_audit/docs_audit/claims.rs
@@ -227,6 +227,12 @@ pub fn extract_claims(content: &str, doc_file: &str, ignore_patterns: &[String])
             continue;
         }
 
+        let claim_context = PathClaimContext {
+            doc_file,
+            line_num,
+            line,
+        };
+
         // Skip inline extraction for lines inside code blocks —
         // code blocks are handled separately as CodeExample claims
         if in_code_block {
@@ -241,42 +247,17 @@ pub fn extract_claims(content: &str, doc_file: &str, ignore_patterns: &[String])
             if !claimed_positions.contains(&pos) {
                 let path = cap.get(1).map(|m| m.as_str()).unwrap_or("");
 
-                // Skip if it looks like a URL
-                if path.contains("://") || path.starts_with("http") {
+                if should_skip_file_path(path, ignore_patterns) {
                     continue;
                 }
 
-                // Skip domain-like patterns (mysite.com, example.org)
-                if is_domain_like(path) {
-                    continue;
-                }
-
-                // Skip MIME types (application/*, text/*, etc.)
-                if is_mime_type(path) {
-                    continue;
-                }
-
-                // Skip component-configured ignore patterns
-                if matches_ignore_pattern(path, ignore_patterns) {
-                    continue;
-                }
-
-                // Skip very short paths that might be false positives
-                if path.len() < 5 {
-                    continue;
-                }
-
-                let confidence = classify_path_confidence(path, line, false);
-
-                claimed_positions.push(pos);
-                claims.push(Claim {
-                    claim_type: ClaimType::FilePath,
-                    value: path.to_string(),
-                    doc_file: doc_file.to_string(),
-                    line: line_num,
-                    confidence,
-                    context: Some(line.trim().to_string()),
-                });
+                record_file_claim(
+                    &mut claims,
+                    &mut claimed_positions,
+                    pos,
+                    path,
+                    claim_context,
+                );
             }
         }
 
@@ -324,13 +305,7 @@ pub fn extract_claims(content: &str, doc_file: &str, ignore_patterns: &[String])
             if !claimed_positions.contains(&pos) {
                 let path = cap.get(1).map(|m| m.as_str()).unwrap_or("");
 
-                // Skip common false positives
-                if path == "./" || path == "../" || path.len() < 4 {
-                    continue;
-                }
-
-                // Skip component-configured ignore patterns
-                if matches_ignore_pattern(path, ignore_patterns) {
+                if should_skip_directory_path(path, ignore_patterns) {
                     continue;
                 }
 
@@ -376,6 +351,83 @@ pub fn extract_claims(content: &str, doc_file: &str, ignore_patterns: &[String])
     }
 
     claims
+}
+
+fn should_skip_file_path(path: &str, ignore_patterns: &[String]) -> bool {
+    path.contains("://")
+        || path.starts_with("http")
+        || is_domain_like(path)
+        || is_mime_type(path)
+        || matches_ignore_pattern(path, ignore_patterns)
+        || path.len() < 5
+}
+
+fn should_skip_directory_path(path: &str, ignore_patterns: &[String]) -> bool {
+    path == "./" || path == "../" || path.len() < 4 || matches_ignore_pattern(path, ignore_patterns)
+}
+
+#[derive(Clone, Copy)]
+struct PathClaimContext<'a> {
+    doc_file: &'a str,
+    line_num: usize,
+    line: &'a str,
+}
+
+fn record_file_claim(
+    claims: &mut Vec<Claim>,
+    claimed_positions: &mut Vec<(usize, usize)>,
+    pos: (usize, usize),
+    path: &str,
+    context: PathClaimContext<'_>,
+) {
+    record_path_claim(
+        claims,
+        claimed_positions,
+        pos,
+        ClaimType::FilePath,
+        path,
+        context,
+    );
+}
+
+fn record_path_claim(
+    claims: &mut Vec<Claim>,
+    claimed_positions: &mut Vec<(usize, usize)>,
+    pos: (usize, usize),
+    claim_type: ClaimType,
+    path: &str,
+    context: PathClaimContext<'_>,
+) {
+    let confidence = classify_path_confidence(path, context.line, false);
+    claimed_positions.push(pos);
+    push_claim(
+        claims,
+        claim_type,
+        path,
+        context.doc_file,
+        context.line_num,
+        confidence,
+        context.line,
+    );
+}
+
+fn push_claim(
+    claims: &mut Vec<Claim>,
+    claim_type: ClaimType,
+    value: &str,
+    doc_file: &str,
+    line_num: usize,
+    confidence: ClaimConfidence,
+    line: &str,
+) {
+    claims.push(Claim {
+        claim_type,
+        value: value.to_string(),
+        doc_file: doc_file.to_string(),
+        line: line_num,
+        confidence,
+        context: Some(line.trim().to_string()),
+    });
 }
 
 /// Check if a path looks like a domain name rather than a file path.


### PR DESCRIPTION
## Summary
- Extract shared finding construction in dead code auditing.
- Share repeated literal shape recording for short and long PHP array literal scans.
- Consolidate markdown path-claim filtering and file-path claim recording to remove intra-method duplicate blocks.

Refs #2714.

## Verification
- `cargo test core::code_audit::dead_code && cargo test core::code_audit::detectors::repeated_literal_shape && cargo test core::code_audit::docs_audit::claims`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@duplicate-cleanup-slice-c --only intra_method_duplicate`

The duplicate audit no longer reports the targeted files: `src/core/code_audit/dead_code.rs`, `src/core/code_audit/detectors/repeated_literal_shape.rs`, or `src/core/code_audit/docs_audit/claims.rs`. Remaining findings are pre-existing unrelated files outside this slice.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the small refactor helpers, ran targeted tests and audit verification, and prepared this PR description for Chris to review.