### PR TITLE
Fix runner exec failure status

### DIFF
--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -511,6 +511,11 @@ impl JobHandle {
         self.store
             .append_event(self.job_id, JobEventKind::Progress, None, Some(data))
     }
+
+    pub(crate) fn result(&self, data: Value) -> Result<JobEvent> {
+        self.store
+            .append_event(self.job_id, JobEventKind::Result, None, Some(data))
+    }
 }
 
 fn validate_transition(current: JobStatus, next: JobStatus) -> Result<()> {

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 use std::sync::OnceLock;
 
 use crate::core::api_jobs::JobStore;
-use crate::core::error::{Error, Result};
+use crate::core::error::{Error, RemoteCommandFailedDetails, Result, TargetDetails};
 use crate::core::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
 use crate::core::paths;
 use crate::core::process::pid_is_running;
@@ -376,7 +376,7 @@ fn enqueue_exec_job(
             } else {
                 None
             };
-            Ok(json!({
+            let result = json!({
                 "runner_id": request.runner_id,
                 "cwd": request.cwd,
                 "command": request.command,
@@ -385,7 +385,23 @@ fn enqueue_exec_job(
                 "stderr": stderr,
                 "source_snapshot": source_snapshot,
                 "patch": patch,
-            }))
+            });
+            if exit_code != 0 {
+                job.result(result.clone())?;
+                return Err(Error::remote_command_failed(RemoteCommandFailedDetails {
+                    command: request.command.join(" "),
+                    exit_code,
+                    stdout,
+                    stderr,
+                    target: TargetDetails {
+                        project_id: None,
+                        server_id: request.runner_id,
+                        host: None,
+                    },
+                }));
+            }
+
+            Ok(result)
         },
     );
     let job = job_store.get(runner.job_id)?;

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::core::api_jobs::JobStore;
+use crate::core::api_jobs::{JobEventKind, JobStatus, JobStore};
 use crate::core::observation::{NewRunRecord, ObservationStore};
 use crate::test_support::HomeGuard;
 
@@ -335,6 +335,50 @@ fn routes_exec_body_to_daemon_job() {
 }
 
 #[test]
+fn exec_failed_command_marks_job_failed_after_result_event() {
+    let store = JobStore::default();
+    let response = route_with_job_store_and_body(
+        "POST",
+        "/exec",
+        Some(serde_json::json!({
+            "runner_id": "lab-local",
+            "cwd": std::env::current_dir().expect("cwd"),
+            "command": ["sh", "-c", "printf out; printf err >&2; exit 7"]
+        })),
+        &store,
+    );
+
+    assert_eq!(response.status_code, 200);
+    let job_id = response.body["body"]["job"]["id"]
+        .as_str()
+        .expect("job id")
+        .to_string();
+    let job = wait_for_job(&store, &job_id);
+    assert_eq!(job.status, JobStatus::Failed);
+
+    let events = store.events(job.id).expect("events");
+    let result = events
+        .iter()
+        .find(|event| event.kind == JobEventKind::Result)
+        .and_then(|event| event.data.as_ref())
+        .expect("result event");
+    assert_eq!(result["exit_code"], 7);
+    assert_eq!(result["stdout"], "out");
+    assert_eq!(result["stderr"], "err");
+
+    let status_events: Vec<_> = events
+        .iter()
+        .filter(|event| event.kind == JobEventKind::Status)
+        .collect();
+    assert!(status_events.iter().all(|event| {
+        event.data.as_ref().and_then(|data| data["status"].as_str()) != Some("succeeded")
+    }));
+    let final_status = status_events.last().expect("final status event");
+    assert_eq!(final_status.data.as_ref().unwrap()["status"], "failed");
+    assert_ne!(final_status.message.as_deref(), Some("job succeeded"));
+}
+
+#[test]
 fn exec_capture_patch_records_remote_delta_artifact() {
     let _home = HomeGuard::new();
     let workspace = tempfile::tempdir().expect("workspace");
@@ -398,9 +442,7 @@ fn wait_for_job(store: &JobStore, job_id: &str) -> crate::core::api_jobs::Job {
         let job = store.get(id).expect("job");
         if matches!(
             job.status,
-            crate::core::api_jobs::JobStatus::Succeeded
-                | crate::core::api_jobs::JobStatus::Failed
-                | crate::core::api_jobs::JobStatus::Cancelled
+            JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
         ) {
             return job;
         }


### PR DESCRIPTION
## Summary
- Mark daemon-backed `homeboy runner exec` jobs failed when the remote command exits non-zero.
- Preserve the command result event with `exit_code`, stdout, stderr, and patch data before failing the job so consumers can inspect command output without misclassifying the lifecycle status.
- Add focused daemon job-event coverage for failed runner exec commands.

Fixes #2723.

## Tests
- `cargo test exec_failed_command_marks_job_failed_after_result_event`
- `cargo test core::daemon::daemon_test::`
- `cargo fmt --check`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-runner-exec-failed-status --extension rust` (failed: unrelated/flaky `core::engine::run_dir::tests::list_outputs`; reran that test directly and it passed)
- `cargo test core::engine::run_dir::tests::list_outputs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the runner daemon job lifecycle, drafting the code/test change, and running local verification for Chris to review.