### PR TITLE
fix: reduce duplicate audit slice G

### DIFF
--- a/src/core/component/inventory.rs
+++ b/src/core/component/inventory.rs
@@ -34,14 +34,17 @@ pub fn inventory() -> Result<Vec<Component>> {
     let projects = project::list().unwrap_or_default();
     let mut components = Vec::new();
     let mut seen = HashSet::new();
+    let mut add_component = |component: Component| {
+        if seen.insert(component.id.clone()) {
+            components.push(component);
+        }
+    };
 
     // 1. Project-attached components (highest priority)
     for project in &projects {
         for attachment in &project.components {
             if let Ok(component) = project::resolve_project_component(project, &attachment.id) {
-                if seen.insert(component.id.clone()) {
-                    components.push(component);
-                }
+                add_component(component);
             }
         }
     }
@@ -52,23 +55,17 @@ pub fn inventory() -> Result<Vec<Component>> {
     //    operations like release, version bump, and changelog.
     if let Ok(standalone) = load_standalone_components() {
         for component in standalone {
-            if seen.insert(component.id.clone()) {
-                components.push(component);
-            }
+            add_component(component);
         }
     }
 
     // 3. CWD portable discovery (lowest priority)
     if let Ok(cwd) = std::env::current_dir() {
         if let Some(component) = discover_from_portable(&cwd) {
-            if seen.insert(component.id.clone()) {
-                components.push(component);
-            }
+            add_component(component);
         } else if let Some(git_root) = crate::core::component::resolution::detect_git_root(&cwd) {
             if let Some(component) = discover_from_portable(&git_root) {
-                if seen.insert(component.id.clone()) {
-                    components.push(component);
-                }
+                add_component(component);
             }
         }
     }

--- a/src/core/db/operations.rs
+++ b/src/core/db/operations.rs
@@ -108,15 +108,7 @@ fn resolve_domain(project: &Project, subtarget: Option<&str>, project_id: &str) 
     }
 
     let Some(sub_id) = subtarget else {
-        let subtarget_list = project
-            .sub_targets
-            .iter()
-            .map(|t| {
-                let slug = project::slugify_id(&t.name).unwrap_or_else(|_| t.name.clone());
-                format!("- {} (use: {})", t.name, slug)
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
+        let subtarget_list = format_subtarget_list(project);
         return Err(Error::validation_invalid_argument(
             "subtarget",
             format!(
@@ -135,15 +127,7 @@ fn resolve_domain(project: &Project, subtarget: Option<&str>, project_id: &str) 
         return Ok(target.domain.clone());
     }
 
-    let subtarget_list = project
-        .sub_targets
-        .iter()
-        .map(|t| {
-            let slug = project::slugify_id(&t.name).unwrap_or_else(|_| t.name.clone());
-            format!("- {} (use: {})", t.name, slug)
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+    let subtarget_list = format_subtarget_list(project);
     Err(Error::validation_invalid_argument(
         "subtarget",
         format!(
@@ -153,6 +137,18 @@ fn resolve_domain(project: &Project, subtarget: Option<&str>, project_id: &str) 
         Some(project_id.to_string()),
         None,
     ))
+}
+
+fn format_subtarget_list(project: &Project) -> String {
+    project
+        .sub_targets
+        .iter()
+        .map(|t| {
+            let slug = project::slugify_id(&t.name).unwrap_or_else(|_| t.name.clone());
+            format!("- {} (use: {})", t.name, slug)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn parse_json_tables(json: &str) -> Vec<String> {

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -252,25 +252,27 @@ fn execute_file_deploy(
     let local_path = Path::new(&component.local_path);
 
     if !local_path.exists() {
-        return ComponentDeployResult::failed(
+        let error = format!("Source file does not exist: {}", component.local_path);
+        return failed_file_deploy_result(
             component,
             base_path,
-            local_version,
-            remote_version,
-            format!("Source file does not exist: {}", component.local_path),
+            &local_version,
+            &remote_version,
+            error,
         );
     }
 
     if !local_path.is_file() {
-        return ComponentDeployResult::failed(
+        let error = format!(
+            "Component '{}' has deploy_strategy 'file' but local_path is not a file: {}",
+            component.id, component.local_path
+        );
+        return failed_file_deploy_result(
             component,
             base_path,
-            local_version,
-            remote_version,
-            format!(
-                "Component '{}' has deploy_strategy 'file' but local_path is not a file: {}",
-                component.id, component.local_path
-            ),
+            &local_version,
+            &remote_version,
+            error,
         );
     }
 
@@ -363,6 +365,22 @@ fn execute_file_deploy(
         )
         .with_remote_path(install_dir.to_string()),
     }
+}
+
+fn failed_file_deploy_result(
+    component: &Component,
+    base_path: &str,
+    local_version: &Option<String>,
+    remote_version: &Option<String>,
+    error: String,
+) -> ComponentDeployResult {
+    ComponentDeployResult::failed(
+        component,
+        base_path,
+        local_version.clone(),
+        remote_version.clone(),
+        error,
+    )
 }
 
 /// Deploy a component via artifact upload (rsync / extension override).

--- a/src/core/engine/cli_tool.rs
+++ b/src/core/engine/cli_tool.rs
@@ -306,26 +306,14 @@ fn resolve_subtarget(project: &Project, args: &[String]) -> Result<(String, Vec<
     }
 
     let Some(sub_id) = args.first() else {
-        let subtarget_list = project
-            .sub_targets
-            .iter()
-            .map(|t| {
-                let slug = project::slugify_id(&t.name).unwrap_or_else(|_| t.name.clone());
-                format!("- {} (use: {})", t.name, slug)
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
+        let subtarget_list = format_subtarget_list(project);
+        let syntax = format_subtarget_syntax(&project.id);
         return Err(Error::validation_invalid_argument(
             "subtarget",
             format!(
                 "This project has subtargets configured. You must specify which subtarget to use.\n\n\
-                 Available subtargets for project '{}':\n{}\n\n\
-                 Syntax: homeboy <tool> {}:<subtarget> <command>...\n\
-                     OR  homeboy <tool> {} <subtarget> <command>...\n\n\
-                 Commands can be quoted or unquoted:\n  \
-                   homeboy wp {}:events post list\n  \
-                   homeboy wp {}:events \"post list\"",
-                project.id, subtarget_list, project.id, project.id, project.id, project.id
+                 Available subtargets for project '{}':\n{}\n\n{}",
+                project.id, subtarget_list, syntax
             ),
             Some(project.id.clone()),
             None,
@@ -339,7 +327,21 @@ fn resolve_subtarget(project: &Project, args: &[String]) -> Result<(String, Vec<
         return Ok((subtarget.domain.clone(), args[1..].to_vec()));
     }
 
-    let subtarget_list = project
+    let subtarget_list = format_subtarget_list(project);
+    let syntax = format_subtarget_syntax(&project.id);
+    Err(Error::validation_invalid_argument(
+        "subtarget",
+        format!(
+            "Subtarget '{}' not found. Available subtargets for project '{}':\n{}\n\n{}",
+            sub_id, project.id, subtarget_list, syntax
+        ),
+        Some(project.id.clone()),
+        None,
+    ))
+}
+
+fn format_subtarget_list(project: &Project) -> String {
+    project
         .sub_targets
         .iter()
         .map(|t| {
@@ -347,21 +349,17 @@ fn resolve_subtarget(project: &Project, args: &[String]) -> Result<(String, Vec<
             format!("- {} (use: {})", t.name, slug)
         })
         .collect::<Vec<_>>()
-        .join("\n");
-    Err(Error::validation_invalid_argument(
-        "subtarget",
-        format!(
-            "Subtarget '{}' not found. Available subtargets for project '{}':\n{}\n\n\
-             Syntax: homeboy <tool> {}:<subtarget> <command>...\n\
-                 OR  homeboy <tool> {} <subtarget> <command>...\n\n\
-             Commands can be quoted or unquoted:\n  \
-               homeboy wp {}:events post list\n  \
-               homeboy wp {}:events \"post list\"",
-            sub_id, project.id, subtarget_list, project.id, project.id, project.id, project.id
-        ),
-        Some(project.id.clone()),
-        None,
-    ))
+        .join("\n")
+}
+
+fn format_subtarget_syntax(project_id: &str) -> String {
+    format!(
+        "Syntax: homeboy <tool> {project_id}:<subtarget> <command>...\n\
+             OR  homeboy <tool> {project_id} <subtarget> <command>...\n\n\
+         Commands can be quoted or unquoted:\n  \
+           homeboy wp {project_id}:events post list\n  \
+           homeboy wp {project_id}:events \"post list\""
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Deduplicate repeated component inventory insertion blocks while preserving source precedence.
- Share subtarget list/syntax formatting inside DB and CLI resolution paths.
- Route file deploy validation failures through a small helper without changing failure payloads.

## Verification
- `cargo test core::component::inventory`
- `cargo test core::db::operations`
- `cargo test core::deploy::execution`
- `cargo test core::engine::cli_tool`
- `homeboy audit homeboy --only intra_method_duplicate` passes with no new drift; remaining findings are unrelated files outside slice G.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the minimal duplicate-sweep refactor and ran targeted verification; Chris remains responsible for review and merge.

Closes #2741