### PR TITLE
Remove standalone SSH runner compatibility

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -45,23 +45,6 @@ homeboy runner connect homeboy-lab
 
 After this, `homeboy-lab` is both the server ID and the runner ID.
 
-### `migrate`
-
-```sh
-homeboy runner migrate <legacy-runner-id>
-homeboy runner migrate <legacy-runner-id> --remove-legacy
-```
-
-Migrates a pre-capability standalone SSH runner onto the server referenced by its `server_id`. Use this for old Lab configs such as runner `lab` pointing at server `homeboy-lab`:
-
-```sh
-homeboy runner migrate lab
-homeboy runner show homeboy-lab
-homeboy runner migrate lab --remove-legacy
-```
-
-The migration copies `workspace_root`, `homeboy_path`, `daemon`, `concurrency_limit`, `artifact_policy`, `env`, and `resources` into the server's embedded `runner` capability. Without `--remove-legacy`, the old `~/.config/homeboy/runners/<legacy-runner-id>.json` file is preserved so the result can be inspected first. With `--remove-legacy`, Homeboy deletes the legacy standalone runner after the server capability has been saved.
-
 Hot commands that support Lab offload (`audit`, full `lint`, `test`, `bench run`, and `trace`) auto-select a default Lab runner when `--runner` is omitted. Selection is conservative:
 
 - `--runner <id>` always wins.
@@ -338,7 +321,7 @@ Rules:
 
 All command output is wrapped in the global JSON envelope described in the [JSON output contract](../architecture/output-system.md). The `data` payload uses the generic entity CRUD shape:
 
-- `command`: action identifier such as `runner.add`, `runner.enable`, `runner.migrate`, `runner.list`, `runner.show`, `runner.set`, `runner.remove`, `runner.doctor`, `runner.connect`, `runner.status`, `runner.disconnect`, `runner.exec`, `runner.workspace.sync`, or `runner.workspace.apply`
+- `command`: action identifier such as `runner.add`, `runner.enable`, `runner.list`, `runner.show`, `runner.set`, `runner.remove`, `runner.doctor`, `runner.connect`, `runner.status`, `runner.disconnect`, `runner.exec`, `runner.workspace.sync`, or `runner.workspace.apply`
 - `id`: present for single-runner actions
 - `entity`: runner configuration for single-runner read/write actions
 - `entities`: list for `list`

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -122,15 +122,6 @@ enum RunnerCommand {
         #[arg(long)]
         artifact_policy: Option<String>,
     },
-    /// Migrate a legacy standalone SSH runner onto its referenced server
-    Migrate {
-        /// Legacy standalone SSH runner ID, for example `lab`
-        runner_id: String,
-
-        /// Delete the old standalone runner after copying it to the server
-        #[arg(long)]
-        remove_legacy: bool,
-    },
     /// List all configured runners
     List,
     /// Display runner configuration
@@ -312,38 +303,6 @@ pub fn run(
                 artifact_policy,
             },
         )),
-        RunnerCommand::Migrate {
-            runner_id,
-            remove_legacy,
-        } => map_registry({
-            let runner = runner::migrate_standalone_ssh_runner(&runner_id, remove_legacy)?;
-            let mut deleted = Vec::new();
-            let hint = if remove_legacy {
-                deleted.push(runner_id.to_string());
-                Some(format!(
-                    "Legacy runner '{runner_id}' was removed. Use runner ID '{}' for this Lab server.",
-                    runner.id
-                ))
-            } else {
-                Some(format!(
-                    "Legacy runner '{runner_id}' was preserved. Re-run with --remove-legacy after verifying runner '{}' works.",
-                    runner.id
-                ))
-            };
-
-            Ok((
-                RunnerOutput {
-                    command: "runner.migrate".to_string(),
-                    id: Some(runner.id.clone()),
-                    entity: Some(runner),
-                    updated_fields: vec!["server.runner".to_string()],
-                    deleted,
-                    hint,
-                    ..Default::default()
-                },
-                0,
-            ))
-        }),
         RunnerCommand::List => map_registry(list()),
         RunnerCommand::Show { id } => map_registry(show(&id)),
         RunnerCommand::Set { args } => map_registry(set(args)),

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -114,15 +114,20 @@ impl ConfigEntity for Runner {
 }
 
 pub fn load(id: &str) -> Result<Runner> {
-    if config::exists::<Runner>(id) {
-        return config::load::<Runner>(id);
+    if let Ok(runner) = config::load::<Runner>(id) {
+        if runner.kind == RunnerKind::Local {
+            return Ok(runner);
+        }
     }
 
     load_server_runner(id)
 }
 
 pub fn list() -> Result<Vec<Runner>> {
-    let mut runners = config::list::<Runner>()?;
+    let mut runners: Vec<Runner> = config::list::<Runner>()?
+        .into_iter()
+        .filter(|runner| runner.kind == RunnerKind::Local)
+        .collect();
     runners.extend(
         server::list()?
             .into_iter()
@@ -236,12 +241,14 @@ pub fn merge(id: Option<&str>, json_spec: &str, replace_fields: &[String]) -> Re
             )
         })?;
 
