### PR TITLE
feat: add runtime sidecar writer helper

### DIFF
--- a/src/core/extension/runtime/sidecar-writer.sh
+++ b/src/core/extension/runtime/sidecar-writer.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+
+# Shared JSON sidecar writer for extension runner scripts.
+#
+# The helper owns the common "sidecar is a JSON array" file mechanics used by
+# lint findings, test failures, and fix results. Callers still build the
+# domain-specific JSON object; this helper validates it, writes atomically, and
+# keeps empty/missing target env vars as no-ops for legacy compatibility.
+#
+# Usage:
+#   source "${HOMEBOY_RUNTIME_SIDECAR_WRITER}"
+#   homeboy_sidecar_append_json "$HOMEBOY_LINT_FINDINGS_FILE" '{"message":"..."}'
+#   homeboy_sidecar_write_json_array "$HOMEBOY_TEST_FAILURES_FILE" "$failure_json"
+#   homeboy_sidecar_merge_json_array "$HOMEBOY_FIX_RESULTS_FILE" "$tmp_results"
+
+homeboy_sidecar_python() {
+    if command -v python3 >/dev/null 2>&1; then
+        command -v python3
+        return 0
+    fi
+    if command -v python >/dev/null 2>&1; then
+        command -v python
+        return 0
+    fi
+    echo "[sidecar-writer] python3 or python is required" >&2
+    return 1
+}
+
+homeboy_sidecar_write_json_array() {
+    local target="${1:-}"
+    shift || true
+
+    if [ -z "$target" ]; then
+        return 0
+    fi
+
+    local python_bin
+    python_bin="$(homeboy_sidecar_python)" || return 1
+
+    "$python_bin" - "$target" "$@" <<'PYEOF'
+import json
+import os
+import sys
+import tempfile
+
+target = sys.argv[1]
+items = [json.loads(raw) for raw in sys.argv[2:]]
+directory = os.path.dirname(target) or "."
+os.makedirs(directory, exist_ok=True)
+fd, tmp = tempfile.mkstemp(prefix=".homeboy-sidecar-", suffix=".json", dir=directory)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(items, handle, separators=(",", ":"), ensure_ascii=False)
+        handle.write("\n")
+    os.replace(tmp, target)
+except Exception:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
+PYEOF
+}
+
+homeboy_sidecar_append_json() {
+    local target="${1:-}"
+    local item="${2:-}"
+
+    if [ -z "$target" ]; then
+        return 0
+    fi
+
+    local python_bin
+    python_bin="$(homeboy_sidecar_python)" || return 1
+
+    "$python_bin" - "$target" "$item" <<'PYEOF'
+import json
+import os
+import sys
+import tempfile
+
+target = sys.argv[1]
+item = json.loads(sys.argv[2])
+items = []
+if os.path.exists(target) and os.path.getsize(target) > 0:
+    with open(target, "r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if isinstance(loaded, list):
+        items = loaded
+    else:
+        raise ValueError(f"sidecar must contain a JSON array: {target}")
+items.append(item)
+directory = os.path.dirname(target) or "."
+os.makedirs(directory, exist_ok=True)
+fd, tmp = tempfile.mkstemp(prefix=".homeboy-sidecar-", suffix=".json", dir=directory)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(items, handle, separators=(",", ":"), ensure_ascii=False)
+        handle.write("\n")
+    os.replace(tmp, target)
+except Exception:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
+PYEOF
+}
+
+homeboy_sidecar_merge_json_array() {
+    local target="${1:-}"
+    local source="${2:-}"
+
+    if [ -z "$target" ] || [ -z "$source" ] || [ ! -s "$source" ]; then
+        return 0
+    fi
+
+    local python_bin
+    python_bin="$(homeboy_sidecar_python)" || return 1
+
+    "$python_bin" - "$target" "$source" <<'PYEOF'
+import json
+import os
+import sys
+import tempfile
+
+target = sys.argv[1]
+source = sys.argv[2]
+items = []
+if os.path.exists(target) and os.path.getsize(target) > 0:
+    with open(target, "r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if isinstance(loaded, list):
+        items = loaded
+    else:
+        raise ValueError(f"sidecar must contain a JSON array: {target}")
+with open(source, "r", encoding="utf-8") as handle:
+    incoming = json.load(handle)
+if not isinstance(incoming, list):
+    raise ValueError(f"source sidecar must contain a JSON array: {source}")
+items.extend(incoming)
+directory = os.path.dirname(target) or "."
+os.makedirs(directory, exist_ok=True)
+fd, tmp = tempfile.mkstemp(prefix=".homeboy-sidecar-", suffix=".json", dir=directory)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(items, handle, separators=(",", ":"), ensure_ascii=False)
+        handle.write("\n")
+    os.replace(tmp, target)
+except Exception:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
+PYEOF
+}
+
+homeboy_write_lint_findings() {
+    homeboy_sidecar_write_json_array "${HOMEBOY_LINT_FINDINGS_FILE:-}" "$@"
+}
+
+homeboy_append_lint_finding() {
+    homeboy_sidecar_append_json "${HOMEBOY_LINT_FINDINGS_FILE:-}" "$1"
+}
+
+homeboy_merge_lint_findings() {
+    homeboy_sidecar_merge_json_array "${HOMEBOY_LINT_FINDINGS_FILE:-}" "$1"
+}
+
+homeboy_write_test_failures() {
+    homeboy_sidecar_write_json_array "${HOMEBOY_TEST_FAILURES_FILE:-}" "$@"
+}
+
+homeboy_append_test_failure() {
+    homeboy_sidecar_append_json "${HOMEBOY_TEST_FAILURES_FILE:-}" "$1"
+}
+
+homeboy_merge_test_failures() {
+    homeboy_sidecar_merge_json_array "${HOMEBOY_TEST_FAILURES_FILE:-}" "$1"
+}
+
+homeboy_write_fix_results() {
+    homeboy_sidecar_write_json_array "${HOMEBOY_FIX_RESULTS_FILE:-}" "$@"
+}
+
+homeboy_append_fix_result() {
+    homeboy_sidecar_append_json "${HOMEBOY_FIX_RESULTS_FILE:-}" "$1"
+}
+
+homeboy_merge_fix_results() {
+    homeboy_sidecar_merge_json_array "${HOMEBOY_FIX_RESULTS_FILE:-}" "$1"
+}

--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -10,6 +10,7 @@ mod assets;
 pub const RUNNER_STEPS_ENV: &str = "HOMEBOY_RUNTIME_RUNNER_STEPS";
 pub const FAILURE_TRAP_ENV: &str = "HOMEBOY_RUNTIME_FAILURE_TRAP";
 pub const WRITE_TEST_RESULTS_ENV: &str = "HOMEBOY_RUNTIME_WRITE_TEST_RESULTS";
+pub const SIDECAR_WRITER_ENV: &str = "HOMEBOY_RUNTIME_SIDECAR_WRITER";
 pub const RESOLVE_CONTEXT_ENV: &str = "HOMEBOY_RUNTIME_RESOLVE_CONTEXT";
 pub const BENCH_HELPER_SH_ENV: &str = "HOMEBOY_RUNTIME_BENCH_HELPER_SH";
 pub const BENCH_HELPER_JS_ENV: &str = "HOMEBOY_RUNTIME_BENCH_HELPER_JS";
@@ -39,6 +40,12 @@ const HELPERS: &[RuntimeHelper] = &[
         filename: "write-test-results.sh",
         content: assets::WRITE_TEST_RESULTS_SH,
         env_var: WRITE_TEST_RESULTS_ENV,
+        legacy_fallback: false,
+    },
+    RuntimeHelper {
+        filename: "sidecar-writer.sh",
+        content: assets::SIDECAR_WRITER_SH,
+        env_var: SIDECAR_WRITER_ENV,
         legacy_fallback: false,
     },
     RuntimeHelper {

--- a/src/core/extension/runtime_helper/assets.rs
+++ b/src/core/extension/runtime_helper/assets.rs
@@ -1,6 +1,7 @@
 pub(super) const RUNNER_STEPS_SH: &str = include_str!("../runtime/runner-steps.sh");
 pub(super) const FAILURE_TRAP_SH: &str = include_str!("../runtime/failure-trap.sh");
 pub(super) const WRITE_TEST_RESULTS_SH: &str = include_str!("../runtime/write-test-results.sh");
+pub(super) const SIDECAR_WRITER_SH: &str = include_str!("../runtime/sidecar-writer.sh");
 pub(super) const RESOLVE_CONTEXT_SH: &str = include_str!("../runtime/resolve-context.sh");
 pub(super) const BENCH_HELPER_SH: &str = include_str!("../runtime/bench-helper.sh");
 pub(super) const BENCH_HELPER_JS: &str = include_str!("../runtime/bench-helper.mjs");
@@ -16,6 +17,7 @@ mod tests {
             RUNNER_STEPS_SH,
             FAILURE_TRAP_SH,
             WRITE_TEST_RESULTS_SH,
+            SIDECAR_WRITER_SH,
             RESOLVE_CONTEXT_SH,
             BENCH_HELPER_SH,
             BENCH_HELPER_JS,

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -22,6 +22,10 @@ fn ensure_all_helpers_writes_all_files() {
             "write test results helper should be in pairs"
         );
         assert!(
+            pairs.iter().any(|(k, _)| k == SIDECAR_WRITER_ENV),
+            "sidecar writer helper should be in pairs"
+        );
+        assert!(
             pairs.iter().any(|(k, _)| k == RESOLVE_CONTEXT_ENV),
             "resolve context helper should be in pairs"
         );
@@ -34,6 +38,72 @@ fn ensure_all_helpers_writes_all_files() {
             "bench PHP helper should be in pairs"
         );
     });
+}
+
+#[test]
+fn sidecar_writer_appends_and_merges_json_arrays() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("sidecar-writer.sh");
+    let target_path = dir.path().join("lint-findings.json");
+    let source_path = dir.path().join("extra-findings.json");
+    std::fs::write(&helper_path, assets::SIDECAR_WRITER_SH).expect("write helper");
+    std::fs::write(&source_path, r#"[{"id":"third","message":"three"}]"#).expect("source");
+
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {}; HOMEBOY_LINT_FINDINGS_FILE={}; homeboy_append_lint_finding '{{\"id\":\"first\",\"message\":\"one\"}}'; homeboy_append_lint_finding '{{\"id\":\"second\",\"message\":\"two\"}}'; homeboy_merge_lint_findings {}; cat {}",
+            helper_path.display(),
+            target_path.display(),
+            source_path.display(),
+            target_path.display()
+        ))
+        .output()
+        .expect("run bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        r#"[{"id":"first","message":"one"},{"id":"second","message":"two"},{"id":"third","message":"three"}]
+"#
+    );
+}
+
+#[test]
+fn sidecar_writer_supports_test_failure_and_fix_result_wrappers() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("sidecar-writer.sh");
+    let failures_path = dir.path().join("test-failures.json");
+    let fixes_path = dir.path().join("fix-results.json");
+    std::fs::write(&helper_path, assets::SIDECAR_WRITER_SH).expect("write helper");
+
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {}; HOMEBOY_TEST_FAILURES_FILE={}; HOMEBOY_FIX_RESULTS_FILE={}; homeboy_write_test_failures '{{\"test_id\":\"suite::case\",\"message\":\"failed\"}}'; homeboy_write_fix_results '{{\"file\":\"src/lib.rs\",\"message\":\"formatted\"}}'; printf '%s\n%s' \"$(cat {})\" \"$(cat {})\"",
+            helper_path.display(),
+            failures_path.display(),
+            fixes_path.display(),
+            failures_path.display(),
+            fixes_path.display()
+        ))
+        .output()
+        .expect("run bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        r#"[{"test_id":"suite::case","message":"failed"}]
+[{"file":"src/lib.rs","message":"formatted"}]"#
+    );
 }
 
 #[test]

