### PR TITLE
Add output contract audit coverage

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -2,8 +2,104 @@
   "auto_cleanup": false,
   "audit": {
     "command_status_contracts": {
+      "required_commands": [
+        "audit",
+        "deploy",
+        "lint",
+        "release",
+        "review",
+        "runs",
+        "stack",
+        "test"
+      ],
+      "required_output_error_commands": [
+        "status"
+      ],
       "scenarios": [
         {
+          "command": "audit",
+          "expected_fields": {
+            "/data/command": "audit.summary",
+            "/success": false
+          },
+          "file": "tests/fixtures/output_contracts/quality/audit-summary.json",
+          "id": "audit-summary-golden"
+        },
+        {
+          "command": "deploy",
+          "expected_fields": {
+            "/scenarios/0/payload/data/command": "deploy.run",
+            "/scenarios/0/payload/success": true
+          },
+          "file": "tests/fixtures/golden_json_contracts/deploy_contract.json",
+          "id": "deploy-golden-contract"
+        },
+        {
+          "command": "lint",
+          "expected_fields": {
+            "/data/phase/phase": "lint",
+            "/success": false
+          },
+          "file": "tests/fixtures/output_contracts/quality/lint-findings.json",
+          "id": "lint-findings-golden"
+        },
+        {
+          "command": "release",
+          "expected_fields": {
+            "/scenarios/0/payload/success": true
+          },
+          "file": "tests/fixtures/golden_json_contracts/release_contract.json",
+          "id": "release-golden-contract"
+        },
+        {
+          "command": "review",
+          "expected_fields": {
+            "/data/command": "review",
+            "/success": false
+          },
+          "file": "tests/fixtures/output_contracts/quality/review-artifact.json",
+          "id": "review-artifact-golden"
+        },
+        {
+          "command": "runs",
+          "expected_fields": {
+            "/scenarios/0/payload/data/command": "runs.list",
+            "/scenarios/0/payload/success": true
+          },
+          "file": "tests/fixtures/golden_json_contracts/runs_contract.json",
+          "id": "runs-golden-contract"
+        },
+        {
+          "command": "stack",
+          "expected_fields": {
+            "/scenarios/0/payload/data/command": "stack.list",
+            "/scenarios/0/payload/success": true
+          },
+          "file": "tests/fixtures/golden_json_contracts/stack_contract.json",
+          "id": "stack-golden-contract"
+        },
+        {
+          "command": "status",
+          "expected_fields": {
+            "/error/code": "validation.invalid_argument",
+            "/success": false
+          },
+          "file": "tests/fixtures/output_contracts/errors/runner-unsupported.json",
+          "id": "status-runner-validation-error-output",
+          "outcome": "validation_error",
+          "output_file": true
+        },
+        {
+          "command": "test",
+          "expected_fields": {
+            "/data/phase/phase": "test",
+            "/success": false
+          },
+          "file": "tests/fixtures/output_contracts/quality/test-summary.json",
+          "id": "test-summary-golden"
+        },
+        {
+          "command": "refactor transform",
           "expected_fields": {
             "/data/command": "refactor.transform",
             "/data/total_replacements": 0,

--- a/src/core/code_audit/detectors/command_status_contracts.rs
+++ b/src/core/code_audit/detectors/command_status_contracts.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use crate::core::component::CommandStatusContractConfig;
+use crate::core::component::{CommandStatusContractConfig, CommandStatusContractScenario};
 
 use super::super::{AuditFinding, Finding, Severity};
 
@@ -11,6 +11,36 @@ pub(in crate::core::code_audit) fn run(
     config: &CommandStatusContractConfig,
 ) -> Vec<Finding> {
     let mut findings = Vec::new();
+
+    for command in &config.required_commands {
+        if !config
+            .scenarios
+            .iter()
+            .any(|scenario| scenario.command.as_deref() == Some(command.as_str()))
+        {
+            findings.push(finding(
+                "homeboy.json",
+                command,
+                "required command has no declared golden output fixture".to_string(),
+                "Add a command_status_contracts scenario with a JSON fixture for this structured-output command.".to_string(),
+            ));
+        }
+    }
+
+    for command in &config.required_output_error_commands {
+        if !config.scenarios.iter().any(|scenario| {
+            scenario.command.as_deref() == Some(command.as_str())
+                && scenario.output_file
+                && is_validation_error_scenario(scenario)
+        }) {
+            findings.push(finding(
+                "homeboy.json",
+                command,
+                "required command lacks a validation-error --output golden fixture".to_string(),
+                "Add an output_file validation_error scenario so validation failures prove they still write structured --output JSON.".to_string(),
+            ));
+        }
+    }
 
     for scenario in &config.scenarios {
         let fixture = root.join(&scenario.file);
@@ -34,6 +64,8 @@ pub(in crate::core::code_audit) fn run(
             ));
             continue;
         };
+
+        findings.extend(validate_json_envelope(scenario, &json));
 
         for (pointer, expected) in &scenario.expected_fields {
             match json.pointer(pointer) {
@@ -65,6 +97,107 @@ pub(in crate::core::code_audit) fn run(
     }
 
     findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
+    findings
+}
+
+fn is_validation_error_scenario(scenario: &CommandStatusContractScenario) -> bool {
+    scenario.outcome.as_deref() == Some("validation_error")
+        || scenario.id.contains("validation-error")
+        || scenario.id.contains("validation_error")
+}
+
+fn validate_json_envelope(
+    scenario: &CommandStatusContractScenario,
+    json: &serde_json::Value,
+) -> Vec<Finding> {
+    if let Some(items) = json.get("scenarios").and_then(|value| value.as_array()) {
+        let mut findings = Vec::new();
+        for (index, item) in items.iter().enumerate() {
+            match item.get("payload") {
+                Some(payload) => findings.extend(validate_single_json_envelope(
+                    scenario,
+                    payload,
+                    &format!("/scenarios/{index}/payload"),
+                )),
+                None => findings.push(finding(
+                    &scenario.file,
+                    &scenario.id,
+                    format!("golden contract scenario at /scenarios/{index} is missing /payload"),
+                    "Store grouped command contract fixtures as scenarios containing Homeboy CLI envelope payloads.".to_string(),
+                )),
+            }
+        }
+        return findings;
+    }
+
+    validate_single_json_envelope(scenario, json, "")
+}
+
+fn validate_single_json_envelope(
+    scenario: &CommandStatusContractScenario,
+    json: &serde_json::Value,
+    pointer_prefix: &str,
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    match json.pointer("/success") {
+        Some(serde_json::Value::Bool(true)) => {
+            if json.pointer("/data").is_none() {
+                findings.push(finding(
+                    &scenario.file,
+                    &scenario.id,
+                    format!("successful JSON envelope is missing {pointer_prefix}/data"),
+                    "Store command output fixtures as Homeboy CLI envelopes with success=true and data.".to_string(),
+                ));
+            }
+        }
+        Some(serde_json::Value::Bool(false)) => {
+            if json.pointer("/data").is_none() && json.pointer("/error").is_none() {
+                findings.push(finding(
+                    &scenario.file,
+                    &scenario.id,
+                    format!("failed JSON envelope is missing {pointer_prefix}/data or {pointer_prefix}/error"),
+                    "Store non-zero command fixtures as Homeboy CLI envelopes with either command data or error details.".to_string(),
+                ));
+            }
+        }
+        Some(_) => findings.push(finding(
+            &scenario.file,
+            &scenario.id,
+            format!("JSON envelope {pointer_prefix}/success is not a boolean"),
+            "Use the standard Homeboy CLI JSON envelope shape for command output fixtures."
+                .to_string(),
+        )),
+        None => findings.push(finding(
+            &scenario.file,
+            &scenario.id,
+            format!("JSON envelope is missing {pointer_prefix}/success"),
+            "Use the standard Homeboy CLI JSON envelope shape for command output fixtures."
+                .to_string(),
+        )),
+    }
+
+    if is_validation_error_scenario(scenario) {
+        if json.pointer("/success") != Some(&serde_json::Value::Bool(false)) {
+            findings.push(finding(
+                &scenario.file,
+                &scenario.id,
+                format!("validation-error scenario must have {pointer_prefix}/success=false"),
+                "Capture the validation failure envelope instead of a successful command response."
+                    .to_string(),
+            ));
+        }
+        if json.pointer("/error/code").is_none() {
+            findings.push(finding(
+                &scenario.file,
+                &scenario.id,
+                format!("validation-error scenario is missing {pointer_prefix}/error/code"),
+                "Expose the stable validation error code in the command output contract fixture."
+                    .to_string(),
+            ));
+        }
+    }
+
     findings
 }
 
@@ -100,9 +233,14 @@ mod tests {
         )
         .expect("fixture");
         let config = CommandStatusContractConfig {
+            required_commands: Vec::new(),
+            required_output_error_commands: Vec::new(),
             scenarios: vec![scenario(
                 "refactor-transform-no-match",
+                Some("refactor transform"),
                 "no-match.json",
+                None,
+                false,
                 [
                     ("/success", serde_json::json!(true)),
                     ("/data/total_replacements", serde_json::json!(0)),
@@ -123,9 +261,14 @@ mod tests {
         )
         .expect("fixture");
         let config = CommandStatusContractConfig {
+            required_commands: Vec::new(),
+            required_output_error_commands: Vec::new(),
             scenarios: vec![scenario(
                 "refactor-transform-no-match",
+                Some("refactor transform"),
                 "no-match.json",
+                None,
+                false,
                 [("/success", serde_json::json!(true))],
             )],
         };
@@ -143,14 +286,93 @@ mod tests {
         assert!(findings[0].description.contains("/success"));
     }
 
+    #[test]
+    fn required_command_without_fixture_is_reported() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = CommandStatusContractConfig {
+            required_commands: vec!["audit".to_string()],
+            required_output_error_commands: Vec::new(),
+            scenarios: Vec::new(),
+        };
+
+        let findings = run(dir.path(), &config);
+
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0]
+            .description
+            .contains("required command has no declared golden output fixture"));
+    }
+
+    #[test]
+    fn required_output_error_command_without_validation_fixture_is_reported() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("audit.json"),
+            r#"{"success":true,"data":{}}"#,
+        )
+        .expect("fixture");
+        let config = CommandStatusContractConfig {
+            required_commands: Vec::new(),
+            required_output_error_commands: vec!["audit".to_string()],
+            scenarios: vec![scenario(
+                "audit-success",
+                Some("audit"),
+                "audit.json",
+                None,
+                false,
+                [],
+            )],
+        };
+
+        let findings = run(dir.path(), &config);
+
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0]
+            .description
+            .contains("validation-error --output golden fixture"));
+    }
+
+    #[test]
+    fn validation_error_fixture_requires_error_code() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("error.json"),
+            r#"{"success":false,"error":{}}"#,
+        )
+        .expect("fixture");
+        let config = CommandStatusContractConfig {
+            required_commands: Vec::new(),
+            required_output_error_commands: Vec::new(),
+            scenarios: vec![scenario(
+                "audit-validation-error",
+                Some("audit"),
+                "error.json",
+                Some("validation_error"),
+                true,
+                [],
+            )],
+        };
+
+        let findings = run(dir.path(), &config);
+
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].description.contains("/error/code"));
+    }
+
     fn scenario<const N: usize>(
         id: &str,
+        command: Option<&str>,
         file: &str,
+        outcome: Option<&str>,
+        output_file: bool,
         expected: [(&str, serde_json::Value); N],
     ) -> CommandStatusContractScenario {
         CommandStatusContractScenario {
             id: id.to_string(),
+            command: command.map(str::to_string),
             file: file.to_string(),
+            outcome: outcome.map(str::to_string),
+            output_file,
             expected_fields: expected
                 .into_iter()
                 .map(|(pointer, value)| (pointer.to_string(), value))

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -74,16 +74,35 @@ pub struct AuditConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct CommandStatusContractConfig {
+    /// Visible command paths that must have at least one golden output fixture.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_commands: Vec<String>,
+    /// Visible command paths that must declare a validation-error scenario using
+    /// `--output`, proving error responses still write the structured file.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_output_error_commands: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub scenarios: Vec<CommandStatusContractScenario>,
 }
 
 impl CommandStatusContractConfig {
     pub fn is_empty(&self) -> bool {
-        self.scenarios.is_empty()
+        self.required_commands.is_empty()
+            && self.required_output_error_commands.is_empty()
+            && self.scenarios.is_empty()
     }
 
     fn merge(&mut self, other: &CommandStatusContractConfig) {
+        for command in &other.required_commands {
+            if !self.required_commands.contains(command) {
+                self.required_commands.push(command.clone());
+            }
+        }
+        for command in &other.required_output_error_commands {
+            if !self.required_output_error_commands.contains(command) {
+                self.required_output_error_commands.push(command.clone());
+            }
+        }
         for scenario in &other.scenarios {
             if !self
                 .scenarios
@@ -100,8 +119,18 @@ impl CommandStatusContractConfig {
 pub struct CommandStatusContractScenario {
     /// Stable scenario id shown in findings.
     pub id: String,
+    /// Visible command path this fixture covers, e.g. `audit` or `runs list`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
     /// JSON fixture path relative to the component root.
     pub file: String,
+    /// Scenario outcome class. `validation_error` requires a failed envelope
+    /// with an error object.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<String>,
+    /// Whether this scenario is expected to cover the global `--output` file path.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub output_file: bool,
     /// Expected JSON Pointer fields and values, e.g. `/success: true`.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub expected_fields: BTreeMap<String, serde_json::Value>,
@@ -755,9 +784,14 @@ mod tests {
     fn command_status_contracts_mark_audit_config_non_empty() {
         let config = AuditConfig {
             command_status_contracts: CommandStatusContractConfig {
+                required_commands: Vec::new(),
+                required_output_error_commands: Vec::new(),
                 scenarios: vec![CommandStatusContractScenario {
                     id: "refactor-transform-no-match".to_string(),
+                    command: Some("refactor transform".to_string()),
                     file: "tests/fixtures/refactor-transform-no-match.json".to_string(),
+                    outcome: None,
+                    output_file: false,
                     expected_fields: BTreeMap::from([(
                         "/success".to_string(),
                         serde_json::json!(true),

--- a/src/core/extension/test/mod.rs
+++ b/src/core/extension/test/mod.rs
@@ -170,6 +170,18 @@ fn changed_test_file_for_path(file: &str) -> Option<String> {
         return Some("tests/refactor_transform_test.rs".to_string());
     }
 
+    if file.starts_with("tests/fixtures/output_contracts/errors/") {
+        return Some("tests/output_errors.rs".to_string());
+    }
+
+    if file.starts_with("tests/fixtures/output_contracts/quality/") {
+        return Some("tests/output_contracts_test.rs".to_string());
+    }
+
+    if file.starts_with("tests/fixtures/golden_json_contracts/") {
+        return Some("src/commands/golden_contract_tests.rs".to_string());
+    }
+
     if crate::core::code_audit::is_test_path(file) && !file.starts_with("tests/fixtures/") {
         return Some(file.to_string());
     }
@@ -222,6 +234,22 @@ mod tests {
         assert_eq!(
             changed_test_file_for_path("tests/fixtures/refactor_transform_no_match.json"),
             Some("tests/refactor_transform_test.rs".to_string())
+        );
+        assert_eq!(
+            changed_test_file_for_path(
+                "tests/fixtures/output_contracts/errors/runner-unsupported.json"
+            ),
+            Some("tests/output_errors.rs".to_string())
+        );
+        assert_eq!(
+            changed_test_file_for_path(
+                "tests/fixtures/output_contracts/quality/audit-summary.json"
+            ),
+            Some("tests/output_contracts_test.rs".to_string())
+        );
+        assert_eq!(
+            changed_test_file_for_path("tests/fixtures/golden_json_contracts/runs_contract.json"),
+            Some("src/commands/golden_contract_tests.rs".to_string())
         );
         assert_eq!(
             changed_test_file_for_path("tests/fixtures/other.json"),

--- a/tests/fixtures/output_contracts/errors/runner-unsupported.json
+++ b/tests/fixtures/output_contracts/errors/runner-unsupported.json
@@ -1,0 +1,11 @@
+{
+  "success": false,
+  "error": {
+    "code": "validation.invalid_argument",
+    "message": "Unsupported runner for command 'status'",
+    "details": {
+      "argument": "--runner",
+      "value": "lab"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Extends command status contract auditing to require declared golden output fixtures for structured command surfaces.
- Validates direct and grouped CLI JSON envelopes, including validation-error `--output` fixtures.
- Maps output contract fixture changes back to their regression tests so `homeboy test --changed-since` does not select zero tests.

Closes #2774.

## Verification
- `cargo fmt --check`
- `cargo test command_status_contracts`
- `cargo test changed_scope_maps_refactor_transform_fixture_to_regression_test`
- `cargo test --test output_contracts_test`
- `cargo test --test output_errors`
- `cargo test --test architecture_core_agnostic_test`
- `homeboy audit --path /Users/chubes/Developer/homeboy@fix-audit-output-contract-coverage --extension rust --changed-since origin/main`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-audit-output-contract-coverage --extension rust --changed-since origin/main`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-audit-output-contract-coverage --extension rust --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the output contract audit implementation, fixture mapping fix, tests, and PR description; Chris remains responsible for review and merge.