### PR TITLE
Fix lab offload output path handling

### DIFF
--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -237,6 +237,9 @@ pub enum AuditFinding {
     /// Command-family files independently assemble the same generic execution
     /// contract phases and contract-call shape.
     ParallelRunnerSetup,
+    /// Remote runner dispatch lacks an explicit preflight for path/artifact
+    /// translation before handing arguments to the runner.
+    RunnerOffloadPreflight,
     /// Repeated exhaustive match blocks over the same enum duplicate a
     /// label/getter/policy contract that should likely live on the enum.
     RepeatedEnumDispatchContract,

--- a/src/core/code_audit/detectors/mod.rs
+++ b/src/core/code_audit/detectors/mod.rs
@@ -14,6 +14,7 @@ pub(super) mod public_registry_exposure;
 pub(super) mod redirect_validation;
 pub(super) mod repeated_literal_shape;
 pub(super) mod requested_detectors;
+pub(super) mod runner_offload_preflight;
 pub(super) mod rust_test_wiring;
 pub(super) mod shared_scaffolding;
 pub(super) mod test_coverage;

--- a/src/core/code_audit/detectors/runner_offload_preflight.rs
+++ b/src/core/code_audit/detectors/runner_offload_preflight.rs
@@ -1,0 +1,161 @@
+//! Runner/offload preflight detector.
+//!
+//! Flags remote runner dispatch sites that can hand local paths or artifacts to
+//! a runner without an explicit translation/mirror contract.
+
+use super::conventions::AuditFinding;
+use super::findings::{Finding, Severity};
+use super::fingerprint::FileFingerprint;
+
+pub(in crate::core::code_audit) fn run(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    for fp in fingerprints {
+        if super::walker::is_test_path(&fp.relative_path) || !is_remote_dispatch_file(&fp.content) {
+            continue;
+        }
+
+        if forwards_args_without_path_preflight(&fp.content) {
+            findings.push(finding(
+                fp,
+                "Remote runner dispatch builds command argv from caller args without an explicit path-translation preflight.",
+                "Route argv through a rewrite/preflight function that strips local-only wrapper flags and translates or rejects local filesystem paths before runner dispatch.",
+            ));
+        }
+
+        if captures_artifacts_without_snapshot(&fp.content) {
+            findings.push(finding(
+                fp,
+                "Remote runner dispatch can request artifact capture without a source snapshot or mirror contract.",
+                "Attach source_snapshot or an equivalent mirror verification contract before reporting remote artifacts as run evidence.",
+            ));
+        }
+    }
+
+    findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
+    findings.dedup_by(|a, b| a.file == b.file && a.description == b.description);
+    findings
+}
+
+fn is_remote_dispatch_file(content: &str) -> bool {
+    content.contains("RunnerExecOptions")
+        || content.contains("runner::exec")
+        || content.contains("core::runner::exec")
+}
+
+fn forwards_args_without_path_preflight(content: &str) -> bool {
+    let forwards_caller_args = contains_any(
+        content,
+        &[
+            "normalized_args",
+            "std::env::args",
+            "args.iter()",
+            "command.extend(args",
+        ],
+    );
+    let has_path_preflight = contains_any(
+        content,
+        &[
+            "rewrite_lab_offload_args",
+            "translate_remote_path",
+            "remote_path",
+            "sync_workspace",
+            "strip_local_output",
+        ],
+    );
+
+    forwards_caller_args && !has_path_preflight
+}
+
+fn captures_artifacts_without_snapshot(content: &str) -> bool {
+    content.contains("capture_patch: true") && !content.contains("source_snapshot")
+}
+
+fn contains_any(value: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| value.contains(needle))
+}
+
+fn finding(fp: &FileFingerprint, description: &str, suggestion: &str) -> Finding {
+    Finding {
+        convention: "runner_offload_preflight".to_string(),
+        severity: Severity::Warning,
+        file: fp.relative_path.clone(),
+        description: description.to_string(),
+        suggestion: suggestion.to_string(),
+        kind: AuditFinding::RunnerOffloadPreflight,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::code_audit::conventions::Language;
+
+    fn fingerprint(path: &str, content: &str) -> FileFingerprint {
+        FileFingerprint {
+            relative_path: path.to_string(),
+            language: Language::Rust,
+            content: content.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn flags_arg_forwarding_without_path_preflight() {
+        let fp = fingerprint(
+            "src/main.rs",
+            r#"
+            fn run(args: &[String]) {
+                let mut command = vec!["homeboy".to_string()];
+                command.extend(args.iter().cloned());
+                runner::exec("lab", RunnerExecOptions { command, capture_patch: false });
+            }
+            "#,
+        );
+
+        let findings = run(&[&fp]);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, AuditFinding::RunnerOffloadPreflight);
+        assert!(findings[0]
+            .suggestion
+            .contains("strips local-only wrapper flags"));
+    }
+
+    #[test]
+    fn accepts_explicit_path_rewrite_and_artifact_snapshot() {
+        let fp = fingerprint(
+            "src/main.rs",
+            r#"
+            fn run(normalized_args: &[String], remote_path: &str) {
+                let mut command = vec!["homeboy".to_string()];
+                command.extend(rewrite_lab_offload_args(normalized_args, remote_path));
+                runner::exec("lab", RunnerExecOptions {
+                    command,
+                    capture_patch: true,
+                    source_snapshot: Some(source_snapshot),
+                });
+            }
+            "#,
+        );
+
+        assert!(run(&[&fp]).is_empty());
+    }
+
+    #[test]
+    fn flags_artifact_capture_without_snapshot_contract() {
+        let fp = fingerprint(
+            "src/core/runner.rs",
+            r#"
+            fn run(command: Vec<String>) {
+                runner::exec("lab", RunnerExecOptions { command, capture_patch: true });
+            }
+            "#,
+        );
+
+        let findings = run(&[&fp]);
+
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].description.contains("artifact capture"));
+    }
+}

