### PR TITLE
Fix runner artifact evidence path proof

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -1180,6 +1180,45 @@ mod tests {
     }
 
     #[test]
+    fn export_rewrites_unproven_remote_artifact_paths_as_metadata_only() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
+                .expect("run");
+            store
+                .import_artifact(&ArtifactRecord {
+                    id: "remote-trace".to_string(),
+                    run_id: run.id.clone(),
+                    kind: "trace".to_string(),
+                    artifact_type: "file".to_string(),
+                    path: "/srv/remote-only/trace.zip".to_string(),
+                    url: None,
+                    sha256: None,
+                    size_bytes: None,
+                    mime: None,
+                    created_at: chrono::Utc::now().to_rfc3339(),
+                })
+                .expect("artifact");
+            let output = home.path().join("remote-artifact-bundle");
+
+            export_runs(RunsExportArgs {
+                run: Some(run.id),
+                since: None,
+                output: output.clone(),
+            })
+            .expect("export");
+
+            let artifacts: Vec<ArtifactRecord> =
+                read_bundle_test_json(&output.join("artifacts.json"));
+            assert_eq!(artifacts.len(), 1);
+            assert_eq!(artifacts[0].artifact_type, "metadata-only");
+            assert_eq!(artifacts[0].path, "metadata-only:trace.zip");
+        });
+    }
+
+    #[test]
     fn export_trace_spans_when_present() {
         with_isolated_home(|home| {
             let _xdg = XdgGuard::unset();

--- a/src/commands/runs/bundle.rs
+++ b/src/commands/runs/bundle.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use homeboy::core::observation::{
     ArtifactRecord, FindingRecord, ObservationStore, RunRecord, TraceSpanRecord,
 };
+use homeboy::core::runner::is_reportable_artifact_evidence_path;
 use homeboy::core::Error;
 
 use super::common::since_threshold;
@@ -257,7 +258,12 @@ fn build_bundle(
     let mut trace_spans = Vec::new();
     let mut findings = Vec::new();
     for run in &runs {
-        artifacts.extend(store.list_artifacts(&run.id)?);
+        artifacts.extend(
+            store
+                .list_artifacts(&run.id)?
+                .into_iter()
+                .map(portable_bundle_artifact_record),
+        );
         trace_spans.extend(store.list_trace_spans(&run.id)?);
         findings.extend(store.list_findings_for_run(&run.id)?);
     }
@@ -285,6 +291,22 @@ fn build_bundle(
         findings,
         test_failures,
     })
+}
+
+fn portable_bundle_artifact_record(artifact: ArtifactRecord) -> ArtifactRecord {
+    if !matches!(artifact.artifact_type.as_str(), "file" | "directory")
+        || is_reportable_artifact_evidence_path(&artifact.path)
+    {
+        return artifact;
+    }
+
+    let mut portable = artifact;
+    portable.artifact_type = "metadata-only".to_string();
+    portable.path = format!(
+        "metadata-only:{}",
+        portable_artifact_label(&portable.path, &portable.id)
+    );
+    portable
 }
 
 fn write_bundle_dir(path: &Path, bundle: &ObservationBundle) -> homeboy::core::Result<()> {

--- a/src/commands/runs/common.rs
+++ b/src/commands/runs/common.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use homeboy::core::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
+use homeboy::core::runner::is_reportable_artifact_evidence_path;
 use homeboy::core::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -195,6 +196,14 @@ pub fn load_artifact_rows(
                         "artifact bytes are not available in this imported metadata-only bundle",
                     ));
                 }
+                continue;
+            }
+            if !is_reportable_artifact_evidence_path(&artifact.path) {
+                skipped.push(skipped_artifact(
+                    &run,
+                    &artifact,
+                    "artifact path is not locally accessible or retrievable",
+                ));
                 continue;
             }
             let path = Path::new(&artifact.path);

