### PR TITLE
Remove dynamic set compatibility parsing

### DIFF
--- a/docs/commands/component.md
+++ b/docs/commands/component.md
@@ -53,10 +53,9 @@ homeboy component show <id>
 
 ```sh
 homeboy component set <id> --json <JSON>
-homeboy component set <id> '<JSON>'
+homeboy component set <id> --base64 <BASE64_JSON>
 homeboy component set --json <JSON>   # id may be provided in JSON body
-homeboy component set <id> --key value   # dynamic flags
-homeboy component set <id> --json '{}' -- --key value   # combining --json with dynamic flags
+homeboy component set <id> --changelog-target "CHANGELOG.md"   # dedicated flag
 ```
 
 Updates a component by merging a JSON object into `components/<id>.json`.
@@ -64,17 +63,14 @@ Updates a component by merging a JSON object into `components/<id>.json`.
 Options:
 
 - `--json <JSON>`: JSON object to merge into config (supports `@file` and `-` for stdin)
+- `--base64 <BASE64_JSON>`: Base64-encoded JSON object for shell-sensitive payloads
 - `--replace <field>`: replace array fields instead of union (repeatable)
-- `--key value`: Dynamic flags that map directly to JSON keys (e.g., `--changelog-target "CHANGELOG.md"`)
+- Dedicated flags for common fields: `--local-path`, `--remote-path`, `--build-artifact`, `--extract-command`, `--changelog-target`, `--version-target`, and `--extension`
 
-**Important:** When combining `--json` with dynamic flags, you must add an explicit `--` separator before the dynamic flags:
+Arbitrary field updates must use `--json` or `--base64`. Positional JSON, positional `key=value`, and trailing arbitrary `--key value` updates are not accepted.
 
 ```sh
-# Correct: explicit separator before dynamic flags
-homeboy component set my-plugin --json '{"type":"plugin"}' -- --docs_dir "docs"
-
-# Incorrect: will fail with "unexpected argument"
-homeboy component set my-plugin --json '{"type":"plugin"}' --docs_dir "docs"
+homeboy component set my-plugin --json '{"type":"plugin","docs_dir":"docs"}'
 ```
 
 Notes:
@@ -116,12 +112,12 @@ homeboy component set <id> --json '{"extensions": {"github": {"settings": {}}, "
 To configure changelog tracking for a component:
 
 ```sh
-# Using dynamic flag (recommended)
+# Using dedicated flag (recommended)
 homeboy component set <id> --changelog-target "CHANGELOG.md"
 homeboy component set <id> --changelog-target "docs/CHANGELOG.md"
 
 # Using JSON format
-homeboy component set <id> '{"changelog_target": "docs/CHANGELOG.md"}'
+homeboy component set <id> --json '{"changelog_target": "docs/CHANGELOG.md"}'
 ```
 
 Note: `changelog_target` is a string path relative to `local_path`, not an object.

--- a/docs/commands/fleet.md
+++ b/docs/commands/fleet.md
@@ -44,10 +44,11 @@ Display fleet configuration including project list.
 
 ```sh
 homeboy fleet set <id> --json <JSON>
-homeboy fleet set <id> '<JSON>'
+homeboy fleet set <id> --base64 <BASE64_JSON>
 ```
 
 Update fleet configuration by merging a JSON object.
+Arbitrary fleet updates must use `--json` or `--base64`; positional JSON and positional `key=value` updates are not accepted.
 
 ### `delete`
 

--- a/docs/commands/project.md
+++ b/docs/commands/project.md
@@ -153,15 +153,17 @@ Only these commands require `server_id`:
 
 ```sh
 homeboy project set <project_id> --json <JSON>
-homeboy project set <project_id> '<JSON>'
+homeboy project set <project_id> --base64 <BASE64_JSON>
 homeboy project set --json <JSON>   # project_id may be provided in JSON body
 ```
 
 Updates a project by merging a JSON object into `projects/<id>.json`.
