### PR TITLE
test: add golden JSON command contracts

### DIFF
--- a/src/commands/golden_contract_tests.rs
+++ b/src/commands/golden_contract_tests.rs
@@ -12,7 +12,7 @@ use super::deploy::{DeployCommandOutput, DeployOutput, MultiProjectDeployOutput}
 use super::release::{BatchReleaseOutput, ReleaseCommandOutput, ReleaseOutput};
 use super::runs::{
     DriftValue, QueryGroup, QueryRow, RunsDriftFilters, RunsDriftOutput, RunsQueryFilters,
-    TestRunsQueryOutput as RunsQueryOutput,
+    SkippedArtifactRow, TestRunsQueryOutput as RunsQueryOutput,
 };
 use super::runs::{RunDetail, RunSummary, RunsArtifactsOutput, RunsListOutput, RunsShowOutput};
 use super::stack::{
@@ -68,6 +68,15 @@ fn runs_command_json_contract_matches_golden_fixture() {
                     select: vec!["$.metrics.ready_ms".to_string()],
                     group_by: Some("$.variant".to_string()),
                     matched_artifact_count: 1,
+                    skipped_artifact_count: 1,
+                    skipped_artifacts: vec![SkippedArtifactRow {
+                        run_id: "run-contract-1".to_string(),
+                        artifact_id: "artifact-log".to_string(),
+                        artifact_kind: "log".to_string(),
+                        artifact_type: "file".to_string(),
+                        path: "artifacts/output.log".to_string(),
+                        reason: "not JSON".to_string(),
+                    }],
                     rows: vec![QueryRow {
                         run_id: "run-contract-1".to_string(),
                         artifact_kind: "summary".to_string(),

--- a/src/commands/golden_contract_tests.rs
+++ b/src/commands/golden_contract_tests.rs
@@ -1,0 +1,405 @@
+use serde::Serialize;
+use std::path::Path;
+
+use serde_json::{json, Value};
+
+const FIXTURE_ROOT: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/golden_json_contracts"
+);
+
+use super::deploy::{DeployCommandOutput, DeployOutput, MultiProjectDeployOutput};
+use super::release::{BatchReleaseOutput, ReleaseCommandOutput, ReleaseOutput};
+use super::runs::{
+    DriftValue, QueryGroup, QueryRow, RunsDriftFilters, RunsDriftOutput, RunsQueryFilters,
+    TestRunsQueryOutput as RunsQueryOutput,
+};
+use super::runs::{RunDetail, RunSummary, RunsArtifactsOutput, RunsListOutput, RunsShowOutput};
+use super::stack::{
+    StackInspectOutput, StackListOutput, StackShowOutput, StackStatusOutput, StackSummary,
+};
+use super::utils::response::CliResponse;
+use crate::core::deploy::{
+    ComponentDeployResult, ComponentStatus, DeployReason, DeploySummary, MultiDeploySummary,
+    ProjectDeployResult,
+};
+use crate::core::observation::ArtifactRecord;
+use crate::core::release::{
+    BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseCommandResult,
+    ReleasePlan, ReleaseSemverCommit, ReleaseSemverRecommendation,
+};
+use crate::core::stack::{
+    GitRef, InspectCommit, InspectCommitDetails, InspectOutput, InspectPr, LocalState,
+    StackPrEntry, StackSpec, StatusOutput, StatusPr,
+};
+
+#[test]
+fn runs_command_json_contract_matches_golden_fixture() {
+    assert_fixture(
+        "runs_contract.json",
+        json!({
+            "scenarios": [
+                scenario("runs list", RunsListOutput {
+                    command: "runs.list",
+                    runs: vec![run_summary()],
+                }),
+                scenario("runs show", RunsShowOutput {
+                    command: "runs.show",
+                    run: RunDetail {
+                        summary: run_summary(),
+                        homeboy_version: Some("0.197.11".to_string()),
+                        metadata: json!({ "scenario": "contract", "score": 0.98 }),
+                        artifacts: vec![artifact_record()],
+                    },
+                }),
+                scenario("runs artifacts", RunsArtifactsOutput {
+                    command: "runs.artifacts",
+                    run_id: "run-contract-1".to_string(),
+                    artifacts: vec![artifact_record()],
+                }),
+                scenario("runs query json", RunsQueryOutput {
+                    command: "runs.query",
+                    filters: RunsQueryFilters {
+                        component_id: Some("homeboy".to_string()),
+                        kind: Some("bench".to_string()),
+                        since: Some("7d".to_string()),
+                        limit: 200,
+                    },
+                    select: vec!["$.metrics.ready_ms".to_string()],
+                    group_by: Some("$.variant".to_string()),
+                    matched_artifact_count: 1,
+                    rows: vec![QueryRow {
+                        run_id: "run-contract-1".to_string(),
+                        artifact_kind: "summary".to_string(),
+                        values: vec![json!(123.4)],
+                    }],
+                    groups: vec![QueryGroup {
+                        group: "candidate".to_string(),
+                        count: 1,
+                    }],
+                    table: None,
+                    csv: None,
+                }),
+                scenario("runs drift json", RunsDriftOutput {
+                    command: "runs.drift",
+                    filters: RunsDriftFilters {
+                        component_id: Some("homeboy".to_string()),
+                        kind: Some("bench".to_string()),
+                        window: "7d".to_string(),
+                        baseline: Some("30d".to_string()),
+                    },
+                    metric: "$.variant".to_string(),
+                    threshold: 0.5,
+                    window_observations: 10,
+                    window_missing_rows: 0,
+                    baseline_observations: Some(40),
+                    baseline_missing_rows: Some(2),
+                    values: vec![DriftValue {
+                        value: "candidate".to_string(),
+                        window_count: 7,
+                        window_share: 0.7,
+                        dominant: true,
+                        baseline_share: Some(0.25),
+                        share_delta: Some(0.45),
+                    }],
+                    table: None,
+                }),
+            ]
+        }),
+    );
+}
+
+#[test]
+fn release_command_json_contract_matches_golden_fixture() {
+    assert_fixture(
+        "release_contract.json",
+        json!({
+            "scenarios": [
+                scenario("release dry-run single", ReleaseCommandOutput::Single(ReleaseOutput {
+                    result: release_result("homeboy", "minor", true, Some(release_plan())),
+                })),
+                scenario("release dry-run batch", ReleaseCommandOutput::Batch(BatchReleaseOutput {
+                    result: BatchReleaseResult {
+                        results: vec![BatchReleaseComponentResult {
+                            component_id: "homeboy".to_string(),
+                            status: "planned".to_string(),
+                            error: None,
+                            result: Some(release_result("homeboy", "minor", true, Some(release_plan()))),
+                        }],
+                        summary: BatchReleaseSummary {
+                            total: 1,
+                            released: 0,
+                            skipped: 0,
+                            failed: 0,
+                        },
+                    },
+                })),
+            ]
+        }),
+    );
+}
+
+#[test]
+fn deploy_command_json_contract_matches_golden_fixture() {
+    assert_fixture(
+        "deploy_contract.json",
+        json!({
+            "scenarios": [
+                scenario("deploy dry-run single", DeployCommandOutput::Single(DeployOutput {
+                    command: "deploy.run".to_string(),
+                    project_id: "production".to_string(),
+                    all: false,
+                    outdated: false,
+                    behind_upstream: false,
+                    dry_run: true,
+                    check: false,
+                    force: false,
+                    results: vec![component_deploy_result("homeboy")],
+                    summary: deploy_summary(1, 0, 0, 1),
+                })),
+                scenario("deploy dry-run multi-project", DeployCommandOutput::Multi(MultiProjectDeployOutput {
+                    command: "deploy.multi".to_string(),
+                    component_ids: vec!["homeboy".to_string()],
+                    projects: vec![ProjectDeployResult {
+                        project_id: "production".to_string(),
+                        status: "planned".to_string(),
+                        error: None,
+                        results: vec![component_deploy_result("homeboy")],
+                        summary: deploy_summary(1, 0, 0, 1),
+                    }],
+                    summary: MultiDeploySummary {
+                        total_projects: 1,
+                        succeeded: 0,
+                        failed: 0,
+                        skipped: 0,
+                        planned: 1,
+                    },
+                    dry_run: true,
+                    check: false,
+                    force: false,
+                })),
+            ]
+        }),
+    );
+}
+
+#[test]
+fn stack_command_json_contract_matches_golden_fixture() {
+    assert_fixture(
+        "stack_contract.json",
+        json!({
+            "scenarios": [
+                scenario("stack list", StackListOutput {
+                    command: "stack.list",
+                    stacks: vec![StackSummary {
+                        id: "combined-fixes".to_string(),
+                        description: "Combined fixes branch".to_string(),
+                        component: "homeboy".to_string(),
+                        component_path: "/work/homeboy".to_string(),
+                        base: "origin/main".to_string(),
+                        target: "origin/dev/combined-fixes".to_string(),
+                        pr_count: 1,
+                    }],
+                }),
+                scenario("stack show", StackShowOutput {
+                    command: "stack.show",
+                    stack: stack_spec(),
+                }),
+                scenario("stack status", StackStatusOutput {
+                    command: "stack.status",
+                    report: StatusOutput {
+                        stack_id: "combined-fixes".to_string(),
+                        component_path: "/work/homeboy".to_string(),
+                        base: "origin/main".to_string(),
+                        target: "dev/combined-fixes".to_string(),
+                        target_ahead: Some(2),
+                        target_behind: Some(0),
+                        prs: vec![StatusPr {
+                            repo: "Extra-Chill/homeboy".to_string(),
+                            number: 2753,
+                            note: Some("contract coverage".to_string()),
+                            title: Some("Add golden JSON contract fixtures".to_string()),
+                            url: Some("https://github.com/Extra-Chill/homeboy/pull/2753".to_string()),
+                            upstream_state: Some("OPEN".to_string()),
+                            review_decision: Some("REVIEW_REQUIRED".to_string()),
+                            merged_at: None,
+                            local_state: LocalState::Applied,
+                            candidate_for_drop: false,
+                            error: None,
+                        }],
+                        merged_count: 0,
+                        success: true,
+                    },
+                }),
+                scenario("stack inspect", StackInspectOutput {
+                    command: "stack.inspect",
+                    report: InspectOutput {
+                        component_id: "homeboy".to_string(),
+                        path: "/work/homeboy".to_string(),
+                        branch: "fix/contract".to_string(),
+                        base: "origin/main".to_string(),
+                        base_auto_detected: false,
+                        commits: vec![InspectCommit {
+                            commit: InspectCommitDetails {
+                                sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+                                short_sha: "aaaaaaaa".to_string(),
+                                subject: "test: pin command JSON contract".to_string(),
+                                author: "Homeboy Bot".to_string(),
+                                date: "2026-05-24T00:00:00Z".to_string(),
+                            },
+                            pr: Some(InspectPr {
+                                number: 2753,
+                                state: "OPEN".to_string(),
+                                title: "Add golden JSON contract fixtures".to_string(),
+                                url: "https://github.com/Extra-Chill/homeboy/pull/2753".to_string(),
+                            }),
+                            pr_lookup_note: None,
+                        }],
+                        merged_count: 0,
+                        success: true,
+                    },
+                }),
+            ]
+        }),
+    );
+}
+
+fn scenario<T: Serialize>(name: &str, data: T) -> Value {
+    json!({
+        "scenario": name,
+        "payload": serde_json::to_value(CliResponse::success(data)).expect("serialize CLI envelope"),
+    })
+}
+
+fn assert_fixture(name: &str, actual: Value) {
+    let path = Path::new(FIXTURE_ROOT).join(name);
+    let expected = std::fs::read_to_string(&path).expect("golden fixture exists");
+    let expected: Value = serde_json::from_str(&expected).expect("golden fixture is valid JSON");
+    assert_eq!(actual, expected);
+}
+
+fn run_summary() -> RunSummary {
+    RunSummary {
+        id: "run-contract-1".to_string(),
+        kind: "bench".to_string(),
+        status: "passed".to_string(),
+        started_at: "2026-05-24T00:00:00Z".to_string(),
+        finished_at: Some("2026-05-24T00:01:00Z".to_string()),
+        component_id: Some("homeboy".to_string()),
+        rig_id: Some("contract-rig".to_string()),
+        git_sha: Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string()),
+        command: Some("homeboy bench --format=json".to_string()),
+        cwd: Some("/work/homeboy".to_string()),
+        status_note: Some("fixture".to_string()),
+    }
+}
+
+fn artifact_record() -> ArtifactRecord {
+    ArtifactRecord {
+        id: "artifact-summary".to_string(),
+        run_id: "run-contract-1".to_string(),
+        kind: "summary".to_string(),
+        artifact_type: "file".to_string(),
+        path: "artifacts/summary.json".to_string(),
+        url: Some("https://example.test/artifacts/summary.json".to_string()),
+        sha256: Some(
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        ),
+        size_bytes: Some(1234),
+        mime: Some("application/json".to_string()),
+        created_at: "2026-05-24T00:01:00Z".to_string(),
+    }
+}
+
+fn release_plan() -> ReleasePlan {
+    ReleasePlan::new(
+        "homeboy",
+        true,
+        Vec::new(),
+        Some(ReleaseSemverRecommendation {
+            latest_tag: Some("v0.197.10".to_string()),
+            range: "v0.197.10..HEAD".to_string(),
+            commits: vec![ReleaseSemverCommit {
+                sha: "aaaaaaaa".to_string(),
+                subject: "feat: add contract fixtures".to_string(),
+                commit_type: "feat".to_string(),
+                breaking: false,
+            }],
+            recommended_bump: Some("minor".to_string()),
+            requested_bump: "minor".to_string(),
+            is_underbump: false,
+            reasons: vec!["feat commit requires a minor release".to_string()],
+        }),
+        vec!["dry run only".to_string()],
+        vec!["review generated plan before releasing".to_string()],
+    )
+}
+
+fn release_result(
+    component_id: &str,
+    bump_type: &str,
+    dry_run: bool,
+    plan: Option<ReleasePlan>,
+) -> ReleaseCommandResult {
+    ReleaseCommandResult {
+        component_id: component_id.to_string(),
+        bump_type: bump_type.to_string(),
+        dry_run,
+        releasable_commits: 1,
+        new_version: Some("0.198.0".to_string()),
+        tag: Some("v0.198.0".to_string()),
+        skipped_reason: None,
+        plan,
+        run: None,
+        deployment: None,
+    }
+}
+
+fn component_deploy_result(id: &str) -> ComponentDeployResult {
+    ComponentDeployResult {
+        id: id.to_string(),
+        status: "planned".to_string(),
+        deploy_reason: Some(DeployReason::ExplicitlySelected),
+        component_status: Some(ComponentStatus::NeedsUpdate),
+        local_version: Some("0.198.0".to_string()),
+        remote_version: Some("0.197.11".to_string()),
+        error: None,
+        artifact_path: Some("target/dist/homeboy.tar.gz".to_string()),
+        remote_path: Some("/srv/homeboy".to_string()),
+        build_exit_code: None,
+        deploy_exit_code: None,
+        release_state: None,
+        deployed_ref: Some("v0.198.0".to_string()),
+    }
+}
+
+fn deploy_summary(total: u32, succeeded: u32, failed: u32, skipped: u32) -> DeploySummary {
+    DeploySummary {
+        total,
+        succeeded,
+        failed,
+        skipped,
+    }
+}
+
+fn stack_spec() -> StackSpec {
+    StackSpec {
+        id: "combined-fixes".to_string(),
+        description: "Combined fixes branch".to_string(),
+        component: "homeboy".to_string(),
+        component_path: "/work/homeboy".to_string(),
+        base: GitRef {
+            remote: "origin".to_string(),
+            branch: "main".to_string(),
+        },
+        target: GitRef {
+            remote: "origin".to_string(),
+            branch: "dev/combined-fixes".to_string(),
+        },
+        prs: vec![StackPrEntry {
+            repo: "Extra-Chill/homeboy".to_string(),
+            number: 2753,
+            note: Some("contract coverage".to_string()),
+        }],
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -381,6 +381,9 @@ pub mod utils;
 pub mod version;
 
 #[cfg(test)]
+mod golden_contract_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -39,6 +39,8 @@ use latest::{RunsLatestFindingOutput, RunsLatestRunArgs, RunsLatestRunOutput};
 use query::{runs_query, RunsQueryArgs, RunsQueryOutput};
 use reconcile::{reconcile_runs, RunsReconcileArgs, RunsReconcileOutput};
 
+#[cfg(test)]
+pub(crate) use common::SkippedArtifactRow;
 pub(crate) use drift::RunsDriftOutput;
 #[cfg(test)]
 pub(crate) use drift::{DriftValue, RunsDriftFilters};

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -32,12 +32,20 @@ use bundle::{
 pub use common::RunSummary;
 use compare::{compare_runs, RunsCompareArgs, RunsCompareOutput};
 pub use distribution::{runs_distribution, RunsDistributionArgs, RunsDistributionOutput};
-use drift::{runs_drift, RunsDriftArgs, RunsDriftOutput};
+use drift::{runs_drift, RunsDriftArgs};
 use findings::{RunsFindingOutput, RunsFindingsOutput};
 use gh_actions::GhActionsImportOutput;
 use latest::{RunsLatestFindingOutput, RunsLatestRunArgs, RunsLatestRunOutput};
 use query::{runs_query, RunsQueryArgs, RunsQueryOutput};
 use reconcile::{reconcile_runs, RunsReconcileArgs, RunsReconcileOutput};
+
+pub(crate) use drift::RunsDriftOutput;
+#[cfg(test)]
+pub(crate) use drift::{DriftValue, RunsDriftFilters};
+#[cfg(test)]
+pub(crate) use query::{
+    QueryGroup, QueryRow, RunsQueryFilters, RunsQueryOutput as TestRunsQueryOutput,
+};
 
 const DEFAULT_LIMIT: i64 = 20;
 

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -27,7 +27,8 @@ pub use types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseArtifact,
     ReleaseCommandInput, ReleaseCommandResult, ReleaseDeploymentResult, ReleaseDeploymentSummary,
     ReleaseOptions, ReleasePipelineOptions, ReleasePlan, ReleaseProjectDeployResult, ReleaseRun,
-    ReleaseRunResult, ReleaseRunSummary, ReleaseStepResult, ReleaseStepStatus,
+    ReleaseRunResult, ReleaseRunSummary, ReleaseSemverCommit, ReleaseSemverRecommendation,
+    ReleaseStepResult, ReleaseStepStatus,
 };
 pub use utils::{extract_latest_notes, parse_release_artifacts};
 pub use workflow::{run_batch, run_command};

--- a/src/core/stack/mod.rs
+++ b/src/core/stack/mod.rs
@@ -35,7 +35,10 @@ pub mod status;
 pub mod sync;
 
 pub use apply::{apply, rebase, AppliedPr, ApplyOutput, PickOutcome, RebaseOutput};
-pub use inspect::{inspect, inspect_at, InspectCommit, InspectOptions, InspectOutput, InspectPr};
+pub use inspect::{
+    inspect, inspect_at, InspectCommit, InspectCommitDetails, InspectOptions, InspectOutput,
+    InspectPr,
+};
 pub use push::{push, PushOutput, PushStatus};
 pub use spec::{
     exists, expand_path, list, list_ids, load, parse_git_ref, save, GitRef, StackPrEntry, StackSpec,

--- a/tests/fixtures/golden_json_contracts/deploy_contract.json
+++ b/tests/fixtures/golden_json_contracts/deploy_contract.json
@@ -1,0 +1,92 @@
+{
+  "scenarios": [
+    {
+      "payload": {
+        "data": {
+          "all": false,
+          "behind_upstream": false,
+          "check": false,
+          "command": "deploy.run",
+          "dry_run": true,
+          "force": false,
+          "outdated": false,
+          "project_id": "production",
+          "results": [
+            {
+              "artifact_path": "target/dist/homeboy.tar.gz",
+              "build_exit_code": null,
+              "component_status": "needs_update",
+              "deploy_exit_code": null,
+              "deploy_reason": "explicitly_selected",
+              "deployed_ref": "v0.198.0",
+              "error": null,
+              "id": "homeboy",
+              "local_version": "0.198.0",
+              "remote_path": "/srv/homeboy",
+              "remote_version": "0.197.11",
+              "status": "planned"
+            }
+          ],
+          "summary": {
+            "failed": 0,
+            "skipped": 1,
+            "succeeded": 0,
+            "total": 1
+          }
+        },
+        "success": true
+      },
+      "scenario": "deploy dry-run single"
+    },
+    {
+      "payload": {
+        "data": {
+          "check": false,
+          "command": "deploy.multi",
+          "component_ids": [
+            "homeboy"
+          ],
+          "dry_run": true,
+          "force": false,
+          "projects": [
+            {
+              "project_id": "production",
+              "results": [
+                {
+                  "artifact_path": "target/dist/homeboy.tar.gz",
+                  "build_exit_code": null,
+                  "component_status": "needs_update",
+                  "deploy_exit_code": null,
+                  "deploy_reason": "explicitly_selected",
+                  "deployed_ref": "v0.198.0",
+                  "error": null,
+                  "id": "homeboy",
+                  "local_version": "0.198.0",
+                  "remote_path": "/srv/homeboy",
+                  "remote_version": "0.197.11",
+                  "status": "planned"
+                }
+              ],
+              "status": "planned",
+              "summary": {
+                "failed": 0,
+                "skipped": 1,
+                "succeeded": 0,
+                "total": 1
+              }
+            }
+          ],
+          "summary": {
+            "failed": 0,
+            "planned": 1,
+            "skipped": 0,
+            "succeeded": 0,
+            "total_projects": 1
+          }
+        },
+        "success": true
+      },
+      "scenario": "deploy dry-run multi-project"
+    }
+  ]
+}

--- a/tests/fixtures/golden_json_contracts/release_contract.json
+++ b/tests/fixtures/golden_json_contracts/release_contract.json
@@ -1,0 +1,160 @@
+{
+  "scenarios": [
+    {
+      "payload": {
+        "data": {
+          "command": "release",
+          "result": {
+            "bump_type": "minor",
+            "component_id": "homeboy",
+            "dry_run": true,
+            "new_version": "0.198.0",
+            "plan": {
+              "component_id": "homeboy",
+              "enabled": true,
+              "hints": [
+                "review generated plan before releasing"
+              ],
+              "id": "release.homeboy",
+              "kind": "release",
+              "policy": {
+                "enabled": true,
+                "semver_recommendation": {
+                  "commits": [
+                    {
+                      "breaking": false,
+                      "commit_type": "feat",
+                      "sha": "aaaaaaaa",
+                      "subject": "feat: add contract fixtures"
+                    }
+                  ],
+                  "is_underbump": false,
+                  "latest_tag": "v0.197.10",
+                  "range": "v0.197.10..HEAD",
+                  "reasons": [
+                    "feat commit requires a minor release"
+                  ],
+                  "recommended_bump": "minor",
+                  "requested_bump": "minor"
+                }
+              },
+              "semver_recommendation": {
+                "commits": [
+                  {
+                    "breaking": false,
+                    "commit_type": "feat",
+                    "sha": "aaaaaaaa",
+                    "subject": "feat: add contract fixtures"
+                  }
+                ],
+                "is_underbump": false,
+                "latest_tag": "v0.197.10",
+                "range": "v0.197.10..HEAD",
+                "reasons": [
+                  "feat commit requires a minor release"
+                ],
+                "recommended_bump": "minor",
+                "requested_bump": "minor"
+              },
+              "subject": {
+                "component_id": "homeboy"
+              },
+              "warnings": [
+                "dry run only"
+              ]
+            },
+            "releasable_commits": 1,
+            "tag": "v0.198.0"
+          }
+        },
+        "success": true
+      },
+      "scenario": "release dry-run single"
+    },
+    {
+      "payload": {
+        "data": {
+          "command": "release.batch",
+          "result": {
+            "results": [
+              {
+                "component_id": "homeboy",
+                "result": {
+                  "bump_type": "minor",
+                  "component_id": "homeboy",
+                  "dry_run": true,
+                  "new_version": "0.198.0",
+                  "plan": {
+                    "component_id": "homeboy",
+                    "enabled": true,
+                    "hints": [
+                      "review generated plan before releasing"
+                    ],
+                    "id": "release.homeboy",
+                    "kind": "release",
+                    "policy": {
+                      "enabled": true,
+                      "semver_recommendation": {
+                        "commits": [
+                          {
+                            "breaking": false,
+                            "commit_type": "feat",
+                            "sha": "aaaaaaaa",
+                            "subject": "feat: add contract fixtures"
+                          }
+                        ],
+                        "is_underbump": false,
+                        "latest_tag": "v0.197.10",
+                        "range": "v0.197.10..HEAD",
+                        "reasons": [
+                          "feat commit requires a minor release"
+                        ],
+                        "recommended_bump": "minor",
+                        "requested_bump": "minor"
+                      }
+                    },
+                    "semver_recommendation": {
+                      "commits": [
+                        {
+                          "breaking": false,
+                          "commit_type": "feat",
+                          "sha": "aaaaaaaa",
+                          "subject": "feat: add contract fixtures"
+                        }
+                      ],
+                      "is_underbump": false,
+                      "latest_tag": "v0.197.10",
+                      "range": "v0.197.10..HEAD",
+                      "reasons": [
+                        "feat commit requires a minor release"
+                      ],
+                      "recommended_bump": "minor",
+                      "requested_bump": "minor"
+                    },
+                    "subject": {
+                      "component_id": "homeboy"
+                    },
+                    "warnings": [
+                      "dry run only"
+                    ]
+                  },
+                  "releasable_commits": 1,
+                  "tag": "v0.198.0"
+                },
+                "status": "planned"
+              }
+            ],
+            "summary": {
+              "failed": 0,
+              "released": 0,
+              "skipped": 0,
+              "total": 1
+            }
+          }
+        },
+        "success": true
+      },
+      "scenario": "release dry-run batch"
+    }
+  ]
+}

--- a/tests/fixtures/golden_json_contracts/runs_contract.json
+++ b/tests/fixtures/golden_json_contracts/runs_contract.json
@@ -118,6 +118,17 @@
           ],
           "select": [
             "$.metrics.ready_ms"
+          ],
+          "skipped_artifact_count": 1,
+          "skipped_artifacts": [
+            {
+              "artifact_id": "artifact-log",
+              "artifact_kind": "log",
+              "artifact_type": "file",
+              "path": "artifacts/output.log",
+              "reason": "not JSON",
+              "run_id": "run-contract-1"
+            }
           ]
         },
         "success": true

--- a/tests/fixtures/golden_json_contracts/runs_contract.json
+++ b/tests/fixtures/golden_json_contracts/runs_contract.json
@@ -1,0 +1,159 @@
+{
+  "scenarios": [
+    {
+      "payload": {
+        "data": {
+          "command": "runs.list",
+          "runs": [
+            {
+              "command": "homeboy bench --format=json",
+              "component_id": "homeboy",
+              "cwd": "/work/homeboy",
+              "finished_at": "2026-05-24T00:01:00Z",
+              "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "id": "run-contract-1",
+              "kind": "bench",
+              "rig_id": "contract-rig",
+              "started_at": "2026-05-24T00:00:00Z",
+              "status": "passed",
+              "status_note": "fixture"
+            }
+          ]
+        },
+        "success": true
+      },
+      "scenario": "runs list"
+    },
+    {
+      "payload": {
+        "data": {
+          "command": "runs.show",
+          "run": {
+            "artifacts": [
+              {
+                "created_at": "2026-05-24T00:01:00Z",
+                "id": "artifact-summary",
+                "kind": "summary",
+                "mime": "application/json",
+                "path": "artifacts/summary.json",
+                "run_id": "run-contract-1",
+                "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "size_bytes": 1234,
+                "type": "file",
+                "url": "https://example.test/artifacts/summary.json"
+              }
+            ],
+            "command": "homeboy bench --format=json",
+            "component_id": "homeboy",
+            "cwd": "/work/homeboy",
+            "finished_at": "2026-05-24T00:01:00Z",
+            "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "homeboy_version": "0.197.11",
+            "id": "run-contract-1",
+            "kind": "bench",
+            "metadata": {
+              "scenario": "contract",
+              "score": 0.98
+            },
+            "rig_id": "contract-rig",
+            "started_at": "2026-05-24T00:00:00Z",
+            "status": "passed",
+            "status_note": "fixture"
+          }
+        },
+        "success": true
+      },
+      "scenario": "runs show"
+    },
+    {
+      "payload": {
+        "data": {
+          "artifacts": [
+            {
+              "created_at": "2026-05-24T00:01:00Z",
+              "id": "artifact-summary",
+              "kind": "summary",
+              "mime": "application/json",
+              "path": "artifacts/summary.json",
+              "run_id": "run-contract-1",
+              "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              "size_bytes": 1234,
+              "type": "file",
+              "url": "https://example.test/artifacts/summary.json"
+            }
+          ],
+          "command": "runs.artifacts",
+          "run_id": "run-contract-1"
+        },
+        "success": true
+      },
+      "scenario": "runs artifacts"
+    },
+    {
+      "payload": {
+        "data": {
+          "command": "runs.query",
+          "filters": {
+            "component_id": "homeboy",
+            "kind": "bench",
+            "limit": 200,
+            "since": "7d"
+          },
+          "group_by": "$.variant",
+          "groups": [
+            {
+              "count": 1,
+              "group": "candidate"
+            }
+          ],
+          "matched_artifact_count": 1,
+          "rows": [
+            {
+              "artifact_kind": "summary",
+              "run_id": "run-contract-1",
+              "values": [
+                123.4
+              ]
+            }
+          ],
+          "select": [
+            "$.metrics.ready_ms"
+          ]
+        },
+        "success": true
+      },
+      "scenario": "runs query json"
+    },
+    {
+      "payload": {
+        "data": {
+          "baseline_missing_rows": 2,
+          "baseline_observations": 40,
+          "command": "runs.drift",
+          "filters": {
+            "baseline": "30d",
+            "component_id": "homeboy",
+            "kind": "bench",
+            "window": "7d"
+          },
+          "metric": "$.variant",
+          "threshold": 0.5,
+          "values": [
+            {
+              "baseline_share": 0.25,
+              "dominant": true,
+              "share_delta": 0.45,
+              "value": "candidate",
+              "window_count": 7,
+              "window_share": 0.7
+            }
+          ],
+          "window_missing_rows": 0,
+          "window_observations": 10
+        },
+        "success": true
+      },
+      "scenario": "runs drift json"
+    }
+  ]
+}

--- a/tests/fixtures/golden_json_contracts/stack_contract.json
+++ b/tests/fixtures/golden_json_contracts/stack_contract.json
@@ -1,0 +1,114 @@
+{
+  "scenarios": [
+    {
+      "payload": {
+        "data": {
+          "command": "stack.list",
+          "stacks": [
+            {
+              "base": "origin/main",
+              "component": "homeboy",
+              "component_path": "/work/homeboy",
+              "description": "Combined fixes branch",
+              "id": "combined-fixes",
+              "pr_count": 1,
+              "target": "origin/dev/combined-fixes"
+            }
+          ]
+        },
+        "success": true
+      },
+      "scenario": "stack list"
+    },
+    {
+      "payload": {
+        "data": {
+          "command": "stack.show",
+          "stack": {
+            "base": {
+              "branch": "main",
+              "remote": "origin"
+            },
+            "component": "homeboy",
+            "component_path": "/work/homeboy",
+            "description": "Combined fixes branch",
+            "id": "combined-fixes",
+            "prs": [
+              {
+                "note": "contract coverage",
+                "number": 2753,
+                "repo": "Extra-Chill/homeboy"
+              }
+            ],
+            "target": {
+              "branch": "dev/combined-fixes",
+              "remote": "origin"
+            }
+          }
+        },
+        "success": true
+      },
+      "scenario": "stack show"
+    },
+    {
+      "payload": {
+        "data": {
+          "base": "origin/main",
+          "command": "stack.status",
+          "component_path": "/work/homeboy",
+          "merged_count": 0,
+          "prs": [
+            {
+              "local_state": "applied",
+              "note": "contract coverage",
+              "number": 2753,
+              "repo": "Extra-Chill/homeboy",
+              "review_decision": "REVIEW_REQUIRED",
+              "title": "Add golden JSON contract fixtures",
+              "upstream_state": "OPEN",
+              "url": "https://github.com/Extra-Chill/homeboy/pull/2753"
+            }
+          ],
+          "stack_id": "combined-fixes",
+          "success": true,
+          "target": "dev/combined-fixes",
+          "target_ahead": 2,
+          "target_behind": 0
+        },
+        "success": true
+      },
+      "scenario": "stack status"
+    },
+    {
+      "payload": {
+        "data": {
+          "base": "origin/main",
+          "base_auto_detected": false,
+          "branch": "fix/contract",
+          "command": "stack.inspect",
+          "commits": [
+            {
+              "author": "Homeboy Bot",
+              "date": "2026-05-24T00:00:00Z",
+              "pr": {
+                "number": 2753,
+                "state": "OPEN",
+                "title": "Add golden JSON contract fixtures",
+                "url": "https://github.com/Extra-Chill/homeboy/pull/2753"
+              },
+              "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "short_sha": "aaaaaaaa",
+              "subject": "test: pin command JSON contract"
+            }
+          ],
+          "component_id": "homeboy",
+          "merged_count": 0,
+          "path": "/work/homeboy",
+          "success": true
+        },
+        "success": true
+      },
+      "scenario": "stack inspect"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds golden CLI JSON envelope fixtures for runs list/show/artifacts/query/drift compatibility payloads.
- Adds release dry-run single/batch fixtures that pin compatibility-projected plan fields including component_id, enabled, and semver_recommendation.
- Adds deploy single/multi and stack list/show/status/inspect fixtures to catch discriminator or flattened-output regressions.

Fixes #2753.

## Verification
- cargo fmt --check
- cargo test --lib golden_contract_tests
- cargo test --test command_surface_test --test core_agnostic_test --test output_errors
- cargo test --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the golden fixture tests and fixtures, rebased against current main, and ran verification; Chris remains responsible for review and merge.