### PR TITLE
fix: align docs with command help

### DIFF
--- a/docs/architecture/output-system.md
+++ b/docs/architecture/output-system.md
@@ -6,8 +6,19 @@ Exceptions:
 
 - `homeboy docs` prints raw markdown (or newline-delimited topic names for `homeboy docs list`).
 - `homeboy changelog` (default show) prints raw markdown by default; in JSON mode it returns JSON with a `content` field containing the markdown.
+- `homeboy review --report pr-comment` prints a raw markdown PR-comment report.
+- `homeboy trace --report markdown` prints a raw markdown trace report.
+- `homeboy runs compare` prints raw markdown unless `--output` is provided.
+- `homeboy report failure-digest` prints raw markdown because markdown is currently the only report format.
 - `homeboy list` prints clap help text (raw; not JSON-wrapped).
 - `homeboy ssh` connect mode and `homeboy logs show --follow` use interactive passthrough output.
+
+For raw markdown commands, `--output <path>` still writes a JSON file when the
+command supports output artifacts. The generic output-file shape is the normal
+success envelope with `data` set to the rendered markdown string. Commands with
+special output artifacts keep their documented artifact contract: `review`
+writes the stable review artifact, and `trace --json-summary` writes the trace
+summary artifact.
 
 ## Top-level envelope
 

--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -19,11 +19,16 @@ Works with registered components (by ID) or raw filesystem paths.
 ## Options
 
 - `--conventions`: Only show discovered conventions (skip findings)
+- `--extension <ID>`: One-shot extension override for the current invocation; repeat to layer multiple extension hints
+- `--only <kind>`: Restrict findings to one or more finding kinds; repeat for multiple kinds
+- `--exclude <kind>`: Exclude one or more finding kinds; repeat for multiple kinds
 - `--baseline`: Save current audit state as baseline for future comparisons
 - `--ignore-baseline`: Skip baseline comparison even if a baseline exists
+- `--ratchet`: Auto-update the baseline when the current run improves on it
 - `--path <PATH>`: Override `local_path` for this audit run (use a workspace clone or temp checkout)
 - `--changed-since <REF>`: Restrict findings to files changed since a git ref
 - `--json-summary`: Return compact machine-readable summary (`audit.summary`) for CI wrappers
+- `--fixability`: Include automated-fixability metadata by running the refactor planner after audit completes
 
 ## Audit Pipeline
 
@@ -99,11 +104,21 @@ homeboy audit /path/to/project
 # Show only conventions (no findings)
 homeboy audit homeboy --conventions
 
+# Drill into or suppress specific finding kinds
+homeboy audit homeboy --only missing_test_file
+homeboy audit homeboy --exclude near_duplicate_file
+
 # Save baseline after a cleanup sprint
 homeboy audit my-plugin --baseline
 
+# Let a cleanup sprint ratchet an improved baseline forward
+homeboy audit my-plugin --ratchet
+
 # Audit a workspace clone instead of local_path
 homeboy audit my-plugin --path /var/lib/datamachine/workspace/my-plugin
+
+# Force a one-shot extension when the checkout has no registered component
+homeboy audit --path /path/to/worktree --extension rust
 ```
 
 ## JSON Output

--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -36,6 +36,7 @@ rig package / local spec
 | `up <id>` | Run the rig's `up` pipeline and materialize the environment. |
 | `check <id>` | Run the rig's `check` pipeline and report all failures. |
 | `down <id>` | Run the rig's `down` pipeline and stop managed services. |
+| `repair <id>` | Repair safe declared drift without running the full `up` pipeline. |
 | `sync <id>` | Sync every stack declared by the rig's components. |
 | `status <id>` | Show running services and last `up` / `check` state. |
 | `runs <id>` | List persisted observation runs for the rig. |
@@ -93,6 +94,21 @@ homeboy rig down studio
 ```
 
 Runs the `down` pipeline, cleans rig-owned shared paths, and stops declared services. `external` services are adopted rather than spawned, so `down` can recycle stale daemons that were started by another tool.
+
+### `repair`
+
+```sh
+homeboy rig repair studio
+```
+
+Repairs safe declared drift without running the full `up` pipeline. Use it after
+`rig check` reports fixable local drift and you do not want to start services,
+run builds, or execute the full materialization sequence.
+
+`repair` is narrower than `up`: it applies only repairs the rig engine classifies
+as safe and declared by the rig spec, and it refuses broader environment
+materialization. `check` remains read-only; `repair` is the middle path for safe
+state correction; `up` is the full mutating setup pipeline.
 
 ### `status`
 

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -45,6 +45,56 @@ homeboy runner connect homeboy-lab
 
 After this, `homeboy-lab` is both the server ID and the runner ID.
 
