### PR TITLE
Extract grammar string scanner

### DIFF
--- a/src/core/extension/grammar.rs
+++ b/src/core/extension/grammar.rs
@@ -31,6 +31,9 @@ use std::sync::{Mutex, OnceLock};
 use crate::core::engine::local_files;
 use crate::core::error::{Error, Result};
 
+pub use super::grammar_strings::find_unclosed_raw_string_on_line;
+use super::grammar_strings::{line_closes_regular_string, line_has_unclosed_regular_string};
+
 // ============================================================================
 // Grammar definition (loaded from extension TOML/JSON)
 // ============================================================================
@@ -573,116 +576,6 @@ pub struct ContextualLine<'a> {
 
     /// What region this line is in.
     pub region: Region,
-}
-
-/// Check if a line opens a Rust raw string (`r#"`, `r##"`, etc.) that doesn't
-/// close on the same line. Returns the closing delimiter pattern if found.
-///
-/// This is the shared implementation used by both the grammar walker (to mark
-/// lines as `StringLiteral` during extraction) and the orphaned test fixer
-/// (to skip function declarations inside test fixture strings).
-pub fn find_unclosed_raw_string_on_line(line: &str) -> Option<String> {
-    let bytes = line.as_bytes();
-    let len = bytes.len();
-    let mut pos = 0;
-
-    while pos < len {
-        // Skip regular strings — don't confuse `"..."` with raw string opening.
-        if bytes[pos] == b'"' && (pos == 0 || bytes[pos - 1] != b'r') {
-            pos += 1;
-            while pos < len {
-                if bytes[pos] == b'"' && bytes[pos - 1] != b'\\' {
-                    pos += 1;
-                    break;
-                }
-                pos += 1;
-            }
-            continue;
-        }
-
-        // Look for r followed by one or more # then "
-        if bytes[pos] == b'r' && pos + 1 < len {
-            let hash_start = pos + 1;
-            let mut hash_end = hash_start;
-            while hash_end < len && bytes[hash_end] == b'#' {
-                hash_end += 1;
-            }
-            let hash_count = hash_end - hash_start;
-
-            if hash_count > 0 && hash_end < len && bytes[hash_end] == b'"' {
-                let close_pattern = format!("\"{}", "#".repeat(hash_count));
-
-                // Check if the closing pattern appears later on the SAME line
-                let after_open = &line[hash_end + 1..];
-                if !after_open.contains(&close_pattern) {
-                    return Some(close_pattern);
-                }
-
-                // Closed on same line — skip past the close and continue
-                if let Some(close_pos) = after_open.find(&close_pattern) {
-                    pos = hash_end + 1 + close_pos + close_pattern.len();
-                    continue;
-                }
-            }
-        }
-
-        pos += 1;
-    }
-
-    None
-}
-
-fn line_has_unclosed_regular_string(line: &str) -> bool {
-    let bytes = line.as_bytes();
-    let mut pos = 0;
-    let mut in_string = false;
-
-    while pos < bytes.len() {
-        let byte = bytes[pos];
-
-        if byte == b'"' && !is_escaped(bytes, pos) {
-            // Raw string openers are handled separately. Treat the opening
-            // delimiter as non-regular so `r#"..."#` does not toggle us.
-            if !in_string && pos > 0 && bytes[pos - 1] == b'r' {
-                pos += 1;
-                continue;
-            }
-            in_string = !in_string;
-        }
-
-        pos += 1;
-    }
-
-    in_string
-}
-
-fn line_closes_regular_string(line: &str) -> bool {
-    let bytes = line.as_bytes();
-    let mut pos = 0;
-
-    while pos < bytes.len() {
-        if bytes[pos] == b'"' && !is_escaped(bytes, pos) {
-            return true;
-        }
-        pos += 1;
-    }
-
-    false
-}
-
-fn is_escaped(bytes: &[u8], pos: usize) -> bool {
-    if pos == 0 {
-        return false;
-    }
-
-    let mut backslashes = 0;
-    let mut i = pos;
-    while i > 0 && bytes[i - 1] == b'\\' {
-        backslashes += 1;
-        i -= 1;
-    }
-
-    backslashes % 2 == 1
 }
 
 /// Iterate lines with structural context, tracking brace depth and regions.

