### PR TITLE
fix: audit artifact portability leaks

### DIFF
--- a/src/core/code_audit/detectors/artifact_portability.rs
+++ b/src/core/code_audit/detectors/artifact_portability.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 use crate::core::code_audit::conventions::AuditFinding;
 use crate::core::code_audit::findings::{Finding, Severity};
 use crate::core::component::ArtifactPortabilityConfig;
-use crate::core::observation::{ObservationStore, RunListFilter};
+use crate::core::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
+use serde_json::Value;
 
 pub(crate) fn run(component_id: &str) -> Vec<Finding> {
     run_with_config(component_id, &ArtifactPortabilityConfig::default())
@@ -33,6 +34,10 @@ pub(crate) fn run_with_config(
         let Ok(artifacts) = store.list_artifacts(&run.id) else {
             continue;
         };
+        let artifact_paths: Vec<String> = artifacts
+            .iter()
+            .map(|artifact| artifact.path.clone())
+            .collect();
         for artifact in artifacts {
             if artifact.artifact_type != "file" && artifact.artifact_type != "directory" {
                 continue;
@@ -40,18 +45,14 @@ pub(crate) fn run_with_config(
             if artifact_path_is_portable(&artifact.path, artifact_root.as_deref(), &path_policy) {
                 continue;
             }
-            findings.push(Finding {
-                convention: "artifact_portability".to_string(),
-                severity: Severity::Warning,
-                file: format!("observation:{}", run.id),
-                description: format!(
-                    "Artifact {} ({}) records non-portable path {}",
-                    artifact.id, artifact.kind, artifact.path
-                ),
-                suggestion: "Record copied artifact-store paths or portable artifact tokens instead of runtime temp paths".to_string(),
-                kind: AuditFinding::NonPortableArtifactPath,
-            });
+            findings.push(artifact_path_finding(&run, &artifact));
         }
+        findings.extend(metadata_path_findings(
+            &run,
+            &artifact_paths,
+            artifact_root.as_deref(),
+            &path_policy,
+        ));
     }
 
     findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
@@ -72,7 +73,190 @@ fn artifact_path_is_portable(
             return true;
         }
     }
-    !looks_like_runtime_temp_path(path, config)
+    !path_ref.is_absolute() && !looks_like_runtime_temp_path(path, config)
+}
+
+fn artifact_path_finding(run: &RunRecord, artifact: &ArtifactRecord) -> Finding {
+    portability_finding(
+        run,
+        "artifact.path",
+        &artifact.path,
+        format!(
+            "Artifact {} ({}) records non-portable path {}",
+            artifact.id, artifact.kind, artifact.path
+        ),
+        "Record copied artifact-store paths or portable artifact tokens instead of runtime temp paths",
+    )
+}
+
+fn metadata_path_findings(
+    run: &RunRecord,
+    artifact_paths: &[String],
+    artifact_root: Option<&Path>,
+    config: &ArtifactPortabilityConfig,
+) -> Vec<Finding> {
+    let cleanup_promised = metadata_promises_cleanup(&run.metadata_json);
+    let mut findings = Vec::new();
+    for field in metadata_string_fields(&run.metadata_json) {
+        if is_runner_artifact_ref(field.value)
+            && !artifact_paths.iter().any(|path| path == field.value)
+        {
+            findings.push(portability_finding(
+                run,
+                &field.path,
+                field.value,
+                format!(
+                    "Run metadata field {} records remote artifact ref {} without a mirrored artifact record",
+                    field.path, field.value
+                ),
+                "Import the remote artifact into the observation store and reference its mirrored artifact record",
+            ));
+            continue;
+        }
+
+        if !field_expects_portable_artifact_ref(&field.path) {
+            continue;
+        }
+        if !looks_like_local_absolute_path(field.value, artifact_root, config) {
+            continue;
+        }
+
+        let mut description = format!(
+            "Run metadata field {} records local-only artifact path {}",
+            field.path, field.value
+        );
+        if cleanup_promised && Path::new(field.value).exists() {
+            description.push_str(" that still exists after cleanup metadata promised cleanup");
+        }
+        findings.push(portability_finding(
+            run,
+            &field.path,
+            field.value,
+            description,
+            "Store the artifact under Homeboy's artifact root and persist that path, or persist a runner-artifact:// token with a mirrored artifact row",
+        ));
+    }
+    findings
+}
+
+fn portability_finding(
+    run: &RunRecord,
+    field: &str,
+    observed_path: &str,
+    description: String,
+    suggestion: &str,
+) -> Finding {
+    let command = run.command.as_deref().unwrap_or("<unknown>");
+    Finding {
+        convention: "artifact_portability".to_string(),
+        severity: Severity::Warning,
+        file: format!("observation:{}", run.id),
+        description: format!("{description}; command `{command}`; field `{field}`"),
+        suggestion: format!(
+            "{suggestion}. Suggested portable ref: artifact-store path under HOMEBOY_ARTIFACT_ROOT or runner-artifact://<runner>/<run>/<artifact> instead of {observed_path}"
+        ),
+        kind: AuditFinding::NonPortableArtifactPath,
+    }
+}
+
+struct MetadataStringField<'a> {
+    path: String,
+    value: &'a str,
+}
+
+fn metadata_string_fields(value: &Value) -> Vec<MetadataStringField<'_>> {
+    let mut fields = Vec::new();
+    collect_metadata_string_fields(value, "$", &mut fields);
+    fields
+}
+
+fn collect_metadata_string_fields<'a>(
+    value: &'a Value,
+    path: &str,
+    fields: &mut Vec<MetadataStringField<'a>>,
+) {
+    match value {
+        Value::String(value) => fields.push(MetadataStringField {
+            path: path.to_string(),
+            value,
+        }),
+        Value::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                collect_metadata_string_fields(item, &format!("{path}[{index}]"), fields);
+            }
+        }
+        Value::Object(map) => {
+            for (key, item) in map {
+                collect_metadata_string_fields(item, &format!("{path}.{key}"), fields);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn field_expects_portable_artifact_ref(path: &str) -> bool {
+    let path = path.to_ascii_lowercase();
+    [
+        "artifact",
+        "evidence",
+        "import",
+        "output_path",
+        "local_output",
+        "temp_dir",
+        "run_dir",
+        "run_path",
+        "patch_artifact_path",
+    ]
+    .iter()
+    .any(|marker| path.contains(marker))
+}
+
+fn looks_like_local_absolute_path(
+    path: &str,
+    artifact_root: Option<&Path>,
+    _config: &ArtifactPortabilityConfig,
+) -> bool {
+    if is_runner_artifact_ref(path) || path.starts_with("metadata-only:") {
+        return false;
+    }
+    let path_ref = Path::new(path);
+    if !path_ref.is_absolute() {
+        return false;
+    }
+    if let Some(root) = artifact_root {
+        if path_ref.starts_with(root) {
+            return false;
+        }
+    }
+    true
+}
+
+fn is_runner_artifact_ref(path: &str) -> bool {
+    path.starts_with("runner-artifact://")
+}
+
+fn metadata_promises_cleanup(value: &Value) -> bool {
+    match value {
+        Value::Bool(true) => false,
+        Value::Array(items) => items.iter().any(metadata_promises_cleanup),
+        Value::Object(map) => map.iter().any(|(key, value)| {
+            key.to_ascii_lowercase().contains("cleanup") && cleanup_value_is_promising(value)
+                || metadata_promises_cleanup(value)
+        }),
+        _ => false,
+    }
+}
+
+fn cleanup_value_is_promising(value: &Value) -> bool {
+    match value {
+        Value::Bool(value) => *value,
+        Value::String(value) => matches!(
+            value.to_ascii_lowercase().as_str(),
+            "true" | "done" | "cleaned" | "cleanup" | "completed" | "success" | "succeeded"
+        ),
+        Value::Object(_) | Value::Array(_) => metadata_promises_cleanup(value),
+        _ => false,
+    }
 }
 
 fn looks_like_runtime_temp_path(path: &str, config: &ArtifactPortabilityConfig) -> bool {
@@ -128,6 +312,179 @@ mod tests {
             assert!(findings[0]
                 .description
                 .contains("/tmp/homeboy-run-abc/trace.json"));
+            assert!(findings[0]
+                .description
+                .contains("command `homeboy observe demo`"));
+            assert!(findings[0].description.contains("field `artifact.path`"));
+            assert!(findings[0].suggestion.contains("Suggested portable ref"));
+        });
+    }
+
+    #[test]
+    fn flags_metadata_artifact_fields_with_local_absolute_paths() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let cwd = std::env::current_dir().expect("cwd");
+            let run_record = store
+                .start_run(
+                    NewRunRecord::builder("runner-exec")
+                        .component_id("demo")
+                        .command("homeboy test demo --runner lab")
+                        .cwd_path(&cwd)
+                        .metadata(serde_json::json!({
+                            "lab": {
+                                "result": {
+                                    "local_output_path": "/Users/chris/project/out/test.json"
+                                }
+                            }
+                        }))
+                        .build(),
+                )
+                .expect("run");
+            store
+                .finish_run(
+                    &run_record.id,
+                    crate::core::observation::RunStatus::Pass,
+                    None,
+                )
+                .expect("finish");
+
+            let findings = super::run("demo");
+
+            assert_eq!(findings.len(), 1);
+            assert!(findings[0]
+                .description
+                .contains("$.lab.result.local_output_path"));
+            assert!(findings[0]
+                .description
+                .contains("command `homeboy test demo --runner lab`"));
+        });
+    }
+
+    #[test]
+    fn flags_remote_artifact_refs_without_mirrored_artifact_rows() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let cwd = std::env::current_dir().expect("cwd");
+            let run_record = store
+                .start_run(
+                    NewRunRecord::builder("runner-exec")
+                        .component_id("demo")
+                        .command("homeboy runs bundle demo")
+                        .cwd_path(&cwd)
+                        .metadata(serde_json::json!({
+                            "patch_artifact_path": "runner-artifact://lab/run-1/patch"
+                        }))
+                        .build(),
+                )
+                .expect("run");
+            store
+                .finish_run(
+                    &run_record.id,
+                    crate::core::observation::RunStatus::Pass,
+                    None,
+                )
+                .expect("finish");
+
+            let findings = super::run("demo");
+
+            assert_eq!(findings.len(), 1);
+            assert!(findings[0]
+                .description
+                .contains("without a mirrored artifact record"));
+            assert!(findings[0]
+                .suggestion
+                .contains("runner-artifact://<runner>/<run>/<artifact>"));
+        });
+    }
+
+    #[test]
+    fn accepts_remote_artifact_refs_with_mirrored_artifact_rows() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let cwd = std::env::current_dir().expect("cwd");
+            let run_record = store
+                .start_run(
+                    NewRunRecord::builder("runner-exec")
+                        .component_id("demo")
+                        .command("homeboy runs bundle demo")
+                        .cwd_path(&cwd)
+                        .metadata(serde_json::json!({
+                            "patch_artifact_path": "runner-artifact://lab/run-1/patch"
+                        }))
+                        .build(),
+                )
+                .expect("run");
+            store
+                .import_artifact(&ArtifactRecord {
+                    id: "patch".to_string(),
+                    run_id: run_record.id.clone(),
+                    kind: "patch".to_string(),
+                    artifact_type: "remote_file".to_string(),
+                    path: "runner-artifact://lab/run-1/patch".to_string(),
+                    url: None,
+                    sha256: None,
+                    size_bytes: None,
+                    mime: None,
+                    created_at: chrono::Utc::now().to_rfc3339(),
+                })
+                .expect("artifact");
+            store
+                .finish_run(
+                    &run_record.id,
+                    crate::core::observation::RunStatus::Pass,
+                    None,
+                )
+                .expect("finish");
+
+            let findings = super::run("demo");
+
+            assert!(findings.is_empty());
+        });
+    }
+
+    #[test]
+    fn flags_cleanup_promised_temp_dirs_that_still_exist() {
+        with_isolated_home(|home| {
+            let temp_dir = home.path().join("homeboy-run-left-behind");
+            std::fs::create_dir_all(&temp_dir).expect("temp dir");
+            let store = ObservationStore::open_initialized().expect("store");
+            let cwd = std::env::current_dir().expect("cwd");
+            let run_record = store
+                .start_run(
+                    NewRunRecord::builder("observe")
+                        .component_id("demo")
+                        .command("homeboy observe demo")
+                        .cwd_path(&cwd)
+                        .metadata(serde_json::json!({
+                            "cleanup": "completed",
+                            "evidence": {
+                                "run_dir": temp_dir.to_string_lossy()
+                            }
+                        }))
+                        .build(),
+                )
+                .expect("run");
+            store
+                .finish_run(
+                    &run_record.id,
+                    crate::core::observation::RunStatus::Pass,
+                    None,
+                )
+                .expect("finish");
+
+            let findings = super::run_with_config(
+                "demo",
+                &ArtifactPortabilityConfig {
+                    non_portable_path_contains: vec!["homeboy-run-".to_string()],
+                    ..Default::default()
+                },
+            );
+
+            assert_eq!(findings.len(), 1);
+            assert!(findings[0]
+                .description
+                .contains("still exists after cleanup metadata promised cleanup"));
         });
     }
 
