### PR TITLE
Add Homeboy artifact retention cleanup

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -127,6 +127,7 @@ pub enum RunsOutput {
     Artifacts(RunsArtifactsOutput),
     ArtifactGet(RunsArtifactGetOutput),
     ArtifactCleanupDownloads(RunsArtifactCleanupDownloadsOutput),
+    ArtifactCleanupPersisted(RunsArtifactCleanupPersistedOutput),
     Findings(RunsFindingsOutput),
     Finding(RunsFindingOutput),
     LatestFinding(RunsLatestFindingOutput),
@@ -171,6 +172,8 @@ enum RunsArtifactCommand {
     Get(RunsArtifactGetArgs),
     /// Plan or delete locally cached runner artifact downloads
     CleanupDownloads(RunsArtifactCleanupDownloadsArgs),
+    /// Plan or delete persisted local run artifacts and their database records
+    CleanupPersisted(RunsArtifactCleanupPersistedArgs),
 }
 
 #[derive(Args, Clone)]
@@ -218,6 +221,70 @@ pub struct RunsArtifactCleanupDownloadsOutput {
     pub directory_count: usize,
     pub size_bytes: u64,
     pub paths: Vec<String>,
+}
+
+#[derive(Args, Clone)]
+pub struct RunsArtifactCleanupPersistedArgs {
+    /// Delete planned artifact files/directories and their DB rows. Without this flag, only reports the plan.
+    #[arg(long)]
+    pub apply: bool,
+    /// Only include artifacts older than this many days.
+    #[arg(long, default_value_t = 30)]
+    pub older_than_days: i64,
+    /// Limit cleanup to one run id.
+    #[arg(long)]
+    pub run_id: Option<String>,
+    /// Limit cleanup to one artifact kind.
+    #[arg(long)]
+    pub kind: Option<String>,
+    /// Limit cleanup to one artifact type (`file` or `directory`).
+    #[arg(long = "type")]
+    pub artifact_type: Option<String>,
+    /// Limit cleanup to one run kind (`bench`, `trace`, etc.).
+    #[arg(long)]
+    pub run_kind: Option<String>,
+    /// Limit cleanup to one component id.
+    #[arg(long = "component")]
+    pub component_id: Option<String>,
+    /// Maximum artifact rows to inspect in one invocation.
+    #[arg(long, default_value_t = 1000)]
+    pub limit: i64,
+}
+
+#[derive(Serialize)]
+pub struct RunsArtifactCleanupPersistedOutput {
+    pub command: &'static str,
+    pub dry_run: bool,
+    pub artifact_root: String,
+    pub older_than_days: i64,
+    pub inspected_count: usize,
+    pub planned_record_count: usize,
+    pub planned_file_count: usize,
+    pub planned_directory_count: usize,
+    pub planned_size_bytes: u64,
+    pub removed_record_count: usize,
+    pub removed_file_count: usize,
+    pub removed_directory_count: usize,
+    pub removed_size_bytes: u64,
+    pub skipped_count: usize,
+    pub rows: Vec<RunsArtifactCleanupPersistedRow>,
+}
+
+#[derive(Serialize)]
+pub struct RunsArtifactCleanupPersistedRow {
+    pub artifact_id: String,
+    pub run_id: String,
+    pub run_kind: String,
+    pub component_id: Option<String>,
+    pub kind: String,
+    #[serde(rename = "type")]
+    pub artifact_type: String,
+    pub path: String,
+    pub created_at: String,
+    pub exists: bool,
+    pub action: String,
+    pub reason: String,
+    pub size_bytes: u64,
 }
 
 #[derive(Serialize)]
@@ -324,6 +391,7 @@ fn artifact_command(args: RunsArtifactArgs) -> CmdResult<RunsOutput> {
     match args.command {
         RunsArtifactCommand::Get(args) => artifact_get(args),
         RunsArtifactCommand::CleanupDownloads(args) => remote_artifact::cleanup_downloads(args),
+        RunsArtifactCommand::CleanupPersisted(args) => remote_artifact::cleanup_persisted(args),
     }
 }
 

--- a/src/commands/runs/remote_artifact.rs
+++ b/src/commands/runs/remote_artifact.rs
@@ -1,13 +1,15 @@
 use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
-use homeboy::core::observation::ArtifactRecord;
+use chrono::{Duration, Utc};
+use homeboy::core::observation::{ArtifactCleanupFilter, ArtifactRecord, ObservationStore};
 use homeboy::core::runner;
 
 use super::{
     CmdResult, RunsArtifactCleanupDownloadsArgs, RunsArtifactCleanupDownloadsOutput,
-    RunsArtifactGetOutput, RunsOutput,
+    RunsArtifactCleanupPersistedArgs, RunsArtifactCleanupPersistedOutput,
+    RunsArtifactCleanupPersistedRow, RunsArtifactGetOutput, RunsOutput,
 };
 
 pub fn is_remote_artifact(artifact: &ArtifactRecord) -> bool {
@@ -60,6 +62,229 @@ pub fn cleanup_downloads(args: RunsArtifactCleanupDownloadsArgs) -> CmdResult<Ru
         }),
         0,
     ))
