### PR TITLE
Make artifact portability path policy configurable

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,5 +1,10 @@
 {
   "audit": {
+    "artifact_portability": {
+      "non_portable_path_contains": [
+        "/homeboy-run-"
+      ]
+    },
     "command_status_contracts": {
       "required_commands": [
         "audit",

--- a/src/core/code_audit/detectors/artifact_portability.rs
+++ b/src/core/code_audit/detectors/artifact_portability.rs
@@ -2,9 +2,17 @@ use std::path::Path;
 
 use crate::core::code_audit::conventions::AuditFinding;
 use crate::core::code_audit::findings::{Finding, Severity};
+use crate::core::component::ArtifactPortabilityConfig;
 use crate::core::observation::{ObservationStore, RunListFilter};
 
 pub(crate) fn run(component_id: &str) -> Vec<Finding> {
+    run_with_config(component_id, &ArtifactPortabilityConfig::default())
+}
+
+pub(crate) fn run_with_config(
+    component_id: &str,
+    config: &ArtifactPortabilityConfig,
+) -> Vec<Finding> {
     let Ok(store) = ObservationStore::open_initialized() else {
         return Vec::new();
     };
@@ -18,6 +26,7 @@ pub(crate) fn run(component_id: &str) -> Vec<Finding> {
         return Vec::new();
     };
     let artifact_root = crate::core::artifact_root().ok();
+    let path_policy = config.with_generic_defaults();
     let mut findings = Vec::new();
 
     for run in runs {
@@ -28,7 +37,7 @@ pub(crate) fn run(component_id: &str) -> Vec<Finding> {
             if artifact.artifact_type != "file" && artifact.artifact_type != "directory" {
                 continue;
             }
-            if artifact_path_is_portable(&artifact.path, artifact_root.as_deref()) {
+            if artifact_path_is_portable(&artifact.path, artifact_root.as_deref(), &path_policy) {
                 continue;
             }
             findings.push(Finding {
@@ -49,7 +58,11 @@ pub(crate) fn run(component_id: &str) -> Vec<Finding> {
     findings
 }
 
-fn artifact_path_is_portable(path: &str, artifact_root: Option<&Path>) -> bool {
+fn artifact_path_is_portable(
+    path: &str,
+    artifact_root: Option<&Path>,
+    config: &ArtifactPortabilityConfig,
+) -> bool {
     if path.starts_with("runner-artifact://") || path.starts_with("metadata-only:") {
         return true;
     }
@@ -59,14 +72,18 @@ fn artifact_path_is_portable(path: &str, artifact_root: Option<&Path>) -> bool {
             return true;
         }
     }
-    !looks_like_runtime_temp_path(path)
+    !looks_like_runtime_temp_path(path, config)
 }
 
-fn looks_like_runtime_temp_path(path: &str) -> bool {
-    path.contains("/homeboy-run-")
-        || path.starts_with("/tmp/")
-        || path.starts_with("/private/tmp/")
-        || path.starts_with("/var/folders/")
+fn looks_like_runtime_temp_path(path: &str, config: &ArtifactPortabilityConfig) -> bool {
+    config
+        .non_portable_path_prefixes
+        .iter()
+        .any(|prefix| path.starts_with(prefix))
+        || config
+            .non_portable_path_contains
+            .iter()
+            .any(|marker| path.contains(marker))
 }
 
 #[cfg(test)]
@@ -122,8 +139,42 @@ mod tests {
 
             assert!(artifact_path_is_portable(
                 &artifact_root.join("run/artifact.json").to_string_lossy(),
-                Some(&artifact_root)
+                Some(&artifact_root),
+                &ArtifactPortabilityConfig::default().with_generic_defaults()
             ));
         });
+    }
+
+    #[test]
+    fn accepts_project_specific_path_markers_from_config() {
+        let config = ArtifactPortabilityConfig {
+            non_portable_path_contains: vec!["/project-run-".to_string()],
+            ..Default::default()
+        }
+        .with_generic_defaults();
+
+        assert!(!artifact_path_is_portable(
+            "/workspace/project-run-abc/trace.json",
+            None,
+            &config
+        ));
+        assert!(artifact_path_is_portable(
+            "/workspace/other-run-abc/trace.json",
+            None,
+            &config
+        ));
+    }
+
+    #[test]
+    fn homeboy_config_declares_homeboy_run_marker() {
+        let raw = std::fs::read_to_string("homeboy.json").expect("homeboy config");
+        let component: crate::core::component::Component =
+            serde_json::from_str(&raw).expect("component config");
+        let audit = component.audit.expect("audit config");
+
+        assert!(audit
+            .artifact_portability
+            .non_portable_path_contains
+            .contains(&"/homeboy-run-".to_string()));
     }
 }

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -1426,7 +1426,11 @@ fn audit_internal(
     }
 
     let artifact_portability_findings = if plan.run_artifact_portability() {
-        artifact_portability::run(component_id)
+        if audit_config.artifact_portability.is_empty() {
+            artifact_portability::run(component_id)
+        } else {
+            artifact_portability::run_with_config(component_id, &audit_config.artifact_portability)
+        }
     } else {
         Vec::new()
     };
@@ -1604,6 +1608,7 @@ fn audit_root_only(
     root: &Path,
     plan: &AuditExecutionPlan,
 ) -> CodeAuditResult {
+    let audit_config = audit_config_for(component_id, root);
     let mut findings = Vec::new();
 
     if plan.run_structural() {
@@ -1691,7 +1696,11 @@ fn audit_root_only(
     }
 
     if plan.run_artifact_portability() {
-        let artifact_portability_findings = artifact_portability::run(component_id);
+        let artifact_portability_findings = if audit_config.artifact_portability.is_empty() {
+            artifact_portability::run(component_id)
+        } else {
+            artifact_portability::run_with_config(component_id, &audit_config.artifact_portability)
+        };
         if !artifact_portability_findings.is_empty() {
             log_status!(
                 "audit",

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -70,6 +70,49 @@ pub struct AuditConfig {
     /// Component-owned command scenario fixtures with expected status fields.
     #[serde(default, skip_serializing_if = "CommandStatusContractConfig::is_empty")]
     pub command_status_contracts: CommandStatusContractConfig,
+    /// Component-owned path policy for durable artifact portability checks.
+    #[serde(default, skip_serializing_if = "ArtifactPortabilityConfig::is_empty")]
+    pub artifact_portability: ArtifactPortabilityConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ArtifactPortabilityConfig {
+    /// Path prefixes that identify local/runtime-only locations in stored artifacts.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub non_portable_path_prefixes: Vec<String>,
+    /// Path substrings that identify project-specific local/runtime-only artifact locations.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub non_portable_path_contains: Vec<String>,
+}
+
+impl ArtifactPortabilityConfig {
+    pub fn is_empty(&self) -> bool {
+        self.non_portable_path_prefixes.is_empty() && self.non_portable_path_contains.is_empty()
+    }
+
+    pub fn with_generic_defaults(&self) -> Self {
+        let mut config = self.clone();
+        extend_unique(
+            &mut config.non_portable_path_prefixes,
+            &[
+                "/tmp/".to_string(),
+                "/private/tmp/".to_string(),
+                "/var/folders/".to_string(),
+            ],
+        );
+        config
+    }
+
+    fn merge(&mut self, other: &ArtifactPortabilityConfig) {
+        extend_unique(
+            &mut self.non_portable_path_prefixes,
+            &other.non_portable_path_prefixes,
+        );
+        extend_unique(
+            &mut self.non_portable_path_contains,
+            &other.non_portable_path_contains,
+        );
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
@@ -699,6 +742,7 @@ impl AuditConfig {
             && self.public_registry_exposure.is_empty()
             && self.config_key_usage.is_empty()
             && self.command_status_contracts.is_empty()
+            && self.artifact_portability.is_empty()
     }
 
     pub fn merge(&mut self, other: &AuditConfig) {
@@ -732,6 +776,7 @@ impl AuditConfig {
         self.config_key_usage.merge(&other.config_key_usage);
         self.command_status_contracts
             .merge(&other.command_status_contracts);
+        self.artifact_portability.merge(&other.artifact_portability);
         for rule in &other.requested_detectors {
             if !self
                 .requested_detectors

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -12,11 +12,12 @@ pub mod scope;
 pub mod versioning;
 
 pub use audit::{
-    AuditConfig, CommandStatusContractConfig, CommandStatusContractScenario, ConfigKeyUsageConfig,
-    ConfigKeyUsagePattern, ConfigKeyUsageRule, ConventionTagGlob, CoreBoundaryLeakConfig,
-    DuplicationDetectorConfig, KnownSymbolEntry, KnownSymbolHeaderVersionProvider, KnownSymbolKind,
-    KnownSymbolVersionedEntry, MutatingResourceAccessConfig, PublicRegistryExposureConfig,
-    RedirectValidationConfig, RequestedDetectorRule, RequestedDetectorRuleBody, RequiredRegexScope,
+    ArtifactPortabilityConfig, AuditConfig, CommandStatusContractConfig,
+    CommandStatusContractScenario, ConfigKeyUsageConfig, ConfigKeyUsagePattern, ConfigKeyUsageRule,
+    ConventionTagGlob, CoreBoundaryLeakConfig, DuplicationDetectorConfig, KnownSymbolEntry,
+    KnownSymbolHeaderVersionProvider, KnownSymbolKind, KnownSymbolVersionedEntry,
+    MutatingResourceAccessConfig, PublicRegistryExposureConfig, RedirectValidationConfig,
+    RequestedDetectorRule, RequestedDetectorRuleBody, RequiredRegexScope,
 };
 pub use inventory::{
     exists, extension_provides_artifact_pattern, inventory, list, list_ids, load,


### PR DESCRIPTION
## Summary
- Adds `artifact_portability` audit config for non-portable path prefixes and project-specific path markers.
- Wires Homeboy's `/homeboy-run-` runtime marker through `homeboy.json` instead of hardcoding it in the detector.
- Keeps generic temp-root detection and focused tests for config-driven markers plus Homeboy config wiring.

Fixes #2837.

## Verification
- `cargo fmt --check`
- `cargo test artifact_portability --lib`
- `cargo test core::component::audit --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@fix-artifact-portability-policy --extension rust --changed-since origin/main --force-hot`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-artifact-portability-policy --extension rust --changed-since origin/main --force-hot`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-artifact-portability-policy --extension rust --changed-since origin/main --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the config-driven artifact portability policy refactor, updated focused tests, and ran verification under Chris's review direction.