--- a/src/core/extension/grammar_strings.rs
+++ b/src/core/extension/grammar_strings.rs
@@ -1,0 +1,107 @@
+//! String-literal scanning helpers for grammar walking.
+
+/// Check if a line opens a Rust raw string (`r#"`, `r##"`, etc.) that doesn't
+/// close on the same line. Returns the closing delimiter pattern if found.
+pub fn find_unclosed_raw_string_on_line(line: &str) -> Option<String> {
+    let bytes = line.as_bytes();
+    let len = bytes.len();
+    let mut pos = 0;
+
+    while pos < len {
+        // Skip regular strings — don't confuse `"..."` with raw string opening.
+        if bytes[pos] == b'"' && (pos == 0 || bytes[pos - 1] != b'r') {
+            pos += 1;
+            while pos < len {
+                if bytes[pos] == b'"' && bytes[pos - 1] != b'\\' {
+                    pos += 1;
+                    break;
+                }
+                pos += 1;
+            }
+            continue;
+        }
+
+        // Look for r followed by one or more # then "
+        if bytes[pos] == b'r' && pos + 1 < len {
+            let hash_start = pos + 1;
+            let mut hash_end = hash_start;
+            while hash_end < len && bytes[hash_end] == b'#' {
+                hash_end += 1;
+            }
+            let hash_count = hash_end - hash_start;
+
+            if hash_count > 0 && hash_end < len && bytes[hash_end] == b'"' {
+                let close_pattern = format!("\"{}", "#".repeat(hash_count));
+
+                // Check if the closing pattern appears later on the SAME line
+                let after_open = &line[hash_end + 1..];
+                if !after_open.contains(&close_pattern) {
+                    return Some(close_pattern);
+                }
+
+                // Closed on same line — skip past the close and continue
+                if let Some(close_pos) = after_open.find(&close_pattern) {
+                    pos = hash_end + 1 + close_pos + close_pattern.len();
+                    continue;
+                }
+            }
+        }
+
+        pos += 1;
+    }
+
+    None
+}
+
+pub(crate) fn line_has_unclosed_regular_string(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    let mut pos = 0;
+    let mut in_string = false;
+
+    while pos < bytes.len() {
+        let byte = bytes[pos];
+
+        if byte == b'"' && !is_escaped(bytes, pos) {
+            // Raw string openers are handled separately. Treat the opening
+            // delimiter as non-regular so `r#"..."#` does not toggle us.
+            if !in_string && pos > 0 && bytes[pos - 1] == b'r' {
+                pos += 1;
+                continue;
+            }
+            in_string = !in_string;
+        }
+
+        pos += 1;
+    }
+
+    in_string
+}
+
+pub(crate) fn line_closes_regular_string(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    let mut pos = 0;
+
+    while pos < bytes.len() {
+        if bytes[pos] == b'"' && !is_escaped(bytes, pos) {
+            return true;
+        }
+        pos += 1;
+    }
+
+    false
+}
+
+fn is_escaped(bytes: &[u8], pos: usize) -> bool {
+    if pos == 0 {
+        return false;
+    }
+
+    let mut backslashes = 0;
+    let mut i = pos;
+    while i > 0 && bytes[i - 1] == b'\\' {
+        backslashes += 1;
+        i -= 1;
+    }
+
+    backslashes % 2 == 1
+}

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -7,6 +7,7 @@ mod execution;
 mod fingerprint;
 pub mod grammar;
 pub mod grammar_items;
+mod grammar_strings;
 mod lifecycle;
 pub mod lint;
 mod maintenance;


### PR DESCRIPTION
## Summary
- Extracts grammar string-literal scanning helpers from `src/core/extension/grammar.rs` into `src/core/extension/grammar_strings.rs`.
- Keeps the existing `grammar::find_unclosed_raw_string_on_line` API by re-exporting the helper from `grammar`.
- Preserves behavior while shaving a small cohesive seam off the grammar god-file.

## Verification
- `cargo fmt --check`
- `cargo test core::extension::grammar`
- `homeboy audit --changed-since origin/main`
- `homeboy lint --changed-since origin/main`
- `homeboy test --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Identified the smallest safe extraction seam, moved the helper code, and ran the verification commands. Chris remains responsible for review and merge.