### PR TITLE
Require object rig workload specs

### DIFF
--- a/docs/architecture/rig-matrix-axis-composition.md
+++ b/docs/architecture/rig-matrix-axis-composition.md
@@ -72,7 +72,9 @@ clone of the base spec.
   },
   "bench": { "default_component": "studio" },
   "bench_workloads": {
-    "nodejs": ["${package.root}/bench/studio-agent-runtime.bench.mjs"]
+    "nodejs": [
+      { "path": "${package.root}/bench/studio-agent-runtime.bench.mjs" }
+    ]
   },
   "matrix": {
     "axes": {
@@ -102,7 +104,7 @@ clone of the base spec.
               { "op": "add", "path": "/components/studio/extensions/nodejs/studio_bfb_plugin_path", "value": "~/Developer/block-format-bridge@refresh-expanded-h2bc" },
               { "op": "add", "path": "/resources/exclusive/-", "value": "studio-agent-bfb-bench" },
               { "op": "add", "path": "/resources/paths/-", "value": "${components.block-format-bridge.path}" },
-              { "op": "add", "path": "/bench_workloads/nodejs/-", "value": "${package.root}/bench/studio-bfb-write-path.bench.mjs" }
+              { "op": "add", "path": "/bench_workloads/nodejs/-", "value": { "path": "${package.root}/bench/studio-bfb-write-path.bench.mjs" } }
             ]
           }
         }
