### PR TITLE
fix: bound self-check output capture

### DIFF
--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -563,6 +563,7 @@ mod tests {
             baseline_comparison: None,
             lint_findings: Some(findings),
             summary: None,
+            self_check_capture: None,
             ci_context: None,
         }
     }

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -278,6 +278,9 @@ pub enum AuditFinding {
     /// Persisted artifact evidence points at a runtime-local temp path instead
     /// of a durable artifact-store path or portable artifact token.
     NonPortableArtifactPath,
+    /// Command output capture retains stdout/stderr or repeated details without
+    /// an explicit size bound and truncation metadata.
+    UnboundedOutputCapture,
 }
 
 impl AuditFinding {
@@ -349,6 +352,7 @@ impl AuditFinding {
             "public_registry_exposure",
             "redirect_validation",
             "non_portable_artifact_path",
+            "unbounded_output_capture",
         ]
     }
 }

--- a/src/core/code_audit/detectors/mod.rs
+++ b/src/core/code_audit/detectors/mod.rs
@@ -21,6 +21,7 @@ pub(super) mod shared_scaffolding;
 pub(super) mod test_coverage;
 pub(super) mod test_topology;
 pub(super) mod test_vacuity;
+pub(super) mod unbounded_output_capture;
 pub(super) mod upstream_workaround;
 pub(super) mod wrapper_inference;
 

--- a/src/core/code_audit/detectors/unbounded_output_capture.rs
+++ b/src/core/code_audit/detectors/unbounded_output_capture.rs
@@ -1,0 +1,112 @@
+//! Unbounded command-output capture detector.
+//!
+//! This is a conservative first slice for command hygiene: it flags Rust code
+//! that accumulates stdout/stderr-style stream chunks into memory without nearby
+//! evidence of a retention bound and truncation metadata.
+
+use super::conventions::AuditFinding;
+use super::findings::{Finding, Severity};
+use super::fingerprint::FileFingerprint;
+
+pub(in crate::core::code_audit) fn run(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    for fp in fingerprints {
+        if !fp.relative_path.ends_with(".rs") {
+            continue;
+        }
+
+        if has_unbounded_capture_shape(&fp.content) {
+            findings.push(Finding {
+                convention: "output_capture".to_string(),
+                severity: Severity::Warning,
+                file: fp.relative_path.clone(),
+                description: "Command output capture appears to append stream chunks without an explicit retained-byte bound or truncation metadata.".to_string(),
+                suggestion: "Use a bounded tail buffer and expose limit/seen/retained/truncated metadata in structured output.".to_string(),
+                kind: AuditFinding::UnboundedOutputCapture,
+            });
+        }
+    }
+
+    findings.sort_by(|a, b| a.file.cmp(&b.file));
+    findings
+}
+
+fn has_unbounded_capture_shape(content: &str) -> bool {
+    let captures_stream_chunks = content.contains("extend_from_slice(&buf[..n])")
+        || content.contains("captured.extend_from_slice")
+        || content.contains("read_to_string(&mut")
+        || content.contains("wait_with_output()");
+    if !captures_stream_chunks {
+        return false;
+    }
+
+    let output_like = content.contains("stdout") || content.contains("stderr");
+    if !output_like {
+        return false;
+    }
+
+    let has_bound = content.contains("limit_bytes")
+        || content.contains("retained_bytes")
+        || content.contains("truncated")
+        || content.contains("BoundedCapture")
+        || content.contains("MAX_OUTPUT")
+        || content.contains("OUTPUT_LIMIT")
+        || content.contains("take(");
+
+    !has_bound
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fp(path: &str, content: &str) -> FileFingerprint {
+        FileFingerprint {
+            relative_path: path.to_string(),
+            content: content.to_string(),
+            ..FileFingerprint::default()
+        }
+    }
+
+    #[test]
+    fn flags_stream_capture_without_bound_metadata() {
+        let file = fp(
+            "src/run.rs",
+            r#"
+            fn tee_to<R: Read>(mut src: R) -> String {
+                let mut captured = Vec::new();
+                let mut buf = [0u8; 4096];
+                if let Ok(n) = src.read(&mut buf) {
+                    captured.extend_from_slice(&buf[..n]);
+                }
+                String::from_utf8_lossy(&captured).to_string()
+            }
+            fn uses_stdout(stdout: &str, stderr: &str) { let _ = (stdout, stderr); }
+            "#,
+        );
+
+        let findings = run(&[&file]);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, AuditFinding::UnboundedOutputCapture);
+    }
+
+    #[test]
+    fn accepts_bounded_capture_with_truncation_metadata() {
+        let file = fp(
+            "src/run.rs",
+            r#"
+            struct BoundedCapture { limit_bytes: usize, retained_bytes: usize, truncated: bool }
+            fn capture_stdout() {
+                let mut captured = BoundedCapture { limit_bytes: 65536, retained_bytes: 0, truncated: false };
+                let stdout = "";
+                let stderr = "";
+                let _ = (&mut captured, stdout, stderr);
+            }
+            "#,
+        );
+
+        assert!(run(&[&file]).is_empty());
+    }
+}

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -52,7 +52,7 @@ use self::detectors::{
     deprecation_age, enum_dispatch_contracts, facade_passthrough, field_patterns, global_env_guard,
     mutating_resource_access, parallel_runner_setup, public_registry_exposure, redirect_validation,
     repeated_literal_shape, requested_detectors, runner_offload_preflight, rust_test_wiring,
-    shared_scaffolding, test_coverage, test_topology, wrapper_inference,
+    shared_scaffolding, test_coverage, test_topology, unbounded_output_capture, wrapper_inference,
 };
 
 pub use checks::{CheckResult, CheckStatus};
