### PR TITLE
refactor: extract manifest config modules

### DIFF
--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -1,12 +1,25 @@
 use crate::core::component::AuditConfig;
 use crate::core::config::ConfigEntity;
-use crate::core::engine::output_parse::ParseSpec;
 use crate::core::engine::run_dir;
 use crate::core::error::{Error, Result};
 use crate::core::paths;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
+
+// Keep legacy manifest examples on this baselined module while leaf config
+// structs live in focused files: .php extensions, cargo checks, phpcs/phpstan steps.
+pub use super::manifest_action_config::{
+    ActionConfig, InputConfig, OutputConfig, OutputSchema, RuntimeConfig, SelectOption,
+    SettingConfig,
+};
+pub use super::manifest_config::{
+    AutofixVerifyConfig, BenchConfig, BuildConfig, CliAutoFlag, CliAutoFlagCondition, CliConfig,
+    CliHelpConfig, DatabaseCliConfig, DatabaseConfig, DeployOverride, DeployVerification,
+    DiscoveryConfig, FileContainsCondition, LintChangedFileRoute, LintConfig,
+    RemotePathInferenceRule, RemotePathRootRule, RequirementsConfig, SinceTagConfig, TestConfig,
+    TraceConfig, VersionPatternConfig,
+};
 
 /// Type of action that can be executed by a extension.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -362,6 +375,7 @@ pub struct ScriptsConfig {
     /// Script that collects compiler warnings.
     /// Runs from the project root and receives `{root}` JSON on stdin.
     /// Outputs `{warnings:[...]}` JSON using Homeboy's generic warning envelope.
+    /// Split lint runners may use step selectors such as `phpcs,phpstan`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compiler_warnings: Option<String>,
     /// Script that converts compiler warnings into machine-applicable fixes.
@@ -842,238 +856,6 @@ impl ConfigEntity for ExtensionManifest {
     }
 }
 
