### PR TITLE
Allow extension refactor source handlers

### DIFF
--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -149,6 +149,16 @@ struct ExtensionRefactorSourceResponse {
     warnings: Vec<String>,
 }
 
+struct AuditStageRequest<'a> {
+    component: &'a Component,
+    root: &'a Path,
+    changed_files: Option<&'a [String]>,
+    only: &'a [crate::core::code_audit::AuditFinding],
+    exclude: &'a [crate::core::code_audit::AuditFinding],
+    write: bool,
+    settings: &'a [(String, String)],
+}
+
 pub fn collect_refactor_sources(
     request: RefactorSourceRequest,
 ) -> crate::core::Result<RefactorSourceRun> {
@@ -258,16 +268,15 @@ pub fn collect_refactor_sources(
 
     for source in &sources {
         let stage = match source.as_str() {
-            "audit" => plan_audit_stage(
-                &request.component,
-                &request.component.id,
-                &request.root,
-                scoped_changed_files.as_deref(),
-                &request.only,
-                &request.exclude,
-                request.write,
-                &request.settings,
-            )?,
+            "audit" => plan_audit_stage(AuditStageRequest {
+                component: &request.component,
+                root: &request.root,
+                changed_files: scoped_changed_files.as_deref(),
+                only: &request.only,
+                exclude: &request.exclude,
+                write: request.write,
+                settings: &request.settings,
+            })?,
             "lint" => run_lint_stage(
                 &request.component,
                 &request.root,
@@ -394,7 +403,7 @@ fn try_extension_audit_refactor_stage(
 ) -> crate::core::Result<Option<PlannedStage>> {
     let source = "audit";
     let setting_key = "refactor.audit.extension";
-    let Some(extension_id) = setting_value(settings, &setting_key) else {
+    let Some(extension_id) = setting_value(settings, setting_key) else {
         return Ok(None);
     };
     let manifest = extension::load_extension(extension_id)?;
@@ -570,19 +579,12 @@ fn format_changed_files(root: &Path, changed_files: &[String], warnings: &mut Ve
     }
 }
 
-fn plan_audit_stage(
-    component: &Component,
-    component_id: &str,
-    root: &Path,
-    changed_files: Option<&[String]>,
-    only: &[crate::core::code_audit::AuditFinding],
-    exclude: &[crate::core::code_audit::AuditFinding],
-    write: bool,
-    settings: &[(String, String)],
-) -> crate::core::Result<PlannedStage> {
+fn plan_audit_stage(request: AuditStageRequest<'_>) -> crate::core::Result<PlannedStage> {
+    let component_id = &request.component.id;
+    let root = request.root;
     let result = if let Some(cached) = try_load_cached_audit() {
         cached
-    } else if let Some(changed) = changed_files {
+    } else if let Some(changed) = request.changed_files {
         if changed.is_empty() {
             crate::core::code_audit::CodeAuditResult {
                 component_id: component_id.to_string(),
@@ -613,11 +615,17 @@ fn plan_audit_stage(
     };
 
     let policy = fixer::FixPolicy {
-        only: (!only.is_empty()).then_some(only.to_vec()),
-        exclude: exclude.to_vec(),
+        only: (!request.only.is_empty()).then_some(request.only.to_vec()),
+        exclude: request.exclude.to_vec(),
     };
     if let Some(stage) = try_extension_audit_refactor_stage(
-        component, root, &result, only, exclude, write, settings,
+        request.component,
+        root,
+        &result,
+        request.only,
+        request.exclude,
+        request.write,
+        request.settings,
     )? {
         return Ok(stage);
     }
@@ -627,7 +635,7 @@ fn plan_audit_stage(
         fixer::PolicySummary,
         Vec<String>,
         Vec<String>,
-    ) = if write {
+    ) = if request.write {
         // Single pass: generate fixes from the provided findings, apply, validate.
         // The audit already ran and provided findings in `result` — the refactor
         // command does not re-run the audit internally. The convergence loop
@@ -635,8 +643,8 @@ fn plan_audit_stage(
         // pipeline, not inside a single refactor invocation.
         let outcome = super::verify::run_audit_refactor(
             result.clone(),
-            only,
-            exclude,
+            request.only,
+            request.exclude,
             AuditConvergenceScoring::default(),
             true,
         )?;
@@ -694,12 +702,12 @@ fn plan_audit_stage(
         summary: SourceStageSummary {
             stage: "audit".to_string(),
             collected: true,
-            applied: write && !changed_files.is_empty(),
+            applied: request.write && !changed_files.is_empty(),
             edit_count,
             files_modified: changed_files.len(),
             detected_findings: Some(result.findings.len()),
             changed_files,
-            fix_summary: if write {
+            fix_summary: if request.write {
                 if fix_result.files_modified > 0 {
                     Some(auto::summarize_audit_fix_result(&fix_result))
                 } else {

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -7,7 +7,7 @@ use crate::core::git;
 use crate::core::refactor::auto as fixer;
 use crate::core::refactor::auto::{self, FixApplied, FixResultsSummary};
 use crate::core::Error;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -135,6 +135,20 @@ pub struct RefactorSourceRun {
     pub guard_block: Option<crate::core::refactor::auto::guard::GuardBlock>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct ExtensionRefactorSourceResponse {
+    #[serde(default)]
+    handled: bool,
+    #[serde(default)]
+    detected_findings: Option<usize>,
+    #[serde(default)]
+    changed_files: Vec<String>,
+    #[serde(default)]
+    fix_results: Vec<FixApplied>,
+    #[serde(default)]
+    warnings: Vec<String>,
+}
+
 pub fn collect_refactor_sources(
     request: RefactorSourceRequest,
 ) -> crate::core::Result<RefactorSourceRun> {
@@ -245,12 +259,14 @@ pub fn collect_refactor_sources(
     for source in &sources {
         let stage = match source.as_str() {
             "audit" => plan_audit_stage(
+                &request.component,
                 &request.component.id,
                 &request.root,
                 scoped_changed_files.as_deref(),
                 &request.only,
                 &request.exclude,
                 request.write,
+                &request.settings,
             )?,
             "lint" => run_lint_stage(
                 &request.component,
@@ -358,6 +374,106 @@ pub fn collect_refactor_sources(
     })
 }
 
+fn setting_value<'a>(settings: &'a [(String, String)], key: &str) -> Option<&'a str> {
+    settings
+        .iter()
+        .rev()
+        .find(|(setting_key, _)| setting_key == key)
+        .map(|(_, value)| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn try_extension_audit_refactor_stage(
+    component: &Component,
+    root: &Path,
+    audit_result: &crate::core::code_audit::CodeAuditResult,
+    only: &[crate::core::code_audit::AuditFinding],
+    exclude: &[crate::core::code_audit::AuditFinding],
+    write: bool,
+    settings: &[(String, String)],
+) -> crate::core::Result<Option<PlannedStage>> {
+    let source = "audit";
+    let setting_key = "refactor.audit.extension";
+    let Some(extension_id) = setting_value(settings, &setting_key) else {
+        return Ok(None);
+    };
+    let manifest = extension::load_extension(extension_id)?;
+    let command = serde_json::json!({
+        "command": "refactor_source",
+        "source": source,
+        "component_id": component.id,
+        "root": root.to_string_lossy(),
+        "audit_result": audit_result,
+        "only": only,
+        "exclude": exclude,
+        "write": write,
+        "settings": settings.iter().cloned().collect::<std::collections::BTreeMap<_, _>>(),
+    });
+    let Some(value) = extension::run_refactor_script(&manifest, &command) else {
+        return Err(Error::validation_invalid_argument(
+            setting_key.to_string(),
+            format!(
+                "Extension '{}' did not handle refactor source '{}'",
+                extension_id, source
+            ),
+            None,
+            Some(vec![
+                "Remove the setting to use Homeboy's built-in refactor source".to_string(),
+                "Or update the extension refactor script to support command=refactor_source"
+                    .to_string(),
+            ]),
+        ));
+    };
+    let response: ExtensionRefactorSourceResponse =
+        serde_json::from_value(value).map_err(|err| {
+            Error::validation_invalid_argument(
+                setting_key,
+                format!(
+                    "Extension '{}' returned an invalid refactor source response: {}",
+                    extension_id, err
+                ),
+                None,
+                None,
+            )
+        })?;
+
+    if !response.handled {
+        return Err(Error::validation_invalid_argument(
+            setting_key.to_string(),
+            format!(
+                "Extension '{}' declined refactor source '{}'",
+                extension_id, source
+            ),
+            None,
+            Some(vec![
+                "Remove the setting to use Homeboy's built-in refactor source".to_string(),
+            ]),
+        ));
+    }
+
+    let fix_summary = if response.fix_results.is_empty() {
+        None
+    } else {
+        Some(auto::summarize_fix_results(&response.fix_results))
+    };
+
+    Ok(Some(PlannedStage {
+        source: source.to_string(),
+        summary: SourceStageSummary {
+            stage: source.to_string(),
+            collected: true,
+            applied: write && !response.changed_files.is_empty(),
+            edit_count: response.fix_results.len(),
+            files_modified: response.changed_files.len(),
+            detected_findings: response.detected_findings,
+            changed_files: response.changed_files,
+            fix_summary,
+            warnings: response.warnings,
+        },
+        fix_results: response.fix_results,
+    }))
+}
+
 fn allows_dirty_worktree_write(request: &RefactorSourceRequest) -> bool {
     request.write
         && request.sources == ["lint"]
@@ -455,12 +571,14 @@ fn format_changed_files(root: &Path, changed_files: &[String], warnings: &mut Ve
 }
 
 fn plan_audit_stage(
+    component: &Component,
     component_id: &str,
     root: &Path,
     changed_files: Option<&[String]>,
     only: &[crate::core::code_audit::AuditFinding],
     exclude: &[crate::core::code_audit::AuditFinding],
     write: bool,
+    settings: &[(String, String)],
 ) -> crate::core::Result<PlannedStage> {
     let result = if let Some(cached) = try_load_cached_audit() {
         cached
@@ -498,6 +616,11 @@ fn plan_audit_stage(
         only: (!only.is_empty()).then_some(only.to_vec()),
         exclude: exclude.to_vec(),
     };
+    if let Some(stage) = try_extension_audit_refactor_stage(
+        component, root, &result, only, exclude, write, settings,
+    )? {
+        return Ok(stage);
+    }
     let mut fix_result = super::generate::generate_audit_fixes(&result, root, &policy);
     let (fix_result, policy_summary, changed_files, stage_warnings): (
         fixer::FixResult,


### PR DESCRIPTION
## Summary
- Adds a generic `refactor.<source>.extension` setting so Homeboy can delegate a refactor source stage to an extension refactor script.
- Passes the canonical audit result into `command=refactor_source` while keeping Homeboy core free of WordPress/WP Codebox-specific behavior.
- Preserves the built-in audit refactor path when no extension override is configured.

## Tests
- `cargo fmt --check`
- `cargo check`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic extension refactor-source seam and ran focused validation; Chris directed the architecture and reviewed the contract direction.