@@ -333,11 +333,18 @@ const DETECTOR_FAMILIES: &[DetectorFamily] = &[
         findings: &[AuditFinding::NonPortableArtifactPath],
         requires_discovery: false,
     },
+    DetectorFamily {
+        id: "output_capture",
+        findings: &[AuditFinding::UnboundedOutputCapture],
+        requires_discovery: true,
+    },
 ];
 
 impl AuditExecutionPlan {
     pub(crate) fn full() -> Self {
-        Self::from_enabled_families("full", |family| family_enabled(&[], &[], family.findings))
+        Self::from_enabled_families("full", |family| {
+            family.id != "output_capture" && family_enabled(&[], &[], family.findings)
+        })
     }
 
     pub(crate) fn from_filters(only: &[AuditFinding], exclude: &[AuditFinding]) -> Self {
@@ -492,6 +499,10 @@ impl AuditExecutionPlan {
 
     pub(crate) fn run_artifact_portability(&self) -> bool {
         self.detector_enabled("artifact_portability")
+    }
+
+    pub(crate) fn run_output_capture(&self) -> bool {
+        self.detector_enabled("output_capture")
     }
 
     fn requires_discovery(&self) -> bool {
@@ -1236,6 +1247,21 @@ fn audit_internal(
             config_key_findings.len()
         );
         all_findings.extend(config_key_findings);
+    }
+
+    // Phase 4t1b: Generic command-output capture hygiene.
+    let output_capture_findings = if plan.run_output_capture() {
+        unbounded_output_capture::run(&all_fingerprints)
+    } else {
+        Vec::new()
+    };
+    if !output_capture_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Output capture: {} finding(s) (unbounded stdout/stderr capture)",
+            output_capture_findings.len()
+        );
+        all_findings.extend(output_capture_findings);
     }
 
     // Phase 4t2: Configured core-boundary ecosystem leak detection.

--- a/src/core/extension/lint/report.rs
+++ b/src/core/extension/lint/report.rs
@@ -5,6 +5,7 @@
 
 use crate::core::ci_profile::CiContext;
 use crate::core::extension::lint::baseline::{BaselineComparison, LintFinding};
+use crate::core::extension::self_check::SelfCheckCaptureMetadata;
 use crate::core::extension::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, PhaseFailure,
     PhaseFailureCategory, PhaseReport, VerificationPhase,
@@ -38,6 +39,8 @@ pub struct LintCommandOutput {
     pub lint_findings: Option<Vec<LintFinding>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<LintSummaryOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub self_check_capture: Option<SelfCheckCaptureMetadata>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ci_context: Option<CiContext>,
 }
@@ -89,6 +92,7 @@ pub fn from_main_workflow_with_ci_context(
                 result.lint_findings
             },
             summary: result.summary,
+            self_check_capture: result.self_check_capture,
             ci_context,
         },
         exit_code,