--- a/src/core/code_audit/detectors/runner_offload_preflight.rs
+++ b/src/core/code_audit/detectors/runner_offload_preflight.rs
@@ -30,6 +30,14 @@ pub(in crate::core::code_audit) fn run(fingerprints: &[&FileFingerprint]) -> Vec
                 "Attach source_snapshot or an equivalent mirror verification contract before reporting remote artifacts as run evidence.",
             ));
         }
+
+        if dispatches_extension_without_parity_preflight(&fp.content) {
+            findings.push(finding(
+                fp,
+                "Remote runner dispatch accepts an extension selector without validating runner extension parity before execution.",
+                "Add a pre-dispatch extension parity check so missing runner-side extension support fails before command execution.",
+            ));
+        }
     }
 
     findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
@@ -69,6 +77,21 @@ fn forwards_args_without_path_preflight(content: &str) -> bool {
 
 fn captures_artifacts_without_snapshot(content: &str) -> bool {
     content.contains("capture_patch: true") && !content.contains("source_snapshot")
+}
+
+fn dispatches_extension_without_parity_preflight(content: &str) -> bool {
+    let accepts_extension = contains_any(content, &["--extension", "extension_id", "extension"]);
+    let has_parity_preflight = contains_any(
+        content,
+        &[
+            "extension_parity",
+            "required_extensions",
+            "runner_extension",
+            "validate_runner_extension",
+        ],
+    );
+
+    accepts_extension && !has_parity_preflight
 }
 
 fn contains_any(value: &str, needles: &[&str]) -> bool {
@@ -157,5 +180,22 @@ mod tests {
 
         assert_eq!(findings.len(), 1);
         assert!(findings[0].description.contains("artifact capture"));
+    }
+
+    #[test]
+    fn flags_extension_dispatch_without_parity_preflight() {
+        let fp = fingerprint(
+            "src/main.rs",
+            r#"
+            fn run(command: Vec<String>, extension_id: &str) {
+                runner::exec("lab", RunnerExecOptions { command, capture_patch: false });
+            }
+            "#,
+        );
+
+        let findings = run(&[&fp]);
+
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].description.contains("extension selector"));
     }
 }

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -51,8 +51,8 @@ use self::detectors::{
     aggregate_construction, config_key_usage, core_boundary_leak, dead_guard, deprecation_age,
     enum_dispatch_contracts, facade_passthrough, field_patterns, global_env_guard,
     mutating_resource_access, parallel_runner_setup, public_registry_exposure, redirect_validation,
-    repeated_literal_shape, requested_detectors, rust_test_wiring, shared_scaffolding,
-    test_coverage, test_topology, wrapper_inference,
+    repeated_literal_shape, requested_detectors, runner_offload_preflight, rust_test_wiring,
+    shared_scaffolding, test_coverage, test_topology, wrapper_inference,
 };
 
 pub use checks::{CheckResult, CheckStatus};
