### PR TITLE
fix: skip dry-run deploy plan for skipped releases

### DIFF
--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -159,10 +159,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         let tag = new_version
             .as_ref()
             .map(|v| format_tag(v, monorepo.as_ref()));
-        let deployment = input
-            .pipeline
-            .deploy
-            .then(|| super::deployment::plan_deployment(&input.component_id));
+        let deployment = dry_run_deployment_plan(&input.component_id, input.pipeline.deploy, &plan);
 
         return Ok((
             ReleaseCommandResult {
@@ -243,6 +240,18 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         },
         exit_code,
     ))
+}
+
+fn dry_run_deployment_plan(
+    component_id: &str,
+    deploy_requested: bool,
+    plan: &ReleasePlan,
+) -> Option<super::types::ReleaseDeploymentResult> {
+    if deploy_requested && plan.enabled() {
+        Some(super::deployment::plan_deployment(component_id))
+    } else {
+        None
+    }
 }
 
 fn current_component_version(
@@ -760,6 +769,25 @@ mod tests {
             extract_new_version_from_plan(&plan).as_deref(),
             Some("1.2.3")
         );
+    }
+
+    #[test]
+    fn dry_run_deployment_plan_is_omitted_when_release_plan_is_disabled() {
+        let plan = ReleasePlan::new(
+            "demo",
+            false,
+            vec![PlanStep::disabled_with_reason(
+                "release.skip",
+                "release.skip",
+                "no-releasable-commits",
+            )
+            .build()],
+            None,
+            Vec::new(),
+            Vec::new(),
+        );
+
+        assert!(dry_run_deployment_plan("demo", true, &plan).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Only include a release dry-run deployment plan when `--deploy` is requested and the release plan is enabled.
- Add a focused workflow unit test covering disabled/skipped release plans so skipped releases do not report deploy projects as planned.

Closes #2748.

## Verification
- `cargo fmt --check`
- `cargo test core::release::workflow`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-2748-release-deploy-dry-run --extension rust --force-hot`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-2748-release-deploy-dry-run --extension rust --force-hot` failed in unrelated `core::extension::trace::probes::http_egress::tests::test_run_http_egress` (`assertion failed: response.contains("hello back")`) after 3312 passed / 1 failed / 18 ignored.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implementing the small release dry-run planning fix, adding the focused unit test, and running local verification. Chris remains responsible for review and merge.