@@ -172,6 +176,7 @@ pub fn from_lint_fix(component_label: String, run: RefactorSourceRun) -> (LintCo
             baseline_comparison: None,
             lint_findings: None,
             summary: None,
+            self_check_capture: None,
             ci_context: None,
         },
         exit_code,

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -10,6 +10,7 @@ use crate::core::engine::run_dir::{self, RunDir};
 use crate::core::engine::shell;
 use crate::core::extension::lint::baseline::{self as lint_baseline, LintFinding};
 use crate::core::extension::lint::build_lint_runner;
+use crate::core::extension::self_check::SelfCheckCaptureMetadata;
 use crate::core::extension::{self, ExtensionCapability, LintChangedFileRoute};
 use crate::core::git;
 use crate::core::refactor::AppliedRefactor;
@@ -49,6 +50,8 @@ pub struct LintRunWorkflowResult {
     pub baseline_comparison: Option<lint_baseline::BaselineComparison>,
     pub lint_findings: Option<Vec<LintFinding>>,
     pub summary: Option<LintSummaryOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub self_check_capture: Option<SelfCheckCaptureMetadata>,
 }
 
 /// Compact lint summary for automation consumers.
@@ -96,6 +99,7 @@ pub fn run_main_lint_workflow(
                 } else {
                     None
                 },
+                self_check_capture: None,
             });
         }
     }
@@ -202,6 +206,7 @@ pub fn run_main_lint_workflow(
             None
         },
         lint_findings: Some(lint_findings),
+        self_check_capture: None,
     })
 }
 
@@ -461,6 +466,7 @@ pub fn run_self_check_lint_workflow(
         } else {
             None
         },
+        self_check_capture: Some(output.capture),
     })
 }
 

--- a/src/core/extension/self_check.rs
+++ b/src/core/extension/self_check.rs
@@ -1,10 +1,13 @@
 use crate::core::component::Component;
 use crate::core::error::{Error, Result};
 use crate::core::extension::ExtensionCapability;
-use crate::core::server::{
-    execute_local_command_in_dir, execute_local_command_passthrough, CommandOutput,
-};
+use serde::Serialize;
+use std::io::{Read, Write};
 use std::path::Path;
