### PR TITLE
Extract observed quality workflow runner

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -14,13 +14,11 @@ use homeboy::core::refactor::plan::{
     collect_refactor_sources, lint_refactor_request, LintSourceOptions,
 };
 
-use super::source_command::{
-    finish_observed_workflow, resolve_ci_job_for_command, resolve_source_context,
-    ObservedWorkflowRunner,
-};
+use super::source_command::{resolve_ci_job_for_command, resolve_source_context};
 use super::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
 };
+use super::utils::observed_workflow::{finish_observed_workflow, ObservedWorkflowRunner};
 use super::{CmdResult, GlobalArgs};
 
 #[derive(Args)]

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -1,7 +1,6 @@
 use clap::Args;
 
 use homeboy::core::ci_profile;
-use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::lint::{
     report, run_main_lint_workflow, run_self_check_lint_workflow, LintCommandOutput,
     LintRunWorkflowArgs,
@@ -17,6 +16,7 @@ use homeboy::core::refactor::plan::{
 
 use super::source_command::{
     finish_observed_workflow, resolve_ci_job_for_command, resolve_source_context,
+    ObservedWorkflowRunner,
 };
 use super::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs, PositionalComponentArgs, SettingArgs,
@@ -155,11 +155,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
         return run_fix(args, &ctx, effective_id, stringified_settings);
     }
 
-    let run_dir = RunDir::create()?;
-    let resource_run = homeboy::core::engine::resource::ResourceSummaryRun::start(Some(format!(
-        "lint {}",
-        effective_id
-    )));
+    let runner = ObservedWorkflowRunner::create(format!("lint {}", effective_id))?;
     let observation = LintObservation::start(
         ctx.component_id.clone(),
         &ctx.source_path,
@@ -191,10 +187,14 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
             },
             json_summary: args.json_summary,
         },
-        &run_dir,
+        runner.run_dir(),
     );
-    resource_run.write_to_run_dir(&run_dir)?;
-    let workflow = finish_lint_workflow(observation, workflow)?;
+    let workflow = runner.finish(
+        observation,
+        workflow,
+        |observation, workflow| observation.finish_workflow(workflow),
+        |observation, _error| observation.finish_error(),
+    )?;
 
     Ok(report::from_main_workflow_with_ci_context(
         workflow,

--- a/src/commands/source_command.rs
+++ b/src/commands/source_command.rs
@@ -1,6 +1,8 @@
 use homeboy::core::ci_profile::{self, CiResolvedJob};
 use homeboy::core::component::Component;
 use homeboy::core::engine::execution_context::{self, ExecutionContext, ResolveOptions};
+use homeboy::core::engine::resource::ResourceSummaryRun;
+use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::ExtensionCapability;
 
 use super::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs};
@@ -62,6 +64,46 @@ where
     }
 }
 
+pub(crate) struct ObservedWorkflowRunner {
+    run_dir: RunDir,
+    resource_run: ResourceSummaryRun,
+}
+
+impl ObservedWorkflowRunner {
+    pub(crate) fn create(resource_label: impl Into<String>) -> homeboy::core::Result<Self> {
+        Ok(Self {
+            run_dir: RunDir::create()?,
+            resource_run: ResourceSummaryRun::start(Some(resource_label.into())),
+        })
+    }
+
+    pub(crate) fn run_dir(&self) -> &RunDir {
+        &self.run_dir
+    }
+
+    pub(crate) fn finish<O, T, F, E>(
+        self,
+        observation: Option<O>,
+        workflow: homeboy::core::Result<T>,
+        finish_success: F,
+        finish_error: E,
+    ) -> homeboy::core::Result<T>
+    where
+        F: FnOnce(O, &T),
+        E: FnOnce(O, &homeboy::core::Error),
+    {
+        match self.resource_run.write_to_run_dir(&self.run_dir) {
+            Ok(_) => finish_observed_workflow(observation, workflow, finish_success, finish_error),
+            Err(error) => {
+                if let Some(observation) = observation {
+                    finish_error(observation, &error);
+                }
+                Err(error)
+            }
+        }
+    }
+}
+
 fn component_extension_ids(component: &Component) -> Vec<String> {
     let mut ids: Vec<String> = component
         .extensions
@@ -74,9 +116,11 @@ fn component_extension_ids(component: &Component) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::component_extension_ids;
+    use super::{component_extension_ids, ObservedWorkflowRunner};
     use homeboy::core::component::{Component, ScopedExtensionConfig};
+    use std::cell::RefCell;
     use std::collections::HashMap;
+    use std::rc::Rc;
 
     #[test]
     fn component_extension_ids_are_sorted() {
@@ -95,5 +139,48 @@ mod tests {
             component_extension_ids(&component),
             vec!["nodejs", "wordpress"]
         );
+    }
+
+    #[test]
+    fn observed_workflow_runner_finishes_success_after_resource_summary() {
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let runner = ObservedWorkflowRunner::create("test demo").expect("runner");
+        let resource_summary_path = runner.run_dir().step_file("resource-summary.json");
+
+        let result = runner.finish(
+            Some(events.clone()),
+            Ok::<_, homeboy::core::Error>(7),
+            |events, workflow| events.borrow_mut().push(format!("success:{workflow}")),
+            |events, error| events.borrow_mut().push(format!("error:{error}")),
+        );
+
+        assert_eq!(result.expect("workflow success"), 7);
+        assert!(resource_summary_path.is_file());
+        assert_eq!(events.borrow().as_slice(), ["success:7"]);
+    }
+
+    #[test]
+    fn observed_workflow_runner_finishes_error_after_resource_summary() {
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let runner = ObservedWorkflowRunner::create("test demo").expect("runner");
+        let resource_summary_path = runner.run_dir().step_file("resource-summary.json");
+        let error = homeboy::core::Error::validation_invalid_argument(
+            "fixture",
+            "simulated workflow error",
+            None,
+            None,
+        );
+
+        let result = runner.finish(
+            Some(events.clone()),
+            Err::<i32, _>(error),
+            |events, workflow| events.borrow_mut().push(format!("success:{workflow}")),
+            |events, error| events.borrow_mut().push(format!("error:{error}")),
+        );
+
+        assert!(result.is_err());
+        assert!(resource_summary_path.is_file());
+        assert_eq!(events.borrow().len(), 1);
+        assert!(events.borrow()[0].contains("simulated workflow error"));
     }
 }

