### PR TITLE
refactor: extract runs bench helpers

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -1,3 +1,4 @@
+mod bench;
 mod bundle;
 mod common;
 mod compare;
@@ -13,7 +14,6 @@ mod reconcile;
 mod remote;
 mod remote_artifact;
 
-use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io;
 use std::path::PathBuf;
@@ -26,6 +26,8 @@ use homeboy::core::observation::{ArtifactRecord, ObservationStore, RunListFilter
 use homeboy::core::Error;
 
 use super::{CmdResult, GlobalArgs};
+pub use bench::{bench_compare, bench_history, BenchCompareOutput, BenchHistoryOutput};
+pub(super) use bench::{bench_numeric_metrics, run_contains_scenario};
 use bundle::{
     export_runs, import_runs, RunsExportArgs, RunsExportOutput, RunsImportArgs, RunsImportOutput,
 };
@@ -219,49 +221,12 @@ pub struct RunsArtifactCleanupDownloadsOutput {
 }
 
 #[derive(Serialize)]
-pub struct BenchHistoryOutput {
-    pub command: &'static str,
-    pub component_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scenario_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rig_id: Option<String>,
-    pub runs: Vec<RunDetail>,
-}
-
-#[derive(Serialize)]
-pub struct BenchCompareOutput {
-    pub command: &'static str,
-    pub from_run: RunSummary,
-    pub to_run: RunSummary,
-    pub comparisons: Vec<BenchMetricComparison>,
-    pub missing: Vec<BenchMissingMetric>,
-}
-
-#[derive(Serialize)]
 pub struct RunDetail {
     #[serde(flatten)]
     pub summary: RunSummary,
     pub homeboy_version: Option<String>,
     pub metadata: Value,
     pub artifacts: Vec<ArtifactRecord>,
-}
-
-#[derive(Serialize, Debug, Clone, PartialEq)]
-pub struct BenchMetricComparison {
-    pub scenario_id: String,
-    pub metric: String,
-    pub from_value: f64,
-    pub to_value: f64,
-    pub delta: f64,
-    pub percent_change: Option<f64>,
-}
-
-#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
-pub struct BenchMissingMetric {
-    pub scenario_id: String,
-    pub metric: String,
-    pub missing_from: String,
 }
 
 pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
@@ -470,97 +435,10 @@ fn artifact_get(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
     ))
 }
 
