### PR TITLE
Fix test coverage detector entry point

### DIFF
--- a/src/core/code_audit/detectors/test_coverage.rs
+++ b/src/core/code_audit/detectors/test_coverage.rs
@@ -26,6 +26,14 @@ use super::test_mapping::{
 use super::test_vacuity::{find_vacuous_test_methods, rust_crate_name};
 use crate::core::extension::TestMappingConfig;
 
+pub(in crate::core::code_audit) fn run(
+    root: &Path,
+    fingerprints: &[&FileFingerprint],
+    config: &TestMappingConfig,
+) -> Vec<Finding> {
+    analyze_test_coverage(root, fingerprints, config)
+}
+
 /// Analyze test coverage gaps given source fingerprints and a test mapping config.
 ///
 /// `root` is the component root directory (for resolving test file existence).

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -1010,11 +1010,8 @@ fn audit_internal(
                 for ext_id in extensions.keys() {
                     if let Ok(ext_manifest) = crate::core::extension::load_extension(ext_id) {
                         if let Some(test_mapping) = ext_manifest.test_mapping() {
-                            let coverage_findings = test_coverage::analyze_test_coverage(
-                                root,
-                                &all_fingerprints,
-                                test_mapping,
-                            );
+                            let coverage_findings =
+                                test_coverage::run(root, &all_fingerprints, test_mapping);
                             if !coverage_findings.is_empty() {
                                 log_status!(
                                     "audit",


### PR DESCRIPTION
## Summary
- Add the standard `run()` entry point to the test coverage audit detector.
- Route the audit pipeline through that entry point so detector convention checks stop flagging `test_coverage.rs` as drift.

## Verification
- `cargo fmt --check`
- `cargo test core::code_audit::detectors::test_coverage --quiet`
- `homeboy audit --path . --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the audit convention drift, drafted the minimal detector entry point change, and ran local verification.