### PR TITLE
fix: trim internal unreferenced exports

### DIFF
--- a/src/commands/utils/response.rs
+++ b/src/commands/utils/response.rs
@@ -43,7 +43,7 @@ impl<T: Serialize> CliResponse<T> {
 }
 
 impl CliResponse<()> {
-    pub fn from_error(err: &Error) -> Self {
+    fn from_error(err: &Error) -> Self {
         Self {
             success: false,
             data: None,

--- a/src/commands/utils/tty.rs
+++ b/src/commands/utils/tty.rs
@@ -4,7 +4,7 @@
 
 use std::io::{self, BufRead, IsTerminal, Write};
 
-pub fn is_stdin_tty() -> bool {
+fn is_stdin_tty() -> bool {
     io::stdin().is_terminal()
 }
 

--- a/src/core/code_audit/detectors/field_patterns.rs
+++ b/src/core/code_audit/detectors/field_patterns.rs
@@ -18,7 +18,7 @@ mod field_patterns_data_contracts {
     const TYPE_SUFFIXES: &[&str] = &["Args", "Buckets", "CommandInput", "Detail", "Drift", "EditOp", "Entry", "Flags", "Group", "Options", "Output", "Overrides", "Report", "Result", "SeverityCounts", "Snapshot", "Status", "Summary"];
     const LOW_VALUE_FIELDS: &[&str] = &["ahead", "behind", "build_artifact", "changelog_next_section_aliases", "changelog_next_section_label", "confidence", "deploy", "deploy_strategy", "docs_only", "expected_methods", "expected_registrations", "extends", "extract_command", "failure", "implements", "info", "manual_only", "namespace", "needs_release", "picked_count", "primitive", "properties", "ready_detail", "ready_reason", "ready_to_deploy", "remote_owner", "results", "runtime", "skip_checks", "skip_publish", "skipped_count", "summary", "warnings"];
 
-    pub(in crate::core::code_audit) fn is_low_value_group(field_names: &[&str], type_names: &[&str], min_group_size: usize, min_occurrences: usize) -> bool {
+    pub(super) fn is_low_value_group(field_names: &[&str], type_names: &[&str], min_group_size: usize, min_occurrences: usize) -> bool {
         (min_group_size..=4).contains(&field_names.len())
             && type_names.len() >= min_occurrences
             && type_names.iter().all(|name| TYPE_NAMES.contains(name) || TYPE_SUFFIXES.iter().any(|suffix| name.ends_with(suffix)))

--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -418,7 +418,7 @@ fn compute_fixability_if_requested(
 }
 
 /// Determine exit code for audit results.
-pub fn default_audit_exit_code(result: &CodeAuditResult, is_scoped: bool) -> i32 {
+fn default_audit_exit_code(result: &CodeAuditResult, is_scoped: bool) -> i32 {
     if is_scoped {
         if result.findings.is_empty() {
             0

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -22,10 +22,10 @@ pub use inventory::{
     exists, extension_provides_artifact_pattern, inventory, list, list_ids, load,
     reconcile_standalone_registration, write_standalone_registration, ComponentReconcileReport,
 };
-pub use mutations::{delete_safe, merge, rename, set_changelog_target};
+pub use mutations::{delete_safe, merge, rename};
 pub use portable::{
-    discover_from_portable, has_portable_config, infer_portable_component_id, mutate_portable,
-    portable_json, read_portable_config, write_portable_config,
+    discover_from_portable, infer_portable_component_id, mutate_portable, portable_json,
+    write_portable_config,
 };
 pub use relationships::{associated_projects, projects_using, rename_component, shared_components};
 pub use resolution::{resolve, resolve_artifact, resolve_effective, validate_local_path};

--- a/src/core/component/mutations.rs
+++ b/src/core/component/mutations.rs
@@ -7,15 +7,6 @@ use crate::core::output::{MergeOutput, MergeResult};
 use serde_json::Value;
 use std::path::Path;
 
-/// Set the changelog target for a component's configuration.
-pub fn set_changelog_target(component_id: &str, file_path: &str) -> Result<()> {
-    mutate_portable(component_id, |component| {
-        component.changelog_target = Some(file_path.to_string());
-        Ok(())
-    })?;
-    Ok(())
-}
-
 pub fn merge(id: Option<&str>, json_spec: &str, replace_fields: &[String]) -> Result<MergeOutput> {
     let id = id.ok_or_else(|| {
         Error::validation_invalid_argument(
@@ -151,26 +142,6 @@ mod tests {
             .expect("write standalone registration");
 
         repo
-    }
-
-    #[test]
-    fn test_set_changelog_target() {
-        crate::test_support::with_isolated_home(|home| {
-            let repo = write_component_repo(home, "demo-plugin");
-
-            set_changelog_target("demo-plugin", "docs/changelog.md").expect("set changelog target");
-
-            let config: serde_json::Value = serde_json::from_str(
-                &fs::read_to_string(repo.join("homeboy.json")).expect("read homeboy.json"),
-            )
-            .expect("parse homeboy.json");
-            assert_eq!(
-                config
-                    .get("changelog_target")
-                    .and_then(|value| value.as_str()),
-                Some("docs/changelog.md")
-            );
-        });
     }
 
     #[test]

--- a/src/core/component/portable.rs
+++ b/src/core/component/portable.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use std::path::{Path, PathBuf};
 
 /// Read a `homeboy.json` portable config from a repo directory.
-pub fn read_portable_config(repo_path: &Path) -> Result<Option<Value>> {
+pub(crate) fn read_portable_config(repo_path: &Path) -> Result<Option<Value>> {
     let config_path = repo_path.join("homeboy.json");
     if !config_path.exists() {
         return Ok(None);
@@ -218,7 +218,7 @@ fn merge_preserving_unknown(existing: Value, component: Value) -> Value {
     }
 }
 
-pub fn has_portable_config(path: &Path) -> bool {
+pub(crate) fn has_portable_config(path: &Path) -> bool {
     read_portable_config(path).ok().flatten().is_some()
 }
 

--- a/src/core/deploy/provenance.rs
+++ b/src/core/deploy/provenance.rs
@@ -65,7 +65,7 @@ pub fn detect_tag_gap(component: &Component) -> Option<TagGap> {
 /// Format a tag gap as a human-readable warning string.
 ///
 /// Used by both `build` and `deploy` commands.
-pub fn format_tag_gap(component_id: &str, gap: &TagGap, context: &str) -> String {
+fn format_tag_gap(component_id: &str, gap: &TagGap, context: &str) -> String {
     let mut lines = vec![format!(
         "[{}] '{}': HEAD is {} commit(s) ahead of latest tag {}",
         context, component_id, gap.ahead, gap.tag

--- a/src/core/engine/refactor_primitive.rs
+++ b/src/core/engine/refactor_primitive.rs
@@ -19,7 +19,7 @@ pub fn insertion(
     }
 }
 
-pub fn tagged_insertion(
+pub(crate) fn tagged_insertion(
     primitive: RefactorPrimitive,
     kind: InsertionKind,
     finding: AuditFinding,
@@ -179,25 +179,6 @@ pub fn function_removal(
         },
         finding,
         code,
-        description,
-    )
-}
-
-pub fn tagged_function_removal(
-    primitive: RefactorPrimitive,
-    finding: AuditFinding,
-    start_line: usize,
-    end_line: usize,
-    description: String,
-) -> Insertion {
-    tagged_insertion(
-        primitive,
-        InsertionKind::FunctionRemoval {
-            start_line,
-            end_line,
-        },
-        finding,
-        String::new(),
         description,
     )
 }

--- a/src/core/engine/symbol_graph.rs
+++ b/src/core/engine/symbol_graph.rs
@@ -180,7 +180,7 @@ pub fn module_path_from_file(file_path: &str) -> String {
 /// Returns structured `ImportRef`s with module paths and imported names.
 /// For Rust, handles both simple (`use crate::mod::Item;`) and grouped
 /// (`use crate::mod::{A, B};`) imports.
-pub fn parse_imports(content: &str, grammar: &Grammar, relative_path: &str) -> Vec<ImportRef> {
+fn parse_imports(content: &str, grammar: &Grammar, relative_path: &str) -> Vec<ImportRef> {
     let symbols = grammar::extract(content, grammar);
     let lines: Vec<&str> = content.lines().collect();
     let import_parser = grammar

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -827,7 +827,7 @@ fn execute_extension_runtime(
 /// instead of loading the component from storage. This supports `--path` overrides
 /// in commands like `homeboy test --path /alt/path`.
 #[allow(clippy::too_many_arguments)]
-pub fn build_exec_env(
+fn build_exec_env(
     extension_id: &str,
     project_id: Option<&str>,
     component_id: Option<&str>,

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -341,16 +341,6 @@ impl IssueCloseReason {
             IssueCloseReason::NotPlanned => "not planned",
         }
     }
-
-    /// Parse from the GraphQL `state_reason` field on a closed issue.
-    /// Returns `None` when the value is unknown or absent (open issues).
-    pub fn from_graphql(s: &str) -> Option<Self> {
-        match s {
-            "completed" | "COMPLETED" => Some(IssueCloseReason::Completed),
-            "not_planned" | "NOT_PLANNED" => Some(IssueCloseReason::NotPlanned),
-            _ => None,
-        }
-    }
 }
 
 /// Parameters for editing an existing issue.
@@ -1364,7 +1354,7 @@ fn comment_matches_key(body: &str, comment_key: &str) -> bool {
 /// malformed markers are skipped silently (no panic, no error) so the merge
 /// loop can always make forward progress even if a comment body was hand-
 /// edited.
-pub fn parse_comment_sections(body: &str) -> Vec<(String, String)> {
+pub(crate) fn parse_comment_sections(body: &str) -> Vec<(String, String)> {
     // The `regex` crate does not support backreferences, so we capture both
     // start-key and end-key and verify equality post-match.
     let re = regex::Regex::new(
@@ -1425,7 +1415,7 @@ fn extract_footer(body: &str) -> Option<String> {
 
 /// Merge `(section_key, body)` into `sections`. Replaces any existing entry
 /// for `section_key`, preserving the original position; otherwise appends.
-pub fn merge_section(
+pub(crate) fn merge_section(
     mut sections: Vec<(String, String)>,
     section_key: &str,
     body: String,
@@ -1450,7 +1440,7 @@ pub fn merge_section(
 /// - `footer` → optional block written after the last section, wrapped in
 ///   dedicated `<!-- homeboy:footer:start|end -->` markers.
 /// - Output is always newline-normalized with a trailing newline.
-pub fn render_comment(
+pub(crate) fn render_comment(
     comment_key: &str,
     header: Option<&str>,
     sections: &[(String, String)],
@@ -1828,37 +1818,6 @@ mod tests {
     fn issue_close_reason_gh_flag() {
         assert_eq!(IssueCloseReason::Completed.as_gh_flag(), "completed");
         assert_eq!(IssueCloseReason::NotPlanned.as_gh_flag(), "not planned");
-    }
-
-    #[test]
-    fn issue_close_reason_from_graphql_completed() {
-        assert_eq!(
-            IssueCloseReason::from_graphql("completed"),
-            Some(IssueCloseReason::Completed)
-        );
-        assert_eq!(
-            IssueCloseReason::from_graphql("COMPLETED"),
-            Some(IssueCloseReason::Completed)
-        );
-    }
-
-    #[test]
-    fn issue_close_reason_from_graphql_not_planned() {
-        assert_eq!(
-            IssueCloseReason::from_graphql("not_planned"),
-            Some(IssueCloseReason::NotPlanned)
-        );
-        assert_eq!(
-            IssueCloseReason::from_graphql("NOT_PLANNED"),
-            Some(IssueCloseReason::NotPlanned)
-        );
-    }
-
-    #[test]
-    fn issue_close_reason_from_graphql_unknown_returns_none() {
-        assert!(IssueCloseReason::from_graphql("").is_none());
-        assert!(IssueCloseReason::from_graphql("reopened").is_none());
-        assert!(IssueCloseReason::from_graphql("nonsense").is_none());
     }
 
     #[test]

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -18,11 +18,11 @@ pub use commits::{
 };
 pub use github::{
     gh_probe_succeeds, issue_close, issue_comment, issue_create, issue_edit, issue_find,
-    merge_section, parse_comment_sections, pr_comment, pr_create, pr_edit, pr_files, pr_find,
-    pr_merge, pr_view, render_comment, GithubFindItem, GithubFindOutput, GithubIssueOutput,
-    GithubPrOutput, GithubPrView, IssueCloseOptions, IssueCloseReason, IssueCommentOptions,
-    IssueCreateOptions, IssueEditOptions, IssueFindOptions, IssueState, PrCommentMode,
-    PrCommentOptions, PrCreateOptions, PrEditOptions, PrFindOptions, PrMergeOptions, PrState,
+    pr_comment, pr_create, pr_edit, pr_files, pr_find, pr_merge, pr_view, GithubFindItem,
+    GithubFindOutput, GithubIssueOutput, GithubPrOutput, GithubPrView, IssueCloseOptions,
+    IssueCloseReason, IssueCommentOptions, IssueCreateOptions, IssueEditOptions, IssueFindOptions,
+    IssueState, PrCommentMode, PrCommentOptions, PrCreateOptions, PrEditOptions, PrFindOptions,
+    PrMergeOptions, PrState,
 };
 pub use operations::{
     build_repo_baseline_snapshot, changes, changes_at, changes_bulk, changes_project,

--- a/src/core/issues/plan.rs
+++ b/src/core/issues/plan.rs
@@ -74,9 +74,6 @@ impl TrackedIssueState {
     pub fn is_open(self) -> bool {
         matches!(self, TrackedIssueState::Open)
     }
-    pub fn is_closed(self) -> bool {
-        !self.is_open()
-    }
 }
 
 /// Configuration that affects reconcile decisions but not finding shape.

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -254,7 +254,7 @@ pub fn stacks() -> Result<PathBuf> {
 }
 
 /// Daemon runtime state directory (~/.config/homeboy/daemon/).
-pub fn daemon_state_dir() -> Result<PathBuf> {
+fn daemon_state_dir() -> Result<PathBuf> {
     Ok(homeboy()?.join("daemon"))
 }
 
@@ -269,7 +269,7 @@ pub fn daemon_jobs_file() -> Result<PathBuf> {
 }
 
 /// Runner connection session state directory (~/.config/homeboy/runner-sessions/).
-pub fn runner_sessions_dir() -> Result<PathBuf> {
+fn runner_sessions_dir() -> Result<PathBuf> {
     Ok(homeboy()?.join("runner-sessions"))
 }
 


### PR DESCRIPTION
## Summary
- Narrows obviously internal helper visibility for CLI response/TTY, audit internals, component portable config helpers, deploy provenance formatting, symbol import parsing, extension runtime env assembly, GitHub comment section helpers, and path helpers.
- Removes two unused helper APIs with only test coverage (`set_changelog_target`, `IssueCloseReason::from_graphql`) plus the unused `tagged_function_removal` primitive.
- Leaves the remaining `unreferenced_export` findings in place where they appear tied to public or semi-public refactor, runner, or validation surfaces rather than a clearly safe behavior-preserving cleanup.

Refs #2716

## Verification
- `cargo check`
- `cargo test`
- `homeboy audit homeboy --only unreferenced_export` passed; drift reduced by 73 findings vs baseline and remaining `unreferenced_export` advisory findings dropped from 32 to 13.

## Remaining triage notes
- Kept `validate_write` public because the module documents it as the post-write validation gate for code-modifying commands.
- Kept `VerificationPhase::canonical_order` public because it belongs to the runner contract vocabulary.
- Kept the refactor auto/plan exports public for now because they are part of the refactor planning/autofix surface and need a broader API boundary decision before privatizing.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting the internal visibility cleanup, running audit/test verification, and preparing this PR description for Chris to review.