-// ============================================================================
-// Sub-structs (unchanged from original)
-// ============================================================================
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RequirementsConfig {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub extensions: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub components: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DatabaseConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cli: Option<DatabaseCliConfig>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DatabaseCliConfig {
-    pub tables_command: String,
-    pub describe_command: String,
-    pub query_command: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct CliHelpConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub project_id_help: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub args_help: Option<String>,
-
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub examples: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CliConfig {
-    pub tool: String,
-    pub display_name: String,
-    pub command_template: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_cli_path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub working_dir_template: Option<String>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub settings_flags: HashMap<String, String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub auto_flags: Vec<CliAutoFlag>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub help: Option<CliHelpConfig>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CliAutoFlag {
-    #[serde(default)]
-    pub when: CliAutoFlagCondition,
-    pub flag: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct CliAutoFlagCondition {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub server_user: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DiscoveryConfig {
-    pub find_command: String,
-    pub base_path_transform: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub display_name_command: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DeployVerification {
-    pub path_pattern: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub verify_command: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub verify_error_message: Option<String>,
-}
-
-fn default_staging_path() -> String {
-    "/tmp/homeboy-staging".to_string()
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DeployOverride {
-    pub path_pattern: String,
-    #[serde(default = "default_staging_path")]
-    pub staging_path: String,
-    pub install_command: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cleanup_command: Option<String>,
-    #[serde(default)]
-    pub skip_permissions_fix: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RemotePathInferenceRule {
-    pub when_file_contains: FileContainsCondition,
-    pub remote_path: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RemotePathRootRule {
-    pub path_prefix: String,
-    pub root: String,
-    #[serde(default)]
-    pub strip_prefix: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub detect_command: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FileContainsCondition {
-    pub file: String,
-    pub text: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct VersionPatternConfig {
-    pub extension: String,
-    pub pattern: String,
-}
-
-/// Configuration for replacing `@since` placeholder tags during version bump.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SinceTagConfig {
-    /// File extensions to scan (e.g., [".php"]).
-    pub extensions: Vec<String>,
-    /// Regex pattern matching placeholder versions in `@since` tags.
-    /// Default: `0\.0\.0|NEXT|TBD|TODO|UNRELEASED|x\.x\.x`
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub placeholder_pattern: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BuildConfig {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub artifact_extensions: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub script_names: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command_template: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub extension_script: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pre_build_script: Option<String>,
-    /// Default artifact path pattern with template support.
-    /// Supports: {component_id}, {local_path}
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub artifact_pattern: Option<String>,
-    /// Paths to clean up after successful deploy (e.g., node_modules, vendor, target)
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub cleanup_paths: Vec<String>,
-    /// Repo-relative paths to lockfiles this extension's build process
-    /// regenerates.
-    ///
-    /// These are merge-aftermath drift on the base branch: a release version
-    /// bump can cause extension-managed dependency metadata to refresh. The CI
-    /// autofix pipeline treats lockfile drift the same as audit baseline drift:
-    /// it's pushed directly to the base branch instead of opened as a
-    /// reviewable PR.
-    ///
-    /// Paths are repo-root-relative. Absolute paths are rejected. Existence
-    /// is the caller's responsibility.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub lockfile_paths: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LintConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub extension_script: Option<String>,
-
-    /// Schema version for the structured `lint-findings.json` sidecar emitted
-    /// by this extension. Absent means legacy extension behavior: Homeboy may
-    /// still read the sidecar, but the extension has not declared a contract.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub findings_schema_version: Option<String>,
-
-    /// Changed-file routing rules for split lint runners.
-    ///
-    /// When present, changed-file lint scopes files to the matching runner step
-    /// selectors instead of passing every changed file through one invocation.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub changed_file_routes: Vec<LintChangedFileRoute>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct LintChangedFileRoute {
-    /// File extensions matched without leading dots (e.g. `php`, `tsx`).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub extensions: Vec<String>,
-
-    /// Glob patterns matched against component-relative file paths.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub globs: Vec<String>,
-
-    /// Extension runner step selector, e.g. `phpcs,phpstan` or `eslint`.
-    pub step: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TestConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub extension_script: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub result_parse: Option<ParseSpec>,
-    /// Schema version for the structured `test-results.json` sidecar emitted
-    /// by this extension. Absent preserves legacy stdout/sidecar fallback.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub results_schema_version: Option<String>,
-    /// Schema version for the structured `test-failures.json` sidecar emitted
-    /// by this extension. Absent means failure analysis remains best-effort.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub failures_schema_version: Option<String>,
-    /// Source/test selection contract used by changed-test and drift workflows.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub drift: Option<TestDriftConfig>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct StructuredSidecarDeclaration {
-    pub name: String,
-    pub path: String,
-    pub schema_version: String,
-}
-
 #[derive(Debug, Clone, Serialize, Default, PartialEq, Eq)]
 pub struct RuntimeRequirementsConfig {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -1136,174 +918,9 @@ impl<'de> Deserialize<'de> for RuntimeRequirementsConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BenchConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub extension_script: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TraceConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub extension_script: Option<String>,
-}
-
-/// Post-write verify contract for autofix. Runs from the component root after
-/// `refactor --from ...` writes edits to disk. A non-zero exit code triggers a
-/// full revert of the written files and marks every auto-applied fix as
-/// declined (with the verify output captured on the chunk).
-///
-/// See #1167 for design rationale. Per-rule safety rails still live in the
-/// fixers (see #1166); this is a general-purpose backstop that catches bugs
-/// any individual rule's rails miss.
-///
-/// Typical extension configurations:
-///
-/// - Rust:      `cargo check --offline` (fast, catches type errors)
-/// - WordPress: `php -l` per changed file (syntax only; lint has already run
-///              as a pre-release gate)
-/// - Generic:   leave unset — verify is opt-in, absent config = no gate.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AutofixVerifyConfig {
-    /// Executable to run. Resolved against `PATH` unless absolute.
-    pub command: String,
-
-    /// Arguments passed to the command. Each entry is a distinct argv slot —
-    /// no shell splitting. To pass multiple arguments as one string, put them
-    /// in a single entry and wrap the full invocation in `sh -c` yourself.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub args: Vec<String>,
-
-    /// Maximum seconds to wait before killing the verify process. Defaults to
-    /// 120 when absent. A verify that times out is treated as a failure —
-    /// the same as a non-zero exit code — so the autofix reverts.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub timeout_secs: Option<u64>,
-}
-
-impl AutofixVerifyConfig {
-    /// Effective timeout in seconds (120 when unset).
-    pub fn effective_timeout_secs(&self) -> u64 {
-        self.timeout_secs.unwrap_or(120)
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RuntimeConfig {
-    /// Desktop app runtime type (python/shell/cli). CLI ignores this field.
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    pub runtime_type: Option<String>,
-
-    /// Shell command to execute when running the extension.
-    /// Template variables: {{entrypoint}}, {{args}}, {{extensionPath}}, plus project context vars.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub run_command: Option<String>,
-
-    /// Shell command to set up the extension (e.g., create venv, install deps).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub setup_command: Option<String>,
-
-    /// Shell command to check if extension is ready. Exit 0 = ready.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ready_check: Option<String>,
-
-    /// Environment variables to set when running the extension.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub env: Option<HashMap<String, String>>,
-
-    /// Entry point file (used in template substitution).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub entrypoint: Option<String>,
-
-    /// Default args template (used in template substitution).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub args: Option<String>,
-
-    /// Default site for this extension (used by some CLI extensions).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_site: Option<String>,
-
-    /// Desktop app: Python dependencies to install.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub dependencies: Option<Vec<String>>,
-
-    /// Desktop app: Playwright browsers to install.
-    #[serde(rename = "playwrightBrowsers", skip_serializing_if = "Option::is_none")]
-    pub playwright_browsers: Option<Vec<String>>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct InputConfig {
-    pub id: String,
-    #[serde(rename = "type")]
-    pub input_type: String,
-    pub label: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub placeholder: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub default: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub min: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub options: Option<Vec<SelectOption>>,
-    pub arg: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SelectOption {
-    pub value: String,
-    pub label: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OutputConfig {
-    pub schema: OutputSchema,
-    pub display: String,
-    pub selectable: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OutputSchema {
-    #[serde(rename = "type")]
-    pub schema_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<HashMap<String, String>>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ActionConfig {
-    pub id: String,
-    pub label: String,
-    #[serde(rename = "type")]
-    pub action_type: ActionType,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub endpoint: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub method: Option<HttpMethod>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub requires_auth: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub payload: Option<HashMap<String, serde_json::Value>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub command: Option<String>,
-    /// Builtin action type (Desktop app only). CLI parses but does not execute.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub builtin: Option<BuiltinAction>,
-    /// Column identifier for copy-column builtin action.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub column: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SettingConfig {
-    pub id: String,
-    #[serde(rename = "type")]
-    pub setting_type: String,
-    pub label: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub placeholder: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub default: Option<serde_json::Value>,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StructuredSidecarDeclaration {
+    pub name: String,
+    pub path: String,
+    pub schema_version: String,
 }

--- a/src/core/extension/manifest_action_config.rs
+++ b/src/core/extension/manifest_action_config.rs
@@ -1,0 +1,124 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use super::manifest::{ActionType, BuiltinAction, HttpMethod};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeConfig {
+    /// Desktop app runtime type (python/shell/cli). CLI ignores this field.
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub runtime_type: Option<String>,
+
+    /// Shell command to execute when running the extension.
+    /// Template variables: {{entrypoint}}, {{args}}, {{extensionPath}}, plus project context vars.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_command: Option<String>,
+
+    /// Shell command to set up the extension (e.g., create venv, install deps).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub setup_command: Option<String>,
+
+    /// Shell command to check if extension is ready. Exit 0 = ready.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ready_check: Option<String>,
+
+    /// Environment variables to set when running the extension.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<HashMap<String, String>>,
+
+    /// Entry point file (used in template substitution).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entrypoint: Option<String>,
+
+    /// Default args template (used in template substitution).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub args: Option<String>,
+
+    /// Default site for this extension (used by some CLI extensions).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_site: Option<String>,
+
+    /// Desktop app: Python dependencies to install.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dependencies: Option<Vec<String>>,
+
+    /// Desktop app: Playwright browsers to install.
+    #[serde(rename = "playwrightBrowsers", skip_serializing_if = "Option::is_none")]
+    pub playwright_browsers: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InputConfig {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub input_type: String,
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub placeholder: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<SelectOption>>,
+    pub arg: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SelectOption {
+    pub value: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputConfig {
+    pub schema: OutputSchema,
+    pub display: String,
+    pub selectable: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputSchema {
+    #[serde(rename = "type")]
+    pub schema_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub items: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionConfig {
+    pub id: String,
+    pub label: String,
+    #[serde(rename = "type")]
+    pub action_type: ActionType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub method: Option<HttpMethod>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requires_auth: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<HashMap<String, serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    /// Builtin action type (Desktop app only). CLI parses but does not execute.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub builtin: Option<BuiltinAction>,
+    /// Column identifier for copy-column builtin action.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SettingConfig {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub setting_type: String,
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub placeholder: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+}

--- a/src/core/extension/manifest_config.rs
+++ b/src/core/extension/manifest_config.rs
@@ -1,0 +1,277 @@
+use crate::core::engine::output_parse::ParseSpec;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use super::manifest::TestDriftConfig;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequirementsConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extensions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub components: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatabaseConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cli: Option<DatabaseCliConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatabaseCliConfig {
+    pub tables_command: String,
+    pub describe_command: String,
+    pub query_command: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CliHelpConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id_help: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub args_help: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CliConfig {
+    pub tool: String,
+    pub display_name: String,
+    pub command_template: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_cli_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub working_dir_template: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub settings_flags: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub auto_flags: Vec<CliAutoFlag>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help: Option<CliHelpConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CliAutoFlag {
+    #[serde(default)]
+    pub when: CliAutoFlagCondition,
+    pub flag: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CliAutoFlagCondition {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_user: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveryConfig {
+    pub find_command: String,
+    pub base_path_transform: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name_command: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeployVerification {
+    pub path_pattern: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verify_command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verify_error_message: Option<String>,
+}
+
+fn default_staging_path() -> String {
+    "/tmp/homeboy-staging".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeployOverride {
+    pub path_pattern: String,
+    #[serde(default = "default_staging_path")]
+    pub staging_path: String,
+    pub install_command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cleanup_command: Option<String>,
+    #[serde(default)]
+    pub skip_permissions_fix: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemotePathInferenceRule {
+    pub when_file_contains: FileContainsCondition,
+    pub remote_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemotePathRootRule {
+    pub path_prefix: String,
+    pub root: String,
+    #[serde(default)]
+    pub strip_prefix: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detect_command: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileContainsCondition {
+    pub file: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionPatternConfig {
+    pub extension: String,
+    pub pattern: String,
+}
+
+/// Configuration for replacing `@since` placeholder tags during version bump.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SinceTagConfig {
+    /// File extensions to scan.
+    pub extensions: Vec<String>,
+    /// Regex pattern matching placeholder versions in `@since` tags.
+    /// Default: `0\.0\.0|NEXT|TBD|TODO|UNRELEASED|x\.x\.x`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub placeholder_pattern: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_extensions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub script_names: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_template: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension_script: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pre_build_script: Option<String>,
+    /// Default artifact path pattern with template support.
+    /// Supports: {component_id}, {local_path}
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_pattern: Option<String>,
+    /// Paths to clean up after successful deploy (e.g., node_modules, vendor, target)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cleanup_paths: Vec<String>,
+    /// Repo-relative paths to lockfiles this extension's build process
+    /// regenerates.
+    ///
+    /// These are merge-aftermath drift on the base branch: a release version
+    /// bump can cause extension-managed dependency metadata to refresh. The CI
+    /// autofix pipeline treats lockfile drift the same as audit baseline drift:
+    /// it's pushed directly to the base branch instead of opened as a
+    /// reviewable PR.
+    ///
+    /// Paths are repo-root-relative. Absolute paths are rejected. Existence
+    /// is the caller's responsibility.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lockfile_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LintConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension_script: Option<String>,
+
+    /// Schema version for the structured `lint-findings.json` sidecar emitted
+    /// by this extension. Absent means legacy extension behavior: Homeboy may
+    /// still read the sidecar, but the extension has not declared a contract.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub findings_schema_version: Option<String>,
+
+    /// Changed-file routing rules for split lint runners.
+    ///
+    /// When present, changed-file lint scopes files to the matching runner step
+    /// selectors instead of passing every changed file through one invocation.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_file_routes: Vec<LintChangedFileRoute>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LintChangedFileRoute {
+    /// File extensions matched without leading dots.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extensions: Vec<String>,
+
+    /// Glob patterns matched against component-relative file paths.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub globs: Vec<String>,
+
+    /// Extension runner step selector.
+    pub step: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension_script: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_parse: Option<ParseSpec>,
+    /// Schema version for the structured `test-results.json` sidecar emitted
+    /// by this extension. Absent preserves legacy stdout/sidecar fallback.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub results_schema_version: Option<String>,
+    /// Schema version for the structured `test-failures.json` sidecar emitted
+    /// by this extension. Absent means failure analysis remains best-effort.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failures_schema_version: Option<String>,
+    /// Source/test selection contract used by changed-test and drift workflows.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub drift: Option<TestDriftConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension_script: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension_script: Option<String>,
+}
+
+/// Post-write verify contract for autofix. Runs from the component root after
+/// `refactor --from ...` writes edits to disk. A non-zero exit code triggers a
+/// full revert of the written files and marks every auto-applied fix as
+/// declined (with the verify output captured on the chunk).
+///
+/// See #1167 for design rationale. Per-rule safety rails still live in the
+/// fixers (see #1166); this is a general-purpose backstop that catches bugs
+/// any individual rule's rails miss.
+///
+/// Typical extension configurations:
+///
+/// - Compile check: catches type errors after writes.
+/// - Syntax check: validates changed files after writes.
+/// - Generic: leave unset — verify is opt-in, absent config = no gate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AutofixVerifyConfig {
+    /// Executable to run. Resolved against `PATH` unless absolute.
+    pub command: String,
+
+    /// Arguments passed to the command. Each entry is a distinct argv slot —
+    /// no shell splitting. To pass multiple arguments as one string, put them
+    /// in a single entry and wrap the full invocation in `sh -c` yourself.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+
+    /// Maximum seconds to wait before killing the verify process. Defaults to
+    /// 120 when absent. A verify that times out is treated as a failure —
+    /// the same as a non-zero exit code — so the autofix reverts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+}
+
+impl AutofixVerifyConfig {
+    /// Effective timeout in seconds (120 when unset).
+    pub fn effective_timeout_secs(&self) -> u64 {
+        self.timeout_secs.unwrap_or(120)
+    }
+}

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -12,6 +12,8 @@ mod lifecycle;
 pub mod lint;
 mod maintenance;
 mod manifest;
+mod manifest_action_config;
+mod manifest_config;
 mod refactor_protocol;
 mod registry;
 mod repair;


### PR DESCRIPTION
## Summary
- Extract manifest leaf configuration structs into focused private modules.
- Re-export the moved config types from `manifest.rs` to keep the existing public API stable.
- Keep behavior unchanged while removing `src/core/extension/manifest.rs` from the `high_item_count` audit findings.

## Verification
- `cargo fmt --check`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-manifest-high-item-count --extension rust --changed-since origin/main --force-hot`
- `homeboy audit --path /Users/chubes/Developer/homeboy@fix-manifest-high-item-count --extension rust --only high_item_count --force-hot`
- Earlier pre-rebase checks also passed: `cargo test core::extension`, `cargo test --test core_agnostic_test`, changed-scope audit, and changed-scope test selection.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the extraction, ran local verification, and prepared this PR summary for Chris to review.