### PR TITLE
refactor: extract defaults builtins

### DIFF
--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -4,6 +4,9 @@ use std::fs;
 use crate::core::engine::local_files;
 use crate::core::paths;
 
+#[path = "defaults/builtins.rs"]
+mod builtins;
+
 /// Root configuration structure for homeboy.json
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HomeboyConfig {
@@ -62,26 +65,26 @@ pub struct TriageConfig {
 /// All configurable defaults that can be overridden via homeboy.json
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Defaults {
-    #[serde(default = "default_install_methods")]
+    #[serde(default = "builtins::default_install_methods")]
     pub install_methods: InstallMethodsConfig,
 
-    #[serde(default = "default_version_candidates")]
+    #[serde(default = "builtins::default_version_candidates")]
     pub version_candidates: Vec<VersionCandidateConfig>,
 
-    #[serde(default = "default_deploy")]
+    #[serde(default = "builtins::default_deploy")]
     pub deploy: DeployConfig,
 
-    #[serde(default = "default_permissions")]
+    #[serde(default = "builtins::default_permissions")]
     pub permissions: PermissionsConfig,
 }
 
 impl Default for Defaults {
     fn default() -> Self {
         Self {
-            install_methods: default_install_methods(),
-            version_candidates: default_version_candidates(),
-            deploy: default_deploy(),
-            permissions: default_permissions(),
+            install_methods: builtins::default_install_methods(),
+            version_candidates: builtins::default_version_candidates(),
+            deploy: builtins::default_deploy(),
+            permissions: builtins::default_permissions(),
         }
     }
 }
@@ -89,16 +92,16 @@ impl Default for Defaults {
 /// Configuration for install method detection and upgrade commands
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstallMethodsConfig {
-    #[serde(default = "default_homebrew_config")]
+    #[serde(default = "builtins::default_homebrew_config")]
     pub homebrew: InstallMethodConfig,
 
-    #[serde(default = "default_cargo_config")]
+    #[serde(default = "builtins::default_cargo_config")]
     pub cargo: InstallMethodConfig,
 
-    #[serde(default = "default_source_config")]
+    #[serde(default = "builtins::default_source_config")]
     pub source: InstallMethodConfig,
 
-    #[serde(default = "default_binary_config")]
+    #[serde(default = "builtins::default_binary_config")]
     pub binary: InstallMethodConfig,
 }
 
@@ -120,23 +123,23 @@ pub struct VersionCandidateConfig {
 /// Configuration for deploy operations
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeployConfig {
-    #[serde(default = "default_scp_flags")]
+    #[serde(default = "builtins::default_scp_flags")]
     pub scp_flags: Vec<String>,
 
-    #[serde(default = "default_artifact_prefix")]
+    #[serde(default = "builtins::default_artifact_prefix")]
     pub artifact_prefix: String,
 
-    #[serde(default = "default_ssh_port")]
+    #[serde(default = "builtins::default_ssh_port")]
     pub default_ssh_port: u16,
 }
 
 /// Configuration for file permissions
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PermissionsConfig {
-    #[serde(default = "default_local_permissions")]
+    #[serde(default = "builtins::default_local_permissions")]
     pub local: PermissionModes,
 
-    #[serde(default = "default_remote_permissions")]
+    #[serde(default = "builtins::default_remote_permissions")]
     pub remote: PermissionModes,
 }
 
@@ -144,193 +147,6 @@ pub struct PermissionsConfig {
 pub struct PermissionModes {
     pub file_mode: String,
     pub dir_mode: String,
-}
-
-// =============================================================================
-// Default value functions (match current hardcoded behavior)
-// =============================================================================
-
-fn default_install_methods() -> InstallMethodsConfig {
-    InstallMethodsConfig {
-        homebrew: default_homebrew_config(),
-        cargo: default_cargo_config(),
-        source: default_source_config(),
-        binary: default_binary_config(),
-    }
-}
-
-fn default_homebrew_config() -> InstallMethodConfig {
-    InstallMethodConfig {
-        path_patterns: vec!["/Cellar/".to_string(), "/homebrew/".to_string()],
-        upgrade_command: "brew update && brew upgrade homeboy".to_string(),
-        list_command: Some("brew list homeboy".to_string()),
-    }
-}
-
-fn default_cargo_config() -> InstallMethodConfig {
-    InstallMethodConfig {
-        path_patterns: vec!["/.cargo/bin/".to_string()],
-        upgrade_command: "cargo install homeboy".to_string(),
-        list_command: None,
-    }
-}
-
-fn default_source_config() -> InstallMethodConfig {
-    InstallMethodConfig {
-        path_patterns: vec!["/target/release/".to_string(), "/target/debug/".to_string()],
-        upgrade_command: "git pull && . \"$HOME/.cargo/env\" && cargo build --release".to_string(),
-        list_command: None,
-    }
-}
-
-fn default_binary_config() -> InstallMethodConfig {
-    // A downloaded release binary (e.g. ~/bin/homeboy, /usr/local/bin/homeboy).
-    //
-    // This default upgrade command is intentionally shell-based so it works without
-    // introducing new Rust deps (tar/xz/sha256). It can be overridden via homeboy.json.
-    InstallMethodConfig {
-        // Matches typical install locations. We intentionally key off "/bin/homeboy" so both
-        // /usr/local/bin/homeboy and ~/bin/homeboy are detected.
-        path_patterns: vec!["/bin/homeboy".to_string(), "homeboy.exe".to_string()],
-        upgrade_command: r#"set -e
-
-BIN_PATH="$(command -v homeboy)"
-OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-ARCH="$(uname -m)"
-
-case "${OS}-${ARCH}" in
-  linux-x86_64)  ASSET="homeboy-x86_64-unknown-linux-gnu.tar.xz" ;;
-  linux-aarch64|linux-arm64) ASSET="homeboy-aarch64-unknown-linux-gnu.tar.xz" ;;
-  darwin-x86_64) ASSET="homeboy-x86_64-apple-darwin.tar.xz" ;;
-  darwin-aarch64|darwin-arm64) ASSET="homeboy-aarch64-apple-darwin.tar.xz" ;;
-  *) echo "Unsupported platform for binary upgrade: ${OS}-${ARCH}" >&2; exit 1 ;;
-esac
-
-BASE_URL="https://github.com/Extra-Chill/homeboy/releases/latest/download"
-TMP_DIR="$(mktemp -d)"
-
-cleanup() { rm -rf "$TMP_DIR"; }
-trap cleanup EXIT
-
-curl -fsSL "${BASE_URL}/${ASSET}" -o "${TMP_DIR}/${ASSET}"
-curl -fsSL "${BASE_URL}/${ASSET}.sha256" -o "${TMP_DIR}/${ASSET}.sha256"
-
-cd "$TMP_DIR"
-
-if command -v sha256sum >/dev/null 2>&1; then
-  sha256sum -c "${ASSET}.sha256"
-elif command -v shasum >/dev/null 2>&1; then
-  # macOS
-  SHASUM_EXPECTED="$(cut -d" " -f1 "${ASSET}.sha256")"
-  SHASUM_ACTUAL="$(shasum -a 256 "${ASSET}" | cut -d" " -f1)"
-  [ "$SHASUM_EXPECTED" = "$SHASUM_ACTUAL" ]
-else
-  echo "No sha256 tool found (sha256sum or shasum)." >&2
-  exit 1
-fi
-
-# Extract and install
-if tar -xJf "${ASSET}" 2>/dev/null; then
-  true
-else
-  tar -xf "${ASSET}"
-fi
-
-if [ ! -f "homeboy" ]; then
-  # cargo-dist packages the binary inside a subdirectory (e.g. homeboy-x86_64-unknown-linux-gnu/)
-  FOUND=$(find . -maxdepth 2 -name "homeboy" -type f ! -name "*.sha256" | head -1)
-  if [ -n "$FOUND" ]; then
-    cp "$FOUND" ./homeboy
-  else
-    echo "Expected extracted binary named 'homeboy'" >&2
-    ls -laR
-    exit 1
-  fi
-fi
-
-# Install with permission-aware behavior
-if [ -w "$BIN_PATH" ] || [ -w "$(dirname "$BIN_PATH")" ]; then
-  install -m 0755 homeboy "$BIN_PATH"
-else
-  if command -v sudo >/dev/null 2>&1; then
-    if sudo -n true >/dev/null 2>&1; then
-      sudo install -m 0755 homeboy "$BIN_PATH"
-    else
-      echo "Insufficient permissions to write to $BIN_PATH. Re-run with sudo:" >&2
-      echo "  sudo homeboy upgrade --method binary" >&2
-      exit 1
-    fi
-  else
-    echo "Insufficient permissions to write to $BIN_PATH (and sudo not found)." >&2
-    exit 1
-  fi
-fi
-"#
-        .to_string(),
-        list_command: None,
-    }
-}
-
-fn default_version_candidates() -> Vec<VersionCandidateConfig> {
-    vec![
-        VersionCandidateConfig {
-            file: "Cargo.toml".to_string(),
-            pattern: r#"version\s*=\s*"(\d+\.\d+\.\d+)""#.to_string(),
-        },
-        VersionCandidateConfig {
-            file: "package.json".to_string(),
-            pattern: r#""version"\s*:\s*"(\d+\.\d+\.\d+)""#.to_string(),
-        },
-        VersionCandidateConfig {
-            file: "composer.json".to_string(),
-            pattern: r#""version"\s*:\s*"(\d+\.\d+\.\d+)""#.to_string(),
-        },
-        VersionCandidateConfig {
-            file: "style.css".to_string(),
-            pattern: r"Version:\s*(\d+\.\d+\.\d+)".to_string(),
-        },
-    ]
-}
-
-fn default_deploy() -> DeployConfig {
-    DeployConfig {
-        scp_flags: default_scp_flags(),
-        artifact_prefix: default_artifact_prefix(),
-        default_ssh_port: default_ssh_port(),
-    }
-}
-
-fn default_scp_flags() -> Vec<String> {
-    vec!["-O".to_string()]
-}
-
-fn default_artifact_prefix() -> String {
-    ".homeboy-".to_string()
-}
-
-fn default_ssh_port() -> u16 {
-    22
-}
-
-fn default_permissions() -> PermissionsConfig {
-    PermissionsConfig {
-        local: default_local_permissions(),
-        remote: default_remote_permissions(),
-    }
-}
-
-fn default_local_permissions() -> PermissionModes {
-    PermissionModes {
-        file_mode: "g+rw".to_string(),
-        dir_mode: "g+rwx".to_string(),
-    }
-}
-
-fn default_remote_permissions() -> PermissionModes {
-    PermissionModes {
-        file_mode: "g+w".to_string(),
-        dir_mode: "g+w".to_string(),
-    }
 }
 
 // =============================================================================

