### PR TITLE
fix: reduce release and rig duplicate blocks

### DIFF
--- a/src/core/release/changelog/sections.rs
+++ b/src/core/release/changelog/sections.rs
@@ -349,10 +349,8 @@ pub(super) fn append_item_to_subsection(
                 if !out.ends_with("\n\n") && !out.is_empty() {
                     out.push('\n');
                 }
-                out.push_str(&target_header);
+                push_subsection_item(&mut out, &target_header, &bullet);
                 out.push('\n');
-                out.push_str(&bullet);
-                out.push_str("\n\n");
             }
             out.push_str(line);
             out.push('\n');
@@ -362,10 +360,7 @@ pub(super) fn append_item_to_subsection(
             if !out.ends_with("\n\n") {
                 out.push('\n');
             }
-            out.push_str(&target_header);
-            out.push('\n');
-            out.push_str(&bullet);
-            out.push('\n');
+            push_subsection_item(&mut out, &target_header, &bullet);
         }
     } else {
         // No subsections exist yet - create the first one after section header
@@ -383,6 +378,13 @@ pub(super) fn append_item_to_subsection(
     }
 
     Ok((out, true))
+}
+
+fn push_subsection_item(out: &mut String, target_header: &str, bullet: &str) {
+    out.push_str(target_header);
+    out.push('\n');
+    out.push_str(bullet);
+    out.push('\n');
 }
 
 #[cfg(test)]

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -24,6 +24,7 @@ use super::utils::{extract_latest_notes, parse_release_artifacts};
 
 pub(crate) mod artifacts;
 pub(crate) mod changelog;
+mod github_release;
 pub(crate) mod prepare;
 
 /// Build a successful step result with optional data and hints.
@@ -476,12 +477,12 @@ pub(crate) fn run_git_tag(
                 crate::core::deploy::release_download::parse_github_url(&remote_url)
             })
             .and_then(|github| {
-                if !gh_is_available() || !gh_is_authenticated() {
+                if !github_release::gh_is_available() || !github_release::gh_is_authenticated() {
                     return None;
                 }
 
                 let repo_flag = format!("{}/{}", github.owner, github.repo);
-                Some(gh_release_exists(tag_name, &repo_flag))
+                Some(github_release::gh_release_exists(tag_name, &repo_flag))
             });
         let github_release_label = match github_release {
             Some(true) => "exists".to_string(),
@@ -963,14 +964,14 @@ pub(crate) fn run_github_release(
             )
         })?;
 
