### PR TITLE
fix: reduce local duplicate audit blocks

### DIFF
--- a/src/core/extension/test/drift.rs
+++ b/src/core/extension/test/drift.rs
@@ -428,29 +428,14 @@ fn extract_changes_from_diff(file: &str, diff: &str) -> Vec<ProductionChange> {
     }
 
     // Match removed methods to added methods (renames)
-    let mut matched_removed: Vec<bool> = vec![false; removed_methods.len()];
-    let mut matched_added: Vec<bool> = vec![false; added_methods.len()];
-
-    for (ri, (removed, rline)) in removed_methods.iter().enumerate() {
-        // Look for a close-by addition (same hunk, ≤10 lines apart)
-        for (ai, (added, aline)) in added_methods.iter().enumerate() {
-            if !matched_added[ai] && removed != added {
-                let dist = (*aline as isize - *rline as isize).unsigned_abs();
-                if dist <= 10 {
-                    changes.push(ProductionChange {
-                        change_type: ChangeType::MethodRename,
-                        file: file.to_string(),
-                        old_symbol: removed.clone(),
-                        new_symbol: Some(added.clone()),
-                        line: *rline,
-                    });
-                    matched_removed[ri] = true;
-                    matched_added[ai] = true;
-                    break;
-                }
-            }
-        }
-    }
+    let matched_removed = match_renamed_symbols(
+        &mut changes,
+        file,
+        &removed_methods,
+        &added_methods,
+        ChangeType::MethodRename,
+        10,
+    );
 
     // Unmatched removals are pure removals
     for (ri, (removed, rline)) in removed_methods.iter().enumerate() {
@@ -466,28 +451,14 @@ fn extract_changes_from_diff(file: &str, diff: &str) -> Vec<ProductionChange> {
     }
 
     // Match removed classes to added classes (renames)
-    let mut cls_matched_removed: Vec<bool> = vec![false; removed_classes.len()];
-    let mut cls_matched_added: Vec<bool> = vec![false; added_classes.len()];
-
-    for (ri, (removed, rline)) in removed_classes.iter().enumerate() {
-        for (ai, (added, aline)) in added_classes.iter().enumerate() {
-            if !cls_matched_added[ai] && removed != added {
-                let dist = (*aline as isize - *rline as isize).unsigned_abs();
-                if dist <= 15 {
-                    changes.push(ProductionChange {
-                        change_type: ChangeType::ClassRename,
-                        file: file.to_string(),
-                        old_symbol: removed.clone(),
-                        new_symbol: Some(added.clone()),
-                        line: *rline,
-                    });
-                    cls_matched_removed[ri] = true;
-                    cls_matched_added[ai] = true;
-                    break;
-                }
-            }
-        }
-    }
+    let cls_matched_removed = match_renamed_symbols(
+        &mut changes,
+        file,
+        &removed_classes,
+        &added_classes,
+        ChangeType::ClassRename,
+        15,
+    );
 
     for (ri, (removed, rline)) in removed_classes.iter().enumerate() {
         if !cls_matched_removed[ri] {
@@ -524,6 +495,52 @@ fn extract_changes_from_diff(file: &str, diff: &str) -> Vec<ProductionChange> {
     }
 
     changes
+}
+
+fn match_renamed_symbols(
+    changes: &mut Vec<ProductionChange>,
+    file: &str,
+    removed_symbols: &[(String, usize)],
+    added_symbols: &[(String, usize)],
+    change_type: ChangeType,
+    max_distance: usize,
+) -> Vec<bool> {
+    let mut matched_removed = vec![false; removed_symbols.len()];
+    let mut matched_added = vec![false; added_symbols.len()];
+
+    for (ri, (removed, rline)) in removed_symbols.iter().enumerate() {
+        for (ai, (added, aline)) in added_symbols.iter().enumerate() {
+            if matched_added[ai] || removed == added {
+                continue;
+            }
+            let dist = (*aline as isize - *rline as isize).unsigned_abs();
+            if dist <= max_distance {
+                push_rename_change(changes, change_type.clone(), file, removed, added, *rline);
+                matched_removed[ri] = true;
+                matched_added[ai] = true;
+                break;
+            }
+        }
+    }
+
+    matched_removed
+}
+
+fn push_rename_change(
+    changes: &mut Vec<ProductionChange>,
+    change_type: ChangeType,
+    file: &str,
+    old_symbol: &str,
+    new_symbol: &str,
+    line: usize,
+) {
+    changes.push(ProductionChange {
+        change_type,
+        file: file.to_string(),
+        old_symbol: old_symbol.to_string(),
+        new_symbol: Some(new_symbol.to_string()),
+        line,
+    });
 }
 
 // ============================================================================

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -210,15 +210,14 @@ pub fn detect_baseline_with_version(
 
                 // No matching release commit - fall back to generic version commit
                 if let Some(hash) = find_version_commit(path)? {
-                    return Ok(BaselineInfo {
-                        latest_tag: Some(tag.clone()),
-                        source: Some(BaselineSource::VersionCommit),
-                        reference: Some(hash),
-                        warning: Some(format!(
+                    return Ok(version_commit_baseline(
+                        Some(tag.clone()),
+                        hash,
+                        format!(
                             "Latest tag '{}' doesn't match version {}. Using most recent version commit.",
                             tag, current
-                        )),
-                    });
+                        ),
+                    ));
                 }
 
                 // No version commits found - use the stale tag but warn
@@ -259,14 +258,11 @@ pub fn detect_baseline_with_version(
 
     // Priority 3: Generic version commit
     if let Some(hash) = find_version_commit(path)? {
-        return Ok(BaselineInfo {
-            latest_tag: None,
-            source: Some(BaselineSource::VersionCommit),
-            reference: Some(hash),
-            warning: Some(
-                "No tags found. Using most recent version commit as baseline.".to_string(),
-            ),
-        });
+        return Ok(version_commit_baseline(
+            None,
+            hash,
+            "No tags found. Using most recent version commit as baseline.".to_string(),
+        ));
     }
 
     // Fallback: No baseline found
@@ -279,6 +275,19 @@ pub fn detect_baseline_with_version(
             DEFAULT_COMMIT_LIMIT
         )),
     })
+}
+
+fn version_commit_baseline(
+    latest_tag: Option<String>,
+    reference: String,
+    warning: String,
+) -> BaselineInfo {
+    BaselineInfo {
+        latest_tag,
+        source: Some(BaselineSource::VersionCommit),
+        reference: Some(reference),
+        warning: Some(warning),
+    }
 }
 
 // Input types for JSON parsing