+### `doctor`
+
+```sh
+homeboy runner doctor local
+homeboy runner doctor <runner-id>
+```
+
+Diagnoses a local or configured SSH runner without mutating it. Use `local`,
+`localhost`, or `self` to inspect this machine without creating a runner record.
+The JSON payload uses `command: "runner.doctor"` and includes `runner_id`,
+`status`, `capabilities`, and warning/error details when a capability probe fails.
+
+Use `doctor` before `connect` when you need to know whether Homeboy, Git, SSH,
+and the configured workspace root are usable on the target machine.
+
+### `connect`
+
+```sh
+homeboy runner connect <runner-id>
+```
+
+Starts a loopback-only Homeboy daemon on the runner and opens an SSH tunnel to
+it. This is the preferred Lab execution path because later `runner exec` calls
+can use the daemon session instead of ad-hoc SSH command execution. The JSON
+payload uses `command: "runner.connect"` and reports connection state such as
+the runner ID, tunnel endpoint, daemon endpoint, and persisted session metadata.
+
+### `status`
+
+```sh
+homeboy runner status <runner-id>
+```
+
+Shows the persisted tunnel/session state for a runner. Use this to determine
+whether `runner exec` will use a connected daemon or needs an explicit fallback.
+The JSON payload uses `command: "runner.status"` and reports whether a saved
+session exists, whether the tunnel still appears live, and the recorded endpoint
+details.
+
+### `disconnect`
+
+```sh
+homeboy runner disconnect <runner-id>
+```
+
+Closes a persisted runner tunnel session and removes its local session state.
+The JSON payload uses `command: "runner.disconnect"` and reports which session
+state was removed. This is safe to run when no live session exists; it is the
+explicit cleanup counterpart to `runner connect`.
+
 ### `list`
 
 ```sh
@@ -88,7 +138,7 @@ Path rules:
 - SSH runners require `workspace_root` so local paths are not silently reused remotely.
 - SSH `--cwd` must be an absolute path under the configured `workspace_root`.
 - Omitting `--cwd` on an SSH runner uses the runner `workspace_root`.
-- `--ssh` is an MVP/diagnostic fallback; daemon execution is preferred because it records job metadata and supports artifact-oriented workflows.
+- `--ssh` is the explicit diagnostic fallback when `connect` is unavailable; daemon execution is preferred because it records job metadata and supports artifact-oriented workflows.
 
 ### `workspace sync`
 
@@ -216,7 +266,7 @@ Rules:
 
 All command output is wrapped in the global JSON envelope described in the [JSON output contract](../architecture/output-system.md). The `data` payload uses the generic entity CRUD shape:
 
-- `command`: action identifier such as `runner.add`, `runner.list`, `runner.show`, `runner.set`, `runner.remove`, `runner.exec`, `runner.workspace.sync`, or `runner.workspace.apply`
+- `command`: action identifier such as `runner.add`, `runner.list`, `runner.show`, `runner.set`, `runner.remove`, `runner.doctor`, `runner.connect`, `runner.status`, `runner.disconnect`, `runner.exec`, `runner.workspace.sync`, or `runner.workspace.apply`
 - `id`: present for single-runner actions
 - `entity`: runner configuration for single-runner read/write actions
 - `entities`: list for `list`

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -339,6 +339,62 @@ mod tests {
         Cli::try_parse_from(args).expect("CLI args should parse")
     }
 
+    fn command_doc(command: &str) -> String {
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        std::fs::read_to_string(root.join("docs/commands").join(format!("{command}.md")))
+            .unwrap_or_else(|error| panic!("failed to read docs for {command}: {error}"))
+    }
+
+    fn root_command(command: &str) -> clap::Command {
+        Cli::command()
+            .find_subcommand(command)
+            .unwrap_or_else(|| panic!("missing command {command}"))
+            .clone()
+    }
+
+    fn visible_child_names(command: &clap::Command) -> Vec<String> {
+        command
+            .get_subcommands()
+            .filter(|subcommand| !subcommand.is_hide_set())
+            .map(|subcommand| subcommand.get_name().to_string())
+            .collect()
+    }
+
+    fn visible_long_flags(command: &clap::Command) -> Vec<String> {
+        let mut flags: Vec<String> = command
+            .get_arguments()
+            .filter(|arg| !arg.is_hide_set())
+            .filter_map(|arg| arg.get_long().map(|long| format!("--{long}")))
+            .collect();
+        flags.sort();
+        flags.dedup();
+        flags
+    }
+
+    fn assert_docs_cover_subcommands(command_name: &str) {
+        let command = root_command(command_name);
+        let docs = command_doc(command_name);
+
+        for subcommand in visible_child_names(&command) {
+            assert!(
+                docs.contains(&format!("`{subcommand}")),
+                "docs/commands/{command_name}.md does not document `{subcommand}` from live help"
+            );
+        }
+    }
+
+    fn assert_docs_cover_flags(command_name: &str) {
+        let command = root_command(command_name);
+        let docs = command_doc(command_name);
+
+        for flag in visible_long_flags(&command) {
+            assert!(
+                docs.contains(&flag),
+                "docs/commands/{command_name}.md does not document `{flag}` from live help"
+            );
+        }
+    }
+
     #[test]
     fn test_current_command_surface() {
         let surface = current_command_surface();
@@ -367,6 +423,41 @@ mod tests {
 
         assert!(surface.contains_path(&["self"]));
         assert!(!surface.contains_path(&["self", "missing"]));
+    }
+
+    #[test]
+    fn docs_cover_high_use_command_surfaces() {
+        for command in ["runner", "rig"] {
+            assert_docs_cover_subcommands(command);
+        }
+
+        assert_docs_cover_flags("audit");
+    }
+
+    #[test]
+    fn documented_command_forms_parse() {
+        for args in [
+            ["homeboy", "refactor", "homeboy", "--all"].as_slice(),
+            [
+                "homeboy",
+                "report",
+                "failure-digest",
+                "--output-dir",
+                ".",
+                "--results",
+                "{\"review\":\"fail\"}",
+            ]
+            .as_slice(),
+            ["homeboy", "rig", "repair", "studio"].as_slice(),
+            ["homeboy", "runner", "doctor", "local"].as_slice(),
+            ["homeboy", "runner", "connect", "homeboy-lab"].as_slice(),
+            ["homeboy", "runner", "status", "homeboy-lab"].as_slice(),
+            ["homeboy", "runner", "disconnect", "homeboy-lab"].as_slice(),
+        ] {
+            Cli::try_parse_from(args).unwrap_or_else(|error| {
+                panic!("documented command form failed to parse: {args:?}\n{error}")
+            });
+        }
     }
 
     #[test]

--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -30,6 +30,10 @@ pub struct RefactorArgs {
     #[arg(long = "from", value_name = "SOURCE", action = clap::ArgAction::Append)]
     from: Vec<String>,
 
+    /// Compatibility alias for `--from all`
+    #[arg(long = "all")]
+    all: bool,
+
     /// Only include files changed since a git ref (branch, tag, or SHA)
     #[arg(long)]
     changed_since: Option<String>,
@@ -262,6 +266,7 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
             &args.component_ids,
             &args.components,
             &args.from,
+            args.all,
             args.changed_since.as_deref(),
             &args.only,
             &args.exclude,
@@ -679,6 +684,7 @@ fn run_refactor_sources(
     component_ids: &[String],
     components: &[String],
     from: &[String],
+    all: bool,
     changed_since: Option<&str>,
     only: &[String],
     exclude: &[String],
@@ -689,11 +695,12 @@ fn run_refactor_sources(
     git_identity: Option<&str>,
 ) -> CmdResult<RefactorOutput> {
     let targets = resolve_top_level_targets(comp, component_ids, components)?;
+    let requested_sources = requested_refactor_sources(from, all);
     run_across_targets("sources", targets, |component_id, path| {
         run_refactor_sources_single(
             component_id,
             path,
-            from,
+            &requested_sources,
             changed_since,
             only,
             exclude,
@@ -704,6 +711,18 @@ fn run_refactor_sources(
             git_identity,
         )
     })
+}
+
+fn requested_refactor_sources(from: &[String], all: bool) -> Vec<String> {
+    let mut sources = from.to_vec();
+    if all
+        && !sources
+            .iter()
+            .any(|source| source.eq_ignore_ascii_case("all"))
+    {
+        sources.push("all".to_string());
+    }
+    sources
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Summary
- Restore the documented `homeboy refactor --all` alias by routing it through the existing `--from all` source expansion.
- Update audit, runner, rig, and output-system docs to match the current live CLI help/output behavior.
- Add a reusable CLI-surface/docs drift harness that checks selected command docs against Clap subcommands/flags and verifies documented command forms parse.

Closes #2768.
Closes #2769.
Closes #2770.
Closes #2771.
Closes #2772.
Closes #2773.

## Verification
- `cargo fmt`
- `cargo test cli_surface::tests::`
- `cargo test` initially hit one unrelated transient failure in `core::rig::check::check_test::test_http_check_retries_until_listener_appears`; rerunning that single test passed.
- `cargo test core::rig::check::check_test::test_http_check_retries_until_listener_appears`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused docs/help drift fixes, parser alias, and test harness; Chris remains responsible for review and merge.