### PR TITLE
Fix observe artifact lifecycle

### DIFF
--- a/src/commands/observe.rs
+++ b/src/commands/observe.rs
@@ -169,17 +169,21 @@ pub fn run(args: ObserveArgs, _global: &GlobalArgs) -> CmdResult<ObserveOutput> 
     };
 
     write_trace_results(&trace_path, &results)?;
-    let _ = store.record_artifact(&run.id, "trace-results", &trace_path);
+    let artifact = store.record_artifact(&run.id, "trace-results", &trace_path)?;
+    let artifact_id = artifact.id.clone();
+    let artifact_path = artifact.path.clone();
     let finished = store.finish_run(
         &run.id,
         status,
         Some(serde_json::json!({
             "duration_ms": duration_millis(args.duration),
             "event_count": results.timeline.len(),
-            "trace_results_path": trace_path,
+            "trace_results_artifact_id": artifact_id,
+            "trace_results_path": artifact_path.clone(),
             "failure": failure,
         })),
     )?;
+    run_dir.cleanup();
 
     Ok((
         ObserveOutput {
@@ -189,7 +193,7 @@ pub fn run(args: ObserveArgs, _global: &GlobalArgs) -> CmdResult<ObserveOutput> 
             status: finished.status,
             duration_ms: duration_millis(args.duration),
             event_count: results.timeline.len(),
-            artifact_path: trace_path.to_string_lossy().to_string(),
+            artifact_path,
             hints: vec![
                 format!("View this run: homeboy runs show {}", finished.id),
                 "List observe runs: homeboy runs list --kind observe".to_string(),
@@ -602,6 +606,7 @@ fn invalid_regex(field: &str, pattern: &str, error: regex::Error) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use homeboy::test_support::with_isolated_home;
 
     #[test]
     fn parse_duration_accepts_supported_units() {
@@ -849,6 +854,42 @@ mod tests {
         let parsed = <ObserveArgs as clap::FromArgMatches>::from_arg_matches(&matches).unwrap();
         assert_eq!(parsed.comp.component.as_deref(), Some("demo"));
         assert!(parsed.comp.path.is_none());
+    }
+
+    #[test]
+    fn observe_reports_persisted_artifact_and_cleans_run_dir() {
+        with_isolated_home(|home| {
+            let runtime = tempfile::tempdir().expect("runtime tmpdir");
+            std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", runtime.path());
+            let target = home.path().join("target");
+            std::fs::create_dir_all(&target).expect("target dir");
+
+            let args = ObserveArgs {
+                comp: PositionalComponentArgs {
+                    component: None,
+                    path: Some(target.to_string_lossy().to_string()),
+                },
+                duration: Duration::from_millis(1),
+                tail_logs: Vec::new(),
+                grep: None,
+                watch_processes: vec!["unlikely-homeboy-observe-test-process".to_string()],
+                watch_process_interval: Duration::from_millis(1),
+                probes: Vec::new(),
+            };
+
+            let (output, exit_code) = run(args, &GlobalArgs {}).expect("observe run");
+
+            assert_eq!(exit_code, 0);
+            assert!(std::path::Path::new(&output.artifact_path).is_file());
+            assert!(!std::path::Path::new(&output.artifact_path).starts_with(runtime.path()));
+            assert!(
+                std::fs::read_dir(runtime.path())
+                    .expect("runtime entries")
+                    .next()
+                    .is_none(),
+                "observe should clean completed run dirs"
+            );
+        });
     }
 
     /// Issue #2366: `--path` pointed at an unregistered directory resolves to

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -272,6 +272,9 @@ pub enum AuditFinding {
     /// Request-derived redirect destination reaches a configured redirect sink
     /// before configured URL validation dominates the sink path.
     RedirectValidation,
+    /// Persisted artifact evidence points at a runtime-local temp path instead
+    /// of a durable artifact-store path or portable artifact token.
+    NonPortableArtifactPath,
 }
 
 impl AuditFinding {
@@ -342,6 +345,7 @@ impl AuditFinding {
             "internal_proxy_scope_missing",
             "public_registry_exposure",
             "redirect_validation",
+            "non_portable_artifact_path",
         ]
     }
 }

--- a/src/core/code_audit/detectors/artifact_portability.rs
+++ b/src/core/code_audit/detectors/artifact_portability.rs
@@ -1,0 +1,129 @@
+use std::path::Path;
+
+use crate::core::code_audit::conventions::AuditFinding;
+use crate::core::code_audit::findings::{Finding, Severity};
+use crate::core::observation::{ObservationStore, RunListFilter};
+
+pub(crate) fn run(component_id: &str) -> Vec<Finding> {
+    let Ok(store) = ObservationStore::open_initialized() else {
+        return Vec::new();
+    };
+    let Ok(runs) = store.list_runs(RunListFilter {
+        kind: None,
+        component_id: Some(component_id.to_string()),
+        status: None,
+        rig_id: None,
+        limit: Some(1000),
+    }) else {
+        return Vec::new();
+    };
+    let artifact_root = crate::core::artifact_root().ok();
+    let mut findings = Vec::new();
+
+    for run in runs {
+        let Ok(artifacts) = store.list_artifacts(&run.id) else {
+            continue;
+        };
+        for artifact in artifacts {
+            if artifact.artifact_type != "file" && artifact.artifact_type != "directory" {
+                continue;
+            }
+            if artifact_path_is_portable(&artifact.path, artifact_root.as_deref()) {
+                continue;
+            }
+            findings.push(Finding {
+                convention: "artifact_portability".to_string(),
+                severity: Severity::Warning,
+                file: format!("observation:{}", run.id),
+                description: format!(
+                    "Artifact {} ({}) records non-portable path {}",
+                    artifact.id, artifact.kind, artifact.path
+                ),
+                suggestion: "Record copied artifact-store paths or portable artifact tokens instead of runtime temp paths".to_string(),
+                kind: AuditFinding::NonPortableArtifactPath,
+            });
+        }
+    }
+
+    findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
+    findings
+}
+
+fn artifact_path_is_portable(path: &str, artifact_root: Option<&Path>) -> bool {
+    if path.starts_with("runner-artifact://") || path.starts_with("metadata-only:") {
+        return true;
+    }
+    let path_ref = Path::new(path);
+    if let Some(root) = artifact_root {
+        if path_ref.starts_with(root) {
+            return true;
+        }
+    }
+    !looks_like_runtime_temp_path(path)
+}
+
+fn looks_like_runtime_temp_path(path: &str) -> bool {
+    path.contains("/homeboy-run-")
+        || path.starts_with("/tmp/")
+        || path.starts_with("/private/tmp/")
+        || path.starts_with("/var/folders/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::observation::{ArtifactRecord, NewRunRecord};
+    use crate::test_support::with_isolated_home;
+
+    #[test]
+    fn flags_runtime_temp_artifact_paths() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let cwd = std::env::current_dir().expect("cwd");
+            let run_record = store
+                .start_run(
+                    NewRunRecord::builder("observe")
+                        .component_id("demo")
+                        .command("homeboy observe demo")
+                        .cwd_path(&cwd)
+                        .build(),
+                )
+                .expect("run");
+            store
+                .import_artifact(&ArtifactRecord {
+                    id: "artifact-1".to_string(),
+                    run_id: run_record.id,
+                    kind: "trace-results".to_string(),
+                    artifact_type: "file".to_string(),
+                    path: "/tmp/homeboy-run-abc/trace.json".to_string(),
+                    url: None,
+                    sha256: None,
+                    size_bytes: None,
+                    mime: None,
+                    created_at: chrono::Utc::now().to_rfc3339(),
+                })
+                .expect("artifact");
+
+            let findings = super::run("demo");
+
+            assert_eq!(findings.len(), 1);
+            assert_eq!(findings[0].kind, AuditFinding::NonPortableArtifactPath);
+            assert!(findings[0]
+                .description
+                .contains("/tmp/homeboy-run-abc/trace.json"));
+        });
+    }
+
+    #[test]
+    fn accepts_artifact_store_paths() {
+        with_isolated_home(|home| {
+            let artifact_root = home.path().join("artifacts");
+            crate::core::set_artifact_root_override(Some(artifact_root.clone()));
+
+            assert!(artifact_path_is_portable(
+                &artifact_root.join("run/artifact.json").to_string_lossy(),
+                Some(&artifact_root)
+            ));
+        });
+    }
+}

--- a/src/core/code_audit/detectors/mod.rs
+++ b/src/core/code_audit/detectors/mod.rs
@@ -1,4 +1,5 @@
 pub(super) mod aggregate_construction;
+pub(super) mod artifact_portability;
 pub(super) mod config_key_usage;
 pub(super) mod core_boundary_leak;
 pub(super) mod dead_guard;

--- a/src/core/code_audit/findings.rs
+++ b/src/core/code_audit/findings.rs
@@ -78,7 +78,8 @@ impl AuditFinding {
             | AuditFinding::CompilerWarning
             | AuditFinding::BrokenDocReference
             | AuditFinding::StaleDocReference
-            | AuditFinding::UnwiredNestedRustTest => FindingConfidence::Structural,
+            | AuditFinding::UnwiredNestedRustTest
+            | AuditFinding::NonPortableArtifactPath => FindingConfidence::Structural,
 
             // Depends on cross-file reference resolution or declared ownership maps.
             AuditFinding::UnusedParameter

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -48,8 +48,8 @@ use std::path::Path;
 
 use self::detectors::layer_ownership::run as run_layer_ownership;
 use self::detectors::{
-    aggregate_construction, config_key_usage, core_boundary_leak, dead_guard, deprecation_age,
-    enum_dispatch_contracts, facade_passthrough, field_patterns, global_env_guard,
+    aggregate_construction, artifact_portability, config_key_usage, core_boundary_leak, dead_guard,
+    deprecation_age, enum_dispatch_contracts, facade_passthrough, field_patterns, global_env_guard,
     mutating_resource_access, parallel_runner_setup, public_registry_exposure, redirect_validation,
     repeated_literal_shape, requested_detectors, rust_test_wiring, shared_scaffolding,
     test_coverage, test_topology, wrapper_inference,
@@ -323,6 +323,11 @@ const DETECTOR_FAMILIES: &[DetectorFamily] = &[
         findings: &[AuditFinding::WriteOnlyConfigKey],
         requires_discovery: true,
     },
+    DetectorFamily {
+        id: "artifact_portability",
+        findings: &[AuditFinding::NonPortableArtifactPath],
+        requires_discovery: false,
+    },
 ];
 
 impl AuditExecutionPlan {
@@ -474,6 +479,10 @@ impl AuditExecutionPlan {
 
     pub(crate) fn run_config_key_usage(&self) -> bool {
         self.detector_enabled("config_key_usage")
+    }
+
+    pub(crate) fn run_artifact_portability(&self) -> bool {
+        self.detector_enabled("artifact_portability")
     }
 
     fn requires_discovery(&self) -> bool {
@@ -1358,6 +1367,20 @@ fn audit_internal(
         all_findings.extend(public_registry_findings);
     }
 
+    let artifact_portability_findings = if plan.run_artifact_portability() {
+        artifact_portability::run(component_id)
+    } else {
+        Vec::new()
+    };
+    if !artifact_portability_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Artifact portability: {} finding(s) (non-portable artifact evidence paths)",
+            artifact_portability_findings.len()
+        );
+        all_findings.extend(artifact_portability_findings);
+    }
+
     // Phase 4p: Impact-scoped filtering — when auditing changed files only,
     // expand scope to include call sites affected by symbol changes, then
     // filter findings to that expanded scope.
@@ -1591,6 +1614,18 @@ fn audit_root_only(
                 field_pattern_findings.len()
             );
             findings.extend(field_pattern_findings);
+        }
+    }
+
+    if plan.run_artifact_portability() {
+        let artifact_portability_findings = artifact_portability::run(component_id);
+        if !artifact_portability_findings.is_empty() {
+            log_status!(
+                "audit",
+                "Artifact portability: {} finding(s) (non-portable artifact evidence paths)",
+                artifact_portability_findings.len()
+            );
+            findings.extend(artifact_portability_findings);
         }
     }
 


### PR DESCRIPTION
## Summary
- Report the persisted observation-store trace artifact from `homeboy observe` instead of the temporary run-dir path.
- Clean completed observe run directories after trace artifacts are copied into durable storage.
- Add the first generic artifact portability audit detector for persisted artifact records that point at runtime temp paths.

Fixes #2752.
Refs #2775.

## Evidence
- Reproduced #2752 before the fix: `artifact_path` pointed at `HOMEBOY_RUNTIME_TMPDIR/homeboy-run-.../trace.json`, and the run directory remained after command exit.
- Verified after the fix: `artifact_path` points under `.local/share/homeboy/artifacts/.../trace.json`, and `HOMEBOY_RUNTIME_TMPDIR` is empty after command exit.
- `cargo fmt --check`
- `cargo test observe_reports_persisted_artifact_and_cleans_run_dir`
- `cargo test artifact_portability`
- `cargo check`
- `cargo test commands::observe::tests`
- `homeboy --force-hot lint`
- `homeboy --force-hot test homeboy --skip-lint -- commands::observe::tests`
- `homeboy audit --path /Users/chubes/Developer/homeboy@fix-observe-artifact-lifecycle --only non_portable_artifact_path` passed against the fixed isolated observe store.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Reproduced the observe artifact lifecycle bug, implemented the lifecycle/path-reporting fix and first artifact portability detector, added regression coverage, ran local verification, and drafted this PR description for Chris to review.