### PR TITLE
Consolidate batch and bulk output totals

### DIFF
--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -8,7 +8,7 @@ use crate::core::engine::command::CapturedOutput;
 use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
 use crate::core::extension::{self, exec_context, ExtensionCapability, ExtensionExecutionContext};
-use crate::core::output::{BulkResult, BulkSummary, ItemOutcome};
+use crate::core::output::{BulkResult, BulkResultBuilder};
 use crate::core::paths;
 use crate::core::server::execute_local_command_in_dir;
 
@@ -268,49 +268,27 @@ pub fn run_with_path(component_id: &str, path: &str) -> Result<(BuildResult, i32
 fn run_bulk(json_spec: &str) -> Result<(BuildResult, i32)> {
     let input = parse_bulk_ids(json_spec)?;
 
-    let mut results = Vec::with_capacity(input.component_ids.len());
-    let mut succeeded = 0usize;
-    let mut failed = 0usize;
+    let mut builder = BulkResultBuilder::with_capacity("build", input.component_ids.len());
 
     for id in &input.component_ids {
         match execute_build(id, None) {
             Ok((output, _)) => {
                 if output.success {
-                    succeeded += 1;
+                    builder.record_success(id.clone(), output);
                 } else {
-                    failed += 1;
+                    builder.record_failed_result(id.clone(), output);
                 }
-                results.push(ItemOutcome {
-                    id: id.clone(),
-                    result: Some(output),
-                    error: None,
-                });
             }
             Err(e) => {
-                failed += 1;
-                results.push(ItemOutcome {
-                    id: id.clone(),
-                    result: None,
-                    error: Some(e.to_string()),
-                });
+                builder.record_error(id.clone(), e.to_string());
             }
         }
     }
 
-    let exit_code = if failed > 0 { 1 } else { 0 };
+    let output = builder.finish();
+    let exit_code = if output.summary.failed > 0 { 1 } else { 0 };
 
-    Ok((
-        BuildResult::Bulk(BulkResult {
-            action: "build".to_string(),
-            results,
-            summary: BulkSummary {
-                total: succeeded + failed,
-                succeeded,
-                failed,
-            },
-        }),
-        exit_code,
-    ))
+    Ok((BuildResult::Bulk(output), exit_code))
 }
 
 /// Build a pre-resolved component (supports both registered and discovered components).
@@ -321,49 +299,27 @@ pub fn run_component(component: &Component) -> Result<(BuildResult, i32)> {
 
 /// Build multiple pre-resolved components.
 pub fn run_components(components: &[Component]) -> Result<(BuildResult, i32)> {
-    let mut results = Vec::with_capacity(components.len());
-    let mut succeeded = 0usize;
-    let mut failed = 0usize;
+    let mut builder = BulkResultBuilder::with_capacity("build", components.len());
 
     for component in components {
         match execute_build_component(component) {
             Ok((output, _)) => {
                 if output.success {
-                    succeeded += 1;
+                    builder.record_success(component.id.clone(), output);
                 } else {
-                    failed += 1;
+                    builder.record_failed_result(component.id.clone(), output);
                 }
-                results.push(ItemOutcome {
-                    id: component.id.clone(),
-                    result: Some(output),
-                    error: None,
-                });
             }
             Err(error) => {
-                failed += 1;
-                results.push(ItemOutcome {
-                    id: component.id.clone(),
-                    result: None,
-                    error: Some(error.to_string()),
-                });
+                builder.record_error(component.id.clone(), error.to_string());
             }
         }
     }
 
-    let exit_code = if failed > 0 { 1 } else { 0 };
+    let output = builder.finish();
+    let exit_code = if output.summary.failed > 0 { 1 } else { 0 };
 
-    Ok((
-        BuildResult::Bulk(BulkResult {
-            action: "build".to_string(),
-            results,
-            summary: BulkSummary {
-                total: succeeded + failed,
-                succeeded,
-                failed,
-            },
-        }),
-        exit_code,
-    ))
+    Ok((BuildResult::Bulk(output), exit_code))
 }
 
 fn execute_build(component_id: &str, path_override: Option<&str>) -> Result<(BuildOutput, i32)> {

--- a/src/core/git/operation_output.rs
+++ b/src/core/git/operation_output.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 use crate::core::error::Result;
-use crate::core::output::{BulkResult, BulkSummary, ItemOutcome};
+use crate::core::output::{BulkResult, BulkResultBuilder};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct GitOutput {
@@ -59,44 +59,24 @@ pub(crate) fn run_bulk_ids<F>(ids: &[String], action: &str, op: F) -> BulkResult
 where
     F: Fn(&str) -> Result<GitOutput>,
 {
-    let mut results = Vec::new();
-    let mut succeeded = 0usize;
-    let mut failed = 0usize;
+    let mut builder = BulkResultBuilder::with_capacity(action, ids.len());
 
     for id in ids {
         match op(id) {
             Ok(output) => {
                 if output.success {
-                    succeeded += 1;
+                    builder.record_success(id.clone(), output);
                 } else {
-                    failed += 1;
+                    builder.record_failed_result(id.clone(), output);
                 }
-                results.push(ItemOutcome {
-                    id: id.clone(),
-                    result: Some(output),
-                    error: None,
-                });
             }
             Err(e) => {
-                failed += 1;
-                results.push(ItemOutcome {
-                    id: id.clone(),
-                    result: None,
-                    error: Some(e.to_string()),
-                });
+                builder.record_error(id.clone(), e.to_string());
             }
         }
     }
 
-    BulkResult {
-        action: action.to_string(),
-        results,
-        summary: BulkSummary {
-            total: succeeded + failed,
-            succeeded,
-            failed,
-        },
-    }
+    builder.finish()
 }
 
 #[cfg(test)]

--- a/src/core/git/operations_changes.rs
+++ b/src/core/git/operations_changes.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::core::config::read_json_spec_to_string;
 use crate::core::error::{Error, Result};
-use crate::core::output::{BulkResult, BulkSummary, ItemOutcome};
+use crate::core::output::{BulkResult, BulkResultBuilder};
 use crate::core::project;
 use crate::core::release::changelog;
 
@@ -326,44 +326,24 @@ fn build_bulk_changes_output(
     component_ids: &[String],
     include_diff: bool,
 ) -> BulkResult<ChangesOutput> {
-    let mut results = Vec::new();
-    let mut succeeded = 0usize;
-    let mut failed = 0usize;
+    let mut builder = BulkResultBuilder::with_capacity("changes", component_ids.len());
 
     for id in component_ids {
         match changes(Some(id), None, include_diff) {
             Ok(output) => {
                 if output.success {
-                    succeeded += 1;
+                    builder.record_success(id.clone(), output);
                 } else {
-                    failed += 1;
+                    builder.record_failed_result(id.clone(), output);
                 }
-                results.push(ItemOutcome {
-                    id: id.clone(),
-                    result: Some(output),
-                    error: None,
-                });
             }
             Err(e) => {
-                failed += 1;
-                results.push(ItemOutcome {
-                    id: id.clone(),
-                    result: None,
-                    error: Some(e.to_string()),
-                });
+                builder.record_error(id.clone(), e.to_string());
             }
         }
     }
 
-    BulkResult {
-        action: "changes".to_string(),
-        results,
-        summary: BulkSummary {
-            total: succeeded + failed,
-            succeeded,
-            failed,
-        },
-    }
+    builder.finish()
 }
 
 /// Get changes for multiple components from JSON spec.

--- a/src/core/git/operations_commit.rs
+++ b/src/core/git/operations_commit.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::core::config::read_json_spec_to_string;
 use crate::core::error::{Error, Result};
-use crate::core::output::{BulkResult, BulkSummary, ItemOutcome};
+use crate::core::output::{BulkResult, BulkResultBuilder};
 
 use super::operation_output::GitOutput;
 use super::{execute_git, resolve_target};
@@ -169,20 +169,13 @@ fn commit_bulk(json_spec: &str) -> Result<BulkResult<GitOutput>> {
         )
     })?;
 
-    let mut results = Vec::new();
-    let mut succeeded = 0usize;
-    let mut failed = 0usize;
+    let mut builder = BulkResultBuilder::with_capacity("commit", input.components.len());
 
     for spec in &input.components {
         let id = match &spec.id {
             Some(id) => id.clone(),
             None => {
-                failed += 1;
-                results.push(ItemOutcome {
-                    id: "unknown".to_string(),
-                    result: None,
-                    error: Some("Missing 'id' field in bulk commit spec".to_string()),
-                });
+                builder.record_error("unknown", "Missing 'id' field in bulk commit spec");
                 continue;
             }
         };
@@ -195,36 +188,18 @@ fn commit_bulk(json_spec: &str) -> Result<BulkResult<GitOutput>> {
         match commit(Some(&id), Some(&spec.message), options) {
             Ok(output) => {
                 if output.success {
-                    succeeded += 1;
+                    builder.record_success(id, output);
                 } else {
-                    failed += 1;
+                    builder.record_failed_result(id, output);
                 }
-                results.push(ItemOutcome {
-                    id,
-                    result: Some(output),
-                    error: None,
-                });
             }
             Err(e) => {
-                failed += 1;
-                results.push(ItemOutcome {
-                    id,
-                    result: None,
-                    error: Some(e.to_string()),
-                });
+                builder.record_error(id, e.to_string());
             }
         }
     }
 
-    Ok(BulkResult {
-        action: "commit".to_string(),
-        results,
-        summary: BulkSummary {
-            total: succeeded + failed,
-            succeeded,
-            failed,
-        },
-    })
+    Ok(builder.finish())
 }
 
 /// Output from commit_from_json - either single or bulk result.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -63,9 +63,9 @@ pub use server::auth;
 // Re-export common types for convenience
 pub use error::{Error, ErrorCode, Result};
 pub use output::{
-    BatchResult, BatchResultItem, BulkResult, BulkSummary, CreateOutput, CreateResult,
-    EntityCrudOutput, ItemOutcome, MergeOutput, MergeResult, NoExtra, ObservationOutputDetails,
-    ObservationOutputMetadata, RemoveResult,
+    BatchResult, BatchResultItem, BulkResult, BulkResultBuilder, BulkSummary, CreateOutput,
+    CreateResult, EntityCrudOutput, ItemOutcome, MergeOutput, MergeResult, NoExtra,
+    ObservationOutputDetails, ObservationOutputMetadata, OutcomeTotals, RemoveResult,
 };
 
 /// Set a process-local artifact root override for the current CLI invocation.

--- a/src/core/output.rs
+++ b/src/core/output.rs
@@ -53,6 +53,7 @@ impl ObservationOutputMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_for_run() {
@@ -125,6 +126,76 @@ mod tests {
         assert_eq!(result.items[0].id, "alpha");
         assert_eq!(result.items[0].status, "error");
         assert_eq!(result.items[0].error.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn batch_outcome_totals_cover_success_partial_failure_skipped_and_empty() {
+        let empty = BatchResult::new();
+        assert_eq!(empty.outcome_totals(), OutcomeTotals::default());
+
+        let mut result = BatchResult::new();
+        result.record_created("created".to_string());
+        result.record_updated("updated".to_string());
+        result.record_skipped("skipped".to_string());
+        result.record_error("failed".to_string(), "boom".to_string());
+
+        assert_eq!(
+            result.outcome_totals(),
+            OutcomeTotals {
+                total: 4,
+                succeeded: 2,
+                failed: 1,
+                skipped: 1,
+            }
+        );
+        assert_eq!(result.exit_code(), 1);
+    }
+
+    #[test]
+    fn bulk_result_builds_summary_without_changing_json_shape() {
+        let output = BulkResult::new(
+            "fixture",
+            vec![
+                ItemOutcome::success("alpha", json!({ "value": 1 })),
+                ItemOutcome::error("beta", "boom"),
+            ],
+        );
+
+        let serialized = serde_json::to_value(output).expect("serialize bulk result");
+        assert_eq!(serialized["action"], "fixture");
+        assert_eq!(serialized["summary"]["total"], 2);
+        assert_eq!(serialized["summary"]["succeeded"], 1);
+        assert_eq!(serialized["summary"]["failed"], 1);
+        assert!(serialized["summary"].get("skipped").is_none());
+        assert_eq!(serialized["results"][0]["id"], "alpha");
+        assert_eq!(serialized["results"][0]["value"], 1);
+        assert_eq!(serialized["results"][1]["id"], "beta");
+        assert_eq!(serialized["results"][1]["error"], "boom");
+    }
+
+    #[test]
+    fn bulk_builder_counts_failed_results_without_changing_item_shape() {
+        let mut builder = BulkResultBuilder::new("fixture");
+        builder.record_success("alpha", json!({ "success": true }));
+        builder.record_failed_result("beta", json!({ "success": false }));
+
+        let serialized = serde_json::to_value(builder.finish()).expect("serialize bulk result");
+        assert_eq!(serialized["summary"]["total"], 2);
+        assert_eq!(serialized["summary"]["succeeded"], 1);
+        assert_eq!(serialized["summary"]["failed"], 1);
+        assert_eq!(serialized["results"][1]["id"], "beta");
+        assert_eq!(serialized["results"][1]["success"], false);
+        assert!(serialized["results"][1].get("error").is_none());
+    }
+
+    #[test]
+    fn bulk_result_handles_empty_results() {
+        let output = BulkResult::<serde_json::Value>::new("fixture", Vec::new());
+
+        assert_eq!(output.summary.total, 0);
+        assert_eq!(output.summary.succeeded, 0);
+        assert_eq!(output.summary.failed, 0);
+        assert!(output.results.is_empty());
     }
 }
 
@@ -199,6 +270,15 @@ pub struct BatchResultItem {
     pub error: Option<String>,
 }
 
+/// Shared outcome counters used by batch and bulk result adapters.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct OutcomeTotals {
+    pub total: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+    pub skipped: usize,
+}
+
 impl BatchResult {
     pub fn new() -> Self {
         Self::default()
@@ -248,6 +328,15 @@ impl BatchResult {
             error: Some(error),
         });
     }
+
+    pub fn outcome_totals(&self) -> OutcomeTotals {
+        OutcomeTotals {
+            total: self.items.len(),
+            succeeded: (self.created + self.updated) as usize,
+            failed: self.errors as usize,
+            skipped: self.skipped as usize,
+        }
+    }
 }
 
 // ============================================================================
@@ -263,6 +352,73 @@ pub struct BulkResult<T: Serialize> {
     pub summary: BulkSummary,
 }
 
+impl<T: Serialize> BulkResult<T> {
+    pub fn new(action: impl Into<String>, results: Vec<ItemOutcome<T>>) -> Self {
+        let summary = BulkSummary::from_outcome_totals(OutcomeTotals {
+            total: results.len(),
+            succeeded: results.iter().filter(|result| result.succeeded()).count(),
+            failed: results.iter().filter(|result| result.failed()).count(),
+            skipped: 0,
+        });
+
+        Self {
+            action: action.into(),
+            results,
+            summary,
+        }
+    }
+}
+
+pub struct BulkResultBuilder<T: Serialize> {
+    action: String,
+    results: Vec<ItemOutcome<T>>,
+    totals: OutcomeTotals,
+}
+
+impl<T: Serialize> BulkResultBuilder<T> {
+    pub fn new(action: impl Into<String>) -> Self {
+        Self {
+            action: action.into(),
+            results: Vec::new(),
+            totals: OutcomeTotals::default(),
+        }
+    }
+
+    pub fn with_capacity(action: impl Into<String>, capacity: usize) -> Self {
+        Self {
+            action: action.into(),
+            results: Vec::with_capacity(capacity),
+            totals: OutcomeTotals::default(),
+        }
+    }
+
+    pub fn record_success(&mut self, id: impl Into<String>, result: T) {
+        self.totals.total += 1;
+        self.totals.succeeded += 1;
+        self.results.push(ItemOutcome::success(id, result));
+    }
+
+    pub fn record_failed_result(&mut self, id: impl Into<String>, result: T) {
+        self.totals.total += 1;
+        self.totals.failed += 1;
+        self.results.push(ItemOutcome::success(id, result));
+    }
+
+    pub fn record_error(&mut self, id: impl Into<String>, error: impl Into<String>) {
+        self.totals.total += 1;
+        self.totals.failed += 1;
+        self.results.push(ItemOutcome::error(id, error));
+    }
+
+    pub fn finish(self) -> BulkResult<T> {
+        BulkResult {
+            action: self.action,
+            results: self.results,
+            summary: BulkSummary::from_outcome_totals(self.totals),
+        }
+    }
+}
+
 /// Outcome for a single item in a bulk operation.
 #[derive(Debug, Serialize)]
 
@@ -275,6 +431,32 @@ pub struct ItemOutcome<T: Serialize> {
     pub error: Option<String>,
 }
 
+impl<T: Serialize> ItemOutcome<T> {
+    pub fn success(id: impl Into<String>, result: T) -> Self {
+        Self {
+            id: id.into(),
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn error(id: impl Into<String>, error: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            result: None,
+            error: Some(error.into()),
+        }
+    }
+
+    fn succeeded(&self) -> bool {
+        self.result.is_some() && self.error.is_none()
+    }
+
+    fn failed(&self) -> bool {
+        !self.succeeded()
+    }
+}
+
 /// Summary of bulk operation results.
 #[derive(Debug, Clone, Serialize)]
 
@@ -282,6 +464,16 @@ pub struct BulkSummary {
     pub total: usize,
     pub succeeded: usize,
     pub failed: usize,
+}
+
+impl BulkSummary {
+    pub fn from_outcome_totals(totals: OutcomeTotals) -> Self {
+        Self {
+            total: totals.total,
+            succeeded: totals.succeeded,
+            failed: totals.failed,
+        }
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Add shared outcome totals plus `BulkResultBuilder` helpers so batch and bulk outputs use one total/succeeded/failed/skipped vocabulary internally.
- Refactor git/build bulk output constructors onto the shared builder while preserving existing public JSON shapes.
- Add output tests covering success, partial failure, skipped batch items, failed-result bulk items, and empty results.

## Testing
- `cargo fmt`
- `cargo test core::output::tests`
- `cargo test git::operation_output::tests`
- `cargo test`
- `git diff --check`

## Known notes
- `cargo clippy --all-targets --all-features -- -D warnings` was attempted and still fails on existing repo-wide Clippy debt unrelated to this change, including duplicate test support modules, large enum variants, and other pre-existing warnings outside the touched DTO path.
- The linked issue body for #2883 currently describes command descriptor consolidation, while this PR follows the requested worker scope for batch/bulk DTO consolidation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing and testing batch/bulk DTO consolidation under Chris review.