### PR TITLE
Unify target resolution

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use homeboy::core::code_audit::{
     self, report, run_main_audit_workflow, AuditCommandOutput, AuditRunWorkflowArgs,
 };
-use homeboy::core::engine::execution_context::{self, ResolveOptions};
+use homeboy::core::component::{self, TargetSpec};
 use homeboy::core::git::short_head_revision_at;
 use homeboy::core::observation::{
     finding_records_from_audit, NewRunRecord, ObservationStore, RunRecord, RunStatus,
@@ -76,34 +76,12 @@ pub fn run(args: AuditArgs, _global: &GlobalArgs) -> CmdResult<AuditCommandOutpu
         run_audit_reference_setup(component_id);
     }
 
-    // Resolve component ID and source path.
-    // When component is omitted, auto-discover from CWD via homeboy.json.
-    let (resolved_id, resolved_path) = if let Some(ref comp_arg) = args.comp.component {
-        if Path::new(comp_arg).is_dir() {
-            // Bare directory path — no registered component
-            let effective = args.comp.path.as_deref().unwrap_or(comp_arg).to_string();
-            let name = Path::new(&effective)
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or_else(|| "unknown".to_string());
-            (name, effective)
-        } else {
-            // Registered component — use unified resolver
-            let ctx = execution_context::resolve(&ResolveOptions::source_only(
-                comp_arg,
-                args.comp.path.clone(),
-            ))?;
-            (
-                ctx.component_id,
-                ctx.source_path.to_string_lossy().to_string(),
-            )
-        }
-    } else {
-        // No component specified — auto-discover from CWD
-        let component = args.comp.load()?;
-        let source_path = component.local_path.clone();
-        (component.id, source_path)
-    };
+    let target = component::resolve_target(TargetSpec::new(
+        args.comp.component.as_deref(),
+        args.comp.path.as_deref(),
+    ))?;
+    let resolved_id = target.component_id;
+    let resolved_path = target.source_path.to_string_lossy().to_string();
 
     let observation = start_audit_observation(&resolved_id, &resolved_path, &args);
     let workflow = run_main_audit_workflow(AuditRunWorkflowArgs {

--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -1,5 +1,6 @@
 use clap::{Args, Subcommand};
 use homeboy::core::code_audit::AuditFinding;
+use homeboy::core::component::{self, TargetSpec};
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::refactor::{
     self, auto, AddResult, MoveResult, RenameContext, RenameScope, RenameSpec, RenameTargeting,
@@ -546,11 +547,7 @@ impl RefactorTargetArgs {
         }
 
         if let Some(path) = &self.path {
-            return Ok(vec![RefactorTarget {
-                component_id: None,
-                path: Some(path.clone()),
-                label: path.clone(),
-            }]);
+            return resolve_refactor_target(None, Some(path));
         }
 
         if component_ids.is_empty() {
@@ -568,6 +565,20 @@ impl RefactorTargetArgs {
             })
             .collect())
     }
+}
+
+fn resolve_refactor_target(
+    component_id: Option<&str>,
+    path: Option<&str>,
+) -> homeboy::core::Result<Vec<RefactorTarget>> {
+    let target = component::resolve_target(TargetSpec::new(component_id, path))?;
+    let path = target.source_path.to_string_lossy().to_string();
+
+    Ok(vec![RefactorTarget {
+        label: target.component_id.clone(),
+        component_id: Some(target.component_id),
+        path: Some(path),
+    }])
 }
 
 fn resolve_top_level_targets(
@@ -588,23 +599,13 @@ fn resolve_top_level_targets(
                 ));
             }
 