--- a/tests/core/extension/runtime_helper_test.rs
+++ b/tests/core/extension/runtime_helper_test.rs
@@ -16,4 +16,8 @@ fn test_ensure_all_helpers() {
         RUNTIME_HELPER_TESTS_RS.contains("ensure_all_helpers_writes_legacy_bench_fallbacks"),
         "unit tests should cover legacy bench helper materialization"
     );
+    assert!(
+        RUNTIME_HELPER_RS.contains("HOMEBOY_RUNTIME_SIDECAR_WRITER"),
+        "extension env should expose the shared sidecar writer helper"
+    );
 }


### PR DESCRIPTION
## Summary
- Adds a core runtime `sidecar-writer.sh` helper exported as `HOMEBOY_RUNTIME_SIDECAR_WRITER`.
- Provides generic JSON-array write/append/merge helpers plus lint findings, test failures, and fix results wrappers.
- Keeps `write-test-results.sh` behavior unchanged; extension migrations can adopt the new helper later.

Fixes https://github.com/Extra-Chill/homeboy/issues/2912

## Verification
- `cargo fmt --check`
- `cargo test core::extension::runtime_helper`
- `bash -n src/core/extension/runtime/sidecar-writer.sh`
- `cargo check`
- `homeboy lint --path /Users/chubes/Developer/homeboy@feat-runtime-sidecar-helpers --extension rust --force-hot`
- `homeboy test --path /Users/chubes/Developer/homeboy@feat-runtime-sidecar-helpers --extension rust --force-hot --skip-lint -- core::extension::runtime_helper`

## Notes
- An initial `homeboy lint --path /Users/chubes/Developer/homeboy@feat-runtime-sidecar-helpers --extension rust` attempt failed before execution because default lab offload selected runner `lab`, which is missing the `rust` extension. Local `--force-hot` verification passed.
- An initial `homeboy test ... --glob core::extension::runtime_helper` attempt failed because `--glob` is not a `homeboy test` option for Rust passthrough. The corrected targeted command above passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the core runtime helper, tests, verification, and PR drafting; Chris remains responsible for review and merge.