--- a/src/core/code_audit/detectors/runner_offload_preflight.rs
+++ b/src/core/code_audit/detectors/runner_offload_preflight.rs
@@ -117,6 +117,9 @@ impl<'a> RemoteExecutionSafetyPolicy<'a> {
             artifact_access_markers: with_defaults(
                 &[
                     "download_remote_artifact",
+                    "is_reportable_artifact_evidence_path",
+                    "is_retrievable_runner_artifact",
+                    "reportable_artifact_evidence_path",
                     "fs::metadata",
                     ".is_file()",
                     "get_artifact",

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -10,6 +10,7 @@ use super::run::{BenchRunFailure, BenchRunWorkflowResult};
 use crate::core::budget::BudgetFinding;
 use crate::core::ci_profile::CiContext;
 use crate::core::rig::RigStateSnapshot;
+use crate::core::runner::reportable_artifact_evidence_path;
 
 pub use super::side_by_side::{
     BenchSideBySideArtifact, BenchSideBySideMetric, BenchSideBySideReport, BenchSideBySideRigReport,
@@ -162,7 +163,7 @@ fn artifact_ref(
         scenario_id: scenario_id.to_string(),
         run_index,
         name: name.to_string(),
-        path: artifact.path.clone(),
+        path: reportable_artifact_evidence_path(artifact.path.as_ref()),
         url: artifact.url.clone(),
         artifact_type: artifact.artifact_type.clone(),
         kind: artifact.kind.clone(),

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -10,6 +10,7 @@ use super::parsing::{
 };
 use super::run::{TraceOverlay, TraceRunWorkflowResult};
 use crate::core::rig::RigStateSnapshot;
+use crate::core::runner::is_reportable_artifact_evidence_path;
 
 #[derive(Serialize)]
 #[serde(untagged)]
@@ -420,7 +421,7 @@ fn from_run_workflow_result(
     let artifacts = result
         .results
         .as_ref()
-        .map(|r| r.artifacts.clone())
+        .map(|r| reportable_trace_artifacts(&r.artifacts))
         .unwrap_or_default();
     TraceCommandOutput::Run(Box::new(TraceRunOutput {
         passed: result.exit_code == 0 && result.status == "pass",
@@ -493,9 +494,10 @@ pub fn render_markdown(results: &TraceResults, overlays: &[TraceOverlay]) -> Str
         }
     }
 
-    if !results.artifacts.is_empty() {
+    let artifacts = reportable_trace_artifacts(&results.artifacts);
+    if !artifacts.is_empty() {
         out.push_str("\n## Artifacts\n\n");
-        for artifact in &results.artifacts {
+        for artifact in &artifacts {
             out.push_str(&format!("- **{}:** `{}`\n", artifact.label, artifact.path));
         }
     }
@@ -511,6 +513,14 @@ pub fn render_markdown(results: &TraceResults, overlays: &[TraceOverlay]) -> Str
     }
 
     out
+}
+
+fn reportable_trace_artifacts(artifacts: &[TraceArtifact]) -> Vec<TraceArtifact> {
+    artifacts
+        .iter()
+        .filter(|artifact| is_reportable_artifact_evidence_path(&artifact.path))
+        .cloned()
+        .collect()
 }
 
 pub fn push_overlay_markdown(out: &mut String, overlays: &[TraceOverlay]) {
@@ -778,5 +788,37 @@ mod tests {
         assert!(markdown.contains("- Applied relative to: `/tmp/studio`"));
         assert!(markdown.contains("- `apps/studio/out/app.js`"));
         assert!(markdown.contains("| `submit_to_cli` | `ui.submit` | `cli.start` | 42ms | ok |"));
+    }
+
+    #[test]
+    fn test_render_markdown_omits_unproven_remote_artifact_paths() {
+        let results = TraceResults {
+            component_id: "studio".to_string(),
+            scenario_id: "create-site".to_string(),
+            status: TraceStatus::Pass,
+            summary: None,
+            failure: None,
+            rig: None,
+            timeline: Vec::new(),
+            span_definitions: Vec::new(),
+            span_results: Vec::new(),
+            assertions: Vec::new(),
+            temporal_assertions: Vec::new(),
+            artifacts: vec![
+                TraceArtifact {
+                    label: "remote trace".to_string(),
+                    path: "/srv/remote-only/trace.zip".to_string(),
+                },
+                TraceArtifact {
+                    label: "mirrored trace".to_string(),
+                    path: "runner-artifact://lab/run-1/trace.zip".to_string(),
+                },
+            ],
+        };
+
+        let markdown = render_markdown(&results, &[]);
+
+        assert!(!markdown.contains("/srv/remote-only/trace.zip"));
+        assert!(markdown.contains("runner-artifact://lab/run-1/trace.zip"));
     }
 }

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -855,6 +855,11 @@ pub(crate) fn run_github_release(
     let artifact_paths: Vec<String> = state
         .artifacts
         .iter()
+        .filter(|artifact| {
+            std::fs::metadata(&artifact.path)
+                .map(|metadata| metadata.is_file())
+                .unwrap_or(false)
+        })
         .map(|artifact| artifact.path.clone())
         .collect();
     let has_artifacts = !artifact_paths.is_empty();

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -16,6 +16,24 @@ pub fn is_remote_runner_artifact_path(path: &str) -> bool {
     path.starts_with("runner-artifact://")
 }
 
+pub fn is_retrievable_runner_artifact(path: &str) -> bool {
+    RemoteArtifactToken::parse(path).is_ok()
+}
+
+pub fn is_reportable_artifact_evidence_path(path: &str) -> bool {
+    is_retrievable_runner_artifact(path)
+        || path.starts_with("metadata-only:")
+        || !std::path::Path::new(path).is_absolute()
+        || fs::metadata(path)
+            .map(|metadata| metadata.is_file() || metadata.is_dir())
+            .unwrap_or(false)
+}
+
+pub fn reportable_artifact_evidence_path(path: Option<&String>) -> Option<String> {
+    path.filter(|path| is_reportable_artifact_evidence_path(path))
+        .cloned()
+}
+
 pub fn download_remote_artifact(
     path: &str,
     output: Option<PathBuf>,
@@ -182,7 +200,7 @@ fn mirrored_patch_result(
             ))
         })?;
 
-    let accessible = is_remote_runner_artifact_path(&artifact.path)
+    let accessible = is_retrievable_runner_artifact(&artifact.path)
         || fs::metadata(&artifact.path)
             .map(|metadata| metadata.is_file())
             .unwrap_or(false);
@@ -579,6 +597,33 @@ mod tests {
         assert_eq!(parsed.runner_id, "runner/a");
         assert_eq!(parsed.run_id, "run b");
         assert_eq!(parsed.artifact_id, "artifact:c");
+    }
+
+    #[test]
+    fn test_reportable_artifact_evidence_requires_local_or_retrievable_path() {
+        crate::test_support::with_isolated_home(|home| {
+            let local = home.path().join("artifact.json");
+            fs::write(&local, b"{}").expect("artifact");
+
+            assert!(is_reportable_artifact_evidence_path(
+                &local.to_string_lossy()
+            ));
+            assert!(is_reportable_artifact_evidence_path(
+                "runner-artifact://lab/run-1/artifact-1"
+            ));
+            assert!(is_reportable_artifact_evidence_path(
+                "metadata-only:trace.zip"
+            ));
+            assert!(is_reportable_artifact_evidence_path(
+                "artifacts/relative-trace.zip"
+            ));
+            assert!(!is_reportable_artifact_evidence_path(
+                "/srv/remote-only/trace.zip"
+            ));
+            assert!(!is_retrievable_runner_artifact(
+                "runner-artifact://missing-segments"
+            ));
+        });
     }
 
     #[test]

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -26,7 +26,8 @@ pub use connection::{
     RunnerSession, RunnerStatusReport,
 };
 pub use evidence::{
-    download_remote_artifact, is_remote_runner_artifact_path, RemoteArtifactDownload,
+    download_remote_artifact, is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,
+    is_retrievable_runner_artifact, reportable_artifact_evidence_path, RemoteArtifactDownload,
 };
 pub(crate) use execution::daemon_api_get;
 pub use execution::{exec, RunnerExecMode, RunnerExecOptions, RunnerExecOutput};

--- a/tests/core/extension/bench/report_comparison_test.rs
+++ b/tests/core/extension/bench/report_comparison_test.rs
@@ -480,6 +480,44 @@ fn test_collect_url_artifacts() {
 }
 
 #[test]
+fn test_collect_artifacts_drops_unproven_remote_absolute_paths() {
+    let mut scenario = scenario("agent-runtime", &[("p95_ms", 100.0)]);
+    scenario.artifacts.insert(
+        "remote_trace".to_string(),
+        artifact(
+            "/srv/remote-run/trace.zip",
+            Some("zip"),
+            Some("Remote trace"),
+        ),
+    );
+    scenario.artifacts.insert(
+        "token_trace".to_string(),
+        artifact(
+            "runner-artifact://lab/run-1/trace.zip",
+            Some("zip"),
+            Some("Mirrored trace"),
+        ),
+    );
+
+    let indexed = collect_artifacts(&results(vec![scenario]));
+
+    assert_eq!(indexed.len(), 2);
+    let remote = indexed
+        .iter()
+        .find(|artifact| artifact.name == "remote_trace")
+        .expect("remote trace");
+    assert_eq!(remote.path, None);
+    let token = indexed
+        .iter()
+        .find(|artifact| artifact.name == "token_trace")
+        .expect("token trace");
+    assert_eq!(
+        token.path.as_deref(),
+        Some("runner-artifact://lab/run-1/trace.zip")
+    );
+}
+
+#[test]
 fn cross_rig_output_serializes_artifact_index() {
     let mut ref_scenario = scenario("agent-runtime", &[("p95_ms", 100.0)]);
     ref_scenario.runs = Some(vec![BenchRunSnapshot {


### PR DESCRIPTION
## Summary
- Adds a shared runner artifact evidence predicate so reported paths are exposed only when locally accessible, metadata-only, relative local evidence, or a retrievable `runner-artifact://` token.
- Filters bench/trace output, run-query artifact loading, observation bundle export, and GitHub release asset upload away from unproven remote-only artifact paths.
- Updates the runner-offload preflight detector markers and adds focused tests for mirrored/retrievable artifact evidence behavior.

Fixes the remote artifact accessibility/mirroring proof slice of #2831.

## Remaining #2831 slices
- Extension parity preflight for remote runner dispatch remains out of scope for this PR.
- General runner capability preflight before remote execution remains out of scope for this PR.

## Verification
- `cargo test core::runner::evidence::tests::test_reportable_artifact_evidence_requires_local_or_retrievable_path`
- `cargo test test_collect_artifacts_drops_unproven_remote_absolute_paths`
- `cargo test core::extension::trace::report::tests::test_render_markdown_omits_unproven_remote_artifact_paths`
- `cargo test commands::runs::tests::export_rewrites_unproven_remote_artifact_paths_as_metadata_only`
- `cargo test runner_offload_preflight`
- `cargo run --bin homeboy -- audit --changed-since origin/main --only runner_offload_preflight --ignore-baseline --json-summary --force-hot`
- `homeboy lint --changed-since origin/main --ignore-baseline --json-summary --force-hot`
- `homeboy test --changed-since origin/main --ignore-baseline --json-summary --force-hot`

Note: `homeboy audit --changed-since origin/main` initially auto-offloaded to the lab runner and failed because the lab workspace could not resolve the local `origin/main` ref/merge-base. The verified audit used `--force-hot` locally with the current branch binary via `cargo run --bin homeboy`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the scoped runner artifact evidence contract, tests, verification commands, and PR drafting for Chris to review.