### PR TITLE
fix: preserve parent-relative deploy paths

### DIFF
--- a/src/core/deploy/path_roots.rs
+++ b/src/core/deploy/path_roots.rs
@@ -23,17 +23,16 @@ pub(super) fn resolve_effective_remote_path(
     fallback_base_path: &str,
 ) -> Result<String> {
     let remote_path = component_remote_path(component);
-    let remote_path = strip_leading_parent_segments(&remote_path);
 
     if remote_path.trim_start().starts_with('/') {
-        return base_path::join_remote_path(Some(fallback_base_path), remote_path);
+        return base_path::join_remote_path(Some(fallback_base_path), &remote_path);
     }
 
-    if let Some(resolved) = resolve_with_project_root(project, component, remote_path)? {
+    if let Some(resolved) = resolve_with_project_root(project, component, &remote_path)? {
         return Ok(resolved);
     }
 
-    base_path::join_remote_path(Some(fallback_base_path), remote_path)
+    base_path::join_remote_path(Some(fallback_base_path), &remote_path)
 }
 
 pub(super) fn project_with_detected_path_roots(
@@ -154,10 +153,6 @@ fn strip_path_prefix<'a>(path: &'a str, prefix: &str) -> &'a str {
         .unwrap_or(path)
 }
 
-fn strip_leading_parent_segments(path: &str) -> &str {
-    path.trim_start_matches("../")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -269,7 +264,7 @@ mod tests {
     }
 
     #[test]
-    fn resolves_legacy_parent_relative_content_paths_through_project_root() {
+    fn parent_relative_content_paths_fall_back_to_base_path() {
         with_isolated_home(|_| {
             install_extension();
 
@@ -280,12 +275,12 @@ mod tests {
             )
             .expect("resolve path");
 
-            assert_eq!(resolved, "/htdocs/wp-content/plugins/foo");
+            assert_eq!(resolved, "/srv/site/../wp-content/plugins/foo");
         });
     }
 
     #[test]
-    fn strips_legacy_parent_relative_paths_before_base_path_fallback() {
+    fn preserves_parent_relative_paths_before_base_path_fallback() {
         with_isolated_home(|_| {
             install_extension();
 
@@ -296,7 +291,7 @@ mod tests {
             )
             .expect("resolve path");
 
-            assert_eq!(resolved, "/srv/site/var/log/app.log");
+            assert_eq!(resolved, "/srv/site/../var/log/app.log");
         });
     }
 


### PR DESCRIPTION
## Summary
- Preserve explicit parent-relative deploy paths like `../wp-content/plugins/data-machine` during effective remote path resolution.
- Keep WordPress managed path-root handling for normal `wp-content/...` paths while allowing project component attachments to target sibling content directories.
- Update deploy path-root regression tests for parent-relative paths.

Fixes #2900.

## Tests
- `cargo fmt --check`
- `cargo test core::deploy::path_roots --lib`
- `cargo test core::project::component::resolution --lib`
- `cargo test --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated issue #2900, drafted the code change, and ran verification. Chris remains responsible for review and merge.