--- a/src/commands/source_command.rs
+++ b/src/commands/source_command.rs
@@ -1,8 +1,6 @@
 use homeboy::core::ci_profile::{self, CiResolvedJob};
 use homeboy::core::component::Component;
 use homeboy::core::engine::execution_context::{self, ExecutionContext, ResolveOptions};
-use homeboy::core::engine::resource::ResourceSummaryRun;
-use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::ExtensionCapability;
 
 use super::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs};
@@ -38,72 +36,6 @@ pub(crate) fn resolve_ci_job_for_command(
     Ok(Some(job))
 }
 
-pub(crate) fn finish_observed_workflow<O, T, F, E>(
-    observation: Option<O>,
-    workflow: homeboy::core::Result<T>,
-    finish_success: F,
-    finish_error: E,
-) -> homeboy::core::Result<T>
-where
-    F: FnOnce(O, &T),
-    E: FnOnce(O, &homeboy::core::Error),
-{
-    match workflow {
-        Ok(workflow) => {
-            if let Some(observation) = observation {
-                finish_success(observation, &workflow);
-            }
-            Ok(workflow)
-        }
-        Err(error) => {
-            if let Some(observation) = observation {
-                finish_error(observation, &error);
-            }
-            Err(error)
-        }
-    }
-}
-
-pub(crate) struct ObservedWorkflowRunner {
-    run_dir: RunDir,
-    resource_run: ResourceSummaryRun,
-}
-
-impl ObservedWorkflowRunner {
-    pub(crate) fn create(resource_label: impl Into<String>) -> homeboy::core::Result<Self> {
-        Ok(Self {
-            run_dir: RunDir::create()?,
-            resource_run: ResourceSummaryRun::start(Some(resource_label.into())),
-        })
-    }
-
-    pub(crate) fn run_dir(&self) -> &RunDir {
-        &self.run_dir
-    }
-
-    pub(crate) fn finish<O, T, F, E>(
-        self,
-        observation: Option<O>,
-        workflow: homeboy::core::Result<T>,
-        finish_success: F,
-        finish_error: E,
-    ) -> homeboy::core::Result<T>
-    where
-        F: FnOnce(O, &T),
-        E: FnOnce(O, &homeboy::core::Error),
-    {
-        match self.resource_run.write_to_run_dir(&self.run_dir) {
-            Ok(_) => finish_observed_workflow(observation, workflow, finish_success, finish_error),
-            Err(error) => {
-                if let Some(observation) = observation {
-                    finish_error(observation, &error);
-                }
-                Err(error)
-            }
-        }
-    }
-}
-
 fn component_extension_ids(component: &Component) -> Vec<String> {
     let mut ids: Vec<String> = component
         .extensions
@@ -116,11 +48,9 @@ fn component_extension_ids(component: &Component) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{component_extension_ids, ObservedWorkflowRunner};
+    use super::component_extension_ids;
     use homeboy::core::component::{Component, ScopedExtensionConfig};
-    use std::cell::RefCell;
     use std::collections::HashMap;
-    use std::rc::Rc;
 
     #[test]
     fn component_extension_ids_are_sorted() {
@@ -139,48 +69,5 @@ mod tests {
             component_extension_ids(&component),
             vec!["nodejs", "wordpress"]
         );
-    }
-
-    #[test]
-    fn observed_workflow_runner_finishes_success_after_resource_summary() {
-        let events = Rc::new(RefCell::new(Vec::new()));
-        let runner = ObservedWorkflowRunner::create("test demo").expect("runner");
-        let resource_summary_path = runner.run_dir().step_file("resource-summary.json");
-
-        let result = runner.finish(
-            Some(events.clone()),
-            Ok::<_, homeboy::core::Error>(7),
-            |events, workflow| events.borrow_mut().push(format!("success:{workflow}")),
-            |events, error| events.borrow_mut().push(format!("error:{error}")),
-        );
-
-        assert_eq!(result.expect("workflow success"), 7);
-        assert!(resource_summary_path.is_file());
-        assert_eq!(events.borrow().as_slice(), ["success:7"]);
-    }
-
-    #[test]
-    fn observed_workflow_runner_finishes_error_after_resource_summary() {
-        let events = Rc::new(RefCell::new(Vec::new()));
-        let runner = ObservedWorkflowRunner::create("test demo").expect("runner");
-        let resource_summary_path = runner.run_dir().step_file("resource-summary.json");
-        let error = homeboy::core::Error::validation_invalid_argument(
-            "fixture",
-            "simulated workflow error",
-            None,
-            None,
-        );
-
-        let result = runner.finish(
-            Some(events.clone()),
-            Err::<i32, _>(error),
-            |events, workflow| events.borrow_mut().push(format!("success:{workflow}")),
-            |events, error| events.borrow_mut().push(format!("error:{error}")),
-        );
-
-        assert!(result.is_err());
-        assert!(resource_summary_path.is_file());
-        assert_eq!(events.borrow().len(), 1);
-        assert!(events.borrow()[0].contains("simulated workflow error"));
     }
 }

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -18,6 +18,7 @@ use std::path::Path;
 
 use super::source_command::{
     finish_observed_workflow, resolve_ci_job_for_command, resolve_source_context,
+    ObservedWorkflowRunner,
 };
 use super::utils::args::{
     filter_passthrough_args, BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs,
@@ -161,18 +162,14 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
     }
 
     // Main test workflow — delegate to core
