### PR TITLE
refactor: extract duplication suppression helpers

### DIFF
--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -21,6 +21,10 @@ use super::idiomatic::is_trivial_method;
 use super::walker::is_test_path;
 use crate::core::component::DuplicationDetectorConfig;
 
+mod intra_method;
+
+use intra_method::is_low_information_literal_or_error_block;
+
 /// Minimum number of locations for a function to count as duplicated.
 const MIN_DUPLICATE_LOCATIONS: usize = 2;
 
@@ -587,6 +591,7 @@ pub(crate) fn detect_intra_method_duplicates(fingerprints: &[&FileFingerprint]) 
                             &normalized,
                             first_norm_idx,
                             match_len,
+                            MIN_INTRA_BLOCK_LINES,
                         )
                     {
                         suppressed_ranges
@@ -841,106 +846,6 @@ fn is_branch_separator(trimmed: &str) -> bool {
         || trimmed.starts_with("} elseif")
         || trimmed.ends_with("=> {")
         || trimmed.starts_with("} => {")
-}
-
-/// Suppress low-information literal/envelope repeats: DTO tails full of
-/// `None`/`Default::default()` and repeated error constructors. These are common
-/// review-noise patterns where extraction usually hides branch intent.
-fn is_low_information_literal_or_error_block(
-    normalized: &[(usize, String)],
-    start: usize,
-    len: usize,
-) -> bool {
-    let end = (start + len).min(normalized.len());
-    if start >= end {
-        return false;
-    }
-
-    let window = &normalized[start..end];
-    let low_info_lines = window
-        .iter()
-        .filter(|(_, line)| is_low_information_literal_or_error_line(line))
-        .count();
-
-    low_info_lines >= MIN_INTRA_BLOCK_LINES && low_info_lines * 100 / window.len() >= 80
-}
-
-fn is_low_information_literal_or_error_line(normalized: &str) -> bool {
-    let t = normalized.trim().trim_end_matches(',');
-
-    if t.is_empty() || is_scaffolding_line(t) {
-        return true;
-    }
-
-    if t == "0" || t == "..default::default()" {
-        return true;
-    }
-
-    if is_neutral_struct_field(t) {
-        return true;
-    }
-
-    if is_error_envelope_line(t) {
-        return true;
-    }
-
-    if is_simple_argument_line(t) {
-        return true;
-    }
-
-    false
-}
-
-fn is_simple_argument_line(line: &str) -> bool {
-    let mut value = line.trim();
-    value = value.strip_prefix("&mut ").unwrap_or(value);
-    value = value.strip_prefix('&').unwrap_or(value).trim();
-
-    if is_simple_identifier_path(value) {
-        return true;
-    }
-
-    if value.ends_with(".clone()") || value.ends_with(".to_string()") {
-        return true;
-    }
-
-    if let Some((left, right)) = value.split_once(" + ") {
-        return is_simple_identifier_path(left.trim()) && right.trim().parse::<u64>().is_ok();
-    }
-
-    false
-}
-
-fn is_simple_identifier_path(value: &str) -> bool {
-    !value.is_empty()
-        && value
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.'))
-        && value.chars().any(|c| c.is_ascii_alphabetic() || c == '_')
-}
-
-fn is_neutral_struct_field(line: &str) -> bool {
-    let Some((_field, value)) = line.split_once(':') else {
-        return false;
-    };
-    let value = value.trim();
-
-    value == "none"
-        || value == "default::default()"
-        || value == "false"
-        || value == "0"
-        || value.ends_with(".clone()")
-        || value.ends_with(".to_string()")
-        || value.starts_with("some(")
-        || is_simple_argument_line(value)
-}
-
-fn is_error_envelope_line(line: &str) -> bool {
-    line.contains("error::")
-        || line.contains("::error")
-        || line.contains("internal_io(")
-        || line.starts_with("format!(")
-        || line.starts_with("some(")
 }
 
 // ============================================================================

--- a/src/core/code_audit/duplication/intra_method.rs
+++ b/src/core/code_audit/duplication/intra_method.rs
@@ -1,0 +1,102 @@
+use super::is_scaffolding_line;
+
+/// Suppress low-information literal/envelope repeats: DTO tails full of
+/// `None`/`Default::default()` and repeated error constructors. These are common
+/// review-noise patterns where extraction usually hides branch intent.
+pub(super) fn is_low_information_literal_or_error_block(
+    normalized: &[(usize, String)],
+    start: usize,
+    len: usize,
+    min_block_lines: usize,
+) -> bool {
+    let end = (start + len).min(normalized.len());
+    if start >= end {
+        return false;
+    }
+
+    let window = &normalized[start..end];
+    let low_info_lines = window
+        .iter()
+        .filter(|(_, line)| is_low_information_literal_or_error_line(line))
+        .count();
+
+    low_info_lines >= min_block_lines && low_info_lines * 100 / window.len() >= 80
+}
+
+fn is_low_information_literal_or_error_line(normalized: &str) -> bool {
+    let t = normalized.trim().trim_end_matches(',');
+
+    if t.is_empty() || is_scaffolding_line(t) {
+        return true;
+    }
+
+    if t == "0" || t == "..default::default()" {
+        return true;
+    }
+
+    if is_neutral_struct_field(t) {
+        return true;
+    }
+
+    if is_error_envelope_line(t) {
+        return true;
+    }
+
+    if is_simple_argument_line(t) {
+        return true;
+    }
+
+    false
+}
+
+fn is_simple_argument_line(line: &str) -> bool {
+    let mut value = line.trim();
+    value = value.strip_prefix("&mut ").unwrap_or(value);
+    value = value.strip_prefix('&').unwrap_or(value).trim();
+
+    if is_simple_identifier_path(value) {
+        return true;
+    }
+
+    if value.ends_with(".clone()") || value.ends_with(".to_string()") {
+        return true;
+    }
+
+    if let Some((left, right)) = value.split_once(" + ") {
+        return is_simple_identifier_path(left.trim()) && right.trim().parse::<u64>().is_ok();
+    }
+
+    false
+}
+
+fn is_simple_identifier_path(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.'))
+        && value.chars().any(|c| c.is_ascii_alphabetic() || c == '_')
+}
+
+fn is_neutral_struct_field(line: &str) -> bool {
+    let Some((_field, value)) = line.split_once(':') else {
+        return false;
+    };
+    let value = value.trim();
+
+    value == "none"
+        || value == "default::default()"
+        || value == "false"
+        || value == "0"
+        || value.ends_with(".clone()")
+        || value.ends_with(".to_string()")
+        || value.starts_with("some(")
+        || is_simple_argument_line(value)
+}
+
+fn is_error_envelope_line(line: &str) -> bool {
+    line.contains("error::")
+        || line.contains("::error")
+        || line.contains("internal_io(")
+        || line.starts_with("format!(")
+        || line.starts_with("some(")
+}


### PR DESCRIPTION
## Summary
- Extract low-information intra-method duplication suppression helpers into `src/core/code_audit/duplication/intra_method.rs`.
- Keep the detector behavior unchanged while reducing `duplication.rs` by one cohesive helper cluster.

## Verification
- `cargo test code_audit::duplication`
- `homeboy audit homeboy --only god_file`

## Notes
- `homeboy audit homeboy --changed-since origin/main` was also run, but the worktree contains unrelated pre-existing `src/core/refactor/plan/*` changes that introduce `src/core/refactor/plan/sources/tests.rs::HighItemCount`, so that changed-since gate failed outside this slice.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the behavior-preserving module extraction and ran local verification; Chris remains responsible for review and merge.