### PR TITLE
refactor: extract GitHub PR comment helpers

### DIFF
--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -27,10 +27,6 @@ use crate::core::component;
 use crate::core::deploy::release_download::{detect_remote_url, parse_github_url, GitHubRepo};
 use crate::core::error::{Error, Result};
 
-use super::github_comment_sections::{
-    comment_matches_key, extract_footer, extract_header, merge_section, parse_comment_sections,
-    render_comment,
-};
 use super::resolve_target;
 
 // ---------------------------------------------------------------------------
@@ -239,71 +235,6 @@ impl PrState {
             PrState::All => "all",
         }
     }
-}
-
-/// Parameters for posting a (potentially sticky) PR comment.
-///
-/// Three shapes are supported, selected by `mode`:
-/// - [`PrCommentMode::Fresh`] — plain append, no marker, no find-or-update.
-/// - [`PrCommentMode::StickyWholeBody`] — single-section sticky (PR #1334
-///   semantics): prepend `<!-- homeboy:key=<key> -->` marker and update the
-///   one matching comment in place.
-/// - [`PrCommentMode::Sectioned`] — multi-section aggregation: a single shared
-///   comment carries `<!-- homeboy:comment-key=<outer> -->` and N section
-///   blocks delimited by `<!-- homeboy:section-key=<inner>:start|end -->`.
-///   Each invocation replaces its own inner section and leaves the others
-///   untouched. Handles race consolidation when parallel jobs raced to create
-///   the shared comment.
-#[derive(Debug, Clone)]
-pub struct PrCommentOptions {
-    pub number: u64,
-    pub body: String,
-    pub mode: PrCommentMode,
-    /// Optional workspace path. See [`IssueCreateOptions::path`].
-    pub path: Option<String>,
-}
-
-impl Default for PrCommentOptions {
-    fn default() -> Self {
-        Self {
-            number: 0,
-            body: String::new(),
-            mode: PrCommentMode::Fresh,
-            path: None,
-        }
-    }
-}
-
-/// Which comment-posting flow to run. Mutually exclusive shapes.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub enum PrCommentMode {
-    /// Plain append. No marker. No find-or-update.
-    #[default]
-    Fresh,
-    /// Single-section sticky comment (PR #1334). The `body` is treated as the
-    /// whole comment body; the marker `<!-- homeboy:key=<key> -->` is prepended.
-    StickyWholeBody { key: String },
-    /// Multi-section aggregated sticky comment. `body` is ONE section's body;
-    /// it is merged under `section_key` into the comment carrying `comment_key`.
-    Sectioned {
-        /// Outer marker (one shared comment per PR per outer key).
-        comment_key: String,
-        /// Inner marker (one section per inner key within the shared comment).
-        section_key: String,
-        /// Optional header line written just after the outer marker on fresh
-        /// comments (e.g. `## Homeboy Results — \`<component>\``). Preserved
-        /// from existing comments on merge.
-        header: Option<String>,
-        /// Optional footer block written after the last section on fresh
-        /// comments (e.g. a `<details><summary>Tooling versions</summary>`
-        /// block). Preserved from existing comments on merge when the caller
-        /// does not pass one explicitly; overwritten when the caller does.
-        footer: Option<String>,
-        /// Optional explicit section ordering. Sections listed here come first
-        /// in the given order; any other sections are appended alphabetically.
-        /// `None` = pure alphabetical.
-        section_order: Option<Vec<String>>,
-    },
 }
 
 /// Parameters for closing an existing issue with a reason.
@@ -896,291 +827,6 @@ fn validate_pr_merge_method(method: &str) -> Result<String> {
     }
 }
 