@@ -416,7 +418,9 @@ The matrix shape can collapse them into one base rig:
   },
   "bench": { "default_component": "studio" },
   "bench_workloads": {
-    "nodejs": ["${package.root}/bench/studio-agent-runtime.bench.mjs"]
+    "nodejs": [
+      { "path": "${package.root}/bench/studio-agent-runtime.bench.mjs" }
+    ]
   },
   "pipeline": {
     "up": [
@@ -455,7 +459,7 @@ The matrix shape can collapse them into one base rig:
             "patch": [
               { "op": "add", "path": "/components/block-format-bridge", "value": { "path": "~/Developer/block-format-bridge@refresh-expanded-h2bc", "branch": "refresh-expanded-h2bc" } },
               { "op": "add", "path": "/components/studio/extensions/nodejs/studio_bfb_plugin_path", "value": "~/Developer/block-format-bridge@refresh-expanded-h2bc" },
-              { "op": "add", "path": "/bench_workloads/nodejs/-", "value": "${package.root}/bench/studio-bfb-write-path.bench.mjs" },
+              { "op": "add", "path": "/bench_workloads/nodejs/-", "value": { "path": "${package.root}/bench/studio-bfb-write-path.bench.mjs" } },
               { "op": "add", "path": "/resources/exclusive/-", "value": "studio-agent-bfb-bench" },
               { "op": "add", "path": "/resources/paths/-", "value": "${components.block-format-bridge.path}" },
               { "op": "add", "path": "/resources/process_patterns/-", "value": "wordpress-server-child.mjs" }

--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -428,7 +428,9 @@ bench workflows:
     "default_baseline_rig": "studio-trunk"
   },
   "bench_workloads": {
-    "wordpress": ["${package.root}/bench/studio-admin.php"]
+    "wordpress": [
+      { "path": "${package.root}/bench/studio-admin.php" }
+    ]
   }
 }
 ```
@@ -447,7 +449,7 @@ bench workflows:
   passes `--ignore-default-baseline`, or the candidate rig declares a
   multi-component `bench.components` matrix.
 - `bench_workloads` supplies rig-owned workload files keyed by extension ID.
-  Paths support `~`, `${env.NAME}`, `${components.<id>.path}`, and
+  Entries must be objects with a `path` field. Paths support `~`, `${env.NAME}`, `${components.<id>.path}`, and
   `${package.root}` expansion. `${package.root}` resolves to the installed
   rig package root, so portable rig packages can keep workload files next
   to the rig spec without hardcoded machine paths.

--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -342,7 +342,7 @@ Rig specs can pin benchmark dispatch for `homeboy bench --rig <id>`.
 | `trace_workloads` | object | Out-of-tree trace workloads keyed by extension ID. |
 | `bench_profiles` | object | Named scenario lists used by `homeboy bench --profile <name>`. |
 
-`bench_workloads` and `trace_workloads` entries support either string paths or object form. String paths preserve historical behaviour: workload commands run the full rig check. Object entries use `path` plus optional `check_groups`; when every workload for the selected extension declares `check_groups`, workload commands run only those grouped check-pipeline steps. Trace workload objects can also declare `trace_phase_presets` and `trace_default_phase_preset`.
+`bench_workloads` and `trace_workloads` entries must use object form with a `path` field. Optional `check_groups` scope workload preflights; when every workload for the selected extension declares `check_groups`, workload commands run only those grouped check-pipeline steps. Workloads that omit `check_groups` run the full rig check. Trace workload objects can also declare `trace_phase_presets` and `trace_default_phase_preset`.
 
 Workload paths support `~`, `${env.NAME}`, `${components.<id>.path}`, and `${package.root}` for package-installed rigs.
 
@@ -354,7 +354,9 @@ Workload paths support `~`, `${env.NAME}`, `${components.<id>.path}`, and `${pac
     "warmup_iterations": 2
   },
   "bench_workloads": {
-    "wordpress": ["${package.root}/bench/workloads/studio-cold-start"],
+    "wordpress": [
+      { "path": "${package.root}/bench/workloads/studio-cold-start" }
+    ],
     "nodejs": [
       {
         "path": "${package.root}/bench/workloads/studio-app.bench.mjs",

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -667,7 +667,7 @@ mod tests {
     fn rig_bench_components_falls_back_to_default_component() {
         let rig_spec: RigSpec = serde_json::from_str(
             r#"{
-                "id": "legacy",
+                "id": "single-component-rig",
                 "bench": { "default_component": "homeboy" }
             }"#,
         )
@@ -723,7 +723,7 @@ mod tests {
             r#"{
                 "id": "studio-bfb",
                 "bench": {
-                    "default_component": "studio",
+                    "components": ["studio"],
                     "metric_gates": {
                         "wordpress-is-dead": {
                             "native_block_quality_pass": { "equals": 1 },

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -202,8 +202,8 @@ fn write_rig_with_profiles(
                     }},
                     "bench": {{ "default_component": "{component_id}" }},
                     "bench_workloads": {{ "nodejs": [
-                        "${{components.{component_id}.path}}/rig-extra.bench.js",
-                        "${{components.{component_id}.path}}/rig-slow.bench.mjs"
+                        {{ "path": "${{components.{component_id}.path}}/rig-extra.bench.js" }},
+                        {{ "path": "${{components.{component_id}.path}}/rig-slow.bench.mjs" }}
                     ] }},
                     "bench_profiles": {bench_profiles}
                 }}"#,

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -770,7 +770,7 @@ fn set(
             None,
             Some(vec![
                 "Arbitrary field updates must use --json or --base64.".to_string(),
-                "Example: homeboy component set <id> --json '{\"remote_path\":\"wp-content/plugins/plugin\"}'".to_string(),
+                "Example: homeboy component set <id> --json '{\"remote_path\":\"deploy/path\"}'".to_string(),
             ]),
         ));
     }

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -1360,11 +1360,9 @@ fn trace_variants_for_args<'a>(
         if trace_workload_scenario_id(workload.path()) != scenario {
             continue;
         }
-        if let Some(workload_variants) = workload.trace_variants() {
-            for (name, variant) in workload_variants {
-                if trace_variant_matches_component(variant, component_id) {
-                    variants.insert(name.clone(), variant);
-                }
+        for (name, variant) in workload.trace_variants() {
+            if trace_variant_matches_component(variant, component_id) {
+                variants.insert(name.clone(), variant);
             }
         }
     }

--- a/src/commands/trace/compare_variant_tests.rs
+++ b/src/commands/trace/compare_variant_tests.rs
@@ -326,7 +326,7 @@ fn write_multi_component_variant_rig(
                     "wordpress": {{ "path": "{}" }}
                 }},
                 "trace_workloads": {{ "nodejs": [
-                    "${{components.studio.path}}/studio-app-create-site.trace.mjs"
+                    {{ "path": "${{components.studio.path}}/studio-app-create-site.trace.mjs" }}
                 ] }},
                 "trace_variants": {{
                     "fresh-install-mode": {{

--- a/src/commands/trace/experiment_tests.rs
+++ b/src/commands/trace/experiment_tests.rs
@@ -112,7 +112,7 @@ fn write_trace_experiment_rig(home: &tempfile::TempDir, component_path: &std::pa
                     "studio": {{ "path": "{}" }}
                 }},
                 "trace_workloads": {{ "nodejs": [
-                    "${{components.studio.path}}/product-workflow.trace.mjs"
+                    {{ "path": "${{components.studio.path}}/product-workflow.trace.mjs" }}
                 ] }},
                 "trace_experiments": {{
                     "template": {{

--- a/src/commands/trace/metadata.rs
+++ b/src/commands/trace/metadata.rs
@@ -41,8 +41,7 @@ pub(super) fn trace_span_metadata_for_args(
     };
     Ok(workload
         .trace_span_metadata()
-        .into_iter()
-        .flat_map(|metadata| metadata.iter())
+        .iter()
         .map(|(id, metadata)| (id.clone(), metadata.clone()))
         .collect())
 }

--- a/src/commands/trace/test_fixture.rs
+++ b/src/commands/trace/test_fixture.rs
@@ -129,8 +129,8 @@ pub(super) fn write_trace_rig(
                         "{component_id}": {{ "path": "{}" }}
                     }},
                     "trace_workloads": {{ "nodejs": [
-                        "${{components.{component_id}.path}}/studio-app-create-site.trace.mjs",
-                        "${{components.{component_id}.path}}/studio-list-sites.trace.mjs"
+                        {{ "path": "${{components.{component_id}.path}}/studio-app-create-site.trace.mjs" }},
+                        {{ "path": "${{components.{component_id}.path}}/studio-list-sites.trace.mjs" }}
                     ] }}
                 }}"#,
             path.display()
@@ -267,7 +267,7 @@ pub(super) fn write_trace_rig_with_variant(
                         "{component_id}": {{ "path": "{}" }}
                     }},
                     "trace_workloads": {{ "nodejs": [
-                        "${{components.{component_id}.path}}/studio-app-create-site.trace.mjs"
+                        {{ "path": "${{components.{component_id}.path}}/studio-app-create-site.trace.mjs" }}
                     ] }},
                     "trace_variants": {{
                         "fresh-install-mode": {{

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -68,7 +68,7 @@ fn write_trace_rig_with_profile(
                         "{component_id}": {{ "path": "{}" }}
                     }},
                     "trace_workloads": {{ "nodejs": [
-                        "${{components.{component_id}.path}}/close-window-running-site.trace.mjs"
+                        {{ "path": "${{components.{component_id}.path}}/close-window-running-site.trace.mjs" }}
                     ] }},
                     "trace_profiles": {{
                         "studio-window-close": {{
@@ -130,7 +130,7 @@ fn rig_component_for_trace_synthesizes_trace_workload_extensions() {
                     "studio": { "path": "/tmp/studio" }
                 },
                 "trace_workloads": {
-                    "nodejs": ["/tmp/create-site.trace.mjs"]
+                    "nodejs": [{ "path": "/tmp/create-site.trace.mjs" }]
                 }
             }"#,
     )

--- a/src/core/engine/invocation/runtime.rs
+++ b/src/core/engine/invocation/runtime.rs
@@ -201,16 +201,11 @@ pub fn short_invocation_id() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
+    use crate::test_support::home_env_guard;
 
     #[test]
     fn override_env_takes_priority() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = home_env_guard();
         let dir = tempfile::tempdir().expect("tempdir");
         let prior = env::var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
         env::set_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, dir.path());
@@ -226,7 +221,7 @@ mod tests {
 
     #[test]
     fn override_env_blank_falls_back_to_platform() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = home_env_guard();
         let prior = env::var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
         env::set_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, "   ");
 

--- a/src/core/release/context.rs
+++ b/src/core/release/context.rs
@@ -40,6 +40,7 @@ mod tests {
         std::fs::write(
             homeboy_json,
             r#"{
+                "id": "fixture",
                 "components": {
                     "fixture": {
                         "type": "nodejs",

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -59,7 +59,7 @@ pub use spec::{
     ComponentSpec, DiscoverSpec, NewerThanSpec, PatchOp, PipelineStep, RigResourcesSpec, RigSpec,
     ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, StackOp, SymlinkSpec, TimeSource,
     TraceExperimentArtifactSpec, TraceExperimentCommandSpec, TraceExperimentSpec,
-    TraceGuardrailSpec, TraceProfileSpec, TraceVariantSpec, WorkloadEntry, WorkloadSpec,
+    TraceGuardrailSpec, TraceProfileSpec, TraceVariantSpec, WorkloadSpec,
 };
 pub use stack::{
     plan_stack_sync, run_component_sync, run_sync, RigStackPlanEntry, RigStackSyncEntry,

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -201,14 +201,12 @@ fn default_app_preflight() -> Vec<AppLauncherPreflight> {
 }
 
 /// Bench composition for a rig. Pins which component(s) `homeboy bench
-/// --rig <id>` benchmarks when no explicit component is passed. The
-/// singular `default_component` remains supported for existing specs;
-/// new multi-component rigs should use `components`.
+/// --rig <id>` benchmarks when no explicit component is passed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BenchSpec {
     /// Component ID to benchmark when `homeboy rig bench <rig>` is invoked
     /// without `--component`. Optional — `--component` is required at the
-    /// CLI when this isn't set.
+    /// CLI when this isn't set and `components` is empty.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_component: Option<String>,
 
@@ -299,18 +297,8 @@ impl BenchMetricGateCondition {
 }
 
 /// Rig-owned extension workload declaration.
-///
-/// The string shorthand keeps existing rig specs valid. Object form lets a
-/// workload opt into scoped rig preflights by naming the check groups it needs.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum WorkloadSpec {
-    Path(String),
-    Detailed(WorkloadEntry),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct WorkloadEntry {
+pub struct WorkloadSpec {
     pub path: String,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -456,76 +444,45 @@ pub enum TraceExperimentArtifactSpec {
 
 impl WorkloadSpec {
     pub fn path(&self) -> &str {
-        match self {
-            WorkloadSpec::Path(path) => path,
-            WorkloadSpec::Detailed(entry) => &entry.path,
-        }
+        &self.path
     }
 
     pub fn check_groups(&self) -> Option<&[String]> {
-        match self {
-            WorkloadSpec::Path(_) => None,
-            WorkloadSpec::Detailed(entry) => entry.check_groups.as_deref(),
-        }
+        self.check_groups.as_deref()
     }
 
     pub fn port_range_size(&self) -> Option<u16> {
-        match self {
-            WorkloadSpec::Path(_) => None,
-            WorkloadSpec::Detailed(entry) => entry.port_range_size,
-        }
+        self.port_range_size
     }
 
     pub fn named_leases(&self) -> &[String] {
-        match self {
-            WorkloadSpec::Path(_) => &[],
-            WorkloadSpec::Detailed(entry) => &entry.named_leases,
-        }
+        &self.named_leases
     }
 
     pub fn trace_phase_preset(&self, name: &str) -> Option<&[String]> {
-        match self {
-            WorkloadSpec::Path(_) => None,
-            WorkloadSpec::Detailed(entry) => entry
-                .trace_phase_presets
-                .get(name)
-                .map(|phases| phases.as_slice()),
-        }
+        self.trace_phase_presets
+            .get(name)
+            .map(|phases| phases.as_slice())
     }
 
-    pub fn trace_span_metadata(&self) -> Option<&HashMap<String, TraceSpanMetadata>> {
-        match self {
-            WorkloadSpec::Path(_) => None,
-            WorkloadSpec::Detailed(entry) => Some(&entry.trace_span_metadata),
-        }
+    pub fn trace_span_metadata(&self) -> &HashMap<String, TraceSpanMetadata> {
+        &self.trace_span_metadata
     }
 
     pub fn trace_default_phase_preset(&self) -> Option<&str> {
-        match self {
-            WorkloadSpec::Path(_) => None,
-            WorkloadSpec::Detailed(entry) => entry.trace_default_phase_preset.as_deref(),
-        }
+        self.trace_default_phase_preset.as_deref()
     }
 
-    pub fn trace_variants(&self) -> Option<&HashMap<String, TraceVariantSpec>> {
-        match self {
-            WorkloadSpec::Path(_) => None,
-            WorkloadSpec::Detailed(entry) => Some(&entry.trace_variants),
-        }
+    pub fn trace_variants(&self) -> &HashMap<String, TraceVariantSpec> {
+        &self.trace_variants
     }
 
     pub fn trace_guardrails(&self) -> &[TraceGuardrailSpec] {
-        match self {
-            WorkloadSpec::Path(_) => &[],
-            WorkloadSpec::Detailed(entry) => &entry.trace_guardrails,
-        }
+        &self.trace_guardrails
     }
 
     pub fn trace_probes(&self) -> &[TraceProbeConfig] {
-        match self {
-            WorkloadSpec::Path(_) => &[],
-            WorkloadSpec::Detailed(entry) => &entry.trace_probes,
-        }
+        &self.trace_probes
     }
 }
 
@@ -570,7 +527,7 @@ mod tests {
 
     #[test]
     fn test_trace_phase_preset() {
-        let workload = WorkloadSpec::Detailed(WorkloadEntry {
+        let workload = WorkloadSpec {
             path: "trace.mjs".to_string(),
             check_groups: None,
             port_range_size: None,
@@ -584,17 +541,16 @@ mod tests {
             trace_variants: HashMap::new(),
             trace_guardrails: Vec::new(),
             trace_probes: Vec::new(),
-        });
+        };
 
         assert_eq!(workload.trace_phase_preset("missing"), None);
         assert_eq!(
             workload.trace_phase_preset("startup"),
             Some(["launch".to_string(), "ready".to_string()].as_slice())
         );
-        assert_eq!(
-            WorkloadSpec::Path("trace.mjs".to_string()).trace_phase_preset("startup"),
-            None
-        );
+        let workload_without_preset: WorkloadSpec =
+            serde_json::from_str(r#"{"path":"trace.mjs"}"#).expect("parse workload");
+        assert_eq!(workload_without_preset.trace_phase_preset("startup"), None);
     }
 
     #[test]
@@ -618,7 +574,6 @@ mod tests {
 
         let metadata = workload
             .trace_span_metadata()
-            .expect("metadata")
             .get("phase.boot_to_ready")
             .expect("span metadata");
         assert!(metadata.critical);
@@ -627,9 +582,10 @@ mod tests {
         assert!(metadata.prewarmable);
         assert_eq!(metadata.blocks.as_deref(), Some("first_site_render"));
         assert_eq!(metadata.category.as_deref(), Some("wordpress_boot"));
-        assert!(WorkloadSpec::Path("/tmp/legacy.trace.mjs".to_string())
-            .trace_span_metadata()
-            .is_none());
+        let workload_without_metadata: WorkloadSpec =
+            serde_json::from_str(r#"{"path":"/tmp/no-metadata.trace.mjs"}"#)
+                .expect("parse workload");
+        assert!(workload_without_metadata.trace_span_metadata().is_empty());
     }
 
     #[test]
@@ -686,9 +642,9 @@ mod tests {
             TraceProbeConfig::CmdRun { command, args }
                 if command == "kimaki" && args == &vec!["--help".to_string()]
         ));
-        assert!(WorkloadSpec::Path("/tmp/legacy.trace.mjs".to_string())
-            .trace_probes()
-            .is_empty());
+        let workload_without_probes: WorkloadSpec =
+            serde_json::from_str(r#"{"path":"/tmp/no-probes.trace.mjs"}"#).expect("parse workload");
+        assert!(workload_without_probes.trace_probes().is_empty());
     }
 
     #[test]
@@ -736,7 +692,7 @@ mod tests {
 
     #[test]
     fn test_trace_default_phase_preset() {
-        let workload = WorkloadSpec::Detailed(WorkloadEntry {
+        let workload = WorkloadSpec {
             path: "trace.mjs".to_string(),
             check_groups: None,
             port_range_size: None,
@@ -747,18 +703,17 @@ mod tests {
             trace_variants: HashMap::new(),
             trace_guardrails: Vec::new(),
             trace_probes: Vec::new(),
-        });
+        };
 
         assert_eq!(workload.trace_default_phase_preset(), Some("startup"));
-        assert_eq!(
-            WorkloadSpec::Path("trace.mjs".to_string()).trace_default_phase_preset(),
-            None
-        );
+        let workload_without_default: WorkloadSpec =
+            serde_json::from_str(r#"{"path":"trace.mjs"}"#).expect("parse workload");
+        assert_eq!(workload_without_default.trace_default_phase_preset(), None);
     }
 
     #[test]
     fn test_port_range_size() {
-        let workload = WorkloadSpec::Detailed(WorkloadEntry {
+        let workload = WorkloadSpec {
             path: "bench.mjs".to_string(),
             check_groups: None,
             port_range_size: Some(8),
@@ -769,18 +724,17 @@ mod tests {
             trace_variants: HashMap::new(),
             trace_guardrails: Vec::new(),
             trace_probes: Vec::new(),
-        });
+        };
 
         assert_eq!(workload.port_range_size(), Some(8));
-        assert_eq!(
-            WorkloadSpec::Path("bench.mjs".to_string()).port_range_size(),
-            None
-        );
+        let workload_without_ports: WorkloadSpec =
+            serde_json::from_str(r#"{"path":"bench.mjs"}"#).expect("parse workload");
+        assert_eq!(workload_without_ports.port_range_size(), None);
     }
 
     #[test]
     fn test_named_leases() {
-        let workload = WorkloadSpec::Detailed(WorkloadEntry {
+        let workload = WorkloadSpec {
             path: "bench.mjs".to_string(),
             check_groups: None,
             port_range_size: None,
@@ -791,12 +745,12 @@ mod tests {
             trace_variants: HashMap::new(),
             trace_guardrails: Vec::new(),
             trace_probes: Vec::new(),
-        });
+        };
 
         assert_eq!(workload.named_leases(), &["browser-profile".to_string()]);
-        assert!(WorkloadSpec::Path("bench.mjs".to_string())
-            .named_leases()
-            .is_empty());
+        let workload_without_leases: WorkloadSpec =
+            serde_json::from_str(r#"{"path":"bench.mjs"}"#).expect("parse workload");
+        assert!(workload_without_leases.named_leases().is_empty());
     }
 
     #[test]
@@ -839,7 +793,7 @@ mod tests {
             workload.trace_guardrails()[0].check.command.as_deref(),
             Some("npm run smoke:list-sites")
         );
-        let variants = workload.trace_variants().expect("variants");
+        let variants = workload.trace_variants();
         assert_eq!(
             variants["fast-install"].trace_guardrails[0]
                 .check

--- a/src/core/rig/workloads.rs
+++ b/src/core/rig/workloads.rs
@@ -44,11 +44,11 @@ pub fn workloads_for_extension(
 /// Return the scoped check groups required by all rig-owned workloads for an
 /// extension.
 ///
-/// `None` means at least one relevant workload uses the legacy string shorthand
-/// (or the extension declares no rig-owned workloads), so callers should keep
-/// the historical full `rig check` behaviour. `Some(groups)` means every
-/// workload opted into scoped preflights; an empty vector intentionally means no
-/// rig check-pipeline step is required.
+/// `None` means at least one relevant workload omits `check_groups` (or the
+/// extension declares no rig-owned workloads), so callers should keep the full
+/// `rig check` behaviour. `Some(groups)` means every workload opted into scoped
+/// preflights; an empty vector intentionally means no rig check-pipeline step is
+/// required.
 pub fn check_groups_for_extension_workloads(
     rig_spec: &RigSpec,
     kind: RigWorkloadKind,

--- a/tests/core/rig/bench_default_baseline_spec_test.rs
+++ b/tests/core/rig/bench_default_baseline_spec_test.rs
@@ -80,10 +80,10 @@ fn test_rig_spec_deserializes_bench_workloads_by_extension() {
             "id": "studio",
             "bench_workloads": {
                 "wordpress": [
-                    "/private/benches/cold-boot.php",
-                    "~/benches/wc-loaded.php"
+                    { "path": "/private/benches/cold-boot.php" },
+                    { "path": "~/benches/wc-loaded.php" }
                 ],
-                "nodejs": ["/private/benches/electron-startup.bench.ts"]
+                "nodejs": [{ "path": "/private/benches/electron-startup.bench.ts" }]
             }
         }"#,
     )
@@ -117,10 +117,10 @@ fn test_rig_spec_deserializes_trace_workloads_by_extension() {
             "id": "studio",
             "trace_workloads": {
                 "nodejs": [
-                    "${package.root}/bench/studio-app-create-site.trace.mjs",
-                    "~/traces/window-close.trace.mjs"
+                    { "path": "${package.root}/bench/studio-app-create-site.trace.mjs" },
+                    { "path": "~/traces/window-close.trace.mjs" }
                 ],
-                "wordpress": ["/private/traces/wp-admin-load.trace.php"]
+                "wordpress": [{ "path": "/private/traces/wp-admin-load.trace.php" }]
             }
         }"#,
     )
@@ -180,10 +180,9 @@ fn test_trace_phase_preset() {
         workload.trace_phase_preset("startup"),
         Some(["launch".to_string(), "ready".to_string()].as_slice())
     );
-    assert_eq!(
-        WorkloadSpec::Path("trace.mjs".to_string()).trace_phase_preset("startup"),
-        None
-    );
+    let workload_without_preset: WorkloadSpec =
+        serde_json::from_str(r#"{"path":"trace.mjs"}"#).expect("parse workload");
+    assert_eq!(workload_without_preset.trace_phase_preset("startup"), None);
 }
 
 #[test]
@@ -210,10 +209,9 @@ fn test_trace_default_phase_preset() {
         .expect("nodejs trace workload");
 
     assert_eq!(workload.trace_default_phase_preset(), Some("startup"));
-    assert_eq!(
-        WorkloadSpec::Path("trace.mjs".to_string()).trace_default_phase_preset(),
-        None
-    );
+    let workload_without_default: WorkloadSpec =
+        serde_json::from_str(r#"{"path":"trace.mjs"}"#).expect("parse workload");
+    assert_eq!(workload_without_default.trace_default_phase_preset(), None);
 }
 
 #[test]

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -3,7 +3,7 @@
 
 use crate::core::rig::{
     PipelineStep, RigResourcesSpec, RigSpec, ServiceKind, ServiceSpec, SharedPathSpec, SymlinkSpec,
-    TraceVariantSpec, WorkloadEntry, WorkloadSpec,
+    TraceVariantSpec, WorkloadSpec,
 };
 
 /// Canonical fixture matching the studio-playground-dev shape used as the
@@ -273,9 +273,10 @@ fn test_spec_check_step_parses_groups() {
 
 #[test]
 fn test_check_groups() {
-    let legacy = WorkloadSpec::Path("/tmp/legacy.trace.mjs".to_string());
-    assert_eq!(legacy.path(), "/tmp/legacy.trace.mjs");
-    assert!(legacy.check_groups().is_none());
+    let unscoped: WorkloadSpec = serde_json::from_str(r#"{ "path": "/tmp/unscoped.trace.mjs" }"#)
+        .expect("parse unscoped workload");
+    assert_eq!(unscoped.path(), "/tmp/unscoped.trace.mjs");
+    assert!(unscoped.check_groups().is_none());
 
     let detailed: WorkloadSpec = serde_json::from_str(
         r#"{
@@ -307,7 +308,9 @@ fn test_trace_default_phase_preset() {
     let workload = workload_with_trace_metadata();
 
     assert_eq!(workload.trace_default_phase_preset(), Some("startup"));
-    assert!(WorkloadSpec::Path("/tmp/legacy.trace.mjs".to_string())
+    let workload_without_default: WorkloadSpec =
+        serde_json::from_str(r#"{ "path": "/tmp/no-default.trace.mjs" }"#).expect("parse workload");
+    assert!(workload_without_default
         .trace_default_phase_preset()
         .is_none());
 }
@@ -315,7 +318,7 @@ fn test_trace_default_phase_preset() {
 #[test]
 fn test_trace_variants() {
     let workload = workload_with_trace_metadata();
-    let variants = workload.trace_variants().expect("variants");
+    let variants = workload.trace_variants();
 
     assert_eq!(
         variants.get("fresh-install-mode"),
@@ -326,13 +329,14 @@ fn test_trace_variants() {
             trace_guardrails: Vec::new(),
         })
     );
-    assert!(WorkloadSpec::Path("/tmp/legacy.trace.mjs".to_string())
-        .trace_variants()
-        .is_none());
+    let workload_without_variants: WorkloadSpec =
+        serde_json::from_str(r#"{ "path": "/tmp/no-variants.trace.mjs" }"#)
+            .expect("parse workload");
+    assert!(workload_without_variants.trace_variants().is_empty());
 }
 
 fn workload_with_trace_metadata() -> WorkloadSpec {
-    WorkloadSpec::Detailed(WorkloadEntry {
+    WorkloadSpec {
         path: "/tmp/scoped.trace.mjs".to_string(),
         check_groups: Some(vec!["desktop-app".to_string()]),
         port_range_size: None,
@@ -354,7 +358,7 @@ fn workload_with_trace_metadata() -> WorkloadSpec {
         )]),
         trace_guardrails: Vec::new(),
         trace_probes: Vec::new(),
-    })
+    }
 }
 
 #[test]

--- a/tests/core/rig/workloads_test.rs
+++ b/tests/core/rig/workloads_test.rs
@@ -17,10 +17,10 @@ fn test_bench_workloads_for_extension_filters_and_expands_paths() {
             },
             "bench_workloads": {
                 "wordpress": [
-                    "${env.HOMEBOY_TEST_BENCH_ROOT}/cold-boot.php",
-                    "${components.playground.path}/fixtures/wc-loaded.php"
+                    { "path": "${env.HOMEBOY_TEST_BENCH_ROOT}/cold-boot.php" },
+                    { "path": "${components.playground.path}/fixtures/wc-loaded.php" }
                 ],
-                "nodejs": ["/tmp/node-only.bench.ts"]
+                "nodejs": [{ "path": "/tmp/node-only.bench.ts" }]
             }
         }"#,
     )
@@ -36,6 +36,25 @@ fn test_bench_workloads_for_extension_filters_and_expands_paths() {
         ]
     );
     assert!(workloads_for_extension(&rig_spec, RigWorkloadKind::Bench, None, "rust").is_empty());
+}
+
+#[test]
+fn test_workload_string_shorthand_is_rejected() {
+    let err = serde_json::from_str::<RigSpec>(
+        r#"{
+            "id": "studio",
+            "bench_workloads": {
+                "nodejs": ["/tmp/legacy.bench.mjs"]
+            }
+        }"#,
+    )
+    .expect_err("string workload shorthand should be rejected");
+
+    assert!(
+        err.to_string().contains("invalid type: string"),
+        "unexpected error: {}",
+        err
+    );
 }
 
 #[test]
@@ -85,10 +104,10 @@ fn test_trace_workloads_for_extension_filters_and_expands_paths() {
             },
             "trace_workloads": {
                 "nodejs": [
-                    "${env.HOMEBOY_TEST_TRACE_ROOT}/create-site.trace.mjs",
-                    "${components.studio.path}/bench/admin-load.trace.mjs"
+                    { "path": "${env.HOMEBOY_TEST_TRACE_ROOT}/create-site.trace.mjs" },
+                    { "path": "${components.studio.path}/bench/admin-load.trace.mjs" }
                 ],
-                "wordpress": ["/tmp/wp.trace.php"]
+                "wordpress": [{ "path": "/tmp/wp.trace.php" }]
             }
         }"#,
     )
@@ -112,10 +131,10 @@ fn test_extension_workloads_expand_package_root_when_available() {
         r#"{
             "id": "studio-agent-sdk",
             "bench_workloads": {
-                "nodejs": ["${package.root}/bench/studio-agent-runtime.bench.mjs"]
+                "nodejs": [{ "path": "${package.root}/bench/studio-agent-runtime.bench.mjs" }]
             },
             "trace_workloads": {
-                "nodejs": ["${package.root}/bench/studio-app-create-site.trace.mjs"]
+                "nodejs": [{ "path": "${package.root}/bench/studio-app-create-site.trace.mjs" }]
             }
         }"#,
     )
@@ -142,10 +161,10 @@ fn test_extension_workloads_leave_package_root_unexpanded_without_metadata() {
         r#"{
             "id": "manual",
             "bench_workloads": {
-                "nodejs": ["${package.root}/bench/manual.bench.mjs"]
+                "nodejs": [{ "path": "${package.root}/bench/manual.bench.mjs" }]
             },
             "trace_workloads": {
-                "nodejs": ["${package.root}/bench/manual.trace.mjs"]
+                "nodejs": [{ "path": "${package.root}/bench/manual.trace.mjs" }]
             }
         }"#,
     )
@@ -200,12 +219,12 @@ fn test_check_groups_for_extension_workloads() {
 }
 
 #[test]
-fn test_string_workloads_keep_full_check_contract() {
+fn test_workloads_without_check_groups_keep_full_check_contract() {
     let rig_spec: RigSpec = serde_json::from_str(
         r#"{
             "id": "studio",
             "trace_workloads": {
-                "nodejs": ["/tmp/create-site.trace.mjs"]
+                "nodejs": [{ "path": "/tmp/create-site.trace.mjs" }]
             }
         }"#,
     )
@@ -218,38 +237,17 @@ fn test_string_workloads_keep_full_check_contract() {
 }
 
 #[test]
-fn test_mixed_workload_declarations_keep_full_check_contract() {
-    let rig_spec: RigSpec = serde_json::from_str(
-        r#"{
-            "id": "studio",
-            "bench_workloads": {
-                "nodejs": [
-                    { "path": "/tmp/scoped.bench.mjs", "check_groups": ["desktop-app"] },
-                    "/tmp/legacy.bench.mjs"
-                ]
-            }
-        }"#,
-    )
-    .expect("parse rig spec");
-
-    assert_eq!(
-        check_groups_for_extension_workloads(&rig_spec, RigWorkloadKind::Bench, "nodejs"),
-        None
-    );
-}
-
-#[test]
 fn test_extension_ids_for_workloads_are_sorted_by_kind() {
     let rig_spec: RigSpec = serde_json::from_str(
         r#"{
             "id": "studio",
             "bench_workloads": {
-                "wordpress": ["/tmp/wp.bench.php"],
-                "nodejs": ["/tmp/node.bench.mjs"]
+                "wordpress": [{ "path": "/tmp/wp.bench.php" }],
+                "nodejs": [{ "path": "/tmp/node.bench.mjs" }]
             },
             "trace_workloads": {
-                "rust": ["/tmp/rust.trace.rs"],
-                "nodejs": ["/tmp/node.trace.mjs"]
+                "rust": [{ "path": "/tmp/rust.trace.rs" }],
+                "nodejs": [{ "path": "/tmp/node.trace.mjs" }]
             }
         }"#,
     )


### PR DESCRIPTION
## Summary
- Remove the rig workload string shorthand by making WorkloadSpec a canonical object with a required path field.
- Update rig workload fixtures, docs, and architecture examples to use object entries.
- Keep bench.default_component as active canonical UX: it is documented in docs/commands/bench.md, used by bench and bench list dispatch, and covered by existing tests.

Closes #2928

## Tests
- cargo test rig --lib --tests
- cargo test bench_default_baseline --lib --tests
- cargo check --all-targets
- cargo test --lib --tests (fails in two unrelated existing/environmental tests: core::engine::resource::tests::writes_summary_to_run_dir_artifact, core::extension::trace::probes::http_egress::tests::test_run_http_egress)

## Blockers / notes
- homeboy test --path . --extension rust could not start because the auto-selected lab runner lab is missing required extension rust.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the rig spec cleanup, docs/test updates, verification commands, and PR description. Chris remains responsible for review and merge.