+Arbitrary project updates must use `--json` or `--base64`; positional JSON and positional `key=value` updates are not accepted.
 
 Options:
 
 - `--json <JSON>`: JSON object to merge into config (supports `@file` and `-` for stdin)
+- `--base64 <BASE64_JSON>`: Base64-encoded JSON object for shell-sensitive payloads
 - `--replace <field>`: replace array fields instead of union (repeatable)
 
 Notes:

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -183,11 +183,12 @@ homeboy runner show <id>
 
 ```sh
 homeboy runner set <id> --json <JSON>
-homeboy runner set <id> workspace_root=/srv/homeboy
-homeboy runner set <id> -- --concurrency_limit 4
+homeboy runner set <id> --base64 <BASE64_JSON>
+homeboy runner set <id> --json '{"workspace_root":"/srv/homeboy","concurrency_limit":4}'
 ```
 
 Updates a runner by merging a JSON object into the runner config. SSH runner settings live under `servers/<id>.json` as the server's `runner` capability; local runners live under `runners/<id>.json`.
+Arbitrary runner updates must use `--json` or `--base64`; positional `key=value` and trailing arbitrary `--key value` updates are not accepted.
 
 ### `remove`
 

--- a/docs/commands/server.md
+++ b/docs/commands/server.md
@@ -42,14 +42,14 @@ homeboy server show <server_id>
 
 ```sh
 homeboy server set <server_id> --json <JSON>
-homeboy server set <server_id> '<JSON>'
-homeboy server set <server_id> auth.mode=key_plus_password_controlmaster
+homeboy server set <server_id> --base64 <BASE64_JSON>
+homeboy server set <server_id> --json '{"auth":{"mode":"key_plus_password_controlmaster"}}'
 homeboy server set --json <JSON>   # server_id may be provided in JSON body
 ```
 
 Updates a server by merging a JSON object into `servers/<id>.json`. Runner-capable servers store their runner settings under the nested `runner` object; `homeboy runner enable <server_id>` is the preferred CLI for adding that capability.
 
-`key=value` arguments support dotted paths, so `auth.mode=value` is equivalent to `{"auth":{"mode":"value"}}`.
+Arbitrary server updates must use `--json` or `--base64`; positional JSON, positional `key=value`, and dotted-path compatibility updates are not accepted.
 
 Use `null` in JSON to clear a field (for example, `{"identity_file": null}`).
 

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -847,6 +847,69 @@ mod tests {
     }
 
     #[test]
