### PR TITLE
Fix imported bundle artifact portability

### DIFF
--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -70,6 +70,6 @@ homeboy-observations/
   test_failures.json
 ```
 
-The v1 bundle is metadata-only: artifact records are exported, but artifact file bytes are not copied. `findings.json` contains normalized observation findings, and `test_failures.json` is an additive subset of findings where test commands recorded individual failures. Zip output is intentionally out of scope for v1; pass a directory path to `--output`.
+The v1 bundle is metadata-only: artifact records are exported, but artifact file bytes are not copied. Imported local file and directory artifacts are stored as `metadata-only` records with portable labels rather than source-machine paths. `homeboy runs query` reports these rows as skipped evidence, and `homeboy runs artifact get` explains that bytes are unavailable. `findings.json` contains normalized observation findings, and `test_failures.json` is an additive subset of findings where test commands recorded individual failures. Zip output is intentionally out of scope for v1; pass a directory path to `--output`.
 
 `homeboy runs import` is idempotent. Existing identical records are accepted, while conflicting records with the same primary key fail clearly.

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -376,6 +376,17 @@ fn artifact_get(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
         if remote_artifact::is_remote_artifact(&artifact) {
             return remote_artifact::get(artifact, args.output);
         }
+        if artifact.artifact_type == "metadata-only" {
+            return Err(Error::validation_invalid_argument(
+                "artifact_id",
+                format!(
+                    "artifact {} was imported as metadata only; artifact bytes are not available in this bundle",
+                    artifact.id
+                ),
+                Some(artifact.id),
+                None,
+            ));
+        }
         return Err(Error::validation_invalid_argument(
             "artifact_id",
             format!(
@@ -388,6 +399,18 @@ fn artifact_get(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
     }
 
     let source = PathBuf::from(&artifact.path);
+    if !source.is_file() {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "artifact {} file is missing or unreadable at {}; rerun the source command or import a bundle that includes artifact bytes",
+                artifact.id,
+                source.display()
+            ),
+            Some(artifact.id),
+            None,
+        ));
+    }
     let file_name = source
         .file_name()
         .and_then(|name| name.to_str())

--- a/src/commands/runs/bundle.rs
+++ b/src/commands/runs/bundle.rs
@@ -90,6 +90,7 @@ struct ObservationBundle {
 pub struct ObservationBundleImportSummary {
     pub runs: usize,
     pub artifacts: usize,
+    pub artifact_metadata_only: usize,
     pub trace_spans: usize,
     pub findings: usize,
     pub test_failures: usize,
@@ -173,8 +174,16 @@ pub(super) fn import_runs(args: RunsImportArgs) -> CmdResult<RunsOutput> {
     for run in &bundle.runs {
         store.import_run(run)?;
     }
+    let mut artifacts = 0usize;
+    let mut artifact_metadata_only = 0usize;
     for artifact in &bundle.artifacts {
-        store.import_artifact(artifact)?;
+        let artifact = imported_artifact_record(artifact);
+        if artifact.artifact_type == "metadata-only" {
+            artifact_metadata_only += 1;
+        } else {
+            artifacts += 1;
+        }
+        store.import_artifact(&artifact)?;
     }
     for span in &bundle.trace_spans {
         store.import_trace_span(span)?;
@@ -189,7 +198,8 @@ pub(super) fn import_runs(args: RunsImportArgs) -> CmdResult<RunsOutput> {
             input: input.to_string_lossy().to_string(),
             imported: ObservationBundleImportSummary {
                 runs: bundle.runs.len(),
-                artifacts: bundle.artifacts.len(),
+                artifacts,
+                artifact_metadata_only,
                 trace_spans: bundle.trace_spans.len(),
                 findings: bundle.findings.len(),
                 test_failures: bundle.test_failures.len(),
@@ -197,6 +207,23 @@ pub(super) fn import_runs(args: RunsImportArgs) -> CmdResult<RunsOutput> {
         }),
         0,
     ))
+}
+
+fn imported_artifact_record(artifact: &ArtifactRecord) -> ArtifactRecord {
+    if !matches!(artifact.artifact_type.as_str(), "file" | "directory") {
+        return artifact.clone();
+    }
+    let mut imported = artifact.clone();
+    imported.artifact_type = "metadata-only".to_string();
+    imported.path = portable_artifact_label(&artifact.path, &artifact.id);
+    imported
+}
+
+fn portable_artifact_label(path: &str, fallback: &str) -> String {
+    path.rsplit(['/', '\\'])
+        .find(|segment| !segment.is_empty())
+        .unwrap_or(fallback)
+        .to_string()
 }
 
 fn import_via_gh_actions(args: RunsImportArgs) -> CmdResult<RunsOutput> {

--- a/src/commands/runs/common.rs
+++ b/src/commands/runs/common.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::path::Path;
 use std::time::Duration;
 
-use homeboy::core::observation::{ObservationStore, RunListFilter, RunRecord};
+use homeboy::core::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
 use homeboy::core::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -146,17 +146,31 @@ pub struct ArtifactJsonRow {
     pub json: Value,
 }
 
+pub struct ArtifactJsonLoadResult {
+    pub rows: Vec<ArtifactJsonRow>,
+    pub skipped: Vec<SkippedArtifactRow>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct SkippedArtifactRow {
+    pub run_id: String,
+    pub artifact_id: String,
+    pub artifact_kind: String,
+    pub artifact_type: String,
+    pub path: String,
+    pub reason: String,
+}
+
 /// Load every JSON artifact attached to runs matching the filter.
 ///
-/// Schema-blind: artifacts whose stored file is missing, unreadable, or not
-/// valid JSON are skipped silently (we record artifacts with non-JSON kinds
-/// like images and zips that callers might not want to project over). The
-/// caller decides what to do with a zero-row result.
+/// Schema-blind: artifacts whose stored file is missing, unreadable, not valid
+/// JSON, or metadata-only are skipped with diagnostics. Non-file artifact types
+/// like images, zips, and URLs are ignored because callers project JSON rows.
 pub fn load_artifact_rows(
     store: &ObservationStore,
     filter: RunListFilter,
     since: Option<&str>,
-) -> homeboy::core::Result<Vec<ArtifactJsonRow>> {
+) -> homeboy::core::Result<ArtifactJsonLoadResult> {
     let runs = if let Some(raw) = since {
         let threshold = since_threshold(raw)?;
         store
@@ -169,17 +183,38 @@ pub fn load_artifact_rows(
     };
 
     let mut rows = Vec::new();
+    let mut skipped = Vec::new();
     for run in runs {
         let artifacts = store.list_artifacts(&run.id)?;
         for artifact in artifacts {
             if artifact.artifact_type != "file" {
+                if artifact.artifact_type == "metadata-only" {
+                    skipped.push(skipped_artifact(
+                        &run,
+                        &artifact,
+                        "artifact bytes are not available in this imported metadata-only bundle",
+                    ));
+                }
                 continue;
             }
             let path = Path::new(&artifact.path);
-            let Ok(raw) = fs::read_to_string(path) else {
-                continue;
+            let raw = match fs::read_to_string(path) {
+                Ok(raw) => raw,
+                Err(_) => {
+                    skipped.push(skipped_artifact(
+                        &run,
+                        &artifact,
+                        "artifact file is missing or unreadable",
+                    ));
+                    continue;
+                }
             };
             let Ok(json) = serde_json::from_str::<Value>(&raw) else {
+                skipped.push(skipped_artifact(
+                    &run,
+                    &artifact,
+                    "artifact file is not valid JSON",
+                ));
                 continue;
             };
             rows.push(ArtifactJsonRow {
@@ -190,7 +225,22 @@ pub fn load_artifact_rows(
             });
         }
     }
-    Ok(rows)
+    Ok(ArtifactJsonLoadResult { rows, skipped })
+}
+
+fn skipped_artifact(
+    run: &RunRecord,
+    artifact: &ArtifactRecord,
+    reason: impl Into<String>,
+) -> SkippedArtifactRow {
+    SkippedArtifactRow {
+        run_id: run.id.clone(),
+        artifact_id: artifact.id.clone(),
+        artifact_kind: artifact.kind.clone(),
+        artifact_type: artifact.artifact_type.clone(),
+        path: artifact.path.clone(),
+        reason: reason.into(),
+    }
 }
 
 /// Apply the same filters `list_runs` applies, but client-side. Used to

--- a/src/commands/runs/corpus_tests.rs
+++ b/src/commands/runs/corpus_tests.rs
@@ -10,7 +10,7 @@
 use homeboy::core::observation::{NewRunRecord, ObservationStore, RunRecord, RunStatus};
 use homeboy::test_support::with_isolated_home;
 
-use super::bundle::RunsImportArgs;
+use super::bundle::{RunsExportArgs, RunsImportArgs};
 use super::{bundle::import_runs, drift, query, RunsOutput};
 
 /// Restore `XDG_DATA_HOME` for the test scope so the observation store
@@ -209,6 +209,87 @@ fn import_from_gh_actions_requires_gh_specific_arguments() {
         .err()
         .expect("must fail without required gh-actions args");
         assert_eq!(err.code.as_str(), "validation.missing_argument");
+    });
+}
+
+#[test]
+fn bundle_import_marks_file_artifacts_metadata_only_and_query_reports_skip() {
+    let bundle_dir = tempfile::tempdir().expect("bundle dir");
+    let mut run_id = String::new();
+    let mut source_home_path = String::new();
+
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        source_home_path = home.path().display().to_string();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = install_artifact(
+            &store,
+            home.path(),
+            "observe",
+            "homeboy",
+            serde_json::json!({ "component_id": "homeboy" }),
+            "trace-results",
+        );
+        run_id = run.id.clone();
+
+        super::bundle::export_runs(RunsExportArgs {
+            run: Some(run.id),
+            since: None,
+            output: bundle_dir.path().to_path_buf(),
+        })
+        .expect("export bundle");
+    });
+
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let (output, _) = import_runs(RunsImportArgs {
+            input: Some(bundle_dir.path().to_path_buf()),
+            ..RunsImportArgs::default()
+        })
+        .expect("import bundle");
+        let RunsOutput::Import(output) = output else {
+            panic!("expected import output");
+        };
+        assert_eq!(output.imported.artifacts, 0);
+        assert_eq!(output.imported.artifact_metadata_only, 1);
+
+        let store = ObservationStore::open_initialized().expect("store");
+        let artifacts = store.list_artifacts(&run_id).expect("artifacts");
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].artifact_type, "metadata-only");
+        assert!(!artifacts[0].path.contains(&source_home_path));
+        assert!(!std::path::Path::new(&artifacts[0].path).is_absolute());
+
+        let (output, _) = query::runs_query(query::RunsQueryArgs {
+            component_id: Some("homeboy".into()),
+            kind: Some("observe".into()),
+            since: None,
+            select: vec!["$.component_id".into()],
+            group_by: None,
+            count: false,
+            format: query::QueryFormat::Json,
+            limit: 200,
+        })
+        .expect("query");
+        let RunsOutput::Query(output) = output else {
+            panic!("expected query output");
+        };
+        assert_eq!(output.matched_artifact_count, 0);
+        assert_eq!(output.skipped_artifact_count, 1);
+        assert_eq!(output.skipped_artifacts[0].artifact_type, "metadata-only");
+        assert!(output.skipped_artifacts[0]
+            .reason
+            .contains("artifact bytes are not available"));
+
+        let err = super::artifact_get(super::RunsArtifactGetArgs {
+            run_id,
+            artifact_id: artifacts[0].id.clone(),
+            output: None,
+        })
+        .err()
+        .expect("metadata-only artifact get must fail");
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("metadata only"));
     });
 }
 

--- a/src/commands/runs/drift.rs
+++ b/src/commands/runs/drift.rs
@@ -126,11 +126,11 @@ pub fn runs_drift(args: RunsDriftArgs) -> CmdResult<RunsOutput> {
         limit: Some(5000),
     };
 
-    let window_rows = load_artifact_rows(&store, filter.clone(), Some(&args.window))?;
+    let window_rows = load_artifact_rows(&store, filter.clone(), Some(&args.window))?.rows;
     let window_snap = distribution_share(&window_rows, &metric_path);
 
     let baseline_snap = if let Some(window) = args.baseline.as_deref() {
-        let rows = load_artifact_rows(&store, filter, Some(window))?;
+        let rows = load_artifact_rows(&store, filter, Some(window))?.rows;
         Some(distribution_share(&rows, &metric_path))
     } else {
         None

--- a/src/commands/runs/query.rs
+++ b/src/commands/runs/query.rs
@@ -18,6 +18,7 @@ use homeboy::core::Error;
 
 use super::common::{
     compile_jsonpath, distribution_share, eval_jsonpath, load_artifact_rows, ArtifactJsonRow,
+    SkippedArtifactRow,
 };
 use super::{CmdResult, RunsOutput};
 
@@ -66,6 +67,9 @@ pub struct RunsQueryOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group_by: Option<String>,
     pub matched_artifact_count: usize,
+    pub skipped_artifact_count: usize,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub skipped_artifacts: Vec<SkippedArtifactRow>,
     /// Flat row list (when `--group-by` is absent or `--count` is false and
     /// the caller wants the raw projection). Each entry has one value per
     /// `--select` expression.
@@ -136,7 +140,8 @@ pub fn runs_query(args: RunsQueryArgs) -> CmdResult<RunsOutput> {
         rig_id: None,
         limit: Some(args.limit.clamp(1, 5000)),
     };
-    let rows = load_artifact_rows(&store, filter, args.since.as_deref())?;
+    let loaded = load_artifact_rows(&store, filter, args.since.as_deref())?;
+    let rows = loaded.rows;
 
     let projected: Vec<QueryRow> = rows
         .iter()
@@ -154,6 +159,8 @@ pub fn runs_query(args: RunsQueryArgs) -> CmdResult<RunsOutput> {
         select: args.select.clone(),
         group_by: args.group_by.clone(),
         matched_artifact_count: rows.len(),
+        skipped_artifact_count: loaded.skipped.len(),
+        skipped_artifacts: loaded.skipped,
         rows: Vec::new(),
         groups: Vec::new(),
         table: None,
@@ -370,6 +377,8 @@ mod tests {
             select: vec!["$.theme".into()],
             group_by: None,
             matched_artifact_count: 1,
+            skipped_artifact_count: 0,
+            skipped_artifacts: vec![],
             rows: vec![QueryRow {
                 run_id: "r1".into(),
                 artifact_kind: "design-distribution".into(),
@@ -402,6 +411,8 @@ mod tests {
             select: vec!["$.greeting".into()],
             group_by: None,
             matched_artifact_count: 1,
+            skipped_artifact_count: 0,
+            skipped_artifacts: vec![],
             rows: vec![row],
             groups: vec![],
             table: None,


### PR DESCRIPTION
## Summary
- Mark local file/directory artifacts from v1 metadata-only bundles as `metadata-only` on import, with portable labels instead of source-machine absolute paths.
- Report skipped metadata-only/missing/unreadable JSON artifacts from `runs query` instead of silently returning zero evidence.
- Return validation-level `runs artifact get` errors for metadata-only or missing local artifact bytes, and document the v1 behavior.

Fixes #2755.

Related: #2775.

## Evidence
- `cargo test bundle_import_marks_file_artifacts_metadata_only_and_query_reports_skip`
- `cargo test commands::runs::corpus_tests`
- `cargo test commands::runs::`
- `cargo check`
- `homeboy lint`
- `homeboy test homeboy --force-hot --skip-lint -- commands::runs::`
- `homeboy test homeboy --force-hot --skip-lint -- commands::runs::corpus_tests::bundle_import_marks_file_artifacts_metadata_only_and_query_reports_skip`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the artifact import/query/get changes, added regression coverage, ran local verification, and drafted this PR description for Chris to review.