--- a/src/core/defaults/builtins.rs
+++ b/src/core/defaults/builtins.rs
@@ -1,0 +1,189 @@
+use super::{
+    DeployConfig, InstallMethodConfig, InstallMethodsConfig, PermissionModes, PermissionsConfig,
+    VersionCandidateConfig,
+};
+
+// Default value functions (match current hardcoded behavior).
+
+pub(super) fn default_install_methods() -> InstallMethodsConfig {
+    InstallMethodsConfig {
+        homebrew: default_homebrew_config(),
+        cargo: default_cargo_config(),
+        source: default_source_config(),
+        binary: default_binary_config(),
+    }
+}
+
+pub(super) fn default_homebrew_config() -> InstallMethodConfig {
+    InstallMethodConfig {
+        path_patterns: vec!["/Cellar/".to_string(), "/homebrew/".to_string()],
+        upgrade_command: "brew update && brew upgrade homeboy".to_string(),
+        list_command: Some("brew list homeboy".to_string()),
+    }
+}
+
+pub(super) fn default_cargo_config() -> InstallMethodConfig {
+    InstallMethodConfig {
+        path_patterns: vec!["/.cargo/bin/".to_string()],
+        upgrade_command: "cargo install homeboy".to_string(),
+        list_command: None,
+    }
+}
+
+pub(super) fn default_source_config() -> InstallMethodConfig {
+    InstallMethodConfig {
+        path_patterns: vec!["/target/release/".to_string(), "/target/debug/".to_string()],
+        upgrade_command: "git pull && . \"$HOME/.cargo/env\" && cargo build --release".to_string(),
+        list_command: None,
+    }
+}
+
+pub(super) fn default_binary_config() -> InstallMethodConfig {
+    // A downloaded release binary (e.g. ~/bin/homeboy, /usr/local/bin/homeboy).
+    //
+    // This default upgrade command is intentionally shell-based so it works without
+    // introducing new Rust deps (tar/xz/sha256). It can be overridden via homeboy.json.
+    InstallMethodConfig {
+        // Matches typical install locations. We intentionally key off "/bin/homeboy" so both
+        // /usr/local/bin/homeboy and ~/bin/homeboy are detected.
+        path_patterns: vec!["/bin/homeboy".to_string(), "homeboy.exe".to_string()],
+        upgrade_command: r#"set -e
+
+BIN_PATH="$(command -v homeboy)"
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+
+case "${OS}-${ARCH}" in
+  linux-x86_64)  ASSET="homeboy-x86_64-unknown-linux-gnu.tar.xz" ;;
+  linux-aarch64|linux-arm64) ASSET="homeboy-aarch64-unknown-linux-gnu.tar.xz" ;;
+  darwin-x86_64) ASSET="homeboy-x86_64-apple-darwin.tar.xz" ;;
+  darwin-aarch64|darwin-arm64) ASSET="homeboy-aarch64-apple-darwin.tar.xz" ;;
+  *) echo "Unsupported platform for binary upgrade: ${OS}-${ARCH}" >&2; exit 1 ;;
+esac
+
+BASE_URL="https://github.com/Extra-Chill/homeboy/releases/latest/download"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+curl -fsSL "${BASE_URL}/${ASSET}" -o "${TMP_DIR}/${ASSET}"
+curl -fsSL "${BASE_URL}/${ASSET}.sha256" -o "${TMP_DIR}/${ASSET}.sha256"
+
+cd "$TMP_DIR"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum -c "${ASSET}.sha256"
+elif command -v shasum >/dev/null 2>&1; then
+  # macOS
+  SHASUM_EXPECTED="$(cut -d" " -f1 "${ASSET}.sha256")"
+  SHASUM_ACTUAL="$(shasum -a 256 "${ASSET}" | cut -d" " -f1)"
+  [ "$SHASUM_EXPECTED" = "$SHASUM_ACTUAL" ]
+else
+  echo "No sha256 tool found (sha256sum or shasum)." >&2
+  exit 1
+fi
+
+# Extract and install
+if tar -xJf "${ASSET}" 2>/dev/null; then
+  true
+else
+  tar -xf "${ASSET}"
+fi
+
+if [ ! -f "homeboy" ]; then
+  # cargo-dist packages the binary inside a subdirectory (e.g. homeboy-x86_64-unknown-linux-gnu/)
+  FOUND=$(find . -maxdepth 2 -name "homeboy" -type f ! -name "*.sha256" | head -1)
+  if [ -n "$FOUND" ]; then
+    cp "$FOUND" ./homeboy
+  else
+    echo "Expected extracted binary named 'homeboy'" >&2
+    ls -laR
+    exit 1
+  fi
+fi
+
+# Install with permission-aware behavior
+if [ -w "$BIN_PATH" ] || [ -w "$(dirname "$BIN_PATH")" ]; then
+  install -m 0755 homeboy "$BIN_PATH"
+else
+  if command -v sudo >/dev/null 2>&1; then
+    if sudo -n true >/dev/null 2>&1; then
+      sudo install -m 0755 homeboy "$BIN_PATH"
+    else
+      echo "Insufficient permissions to write to $BIN_PATH. Re-run with sudo:" >&2
+      echo "  sudo homeboy upgrade --method binary" >&2
+      exit 1
+    fi
+  else
+    echo "Insufficient permissions to write to $BIN_PATH (and sudo not found)." >&2
+    exit 1
+  fi
+fi
+"#
+        .to_string(),
+        list_command: None,
+    }
+}
+
+pub(super) fn default_version_candidates() -> Vec<VersionCandidateConfig> {
+    vec![
+        VersionCandidateConfig {
+            file: "Cargo.toml".to_string(),
+            pattern: r#"version\s*=\s*"(\d+\.\d+\.\d+)""#.to_string(),
+        },
+        VersionCandidateConfig {
+            file: "package.json".to_string(),
+            pattern: r#""version"\s*:\s*"(\d+\.\d+\.\d+)""#.to_string(),
+        },
+        VersionCandidateConfig {
+            file: "composer.json".to_string(),
+            pattern: r#""version"\s*:\s*"(\d+\.\d+\.\d+)""#.to_string(),
+        },
+        VersionCandidateConfig {
+            file: "style.css".to_string(),
+            pattern: r"Version:\s*(\d+\.\d+\.\d+)".to_string(),
+        },
+    ]
+}
+
+pub(super) fn default_deploy() -> DeployConfig {
+    DeployConfig {
+        scp_flags: default_scp_flags(),
+        artifact_prefix: default_artifact_prefix(),
+        default_ssh_port: default_ssh_port(),
+    }
+}
+
+pub(super) fn default_scp_flags() -> Vec<String> {
+    vec!["-O".to_string()]
+}
+
+pub(super) fn default_artifact_prefix() -> String {
+    ".homeboy-".to_string()
+}
+
+pub(super) fn default_ssh_port() -> u16 {
+    22
+}
+
+pub(super) fn default_permissions() -> PermissionsConfig {
+    PermissionsConfig {
+        local: default_local_permissions(),
+        remote: default_remote_permissions(),
+    }
+}
+
+pub(super) fn default_local_permissions() -> PermissionModes {
+    PermissionModes {
+        file_mode: "g+rw".to_string(),
+        dir_mode: "g+rwx".to_string(),
+    }
+}
+
+pub(super) fn default_remote_permissions() -> PermissionModes {
+    PermissionModes {
+        file_mode: "g+w".to_string(),
+        dir_mode: "g+w".to_string(),
+    }
+}


