### PR TITLE
Auto-select default Lab runner

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -62,6 +62,20 @@ homeboy runner migrate lab --remove-legacy
 
 The migration copies `workspace_root`, `homeboy_path`, `daemon`, `concurrency_limit`, `artifact_policy`, `env`, and `resources` into the server's embedded `runner` capability. Without `--remove-legacy`, the old `~/.config/homeboy/runners/<legacy-runner-id>.json` file is preserved so the result can be inspected first. With `--remove-legacy`, Homeboy deletes the legacy standalone runner after the server capability has been saved.
 
+Hot commands that support Lab offload (`audit`, full `lint`, `test`, `bench run`, and `trace`) auto-select a connected default Lab runner when `--runner` is omitted. Selection is conservative:
+
+- `--runner <id>` always wins.
+- `--force-hot` keeps the command local.
+- `lab.preferred_runner` is used when it names a connected SSH runner.
+- Without `lab.preferred_runner`, Homeboy auto-selects only when exactly one SSH runner is connected.
+- Local runners and disconnected SSH runners are not auto-selected.
+
+Configure a preferred Lab runner with:
+
+```sh
+homeboy config set /lab/preferred_runner '"homeboy-lab"'
+```
+
 ### `doctor`
 
 ```sh

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -429,7 +429,7 @@ fn warning_message(
     let severity = severity_str(recommendation);
     let reason = primary_reason(resources);
     format!(
-        "Resource policy warning: machine is {severity}; starting `{command}` may skew results or add pressure. {reason} Use --runner <id> to offload this hot command to a connected Homeboy Lab runner, or use --force-hot to run locally without this warning."
+        "Resource policy warning: machine is {severity}; starting `{command}` may skew results or add pressure. {reason} Connect a default Homeboy Lab runner or use --runner <id> to offload this hot command, or use --force-hot to run locally without this warning."
     )
 }
 

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -11,6 +11,9 @@ pub struct HomeboyConfig {
     pub defaults: Defaults,
 
     #[serde(default)]
+    pub lab: LabConfig,
+
+    #[serde(default)]
     pub triage: TriageConfig,
 
     /// Directory where persisted run artifacts are copied.
@@ -32,6 +35,7 @@ impl Default for HomeboyConfig {
     fn default() -> Self {
         Self {
             defaults: Defaults::default(),
+            lab: LabConfig::default(),
             triage: TriageConfig::default(),
             artifact_root: None,
             update_check: true,
@@ -41,6 +45,12 @@ impl Default for HomeboyConfig {
 
 pub fn default_true() -> bool {
     true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LabConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preferred_runner: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -452,9 +462,30 @@ mod tests {
     }
 
     #[test]
+    fn homeboy_config_parses_lab_preferred_runner() {
+        let config: HomeboyConfig = serde_json::from_str(
+            r#"{
+                "lab": {
+                    "preferred_runner": "homeboy-lab"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.lab.preferred_runner.as_deref(), Some("homeboy-lab"));
+    }
+
+    #[test]
     fn homeboy_config_leaves_triage_priority_labels_unset_by_default() {
         let config = HomeboyConfig::default();
 
         assert!(config.triage.priority_labels.is_none());
+    }
+
+    #[test]
+    fn homeboy_config_leaves_lab_preferred_runner_unset_by_default() {
+        let config = HomeboyConfig::default();
+
+        assert!(config.lab.preferred_runner.is_none());
     }
 }

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::core::config::{self, ConfigEntity};
+use crate::core::defaults;
 use crate::core::error::{Error, Result};
 use crate::core::output::{BatchResult, CreateOutput, CreateResult, MergeOutput, MergeResult};
 use crate::core::server::{self, RunnerSettings, ServerRunner};
@@ -119,6 +120,53 @@ pub fn list() -> Result<Vec<Runner>> {
     );
     runners.sort_by(|a, b| a.id.cmp(&b.id));
     Ok(runners)
+}
+
+pub fn resolve_default_lab_runner() -> Result<Option<String>> {
+    let preferred = defaults::load_config().lab.preferred_runner;
+    let runners = list()?;
+    Ok(resolve_default_lab_runner_from_candidates(
+        preferred.as_deref(),
+        runners.into_iter().filter_map(|runner| {
+            if runner.kind != RunnerKind::Ssh {
+                return None;
+            }
+            let connected = status(&runner.id).ok()?.connected;
+            Some(DefaultLabRunnerCandidate {
+                id: runner.id,
+                connected,
+            })
+        }),
+    ))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DefaultLabRunnerCandidate {
+    id: String,
+    connected: bool,
+}
+
+fn resolve_default_lab_runner_from_candidates(
+    preferred: Option<&str>,
+    candidates: impl IntoIterator<Item = DefaultLabRunnerCandidate>,
+) -> Option<String> {
+    let connected: Vec<DefaultLabRunnerCandidate> = candidates
+        .into_iter()
+        .filter(|candidate| candidate.connected)
+        .collect();
+
+    if let Some(preferred) = preferred {
+        return connected
+            .into_iter()
+            .find(|candidate| candidate.id == preferred)
+            .map(|candidate| candidate.id);
+    }
+
+    if connected.len() == 1 {
+        connected.into_iter().next().map(|candidate| candidate.id)
+    } else {
+        None
+    }
 }
 
 pub fn create(json_spec: &str, skip_existing: bool) -> Result<CreateOutput<Runner>> {
@@ -596,5 +644,83 @@ mod tests {
             assert!(!config::exists::<Runner>("lab"));
             assert!(load("homeboy-lab").is_ok());
         });
+    }
+
+    #[test]
+    fn default_lab_runner_prefers_configured_connected_runner() {
+        let selected = resolve_default_lab_runner_from_candidates(
+            Some("lab-b"),
+            vec![
+                DefaultLabRunnerCandidate {
+                    id: "lab-a".to_string(),
+                    connected: true,
+                },
+                DefaultLabRunnerCandidate {
+                    id: "lab-b".to_string(),
+                    connected: true,
+                },
+            ],
+        );
+
+        assert_eq!(selected.as_deref(), Some("lab-b"));
+    }
+
+    #[test]
+    fn default_lab_runner_selects_single_connected_runner_when_unconfigured() {
+        let selected = resolve_default_lab_runner_from_candidates(
+            None,
+            vec![
+                DefaultLabRunnerCandidate {
+                    id: "lab-a".to_string(),
+                    connected: false,
+                },
+                DefaultLabRunnerCandidate {
+                    id: "lab-b".to_string(),
+                    connected: true,
+                },
+            ],
+        );
+
+        assert_eq!(selected.as_deref(), Some("lab-b"));
+    }
+
+    #[test]
+    fn default_lab_runner_is_conservative_without_unique_connected_runner() {
+        let none_connected = resolve_default_lab_runner_from_candidates(
+            None,
+            vec![DefaultLabRunnerCandidate {
+                id: "lab-a".to_string(),
+                connected: false,
+            }],
+        );
+        let multiple_connected = resolve_default_lab_runner_from_candidates(
+            None,
+            vec![
+                DefaultLabRunnerCandidate {
+                    id: "lab-a".to_string(),
+                    connected: true,
+                },
+                DefaultLabRunnerCandidate {
+                    id: "lab-b".to_string(),
+                    connected: true,
+                },
+            ],
+        );
+
+        assert!(none_connected.is_none());
+        assert!(multiple_connected.is_none());
+    }
+
+    #[test]
+    fn default_lab_runner_skips_disconnected_preferred_runner() {
+        let selected = resolve_default_lab_runner_from_candidates(
+            Some("lab-a"),
+            vec![DefaultLabRunnerCandidate {
+                id: "lab-a".to_string(),
+                connected: false,
+            }],
+        );
+
+        assert!(selected.is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,25 +165,29 @@ fn main() -> std::process::ExitCode {
         Err(e) => e.exit(),
     };
 
-    if let Some(runner_id) = cli.runner.as_deref() {
-        if !cli.command.supports_lab_runner() {
-            let err = homeboy::core::Error::validation_invalid_argument(
-                "runner",
-                "--runner is only supported for hot Lab-offload commands: lint, test, audit, bench, and trace",
-                Some(runner_id.to_string()),
-                None,
+    match resolve_lab_runner_selection(&cli.command, cli.runner.as_deref(), cli.force_hot) {
+        Ok(Some(selection)) => {
+            if matches!(selection.source, LabRunnerSelectionSource::Default) {
+                eprintln!(
+                    "Lab offload: auto-selected default runner `{}`.",
+                    selection.runner_id
+                );
+            }
+
+            let capture_patch = cli.command.lab_offload_mutation_flag().is_some();
+            return run_lab_offload(
+                &selection.runner_id,
+                &cli.command,
+                &normalized,
+                output_file.as_deref(),
+                capture_patch,
             );
+        }
+        Ok(None) => {}
+        Err(err) => {
             emit_json_result(Err(err), output_file.as_deref(), 2);
             return std::process::ExitCode::from(exit_code_to_u8(2));
         }
-        let capture_patch = cli.command.lab_offload_mutation_flag().is_some();
-        return run_lab_offload(
-            runner_id,
-            &cli.command,
-            &normalized,
-            output_file.as_deref(),
-            capture_patch,
-        );
     }
 
     homeboy::core::set_artifact_root_override(cli.artifact_root.clone().or(artifact_root_override));
@@ -247,6 +251,65 @@ fn main() -> std::process::ExitCode {
     let exit_code = commands::response::run(cli.command, &global, output_file.as_deref());
 
     std::process::ExitCode::from(exit_code_to_u8(exit_code))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LabRunnerSelectionSource {
+    Explicit,
+    Default,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LabRunnerSelection {
+    runner_id: String,
+    source: LabRunnerSelectionSource,
+}
+
+fn resolve_lab_runner_selection(
+    command: &Commands,
+    explicit_runner: Option<&str>,
+    force_hot: bool,
+) -> homeboy::core::Result<Option<LabRunnerSelection>> {
+    let default_runner = if explicit_runner.is_none() && !force_hot && command.supports_lab_runner()
+    {
+        homeboy::core::runner::resolve_default_lab_runner()?
+    } else {
+        None
+    };
+
+    resolve_lab_runner_selection_from_default(command, explicit_runner, force_hot, default_runner)
+}
+
+fn resolve_lab_runner_selection_from_default(
+    command: &Commands,
+    explicit_runner: Option<&str>,
+    force_hot: bool,
+    default_runner: Option<String>,
+) -> homeboy::core::Result<Option<LabRunnerSelection>> {
+    if let Some(runner_id) = explicit_runner {
+        if !command.supports_lab_runner() {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "runner",
+                "--runner is only supported for hot Lab-offload commands: lint, test, audit, bench, and trace",
+                Some(runner_id.to_string()),
+                None,
+            ));
+        }
+
+        return Ok(Some(LabRunnerSelection {
+            runner_id: runner_id.to_string(),
+            source: LabRunnerSelectionSource::Explicit,
+        }));
+    }
+
+    if force_hot || !command.supports_lab_runner() {
+        return Ok(None);
+    }
+
+    Ok(default_runner.map(|runner_id| LabRunnerSelection {
+        runner_id,
+        source: LabRunnerSelectionSource::Default,
+    }))
 }
 
 fn exit_code_to_u8(code: i32) -> u8 {
@@ -698,8 +761,9 @@ fn extract_parent_command_from_error(e: &clap::Error) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        lab_offload_source_path, lab_offload_test_extension_ids, rewrite_lab_offload_args,
-        runner_extension_preflight_tail,
+        lab_offload_source_path, lab_offload_test_extension_ids,
+        resolve_lab_runner_selection_from_default, rewrite_lab_offload_args,
+        runner_extension_preflight_tail, LabRunnerSelectionSource,
     };
     use homeboy::cli_surface::Commands;
     use homeboy::commands::test::TestArgs;
@@ -926,5 +990,75 @@ mod tests {
 
         assert!(tail.contains("two\nthree\nfour"));
         assert!(!tail.contains("one"));
+    }
+
+    #[test]
+    fn lab_runner_selection_keeps_explicit_runner_precedence() {
+        let command = Commands::Test(test_args_for_path(std::path::Path::new("/tmp/project")));
+        let selection = resolve_lab_runner_selection_from_default(
+            &command,
+            Some("lab-explicit"),
+            false,
+            Some("lab-default".to_string()),
+        )
+        .expect("selection")
+        .expect("explicit runner selected");
+
+        assert_eq!(selection.runner_id, "lab-explicit");
+        assert_eq!(selection.source, LabRunnerSelectionSource::Explicit);
+    }
+
+    #[test]
+    fn lab_runner_selection_uses_default_for_supported_commands() {
+        let command = Commands::Test(test_args_for_path(std::path::Path::new("/tmp/project")));
+        let selection = resolve_lab_runner_selection_from_default(
+            &command,
+            None,
+            false,
+            Some("lab-default".to_string()),
+        )
+        .expect("selection")
+        .expect("default runner selected");
+
+        assert_eq!(selection.runner_id, "lab-default");
+        assert_eq!(selection.source, LabRunnerSelectionSource::Default);
+    }
+
+    #[test]
+    fn lab_runner_selection_runs_locally_without_default_runner() {
+        let command = Commands::Test(test_args_for_path(std::path::Path::new("/tmp/project")));
+
+        assert!(
+            resolve_lab_runner_selection_from_default(&command, None, false, None)
+                .expect("selection")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn lab_runner_selection_force_hot_is_local_escape_hatch() {
+        let command = Commands::Test(test_args_for_path(std::path::Path::new("/tmp/project")));
+
+        assert!(resolve_lab_runner_selection_from_default(
+            &command,
+            None,
+            true,
+            Some("lab-default".to_string())
+        )
+        .expect("selection")
+        .is_none());
+    }
+
+    #[test]
+    fn lab_runner_selection_rejects_explicit_runner_on_unsupported_command() {
+        let err = resolve_lab_runner_selection_from_default(
+            &Commands::List,
+            Some("lab-explicit"),
+            false,
+            Some("lab-default".to_string()),
+        )
+        .expect_err("unsupported command rejects explicit runner");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
     }
 }


### PR DESCRIPTION
## Summary
- Adds `lab.preferred_runner` config and conservative default Lab runner resolution for supported hot commands.
- Auto-offloads only to connected SSH runners; explicit `--runner` still wins and `--force-hot` remains the local escape hatch.
- Documents default runner behavior and updates resource-policy guidance.

Closes #2807.

## Testing
- `cargo fmt --check`
- `cargo test lab_runner_selection --bin homeboy`
- `cargo test default_lab_runner --lib`
- `cargo test lab_preferred_runner --lib`
- `cargo test warns_when_hot_command_runs_on_warm_or_hot_machine --lib`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the default Lab runner selection path, focused tests, docs, and verification; Chris remains responsible for review and merge.