### PR TITLE
fix: clarify audit baseline summary counts

### DIFF
--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -31,6 +31,8 @@ pub struct AuditSummaryOutput {
     pub fixability: Option<AuditFixability>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub changed_since: Option<AuditChangedSinceSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_filtering: Option<AuditBaselineFilteringSummary>,
     pub exit_code: i32,
 }
 
@@ -69,6 +71,23 @@ struct AuditSummaryGroupAccumulator {
 pub struct AuditChangedSinceSummary {
     pub introduced_findings: usize,
     pub contextual_findings: usize,
+}
+
+/// Baseline filtering counters for compact audit summaries.
+///
+/// `total_findings` on [`AuditSummaryOutput`] is the current findings count.
+/// These counters make the baseline-filtered blocking scope explicit: known
+/// findings may be present while only unbaselined findings affect the exit code.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct AuditBaselineFilteringSummary {
+    pub current_findings: usize,
+    pub unbaselined_findings: usize,
+    pub baseline_known_findings: usize,
+    pub baseline_filtered_findings: usize,
+    pub baseline_total_findings: usize,
+    pub resolved_findings: usize,
+    pub drift_delta: i64,
+    pub drift_increased: bool,
 }
 
 /// Individual finding in the summary.
@@ -206,7 +225,29 @@ pub fn build_audit_summary(result: &CodeAuditResult, exit_code: i32) -> AuditSum
         top_findings,
         fixability: None,
         changed_since: None,
+        baseline_filtering: None,
         exit_code,
+    }
+}
+
+pub fn build_baseline_filtering_summary(
+    result: &CodeAuditResult,
+    comparison: &baseline::BaselineComparison,
+    baseline: &baseline::AuditBaseline,
+) -> AuditBaselineFilteringSummary {
+    let current_findings = result.findings.len();
+    let unbaselined_findings = comparison.new_items.len();
+    let baseline_known_findings = current_findings.saturating_sub(unbaselined_findings);
+
+    AuditBaselineFilteringSummary {
+        current_findings,
+        unbaselined_findings,
+        baseline_known_findings,
+        baseline_filtered_findings: baseline_known_findings,
+        baseline_total_findings: baseline.item_count,
+        resolved_findings: comparison.resolved_fingerprints.len(),
+        drift_delta: comparison.delta,
+        drift_increased: comparison.drift_increased,
     }
 }
 