-            return Ok(vec![RefactorTarget {
-                component_id: Some(component_id.clone()),
-                path: comp.path.clone(),
-                label: component_id.clone(),
-            }]);
+            return resolve_refactor_target(Some(component_id), comp.path.as_deref());
         }
         // Component omitted — fall through to flagged_ids or CWD auto-discovery
     }
 
     if flagged_ids.is_empty() {
-        // No component specified anywhere — try CWD auto-discovery
-        let component = homeboy::core::component::resolution::resolve(None)?;
-        return Ok(vec![RefactorTarget {
-            label: component.id.clone(),
-            component_id: Some(component.id),
-            path: None,
-        }]);
+        return resolve_refactor_target(None, None);
     }
 
     Ok(flagged_ids

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -29,7 +29,10 @@ pub use portable::{
     write_portable_config,
 };
 pub use relationships::{associated_projects, projects_using, rename_component, shared_components};
-pub use resolution::{resolve, resolve_artifact, resolve_effective, validate_local_path};
+pub use resolution::{
+    resolve, resolve_artifact, resolve_effective, resolve_target, validate_local_path,
+    ResolvedTarget, TargetSpec,
+};
 pub use scope::{resolve_component_scope, EffectiveScope, ScopeCommand};
 pub use versioning::{
     normalize_version_pattern, parse_version_targets, validate_version_pattern,

--- a/src/core/component/resolution.rs
+++ b/src/core/component/resolution.rs
@@ -1,6 +1,62 @@
 use crate::core::component::{discover_from_portable, inventory, load, Component};
 use crate::core::error::{Error, Result};
+use crate::core::extension::{self, ExtensionCapability};
 use std::path::{Path, PathBuf};
+
+/// Shared target-resolution input for component/path-oriented commands.
+///
+/// This is the single contract for commands that need to turn user input into
+/// an effective component and source path. Callers can keep command-specific
+/// validation before this point, then rely on the same resolution order for
+/// registered components, `--path`, bare directories, CWD discovery, project
+/// scope, synthetic targets, and optional capability checks.
+#[derive(Debug, Clone, Default)]
+pub struct TargetSpec<'a> {
+    /// Positional or flagged component ID. May also be a bare directory when
+    /// `accept_bare_directory` is enabled.
+    pub component_id: Option<&'a str>,
+
+    /// Explicit `--path` override.
+    pub path_override: Option<&'a str>,
+
+    /// Optional project scope for project-attached component lookup.
+    pub project: Option<&'a crate::core::project::Project>,
+
+    /// Optional extension capability required by the caller.
+    pub capability: Option<ExtensionCapability>,
+
+    /// Whether an explicit path without registration/portable config may
+    /// produce a synthetic component.
+    pub allow_synthetic: bool,
+
+    /// Whether a positional component value that is a directory is accepted as
+    /// an ad-hoc target.
+    pub accept_bare_directory: bool,
+}
+
+impl<'a> TargetSpec<'a> {
+    pub fn new(component_id: Option<&'a str>, path_override: Option<&'a str>) -> Self {
+        Self {
+            component_id,
+            path_override,
+            project: None,
+            capability: None,
+            allow_synthetic: true,
+            accept_bare_directory: true,
+        }
+    }
+}
+
+/// Resolved target shared by git, audit, refactor, and execution context setup.
+#[derive(Debug, Clone)]
+pub struct ResolvedTarget {
+    pub component: Component,
+    pub component_id: String,
+    pub source_path: PathBuf,
+    pub git_root: Option<PathBuf>,
+    pub extension_id: Option<String>,
+    pub synthetic: bool,
+}
 
 pub fn resolve_artifact(component: &Component) -> Option<String> {
     if let Some(ref artifact) = component.build_artifact {
@@ -140,7 +196,102 @@ fn resolve_path_override(path: &str) -> Component {
         return discovered;
     }
 
+    let dir = Path::new(path);
+    if let Some(git_root) = detect_git_root(dir) {
+        if git_root != dir {
+            if let Some(mut discovered) = discover_from_portable(&git_root) {
+                discovered.local_path = path.to_string();
+                discovered.resolve_remote_path();
+                return discovered;
+            }
+        }
+    }
+
     synthetic_component_for_path(path)
+}
+
+fn path_has_portable_config(path: &Path) -> bool {
+    if discover_from_portable(path).is_some() {
+        return true;
+    }
+
+    if let Some(git_root) = detect_git_root(path) {
+        if git_root != path {
+            return discover_from_portable(&git_root).is_some();
+        }
+    }
+
+    false
+}
+
+/// Resolve a target from the shared command-facing contract.
+///
+/// Resolution order:
+/// 1. project-scoped component ID, when a project is supplied
+/// 2. explicit `--path`, optionally preserving an explicit component ID
+/// 3. positional bare directory, when enabled
+/// 4. CWD checkout matching the requested component ID
+/// 5. registered component lookup
+/// 6. CWD registry/portable discovery
+pub fn resolve_target(spec: TargetSpec<'_>) -> Result<ResolvedTarget> {
+    let component_id_is_bare_dir = spec
+        .component_id
+        .map(|id| Path::new(id).is_dir())
+        .unwrap_or(false);
+
+    if component_id_is_bare_dir && !spec.accept_bare_directory && spec.path_override.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "component",
+            "Bare directory targets are not accepted by this command",
+            spec.component_id.map(ToOwned::to_owned),
+            Some(vec![
+                "Use --path when this command supports ad-hoc paths".to_string()
+            ]),
+        ));
+    }
+
+    let mut component = resolve_effective_inner(
+        spec.component_id,
+        spec.path_override,
+        spec.project,
+        spec.accept_bare_directory,
+    )?;
+
+    let explicit_path = spec
+        .path_override
+        .or_else(|| component_id_is_bare_dir.then_some(component.local_path.as_str()));
+    let synthetic = explicit_path
+        .map(|path| !path_has_portable_config(Path::new(path)))
+        .unwrap_or(false);
+    if synthetic && !spec.allow_synthetic {
+        return Err(Error::validation_invalid_argument(
+            "target",
+            "Target is not registered and has no homeboy.json",
+            Some(component.local_path.clone()),
+            Some(vec![
+                "Register the component or add a repo-owned homeboy.json".to_string(),
+            ]),
+        ));
+    }
+
+    let source_path = PathBuf::from(shellexpand::tilde(&component.local_path).into_owned());
+    let git_root = detect_git_root(&source_path);
+    let extension_id = if let Some(capability) = spec.capability {
+        Some(extension::resolve_execution_context(&component, capability)?.extension_id)
+    } else {
+        None
+    };
+
+    component.resolve_remote_path();
+
+    Ok(ResolvedTarget {
+        component_id: component.id.clone(),
+        component,
+        source_path,
+        git_root,
+        extension_id,
+        synthetic,
+    })
 }
 
 /// Find the git root directory for a given path.
