### PR TITLE
Document Lab offload support boundaries

### DIFF
--- a/docs/commands/fleet.md
+++ b/docs/commands/fleet.md
@@ -131,6 +131,14 @@ Returns per-project status with:
 
 Summary includes counts for quick overview.
 
+### `exec`
+
+```sh
+homeboy fleet exec <id> -- <command>
+```
+
+Runs a command across projects in the fleet via each project's configured SSH connection. `fleet exec` participates in resource-policy warnings because it can create heavy remote work, but it intentionally stays local for Lab offload: the command depends on local fleet, project, and server configuration before opening those SSH sessions, and runner-side config parity is not guaranteed.
+
 ### `sync` (deprecated)
 
 > **Deprecated.** Use `homeboy deploy` to sync files across servers instead. Register shared configs as components and deploy them like any other component. See [#101](https://github.com/Extra-Chill/homeboy/issues/101).

--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -76,6 +76,9 @@ Runs the `up` pipeline. Mutating rig commands acquire a resource lease first whe
 `rig up` also participates in resource-policy warnings. If the machine is
 already warm or hot, Homeboy warns on stderr before adding more load. The warning
 is advisory only; use global `--force-hot` when the extra pressure is expected.
+`rig up` intentionally stays local for Lab offload: the pipeline can manage local
+services, leases, ports, and declared filesystem paths that are not portable
+through the current single-workspace runner snapshot.
 
 The pipeline can start services, run typed `git` / `build` / `extension` / `stack` steps, apply idempotent local patches, create symlinks/shared paths, and run checks.
 

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -74,6 +74,20 @@ Hot commands that support Lab offload (`audit`, full `lint`, `test`, `bench run`
 
 Observation metadata records the routing decision under `metadata.lab_offload` when an observed run is created. `source` is `automatic` or `explicit`; `status` is `offloaded`, `skipped`, or `fallback`; and successful offloads include `runner_id` plus `remote_workspace`. Local fallback records the runner and `fallback_reason`, while skipped local execution records why no automatic offload was used, such as `force_hot` or `no_default_runner`.
 
+Lab offload support is intentionally command-specific:
+
+| Command | Auto offload | Explicit `--runner` | Decision |
+|---|---:|---:|---|
+| `audit` full workspace | Yes | Yes | Safe single-workspace replay after snapshot sync. |
+| `bench run` / default bench run | Yes | Yes | Safe single-workspace replay; local baseline/ratchet writes are treated as mutation flags. |
+| `lint` full workspace | Yes | Yes | Safe single-workspace replay; `--fix` is treated as a mutation flag. |
+| `test` full workspace | Yes | Yes | Safe single-workspace replay with runner extension parity preflight. |
+| `trace` | Yes | Yes | Safe single-workspace replay with Playwright/browser capability gate. |
+| `rig up` | No | No | Stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace snapshot cannot safely mirror. |
+| `fleet exec` | No | No | Stays local because fleet execution depends on local fleet/project/server config before opening SSH sessions to each project; runner-side config parity is not guaranteed. |
+
+Unsupported hot commands still get resource-policy warnings, but those warnings explain why Lab offload is unavailable instead of suggesting `--runner`.
+
 Configure a preferred Lab runner with:
 
 ```sh

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -198,6 +198,18 @@ impl Commands {
         }
     }
 
+    pub fn lab_runner_unsupported_reason(&self) -> Option<&'static str> {
+        match self {
+            Commands::Rig(args) if args.is_hot_resource_command() => Some(
+                "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.",
+            ),
+            Commands::Fleet(args) if args.is_hot_resource_command() => Some(
+                "`fleet exec` stays local because it depends on local fleet, project, and server configuration before opening SSH sessions to each project; runner-side config parity is not guaranteed.",
+            ),
+            _ => None,
+        }
+    }
+
     pub fn lab_offload_mutation_flag(&self) -> Option<&'static str> {
         match self {
             Commands::Bench(args) if args.lab_offload_writes_local_state() => {
@@ -523,12 +535,34 @@ mod tests {
         assert!(parsed_command(&["homeboy", "audit"]).supports_lab_runner());
         assert!(parsed_command(&["homeboy", "bench"]).supports_lab_runner());
         assert!(parsed_command(&["homeboy", "trace"]).supports_lab_runner());
+        assert!(!parsed_command(&["homeboy", "rig", "up", "studio"]).supports_lab_runner());
+        assert!(
+            !parsed_command(&["homeboy", "fleet", "exec", "prod", "wp", "plugin", "list"])
+                .supports_lab_runner()
+        );
         assert!(!parsed_command(&["homeboy", "status"]).supports_lab_runner());
         assert!(!parsed_command(&["homeboy", "bench", "list"]).supports_lab_runner());
 
         let cli = parsed_cli(&["homeboy", "lint", "--runner", "lab-a"]);
         assert_eq!(cli.runner.as_deref(), Some("lab-a"));
         assert!(cli.command.supports_lab_runner());
+    }
+
+    #[test]
+    fn test_lab_runner_unsupported_hot_command_reasons() {
+        assert!(parsed_command(&["homeboy", "rig", "up", "studio"])
+            .lab_runner_unsupported_reason()
+            .expect("rig up reason")
+            .contains("single-workspace Lab snapshot"));
+        assert!(
+            parsed_command(&["homeboy", "fleet", "exec", "prod", "wp", "plugin", "list"])
+                .lab_runner_unsupported_reason()
+                .expect("fleet exec reason")
+                .contains("config parity")
+        );
+        assert!(parsed_command(&["homeboy", "status"])
+            .lab_runner_unsupported_reason()
+            .is_none());
     }
 
     #[test]

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -916,10 +916,10 @@ mod tests {
             resource_policy::reset_captured_context_for_test();
 
             let synthetic = synthetic_resources(ResourceRecommendation::Hot);
-            let warning = resource_policy::evaluate(HotCommand { label: "bench" }, &synthetic)
+            let warning = resource_policy::evaluate(HotCommand::lab_supported("bench"), &synthetic)
                 .expect("synthetic warning");
             resource_policy::capture_context(ResourcePolicyContext::from_evaluation(
-                HotCommand { label: "bench" },
+                HotCommand::lab_supported("bench"),
                 &synthetic,
                 Some(&warning),
                 false,
@@ -983,10 +983,10 @@ mod tests {
             resource_policy::reset_captured_context_for_test();
 
             let synthetic = synthetic_resources(ResourceRecommendation::Hot);
-            let warning = resource_policy::evaluate(HotCommand { label: "bench" }, &synthetic)
+            let warning = resource_policy::evaluate(HotCommand::lab_supported("bench"), &synthetic)
                 .expect("synthetic warning");
             resource_policy::capture_context(ResourcePolicyContext::from_evaluation(
-                HotCommand { label: "bench" },
+                HotCommand::lab_supported("bench"),
                 &synthetic,
                 Some(&warning),
                 true,

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -11,6 +11,26 @@ use crate::commands::runner::doctor::RunnerDoctorOutput;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HotCommand {
     pub label: &'static str,
+    pub lab_offload_supported: bool,
+    pub lab_offload_unsupported_reason: Option<&'static str>,
+}
+
+impl HotCommand {
+    pub fn lab_supported(label: &'static str) -> Self {
+        Self {
+            label,
+            lab_offload_supported: true,
+            lab_offload_unsupported_reason: None,
+        }
+    }
+
+    fn local_only(label: &'static str, reason: Option<&'static str>) -> Self {
+        Self {
+            label,
+            lab_offload_supported: false,
+            lab_offload_unsupported_reason: reason,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -251,20 +271,23 @@ pub fn reset_captured_context_for_test() {
 }
 
 pub fn hot_command(command: &Commands) -> Option<HotCommand> {
-    match command {
-        Commands::Bench(args) if args.is_run_command() => Some(HotCommand { label: "bench" }),
-        Commands::Rig(args) if args.is_hot_resource_command() => {
-            Some(HotCommand { label: "rig up" })
-        }
-        Commands::Fleet(args) if args.is_hot_resource_command() => Some(HotCommand {
-            label: "fleet exec",
-        }),
-        Commands::Audit(args) if args.changed_since.is_none() && !args.conventions => {
-            Some(HotCommand { label: "audit" })
-        }
-        Commands::Lint(args) if args.is_full_workspace_run() => Some(HotCommand { label: "lint" }),
-        Commands::Test(args) if args.changed_since.is_none() => Some(HotCommand { label: "test" }),
-        _ => None,
+    let label = match command {
+        Commands::Bench(args) if args.is_run_command() => "bench",
+        Commands::Rig(args) if args.is_hot_resource_command() => "rig up",
+        Commands::Fleet(args) if args.is_hot_resource_command() => "fleet exec",
+        Commands::Audit(args) if args.changed_since.is_none() && !args.conventions => "audit",
+        Commands::Lint(args) if args.is_full_workspace_run() => "lint",
+        Commands::Test(args) if args.changed_since.is_none() => "test",
+        _ => return None,
+    };
+
+    if command.supports_lab_runner() {
+        Some(HotCommand::lab_supported(label))
+    } else {
+        Some(HotCommand::local_only(
+            label,
+            command.lab_runner_unsupported_reason(),
+        ))
     }
 }
 
@@ -416,20 +439,31 @@ pub fn evaluate(command: HotCommand, resources: &DoctorOutput) -> Option<Resourc
         recommendation => Some(ResourcePolicyWarning {
             command: command.label,
             recommendation,
-            message: warning_message(command.label, recommendation, resources),
+            message: warning_message(command, recommendation, resources),
         }),
     }
 }
 
 fn warning_message(
-    command: &'static str,
+    command: HotCommand,
     recommendation: ResourceRecommendation,
     resources: &DoctorOutput,
 ) -> String {
     let severity = severity_str(recommendation);
     let reason = primary_reason(resources);
+    if command.lab_offload_supported {
+        return format!(
+            "Resource policy warning: machine is {severity}; starting `{}` may skew results or add pressure. {reason} Connect a default Homeboy Lab runner or use --runner <id> to offload this hot command, or use --force-hot to run locally without this warning.",
+            command.label
+        );
+    }
+
+    let local_only_reason = command
+        .lab_offload_unsupported_reason
+        .unwrap_or("This hot command does not have a portable Lab offload contract yet.");
     format!(
-        "Resource policy warning: machine is {severity}; starting `{command}` may skew results or add pressure. {reason} Connect a default Homeboy Lab runner or use --runner <id> to offload this hot command, or use --force-hot to run locally without this warning."
+        "Resource policy warning: machine is {severity}; starting `{}` may skew results or add pressure. {reason} {local_only_reason} Use --force-hot to run locally without this warning.",
+        command.label
     )
 }
 
@@ -542,10 +576,26 @@ mod tests {
         }
     }
 
+    fn lab_supported_hot(label: &'static str) -> HotCommand {
+        HotCommand {
+            label,
+            lab_offload_supported: true,
+            lab_offload_unsupported_reason: None,
+        }
+    }
+
+    fn local_only_hot(label: &'static str, reason: &'static str) -> HotCommand {
+        HotCommand {
+            label,
+            lab_offload_supported: false,
+            lab_offload_unsupported_reason: Some(reason),
+        }
+    }
+
     #[test]
     fn warns_when_hot_command_runs_on_warm_or_hot_machine() {
         let warning = evaluate(
-            HotCommand { label: "bench" },
+            lab_supported_hot("bench"),
             &resources(ResourceRecommendation::Hot),
         )
         .expect("hot machines warn");
@@ -556,16 +606,29 @@ mod tests {
         assert!(warning.message.contains("Load average is 9.0"));
 
         assert!(evaluate(
-            HotCommand { label: "bench" },
+            lab_supported_hot("bench"),
             &resources(ResourceRecommendation::Warm)
         )
         .is_some());
     }
 
     #[test]
+    fn warning_for_local_only_hot_command_explains_runner_unavailability() {
+        let warning = evaluate(
+            local_only_hot("rig up", "`rig up` stays local for test reasons."),
+            &resources(ResourceRecommendation::Hot),
+        )
+        .expect("hot machines warn");
+
+        assert!(warning.message.contains("`rig up` stays local"));
+        assert!(warning.message.contains("--force-hot"));
+        assert!(!warning.message.contains("--runner <id>"));
+    }
+
+    #[test]
     fn does_not_warn_when_machine_is_ok() {
         assert!(evaluate(
-            HotCommand { label: "bench" },
+            lab_supported_hot("bench"),
             &resources(ResourceRecommendation::Ok)
         )
         .is_none());
@@ -574,9 +637,9 @@ mod tests {
     #[test]
     fn context_records_severity_warning_and_host_snapshot_when_hot() {
         let resources = resources(ResourceRecommendation::Hot);
-        let warning = evaluate(HotCommand { label: "bench" }, &resources).expect("warning");
+        let warning = evaluate(lab_supported_hot("bench"), &resources).expect("warning");
         let context = ResourcePolicyContext::from_evaluation(
-            HotCommand { label: "bench" },
+            lab_supported_hot("bench"),
             &resources,
             Some(&warning),
             false,
@@ -604,9 +667,9 @@ mod tests {
     #[test]
     fn context_records_force_hot_bypass_for_hot_machine() {
         let resources = resources(ResourceRecommendation::Hot);
-        let warning = evaluate(HotCommand { label: "bench" }, &resources).expect("warning");
+        let warning = evaluate(lab_supported_hot("bench"), &resources).expect("warning");
         let context = ResourcePolicyContext::from_evaluation(
-            HotCommand { label: "bench" },
+            lab_supported_hot("bench"),
             &resources,
             Some(&warning),
             true,
@@ -621,9 +684,9 @@ mod tests {
     #[test]
     fn context_records_ok_machine_with_no_warning() {
         let resources = resources(ResourceRecommendation::Ok);
-        assert!(evaluate(HotCommand { label: "bench" }, &resources).is_none());
+        assert!(evaluate(lab_supported_hot("bench"), &resources).is_none());
         let context = ResourcePolicyContext::from_evaluation(
-            HotCommand { label: "bench" },
+            lab_supported_hot("bench"),
             &resources,
             None,
             false,
@@ -645,7 +708,7 @@ mod tests {
             recommendation: ResourceRecommendation::Warm,
         });
         let context = ResourcePolicyContext::from_evaluation(
-            HotCommand { label: "bench" },
+            lab_supported_hot("bench"),
             &resources,
             None,
             false,
@@ -659,9 +722,9 @@ mod tests {
     #[test]
     fn context_serializes_to_json_with_expected_keys() {
         let resources = resources(ResourceRecommendation::Hot);
-        let warning = evaluate(HotCommand { label: "bench" }, &resources).expect("warning");
+        let warning = evaluate(lab_supported_hot("bench"), &resources).expect("warning");
         let context = ResourcePolicyContext::from_evaluation(
-            HotCommand { label: "bench" },
+            lab_supported_hot("bench"),
             &resources,
             Some(&warning),
             false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -517,11 +517,16 @@ fn resolve_lab_runner_selection_from_default(
 ) -> homeboy::core::Result<Option<LabRunnerSelection>> {
     if let Some(runner_id) = explicit_runner {
         if !command.supports_lab_runner() {
+            let reason = command.lab_runner_unsupported_reason();
+            let message = reason.map_or_else(
+                || "--runner is only supported for hot Lab-offload commands: lint, test, audit, bench, and trace".to_string(),
+                |reason| format!("--runner is unavailable for this hot command. {reason}"),
+            );
             return Err(homeboy::core::Error::validation_invalid_argument(
                 "runner",
-                "--runner is only supported for hot Lab-offload commands: lint, test, audit, bench, and trace",
+                message,
                 Some(runner_id.to_string()),
-                None,
+                Some(vec!["Current Lab offload support: audit, bench run, full lint, full test, and trace.".to_string()]),
             ));
         }
 
@@ -1015,6 +1020,7 @@ mod tests {
         rewrite_lab_offload_args, runner_extension_preflight_tail, LabRunnerPreparation,
         LabRunnerSelection, LabRunnerSelectionSource,
     };
+    use clap::Parser;
     use homeboy::cli_surface::Commands;
     use homeboy::commands::test::TestArgs;
     use homeboy::commands::utils::args::{
@@ -1310,6 +1316,22 @@ mod tests {
         .expect_err("unsupported command rejects explicit runner");
 
         assert_eq!(err.code.as_str(), "validation.invalid_argument");
+    }
+
+    #[test]
+    fn lab_runner_selection_explains_hot_commands_that_stay_local() {
+        let err = resolve_lab_runner_selection_from_default(
+            &homeboy::cli_surface::Cli::try_parse_from(["homeboy", "rig", "up", "studio"])
+                .expect("parse")
+                .command,
+            Some("lab-explicit"),
+            false,
+            Some("lab-default".to_string()),
+        )
+        .expect_err("rig up rejects explicit runner");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("single-workspace Lab snapshot"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds explicit Lab offload support reasons for hot commands that remain local, currently `rig up` and `fleet exec`.
- Updates resource-policy warnings so unsupported hot commands explain why Lab offload is unavailable instead of suggesting `--runner`.
- Documents the Lab command-support matrix and the scoped `rig up` / `fleet exec` decisions.

Fixes #2811

## Testing
- `cargo fmt --check`
- `cargo test test_supports_lab_runner`
- `cargo test test_lab_runner_unsupported_hot_command_reasons`
- `cargo test lab_runner_selection_explains_hot_commands_that_stay_local`
- `cargo test warning_for_local_only_hot_command_explains_runner_unavailability`
- `homeboy audit --path /Users/chubes/Developer/homeboy@fix-lab-expanded-offload --extension rust --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-lab-expanded-offload --extension rust --changed-since origin/main`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-lab-expanded-offload --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, tests, documentation, and local verification commands; Chris remains responsible for review and merge.