### PR TITLE
Preserve extension setup scripts in runner snapshots

### DIFF
--- a/src/core/extension/repair.rs
+++ b/src/core/extension/repair.rs
@@ -5,9 +5,10 @@ use crate::core::git;
 use crate::core::paths;
 use std::path::{Path, PathBuf};
 
+use super::execution::run_setup;
 use super::lifecycle::{
-    derive_id_from_url, is_git_url, rename_dir, resolve_cloned_extension, run_setup_if_configured,
-    slugify_id, write_source_metadata,
+    derive_id_from_url, is_git_url, rename_dir, resolve_cloned_extension, slugify_id,
+    write_source_metadata,
 };
 use super::manifest::ExtensionManifest;
 
@@ -86,8 +87,8 @@ fn replace_from_url(
         return Err(err);
     }
 
+    run_setup_or_restore(&extension_id, &extension_dir, &backup_dir)?;
     remove_existing_install(&backup_dir)?;
-    run_setup_if_configured(&extension_id);
 
     Ok(ReplaceResult {
         extension_id,
@@ -142,8 +143,8 @@ fn replace_from_path(
         return Err(err);
     }
 
+    run_setup_or_restore(&extension_id, &extension_dir, &backup_dir)?;
     remove_existing_install(&backup_dir)?;
-    run_setup_if_configured(&extension_id);
 
     Ok(ReplaceResult {
         extension_id,
@@ -290,6 +291,16 @@ fn remove_existing_install(path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn run_setup_or_restore(extension_id: &str, extension_dir: &Path, backup_dir: &Path) -> Result<()> {
+    if let Err(err) = run_setup(extension_id) {
+        let _ = remove_existing_install(extension_dir);
+        let _ = restore_existing_install(backup_dir, extension_dir);
+        return Err(err);
+    }
+
+    Ok(())
+}
+
 fn clean_replace_temp(path: &Path) -> Result<()> {
     if path_exists_or_symlink(path) {
         remove_existing_install(path)?;
@@ -322,6 +333,27 @@ mod tests {
   "version": "{}"
 }}"#,
                 id, version
+            ),
+        )
+        .expect("extension manifest");
+    }
+
+    fn write_extension_fixture_with_setup_command(root: &Path, id: &str, setup_command: &str) {
+        let dir = root.join(id);
+        fs::create_dir_all(&dir).expect("extension dir");
+        fs::write(
+            dir.join(format!("{}.json", id)),
+            format!(
+                r#"{{
+  "name": "{} extension",
+  "version": "1.0.0",
+  "executable": {{
+    "runtime": {{
+      "setup_command": "{}"
+    }}
+  }}
+}}"#,
+                id, setup_command
             ),
         )
         .expect("extension manifest");
@@ -435,6 +467,36 @@ mod tests {
 
             let extension = load_extension("swift").expect("load relinked extension");
             assert_eq!(extension.version, "2.0.0");
+        });
+    }
+
+    #[test]
+    fn relink_fails_and_restores_existing_link_when_setup_fails() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let old_source = home.join("old-source");
+            let new_source = home.join("new-source");
+            write_extension_fixture(&old_source, "swift");
+            write_extension_fixture_with_setup_command(
+                &new_source,
+                "swift",
+                "bash {{extension_path}}/scripts/build/setup.sh",
+            );
+
+            install(&old_source.join("swift").to_string_lossy(), Some("swift"))
+                .expect("install linked extension");
+
+            let err = relink("swift", &new_source.join("swift").to_string_lossy())
+                .expect_err("relink should fail when setup fails");
+
+            assert_eq!(err.message, "IO error");
+            assert!(err.details.to_string().contains("Setup command failed"));
+            let installed_path = home.join(".config/homeboy/extensions/swift");
+            assert!(installed_path.is_symlink());
+            assert_eq!(
+                fs::read_link(installed_path).expect("read restored link"),
+                old_source.join("swift")
+            );
         });
     }
 

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -33,8 +33,6 @@ const DEFAULT_EXCLUDES: &[&str] = &[
     "target/**",
     "dist",
     "dist/**",
-    "build",
-    "build/**",
     ".next",
     ".next/**",
     ".turbo",
@@ -625,9 +623,18 @@ mod tests {
             let source = tempfile::tempdir().expect("source tempdir");
             let runner_root = tempfile::tempdir().expect("runner root tempdir");
             fs::create_dir_all(source.path().join("src")).expect("src dir");
+            fs::create_dir_all(source.path().join("build")).expect("root build dir");
+            fs::create_dir_all(source.path().join("wordpress/scripts/build"))
+                .expect("extension scripts build dir");
             fs::create_dir_all(source.path().join(".git")).expect("git dir");
             fs::create_dir_all(source.path().join("target/debug")).expect("target dir");
             fs::write(source.path().join("src/main.rs"), "fn main() {}\n").expect("source file");
+            fs::write(source.path().join("build/bundle.js"), "artifact").expect("build file");
+            fs::write(
+                source.path().join("wordpress/scripts/build/setup.sh"),
+                "#!/bin/sh\n",
+            )
+            .expect("extension setup source file");
             fs::write(source.path().join(".git/HEAD"), "ref: refs/heads/main\n")
                 .expect("git metadata");
             fs::write(source.path().join("src/._main.rs"), "appledouble").expect("sidecar file");
@@ -655,9 +662,15 @@ mod tests {
 
             assert_eq!(exit_code, 0);
             assert_eq!(output.sync_mode, RunnerWorkspaceSyncMode::Snapshot);
-            assert_eq!(output.files, 1);
+            assert_eq!(output.files, 3);
             assert!(Path::new(&output.remote_path).join("src/main.rs").exists());
+            assert!(Path::new(&output.remote_path)
+                .join("wordpress/scripts/build/setup.sh")
+                .exists());
             assert!(!Path::new(&output.remote_path).join(".git").exists());
+            assert!(Path::new(&output.remote_path)
+                .join("build/bundle.js")
+                .exists());
             assert!(!Path::new(&output.remote_path)
                 .join("src/._main.rs")
                 .exists());


### PR DESCRIPTION
## Summary
- Stop excluding generic `build/**` paths from runner workspace snapshots so source-controlled extension setup files such as `wordpress/scripts/build/setup.sh` survive snapshot sync.
- Make extension replace/relink setup transactional: setup failures now return an error and restore the previous installed path instead of reporting success.
- Add regressions for snapshot preservation and relink setup failure rollback.

Fixes #2943

## Tests
- `cargo test core::runner::workspace::tests::test_sync_workspace`
- `cargo test core::extension::repair::tests::`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runner snapshot and extension relink setup-failure fix, added regression tests, and ran targeted validation; Chris remains responsible for review and merge.