### PR TITLE
feat: generalize refactor source extension dispatch

### DIFF
--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -392,18 +392,16 @@ fn setting_value<'a>(settings: &'a [(String, String)], key: &str) -> Option<&'a 
         .filter(|value| !value.trim().is_empty())
 }
 
-fn try_extension_audit_refactor_stage(
+fn try_extension_refactor_source_stage<T: Serialize>(
+    source: &str,
     component: &Component,
     root: &Path,
-    audit_result: &crate::core::code_audit::CodeAuditResult,
-    only: &[crate::core::code_audit::AuditFinding],
-    exclude: &[crate::core::code_audit::AuditFinding],
+    source_result: &T,
     write: bool,
     settings: &[(String, String)],
 ) -> crate::core::Result<Option<PlannedStage>> {
-    let source = "audit";
-    let setting_key = "refactor.audit.extension";
-    let Some(extension_id) = setting_value(settings, setting_key) else {
+    let setting_key = format!("refactor.{}.extension", source);
+    let Some(extension_id) = setting_value(settings, &setting_key) else {
         return Ok(None);
     };
     let manifest = extension::load_extension(extension_id)?;
@@ -412,15 +410,13 @@ fn try_extension_audit_refactor_stage(
         "source": source,
         "component_id": component.id,
         "root": root.to_string_lossy(),
-        "audit_result": audit_result,
-        "only": only,
-        "exclude": exclude,
+        "source_result": source_result,
         "write": write,
         "settings": settings.iter().cloned().collect::<std::collections::BTreeMap<_, _>>(),
     });
     let Some(value) = extension::run_refactor_script(&manifest, &command) else {
         return Err(Error::validation_invalid_argument(
-            setting_key.to_string(),
+            setting_key.clone(),
             format!(
                 "Extension '{}' did not handle refactor source '{}'",
                 extension_id, source
@@ -436,7 +432,7 @@ fn try_extension_audit_refactor_stage(
     let response: ExtensionRefactorSourceResponse =
         serde_json::from_value(value).map_err(|err| {
             Error::validation_invalid_argument(
-                setting_key,
+                setting_key.clone(),
                 format!(
                     "Extension '{}' returned an invalid refactor source response: {}",
                     extension_id, err
@@ -448,7 +444,7 @@ fn try_extension_audit_refactor_stage(
 
     if !response.handled {
         return Err(Error::validation_invalid_argument(
-            setting_key.to_string(),
+            setting_key,
             format!(
                 "Extension '{}' declined refactor source '{}'",
                 extension_id, source
@@ -618,12 +614,11 @@ fn plan_audit_stage(request: AuditStageRequest<'_>) -> crate::core::Result<Plann
         only: (!request.only.is_empty()).then_some(request.only.to_vec()),
         exclude: request.exclude.to_vec(),
     };
-    if let Some(stage) = try_extension_audit_refactor_stage(
+    if let Some(stage) = try_extension_refactor_source_stage(
+        "audit",
         request.component,
         root,
         &result,
-        request.only,
-        request.exclude,
         request.write,
         request.settings,
     )? {
@@ -809,6 +804,20 @@ fn run_lint_stage(
             .unwrap_or_default()
     };
 
+    let lint_source_result = serde_json::json!({
+        "lint_findings": &lint_findings,
+    });
+    if let Some(stage) = try_extension_refactor_source_stage(
+        "lint",
+        component,
+        root,
+        &lint_source_result,
+        write,
+        settings,
+    )? {
+        return Ok(stage);
+    }
+
     // ── Phase 2: Apply fixes (only when --write) ───────────────────────
     // The engine controls fix application. The extension's fix-mode
     // invocation runs ONLY the fixers, not the diagnostic pass. The engine
@@ -970,6 +979,21 @@ fn run_test_stage(
 
     runner.run()?;
 
+    let test_source_result = serde_json::json!({
+        "test_results": read_optional_json(&run_dir.step_file(run_dir::files::TEST_RESULTS)),
+        "test_failures": read_optional_json(&run_dir.step_file(run_dir::files::TEST_FAILURES)),
+    });
+    if let Some(stage) = try_extension_refactor_source_stage(
+        "test",
+        component,
+        root,
+        &test_source_result,
+        write,
+        settings,
+    )? {
+        return Ok(stage);
+    }
+
     // ── Phase 2: Apply fixes (only when --write) ───────────────────────
     // The engine controls fix application. The extension's fix-mode
     // invocation runs ONLY the fixers, not the diagnostic pass.
@@ -1024,6 +1048,12 @@ fn run_test_stage(
         },
         fix_results,
     })
+}
+
+fn read_optional_json(path: &Path) -> Option<serde_json::Value> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|content| serde_json::from_str(&content).ok())
 }
 
 /// Count fixes whose edits are ALL blocked from auto-apply — i.e., they'd be
@@ -1128,6 +1158,41 @@ mod tests {
         }
     }
 
+    fn write_refactor_source_extension(home: &Path, id: &str, capture_file: &Path) {
+        let extension_dir = home.join(".config/homeboy/extensions").join(id);
+        fs::create_dir_all(&extension_dir).unwrap();
+        fs::write(
+            extension_dir.join(format!("{id}.json")),
+            serde_json::json!({
+                "name": "Generic Refactor Source Fixture",
+                "version": "0.0.0",
+                "scripts": {
+                    "refactor": "refactor-source.sh"
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        fs::write(
+            extension_dir.join("refactor-source.sh"),
+            format!(
+                "#!/bin/sh\ncat > '{}'\nprintf '%s' '{{\"handled\":true,\"detected_findings\":2,\"changed_files\":[\"src/lib.rs\"],\"fix_results\":[{{\"file\":\"src/lib.rs\",\"rule\":\"demo\"}}],\"warnings\":[\"extension handled\"]}}'\n",
+                capture_file.display()
+            ),
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let script = extension_dir.join("refactor-source.sh");
+            let mut permissions = fs::metadata(&script).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(script, permissions).unwrap();
+        }
+    }
+
     #[test]
     fn test_lint_refactor_request() {
         let root = PathBuf::from("/tmp/homeboy-lint-refactor-request");
@@ -1187,6 +1252,76 @@ mod tests {
 
         assert_eq!(request.sources, vec!["test".to_string()]);
         assert!(!request.write);
+    }
+
+    #[test]
+    fn extension_refactor_source_dispatch_uses_generic_source_result() {
+        crate::test_support::with_isolated_home(|home| {
+            let root = tmp_dir("generic-extension-dispatch");
+            fs::create_dir_all(&root).unwrap();
+            let capture_file = root.join("command.json");
+            write_refactor_source_extension(home.path(), "generic", &capture_file);
+
+            let audit_stage = try_extension_refactor_source_stage(
+                "audit",
+                &test_component(&root),
+                &root,
+                &serde_json::json!({
+                    "component_id": "component",
+                    "findings": []
+                }),
+                false,
+                &[(
+                    "refactor.audit.extension".to_string(),
+                    "generic".to_string(),
+                )],
+            )
+            .unwrap()
+            .expect("extension should handle audit refactor source");
+
+            assert_eq!(audit_stage.source, "audit");
+            let audit_command: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&capture_file).unwrap()).unwrap();
+            assert_eq!(audit_command["source"], "audit");
+            assert_eq!(audit_command["source_result"]["component_id"], "component");
+            assert!(audit_command.get("audit_result").is_none());
+
+            let stage = try_extension_refactor_source_stage(
+                "lint",
+                &test_component(&root),
+                &root,
+                &serde_json::json!({
+                    "lint_findings": [{
+                        "id": "lint-1",
+                        "message": "demo",
+                        "category": "style"
+                    }]
+                }),
+                true,
+                &[
+                    ("refactor.lint.extension".to_string(), "generic".to_string()),
+                    ("extension.setting".to_string(), "value".to_string()),
+                ],
+            )
+            .unwrap()
+            .expect("extension should handle lint refactor source");
+
+            assert_eq!(stage.source, "lint");
+            assert_eq!(stage.summary.detected_findings, Some(2));
+            assert_eq!(stage.summary.changed_files, vec!["src/lib.rs"]);
+            assert_eq!(stage.fix_results.len(), 1);
+
+            let command: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&capture_file).unwrap()).unwrap();
+            assert_eq!(command["command"], "refactor_source");
+            assert_eq!(command["source"], "lint");
+            assert_eq!(command["write"], true);
+            assert_eq!(command["settings"]["extension.setting"], "value");
+            assert_eq!(command["source_result"]["lint_findings"][0]["id"], "lint-1");
+            assert!(command.get("audit_result").is_none());
+
+            let _ = fs::remove_dir_all(root);
+        });
     }
 
     #[test]

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -11,11 +11,13 @@ use serde::Serialize;
 use std::collections::{BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
+mod audit_source;
 mod cache;
 mod extension_source;
 mod lint_scope;
 mod planning;
 
+use audit_source::filtered_audit_source_result;
 use cache::{
     try_load_cached_audit, try_load_cached_lint, try_load_cached_test, CachedLintResult,
     CachedTestResult, OUTPUT_DIR_ENV,
@@ -963,23 +965,6 @@ fn count_manual_only_fixes(fix_result: &fixer::FixResult) -> usize {
     manual_only_fixes + manual_only_new_files
 }
 
-fn filtered_audit_source_result(
-    result: &crate::core::code_audit::CodeAuditResult,
-    policy: &fixer::FixPolicy,
-) -> crate::core::code_audit::CodeAuditResult {
-    let mut filtered = result.clone();
-    filtered.findings.retain(|finding| {
-        let allowed = policy
-            .only
-            .as_ref()
-            .is_none_or(|only| only.contains(&finding.kind));
-        let denied = policy.exclude.contains(&finding.kind);
-        allowed && !denied
-    });
-    filtered.summary.outliers_found = filtered.findings.len();
-    filtered
-}
-
 /// Count only files that `--write` mode would actually modify.
 ///
 /// `apply_fix_policy` keeps all policy-selected edits visible in dry-run, but
@@ -1297,55 +1282,6 @@ mod tests {
             total_insertions,
             files_modified: 0,
         }
-    }
-
-    fn audit_result_with(kinds: Vec<AuditFinding>) -> crate::core::code_audit::CodeAuditResult {
-        crate::core::code_audit::CodeAuditResult {
-            component_id: "component".to_string(),
-            source_path: "/tmp/component".to_string(),
-            summary: crate::core::code_audit::AuditSummary {
-                files_scanned: 1,
-                conventions_detected: 1,
-                outliers_found: kinds.len(),
-                alignment_score: None,
-                files_skipped: 0,
-                warnings: Vec::new(),
-            },
-            conventions: Vec::new(),
-            directory_conventions: Vec::new(),
-            findings: kinds
-                .into_iter()
-                .map(|kind| crate::core::code_audit::Finding {
-                    convention: "fixture".to_string(),
-                    severity: crate::core::code_audit::Severity::Warning,
-                    file: "src/lib.rs".to_string(),
-                    description: "fixture finding".to_string(),
-                    suggestion: "fix it".to_string(),
-                    kind,
-                })
-                .collect(),
-            duplicate_groups: Vec::new(),
-        }
-    }
-
-    #[test]
-    fn filtered_audit_source_result_applies_only_and_exclude() {
-        let result = audit_result_with(vec![
-            AuditFinding::DuplicateFunction,
-            AuditFinding::MissingMethod,
-            AuditFinding::GodFile,
-        ]);
-        let policy = fixer::FixPolicy {
-            only: Some(vec![AuditFinding::DuplicateFunction, AuditFinding::GodFile]),
-            exclude: vec![AuditFinding::GodFile],
-        };
-
-        let filtered = filtered_audit_source_result(&result, &policy);
-
-        assert_eq!(filtered.findings.len(), 1);
-        assert_eq!(filtered.findings[0].kind, AuditFinding::DuplicateFunction);
-        assert_eq!(filtered.summary.outliers_found, 1);
-        assert_eq!(result.findings.len(), 3);
     }
 
     #[test]

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -7,11 +7,12 @@ use crate::core::git;
 use crate::core::refactor::auto as fixer;
 use crate::core::refactor::auto::{self, FixApplied, FixResultsSummary};
 use crate::core::Error;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::collections::{BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
 mod cache;
+mod extension_source;
 mod lint_scope;
 mod planning;
 
@@ -19,6 +20,7 @@ use cache::{
     try_load_cached_audit, try_load_cached_lint, try_load_cached_test, CachedLintResult,
     CachedTestResult, OUTPUT_DIR_ENV,
 };
+use extension_source::{read_optional_json, try_extension_refactor_source_stage};
 use lint_scope::{
     capture_release_owned_files, constrain_lint_fix_changes, lint_finding_scope_files,
     lint_scope_glob, restore_release_owned_files,
@@ -133,20 +135,6 @@ pub struct RefactorSourceRun {
     /// short-circuited without modifying any files.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guard_block: Option<crate::core::refactor::auto::guard::GuardBlock>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct ExtensionRefactorSourceResponse {
-    #[serde(default)]
-    handled: bool,
-    #[serde(default)]
-    detected_findings: Option<usize>,
-    #[serde(default)]
-    changed_files: Vec<String>,
-    #[serde(default)]
-    fix_results: Vec<FixApplied>,
-    #[serde(default)]
-    warnings: Vec<String>,
 }
 
 struct AuditStageRequest<'a> {
@@ -383,102 +371,6 @@ pub fn collect_refactor_sources(
     })
 }
 
-fn setting_value<'a>(settings: &'a [(String, String)], key: &str) -> Option<&'a str> {
-    settings
-        .iter()
-        .rev()
-        .find(|(setting_key, _)| setting_key == key)
-        .map(|(_, value)| value.as_str())
-        .filter(|value| !value.trim().is_empty())
-}
-
-fn try_extension_refactor_source_stage<T: Serialize>(
-    source: &str,
-    component: &Component,
-    root: &Path,
-    source_result: &T,
-    write: bool,
-    settings: &[(String, String)],
-) -> crate::core::Result<Option<PlannedStage>> {
-    let setting_key = format!("refactor.{}.extension", source);
-    let Some(extension_id) = setting_value(settings, &setting_key) else {
-        return Ok(None);
-    };
-    let manifest = extension::load_extension(extension_id)?;
-    let command = serde_json::json!({
-        "command": "refactor_source",
-        "source": source,
-        "component_id": component.id,
-        "root": root.to_string_lossy(),
-        "source_result": source_result,
-        "write": write,
-        "settings": settings.iter().cloned().collect::<std::collections::BTreeMap<_, _>>(),
-    });
-    let Some(value) = extension::run_refactor_script(&manifest, &command) else {
-        return Err(Error::validation_invalid_argument(
-            setting_key.clone(),
-            format!(
-                "Extension '{}' did not handle refactor source '{}'",
-                extension_id, source
-            ),
-            None,
-            Some(vec![
-                "Remove the setting to use Homeboy's built-in refactor source".to_string(),
-                "Or update the extension refactor script to support command=refactor_source"
-                    .to_string(),
-            ]),
-        ));
-    };
-    let response: ExtensionRefactorSourceResponse =
-        serde_json::from_value(value).map_err(|err| {
-            Error::validation_invalid_argument(
-                setting_key.clone(),
-                format!(
-                    "Extension '{}' returned an invalid refactor source response: {}",
-                    extension_id, err
-                ),
-                None,
-                None,
-            )
-        })?;
-
-    if !response.handled {
-        return Err(Error::validation_invalid_argument(
-            setting_key,
-            format!(
-                "Extension '{}' declined refactor source '{}'",
-                extension_id, source
-            ),
-            None,
-            Some(vec![
-                "Remove the setting to use Homeboy's built-in refactor source".to_string(),
-            ]),
-        ));
-    }
-
-    let fix_summary = if response.fix_results.is_empty() {
-        None
-    } else {
-        Some(auto::summarize_fix_results(&response.fix_results))
-    };
-
-    Ok(Some(PlannedStage {
-        source: source.to_string(),
-        summary: SourceStageSummary {
-            stage: source.to_string(),
-            collected: true,
-            applied: write && !response.changed_files.is_empty(),
-            edit_count: response.fix_results.len(),
-            files_modified: response.changed_files.len(),
-            detected_findings: response.detected_findings,
-            changed_files: response.changed_files,
-            fix_summary,
-            warnings: response.warnings,
-        },
-        fix_results: response.fix_results,
-    }))
-}
-
 fn allows_dirty_worktree_write(request: &RefactorSourceRequest) -> bool {
     request.write
         && request.sources == ["lint"]
@@ -614,11 +506,12 @@ fn plan_audit_stage(request: AuditStageRequest<'_>) -> crate::core::Result<Plann
         only: (!request.only.is_empty()).then_some(request.only.to_vec()),
         exclude: request.exclude.to_vec(),
     };
+    let extension_result = filtered_audit_source_result(&result, &policy);
     if let Some(stage) = try_extension_refactor_source_stage(
         "audit",
         request.component,
         root,
-        &result,
+        &extension_result,
         request.write,
         request.settings,
     )? {
@@ -1050,12 +943,6 @@ fn run_test_stage(
     })
 }
 
-fn read_optional_json(path: &Path) -> Option<serde_json::Value> {
-    std::fs::read_to_string(path)
-        .ok()
-        .and_then(|content| serde_json::from_str(&content).ok())
-}
-
 /// Count fixes whose edits are ALL blocked from auto-apply — i.e., they'd be
 /// dropped entirely by `apply_fix_policy(write=true)`. Used to surface a warning
 /// when dry-run previews edits that `--write` will silently decline.
@@ -1074,6 +961,23 @@ fn count_manual_only_fixes(fix_result: &fixer::FixResult) -> usize {
         .filter(|nf| !nf.auto_apply)
         .count();
     manual_only_fixes + manual_only_new_files
+}
+
+fn filtered_audit_source_result(
+    result: &crate::core::code_audit::CodeAuditResult,
+    policy: &fixer::FixPolicy,
+) -> crate::core::code_audit::CodeAuditResult {
+    let mut filtered = result.clone();
+    filtered.findings.retain(|finding| {
+        let allowed = policy
+            .only
+            .as_ref()
+            .is_none_or(|only| only.contains(&finding.kind));
+        let denied = policy.exclude.contains(&finding.kind);
+        allowed && !denied
+    });
+    filtered.summary.outliers_found = filtered.findings.len();
+    filtered
 }
 
 /// Count only files that `--write` mode would actually modify.
@@ -1158,41 +1062,6 @@ mod tests {
         }
     }
 
-    fn write_refactor_source_extension(home: &Path, id: &str, capture_file: &Path) {
-        let extension_dir = home.join(".config/homeboy/extensions").join(id);
-        fs::create_dir_all(&extension_dir).unwrap();
-        fs::write(
-            extension_dir.join(format!("{id}.json")),
-            serde_json::json!({
-                "name": "Generic Refactor Source Fixture",
-                "version": "0.0.0",
-                "scripts": {
-                    "refactor": "refactor-source.sh"
-                }
-            })
-            .to_string(),
-        )
-        .unwrap();
-
-        fs::write(
-            extension_dir.join("refactor-source.sh"),
-            format!(
-                "#!/bin/sh\ncat > '{}'\nprintf '%s' '{{\"handled\":true,\"detected_findings\":2,\"changed_files\":[\"src/lib.rs\"],\"fix_results\":[{{\"file\":\"src/lib.rs\",\"rule\":\"demo\"}}],\"warnings\":[\"extension handled\"]}}'\n",
-                capture_file.display()
-            ),
-        )
-        .unwrap();
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let script = extension_dir.join("refactor-source.sh");
-            let mut permissions = fs::metadata(&script).unwrap().permissions();
-            permissions.set_mode(0o755);
-            fs::set_permissions(script, permissions).unwrap();
-        }
-    }
-
     #[test]
     fn test_lint_refactor_request() {
         let root = PathBuf::from("/tmp/homeboy-lint-refactor-request");
@@ -1252,76 +1121,6 @@ mod tests {
 
         assert_eq!(request.sources, vec!["test".to_string()]);
         assert!(!request.write);
-    }
-
-    #[test]
-    fn extension_refactor_source_dispatch_uses_generic_source_result() {
-        crate::test_support::with_isolated_home(|home| {
-            let root = tmp_dir("generic-extension-dispatch");
-            fs::create_dir_all(&root).unwrap();
-            let capture_file = root.join("command.json");
-            write_refactor_source_extension(home.path(), "generic", &capture_file);
-
-            let audit_stage = try_extension_refactor_source_stage(
-                "audit",
-                &test_component(&root),
-                &root,
-                &serde_json::json!({
-                    "component_id": "component",
-                    "findings": []
-                }),
-                false,
-                &[(
-                    "refactor.audit.extension".to_string(),
-                    "generic".to_string(),
-                )],
-            )
-            .unwrap()
-            .expect("extension should handle audit refactor source");
-
-            assert_eq!(audit_stage.source, "audit");
-            let audit_command: serde_json::Value =
-                serde_json::from_str(&fs::read_to_string(&capture_file).unwrap()).unwrap();
-            assert_eq!(audit_command["source"], "audit");
-            assert_eq!(audit_command["source_result"]["component_id"], "component");
-            assert!(audit_command.get("audit_result").is_none());
-
-            let stage = try_extension_refactor_source_stage(
-                "lint",
-                &test_component(&root),
-                &root,
-                &serde_json::json!({
-                    "lint_findings": [{
-                        "id": "lint-1",
-                        "message": "demo",
-                        "category": "style"
-                    }]
-                }),
-                true,
-                &[
-                    ("refactor.lint.extension".to_string(), "generic".to_string()),
-                    ("extension.setting".to_string(), "value".to_string()),
-                ],
-            )
-            .unwrap()
-            .expect("extension should handle lint refactor source");
-
-            assert_eq!(stage.source, "lint");
-            assert_eq!(stage.summary.detected_findings, Some(2));
-            assert_eq!(stage.summary.changed_files, vec!["src/lib.rs"]);
-            assert_eq!(stage.fix_results.len(), 1);
-
-            let command: serde_json::Value =
-                serde_json::from_str(&fs::read_to_string(&capture_file).unwrap()).unwrap();
-            assert_eq!(command["command"], "refactor_source");
-            assert_eq!(command["source"], "lint");
-            assert_eq!(command["write"], true);
-            assert_eq!(command["settings"]["extension.setting"], "value");
-            assert_eq!(command["source_result"]["lint_findings"][0]["id"], "lint-1");
-            assert!(command.get("audit_result").is_none());
-
-            let _ = fs::remove_dir_all(root);
-        });
     }
 
     #[test]
@@ -1498,6 +1297,55 @@ mod tests {
             total_insertions,
             files_modified: 0,
         }
+    }
+
+    fn audit_result_with(kinds: Vec<AuditFinding>) -> crate::core::code_audit::CodeAuditResult {
+        crate::core::code_audit::CodeAuditResult {
+            component_id: "component".to_string(),
+            source_path: "/tmp/component".to_string(),
+            summary: crate::core::code_audit::AuditSummary {
+                files_scanned: 1,
+                conventions_detected: 1,
+                outliers_found: kinds.len(),
+                alignment_score: None,
+                files_skipped: 0,
+                warnings: Vec::new(),
+            },
+            conventions: Vec::new(),
+            directory_conventions: Vec::new(),
+            findings: kinds
+                .into_iter()
+                .map(|kind| crate::core::code_audit::Finding {
+                    convention: "fixture".to_string(),
+                    severity: crate::core::code_audit::Severity::Warning,
+                    file: "src/lib.rs".to_string(),
+                    description: "fixture finding".to_string(),
+                    suggestion: "fix it".to_string(),
+                    kind,
+                })
+                .collect(),
+            duplicate_groups: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn filtered_audit_source_result_applies_only_and_exclude() {
+        let result = audit_result_with(vec![
+            AuditFinding::DuplicateFunction,
+            AuditFinding::MissingMethod,
+            AuditFinding::GodFile,
+        ]);
+        let policy = fixer::FixPolicy {
+            only: Some(vec![AuditFinding::DuplicateFunction, AuditFinding::GodFile]),
+            exclude: vec![AuditFinding::GodFile],
+        };
+
+        let filtered = filtered_audit_source_result(&result, &policy);
+
+        assert_eq!(filtered.findings.len(), 1);
+        assert_eq!(filtered.findings[0].kind, AuditFinding::DuplicateFunction);
+        assert_eq!(filtered.summary.outliers_found, 1);
+        assert_eq!(result.findings.len(), 3);
     }
 
     #[test]

--- a/src/core/refactor/plan/sources/audit_source.rs
+++ b/src/core/refactor/plan/sources/audit_source.rs
@@ -1,0 +1,73 @@
+use crate::core::refactor::auto as fixer;
+
+pub(super) fn filtered_audit_source_result(
+    result: &crate::core::code_audit::CodeAuditResult,
+    policy: &fixer::FixPolicy,
+) -> crate::core::code_audit::CodeAuditResult {
+    let mut filtered = result.clone();
+    filtered.findings.retain(|finding| {
+        let allowed = policy
+            .only
+            .as_ref()
+            .is_none_or(|only| only.contains(&finding.kind));
+        let denied = policy.exclude.contains(&finding.kind);
+        allowed && !denied
+    });
+    filtered.summary.outliers_found = filtered.findings.len();
+    filtered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::code_audit::{AuditFinding, AuditSummary, CodeAuditResult, Finding, Severity};
+
+    fn audit_result_with(kinds: Vec<AuditFinding>) -> CodeAuditResult {
+        CodeAuditResult {
+            component_id: "component".to_string(),
+            source_path: "/tmp/component".to_string(),
+            summary: AuditSummary {
+                files_scanned: 1,
+                conventions_detected: 1,
+                outliers_found: kinds.len(),
+                alignment_score: None,
+                files_skipped: 0,
+                warnings: Vec::new(),
+            },
+            conventions: Vec::new(),
+            directory_conventions: Vec::new(),
+            findings: kinds
+                .into_iter()
+                .map(|kind| Finding {
+                    convention: "fixture".to_string(),
+                    severity: Severity::Warning,
+                    file: "src/lib.rs".to_string(),
+                    description: "fixture finding".to_string(),
+                    suggestion: "fix it".to_string(),
+                    kind,
+                })
+                .collect(),
+            duplicate_groups: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn filtered_audit_source_result_applies_only_and_exclude() {
+        let result = audit_result_with(vec![
+            AuditFinding::DuplicateFunction,
+            AuditFinding::MissingMethod,
+            AuditFinding::GodFile,
+        ]);
+        let policy = fixer::FixPolicy {
+            only: Some(vec![AuditFinding::DuplicateFunction, AuditFinding::GodFile]),
+            exclude: vec![AuditFinding::GodFile],
+        };
+
+        let filtered = filtered_audit_source_result(&result, &policy);
+
+        assert_eq!(filtered.findings.len(), 1);
+        assert_eq!(filtered.findings[0].kind, AuditFinding::DuplicateFunction);
+        assert_eq!(filtered.summary.outliers_found, 1);
+        assert_eq!(result.findings.len(), 3);
+    }
+}

--- a/src/core/refactor/plan/sources/extension_source.rs
+++ b/src/core/refactor/plan/sources/extension_source.rs
@@ -1,0 +1,255 @@
+use crate::core::component::Component;
+use crate::core::extension;
+use crate::core::refactor::auto::{self, FixApplied};
+use crate::core::Error;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+use super::planning::{PlannedStage, SourceStageSummary};
+
+#[derive(Debug, Clone, Deserialize)]
+struct ExtensionRefactorSourceResponse {
+    #[serde(default)]
+    handled: bool,
+    #[serde(default)]
+    detected_findings: Option<usize>,
+    #[serde(default)]
+    changed_files: Vec<String>,
+    #[serde(default)]
+    fix_results: Vec<FixApplied>,
+    #[serde(default)]
+    warnings: Vec<String>,
+}
+
+pub(super) fn try_extension_refactor_source_stage<T: Serialize>(
+    source: &str,
+    component: &Component,
+    root: &Path,
+    source_result: &T,
+    write: bool,
+    settings: &[(String, String)],
+) -> crate::core::Result<Option<PlannedStage>> {
+    let setting_key = format!("refactor.{}.extension", source);
+    let Some(extension_id) = setting_value(settings, &setting_key) else {
+        return Ok(None);
+    };
+    let manifest = extension::load_extension(extension_id)?;
+    let command = serde_json::json!({
+        "command": "refactor_source",
+        "source": source,
+        "component_id": component.id,
+        "root": root.to_string_lossy(),
+        "source_result": source_result,
+        "write": write,
+        "settings": settings.iter().cloned().collect::<std::collections::BTreeMap<_, _>>(),
+    });
+    let Some(value) = extension::run_refactor_script(&manifest, &command) else {
+        return Err(Error::validation_invalid_argument(
+            setting_key.clone(),
+            format!(
+                "Extension '{}' did not handle refactor source '{}'",
+                extension_id, source
+            ),
+            None,
+            Some(vec![
+                "Remove the setting to use Homeboy's built-in refactor source".to_string(),
+                "Or update the extension refactor script to support command=refactor_source"
+                    .to_string(),
+            ]),
+        ));
+    };
+    let response: ExtensionRefactorSourceResponse =
+        serde_json::from_value(value).map_err(|err| {
+            Error::validation_invalid_argument(
+                setting_key.clone(),
+                format!(
+                    "Extension '{}' returned an invalid refactor source response: {}",
+                    extension_id, err
+                ),
+                None,
+                None,
+            )
+        })?;
+
+    if !response.handled {
+        return Err(Error::validation_invalid_argument(
+            setting_key,
+            format!(
+                "Extension '{}' declined refactor source '{}'",
+                extension_id, source
+            ),
+            None,
+            Some(vec![
+                "Remove the setting to use Homeboy's built-in refactor source".to_string(),
+            ]),
+        ));
+    }
+
+    let fix_summary = if response.fix_results.is_empty() {
+        None
+    } else {
+        Some(auto::summarize_fix_results(&response.fix_results))
+    };
+
+    Ok(Some(PlannedStage {
+        source: source.to_string(),
+        summary: SourceStageSummary {
+            stage: source.to_string(),
+            collected: true,
+            applied: write && !response.changed_files.is_empty(),
+            edit_count: response.fix_results.len(),
+            files_modified: response.changed_files.len(),
+            detected_findings: response.detected_findings,
+            changed_files: response.changed_files,
+            fix_summary,
+            warnings: response.warnings,
+        },
+        fix_results: response.fix_results,
+    }))
+}
+
+pub(super) fn read_optional_json(path: &Path) -> Option<serde_json::Value> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|content| serde_json::from_str(&content).ok())
+}
+
+fn setting_value<'a>(settings: &'a [(String, String)], key: &str) -> Option<&'a str> {
+    settings
+        .iter()
+        .rev()
+        .find(|(setting_key, _)| setting_key == key)
+        .map(|(_, value)| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::component::Component;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn tmp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("homeboy-refactor-sources-{name}-{nanos}"))
+    }
+
+    fn test_component(root: &Path) -> Component {
+        Component {
+            id: "component".to_string(),
+            local_path: root.to_string_lossy().to_string(),
+            remote_path: String::new(),
+            ..Default::default()
+        }
+    }
+
+    fn write_refactor_source_extension(home: &Path, id: &str, capture_file: &Path) {
+        let extension_dir = home.join(".config/homeboy/extensions").join(id);
+        fs::create_dir_all(&extension_dir).unwrap();
+        fs::write(
+            extension_dir.join(format!("{id}.json")),
+            serde_json::json!({
+                "name": "Generic Refactor Source Fixture",
+                "version": "0.0.0",
+                "scripts": {
+                    "refactor": "refactor-source.sh"
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        fs::write(
+            extension_dir.join("refactor-source.sh"),
+            format!(
+                "#!/bin/sh\ncat > '{}'\nprintf '%s' '{{\"handled\":true,\"detected_findings\":2,\"changed_files\":[\"src/lib.rs\"],\"fix_results\":[{{\"file\":\"src/lib.rs\",\"rule\":\"demo\"}}],\"warnings\":[\"extension handled\"]}}'\n",
+                capture_file.display()
+            ),
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let script = extension_dir.join("refactor-source.sh");
+            let mut permissions = fs::metadata(&script).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(script, permissions).unwrap();
+        }
+    }
+
+    #[test]
+    fn extension_refactor_source_dispatch_uses_generic_source_result() {
+        crate::test_support::with_isolated_home(|home| {
+            let root = tmp_dir("generic-extension-dispatch");
+            fs::create_dir_all(&root).unwrap();
+            let capture_file = root.join("command.json");
+            write_refactor_source_extension(home.path(), "generic", &capture_file);
+
+            let audit_stage = try_extension_refactor_source_stage(
+                "audit",
+                &test_component(&root),
+                &root,
+                &serde_json::json!({
+                    "component_id": "component",
+                    "findings": []
+                }),
+                false,
+                &[(
+                    "refactor.audit.extension".to_string(),
+                    "generic".to_string(),
+                )],
+            )
+            .unwrap()
+            .expect("extension should handle audit refactor source");
+
+            assert_eq!(audit_stage.source, "audit");
+            let audit_command: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&capture_file).unwrap()).unwrap();
+            assert_eq!(audit_command["source"], "audit");
+            assert_eq!(audit_command["source_result"]["component_id"], "component");
+            assert!(audit_command.get("audit_result").is_none());
+
+            let stage = try_extension_refactor_source_stage(
+                "lint",
+                &test_component(&root),
+                &root,
+                &serde_json::json!({
+                    "lint_findings": [{
+                        "id": "lint-1",
+                        "message": "demo",
+                        "category": "style"
+                    }]
+                }),
+                true,
+                &[
+                    ("refactor.lint.extension".to_string(), "generic".to_string()),
+                    ("extension.setting".to_string(), "value".to_string()),
+                ],
+            )
+            .unwrap()
+            .expect("extension should handle lint refactor source");
+
+            assert_eq!(stage.source, "lint");
+            assert_eq!(stage.summary.detected_findings, Some(2));
+            assert_eq!(stage.summary.changed_files, vec!["src/lib.rs"]);
+            assert_eq!(stage.fix_results.len(), 1);
+
+            let command: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&capture_file).unwrap()).unwrap();
+            assert_eq!(command["command"], "refactor_source");
+            assert_eq!(command["source"], "lint");
+            assert_eq!(command["write"], true);
+            assert_eq!(command["settings"]["extension.setting"], "value");
+            assert_eq!(command["source_result"]["lint_findings"][0]["id"], "lint-1");
+            assert!(command.get("audit_result").is_none());
+
+            let _ = fs::remove_dir_all(root);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Generalize refactor source extension dispatch from the audit-only helper to `refactor.<source>.extension`.
- Send extension refactor scripts a canonical `source_result` payload for audit, lint, and test sources while preserving built-in fallback behavior.
- Add focused unit coverage that verifies audit and lint dispatch use the generic command shape.

Closes https://github.com/Extra-Chill/homeboy/issues/2877

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo test core::refactor::plan::sources::tests --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and focused tests; Chris remains responsible for review and validation.