### PR TITLE
Remove legacy untagged output contracts

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -67,7 +67,8 @@
         {
           "command": "runs",
           "expected_fields": {
-            "/scenarios/0/payload/data/command": "runs.list",
+            "/scenarios/0/payload/data/payload/command": "runs.list",
+            "/scenarios/0/payload/data/variant": "list",
             "/scenarios/0/payload/success": true
           },
           "file": "tests/fixtures/golden_json_contracts/runs_contract.json",

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -179,8 +179,6 @@ pub enum CommandJsonFamily {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandOutputContractKind {
     JsonEnvelope,
-    LegacyUntaggedWithDiscriminators,
-    LegacyUntaggedWithGoldenFixtures,
     RawOnly,
 }
 
@@ -273,7 +271,7 @@ impl Commands {
                     CommandResponseMode::Json
                 },
                 output_file_mode,
-                CommandOutputContractKind::LegacyUntaggedWithDiscriminators,
+                CommandOutputContractKind::JsonEnvelope,
             ),
             Commands::Report(args) if report::is_markdown_mode(args) => workspace_descriptor(
                 CommandResponseMode::Raw(CommandRawOutputMode::Markdown),
@@ -300,7 +298,7 @@ impl Commands {
                 args.is_run_command(),
                 args.lab_offload_writes_local_state()
                     .then_some("--baseline/--ratchet"),
-                CommandOutputContractKind::LegacyUntaggedWithGoldenFixtures,
+                CommandOutputContractKind::JsonEnvelope,
             ),
             Commands::Lint(args) => quality_json_descriptor(
                 output_file_mode,
@@ -355,7 +353,7 @@ impl Commands {
                     "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.",
                 ),
                 lab_offload_mutation_flag: None,
-                output_contract: CommandOutputContractKind::LegacyUntaggedWithDiscriminators,
+                output_contract: CommandOutputContractKind::JsonEnvelope,
             },
             Commands::Status(_)
             | Commands::Ci(_)
@@ -493,155 +491,148 @@ pub const PUBLIC_OUTPUT_VARIANT_CONTRACTS: &[PublicOutputVariantContract] = &[
     PublicOutputVariantContract {
         command: "bench",
         variant: "single",
-        discriminator_field: None,
-        discriminator_value: None,
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("single"),
         golden_fixture: Some("bench_contract.json"),
     },
     PublicOutputVariantContract {
         command: "bench",
         variant: "comparison",
-        discriminator_field: Some("comparison"),
-        discriminator_value: Some("cross_rig"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("comparison"),
         golden_fixture: None,
     },
     PublicOutputVariantContract {
         command: "bench",
         variant: "comparison_summary",
-        discriminator_field: Some("comparison+summary_only"),
-        discriminator_value: Some("cross_rig+true"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("comparison_summary"),
         golden_fixture: None,
     },
     PublicOutputVariantContract {
         command: "bench",
         variant: "list",
-        discriminator_field: None,
-        discriminator_value: None,
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("list"),
         golden_fixture: Some("bench_contract.json"),
     },
     PublicOutputVariantContract {
         command: "runs",
         variant: "list",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("runs.list"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("list"),
         golden_fixture: Some("runs_contract.json"),
     },
     PublicOutputVariantContract {
         command: "runs",
         variant: "show",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("runs.show"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("show"),
         golden_fixture: Some("runs_contract.json"),
     },
     PublicOutputVariantContract {
         command: "runs",
         variant: "artifacts",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("runs.artifacts"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("artifacts"),
         golden_fixture: Some("runs_contract.json"),
     },
     PublicOutputVariantContract {
         command: "runs",
         variant: "query",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("runs.query"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("query"),
         golden_fixture: Some("runs_contract.json"),
     },
     PublicOutputVariantContract {
         command: "runs",
         variant: "drift",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("runs.drift"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("drift"),
         golden_fixture: Some("runs_contract.json"),
     },
     PublicOutputVariantContract {
         command: "rig",
         variant: "list",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("rig.list"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("list"),
         golden_fixture: None,
     },
     PublicOutputVariantContract {
         command: "rig",
         variant: "show",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("rig.show"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("show"),
         golden_fixture: None,
     },
     PublicOutputVariantContract {
         command: "rig",
         variant: "up",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("rig.up"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("up"),
         golden_fixture: None,
     },
     PublicOutputVariantContract {
         command: "rig",
         variant: "check",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("rig.check"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("check"),
         golden_fixture: None,
     },
     PublicOutputVariantContract {
         command: "rig",
         variant: "down",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("rig.down"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("down"),
         golden_fixture: None,
     },
     PublicOutputVariantContract {
         command: "rig",
         variant: "repair",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("rig.repair"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("repair"),
         golden_fixture: None,
     },
     PublicOutputVariantContract {
         command: "rig",
         variant: "sync",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("rig.sync"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("sync"),
         golden_fixture: None,
     },
     PublicOutputVariantContract {
         command: "rig",
         variant: "status",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("rig.status"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("status"),
         golden_fixture: None,
     },
     PublicOutputVariantContract {
         command: "rig",
         variant: "install",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("rig.install"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("install"),
         golden_fixture: None,
     },
     PublicOutputVariantContract {
         command: "rig",
         variant: "update",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("rig.update"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("update"),
         golden_fixture: None,
     },
     PublicOutputVariantContract {
         command: "rig",
-        variant: "sources_list",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("rig.sources.list"),
-        golden_fixture: None,
-    },
-    PublicOutputVariantContract {
-        command: "rig",
-        variant: "sources_remove",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("rig.sources.remove"),
+        variant: "sources",
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("sources"),
         golden_fixture: None,
     },
     PublicOutputVariantContract {
         command: "rig",
         variant: "app",
-        discriminator_field: Some("command"),
-        discriminator_value: Some("rig.app.*"),
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("app"),
         golden_fixture: None,
     },
 ];
@@ -874,7 +865,7 @@ mod tests {
         assert!(bench_descriptor.supports_lab_runner);
         assert_eq!(
             bench_descriptor.output_contract,
-            CommandOutputContractKind::LegacyUntaggedWithGoldenFixtures
+            CommandOutputContractKind::JsonEnvelope
         );
 
         let runs = parsed_command(&["homeboy", "runs", "list"]);
@@ -883,7 +874,7 @@ mod tests {
         assert_eq!(runs_descriptor.response_mode, CommandResponseMode::Json);
         assert_eq!(
             runs_descriptor.output_contract,
-            CommandOutputContractKind::LegacyUntaggedWithDiscriminators
+            CommandOutputContractKind::JsonEnvelope
         );
 
         let list_descriptor = Commands::List.descriptor(false);

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -278,17 +278,9 @@ fn filter_homeboy_flags(args: &[String]) -> Vec<String> {
     filter_passthrough_args(PassthroughCommand::Bench, args)
 }
 
-/// Output envelope for `homeboy bench`.
-///
-/// Two shapes:
-/// - `Single` — bare `bench`, `bench <component>`, or `bench --rig <id>`.
-///   Indistinguishable from the pre-cross-rig output for backward
-///   compatibility (`#[serde(untagged)]`, no wrapper key).
-/// - `Comparison` — `bench --rig <a>,<b>[,...]`. Has a top-level
-///   `comparison: "cross_rig"` discriminator field that consumers can
-///   check.
+/// Tagged output envelope for `homeboy bench`.
 #[derive(Serialize)]
-#[serde(untagged)]
+#[serde(tag = "variant", content = "payload", rename_all = "snake_case")]
 pub enum BenchOutput {
     Single(BenchCommandOutput),
     Comparison(BenchComparisonOutput),
@@ -333,8 +325,8 @@ pub fn run(mut args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> 
         };
     }
 
-    // No --rig: legacy single bare run. No rig pinning, no rig
-    // snapshot, baseline key untouched. Identical to before this PR.
+    // No --rig: single component run. No rig pinning, no rig
+    // snapshot, baseline key untouched.
     if args.run.rig.is_empty() {
         validate_report_selection_for_single_run(&args.run)?;
         let passthrough_args = filter_homeboy_flags(&args.run.args);
@@ -362,7 +354,7 @@ pub fn run(mut args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> 
     // --rig with one value: single rig-pinned run. A rig that declares
     // bench.components fans out across those components while preserving
     // one rig-state snapshot. Rigs with only default_component keep the
-    // legacy one-component shape.
+    // one-component payload shape.
     if run_args.rig.len() == 1 {
         validate_report_selection_for_single_run(run_args)?;
         let rig_id = run_args.rig[0].clone();

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -1433,12 +1433,7 @@ fn filter_handles_mixed() {
 }
 
 #[test]
-fn bench_output_single_serializes_without_wrapper_key() {
-    // Backcompat: single-rig and bare-bench output must serialize
-    // identically to the pre-cross-rig shape (no top-level
-    // discriminator field). The `untagged` enum representation
-    // gives us that for free, but pin it with a test so a future
-    // refactor can't quietly break consumers.
+fn bench_output_single_serializes_with_tagged_payload() {
     let single = BenchCommandOutput {
         passed: true,
         status: "passed".to_string(),
@@ -1457,20 +1452,32 @@ fn bench_output_single_serializes_without_wrapper_key() {
         ci_context: None,
     };
     let value = serde_json::to_value(BenchOutput::Single(single)).unwrap();
-    assert!(value.get("comparison").is_none());
-    assert_eq!(value.get("passed"), Some(&serde_json::Value::Bool(true)));
     assert_eq!(
-        value.get("component"),
+        value.get("variant"),
+        Some(&serde_json::Value::String("single".to_string()))
+    );
+    let payload = value
+        .get("payload")
+        .expect("single bench output has payload");
+    assert_eq!(payload.get("passed"), Some(&serde_json::Value::Bool(true)));
+    assert_eq!(
+        payload.get("component"),
         Some(&serde_json::Value::String("studio".to_string()))
     );
 }
 
 #[test]
-fn bench_output_comparison_serializes_with_discriminator() {
+fn bench_output_comparison_serializes_with_tagged_payload() {
     let (cmp, _) = aggregate_comparison("studio".to_string(), 10, Vec::new());
     let value = serde_json::to_value(BenchOutput::Comparison(cmp)).unwrap();
     assert_eq!(
-        value.get("comparison"),
+        value.get("variant"),
+        Some(&serde_json::Value::String("comparison".to_string()))
+    );
+    assert_eq!(
+        value
+            .get("payload")
+            .and_then(|payload| payload.get("comparison")),
         Some(&serde_json::Value::String("cross_rig".to_string()))
     );
 }

--- a/src/commands/golden_contract_tests.rs
+++ b/src/commands/golden_contract_tests.rs
@@ -15,7 +15,9 @@ use super::runs::{
     DriftValue, QueryGroup, QueryRow, RunsDriftFilters, RunsDriftOutput, RunsQueryFilters,
     SkippedArtifactRow, TestRunsQueryOutput as RunsQueryOutput,
 };
-use super::runs::{RunDetail, RunSummary, RunsArtifactsOutput, RunsListOutput, RunsShowOutput};
+use super::runs::{
+    RunDetail, RunSummary, RunsArtifactsOutput, RunsListOutput, RunsOutput, RunsShowOutput,
+};
 use super::stack::{
     StackInspectOutput, StackListOutput, StackShowOutput, StackStatusOutput, StackSummary,
 };
@@ -41,7 +43,7 @@ fn bench_command_json_contract_matches_golden_fixture() {
         "bench_contract.json",
         json!({
             "scenarios": [
-                scenario("bench single legacy", BenchOutput::Single(BenchCommandOutput {
+                scenario("bench single", BenchOutput::Single(BenchCommandOutput {
                     passed: true,
                     status: "passed".to_string(),
                     component: "homeboy".to_string(),
@@ -58,7 +60,7 @@ fn bench_command_json_contract_matches_golden_fixture() {
                     diagnostics: Vec::new(),
                     ci_context: None,
                 })),
-                scenario("bench list legacy", BenchOutput::List(BenchListWorkflowResult {
+                scenario("bench list", BenchOutput::List(BenchListWorkflowResult {
                     component: "homeboy".to_string(),
                     component_id: "homeboy".to_string(),
                     scenarios: Vec::new(),
@@ -75,11 +77,11 @@ fn runs_command_json_contract_matches_golden_fixture() {
         "runs_contract.json",
         json!({
             "scenarios": [
-                scenario("runs list", RunsListOutput {
+                scenario("runs list", RunsOutput::List(RunsListOutput {
                     command: "runs.list",
                     runs: vec![run_summary()],
-                }),
-                scenario("runs show", RunsShowOutput {
+                })),
+                scenario("runs show", RunsOutput::Show(RunsShowOutput {
                     command: "runs.show",
                     run: RunDetail {
                         summary: run_summary(),
@@ -87,13 +89,13 @@ fn runs_command_json_contract_matches_golden_fixture() {
                         metadata: json!({ "scenario": "contract", "score": 0.98 }),
                         artifacts: vec![artifact_record()],
                     },
-                }),
-                scenario("runs artifacts", RunsArtifactsOutput {
+                })),
+                scenario("runs artifacts", RunsOutput::Artifacts(RunsArtifactsOutput {
                     command: "runs.artifacts",
                     run_id: "run-contract-1".to_string(),
                     artifacts: vec![artifact_record()],
-                }),
-                scenario("runs query json", RunsQueryOutput {
+                })),
+                scenario("runs query json", RunsOutput::Query(RunsQueryOutput {
                     command: "runs.query",
                     filters: RunsQueryFilters {
                         component_id: Some("homeboy".to_string()),
@@ -124,8 +126,8 @@ fn runs_command_json_contract_matches_golden_fixture() {
                     }],
                     table: None,
                     csv: None,
-                }),
-                scenario("runs drift json", RunsDriftOutput {
+                })),
+                scenario("runs drift json", RunsOutput::Drift(RunsDriftOutput {
                     command: "runs.drift",
                     filters: RunsDriftFilters {
                         component_id: Some("homeboy".to_string()),
@@ -148,7 +150,7 @@ fn runs_command_json_contract_matches_golden_fixture() {
                         share_delta: Some(0.45),
                     }],
                     table: None,
-                }),
+                })),
             ]
         }),
     );

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -8,11 +8,9 @@ use serde::Serialize;
 use crate::commands::runs::RunsOutput;
 use homeboy::core::rig::{self, RigResourcesSpec, RigSpec};
 
-/// Tagged union of every rig command's output. `untagged` so each variant
-/// serializes to its own shape — consumers discriminate on the `command`
-/// field inside the shape.
+/// Tagged union of every rig command's output.
 #[derive(Serialize)]
-#[serde(untagged)]
+#[serde(tag = "variant", content = "payload", rename_all = "snake_case")]
 pub enum RigCommandOutput {
     List(RigListOutput),
     Show(RigShowOutput),
@@ -153,7 +151,7 @@ pub struct RigSourcesOutput {
 }
 
 #[derive(Serialize)]
-#[serde(untagged)]
+#[serde(tag = "variant", content = "payload", rename_all = "snake_case")]
 pub enum RigSourcesReport {
     List(rig::RigSourceListResult),
     Remove(rig::RigSourceRemoveResult),

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -117,7 +117,7 @@ pub struct RunsListArgs {
 }
 
 #[derive(Serialize)]
-#[serde(untagged)]
+#[serde(tag = "variant", content = "payload", rename_all = "snake_case")]
 pub enum RunsOutput {
     List(RunsListOutput),
     Distribution(RunsDistributionOutput),

--- a/src/core/refactor/plan/sources/extension_source.rs
+++ b/src/core/refactor/plan/sources/extension_source.rs
@@ -58,8 +58,9 @@ pub(super) fn try_extension_refactor_source_stage<T: Serialize>(
             ]),
         ));
     };
-    let response: ExtensionRefactorSourceResponse =
-        serde_json::from_value(value).map_err(|err| {
+    let response_value = unwrap_refactor_source_payload(value);
+    let response: ExtensionRefactorSourceResponse = serde_json::from_value(response_value)
+        .map_err(|err| {
             Error::validation_invalid_argument(
                 setting_key.clone(),
                 format!(
@@ -106,6 +107,17 @@ pub(super) fn try_extension_refactor_source_stage<T: Serialize>(
         },
         fix_results: response.fix_results,
     }))
+}
+
+fn unwrap_refactor_source_payload(value: serde_json::Value) -> serde_json::Value {
+    if value.get("variant").and_then(serde_json::Value::as_str) != Some("refactor_source") {
+        return value;
+    }
+
+    value
+        .get("payload")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null)
 }
 
 pub(super) fn read_optional_json(path: &Path) -> Option<serde_json::Value> {
@@ -167,7 +179,7 @@ mod tests {
         fs::write(
             extension_dir.join("refactor-source.sh"),
             format!(
-                "#!/bin/sh\ncat > '{}'\nprintf '%s' '{{\"handled\":true,\"detected_findings\":2,\"changed_files\":[\"src/lib.rs\"],\"fix_results\":[{{\"file\":\"src/lib.rs\",\"rule\":\"demo\"}}],\"warnings\":[\"extension handled\"]}}'\n",
+                "#!/bin/sh\ncat > '{}'\nprintf '%s' '{{\"variant\":\"refactor_source\",\"payload\":{{\"handled\":true,\"detected_findings\":2,\"changed_files\":[\"src/lib.rs\"],\"fix_results\":[{{\"file\":\"src/lib.rs\",\"rule\":\"demo\"}}],\"warnings\":[\"extension handled\"]}}}}'\n",
                 capture_file.display()
             ),
         )

--- a/tests/fixtures/golden_json_contracts/bench_contract.json
+++ b/tests/fixtures/golden_json_contracts/bench_contract.json
@@ -3,27 +3,33 @@
     {
       "payload": {
         "data": {
-          "component": "homeboy",
-          "exit_code": 0,
-          "iterations": 3,
-          "passed": true,
-          "status": "passed"
+          "payload": {
+            "component": "homeboy",
+            "exit_code": 0,
+            "iterations": 3,
+            "passed": true,
+            "status": "passed"
+          },
+          "variant": "single"
         },
         "success": true
       },
-      "scenario": "bench single legacy"
+      "scenario": "bench single"
     },
     {
       "payload": {
         "data": {
-          "component": "homeboy",
-          "component_id": "homeboy",
-          "count": 0,
-          "scenarios": []
+          "payload": {
+            "component": "homeboy",
+            "component_id": "homeboy",
+            "count": 0,
+            "scenarios": []
+          },
+          "variant": "list"
         },
         "success": true
       },
-      "scenario": "bench list legacy"
+      "scenario": "bench list"
     }
   ]
 }

--- a/tests/fixtures/golden_json_contracts/runs_contract.json
+++ b/tests/fixtures/golden_json_contracts/runs_contract.json
@@ -3,22 +3,25 @@
     {
       "payload": {
         "data": {
-          "command": "runs.list",
-          "runs": [
-            {
-              "command": "homeboy bench --format=json",
-              "component_id": "homeboy",
-              "cwd": "/work/homeboy",
-              "finished_at": "2026-05-24T00:01:00Z",
-              "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-              "id": "run-contract-1",
-              "kind": "bench",
-              "rig_id": "contract-rig",
-              "started_at": "2026-05-24T00:00:00Z",
-              "status": "passed",
-              "status_note": "fixture"
-            }
-          ]
+          "payload": {
+            "command": "runs.list",
+            "runs": [
+              {
+                "command": "homeboy bench --format=json",
+                "component_id": "homeboy",
+                "cwd": "/work/homeboy",
+                "finished_at": "2026-05-24T00:01:00Z",
+                "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "id": "run-contract-1",
+                "kind": "bench",
+                "rig_id": "contract-rig",
+                "started_at": "2026-05-24T00:00:00Z",
+                "status": "passed",
+                "status_note": "fixture"
+              }
+            ]
+          },
+          "variant": "list"
         },
         "success": true
       },
@@ -27,8 +30,51 @@
     {
       "payload": {
         "data": {
-          "command": "runs.show",
-          "run": {
+          "payload": {
+            "command": "runs.show",
+            "run": {
+              "artifacts": [
+                {
+                  "created_at": "2026-05-24T00:01:00Z",
+                  "id": "artifact-summary",
+                  "kind": "summary",
+                  "mime": "application/json",
+                  "path": "artifacts/summary.json",
+                  "run_id": "run-contract-1",
+                  "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                  "size_bytes": 1234,
+                  "type": "file",
+                  "url": "https://example.test/artifacts/summary.json"
+                }
+              ],
+              "command": "homeboy bench --format=json",
+              "component_id": "homeboy",
+              "cwd": "/work/homeboy",
+              "finished_at": "2026-05-24T00:01:00Z",
+              "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "homeboy_version": "0.197.11",
+              "id": "run-contract-1",
+              "kind": "bench",
+              "metadata": {
+                "scenario": "contract",
+                "score": 0.98
+              },
+              "rig_id": "contract-rig",
+              "started_at": "2026-05-24T00:00:00Z",
+              "status": "passed",
+              "status_note": "fixture"
+            }
+          },
+          "variant": "show"
+        },
+        "success": true
+      },
+      "scenario": "runs show"
+    },
+    {
+      "payload": {
+        "data": {
+          "payload": {
             "artifacts": [
               {
                 "created_at": "2026-05-24T00:01:00Z",
@@ -43,47 +89,10 @@
                 "url": "https://example.test/artifacts/summary.json"
               }
             ],
-            "command": "homeboy bench --format=json",
-            "component_id": "homeboy",
-            "cwd": "/work/homeboy",
-            "finished_at": "2026-05-24T00:01:00Z",
-            "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "homeboy_version": "0.197.11",
-            "id": "run-contract-1",
-            "kind": "bench",
-            "metadata": {
-              "scenario": "contract",
-              "score": 0.98
-            },
-            "rig_id": "contract-rig",
-            "started_at": "2026-05-24T00:00:00Z",
-            "status": "passed",
-            "status_note": "fixture"
-          }
-        },
-        "success": true
-      },
-      "scenario": "runs show"
-    },
-    {
-      "payload": {
-        "data": {
-          "artifacts": [
-            {
-              "created_at": "2026-05-24T00:01:00Z",
-              "id": "artifact-summary",
-              "kind": "summary",
-              "mime": "application/json",
-              "path": "artifacts/summary.json",
-              "run_id": "run-contract-1",
-              "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-              "size_bytes": 1234,
-              "type": "file",
-              "url": "https://example.test/artifacts/summary.json"
-            }
-          ],
-          "command": "runs.artifacts",
-          "run_id": "run-contract-1"
+            "command": "runs.artifacts",
+            "run_id": "run-contract-1"
+          },
+          "variant": "artifacts"
         },
         "success": true
       },
@@ -92,44 +101,47 @@
     {
       "payload": {
         "data": {
-          "command": "runs.query",
-          "filters": {
-            "component_id": "homeboy",
-            "kind": "bench",
-            "limit": 200,
-            "since": "7d"
+          "payload": {
+            "command": "runs.query",
+            "filters": {
+              "component_id": "homeboy",
+              "kind": "bench",
+              "limit": 200,
+              "since": "7d"
+            },
+            "group_by": "$.variant",
+            "groups": [
+              {
+                "count": 1,
+                "group": "candidate"
+              }
+            ],
+            "matched_artifact_count": 1,
+            "rows": [
+              {
+                "artifact_kind": "summary",
+                "run_id": "run-contract-1",
+                "values": [
+                  123.4
+                ]
+              }
+            ],
+            "select": [
+              "$.metrics.ready_ms"
+            ],
+            "skipped_artifact_count": 1,
+            "skipped_artifacts": [
+              {
+                "artifact_id": "artifact-log",
+                "artifact_kind": "log",
+                "artifact_type": "file",
+                "path": "artifacts/output.log",
+                "reason": "not JSON",
+                "run_id": "run-contract-1"
+              }
+            ]
           },
-          "group_by": "$.variant",
-          "groups": [
-            {
-              "count": 1,
-              "group": "candidate"
-            }
-          ],
-          "matched_artifact_count": 1,
-          "rows": [
-            {
-              "artifact_kind": "summary",
-              "run_id": "run-contract-1",
-              "values": [
-                123.4
-              ]
-            }
-          ],
-          "select": [
-            "$.metrics.ready_ms"
-          ],
-          "skipped_artifact_count": 1,
-          "skipped_artifacts": [
-            {
-              "artifact_id": "artifact-log",
-              "artifact_kind": "log",
-              "artifact_type": "file",
-              "path": "artifacts/output.log",
-              "reason": "not JSON",
-              "run_id": "run-contract-1"
-            }
-          ]
+          "variant": "query"
         },
         "success": true
       },
@@ -138,29 +150,32 @@
     {
       "payload": {
         "data": {
-          "baseline_missing_rows": 2,
-          "baseline_observations": 40,
-          "command": "runs.drift",
-          "filters": {
-            "baseline": "30d",
-            "component_id": "homeboy",
-            "kind": "bench",
-            "window": "7d"
+          "payload": {
+            "baseline_missing_rows": 2,
+            "baseline_observations": 40,
+            "command": "runs.drift",
+            "filters": {
+              "baseline": "30d",
+              "component_id": "homeboy",
+              "kind": "bench",
+              "window": "7d"
+            },
+            "metric": "$.variant",
+            "threshold": 0.5,
+            "values": [
+              {
+                "baseline_share": 0.25,
+                "dominant": true,
+                "share_delta": 0.45,
+                "value": "candidate",
+                "window_count": 7,
+                "window_share": 0.7
+              }
+            ],
+            "window_missing_rows": 0,
+            "window_observations": 10
           },
-          "metric": "$.variant",
-          "threshold": 0.5,
-          "values": [
-            {
-              "baseline_share": 0.25,
-              "dominant": true,
-              "share_delta": 0.45,
-              "value": "candidate",
-              "window_count": 7,
-              "window_share": 0.7
-            }
-          ],
-          "window_missing_rows": 0,
-          "window_observations": 10
+          "variant": "drift"
         },
         "success": true
       },

--- a/tests/output_contracts_test.rs
+++ b/tests/output_contracts_test.rs
@@ -252,7 +252,7 @@ fn runs_rig_and_bench_output_variants_have_unambiguous_contracts() {
         "bench",
         vec![
             variant_contract(
-                "single_legacy",
+                "single",
                 json!({
                     "passed": true,
                     "status": "passed",
@@ -287,7 +287,7 @@ fn runs_rig_and_bench_output_variants_have_unambiguous_contracts() {
                 }),
             ),
             variant_contract(
-                "list_legacy",
+                "list",
                 json!({
                     "component": "homeboy",
                     "component_id": "homeboy",
@@ -340,7 +340,13 @@ fn typed_output_value<T: Serialize>(output: T) -> Value {
 }
 
 fn variant_contract(name: &'static str, value: Value) -> VariantContract {
-    VariantContract { name, value }
+    VariantContract {
+        name,
+        value: json!({
+            "variant": name,
+            "payload": value,
+        }),
+    }
 }
 
 fn assert_unique_variant_signatures(group: &str, contracts: Vec<VariantContract>) {
@@ -358,6 +364,10 @@ fn assert_unique_variant_signatures(group: &str, contracts: Vec<VariantContract>
 }
 
 fn variant_signature(value: &Value) -> String {
+    if let Some(variant) = value.get("variant").and_then(Value::as_str) {
+        return format!("variant={variant}");
+    }
+
     if let Some(command) = value.get("command").and_then(Value::as_str) {
         return format!("command={command}");
     }


### PR DESCRIPTION
## Summary
- Remove the explicit LegacyUntagged output contract kinds from the CLI surface.
- Switch bench, runs, rig, and rig sources command output enums to tagged JSON payloads.
- Update golden output fixtures and output contract tests to assert canonical tagged shapes.
- Rebase onto current main and update command_status_contracts expectations for the tagged runs envelope.
- Accept canonical tagged refactor-source extension responses and update the generic extension test stub.

Closes https://github.com/Extra-Chill/homeboy/issues/2921

## Tests
- cargo test --test output_contracts_test
- cargo test golden_contract_tests
- cargo test bench_
- cargo test runs_
- cargo run --bin homeboy -- audit
- cargo test extension_refactor_source_dispatch_uses_generic_source_result -- --nocapture
- cargo run --bin homeboy -- --force-hot test --changed-since origin/main
- git diff --check

## Blockers
- None.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the output contract migration, fixture/test updates, rebase refresh, audit expectation fix, tagged refactor-source test fix, and targeted verification; Chris remains responsible for review and merge.