### PR TITLE
Remove legacy component manifest fields

### DIFF
--- a/docs/architecture/hooks.md
+++ b/docs/architecture/hooks.md
@@ -146,30 +146,6 @@ For non-fatal events (`post:release`, `post:deploy`):
 - Remaining commands continue executing
 - All results are captured in the operation output
 
-## Backward Compatibility
-
-Legacy flat fields (`pre_version_bump_commands`, `post_version_bump_commands`, `post_release_commands`) are still supported in component JSON. They are automatically migrated into the `hooks` map during deserialization:
-
-```json
-{
-  "pre_version_bump_commands": ["cargo build --release"],
-  "post_version_bump_commands": ["git add Cargo.lock"]
-}
-```
-
-is equivalent to:
-
-```json
-{
-  "hooks": {
-    "pre:version:bump": ["cargo build --release"],
-    "post:version:bump": ["git add Cargo.lock"]
-  }
-}
-```
-
-Both formats work. The `hooks` map is the canonical format going forward.
-
 ## Extension Hooks
 
 Extensions declare hooks in their manifest using the same format:

--- a/docs/commands/component.md
+++ b/docs/commands/component.md
@@ -81,7 +81,7 @@ Notes:
 
 - If the JSON contains an `id` field that differs from `<id>`, the component is automatically renamed first (equivalent to calling `rename`), then the remaining fields are merged. Project references are updated automatically.
 - `remote_url` and `triage_remote_url` must be GitHub remotes (`https://github.com/<owner>/<repo>.git` or `git@github.com:<owner>/<repo>.git`). Local filesystem paths and unsupported providers are rejected when writing component config.
-- Use `null` in JSON to clear a field (for example, `{"post_version_bump_commands": null}`).
+- Use `null` in JSON to clear a field (for example, `{"changelog_target": null}`).
 
 #### Release configuration
 
@@ -94,7 +94,7 @@ homeboy component set <id> --json '{"release": {"enabled": true, "steps": []}}'
 Components also define extension usage via `extensions`:
 
 ```sh
-homeboy component set <id> --json '{"extensions": {"github": {"settings": {}}, "rust": {"settings": {}}}}'
+homeboy component set <id> --json '{"extensions": {"github": {}, "rust": {}}}'
 ```
 
 `homeboy build`, `homeboy lint`, `homeboy test`, `homeboy bench`, and `homeboy trace` check component-owned `scripts.<capability>` first, then linked extensions. Components do not support a standalone `build_command` field; use `scripts.build` for component-owned shell builds.

--- a/docs/schemas/component-schema.md
+++ b/docs/schemas/component-schema.md
@@ -19,6 +19,12 @@ Component configuration defines buildable and deployable units stored in `compon
     }
   ],
   "changelog_target": "string",
+  "hooks": {
+    "pre:version:bump": ["shell command"],
+    "post:version:bump": ["shell command"],
+    "post:release": ["shell command"],
+    "post:deploy": ["shell command"]
+  },
   "scripts": {
     "lint": ["shell command"],
     "test": ["shell command"],
@@ -53,7 +59,7 @@ Component configuration defines buildable and deployable units stored in `compon
 - **`changelog_target`** (string): Path to changelog file (relative to `local_path`)
 - **`extensions`** (object): Extension-specific settings
   - Keys are extension IDs (e.g., `"wordpress"`, `"rust"`)
-  - Values are extension setting objects
+  - Values are flat extension setting objects; `version` is reserved for extension version constraints
 - **`scripts`** (object): Component-owned shell commands for extension-shaped capabilities
   - Supported keys: `lint`, `test`, `build`, `bench`, `trace`
   - Each value is an array of shell commands run sequentially in `local_path`
@@ -81,24 +87,16 @@ Component configuration defines buildable and deployable units stored in `compon
 }
 ```
 
-Runtime IDs are extension-owned strings. `source` is `component` for component config or detector output and `extension:<id>` for extension-provided defaults. Legacy component extension settings such as `{ "php": "8.2", "node": "22" }` are still parsed for compatibility; new config should use `runtimes`.
+Runtime IDs are extension-owned strings. `source` is `component` for component config or detector output and `extension:<id>` for extension-provided defaults. Runtime requirements should use `runtimes`.
 
 ### Hook Fields
 
