### PR TITLE
Fix broken extension symlink diagnostics

### DIFF
--- a/src/core/extension/registry.rs
+++ b/src/core/extension/registry.rs
@@ -1,12 +1,23 @@
 use crate::core::config;
-use crate::core::error::Result;
+use crate::core::error::{Error, ErrorCode, Result};
 use crate::core::output::MergeOutput;
 use crate::core::paths;
 use std::path::PathBuf;
 
 use super::manifest::ExtensionManifest;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BrokenExtensionLink {
+    pub(crate) id: String,
+    pub(crate) path: PathBuf,
+    pub(crate) target: PathBuf,
+}
+
 pub fn load_extension(id: &str) -> Result<ExtensionManifest> {
+    if let Some(link) = broken_extension_link(id) {
+        return Err(broken_extension_error(&link));
+    }
+
     let mut manifest = config::load::<ExtensionManifest>(id)?;
     let extension_dir = paths::extension(id)?;
     manifest.extension_path = Some(extension_dir.to_string_lossy().to_string());
@@ -22,6 +33,68 @@ pub fn load_all_extensions() -> Result<Vec<ExtensionManifest>> {
         extensions_with_paths.push(extension);
     }
     Ok(extensions_with_paths)
+}
+
+pub(crate) fn broken_extension_links() -> Vec<BrokenExtensionLink> {
+    let Ok(dir) = paths::extensions() else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+
+    let mut links: Vec<BrokenExtensionLink> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            let metadata = std::fs::symlink_metadata(&path).ok()?;
+            if !metadata.file_type().is_symlink() || path.exists() {
+                return None;
+            }
+
+            Some(BrokenExtensionLink {
+                id: path.file_name()?.to_string_lossy().to_string(),
+                target: std::fs::read_link(&path).ok()?,
+                path,
+            })
+        })
+        .collect();
+    links.sort_by(|a, b| a.id.cmp(&b.id));
+    links
+}
+
+fn broken_extension_link(id: &str) -> Option<BrokenExtensionLink> {
+    let path = paths::extension(id).ok()?;
+    let metadata = std::fs::symlink_metadata(&path).ok()?;
+    if !metadata.file_type().is_symlink() || path.exists() {
+        return None;
+    }
+
+    Some(BrokenExtensionLink {
+        id: id.to_string(),
+        target: std::fs::read_link(&path).ok()?,
+        path,
+    })
+}
+
+fn broken_extension_error(link: &BrokenExtensionLink) -> Error {
+    Error::new(
+        ErrorCode::ExtensionNotFound,
+        format!(
+            "Extension '{}' is linked but its target is missing",
+            link.id
+        ),
+        serde_json::json!({
+            "id": link.id,
+            "error": "target_missing",
+            "path": link.path.to_string_lossy(),
+            "target": link.target.to_string_lossy(),
+        }),
+    )
+    .with_hint(format!(
+        "Relink it with: homeboy extension relink {} <path>",
+        link.id
+    ))
 }
 
 pub fn find_extension_by_tool(tool: &str) -> Option<ExtensionManifest> {
@@ -73,7 +146,7 @@ pub fn merge(id: Option<&str>, json_spec: &str, replace_fields: &[String]) -> Re
 /// Check if a extension is a symlink (linked, not installed).
 pub fn is_extension_linked(extension_id: &str) -> bool {
     paths::extension(extension_id)
-        .map(|p| p.is_symlink())
+        .map(|p| std::fs::symlink_metadata(p).is_ok_and(|m| m.file_type().is_symlink()))
         .unwrap_or(false)
 }
 
@@ -136,6 +209,50 @@ mod tests {
     fn test_is_extension_linked() {
         crate::test_support::with_isolated_home(|_| {
             assert!(!is_extension_linked("missing-extension"));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_broken_extension_link_detects_missing_symlink_target() {
+        crate::test_support::with_isolated_home(|_| {
+            let extensions_dir = paths::extensions().unwrap();
+            std::fs::create_dir_all(&extensions_dir).unwrap();
+            let link = extensions_dir.join("wordpress");
+            let target = extensions_dir.join("missing-wordpress");
+            std::os::unix::fs::symlink(&target, &link).unwrap();
+
+            let broken = broken_extension_link("wordpress").expect("broken link");
+            assert_eq!(broken.id, "wordpress");
+            assert_eq!(broken.path, link);
+            assert_eq!(broken.target, target);
+            assert!(is_extension_linked("wordpress"));
+
+            let err = load_extension("wordpress").expect_err("broken link error");
+            assert_eq!(err.code, ErrorCode::ExtensionNotFound);
+            assert_eq!(err.details["error"], "target_missing");
+            assert!(err.message.contains("target is missing"));
+            assert!(err
+                .hints
+                .iter()
+                .any(|hint| hint.message.contains("homeboy extension relink wordpress")));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_broken_extension_links_lists_missing_symlink_targets() {
+        crate::test_support::with_isolated_home(|_| {
+            let extensions_dir = paths::extensions().unwrap();
+            std::fs::create_dir_all(&extensions_dir).unwrap();
+            let link = extensions_dir.join("wordpress");
+            let target = extensions_dir.join("missing-wordpress");
+            std::os::unix::fs::symlink(&target, &link).unwrap();
+
+            let broken = broken_extension_links();
+            assert_eq!(broken.len(), 1);
+            assert_eq!(broken[0].id, "wordpress");
+            assert_eq!(broken[0].target, target);
         });
     }
 }

--- a/src/core/extension/summary.rs
+++ b/src/core/extension/summary.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use super::execution::{extension_ready_status, is_extension_compatible};
 use super::lifecycle::read_source_revision;
 use super::manifest::ActionType;
-use super::registry::{is_extension_linked, load_all_extensions};
+use super::registry::{broken_extension_links, is_extension_linked, load_all_extensions};
 
 /// Summary of an extension for list views.
 #[derive(Debug, Clone, Serialize)]
@@ -21,6 +21,10 @@ pub struct ExtensionSummary {
     pub ready_detail: Option<String>,
     pub linked: bool,
     pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symlink_target: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_revision: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -51,7 +55,7 @@ pub struct ActionSummary {
 pub fn list_summaries(project: Option<&crate::core::project::Project>) -> Vec<ExtensionSummary> {
     let extensions = load_all_extensions().unwrap_or_default();
 
-    extensions
+    let mut summaries: Vec<ExtensionSummary> = extensions
         .iter()
         .map(|ext| {
             let ready_status = extension_ready_status(ext);
@@ -106,6 +110,8 @@ pub fn list_summaries(project: Option<&crate::core::project::Project>) -> Vec<Ex
                 ready_detail: ready_status.detail,
                 linked,
                 path: ext.extension_path.clone().unwrap_or_default(),
+                error: None,
+                symlink_target: None,
                 source_revision,
                 cli_tool,
                 cli_display_name,
@@ -114,5 +120,64 @@ pub fn list_summaries(project: Option<&crate::core::project::Project>) -> Vec<Ex
                 has_ready_check,
             }
         })
-        .collect()
+        .collect();
+
+    summaries.extend(broken_extension_links().into_iter().map(|link| {
+        let target = link.target.to_string_lossy().to_string();
+        ExtensionSummary {
+            id: link.id,
+            name: String::new(),
+            version: String::new(),
+            description: String::new(),
+            runtime: String::new(),
+            compatible: false,
+            ready: false,
+            ready_reason: Some("target_missing".to_string()),
+            ready_detail: Some(format!("Linked target does not exist: {}", target)),
+            linked: true,
+            path: link.path.to_string_lossy().to_string(),
+            error: Some("target_missing".to_string()),
+            symlink_target: Some(target),
+            source_revision: None,
+            cli_tool: None,
+            cli_display_name: None,
+            actions: Vec::new(),
+            has_setup: None,
+            has_ready_check: None,
+        }
+    }));
+
+    summaries.sort_by(|a, b| a.id.cmp(&b.id));
+    summaries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::paths;
+
+    #[cfg(unix)]
+    #[test]
+    fn list_summaries_includes_broken_extension_symlinks() {
+        crate::test_support::with_isolated_home(|_| {
+            let extensions_dir = paths::extensions().unwrap();
+            std::fs::create_dir_all(&extensions_dir).unwrap();
+            let link = extensions_dir.join("wordpress");
+            let target = extensions_dir.join("missing-wordpress");
+            std::os::unix::fs::symlink(&target, &link).unwrap();
+
+            let summaries = list_summaries(None);
+
+            assert_eq!(summaries.len(), 1);
+            assert_eq!(summaries[0].id, "wordpress");
+            assert!(!summaries[0].ready);
+            assert!(summaries[0].linked);
+            assert_eq!(summaries[0].error.as_deref(), Some("target_missing"));
+            assert_eq!(summaries[0].ready_reason.as_deref(), Some("target_missing"));
+            assert_eq!(
+                summaries[0].symlink_target.as_deref(),
+                Some(target.to_string_lossy().as_ref())
+            );
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- Include broken extension symlink entries in `homeboy extension list` with `ready: false`, `linked: true`, and `error: target_missing`.
- Make `homeboy extension show <id>` report when an installed symlink target is missing and suggest `homeboy extension relink <id> <path>`.
- Add focused Unix symlink tests for registry detection and list summaries.

Fixes #2740.

## Verification
- `cargo test broken_extension`
- `cargo test core::extension`
- `homeboy audit --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the broken symlink detection, focused tests, verification runs, and PR draft under Chris's review.