### PR TITLE
Add Linux rig app launchers

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -389,11 +389,11 @@ Workload paths support `~`, `${env.NAME}`, `${components.<id>.path}`, and `${pac
 
 | Field | Type | Description |
 |---|---|---|
-| `platform` | enum | Currently `macos`. |
-| `wrapper_display_name` | string | Display name for the generated `.app` bundle. |
-| `wrapper_bundle_id` | string | Bundle identifier written to `Info.plist`. |
+| `platform` | enum | `macos` or `linux`. |
+| `wrapper_display_name` | string | Display name for the generated launcher. |
+| `wrapper_bundle_id` | string | Bundle identifier written to `Info.plist` on macOS. |
 | `target_app` | string | App or executable opened after rig prep succeeds. |
-| `install_dir` | string | Optional install directory; defaults to `/Applications`. |
+| `install_dir` | string | Optional install directory; defaults to `/Applications` on macOS and `$HOME/.local/share/applications` on Linux. |
 | `preflight` | array | Preflight actions; defaults to `rig:check`. |
 | `on_preflight_fail` | string | Optional failure behavior for generated launcher scripts. |
 
@@ -408,6 +408,8 @@ Workload paths support `~`, `${env.NAME}`, `${components.<id>.path}`, and `${pac
   }
 }
 ```
+
+Linux launchers use the same block with `"platform": "linux"` and write a `.desktop` file that invokes the target executable after preflight and `rig up` succeed.
 
 ## Variable Expansion
 

--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -181,7 +181,7 @@ homeboy rig app update studio --dry-run
 homeboy rig app uninstall studio
 ```
 
-`rig app` manages an optional desktop launcher declared in `app_launcher`. The current implementation generates a macOS `.app` wrapper that runs rig preflight, runs `rig up`, and opens the target app when the rig is ready. Use `--dry-run` to preview generated paths without writing or deleting files.
+`rig app` manages an optional desktop launcher declared in `app_launcher`. It can generate a macOS `.app` wrapper or a Linux `.desktop` file that runs rig preflight, runs `rig up`, and opens the target app when the rig is ready. Use `--dry-run` to preview generated paths without writing or deleting files.
 
 ## Minimal Example
 

--- a/src/core/rig/app.rs
+++ b/src/core/rig/app.rs
@@ -1,8 +1,8 @@
 //! Desktop launcher wrappers for rigs.
 //!
-//! v1 intentionally ships the smallest useful surface: a macOS `.app` bundle
-//! whose executable is a shell script. Native Swift/Platypus launchers and
-//! cross-platform `.desktop` / `.lnk` generators can layer on this contract.
+//! The first launcher surfaces are a macOS `.app` bundle whose executable is a
+//! shell script and a Linux `.desktop` file. Native Swift/Platypus launchers and
+//! Windows `.lnk` generators can layer on this contract.
 
 use std::fs;
 use std::path::PathBuf;
@@ -16,6 +16,7 @@ use crate::core::error::{Error, Result};
 mod bundle;
 
 const DEFAULT_MACOS_INSTALL_DIR: &str = "/Applications";
