### PR TITLE
fix: hide lab runner flag from unsupported help

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -30,7 +30,7 @@ pub struct Cli {
     pub artifact_root: Option<PathBuf>,
 
     /// Offload supported hot commands to a connected Homeboy Lab runner.
-    #[arg(long, global = true, value_name = "RUNNER_ID")]
+    #[arg(long, global = true, hide = true, value_name = "RUNNER_ID")]
     pub runner: Option<String>,
 
     #[command(subcommand)]
@@ -438,6 +438,30 @@ mod tests {
         let cli = parsed_cli(&["homeboy", "lint", "--runner", "lab-a"]);
         assert_eq!(cli.runner.as_deref(), Some("lab-a"));
         assert!(cli.command.supports_lab_runner());
+    }
+
+    #[test]
+    fn test_lab_runner_flag_is_hidden_from_help() {
+        let root_help = Cli::command()
+            .try_get_matches_from(["homeboy", "--help"])
+            .expect_err("help exits")
+            .to_string();
+        assert!(!root_help.contains("--runner"));
+
+        for args in [
+            ["homeboy", "rig", "check", "--help"].as_slice(),
+            ["homeboy", "build", "--help"].as_slice(),
+            ["homeboy", "bench", "list", "--help"].as_slice(),
+        ] {
+            let help = Cli::command()
+                .try_get_matches_from(args)
+                .expect_err("help exits")
+                .to_string();
+            assert!(
+                !help.contains("--runner"),
+                "{args:?} help advertised --runner"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Hide the global `--runner` flag from generated help so unsupported commands no longer advertise an option they reject.
- Keep the existing centralized validation/offload contract intact: runner offload remains limited to lint, test, audit, bench run mode, and trace.
- Add a focused CLI surface regression test for root help plus `rig check`, `build`, and `bench list` help.

Closes #2722

## Tests
- `cargo test cli_surface`
- `cargo test --test command_surface_test`
- `cargo run --quiet --bin homeboy -- rig check --help`
- `cargo run --quiet --bin homeboy -- build --help`
- `cargo run --quiet --bin homeboy -- build --runner lab`
- `cargo run --quiet --bin homeboy -- rig check --runner lab example-rig`
- `cargo run --quiet --bin homeboy -- lint --runner lab --help`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause analysis of the CLI option/help handling, implementation, focused test coverage, and verification command selection. Chris remains responsible for review and merge decisions.