@@ -158,8 +515,13 @@ mod tests {
             None,
             &config
         ));
-        assert!(artifact_path_is_portable(
+        assert!(!artifact_path_is_portable(
             "/workspace/other-run-abc/trace.json",
+            None,
+            &config
+        ));
+        assert!(artifact_path_is_portable(
+            "artifacts/other-run-abc/trace.json",
             None,
             &config
         ));


### PR DESCRIPTION
## Summary
- Extends the artifact portability audit to flag absolute local artifact paths persisted outside the Homeboy artifact root.
- Scans run metadata artifact/evidence/import/output fields for local-only paths, dangling `runner-artifact://` refs, and cleanup-promised run/temp dirs that still exist.
- Includes command, metadata field, and suggested portable artifact ref guidance in findings.

Fixes #2775.

## Verification
- `cargo test artifact_portability`
- `homeboy audit --path . --extension rust --changed-since origin/main --force-hot`
- `homeboy lint --path . --extension rust --changed-since origin/main --force-hot`
- `homeboy test --path . --extension rust --changed-since origin/main --force-hot`

## Follow-up
- This PR keeps the slice focused on observed artifact/run records. Static source-level coverage for every future command output field can layer on top if a new leak shape appears.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the detector extension and focused tests; Chris remains responsible for review and merge.