### PR TITLE
Fix changed-since Lab offload base prep

### DIFF
--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -664,6 +664,7 @@ fn workspace_sync(
         runner::RunnerWorkspaceSyncOptions {
             path,
             mode: RunnerWorkspaceSyncMode::from(mode),
+            changed_since_base: None,
         },
     )
 }

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -30,7 +30,10 @@ pub use evidence::{
 };
 pub(crate) use execution::daemon_api_get;
 pub use execution::{exec, RunnerExecMode, RunnerExecOptions, RunnerExecOutput};
-pub use offload_changed_since::preflight_lab_offload_changed_since;
+pub use offload_changed_since::{
+    lab_offload_changed_since_ref, preflight_lab_offload_changed_since,
+    prepare_git_lab_offload_changed_since,
+};
 pub use offload_metadata::{capture_lab_offload_metadata, lab_offload_metadata};
 pub use workspace::{
     sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,

--- a/src/core/runner/offload_changed_since.rs
+++ b/src/core/runner/offload_changed_since.rs
@@ -1,18 +1,33 @@
+use std::path::Path;
+use std::process::Command;
+
 use crate::core::error::{Error, Result};
 
 use super::RunnerWorkspaceSyncMode;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabOffloadChangedSincePreflight {
+    pub args: Vec<String>,
+    pub resolved_base: Option<String>,
+}
+
 pub fn preflight_lab_offload_changed_since(
     args: &[String],
     sync_mode: RunnerWorkspaceSyncMode,
-) -> Result<()> {
-    if sync_mode != RunnerWorkspaceSyncMode::Snapshot {
-        return Ok(());
-    }
-
+) -> Result<LabOffloadChangedSincePreflight> {
     let Some(git_ref) = lab_offload_changed_since_ref(args) else {
-        return Ok(());
+        return Ok(LabOffloadChangedSincePreflight {
+            args: args.to_vec(),
+            resolved_base: None,
+        });
     };
+
+    if sync_mode != RunnerWorkspaceSyncMode::Snapshot {
+        return Ok(LabOffloadChangedSincePreflight {
+            args: args.to_vec(),
+            resolved_base: Some(git_ref),
+        });
+    }
 
     Err(Error::validation_invalid_argument(
         "changed_since",
@@ -27,7 +42,27 @@ pub fn preflight_lab_offload_changed_since(
     ))
 }
 
-fn lab_offload_changed_since_ref(args: &[String]) -> Option<String> {
+pub fn prepare_git_lab_offload_changed_since(
+    args: &[String],
+    source_path: &Path,
+) -> Result<LabOffloadChangedSincePreflight> {
+    let Some(git_ref) = lab_offload_changed_since_ref(args) else {
+        return Ok(LabOffloadChangedSincePreflight {
+            args: args.to_vec(),
+            resolved_base: None,
+        });
+    };
+
+    let resolved_base = resolve_changed_since_base(source_path, &git_ref)?;
+    ensure_local_merge_base(source_path, &git_ref)?;
+
+    Ok(LabOffloadChangedSincePreflight {
+        args: rewrite_changed_since_ref(args, &resolved_base),
+        resolved_base: Some(resolved_base),
+    })
+}
+
+pub fn lab_offload_changed_since_ref(args: &[String]) -> Option<String> {
     let mut iter = args.iter().skip(1);
     while let Some(arg) = iter.next() {
         if arg == "--" {
@@ -41,6 +76,90 @@ fn lab_offload_changed_since_ref(args: &[String]) -> Option<String> {
         }
     }
     None
+}
+
+fn rewrite_changed_since_ref(args: &[String], resolved_base: &str) -> Vec<String> {
+    let mut rewritten = Vec::with_capacity(args.len());
+    let mut iter = args.iter().peekable();
+    let mut passthrough = false;
+
+    while let Some(arg) = iter.next() {
+        if passthrough {
+            rewritten.push(arg.clone());
+            continue;
+        }
+        if arg == "--" {
+            passthrough = true;
+            rewritten.push(arg.clone());
+            continue;
+        }
+        if arg == "--changed-since" {
+            rewritten.push(arg.clone());
+            if iter.peek().is_some() {
+                let _ = iter.next();
+                rewritten.push(resolved_base.to_string());
+            }
+            continue;
+        }
+        if arg.starts_with("--changed-since=") {
+            rewritten.push(format!("--changed-since={resolved_base}"));
+            continue;
+        }
+        rewritten.push(arg.clone());
+    }
+
+    rewritten
+}
+
+fn resolve_changed_since_base(path: &Path, git_ref: &str) -> Result<String> {
+    git_output(
+        path,
+        &["rev-parse", "--verify", &format!("{git_ref}^{{commit}}")],
+    )
+}
+
+fn ensure_local_merge_base(path: &Path, git_ref: &str) -> Result<()> {
+    let output = Command::new("git")
+        .args(["merge-base", git_ref, "HEAD"])
+        .current_dir(path)
+        .output()
+        .map_err(|err| {
+            Error::internal_io(err.to_string(), Some("run git merge-base".to_string()))
+        })?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "changed_since",
+        "Lab offload cannot resolve the requested --changed-since base before dispatch",
+        Some(git_ref.to_string()),
+        Some(vec![
+            format!("Fetch or correct the base ref locally: git fetch origin {git_ref}"),
+            "Run with --force-hot to execute the changed-since command locally.".to_string(),
+        ]),
+    ))
+}
+
+fn git_output(path: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .map_err(|err| Error::internal_io(err.to_string(), Some("run git".to_string())))?;
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).trim().to_string());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "changed_since",
+        "Lab offload cannot resolve the requested --changed-since base before dispatch",
+        Some(args.last().copied().unwrap_or_default().to_string()),
+        Some(vec![
+            "Fetch the base ref locally before using Lab offload.".to_string(),
+            "Run with --force-hot to execute the changed-since command locally.".to_string(),
+        ]),
+    ))
 }
 
 #[cfg(test)]
