### PR TITLE
fix: write runner validation errors to output file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -156,10 +156,7 @@ fn main() -> std::process::ExitCode {
         let result = cli::run(cli_args, &global);
 
         let (json_result, exit_code) = output::map_cmd_result_to_json(result);
-        if let Some(ref path) = output_file {
-            output::write_json_to_file(&json_result, path, exit_code);
-        }
-        output::print_json_result(json_result, exit_code).ok();
+        emit_json_result(json_result, output_file.as_deref(), exit_code);
         return std::process::ExitCode::from(exit_code_to_u8(exit_code));
     }
 
@@ -176,7 +173,7 @@ fn main() -> std::process::ExitCode {
                 Some(runner_id.to_string()),
                 None,
             );
-            output::print_result::<serde_json::Value>(Err(err)).ok();
+            emit_json_result(Err(err), output_file.as_deref(), 2);
             return std::process::ExitCode::from(exit_code_to_u8(2));
         }
         let capture_patch = cli.command.lab_offload_mutation_flag().is_some();
@@ -261,6 +258,17 @@ fn exit_code_to_u8(code: i32) -> u8 {
     }
 }
 
+fn emit_json_result(
+    result: homeboy::core::Result<serde_json::Value>,
+    output_file: Option<&str>,
+    exit_code: i32,
+) {
+    if let Some(path) = output_file {
+        output::write_json_to_file(&result, path, exit_code);
+    }
+    output::print_json_result(result, exit_code).ok();
+}
+
 fn run_lab_offload(
     runner_id: &str,
     normalized_args: &[String],
@@ -270,8 +278,10 @@ fn run_lab_offload(
     match run_lab_offload_inner(runner_id, normalized_args, output_file, capture_patch) {
         Ok(exit_code) => std::process::ExitCode::from(exit_code_to_u8(exit_code)),
         Err(err) => {
-            output::print_result::<serde_json::Value>(Err(err)).ok();
-            std::process::ExitCode::from(exit_code_to_u8(1))
+            let (json_result, exit_code) =
+                output::map_cmd_result_to_json::<serde_json::Value>(Err(err));
+            emit_json_result(json_result, output_file, exit_code);
+            std::process::ExitCode::from(exit_code_to_u8(exit_code))
         }
     }
 }

--- a/tests/output_errors.rs
+++ b/tests/output_errors.rs
@@ -1,5 +1,8 @@
 use homeboy::core::error::{RemoteCommandFailedDetails, TargetDetails};
 use homeboy::core::Error;
+use serde_json::Value;
+use std::path::PathBuf;
+use std::process::Command;
 
 #[test]
 fn remote_command_failed_creates_error_with_details() {
@@ -22,4 +25,40 @@ fn remote_command_failed_creates_error_with_details() {
     assert!(details_str.contains("ls -la"));
     assert!(details_str.contains("some stdout"));
     assert!(details_str.contains("some stderr"));
+}
+
+#[test]
+fn unsupported_runner_validation_error_writes_json_output_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let output_path = dir.path().join("runner-unsupported.json");
+
+    let output = Command::new(homeboy_bin())
+        .args(["--runner", "lab", "--output"])
+        .arg(&output_path)
+        .arg("status")
+        .env("HOME", dir.path())
+        .output()
+        .expect("run homeboy");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        output_path.exists(),
+        "expected --output file to be written; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout_json: Value = serde_json::from_slice(&output.stdout).expect("stdout json");
+    let file_json: Value =
+        serde_json::from_str(&std::fs::read_to_string(&output_path).expect("read output file"))
+            .expect("output file json");
+
+    assert_eq!(file_json, stdout_json);
+    assert_eq!(file_json["success"], false);
+    assert_eq!(file_json["error"]["code"], "validation.invalid_argument");
+    assert!(file_json.get("data").is_none());
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
 }


### PR DESCRIPTION
## Summary
- Route early unsupported `--runner` validation failures through the shared JSON output emitter so `--output` receives the same failure envelope as stdout.
- Reuse the same emitter for extension CLI results and lab-offload setup failures so early error paths keep structured output/file-output behavior aligned.
- Add an integration regression test for `--runner <id> --output <file> status` asserting the file contains `success: false`, `validation.invalid_argument`, and no `data` field.

Fixes #2750.

## Evidence
- Reproduced before fix: `cargo run --quiet --bin homeboy -- --runner lab --output /tmp/homeboy-runner-unsupported-2750-repro.json status` printed the JSON validation envelope and `test -f /tmp/homeboy-runner-unsupported-2750-repro.json` returned `1`.
- Verified after fix: `cargo run --quiet --bin homeboy -- --runner lab --output /tmp/homeboy-runner-unsupported-2750-rebased.json status` exited `2` and wrote the requested output file.
- `cargo test --test output_errors`
- `cargo fmt --check`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Reproducing the issue, drafting the fix and regression test, running verification, and preparing this PR. Chris remains responsible for review and merge.