-pub fn bench_history(
-    component_id: &str,
-    scenario_id: Option<&str>,
-    rig_id: Option<&str>,
-    limit: i64,
-) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    let runs = store
-        .list_runs(RunListFilter {
-            kind: Some("bench".to_string()),
-            component_id: Some(component_id.to_string()),
-            rig_id: rig_id.map(str::to_string),
-            limit: Some(limit.clamp(1, 1000)),
-            ..RunListFilter::default()
-        })?
-        .into_iter()
-        .filter(|run| scenario_id.is_none_or(|scenario| run_contains_scenario(run, scenario)))
-        .take(limit.max(1) as usize)
-        .map(|run| run_detail(&store, run))
-        .collect::<homeboy::core::Result<Vec<_>>>()?;
-
-    Ok((
-        RunsOutput::BenchHistory(BenchHistoryOutput {
-            command: "bench.history",
-            component_id: component_id.to_string(),
-            scenario_id: scenario_id.map(str::to_string),
-            rig_id: rig_id.map(str::to_string),
-            runs,
-        }),
-        0,
-    ))
-}
-
-pub fn bench_compare(from_run_id: &str, to_run_id: &str) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    let from_run = require_run(&store, from_run_id)?;
-    let to_run = require_run(&store, to_run_id)?;
-    require_kind(&from_run, "bench")?;
-    require_kind(&to_run, "bench")?;
-
-    let from_summary = run_summary(from_run.clone());
-    let to_summary = run_summary(to_run.clone());
-    let from_metrics = bench_numeric_metrics(&from_run.metadata_json);
-    let to_metrics = bench_numeric_metrics(&to_run.metadata_json);
-    let mut keys = BTreeSet::new();
-    keys.extend(from_metrics.keys().cloned());
-    keys.extend(to_metrics.keys().cloned());
-
-    let mut comparisons = Vec::new();
-    let mut missing = Vec::new();
-    for key in keys {
-        match (from_metrics.get(&key), to_metrics.get(&key)) {
-            (Some(from), Some(to)) => comparisons.push(BenchMetricComparison {
-                scenario_id: key.0,
-                metric: key.1,
-                from_value: *from,
-                to_value: *to,
-                delta: to - from,
-                percent_change: if *from == 0.0 {
-                    None
-                } else {
-                    Some(((to - from) / from) * 100.0)
-                },
-            }),
-            (Some(_), None) => missing.push(BenchMissingMetric {
-                scenario_id: key.0,
-                metric: key.1,
-                missing_from: "to_run".to_string(),
-            }),
-            (None, Some(_)) => missing.push(BenchMissingMetric {
-                scenario_id: key.0,
-                metric: key.1,
-                missing_from: "from_run".to_string(),
-            }),
-            (None, None) => {}
-        }
-    }
-
-    Ok((
-        RunsOutput::BenchCompare(BenchCompareOutput {
-            command: "bench.compare",
-            from_run: from_summary,
-            to_run: to_summary,
-            comparisons,
-            missing,
-        }),
-        0,
-    ))
-}
-
-fn require_run(store: &ObservationStore, run_id: &str) -> homeboy::core::Result<RunRecord> {
+pub(super) fn require_run(
+    store: &ObservationStore,
+    run_id: &str,
+) -> homeboy::core::Result<RunRecord> {
     store.get_run(run_id)?.ok_or_else(|| {
         Error::validation_invalid_argument(
             "run_id",
@@ -571,22 +449,10 @@ fn require_run(store: &ObservationStore, run_id: &str) -> homeboy::core::Result<
     })
 }
 
-fn require_kind(run: &RunRecord, expected: &str) -> homeboy::core::Result<()> {
-    if run.kind == expected {
-        return Ok(());
-    }
-    Err(Error::validation_invalid_argument(
-        "run_id",
-        format!(
-            "run {} is kind '{}', expected '{expected}'",
-            run.id, run.kind
-        ),
-        Some(run.id.clone()),
-        None,
-    ))
-}
-
-fn run_detail(store: &ObservationStore, run: RunRecord) -> homeboy::core::Result<RunDetail> {
+pub(super) fn run_detail(
+    store: &ObservationStore,
+    run: RunRecord,
+) -> homeboy::core::Result<RunDetail> {
     let artifacts = store.list_artifacts(&run.id)?;
     Ok(RunDetail {
         summary: run_summary(run.clone()),
@@ -613,75 +479,10 @@ pub(crate) fn run_summary(run: RunRecord) -> RunSummary {
     }
 }
 
-pub(super) fn run_contains_scenario(run: &RunRecord, scenario_id: &str) -> bool {
-    if run.metadata_json["selected_scenarios"]
-        .as_array()
-        .is_some_and(|items| items.iter().any(|item| item.as_str() == Some(scenario_id)))
-    {
-        return true;
-    }
-    bench_numeric_metrics(&run.metadata_json)
-        .keys()
-        .any(|(scenario, _)| scenario == scenario_id)
-}
-
-fn bench_numeric_metrics(metadata: &Value) -> BTreeMap<(String, String), f64> {
-    let mut metrics = BTreeMap::new();
-    if let Some(scenarios) = metadata["scenario_metrics"].as_array() {
-        for scenario in scenarios {
-            collect_scenario_metrics(scenario, &mut metrics);
-        }
-    }
-    if metrics.is_empty() {
-        if let Some(scenarios) = metadata["results"]["scenarios"].as_array() {
-            for scenario in scenarios {
-                collect_scenario_metrics(scenario, &mut metrics);
-            }
-        }
-    }
-    metrics
-}
-
-fn collect_scenario_metrics(scenario: &Value, metrics: &mut BTreeMap<(String, String), f64>) {
-    let Some(scenario_id) = scenario["scenario_id"]
-        .as_str()
-        .or_else(|| scenario["id"].as_str())
-    else {
-        return;
-    };
-
-    collect_numeric_object(scenario_id, None, &scenario["metrics"], metrics);
-    if let Some(groups) = scenario["metric_groups"].as_object() {
-        for (group, values) in groups {
-            collect_numeric_object(scenario_id, Some(group), values, metrics);
-        }
-    }
-}
-
-fn collect_numeric_object(
-    scenario_id: &str,
-    prefix: Option<&str>,
-    value: &Value,
-    metrics: &mut BTreeMap<(String, String), f64>,
-) {
-    let Some(object) = value.as_object() else {
-        return;
-    };
-    for (name, value) in object {
-        let Some(number) = value.as_f64() else {
-            continue;
-        };
-        let metric = match prefix {
-            Some(prefix) => format!("{prefix}.{name}"),
-            None => name.clone(),
-        };
-        metrics.insert((scenario_id.to_string(), metric), number);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
     use std::path::Path;
 
     use homeboy::core::observation::{

--- a/src/commands/runs/bench.rs
+++ b/src/commands/runs/bench.rs
@@ -1,0 +1,216 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use homeboy::core::observation::{ObservationStore, RunListFilter, RunRecord};
+use homeboy::core::Error;
+use serde::Serialize;
+use serde_json::Value;
+
+use super::{require_run, run_detail, run_summary, CmdResult, RunDetail, RunSummary, RunsOutput};
+
+#[derive(Serialize)]
+pub struct BenchHistoryOutput {
+    pub command: &'static str,
+    pub component_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scenario_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rig_id: Option<String>,
+    pub runs: Vec<RunDetail>,
+}
+
+#[derive(Serialize)]
+pub struct BenchCompareOutput {
+    pub command: &'static str,
+    pub from_run: RunSummary,
+    pub to_run: RunSummary,
+    pub comparisons: Vec<BenchMetricComparison>,
+    pub missing: Vec<BenchMissingMetric>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct BenchMetricComparison {
+    pub scenario_id: String,
+    pub metric: String,
+    pub from_value: f64,
+    pub to_value: f64,
+    pub delta: f64,
+    pub percent_change: Option<f64>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct BenchMissingMetric {
+    pub scenario_id: String,
+    pub metric: String,
+    pub missing_from: String,
+}
+
+pub fn bench_history(
+    component_id: &str,
+    scenario_id: Option<&str>,
+    rig_id: Option<&str>,
+    limit: i64,
+) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let runs = store
+        .list_runs(RunListFilter {
+            kind: Some("bench".to_string()),
+            component_id: Some(component_id.to_string()),
+            rig_id: rig_id.map(str::to_string),
+            limit: Some(limit.clamp(1, 1000)),
+            ..RunListFilter::default()
+        })?
+        .into_iter()
+        .filter(|run| scenario_id.is_none_or(|scenario| run_contains_scenario(run, scenario)))
+        .take(limit.max(1) as usize)
+        .map(|run| run_detail(&store, run))
+        .collect::<homeboy::core::Result<Vec<_>>>()?;
+
+    Ok((
+        RunsOutput::BenchHistory(BenchHistoryOutput {
+            command: "bench.history",
+            component_id: component_id.to_string(),
+            scenario_id: scenario_id.map(str::to_string),
+            rig_id: rig_id.map(str::to_string),
+            runs,
+        }),
+        0,
+    ))
+}
+
+pub fn bench_compare(from_run_id: &str, to_run_id: &str) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let from_run = require_run(&store, from_run_id)?;
+    let to_run = require_run(&store, to_run_id)?;
+    require_kind(&from_run, "bench")?;
+    require_kind(&to_run, "bench")?;
+
+    let from_summary = run_summary(from_run.clone());
+    let to_summary = run_summary(to_run.clone());
+    let from_metrics = bench_numeric_metrics(&from_run.metadata_json);
+    let to_metrics = bench_numeric_metrics(&to_run.metadata_json);
+    let mut keys = BTreeSet::new();
+    keys.extend(from_metrics.keys().cloned());
+    keys.extend(to_metrics.keys().cloned());
+
+    let mut comparisons = Vec::new();
+    let mut missing = Vec::new();
+    for key in keys {
+        match (from_metrics.get(&key), to_metrics.get(&key)) {
+            (Some(from), Some(to)) => comparisons.push(BenchMetricComparison {
+                scenario_id: key.0,
+                metric: key.1,
+                from_value: *from,
+                to_value: *to,
+                delta: to - from,
+                percent_change: if *from == 0.0 {
+                    None
+                } else {
+                    Some(((to - from) / from) * 100.0)
+                },
+            }),
+            (Some(_), None) => missing.push(BenchMissingMetric {
+                scenario_id: key.0,
+                metric: key.1,
+                missing_from: "to_run".to_string(),
+            }),
+            (None, Some(_)) => missing.push(BenchMissingMetric {
+                scenario_id: key.0,
+                metric: key.1,
+                missing_from: "from_run".to_string(),
+            }),
+            (None, None) => {}
+        }
+    }
+
+    Ok((
+        RunsOutput::BenchCompare(BenchCompareOutput {
+            command: "bench.compare",
+            from_run: from_summary,
+            to_run: to_summary,
+            comparisons,
+            missing,
+        }),
+        0,
+    ))
+}
+
+fn require_kind(run: &RunRecord, expected: &str) -> homeboy::core::Result<()> {
+    if run.kind == expected {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        "run_id",
+        format!(
+            "run {} is kind '{}', expected '{expected}'",
+            run.id, run.kind
+        ),
+        Some(run.id.clone()),
+        None,
+    ))
+}
+
+pub(crate) fn run_contains_scenario(run: &RunRecord, scenario_id: &str) -> bool {
+    if run.metadata_json["selected_scenarios"]
+        .as_array()
+        .is_some_and(|items| items.iter().any(|item| item.as_str() == Some(scenario_id)))
+    {
+        return true;
+    }
+    bench_numeric_metrics(&run.metadata_json)
+        .keys()
+        .any(|(scenario, _)| scenario == scenario_id)
+}
+
+pub(crate) fn bench_numeric_metrics(metadata: &Value) -> BTreeMap<(String, String), f64> {
+    let mut metrics = BTreeMap::new();
+    if let Some(scenarios) = metadata["scenario_metrics"].as_array() {
+        for scenario in scenarios {
+            collect_scenario_metrics(scenario, &mut metrics);
+        }
+    }
+    if metrics.is_empty() {
+        if let Some(scenarios) = metadata["results"]["scenarios"].as_array() {
+            for scenario in scenarios {
+                collect_scenario_metrics(scenario, &mut metrics);
+            }
+        }
+    }
+    metrics
+}
+
+fn collect_scenario_metrics(scenario: &Value, metrics: &mut BTreeMap<(String, String), f64>) {
+    let Some(scenario_id) = scenario["scenario_id"]
+        .as_str()
+        .or_else(|| scenario["id"].as_str())
+    else {
+        return;
+    };
+
+    collect_numeric_object(scenario_id, None, &scenario["metrics"], metrics);
+    if let Some(groups) = scenario["metric_groups"].as_object() {
+        for (group, values) in groups {
+            collect_numeric_object(scenario_id, Some(group), values, metrics);
+        }
+    }
+}
+
+fn collect_numeric_object(
+    scenario_id: &str,
+    prefix: Option<&str>,
+    value: &Value,
+    metrics: &mut BTreeMap<(String, String), f64>,
+) {
+    let Some(object) = value.as_object() else {
+        return;
+    };
+    for (name, value) in object {
+        let Some(number) = value.as_f64() else {
+            continue;
+        };
+        let metric = match prefix {
+            Some(prefix) => format!("{prefix}.{name}"),
+            None => name.clone(),
+        };
+        metrics.insert((scenario_id.to_string(), metric), number);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract the bench history/compare slice from `src/commands/runs.rs` into `src/commands/runs/bench.rs`.
- Keep the existing `runs` module public surface intact through re-exports so behavior and output shapes remain unchanged.

## Verification
- `cargo test runs::tests::bench`
- `cargo test commands::runs::`
- `homeboy audit --changed-since origin/main`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the focused extraction; Chris remains responsible for review and merge.