-/// Post a comment on a PR.
-///
-/// Dispatches on [`PrCommentOptions::mode`]:
-/// - [`PrCommentMode::Fresh`] — plain append, no marker.
-/// - [`PrCommentMode::StickyWholeBody`] — find-or-update the one comment
-///   tagged `<!-- homeboy:key=<key> -->` (single-section sticky, PR #1334).
-/// - [`PrCommentMode::Sectioned`] — multi-section aggregation: merge this
-///   invocation's section under `section_key` into the shared comment tagged
-///   `<!-- homeboy:comment-key=<comment_key> -->`.
-pub fn pr_comment(component_id: Option<&str>, options: PrCommentOptions) -> Result<GithubPrOutput> {
-    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
-    ensure_gh_ready()?;
-
-    match options.mode.clone() {
-        PrCommentMode::Fresh => pr_comment_fresh(id, repo, options),
-        PrCommentMode::StickyWholeBody { key } => {
-            pr_comment_sticky_whole(id, repo, options.number, options.body, key)
-        }
-        PrCommentMode::Sectioned {
-            comment_key,
-            section_key,
-            header,
-            footer,
-            section_order,
-        } => pr_comment_sectioned(
-            id,
-            repo,
-            options.number,
-            options.body,
-            comment_key,
-            section_key,
-            header,
-            footer,
-            section_order,
-        ),
-    }
-}
-
-/// Plain append flow. Shared by `Fresh` mode and the "no existing comment"
-/// branch of the sticky flow.
-fn pr_comment_fresh(
-    id: String,
-    repo: GitHubRepo,
-    options: PrCommentOptions,
-) -> Result<GithubPrOutput> {
-    let repo_flag = format!("{}/{}", repo.owner, repo.repo);
-    let args: Vec<String> = vec![
-        "pr".into(),
-        "comment".into(),
-        options.number.to_string(),
-        "-R".into(),
-        repo_flag,
-        "--body".into(),
-        options.body,
-    ];
-    let output = run_gh(&args)?;
-    Ok(GithubPrOutput {
-        component_id: id,
-        owner: repo.owner,
-        repo: repo.repo,
-        action: "pr.comment.create".to_string(),
-        success: true,
-        number: Some(options.number),
-        url: Some(output.trim().to_string()),
-        ..Default::default()
-    })
-}
-
-/// Sticky single-section flow (PR #1334 semantics).
-fn pr_comment_sticky_whole(
-    id: String,
-    repo: GitHubRepo,
-    pr_number: u64,
-    body: String,
-    key: String,
-) -> Result<GithubPrOutput> {
-    let full_body = format!("{}\n{}", marker_for_key(&key), body);
-
-    if let Some(existing_id) = find_sticky_comment_id(&repo, pr_number, &key)? {
-        let args: Vec<String> = vec![
-            "api".into(),
-            format!(
-                "repos/{}/{}/issues/comments/{}",
-                repo.owner, repo.repo, existing_id
-            ),
-            "--method".into(),
-            "PATCH".into(),
-            "-f".into(),
-            format!("body={}", full_body),
-        ];
-        run_gh(&args)?;
-        return Ok(GithubPrOutput {
-            component_id: id,
-            owner: repo.owner,
-            repo: repo.repo,
-            action: "pr.comment.update".to_string(),
-            success: true,
-            number: Some(pr_number),
-            comment_id: Some(existing_id),
-            ..Default::default()
-        });
-    }
-
-    // Fall through to fresh-comment.
-    let repo_flag = format!("{}/{}", repo.owner, repo.repo);
-    let args: Vec<String> = vec![
-        "pr".into(),
-        "comment".into(),
-        pr_number.to_string(),
-        "-R".into(),
-        repo_flag,
-        "--body".into(),
-        full_body,
-    ];
-    let output = run_gh(&args)?;
-    Ok(GithubPrOutput {
-        component_id: id,
-        owner: repo.owner,
-        repo: repo.repo,
-        action: "pr.comment.create".to_string(),
-        success: true,
-        number: Some(pr_number),
-        url: Some(output.trim().to_string()),
-        ..Default::default()
-    })
-}
-
-/// Sectioned-comment flow.
-///
-/// Flow:
-/// 1. List the PR's issue-comments, filter to those carrying the comment-key
-///    marker.
-/// 2. If none: create one with a single section block.
-/// 3. If one: parse existing sections, merge this invocation's section, render.
-///    Byte-compare to the existing body — if equal, emit `pr.comment.section.noop`
-///    and skip the PATCH. Otherwise PATCH.
-/// 4. If many (race): pick lowest id as canonical, merge sections from ALL
-///    matching comments (current invocation wins last for duplicate keys),
-///    PATCH canonical, DELETE the rest. Failed DELETEs become warnings, not
-///    hard errors — the next invocation will consolidate.
-#[allow(clippy::too_many_arguments)]
-fn pr_comment_sectioned(
-    id: String,
-    repo: GitHubRepo,
-    pr_number: u64,
-    section_body: String,
-    comment_key: String,
-    section_key: String,
-    header: Option<String>,
-    footer: Option<String>,
-    section_order: Option<Vec<String>>,
-) -> Result<GithubPrOutput> {
-    // 1. Fetch every matching comment (with bodies) — we need the bodies to
-    //    merge the race case. `gh api --paginate` returns a stream of JSON
-    //    arrays concatenated with no separator; we parse each array
-    //    independently and flatten the results.
-    let matches = list_matching_comments(&repo, pr_number, &comment_key)?;
-
-    if matches.is_empty() {
-        // 2. No existing comment — create fresh with a single section.
-        let mut sections: Vec<(String, String)> = Vec::new();
-        sections.push((section_key.clone(), section_body.clone()));
-        let rendered = render_comment(
-            &comment_key,
-            header.as_deref(),
-            &sections,
-            section_order.as_deref(),
-            footer.as_deref(),
-        );
-        let repo_flag = format!("{}/{}", repo.owner, repo.repo);
-        let args: Vec<String> = vec![
-            "pr".into(),
-            "comment".into(),
-            pr_number.to_string(),
-            "-R".into(),
-            repo_flag,
-            "--body".into(),
-            rendered,
-        ];
-        let output = run_gh(&args)?;
-        return Ok(GithubPrOutput {
-            component_id: id,
-            owner: repo.owner,
-            repo: repo.repo,
-            action: "pr.comment.section.create".to_string(),
-            success: true,
-            number: Some(pr_number),
-            url: Some(output.trim().to_string()),
-            ..Default::default()
-        });
-    }
-
-    // 3/4. Canonical = lowest id. Merge sections from every matching comment
-    //      (ascending id order so later comments override earlier ones), then
-    //      overwrite this invocation's section last.
-    let mut matches = matches;
-    matches.sort_by_key(|m| m.id);
-    let canonical_id = matches[0].id;
-    let canonical_body = matches[0].body.clone();
-
-    let mut merged: Vec<(String, String)> = Vec::new();
-    let mut discovered_header: Option<String> = header.clone();
-    let mut discovered_footer: Option<String> = footer.clone();
-    for comment in &matches {
-        let parsed = parse_comment_sections(&comment.body);
-        for (k, v) in parsed {
-            merged = merge_section(merged, &k, v);
-        }
-        // First comment wins the header / footer (in ascending id order =
-        // lowest id), but only if caller didn't pass one explicitly.
-        if discovered_header.is_none() {
-            discovered_header = extract_header(&comment.body);
-        }
-        if discovered_footer.is_none() {
-            discovered_footer = extract_footer(&comment.body);
-        }
-    }
-    // Current invocation wins last.
-    merged = merge_section(merged, &section_key, section_body);
-
-    let rendered = render_comment(
-        &comment_key,
-        discovered_header.as_deref(),
-        &merged,
-        section_order.as_deref(),
-        discovered_footer.as_deref(),
-    );
-
-    // Idempotency: byte-compare rendered to canonical's existing body.
-    let patch_needed = rendered.trim_end() != canonical_body.trim_end();
-    let mut warnings: Vec<String> = Vec::new();
-
-    if patch_needed {
-        let args: Vec<String> = vec![
-            "api".into(),
-            format!(
-                "repos/{}/{}/issues/comments/{}",
-                repo.owner, repo.repo, canonical_id
-            ),
-            "--method".into(),
-            "PATCH".into(),
-            "-f".into(),
-            format!("body={}", rendered),
-        ];
-        run_gh(&args)?;
-    }
-
-    // Delete duplicates (best-effort — warn instead of failing).
-    for comment in matches.iter().skip(1) {
-        let args: Vec<String> = vec![
-            "api".into(),
-            format!(
-                "repos/{}/{}/issues/comments/{}",
-                repo.owner, repo.repo, comment.id
-            ),
-            "--method".into(),
-            "DELETE".into(),
-        ];
-        if run_gh(&args).is_err() {
-            warnings.push(format!(
-                "failed to delete duplicate comment id={} — next invocation will retry",
-                comment.id
-            ));
-        }
-    }
-
-    let action = if patch_needed {
-        "pr.comment.section.update"
-    } else {
-        "pr.comment.section.noop"
-    };
-
-    Ok(GithubPrOutput {
-        component_id: id,
-        owner: repo.owner,
-        repo: repo.repo,
-        action: action.to_string(),
-        success: true,
-        number: Some(pr_number),
-        comment_id: Some(canonical_id),
-        warnings,
-        ..Default::default()
-    })
-}
-
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -1191,7 +837,7 @@ fn pr_comment_sectioned(
 /// runner workspace with a portable `homeboy.json` but no global component
 /// registry entry). When set, the component is discovered from the portable
 /// config at that path instead of the global registry.
-fn resolve_component_github(
+pub(super) fn resolve_component_github(
     component_id: Option<&str>,
     path_override: Option<&str>,
 ) -> Result<(String, GitHubRepo)> {
@@ -1254,7 +900,7 @@ pub fn gh_probe_succeeds(args: &[&str]) -> bool {
 /// Error out if `gh` is missing or unauthenticated. Unlike `run_github_release`
 /// (which soft-fails because the tag is already pushed), primitive operations
 /// have no already-committed side effect to preserve — fail loudly.
-fn ensure_gh_ready() -> Result<()> {
+pub(super) fn ensure_gh_ready() -> Result<()> {
     if !gh_probe_succeeds(&["--version"]) {
         return Err(Error::internal_io(
             "`gh` CLI not found on PATH".to_string(),
@@ -1276,7 +922,7 @@ fn ensure_gh_ready() -> Result<()> {
 
 /// Run `gh <args>` and return stdout on success, or a structured error on
 /// failure (with stderr captured in the error message).
-fn run_gh(args: &[String]) -> Result<String> {
+pub(super) fn run_gh(args: &[String]) -> Result<String> {
     let output = Command::new("gh")
         .args(args.iter().map(|s| s.as_str()))
         .output()
@@ -1300,84 +946,6 @@ fn run_gh(args: &[String]) -> Result<String> {
 
 fn parse_issue_number_from_url(url: &str) -> Option<u64> {
     url.trim_end_matches('/').rsplit('/').next()?.parse().ok()
-}
-
-fn marker_for_key(key: &str) -> String {
-    format!("<!-- homeboy:key={} -->", key)
-}
-
-/// Search a PR's issue-comments for one carrying our sticky marker.
-fn find_sticky_comment_id(repo: &GitHubRepo, pr_number: u64, key: &str) -> Result<Option<u64>> {
-    let marker = marker_for_key(key);
-    let args: Vec<String> = vec![
-        "api".into(),
-        format!(
-            "repos/{}/{}/issues/{}/comments?per_page=100",
-            repo.owner, repo.repo, pr_number
-        ),
-        "--paginate".into(),
-        "--jq".into(),
-        format!(".[] | select(.body | contains(\"{}\")) | .id", marker),
-    ];
-    let raw = run_gh(&args)?;
-    Ok(raw.lines().next().and_then(|l| l.trim().parse().ok()))
-}
-
-/// Minimal shape for a fetched PR comment (id + body).
-struct FetchedComment {
-    id: u64,
-    body: String,
-}
-
-/// List all PR issue-comments that carry the given comment-key marker. Returns
-/// `(id, body)` pairs so the merge step can parse each body.
-fn list_matching_comments(
-    repo: &GitHubRepo,
-    pr_number: u64,
-    comment_key: &str,
-) -> Result<Vec<FetchedComment>> {
-    let args: Vec<String> = vec![
-        "api".into(),
-        format!(
-            "repos/{}/{}/issues/{}/comments?per_page=100",
-            repo.owner, repo.repo, pr_number
-        ),
-        "--paginate".into(),
-    ];
-    let raw = run_gh(&args)?;
-    parse_comments_list_json(&raw, comment_key)
-}
-
-/// Parse `gh api --paginate issues/:n/comments` output and filter to those
-/// carrying the outer marker. With `--paginate`, `gh` concatenates JSON
-/// arrays (no separator between pages) — we re-parse as a stream.
-fn parse_comments_list_json(raw: &str, comment_key: &str) -> Result<Vec<FetchedComment>> {
-    #[derive(serde::Deserialize)]
-    struct RawComment {
-        id: u64,
-        body: Option<String>,
-    }
-
-    let mut out: Vec<FetchedComment> = Vec::new();
-
-    // `--paginate` output is one or more JSON arrays concatenated. Use a
-    // streaming deserializer to eat them in order.
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return Ok(out);
-    }
-    let de = serde_json::Deserializer::from_str(trimmed);
-    for value in de.into_iter::<Vec<RawComment>>() {
-        let page = value
-            .map_err(|e| Error::internal_json(e.to_string(), Some("gh api comments".into())))?;
-        for c in page {
-            let body = c.body.unwrap_or_default();
-            if comment_matches_key(&body, comment_key) {
-                out.push(FetchedComment { id: c.id, body });
-            }
-        }
-    }
-    Ok(out)
 }
 
 fn parse_issue_list_json(raw: &str, options: &IssueFindOptions) -> Result<Vec<GithubFindItem>> {
@@ -1493,14 +1061,6 @@ mod tests {
         assert_eq!(
             parse_issue_number_from_url("https://github.com/owner/repo/issues/not-a-number"),
             None
-        );
-    }
-
-    #[test]
-    fn marker_format_is_stable() {
-        assert_eq!(
-            marker_for_key("ci-status"),
-            "<!-- homeboy:key=ci-status -->"
         );
     }
 
@@ -1690,32 +1250,5 @@ mod tests {
         assert_eq!(items[0].state_reason, "");
         assert_eq!(items[0].closed_at, "");
         assert!(items[0].labels.is_empty());
-    }
-
-    #[test]
-    fn parse_comments_list_filters_by_key_and_handles_pagination() {
-        // Two pages: gh --paginate concatenates JSON arrays with no separator.
-        let raw = r#"[
-            {"id": 1, "body": "<!-- homeboy:comment-key=ci:x -->\nsection"},
-            {"id": 2, "body": "unrelated"}
-        ][
-            {"id": 3, "body": "<!-- homeboy:comment-key=ci:y -->\nother key"},
-            {"id": 4, "body": "<!-- homeboy:comment-key=other -->\nother"}
-        ]"#;
-        let got = parse_comments_list_json(raw, "ci:x").unwrap();
-        assert_eq!(got.len(), 1);
-        assert_eq!(got[0].id, 1);
-    }
-
-    #[test]
-    fn parse_comments_list_empty_input_is_ok() {
-        let got = parse_comments_list_json("", "ci:x").unwrap();
-        assert!(got.is_empty());
-    }
-
-    #[test]
-    fn pr_comment_mode_default_is_fresh() {
-        let opts = PrCommentOptions::default();
-        assert_eq!(opts.mode, PrCommentMode::Fresh);
     }
 }

--- a/src/core/git/github_pr_comments.rs
+++ b/src/core/git/github_pr_comments.rs
@@ -1,0 +1,460 @@
+//! GitHub pull-request comment helpers.
+
+use crate::core::deploy::release_download::GitHubRepo;
+use crate::core::error::{Error, Result};
+
+use super::github::{ensure_gh_ready, resolve_component_github, run_gh, GithubPrOutput};
+use super::github_comment_sections::{
+    comment_matches_key, extract_footer, extract_header, merge_section, parse_comment_sections,
+    render_comment,
+};
+
+/// Parameters for posting a (potentially sticky) PR comment.
+///
+/// Three shapes are supported, selected by `mode`:
+/// - [`PrCommentMode::Fresh`] — plain append, no marker, no find-or-update.
+/// - [`PrCommentMode::StickyWholeBody`] — single-section sticky (PR #1334
+///   semantics): prepend `<!-- homeboy:key=<key> -->` marker and update the
+///   one matching comment in place.
+/// - [`PrCommentMode::Sectioned`] — multi-section aggregation: a single shared
+///   comment carries `<!-- homeboy:comment-key=<outer> -->` and N section
+///   blocks delimited by `<!-- homeboy:section-key=<inner>:start|end -->`.
+///   Each invocation replaces its own inner section and leaves the others
+///   untouched. Handles race consolidation when parallel jobs raced to create
+///   the shared comment.
+#[derive(Debug, Clone)]
+pub struct PrCommentOptions {
+    pub number: u64,
+    pub body: String,
+    pub mode: PrCommentMode,
+    /// Optional workspace path. See `IssueCreateOptions::path`.
+    pub path: Option<String>,
+}
+
+impl Default for PrCommentOptions {
+    fn default() -> Self {
+        Self {
+            number: 0,
+            body: String::new(),
+            mode: PrCommentMode::Fresh,
+            path: None,
+        }
+    }
+}
+
+/// Which comment-posting flow to run. Mutually exclusive shapes.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum PrCommentMode {
+    /// Plain append. No marker. No find-or-update.
+    #[default]
+    Fresh,
+    /// Single-section sticky comment (PR #1334). The `body` is treated as the
+    /// whole comment body; the marker `<!-- homeboy:key=<key> -->` is prepended.
+    StickyWholeBody { key: String },
+    /// Multi-section aggregated sticky comment. `body` is ONE section's body;
+    /// it is merged under `section_key` into the comment carrying `comment_key`.
+    Sectioned {
+        /// Outer marker (one shared comment per PR per outer key).
+        comment_key: String,
+        /// Inner marker (one section per inner key within the shared comment).
+        section_key: String,
+        /// Optional header line written just after the outer marker on fresh
+        /// comments (e.g. `## Homeboy Results — \`<component>\``). Preserved
+        /// from existing comments on merge.
+        header: Option<String>,
+        /// Optional footer block written after the last section on fresh
+        /// comments (e.g. a `<details><summary>Tooling versions</summary>`
+        /// block). Preserved from existing comments on merge when the caller
+        /// does not pass one explicitly; overwritten when the caller does.
+        footer: Option<String>,
+        /// Optional explicit section ordering. Sections listed here come first
+        /// in the given order; any other sections are appended alphabetically.
+        /// `None` = pure alphabetical.
+        section_order: Option<Vec<String>>,
+    },
+}
+
+/// Post a comment on a PR.
+///
+/// Dispatches on [`PrCommentOptions::mode`]:
+/// - [`PrCommentMode::Fresh`] — plain append, no marker.
+/// - [`PrCommentMode::StickyWholeBody`] — find-or-update the one comment
+///   tagged `<!-- homeboy:key=<key> -->` (single-section sticky, PR #1334).
+/// - [`PrCommentMode::Sectioned`] — multi-section aggregation: merge this
+///   invocation's section under `section_key` into the shared comment tagged
+///   `<!-- homeboy:comment-key=<comment_key> -->`.
+pub fn pr_comment(component_id: Option<&str>, options: PrCommentOptions) -> Result<GithubPrOutput> {
+    let (id, repo) = resolve_component_github(component_id, options.path.as_deref())?;
+    ensure_gh_ready()?;
+
+    match options.mode.clone() {
+        PrCommentMode::Fresh => pr_comment_fresh(id, repo, options),
+        PrCommentMode::StickyWholeBody { key } => {
+            pr_comment_sticky_whole(id, repo, options.number, options.body, key)
+        }
+        PrCommentMode::Sectioned {
+            comment_key,
+            section_key,
+            header,
+            footer,
+            section_order,
+        } => pr_comment_sectioned(
+            id,
+            repo,
+            options.number,
+            options.body,
+            comment_key,
+            section_key,
+            header,
+            footer,
+            section_order,
+        ),
+    }
+}
+
+/// Plain append flow. Shared by `Fresh` mode and the "no existing comment"
+/// branch of the sticky flow.
+fn pr_comment_fresh(
+    id: String,
+    repo: GitHubRepo,
+    options: PrCommentOptions,
+) -> Result<GithubPrOutput> {
+    let repo_flag = format!("{}/{}", repo.owner, repo.repo);
+    let args: Vec<String> = vec![
+        "pr".into(),
+        "comment".into(),
+        options.number.to_string(),
+        "-R".into(),
+        repo_flag,
+        "--body".into(),
+        options.body,
+    ];
+    let output = run_gh(&args)?;
+    Ok(GithubPrOutput {
+        component_id: id,
+        owner: repo.owner,
+        repo: repo.repo,
+        action: "pr.comment.create".to_string(),
+        success: true,
+        number: Some(options.number),
+        url: Some(output.trim().to_string()),
+        ..Default::default()
+    })
+}
+
+/// Sticky single-section flow (PR #1334 semantics).
+fn pr_comment_sticky_whole(
+    id: String,
+    repo: GitHubRepo,
+    pr_number: u64,
+    body: String,
+    key: String,
+) -> Result<GithubPrOutput> {
+    let full_body = format!("{}\n{}", marker_for_key(&key), body);
+
+    if let Some(existing_id) = find_sticky_comment_id(&repo, pr_number, &key)? {
+        let args: Vec<String> = vec![
+            "api".into(),
+            format!(
+                "repos/{}/{}/issues/comments/{}",
+                repo.owner, repo.repo, existing_id
+            ),
+            "--method".into(),
+            "PATCH".into(),
+            "-f".into(),
+            format!("body={}", full_body),
+        ];
+        run_gh(&args)?;
+        return Ok(GithubPrOutput {
+            component_id: id,
+            owner: repo.owner,
+            repo: repo.repo,
+            action: "pr.comment.update".to_string(),
+            success: true,
+            number: Some(pr_number),
+            comment_id: Some(existing_id),
+            ..Default::default()
+        });
+    }
+
+    let repo_flag = format!("{}/{}", repo.owner, repo.repo);
+    let args: Vec<String> = vec![
+        "pr".into(),
+        "comment".into(),
+        pr_number.to_string(),
+        "-R".into(),
+        repo_flag,
+        "--body".into(),
+        full_body,
+    ];
+    let output = run_gh(&args)?;
+    Ok(GithubPrOutput {
+        component_id: id,
+        owner: repo.owner,
+        repo: repo.repo,
+        action: "pr.comment.create".to_string(),
+        success: true,
+        number: Some(pr_number),
+        url: Some(output.trim().to_string()),
+        ..Default::default()
+    })
+}
+
+/// Sectioned-comment flow.
+///
+/// Flow:
+/// 1. List the PR's issue-comments, filter to those carrying the comment-key
+///    marker.
+/// 2. If none: create one with a single section block.
+/// 3. If one: parse existing sections, merge this invocation's section, render.
+///    Byte-compare to the existing body — if equal, emit `pr.comment.section.noop`
+///    and skip the PATCH. Otherwise PATCH.
+/// 4. If many (race): pick lowest id as canonical, merge sections from ALL
+///    matching comments (current invocation wins last for duplicate keys),
+///    PATCH canonical, DELETE the rest. Failed DELETEs become warnings, not
+///    hard errors — the next invocation will consolidate.
+#[allow(clippy::too_many_arguments)]
+fn pr_comment_sectioned(
+    id: String,
+    repo: GitHubRepo,
+    pr_number: u64,
+    section_body: String,
+    comment_key: String,
+    section_key: String,
+    header: Option<String>,
+    footer: Option<String>,
+    section_order: Option<Vec<String>>,
+) -> Result<GithubPrOutput> {
+    let matches = list_matching_comments(&repo, pr_number, &comment_key)?;
+
+    if matches.is_empty() {
+        let sections: Vec<(String, String)> = vec![(section_key.clone(), section_body.clone())];
+        let rendered = render_comment(
+            &comment_key,
+            header.as_deref(),
+            &sections,
+            section_order.as_deref(),
+            footer.as_deref(),
+        );
+        let repo_flag = format!("{}/{}", repo.owner, repo.repo);
+        let args: Vec<String> = vec![
+            "pr".into(),
+            "comment".into(),
+            pr_number.to_string(),
+            "-R".into(),
+            repo_flag,
+            "--body".into(),
+            rendered,
+        ];
+        let output = run_gh(&args)?;
+        return Ok(GithubPrOutput {
+            component_id: id,
+            owner: repo.owner,
+            repo: repo.repo,
+            action: "pr.comment.section.create".to_string(),
+            success: true,
+            number: Some(pr_number),
+            url: Some(output.trim().to_string()),
+            ..Default::default()
+        });
+    }
+
+    let mut matches = matches;
+    matches.sort_by_key(|m| m.id);
+    let canonical_id = matches[0].id;
+    let canonical_body = matches[0].body.clone();
+
+    let mut merged: Vec<(String, String)> = Vec::new();
+    let mut discovered_header: Option<String> = header.clone();
+    let mut discovered_footer: Option<String> = footer.clone();
+    for comment in &matches {
+        let parsed = parse_comment_sections(&comment.body);
+        for (k, v) in parsed {
+            merged = merge_section(merged, &k, v);
+        }
+        if discovered_header.is_none() {
+            discovered_header = extract_header(&comment.body);
+        }
+        if discovered_footer.is_none() {
+            discovered_footer = extract_footer(&comment.body);
+        }
+    }
+    merged = merge_section(merged, &section_key, section_body);
+
+    let rendered = render_comment(
+        &comment_key,
+        discovered_header.as_deref(),
+        &merged,
+        section_order.as_deref(),
+        discovered_footer.as_deref(),
+    );
+
+    let patch_needed = rendered.trim_end() != canonical_body.trim_end();
+    let mut warnings: Vec<String> = Vec::new();
+
+    if patch_needed {
+        let args: Vec<String> = vec![
+            "api".into(),
+            format!(
+                "repos/{}/{}/issues/comments/{}",
+                repo.owner, repo.repo, canonical_id
+            ),
+            "--method".into(),
+            "PATCH".into(),
+            "-f".into(),
+            format!("body={}", rendered),
+        ];
+        run_gh(&args)?;
+    }
+
+    for comment in matches.iter().skip(1) {
+        let args: Vec<String> = vec![
+            "api".into(),
+            format!(
+                "repos/{}/{}/issues/comments/{}",
+                repo.owner, repo.repo, comment.id
+            ),
+            "--method".into(),
+            "DELETE".into(),
+        ];
+        if run_gh(&args).is_err() {
+            warnings.push(format!(
+                "failed to delete duplicate comment id={} — next invocation will retry",
+                comment.id
+            ));
+        }
+    }
+
+    let action = if patch_needed {
+        "pr.comment.section.update"
+    } else {
+        "pr.comment.section.noop"
+    };
+
+    Ok(GithubPrOutput {
+        component_id: id,
+        owner: repo.owner,
+        repo: repo.repo,
+        action: action.to_string(),
+        success: true,
+        number: Some(pr_number),
+        comment_id: Some(canonical_id),
+        warnings,
+        ..Default::default()
+    })
+}
+
+fn marker_for_key(key: &str) -> String {
+    format!("<!-- homeboy:key={} -->", key)
+}
+
+/// Search a PR's issue-comments for one carrying our sticky marker.
+fn find_sticky_comment_id(repo: &GitHubRepo, pr_number: u64, key: &str) -> Result<Option<u64>> {
+    let marker = marker_for_key(key);
+    let args: Vec<String> = vec![
+        "api".into(),
+        format!(
+            "repos/{}/{}/issues/{}/comments?per_page=100",
+            repo.owner, repo.repo, pr_number
+        ),
+        "--paginate".into(),
+        "--jq".into(),
+        format!(".[] | select(.body | contains(\"{}\")) | .id", marker),
+    ];
+    let raw = run_gh(&args)?;
+    Ok(raw.lines().next().and_then(|l| l.trim().parse().ok()))
+}
+
+/// Minimal shape for a fetched PR comment (id + body).
+struct FetchedComment {
+    id: u64,
+    body: String,
+}
+
+/// List all PR issue-comments that carry the given comment-key marker. Returns
+/// `(id, body)` pairs so the merge step can parse each body.
+fn list_matching_comments(
+    repo: &GitHubRepo,
+    pr_number: u64,
+    comment_key: &str,
+) -> Result<Vec<FetchedComment>> {
+    let args: Vec<String> = vec![
+        "api".into(),
+        format!(
+            "repos/{}/{}/issues/{}/comments?per_page=100",
+            repo.owner, repo.repo, pr_number
+        ),
+        "--paginate".into(),
+    ];
+    let raw = run_gh(&args)?;
+    parse_comments_list_json(&raw, comment_key)
+}
+
+/// Parse `gh api --paginate issues/:n/comments` output and filter to those
+/// carrying the outer marker. With `--paginate`, `gh` concatenates JSON arrays
+/// (no separator between pages), so we re-parse as a stream.
+fn parse_comments_list_json(raw: &str, comment_key: &str) -> Result<Vec<FetchedComment>> {
+    #[derive(serde::Deserialize)]
+    struct RawComment {
+        id: u64,
+        body: Option<String>,
+    }
+
+    let mut out: Vec<FetchedComment> = Vec::new();
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(out);
+    }
+
+    let de = serde_json::Deserializer::from_str(trimmed);
+    for value in de.into_iter::<Vec<RawComment>>() {
+        let page = value
+            .map_err(|e| Error::internal_json(e.to_string(), Some("gh api comments".into())))?;
+        for c in page {
+            let body = c.body.unwrap_or_default();
+            if comment_matches_key(&body, comment_key) {
+                out.push(FetchedComment { id: c.id, body });
+            }
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn marker_format_is_stable() {
+        assert_eq!(
+            marker_for_key("ci-status"),
+            "<!-- homeboy:key=ci-status -->"
+        );
+    }
+
+    #[test]
+    fn parse_comments_list_filters_by_key_and_handles_pagination() {
+        let raw = r#"[
+            {"id": 1, "body": "<!-- homeboy:comment-key=ci:x -->\nsection"},
+            {"id": 2, "body": "unrelated"}
+        ][
+            {"id": 3, "body": "<!-- homeboy:comment-key=ci:y -->\nother key"},
+            {"id": 4, "body": "<!-- homeboy:comment-key=other -->\nother"}
+        ]"#;
+        let got = parse_comments_list_json(raw, "ci:x").unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].id, 1);
+    }
+
+    #[test]
+    fn parse_comments_list_empty_input_is_ok() {
+        let got = parse_comments_list_json("", "ci:x").unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn pr_comment_mode_default_is_fresh() {
+        let opts = PrCommentOptions::default();
+        assert_eq!(opts.mode, PrCommentMode::Fresh);
+    }
+}

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -2,6 +2,7 @@ mod changes;
 mod commits;
 mod github;
 mod github_comment_sections;
+mod github_pr_comments;
 mod operation_output;
 mod operations;
 mod pr_policy;
@@ -22,13 +23,13 @@ pub use commits::{
     CommitInfo, MonorepoContext, SemverBump,
 };
 pub use github::{
-    gh_probe_succeeds, issue_close, issue_comment, issue_create, issue_edit, issue_find,
-    pr_comment, pr_create, pr_edit, pr_files, pr_find, pr_merge, pr_view, GithubFindItem,
-    GithubFindOutput, GithubIssueOutput, GithubPrOutput, GithubPrView, IssueCloseOptions,
-    IssueCloseReason, IssueCommentOptions, IssueCreateOptions, IssueEditOptions, IssueFindOptions,
-    IssueState, PrCommentMode, PrCommentOptions, PrCreateOptions, PrEditOptions, PrFindOptions,
-    PrMergeOptions, PrState,
+    gh_probe_succeeds, issue_close, issue_comment, issue_create, issue_edit, issue_find, pr_create,
+    pr_edit, pr_files, pr_find, pr_merge, pr_view, GithubFindItem, GithubFindOutput,
+    GithubIssueOutput, GithubPrOutput, GithubPrView, IssueCloseOptions, IssueCloseReason,
+    IssueCommentOptions, IssueCreateOptions, IssueEditOptions, IssueFindOptions, IssueState,
+    PrCreateOptions, PrEditOptions, PrFindOptions, PrMergeOptions, PrState,
 };
+pub use github_pr_comments::{pr_comment, PrCommentMode, PrCommentOptions};
 pub use operation_output::GitOutput;
 pub use operations::{
     build_repo_baseline_snapshot, changes, changes_at, changes_bulk, changes_project,


### PR DESCRIPTION
## Summary
- Extract GitHub PR comment mode/types, sticky comment helpers, sectioned comment helpers, and comment parsing tests into `github_pr_comments`.
- Keep the existing `core::git` public re-exports intact while reducing `src/core/git/github.rs` below the warning-level `god_file` line threshold.

## Verification
- `cargo fmt --check`
- `cargo test core::git::github`
- `cargo test core::git::github_pr_comments`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@refactor-github-god-file-slice --extension rust --only god_file --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused module extraction and ran local formatting, tests, and audit verification; Chris remains responsible for review and merge.