+}
+
+pub fn cleanup_persisted(args: RunsArtifactCleanupPersistedArgs) -> CmdResult<RunsOutput> {
+    if args.older_than_days < 0 {
+        return Err(crate::core::Error::validation_invalid_argument(
+            "older_than_days",
+            "--older-than-days must be zero or greater",
+            Some(args.older_than_days.to_string()),
+            None,
+        ));
+    }
+
+    let artifact_root = homeboy::core::artifact_root()?;
+    let created_before = (Utc::now() - Duration::days(args.older_than_days)).to_rfc3339();
+    let store = ObservationStore::open_initialized()?;
+    let candidates = store.list_artifact_cleanup_candidates(ArtifactCleanupFilter {
+        created_before: Some(created_before),
+        run_id: args.run_id.clone(),
+        kind: args.kind.clone(),
+        artifact_type: args.artifact_type.clone(),
+        run_kind: args.run_kind.clone(),
+        component_id: args.component_id.clone(),
+        limit: Some(args.limit),
+    })?;
+
+    let mut rows = Vec::new();
+    let mut planned_record_count = 0;
+    let mut planned_file_count = 0;
+    let mut planned_directory_count = 0;
+    let mut planned_size_bytes = 0;
+    let mut removed_record_count = 0;
+    let mut removed_file_count = 0;
+    let mut removed_directory_count = 0;
+    let mut removed_size_bytes = 0;
+    let mut skipped_count = 0;
+
+    for candidate in candidates.iter() {
+        let mut row = classify_persisted_artifact(candidate, &artifact_root)?;
+        if row.action == "remove" {
+            planned_record_count += 1;
+            planned_size_bytes += row.size_bytes;
+            match row.artifact_type.as_str() {
+                "directory" => planned_directory_count += 1,
+                _ => planned_file_count += usize::from(row.exists),
+            }
+            if args.apply {
+                apply_persisted_artifact_cleanup(&store, &candidate.artifact, &artifact_root)?;
+                removed_record_count += 1;
+                removed_size_bytes += row.size_bytes;
+                match row.artifact_type.as_str() {
+                    "directory" => removed_directory_count += 1,
+                    _ => removed_file_count += usize::from(row.exists),
+                }
+                row.action = "removed".to_string();
+            }
+        } else {
+            skipped_count += 1;
+        }
+        rows.push(row);
+    }
+
+    Ok((
+        RunsOutput::ArtifactCleanupPersisted(RunsArtifactCleanupPersistedOutput {
+            command: "runs.artifact.cleanup-persisted",
+            dry_run: !args.apply,
+            artifact_root: artifact_root.display().to_string(),
+            older_than_days: args.older_than_days,
+            inspected_count: candidates.len(),
+            planned_record_count,
+            planned_file_count,
+            planned_directory_count,
+            planned_size_bytes,
+            removed_record_count,
+            removed_file_count,
+            removed_directory_count,
+            removed_size_bytes,
+            skipped_count,
+            rows,
+        }),
+        0,
+    ))
+}
+
+fn classify_persisted_artifact(
+    candidate: &homeboy::core::observation::ArtifactCleanupCandidateRecord,
+    artifact_root: &Path,
+) -> crate::core::Result<RunsArtifactCleanupPersistedRow> {
+    let artifact = &candidate.artifact;
+    let path = persisted_artifact_path_from_record(artifact_root, &artifact.path);
+    let mut exists = false;
+    let mut size_bytes = 0;
+    let (action, reason) = if artifact.artifact_type == "url"
+        || runner::is_remote_runner_artifact_path(&artifact.path)
+        || artifact.path.starts_with("metadata-only:")
+    {
+        ("skip", "artifact is not local persisted bytes")
+    } else if let Some(metadata) = symlink_metadata_if_exists(&path)? {
+        exists = true;
+        if !path_is_within_root(&path, artifact_root) {
+            ("skip", "existing artifact path is outside artifact root")
+        } else if metadata.file_type().is_symlink() {
+            ("skip", "artifact path is a symlink")
+        } else {
+            size_bytes = path_size_bytes(&path, &metadata)?;
+            ("remove", "artifact bytes and DB row are eligible")
+        }
+    } else {
+        ("remove", "artifact bytes are missing; DB row is stale")
+    };
+
+    Ok(RunsArtifactCleanupPersistedRow {
+        artifact_id: artifact.id.clone(),
+        run_id: artifact.run_id.clone(),
+        run_kind: candidate.run_kind.clone(),
+        component_id: candidate.component_id.clone(),
+        kind: artifact.kind.clone(),
+        artifact_type: artifact.artifact_type.clone(),
+        path: artifact.path.clone(),
+        created_at: artifact.created_at.clone(),
+        exists,
+        action: action.to_string(),
+        reason: reason.to_string(),
+        size_bytes,
+    })
+}
+
+fn apply_persisted_artifact_cleanup(
+    store: &ObservationStore,
+    artifact: &ArtifactRecord,
+    artifact_root: &Path,
+) -> crate::core::Result<()> {
+    let path = persisted_artifact_path_from_record(artifact_root, &artifact.path);
+    if let Some(metadata) = symlink_metadata_if_exists(&path)? {
+        if metadata.file_type().is_symlink() || !path_is_within_root(&path, artifact_root) {
+            return Err(crate::core::Error::validation_invalid_argument(
+                "path",
+                "artifact path failed cleanup safety revalidation",
+                Some(path.display().to_string()),
+                None,
+            ));
+        }
+        if metadata.is_dir() {
+            fs::remove_dir_all(&path).map_err(|err| persisted_artifact_remove_error(&path, err))?;
+        } else {
+            fs::remove_file(&path).map_err(|err| persisted_artifact_remove_error(&path, err))?;
+        }
+    }
+    store.delete_artifact_record(&artifact.id)?;
+    Ok(())
+}
+
+fn persisted_artifact_path_from_record(artifact_root: &Path, raw: &str) -> PathBuf {
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        artifact_root.join(path)
+    }
+}
+
+fn symlink_metadata_if_exists(path: &Path) -> crate::core::Result<Option<fs::Metadata>> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(crate::core::Error::internal_io(
+            err.to_string(),
+            Some(format!("read persisted artifact {}", path.display())),
+        )),
+    }
+}
+
+fn path_is_within_root(path: &Path, artifact_root: &Path) -> bool {
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return false;
+    }
+    let root = fs::canonicalize(artifact_root).unwrap_or_else(|_| artifact_root.to_path_buf());
+    let candidate = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    candidate.starts_with(root)
+}
+
+fn path_size_bytes(path: &Path, metadata: &fs::Metadata) -> crate::core::Result<u64> {
+    if metadata.is_dir() {
+        let mut total = 0;
+        for entry in
+            fs::read_dir(path).map_err(|err| persisted_artifact_read_dir_error(path, err))?
+        {
+            let entry = entry.map_err(|err| persisted_artifact_read_dir_error(path, err))?;
+            let entry_path = entry.path();
+            let metadata = fs::symlink_metadata(&entry_path).map_err(|err| {
+                crate::core::Error::internal_io(
+                    err.to_string(),
+                    Some(format!("read persisted artifact {}", entry_path.display())),
+                )
+            })?;
+            if metadata.file_type().is_symlink() {
+                continue;
+            }
+            total += path_size_bytes(&entry_path, &metadata)?;
+        }
+        Ok(total)
+    } else {
+        Ok(metadata.len())
+    }
+}
+
+fn persisted_artifact_read_dir_error(path: &Path, err: io::Error) -> crate::core::Error {
+    crate::core::Error::internal_io(
+        err.to_string(),
+        Some(format!(
+            "read persisted artifact directory {}",
+            path.display()
+        )),
+    )
+}
+
+fn persisted_artifact_remove_error(path: &Path, err: io::Error) -> crate::core::Error {
+    crate::core::Error::internal_io(
+        err.to_string(),
+        Some(format!("remove persisted artifact {}", path.display())),
+    )
 }
 
 #[derive(Debug, Default)]
