### PR TITLE
docs: fix unsupported report command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Useful commands for parallel work:
 homeboy status --all
 homeboy git status
 homeboy review --changed-since origin/main --report pr-comment
-homeboy report review.json
+homeboy report failure-digest --output-dir .homeboy/runs/<run-id> --results @results.json
 homeboy runs list
 ```
 


### PR DESCRIPTION
## Summary
- replace the unsupported `homeboy report review.json` example in the README
- point readers to the live `homeboy report failure-digest` subcommand with explicit required flags

## Validation
- verified the stale `homeboy report review.json` example no longer appears in `README.md`
- verified the replacement command matches the existing `failure-digest` subcommand documented in `docs/commands/report.md` and implemented in `src/commands/report.rs`
- could not run `cargo` commands in this environment because Rust tooling is not installed

Closes #2767