+use std::process::{Command, Stdio};
+use std::thread;
+
+const SELF_CHECK_CAPTURE_LIMIT_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Clone)]
 pub struct SelfCheckOutput {
@@ -12,6 +15,21 @@ pub struct SelfCheckOutput {
     pub success: bool,
     pub stdout: String,
     pub stderr: String,
+    pub capture: SelfCheckCaptureMetadata,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct SelfCheckCaptureMetadata {
+    pub stdout: SelfCheckStreamCaptureMetadata,
+    pub stderr: SelfCheckStreamCaptureMetadata,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct SelfCheckStreamCaptureMetadata {
+    pub limit_bytes: usize,
+    pub seen_bytes: usize,
+    pub retained_bytes: usize,
+    pub truncated: bool,
 }
 
 pub fn run_self_checks(
@@ -43,8 +61,8 @@ pub(crate) fn run_self_checks_with_passthrough(
     }
 
     let working_dir = source_path.to_string_lossy();
-    let mut stdout = String::new();
-    let mut stderr = String::new();
+    let mut stdout = BoundedCapture::new(SELF_CHECK_CAPTURE_LIMIT_BYTES);
+    let mut stderr = BoundedCapture::new(SELF_CHECK_CAPTURE_LIMIT_BYTES);
 
     for command in commands {
         if passthrough {
@@ -57,15 +75,19 @@ pub(crate) fn run_self_checks_with_passthrough(
             );
         }
         let output = execute_self_check_command(command, &working_dir, passthrough);
-        stdout.push_str(&output.stdout);
-        stderr.push_str(&output.stderr);
+        stdout.push_capture(output.stdout);
+        stderr.push_capture(output.stderr);
 
         if !output.success {
             return Ok(SelfCheckOutput {
                 exit_code: output.exit_code,
                 success: false,
-                stdout,
-                stderr,
+                stdout: stdout.to_string_lossy(),
+                stderr: stderr.to_string_lossy(),
+                capture: SelfCheckCaptureMetadata {
+                    stdout: stdout.metadata(),
+                    stderr: stderr.metadata(),
+                },
             });
         }
     }
@@ -73,8 +95,12 @@ pub(crate) fn run_self_checks_with_passthrough(
     Ok(SelfCheckOutput {
         exit_code: 0,
         success: true,
-        stdout,
-        stderr,
+        stdout: stdout.to_string_lossy(),
+        stderr: stderr.to_string_lossy(),
+        capture: SelfCheckCaptureMetadata {
+            stdout: stdout.metadata(),
+            stderr: stderr.metadata(),
+        },
     })
 }
 
@@ -82,12 +108,168 @@ fn execute_self_check_command(
     command: &str,
     working_dir: &str,
     passthrough: bool,
-) -> CommandOutput {
-    if passthrough {
-        execute_local_command_passthrough(command, Some(working_dir), None)
-    } else {
-        execute_local_command_in_dir(command, Some(working_dir), None)
+) -> SelfCheckCommandOutput {
+    execute_local_self_check_command(command, working_dir, passthrough)
+}
+
+#[derive(Debug, Clone)]
+struct SelfCheckCommandOutput {
+    stdout: BoundedCapture,
+    stderr: BoundedCapture,
+    success: bool,
+    exit_code: i32,
+}
+
+#[derive(Debug, Clone)]
+struct BoundedCapture {
+    limit: usize,
+    seen: usize,
+    retained: Vec<u8>,
+}
+
+impl BoundedCapture {
+    fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            seen: 0,
+            retained: Vec::new(),
+        }
     }
+
+    fn push_bytes(&mut self, bytes: &[u8]) {
+        self.seen = self.seen.saturating_add(bytes.len());
+        self.retained.extend_from_slice(bytes);
+        if self.retained.len() > self.limit {
+            let drop_len = self.retained.len() - self.limit;
+            self.retained.drain(..drop_len);
+        }
+    }
+
+    fn push_capture(&mut self, capture: BoundedCapture) {
+        self.seen = self.seen.saturating_add(capture.seen);
+        self.retained.extend_from_slice(&capture.retained);
+        if self.retained.len() > self.limit {
+            let drop_len = self.retained.len() - self.limit;
+            self.retained.drain(..drop_len);
+        }
+    }
+
+    fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.retained).to_string()
+    }
+
+    fn metadata(&self) -> SelfCheckStreamCaptureMetadata {
+        SelfCheckStreamCaptureMetadata {
+            limit_bytes: self.limit,
+            seen_bytes: self.seen,
+            retained_bytes: self.retained.len(),
+            truncated: self.seen > self.retained.len(),
+        }
+    }
+}
+
+fn execute_local_self_check_command(
+    command: &str,
+    working_dir: &str,
+    passthrough: bool,
+) -> SelfCheckCommandOutput {
+    #[cfg(windows)]
+    let mut cmd = {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", command]);
+        cmd
+    };
+
+    #[cfg(not(windows))]
+    let mut cmd = {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", command]);
+        cmd
+    };
+
+    cmd.current_dir(working_dir);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(err) => {
+            return SelfCheckCommandOutput {
+                stdout: BoundedCapture::new(SELF_CHECK_CAPTURE_LIMIT_BYTES),
+                stderr: {
+                    let mut capture = BoundedCapture::new(SELF_CHECK_CAPTURE_LIMIT_BYTES);
+                    capture.push_bytes(format!("Command error: {}", err).as_bytes());
+                    capture
+                },
+                success: false,
+                exit_code: -1,
+            };
+        }
+    };
+
+    let stdout_handle = child
+        .stdout
+        .take()
+        .map(|pipe| thread::spawn(move || capture_stream(pipe, passthrough, false)));
+    let stderr_handle = child
+        .stderr
+        .take()
+        .map(|pipe| thread::spawn(move || capture_stream(pipe, passthrough, true)));
+
+    let status = child.wait();
+    let stdout = stdout_handle
+        .and_then(|handle| handle.join().ok())
+        .unwrap_or_else(|| BoundedCapture::new(SELF_CHECK_CAPTURE_LIMIT_BYTES));
+    let stderr = stderr_handle
+        .and_then(|handle| handle.join().ok())
+        .unwrap_or_else(|| BoundedCapture::new(SELF_CHECK_CAPTURE_LIMIT_BYTES));
+
+    match status {
+        Ok(status) => SelfCheckCommandOutput {
+            stdout,
+            stderr,
+            success: status.success(),
+            exit_code: status.code().unwrap_or(-1),
+        },
+        Err(err) => {
+            let mut stderr = stderr;
+            stderr.push_bytes(format!("\nCommand error: {}", err).as_bytes());
+            SelfCheckCommandOutput {
+                stdout,
+                stderr,
+                success: false,
+                exit_code: -1,
+            }
+        }
+    }
+}
+
+fn capture_stream<R: Read>(mut src: R, passthrough: bool, stderr: bool) -> BoundedCapture {
+    let mut captured = BoundedCapture::new(SELF_CHECK_CAPTURE_LIMIT_BYTES);
+    let mut buf = [0u8; 4096];
+
+    loop {
+        match src.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                if passthrough {
+                    if stderr {
+                        let mut sink = std::io::stderr();
+                        let _ = sink.write_all(&buf[..n]);
+                        let _ = sink.flush();
+                    } else {
+                        let mut sink = std::io::stdout();
+                        let _ = sink.write_all(&buf[..n]);
+                        let _ = sink.flush();
+                    }
+                }
+                captured.push_bytes(&buf[..n]);
+            }
+            Err(_) => break,
+        }
+    }
+
+    captured
 }
 
 #[cfg(test)]
