### PR TITLE
Extract trace aggregate test support

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -1685,6 +1685,8 @@ fn trace_run_finish_metadata(
 }
 
 #[cfg(test)]
+mod aggregate_test_support;
+#[cfg(test)]
 mod compare_tests;
 #[cfg(test)]
 mod compare_variant_tests;

--- a/src/commands/trace/aggregate_test_support.rs
+++ b/src/commands/trace/aggregate_test_support.rs
@@ -1,0 +1,13 @@
+use super::TraceAggregateSpanSample;
+
+pub(super) fn aggregate_samples(durations: &[u64]) -> Vec<TraceAggregateSpanSample> {
+    durations
+        .iter()
+        .enumerate()
+        .map(|(index, duration_ms)| TraceAggregateSpanSample {
+            duration_ms: *duration_ms,
+            run_index: index + 1,
+            artifact_path: format!("/tmp/trace-run-{}.json", index + 1),
+        })
+        .collect()
+}

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -6,24 +6,13 @@ use crate::test_support::with_isolated_home;
 use homeboy::core::component::ScopedExtensionConfig;
 use homeboy::core::rig::ComponentSpec;
 
+use super::aggregate_test_support::aggregate_samples;
 use super::test_fixture::{
     init_overlay_component, write_trace_extension, write_trace_rig,
     write_trace_rig_with_phase_preset, write_trace_rig_with_span_metadata,
     write_trace_rig_with_variant,
 };
 use super::*;
-
-fn aggregate_samples(durations: &[u64]) -> Vec<TraceAggregateSpanSample> {
-    durations
-        .iter()
-        .enumerate()
-        .map(|(index, duration_ms)| TraceAggregateSpanSample {
-            duration_ms: *duration_ms,
-            run_index: index + 1,
-            artifact_path: format!("/tmp/trace-run-{}.json", index + 1),
-        })
-        .collect()
-}
 
 fn trace_args_for_profile(profile: &str) -> TraceArgs {
     TraceArgs {


### PR DESCRIPTION
## Summary
- Extract `aggregate_samples` from `src/commands/trace/tests.rs` into a focused `aggregate_test_support` module.
- Keep trace aggregate test behavior unchanged while reducing the trace test god-file by one support helper.

## Verification
- `cargo test commands::trace::tests::aggregate --lib`
- `cargo test commands::trace:: --lib`
- `homeboy audit --changed-since origin/main`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Inspected the trace test slice, extracted the helper module, ran verification, and drafted this PR. Chris remains responsible for review and merge.