### PR TITLE
Require explicit portable component ids

### DIFF
--- a/docs/schemas/portable-config.md
+++ b/docs/schemas/portable-config.md
@@ -6,6 +6,7 @@ A `homeboy.json` file in a repo root defines portable component configuration th
 
 ```json
 {
+  "id": "string",
   "remote_path": "string",
   "build_artifact": "string",
   "extract_command": "string",
@@ -22,12 +23,13 @@ A `homeboy.json` file in a repo root defines portable component configuration th
 }
 ```
 
-All fields are optional. The component `id` is derived from the directory name, and `local_path` is always machine-specific (provided at registration time).
+The component `id` field is required and must be a non-empty string. All other fields are optional. `local_path` is always machine-specific and provided at registration or resolution time.
 
 ## Example
 
 ```json
 {
+  "id": "data-machine",
   "remote_path": "wp-content/plugins/data-machine",
   "version_targets": [
     {
@@ -62,12 +64,12 @@ homeboy component create --local-path /path/to/repo --changelog-target "CHANGELO
 | Field | Why |
 |-------|-----|
 | `local_path` | Absolute path, varies per machine |
-| `id` | Derived from directory name automatically |
 
 ### What goes in homeboy.json
 
 | Field | Description |
 |-------|-------------|
+| `id` | Required stable component identifier |
 | `remote_path` | Deploy target relative to project `base_path` |
 | `build_artifact` | Build output path relative to repo root |
 | `extract_command` | Post-upload command (supports `{artifact}`, `{targetDir}`) |

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -26,7 +26,7 @@ pub use inventory::{
 pub use mutations::{delete_safe, merge, rename};
 pub use portable::{
     discover_from_portable, infer_portable_component_id, mutate_portable, portable_json,
-    write_portable_config,
+    try_discover_from_portable, write_portable_config,
 };
 pub use relationships::{associated_projects, projects_using, rename_component, shared_components};
 pub use resolution::{

--- a/src/core/component/portable.rs
+++ b/src/core/component/portable.rs
@@ -28,29 +28,49 @@ pub(crate) fn read_portable_config(repo_path: &Path) -> Result<Option<Value>> {
     Ok(Some(value))
 }
 
-fn portable_component_id_from_value(portable: &Value, dir: &Path) -> Option<String> {
-    // If "id" key exists, it must be non-empty. A blank id in homeboy.json is an error,
-    // not a fallback signal. (#801: blank ids caused split-brain between project/component
-    // discovery and the component registry.)
-    if let Some(id_value) = portable.get("id") {
-        if let Some(id_str) = id_value.as_str() {
-            if id_str.trim().is_empty() {
-                // Blank id is present — log a warning and reject (return None so
-                // discover_from_portable returns None, forcing explicit registration).
-                crate::log_status!(
-                    "warning",
-                    "homeboy.json at {} has a blank 'id' field — skipping. Fix the file or run `homeboy component create`",
-                    dir.display()
-                );
-                return None;
-            }
-            return crate::core::engine::identifier::slugify_id(id_str, "component_id").ok();
-        }
+fn portable_component_id_from_value(portable: &Value, dir: &Path) -> Result<String> {
+    let id_value = portable.get("id").ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "id",
+            format!(
+                "homeboy.json at {} is missing required 'id' field",
+                dir.display()
+            ),
+            None,
+            Some(vec![
+                "Add an explicit non-empty id to homeboy.json".to_string(),
+                "Example: \"id\": \"my-component\"".to_string(),
+            ]),
+        )
+    })?;
+
+    let Some(id_str) = id_value.as_str() else {
+        return Err(Error::validation_invalid_argument(
+            "id",
+            format!(
+                "homeboy.json at {} must define 'id' as a non-empty string",
+                dir.display()
+            ),
+            Some(id_value.to_string()),
+            Some(vec![
+                "Set id to a string such as \"my-component\"".to_string()
+            ]),
+        ));
+    };
+
+    if id_str.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "id",
+            format!("homeboy.json at {} has a blank 'id' field", dir.display()),
+            None,
+            Some(vec![
+                "Add an explicit non-empty id to homeboy.json".to_string(),
+                "Example: \"id\": \"my-component\"".to_string(),
+            ]),
+        ));
     }
 
-    // No "id" key at all — infer from directory name (backward compat for minimal configs)
-    let dir_name = dir.file_name()?.to_string_lossy();
-    crate::core::engine::identifier::slugify_id(&dir_name, "component_id").ok()
+    crate::core::engine::identifier::slugify_id(id_str, "component_id")
 }
 
 pub fn infer_portable_component_id(dir: &Path) -> Result<String> {
@@ -63,14 +83,7 @@ pub fn infer_portable_component_id(dir: &Path) -> Result<String> {
         )
     })?;
 
-    portable_component_id_from_value(&portable, dir).ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "id",
-            format!("Could not derive component ID from {}", dir.display()),
-            None,
-            None,
-        )
-    })
+    portable_component_id_from_value(&portable, dir)
 }
 
 pub fn portable_json(component: &Component) -> Result<Value> {
@@ -261,7 +274,19 @@ where
 /// If the directory is a git repo and `remote_url` isn't set in the portable config,
 /// auto-detects it from `git remote get-url origin`.
 pub fn discover_from_portable(dir: &Path) -> Option<Component> {
-    let portable = read_portable_config(dir).ok()??;
+    match try_discover_from_portable(dir) {
+        Ok(component) => component,
+        Err(error) => {
+            crate::log_status!("warning", "{}", error);
+            None
+        }
+    }
+}
+
+pub fn try_discover_from_portable(dir: &Path) -> Result<Option<Component>> {
+    let Some(portable) = read_portable_config(dir)? else {
+        return Ok(None);
+    };
 
     let id = portable_component_id_from_value(&portable, dir)?;
     let local_path = dir.to_string_lossy().to_string();
@@ -281,7 +306,7 @@ pub fn discover_from_portable(dir: &Path) -> Option<Component> {
         }
     }
 
-    serde_json::from_value::<Component>(json).ok()
+    Ok(serde_json::from_value::<Component>(json).ok())
 }
 
 #[cfg(test)]
@@ -434,6 +459,84 @@ mod tests {
         assert!(
             result.is_none(),
             "blank id should cause discover to return None"
+        );
+    }
+
+    #[test]
+    fn missing_id_in_homeboy_json_is_validation_error() {
+        let dir = TempDir::new().expect("temp dir");
+        let json = serde_json::json!({
+            "remote_path": "wp-content/plugins/test"
+        });
+        fs::write(
+            dir.path().join("homeboy.json"),
+            serde_json::to_string_pretty(&json).unwrap(),
+        )
+        .unwrap();
+
+        let error = infer_portable_component_id(dir.path()).expect_err("missing id must fail");
+
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("missing required 'id' field"),
+            "{rendered}"
+        );
+        assert!(
+            error
+                .details
+                .to_string()
+                .contains("Add an explicit non-empty id to homeboy.json"),
+            "{}",
+            error.details
+        );
+    }
+
+    #[test]
+    fn blank_id_in_homeboy_json_is_validation_error() {
+        let dir = TempDir::new().expect("temp dir");
+        let json = serde_json::json!({
+            "id": "   ",
+            "remote_path": "wp-content/plugins/test"
+        });
+        fs::write(
+            dir.path().join("homeboy.json"),
+            serde_json::to_string_pretty(&json).unwrap(),
+        )
+        .unwrap();
+
+        let error = infer_portable_component_id(dir.path()).expect_err("blank id must fail");
+
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        let rendered = error.to_string();
+        assert!(rendered.contains("blank 'id' field"), "{rendered}");
+        assert!(
+            error
+                .details
+                .to_string()
+                .contains("Add an explicit non-empty id to homeboy.json"),
+            "{}",
+            error.details
+        );
+    }
+
+    #[test]
+    fn missing_id_in_homeboy_json_returns_none_from_discover() {
+        let dir = TempDir::new().expect("temp dir");
+        let json = serde_json::json!({
+            "remote_path": "wp-content/plugins/test"
+        });
+        fs::write(
+            dir.path().join("homeboy.json"),
+            serde_json::to_string_pretty(&json).unwrap(),
+        )
+        .unwrap();
+
+        let result = discover_from_portable(dir.path());
+
+        assert!(
+            result.is_none(),
+            "missing id should cause discover to return None"
         );
     }
 

--- a/src/core/component/portable.rs
+++ b/src/core/component/portable.rs
@@ -28,6 +28,13 @@ pub(crate) fn read_portable_config(repo_path: &Path) -> Result<Option<Value>> {
     Ok(Some(value))
 }
 
+fn explicit_id_hints() -> Vec<String> {
+    vec![
+        "Add an explicit non-empty id to homeboy.json".to_string(),
+        "Example: \"id\": \"my-component\"".to_string(),
+    ]
+}
+
 fn portable_component_id_from_value(portable: &Value, dir: &Path) -> Result<String> {
     let id_value = portable.get("id").ok_or_else(|| {
         Error::validation_invalid_argument(
@@ -37,10 +44,7 @@ fn portable_component_id_from_value(portable: &Value, dir: &Path) -> Result<Stri
                 dir.display()
             ),
             None,
-            Some(vec![
-                "Add an explicit non-empty id to homeboy.json".to_string(),
-                "Example: \"id\": \"my-component\"".to_string(),
-            ]),
+            Some(explicit_id_hints()),
         )
     })?;
 
@@ -63,10 +67,7 @@ fn portable_component_id_from_value(portable: &Value, dir: &Path) -> Result<Stri
             "id",
             format!("homeboy.json at {} has a blank 'id' field", dir.display()),
             None,
-            Some(vec![
-                "Add an explicit non-empty id to homeboy.json".to_string(),
-                "Example: \"id\": \"my-component\"".to_string(),
-            ]),
+            Some(explicit_id_hints()),
         ));
     }
 

--- a/src/core/component/resolution.rs
+++ b/src/core/component/resolution.rs
@@ -1,4 +1,6 @@
-use crate::core::component::{discover_from_portable, inventory, load, Component};
+use crate::core::component::{
+    discover_from_portable, inventory, load, try_discover_from_portable, Component,
+};
 use crate::core::error::{Error, Result};
 use crate::core::extension::{self, ExtensionCapability};
 use std::path::{Path, PathBuf};
@@ -189,39 +191,39 @@ fn synthetic_component_for_path(path: &str) -> Component {
     }
 }
 
-fn resolve_path_override(path: &str) -> Component {
-    if let Some(mut discovered) = discover_from_portable(Path::new(path)) {
+fn resolve_path_override(path: &str) -> Result<Component> {
+    if let Some(mut discovered) = try_discover_from_portable(Path::new(path))? {
         discovered.local_path = path.to_string();
         discovered.resolve_remote_path();
-        return discovered;
+        return Ok(discovered);
     }
 
     let dir = Path::new(path);
     if let Some(git_root) = detect_git_root(dir) {
         if git_root != dir {
-            if let Some(mut discovered) = discover_from_portable(&git_root) {
+            if let Some(mut discovered) = try_discover_from_portable(&git_root)? {
                 discovered.local_path = path.to_string();
                 discovered.resolve_remote_path();
-                return discovered;
+                return Ok(discovered);
             }
         }
     }
 
-    synthetic_component_for_path(path)
+    Ok(synthetic_component_for_path(path))
 }
 
-fn path_has_portable_config(path: &Path) -> bool {
-    if discover_from_portable(path).is_some() {
-        return true;
+fn path_has_portable_config(path: &Path) -> Result<bool> {
+    if try_discover_from_portable(path)?.is_some() {
+        return Ok(true);
     }
 
     if let Some(git_root) = detect_git_root(path) {
         if git_root != path {
-            return discover_from_portable(&git_root).is_some();
+            return Ok(try_discover_from_portable(&git_root)?.is_some());
         }
     }
 
-    false
+    Ok(false)
 }
 
 /// Resolve a target from the shared command-facing contract.
@@ -261,7 +263,8 @@ pub fn resolve_target(spec: TargetSpec<'_>) -> Result<ResolvedTarget> {
         .path_override
         .or_else(|| component_id_is_bare_dir.then_some(component.local_path.as_str()));
     let synthetic = explicit_path
-        .map(|path| !path_has_portable_config(Path::new(path)))
+        .map(|path| path_has_portable_config(Path::new(path)).map(|has_config| !has_config))
+        .transpose()?
         .unwrap_or(false);
     if synthetic && !spec.allow_synthetic {
         return Err(Error::validation_invalid_argument(
@@ -323,13 +326,13 @@ pub fn resolve(id: Option<&str>) -> Result<Component> {
 
     let cwd = std::env::current_dir().map_err(|e| Error::internal_io(e.to_string(), None))?;
 
-    if let Some(component) = discover_from_portable(&cwd) {
+    if let Some(component) = try_discover_from_portable(&cwd)? {
         return Ok(component);
     }
 
     if let Some(git_root) = detect_git_root(&cwd) {
         if git_root != cwd {
-            if let Some(component) = discover_from_portable(&git_root) {
+            if let Some(component) = try_discover_from_portable(&git_root)? {
                 return Ok(component);
             }
         }
@@ -380,7 +383,7 @@ fn resolve_effective_inner(
 
     if let Some(id) = id {
         if let Some(path) = path_override {
-            if let Some(mut discovered) = discover_from_portable(Path::new(path)) {
+            if let Some(mut discovered) = try_discover_from_portable(Path::new(path))? {
                 discovered.id = id.to_string();
                 discovered.local_path = path.to_string();
                 discovered.resolve_remote_path();
@@ -398,7 +401,7 @@ fn resolve_effective_inner(
         } else {
             let id_path = Path::new(id);
             if accept_bare_directory && id_path.is_dir() {
-                if let Some(mut discovered) = discover_from_portable(id_path) {
+                if let Some(mut discovered) = try_discover_from_portable(id_path)? {
                     discovered.local_path = id.to_string();
                     discovered.resolve_remote_path();
                     return Ok(discovered);
@@ -427,7 +430,7 @@ fn resolve_effective_inner(
         }
     } else {
         if let Some(path) = path_override {
-            return Ok(resolve_path_override(path));
+            return resolve_path_override(path);
         }
 
         resolve(None)
@@ -609,6 +612,24 @@ mod tests {
     }
 
     #[test]
+    fn resolve_effective_path_override_rejects_portable_config_without_id() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let repo = dir.path().join("portable-repo");
+        std::fs::create_dir_all(&repo).expect("create repo dir");
+        std::fs::write(repo.join("homeboy.json"), r#"{"extensions":{"nodejs":{}}}"#)
+            .expect("write portable config");
+
+        let error = resolve_effective(None, repo.to_str(), None)
+            .expect_err("path-only portable config without id should fail");
+
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(
+            error.to_string().contains("missing required 'id' field"),
+            "{error}"
+        );
+    }
+
+    #[test]
     fn target_spec_resolves_registered_component() {
         crate::test_support::with_isolated_home(|home| {
             let repo = home.path().join("registered-repo");
@@ -655,6 +676,24 @@ mod tests {
         assert_eq!(target.component_id, "path-id");
         assert_eq!(target.source_path, repo);
         assert!(!target.synthetic);
+    }
+
+    #[test]
+    fn target_spec_rejects_path_override_portable_config_without_id() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let repo = dir.path().join("path-repo");
+        std::fs::create_dir_all(&repo).expect("repo dir");
+        std::fs::write(repo.join("homeboy.json"), r#"{"remote_path":"remote"}"#)
+            .expect("portable config");
+
+        let error = resolve_target(TargetSpec::new(None, repo.to_str()))
+            .expect_err("portable config without id should fail");
+
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(
+            error.to_string().contains("missing required 'id' field"),
+            "{error}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- require repo-local homeboy.json files to define a non-empty explicit id
- surface missing, blank, or non-string id as validation errors instead of directory-name inference
- preserve path-only synthetic fallback only when no portable homeboy.json exists
- update portable config docs and coverage

Closes https://github.com/Extra-Chill/homeboy/issues/2924

## Tests
- cargo test core::component::portable::tests --lib
- cargo test core::component --lib
- cargo check --all-targets
- cargo test core::git --lib
- cargo test commands::component --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the portable component validation change, tests, docs update, and verification commands for Chris to review.