-    let run_dir = RunDir::create()?;
+    let runner = ObservedWorkflowRunner::create(format!("test {}", effective_id))?;
     let observation = start_test_observation(
         &ctx.component_id,
         &ctx.source_path,
         &args,
         "test",
-        Some(&run_dir),
+        Some(runner.run_dir()),
     );
-    let resource_run = homeboy::core::engine::resource::ResourceSummaryRun::start(Some(format!(
-        "test {}",
-        effective_id
-    )));
     let mut passthrough_args = ci_job_passthrough_args(ci_job.as_ref());
     passthrough_args.extend(filter_homeboy_flags(&args.args));
     let workflow = extension_test::run_main_test_workflow(
@@ -197,10 +194,14 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
             ci_env: ci_profile::ci_job_env(ci_job.as_ref()),
             passthrough_args: passthrough_args.clone(),
         },
-        &run_dir,
+        runner.run_dir(),
     );
-    resource_run.write_to_run_dir(&run_dir)?;
-    let workflow = finish_test_workflow_observation(observation, workflow)?;
+    let workflow = runner.finish(
+        observation,
+        workflow,
+        |observation, workflow| finish_test_observation(Some(observation), workflow),
+        |observation, error| finish_test_observation_error(Some(observation), error),
+    )?;
 
     Ok(report::from_main_workflow_with_ci_context(
         workflow,

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -16,14 +16,12 @@ use homeboy::core::observation::{
 };
 use std::path::Path;
 
-use super::source_command::{
-    finish_observed_workflow, resolve_ci_job_for_command, resolve_source_context,
-    ObservedWorkflowRunner,
-};
+use super::source_command::{resolve_ci_job_for_command, resolve_source_context};
 use super::utils::args::{
     filter_passthrough_args, BaselineArgs, ExtensionOverrideArgs, HiddenJsonArgs,
     PassthroughCommand, PositionalComponentArgs, SettingArgs,
 };
+use super::utils::observed_workflow::{finish_observed_workflow, ObservedWorkflowRunner};
 use super::{CmdResult, GlobalArgs};
 
 #[derive(Args)]

--- a/src/commands/utils/mod.rs
+++ b/src/commands/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod args;
 pub mod entity_suggest;
+pub(crate) mod observed_workflow;
 pub mod resolve;
 pub mod resource_policy;
 pub mod response;

--- a/src/commands/utils/observed_workflow.rs
+++ b/src/commands/utils/observed_workflow.rs
@@ -1,0 +1,118 @@
+use homeboy::core::engine::resource::ResourceSummaryRun;
+use homeboy::core::engine::run_dir::RunDir;
+
+pub(crate) fn finish_observed_workflow<O, T, F, E>(
+    observation: Option<O>,
+    workflow: homeboy::core::Result<T>,
+    finish_success: F,
+    finish_error: E,
+) -> homeboy::core::Result<T>
+where
+    F: FnOnce(O, &T),
+    E: FnOnce(O, &homeboy::core::Error),
+{
+    match workflow {
+        Ok(workflow) => {
+            if let Some(observation) = observation {
+                finish_success(observation, &workflow);
+            }
+            Ok(workflow)
+        }
+        Err(error) => {
+            if let Some(observation) = observation {
+                finish_error(observation, &error);
+            }
+            Err(error)
+        }
+    }
+}
+
+pub(crate) struct ObservedWorkflowRunner {
+    run_dir: RunDir,
+    resource_run: ResourceSummaryRun,
+}
+
+impl ObservedWorkflowRunner {
+    pub(crate) fn create(resource_label: impl Into<String>) -> homeboy::core::Result<Self> {
+        Ok(Self {
+            run_dir: RunDir::create()?,
+            resource_run: ResourceSummaryRun::start(Some(resource_label.into())),
+        })
+    }
+
+    pub(crate) fn run_dir(&self) -> &RunDir {
+        &self.run_dir
+    }
+
+    pub(crate) fn finish<O, T, F, E>(
+        self,
+        observation: Option<O>,
+        workflow: homeboy::core::Result<T>,
+        finish_success: F,
+        finish_error: E,
+    ) -> homeboy::core::Result<T>
+    where
+        F: FnOnce(O, &T),
+        E: FnOnce(O, &homeboy::core::Error),
+    {
+        match self.resource_run.write_to_run_dir(&self.run_dir) {
+            Ok(_) => finish_observed_workflow(observation, workflow, finish_success, finish_error),
+            Err(error) => {
+                if let Some(observation) = observation {
+                    finish_error(observation, &error);
+                }
+                Err(error)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ObservedWorkflowRunner;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    #[test]
+    fn observed_workflow_runner_finishes_success_after_resource_summary() {
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let runner = ObservedWorkflowRunner::create("test demo").expect("runner");
+        let resource_summary_path = runner.run_dir().step_file("resource-summary.json");
+
+        let result = runner.finish(
+            Some(events.clone()),
+            Ok::<_, homeboy::core::Error>(7),
+            |events, workflow| events.borrow_mut().push(format!("success:{workflow}")),
+            |events, error| events.borrow_mut().push(format!("error:{error}")),
+        );
+
+        assert_eq!(result.expect("workflow success"), 7);
+        assert!(resource_summary_path.is_file());
+        assert_eq!(events.borrow().as_slice(), ["success:7"]);
+    }
+
+    #[test]
+    fn observed_workflow_runner_finishes_error_after_resource_summary() {
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let runner = ObservedWorkflowRunner::create("test demo").expect("runner");
+        let resource_summary_path = runner.run_dir().step_file("resource-summary.json");
+        let error = homeboy::core::Error::validation_invalid_argument(
+            "fixture",
+            "simulated workflow error",
+            None,
+            None,
+        );
+
+        let result = runner.finish(
+            Some(events.clone()),
+            Err::<i32, _>(error),
+            |events, workflow| events.borrow_mut().push(format!("success:{workflow}")),
+            |events, error| events.borrow_mut().push(format!("error:{error}")),
+        );
+
+        assert!(result.is_err());
+        assert!(resource_summary_path.is_file());
+        assert_eq!(events.borrow().len(), 1);
+        assert!(events.borrow()[0].contains("simulated workflow error"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an `ObservedWorkflowRunner` seam that owns run-dir creation, resource summary persistence, and observed workflow success/error finalization for quality commands.
- Migrates the main `lint` and `test` workflows to the shared runner while preserving command output/reporting adapters.
- Adds centralized success/error tests for the shared runner.

## Notes
- `audit` remains on its existing custom observation path in this slice because it does not currently create a `RunDir` or resource summary, so forcing it through this runner would broaden the PR beyond the shared lifecycle used by `lint` and `test`.
- Bench remains separate because its observation lifecycle records artifacts, mutates workflow artifact paths, and appends history hints before output conversion.

## Tests
- `cargo fmt`
- `cargo test source_command::tests::observed_workflow_runner --lib`
- `cargo test commands::source_command::tests --lib`
- `cargo test commands::lint::tests --lib`
- `cargo test commands::test::tests --lib`
- `cargo test --lib`
- `cargo test --tests`

Fixes #2881

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing and testing the observed workflow runner refactor under Chris review