### PR TITLE
fix: offload hot refactor runs to lab

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -314,6 +314,17 @@ impl Commands {
                 None,
                 CommandOutputContractKind::JsonEnvelope,
             ),
+            Commands::Refactor(args) => CommandDescriptor {
+                response_mode: CommandResponseMode::Json,
+                output_file_mode,
+                json_family: CommandJsonFamily::Workspace,
+                supports_lab_runner: args.is_hot_resource_command(),
+                lab_runner_unsupported_reason: None,
+                lab_offload_mutation_flag: args
+                    .lab_offload_writes_local_state()
+                    .then_some("--write/--commit"),
+                output_contract: CommandOutputContractKind::JsonEnvelope,
+            },
             Commands::Project(_)
             | Commands::Component(_)
             | Commands::Config(_)
@@ -324,7 +335,6 @@ impl Commands {
             | Commands::Changes(_)
             | Commands::Release(_)
             | Commands::Report(_)
-            | Commands::Refactor(_)
             | Commands::Runner(_)
             | Commands::Stack(_)
             | Commands::Undo(_) => CommandDescriptor {
@@ -949,8 +959,14 @@ mod tests {
         assert!(parsed_command(&["homeboy", "lint"]).supports_lab_runner());
         assert!(parsed_command(&["homeboy", "test"]).supports_lab_runner());
         assert!(parsed_command(&["homeboy", "audit"]).supports_lab_runner());
+        assert!(parsed_command(&["homeboy", "refactor", "--from", "audit"]).supports_lab_runner());
+        assert!(parsed_command(&["homeboy", "refactor", "--all"]).supports_lab_runner());
         assert!(parsed_command(&["homeboy", "bench"]).supports_lab_runner());
         assert!(parsed_command(&["homeboy", "trace"]).supports_lab_runner());
+        assert!(!parsed_command(&[
+            "homeboy", "refactor", "rename", "--from", "old", "--to", "new",
+        ])
+        .supports_lab_runner());
         assert!(!parsed_command(&["homeboy", "rig", "up", "studio"]).supports_lab_runner());
         assert!(
             !parsed_command(&["homeboy", "fleet", "exec", "prod", "wp", "plugin", "list"])
@@ -1022,6 +1038,11 @@ mod tests {
         assert_eq!(
             parsed_command(&["homeboy", "trace", "--keep-overlay"]).lab_offload_mutation_flag(),
             Some("--keep-overlay")
+        );
+        assert_eq!(
+            parsed_command(&["homeboy", "refactor", "--from", "audit", "--write"])
+                .lab_offload_mutation_flag(),
+            Some("--write/--commit")
         );
         assert_eq!(
             parsed_command(&["homeboy", "audit"]).lab_offload_mutation_flag(),

--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -401,6 +401,28 @@ pub fn run(args: RefactorArgs, _global: &crate::commands::GlobalArgs) -> CmdResu
     }
 }
 
+impl RefactorArgs {
+    pub fn is_hot_resource_command(&self) -> bool {
+        self.command.is_none()
+            && (self.all
+                || self
+                    .from
+                    .iter()
+                    .any(|source| matches_hot_refactor_source(source)))
+    }
+
+    pub fn lab_offload_writes_local_state(&self) -> bool {
+        self.write_mode.write || self.commit
+    }
+}
+
+fn matches_hot_refactor_source(source: &str) -> bool {
+    matches!(
+        source.to_ascii_lowercase().as_str(),
+        "all" | "audit" | "lint" | "test"
+    )
+}
+
 #[derive(Serialize)]
 #[serde(tag = "command")]
 pub enum RefactorOutput {

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -275,6 +275,7 @@ pub fn hot_command(command: &Commands) -> Option<HotCommand> {
         Commands::Bench(args) if args.is_run_command() => "bench",
         Commands::Rig(args) if args.is_hot_resource_command() => "rig up",
         Commands::Fleet(args) if args.is_hot_resource_command() => "fleet exec",
+        Commands::Refactor(args) if args.is_hot_resource_command() => "refactor",
         Commands::Audit(args) if args.changed_since.is_none() && !args.conventions => "audit",
         Commands::Lint(args) if args.is_full_workspace_run() => "lint",
         Commands::Test(args) if args.changed_since.is_none() => "test",

--- a/src/main.rs
+++ b/src/main.rs
@@ -521,14 +521,14 @@ fn resolve_lab_runner_selection_from_default(
         if !command.supports_lab_runner() {
             let reason = command.lab_runner_unsupported_reason();
             let message = reason.map_or_else(
-                || "--runner is only supported for hot Lab-offload commands: lint, test, audit, bench, and trace".to_string(),
+                || "--runner is only supported for hot Lab-offload commands: lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this hot command. {reason}"),
             );
             return Err(homeboy::core::Error::validation_invalid_argument(
                 "runner",
                 message,
                 Some(runner_id.to_string()),
-                Some(vec!["Current Lab offload support: audit, bench run, full lint, full test, and trace.".to_string()]),
+                Some(vec!["Current Lab offload support: audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
             ));
         }
 
@@ -780,6 +780,7 @@ fn rewrite_lab_offload_args(args: &[String], remote_path: &str) -> Vec<String> {
     let mut stripped = Vec::with_capacity(args.len());
     let mut iter = args.iter().peekable();
     let mut passthrough = false;
+    let has_force_hot = args.iter().any(|arg| arg == "--force-hot");
     while let Some(arg) = iter.next() {
         if passthrough {
             stripped.push(arg.clone());
@@ -815,6 +816,9 @@ fn rewrite_lab_offload_args(args: &[String], remote_path: &str) -> Vec<String> {
             continue;
         }
         stripped.push(arg.clone());
+    }
+    if !has_force_hot {
+        stripped.insert(1, "--force-hot".to_string());
     }
     stripped
 }
@@ -966,6 +970,7 @@ mod tests {
             rewrite_lab_offload_args(&args, "/home/chubes/Developer/project"),
             vec![
                 "homeboy".to_string(),
+                "--force-hot".to_string(),
                 "lint".to_string(),
                 "--path".to_string(),
                 "/home/chubes/Developer/project".to_string(),
@@ -987,6 +992,7 @@ mod tests {
             rewrite_lab_offload_args(&args, "/home/chubes/Developer/project"),
             vec![
                 "homeboy".to_string(),
+                "--force-hot".to_string(),
                 "test".to_string(),
                 "--path=/home/chubes/Developer/project".to_string()
             ]
@@ -1014,6 +1020,7 @@ mod tests {
             rewritten,
             vec![
                 "homeboy".to_string(),
+                "--force-hot".to_string(),
                 "audit".to_string(),
                 "--path".to_string(),
                 "/home/chubes/Developer/project".to_string(),
@@ -1042,6 +1049,7 @@ mod tests {
             rewrite_lab_offload_args(&args, "/home/chubes/Developer/project"),
             vec![
                 "homeboy".to_string(),
+                "--force-hot".to_string(),
                 "test".to_string(),
                 "--path".to_string(),
                 "/home/chubes/Developer/project".to_string(),
@@ -1068,6 +1076,32 @@ mod tests {
     }
 
     #[test]
+    fn rewrite_lab_offload_args_does_not_duplicate_force_hot() {
+        let args = vec![
+            "homeboy".to_string(),
+            "--force-hot".to_string(),
+            "refactor".to_string(),
+            "--from".to_string(),
+            "audit".to_string(),
+            "--path".to_string(),
+            "/Users/chubes/Developer/project".to_string(),
+        ];
+
+        assert_eq!(
+            rewrite_lab_offload_args(&args, "/home/chubes/Developer/project"),
+            vec![
+                "homeboy".to_string(),
+                "--force-hot".to_string(),
+                "refactor".to_string(),
+                "--from".to_string(),
+                "audit".to_string(),
+                "--path".to_string(),
+                "/home/chubes/Developer/project".to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn lab_runner_selection_keeps_explicit_runner_precedence() {
         let command = Commands::Test(test_args_for_path(std::path::Path::new("/tmp/project")));
         let selection = resolve_lab_runner_selection_from_default(
@@ -1086,6 +1120,31 @@ mod tests {
     #[test]
     fn lab_runner_selection_uses_default_for_supported_commands() {
         let command = Commands::Test(test_args_for_path(std::path::Path::new("/tmp/project")));
+        let selection = resolve_lab_runner_selection_from_default(
+            &command,
+            None,
+            false,
+            Some("lab-default".to_string()),
+        )
+        .expect("selection")
+        .expect("default runner selected");
+
+        assert_eq!(selection.runner_id, "lab-default");
+        assert_eq!(selection.source, LabRunnerSelectionSource::Default);
+    }
+
+    #[test]
+    fn lab_runner_selection_uses_default_for_hot_refactor_sources() {
+        let command = homeboy::cli_surface::Cli::try_parse_from([
+            "homeboy",
+            "refactor",
+            "--from",
+            "audit",
+            "--path",
+            "/tmp/project",
+        ])
+        .expect("parse")
+        .command;
         let selection = resolve_lab_runner_selection_from_default(
             &command,
             None,


### PR DESCRIPTION
## Summary
- Marks `homeboy refactor --from audit|lint|test|all` source runs as hot Lab-offload candidates so a configured/available default lab runner is selected automatically.
- Captures refactor write/commit runs as mutating Lab offloads and rewrites remote Lab invocations with `--force-hot` to prevent recursive offload on the runner.
- Updates Lab routing tests for default refactor selection and recursive-offload prevention.

Closes #2901.

## Testing
- `cargo test cli_surface::tests -- --nocapture`
- `cargo test --bin homeboy tests:: -- --nocapture`
- `cargo test core::extension::execution::tests::build_exec_env_includes_runtime_runner_helper_path -- --nocapture`
- `cargo test core::extension::trace::attach::tests::test_append_attach_observations -- --nocapture`
- `cargo check`
- `cargo test --lib -- --test-threads=1`

## Lab smoke
- `target/debug/homeboy runner list` shows configured SSH runner `lab` with `workspace_root=/home/chubes/Developer`.
- `target/debug/homeboy runner status lab` shows `connected: true`.
- `target/debug/homeboy --output /tmp/homeboy-2901-refactor-lab-smoke.json refactor --from audit --changed-since HEAD --path /Users/chubes/Developer/homeboy@fix-2901-default-lab-hot-commands` printed `Lab offload: auto-selected default runner \`lab\`.`
- The smoke then stopped before remote execution because changed-since git sync requires a clean worktree and this fix was still uncommitted during the smoke.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Lab routing fix, updated tests, and ran verification; Chris remains responsible for review and merge.