### PR TITLE
Project workflow payloads from HomeboyPlan

### DIFF
--- a/src/core/deps/stack.rs
+++ b/src/core/deps/stack.rs
@@ -1,7 +1,7 @@
 use crate::core::component::{self, Component, DependencyStackEdge};
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
 use crate::core::{Error, Result};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::process::Command;
 
@@ -31,7 +31,7 @@ pub struct DependencyStackPlan {
     pub steps: Vec<DependencyStackPlanStep>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DependencyStackPlanStep {
     pub sequence: usize,
     pub declaring_component_id: String,
@@ -100,7 +100,7 @@ pub fn stack_apply(upstream: &str, dry_run: bool) -> Result<DependencyStackApply
     let plan = stack_plan(upstream)?;
     let mut steps = Vec::new();
 
-    for step in &plan.steps {
+    for step in plan.planned_steps() {
         let mut command_results = Vec::new();
         command_results.push(run_stack_command(
             "update",
@@ -212,13 +212,22 @@ impl DependencyStackPlan {
             .steps(steps.iter().map(stack_step))
             .summarize()
             .build();
+        let steps = stack_steps_from_plan(&plan);
 
         Self {
+            step_count: plan
+                .summary
+                .as_ref()
+                .map(|summary| summary.total_steps)
+                .unwrap_or_else(|| plan.steps.len()),
             plan,
             upstream,
-            step_count: steps.len(),
             steps,
         }
+    }
+
+    pub fn planned_steps(&self) -> Vec<DependencyStackPlanStep> {
+        stack_steps_from_plan(&self.plan)
     }
 }
 
@@ -242,9 +251,20 @@ fn stack_step(step: &DependencyStackPlanStep) -> PlanStep {
             .string("downstream", step.downstream.clone())
             .string("downstream_path", step.downstream_path.clone())
             .string("package", step.package.clone())
-            .string("update_command", step.update_command.clone()),
+            .string("update_command", step.update_command.clone())
+            .json("post_update", &step.post_update)
+            .json("test", &step.test)
+            .json("stack_step", step),
     )
     .build()
+}
+
+fn stack_steps_from_plan(plan: &HomeboyPlan) -> Vec<DependencyStackPlanStep> {
+    plan.steps
+        .iter()
+        .filter_map(|step| step.inputs.get("stack_step"))
+        .filter_map(|value| serde_json::from_value(value.clone()).ok())
+        .collect()
 }
 
 fn edge_status(component: &Component, edge: &DependencyStackEdge) -> DependencyStackEdgeStatus {

--- a/src/core/issues/apply.rs
+++ b/src/core/issues/apply.rs
@@ -19,9 +19,10 @@ use super::tracker::{CloseReason, Tracker};
 /// long as we produced a result; callers inspect `failed_count` to decide
 /// whether to exit non-zero.
 pub fn apply_plan(plan: ReconcilePlan, tracker: &dyn Tracker) -> Result<ReconcileResult> {
-    let mut executions: Vec<ReconcileExecution> = Vec::with_capacity(plan.actions.len());
+    let actions = plan.planned_actions();
+    let mut executions: Vec<ReconcileExecution> = Vec::with_capacity(actions.len());
 
-    for action in &plan.actions {
+    for action in &actions {
         let exec = execute_action(action, tracker);
         executions.push(exec);
     }

--- a/src/core/issues/plan.rs
+++ b/src/core/issues/plan.rs
@@ -184,15 +184,20 @@ impl ReconcilePlan {
             .steps(actions.iter().enumerate().map(action_step))
             .summarize()
             .build();
+        let actions = actions_from_plan(&plan);
 
         Self { plan, actions }
+    }
+
+    pub fn planned_actions(&self) -> Vec<ReconcileAction> {
+        actions_from_plan(&self.plan)
     }
 
     /// Count actions by variant (file_new, update, etc.). Used by the CLI
     /// to render a one-line summary.
     pub fn counts(&self) -> ReconcilePlanCounts {
         let mut c = ReconcilePlanCounts::default();
-        for action in &self.actions {
+        for action in self.planned_actions() {
             match action {
                 ReconcileAction::FileNew { .. } => c.file_new += 1,
                 ReconcileAction::Update { .. } => c.update += 1,
@@ -206,10 +211,18 @@ impl ReconcilePlan {
     }
 
     pub fn is_noop(&self) -> bool {
-        self.actions
-            .iter()
+        self.planned_actions()
+            .into_iter()
             .all(|a| matches!(a, ReconcileAction::Skip { .. }))
     }
+}
+
+fn actions_from_plan(plan: &HomeboyPlan) -> Vec<ReconcileAction> {
+    plan.steps
+        .iter()
+        .filter_map(|step| step.inputs.get("action"))
+        .filter_map(|value| serde_json::from_value(value.clone()).ok())
+        .collect()
 }
 
 fn action_step((index, action): (usize, &ReconcileAction)) -> PlanStep {
@@ -293,4 +306,41 @@ pub struct ReconcilePlanCounts {
     pub close: usize,
     pub close_duplicate: usize,
     pub skip: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{action_kind, ReconcileAction, ReconcilePlan, ReconcileSkipReason};
+
+    #[test]
+    fn planned_actions_are_projected_from_homeboy_plan_steps() {
+        let actions = vec![
+            ReconcileAction::FileNew {
+                command: "audit".to_string(),
+                component_id: "homeboy".to_string(),
+                category: "missing_method".to_string(),
+                title: "audit: missing method".to_string(),
+                body: "body".to_string(),
+                labels: vec!["audit".to_string()],
+                count: 2,
+            },
+            ReconcileAction::Skip {
+                category: "resolved".to_string(),
+                component_id: "homeboy".to_string(),
+                reason: ReconcileSkipReason::NoFindingsNoIssue,
+            },
+        ];
+
+        let plan = ReconcilePlan::new("homeboy", actions.clone());
+
+        assert_eq!(plan.actions.len(), 2);
+        assert_eq!(plan.planned_actions().len(), 2);
+        assert_eq!(
+            action_kind(&plan.planned_actions()[0]),
+            action_kind(&actions[0])
+        );
+        assert_eq!(plan.counts().file_new, 1);
+        assert_eq!(plan.counts().skip, 1);
+        assert!(!plan.is_noop());
+    }
 }

--- a/src/core/refactor/decompose.rs
+++ b/src/core/refactor/decompose.rs
@@ -33,7 +33,7 @@ pub struct DecomposeAuditImpact {
     pub likely_findings: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DecomposeGroup {
     pub name: String,
     pub suggested_target: String,
@@ -131,9 +131,24 @@ fn decompose_group_step(group: &DecomposeGroup) -> PlanStep {
         PlanValues::new()
             .string("group", group.name.clone())
             .string("suggested_target", group.suggested_target.clone())
-            .json("item_names", &group.item_names),
+            .json("item_names", &group.item_names)
+            .json("group_payload", group),
     )
     .build()
+}
+
+impl DecomposePlan {
+    pub fn planned_groups(&self) -> Vec<DecomposeGroup> {
+        decompose_groups_from_plan(&self.plan)
+    }
+}
+
+fn decompose_groups_from_plan(plan: &HomeboyPlan) -> Vec<DecomposeGroup> {
+    plan.steps
+        .iter()
+        .filter_map(|step| step.inputs.get("group_payload"))
+        .filter_map(|value| serde_json::from_value(value.clone()).ok())
+        .collect()
 }
 
 pub fn apply_plan(plan: &DecomposePlan, root: &Path, write: bool) -> Result<Vec<MoveResult>> {
@@ -177,7 +192,7 @@ fn generate_source_module_index(plan: &DecomposePlan, root: &Path) {
 
     // Build submodule entries from the plan groups
     let submodules: Vec<super::move_items::ModuleIndexEntry> = plan
-        .groups
+        .planned_groups()
         .iter()
         .filter_map(|group| {
             // Derive module name from the target path
@@ -254,7 +269,7 @@ fn remove_conflicting_use_imports(content: &str, submodule_names: &[&str]) -> St
 pub fn apply_plan_skeletons(plan: &DecomposePlan, root: &Path) -> Result<Vec<String>> {
     let mut created = Vec::new();
 
-    for group in &plan.groups {
+    for group in plan.planned_groups() {
         let path = root.join(&group.suggested_target);
         if path.exists() {
             continue;
@@ -281,7 +296,7 @@ pub fn apply_plan_skeletons(plan: &DecomposePlan, root: &Path) -> Result<Vec<Str
                 Some(format!("write {}", path.display())),
             )
         })?;
-        created.push(group.suggested_target.clone());
+        created.push(group.suggested_target);
     }
 
     Ok(created)
@@ -290,7 +305,7 @@ pub fn apply_plan_skeletons(plan: &DecomposePlan, root: &Path) -> Result<Vec<Str
 fn run_moves(plan: &DecomposePlan, root: &Path, write: bool) -> Result<Vec<MoveResult>> {
     let mut results = Vec::new();
 
-    for group in &plan.groups {
+    for group in plan.planned_groups() {
         let mut seen = HashSet::new();
         let deduped_item_names: Vec<&str> = group
             .item_names
@@ -1784,6 +1799,32 @@ mod tests {
             source: String::new(),
             visibility: String::new(),
         }
+    }
+
+    #[test]
+    fn planned_groups_are_projected_from_homeboy_plan_steps() {
+        let groups = vec![DecomposeGroup {
+            name: "helpers".to_string(),
+            suggested_target: "src/helpers.rs".to_string(),
+            item_names: vec!["format_label".to_string()],
+        }];
+        let plan = DecomposePlan {
+            plan: decompose_homeboy_plan("src/lib.rs", "grouped", 1, &groups, &[]),
+            file: "src/lib.rs".to_string(),
+            strategy: "grouped".to_string(),
+            total_items: 1,
+            groups: groups.clone(),
+            projected_audit_impact: DecomposeAuditImpact {
+                estimated_new_files: 1,
+                estimated_new_test_files: 0,
+                recommended_test_files: Vec::new(),
+                likely_findings: Vec::new(),
+            },
+            checklist: Vec::new(),
+            warnings: Vec::new(),
+        };
+
+        assert_eq!(plan.planned_groups(), groups);
     }
 
     #[test]

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -181,6 +181,8 @@ fn stack_plan_walks_declared_downstream_edges_in_order() {
     let plan = deps::stack_plan_from_components("chubes4/html-to-blocks-converter", &components).unwrap();
 
     assert_eq!(plan.step_count, 2);
+    assert_eq!(plan.step_count, plan.plan.steps.len());
+    assert_eq!(plan.planned_steps(), plan.steps);
     assert_eq!(plan.steps[0].downstream, "block-format-bridge");
     assert_eq!(plan.steps[0].package, "chubes4/html-to-blocks-converter");
     assert_eq!(


### PR DESCRIPTION
## Summary
- Projects dependency stack steps, issue reconcile actions, and refactor decompose groups from canonical `HomeboyPlan` step inputs.
- Keeps existing compatibility fields populated from the canonical plan payloads so current JSON consumers continue to see the same shapes.
- Leaves stack sync preview work to #2705 and only touches the remaining #2696 payload duplication sites.

Closes #2696.

## Testing
- `cargo test --test deps_test`
- `cargo test core::issues --lib`
- `cargo test decompose --lib`
- `cargo check`
- `cargo fmt --check`
- `git diff --check`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@fix-homeboyplan-payloads --extension rust --changed-since origin/main` (`introduced_findings: 0`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused implementation and tests; Chris remains responsible for review and merge.