### PR TITLE
Add golden JSON contract fixtures for quality outputs

### DIFF
--- a/docs/architecture/output-system.md
+++ b/docs/architecture/output-system.md
@@ -142,6 +142,17 @@ The `next_steps` array contains context-aware actionable guidance based on the c
 
 On success, `data` is the command-specific output struct (varies by command).
 
+## Golden Output Fixtures
+
+Automation-facing JSON surfaces should have golden output fixtures that serialize
+typed command payloads through the same `CliResponse` envelope used by stdout and
+`--output`.
+
+Quality command fixtures live under `tests/fixtures/output_contracts/quality/`
+and are enforced by `tests/output_contracts_test.rs`. The first required quality
+set covers `audit`, `lint`, `test`, and `review`; adding or changing stable fields
+in those payloads should update the matching fixture deliberately.
+
 ## Observation-backed payloads
 
 `--output` remains the per-invocation command-result artifact. It must continue

--- a/src/commands/utils/response.rs
+++ b/src/commands/utils/response.rs
@@ -160,25 +160,14 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
 }
 
 pub fn print_json_result(result: Result<serde_json::Value>, exit_code: i32) -> Result<()> {
-    match result {
-        Ok(data) if exit_code == 0 => print_success(data),
-        Ok(data) => {
-            // Command returned data but with a non-zero exit code (e.g., release
-            // succeeded but deploy failed). The envelope should reflect the failure.
-            print_response(&CliResponse {
-                success: false,
-                data: Some(data),
-                error: None,
-            })
-        }
-        Err(err) => print_response(&CliResponse::<()>::from_error(&err)),
-    }
+    print_response(&cli_response_for_json_result(&result, exit_code))
 }
 