-    if !gh_is_available() {
-        let fallback = fallback_gh_command(&tag);
+    if !github_release::gh_is_available() {
+        let fallback = github_release::fallback_gh_command(&tag);
         log_status!(
             "release",
             "⚠ `gh` CLI not found on PATH — skipping GitHub Release creation"
         );
         log_status!("release", "Manual fallback: {}", fallback);
-        return Ok(github_release_skipped_result(
+        return Ok(github_release::skipped_result(
             &tag,
             &github,
             "gh-not-available",
@@ -978,8 +979,8 @@ pub(crate) fn run_github_release(
         ));
     }
 
-    if !gh_is_authenticated() {
-        let fallback = fallback_gh_command(&tag);
+    if !github_release::gh_is_authenticated() {
+        let fallback = github_release::fallback_gh_command(&tag);
         log_status!(
             "release",
             "⚠ `gh` is not authenticated — skipping GitHub Release creation"
@@ -989,7 +990,7 @@ pub(crate) fn run_github_release(
             "Authenticate with `gh auth login`, then manual fallback: {}",
             fallback
         );
-        return Ok(github_release_skipped_result(
+        return Ok(github_release::skipped_result(
             &tag,
             &github,
             "gh-not-authenticated",
@@ -1012,7 +1013,7 @@ pub(crate) fn run_github_release(
     let has_artifacts = !artifact_paths.is_empty();
 
     let repo_flag = format!("{}/{}", github.owner, github.repo);
-    if gh_release_exists(&tag, &repo_flag) {
+    if github_release::gh_release_exists(&tag, &repo_flag) {
         // Release entry already exists (idempotent retry, or release
         // created out of band). When the release has no artifacts to
         // attach, skip — there is nothing to update. When artifacts are
@@ -1025,7 +1026,7 @@ pub(crate) fn run_github_release(
                 tag,
                 repo_flag
             );
-            return Ok(github_release_skipped_result(
+            return Ok(github_release::skipped_result(
                 &tag,
                 &github,
                 "release-already-exists",
@@ -1061,7 +1062,7 @@ pub(crate) fn run_github_release(
             let stderr = String::from_utf8_lossy(&upload_output.stderr).to_string();
             let stdout = String::from_utf8_lossy(&upload_output.stdout).to_string();
             log_status!("release", "⚠ `gh release upload` failed: {}", stderr.trim());
-            return Ok(github_release_upload_failed_result(
+            return Ok(github_release::upload_failed_result(
                 &tag,
                 &github,
                 stdout,
@@ -1070,7 +1071,7 @@ pub(crate) fn run_github_release(
             ));
         }
 
-        return Ok(github_release_upload_success_result(
+        return Ok(github_release::upload_success_result(
             &tag,
             &github,
             artifact_paths.len(),
@@ -1084,7 +1085,10 @@ pub(crate) fn run_github_release(
     };
 
     let tmp_dir = crate::core::engine::temp::runtime_temp_dir("github-release")?;
-    let notes_path = tmp_dir.join(format!("notes-{}.md", sanitize_tag_for_filename(&tag)));
+    let notes_path = tmp_dir.join(format!(
+        "notes-{}.md",
+        github_release::sanitize_tag_for_filename(&tag)
+    ));
     std::fs::write(&notes_path, &notes_body).map_err(|e| {
         Error::internal_io(
             format!("Failed to write release notes file: {}", e),
@@ -1135,7 +1139,7 @@ pub(crate) fn run_github_release(
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let fallback = fallback_gh_command(&tag);
+        let fallback = github_release::fallback_gh_command(&tag);
         log_status!("release", "⚠ `gh release create` failed: {}", stderr.trim());
         log_status!("release", "Manual fallback: {}", fallback);
         return Ok(step_success(
@@ -1296,110 +1300,9 @@ fn store_artifacts_from_output(
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// `gh` CLI probes
-// ---------------------------------------------------------------------------
-
-fn github_release_skipped_result(
-    tag: &str,
-    github: &crate::core::deploy::release_download::GitHubRepo,
-    reason: &str,
-    fallback_command: Option<String>,
-) -> ReleaseStepResult {
-    let mut data = serde_json::json!({
-        "skipped": true,
-        "reason": reason,
-        "tag": tag,
-        "owner": github.owner,
-        "repo": github.repo,
-    });
-    if let Some(fallback) = fallback_command {
-        data["fallback_command"] = serde_json::json!(fallback);
-    }
-
-    step_success("github.release", "github.release", Some(data), Vec::new())
-}
-
-fn github_release_upload_failed_result(
-    tag: &str,
-    github: &crate::core::deploy::release_download::GitHubRepo,
-    stdout: String,
-    stderr: String,
-    artifact_count: usize,
-) -> ReleaseStepResult {
-    step_success(
-        "github.release",
-        "github.release",
-        Some(serde_json::json!({
-            "skipped": true,
-            "reason": "gh-upload-failed",
-            "tag": tag,
-            "owner": github.owner,
-            "repo": github.repo,
-            "stdout": stdout,
-            "stderr": stderr,
-            "artifact_count": artifact_count,
-        })),
-        Vec::new(),
-    )
-}
-
-fn github_release_upload_success_result(
-    tag: &str,
-    github: &crate::core::deploy::release_download::GitHubRepo,
-    artifact_count: usize,
-) -> ReleaseStepResult {
-    step_success(
-        "github.release",
-        "github.release",
-        Some(serde_json::json!({
-            "action": "github.release.upload",
-            "tag": tag,
-            "owner": github.owner,
-            "repo": github.repo,
-            "artifact_count": artifact_count,
-        })),
-        Vec::new(),
-    )
-}
-
-fn gh_is_available() -> bool {
-    crate::core::git::gh_probe_succeeds(&["--version"])
-}
-
-fn gh_is_authenticated() -> bool {
-    crate::core::git::gh_probe_succeeds(&["auth", "status", "--hostname", "github.com"])
-}
-
-fn gh_release_exists(tag: &str, repo_flag: &str) -> bool {
-    crate::core::git::gh_probe_succeeds(&["release", "view", tag, "-R", repo_flag])
-}
-
-fn fallback_gh_command(tag: &str) -> String {
-    format!(
-        "gh release create {} --title {} --notes-file <path-to-release-notes>",
-        tag, tag
-    )
-}
-
-fn sanitize_tag_for_filename(tag: &str) -> String {
-    tag.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
-                c
-            } else {
-                '-'
-            }
-        })
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
-        fallback_gh_command, publish_step_result, run_git_push, sanitize_tag_for_filename,
-        store_artifacts_from_output,
-    };
+    use super::{github_release, publish_step_result, run_git_push, store_artifacts_from_output};
     use crate::core::component::Component;
     use crate::core::release::ReleaseStepStatus;
     use std::process::Command;
@@ -1420,22 +1323,31 @@ mod tests {
 
     #[test]
     fn sanitize_tag_for_filename_preserves_safe_chars() {
-        assert_eq!(sanitize_tag_for_filename("v1.2.3"), "v1.2.3");
         assert_eq!(
-            sanitize_tag_for_filename("data-machine-v0.70.2"),
+            github_release::sanitize_tag_for_filename("v1.2.3"),
+            "v1.2.3"
+        );
+        assert_eq!(
+            github_release::sanitize_tag_for_filename("data-machine-v0.70.2"),
             "data-machine-v0.70.2"
         );
     }
 
     #[test]
     fn sanitize_tag_for_filename_strips_unsafe_chars() {
-        assert_eq!(sanitize_tag_for_filename("v1.2.3 rc1"), "v1.2.3-rc1");
-        assert_eq!(sanitize_tag_for_filename("feat/foo@1"), "feat-foo-1");
+        assert_eq!(
+            github_release::sanitize_tag_for_filename("v1.2.3 rc1"),
+            "v1.2.3-rc1"
+        );
+        assert_eq!(
+            github_release::sanitize_tag_for_filename("feat/foo@1"),
+            "feat-foo-1"
+        );
     }
 
     #[test]
     fn fallback_gh_command_includes_tag_twice() {
-        let cmd = fallback_gh_command("v1.2.3");
+        let cmd = github_release::fallback_gh_command("v1.2.3");
         assert!(cmd.contains("gh release create v1.2.3"));
         assert!(cmd.contains("--title v1.2.3"));
         assert!(cmd.contains("--notes-file"));

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -970,18 +970,11 @@ pub(crate) fn run_github_release(
             "⚠ `gh` CLI not found on PATH — skipping GitHub Release creation"
         );
         log_status!("release", "Manual fallback: {}", fallback);
-        return Ok(step_success(
-            "github.release",
-            "github.release",
-            Some(serde_json::json!({
-                "skipped": true,
-                "reason": "gh-not-available",
-                "tag": tag,
-                "owner": github.owner,
-                "repo": github.repo,
-                "fallback_command": fallback,
-            })),
-            Vec::new(),
+        return Ok(github_release_skipped_result(
+            &tag,
+            &github,
+            "gh-not-available",
+            Some(fallback),
         ));
     }
 
@@ -996,18 +989,11 @@ pub(crate) fn run_github_release(
             "Authenticate with `gh auth login`, then manual fallback: {}",
             fallback
         );
-        return Ok(step_success(
-            "github.release",
-            "github.release",
-            Some(serde_json::json!({
-                "skipped": true,
-                "reason": "gh-not-authenticated",
-                "tag": tag,
-                "owner": github.owner,
-                "repo": github.repo,
-                "fallback_command": fallback,
-            })),
-            Vec::new(),
+        return Ok(github_release_skipped_result(
+            &tag,
+            &github,
+            "gh-not-authenticated",
+            Some(fallback),
         ));
     }
 
@@ -1039,17 +1025,11 @@ pub(crate) fn run_github_release(
                 tag,
                 repo_flag
             );
-            return Ok(step_success(
-                "github.release",
-                "github.release",
-                Some(serde_json::json!({
-                    "skipped": true,
-                    "reason": "release-already-exists",
-                    "tag": tag,
-                    "owner": github.owner,
-                    "repo": github.repo,
-                })),
-                Vec::new(),
+            return Ok(github_release_skipped_result(
+                &tag,
+                &github,
+                "release-already-exists",
+                None,
             ));
         }
 
@@ -1081,34 +1061,19 @@ pub(crate) fn run_github_release(
             let stderr = String::from_utf8_lossy(&upload_output.stderr).to_string();
             let stdout = String::from_utf8_lossy(&upload_output.stdout).to_string();
             log_status!("release", "⚠ `gh release upload` failed: {}", stderr.trim());
-            return Ok(step_success(
-                "github.release",
-                "github.release",
-                Some(serde_json::json!({
-                    "skipped": true,
-                    "reason": "gh-upload-failed",
-                    "tag": tag,
-                    "owner": github.owner,
-                    "repo": github.repo,
-                    "stdout": stdout,
-                    "stderr": stderr,
-                    "artifact_count": artifact_paths.len(),
-                })),
-                Vec::new(),
+            return Ok(github_release_upload_failed_result(
+                &tag,
+                &github,
+                stdout,
+                stderr,
+                artifact_paths.len(),
             ));
         }
 
-        return Ok(step_success(
-            "github.release",
-            "github.release",
-            Some(serde_json::json!({
-                "action": "github.release.upload",
-                "tag": tag,
-                "owner": github.owner,
-                "repo": github.repo,
-                "artifact_count": artifact_paths.len(),
-            })),
-            Vec::new(),
+        return Ok(github_release_upload_success_result(
+            &tag,
+            &github,
+            artifact_paths.len(),
         ));
     }
 
@@ -1334,6 +1299,69 @@ fn store_artifacts_from_output(
 // ---------------------------------------------------------------------------
 // `gh` CLI probes
 // ---------------------------------------------------------------------------
+
+fn github_release_skipped_result(
+    tag: &str,
+    github: &crate::core::deploy::release_download::GitHubRepo,
+    reason: &str,
+    fallback_command: Option<String>,
+) -> ReleaseStepResult {
+    let mut data = serde_json::json!({
+        "skipped": true,
+        "reason": reason,
+        "tag": tag,
+        "owner": github.owner,
+        "repo": github.repo,
+    });
+    if let Some(fallback) = fallback_command {
+        data["fallback_command"] = serde_json::json!(fallback);
+    }
+
+    step_success("github.release", "github.release", Some(data), Vec::new())
+}
+
+fn github_release_upload_failed_result(
+    tag: &str,
+    github: &crate::core::deploy::release_download::GitHubRepo,
+    stdout: String,
+    stderr: String,
+    artifact_count: usize,
+) -> ReleaseStepResult {
+    step_success(
+        "github.release",
+        "github.release",
+        Some(serde_json::json!({
+            "skipped": true,
+            "reason": "gh-upload-failed",
+            "tag": tag,
+            "owner": github.owner,
+            "repo": github.repo,
+            "stdout": stdout,
+            "stderr": stderr,
+            "artifact_count": artifact_count,
+        })),
+        Vec::new(),
+    )
+}
+
+fn github_release_upload_success_result(
+    tag: &str,
+    github: &crate::core::deploy::release_download::GitHubRepo,
+    artifact_count: usize,
+) -> ReleaseStepResult {
+    step_success(
+        "github.release",
+        "github.release",
+        Some(serde_json::json!({
+            "action": "github.release.upload",
+            "tag": tag,
+            "owner": github.owner,
+            "repo": github.repo,
+            "artifact_count": artifact_count,
+        })),
+        Vec::new(),
+    )
+}
 
 fn gh_is_available() -> bool {
     crate::core::git::gh_probe_succeeds(&["--version"])

--- a/src/core/release/executor/github_release.rs
+++ b/src/core/release/executor/github_release.rs
@@ -1,0 +1,100 @@
+//! GitHub Release helper result builders and probes.
+
+use crate::core::deploy::release_download::GitHubRepo;
+
+use super::step_success;
+use crate::core::release::types::ReleaseStepResult;
+
+pub(super) fn skipped_result(
+    tag: &str,
+    github: &GitHubRepo,
+    reason: &str,
+    fallback_command: Option<String>,
+) -> ReleaseStepResult {
+    let mut data = serde_json::json!({
+        "skipped": true,
+        "reason": reason,
+        "tag": tag,
+        "owner": github.owner,
+        "repo": github.repo,
+    });
+    if let Some(fallback) = fallback_command {
+        data["fallback_command"] = serde_json::json!(fallback);
+    }
+
+    step_success("github.release", "github.release", Some(data), Vec::new())
+}
+
+pub(super) fn upload_failed_result(
+    tag: &str,
+    github: &GitHubRepo,
+    stdout: String,
+    stderr: String,
+    artifact_count: usize,
+) -> ReleaseStepResult {
+    step_success(
+        "github.release",
+        "github.release",
+        Some(serde_json::json!({
+            "skipped": true,
+            "reason": "gh-upload-failed",
+            "tag": tag,
+            "owner": github.owner,
+            "repo": github.repo,
+            "stdout": stdout,
+            "stderr": stderr,
+            "artifact_count": artifact_count,
+        })),
+        Vec::new(),
+    )
+}
+
+pub(super) fn upload_success_result(
+    tag: &str,
+    github: &GitHubRepo,
+    artifact_count: usize,
+) -> ReleaseStepResult {
+    step_success(
+        "github.release",
+        "github.release",
+        Some(serde_json::json!({
+            "action": "github.release.upload",
+            "tag": tag,
+            "owner": github.owner,
+            "repo": github.repo,
+            "artifact_count": artifact_count,
+        })),
+        Vec::new(),
+    )
+}
+
+pub(super) fn gh_is_available() -> bool {
+    crate::core::git::gh_probe_succeeds(&["--version"])
+}
+
+pub(super) fn gh_is_authenticated() -> bool {
+    crate::core::git::gh_probe_succeeds(&["auth", "status", "--hostname", "github.com"])
+}
+
+pub(super) fn gh_release_exists(tag: &str, repo_flag: &str) -> bool {
+    crate::core::git::gh_probe_succeeds(&["release", "view", tag, "-R", repo_flag])
+}
+
+pub(super) fn fallback_gh_command(tag: &str) -> String {
+    format!(
+        "gh release create {} --title {} --notes-file <path-to-release-notes>",
+        tag, tag
+    )
+}
+
+pub(super) fn sanitize_tag_for_filename(tag: &str) -> String {
+    tag.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}

--- a/src/core/rig/source.rs
+++ b/src/core/rig/source.rs
@@ -428,30 +428,9 @@ fn group_source_entries(entries: SourceEntries) -> RigSourceListResult {
 
         groups
             .entry(key)
-            .or_insert_with(|| RigSourceGroup {
-                source: entry.metadata.source.clone(),
-                package_id: package_id_from_path(&entry.metadata.package_path),
-                package_path: entry.metadata.package_path.clone(),
-                discovery_path: entry
-                    .metadata
-                    .discovery_path
-                    .clone()
-                    .unwrap_or_else(|| infer_discovery_path(&entry.metadata.rig_path)),
-                linked: entry.metadata.linked,
-                source_revision: entry.metadata.source_revision.clone(),
-                rigs: Vec::new(),
-                stacks: Vec::new(),
-            })
+            .or_insert_with(|| new_rig_source_group(&entry.metadata))
             .rigs
-            .push(RigSourceRig {
-                id: entry.id,
-                rig_path: entry.metadata.rig_path,
-                config_path: config_path
-                    .map(|path| path.to_string_lossy().to_string())
-                    .unwrap_or_default(),
-                config_present,
-                config_owned,
-            });
+            .push(source_rig(entry, config_path, config_present, config_owned));
     }
 
     for entry in entries.valid_stacks {
@@ -464,26 +443,14 @@ fn group_source_entries(entries: SourceEntries) -> RigSourceListResult {
 
         groups
             .entry(key)
-            .or_insert_with(|| RigSourceGroup {
-                source: entry.metadata.source.clone(),
-                package_id: package_id_from_path(&entry.metadata.package_path),
-                package_path: entry.metadata.package_path.clone(),
-                discovery_path: entry.metadata.discovery_path.clone(),
-                linked: entry.metadata.linked,
-                source_revision: entry.metadata.source_revision.clone(),
-                rigs: Vec::new(),
-                stacks: Vec::new(),
-            })
+            .or_insert_with(|| new_stack_source_group(&entry.metadata))
             .stacks
-            .push(RigSourceStack {
-                id: entry.id,
-                stack_path: entry.metadata.stack_path,
-                config_path: config_path
-                    .map(|path| path.to_string_lossy().to_string())
-                    .unwrap_or_default(),
+            .push(source_stack(
+                entry,
+                config_path,
                 config_present,
                 config_owned,
-            });
+            ));
     }
 
     let mut sources = groups.into_values().collect::<Vec<_>>();
@@ -514,6 +481,84 @@ fn infer_discovery_path(rig_path: &str) -> String {
             .to_string(),
         _ => path.parent().unwrap_or(path).to_string_lossy().to_string(),
     }
+}
+
+fn new_source_group(
+    source: &str,
+    package_path: &str,
+    discovery_path: String,
+    linked: bool,
+    source_revision: Option<String>,
+) -> RigSourceGroup {
+    RigSourceGroup {
+        source: source.to_string(),
+        package_id: package_id_from_path(package_path),
+        package_path: package_path.to_string(),
+        discovery_path,
+        linked,
+        source_revision,
+        rigs: Vec::new(),
+        stacks: Vec::new(),
+    }
+}
+
+fn new_rig_source_group(metadata: &RigSourceMetadata) -> RigSourceGroup {
+    new_source_group(
+        &metadata.source,
+        &metadata.package_path,
+        metadata
+            .discovery_path
+            .clone()
+            .unwrap_or_else(|| infer_discovery_path(&metadata.rig_path)),
+        metadata.linked,
+        metadata.source_revision.clone(),
+    )
+}
+
+fn new_stack_source_group(metadata: &StackSourceMetadata) -> RigSourceGroup {
+    new_source_group(
+        &metadata.source,
+        &metadata.package_path,
+        metadata.discovery_path.clone(),
+        metadata.linked,
+        metadata.source_revision.clone(),
+    )
+}
+
+fn source_rig(
+    entry: RigSourceEntry,
+    config_path: Option<PathBuf>,
+    config_present: bool,
+    config_owned: bool,
+) -> RigSourceRig {
+    RigSourceRig {
+        id: entry.id,
+        rig_path: entry.metadata.rig_path,
+        config_path: source_config_path(config_path),
+        config_present,
+        config_owned,
+    }
+}
+
+fn source_stack(
+    entry: StackSourceEntry,
+    config_path: Option<PathBuf>,
+    config_present: bool,
+    config_owned: bool,
+) -> RigSourceStack {
+    RigSourceStack {
+        id: entry.id,
+        stack_path: entry.metadata.stack_path,
+        config_path: source_config_path(config_path),
+        config_present,
+        config_owned,
+    }
+}
+
+fn source_config_path(config_path: Option<PathBuf>) -> String {
+    config_path
+        .map(|path| path.to_string_lossy().to_string())
+        .unwrap_or_default()
 }
 
 fn source_matches(source: &RigSourceGroup, selector: &str) -> bool {


### PR DESCRIPTION
## Summary
- Extract shared changelog subsection writing, GitHub release result construction, and rig source grouping helpers.
- Clears the slice H intra-method duplicate findings in `sections.rs`, `executor.rs`, and `source.rs` without changing behavior.

## Verification
- `cargo test changelog::sections`
- `cargo test core::rig::source`
- `cargo test github_release`
- `homeboy audit homeboy --only intra_method_duplicate --path /Users/chubes/Developer/homeboy@fix-issue-2741-duplicate-sweep-slice-h`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the duplicate-block refactor and ran targeted verification; Chris remains responsible for review and merge.