### PR TITLE
Test Linux rig app launcher update regeneration

### DIFF
--- a/src/core/rig/app.rs
+++ b/src/core/rig/app.rs
@@ -57,7 +57,15 @@ pub fn install(rig: &RigSpec, options: AppLauncherOptions) -> Result<AppLauncher
 }
 
 pub fn update(rig: &RigSpec, options: AppLauncherOptions) -> Result<AppLauncherReport> {
-    let mut report = install_inner(rig, options, true)?;
+    update_inner(rig, options, true)
+}
+
+fn update_inner(
+    rig: &RigSpec,
+    options: AppLauncherOptions,
+    enforce_platform: bool,
+) -> Result<AppLauncherReport> {
+    let mut report = install_inner(rig, options, enforce_platform)?;
     report.action = AppLauncherAction::Update;
     Ok(report)
 }

--- a/tests/core/rig/app_test.rs
+++ b/tests/core/rig/app_test.rs
@@ -217,6 +217,25 @@ fn test_linux_install_writes_desktop_file_to_temp_dir() {
 }
 
 #[test]
+fn test_linux_update_regenerates_desktop_file_in_place() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let rig = rig_with_linux_launcher(&tmp.path().to_string_lossy());
+    install_inner(&rig, AppLauncherOptions { dry_run: false }, false).expect("install");
+    let desktop = tmp.path().join("Studio (Dev).desktop");
+    fs::write(&desktop, "stale desktop entry").expect("write stale desktop");
+
+    let report =
+        super::update_inner(&rig, AppLauncherOptions { dry_run: false }, false).expect("update");
+    let content = fs::read_to_string(&desktop).expect("read desktop");
+
+    assert_eq!(report.action, AppLauncherAction::Update);
+    assert_eq!(report.files, vec![desktop.display().to_string()]);
+    assert!(content.starts_with("[Desktop Entry]"));
+    assert!(content.contains("Exec=/bin/sh -lc"));
+    assert!(!content.contains("stale desktop entry"));
+}
+
+#[test]
 fn test_uninstall_removes_generated_bundle_from_temp_dir() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let rig = rig_with_launcher(&tmp.path().to_string_lossy());


### PR DESCRIPTION
## Summary
- Adds focused coverage that Linux `.desktop` rig app updates regenerate the launcher in place and replace stale generated content.
- Keeps the behavior behind the existing `app_launcher` boundary by routing `update` through the same install writer with a testable internal path.
- Refs #1635.

## Remaining platform follow-up
- Native macOS launcher, icons, explicit login item replacement, Windows launchers, and optional URL/document association copying remain separate #1635 follow-ups.

## Verification
- `cargo test app::app_test -- --nocapture`
- `homeboy --force-hot audit --path /Users/chubes/Developer/homeboy@feat-issue-1635-linux-desktop-launcher --changed-since origin/main --json-summary`
- `homeboy --force-hot lint --path /Users/chubes/Developer/homeboy@feat-issue-1635-linux-desktop-launcher --changed-since origin/main --json-summary`
- `homeboy --force-hot test --path /Users/chubes/Developer/homeboy@feat-issue-1635-linux-desktop-launcher --changed-since origin/main --json-summary`

## Notes
- Initial changed-scope Homeboy runs without `--force-hot` were blocked because automatic Lab snapshot offload cannot honor `--changed-since` without `.git` metadata; reran the same changed-scope checks locally with `--force-hot`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the focused Linux launcher update-regeneration test slice, ran local verification, and drafted this PR summary. Chris remains responsible for review and merge.