@@ -304,6 +304,11 @@ const DETECTOR_FAMILIES: &[DetectorFamily] = &[
         requires_discovery: true,
     },
     DetectorFamily {
+        id: "runner_offload_preflight",
+        findings: &[AuditFinding::RunnerOffloadPreflight],
+        requires_discovery: true,
+    },
+    DetectorFamily {
         id: "enum_dispatch_contracts",
         findings: &[AuditFinding::RepeatedEnumDispatchContract],
         requires_discovery: true,
@@ -458,6 +463,10 @@ impl AuditExecutionPlan {
 
     pub(crate) fn run_parallel_runner_setup(&self) -> bool {
         self.detector_enabled("parallel_runner_setup")
+    }
+
+    pub(crate) fn run_runner_offload_preflight(&self) -> bool {
+        self.detector_enabled("runner_offload_preflight")
     }
 
     pub(crate) fn run_enum_dispatch_contracts(&self) -> bool {
@@ -1310,6 +1319,22 @@ fn audit_internal(
             parallel_runner_findings.len()
         );
         all_findings.extend(parallel_runner_findings);
+    }
+
+    // Phase 4w1: Runner/offload preflight detection — remote dispatch sites
+    // that do not prove path/artifact parity before runner execution.
+    let runner_offload_findings = if plan.run_runner_offload_preflight() {
+        runner_offload_preflight::run(&all_fingerprints)
+    } else {
+        Vec::new()
+    };
+    if !runner_offload_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Runner offload preflight: {} finding(s) (remote path/artifact parity gaps)",
+            runner_offload_findings.len()
+        );
+        all_findings.extend(runner_offload_findings);
     }
 
     // Phase 4w: Repeated enum-dispatch contract detection.

--- a/src/main.rs
+++ b/src/main.rs
@@ -428,6 +428,13 @@ fn rewrite_lab_offload_args(args: &[String], remote_path: &str) -> Vec<String> {
         if arg.starts_with("--runner=") {
             continue;
         }
+        if arg == "--output" {
+            let _ = iter.next();
+            continue;
+        }
+        if arg.starts_with("--output=") {
+            continue;
+        }
         stripped.push(arg.clone());
     }
     stripped
@@ -572,6 +579,39 @@ mod tests {
                 "--path=/home/chubes/Developer/project".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn strips_local_output_path_before_remote_exec() {
+        let args = vec![
+            "homeboy".to_string(),
+            "audit".to_string(),
+            "--path".to_string(),
+            "/Users/chubes/Developer/project".to_string(),
+            "--runner".to_string(),
+            "lab".to_string(),
+            "--json-summary".to_string(),
+            "--output".to_string(),
+            "/var/folders/local/homeboy-audit.json".to_string(),
+            "--output=/tmp/other-local-output.json".to_string(),
+        ];
+
+        let rewritten = rewrite_lab_offload_args(&args, "/home/chubes/Developer/project");
+
+        assert_eq!(
+            rewritten,
+            vec![
+                "homeboy".to_string(),
+                "audit".to_string(),
+                "--path".to_string(),
+                "/home/chubes/Developer/project".to_string(),
+                "--json-summary".to_string(),
+            ]
+        );
+        assert!(!rewritten.iter().any(|arg| arg.contains("/var/folders")));
+        assert!(!rewritten
+            .iter()
+            .any(|arg| arg.contains("/tmp/other-local-output.json")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Keep Lab offload `--output` paths local by stripping the wrapper-owned output flag before remote Homeboy dispatch.
- Add `runner_offload_preflight` audit coverage for remote runner path translation, artifact mirror/snapshot, and extension parity preflight gaps.
- Cover the remote argv rewrite and preflight detector behavior with unit tests.

Closes #2759
Refs #2777

## Evidence
- Reproduced before fix: remote command forwarded `/var/folders/.../homeboy-offload-output-repro.json` and emitted `failed to write --output file`.
- Verified after fix: `cargo run --bin homeboy -- --runner lab audit --path /Users/chubes/Developer/homeboy@fix-lab-offload-output-preflight --extension rust --json-summary --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-offload-output-after.json` ran remote command without `--output`, emitted no remote output-write warning, and wrote a 149-byte local output file.
- `cargo test strips_local_output_path_before_remote_exec`
- `cargo test runner_offload_preflight`
- `cargo check --all-targets`
- `cargo test -- --test-threads=1`
- `cargo run --bin homeboy -- audit --path /Users/chubes/Developer/homeboy@fix-lab-offload-output-preflight --extension rust --only runner_offload_preflight --json-summary`

## Notes
- Parallel `cargo test` still exposed an existing global environment race in `core::engine::run_dir::tests::list_outputs`; the single test and serial full suite pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the code changes, tests, reproduction commands, verification runs, and PR description; Chris remains responsible for review and merge.