-- **`pre_version_bump_commands`** (array of strings): Commands to run BEFORE version targets are updated
-  - Execution: Sequential, runs in `local_path` directory
-  - Failure behavior: **Fatal** - stops version bump on non-zero exit code
-  - Use case: Validate generated sources before changing version files
-
-- **`post_version_bump_commands`** (array of strings): Commands to run AFTER version files are updated
-  - Execution: Sequential, runs in `local_path` directory
-  - Failure behavior: **Fatal** - stops version bump on non-zero exit code
-  - Use case: Regenerate files that depend on version, run linters, stage additional files
-
-- **`post_release_commands`** (array of strings): Commands to run after the release pipeline completes
-  - Execution: Sequential, runs in `local_path` directory
-  - Failure behavior: **Non-fatal** - logs warnings but doesn't fail the release
-  - Use case: Cleanup tasks, notifications, non-critical post-release actions
+- **`hooks`** (object): Lifecycle hook commands keyed by event name
+  - `pre:version:bump`: Commands to run before version targets are updated
+  - `post:version:bump`: Commands to run after version files are updated
+  - `post:release`: Commands to run after the release pipeline completes
+  - `post:deploy`: Commands to run on the deployment target after deploy
+  - Each value is an array of shell commands run sequentially
 
 ## local_path vs remote_path
 
@@ -133,20 +131,20 @@ Setting `local_path` to the same directory as the deploy target is a misconfigur
     }
   ],
   "changelog_target": "CHANGELOG.md",