-/// Write the JSON output envelope to a file. Best-effort — failures are
-/// logged to stderr but don't affect the command's exit code.
-pub fn write_json_to_file(result: &Result<serde_json::Value>, path: &str, exit_code: i32) {
-    let response = match result {
+pub fn cli_response_for_json_result(
+    result: &Result<serde_json::Value>,
+    exit_code: i32,
+) -> CliResponse<serde_json::Value> {
+    match result {
         Ok(data) => CliResponse {
             success: exit_code == 0,
             data: Some(data.clone()),
@@ -192,7 +181,13 @@ pub fn write_json_to_file(result: &Result<serde_json::Value>, path: &str, exit_c
                 error: error_response.error,
             }
         }
-    };
+    }
+}
+
+/// Write the JSON output envelope to a file. Best-effort — failures are
+/// logged to stderr but don't affect the command's exit code.
+pub fn write_json_to_file(result: &Result<serde_json::Value>, path: &str, exit_code: i32) {
+    let response = cli_response_for_json_result(result, exit_code);
 
     let json = match serde_json::to_string_pretty(&response) {
         Ok(j) => j,

--- a/tests/fixtures/output_contracts/quality/audit-summary.json
+++ b/tests/fixtures/output_contracts/quality/audit-summary.json
@@ -1,0 +1,52 @@
+{
+  "success": false,
+  "data": {
+    "command": "audit.summary",
+    "alignment_score": 0.8199999928474426,
+    "total_findings": 2,
+    "warnings": 1,
+    "info": 1,
+    "finding_groups": [
+      {
+        "kind": "god_file",
+        "count": 2,
+        "warnings": 1,
+        "info": 1,
+        "confidence": "heuristic",
+        "sample_files": [
+          "src/large.rs",
+          "src/also-large.rs"
+        ],
+        "drilldown_command": "homeboy audit fixture --only god_file"
+      }
+    ],
+    "top_findings": [
+      {
+        "file": "src/large.rs",
+        "convention": "structural",
+        "kind": "god_file",
+        "confidence": "heuristic",
+        "severity": "warning",
+        "description": "File exceeds the size threshold",
+        "suggestion": "Split the module into focused pieces"
+      }
+    ],
+    "fixability": {
+      "fixable_count": 2,
+      "automated_count": 1,
+      "manual_only_count": 1,
+      "by_kind": {
+        "god_file": {
+          "total": 2,
+          "automated": 1,
+          "manual_only": 1
+        }
+      }
+    },
+    "changed_since": {
+      "introduced_findings": 1,
+      "contextual_findings": 1
+    },
+    "exit_code": 1
+  }
+}

--- a/tests/fixtures/output_contracts/quality/lint-findings.json
+++ b/tests/fixtures/output_contracts/quality/lint-findings.json
@@ -1,0 +1,33 @@
+{
+  "success": false,
+  "data": {
+    "passed": false,
+    "status": "failed",
+    "component": "fixture",
+    "exit_code": 1,
+    "phase": {
+      "phase": "lint",
+      "status": "failed",
+      "exit_code": 1,
+      "summary": "lint phase reported 1 finding(s)"
+    },
+    "failure": {
+      "phase": "lint",
+      "category": "findings",
+      "summary": "1 lint finding(s) detected"
+    },
+    "hints": [
+      "Run `homeboy lint fixture --fix` to apply safe fixes."
+    ],
+    "lint_findings": [
+      {
+        "id": "lint:src/lib.rs:12:trailing-whitespace",
+        "message": "Trailing whitespace",
+        "category": "whitespace",
+        "tool": "fixture-linter",
+        "file": "src/lib.rs",
+        "severity": "warning"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/output_contracts/quality/review-artifact.json
+++ b/tests/fixtures/output_contracts/quality/review-artifact.json
@@ -1,0 +1,75 @@
+{
+  "success": false,
+  "data": {
+    "command": "review",
+    "plan": {
+      "id": "custom.unspecified",
+      "kind": "custom",
+      "subject": {
+        "description": "unspecified"
+      }
+    },
+    "artifact": {
+      "schema": "homeboy/review/v1",
+      "component": "fixture",
+      "status": "fail",
+      "generated_at": "2026-05-24T00:00:00Z",
+      "base_ref": "origin/main",
+      "head_ref": "HEAD",
+      "commands": [
+        {
+          "name": "lint",
+          "status": "fail",
+          "exit_code": 1,
+          "summary": "1 lint finding(s) detected",
+          "findings": [
+            {
+              "id": "lint:src/lib.rs:12:trailing-whitespace",
+              "message": "Trailing whitespace"
+            }
+          ],
+          "artifacts": []
+        }
+      ]
+    },
+    "summary": {
+      "passed": false,
+      "status": "fail",
+      "component": "fixture",
+      "scope": "changed-since",
+      "changed_since": "origin/main",
+      "total_findings": 1,
+      "changed_file_count": 2,
+      "hints": [
+        "Deep dive: homeboy lint fixture --changed-since origin/main"
+      ]
+    },
+    "audit": {
+      "stage": "audit",
+      "ran": false,
+      "passed": true,
+      "exit_code": 0,
+      "finding_count": 0,
+      "hint": "Skipped audit in contract fixture",
+      "skipped_reason": "fixture keeps nested command payloads in their own golden files"
+    },
+    "lint": {
+      "stage": "lint",
+      "ran": false,
+      "passed": true,
+      "exit_code": 0,
+      "finding_count": 0,
+      "hint": "Skipped lint in contract fixture",
+      "skipped_reason": "fixture keeps nested command payloads in their own golden files"
+    },
+    "test": {
+      "stage": "test",
+      "ran": false,
+      "passed": true,
+      "exit_code": 0,
+      "finding_count": 0,
+      "hint": "Skipped test in contract fixture",
+      "skipped_reason": "fixture keeps nested command payloads in their own golden files"
+    }
+  }
+}

--- a/tests/fixtures/output_contracts/quality/test-summary.json
+++ b/tests/fixtures/output_contracts/quality/test-summary.json
@@ -1,0 +1,48 @@
+{
+  "success": false,
+  "data": {
+    "passed": false,
+    "status": "failed",
+    "component": "fixture",
+    "exit_code": 1,
+    "phase": {
+      "phase": "test",
+      "status": "failed",
+      "exit_code": 1,
+      "summary": "test phase reported 1 failure(s) out of 3 test(s)"
+    },
+    "failure": {
+      "phase": "test",
+      "category": "findings",
+      "summary": "1 test failure(s) detected"
+    },
+    "test_counts": {
+      "total": 3,
+      "passed": 2,
+      "failed": 1,
+      "skipped": 0
+    },
+    "failed_tests": [
+      {
+        "name": "fixture::fails_contract",
+        "detail": "expected stable JSON envelope",
+        "location": "tests/output_contract.rs:24"
+      }
+    ],
+    "hints": [
+      "Re-run: homeboy test fixture --json-summary"
+    ],
+    "summary": {
+      "total": 3,
+      "passed": 2,
+      "failed": 1,
+      "skipped": 0,
+      "exit_code": 1
+    },
+    "raw_output": {
+      "stdout_tail": "running 3 tests\nfixture::fails_contract FAILED",
+      "stderr_tail": "assertion failed: stable envelope",
+      "truncated": false
+    }
+  }
+}

--- a/tests/output_contracts_test.rs
+++ b/tests/output_contracts_test.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use homeboy::cli_surface::current_command_surface;
 use homeboy::commands::review::{
     ReviewArtifact, ReviewArtifactCommand, ReviewCommandOutput, ReviewStage, ReviewSummary,
 };
@@ -30,18 +31,23 @@ struct OutputContractScenario {
 }
 
 #[test]
-fn quality_commands_have_declared_golden_json_contract_fixtures() {
+fn visible_quality_commands_have_declared_golden_json_contract_fixtures() {
+    let surface = current_command_surface();
     let covered: BTreeSet<_> = quality_output_contract_scenarios()
         .iter()
         .map(|scenario| scenario.command)
         .collect();
-    let required: BTreeSet<_> = REQUIRED_QUALITY_COMMAND_FIXTURES.iter().copied().collect();
 
-    let missing: Vec<_> = required.difference(&covered).copied().collect();
-    assert!(
-        missing.is_empty(),
-        "missing golden JSON output contract fixture(s) for quality command(s): {missing:?}"
-    );
+    for command in REQUIRED_QUALITY_COMMAND_FIXTURES {
+        assert!(
+            surface.contains_path(&[*command]),
+            "required quality output contract command is not visible in the CLI surface: {command}"
+        );
+        assert!(
+            covered.contains(command),
+            "missing golden JSON output contract fixture for visible quality command: {command}"
+        );
+    }
 }
 
 #[test]

--- a/tests/output_contracts_test.rs
+++ b/tests/output_contracts_test.rs
@@ -1,0 +1,302 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use homeboy::commands::review::{
+    ReviewArtifact, ReviewArtifactCommand, ReviewCommandOutput, ReviewStage, ReviewSummary,
+};
+use homeboy::commands::utils::response::cli_response_for_json_result;
+use homeboy::core::code_audit::report::{
+    AuditChangedSinceSummary, AuditCommandOutput, AuditFixability, AuditSummaryFinding,
+    AuditSummaryGroup, AuditSummaryOutput, FixabilityKindBreakdown,
+};
+use homeboy::core::code_audit::{AuditFinding, FindingConfidence, Severity};
+use homeboy::core::extension::lint::{LintCommandOutput, LintFinding};
+use homeboy::core::extension::test::{
+    FailedTest, RawTestOutput, TestCommandOutput, TestCounts, TestSummaryOutput,
+};
+use homeboy::core::extension::{
+    PhaseFailure, PhaseFailureCategory, PhaseReport, PhaseStatus, VerificationPhase,
+};
+use homeboy::core::plan::HomeboyPlan;
+use serde::Serialize;
+use serde_json::{json, Value};
+
+const REQUIRED_QUALITY_COMMAND_FIXTURES: &[&str] = &["audit", "lint", "review", "test"];
+
+struct OutputContractScenario {
+    command: &'static str,
+    fixture: &'static str,
+    exit_code: i32,
+    payload: fn() -> Value,
+}
+
+#[test]
+fn quality_commands_have_declared_golden_json_contract_fixtures() {
+    let covered: BTreeSet<_> = quality_output_contract_scenarios()
+        .iter()
+        .map(|scenario| scenario.command)
+        .collect();
+    let required: BTreeSet<_> = REQUIRED_QUALITY_COMMAND_FIXTURES.iter().copied().collect();
+
+    let missing: Vec<_> = required.difference(&covered).copied().collect();
+    assert!(
+        missing.is_empty(),
+        "missing golden JSON output contract fixture(s) for quality command(s): {missing:?}"
+    );
+}
+
+#[test]
+fn quality_command_golden_json_contract_fixtures_match_typed_payloads() {
+    for scenario in quality_output_contract_scenarios() {
+        let actual = enveloped_json((scenario.payload)(), scenario.exit_code);
+        let expected: Value = serde_json::from_str(scenario.fixture)
+            .unwrap_or_else(|err| panic!("{} fixture should parse: {err}", scenario.command));
+
+        assert_eq!(actual, expected, "{} golden JSON drifted", scenario.command);
+    }
+}
+
+fn quality_output_contract_scenarios() -> Vec<OutputContractScenario> {
+    vec![
+        OutputContractScenario {
+            command: "audit",
+            fixture: include_str!("fixtures/output_contracts/quality/audit-summary.json"),
+            exit_code: 1,
+            payload: audit_summary_payload,
+        },
+        OutputContractScenario {
+            command: "lint",
+            fixture: include_str!("fixtures/output_contracts/quality/lint-findings.json"),
+            exit_code: 1,
+            payload: lint_findings_payload,
+        },
+        OutputContractScenario {
+            command: "test",
+            fixture: include_str!("fixtures/output_contracts/quality/test-summary.json"),
+            exit_code: 1,
+            payload: test_summary_payload,
+        },
+        OutputContractScenario {
+            command: "review",
+            fixture: include_str!("fixtures/output_contracts/quality/review-artifact.json"),
+            exit_code: 1,
+            payload: review_artifact_payload,
+        },
+    ]
+}
+
+fn enveloped_json(payload: Value, exit_code: i32) -> Value {
+    let result = Ok(payload);
+    serde_json::to_value(cli_response_for_json_result(&result, exit_code))
+        .expect("CLI response should serialize")
+}
+
+fn typed_output_value<T: Serialize>(output: T) -> Value {
+    serde_json::to_value(output).expect("command output should serialize")
+}
+
+fn audit_summary_payload() -> Value {
+    typed_output_value(audit_summary_output())
+}
+
+fn lint_findings_payload() -> Value {
+    typed_output_value(lint_findings_output())
+}
+
+fn test_summary_payload() -> Value {
+    typed_output_value(test_summary_output())
+}
+
+fn review_artifact_payload() -> Value {
+    typed_output_value(review_artifact_output())
+}
+
+fn audit_summary_output() -> AuditCommandOutput {
+    let mut by_kind = BTreeMap::new();
+    by_kind.insert(
+        "god_file".to_string(),
+        FixabilityKindBreakdown {
+            total: 2,
+            automated: 1,
+            manual_only: 1,
+        },
+    );
+
+    AuditCommandOutput::Summary(AuditSummaryOutput {
+        alignment_score: Some(0.82),
+        total_findings: 2,
+        warnings: 1,
+        info: 1,
+        finding_groups: vec![AuditSummaryGroup {
+            kind: "god_file".to_string(),
+            count: 2,
+            warnings: 1,
+            info: 1,
+            confidence: FindingConfidence::Heuristic,
+            sample_files: vec!["src/large.rs".to_string(), "src/also-large.rs".to_string()],
+            drilldown_command: "homeboy audit fixture --only god_file".to_string(),
+        }],
+        top_findings: vec![AuditSummaryFinding {
+            file: "src/large.rs".to_string(),
+            convention: "structural".to_string(),
+            kind: AuditFinding::GodFile,
+            confidence: FindingConfidence::Heuristic,
+            severity: Severity::Warning,
+            description: "File exceeds the size threshold".to_string(),
+            suggestion: "Split the module into focused pieces".to_string(),
+        }],
+        fixability: Some(AuditFixability {
+            fixable_count: 2,
+            automated_count: 1,
+            manual_only_count: 1,
+            by_kind,
+        }),
+        changed_since: Some(AuditChangedSinceSummary {
+            introduced_findings: 1,
+            contextual_findings: 1,
+        }),
+        exit_code: 1,
+    })
+}
+
+fn lint_findings_output() -> LintCommandOutput {
+    LintCommandOutput {
+        passed: false,
+        status: "failed".to_string(),
+        component: "fixture".to_string(),
+        exit_code: 1,
+        phase: PhaseReport {
+            phase: VerificationPhase::Lint,
+            status: PhaseStatus::Failed,
+            exit_code: Some(1),
+            summary: "lint phase reported 1 finding(s)".to_string(),
+        },
+        failure: Some(PhaseFailure {
+            phase: VerificationPhase::Lint,
+            category: PhaseFailureCategory::Findings,
+            summary: "1 lint finding(s) detected".to_string(),
+        }),
+        autofix: None,
+        hints: Some(vec![
+            "Run `homeboy lint fixture --fix` to apply safe fixes.".to_string(),
+        ]),
+        baseline_comparison: None,
+        lint_findings: Some(vec![LintFinding {
+            id: "lint:src/lib.rs:12:trailing-whitespace".to_string(),
+            message: "Trailing whitespace".to_string(),
+            category: "whitespace".to_string(),
+            tool: Some("fixture-linter".to_string()),
+            file: Some("src/lib.rs".to_string()),
+            severity: Some("warning".to_string()),
+            extra: BTreeMap::new(),
+        }]),
+        summary: None,
+        ci_context: None,
+    }
+}
+
+fn test_summary_output() -> TestCommandOutput {
+    TestCommandOutput {
+        passed: false,
+        status: "failed".to_string(),
+        component: "fixture".to_string(),
+        exit_code: 1,
+        phase: Some(PhaseReport {
+            phase: VerificationPhase::Test,
+            status: PhaseStatus::Failed,
+            exit_code: Some(1),
+            summary: "test phase reported 1 failure(s) out of 3 test(s)".to_string(),
+        }),
+        failure: Some(PhaseFailure {
+            phase: VerificationPhase::Test,
+            category: PhaseFailureCategory::Findings,
+            summary: "1 test failure(s) detected".to_string(),
+        }),
+        test_counts: Some(TestCounts::new(3, 2, 1, 0)),
+        failed_tests: Some(vec![FailedTest {
+            name: "fixture::fails_contract".to_string(),
+            detail: Some("expected stable JSON envelope".to_string()),
+            location: Some("tests/output_contract.rs:24".to_string()),
+        }]),
+        coverage: None,
+        baseline_comparison: None,
+        analysis: None,
+        autofix: None,
+        hints: Some(vec![
+            "Re-run: homeboy test fixture --json-summary".to_string()
+        ]),
+        drift: None,
+        auto_fix_drift: None,
+        test_scope: None,
+        summary: Some(TestSummaryOutput {
+            total: 3,
+            passed: 2,
+            failed: 1,
+            skipped: 0,
+            failures: Vec::new(),
+            exit_code: 1,
+        }),
+        raw_output: Some(RawTestOutput {
+            stdout_tail: "running 3 tests\nfixture::fails_contract FAILED".to_string(),
+            stderr_tail: "assertion failed: stable envelope".to_string(),
+            truncated: false,
+        }),
+        ci_context: None,
+    }
+}
+
+fn review_artifact_output() -> ReviewCommandOutput {
+    ReviewCommandOutput {
+        command: "review".to_string(),
+        plan: HomeboyPlan::default(),
+        observation: None,
+        artifact: ReviewArtifact {
+            schema: "homeboy/review/v1".to_string(),
+            component: "fixture".to_string(),
+            status: "fail".to_string(),
+            generated_at: "2026-05-24T00:00:00Z".to_string(),
+            base_ref: "origin/main".to_string(),
+            head_ref: "HEAD".to_string(),
+            observation: None,
+            commands: vec![ReviewArtifactCommand {
+                name: "lint".to_string(),
+                status: "fail".to_string(),
+                exit_code: 1,
+                summary: "1 lint finding(s) detected".to_string(),
+                findings: vec![json!({
+                    "id": "lint:src/lib.rs:12:trailing-whitespace",
+                    "message": "Trailing whitespace"
+                })],
+                artifacts: Vec::new(),
+            }],
+        },
+        summary: ReviewSummary {
+            passed: false,
+            status: "fail".to_string(),
+            component: "fixture".to_string(),
+            scope: "changed-since".to_string(),
+            changed_since: Some("origin/main".to_string()),
+            total_findings: 1,
+            changed_file_count: Some(2),
+            hints: vec!["Deep dive: homeboy lint fixture --changed-since origin/main".to_string()],
+        },
+        audit: skipped_review_stage("audit"),
+        lint: skipped_review_stage("lint"),
+        test: skipped_review_stage("test"),
+        ci_profile: None,
+    }
+}
+
+fn skipped_review_stage<T: Serialize>(stage: &str) -> ReviewStage<T> {
+    ReviewStage {
+        stage: stage.to_string(),
+        ran: false,
+        passed: true,
+        exit_code: 0,
+        finding_count: 0,
+        hint: format!("Skipped {stage} in contract fixture"),
+        skipped_reason: Some(
+            "fixture keeps nested command payloads in their own golden files".to_string(),
+        ),
+        output: None,
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a reusable golden JSON contract harness for quality command output scenarios.
- Covers `audit`, `lint`, `test`, and `review` payloads through the same CLI `CliResponse` envelope used by stdout and `--output`.
- Documents where golden output fixtures live and when they should be updated.

Closes #2751.
Refs #2774.

## Verification
- `cargo fmt --check`
- `cargo test --test output_contracts_test`
- `cargo test response::tests`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the golden output contract harness, fixtures, documentation update, and verification commands; Chris remains responsible for review and merge.