@@ -113,5 +232,65 @@ mod tests {
 
         preflight_lab_offload_changed_since(&args, RunnerWorkspaceSyncMode::Git)
             .expect("git Lab offload can preserve changed-since semantics");
+    }
+
+    #[test]
+    fn rewrites_changed_since_to_resolved_commit_for_git_lab_offload() {
+        let dir = tempfile::tempdir().expect("repo");
+        git(dir.path(), &["init"]);
+        git(dir.path(), &["config", "user.email", "test@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(dir.path().join("file.txt"), "base\n").expect("write base");
+        git(dir.path(), &["add", "."]);
+        git(dir.path(), &["commit", "-m", "base"]);
+        git(dir.path(), &["branch", "base"]);
+        std::fs::write(dir.path().join("file.txt"), "head\n").expect("write head");
+        git(dir.path(), &["commit", "-am", "head"]);
+        let base_sha = git_stdout(dir.path(), &["rev-parse", "base"]);
+
+        let args = vec![
+            "homeboy".to_string(),
+            "audit".to_string(),
+            "--changed-since".to_string(),
+            "base".to_string(),
+        ];
+
+        let preflight = prepare_git_lab_offload_changed_since(&args, dir.path())
+            .expect("changed-since preflight");
+
+        assert_eq!(preflight.resolved_base.as_deref(), Some(base_sha.as_str()));
+        assert_eq!(
+            preflight.args,
+            vec![
+                "homeboy".to_string(),
+                "audit".to_string(),
+                "--changed-since".to_string(),
+                base_sha,
+            ]
+        );
+    }
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_stdout(path: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(output.status.success());
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
     }
 }

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -56,6 +56,7 @@ pub enum RunnerWorkspaceSyncMode {
 pub struct RunnerWorkspaceSyncOptions {
     pub path: String,
     pub mode: RunnerWorkspaceSyncMode,
+    pub changed_since_base: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -116,9 +117,15 @@ pub fn sync_workspace(
             ))
         }
         RunnerWorkspaceSyncMode::Git => {
-            let git = git_snapshot(&local_path)?;
+            let git = git_snapshot(&local_path, options.changed_since_base.as_deref())?;
             let remote_path = deterministic_remote_path(workspace_root, &local_path, &git.head);
-            materialize_git(&runner, &remote_path, &git.remote_url, &git.head)?;
+            materialize_git(
+                &runner,
+                &remote_path,
+                &git.remote_url,
+                &git.head,
+                git.changed_since_base.as_deref(),
+            )?;
             Ok((
                 RunnerWorkspaceSyncOutput {
                     command: "runner.workspace.sync",
@@ -145,6 +152,7 @@ struct SnapshotStats {
 struct GitSnapshot {
     remote_url: String,
     head: String,
+    changed_since_base: Option<String>,
 }
 
 fn canonical_workspace_path(path: &str) -> Result<PathBuf> {
@@ -210,7 +218,7 @@ fn snapshot_identity(local_path: &Path) -> Result<String> {
     Ok(format!("snapshot:{}", hex_prefix(&hasher.finalize(), 16)))
 }
 
-fn git_snapshot(local_path: &Path) -> Result<GitSnapshot> {
+fn git_snapshot(local_path: &Path, changed_since_base: Option<&str>) -> Result<GitSnapshot> {
     let status = git_output(local_path, &["status", "--porcelain=v1"])?;
     if !status.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -230,7 +238,11 @@ fn git_snapshot(local_path: &Path) -> Result<GitSnapshot> {
             None,
         ));
     }
-    Ok(GitSnapshot { remote_url, head })
+    Ok(GitSnapshot {
+        remote_url,
+        head,
+        changed_since_base: changed_since_base.map(str::to_string),
+    })
 }
 
 fn git_output(local_path: &Path, args: &[&str]) -> Result<String> {
@@ -402,14 +414,14 @@ fn materialize_snapshot_ssh(
     run_shell_command(&command, "materialize SSH workspace snapshot")
 }
 
-fn materialize_git(runner: &Runner, remote_path: &str, remote_url: &str, head: &str) -> Result<()> {
-    let command = format!(
-        "mkdir -p {parent} && if [ -d {dest}/.git ]; then git -C {dest} fetch --prune origin; else rm -rf {dest} && git clone {url} {dest}; fi && git -C {dest} checkout --detach {head} && git -C {dest} clean -ffdqx",
-        parent = shell::quote_arg(parent_remote_path(remote_path).as_str()),
-        dest = shell::quote_arg(remote_path),
-        url = shell::quote_arg(remote_url),
-        head = shell::quote_arg(head),
-    );
+fn materialize_git(
+    runner: &Runner,
+    remote_path: &str,
+    remote_url: &str,
+    head: &str,
+    changed_since_base: Option<&str>,
+) -> Result<()> {
+    let command = materialize_git_command(remote_path, remote_url, head, changed_since_base);
     match runner.kind {
         RunnerKind::Local => run_shell_command(&command, "materialize local git workspace"),
         RunnerKind::Ssh => {
@@ -418,13 +430,47 @@ fn materialize_git(runner: &Runner, remote_path: &str, remote_url: &str, head: &
             if output.success {
                 Ok(())
             } else {
-                Err(Error::internal_unexpected(format!(
-                    "materialize git workspace failed: {}",
-                    output.stderr
-                )))
+                Err(Error::validation_invalid_argument(
+                    "changed_since",
+                    "Lab offload could not make the requested --changed-since base reachable in the runner workspace before dispatch",
+                    changed_since_base.map(str::to_string),
+                    Some(vec![
+                        "Verify the branch and base commit are pushed to origin.".to_string(),
+                        "Run with --force-hot to execute the changed-since command locally."
+                            .to_string(),
+                        format!("Remote git error: {}", output.stderr.trim()),
+                    ]),
+                ))
             }
         }
     }
+}
+
+fn materialize_git_command(
+    remote_path: &str,
+    remote_url: &str,
+    head: &str,
+    changed_since_base: Option<&str>,
+) -> String {
+    let dest = shell::quote_arg(remote_path);
+    let fetch_changed_since = changed_since_base
+        .map(|base| {
+            format!(
+                " && (git -C {dest} rev-parse --verify -q {} >/dev/null || git -C {dest} fetch origin {})",
+                shell::quote_arg(&format!("{base}^{{commit}}")),
+                shell::quote_arg(base)
+            )
+        })
+        .unwrap_or_default();
+
+    format!(
+        "mkdir -p {parent} && if [ -d {dest}/.git ]; then git -C {dest} fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf {dest} && git clone {url} {dest} && git -C {dest} fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_changed_since} && git -C {dest} checkout --detach {head} && git -C {dest} clean -ffdqx",
+        parent = shell::quote_arg(parent_remote_path(remote_path).as_str()),
+        dest = dest,
+        url = shell::quote_arg(remote_url),
+        head = shell::quote_arg(head),
+        fetch_changed_since = fetch_changed_since,
+    )
 }
 
 fn ssh_client_for_runner(runner: &Runner) -> Result<(Server, SshClient)> {
@@ -602,6 +648,7 @@ mod tests {
                 RunnerWorkspaceSyncOptions {
                     path: source.path().display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
+                    changed_since_base: None,
                 },
             )
             .expect("sync workspace");
@@ -619,5 +666,20 @@ mod tests {
                 .join("target/debug/homeboy")
                 .exists());
         });
+    }
+
+    #[test]
+    fn git_materialization_fetches_changed_since_base_before_checkout() {
+        let command = materialize_git_command(
+            "/srv/homeboy/_lab_workspaces/homeboy-abc",
+            "https://github.com/Extra-Chill/homeboy.git",
+            "abc123",
+            Some("def456"),
+        );
+
+        assert!(command.contains("fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'"));
+        assert!(command.contains("rev-parse --verify -q 'def456^{commit}'"));
+        assert!(command.contains("fetch origin def456"));
+        assert!(command.contains("checkout --detach abc123"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -638,15 +638,25 @@ fn run_lab_offload_inner(
     })?;
     let source_path = lab_offload_source_path(normalized_args)?;
     preflight_lab_runner_capabilities(runner_id, command_kind, &source_path)?;
-    homeboy::core::runner::preflight_lab_offload_changed_since(
-        normalized_args,
-        homeboy::core::runner::RunnerWorkspaceSyncMode::Snapshot,
-    )?;
+    let sync_mode =
+        if homeboy::core::runner::lab_offload_changed_since_ref(normalized_args).is_some() {
+            homeboy::core::runner::RunnerWorkspaceSyncMode::Git
+        } else {
+            homeboy::core::runner::RunnerWorkspaceSyncMode::Snapshot
+        };
+    let changed_since_preflight = if sync_mode
+        == homeboy::core::runner::RunnerWorkspaceSyncMode::Git
+    {
+        homeboy::core::runner::prepare_git_lab_offload_changed_since(normalized_args, &source_path)?
+    } else {
+        homeboy::core::runner::preflight_lab_offload_changed_since(normalized_args, sync_mode)?
+    };
     let synced = homeboy::core::runner::sync_workspace(
         runner_id,
         homeboy::core::runner::RunnerWorkspaceSyncOptions {
             path: source_path.display().to_string(),
-            mode: homeboy::core::runner::RunnerWorkspaceSyncMode::Snapshot,
+            mode: sync_mode,
+            changed_since_base: changed_since_preflight.resolved_base.clone(),
         },
     )?
     .0;
@@ -662,7 +672,7 @@ fn run_lab_offload_inner(
 
     let mut command = vec![homeboy_path.to_string()];
     command.extend(
-        rewrite_lab_offload_args(normalized_args, &remote_cwd)
+        rewrite_lab_offload_args(&changed_since_preflight.args, &remote_cwd)
             .into_iter()
             .skip(1),
     );


### PR DESCRIPTION
## Summary
- Fixes Lab offload for `--changed-since` by using git workspace sync when a changed-since base is present.
- Resolves the requested base locally to a commit, rewrites the remote command to use that reachable commit, and fetches/validates it in the runner workspace before dispatch.
- Keeps snapshot offload unchanged for commands without `--changed-since` and adds focused unit coverage for base rewriting and runner git materialization.

Closes #2874.

## Verification
- `cargo test offload_changed_since`
- `cargo test git_materialization_fetches_changed_since_base_before_checkout`
- `cargo test --lib`
- `cargo run --bin homeboy -- lint --path /Users/chubes/Developer/homeboy@fix-issue-2874-lab-changed-since --changed-since origin/main --force-hot`
- `cargo run --bin homeboy -- test --path /Users/chubes/Developer/homeboy@fix-issue-2874-lab-changed-since --changed-since origin/main --force-hot`
- `cargo run --bin homeboy -- audit --path /Users/chubes/Developer/homeboy@fix-issue-2874-lab-changed-since --changed-since origin/main --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the Lab offload changed-since failure path, drafted the base-resolution and runner git sync changes, added focused tests, and ran local verification. Chris remains responsible for review and merge.