### PR TITLE
Refactor test coverage source symbol helpers

### DIFF
--- a/src/core/code_audit/detectors/test_coverage.rs
+++ b/src/core/code_audit/detectors/test_coverage.rs
@@ -11,11 +11,16 @@
 //! 3. Orphaned tests — test files with no corresponding source file
 //! 4. Orphaned test methods — test methods whose source method no longer exists
 
+mod symbols;
+
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use regex::Regex;
 
+use self::symbols::{
+    collect_source_symbol_names, references_multiple_source_symbols, references_source_file,
+};
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use super::fingerprint::FileFingerprint;
@@ -413,115 +418,6 @@ pub(crate) fn analyze_test_coverage(
     // Sort by file path for deterministic output
     findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
     findings
-}
-
-fn collect_source_symbol_names(source_fps: &[&FileFingerprint]) -> HashSet<String> {
-    let mut names = HashSet::new();
-
-    for fp in source_fps {
-        if let Some(type_name) = &fp.type_name {
-            if is_meaningful_symbol_name(type_name) {
-                names.insert(type_name.clone());
-            }
-        }
-        for type_name in &fp.type_names {
-            if is_meaningful_symbol_name(type_name) {
-                names.insert(type_name.clone());
-            }
-        }
-        if let Some(stem) = Path::new(&fp.relative_path)
-            .file_stem()
-            .and_then(|s| s.to_str())
-        {
-            if is_meaningful_symbol_name(stem) {
-                names.insert(stem.to_string());
-            }
-        }
-    }
-
-    names
-}
-
-fn references_multiple_source_symbols(
-    test_fp: &FileFingerprint,
-    source_symbol_names: &HashSet<String>,
-) -> bool {
-    let mut referenced = HashSet::new();
-    let mut haystacks = Vec::new();
-    haystacks.push(test_fp.content.as_str());
-    haystacks.extend(test_fp.imports.iter().map(|s| s.as_str()));
-
-    for symbol in source_symbol_names {
-        if haystacks
-            .iter()
-            .any(|haystack| contains_symbol(haystack, symbol))
-        {
-            referenced.insert(symbol.as_str());
-            if referenced.len() >= 2 {
-                return true;
-            }
-        }
-    }
-
-    false
-}
-
-fn references_source_file(test_fp: &FileFingerprint, source_fp: &FileFingerprint) -> bool {
-    let symbols = collect_source_file_symbols(source_fp);
-    if symbols.is_empty() {
-        return false;
-    }
-
-    let mut haystacks = Vec::new();
-    haystacks.push(test_fp.content.as_str());
-    haystacks.extend(test_fp.imports.iter().map(|s| s.as_str()));
-
-    symbols.iter().any(|symbol| {
-        haystacks
-            .iter()
-            .any(|haystack| contains_symbol(haystack, symbol))
-    })
-}
-
-fn collect_source_file_symbols(source_fp: &FileFingerprint) -> HashSet<String> {
-    let mut symbols = HashSet::new();
-
-    if let Some(type_name) = &source_fp.type_name {
-        if is_meaningful_symbol_name(type_name) {
-            symbols.insert(type_name.clone());
-        }
-    }
-    for type_name in &source_fp.type_names {
-        if is_meaningful_symbol_name(type_name) {
-            symbols.insert(type_name.clone());
-        }
-    }
-    if let Some(stem) = Path::new(&source_fp.relative_path)
-        .file_stem()
-        .and_then(|s| s.to_str())
-    {
-        if is_meaningful_symbol_name(stem) {
-            symbols.insert(stem.to_string());
-        }
-    }
-
-    symbols
-}
-
-fn is_meaningful_symbol_name(name: &str) -> bool {
-    name.len() >= 3 && name.chars().any(|c| c.is_alphabetic())
-}
-
-fn contains_symbol(haystack: &str, symbol: &str) -> bool {
-    haystack.match_indices(symbol).any(|(start, _)| {
-        let before = haystack[..start].chars().next_back();
-        let after = haystack[start + symbol.len()..].chars().next();
-        !before.is_some_and(is_identifier_char) && !after.is_some_and(is_identifier_char)
-    })
-}
-
-fn is_identifier_char(ch: char) -> bool {
-    ch.is_alphanumeric() || ch == '_'
 }
 
 /// Load test methods from disk for a known test file path.

