### PR TITLE
fix: include errored commands in failure digest

### DIFF
--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -180,7 +180,11 @@ fn command_failed(results: &Map<String, Value>, command: &str) -> bool {
     results
         .get(command)
         .and_then(Value::as_str)
-        .is_some_and(|status| status == "fail")
+        .is_some_and(is_failure_status)
+}
+
+fn is_failure_status(status: &str) -> bool {
+    matches!(status, "fail" | "error")
 }
 
 fn command_reported(results: &Map<String, Value>, command: &str) -> bool {
@@ -202,7 +206,7 @@ fn failed_commands(results: &Map<String, Value>) -> Vec<String> {
         .filter_map(|(name, status)| {
             status
                 .as_str()
-                .filter(|value| *value == "fail")
+                .filter(|value| is_failure_status(value))
                 .map(|_| name.clone())
         })
         .collect::<Vec<_>>();

--- a/tests/report_failure_digest_test.rs
+++ b/tests/report_failure_digest_test.rs
@@ -237,6 +237,39 @@ fn missing_json_renders_explicit_structured_details_unavailable() {
 }
 
 #[test]
+fn error_statuses_render_command_sections_and_classify_as_failures() {
+    let dir = tmp_dir("error-statuses");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+
+    let markdown = render(
+        &dir,
+        r#"{"lint":"error","test":"error","audit":"error"}"#,
+        false,
+        false,
+    );
+
+    assert!(markdown.contains("### Lint Failure Digest"));
+    assert!(markdown.contains("### Test Failure Digest"));
+    assert!(markdown.contains("### Audit Failure Digest"));
+    assert!(markdown.contains("- No structured lint details available."));
+    assert!(markdown.contains("- No structured test failure details available."));
+    assert!(markdown.contains("- No structured audit findings available."));
+    assert!(markdown.contains("- Overall: **human_needed**"));
+    assert!(markdown.contains("- Human-needed failed commands:"));
+    assert!(markdown.contains("  - `audit`"));
+    assert!(markdown.contains("  - `lint`"));
+    assert!(markdown.contains("  - `test`"));
+    assert!(markdown
+        .contains("- Full lint log: https://github.com/Extra-Chill/homeboy/actions/runs/123"));
+    assert!(markdown
+        .contains("- Full test log: https://github.com/Extra-Chill/homeboy/actions/runs/123"));
+    assert!(markdown
+        .contains("- Full audit log: https://github.com/Extra-Chill/homeboy/actions/runs/123"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn renders_tooling_metadata_from_json_file() {
     let dir = tmp_dir("tooling");
     fs::create_dir_all(&dir).expect("temp dir should exist");


### PR DESCRIPTION
## Summary
- Treat `error` statuses as failure statuses when composing `report failure-digest` sections.
- Reuse the same failure predicate for autofixability classification so errored lint/test/audit commands are human-needed instead of `none`.
- Add regression coverage for `lint`, `test`, and `audit` all returning `error`.

Fixes #2754.

## Evidence
- `cargo test --test report_failure_digest_test`
- `cargo fmt --check`
- `git diff --check`
- `cargo run --quiet --bin homeboy -- report failure-digest --output-dir /tmp/homeboy-empty-output --results '{"lint":"error","test":"error","audit":"error"}' --run-url https://github.com/Extra-Chill/homeboy/actions/runs/123`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Reproduced the failure digest omission, drafted the focused Rust fix and regression test, ran validation, and prepared this PR for Chris to review.