### PR TITLE
fix: preflight lab runner test extensions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,7 @@ fn main() -> std::process::ExitCode {
         let capture_patch = cli.command.lab_offload_mutation_flag().is_some();
         return run_lab_offload(
             runner_id,
+            &cli.command,
             &normalized,
             output_file.as_deref(),
             capture_patch,
@@ -263,11 +264,18 @@ fn exit_code_to_u8(code: i32) -> u8 {
 
 fn run_lab_offload(
     runner_id: &str,
+    command: &Commands,
     normalized_args: &[String],
     output_file: Option<&str>,
     capture_patch: bool,
 ) -> std::process::ExitCode {
-    match run_lab_offload_inner(runner_id, normalized_args, output_file, capture_patch) {
+    match run_lab_offload_inner(
+        runner_id,
+        command,
+        normalized_args,
+        output_file,
+        capture_patch,
+    ) {
         Ok(exit_code) => std::process::ExitCode::from(exit_code_to_u8(exit_code)),
         Err(err) => {
             output::print_result::<serde_json::Value>(Err(err)).ok();
@@ -278,6 +286,7 @@ fn run_lab_offload(
 
 fn run_lab_offload_inner(
     runner_id: &str,
+    command_kind: &Commands,
     normalized_args: &[String],
     output_file: Option<&str>,
     capture_patch: bool,
@@ -334,6 +343,8 @@ fn run_lab_offload_inner(
         "lab_offload",
     );
     let homeboy_path = runner.settings.homeboy_path.as_deref().unwrap_or("homeboy");
+    preflight_lab_offload_test_extensions(command_kind, runner_id, homeboy_path, &remote_cwd)?;
+
     let mut command = vec![homeboy_path.to_string()];
     command.extend(
         rewrite_lab_offload_args(normalized_args, &remote_cwd)
@@ -368,6 +379,117 @@ fn run_lab_offload_inner(
     }
     print!("{}", exec_output.stdout);
     Ok(exit_code)
+}
+
+fn preflight_lab_offload_test_extensions(
+    command: &Commands,
+    runner_id: &str,
+    homeboy_path: &str,
+    remote_cwd: &str,
+) -> homeboy::core::Result<()> {
+    let extension_ids = lab_offload_test_extension_ids(command)?;
+    for extension_id in extension_ids {
+        let (output, exit_code) = homeboy::core::runner::exec(
+            runner_id,
+            homeboy::core::runner::RunnerExecOptions {
+                cwd: Some(remote_cwd.to_string()),
+                allow_ssh: false,
+                command: vec![
+                    homeboy_path.to_string(),
+                    "extension".to_string(),
+                    "show".to_string(),
+                    extension_id.clone(),
+                ],
+                capture_patch: false,
+                source_snapshot: None,
+            },
+        )?;
+
+        if exit_code != 0 {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "runner_extension",
+                format!(
+                    "Lab offload runner '{runner_id}' is missing required test extension '{extension_id}' before test execution"
+                ),
+                Some(extension_id.clone()),
+                Some(vec![
+                    format!(
+                        "Install the extension on the runner before offloading tests: {homeboy_path} extension install <source> --id {extension_id}"
+                    ),
+                    format!(
+                        "Remote preflight command failed: {homeboy_path} extension show {extension_id}"
+                    ),
+                    runner_extension_preflight_tail(&output.stderr, &output.stdout),
+                ]),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn lab_offload_test_extension_ids(command: &Commands) -> homeboy::core::Result<Vec<String>> {
+    let Commands::Test(args) = command else {
+        return Ok(Vec::new());
+    };
+
+    let source_context = homeboy::core::engine::execution_context::resolve(
+        &homeboy::core::engine::execution_context::ResolveOptions {
+            component_id: args.comp.component.clone(),
+            path_override: args.comp.path.clone(),
+            capability: None,
+            settings_overrides: args.setting_args.setting.clone(),
+            settings_json_overrides: args.setting_args.setting_json.clone(),
+            extension_overrides: args.extension_override.extensions.clone(),
+        },
+    )?;
+
+    if !args.drift
+        && args.ci_job.is_none()
+        && source_context
+            .component
+            .has_script(homeboy::core::extension::ExtensionCapability::Test)
+    {
+        return Ok(Vec::new());
+    }
+
+    let context = homeboy::core::engine::execution_context::resolve(
+        &homeboy::core::engine::execution_context::ResolveOptions {
+            component_id: args.comp.component.clone(),
+            path_override: args.comp.path.clone(),
+            capability: Some(homeboy::core::extension::ExtensionCapability::Test),
+            settings_overrides: args.setting_args.setting.clone(),
+            settings_json_overrides: args.setting_args.setting_json.clone(),
+            extension_overrides: args.extension_override.extensions.clone(),
+        },
+    )?;
+
+    Ok(context.extension_id.into_iter().collect())
+}
+
+fn runner_extension_preflight_tail(stderr: &str, stdout: &str) -> String {
+    let output = if stderr.trim().is_empty() {
+        stdout
+    } else {
+        stderr
+    };
+    let tail = output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .rev()
+        .take(3)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if tail.is_empty() {
+        "Runner extension preflight produced no diagnostic output.".to_string()
+    } else {
+        format!("Runner extension preflight output:\n{tail}")
+    }
 }
 
 fn lab_offload_source_path(args: &[String]) -> homeboy::core::Result<PathBuf> {
@@ -528,7 +650,59 @@ fn extract_parent_command_from_error(e: &clap::Error) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{lab_offload_source_path, rewrite_lab_offload_args};
+    use super::{
+        lab_offload_source_path, lab_offload_test_extension_ids, rewrite_lab_offload_args,
+        runner_extension_preflight_tail,
+    };
+    use homeboy::cli_surface::Commands;
+    use homeboy::commands::test::TestArgs;
+    use homeboy::commands::utils::args::{
+        BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
+    };
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn test_args_for_path(path: &std::path::Path) -> TestArgs {
+        TestArgs {
+            comp: PositionalComponentArgs {
+                component: None,
+                path: Some(path.to_string_lossy().to_string()),
+            },
+            extension_override: ExtensionOverrideArgs::default(),
+            skip_lint: false,
+            coverage: false,
+            coverage_min: None,
+            baseline_args: BaselineArgs::default(),
+            analyze: false,
+            drift: false,
+            write: false,
+            since: "HEAD~10".to_string(),
+            changed_since: None,
+            ci_job: None,
+            setting_args: SettingArgs::default(),
+            args: Vec::new(),
+            _json: HiddenJsonArgs::default(),
+            json_summary: false,
+        }
+    }
+
+    fn with_temp_home<T>(f: impl FnOnce(&std::path::Path) -> T) -> T {
+        let _guard = env_lock().lock().expect("env lock");
+        let previous_home = std::env::var("HOME").ok();
+        let home = tempfile::tempdir().expect("temp home");
+        std::env::set_var("HOME", home.path());
+        let result = f(home.path());
+        if let Some(previous_home) = previous_home {
+            std::env::set_var("HOME", previous_home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        result
+    }
 
     #[test]
     fn rewrites_lab_offload_path_and_strips_runner_flag_before_remote_exec() {
@@ -613,5 +787,64 @@ mod tests {
             lab_offload_source_path(&args).expect("path"),
             std::path::PathBuf::from("/Users/chubes/Developer/project")
         );
+    }
+
+    #[test]
+    fn lab_offload_test_preflight_skips_component_script_components() {
+        with_temp_home(|_| {
+            let dir = tempfile::tempdir().expect("component dir");
+            std::fs::write(
+                dir.path().join("homeboy.json"),
+                r#"{"id":"fixture","scripts":{"test":["printf ok\n"]},"extensions":{"missing-runner-extension":{}}}"#,
+            )
+            .expect("write component config");
+
+            let ids =
+                lab_offload_test_extension_ids(&Commands::Test(test_args_for_path(dir.path())))
+                    .expect("component script should not require extension parity preflight");
+
+            assert!(ids.is_empty());
+        });
+    }
+
+    #[test]
+    fn lab_offload_test_preflight_resolves_selected_test_extension() {
+        with_temp_home(|home| {
+            let extension_dir = home
+                .join(".config")
+                .join("homeboy")
+                .join("extensions")
+                .join("fixture-extension");
+            std::fs::create_dir_all(&extension_dir).expect("extension dir");
+            std::fs::write(
+                extension_dir.join("fixture-extension.json"),
+                r#"{"name":"Fixture","version":"1.0.0","test":{"extension_script":"test.sh"}}"#,
+            )
+            .expect("write extension manifest");
+
+            let dir = tempfile::tempdir().expect("component dir");
+            std::fs::write(
+                dir.path().join("homeboy.json"),
+                r#"{"id":"fixture","extensions":{"fixture-extension":{}}}"#,
+            )
+            .expect("write component config");
+
+            let ids =
+                lab_offload_test_extension_ids(&Commands::Test(test_args_for_path(dir.path())))
+                    .expect("test extension should resolve locally before runner parity check");
+
+            assert_eq!(ids, vec!["fixture-extension".to_string()]);
+        });
+    }
+
+    #[test]
+    fn runner_extension_preflight_tail_prefers_recent_diagnostics() {
+        let tail = runner_extension_preflight_tail(
+            "one\ntwo\nthree\nfour",
+            "stdout should be ignored when stderr has enough lines",
+        );
+
+        assert!(tail.contains("two\nthree\nfour"));
+        assert!(!tail.contains("one"));
     }
 }


### PR DESCRIPTION
## Summary
- Adds a Lab offload preflight for `homeboy test --runner` that checks the selected test extension exists on the connected runner before executing the remote test command.
- Keeps component-script test commands out of the extension parity check so script-backed components preserve their existing behavior.
- Adds fixtures for extension-backed and component-script test command resolution, plus diagnostic tail coverage for preflight failures.

Closes #2760.

## Evidence
- `cargo fmt --check`
- `cargo test lab_offload_test_preflight --bin homeboy`
- `cargo test runner_extension_preflight_tail --bin homeboy`
- `cargo test --bin homeboy`
- `cargo test core::extension::trace::probes::http_egress::tests::test_run_http_egress --lib`

## Notes
- `cargo test` full suite passed 3311 tests before one unrelated transient `test_run_http_egress` socket reset; rerunning that exact test passed.
- `cargo clippy --all-targets -- -D warnings` and `cargo clippy --bin homeboy -- -D warnings` still fail on existing repo-wide Clippy baseline warnings outside this change.
- #2777 is related conceptually, but this PR is intentionally limited to missing runner extension parity before Lab-offloaded test execution.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused Lab offload preflight implementation, test fixtures, and verification commands for Chris to review.