### PR TITLE
fix: gate Lab offload by runner capabilities

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -60,6 +60,21 @@ The JSON payload uses `command: "runner.doctor"` and includes `runner_id`,
 Use `doctor` before `connect` when you need to know whether Homeboy, Git, SSH,
 and the configured workspace root are usable on the target machine.
 
+Hot-command Lab offload uses the same capability vocabulary before running on
+an explicit `--runner`. Homeboy currently gates `lint`, `test`, `audit`,
+`bench`, and `trace` against the source worktree's lightweight tool signals:
+
+- `package.json` requires `node` and `npm`.
+- `pnpm-lock.yaml` requires `node` and `pnpm`.
+- `composer.json` requires `php` and `composer`.
+- Docker/Compose files require `docker`.
+- `trace` requires Playwright plus browser binaries.
+
+When an explicit runner is missing required tools, the command fails before
+workspace sync with a `runner_capabilities` validation error and remediation.
+The same central policy returns a local fallback reason for future automatic
+Lab offload selection.
+
 ### `connect`
 
 ```sh

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -14,7 +14,7 @@ use homeboy::core::{EntityCrudOutput, MergeOutput};
 
 use super::{CmdResult, DynamicSetArgs};
 
-mod doctor;
+pub mod doctor;
 
 #[derive(Debug, Default, Serialize)]
 pub struct RunnerExtra {

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::sync::RwLock;
 
 use serde::{Deserialize, Serialize};
@@ -5,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::cli_surface::Commands;
 
 use crate::commands::doctor::resources::{DoctorOutput, ResourceRecommendation};
+use crate::commands::runner::doctor::RunnerDoctorOutput;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HotCommand {
@@ -16,6 +18,82 @@ pub struct ResourcePolicyWarning {
     pub command: &'static str,
     pub recommendation: ResourceRecommendation,
     pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabRunnerGateMode {
+    Automatic,
+    Explicit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabRunnerTool {
+    Git,
+    Node,
+    Npm,
+    Pnpm,
+    Php,
+    Composer,
+    Docker,
+    Playwright,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabRunnerCapabilityPlan {
+    pub command: &'static str,
+    pub required_tools: Vec<LabRunnerTool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LabRunnerGateDecision {
+    Eligible,
+    Missing {
+        runner_id: String,
+        command: &'static str,
+        missing_tools: Vec<LabRunnerTool>,
+        reason: String,
+        remediation: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LabRunnerCapabilities {
+    pub git: bool,
+    pub node: bool,
+    pub npm: bool,
+    pub pnpm: bool,
+    pub php: bool,
+    pub composer: bool,
+    pub docker: bool,
+    pub playwright: bool,
+}
+
+impl LabRunnerCapabilities {
+    pub fn from_doctor(report: &RunnerDoctorOutput) -> Self {
+        Self {
+            git: report.capabilities.git,
+            node: report.capabilities.node,
+            npm: report.capabilities.npm,
+            pnpm: report.capabilities.pnpm,
+            php: report.capabilities.php,
+            composer: report.capabilities.composer,
+            docker: report.capabilities.docker,
+            playwright: report.capabilities.playwright && report.capabilities.browser_ready,
+        }
+    }
+
+    fn has(&self, tool: LabRunnerTool) -> bool {
+        match tool {
+            LabRunnerTool::Git => self.git,
+            LabRunnerTool::Node => self.node,
+            LabRunnerTool::Npm => self.npm,
+            LabRunnerTool::Pnpm => self.pnpm,
+            LabRunnerTool::Php => self.php,
+            LabRunnerTool::Composer => self.composer,
+            LabRunnerTool::Docker => self.docker,
+            LabRunnerTool::Playwright => self.playwright,
+        }
+    }
 }
 
 /// Persisted, host-pressure context captured at preflight time for any
@@ -190,6 +268,148 @@ pub fn hot_command(command: &Commands) -> Option<HotCommand> {
     }
 }
 
+pub fn lab_runner_capability_plan(
+    command: &Commands,
+    source_path: &Path,
+) -> Option<LabRunnerCapabilityPlan> {
+    let hot_command = hot_command(command)?;
+    let mut required_tools = vec![LabRunnerTool::Git];
+
+    if source_path.join("package.json").is_file() {
+        push_unique(&mut required_tools, LabRunnerTool::Node);
+        push_unique(&mut required_tools, LabRunnerTool::Npm);
+    }
+
+    if source_path.join("pnpm-lock.yaml").is_file() {
+        push_unique(&mut required_tools, LabRunnerTool::Node);
+        push_unique(&mut required_tools, LabRunnerTool::Pnpm);
+    }
+
+    if source_path.join("composer.json").is_file() {
+        push_unique(&mut required_tools, LabRunnerTool::Php);
+        push_unique(&mut required_tools, LabRunnerTool::Composer);
+    }
+
+    if has_docker_signal(source_path) {
+        push_unique(&mut required_tools, LabRunnerTool::Docker);
+    }
+
+    if matches!(command, Commands::Trace(_)) {
+        push_unique(&mut required_tools, LabRunnerTool::Playwright);
+    }
+
+    Some(LabRunnerCapabilityPlan {
+        command: hot_command.label,
+        required_tools,
+    })
+}
+
+pub fn evaluate_lab_runner_capabilities(
+    runner_id: &str,
+    plan: &LabRunnerCapabilityPlan,
+    capabilities: &LabRunnerCapabilities,
+    mode: LabRunnerGateMode,
+) -> LabRunnerGateDecision {
+    let missing_tools = plan
+        .required_tools
+        .iter()
+        .copied()
+        .filter(|tool| !capabilities.has(*tool))
+        .collect::<Vec<_>>();
+
+    if missing_tools.is_empty() {
+        return LabRunnerGateDecision::Eligible;
+    }
+
+    let missing = tool_list(&missing_tools);
+    let reason = match mode {
+        LabRunnerGateMode::Automatic => format!(
+            "Local fallback: runner '{runner_id}' is missing required tool(s) for `{}`: {missing}.",
+            plan.command
+        ),
+        LabRunnerGateMode::Explicit => format!(
+            "Lab offload runner '{runner_id}' is missing required tool(s) for `{}`: {missing}.",
+            plan.command
+        ),
+    };
+    let mut remediation = missing_tools
+        .iter()
+        .map(|tool| tool.remediation().to_string())
+        .collect::<Vec<_>>();
+    match mode {
+        LabRunnerGateMode::Automatic => remediation.push(
+            "Homeboy will run locally instead of auto-offloading to this runner.".to_string(),
+        ),
+        LabRunnerGateMode::Explicit => remediation.push(
+            "Install the missing tool(s) on the runner, choose a capable runner, or omit --runner to run locally.".to_string(),
+        ),
+    }
+
+    LabRunnerGateDecision::Missing {
+        runner_id: runner_id.to_string(),
+        command: plan.command,
+        missing_tools,
+        reason,
+        remediation,
+    }
+}
+
+fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
+    if !items.contains(&item) {
+        items.push(item);
+    }
+}
+
+fn has_docker_signal(source_path: &Path) -> bool {
+    [
+        "Dockerfile",
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        "compose.yml",
+        "compose.yaml",
+    ]
+    .iter()
+    .any(|name| source_path.join(name).is_file())
+}
+
+fn tool_list(tools: &[LabRunnerTool]) -> String {
+    tools
+        .iter()
+        .map(|tool| tool.id())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+impl LabRunnerTool {
+    pub fn id(self) -> &'static str {
+        match self {
+            LabRunnerTool::Git => "git",
+            LabRunnerTool::Node => "node",
+            LabRunnerTool::Npm => "npm",
+            LabRunnerTool::Pnpm => "pnpm",
+            LabRunnerTool::Php => "php",
+            LabRunnerTool::Composer => "composer",
+            LabRunnerTool::Docker => "docker",
+            LabRunnerTool::Playwright => "playwright+browsers",
+        }
+    }
+
+    fn remediation(self) -> &'static str {
+        match self {
+            LabRunnerTool::Git => "Install git and ensure it is on the runner PATH.",
+            LabRunnerTool::Node => "Install Node.js and ensure node is on the runner PATH.",
+            LabRunnerTool::Npm => "Install npm with Node.js and ensure npm is on the runner PATH.",
+            LabRunnerTool::Pnpm => "Install pnpm for repositories with pnpm-lock.yaml.",
+            LabRunnerTool::Php => "Install PHP for repositories with composer.json.",
+            LabRunnerTool::Composer => "Install Composer for repositories with composer.json.",
+            LabRunnerTool::Docker => "Install and start Docker for container-backed repositories.",
+            LabRunnerTool::Playwright => {
+                "Install Playwright CLI and browser binaries on the runner."
+            }
+        }
+    }
+}
+
 pub fn evaluate(command: HotCommand, resources: &DoctorOutput) -> Option<ResourcePolicyWarning> {
     match resources.recommendation {
         ResourceRecommendation::Ok => None,
@@ -264,6 +484,36 @@ mod tests {
     use crate::commands::doctor::resources::{
         LoadSummary, MemorySummary, ProcessSummary, RigLeaseSummary,
     };
+    use crate::commands::lint::LintArgs;
+    use crate::commands::utils::args::{
+        BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
+    };
+
+    fn lint_command() -> Commands {
+        Commands::Lint(LintArgs {
+            comp: PositionalComponentArgs {
+                component: None,
+                path: None,
+            },
+            extension_override: ExtensionOverrideArgs::default(),
+            summary: false,
+            file: None,
+            glob: None,
+            changed_only: false,
+            changed_since: None,
+            ci_job: None,
+            errors_only: false,
+            sniffs: None,
+            exclude_sniffs: None,
+            category: None,
+            fix: false,
+            force: false,
+            setting_args: SettingArgs::default(),
+            baseline_args: BaselineArgs::default(),
+            _json: HiddenJsonArgs::default(),
+            json_summary: false,
+        })
+    }
 
     fn resources(recommendation: ResourceRecommendation) -> DoctorOutput {
         DoctorOutput {
@@ -425,5 +675,121 @@ mod tests {
         assert!(value["message"].is_string());
         assert_eq!(value["host"]["load_severity"], "hot");
         assert_eq!(value["host"]["cpu_count"], 4);
+    }
+
+    #[test]
+    fn lab_runner_capability_plan_detects_project_tool_needs() {
+        let dir = tempfile::tempdir().expect("temp project");
+        std::fs::write(dir.path().join("package.json"), "{}").expect("package.json");
+        std::fs::write(dir.path().join("pnpm-lock.yaml"), "lockfileVersion: '9'\n")
+            .expect("pnpm-lock");
+        std::fs::write(dir.path().join("composer.json"), "{}").expect("composer.json");
+        std::fs::write(dir.path().join("Dockerfile"), "FROM scratch\n").expect("Dockerfile");
+
+        let plan = lab_runner_capability_plan(&lint_command(), dir.path()).expect("plan");
+
+        assert_eq!(plan.command, "lint");
+        assert_eq!(
+            plan.required_tools,
+            vec![
+                LabRunnerTool::Git,
+                LabRunnerTool::Node,
+                LabRunnerTool::Npm,
+                LabRunnerTool::Pnpm,
+                LabRunnerTool::Php,
+                LabRunnerTool::Composer,
+                LabRunnerTool::Docker,
+            ]
+        );
+    }
+
+    #[test]
+    fn lab_runner_gate_allows_capable_runner() {
+        let plan = LabRunnerCapabilityPlan {
+            command: "lint",
+            required_tools: vec![LabRunnerTool::Git, LabRunnerTool::Node, LabRunnerTool::Pnpm],
+        };
+        let capabilities = LabRunnerCapabilities {
+            git: true,
+            node: true,
+            pnpm: true,
+            ..LabRunnerCapabilities::default()
+        };
+
+        assert_eq!(
+            evaluate_lab_runner_capabilities(
+                "lab",
+                &plan,
+                &capabilities,
+                LabRunnerGateMode::Explicit,
+            ),
+            LabRunnerGateDecision::Eligible
+        );
+    }
+
+    #[test]
+    fn lab_runner_gate_reports_missing_tool_for_explicit_runner() {
+        let plan = LabRunnerCapabilityPlan {
+            command: "test",
+            required_tools: vec![LabRunnerTool::Git, LabRunnerTool::Pnpm],
+        };
+        let capabilities = LabRunnerCapabilities {
+            git: true,
+            ..LabRunnerCapabilities::default()
+        };
+
+        let decision = evaluate_lab_runner_capabilities(
+            "lab",
+            &plan,
+            &capabilities,
+            LabRunnerGateMode::Explicit,
+        );
+
+        let LabRunnerGateDecision::Missing {
+            missing_tools,
+            reason,
+            remediation,
+            ..
+        } = decision
+        else {
+            panic!("expected missing tool decision");
+        };
+        assert_eq!(missing_tools, vec![LabRunnerTool::Pnpm]);
+        assert!(reason.contains("Lab offload runner 'lab'"));
+        assert!(reason.contains("pnpm"));
+        assert!(remediation
+            .iter()
+            .any(|item| item.contains("omit --runner")));
+    }
+
+    #[test]
+    fn lab_runner_gate_reports_local_fallback_for_auto_runner() {
+        let plan = LabRunnerCapabilityPlan {
+            command: "trace",
+            required_tools: vec![LabRunnerTool::Git, LabRunnerTool::Playwright],
+        };
+        let capabilities = LabRunnerCapabilities {
+            git: true,
+            ..LabRunnerCapabilities::default()
+        };
+
+        let decision = evaluate_lab_runner_capabilities(
+            "lab",
+            &plan,
+            &capabilities,
+            LabRunnerGateMode::Automatic,
+        );
+
+        let LabRunnerGateDecision::Missing {
+            reason,
+            remediation,
+            ..
+        } = decision
+        else {
+            panic!("expected local fallback decision");
+        };
+        assert!(reason.contains("Local fallback"));
+        assert!(reason.contains("playwright+browsers"));
+        assert!(remediation.iter().any(|item| item.contains("run locally")));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,6 +337,7 @@ fn run_lab_offload_inner(
         )
     })?;
     let source_path = lab_offload_source_path(normalized_args)?;
+    preflight_lab_runner_capabilities(runner_id, command_kind, &source_path)?;
     let synced = homeboy::core::runner::sync_workspace(
         runner_id,
         homeboy::core::runner::RunnerWorkspaceSyncOptions {
@@ -389,6 +390,35 @@ fn run_lab_offload_inner(
     }
     print!("{}", exec_output.stdout);
     Ok(exit_code)
+}
+
+fn preflight_lab_runner_capabilities(
+    runner_id: &str,
+    command: &Commands,
+    source_path: &Path,
+) -> homeboy::core::Result<()> {
+    let Some(plan) = resource_policy::lab_runner_capability_plan(command, source_path) else {
+        return Ok(());
+    };
+    let (doctor, _) = homeboy::commands::runner::doctor::run(runner_id)?;
+    match resource_policy::evaluate_lab_runner_capabilities(
+        runner_id,
+        &plan,
+        &resource_policy::LabRunnerCapabilities::from_doctor(&doctor),
+        resource_policy::LabRunnerGateMode::Explicit,
+    ) {
+        resource_policy::LabRunnerGateDecision::Eligible => Ok(()),
+        resource_policy::LabRunnerGateDecision::Missing {
+            reason,
+            remediation,
+            ..
+        } => Err(homeboy::core::Error::validation_invalid_argument(
+            "runner_capabilities",
+            reason,
+            Some(runner_id.to_string()),
+            Some(remediation),
+        )),
+    }
 }
 
 fn preflight_lab_offload_test_extensions(

--- a/tests/output_contracts_test.rs
+++ b/tests/output_contracts_test.rs
@@ -196,6 +196,7 @@ fn lint_findings_output() -> LintCommandOutput {
             extra: BTreeMap::new(),
         }]),
         summary: None,
+        self_check_capture: None,
         ci_context: None,
     }
 }
@@ -245,6 +246,12 @@ fn test_summary_output() -> TestCommandOutput {
             stdout_tail: "running 3 tests\nfixture::fails_contract FAILED".to_string(),
             stderr_tail: "assertion failed: stable envelope".to_string(),
             truncated: false,
+            stdout_truncated: false,
+            stderr_truncated: false,
+            stdout_seen_bytes: 0,
+            stderr_seen_bytes: 0,
+            stdout_limit_bytes: 0,
+            stderr_limit_bytes: 0,
         }),
         ci_context: None,
     }


### PR DESCRIPTION
## Summary
- Add a centralized Lab runner capability policy for hot commands that maps source worktree signals to required tools.
- Gate explicit `--runner` Lab offload before workspace sync and return clear remediation when the runner lacks required tools.
- Document the capability gate and refresh output contract fixtures that were stale against current output structs.

Closes #2808

## Tests
- `cargo test resource_policy --lib`
- `cargo test lab_offload`
- `cargo test --test output_contracts_test`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the capability gate implementation, focused tests/docs, verification, and PR preparation for Chris to review.