-    if config::exists::<Runner>(&effective_id) {
-        return Ok(MergeOutput::Single(config::merge_from_json::<Runner>(
-            Some(&effective_id),
-            &raw,
-            replace_fields,
-        )?));
+    if let Ok(runner) = config::load::<Runner>(&effective_id) {
+        if runner.kind == RunnerKind::Local {
+            return Ok(MergeOutput::Single(config::merge_from_json::<Runner>(
+                Some(&effective_id),
+                &raw,
+                replace_fields,
+            )?));
+        }
     }
 
     Ok(MergeOutput::Single(merge_server_runner(
@@ -252,8 +259,10 @@ pub fn merge(id: Option<&str>, json_spec: &str, replace_fields: &[String]) -> Re
 }
 
 pub fn delete_safe(id: &str) -> Result<()> {
-    if config::exists::<Runner>(id) {
-        return config::delete_safe::<Runner>(id);
+    if let Ok(runner) = config::load::<Runner>(id) {
+        if runner.kind == RunnerKind::Local {
+            return config::delete_safe::<Runner>(id);
+        }
     }
 
     let mut server = server::load(id)?;
@@ -265,7 +274,10 @@ pub fn delete_safe(id: &str) -> Result<()> {
 }
 
 pub fn exists(id: &str) -> bool {
-    config::exists::<Runner>(id) || load_server_runner(id).is_ok()
+    config::load::<Runner>(id)
+        .map(|runner| runner.kind == RunnerKind::Local)
+        .unwrap_or(false)
+        || load_server_runner(id).is_ok()
 }
 
 pub fn enable_server_runner(server_id: &str, patch: Value) -> Result<Runner> {
@@ -279,51 +291,6 @@ pub fn enable_server_runner(server_id: &str, patch: Value) -> Result<Runner> {
     server.runner = Some(runner.clone());
     server::save(&server)?;
     Ok(runner_from_server(server_id, runner))
-}
-
-pub fn migrate_standalone_ssh_runner(id: &str, remove_legacy: bool) -> Result<Runner> {
-    let runner = config::load::<Runner>(id)?;
-    if !matches!(runner.kind, RunnerKind::Ssh) {
-        return Err(Error::validation_invalid_argument(
-            "runner_id",
-            "Only standalone SSH runners can be migrated to server capabilities",
-            Some(id.to_string()),
-            None,
-        ));
-    }
-
-    let server_id = runner.server_id.as_deref().ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "server_id",
-            "SSH runners require server_id before migration",
-            Some(id.to_string()),
-            None,
-        )
-    })?;
-    if server_id == id {
-        return Err(Error::validation_invalid_argument(
-            "runner_id",
-            "Runner already uses its server ID; no migration is needed",
-            Some(id.to_string()),
-            None,
-        ));
-    }
-
-    let mut server = server::load(server_id)?;
-    let mut server_runner = server.runner.unwrap_or_default();
-    server_runner.workspace_root = runner.workspace_root.clone();
-    server_runner.settings = runner.settings.clone();
-    server_runner.env.extend(runner.env.clone());
-    server_runner.resources.extend(runner.resources.clone());
-    validate_server_runner(server_id, &server_runner)?;
-    server.runner = Some(server_runner.clone());
-    server::save(&server)?;
-
-    if remove_legacy {
-        config::delete_safe::<Runner>(id)?;
-    }
-
-    Ok(runner_from_server(server_id, server_runner))
 }
 
 fn create_single_value(value: Value) -> Result<CreateResult<Runner>> {
@@ -585,7 +552,7 @@ mod tests {
     }
 
     #[test]
-    fn migrates_standalone_ssh_runner_to_server_capability() {
+    fn standalone_ssh_runner_config_is_not_loaded_or_listed() {
         test_support::with_isolated_home(|_| {
             server::create(
                 r#"{"id":"homeboy-lab","host":"192.168.86.63","user":"chubes"}"#,
@@ -593,59 +560,7 @@ mod tests {
             )
             .expect("create server");
 
-            let legacy = Runner {
-                id: "lab".to_string(),
-                kind: RunnerKind::Ssh,
-                server_id: Some("homeboy-lab".to_string()),
-                workspace_root: Some("/home/chubes/Developer".to_string()),
-                settings: RunnerSettings {
-                    homeboy_path: Some("/usr/local/bin/homeboy".to_string()),
-                    daemon: true,
-                    concurrency_limit: Some(4),
-                    artifact_policy: Some("copy".to_string()),
-                },
-                env: HashMap::from([("RUST_LOG".to_string(), "info".to_string())]),
-                resources: HashMap::from([("cpu".to_string(), Value::from(16))]),
-            };
-            config::save(&legacy).expect("save legacy runner");
-
-            let migrated = migrate_standalone_ssh_runner("lab", false).expect("migrate runner");
-
-            assert_eq!(migrated.id, "homeboy-lab");
-            assert_eq!(migrated.server_id.as_deref(), Some("homeboy-lab"));
-            assert_eq!(
-                migrated.workspace_root.as_deref(),
-                Some("/home/chubes/Developer")
-            );
-            assert_eq!(
-                migrated.settings.homeboy_path.as_deref(),
-                Some("/usr/local/bin/homeboy")
-            );
-            assert!(migrated.settings.daemon);
-            assert_eq!(migrated.settings.concurrency_limit, Some(4));
-            assert_eq!(migrated.settings.artifact_policy.as_deref(), Some("copy"));
-            assert_eq!(
-                migrated.env.get("RUST_LOG").map(String::as_str),
-                Some("info")
-            );
-            assert_eq!(migrated.resources.get("cpu"), Some(&Value::from(16)));
-            assert!(config::exists::<Runner>("lab"));
-
-            let stored_server = server::load("homeboy-lab").expect("load server");
-            assert!(stored_server.runner.is_some());
-        });
-    }
-
-    #[test]
-    fn migrate_can_remove_legacy_runner_when_requested() {
-        test_support::with_isolated_home(|_| {
-            server::create(
-                r#"{"id":"homeboy-lab","host":"192.168.86.63","user":"chubes"}"#,
-                false,
-            )
-            .expect("create server");
-
-            let legacy = Runner {
+            let standalone_ssh_runner = Runner {
                 id: "lab".to_string(),
                 kind: RunnerKind::Ssh,
                 server_id: Some("homeboy-lab".to_string()),
@@ -654,12 +569,17 @@ mod tests {
                 env: HashMap::new(),
                 resources: HashMap::new(),
             };
-            config::save(&legacy).expect("save legacy runner");
+            config::save(&standalone_ssh_runner).expect("save standalone ssh runner");
 
-            migrate_standalone_ssh_runner("lab", true).expect("migrate runner");
-
-            assert!(!config::exists::<Runner>("lab"));
-            assert!(load("homeboy-lab").is_ok());
+            assert_eq!(
+                load("lab")
+                    .expect_err("standalone ssh ignored")
+                    .code
+                    .as_str(),
+                "server.not_found"
+            );
+            assert!(!exists("lab"));
+            assert!(list().expect("list runners").is_empty());
         });
     }
 


### PR DESCRIPTION
## Summary
- Remove the legacy `homeboy runner migrate` subcommand and standalone SSH runner migration path.
- Stop loading, listing, merging, removing, or detecting `kind: ssh` runner registry records as canonical runners.
- Keep local runner registry records and server-embedded SSH runner capabilities intact.
- Update runner docs and tests for the canonical server runner model.

Fixes https://github.com/Extra-Chill/homeboy/issues/2926

## Tests
- `cargo test runner`
- `cargo test core::runner::tests`
- `cargo check`
- `cargo run --bin homeboy -- runner --help`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the code/docs/test changes, ran verification commands, and prepared the PR. Chris remains responsible for review and merge.