### PR TITLE
Record Lab offload provenance metadata

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -72,6 +72,8 @@ Hot commands that support Lab offload (`audit`, full `lint`, `test`, `bench run`
 - If the auto-selected runner is disconnected, Homeboy attempts a short bounded `runner connect` before execution. Connection failure prints the reason and falls back to local execution.
 - Explicit `--runner <id>` also attempts to connect a disconnected runner, but connection failure remains a command error instead of falling back silently.
 
+Observation metadata records the routing decision under `metadata.lab_offload` when an observed run is created. `source` is `automatic` or `explicit`; `status` is `offloaded`, `skipped`, or `fallback`; and successful offloads include `runner_id` plus `remote_workspace`. Local fallback records the runner and `fallback_reason`, while skipped local execution records why no automatic offload was used, such as `force_hot` or `no_default_runner`.
+
 Configure a preferred Lab runner with:
 
 ```sh

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -629,6 +629,7 @@ fn exec(
             cwd,
             allow_ssh,
             command,
+            env: Default::default(),
             capture_patch,
             source_snapshot: None,
         },

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -22,7 +22,9 @@ pub use records::{
     NewTriageItemRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord,
     TriageItemRecord, TriagePullRequestSignals,
 };
-pub use store::{ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION};
+pub use store::{
+    ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION, LAB_OFFLOAD_METADATA_ENV,
+};
 pub use timeline::{
     ObservationEvent, ObservationPhaseMilestone, ObservationSpanDefinition, ObservationSpanResult,
     ObservationSpanStatus,

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -18,6 +18,7 @@ use super::records::{
 use crate::core::{paths, Error, Result};
 
 pub const CURRENT_SCHEMA_VERSION: i64 = 5;
+pub const LAB_OFFLOAD_METADATA_ENV: &str = "HOMEBOY_LAB_OFFLOAD_JSON";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ObservationDbStatus {
@@ -802,23 +803,34 @@ fn with_run_owner_metadata(mut metadata: serde_json::Value) -> serde_json::Value
     let source_snapshot = std::env::var("HOMEBOY_SOURCE_SNAPSHOT_JSON")
         .ok()
         .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok());
+    let lab_offload = std::env::var(LAB_OFFLOAD_METADATA_ENV)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok());
 
-    if let Some(object) = metadata.as_object_mut() {
-        object.insert("homeboy_run_owner".to_string(), owner);
-        if let Some(source_snapshot) = source_snapshot {
-            object.insert("source_snapshot".to_string(), source_snapshot);
+    let mut additions = vec![("homeboy_run_owner".to_string(), owner)];
+    if let Some(source_snapshot) = source_snapshot {
+        additions.push(("source_snapshot".to_string(), source_snapshot));
+    }
+    if let Some(lab_offload) = lab_offload {
+        additions.push(("lab_offload".to_string(), lab_offload));
+    }
+
+    let target = if metadata.is_object() {
+        &mut metadata
+    } else {
+        metadata = serde_json::json!({
+            "homeboy_original_metadata": metadata,
+        });
+        &mut metadata
+    };
+
+    if let Some(object) = target.as_object_mut() {
+        for (key, value) in additions {
+            object.insert(key, value);
         }
-        return metadata;
     }
 
-    let mut wrapped = serde_json::json!({
-        "homeboy_run_owner": owner,
-        "homeboy_original_metadata": metadata,
-    });
-    if let (Some(object), Some(source_snapshot)) = (wrapped.as_object_mut(), source_snapshot) {
-        object.insert("source_snapshot".to_string(), source_snapshot);
-    }
-    wrapped
+    metadata
 }
 
 fn parse_metadata(raw: String) -> rusqlite::Result<serde_json::Value> {
@@ -1119,6 +1131,27 @@ mod api_coverage_tests {
             std::env::remove_var("HOMEBOY_SOURCE_SNAPSHOT_JSON");
 
             assert_eq!(run.metadata_json["source_snapshot"], snapshot);
+        });
+    }
+
+    #[test]
+    fn test_start_run_records_lab_offload_metadata_from_environment() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let lab = serde_json::json!({
+                "source": "automatic",
+                "status": "fallback",
+                "runner_id": "lab",
+                "remote_workspace": null,
+                "fallback_reason": "runner connect timed out after 3s"
+            });
+
+            std::env::set_var(LAB_OFFLOAD_METADATA_ENV, lab.to_string());
+            let run = store.start_run(new_run("test")).expect("start");
+            std::env::remove_var(LAB_OFFLOAD_METADATA_ENV);
+
+            assert_eq!(run.metadata_json["lab_offload"], lab);
         });
     }
 

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use reqwest::blocking::Client;
@@ -18,6 +19,7 @@ pub struct RunnerExecOptions {
     pub cwd: Option<String>,
     pub allow_ssh: bool,
     pub command: Vec<String>,
+    pub env: HashMap<String, String>,
     pub capture_patch: bool,
     pub source_snapshot: Option<SourceSnapshot>,
 }
@@ -82,6 +84,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
                 &session.local_url,
                 cwd,
                 options.command,
+                options.env,
                 options.capture_patch,
                 options.source_snapshot,
             );
@@ -89,8 +92,8 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
     }
 
     match runner.kind {
-        RunnerKind::Local => exec_local(&runner, cwd, options.command),
-        RunnerKind::Ssh if options.allow_ssh => exec_ssh(&runner, cwd, options.command),
+        RunnerKind::Local => exec_local(&runner, cwd, options.command, options.env),
+        RunnerKind::Ssh if options.allow_ssh => exec_ssh(&runner, cwd, options.command, options.env),
         RunnerKind::Ssh => Err(Error::validation_invalid_argument(
             "runner",
             "runner is not connected to a daemon; run `homeboy runner connect <runner-id>` or pass `--ssh` for explicit SSH diagnostics",
@@ -108,6 +111,7 @@ fn exec_via_daemon(
     local_url: &str,
     cwd: String,
     command: Vec<String>,
+    env: HashMap<String, String>,
     capture_patch: bool,
     source_snapshot_override: Option<SourceSnapshot>,
 ) -> Result<(RunnerExecOutput, i32)> {
@@ -118,13 +122,15 @@ fn exec_via_daemon(
     let source_snapshot = source_snapshot_override.unwrap_or_else(|| {
         SourceSnapshot::existing_remote(&runner.id, &cwd, runner.workspace_root.as_deref())
     });
+    let mut request_env = runner.env.clone();
+    request_env.extend(env);
     let response = client
         .post(format!("{}/exec", local_url.trim_end_matches('/')))
         .json(&json!({
             "runner_id": runner.id,
             "cwd": cwd,
             "command": command,
-            "env": runner.env,
+            "env": request_env,
             "capture_patch": capture_patch,
             "source_snapshot": source_snapshot,
         }))
@@ -276,11 +282,13 @@ fn exec_local(
     runner: &Runner,
     cwd: String,
     command: Vec<String>,
+    env: HashMap<String, String>,
 ) -> Result<(RunnerExecOutput, i32)> {
     let output = command_output(
         std::process::Command::new(&command[0])
             .args(&command[1..])
-            .current_dir(&cwd),
+            .current_dir(&cwd)
+            .envs(env),
     )?;
     let source_snapshot = SourceSnapshot::collect_local(
         &runner.id,
@@ -298,7 +306,12 @@ fn exec_local(
     ))
 }
 
-fn exec_ssh(runner: &Runner, cwd: String, command: Vec<String>) -> Result<(RunnerExecOutput, i32)> {
+fn exec_ssh(
+    runner: &Runner,
+    cwd: String,
+    command: Vec<String>,
+    env: HashMap<String, String>,
+) -> Result<(RunnerExecOutput, i32)> {
     let server_id = runner.server_id.as_deref().ok_or_else(|| {
         Error::validation_invalid_argument(
             "server_id",
@@ -310,6 +323,7 @@ fn exec_ssh(runner: &Runner, cwd: String, command: Vec<String>) -> Result<(Runne
     let server = server::load(server_id)?;
     let mut client = SshClient::from_server(&server, server_id)?;
     client.env.extend(runner.env.clone());
+    client.env.extend(env);
     let command_line = format!(
         "cd {} && {}",
         shell::quote_arg(&cwd),
@@ -498,6 +512,7 @@ mod tests {
                     cwd: None,
                     allow_ssh: false,
                     command: vec!["sh".to_string(), "-c".to_string(), "printf ok".to_string()],
+                    env: Default::default(),
                     capture_patch: false,
                     source_snapshot: None,
                 },

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -13,6 +13,7 @@ mod apply;
 mod connection;
 mod evidence;
 mod execution;
+mod offload_metadata;
 mod workspace;
 
 pub use apply::{
@@ -28,6 +29,7 @@ pub use evidence::{
 };
 pub(crate) use execution::daemon_api_get;
 pub use execution::{exec, RunnerExecMode, RunnerExecOptions, RunnerExecOutput};
+pub use offload_metadata::{capture_lab_offload_metadata, lab_offload_metadata};
 pub use workspace::{
     sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };

--- a/src/core/runner/offload_metadata.rs
+++ b/src/core/runner/offload_metadata.rs
@@ -1,0 +1,69 @@
+pub fn lab_offload_metadata(
+    source: &str,
+    runner_id: Option<&str>,
+    status: &str,
+    remote_workspace: Option<&str>,
+    fallback_reason: Option<&str>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "source": source,
+        "status": status,
+        "runner_id": runner_id,
+        "remote_workspace": remote_workspace,
+        "fallback_reason": fallback_reason,
+    })
+}
+
+pub fn capture_lab_offload_metadata(metadata: serde_json::Value) {
+    if let Ok(raw) = serde_json::to_string(&metadata) {
+        std::env::set_var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV, raw);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lab_offload_metadata;
+
+    #[test]
+    fn lab_offload_metadata_records_explicit_auto_skipped_and_fallback_states() {
+        let explicit = lab_offload_metadata(
+            "explicit",
+            Some("lab-explicit"),
+            "offloaded",
+            Some("/srv/homeboy/project"),
+            None,
+        );
+        assert_eq!(explicit["source"], "explicit");
+        assert_eq!(explicit["status"], "offloaded");
+        assert_eq!(explicit["runner_id"], "lab-explicit");
+        assert_eq!(explicit["remote_workspace"], "/srv/homeboy/project");
+        assert!(explicit["fallback_reason"].is_null());
+
+        let fallback = lab_offload_metadata(
+            "automatic",
+            Some("lab"),
+            "fallback",
+            None,
+            Some("runner connect timed out after 3s"),
+        );
+        assert_eq!(fallback["source"], "automatic");
+        assert_eq!(fallback["status"], "fallback");
+        assert_eq!(fallback["runner_id"], "lab");
+        assert_eq!(
+            fallback["fallback_reason"],
+            "runner connect timed out after 3s"
+        );
+
+        let skipped = lab_offload_metadata(
+            "automatic",
+            None,
+            "skipped",
+            None,
+            Some("no_default_runner"),
+        );
+        assert_eq!(skipped["source"], "automatic");
+        assert_eq!(skipped["status"], "skipped");
+        assert!(skipped["runner_id"].is_null());
+        assert_eq!(skipped["fallback_reason"], "no_default_runner");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,7 @@ fn main() -> std::process::ExitCode {
                     let capture_patch = cli.command.lab_offload_mutation_flag().is_some();
                     return run_lab_offload(
                         &selection.runner_id,
+                        selection.source,
                         &cli.command,
                         &normalized,
                         output_file.as_deref(),
@@ -189,6 +190,18 @@ fn main() -> std::process::ExitCode {
                     );
                 }
                 Ok(LabRunnerPreparation::FallBackLocal { reason }) => {
+                    homeboy::core::runner::capture_lab_offload_metadata(
+                        homeboy::core::runner::lab_offload_metadata(
+                            match selection.source {
+                                LabRunnerSelectionSource::Explicit => "explicit",
+                                LabRunnerSelectionSource::Default => "automatic",
+                            },
+                            Some(&selection.runner_id),
+                            "fallback",
+                            None,
+                            Some(&reason),
+                        ),
+                    );
                     eprintln!("Lab offload: {reason}; running locally.");
                     // Continue into the normal local command path below.
                 }
@@ -198,7 +211,23 @@ fn main() -> std::process::ExitCode {
                 }
             }
         }
-        Ok(None) => {}
+        Ok(None) => {
+            if cli.command.supports_lab_runner() {
+                homeboy::core::runner::capture_lab_offload_metadata(
+                    homeboy::core::runner::lab_offload_metadata(
+                        "automatic",
+                        None,
+                        "skipped",
+                        None,
+                        Some(if cli.force_hot {
+                            "force_hot"
+                        } else {
+                            "no_default_runner"
+                        }),
+                    ),
+                );
+            }
+        }
         Err(err) => {
             emit_json_result(Err(err), output_file.as_deref(), 2);
             return std::process::ExitCode::from(exit_code_to_u8(2));
@@ -535,6 +564,7 @@ fn emit_json_result(
 
 fn run_lab_offload(
     runner_id: &str,
+    source: LabRunnerSelectionSource,
     command: &Commands,
     normalized_args: &[String],
     output_file: Option<&str>,
@@ -542,6 +572,7 @@ fn run_lab_offload(
 ) -> std::process::ExitCode {
     match run_lab_offload_inner(
         runner_id,
+        source,
         command,
         normalized_args,
         output_file,
@@ -559,6 +590,7 @@ fn run_lab_offload(
 
 fn run_lab_offload_inner(
     runner_id: &str,
+    source: LabRunnerSelectionSource,
     command_kind: &Commands,
     normalized_args: &[String],
     output_file: Option<&str>,
@@ -632,12 +664,28 @@ fn run_lab_offload_inner(
         runner_id,
         remote_cwd
     );
+    let lab_metadata = homeboy::core::runner::lab_offload_metadata(
+        match source {
+            LabRunnerSelectionSource::Explicit => "explicit",
+            LabRunnerSelectionSource::Default => "automatic",
+        },
+        Some(runner_id),
+        "offloaded",
+        Some(&remote_cwd),
+        None,
+    );
+    let mut env = std::collections::HashMap::new();
+    env.insert(
+        homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV.to_string(),
+        serde_json::to_string(&lab_metadata).unwrap_or_default(),
+    );
     let (exec_output, exit_code) = homeboy::core::runner::exec(
         runner_id,
         homeboy::core::runner::RunnerExecOptions {
             cwd: Some(remote_cwd),
             allow_ssh: false,
             command,
+            env,
             capture_patch,
             source_snapshot: Some(source_snapshot),
         },
@@ -703,6 +751,7 @@ fn preflight_lab_offload_test_extensions(
                     "show".to_string(),
                     extension_id.clone(),
                 ],
+                env: Default::default(),
                 capture_patch: false,
                 source_snapshot: None,
             },


### PR DESCRIPTION
## Summary
- Records Lab offload routing decisions in observation metadata for offloaded, skipped, and fallback runs.
- Threads per-exec environment overrides through runner daemon/local/SSH paths so remote observed runs can persist the same provenance.
- Documents the `metadata.lab_offload` shape for runner-backed hot commands.

Fixes #2810

## Testing
- `cargo fmt --check`
- `cargo test test_start_run_records_lab_offload_metadata_from_environment`
- `cargo test lab_offload_metadata_records_explicit_auto_skipped_and_fallback_states`
- `homeboy audit --path /Users/chubes/Developer/homeboy@fix-lab-auto-offload-provenance --extension rust --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-lab-auto-offload-provenance --extension rust --changed-since origin/main`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-lab-auto-offload-provenance --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, tests, docs, and local verification commands; Chris remains responsible for review and merge.