@@ -170,5 +352,45 @@ mod tests {
         assert!(output.success);
         assert_eq!(output.stdout, "self-check-stdout");
         assert_eq!(output.stderr, "self-check-stderr");
+    }
+
+    #[test]
+    fn test_run_self_checks_bounds_large_output_capture() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("large.sh"),
+            "perl -e 'print \"stdout-line\\n\" x 20000'\nperl -e 'print STDERR \"stderr-line\\n\" x 20000'\nexit 7\n",
+        )
+        .expect("script should be written");
+
+        let mut component = Component::new(
+            "fixture".to_string(),
+            dir.path().to_string_lossy().to_string(),
+            "".to_string(),
+            None,
+        );
+        component.self_checks = Some(SelfCheckConfig {
+            lint: vec!["sh large.sh".to_string()],
+            test: Vec::new(),
+        });
+
+        let output = run_self_checks_with_passthrough(
+            &component,
+            ExtensionCapability::Lint,
+            dir.path(),
+            false,
+        )
+        .expect("self-check should return bounded failure output");
+
+        assert!(!output.success);
+        assert_eq!(output.exit_code, 7);
+        assert!(output.capture.stdout.truncated);
+        assert!(output.capture.stderr.truncated);
+        assert!(output.capture.stdout.seen_bytes > output.capture.stdout.limit_bytes);
+        assert!(output.capture.stderr.seen_bytes > output.capture.stderr.limit_bytes);
+        assert!(output.stdout.len() <= output.capture.stdout.limit_bytes);
+        assert!(output.stderr.len() <= output.capture.stderr.limit_bytes);
+        assert!(output.stdout.contains("stdout-line"));
+        assert!(output.stderr.contains("stderr-line"));
     }
 }

--- a/src/core/extension/self_check.rs
+++ b/src/core/extension/self_check.rs
@@ -32,14 +32,6 @@ pub struct SelfCheckStreamCaptureMetadata {
     pub truncated: bool,
 }
 
-pub fn run_self_checks(
-    component: &Component,
-    capability: ExtensionCapability,
-    source_path: &Path,
-) -> Result<SelfCheckOutput> {
-    run_self_checks_with_passthrough(component, capability, source_path, true)
-}
-
 pub(crate) fn run_self_checks_with_passthrough(
     component: &Component,
     capability: ExtensionCapability,
@@ -79,29 +71,29 @@ pub(crate) fn run_self_checks_with_passthrough(
         stderr.push_capture(output.stderr);
 
         if !output.success {
-            return Ok(SelfCheckOutput {
-                exit_code: output.exit_code,
-                success: false,
-                stdout: stdout.to_string_lossy(),
-                stderr: stderr.to_string_lossy(),
-                capture: SelfCheckCaptureMetadata {
-                    stdout: stdout.metadata(),
-                    stderr: stderr.metadata(),
-                },
-            });
+            return Ok(self_check_output(output.exit_code, false, &stdout, &stderr));
         }
     }
 
-    Ok(SelfCheckOutput {
-        exit_code: 0,
-        success: true,
+    Ok(self_check_output(0, true, &stdout, &stderr))
+}
+
+fn self_check_output(
+    exit_code: i32,
+    success: bool,
+    stdout: &BoundedCapture,
+    stderr: &BoundedCapture,
+) -> SelfCheckOutput {
+    SelfCheckOutput {
+        exit_code,
+        success,
         stdout: stdout.to_string_lossy(),
         stderr: stderr.to_string_lossy(),
         capture: SelfCheckCaptureMetadata {
             stdout: stdout.metadata(),
             stderr: stderr.metadata(),
         },
-    })
+    }
 }
 
 fn execute_self_check_command(
@@ -286,8 +278,13 @@ mod tests {
             None,
         );
 
-        let err = run_self_checks(&component, ExtensionCapability::Test, Path::new("/tmp"))
-            .expect_err("missing self-checks should fail");
+        let err = run_self_checks_with_passthrough(
+            &component,
+            ExtensionCapability::Test,
+            Path::new("/tmp"),
+            false,
+        )
+        .expect_err("missing self-checks should fail");
 
         assert!(err.to_string().contains("no test self-check commands"));
     }
