### PR TITLE
Reject changed-since Lab offload for snapshot workspaces

### DIFF
--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -13,6 +13,7 @@ mod apply;
 mod connection;
 mod evidence;
 mod execution;
+mod offload_changed_since;
 mod offload_metadata;
 mod workspace;
 
@@ -29,6 +30,7 @@ pub use evidence::{
 };
 pub(crate) use execution::daemon_api_get;
 pub use execution::{exec, RunnerExecMode, RunnerExecOptions, RunnerExecOutput};
+pub use offload_changed_since::preflight_lab_offload_changed_since;
 pub use offload_metadata::{capture_lab_offload_metadata, lab_offload_metadata};
 pub use workspace::{
     sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,

--- a/src/core/runner/offload_changed_since.rs
+++ b/src/core/runner/offload_changed_since.rs
@@ -1,0 +1,117 @@
+use crate::core::error::{Error, Result};
+
+use super::RunnerWorkspaceSyncMode;
+
+pub fn preflight_lab_offload_changed_since(
+    args: &[String],
+    sync_mode: RunnerWorkspaceSyncMode,
+) -> Result<()> {
+    if sync_mode != RunnerWorkspaceSyncMode::Snapshot {
+        return Ok(());
+    }
+
+    let Some(git_ref) = lab_offload_changed_since_ref(args) else {
+        return Ok(());
+    };
+
+    Err(Error::validation_invalid_argument(
+        "changed_since",
+        "Lab offload cannot honor --changed-since in snapshot workspaces because snapshot sync excludes .git metadata",
+        Some(git_ref),
+        Some(vec![
+            "Use a git-backed Lab workspace sync mode before offloading changed-since commands."
+                .to_string(),
+            "Run the changed-since command locally when the Lab workspace is snapshot-only."
+                .to_string(),
+        ]),
+    ))
+}
+
+fn lab_offload_changed_since_ref(args: &[String]) -> Option<String> {
+    let mut iter = args.iter().skip(1);
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--changed-since" {
+            return iter.next().cloned();
+        }
+        if let Some(value) = arg.strip_prefix("--changed-since=") {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_changed_since_before_passthrough_args() {
+        let args = vec![
+            "homeboy".to_string(),
+            "test".to_string(),
+            "--path".to_string(),
+            "/Users/chubes/Developer/project".to_string(),
+            "--changed-since=origin/main".to_string(),
+            "--".to_string(),
+            "--changed-since".to_string(),
+            "fixture".to_string(),
+        ];
+
+        assert_eq!(
+            lab_offload_changed_since_ref(&args),
+            Some("origin/main".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_passthrough_changed_since_args() {
+        let args = vec![
+            "homeboy".to_string(),
+            "test".to_string(),
+            "--path".to_string(),
+            "/Users/chubes/Developer/project".to_string(),
+            "--".to_string(),
+            "--changed-since".to_string(),
+            "fixture".to_string(),
+        ];
+
+        assert_eq!(lab_offload_changed_since_ref(&args), None);
+    }
+
+    #[test]
+    fn rejects_changed_since_for_snapshot_lab_offload() {
+        let args = vec![
+            "homeboy".to_string(),
+            "test".to_string(),
+            "--path".to_string(),
+            "/Users/chubes/Developer/project".to_string(),
+            "--changed-since".to_string(),
+            "origin/main".to_string(),
+        ];
+
+        let err = preflight_lab_offload_changed_since(&args, RunnerWorkspaceSyncMode::Snapshot)
+            .expect_err("snapshot Lab offload must reject changed-since");
+
+        assert!(err.message.contains("cannot honor --changed-since"));
+        assert!(err.message.contains("snapshot workspaces"));
+        assert_eq!(err.details["id"], "origin/main");
+    }
+
+    #[test]
+    fn allows_changed_since_for_git_lab_offload() {
+        let args = vec![
+            "homeboy".to_string(),
+            "test".to_string(),
+            "--path".to_string(),
+            "/Users/chubes/Developer/project".to_string(),
+            "--changed-since".to_string(),
+            "origin/main".to_string(),
+        ];
+
+        preflight_lab_offload_changed_since(&args, RunnerWorkspaceSyncMode::Git)
+            .expect("git Lab offload can preserve changed-since semantics");
+    }
+}

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -579,8 +579,11 @@ mod tests {
             let source = tempfile::tempdir().expect("source tempdir");
             let runner_root = tempfile::tempdir().expect("runner root tempdir");
             fs::create_dir_all(source.path().join("src")).expect("src dir");
+            fs::create_dir_all(source.path().join(".git")).expect("git dir");
             fs::create_dir_all(source.path().join("target/debug")).expect("target dir");
             fs::write(source.path().join("src/main.rs"), "fn main() {}\n").expect("source file");
+            fs::write(source.path().join(".git/HEAD"), "ref: refs/heads/main\n")
+                .expect("git metadata");
             fs::write(source.path().join("src/._main.rs"), "appledouble").expect("sidecar file");
             fs::write(source.path().join(".env.local"), "SECRET=1\n").expect("secret file");
             fs::write(source.path().join("target/debug/homeboy"), "binary").expect("build file");
@@ -607,6 +610,7 @@ mod tests {
             assert_eq!(output.sync_mode, RunnerWorkspaceSyncMode::Snapshot);
             assert_eq!(output.files, 1);
             assert!(Path::new(&output.remote_path).join("src/main.rs").exists());
+            assert!(!Path::new(&output.remote_path).join(".git").exists());
             assert!(!Path::new(&output.remote_path)
                 .join("src/._main.rs")
                 .exists());

--- a/src/main.rs
+++ b/src/main.rs
@@ -638,7 +638,7 @@ fn run_lab_offload_inner(
     })?;
     let source_path = lab_offload_source_path(normalized_args)?;
     preflight_lab_runner_capabilities(runner_id, command_kind, &source_path)?;
-    preflight_lab_offload_changed_since(
+    homeboy::core::runner::preflight_lab_offload_changed_since(
         normalized_args,
         homeboy::core::runner::RunnerWorkspaceSyncMode::Snapshot,
     )?;
@@ -826,47 +826,6 @@ fn lab_offload_test_extension_ids(command: &Commands) -> homeboy::core::Result<V
     )?;
 
     Ok(context.extension_id.into_iter().collect())
-}
-
-fn preflight_lab_offload_changed_since(
-    args: &[String],
-    sync_mode: homeboy::core::runner::RunnerWorkspaceSyncMode,
-) -> homeboy::core::Result<()> {
-    if sync_mode != homeboy::core::runner::RunnerWorkspaceSyncMode::Snapshot {
-        return Ok(());
-    }
-
-    let Some(git_ref) = lab_offload_changed_since_ref(args) else {
-        return Ok(());
-    };
-
-    Err(homeboy::core::Error::validation_invalid_argument(
-        "changed_since",
-        "Lab offload cannot honor --changed-since in snapshot workspaces because snapshot sync excludes .git metadata",
-        Some(git_ref),
-        Some(vec![
-            "Use a git-backed Lab workspace sync mode before offloading changed-since commands."
-                .to_string(),
-            "Run the changed-since command locally when the Lab workspace is snapshot-only."
-                .to_string(),
-        ]),
-    ))
-}
-
-fn lab_offload_changed_since_ref(args: &[String]) -> Option<String> {
-    let mut iter = args.iter().skip(1);
-    while let Some(arg) = iter.next() {
-        if arg == "--" {
-            break;
-        }
-        if arg == "--changed-since" {
-            return iter.next().cloned();
-        }
-        if let Some(value) = arg.strip_prefix("--changed-since=") {
-            return Some(value.to_string());
-        }
-    }
-    None
 }
 
 fn runner_extension_preflight_tail(stderr: &str, stdout: &str) -> String {
@@ -1060,11 +1019,10 @@ fn extract_parent_command_from_error(e: &clap::Error) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        lab_offload_changed_since_ref, lab_offload_source_path, lab_offload_test_extension_ids,
-        preflight_lab_offload_changed_since, prepare_lab_runner_for_offload_with,
-        resolve_lab_runner_selection_from_default, rewrite_lab_offload_args,
-        runner_extension_preflight_tail, LabRunnerPreparation, LabRunnerSelection,
-        LabRunnerSelectionSource,
+        lab_offload_source_path, lab_offload_test_extension_ids,
+        prepare_lab_runner_for_offload_with, resolve_lab_runner_selection_from_default,
+        rewrite_lab_offload_args, runner_extension_preflight_tail, LabRunnerPreparation,
+        LabRunnerSelection, LabRunnerSelectionSource,
     };
     use clap::Parser;
     use homeboy::cli_surface::Commands;
@@ -1218,80 +1176,6 @@ mod tests {
                 "test-fixture".to_string()
             ]
         );
-    }
-
-    #[test]
-    fn detects_changed_since_before_passthrough_args() {
-        let args = vec![
-            "homeboy".to_string(),
-            "test".to_string(),
-            "--path".to_string(),
-            "/Users/chubes/Developer/project".to_string(),
-            "--changed-since=origin/main".to_string(),
-            "--".to_string(),
-            "--changed-since".to_string(),
-            "fixture".to_string(),
-        ];
-
-        assert_eq!(
-            lab_offload_changed_since_ref(&args),
-            Some("origin/main".to_string())
-        );
-    }
-
-    #[test]
-    fn ignores_passthrough_changed_since_args() {
-        let args = vec![
-            "homeboy".to_string(),
-            "test".to_string(),
-            "--path".to_string(),
-            "/Users/chubes/Developer/project".to_string(),
-            "--".to_string(),
-            "--changed-since".to_string(),
-            "fixture".to_string(),
-        ];
-
-        assert_eq!(lab_offload_changed_since_ref(&args), None);
-    }
-
-    #[test]
-    fn rejects_changed_since_for_snapshot_lab_offload() {
-        let args = vec![
-            "homeboy".to_string(),
-            "test".to_string(),
-            "--path".to_string(),
-            "/Users/chubes/Developer/project".to_string(),
-            "--changed-since".to_string(),
-            "origin/main".to_string(),
-        ];
-
-        let err = preflight_lab_offload_changed_since(
-            &args,
-            homeboy::core::runner::RunnerWorkspaceSyncMode::Snapshot,
-        )
-        .expect_err("snapshot Lab offload must reject changed-since");
-
-        assert!(err.message.contains("cannot honor --changed-since"));
-        assert!(err.message.contains("snapshot workspaces"));
-        assert_eq!(err.details["id"], "origin/main");
-    }
-
-    #[test]
-    fn allows_changed_since_for_git_lab_offload() {
-        let args = vec![
-            "homeboy".to_string(),
-            "test".to_string(),
-            "--path".to_string(),
-            "/Users/chubes/Developer/project".to_string(),
-            "--changed-since".to_string(),
-            "origin/main".to_string(),
-        ];
-
-        preflight_lab_offload_changed_since(
-            &args,
-            homeboy::core::runner::RunnerWorkspaceSyncMode::Git,
-        )
-        .expect("git Lab offload can preserve changed-since semantics");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -638,6 +638,10 @@ fn run_lab_offload_inner(
     })?;
     let source_path = lab_offload_source_path(normalized_args)?;
     preflight_lab_runner_capabilities(runner_id, command_kind, &source_path)?;
+    preflight_lab_offload_changed_since(
+        normalized_args,
+        homeboy::core::runner::RunnerWorkspaceSyncMode::Snapshot,
+    )?;
     let synced = homeboy::core::runner::sync_workspace(
         runner_id,
         homeboy::core::runner::RunnerWorkspaceSyncOptions {
@@ -822,6 +826,47 @@ fn lab_offload_test_extension_ids(command: &Commands) -> homeboy::core::Result<V
     )?;
 
     Ok(context.extension_id.into_iter().collect())
+}
+
+fn preflight_lab_offload_changed_since(
+    args: &[String],
+    sync_mode: homeboy::core::runner::RunnerWorkspaceSyncMode,
+) -> homeboy::core::Result<()> {
+    if sync_mode != homeboy::core::runner::RunnerWorkspaceSyncMode::Snapshot {
+        return Ok(());
+    }
+
+    let Some(git_ref) = lab_offload_changed_since_ref(args) else {
+        return Ok(());
+    };
+
+    Err(homeboy::core::Error::validation_invalid_argument(
+        "changed_since",
+        "Lab offload cannot honor --changed-since in snapshot workspaces because snapshot sync excludes .git metadata",
+        Some(git_ref),
+        Some(vec![
+            "Use a git-backed Lab workspace sync mode before offloading changed-since commands."
+                .to_string(),
+            "Run the changed-since command locally when the Lab workspace is snapshot-only."
+                .to_string(),
+        ]),
+    ))
+}
+
+fn lab_offload_changed_since_ref(args: &[String]) -> Option<String> {
+    let mut iter = args.iter().skip(1);
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--changed-since" {
+            return iter.next().cloned();
+        }
+        if let Some(value) = arg.strip_prefix("--changed-since=") {
+            return Some(value.to_string());
+        }
+    }
+    None
 }
 
 fn runner_extension_preflight_tail(stderr: &str, stdout: &str) -> String {
@@ -1015,10 +1060,11 @@ fn extract_parent_command_from_error(e: &clap::Error) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        lab_offload_source_path, lab_offload_test_extension_ids,
-        prepare_lab_runner_for_offload_with, resolve_lab_runner_selection_from_default,
-        rewrite_lab_offload_args, runner_extension_preflight_tail, LabRunnerPreparation,
-        LabRunnerSelection, LabRunnerSelectionSource,
+        lab_offload_changed_since_ref, lab_offload_source_path, lab_offload_test_extension_ids,
+        preflight_lab_offload_changed_since, prepare_lab_runner_for_offload_with,
+        resolve_lab_runner_selection_from_default, rewrite_lab_offload_args,
+        runner_extension_preflight_tail, LabRunnerPreparation, LabRunnerSelection,
+        LabRunnerSelectionSource,
     };
     use clap::Parser;
     use homeboy::cli_surface::Commands;