--- a/src/core/issues/reconcile.rs
+++ b/src/core/issues/reconcile.rs
@@ -193,15 +193,7 @@ fn reconcile_with_scope(
                 }
                 TrackedIssueState::ClosedCompleted => {
                     // Resolved-then-returned: file a fresh issue.
-                    actions.push(ReconcileAction::FileNew {
-                        command: group.command.clone(),
-                        component_id: group.component_id.clone(),
-                        category: group.category.clone(),
-                        title: render_title(group),
-                        body: body_with_issue_key(group),
-                        labels: vec![group.command.clone()],
-                        count: group.count,
-                    });
+                    push_file_new(&mut actions, group);
                     continue;
                 }
                 TrackedIssueState::Open => unreachable!("partitioned above"),
@@ -209,15 +201,7 @@ fn reconcile_with_scope(
         }
 
         // No issue ever existed (open or closed) for this category.
-        actions.push(ReconcileAction::FileNew {
-            command: group.command.clone(),
-            component_id: group.component_id.clone(),
-            category: group.category.clone(),
-            title: render_title(group),
-            body: body_with_issue_key(group),
-            labels: vec![group.command.clone()],
-            count: group.count,
-        });
+        push_file_new(&mut actions, group);
     }
 
     if let Some((command, component_id)) = scope {
@@ -243,6 +227,18 @@ fn reconcile_with_scope(
         .unwrap_or_else(|| "unknown".to_string());
 
     ReconcilePlan::new(component_id, actions)
+}
+
+fn push_file_new(actions: &mut Vec<ReconcileAction>, group: &IssueGroup) {
+    actions.push(ReconcileAction::FileNew {
+        command: group.command.clone(),
+        component_id: group.component_id.clone(),
+        category: group.category.clone(),
+        title: render_title(group),
+        body: body_with_issue_key(group),
+        labels: vec![group.command.clone()],
+        count: group.count,
+    });
 }
 
 fn close_absent_open_issues(

--- a/src/core/refactor/plan/generate/duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/duplicate_fixes.rs
@@ -167,13 +167,11 @@ pub(crate) fn generate_unreferenced_export_fixes(
         };
 
         if symbol_surface.has_external_usage(&finding.file) {
-            skipped.push(SkippedFile {
-                file: finding.file.clone(),
-                reason: format!(
-                    "Module surface shows '{}' still has external callers/importers/re-exports",
-                    fn_name
-                ),
-            });
+            skip_file(
+                skipped,
+                finding.file.clone(),
+                external_usage_reason(&fn_name),
+            );
             continue;
         }
 
@@ -190,13 +188,11 @@ pub(crate) fn generate_unreferenced_export_fixes(
 
         // Hard block: binary crate directly references this function.
         if is_used_by_binary_crate(&fn_name, root) {
-            skipped.push(SkippedFile {
-                file: finding.file.clone(),
-                reason: format!(
-                    "Function '{}' is used by binary crate — cannot narrow visibility",
-                    fn_name
-                ),
-            });
+            skip_file(
+                skipped,
+                finding.file.clone(),
+                binary_crate_usage_reason(&fn_name),
+            );
             continue;
         }
 
@@ -591,13 +587,11 @@ fn generate_simple_duplicate_fixes(
         if crate::core::code_audit::walker::is_test_path(remove_file)
             || crate::core::code_audit::walker::is_test_path(&group.canonical_file)
         {
-            skipped.push(SkippedFile {
-                file: remove_file.clone(),
-                reason: format!(
-                    "Duplicate `{}` spans integration test files — test binaries cannot cross-import",
-                    group.function_name
-                ),
-            });
+            skip_file(
+                skipped,
+                remove_file.clone(),
+                integration_test_duplicate_reason(&group.function_name),
+            );
             continue;
         }
 
@@ -629,13 +623,11 @@ fn generate_simple_duplicate_fixes(
                 .is_some_and(|surface| surface.has_external_usage(&group.canonical_file))
             && remove_surface.owns_public_symbol(&group.function_name)
         {
-            skipped.push(SkippedFile {
-                file: remove_file.clone(),
-                reason: format!(
-                    "Duplicate '{}' is externally surfaced in more than one module; keep ownership stable",
-                    group.function_name
-                ),
-            });
+            skip_file(
+                skipped,
+                remove_file.clone(),
+                externally_surfaced_duplicate_reason(&group.function_name),
+            );
             continue;
         }
 
@@ -648,37 +640,31 @@ fn generate_simple_duplicate_fixes(
         let content = match std::fs::read_to_string(&abs_path) {
             Ok(content) => content,
             Err(_) => {
-                skipped.push(SkippedFile {
-                    file: remove_file.clone(),
-                    reason: format!(
-                        "Cannot read file to remove duplicate `{}`",
-                        group.function_name
-                    ),
-                });
+                skip_file(
+                    skipped,
+                    remove_file.clone(),
+                    cannot_read_duplicate_reason(&group.function_name),
+                );
                 continue;
             }
         };
 
         let items = parse_items_for_dedup(ext, &content, remove_file);
         let Some(items) = items else {
-            skipped.push(SkippedFile {
-                file: remove_file.clone(),
-                reason: format!(
-                    "Cannot locate `{}` boundaries in {} — no grammar or extension available",
-                    group.function_name, remove_file
-                ),
-            });
+            skip_file(
+                skipped,
+                remove_file.clone(),
+                cannot_locate_boundaries_reason(&group.function_name, remove_file),
+            );
             continue;
         };
 
         let Some(item) = find_parsed_item_by_name(&items, &group.function_name) else {
-            skipped.push(SkippedFile {
-                file: remove_file.clone(),
-                reason: format!(
-                    "Function `{}` not found by parser in {}",
-                    group.function_name, remove_file
-                ),
-            });
+            skip_file(
+                skipped,
+                remove_file.clone(),
+                function_not_found_reason(&group.function_name, remove_file),
+            );
             continue;
         };
 
@@ -724,32 +710,12 @@ fn is_used_by_binary_crate(fn_name: &str, root: &Path) -> bool {
 
     let src = root.join("src");
     let main_rs = src.join("main.rs");
-    if main_rs.exists()
-        && std::fs::read_to_string(&main_rs)
-            .ok()
-            .is_some_and(|content| word_re.is_match(&content))
-    {
+    if main_rs.exists() && file_contains_word(&main_rs, &word_re) {
         return true;
     }
 
-    let lib_rs = src.join("lib.rs");
-    let lib_mods = if lib_rs.exists() {
-        std::fs::read_to_string(&lib_rs)
-            .ok()
-            .map(|content| extract_mod_names(&content))
-            .unwrap_or_default()
-    } else {
-        HashSet::new()
-    };
-
-    let main_mods = if main_rs.exists() {
-        std::fs::read_to_string(&main_rs)
-            .ok()
-            .map(|content| extract_mod_names(&content))
-            .unwrap_or_default()
-    } else {
-        HashSet::new()
-    };
+    let lib_mods = read_mod_names(&src.join("lib.rs"));
+    let main_mods = read_mod_names(&main_rs);
 
     for mod_name in main_mods.difference(&lib_mods) {
         let mod_dir = src.join(mod_name);
@@ -758,16 +724,79 @@ fn is_used_by_binary_crate(fn_name: &str, root: &Path) -> bool {
         }
 
         let mod_file = src.join(format!("{}.rs", mod_name));
-        if mod_file.exists()
-            && std::fs::read_to_string(&mod_file)
-                .ok()
-                .is_some_and(|content| word_re.is_match(&content))
-        {
+        if mod_file.exists() && file_contains_word(&mod_file, &word_re) {
             return true;
         }
     }
 
     false
+}
+
+fn skip_file(skipped: &mut Vec<SkippedFile>, file: String, reason: String) {
+    skipped.push(SkippedFile { file, reason });
+}
+
+fn external_usage_reason(fn_name: &str) -> String {
+    format!(
+        "Module surface shows '{}' still has external callers/importers/re-exports",
+        fn_name
+    )
+}
+
+fn binary_crate_usage_reason(fn_name: &str) -> String {
+    format!(
+        "Function '{}' is used by binary crate — cannot narrow visibility",
+        fn_name
+    )
+}
+
+fn integration_test_duplicate_reason(function_name: &str) -> String {
+    format!(
+        "Duplicate `{}` spans integration test files — test binaries cannot cross-import",
+        function_name
+    )
+}
+
+fn externally_surfaced_duplicate_reason(function_name: &str) -> String {
+    format!(
+        "Duplicate '{}' is externally surfaced in more than one module; keep ownership stable",
+        function_name
+    )
+}
+
+fn cannot_read_duplicate_reason(function_name: &str) -> String {
+    format!("Cannot read file to remove duplicate `{}`", function_name)
+}
+
+fn cannot_locate_boundaries_reason(function_name: &str, file: &str) -> String {
+    format!(
+        "Cannot locate `{}` boundaries in {} — no grammar or extension available",
+        function_name, file
+    )
+}
+
+fn function_not_found_reason(function_name: &str, file: &str) -> String {
+    format!(
+        "Function `{}` not found by parser in {}",
+        function_name, file
+    )
+}
+
+fn file_contains_word(path: &Path, word_re: &Regex) -> bool {
+    std::fs::read_to_string(path)
+        .ok()
+        .is_some_and(|content| word_re.is_match(&content))
+}
+
+fn read_mod_names(path: &Path) -> HashSet<String> {
+    if path.exists() {
+        std::fs::read_to_string(path)
+            .ok()
+            .map(|content| extract_mod_names(&content))
+            .unwrap_or_default()
+    } else {
+        HashSet::new()
+    }
 }
 
 fn extract_mod_names(content: &str) -> HashSet<String> {


### PR DESCRIPTION
## Summary
- Extract shared rename matching, baseline construction, and issue filing helpers to remove local duplicate blocks.
- Consolidate duplicate-fix skip reason helpers while preserving existing skip behavior.
- Closes #2714 slice E coverage for `drift.rs`, `operations.rs`, `reconcile.rs`, and `duplicate_fixes.rs`.

## Verification
- `cargo test core::extension::test::drift::tests`
- `cargo test core::git::operations::tests`
- `cargo test core::issues::reconcile::tests`
- `cargo test core::refactor::plan::generate::duplicate_fixes::tests`
- `homeboy audit homeboy --only intra_method_duplicate` reports the touched file findings resolved; unrelated duplicate warnings remain in other files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the small helper extractions and ran targeted verification; Chris remains responsible for review and merge.