@@ -210,6 +361,15 @@ pub fn resolve_effective(
     path_override: Option<&str>,
     project: Option<&crate::core::project::Project>,
 ) -> Result<Component> {
+    resolve_effective_inner(id, path_override, project, true)
+}
+
+fn resolve_effective_inner(
+    id: Option<&str>,
+    path_override: Option<&str>,
+    project: Option<&crate::core::project::Project>,
+    accept_bare_directory: bool,
+) -> Result<Component> {
     if let (Some(project), Some(id)) = (project, id) {
         let mut component = crate::core::project::resolve_project_component(project, id)?;
         if let Some(path) = path_override {
@@ -237,7 +397,7 @@ pub fn resolve_effective(
             }
         } else {
             let id_path = Path::new(id);
-            if id_path.is_dir() {
+            if accept_bare_directory && id_path.is_dir() {
                 if let Some(mut discovered) = discover_from_portable(id_path) {
                     discovered.local_path = id.to_string();
                     discovered.resolve_remote_path();
@@ -295,6 +455,20 @@ mod tests {
         let result = f();
         std::env::set_current_dir(previous).expect("restore cwd");
         result
+    }
+
+    fn write_standalone_registration(home: &Path, id: &str, local_path: &Path) {
+        let components = home.join(".config").join("homeboy").join("components");
+        std::fs::create_dir_all(&components).expect("components dir");
+        std::fs::write(
+            components.join(format!("{id}.json")),
+            serde_json::json!({
+                "local_path": local_path,
+                "remote_path": format!("wp-content/plugins/{id}")
+            })
+            .to_string(),
+        )
+        .expect("standalone registration");
     }
 
     #[test]
@@ -432,5 +606,98 @@ mod tests {
             .as_ref()
             .expect("extensions")
             .contains_key("nodejs"));
+    }
+
+    #[test]
+    fn target_spec_resolves_registered_component() {
+        crate::test_support::with_isolated_home(|home| {
+            let repo = home.path().join("registered-repo");
+            std::fs::create_dir_all(&repo).expect("repo dir");
+            write_standalone_registration(home.path(), "registered", &repo);
+
+            let target = resolve_target(TargetSpec::new(Some("registered"), None))
+                .expect("registered target");
+
+            assert_eq!(target.component_id, "registered");
+            assert_eq!(target.source_path, repo);
+            assert!(!target.synthetic);
+        });
+    }
+
+    #[test]
+    fn target_spec_resolves_from_cwd_portable_config() {
+        crate::test_support::with_isolated_home(|_home| {
+            let dir = tempfile::tempdir().expect("temp dir");
+            let repo = dir.path().join("cwd-repo");
+            std::fs::create_dir_all(&repo).expect("repo dir");
+            std::fs::write(repo.join("homeboy.json"), r#"{"id":"cwd-id"}"#)
+                .expect("portable config");
+
+            with_cwd(&repo, || {
+                let target = resolve_target(TargetSpec::new(None, None)).expect("cwd target");
+
+                assert_eq!(target.component_id, "cwd-id");
+                assert_eq!(target.source_path, repo.canonicalize().unwrap());
+                assert!(!target.synthetic);
+            });
+        });
+    }
+
+    #[test]
+    fn target_spec_resolves_path_override() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let repo = dir.path().join("path-repo");
+        std::fs::create_dir_all(&repo).expect("repo dir");
+        std::fs::write(repo.join("homeboy.json"), r#"{"id":"path-id"}"#).expect("portable config");
+
+        let target = resolve_target(TargetSpec::new(None, repo.to_str())).expect("path target");
+
+        assert_eq!(target.component_id, "path-id");
+        assert_eq!(target.source_path, repo);
+        assert!(!target.synthetic);
+    }
+
+    #[test]
+    fn target_spec_accepts_bare_directory_positional_target() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let repo = dir.path().join("bare-repo");
+        std::fs::create_dir_all(&repo).expect("repo dir");
+
+        let target = resolve_target(TargetSpec::new(repo.to_str(), None)).expect("bare target");
+
+        assert_eq!(target.component_id, "bare-repo");
+        assert_eq!(target.source_path, repo);
+        assert!(target.synthetic);
+    }
+
+    #[test]
+    fn target_spec_allows_synthetic_path_target() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let repo = dir.path().join("synthetic-repo");
+        std::fs::create_dir_all(&repo).expect("repo dir");
+
+        let target =
+            resolve_target(TargetSpec::new(None, repo.to_str())).expect("synthetic target");
+
+        assert_eq!(target.component_id, "synthetic-repo");
+        assert_eq!(target.source_path, repo);
+        assert!(target.synthetic);
+    }
+
+    #[test]
+    fn target_spec_can_reject_synthetic_target() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let repo = dir.path().join("synthetic-repo");
+        std::fs::create_dir_all(&repo).expect("repo dir");
+
+        let err = resolve_target(TargetSpec {
+            component_id: None,
+            path_override: repo.to_str(),
+            allow_synthetic: false,
+            ..TargetSpec::default()
+        })
+        .expect_err("synthetic target should be rejected");
+
+        assert!(err.to_string().contains("not registered"));
     }
 }

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -406,34 +406,6 @@ impl<'a> ResolvedSettings<'a> {
     }
 }
 
-/// Detect the git repository root for a given directory.
-///
-/// Returns `None` if the path is not inside a git repository.
-fn detect_git_root(dir: &std::path::Path) -> Option<PathBuf> {
-    let effective_dir = if dir.is_file() {
-        dir.parent()?
-    } else if dir.exists() {
-        dir
-    } else {
-        // Directory doesn't exist yet — try parent
-        dir.parent()?
-    };
-
-    let output = std::process::Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .current_dir(effective_dir)
-        .output()
-        .ok()?;
-
-    if output.status.success() {
-        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !path.is_empty() {
-            return Some(PathBuf::from(path));
-        }
-    }
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -462,33 +434,6 @@ mod tests {
             ),
         )
         .expect("write extension manifest");
-    }
-
-    #[test]
-    fn detect_git_root_finds_repo() {
-        let dir = TempDir::new().expect("temp dir");
-        let root = dir.path();
-
-        Command::new("git")
-            .args(["init"])
-            .current_dir(root)
-            .output()
-            .expect("git init");
-
-        let result = detect_git_root(root);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap(), root.canonicalize().unwrap());
-    }
-
-    #[test]
-    fn detect_git_root_returns_none_outside_repo() {
-        let dir = TempDir::new().expect("temp dir");
-        let non_git = dir.path().join("not-a-repo");
-        fs::create_dir_all(&non_git).expect("create dir");
-
-        let result = detect_git_root(&non_git);
-        // May still find a parent repo, so we just test it doesn't panic
-        assert!(result.is_none() || result.is_some());
     }
 
     #[test]

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -227,26 +227,25 @@ pub fn resolve_with_component(
         }
         component
     } else {
-        component::resolve_effective(
+        component::resolve_target(component::TargetSpec::new(
             options.component_id.as_deref(),
             options.path_override.as_deref(),
-            None,
-        )?
+        ))?
+        .component
     };
 
     let declared_extension_ids = declared_extension_ids(&component);
     apply_extension_overrides(&mut component, &options.extension_overrides);
 
     // 2. Resolve source path