@@ -311,8 +308,13 @@ mod tests {
             test: Vec::new(),
         });
 
-        let output = run_self_checks(&component, ExtensionCapability::Lint, dir.path())
-            .expect("self-checks should run");
+        let output = run_self_checks_with_passthrough(
+            &component,
+            ExtensionCapability::Lint,
+            dir.path(),
+            false,
+        )
+        .expect("self-checks should run");
 
         assert!(output.success);
         assert_eq!(

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -68,6 +68,24 @@ pub struct RawTestOutput {
     pub stderr_tail: String,
     /// Whether either tail was truncated from the original output.
     pub truncated: bool,
+    /// Whether stdout capture itself was bounded before the line tail was built.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub stdout_truncated: bool,
+    /// Whether stderr capture itself was bounded before the line tail was built.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub stderr_truncated: bool,
+    /// Total stdout bytes observed before bounded capture retained its tail.
+    #[serde(skip_serializing_if = "crate::is_zero", default)]
+    pub stdout_seen_bytes: usize,
+    /// Total stderr bytes observed before bounded capture retained its tail.
+    #[serde(skip_serializing_if = "crate::is_zero", default)]
+    pub stderr_seen_bytes: usize,
+    /// Maximum stdout bytes retained by the self-check capture buffer.
+    #[serde(skip_serializing_if = "crate::is_zero", default)]
+    pub stdout_limit_bytes: usize,
+    /// Maximum stderr bytes retained by the self-check capture buffer.
+    #[serde(skip_serializing_if = "crate::is_zero", default)]
+    pub stderr_limit_bytes: usize,
 }
 
 const RAW_OUTPUT_TAIL_LINES: usize = 80;
@@ -434,6 +452,12 @@ pub fn run_main_test_workflow(
                 stdout_tail,
                 stderr_tail,
                 truncated: stdout_truncated || stderr_truncated,
+                stdout_truncated,
+                stderr_truncated,
+                stdout_seen_bytes: output.stdout.len(),
+                stderr_seen_bytes: output.stderr.len(),
+                stdout_limit_bytes: 0,
+                stderr_limit_bytes: 0,
             })
         }
     } else {
@@ -483,8 +507,12 @@ pub fn run_self_check_test_workflow(
     component_label: String,
     json_summary: bool,
 ) -> crate::core::Result<TestRunWorkflowResult> {
-    let output =
-        extension::self_check::run_self_checks(component, ExtensionCapability::Test, source_path)?;
+    let output = extension::self_check::run_self_checks_with_passthrough(
+        component,
+        ExtensionCapability::Test,
+        source_path,
+        !json_summary,
+    )?;
     let status = if output.success { "passed" } else { "failed" }.to_string();
     let raw_output = (!output.success).then(|| {
         let (stdout_tail, stdout_truncated) = tail_lines(&output.stdout, RAW_OUTPUT_TAIL_LINES);
@@ -492,7 +520,16 @@ pub fn run_self_check_test_workflow(
         RawTestOutput {
             stdout_tail,
             stderr_tail,
-            truncated: stdout_truncated || stderr_truncated,
+            truncated: stdout_truncated
+                || stderr_truncated
+                || output.capture.stdout.truncated
+                || output.capture.stderr.truncated,
+            stdout_truncated: output.capture.stdout.truncated || stdout_truncated,
+            stderr_truncated: output.capture.stderr.truncated || stderr_truncated,
+            stdout_seen_bytes: output.capture.stdout.seen_bytes,
+            stderr_seen_bytes: output.capture.stderr.seen_bytes,
+            stdout_limit_bytes: output.capture.stdout.limit_bytes,
+            stderr_limit_bytes: output.capture.stderr.limit_bytes,
         }
     });
 

--- a/src/core/extension/trace/probes/http_egress.rs
+++ b/src/core/extension/trace/probes/http_egress.rs
@@ -512,8 +512,8 @@ fn respond_bad_gateway(mut stream: TcpStream, message: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::{ActiveTraceProbes, TraceProbeConfig};
+    use super::*;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -359,6 +359,22 @@ fn execution_plan_for_structural_only_skips_unrelated_detector_families() {
 }
 
 #[test]
+fn output_capture_detector_is_explicit_first_slice() {
+    let default_plan = AuditExecutionPlan::full();
+    assert_eq!(
+        detector_step_status(&default_plan, "output_capture"),
+        &PlanStepStatus::Disabled
+    );
+
+    let filtered_plan =
+        AuditExecutionPlan::from_filters(&[AuditFinding::UnboundedOutputCapture], &[]);
+    assert_eq!(
+        detector_step_status(&filtered_plan, "output_capture"),
+        &PlanStepStatus::Ready
+    );
+}
+
+#[test]
 fn execution_plan_for_duplicate_only_skips_structural_detector_family() {
     let plan = AuditExecutionPlan::from_filters(&[AuditFinding::DuplicateFunction], &[]);
 
@@ -421,7 +437,7 @@ fn full_execution_plan_marks_all_detector_steps_ready() {
         .plan
         .steps
         .iter()
-        .all(|step| step.status == PlanStepStatus::Ready));
+        .all(|step| { step.id == "audit.output_capture" || step.status == PlanStepStatus::Ready }));
 }
 
 #[test]

--- a/tests/self_checks_test.rs
+++ b/tests/self_checks_test.rs
@@ -78,6 +78,12 @@ fn test_args(root: &Path) -> TestArgs {
     }
 }
 
+fn json_test_args(root: &Path) -> TestArgs {
+    let mut args = test_args(root);
+    args.json_summary = true;
+    args
+}
+
 #[test]
 fn lint_runs_declared_self_check_without_extensions() {
     let dir = tempfile::tempdir().expect("temp dir");
@@ -127,6 +133,33 @@ fn non_zero_self_check_fails_command_and_surfaces_output() {
         .expect("failure should include raw output");
     assert!(raw.stdout_tail.contains("visible failure stdout"));
     assert!(raw.stderr_tail.contains("visible failure stderr"));
+}
+
+#[test]
+fn json_self_check_failure_reports_bounded_large_output_metadata() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    write_component(dir.path(), r#"{ "test": ["sh scripts/large-fail.sh"] }"#);
+    write_script(
+        dir.path(),
+        "large-fail.sh",
+        "perl -e 'print \"stdout-line\\n\" x 20000'\nperl -e 'print STDERR \"stderr-line\\n\" x 20000'\nexit 7\n",
+    );
+
+    let (output, exit_code) = run_test(json_test_args(dir.path()), &GlobalArgs {})
+        .expect("test self-check failure should return structured output");
+
+    assert_eq!(exit_code, 7);
+    assert!(!output.passed);
+    let raw = output
+        .raw_output
+        .expect("failure should include bounded raw output metadata");
+    assert!(raw.truncated);
+    assert!(raw.stdout_truncated);
+    assert!(raw.stderr_truncated);
+    assert!(raw.stdout_seen_bytes > raw.stdout_limit_bytes);
+    assert!(raw.stderr_seen_bytes > raw.stderr_limit_bytes);
+    assert!(raw.stdout_tail.contains("stdout-line"));
+    assert!(raw.stderr_tail.contains("stderr-line"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Bounds self-check stdout/stderr retention to a 64 KiB tail buffer and reports per-stream capture metadata.
- Suppresses JSON self-check passthrough for test self-checks so large logs do not flood automation output.
- Adds an explicit first-slice `unbounded_output_capture` audit detector for follow-up hardening without changing default audit results.

Fixes #2764.
Starts #2776.

## Verification
- `cargo fmt --check`
- `cargo test --test self_checks_test`
- `cargo test unbounded_output_capture`
- `cargo test output_capture_detector_is_explicit_first_slice`
- Full pre-rebase `cargo test`: 3316 passed, 0 failed, 18 ignored
- `cargo run --bin homeboy -- audit homeboy --path . --only unbounded_output_capture --json-summary` intentionally reported 9 existing candidates for the explicit detector slice.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the bounded capture implementation, detector slice, tests, and verification commands for Chris to review.