### PR TITLE
Require directory project configs

### DIFF
--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -81,7 +81,7 @@ enum ProjectCommand {
         /// Project ID
         project_id: String,
     },
-    /// Initialize a project directory (migrate from flat file to directory layout)
+    /// Initialize a project directory
     Init {
         /// Project ID
         project_id: String,

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -58,6 +58,11 @@ pub(crate) trait ConfigEntity: Serialize + DeserializeOwned {
         Ok(Self::config_dir()?.join(format!("{}.json", id)))
     }
 
+    /// Whether this entity accepts `{dir}/{id}.json` entries while listing.
+    fn supports_flat_config_entries() -> bool {
+        true
+    }
+
     /// Entity-specific validation. Override to add custom validation rules.
     fn validate(&self) -> Result<()> {
         Ok(())
@@ -181,8 +186,7 @@ pub(crate) fn list<T: ConfigEntity>() -> Result<Vec<T>> {
                 } else {
                     return None;
                 }
-            } else if e.is_json() {
-                // For flat files: use existing behavior
+            } else if T::supports_flat_config_entries() && e.is_json() {
                 let id = e.path.file_stem()?.to_string_lossy().to_string();
                 (e.path.clone(), id)
             } else {
@@ -394,8 +398,7 @@ pub(crate) fn list_ids<T: ConfigEntity>() -> Result<Vec<String>> {
                 } else {
                     None
                 }
-            } else if e.is_json() {
-                // For flat files: use existing behavior
+            } else if T::supports_flat_config_entries() && e.is_json() {
                 e.path.file_stem().map(|s| s.to_string_lossy().to_string())
             } else {
                 None

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -165,25 +165,12 @@ impl ConfigEntity for Project {
         Error::project_not_found(id, suggestions)
     }
 
-    /// Directory-based config: `~/.config/homeboy/projects/{id}/{id}.json`.
-    ///
-    /// Falls back to legacy flat file `~/.config/homeboy/projects/{id}.json`
-    /// if the directory-based path doesn't exist yet. This allows transparent
-    /// migration — existing projects keep working, new projects use directories.
     fn config_path(id: &str) -> Result<PathBuf> {
-        let dir_path = paths::project_config(id)?;
-        if dir_path.exists() {
-            return Ok(dir_path);
-        }
+        paths::project_config(id)
+    }
 
-        // Check for legacy flat file
-        let flat_path = Self::config_dir()?.join(format!("{}.json", id));
-        if flat_path.exists() {
-            return Ok(flat_path);
-        }
-
-        // Default to directory-based for new projects
-        Ok(dir_path)
+    fn supports_flat_config_entries() -> bool {
+        false
     }
 
     fn validate(&self) -> Result<()> {
@@ -416,14 +403,10 @@ entity_crud!(Project; list_ids, merge, slugify_id);
 // ============================================================================
 
 /// Initialize a project directory at `~/.config/homeboy/projects/{id}/`.
-///
-/// Creates the directory structure and an initial `{id}.json` config file.
-/// If the project already exists as a flat file, migrates it to directory form.
 pub fn init_project_dir(id: &str) -> Result<PathBuf> {
     let dir = paths::project_dir(id)?;
     let config_path = paths::project_config(id)?;
 
-    // If directory config already exists, nothing to do
     if config_path.exists() {
         return Err(Error::validation_invalid_argument(
             "id",
@@ -433,13 +416,6 @@ pub fn init_project_dir(id: &str) -> Result<PathBuf> {
         ));
     }
 
-    // Check if a flat-file project exists that should be migrated
-    let flat_path = paths::projects()?.join(format!("{}.json", id));
-    if flat_path.exists() {
-        return migrate_to_directory(id);
-    }
-
-    // Check the project exists in the registry
     if !exists(id) {
         return Err(Error::validation_invalid_argument(
             "id",
@@ -452,13 +428,7 @@ pub fn init_project_dir(id: &str) -> Result<PathBuf> {
         ));
     }
 
-    // Load, then re-save — save() now creates the directory via config_path()
     let project = load(id)?;
-    // Delete the old flat file if it exists
-    if flat_path.exists() {
-        let _ = std::fs::remove_file(&flat_path);
-    }
-    // Force the directory path for the new save
     local_files::local().ensure_dir(&dir)?;
     let content = config::to_string_pretty(&project)?;
     local_files::local().write(&config_path, &content)?;
@@ -466,75 +436,7 @@ pub fn init_project_dir(id: &str) -> Result<PathBuf> {
     Ok(dir)
 }
 
-/// Migrate a project from flat file `{id}.json` to directory `{id}/{id}.json`.
-fn migrate_to_directory(id: &str) -> Result<PathBuf> {
-    let flat_path = paths::projects()?.join(format!("{}.json", id));
-    let dir = paths::project_dir(id)?;
-    let config_path = paths::project_config(id)?;
-
-    // Create the project directory
-    local_files::local().ensure_dir(&dir)?;
-
-    // Move the flat file into the directory with the correct name
-    std::fs::rename(&flat_path, &config_path).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!("migrate project '{}' to directory", id)),
-        )
-    })?;
-
-    Ok(dir)
-}
-
-/// Check if a project is using the directory-based config layout.
-pub fn is_directory_based(id: &str) -> bool {
-    paths::project_config(id)
-        .map(|p| p.exists())
-        .unwrap_or(false)
-}
-
-/// Check if a project is still using the legacy flat-file layout.
-pub fn needs_directory_migration(id: &str) -> bool {
-    let flat_exists = paths::projects()
-        .map(|p| p.join(format!("{}.json", id)).exists())
-        .unwrap_or(false);
-    flat_exists && !is_directory_based(id)
-}
-
-/// Migrate all flat-file projects to directory-based layout.
-///
-/// Called during `homeboy upgrade` to transparently move projects from
-/// `projects/{id}.json` to `projects/{id}/{id}.json`. Returns a list
-/// of (project_id, success) tuples.
-pub fn migrate_all_to_directories() -> Vec<(String, bool, String)> {
-    let project_ids = match list_ids() {
-        Ok(ids) => ids,
-        Err(_) => return vec![],
-    };
-
-    let mut results = Vec::new();
-
-    for id in &project_ids {
-        if !needs_directory_migration(id) {
-            continue;
-        }
-
-        match migrate_to_directory(id) {
-            Ok(dir) => {
-                results.push((id.clone(), true, format!("migrated to {}", dir.display())));
-            }
-            Err(e) => {
-                results.push((id.clone(), false, e.message.clone()));
-            }
-        }
-    }
-
-    results
-}
-
 /// Get the project directory path for a given project ID.
-/// Returns the directory path regardless of whether the project uses
-/// directory-based or flat-file config.
 pub fn project_dir_path(id: &str) -> Result<PathBuf> {
     paths::project_dir(id)
 }
@@ -683,6 +585,44 @@ pub fn project_cli_path(project: &Project) -> Option<String> {
         return Some("studio wp".to_string());
     }
     None
+}
+
+#[cfg(test)]
+mod config_layout_tests {
+    use super::*;
+    use crate::test_support::with_isolated_home;
+
+    #[test]
+    fn load_requires_directory_project_config() {
+        with_isolated_home(|_| {
+            let projects = paths::projects().expect("projects path");
+            std::fs::create_dir_all(&projects).expect("projects dir");
+            std::fs::write(projects.join("legacy.json"), r#"{"domain":"legacy.test"}"#)
+                .expect("legacy project config");
+
+            let error = load("legacy").expect_err("flat project config should not load");
+            assert_eq!(error.code.as_str(), "project.not_found");
+        });
+    }
+
+    #[test]
+    fn list_ids_ignores_flat_project_configs() {
+        with_isolated_home(|_| {
+            let projects = paths::projects().expect("projects path");
+            std::fs::create_dir_all(&projects).expect("projects dir");
+            std::fs::write(projects.join("legacy.json"), r#"{"domain":"legacy.test"}"#)
+                .expect("legacy project config");
+
+            let canonical = Project {
+                id: "canonical".to_string(),
+                domain: Some("canonical.test".to_string()),
+                ..Default::default()
+            };
+            save(&canonical).expect("canonical project config");
+
+            assert_eq!(list_ids().expect("project ids"), vec!["canonical"]);
+        });
+    }
 }
 
 #[cfg(test)]

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -176,14 +176,12 @@ pub fn run_upgrade_with_method(
     if !force {
         let check = check_for_updates()?;
         if !check.update_available {
-            // Even when no binary update is needed, still run extension updates
-            // and config migrations — these are independent of the binary version.
+            // Even when no binary update is needed, still run extension updates.
             let (extensions_updated, extensions_skipped) = if skip_extensions {
                 (vec![], vec![])
             } else {
                 update_all_extensions()
             };
-            let projects_migrated = migrate_all_projects();
             let (runners_updated, runners_skipped) = if skip_runners {
                 (vec![], vec![])
             } else {
@@ -199,7 +197,6 @@ pub fn run_upgrade_with_method(
                 restart_required: false,
                 extensions_updated,
                 extensions_skipped,
-                projects_migrated,
                 runners_updated,
                 runners_skipped,
             });
@@ -217,11 +214,6 @@ pub fn run_upgrade_with_method(
     } else {
         (vec![], vec![])
     };
-
-    // Migrate flat-file projects to directory-based layout.
-    // Runs on every upgrade (even failed ones) since this is a config-only
-    // operation that doesn't depend on the binary version.
-    let projects_migrated = migrate_all_projects();
 
     let (runners_updated, runners_skipped) = if success && !skip_runners {
         runners::upgrade_configured_runners(runner_targets)?
@@ -248,42 +240,9 @@ pub fn run_upgrade_with_method(
         restart_required: success && matches!(install_method, InstallMethod::Source),
         extensions_updated,
         extensions_skipped,
-        projects_migrated,
         runners_updated,
         runners_skipped,
     })
-}
-
-/// Migrate all flat-file projects to directory-based layout.
-/// Best-effort — failures are logged and returned in the result.
-fn migrate_all_projects() -> Vec<ProjectMigrationEntry> {
-    let results = crate::core::project::migrate_all_to_directories();
-
-    if results.is_empty() {
-        return vec![];
-    }
-
-    log_status!(
-        "upgrade",
-        "Migrating {} project(s) to directory layout...",
-        results.len()
-    );
-
-    let mut entries = Vec::new();
-    for (id, success, detail) in results {
-        if success {
-            log_status!("upgrade", "  {} migrated", id);
-        } else {
-            log_status!("upgrade", "  {} failed: {}", id, detail);
-        }
-        entries.push(ProjectMigrationEntry {
-            project_id: id,
-            success,
-            detail,
-        });
-    }
-
-    entries
 }
 
 /// Update all installed extensions. Best-effort — failures are logged and

--- a/src/core/upgrade/mod.rs
+++ b/src/core/upgrade/mod.rs
@@ -13,8 +13,7 @@ pub use helpers::{
 };
 pub use planning::resolve_binary_on_path;
 pub use types::{
-    ExtensionUpgradeEntry, InstallMethod, ProjectMigrationEntry, RunnerUpgradeEntry, UpgradeResult,
-    VersionCheck,
+    ExtensionUpgradeEntry, InstallMethod, RunnerUpgradeEntry, UpgradeResult, VersionCheck,
 };
 pub use validation::check_for_updates;
 

--- a/src/core/upgrade/types.rs
+++ b/src/core/upgrade/types.rs
@@ -38,8 +38,6 @@ pub struct UpgradeResult {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extensions_skipped: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub projects_migrated: Vec<ProjectMigrationEntry>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub runners_updated: Vec<RunnerUpgradeEntry>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub runners_skipped: Vec<RunnerUpgradeEntry>,
@@ -57,13 +55,6 @@ pub struct ExtensionUpgradeEntry {
     pub git_root: Option<String>,
     #[serde(flatten)]
     pub source_update: ExtensionSourceUpdate,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProjectMigrationEntry {
-    pub project_id: String,
-    pub success: bool,
-    pub detail: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- remove the legacy `projects/{id}.json` fallback from project config resolution
- ignore flat project JSON files when listing projects while keeping other config entities unchanged
- remove project directory migration helpers and upgrade migration output

Closes #2925

## Tests
- `cargo test project`
- `cargo test` (one daemon integration test failed once, then passed when rerun: `cargo test core::daemon::daemon_test::test_serve_writes_state_and_routes_health_requests`)
- `cargo test core::daemon::daemon_test::test_serve_writes_state_and_routes_health_requests`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings` (fails on existing repo-wide clippy warnings unrelated to this PR, including duplicate test support modules and large enum variants)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the compatibility removal, regression tests, verification commands, and PR description for Chris to review.