-    let source_path = if let Some(ref path) = options.path_override {
-        PathBuf::from(path)
-    } else {
-        let expanded = shellexpand::tilde(&component.local_path);
-        PathBuf::from(expanded.as_ref())
-    };
+    let target = component::resolve_target(component::TargetSpec::new(
+        Some(&component.id),
+        Some(&component.local_path),
+    ))?;
+    let source_path = target.source_path;
 
     // 3. Detect git root
-    let git_root = detect_git_root(&source_path);
+    let git_root = target.git_root;
 
     // 4. Optionally resolve extension context
     let (extension_id, extension_path, settings) = if let Some(capability) = options.capability {

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -147,42 +147,15 @@ pub(crate) fn resolve_target(
     component_id: Option<&str>,
     path_override: Option<&str>,
 ) -> crate::core::error::Result<(String, String)> {
-    // Case 1 & 2: explicit path given.
-    if let Some(path) = path_override {
-        if let Some(id) = component_id {
-            return Ok((id.to_string(), path.to_string()));
-        }
-        // Discover ID from path or its git root via portable homeboy.json.
-        let dir = std::path::Path::new(path);
-        if let Some(comp) = crate::core::component::discover_from_portable(dir) {
-            return Ok((comp.id, path.to_string()));
-        }
-        if let Some(git_root) = crate::core::component::resolution::detect_git_root(dir) {
-            if git_root != dir {
-                if let Some(comp) = crate::core::component::discover_from_portable(&git_root) {
-                    return Ok((comp.id, path.to_string()));
-                }
-            }
-        }
-        // No portable config — synthesize an ID from the path basename so
-        // downstream output still has a meaningful identifier.
-        let basename = dir
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or("(unknown)")
-            .to_string();
-        return Ok((basename, path.to_string()));
-    }
+    let target = crate::core::component::resolve_target(crate::core::component::TargetSpec::new(
+        component_id,
+        path_override,
+    ))?;
 
-    // Case 3: ID without path — look it up in the registry.
-    if let Some(id) = component_id {
-        let comp = crate::core::component::resolve_effective(Some(id), None, None)?;
-        return Ok((id.to_string(), comp.local_path));
-    }
-
-    // Case 4: neither — CWD detection.
-    let comp = crate::core::component::resolve(None)?;
-    Ok((comp.id, comp.local_path))
+    Ok((
+        target.component_id,
+        target.source_path.to_string_lossy().to_string(),
+    ))
 }
 
 #[cfg(test)]

--- a/src/core/refactor/mod.rs
+++ b/src/core/refactor/mod.rs
@@ -21,21 +21,20 @@ pub fn resolve_root(
     component_id: Option<&str>,
     path: Option<&str>,
 ) -> crate::core::Result<PathBuf> {
-    if let Some(p) = path {
-        let pb = PathBuf::from(p);
-        if !pb.is_dir() {
-            return Err(crate::core::Error::validation_invalid_argument(
-                "path",
-                format!("Not a directory: {}", p),
-                None,
-                None,
-            ));
-        }
-        Ok(pb)
-    } else {
-        let comp = crate::core::component::resolve(component_id)?;
-        crate::core::component::validate_local_path(&comp)
+    let target = crate::core::component::resolve_target(crate::core::component::TargetSpec::new(
+        component_id,
+        path,
+    ))?;
+    if !target.source_path.is_dir() {
+        return Err(crate::core::Error::validation_invalid_argument(
+            "path",
+            format!("Not a directory: {}", target.source_path.display()),
+            None,
+            None,
+        ));
     }
+
+    Ok(target.source_path)
 }
 
 /// Shared output for refactors/fixes.


### PR DESCRIPTION
## Summary
- Add a shared `TargetSpec` -> `ResolvedTarget` resolver for component/path-oriented commands.
- Route git target resolution, audit target setup, execution-context source/git-root resolution, and representative refactor target/root handling through the shared contract.
- Cover registered component, CWD discovery, `--path`, bare directory, and synthetic target cases.

Fixes #2880.

## Tests
- `cargo fmt --check`
- `cargo test core::component::resolution::tests::target_spec --lib`
- `cargo test core::git::resolve_target_tests --lib`
- `cargo test core::engine::execution_context --lib`
- `cargo test commands::refactor --lib`
- `cargo test commands::audit --lib`
- `cargo test --lib`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing and testing the target resolver refactor under Chris review