### PR TITLE
Refactor convention membership helpers

### DIFF
--- a/src/core/code_audit/convention_membership.rs
+++ b/src/core/code_audit/convention_membership.rs
@@ -1,0 +1,69 @@
+use super::conventions::{AuditFinding, Deviation};
+use super::fingerprint::FileFingerprint;
+use crate::core::component::AuditConfig;
+
+const GENERIC_UTILITY_SUFFIXES: &[&str] = &[
+    "Base",
+    "Handler",
+    "Handlers",
+    "Helper",
+    "Helpers",
+    "Projector",
+    "Projectors",
+];
+
+pub(super) fn member_requirement_deviation(
+    kind: AuditFinding,
+    description_label: &str,
+    suggestion_verb: &str,
+    expected: &str,
+    expected_suffix: &str,
+    group_name: &str,
+) -> Deviation {
+    Deviation {
+        kind,
+        description: format!("{}: {}", description_label, expected),
+        suggestion: format!(
+            "{} {}{} to match the convention in {}",
+            suggestion_verb, expected, expected_suffix, group_name
+        ),
+    }
+}
+
+pub(super) fn declared_trait_name(fp: &FileFingerprint) -> Option<String> {
+    let re = regex::Regex::new(r"(?m)^\s*trait\s+([A-Za-z_][A-Za-z0-9_]*)\b").ok()?;
+    re.captures(&fp.content)
+        .and_then(|cap| cap.get(1))
+        .map(|m| m.as_str().to_string())
+}
+
+pub(super) fn declares_type_subject(fp: &FileFingerprint) -> bool {
+    fp.type_name.is_some() || !fp.type_names.is_empty()
+}
+
+pub(super) fn is_utility_like_file(fp: &FileFingerprint, audit_config: &AuditConfig) -> bool {
+    let names_to_check: Vec<&str> = if !fp.type_names.is_empty() {
+        fp.type_names.iter().map(|s| s.as_str()).collect()
+    } else {
+        fp.type_name.as_deref().into_iter().collect()
+    };
+
+    declared_trait_name(fp).is_some()
+        || names_to_check.iter().any(|name| {
+            GENERIC_UTILITY_SUFFIXES
+                .iter()
+                .any(|suffix| name.ends_with(suffix))
+                || audit_config
+                    .utility_suffixes
+                    .iter()
+                    .any(|suffix| name.ends_with(suffix))
+        })
+}
+
+pub(super) fn is_convention_exception(fp: &FileFingerprint, audit_config: &AuditConfig) -> bool {
+    let normalized = fp.relative_path.replace('\\', "/");
+    audit_config
+        .convention_exception_globs
+        .iter()
+        .any(|pattern| glob_match::glob_match(pattern, &normalized))
+}

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -7,21 +7,15 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use super::convention_membership::{
+    declared_trait_name, declares_type_subject, is_convention_exception, is_utility_like_file,
+    member_requirement_deviation,
+};
 use super::fingerprint::FileFingerprint;
 use super::import_matching::has_import_with_context;
 use super::naming::{detect_naming_suffix, suffix_matches};
 use super::signatures::{compute_signature_skeleton, tokenize_signature};
 use crate::core::component::AuditConfig;
-
-const GENERIC_UTILITY_SUFFIXES: &[&str] = &[
-    "Base",
-    "Handler",
-    "Handlers",
-    "Helper",
-    "Helpers",
-    "Projector",
-    "Projectors",
-];
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -690,62 +684,6 @@ pub fn discover_conventions_with_config(
         total_files: total,
         confidence,
     })
-}
-
-fn member_requirement_deviation(
-    kind: AuditFinding,
-    description_label: &str,
-    suggestion_verb: &str,
-    expected: &str,
-    expected_suffix: &str,
-    group_name: &str,
-) -> Deviation {
-    Deviation {
-        kind,
-        description: format!("{}: {}", description_label, expected),
-        suggestion: format!(
-            "{} {}{} to match the convention in {}",
-            suggestion_verb, expected, expected_suffix, group_name
-        ),
-    }
-}
-
-fn declared_trait_name(fp: &FileFingerprint) -> Option<String> {
-    let re = regex::Regex::new(r"(?m)^\s*trait\s+([A-Za-z_][A-Za-z0-9_]*)\b").ok()?;
-    re.captures(&fp.content)
-        .and_then(|cap| cap.get(1))
-        .map(|m| m.as_str().to_string())
-}
-
-fn declares_type_subject(fp: &FileFingerprint) -> bool {
-    fp.type_name.is_some() || !fp.type_names.is_empty()
-}
-
-fn is_utility_like_file(fp: &FileFingerprint, audit_config: &AuditConfig) -> bool {
-    let names_to_check: Vec<&str> = if !fp.type_names.is_empty() {
-        fp.type_names.iter().map(|s| s.as_str()).collect()
-    } else {
-        fp.type_name.as_deref().into_iter().collect()
-    };
-
-    declared_trait_name(fp).is_some()
-        || names_to_check.iter().any(|name| {
-            GENERIC_UTILITY_SUFFIXES
-                .iter()
-                .any(|suffix| name.ends_with(suffix))
-                || audit_config
-                    .utility_suffixes
-                    .iter()
-                    .any(|suffix| name.ends_with(suffix))
-        })
-}
-
-fn is_convention_exception(fp: &FileFingerprint, audit_config: &AuditConfig) -> bool {
-    let normalized = fp.relative_path.replace('\\', "/");
-    audit_config
-        .convention_exception_globs
-        .iter()
-        .any(|pattern| glob_match::glob_match(pattern, &normalized))
 }
 
 // ============================================================================

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -18,6 +18,7 @@ mod comment_blocks;
 mod comment_hygiene;
 pub mod compare;
 mod compiler_warnings;
+mod convention_membership;
 pub(crate) mod conventions;
 pub(crate) mod core_fingerprint;
 mod dead_code;


### PR DESCRIPTION
## Summary
- Extract convention member-classification helpers from `conventions.rs` into a private `convention_membership` module.
- Keep convention discovery behavior unchanged while narrowing the target god-file slice.

## Verification
- `cargo fmt`
- `cargo test core::code_audit::conventions::tests`
- `homeboy audit --changed-since origin/main`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the helper-module extraction, ran targeted verification, and prepared this PR; Chris remains responsible for review and merge.