### PR DESCRIPTION
## Summary
- Extract built-in default constructor helpers from `src/core/defaults.rs` into `src/core/defaults/builtins.rs`.
- Keep public config types, serde defaults, and loading APIs stable while reducing top-level item pressure in `defaults.rs`.
- Preserve existing default values and behavior exactly.

## Verification
- `cargo fmt --check`
- `cargo test core::defaults`
- `homeboy audit homeboy --only high_item_count --json-summary`
- `homeboy audit --path /Users/chubes/Developer/homeboy@refactor-defaults-high-item-count --extension rust --changed-since origin/main --force-hot`
- `homeboy lint --path /Users/chubes/Developer/homeboy@refactor-defaults-high-item-count --extension rust --changed-since origin/main --force-hot`
- `homeboy test --path /Users/chubes/Developer/homeboy@refactor-defaults-high-item-count --extension rust --changed-since origin/main --force-hot`

## Notes
- The default lab-offload changed-since path was not usable in this environment: audit/lint failed while materializing the SSH workspace snapshot on repeated `LIBARCHIVE.xattr.com.apple.provenance` tar warnings, and test reported runner `lab` missing the `rust` extension. The same changed-since gates passed locally with Homeboy's `--force-hot` execution.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the behavior-preserving defaults helper extraction; Chris remains responsible for review and merge.