@@ -1172,6 +1218,80 @@ mod tests {
                 "test-fixture".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn detects_changed_since_before_passthrough_args() {
+        let args = vec![
+            "homeboy".to_string(),
+            "test".to_string(),
+            "--path".to_string(),
+            "/Users/chubes/Developer/project".to_string(),
+            "--changed-since=origin/main".to_string(),
+            "--".to_string(),
+            "--changed-since".to_string(),
+            "fixture".to_string(),
+        ];
+
+        assert_eq!(
+            lab_offload_changed_since_ref(&args),
+            Some("origin/main".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_passthrough_changed_since_args() {
+        let args = vec![
+            "homeboy".to_string(),
+            "test".to_string(),
+            "--path".to_string(),
+            "/Users/chubes/Developer/project".to_string(),
+            "--".to_string(),
+            "--changed-since".to_string(),
+            "fixture".to_string(),
+        ];
+
+        assert_eq!(lab_offload_changed_since_ref(&args), None);
+    }
+
+    #[test]
+    fn rejects_changed_since_for_snapshot_lab_offload() {
+        let args = vec![
+            "homeboy".to_string(),
+            "test".to_string(),
+            "--path".to_string(),
+            "/Users/chubes/Developer/project".to_string(),
+            "--changed-since".to_string(),
+            "origin/main".to_string(),
+        ];
+
+        let err = preflight_lab_offload_changed_since(
+            &args,
+            homeboy::core::runner::RunnerWorkspaceSyncMode::Snapshot,
+        )
+        .expect_err("snapshot Lab offload must reject changed-since");
+
+        assert!(err.message.contains("cannot honor --changed-since"));
+        assert!(err.message.contains("snapshot workspaces"));
+        assert_eq!(err.details["id"], "origin/main");
+    }
+
+    #[test]
+    fn allows_changed_since_for_git_lab_offload() {
+        let args = vec![
+            "homeboy".to_string(),
+            "test".to_string(),
+            "--path".to_string(),
+            "/Users/chubes/Developer/project".to_string(),
+            "--changed-since".to_string(),
+            "origin/main".to_string(),
+        ];
+
+        preflight_lab_offload_changed_since(
+            &args,
+            homeboy::core::runner::RunnerWorkspaceSyncMode::Git,
+        )
+        .expect("git Lab offload can preserve changed-since semantics");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Reject Lab offload before dispatch when `--changed-since` is used with snapshot workspace sync, since snapshot sync excludes `.git` and cannot resolve refs remotely.
- Preserve the future git-backed path by allowing the preflight for `RunnerWorkspaceSyncMode::Git`.
- Extend workspace sync coverage to prove snapshot mirrors omit `.git` metadata.

Fixes #2856.

## Verification
- `cargo fmt --all`
- `cargo test --bin homeboy changed_since -- --nocapture`
- `cargo test --lib core::runner::workspace::tests::test_sync_workspace -- --nocapture`
- `cargo test --bin homeboy lab_offload -- --nocapture`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the Lab offload changed-since failure path, implemented the preflight rejection and focused coverage, and ran verification.