+    fn dynamic_set_commands_require_canonical_update_inputs() {
+        for args in [
+            [
+                "homeboy",
+                "server",
+                "set",
+                "sandbox",
+                "auth.mode=key_plus_password_controlmaster",
+            ]
+            .as_slice(),
+            [
+                "homeboy",
+                "project",
+                "set",
+                "sandbox",
+                r#"{"base_path":"/srv/site"}"#,
+            ]
+            .as_slice(),
+            [
+                "homeboy",
+                "runner",
+                "set",
+                "sandbox",
+                "--",
+                "--concurrency_limit",
+                "4",
+            ]
+            .as_slice(),
+        ] {
+            assert!(
+                Cli::try_parse_from(args).is_err(),
+                "dynamic set compatibility form should not parse: {args:?}"
+            );
+        }
+
+        for args in [
+            [
+                "homeboy",
+                "server",
+                "set",
+                "sandbox",
+                "--json",
+                r#"{"host":"example.com"}"#,
+            ]
+            .as_slice(),
+            ["homeboy", "project", "set", "sandbox", "--base64", "e30="].as_slice(),
+            [
+                "homeboy",
+                "component",
+                "set",
+                "sandbox",
+                "--changelog-target",
+                "CHANGELOG.md",
+            ]
+            .as_slice(),
+        ] {
+            Cli::try_parse_from(args).unwrap_or_else(|error| {
+                panic!("canonical dynamic set form failed to parse: {args:?}\n{error}")
+            });
+        }
+    }
+
+    #[test]
     fn test_response_mode() {
         assert_eq!(
             parsed_command(&["homeboy", "status"]).response_mode(false),

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -71,8 +71,7 @@ enum ComponentCommand {
     /// Update component configuration fields
     ///
     /// Supports dedicated flags for common fields (e.g., --local-path, --changelog-target)
-    /// as well as --json for arbitrary updates. When combining --json with dynamic
-    /// trailing flags, use '--' separator.
+    /// as well as --json/--base64 for arbitrary object updates.
     #[command(visible_aliases = ["edit", "merge"])]
     Set {
         #[command(flatten)]
@@ -763,13 +762,16 @@ fn set(
     extensions: Vec<String>,
 ) -> CmdResult<ComponentOutput> {
     // Check if there's any input at all
-    let has_dynamic = args.json_spec()?.is_some() || !args.effective_extra().is_empty();
+    let has_dynamic = args.json_spec()?.is_some();
     if !has_dynamic && !flags.has_any() && version_targets.is_empty() && extensions.is_empty() {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "spec",
-            "Provide a flag (e.g., --local-path), --json spec, --base64, --key value, --version-target, or --extension",
+            "Provide a dedicated flag (e.g., --local-path), --json '<object>', --base64 <encoded-json>, --version-target, or --extension",
             None,
-            None,
+            Some(vec![
+                "Arbitrary field updates must use --json or --base64.".to_string(),
+                "Example: homeboy component set <id> --json '{\"remote_path\":\"wp-content/plugins/plugin\"}'".to_string(),
+            ]),
         ));
     }
 

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -228,9 +228,12 @@ fn set(args: DynamicSetArgs) -> CmdResult<FleetOutput> {
     let merged = super::merge_dynamic_args(&args)?.ok_or_else(|| {
         homeboy::core::Error::validation_invalid_argument(
             "spec",
-            "Provide JSON spec, --json flag, --base64 flag, or --key value flags",
+            "Provide --json '<object>' or --base64 <encoded-json>",
             None,
-            None,
+            Some(vec![
+                "Arbitrary fleet updates must use explicit JSON input.".to_string(),
+                "Example: homeboy fleet set <id> --json '{\"projects\":[\"site\"]}'".to_string(),
+            ]),
         )
     })?;
     let (json_string, replace_fields) = super::finalize_set_spec(&merged, &args.replace)?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,6 @@
 use base64::Engine;
 use clap::Args;
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value};
 
 pub type CmdResult<T> = homeboy::core::Result<(T, i32)>;
 
@@ -49,60 +49,27 @@ pub fn parse_key_json(s: &str) -> Result<(String, serde_json::Value), String> {
 pub struct GlobalArgs {}
 
 /// Shared arguments for dynamic set commands.
-///
-/// Allows arbitrary `--key value` pairs that map directly to JSON keys.
-/// Also accepts positional `key=value` pairs for copy-pasteable remediation
-/// commands. Flag names become JSON keys with no case conversion.
-///
-/// # Combining --json with dynamic flags
-///
-/// When using both `--json` and dynamic `--key value` flags, you MUST add
-/// an explicit `--` separator before the dynamic flags:
-///
-/// ```sh
-/// # Correct: explicit separator before dynamic flags
-/// homeboy component set my-component --json '{"type":"plugin"}' -- --extract_command "unzip -o artifact.zip"
-///
-/// # Incorrect: will fail with "unexpected argument"
-/// homeboy component set my-component --json '{"type":"plugin"}' --extract_command "unzip -o artifact.zip"
-/// ```
-///
-/// This is required because without the positional JSON spec, the parser
-/// cannot determine where dynamic trailing arguments begin.
 #[derive(Args, Default, Debug)]
 pub struct DynamicSetArgs {
     /// Entity ID (optional if provided in JSON body)
     pub id: Option<String>,
 
-    /// JSON spec (positional, supports @file and - for stdin)
-    pub spec: Option<String>,
-
-    /// Explicit JSON spec (takes precedence over positional)
+    /// JSON object to merge into the entity (supports @file and - for stdin)
     #[arg(long, value_name = "JSON")]
     pub json: Option<String>,
 
-    /// Base64-encoded JSON spec (bypasses shell escaping issues)
+    /// Base64-encoded JSON object (bypasses shell escaping issues)
     #[arg(long, value_name = "BASE64")]
     pub base64: Option<String>,
 
     /// Replace these fields instead of merging arrays
     #[arg(long, value_name = "FIELD")]
     pub replace: Vec<String>,
-
-    /// Dynamic key=value flags (e.g., --remote_path /var/www).
-    /// When combined with --json, add '--' separator first:
-    /// `homeboy component set ID --json '{}' -- --key value`
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    pub extra: Vec<String>,
 }
 
 impl DynamicSetArgs {
-    /// Get the JSON spec from --base64, --json, or positional argument.
-    /// Priority: --base64 > --json > positional spec
-    ///
-    /// If the positional `spec` looks like a flag (starts with `--`), it was
-    /// misrouted by clap after a `--` separator and is not a JSON spec.
-    /// Use `effective_extra()` to recover it as a key-value flag.
+    /// Get the JSON spec from --base64 or --json.
+    /// Priority: --base64 > --json.
     pub fn json_spec(&self) -> Result<Option<String>, homeboy::core::Error> {
         // Base64 takes priority - decode and return
         if let Some(b64) = &self.base64 {
@@ -126,137 +93,17 @@ impl DynamicSetArgs {
             })?;
             return Ok(Some(decoded_str));
         }
-        // If spec looks like a dynamic set argument, it was misrouted — not a JSON spec
-        if let Some(ref s) = self.spec {
-            if is_dynamic_set_arg(s) {
-                return Ok(self.json.clone());
-            }
-        }
-        Ok(self.json.clone().or_else(|| self.spec.clone()))
+        Ok(self.json.clone())
     }
-
-    /// Return the full list of trailing key-value args, including any flag
-    /// that was misrouted into the `spec` positional by clap.
-    ///
-    /// When `--` separates trailing args, clap assigns the first positional
-    /// after the ID to `spec`. If that value is a dynamic set argument, it
-    /// belongs with `extra`.
-    pub fn effective_extra(&self) -> Vec<String> {
-        match &self.spec {
-            Some(s) if is_dynamic_set_arg(s) => {
-                let mut combined = vec![s.clone()];
-                combined.extend(self.extra.iter().cloned());
-                combined
-            }
-            _ => self.extra.clone(),
-        }
-    }
-}
-
-fn is_dynamic_set_arg(arg: &str) -> bool {
-    arg.starts_with("--") || parse_key_value_arg(arg).is_some()
 }
 
 // ============================================================================
 // JSON Input Parsing (CLI layer)
 // ============================================================================
 
-/// Parse --key value and key=value pairs into a JSON object.
-fn parse_kv_flags(extra: &[String]) -> homeboy::core::Result<Value> {
-    let mut obj = Map::new();
-    let mut iter = extra.iter().peekable();
-
-    while let Some(arg) = iter.next() {
-        if let Some((key, value)) = parse_key_value_arg(arg) {
-            insert_path_value(&mut obj, &key, parse_value(&value));
-        } else if let Some(key) = arg.strip_prefix("--") {
-            let value = iter.next().ok_or_else(|| {
-                homeboy::core::Error::validation_invalid_argument(
-                    key,
-                    format!("Missing value for flag --{}", key),
-                    None,
-                    None,
-                )
-            })?;
-            let parsed = parse_value(value);
-            insert_path_value(&mut obj, key, parsed);
-        }
-    }
-
-    Ok(Value::Object(obj))
-}
-
-fn parse_key_value_arg(arg: &str) -> Option<(String, String)> {
-    let (key, value) = arg.split_once('=')?;
-    if key.is_empty() || key.starts_with('-') {
-        return None;
-    }
-    Some((key.to_string(), value.to_string()))
-}
-
-fn insert_path_value(obj: &mut Map<String, Value>, key: &str, value: Value) {
-    let mut parts = key.split('.').filter(|part| !part.is_empty()).peekable();
-    let Some(first) = parts.next() else {
-        return;
-    };
-
-    if parts.peek().is_none() {
-        obj.insert(first.to_string(), value);
-        return;
-    }
-
-    let mut current = obj
-        .entry(first.to_string())
-        .or_insert_with(|| Value::Object(Map::new()));
-
-    while let Some(part) = parts.next() {
-        if parts.peek().is_none() {
-            if let Value::Object(map) = current {
-                map.insert(part.to_string(), value);
-            }
-            return;
-        }
-
-        if !current.is_object() {
-            *current = Value::Object(Map::new());
-        }
-        let Value::Object(map) = current else {
-            return;
-        };
-        current = map
-            .entry(part.to_string())
-            .or_insert_with(|| Value::Object(Map::new()));
-    }
-}
-
-/// Parse a string value into appropriate JSON type.
-/// Order: JSON literal → bool → number → string
-fn parse_value(s: &str) -> Value {
-    // Try JSON first (handles arrays, objects, quoted strings)
-    if let Ok(v) = serde_json::from_str(s) {
-        return v;
-    }
-    // Try bool
-    if s == "true" {
-        return json!(true);
-    }
-    if s == "false" {
-        return json!(false);
-    }
-    // Try number
-    if let Ok(n) = s.parse::<i64>() {
-        return json!(n);
-    }
-    if let Ok(n) = s.parse::<f64>() {
-        return json!(n);
-    }
-    // Default to string
-    json!(s)
-}
-
-/// Merge JSON spec with --key value flags. Flags override spec values.
-pub fn merge_json_sources(spec: Option<&str>, extra: &[String]) -> homeboy::core::Result<Value> {
-    let mut base = if let Some(spec) = spec {
+/// Parse the canonical JSON spec for a set-style update.
+pub fn merge_json_sources(spec: Option<&str>) -> homeboy::core::Result<Value> {
+    let base = if let Some(spec) = spec {
         let raw = homeboy::core::config::read_json_spec_to_string(spec)?;
         serde_json::from_str(&raw).map_err(|e| {
             let hint = if raw.contains('\\') {
@@ -283,15 +130,6 @@ pub fn merge_json_sources(spec: Option<&str>, extra: &[String]) -> homeboy::core
         Value::Object(Map::new())
     };
 
-    if !extra.is_empty() {
-        let flags = parse_kv_flags(extra)?;
-        if let (Value::Object(base_obj), Value::Object(flags_obj)) = (&mut base, flags) {
-            for (k, v) in flags_obj {
-                base_obj.insert(k, v);
-            }
-        }
-    }
-
     Ok(base)
 }
 
@@ -300,14 +138,13 @@ pub fn merge_json_sources(spec: Option<&str>, extra: &[String]) -> homeboy::core
 // ============================================================================
 
 /// Merge JSON sources from `DynamicSetArgs` into a single JSON value.
-/// Returns `None` if no JSON/base64/key-value input was provided.
+/// Returns `None` if no JSON/base64 input was provided.
 pub fn merge_dynamic_args(args: &DynamicSetArgs) -> homeboy::core::Result<Option<Value>> {
     let spec = args.json_spec()?;
-    let extra = args.effective_extra();
-    if spec.is_none() && extra.is_empty() {
+    if spec.is_none() {
         return Ok(None);
     }
-    Ok(Some(merge_json_sources(spec.as_deref(), &extra)?))
+    Ok(Some(merge_json_sources(spec.as_deref())?))
 }
 
 /// Serialize a merged JSON value to a string and compute the full replace
@@ -389,10 +226,10 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn merge_dynamic_args_accepts_positional_key_value_pair() {
+    fn merge_dynamic_args_accepts_explicit_json() {
         let args = DynamicSetArgs {
             id: Some("sandbox".to_string()),
-            spec: Some("auth.mode=key_plus_password_controlmaster".to_string()),
+            json: Some(r#"{"auth":{"mode":"key_plus_password_controlmaster"}}"#.to_string()),
             ..Default::default()
         };
 
@@ -405,11 +242,12 @@ mod tests {
     }
 
     #[test]
-    fn merge_dynamic_args_accepts_dotted_flag_path() {
+    fn merge_dynamic_args_accepts_base64_json() {
+        let encoded = base64::engine::general_purpose::STANDARD
+            .encode(r#"{"auth":{"mode":"key_plus_password_controlmaster"}}"#);
         let args = DynamicSetArgs {
             id: Some("sandbox".to_string()),
-            spec: Some("--auth.mode".to_string()),
-            extra: vec!["key_plus_password_controlmaster".to_string()],
+            base64: Some(encoded),
             ..Default::default()
         };
 

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -292,9 +292,13 @@ fn set(args: super::DynamicSetArgs) -> CmdResult<ProjectOutput> {
     let merged = super::merge_dynamic_args(&args)?.ok_or_else(|| {
         homeboy::core::Error::validation_invalid_argument(
             "spec",
-            "Provide JSON spec, --json flag, --base64 flag, or --key value flags",
+            "Provide --json '<object>' or --base64 <encoded-json>",
             None,
-            None,
+            Some(vec![
+                "Arbitrary project updates must use explicit JSON input.".to_string(),
+                "Example: homeboy project set <id> --json '{\"base_path\":\"/var/www/site\"}'"
+                    .to_string(),
+            ]),
         )
     })?;
     let (json_string, replace_fields) = super::finalize_set_spec(&merged, &args.replace)?;

--- a/src/commands/refactor/operations_command.rs
+++ b/src/commands/refactor/operations_command.rs
@@ -109,7 +109,7 @@ fn run_add_from_audit(source: &str, write: bool) -> CmdResult<RefactorOutput> {
         source.to_string()
     };
 
-    let json_content = crate::commands::merge_json_sources(Some(&effective_source), &[])?;
+    let json_content = crate::commands::merge_json_sources(Some(&effective_source))?;
     let audit: CodeAuditResult = if let Some(data) = json_content.get("data") {
         serde_json::from_value(data.clone())
     } else {

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -543,9 +543,13 @@ fn set(args: DynamicSetArgs) -> CmdResult<RunnerOutput> {
     let merged = super::merge_dynamic_args(&args)?.ok_or_else(|| {
         homeboy::core::Error::validation_invalid_argument(
             "spec",
-            "Provide JSON spec, --json flag, --base64 flag, or --key value flags",
+            "Provide --json '<object>' or --base64 <encoded-json>",
             None,
-            None,
+            Some(vec![
+                "Arbitrary runner updates must use explicit JSON input.".to_string(),
+                "Example: homeboy runner set <id> --json '{\"workspace_root\":\"/srv/homeboy\"}'"
+                    .to_string(),
+            ]),
         )
     })?;
     let (json_string, replace_fields) = super::finalize_set_spec(&merged, &args.replace)?;

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -316,9 +316,12 @@ fn set(args: DynamicSetArgs) -> CmdResult<ServerOutput> {
     let merged = super::merge_dynamic_args(&args)?.ok_or_else(|| {
         homeboy::core::Error::validation_invalid_argument(
             "spec",
-            "Provide JSON spec, --json flag, --base64 flag, or --key value flags",
+            "Provide --json '<object>' or --base64 <encoded-json>",
             None,
-            None,
+            Some(vec![
+                "Arbitrary server updates must use explicit JSON input.".to_string(),
+                "Example: homeboy server set <id> --json '{\"host\":\"example.com\",\"user\":\"deploy\"}'".to_string(),
+            ]),
         )
     })?;
     let (json_string, replace_fields) = super::finalize_set_spec(&merged, &args.replace)?;

--- a/src/core/deploy/safety_and_artifact.rs
+++ b/src/core/deploy/safety_and_artifact.rs
@@ -127,7 +127,7 @@ pub(super) fn deploy_artifact(
                 1,
                 format!(
                     "Archive artifact '{}' requires an extractCommand. \
-                     Add one with: homeboy component set <id> '{{\"extractCommand\": \"unzip -o {{artifact}} && rm {{artifact}}\"}}'",
+                     Add one with: homeboy component set <id> --json '{{\"extract_command\": \"unzip -o {{artifact}} && rm {{artifact}}\"}}'",
                     local_path.display()
                 ),
             ));

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -590,7 +590,7 @@ pub(super) fn resolve_component_github(
                 ),
                 None,
                 Some(vec![
-                    "Set it: homeboy component set <id> -- --remote_url https://github.com/<owner>/<repo>".to_string(),
+                    "Set it: homeboy component set <id> --json '{\"remote_url\":\"https://github.com/<owner>/<repo>\"}'".to_string(),
                     "Or configure a git remote in the component's local_path".to_string(),
                     "Or pass --path <workspace> to discover from a portable homeboy.json".to_string(),
                 ]),

--- a/src/core/project/readiness.rs
+++ b/src/core/project/readiness.rs
@@ -8,13 +8,13 @@ pub fn calculate_deploy_readiness(project: &Project) -> (bool, Vec<String>) {
     match &project.server_id {
         None => {
             blockers.push(format!(
-                "Missing server_id - set with: homeboy project set {} '{{\"server_id\": \"<server-id>\"}}'",
+                "Missing server_id - set with: homeboy project set {} --json '{{\"server_id\": \"<server-id>\"}}'",
                 project.id
             ));
         }
         Some(sid) if !crate::core::server::exists(sid) => {
             blockers.push(format!(
-                "Server '{}' not found - create with: homeboy server set {} '{{\"host\": \"...\", \"user\": \"...\"}}'",
+                "Server '{}' not found - create with: homeboy server set {} --json '{{\"host\": \"...\", \"user\": \"...\"}}'",
                 sid, sid
             ));
         }
@@ -28,7 +28,7 @@ pub fn calculate_deploy_readiness(project: &Project) -> (bool, Vec<String>) {
         .unwrap_or(true)
     {
         blockers.push(format!(
-            "Missing base_path - set with: homeboy project set {} '{{\"base_path\": \"/path/to/webroot\"}}'",
+            "Missing base_path - set with: homeboy project set {} --json '{{\"base_path\": \"/path/to/webroot\"}}'",
             project.id
         ));
     }

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -143,8 +143,7 @@ impl SshClient {
                 "Server is not configured for managed SSH sessions",
                 None,
                 Some(vec![
-                    "Run: homeboy server set <server> auth.mode=key_plus_password_controlmaster"
-                        .to_string(),
+                    "Run: homeboy server set <server> --json '{\"auth\":{\"mode\":\"key_plus_password_controlmaster\"}}'".to_string(),
                     "Then run: homeboy server connect <server>".to_string(),
                 ]),
             )
@@ -180,8 +179,7 @@ impl SshClient {
                 "Server is not configured for managed SSH sessions",
                 None,
                 Some(vec![
-                    "Run: homeboy server set <server> auth.mode=key_plus_password_controlmaster"
-                        .to_string(),
+                    "Run: homeboy server set <server> --json '{\"auth\":{\"mode\":\"key_plus_password_controlmaster\"}}'".to_string(),
                     "Then run: homeboy server connect <server>".to_string(),
                 ]),
             )


### PR DESCRIPTION
## Summary
- Require dynamic set commands to use explicit --json/--base64 arbitrary update payloads.
- Remove positional JSON, positional key=value, trailing arbitrary --key value, clap misrouting recovery, and dotted-path compatibility parsing from DynamicSetArgs.
- Update command errors, remediation hints, docs, and parser tests around canonical update forms.

Closes #2919.

## Testing
- cargo fmt --check
- cargo test dynamic_set_commands_require_canonical_update_inputs
- cargo test commands::tests::merge_dynamic_args
- cargo check

Note: cargo test --lib was started and externally aborted after many tests had passed, so the PR uses the targeted regression tests plus full crate compilation as the completed verification set.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the parser cleanup, updated related tests/docs/errors, and ran local verification. Chris remains responsible for review and merge.