### PR TITLE
fix: upgrade configured runners

### DIFF
--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -10,13 +10,16 @@ homeboy upgrade [OPTIONS]
 
 Upgrades Homeboy to the latest version. The command auto-detects the installation method (Homebrew, Cargo, source build, or downloaded release binary) and runs the appropriate upgrade process.
 
-By default, after a successful upgrade, Homeboy restarts itself to use the new version.
+By default, after a successful local upgrade, Homeboy also checks configured SSH runners and runs their configured Homeboy binary through the same upgrade path. This keeps lab runners from drifting behind the local CLI.
 
 ## Options
 
 - `--check`: Check for updates without installing. Returns version information without making changes.
 - `--force`: Force upgrade even if already at the latest version.
 - `--no-restart`: Skip automatic restart after upgrade. Useful for scripted environments.
+- `--skip-extensions`: Skip automatic extension updates.
+- `--skip-runners`: Skip automatic configured runner upgrades.
+- `--runner`: Upgrade only the named configured runner. Repeat to target multiple runners.
 - `--method`: Override install method detection (`homebrew|cargo|source|binary`).
 
 ## Installation Method Detection
@@ -62,6 +65,18 @@ Force reinstall:
 homeboy upgrade --force
 ```
 
+Upgrade only a specific runner after the local upgrade:
+
+```sh
+homeboy upgrade --runner lab
+```
+
+Upgrade locally without touching configured runners:
+
+```sh
+homeboy upgrade --skip-runners
+```
+
 ## JSON output
 
 > Note: all command output is wrapped in the global JSON envelope described in the [JSON output contract](../architecture/output-system.md).
@@ -83,6 +98,11 @@ homeboy upgrade --force
 - `upgraded`: Boolean indicating if upgrade was performed
 - `message`: Human-readable status message
 - `restart_required`: Boolean indicating if a restart is needed (true only for source installs)
+- `extensions_updated`: Extension upgrade entries when installed extensions were checked
+- `extensions_skipped`: Extension IDs that could not be updated
+- `projects_migrated`: Project config migration entries
+- `runners_updated`: Runner upgrade entries for configured runners that completed successfully
+- `runners_skipped`: Runner upgrade entries for configured runners that failed or could not verify a version
 
 ## Exit code
 

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -24,6 +24,14 @@ pub struct UpgradeArgs {
     #[arg(long)]
     pub skip_extensions: bool,
 
+    /// Skip configured runner upgrades after the local upgrade
+    #[arg(long)]
+    pub skip_runners: bool,
+
+    /// Upgrade only the named configured runner. Repeat to target multiple runners.
+    #[arg(long = "runner", value_name = "RUNNER_ID")]
+    pub runners: Vec<String>,
+
     /// Override install method detection (homebrew|cargo|source|binary)
     #[arg(long)]
     pub method: Option<String>,
@@ -65,6 +73,8 @@ pub fn run(args: UpgradeArgs, _global: &GlobalArgs) -> CmdResult<Value> {
         args.force,
         method_override,
         args.skip_extensions,
+        args.skip_runners,
+        &args.runners,
         args.source_path.as_deref(),
     )?;
     let json = serde_json::to_value(&result)

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -35,6 +35,7 @@ pub struct RunnerCapabilityPreflight {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RunnerRequiredTool {
+    Homeboy,
     Git,
     Node,
     Npm,
@@ -280,6 +281,9 @@ impl RunnerCapabilitySnapshot {
         runner: &Runner,
     ) -> Self {
         let mut tools = BTreeSet::new();
+        if !report.resources.homeboy.version.is_empty() || report.resources.homeboy.path.is_some() {
+            tools.insert(RunnerRequiredTool::Homeboy);
+        }
         if report.capabilities.git {
             tools.insert(RunnerRequiredTool::Git);
         }
@@ -427,6 +431,7 @@ impl RunnerCapabilityPreflight {
 impl RunnerRequiredTool {
     pub fn id(self) -> &'static str {
         match self {
+            RunnerRequiredTool::Homeboy => "homeboy",
             RunnerRequiredTool::Git => "git",
             RunnerRequiredTool::Node => "node",
             RunnerRequiredTool::Npm => "npm",
@@ -440,6 +445,9 @@ impl RunnerRequiredTool {
 
     fn remediation(self) -> &'static str {
         match self {
+            RunnerRequiredTool::Homeboy => {
+                "Install Homeboy on the runner and ensure the configured homeboy_path works."
+            }
             RunnerRequiredTool::Git => "Install git and ensure it is on the runner PATH.",
             RunnerRequiredTool::Node => "Install Node.js and ensure node is on the runner PATH.",
             RunnerRequiredTool::Npm => {

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 use super::constants::{CRATES_IO_API, GITHUB_RELEASES_API, VERSION};
 use super::execution::execute_upgrade;
 use super::planning::resolve_binary_on_path;
+use super::runners;
 use super::types::*;
 use super::validation::check_for_updates;
 
@@ -152,6 +153,8 @@ pub fn run_upgrade_with_method(
     force: bool,
     method_override: Option<InstallMethod>,
     skip_extensions: bool,
+    skip_runners: bool,
+    runner_targets: &[String],
     source_path: Option<&Path>,
 ) -> Result<UpgradeResult> {
     let install_method = method_override.unwrap_or_else(detect_install_method);
@@ -181,6 +184,11 @@ pub fn run_upgrade_with_method(
                 update_all_extensions()
             };
             let projects_migrated = migrate_all_projects();
+            let (runners_updated, runners_skipped) = if skip_runners {
+                (vec![], vec![])
+            } else {
+                runners::upgrade_configured_runners(runner_targets)?
+            };
             return Ok(UpgradeResult {
                 command: "upgrade".to_string(),
                 install_method,
@@ -192,6 +200,8 @@ pub fn run_upgrade_with_method(
                 extensions_updated,
                 extensions_skipped,
                 projects_migrated,
+                runners_updated,
+                runners_skipped,
             });
         }
     }
@@ -213,6 +223,12 @@ pub fn run_upgrade_with_method(
     // operation that doesn't depend on the binary version.
     let projects_migrated = migrate_all_projects();
 
+    let (runners_updated, runners_skipped) = if success && !skip_runners {
+        runners::upgrade_configured_runners(runner_targets)?
+    } else {
+        (vec![], vec![])
+    };
+
     Ok(UpgradeResult {
         command: "upgrade".to_string(),
         install_method,
@@ -233,6 +249,8 @@ pub fn run_upgrade_with_method(
         extensions_updated,
         extensions_skipped,
         projects_migrated,
+        runners_updated,
+        runners_skipped,
     })
 }
 

--- a/src/core/upgrade/mod.rs
+++ b/src/core/upgrade/mod.rs
@@ -2,6 +2,7 @@ mod constants;
 mod execution;
 mod helpers;
 mod planning;
+mod runners;
 mod types;
 pub mod update_check;
 mod validation;
@@ -12,7 +13,8 @@ pub use helpers::{
 };
 pub use planning::resolve_binary_on_path;
 pub use types::{
-    ExtensionUpgradeEntry, InstallMethod, ProjectMigrationEntry, UpgradeResult, VersionCheck,
+    ExtensionUpgradeEntry, InstallMethod, ProjectMigrationEntry, RunnerUpgradeEntry, UpgradeResult,
+    VersionCheck,
 };
 pub use validation::check_for_updates;
 

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -1,0 +1,325 @@
+use regex::Regex;
+
+use crate::core::runner::{self, Runner, RunnerExecOptions, RunnerKind};
+use crate::core::upgrade::RunnerUpgradeEntry;
+use crate::core::Result;
+
+pub(super) fn upgrade_configured_runners(
+    runner_targets: &[String],
+) -> Result<(Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>)> {
+    let runners = runner_upgrade_targets(runner_targets)?;
+    if runners.is_empty() {
+        return Ok((vec![], vec![]));
+    }
+
+    crate::log_status!(
+        "upgrade",
+        "Updating {} configured runner(s)...",
+        runners.len()
+    );
+    Ok(upgrade_runners_with_executor(
+        &runners,
+        |runner_id, options| runner::exec(runner_id, options),
+    ))
+}
+
+fn runner_upgrade_targets(runner_targets: &[String]) -> Result<Vec<Runner>> {
+    if !runner_targets.is_empty() {
+        return runner_targets
+            .iter()
+            .map(|runner_id| runner::load(runner_id))
+            .collect();
+    }
+
+    Ok(runner::list()?
+        .into_iter()
+        .filter(|runner| runner.kind == RunnerKind::Ssh)
+        .collect())
+}
+
+fn upgrade_runners_with_executor(
+    runners: &[Runner],
+    mut exec: impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
+) -> (Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>) {
+    let mut updated = Vec::new();
+    let mut skipped = Vec::new();
+
+    for runner in runners {
+        let entry = upgrade_runner_with_executor(runner, &mut exec);
+        if entry.success {
+            crate::log_status!(
+                "upgrade",
+                "  {} {}",
+                entry.runner_id,
+                runner_upgrade_summary(&entry)
+            );
+            updated.push(entry);
+        } else {
+            crate::log_status!("upgrade", "  {} skipped: {}", entry.runner_id, entry.detail);
+            skipped.push(entry);
+        }
+    }
+
+    (updated, skipped)
+}
+
+fn upgrade_runner_with_executor(
+    runner: &Runner,
+    exec: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
+) -> RunnerUpgradeEntry {
+    let homeboy_path = runner
+        .settings
+        .homeboy_path
+        .clone()
+        .unwrap_or_else(|| "homeboy".to_string());
+    let previous_version = runner_homeboy_version(runner, &homeboy_path, exec)
+        .ok()
+        .flatten();
+    let upgrade = exec(
+        &runner.id,
+        runner_exec_options(
+            runner,
+            vec![
+                homeboy_path.clone(),
+                "upgrade".to_string(),
+                "--no-restart".to_string(),
+                "--skip-runners".to_string(),
+            ],
+        ),
+    );
+
+    let (exit_code, detail) = match upgrade {
+        Ok((output, exit_code)) if exit_code == 0 => (exit_code, runner_upgrade_detail(&output)),
+        Ok((output, exit_code)) => {
+            return RunnerUpgradeEntry {
+                runner_id: runner.id.clone(),
+                homeboy_path,
+                success: false,
+                upgraded: false,
+                previous_version,
+                new_version: None,
+                exit_code,
+                detail: runner_upgrade_detail(&output),
+            };
+        }
+        Err(err) => {
+            return RunnerUpgradeEntry {
+                runner_id: runner.id.clone(),
+                homeboy_path,
+                success: false,
+                upgraded: false,
+                previous_version,
+                new_version: None,
+                exit_code: 1,
+                detail: err.message,
+            };
+        }
+    };
+
+    let new_version = runner_homeboy_version(runner, &homeboy_path, exec)
+        .ok()
+        .flatten();
+    let upgraded = match (previous_version.as_deref(), new_version.as_deref()) {
+        (Some(previous), Some(new)) => new != previous,
+        _ => false,
+    };
+
+    RunnerUpgradeEntry {
+        runner_id: runner.id.clone(),
+        homeboy_path,
+        success: new_version.is_some(),
+        upgraded,
+        previous_version,
+        new_version,
+        exit_code,
+        detail,
+    }
+}
+
+fn runner_homeboy_version(
+    runner: &Runner,
+    homeboy_path: &str,
+    exec: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
+) -> Result<Option<String>> {
+    let (output, exit_code) = exec(
+        &runner.id,
+        runner_exec_options(
+            runner,
+            vec![homeboy_path.to_string(), "--version".to_string()],
+        ),
+    )?;
+    if exit_code != 0 {
+        return Ok(None);
+    }
+
+    Ok(parse_cli_version_output(&output.stdout)
+        .or_else(|| parse_cli_version_output(&output.stderr)))
+}
+
+fn runner_exec_options(runner: &Runner, command: Vec<String>) -> RunnerExecOptions {
+    RunnerExecOptions {
+        cwd: None,
+        allow_ssh: true,
+        command,
+        env: runner.env.clone(),
+        capture_patch: false,
+        source_snapshot: None,
+        capability_preflight: None,
+    }
+}
+
+fn parse_cli_version_output(output: &str) -> Option<String> {
+    let re = Regex::new(r"(\d+\.\d+\.\d+)").ok()?;
+    re.find(output).map(|m| m.as_str().to_string())
+}
+
+fn runner_upgrade_detail(output: &runner::RunnerExecOutput) -> String {
+    let stdout = output.stdout.trim();
+    let stderr = output.stderr.trim();
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (false, false) => format!("{}\n{}", stdout, stderr),
+        (false, true) => stdout.to_string(),
+        (true, false) => stderr.to_string(),
+        (true, true) => "runner upgrade produced no output".to_string(),
+    }
+}
+
+fn runner_upgrade_summary(entry: &RunnerUpgradeEntry) -> String {
+    match (
+        entry.previous_version.as_deref(),
+        entry.new_version.as_deref(),
+        entry.upgraded,
+    ) {
+        (Some(previous), Some(new), true) => format!("{} -> {}", previous, new),
+        (_, Some(new), false) => format!("{} (up to date)", new),
+        _ => "updated".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::runner::{RunnerExecMode, RunnerExecOutput};
+    use crate::core::server::RunnerSettings;
+    use std::collections::HashMap;
+
+    #[test]
+    fn upgrades_configured_runner_with_homeboy_path_and_skip_runner_guard() {
+        let runner = ssh_runner("lab", Some("/home/chubes/.local/bin/homeboy"));
+        let mut commands = Vec::new();
+        let (updated, skipped) = upgrade_runners_with_executor(&[runner], |runner_id, options| {
+            commands.push((
+                runner_id.to_string(),
+                options.command.clone(),
+                options.allow_ssh,
+            ));
+            let stdout = match commands.len() {
+                1 => "homeboy 0.199.1\n",
+                2 => "{\"success\":true}\n",
+                3 => "homeboy 0.199.2\n",
+                _ => "",
+            };
+            Ok((exec_output(runner_id, options.command, stdout, "", 0), 0))
+        });
+
+        assert!(skipped.is_empty());
+        assert_eq!(updated.len(), 1);
+        assert_eq!(updated[0].runner_id, "lab");
+        assert!(updated[0].success);
+        assert!(updated[0].upgraded);
+        assert_eq!(updated[0].previous_version.as_deref(), Some("0.199.1"));
+        assert_eq!(updated[0].new_version.as_deref(), Some("0.199.2"));
+        assert_eq!(
+            commands[1].1,
+            vec![
+                "/home/chubes/.local/bin/homeboy",
+                "upgrade",
+                "--no-restart",
+                "--skip-runners"
+            ]
+        );
+        assert!(commands.iter().all(|(_, _, allow_ssh)| *allow_ssh));
+    }
+
+    #[test]
+    fn reports_runner_upgrade_failure_without_stopping_other_runners() {
+        let runners = vec![ssh_runner("lab", None), ssh_runner("bench", None)];
+        let mut calls = HashMap::<String, usize>::new();
+        let (updated, skipped) = upgrade_runners_with_executor(&runners, |runner_id, options| {
+            let count = calls.entry(runner_id.to_string()).or_default();
+            *count += 1;
+            match (runner_id, *count) {
+                ("lab", 1) => Ok((
+                    exec_output(runner_id, options.command, "homeboy 0.199.1\n", "", 0),
+                    0,
+                )),
+                ("lab", 2) => Ok((
+                    exec_output(runner_id, options.command, "", "download failed", 1),
+                    1,
+                )),
+                ("bench", 1) => Ok((
+                    exec_output(runner_id, options.command, "homeboy 0.199.1\n", "", 0),
+                    0,
+                )),
+                ("bench", 2) => Ok((
+                    exec_output(runner_id, options.command, "already latest", "", 0),
+                    0,
+                )),
+                ("bench", 3) => Ok((
+                    exec_output(runner_id, options.command, "homeboy 0.199.1\n", "", 0),
+                    0,
+                )),
+                _ => panic!("unexpected call {runner_id} {count}"),
+            }
+        });
+
+        assert_eq!(updated.len(), 1);
+        assert_eq!(updated[0].runner_id, "bench");
+        assert!(!updated[0].upgraded);
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].runner_id, "lab");
+        assert!(!skipped[0].success);
+        assert_eq!(skipped[0].exit_code, 1);
+        assert!(skipped[0].detail.contains("download failed"));
+    }
+
+    fn ssh_runner(id: &str, homeboy_path: Option<&str>) -> Runner {
+        Runner {
+            id: id.to_string(),
+            kind: RunnerKind::Ssh,
+            server_id: Some(format!("{id}-server")),
+            workspace_root: Some("/home/chubes/workspace".to_string()),
+            settings: RunnerSettings {
+                homeboy_path: homeboy_path.map(str::to_string),
+                ..Default::default()
+            },
+            env: HashMap::new(),
+            resources: HashMap::new(),
+        }
+    }
+
+    fn exec_output(
+        runner_id: &str,
+        argv: Vec<String>,
+        stdout: &str,
+        stderr: &str,
+        exit_code: i32,
+    ) -> RunnerExecOutput {
+        RunnerExecOutput {
+            command: "runner.exec",
+            runner_id: runner_id.to_string(),
+            mode: RunnerExecMode::Ssh,
+            argv,
+            remote_cwd: "/home/chubes/workspace".to_string(),
+            exit_code,
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+            source_snapshot: None,
+            job: None,
+            job_id: None,
+            job_events: None,
+            mirror_run_id: None,
+            patch: None,
+        }
+    }
+}

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -1,6 +1,8 @@
 use regex::Regex;
 
-use crate::core::runner::{self, Runner, RunnerExecOptions, RunnerKind};
+use crate::core::runner::{
+    self, Runner, RunnerCapabilityPreflight, RunnerExecOptions, RunnerKind, RunnerRequiredTool,
+};
 use crate::core::upgrade::RunnerUpgradeEntry;
 use crate::core::Result;
 
@@ -164,7 +166,16 @@ fn runner_exec_options(runner: &Runner, command: Vec<String>) -> RunnerExecOptio
         env: runner.env.clone(),
         capture_patch: false,
         source_snapshot: None,
-        capability_preflight: None,
+        capability_preflight: Some(runner_upgrade_capability_plan()),
+    }
+}
+
+fn runner_upgrade_capability_plan() -> RunnerCapabilityPreflight {
+    RunnerCapabilityPreflight {
+        command: "homeboy upgrade".to_string(),
+        required_tools: vec![RunnerRequiredTool::Homeboy],
+        required_components: Vec::new(),
+        required_env: Vec::new(),
     }
 }
 
@@ -239,6 +250,13 @@ mod tests {
             ]
         );
         assert!(commands.iter().all(|(_, _, allow_ssh)| *allow_ssh));
+
+        let capability_plan = runner_upgrade_capability_plan();
+        assert_eq!(
+            capability_plan.required_tools,
+            vec![RunnerRequiredTool::Homeboy]
+        );
+        assert_eq!(capability_plan.command, "homeboy upgrade");
     }
 
     #[test]

--- a/src/core/upgrade/types.rs
+++ b/src/core/upgrade/types.rs
@@ -39,6 +39,10 @@ pub struct UpgradeResult {
     pub extensions_skipped: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub projects_migrated: Vec<ProjectMigrationEntry>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub runners_updated: Vec<RunnerUpgradeEntry>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub runners_skipped: Vec<RunnerUpgradeEntry>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,6 +63,20 @@ pub struct ExtensionUpgradeEntry {
 pub struct ProjectMigrationEntry {
     pub project_id: String,
     pub success: bool,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerUpgradeEntry {
+    pub runner_id: String,
+    pub homeboy_path: String,
+    pub success: bool,
+    pub upgraded: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_version: Option<String>,
+    pub exit_code: i32,
     pub detail: String,
 }
 


### PR DESCRIPTION
## Summary
- Adds a runner-aware phase to `homeboy upgrade` so configured SSH runners run their configured Homeboy binary through the remote upgrade path.
- Adds `--skip-runners` plus repeatable `--runner <id>` targeting, and records runner upgrade/skipped results in JSON output.
- Documents the new runner upgrade behavior and covers successful upgrades plus failure reporting with focused unit tests.

Fixes #2904

## Tests
- `cargo test core::upgrade::runners`
- `cargo test --test command_surface_test`
- `cargo check`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner-aware upgrade path, focused tests, and PR description draft for Chris to review.