--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -383,6 +383,11 @@ fn build_comparison_output(
         let mut summary = report::build_audit_summary(&result, exit_code);
         summary.fixability = compute_fixability_if_requested(&result, analysis, args);
         summary.changed_since = changed_since_summary;
+        summary.baseline_filtering = Some(report::build_baseline_filtering_summary(
+            &result,
+            &comparison,
+            &existing_baseline,
+        ));
         Ok(AuditRunWorkflowResult {
             output: AuditCommandOutput::Summary(summary),
             exit_code,

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -118,6 +118,22 @@ fn make_changed_since_args() -> AuditRunWorkflowArgs {
     args
 }
 
+fn make_baseline(
+    known_fingerprints: Vec<&str>,
+) -> crate::core::code_audit::baseline::AuditBaseline {
+    crate::core::code_audit::baseline::AuditBaseline {
+        created_at: "2026-04-28T00:00:00Z".to_string(),
+        context_id: "test".to_string(),
+        item_count: known_fingerprints.len(),
+        known_fingerprints: known_fingerprints.into_iter().map(str::to_string).collect(),
+        metadata: crate::core::code_audit::baseline::AuditBaselineMetadata {
+            outliers_count: 0,
+            alignment_score: None,
+            known_outliers: vec![],
+        },
+    }
+}
+
 #[test]
 fn filter_noop_when_both_lists_empty() {
     // The common case: no flags → no-op, untouched findings AND untouched summary.
@@ -333,6 +349,83 @@ fn changed_since_comparison_counts_new_findings_as_introduced() {
             );
         }
         _ => panic!("expected compared output"),
+    }
+}
+
+#[test]
+fn json_summary_names_baseline_known_findings_separately_from_blocking_findings() {
+    let mut known_finding = make_finding(AuditFinding::GodFile, "src/large.rs");
+    known_finding.convention = "structural".to_string();
+    let result = make_result(vec![known_finding]);
+    let baseline = make_baseline(vec![
+        "structural::src/large.rs::GodFile",
+        "structural::src/resolved.rs::GodFile",
+    ]);
+    let mut args = make_args(false);
+    args.json_summary = true;
+
+    let workflow = build_comparison_output(result, &make_analysis(), baseline, &args)
+        .expect("comparison output builds");
+
+    assert_eq!(workflow.exit_code, 0);
+    match workflow.output {
+        crate::core::code_audit::report::AuditCommandOutput::Summary(summary) => {
+            assert_eq!(summary.total_findings, 1);
+            assert_eq!(summary.finding_groups.len(), 1);
+
+            let filtering = summary
+                .baseline_filtering
+                .expect("baseline summary should describe filtering scope");
+            assert_eq!(filtering.current_findings, 1);
+            assert_eq!(filtering.unbaselined_findings, 0);
+            assert_eq!(filtering.baseline_known_findings, 1);
+            assert_eq!(filtering.baseline_filtered_findings, 1);
+            assert_eq!(filtering.baseline_total_findings, 2);
+            assert_eq!(filtering.resolved_findings, 1);
+            assert_eq!(filtering.drift_delta, -1);
+            assert!(!filtering.drift_increased);
+        }
+        _ => panic!("expected summary output"),
+    }
+}
+
+#[test]
+fn json_summary_for_targeted_detector_counts_current_and_unbaselined_findings() {
+    let mut first = make_finding(AuditFinding::GodFile, "src/large.rs");
+    first.convention = "structural".to_string();
+    let mut second = make_finding(AuditFinding::GodFile, "src/also-large.rs");
+    second.convention = "structural".to_string();
+    let result = make_result(vec![first, second]);
+    let baseline = make_baseline(vec![]);
+    let mut args = make_args(false);
+    args.json_summary = true;
+    args.only_kinds = vec![AuditFinding::GodFile];
+    args.only_labels = vec!["god_file".to_string()];
+
+    let workflow = build_comparison_output(result, &make_analysis(), baseline, &args)
+        .expect("comparison output builds");
+
+    assert_eq!(workflow.exit_code, 1);
+    match workflow.output {
+        crate::core::code_audit::report::AuditCommandOutput::Summary(summary) => {
+            assert_eq!(summary.total_findings, 2);
+            assert_eq!(summary.finding_groups.len(), 1);
+            assert_eq!(summary.finding_groups[0].kind, "god_file");
+            assert_eq!(summary.finding_groups[0].count, 2);
+
+            let filtering = summary
+                .baseline_filtering
+                .expect("baseline summary should describe filtering scope");
+            assert_eq!(filtering.current_findings, 2);
+            assert_eq!(filtering.unbaselined_findings, 2);
+            assert_eq!(filtering.baseline_known_findings, 0);
+            assert_eq!(filtering.baseline_filtered_findings, 0);
+            assert_eq!(filtering.baseline_total_findings, 0);
+            assert_eq!(filtering.resolved_findings, 0);
+            assert_eq!(filtering.drift_delta, 2);
+            assert!(filtering.drift_increased);
+        }
+        _ => panic!("expected summary output"),
     }
 }
 

--- a/tests/output_contracts_test.rs
+++ b/tests/output_contracts_test.rs
@@ -160,6 +160,7 @@ fn audit_summary_output() -> AuditCommandOutput {
             introduced_findings: 1,
             contextual_findings: 1,
         }),
+        baseline_filtering: None,
         exit_code: 1,
     })
 }


### PR DESCRIPTION
## Summary
- Add `baseline_filtering` metadata to audit JSON summaries produced from baseline comparisons.
- Keep `total_findings` as the current scoped finding count while exposing unbaselined, baseline-known/filtered, baseline total, resolved, delta, and drift status counters.
- Add regression coverage for clean baseline-known output and targeted `god_file` summary semantics.

Fixes #2851.

## Verification
- `cargo fmt --check`
- `cargo test json_summary`
- `cargo test quality_command_golden_json_contract_fixtures_match_typed_payloads`
- `homeboy lint --extension rust --changed-since origin/main`
- Fixed JSON shape confirmed locally with `baseline_filtering.current_findings`, `unbaselined_findings`, `baseline_known_findings`, `baseline_filtered_findings`, `baseline_total_findings`, `resolved_findings`, `drift_delta`, and `drift_increased`.

## Notes
- `homeboy test --extension rust --changed-since origin/main` ran the full Rust suite and hit one transient-looking infrastructure failure in `core::engine::resource::tests::writes_summary_to_run_dir_artifact`; rerunning that exact test passed.
- `homeboy audit --extension rust --changed-since origin/main` did not complete locally within the timeout. The installed Lab-offloaded audit path failed before audit execution because the Lab workspace could not resolve `origin/main` as a reachable ref. This change does not modify Lab/offload behavior.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the focused audit JSON summary contract change, added regression tests, and ran local verification. Chris remains responsible for review and merge.