@@ -213,11 +438,20 @@ fn relative_cleanup_path(root: &Path, path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    use homeboy::core::observation::NewRunRecord;
 
     use super::*;
 
+    fn artifact_root_test_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
     #[test]
     fn cleanup_downloads_plans_and_removes_runner_cache() {
+        let _guard = artifact_root_test_lock();
         let temp = tempfile::tempdir().expect("tempdir");
         let artifact_root = temp.path().join("artifacts");
         homeboy::core::set_artifact_root_override(Some(artifact_root.clone()));
@@ -261,6 +495,79 @@ mod tests {
         assert!(!run_dir.exists());
 
         homeboy::core::set_artifact_root_override(None);
+    }
+
+    #[test]
+    fn cleanup_persisted_plans_and_removes_local_artifacts() {
+        let _guard = artifact_root_test_lock();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("XDG_DATA_HOME", temp.path().join("data"));
+        let artifact_root = temp.path().join("artifacts");
+        homeboy::core::set_artifact_root_override(Some(artifact_root.clone()));
+
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(
+                NewRunRecord::builder("bench")
+                    .component_id("homeboy")
+                    .command("homeboy bench")
+                    .metadata(serde_json::json!({ "test": true }))
+                    .build(),
+            )
+            .expect("run");
+        let source = temp.path().join("bench.json");
+        fs::write(&source, b"bench").expect("source");
+        let artifact = store
+            .record_artifact(&run.id, "summary", &source)
+            .expect("artifact");
+        let stored_path = PathBuf::from(&artifact.path);
+        assert!(stored_path.exists());
+
+        let dry = cleanup_persisted(RunsArtifactCleanupPersistedArgs {
+            apply: false,
+            older_than_days: 0,
+            run_id: Some(run.id.clone()),
+            kind: None,
+            artifact_type: None,
+            run_kind: None,
+            component_id: None,
+            limit: 100,
+        })
+        .expect("dry-run")
+        .0;
+        let RunsOutput::ArtifactCleanupPersisted(dry) = dry else {
+            panic!("unexpected output");
+        };
+        assert!(dry.dry_run);
+        assert_eq!(dry.planned_record_count, 1);
+        assert_eq!(dry.planned_file_count, 1);
+        assert_eq!(dry.planned_size_bytes, 5);
+        assert!(stored_path.exists());
+        assert!(store.get_artifact(&artifact.id).expect("get").is_some());
+
+        let applied = cleanup_persisted(RunsArtifactCleanupPersistedArgs {
+            apply: true,
+            older_than_days: 0,
+            run_id: Some(run.id.clone()),
+            kind: None,
+            artifact_type: None,
+            run_kind: None,
+            component_id: None,
+            limit: 100,
+        })
+        .expect("apply")
+        .0;
+        let RunsOutput::ArtifactCleanupPersisted(applied) = applied else {
+            panic!("unexpected output");
+        };
+        assert!(!applied.dry_run);
+        assert_eq!(applied.removed_record_count, 1);
+        assert_eq!(applied.removed_file_count, 1);
+        assert!(!stored_path.exists());
+        assert!(store.get_artifact(&artifact.id).expect("get").is_none());
+
+        homeboy::core::set_artifact_root_override(None);
+        std::env::remove_var("XDG_DATA_HOME");
     }
 
     #[test]

--- a/src/commands/self_cmd.rs
+++ b/src/commands/self_cmd.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Subcommand};
+use homeboy::core::engine;
 use homeboy::core::self_status;
 use serde_json::Value;
 
@@ -15,6 +16,8 @@ pub struct SelfArgs {
 pub enum SelfCommand {
     /// Report active binary, version, and nearby install/update signals
     Status(SelfStatusArgs),
+    /// Plan or delete orphaned Homeboy runtime temp entries
+    CleanupRuntimeTmp(SelfCleanupRuntimeTmpArgs),
 }
 
 #[derive(Args)]
@@ -23,11 +26,38 @@ pub struct SelfStatusArgs {
     _json: HiddenJsonArgs,
 }
 
+#[derive(Args)]
+pub struct SelfCleanupRuntimeTmpArgs {
+    /// Delete planned temp entries. Without this flag, only reports the plan.
+    #[arg(long)]
+    pub apply: bool,
+    /// Only include entries older than this many days.
+    #[arg(long, default_value_t = 7)]
+    pub older_than_days: u64,
+    /// Only include entries whose directory/file name starts with this prefix.
+    #[arg(long)]
+    pub prefix: Option<String>,
+    /// Maximum temp entries to inspect in one invocation.
+    #[arg(long, default_value_t = 1000)]
+    pub limit: usize,
+}
+
 pub fn run(args: SelfArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     match args.command {
         SelfCommand::Status(_) => {
             let status = self_status::collect_status();
             let json = serde_json::to_value(status)
+                .map_err(|e| homeboy::core::Error::internal_json(e.to_string(), None))?;
+            Ok((json, 0))
+        }
+        SelfCommand::CleanupRuntimeTmp(args) => {
+            let output = engine::temp::cleanup_runtime_tmp(
+                args.apply,
+                args.older_than_days,
+                args.prefix.as_deref(),
+                args.limit,
+            )?;
+            let json = serde_json::to_value(output)
                 .map_err(|e| homeboy::core::Error::internal_json(e.to_string(), None))?;
             Ok((json, 0))
         }

--- a/src/core/engine/temp.rs
+++ b/src/core/engine/temp.rs
@@ -1,12 +1,14 @@
 use crate::core::error::{Error, Result};
 use crate::core::paths;
+use serde::Serialize;
 use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
+use std::time::{Duration, SystemTime};
 
 const HOMEBOY_RUNTIME_TMPDIR_ENV: &str = "HOMEBOY_RUNTIME_TMPDIR";
 
-fn runtime_root() -> Result<PathBuf> {
+pub fn runtime_root() -> Result<PathBuf> {
     if let Ok(override_dir) = env::var(HOMEBOY_RUNTIME_TMPDIR_ENV) {
         let trimmed = override_dir.trim();
         if !trimmed.is_empty() {
@@ -15,6 +17,171 @@ fn runtime_root() -> Result<PathBuf> {
     }
 
     Ok(paths::homeboy()?.join("runtime").join("tmp"))
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeTempCleanupOutput {
+    pub command: &'static str,
+    pub dry_run: bool,
+    pub runtime_tmp_root: String,
+    pub older_than_days: u64,
+    pub prefix: Option<String>,
+    pub inspected_count: usize,
+    pub planned_count: usize,
+    pub planned_size_bytes: u64,
+    pub removed_count: usize,
+    pub removed_size_bytes: u64,
+    pub skipped_count: usize,
+    pub rows: Vec<RuntimeTempCleanupRow>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeTempCleanupRow {
+    pub path: String,
+    pub name: String,
+    pub action: String,
+    pub reason: String,
+    pub size_bytes: u64,
+}
+
+pub fn cleanup_runtime_tmp(
+    apply: bool,
+    older_than_days: u64,
+    prefix: Option<&str>,
+    limit: usize,
+) -> Result<RuntimeTempCleanupOutput> {
+    let root = runtime_root()?;
+    let mut output = RuntimeTempCleanupOutput {
+        command: "self.cleanup-runtime-tmp",
+        dry_run: !apply,
+        runtime_tmp_root: root.display().to_string(),
+        older_than_days,
+        prefix: prefix.map(str::to_string),
+        inspected_count: 0,
+        planned_count: 0,
+        planned_size_bytes: 0,
+        removed_count: 0,
+        removed_size_bytes: 0,
+        skipped_count: 0,
+        rows: Vec::new(),
+    };
+
+    if !root.exists() {
+        return Ok(output);
+    }
+
+    let cutoff = SystemTime::now()
+        .checked_sub(Duration::from_secs(older_than_days.saturating_mul(86_400)))
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+
+    let mut entries = fs::read_dir(&root)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("read runtime tmp directory".into())))?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|e| Error::internal_io(e.to_string(), Some("read runtime tmp entry".into())))?;
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries.into_iter().take(limit.max(1)) {
+        output.inspected_count += 1;
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        let mut row = RuntimeTempCleanupRow {
+            path: path.display().to_string(),
+            name: name.clone(),
+            action: "skip".to_string(),
+            reason: String::new(),
+            size_bytes: 0,
+        };
+
+        let metadata = fs::symlink_metadata(&path).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("read runtime tmp {}", path.display())),
+            )
+        })?;
+
+        if prefix.is_some_and(|prefix| !name.starts_with(prefix)) {
+            row.reason = "entry does not match prefix".to_string();
+            output.skipped_count += 1;
+        } else if metadata.file_type().is_symlink() {
+            row.reason = "entry is a symlink".to_string();
+            output.skipped_count += 1;
+        } else if !path_is_within_root(&path, &root) {
+            row.reason = "entry path is outside runtime tmp root".to_string();
+            output.skipped_count += 1;
+        } else if metadata.modified().is_ok_and(|modified| modified > cutoff) {
+            row.reason = "entry is newer than retention cutoff".to_string();
+            output.skipped_count += 1;
+        } else {
+            row.action = if apply { "removed" } else { "remove" }.to_string();
+            row.reason = "runtime tmp entry is eligible".to_string();
+            row.size_bytes = path_size_bytes(&path, &metadata)?;
+            output.planned_count += 1;
+            output.planned_size_bytes += row.size_bytes;
+            if apply {
+                remove_runtime_tmp_entry(&path, &metadata)?;
+                output.removed_count += 1;
+                output.removed_size_bytes += row.size_bytes;
+            }
+        }
+
+        output.rows.push(row);
+    }
+
+    Ok(output)
+}
+
+fn path_is_within_root(path: &Path, root: &Path) -> bool {
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return false;
+    }
+    let root = fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let candidate = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    candidate.starts_with(root)
+}
+
+fn path_size_bytes(path: &Path, metadata: &fs::Metadata) -> Result<u64> {
+    if metadata.is_dir() {
+        let mut total = 0;
+        for entry in fs::read_dir(path).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("read directory {}", path.display())),
+            )
+        })? {
+            let entry = entry.map_err(|e| {
+                Error::internal_io(
+                    e.to_string(),
+                    Some(format!("read directory {}", path.display())),
+                )
+            })?;
+            let entry_path = entry.path();
+            let metadata = fs::symlink_metadata(&entry_path).map_err(|e| {
+                Error::internal_io(
+                    e.to_string(),
+                    Some(format!("read runtime tmp {}", entry_path.display())),
+                )
+            })?;
+            if metadata.file_type().is_symlink() {
+                continue;
+            }
+            total += path_size_bytes(&entry_path, &metadata)?;
+        }
+        Ok(total)
+    } else {
+        Ok(metadata.len())
+    }
+}
+
+fn remove_runtime_tmp_entry(path: &Path, metadata: &fs::Metadata) -> Result<()> {
+    if metadata.is_dir() {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_file(path)
+    }
+    .map_err(|e| Error::internal_io(e.to_string(), Some(format!("remove {}", path.display()))))
 }
 
 fn ensure_runtime_tmp_dir() -> Result<PathBuf> {
@@ -74,5 +241,26 @@ mod tests {
         if let Ok(path) = result {
             assert!(path.is_dir());
         }
+    }
+
+    #[test]
+    fn cleanup_runtime_tmp_plans_and_removes_old_entries() {
+        let _guard = home_env_guard();
+        let dir = tempfile::tempdir().expect("tempdir");
+        env::set_var(HOMEBOY_RUNTIME_TMPDIR_ENV, dir.path());
+        let stale = runtime_temp_dir("homeboy-run").expect("temp dir");
+        fs::write(stale.join("trace.json"), b"trace").expect("write trace");
+
+        let dry = cleanup_runtime_tmp(false, 0, Some("homeboy-run"), 100).expect("dry-run");
+        assert!(dry.dry_run);
+        assert_eq!(dry.planned_count, 1);
+        assert!(stale.exists());
+
+        let applied = cleanup_runtime_tmp(true, 0, Some("homeboy-run"), 100).expect("apply");
+        assert!(!applied.dry_run);
+        assert_eq!(applied.removed_count, 1);
+        assert!(!stale.exists());
+
+        env::remove_var(HOMEBOY_RUNTIME_TMPDIR_ENV);
     }
 }

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -16,11 +16,12 @@ pub use budget_findings::finding_records_from_budget;
 pub use records::{
     finding_record_from_annotation, finding_record_from_audit, finding_record_from_lint,
     finding_records_from_annotation_file, finding_records_from_annotations_dir,
-    finding_records_from_audit, finding_records_from_lint, AnnotationFindingRecord, ArtifactRecord,
-    FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord, NewRunRecordBuilder,
-    NewTraceRunRecord, NewTraceRunRecordBuilder, NewTraceSpanRecord, NewTraceSpanRecordBuilder,
-    NewTriageItemRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord,
-    TriageItemRecord, TriagePullRequestSignals,
+    finding_records_from_audit, finding_records_from_lint, AnnotationFindingRecord,
+    ArtifactCleanupCandidateRecord, ArtifactCleanupFilter, ArtifactRecord, FindingListFilter,
+    FindingRecord, NewFindingRecord, NewRunRecord, NewRunRecordBuilder, NewTraceRunRecord,
+    NewTraceRunRecordBuilder, NewTraceSpanRecord, NewTraceSpanRecordBuilder, NewTriageItemRecord,
+    RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord,
+    TriagePullRequestSignals,
 };
 pub use store::{
     ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION, LAB_OFFLOAD_METADATA_ENV,

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -76,6 +76,26 @@ pub struct ArtifactRecord {
     pub created_at: String,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ArtifactCleanupFilter {
+    pub created_before: Option<String>,
+    pub run_id: Option<String>,
+    pub kind: Option<String>,
+    pub artifact_type: Option<String>,
+    pub run_kind: Option<String>,
+    pub component_id: Option<String>,
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactCleanupCandidateRecord {
+    pub artifact: ArtifactRecord,
+    pub run_kind: String,
+    pub component_id: Option<String>,
+    pub run_started_at: String,
+    pub run_status: String,
+}
+
 fn default_artifact_type() -> String {
     "file".to_string()
 }

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -11,9 +11,10 @@ mod schema;
 mod triage_items;
 
 use super::records::{
-    ArtifactRecord, FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord,
-    NewTraceRunRecord, NewTraceSpanRecord, NewTriageItemRecord, RunListFilter, RunRecord,
-    RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord, TriagePullRequestSignals,
+    ArtifactCleanupCandidateRecord, ArtifactCleanupFilter, ArtifactRecord, FindingListFilter,
+    FindingRecord, NewFindingRecord, NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord,
+    NewTriageItemRecord, RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord,
+    TriageItemRecord, TriagePullRequestSignals,
 };
 use crate::core::{paths, Error, Result};
 
@@ -562,6 +563,58 @@ impl ObservationStore {
             .map_err(sqlite_error("read artifact record"))
     }
 
+    pub fn list_artifact_cleanup_candidates(
+        &self,
+        filter: ArtifactCleanupFilter,
+    ) -> Result<Vec<ArtifactCleanupCandidateRecord>> {
+        let limit = filter.limit.unwrap_or(1000).clamp(1, 10_000);
+        let mut statement = self
+            .connection
+            .prepare(
+                r#"
+                SELECT a.id, a.run_id, a.kind, a.artifact_type, a.path, a.sha256,
+                       a.size_bytes, a.mime, a.created_at,
+                       r.kind, r.component_id, r.started_at, r.status
+                FROM artifacts a
+                INNER JOIN runs r ON r.id = a.run_id
+                WHERE (?1 IS NULL OR a.created_at < ?1)
+                  AND (?2 IS NULL OR a.run_id = ?2)
+                  AND (?3 IS NULL OR a.kind = ?3)
+                  AND (?4 IS NULL OR a.artifact_type = ?4)
+                  AND (?5 IS NULL OR r.kind = ?5)
+                  AND (?6 IS NULL OR r.component_id = ?6)
+                ORDER BY a.created_at ASC, a.id ASC
+                LIMIT ?7
+                "#,
+            )
+            .map_err(sqlite_error("prepare artifact cleanup candidates"))?;
+        let rows = statement
+            .query_map(
+                params![
+                    filter.created_before.as_deref(),
+                    filter.run_id.as_deref(),
+                    filter.kind.as_deref(),
+                    filter.artifact_type.as_deref(),
+                    filter.run_kind.as_deref(),
+                    filter.component_id.as_deref(),
+                    limit,
+                ],
+                row_to_artifact_cleanup_candidate,
+            )
+            .map_err(sqlite_error("list artifact cleanup candidates"))?;
+
+        collect_rows(rows, "collect artifact cleanup candidates")
+    }
+
+    pub fn delete_artifact_record(&self, artifact_id: &str) -> Result<bool> {
+        validate_required("artifact_id", artifact_id)?;
+        let rows = self
+            .connection
+            .execute("DELETE FROM artifacts WHERE id = ?1", [artifact_id])
+            .map_err(sqlite_error("delete artifact record"))?;
+        Ok(rows > 0)
+    }
+
     pub fn record_trace_run(&self, record: NewTraceRunRecord) -> Result<TraceRunRecord> {
         let run_id = record.run_id.clone();
         validate_required("run_id", &record.run_id)?;
@@ -883,6 +936,18 @@ fn row_to_artifact_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<ArtifactR
         size_bytes: row.get(6)?,
         mime: row.get(7)?,
         created_at: row.get(8)?,
+    })
+}
+
+fn row_to_artifact_cleanup_candidate(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<ArtifactCleanupCandidateRecord> {
+    Ok(ArtifactCleanupCandidateRecord {
+        artifact: row_to_artifact_record(row)?,
+        run_kind: row.get(9)?,
+        component_id: row.get(10)?,
+        run_started_at: row.get(11)?,
+        run_status: row.get(12)?,
     })
 }
 

--- a/tests/output_contracts_test.rs
+++ b/tests/output_contracts_test.rs
@@ -123,6 +123,26 @@ fn runs_rig_and_bench_output_variants_have_unambiguous_contracts() {
                 }),
             ),
             variant_contract(
+                "artifact_cleanup_persisted",
+                json!({
+                    "command": "runs.artifact.cleanup-persisted",
+                    "dry_run": true,
+                    "artifact_root": "/tmp/homeboy/artifacts",
+                    "older_than_days": 30,
+                    "inspected_count": 0,
+                    "planned_record_count": 0,
+                    "planned_file_count": 0,
+                    "planned_directory_count": 0,
+                    "planned_size_bytes": 0,
+                    "removed_record_count": 0,
+                    "removed_file_count": 0,
+                    "removed_directory_count": 0,
+                    "removed_size_bytes": 0,
+                    "skipped_count": 0,
+                    "rows": []
+                }),
+            ),
+            variant_contract(
                 "findings",
                 json!({ "command": "runs.findings", "findings": [] }),
             ),


### PR DESCRIPTION
## Summary
- add `runs artifact cleanup-persisted` to dry-run/apply cleanup of persisted local artifact bytes and stale artifact DB rows
- add `self cleanup-runtime-tmp` to dry-run/apply cleanup of orphaned runtime temp entries
- keep cleanup bounded with retention, prefix/filter, limit, symlink, and root-containment safeguards

## Verification
- `cargo test commands::runs::remote_artifact::tests --lib`
- `cargo test cleanup_runtime_tmp_plans_and_removes_old_entries --lib`
- `cargo test --test output_contracts_test`
- local cleanup smoke: persisted artifact root reduced to `0B`; runtime tmp reduced to `408K`; follow-up dry-runs reported no remaining eligible cleanup

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the cleanup command implementation, tests, local cleanup execution, and verification summary; Chris remains responsible for review and merge.