--- a/src/core/code_audit/detectors/test_coverage/symbols.rs
+++ b/src/core/code_audit/detectors/test_coverage/symbols.rs
@@ -1,0 +1,96 @@
+use std::collections::HashSet;
+use std::path::Path;
+
+use crate::core::code_audit::fingerprint::FileFingerprint;
+
+pub(super) fn collect_source_symbol_names(source_fps: &[&FileFingerprint]) -> HashSet<String> {
+    let mut names = HashSet::new();
+
+    for fp in source_fps {
+        collect_source_symbols(fp, &mut names);
+    }
+
+    names
+}
+
+pub(super) fn references_multiple_source_symbols(
+    test_fp: &FileFingerprint,
+    source_symbol_names: &HashSet<String>,
+) -> bool {
+    let mut referenced = HashSet::new();
+    let mut haystacks = Vec::new();
+    haystacks.push(test_fp.content.as_str());
+    haystacks.extend(test_fp.imports.iter().map(|s| s.as_str()));
+
+    for symbol in source_symbol_names {
+        if haystacks
+            .iter()
+            .any(|haystack| contains_symbol(haystack, symbol))
+        {
+            referenced.insert(symbol.as_str());
+            if referenced.len() >= 2 {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+pub(super) fn references_source_file(
+    test_fp: &FileFingerprint,
+    source_fp: &FileFingerprint,
+) -> bool {
+    let mut symbols = HashSet::new();
+    collect_source_symbols(source_fp, &mut symbols);
+    if symbols.is_empty() {
+        return false;
+    }
+
+    let mut haystacks = Vec::new();
+    haystacks.push(test_fp.content.as_str());
+    haystacks.extend(test_fp.imports.iter().map(|s| s.as_str()));
+
+    symbols.iter().any(|symbol| {
+        haystacks
+            .iter()
+            .any(|haystack| contains_symbol(haystack, symbol))
+    })
+}
+
+fn collect_source_symbols(fp: &FileFingerprint, symbols: &mut HashSet<String>) {
+    if let Some(type_name) = &fp.type_name {
+        if is_meaningful_symbol_name(type_name) {
+            symbols.insert(type_name.clone());
+        }
+    }
+    for type_name in &fp.type_names {
+        if is_meaningful_symbol_name(type_name) {
+            symbols.insert(type_name.clone());
+        }
+    }
+    if let Some(stem) = Path::new(&fp.relative_path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+    {
+        if is_meaningful_symbol_name(stem) {
+            symbols.insert(stem.to_string());
+        }
+    }
+}
+
+fn is_meaningful_symbol_name(name: &str) -> bool {
+    name.len() >= 3 && name.chars().any(|c| c.is_alphabetic())
+}
+
+fn contains_symbol(haystack: &str, symbol: &str) -> bool {
+    haystack.match_indices(symbol).any(|(start, _)| {
+        let before = haystack[..start].chars().next_back();
+        let after = haystack[start + symbol.len()..].chars().next();
+        !before.is_some_and(is_identifier_char) && !after.is_some_and(is_identifier_char)
+    })
+}
+
+fn is_identifier_char(ch: char) -> bool {
+    ch.is_alphanumeric() || ch == '_'
+}


### PR DESCRIPTION
## Summary
- Extract source-symbol reference detection from `test_coverage.rs` into a private `test_coverage::symbols` helper module.
- Keep detector behavior unchanged while reducing the god-file slice and avoiding standalone detector convention drift.

## Verification
- `cargo test core::code_audit::detectors::test_coverage::tests`
- `homeboy audit --changed-since origin/main`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the helper-module extraction, ran targeted/local verification, and drafted this PR description; Chris remains responsible for review and merge.