-  "pre_version_bump_commands": [
-    "./scripts/verify-generated-sources"
-  ],
-  "post_version_bump_commands": [
-    "./scripts/refresh-versioned-artifacts"
-  ],
-  "post_release_commands": [
-    "echo 'Release complete!'"
-  ],
+  "hooks": {
+    "pre:version:bump": [
+      "./scripts/verify-generated-sources"
+    ],
+    "post:version:bump": [
+      "./scripts/refresh-versioned-artifacts"
+    ],
+    "post:release": [
+      "echo 'Release complete!'"
+    ]
+  },
   "extensions": {
     "wordpress": {
-      "settings": {
-        "php_version": "8.1"
-      }
+      "php_version": "8.1"
     }
   },
   "release": {

--- a/docs/schemas/project-schema.md
+++ b/docs/schemas/project-schema.md
@@ -101,7 +101,7 @@ Project configuration defines deployable environments stored in `projects/<id>.j
   - Values are tool-specific setting objects
 - **`extensions`** (object): Extension-specific settings for this project
   - Keys are extension IDs
-  - Values are extension setting objects
+  - Values are flat extension setting objects; `version` is reserved for extension version constraints
 
 ## Example
 
@@ -170,9 +170,7 @@ Project configuration defines deployable environments stored in `projects/<id>.j
   ],
   "extensions": {
     "wordpress": {
-      "settings": {
-        "wp_cli_path": "/usr/local/bin/wp"
-      }
+      "wp_cli_path": "/usr/local/bin/wp"
     }
   }
 }

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -765,7 +765,7 @@ mod tests {
                         "path": "{}",
                         "extensions": {{
                             "nodejs": {{
-                                "settings": {{ "package_manager": "pnpm" }},
+                                "package_manager": "pnpm",
                                 "workspace": "apps/studio"
                             }}
                         }}

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{HashMap, HashSet};
 
 pub mod audit;
@@ -47,27 +47,35 @@ pub struct VersionTarget {
     pub pattern: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct ScopedExtensionConfig {
     /// Version constraint string (e.g., ">=2.0.0", "^1.0").
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
     /// Settings passed to the extension at runtime.
     ///
-    /// Populated from both an explicit `"settings": { ... }` sub-object AND
-    /// any flat keys that aren't `version` or `settings`.  This lets both
-    /// formats work:
+    /// Populated from flat keys that aren't reserved struct fields:
     ///
     /// ```json
-    /// // flat (current convention)
     /// { "database_type": "mysql", "mysql_host": "localhost" }
-    /// // nested
-    /// { "settings": { "database_type": "mysql" } }
-    /// // mixed (flat keys merged into settings)
-    /// { "settings": { "a": 1 }, "b": 2 }
     /// ```
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub settings: HashMap<String, serde_json::Value>,
+}
+
+impl serde::Serialize for ScopedExtensionConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let len = self.settings.len() + usize::from(self.version.is_some());
+        let mut map = serializer.serialize_map(Some(len))?;
+        if let Some(version) = self.version.as_ref() {
+            map.serialize_entry("version", version)?;
+        }
+        for (key, value) in &self.settings {
+            map.serialize_entry(key, value)?;
+        }
+        map.end()
+    }
 }
 
 impl<'de> serde::Deserialize<'de> for ScopedExtensionConfig {
@@ -84,16 +92,7 @@ impl<'de> serde::Deserialize<'de> for ScopedExtensionConfig {
             .remove("version")
             .and_then(|v| v.as_str().map(String::from));
 
-        // Start with the explicit "settings" sub-object (if present).
-        let mut settings: HashMap<String, serde_json::Value> = map
-            .remove("settings")
-            .and_then(|v| serde_json::from_value(v).ok())
-            .unwrap_or_default();
-
-        // Merge remaining flat keys — flat keys do NOT overwrite explicit settings.
-        for (key, value) in map {
-            settings.entry(key).or_insert(value);
-        }
+        let settings = map.into_iter().collect();
 
         Ok(ScopedExtensionConfig { version, settings })
     }
@@ -125,14 +124,6 @@ pub struct ScopeConfig {
     pub release: Option<CommandScopeConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fleet: Option<CommandScopeConfig>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct SelfCheckConfig {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub lint: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub test: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -195,8 +186,6 @@ pub struct Component {
     pub docs_dir: Option<String>,
     pub docs_dirs: Vec<String>,
     pub scopes: Option<ScopeConfig>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub self_checks: Option<SelfCheckConfig>,
     /// Component-owned shell scripts that satisfy Homeboy command capabilities
     /// without requiring an extension. Resolution order is `scripts.*` first,
     /// then extension-claimed behavior, then not-applicable.
@@ -222,8 +211,6 @@ pub struct Component {
     pub extra_drift_files: Vec<String>,
 }
 
-/// Raw JSON shape for Component — handles backward-compatible deserialization
-/// of legacy hook fields (`pre_version_bump_commands` etc.) into the `hooks` map.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct RawComponent {
     #[serde(default, skip_serializing)]
@@ -244,7 +231,7 @@ struct RawComponent {
     extensions: Option<HashMap<String, ScopedExtensionConfig>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     version_targets: Option<Vec<VersionTarget>>,
-    #[serde(skip_serializing_if = "Option::is_none", alias = "changelog_targets")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     changelog_target: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     changelog_next_section_label: Option<String>,
@@ -252,13 +239,6 @@ struct RawComponent {
     changelog_next_section_aliases: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     hooks: HashMap<String, Vec<String>>,
-    // Legacy hook fields — read from old JSON, merged into hooks
-    #[serde(default, skip_serializing)]
-    pre_version_bump_commands: Vec<String>,
-    #[serde(default, skip_serializing)]
-    post_version_bump_commands: Vec<String>,
-    #[serde(default, skip_serializing)]
-    post_release_commands: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     extract_command: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -282,8 +262,6 @@ struct RawComponent {
     #[serde(skip_serializing_if = "Option::is_none")]
     scopes: Option<ScopeConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    self_checks: Option<SelfCheckConfig>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     scripts: Option<ComponentScriptsConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     audit: Option<AuditConfig>,
@@ -295,28 +273,8 @@ struct RawComponent {
     extra_drift_files: Vec<String>,
 }
 
-/// Insert legacy commands into hooks map if the event key doesn't already exist.
-fn merge_legacy_hook(hooks: &mut HashMap<String, Vec<String>>, event: &str, commands: Vec<String>) {
-    if !commands.is_empty() && !hooks.contains_key(event) {
-        hooks.insert(event.to_string(), commands);
-    }
-}
-
 impl From<RawComponent> for Component {
     fn from(raw: RawComponent) -> Self {
-        let mut hooks = raw.hooks;
-        merge_legacy_hook(
-            &mut hooks,
-            "pre:version:bump",
-            raw.pre_version_bump_commands,
-        );
-        merge_legacy_hook(
-            &mut hooks,
-            "post:version:bump",
-            raw.post_version_bump_commands,
-        );
-        merge_legacy_hook(&mut hooks, "post:release", raw.post_release_commands);
-
         Component {
             id: raw.id,
             aliases: raw.aliases,
@@ -328,7 +286,7 @@ impl From<RawComponent> for Component {
             changelog_target: raw.changelog_target,
             changelog_next_section_label: raw.changelog_next_section_label,
             changelog_next_section_aliases: raw.changelog_next_section_aliases,
-            hooks,
+            hooks: raw.hooks,
             extract_command: raw.extract_command,
             remote_owner: raw.remote_owner,
             deploy_strategy: raw.deploy_strategy,
@@ -340,7 +298,6 @@ impl From<RawComponent> for Component {
             docs_dir: raw.docs_dir,
             docs_dirs: raw.docs_dirs,
             scopes: raw.scopes,
-            self_checks: raw.self_checks,
             scripts: raw.scripts,
             audit: raw.audit,
             dependency_stack: raw.dependency_stack,
@@ -364,9 +321,6 @@ impl From<Component> for RawComponent {
             changelog_next_section_label: c.changelog_next_section_label,
             changelog_next_section_aliases: c.changelog_next_section_aliases,
             hooks: c.hooks,
-            pre_version_bump_commands: Vec::new(),
-            post_version_bump_commands: Vec::new(),
-            post_release_commands: Vec::new(),
             extract_command: c.extract_command,
             remote_owner: c.remote_owner,
             deploy_strategy: c.deploy_strategy,
@@ -378,7 +332,6 @@ impl From<Component> for RawComponent {
             docs_dir: c.docs_dir,
             docs_dirs: c.docs_dirs,
             scopes: c.scopes,
-            self_checks: c.self_checks,
             scripts: c.scripts,
             audit: c.audit,
             dependency_stack: c.dependency_stack,
@@ -453,7 +406,6 @@ impl Component {
             docs_dir: None,
             docs_dirs: Vec::new(),
             scopes: None,
-            self_checks: None,
             scripts: None,
             audit: None,
             dependency_stack: Vec::new(),
@@ -542,25 +494,6 @@ impl Component {
             || (std::path::Path::new(&self.local_path).is_file() && self.deploy_strategy.is_none())
     }
 
-    pub fn self_check_commands(
-        &self,
-        capability: crate::core::extension::ExtensionCapability,
-    ) -> &[String] {
-        let Some(checks) = self.self_checks.as_ref() else {
-            return &[];
-        };
-
-        match capability {
-            crate::core::extension::ExtensionCapability::Lint => &checks.lint,
-            crate::core::extension::ExtensionCapability::Test => &checks.test,
-            _ => &[],
-        }
-    }
-
-    pub fn has_self_check(&self, capability: crate::core::extension::ExtensionCapability) -> bool {
-        !self.self_check_commands(capability).is_empty()
-    }
-
     pub fn script_commands(
         &self,
         capability: crate::core::extension::ExtensionCapability,
@@ -578,8 +511,7 @@ impl Component {
             }
         }
 
-        // Existing `self_checks` remains a lint/test compatibility source.
-        self.self_check_commands(capability)
+        &[]
     }
 
     pub fn has_script(&self, capability: crate::core::extension::ExtensionCapability) -> bool {
@@ -683,6 +615,39 @@ mod tests {
         let parsed: Component = serde_json::from_str(&json).unwrap();
 
         assert_eq!(parsed.priority_labels, Some(vec!["urgent".to_string()]));
+    }
+
+    #[test]
+    fn component_ignores_legacy_hook_fields() {
+        let component: Component = serde_json::from_value(serde_json::json!({
+            "id": "fixture",
+            "pre_version_bump_commands": ["cargo build"],
+            "post_version_bump_commands": ["cargo test"],
+            "post_release_commands": ["echo done"],
+            "hooks": {
+                "post:deploy": ["wp cache flush"]
+            }
+        }))
+        .unwrap();
+
+        assert!(component.hooks.get("pre:version:bump").is_none());
+        assert!(component.hooks.get("post:version:bump").is_none());
+        assert!(component.hooks.get("post:release").is_none());
+        assert_eq!(
+            component.hooks.get("post:deploy"),
+            Some(&vec!["wp cache flush".to_string()])
+        );
+    }
+
+    #[test]
+    fn component_ignores_changelog_targets_alias() {
+        let component: Component = serde_json::from_value(serde_json::json!({
+            "id": "fixture",
+            "changelog_targets": "CHANGELOG.md"
+        }))
+        .unwrap();
+
+        assert!(component.changelog_target.is_none());
     }
 
     #[test]
@@ -1121,8 +1086,7 @@ mod tests {
     }
 
     #[test]
-    fn scoped_extension_config_nested_settings_still_work() {
-        // Explicit "settings" sub-object must still work.
+    fn scoped_extension_config_treats_settings_as_flat_key() {
         let json = serde_json::json!({
             "version": ">=2.0.0",
             "settings": {
@@ -1136,19 +1100,17 @@ mod tests {
         assert_eq!(
             config
                 .settings
-                .get("database_type")
+                .get("settings")
+                .and_then(|v| v.as_object())
+                .and_then(|settings| settings.get("database_type"))
                 .and_then(|v| v.as_str()),
             Some("mysql")
         );
-        assert_eq!(
-            config.settings.get("mysql_host").and_then(|v| v.as_str()),
-            Some("localhost")
-        );
+        assert!(config.settings.get("database_type").is_none());
     }
 
     #[test]
-    fn scoped_extension_config_mixed_flat_and_nested() {
-        // Flat keys merge with nested settings. Explicit settings win on conflict.
+    fn scoped_extension_config_does_not_merge_nested_settings() {
         let json = serde_json::json!({
             "settings": {
                 "database_type": "mysql"
@@ -1158,20 +1120,32 @@ mod tests {
         });
 
         let config: ScopedExtensionConfig = serde_json::from_value(json).unwrap();
-        // Explicit settings win over flat keys.
         assert_eq!(
             config
                 .settings
                 .get("database_type")
                 .and_then(|v| v.as_str()),
-            Some("mysql"),
-            "explicit settings sub-object should take precedence over flat keys"
+            Some("sqlite"),
+            "flat keys are canonical and must not be overwritten by nested settings"
         );
-        // Flat-only key is captured.
         assert_eq!(
             config.settings.get("mysql_host").and_then(|v| v.as_str()),
             Some("localhost")
         );
+        assert!(config.settings.get("settings").is_some());
+    }
+
+    #[test]
+    fn scoped_extension_config_serializes_flat_settings() {
+        let config = ScopedExtensionConfig {
+            version: Some(">=2.0.0".to_string()),
+            settings: HashMap::from([("package_manager".to_string(), serde_json::json!("pnpm"))]),
+        };
+
+        let json = serde_json::to_value(config).unwrap();
+        assert_eq!(json["version"], serde_json::json!(">=2.0.0"));
+        assert_eq!(json["package_manager"], serde_json::json!("pnpm"));
+        assert!(json.get("settings").is_none());
     }
 
     #[test]

--- a/src/core/engine/hooks.rs
+++ b/src/core/engine/hooks.rs
@@ -51,8 +51,6 @@ pub enum HookFailureMode {
 /// 1. Extension hooks (platform behavior) — from all linked extensions, in extension iteration order
 /// 2. Component hooks (user customization)
 ///
-/// Legacy fields (`pre_version_bump_commands`, etc.) are migrated into the `hooks` map
-/// during deserialization, so they are already included here.
 pub fn resolve_hooks(component: &Component, event: &str) -> Vec<String> {
     let mut commands = Vec::new();
 
@@ -67,9 +65,7 @@ pub fn resolve_hooks(component: &Component, event: &str) -> Vec<String> {
         }
     }
 
-    // Component hooks second (from the new `hooks` map).
-    // Legacy fields (pre_version_bump_commands, etc.) are already merged into this
-    // map during deserialization via RawComponent, so no separate fallback is needed.
+    // Component hooks second.
     if let Some(component_commands) = component.hooks.get(event) {
         commands.extend(component_commands.clone());
     }

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -448,7 +448,7 @@ pub fn run_self_check_lint_workflow(
     let status = if output.success { "passed" } else { "failed" }.to_string();
     let hints = (!output.success).then(|| {
         vec![format!(
-            "Fix the failing self-check command declared in {}'s homeboy.json self_checks.lint",
+            "Fix the failing self-check command declared in {}'s homeboy.json scripts.lint",
             component.id
         )]
     });
@@ -639,7 +639,7 @@ fn process_baseline(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::component::SelfCheckConfig;
+    use crate::core::component::ComponentScriptsConfig;
     use crate::core::engine::baseline::BaselineFlags;
 
     fn component(root: &str) -> Component {
@@ -732,9 +732,12 @@ mod tests {
             "".to_string(),
             None,
         );
-        component.self_checks = Some(SelfCheckConfig {
+        component.scripts = Some(ComponentScriptsConfig {
             lint: vec!["sh lint.sh".to_string()],
             test: Vec::new(),
+            build: Vec::new(),
+            bench: Vec::new(),
+            trace: Vec::new(),
         });
 
         let result =

--- a/src/core/extension/self_check.rs
+++ b/src/core/extension/self_check.rs
@@ -41,7 +41,7 @@ pub(crate) fn run_self_checks_with_passthrough(
     let commands = component.script_commands(capability);
     if commands.is_empty() {
         return Err(Error::validation_invalid_argument(
-            "self_checks",
+            "scripts",
             format!(
                 "Component '{}' has no {} self-check commands configured",
                 component.id,
@@ -267,7 +267,7 @@ fn capture_stream<R: Read>(mut src: R, passthrough: bool, stderr: bool) -> Bound
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::component::{Component, SelfCheckConfig};
+    use crate::core::component::{Component, ComponentScriptsConfig};
 
     #[test]
     fn test_run_self_checks_requires_configured_commands() {
@@ -303,9 +303,12 @@ mod tests {
             "".to_string(),
             None,
         );
-        component.self_checks = Some(SelfCheckConfig {
+        component.scripts = Some(ComponentScriptsConfig {
             lint: vec!["sh one.sh".to_string(), "sh two.sh".to_string()],
             test: Vec::new(),
+            build: Vec::new(),
+            bench: Vec::new(),
+            trace: Vec::new(),
         });
 
         let output = run_self_checks_with_passthrough(
@@ -338,9 +341,12 @@ mod tests {
             "".to_string(),
             None,
         );
-        component.self_checks = Some(SelfCheckConfig {
+        component.scripts = Some(ComponentScriptsConfig {
             lint: vec!["sh lint.sh".to_string()],
             test: Vec::new(),
+            build: Vec::new(),
+            bench: Vec::new(),
+            trace: Vec::new(),
         });
 
         let output = run_self_checks_with_passthrough(
@@ -371,9 +377,12 @@ mod tests {
             "".to_string(),
             None,
         );
-        component.self_checks = Some(SelfCheckConfig {
+        component.scripts = Some(ComponentScriptsConfig {
             lint: vec!["sh large.sh".to_string()],
             test: Vec::new(),
+            build: Vec::new(),
+            bench: Vec::new(),
+            trace: Vec::new(),
         });
 
         let output = run_self_checks_with_passthrough(

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -546,7 +546,7 @@ pub fn run_self_check_test_workflow(
         autofix: None,
         hints: (!output.success).then(|| {
             vec![format!(
-                "Fix the failing self-check command declared in {}'s homeboy.json self_checks.test",
+                "Fix the failing self-check command declared in {}'s homeboy.json scripts.test",
                 component.id
             )]
         }),
@@ -563,7 +563,7 @@ pub fn run_self_check_test_workflow(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::component::SelfCheckConfig;
+    use crate::core::component::ComponentScriptsConfig;
     use crate::core::extension::test::TestFailure;
 
     #[test]
@@ -672,9 +672,12 @@ mod tests {
             "".to_string(),
             None,
         );
-        component.self_checks = Some(SelfCheckConfig {
+        component.scripts = Some(ComponentScriptsConfig {
             lint: Vec::new(),
             test: vec!["sh test.sh".to_string()],
+            build: Vec::new(),
+            bench: Vec::new(),
+            trace: Vec::new(),
         });
 
         let result =

--- a/tests/core/rig/bench_default_baseline_spec_test.rs
+++ b/tests/core/rig/bench_default_baseline_spec_test.rs
@@ -261,7 +261,7 @@ fn test_rig_component_deserializes_extension_config() {
                     "path": "~/Developer/studio",
                     "extensions": {
                         "nodejs": {
-                            "settings": { "package_manager": "pnpm" },
+                            "package_manager": "pnpm",
                             "workspace": "apps/studio"
                         }
                     }
@@ -295,7 +295,7 @@ fn test_rig_component_extension_config_round_trips() {
             "studio": {
                 "path": "/tmp/studio",
                 "extensions": {
-                    "nodejs": { "settings": { "package_manager": "pnpm" } }
+                    "nodejs": { "package_manager": "pnpm" }
                 }
             }
         }

--- a/tests/self_checks_test.rs
+++ b/tests/self_checks_test.rs
@@ -7,16 +7,27 @@ use homeboy::commands::GlobalArgs;
 use std::fs;
 use std::path::Path;
 
-fn write_component(root: &Path, self_checks: &str) {
+fn write_component(root: &Path, scripts: &str) {
     fs::write(
         root.join("homeboy.json"),
         format!(
             r#"{{
   "id": "fixture",
-  "self_checks": {}
+  "scripts": {}
 }}"#,
-            self_checks
+            scripts
         ),
+    )
+    .expect("homeboy.json should be written");
+}
+
+fn write_legacy_self_checks_component(root: &Path) {
+    fs::write(
+        root.join("homeboy.json"),
+        r#"{
+  "id": "fixture",
+  "self_checks": { "lint": ["sh scripts/lint.sh"] }
+}"#,
     )
     .expect("homeboy.json should be written");
 }
@@ -169,6 +180,29 @@ fn missing_extension_and_self_check_keeps_existing_error() {
 
     let err = match run_lint(lint_args(dir.path()), &GlobalArgs {}) {
         Ok(_) => panic!("lint without extension or self-check should fail"),
+        Err(err) => err,
+    };
+
+    assert_eq!(err.code.as_str(), "extension.unsupported");
+    assert!(
+        err.to_string()
+            .contains("No extension provider configured for component 'fixture'"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn legacy_self_checks_are_not_a_script_source() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    write_legacy_self_checks_component(dir.path());
+    write_script(
+        dir.path(),
+        "lint.sh",
+        "printf 'legacy lint should not run\\n'\n",
+    );
+
+    let err = match run_lint(lint_args(dir.path()), &GlobalArgs {}) {
+        Ok(_) => panic!("legacy self_checks should not satisfy lint"),
         Err(err) => err,
     };
 


### PR DESCRIPTION
## Summary
- remove legacy component manifest compatibility fields for hooks, `changelog_targets`, and `self_checks`
- make extension config settings serialize/deserialize as the canonical flat shape only
- update component/project schema docs and tests for canonical `hooks`, `scripts`, and flat extension settings

Fixes #2922

## Testing
- `cargo test scoped_extension_config`
- `cargo test component_ignores`
- `cargo test test_rig_component`
- `cargo test --test self_checks_test`
- `cargo test commands::bench::matrix::tests::rig_component_for_bench_synthesizes_extension_config`
- `cargo test --lib`
- `git diff --check`

## Known repo check status
- `cargo test` currently fails in `tests/architecture_core_agnostic_test.rs` on existing architecture guard debt unrelated to this PR: `core_source_does_not_depend_on_command_layer` and `detector_implementations_stay_domain_agnostic`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the schema cleanup, tests, docs updates, and local verification; Chris remains responsible for review and merge.