+const DEFAULT_LINUX_INSTALL_DIR_SUFFIX: &str = ".local/share/applications";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -77,7 +78,12 @@ fn uninstall_inner(
     let files = bundle::planned_files(&launcher);
 
     if !options.dry_run && launcher.launcher_path.exists() {
-        fs::remove_dir_all(&launcher.launcher_path).map_err(|e| {
+        let remove_result = if launcher.launcher_path.is_dir() {
+            fs::remove_dir_all(&launcher.launcher_path)
+        } else {
+            fs::remove_file(&launcher.launcher_path)
+        };
+        remove_result.map_err(|e| {
             Error::internal_unexpected(format!(
                 "Failed to remove launcher {}: {}",
                 launcher.launcher_path.display(),
@@ -107,7 +113,7 @@ fn install_inner(
     let files = bundle::planned_files(&launcher);
 
     if !options.dry_run {
-        bundle::write_macos_bundle(rig, &launcher)?;
+        bundle::write_launcher(rig, &launcher)?;
     }
 
     Ok(report(
@@ -153,10 +159,10 @@ fn resolve_launcher(rig: &RigSpec) -> Result<ResolvedLauncher> {
         .install_dir
         .as_deref()
         .map(|p| expand_vars(rig, p))
-        .unwrap_or_else(|| DEFAULT_MACOS_INSTALL_DIR.to_string());
+        .unwrap_or_else(|| default_install_dir(spec.platform));
     let install_dir = PathBuf::from(install_dir);
     let display_name = spec.wrapper_display_name.trim().to_string();
-    let launcher_path = install_dir.join(format!("{}.app", display_name));
+    let launcher_path = install_dir.join(launcher_file_name(spec.platform, &display_name));
 
     Ok(ResolvedLauncher {
         platform: spec.platform,
@@ -175,14 +181,41 @@ fn resolve_launcher(rig: &RigSpec) -> Result<ResolvedLauncher> {
 fn validate_platform(platform: AppLauncherPlatform) -> Result<()> {
     match platform {
         AppLauncherPlatform::Macos if cfg!(target_os = "macos") => Ok(()),
+        AppLauncherPlatform::Linux if cfg!(target_os = "linux") => Ok(()),
         AppLauncherPlatform::Macos => Err(Error::validation_invalid_argument(
             "app_launcher.platform",
             "macOS app launchers can only be installed on macOS; use --dry-run to preview generated paths",
             None,
             Some(vec![
-                "Linux .desktop and Windows .lnk launchers are deferred from v1".to_string(),
+                "Set app_launcher.platform to linux for Linux .desktop launchers".to_string(),
+                "Windows .lnk launchers are deferred".to_string(),
             ]),
         )),
+        AppLauncherPlatform::Linux => Err(Error::validation_invalid_argument(
+            "app_launcher.platform",
+            "Linux .desktop launchers can only be installed on Linux; use --dry-run to preview generated paths",
+            None,
+            Some(vec![
+                "Set app_launcher.platform to macos for macOS .app launchers".to_string(),
+                "Windows .lnk launchers are deferred".to_string(),
+            ]),
+        )),
+    }
+}
+
+fn default_install_dir(platform: AppLauncherPlatform) -> String {
+    match platform {
+        AppLauncherPlatform::Macos => DEFAULT_MACOS_INSTALL_DIR.to_string(),
+        AppLauncherPlatform::Linux => std::env::var("HOME")
+            .map(|home| format!("{home}/{DEFAULT_LINUX_INSTALL_DIR_SUFFIX}"))
+            .unwrap_or_else(|_| format!("~/{DEFAULT_LINUX_INSTALL_DIR_SUFFIX}")),
+    }
+}
+
+fn launcher_file_name(platform: AppLauncherPlatform, display_name: &str) -> String {
+    match platform {
+        AppLauncherPlatform::Macos => format!("{display_name}.app"),
+        AppLauncherPlatform::Linux => format!("{display_name}.desktop"),
     }
 }
 

--- a/src/core/rig/app/bundle.rs
+++ b/src/core/rig/app/bundle.rs
@@ -1,14 +1,21 @@
-//! macOS script-backed launcher bundle generation.
+//! Script-backed desktop launcher generation.
 
 use std::fs;
 use std::path::Path;
 
 use super::ResolvedLauncher;
 use crate::core::error::{Error, Result};
-use crate::core::rig::spec::AppLauncherPreflight;
+use crate::core::rig::spec::{AppLauncherPlatform, AppLauncherPreflight};
 use crate::core::rig::RigSpec;
 
-pub(super) fn write_macos_bundle(rig: &RigSpec, launcher: &ResolvedLauncher) -> Result<()> {
+pub(super) fn write_launcher(rig: &RigSpec, launcher: &ResolvedLauncher) -> Result<()> {
+    match launcher.platform {
+        AppLauncherPlatform::Macos => write_macos_bundle(rig, launcher),
+        AppLauncherPlatform::Linux => write_linux_desktop(rig, launcher),
+    }
+}
+
+fn write_macos_bundle(rig: &RigSpec, launcher: &ResolvedLauncher) -> Result<()> {
     let contents = launcher.launcher_path.join("Contents");
     let macos = contents.join("MacOS");
     fs::create_dir_all(&macos).map_err(|e| {
@@ -41,19 +48,44 @@ pub(super) fn write_macos_bundle(rig: &RigSpec, launcher: &ResolvedLauncher) -> 
 }
 
 pub(super) fn planned_files(launcher: &ResolvedLauncher) -> Vec<String> {
-    vec![
-        launcher.launcher_path.display().to_string(),
-        launcher
-            .launcher_path
-            .join("Contents/Info.plist")
-            .display()
-            .to_string(),
-        launcher
-            .launcher_path
-            .join("Contents/MacOS/launch")
-            .display()
-            .to_string(),
-    ]
+    match launcher.platform {
+        AppLauncherPlatform::Macos => vec![
+            launcher.launcher_path.display().to_string(),
+            launcher
+                .launcher_path
+                .join("Contents/Info.plist")
+                .display()
+                .to_string(),
+            launcher
+                .launcher_path
+                .join("Contents/MacOS/launch")
+                .display()
+                .to_string(),
+        ],
+        AppLauncherPlatform::Linux => vec![launcher.launcher_path.display().to_string()],
+    }
+}
+
+fn write_linux_desktop(rig: &RigSpec, launcher: &ResolvedLauncher) -> Result<()> {
+    if let Some(parent) = launcher.launcher_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| {
+            Error::internal_unexpected(format!(
+                "Failed to create launcher directory {}: {}",
+                parent.display(),
+                e
+            ))
+        })?;
+    }
+
+    fs::write(&launcher.launcher_path, render_desktop_entry(rig, launcher)).map_err(|e| {
+        Error::internal_unexpected(format!(
+            "Failed to write launcher desktop file {}: {}",
+            launcher.launcher_path.display(),
+            e
+        ))
+    })?;
+    make_executable(&launcher.launcher_path)?;
+    Ok(())
 }
 
 pub(super) fn render_info_plist(launcher: &ResolvedLauncher) -> String {
@@ -117,6 +149,43 @@ exec "$TARGET_APP" "$@"
     )
 }
 
+pub(super) fn render_desktop_entry(rig: &RigSpec, launcher: &ResolvedLauncher) -> String {
+    format!(
+        r#"[Desktop Entry]
+Type=Application
+Name={}
+Exec=/bin/sh -lc {} homeboy-launcher %U
+Terminal=false
+Categories=Development;
+"#,
+        desktop_escape(&launcher.display_name),
+        sh_single_quote(&render_linux_exec_command(rig, launcher))
+    )
+}
+
+fn render_linux_exec_command(rig: &RigSpec, launcher: &ResolvedLauncher) -> String {
+    let mut commands = vec!["HOMEBOY_BIN=\"${HOMEBOY_BIN:-homeboy}\"".to_string()];
+    for step in &launcher.preflight {
+        match step {
+            AppLauncherPreflight::RigCheck => {
+                commands.push(format!(
+                    "\"$HOMEBOY_BIN\" rig check {}",
+                    sh_single_quote(&rig.id)
+                ));
+            }
+        }
+    }
+    commands.push(format!(
+        "\"$HOMEBOY_BIN\" rig up {}",
+        sh_single_quote(&rig.id)
+    ));
+    commands.push(format!(
+        "exec {} \"$@\"",
+        sh_single_quote(&launcher.target_path)
+    ));
+    commands.join(" && ")
+}
+
 fn push_rig_check_preflight(rig: &RigSpec, preflight: &mut String) {
     let rig_id = sh_single_quote(&rig.id);
     let terminal_command =
@@ -166,6 +235,13 @@ fn xml_escape(value: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&apos;")
+}
+
+fn desktop_escape(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('\r', "")
 }
 
 fn applescript_string_literal(value: &str) -> String {

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -109,8 +109,8 @@ pub struct RigSpec {
 
     /// Optional desktop launcher wrapper for this rig.
     ///
-    /// v1 is macOS-only and generates a script-backed `.app` bundle that runs
-    /// `homeboy rig check` and `homeboy rig up` before opening the target app.
+    /// Generates a desktop launcher that runs `homeboy rig check` and
+    /// `homeboy rig up` before opening the target app.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub app_launcher: Option<AppLauncherSpec>,
 }
@@ -147,13 +147,13 @@ impl RigResourcesSpec {
 /// Desktop launcher settings for a rig.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppLauncherSpec {
-    /// Launcher platform. v1 supports `macos` only.
+    /// Launcher platform. Supports `macos` and `linux`.
     pub platform: AppLauncherPlatform,
 
-    /// Display name for the generated launcher bundle.
+    /// Display name for the generated launcher.
     pub wrapper_display_name: String,
 
-    /// Bundle identifier written to Info.plist.
+    /// Bundle identifier written to Info.plist on macOS.
     pub wrapper_bundle_id: String,
 
     /// Target app or executable to launch after rig prep succeeds.
@@ -161,8 +161,8 @@ pub struct AppLauncherSpec {
     pub target_app: String,
 
     /// Directory that receives the generated wrapper. Defaults to
-    /// `/Applications`; tests and non-global installs can point this at a
-    /// writable directory.
+    /// `/Applications` on macOS and `$HOME/.local/share/applications` on Linux;
+    /// tests and non-global installs can point this at a writable directory.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub install_dir: Option<String>,
 
@@ -173,8 +173,9 @@ pub struct AppLauncherSpec {
     )]
     pub preflight: Vec<AppLauncherPreflight>,
 
-    /// Failure behaviour for preflight. v1 implements the dialog + terminal
-    /// script path on macOS.
+    /// Failure behaviour for preflight. macOS implements the dialog + terminal
+    /// script path; Linux exits the generated `.desktop` command with the
+    /// failing preflight status.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub on_preflight_fail: Option<String>,
 }
@@ -184,6 +185,7 @@ pub struct AppLauncherSpec {
 #[serde(rename_all = "kebab-case")]
 pub enum AppLauncherPlatform {
     Macos,
+    Linux,
 }
 
 /// Preflight command run by a generated launcher before `rig up`.

--- a/tests/core/rig/app_test.rs
+++ b/tests/core/rig/app_test.rs
@@ -53,6 +53,14 @@ fn rig_with_launcher(install_dir: &str) -> RigSpec {
     }
 }
 
+fn rig_with_linux_launcher(install_dir: &str) -> RigSpec {
+    let mut rig = rig_with_launcher(install_dir);
+    let launcher = rig.app_launcher.as_mut().expect("launcher");
+    launcher.platform = AppLauncherPlatform::Linux;
+    launcher.target_app = "${components.studio.path}/out/studio".to_string();
+    rig
+}
+
 #[test]
 fn test_app_launcher_spec_parses() {
     let json = r#"{
@@ -77,12 +85,42 @@ fn test_app_launcher_spec_parses() {
 }
 
 #[test]
+fn test_linux_app_launcher_spec_parses() {
+    let json = r#"{
+        "id": "studio-dev",
+        "components": { "studio": { "path": "/tmp/studio" } },
+        "app_launcher": {
+            "platform": "linux",
+            "wrapper_display_name": "Studio Dev",
+            "wrapper_bundle_id": "com.chubes.studio-dev",
+            "target_app": "${components.studio.path}/out/studio",
+            "install_dir": "/tmp/apps",
+            "preflight": ["rig:check"]
+        }
+    }"#;
+    let spec: RigSpec = serde_json::from_str(json).expect("parse");
+    let launcher = spec.app_launcher.expect("launcher");
+    assert_eq!(launcher.platform, AppLauncherPlatform::Linux);
+    assert_eq!(launcher.wrapper_display_name, "Studio Dev");
+}
+
+#[test]
 fn test_resolve_launcher_expands_paths() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let rig = rig_with_launcher(&tmp.path().to_string_lossy());
     let launcher = super::resolve_launcher(&rig).expect("resolve");
     assert_eq!(launcher.target_path, "/tmp/studio-dev/out/Studio.app");
     assert!(launcher.launcher_path.ends_with("Studio (Dev).app"));
+    assert_eq!(launcher.launcher_path.parent().unwrap(), tmp.path());
+}
+
+#[test]
+fn test_resolve_linux_launcher_uses_desktop_extension() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_linux_launcher(&tmp.path().to_string_lossy());
+    let launcher = super::resolve_launcher(&rig).expect("resolve");
+    assert_eq!(launcher.target_path, "/tmp/studio-dev/out/studio");
+    assert!(launcher.launcher_path.ends_with("Studio (Dev).desktop"));
     assert_eq!(launcher.launcher_path.parent().unwrap(), tmp.path());
 }
 
@@ -102,6 +140,23 @@ fn test_generated_wrapper_content_runs_check_up_then_target() {
 }
 
 #[test]
+fn test_generated_linux_desktop_entry_runs_check_up_then_target() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_linux_launcher(&tmp.path().to_string_lossy());
+    let launcher = super::resolve_launcher(&rig).expect("resolve");
+    let desktop = super::bundle::render_desktop_entry(&rig, &launcher);
+    assert!(desktop.starts_with("[Desktop Entry]"));
+    assert!(desktop.contains("Name=Studio (Dev)"));
+    assert!(desktop.contains("HOMEBOY_BIN=\"${HOMEBOY_BIN:-homeboy}\""));
+    assert!(desktop.contains("rig check"));
+    assert!(desktop.contains("rig up"));
+    assert!(desktop.contains("studio-dev"));
+    assert!(desktop.contains("/tmp/studio-dev/out/studio"));
+    assert!(desktop.contains("\"$@\""));
+    assert!(desktop.contains("homeboy-launcher %U"));
+}
+
+#[test]
 fn test_install_dry_run_reports_paths_without_writing() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let rig = rig_with_launcher(&tmp.path().to_string_lossy());
@@ -111,6 +166,18 @@ fn test_install_dry_run_reports_paths_without_writing() {
     assert!(report.launcher_path.ends_with("Studio (Dev).app"));
     assert_eq!(report.files.len(), 3);
     assert!(!tmp.path().join("Studio (Dev).app").exists());
+}
+
+#[test]
+fn test_linux_install_dry_run_reports_desktop_file_without_writing() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_linux_launcher(&tmp.path().to_string_lossy());
+    let report = install_inner(&rig, AppLauncherOptions { dry_run: true }, false).expect("plan");
+    assert!(report.dry_run);
+    assert_eq!(report.platform, AppLauncherPlatform::Linux);
+    assert!(report.launcher_path.ends_with("Studio (Dev).desktop"));
+    assert_eq!(report.files.len(), 1);
+    assert!(!tmp.path().join("Studio (Dev).desktop").exists());
 }
 
 #[test]
@@ -135,6 +202,21 @@ fn test_install_writes_script_backed_bundle_to_temp_dir() {
 }
 
 #[test]
+fn test_linux_install_writes_desktop_file_to_temp_dir() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_linux_launcher(&tmp.path().to_string_lossy());
+    let report =
+        install_inner(&rig, AppLauncherOptions { dry_run: false }, false).expect("install");
+    let desktop = tmp.path().join("Studio (Dev).desktop");
+
+    assert!(!report.dry_run);
+    assert!(desktop.exists(), "desktop file written");
+    assert!(fs::read_to_string(desktop)
+        .expect("read desktop")
+        .contains("Exec=/bin/sh -lc"));
+}
+
+#[test]
 fn test_uninstall_removes_generated_bundle_from_temp_dir() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let rig = rig_with_launcher(&tmp.path().to_string_lossy());
@@ -146,6 +228,33 @@ fn test_uninstall_removes_generated_bundle_from_temp_dir() {
         uninstall_inner(&rig, AppLauncherOptions { dry_run: false }, false).expect("uninstall");
     assert_eq!(report.action, AppLauncherAction::Uninstall);
     assert!(!app.exists(), "bundle removed");
+}
+
+#[test]
+fn test_uninstall_removes_generated_linux_desktop_file_from_temp_dir() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_linux_launcher(&tmp.path().to_string_lossy());
+    install_inner(&rig, AppLauncherOptions { dry_run: false }, false).expect("install");
+    let desktop = tmp.path().join("Studio (Dev).desktop");
+    assert!(desktop.exists());
+
+    let report =
+        uninstall_inner(&rig, AppLauncherOptions { dry_run: false }, false).expect("uninstall");
+    assert_eq!(report.action, AppLauncherAction::Uninstall);
+    assert!(!desktop.exists(), "desktop file removed");
+}
+
+#[test]
+fn test_public_linux_install_refuses_on_non_linux_hosts() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_linux_launcher(&tmp.path().to_string_lossy());
+    let result = crate::core::rig::app::install(&rig, AppLauncherOptions { dry_run: false });
+    if cfg!(target_os = "linux") {
+        assert!(result.is_ok(), "Linux should allow install");
+    } else {
+        let err = result.expect_err("non-Linux refuses install");
+        assert!(err.to_string().contains("Linux .desktop launchers"));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `app_launcher.platform: "linux"` support that writes script-backed `.desktop` files under the same rig app launcher contract as macOS.
- Keep install/update/uninstall idempotent by resolving platform-specific file paths and removing either generated `.app` directories or `.desktop` files.
- Document the Linux launcher shape and default install directory.

Refs #1635

## Testing
- `cargo test core::rig::app`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the focused Linux `.desktop` launcher slice, added tests/docs, and ran verification before opening this PR.