### PR TITLE
Migrate legacy SSH runner configs

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -45,6 +45,23 @@ homeboy runner connect homeboy-lab
 
 After this, `homeboy-lab` is both the server ID and the runner ID.
 
+### `migrate`
+
+```sh
+homeboy runner migrate <legacy-runner-id>
+homeboy runner migrate <legacy-runner-id> --remove-legacy
+```
+
+Migrates a pre-capability standalone SSH runner onto the server referenced by its `server_id`. Use this for old Lab configs such as runner `lab` pointing at server `homeboy-lab`:
+
+```sh
+homeboy runner migrate lab
+homeboy runner show homeboy-lab
+homeboy runner migrate lab --remove-legacy
+```
+
+The migration copies `workspace_root`, `homeboy_path`, `daemon`, `concurrency_limit`, `artifact_policy`, `env`, and `resources` into the server's embedded `runner` capability. Without `--remove-legacy`, the old `~/.config/homeboy/runners/<legacy-runner-id>.json` file is preserved so the result can be inspected first. With `--remove-legacy`, Homeboy deletes the legacy standalone runner after the server capability has been saved.
+
 ### `doctor`
 
 ```sh
@@ -281,7 +298,7 @@ Rules:
 
 All command output is wrapped in the global JSON envelope described in the [JSON output contract](../architecture/output-system.md). The `data` payload uses the generic entity CRUD shape:
 
-- `command`: action identifier such as `runner.add`, `runner.list`, `runner.show`, `runner.set`, `runner.remove`, `runner.doctor`, `runner.connect`, `runner.status`, `runner.disconnect`, `runner.exec`, `runner.workspace.sync`, or `runner.workspace.apply`
+- `command`: action identifier such as `runner.add`, `runner.enable`, `runner.migrate`, `runner.list`, `runner.show`, `runner.set`, `runner.remove`, `runner.doctor`, `runner.connect`, `runner.status`, `runner.disconnect`, `runner.exec`, `runner.workspace.sync`, or `runner.workspace.apply`
 - `id`: present for single-runner actions
 - `entity`: runner configuration for single-runner read/write actions
 - `entities`: list for `list`

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -122,6 +122,15 @@ enum RunnerCommand {
         #[arg(long)]
         artifact_policy: Option<String>,
     },
+    /// Migrate a legacy standalone SSH runner onto its referenced server
+    Migrate {
+        /// Legacy standalone SSH runner ID, for example `lab`
+        runner_id: String,
+
+        /// Delete the old standalone runner after copying it to the server
+        #[arg(long)]
+        remove_legacy: bool,
+    },
     /// List all configured runners
     List,
     /// Display runner configuration
@@ -295,6 +304,10 @@ pub fn run(
                 artifact_policy,
             },
         )),
+        RunnerCommand::Migrate {
+            runner_id,
+            remove_legacy,
+        } => map_registry(migrate(&runner_id, remove_legacy)),
         RunnerCommand::List => map_registry(list()),
         RunnerCommand::Show { id } => map_registry(show(&id)),
         RunnerCommand::Set { args } => map_registry(set(args)),
@@ -461,6 +474,36 @@ fn enable(
             id: Some(runner.id.clone()),
             entity: Some(runner),
             updated_fields: vec!["runner".to_string()],
+            ..Default::default()
+        },
+        0,
+    ))
+}
+
+fn migrate(runner_id: &str, remove_legacy: bool) -> CmdResult<RunnerOutput> {
+    let runner = runner::migrate_standalone_ssh_runner(runner_id, remove_legacy)?;
+    let mut deleted = Vec::new();
+    let hint = if remove_legacy {
+        deleted.push(runner_id.to_string());
+        Some(format!(
+            "Legacy runner '{runner_id}' was removed. Use runner ID '{}' for this Lab server.",
+            runner.id
+        ))
+    } else {
+        Some(format!(
+            "Legacy runner '{runner_id}' was preserved. Re-run with --remove-legacy after verifying runner '{}' works.",
+            runner.id
+        ))
+    };
+
+    Ok((
+        RunnerOutput {
+            command: "runner.migrate".to_string(),
+            id: Some(runner.id.clone()),
+            entity: Some(runner),
+            updated_fields: vec!["server.runner".to_string()],
+            deleted,
+            hint,
             ..Default::default()
         },
         0,

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -307,7 +307,35 @@ pub fn run(
         RunnerCommand::Migrate {
             runner_id,
             remove_legacy,
-        } => map_registry(migrate(&runner_id, remove_legacy)),
+        } => map_registry({
+            let runner = runner::migrate_standalone_ssh_runner(&runner_id, remove_legacy)?;
+            let mut deleted = Vec::new();
+            let hint = if remove_legacy {
+                deleted.push(runner_id.to_string());
+                Some(format!(
+                    "Legacy runner '{runner_id}' was removed. Use runner ID '{}' for this Lab server.",
+                    runner.id
+                ))
+            } else {
+                Some(format!(
+                    "Legacy runner '{runner_id}' was preserved. Re-run with --remove-legacy after verifying runner '{}' works.",
+                    runner.id
+                ))
+            };
+
+            Ok((
+                RunnerOutput {
+                    command: "runner.migrate".to_string(),
+                    id: Some(runner.id.clone()),
+                    entity: Some(runner),
+                    updated_fields: vec!["server.runner".to_string()],
+                    deleted,
+                    hint,
+                    ..Default::default()
+                },
+                0,
+            ))
+        }),
         RunnerCommand::List => map_registry(list()),
         RunnerCommand::Show { id } => map_registry(show(&id)),
         RunnerCommand::Set { args } => map_registry(set(args)),
@@ -474,36 +502,6 @@ fn enable(
             id: Some(runner.id.clone()),
             entity: Some(runner),
             updated_fields: vec!["runner".to_string()],
-            ..Default::default()
-        },
-        0,
-    ))
-}
-
-fn migrate(runner_id: &str, remove_legacy: bool) -> CmdResult<RunnerOutput> {
-    let runner = runner::migrate_standalone_ssh_runner(runner_id, remove_legacy)?;
-    let mut deleted = Vec::new();
-    let hint = if remove_legacy {
-        deleted.push(runner_id.to_string());
-        Some(format!(
-            "Legacy runner '{runner_id}' was removed. Use runner ID '{}' for this Lab server.",
-            runner.id
-        ))
-    } else {
-        Some(format!(
-            "Legacy runner '{runner_id}' was preserved. Re-run with --remove-legacy after verifying runner '{}' works.",
-            runner.id
-        ))
-    };
-
-    Ok((
-        RunnerOutput {
-            command: "runner.migrate".to_string(),
-            id: Some(runner.id.clone()),
-            entity: Some(runner),
-            updated_fields: vec!["server.runner".to_string()],
-            deleted,
-            hint,
             ..Default::default()
         },
         0,

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -216,6 +216,51 @@ pub fn enable_server_runner(server_id: &str, patch: Value) -> Result<Runner> {
     Ok(runner_from_server(server_id, runner))
 }
 
+pub fn migrate_standalone_ssh_runner(id: &str, remove_legacy: bool) -> Result<Runner> {
+    let runner = config::load::<Runner>(id)?;
+    if !matches!(runner.kind, RunnerKind::Ssh) {
+        return Err(Error::validation_invalid_argument(
+            "runner_id",
+            "Only standalone SSH runners can be migrated to server capabilities",
+            Some(id.to_string()),
+            None,
+        ));
+    }
+
+    let server_id = runner.server_id.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "server_id",
+            "SSH runners require server_id before migration",
+            Some(id.to_string()),
+            None,
+        )
+    })?;
+    if server_id == id {
+        return Err(Error::validation_invalid_argument(
+            "runner_id",
+            "Runner already uses its server ID; no migration is needed",
+            Some(id.to_string()),
+            None,
+        ));
+    }
+
+    let mut server = server::load(server_id)?;
+    let mut server_runner = server.runner.unwrap_or_default();
+    server_runner.workspace_root = runner.workspace_root.clone();
+    server_runner.settings = runner.settings.clone();
+    server_runner.env.extend(runner.env.clone());
+    server_runner.resources.extend(runner.resources.clone());
+    validate_server_runner(server_id, &server_runner)?;
+    server.runner = Some(server_runner.clone());
+    server::save(&server)?;
+
+    if remove_legacy {
+        config::delete_safe::<Runner>(id)?;
+    }
+
+    Ok(runner_from_server(server_id, server_runner))
+}
+
 fn create_single_value(value: Value) -> Result<CreateResult<Runner>> {
     let id = value
         .get("id")
@@ -471,6 +516,85 @@ mod tests {
             let runner = load("lab-local").expect("load runner");
             assert_eq!(runner.workspace_root.as_deref(), Some("/tmp/b"));
             assert_eq!(runner.settings.concurrency_limit, Some(3));
+        });
+    }
+
+    #[test]
+    fn migrates_standalone_ssh_runner_to_server_capability() {
+        test_support::with_isolated_home(|_| {
+            server::create(
+                r#"{"id":"homeboy-lab","host":"192.168.86.63","user":"chubes"}"#,
+                false,
+            )
+            .expect("create server");
+
+            let legacy = Runner {
+                id: "lab".to_string(),
+                kind: RunnerKind::Ssh,
+                server_id: Some("homeboy-lab".to_string()),
+                workspace_root: Some("/home/chubes/Developer".to_string()),
+                settings: RunnerSettings {
+                    homeboy_path: Some("/usr/local/bin/homeboy".to_string()),
+                    daemon: true,
+                    concurrency_limit: Some(4),
+                    artifact_policy: Some("copy".to_string()),
+                },
+                env: HashMap::from([("RUST_LOG".to_string(), "info".to_string())]),
+                resources: HashMap::from([("cpu".to_string(), Value::from(16))]),
+            };
+            config::save(&legacy).expect("save legacy runner");
+
+            let migrated = migrate_standalone_ssh_runner("lab", false).expect("migrate runner");
+
+            assert_eq!(migrated.id, "homeboy-lab");
+            assert_eq!(migrated.server_id.as_deref(), Some("homeboy-lab"));
+            assert_eq!(
+                migrated.workspace_root.as_deref(),
+                Some("/home/chubes/Developer")
+            );
+            assert_eq!(
+                migrated.settings.homeboy_path.as_deref(),
+                Some("/usr/local/bin/homeboy")
+            );
+            assert!(migrated.settings.daemon);
+            assert_eq!(migrated.settings.concurrency_limit, Some(4));
+            assert_eq!(migrated.settings.artifact_policy.as_deref(), Some("copy"));
+            assert_eq!(
+                migrated.env.get("RUST_LOG").map(String::as_str),
+                Some("info")
+            );
+            assert_eq!(migrated.resources.get("cpu"), Some(&Value::from(16)));
+            assert!(config::exists::<Runner>("lab"));
+
+            let stored_server = server::load("homeboy-lab").expect("load server");
+            assert!(stored_server.runner.is_some());
+        });
+    }
+
+    #[test]
+    fn migrate_can_remove_legacy_runner_when_requested() {
+        test_support::with_isolated_home(|_| {
+            server::create(
+                r#"{"id":"homeboy-lab","host":"192.168.86.63","user":"chubes"}"#,
+                false,
+            )
+            .expect("create server");
+
+            let legacy = Runner {
+                id: "lab".to_string(),
+                kind: RunnerKind::Ssh,
+                server_id: Some("homeboy-lab".to_string()),
+                workspace_root: Some("/home/chubes/Developer".to_string()),
+                settings: RunnerSettings::default(),
+                env: HashMap::new(),
+                resources: HashMap::new(),
+            };
+            config::save(&legacy).expect("save legacy runner");
+
+            migrate_standalone_ssh_runner("lab", true).expect("migrate runner");
+
+            assert!(!config::exists::<Runner>("lab"));
+            assert!(load("homeboy-lab").is_ok());
         });
     }
 }


### PR DESCRIPTION
## Summary
- Add `homeboy runner migrate <legacy-runner-id>` to copy pre-capability standalone SSH runner settings onto the referenced server's `runner` capability.
- Keep legacy runner files by default, with explicit `--remove-legacy` cleanup after verification.
- Document the Lab one-machine/one-ID migration path and refresh stale output contract test fixtures from recent main changes.

Fixes https://github.com/Extra-Chill/homeboy/issues/2812

## Verification
- `cargo test core::runner::tests --lib`
- `cargo test command_surface`
- `cargo test output_contracts`
- `cargo check`
- `rustfmt --check src/core/runner/mod.rs src/commands/runner.rs tests/output_contracts_test.rs`
- `git diff --check HEAD~2..HEAD`
- `homeboy lint --path . --extension rust --changed-since origin/main`
- `homeboy test --path . --extension rust --changed-since origin/main`

## Notes
- Full `cargo fmt --check` still reports an import-order diff in `src/core/extension/trace/probes/http_egress.rs`, which is outside this PR's touched files. Homeboy changed-file lint passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the migration command/core implementation, focused tests/docs, and verification commands; Chris remains responsible for review and merge.