### PR TITLE
Add reverse runner session substrate

### DIFF
--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -5,9 +5,9 @@ use serde::Serialize;
 use serde_json::Value;
 
 use homeboy::core::runner::{
-    self, Runner, RunnerConnectReport, RunnerDisconnectReport, RunnerExecOutput, RunnerKind,
-    RunnerStatusReport, RunnerWorkspaceApplyOutput, RunnerWorkspaceSyncMode,
-    RunnerWorkspaceSyncOutput,
+    self, ReverseRunnerConnectOptions, Runner, RunnerConnectReport, RunnerDisconnectReport,
+    RunnerExecOutput, RunnerKind, RunnerStatusReport, RunnerWorkspaceApplyOutput,
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOutput,
 };
 use homeboy::core::server::RunnerSettings;
 use homeboy::core::{EntityCrudOutput, MergeOutput};
@@ -20,6 +20,8 @@ pub mod doctor;
 pub struct RunnerExtra {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection: Option<RunnerConnectionOutput>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub sessions: Vec<RunnerStatusReport>,
 }
 
 #[derive(Debug, Serialize)]
@@ -165,13 +167,25 @@ enum RunnerCommand {
     },
     /// Connect to a runner by starting a loopback-only remote daemon and SSH tunnel
     Connect {
-        /// Runner ID
+        /// Runner ID for direct SSH connect, or controller/broker ID when --reverse is set
         id: String,
+
+        /// Record a runner-initiated reverse tunnel session substrate
+        #[arg(long)]
+        reverse: bool,
+
+        /// Runner ID initiating the reverse connection
+        #[arg(long = "reverse-runner")]
+        reverse_runner: Option<String>,
+
+        /// Broker/controller URL observed by the reverse runner
+        #[arg(long)]
+        broker_url: Option<String>,
     },
     /// Show persisted runner tunnel status
     Status {
-        /// Runner ID
-        id: String,
+        /// Runner ID. Omit to show all runner session states.
+        id: Option<String>,
     },
     /// Close a runner tunnel and remove its persisted session state
     Disconnect {
@@ -359,8 +373,13 @@ pub fn run(
                 extensions: required_extensions,
             },
         )),
-        RunnerCommand::Connect { id } => map_registry(connect(&id)),
-        RunnerCommand::Status { id } => map_registry(status(&id)),
+        RunnerCommand::Connect {
+            id,
+            reverse,
+            reverse_runner,
+            broker_url,
+        } => map_registry(connect(&id, reverse, reverse_runner, broker_url)),
+        RunnerCommand::Status { id } => map_registry(status(id.as_deref())),
         RunnerCommand::Disconnect { id } => map_registry(disconnect(&id)),
         RunnerCommand::Exec {
             id,
@@ -486,6 +505,10 @@ fn list() -> CmdResult<RunnerOutput> {
         RunnerOutput {
             command: "runner.list".to_string(),
             entities: runner::list()?,
+            extra: RunnerExtra {
+                sessions: runner::statuses()?,
+                ..Default::default()
+            },
             ..Default::default()
         },
         0,
@@ -591,14 +614,36 @@ fn remove(id: &str) -> CmdResult<RunnerOutput> {
     ))
 }
 
-fn connect(id: &str) -> CmdResult<RunnerOutput> {
-    let (report, exit_code) = runner::connect(id)?;
+fn connect(
+    id: &str,
+    reverse: bool,
+    runner_id: Option<String>,
+    broker_url: Option<String>,
+) -> CmdResult<RunnerOutput> {
+    let (report, exit_code) = if reverse {
+        let runner_id = runner_id.ok_or_else(|| {
+            homeboy::core::Error::validation_invalid_argument(
+                "runner",
+                "Provide --reverse-runner <runner-id> when using --reverse",
+                None,
+                None,
+            )
+        })?;
+        runner::connect_reverse(ReverseRunnerConnectOptions {
+            controller_id: id.to_string(),
+            runner_id,
+            broker_url,
+        })?
+    } else {
+        runner::connect(id)?
+    };
     Ok((
         RunnerOutput {
             command: "runner.connect".to_string(),
-            id: Some(id.to_string()),
+            id: Some(report.runner_id.clone()),
             extra: RunnerExtra {
                 connection: Some(RunnerConnectionOutput::Connect(report)),
+                ..Default::default()
             },
             ..Default::default()
         },
@@ -606,13 +651,28 @@ fn connect(id: &str) -> CmdResult<RunnerOutput> {
     ))
 }
 
-fn status(id: &str) -> CmdResult<RunnerOutput> {
+fn status(id: Option<&str>) -> CmdResult<RunnerOutput> {
+    if let Some(id) = id {
+        return Ok((
+            RunnerOutput {
+                command: "runner.status".to_string(),
+                id: Some(id.to_string()),
+                extra: RunnerExtra {
+                    connection: Some(RunnerConnectionOutput::Status(runner::status(id)?)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            0,
+        ));
+    }
+
     Ok((
         RunnerOutput {
             command: "runner.status".to_string(),
-            id: Some(id.to_string()),
             extra: RunnerExtra {
-                connection: Some(RunnerConnectionOutput::Status(runner::status(id)?)),
+                sessions: runner::statuses()?,
+                ..Default::default()
             },
             ..Default::default()
         },
@@ -627,6 +687,7 @@ fn disconnect(id: &str) -> CmdResult<RunnerOutput> {
             id: Some(id.to_string()),
             extra: RunnerExtra {
                 connection: Some(RunnerConnectionOutput::Disconnect(runner::disconnect(id)?)),
+                ..Default::default()
             },
             ..Default::default()
         },

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -4,7 +4,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::Value;
 
 use crate::core::engine::shell;
@@ -12,128 +12,11 @@ use crate::core::error::{Error, Result};
 use crate::core::paths;
 use crate::core::server::{self, Server, ServerAuthMode, SshClient};
 
+use super::session::{
+    ReverseRunnerConnectOptions, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
+    RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStatusReport, RunnerTunnelMode,
+};
 use super::{load, Runner, RunnerKind};
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum RunnerTunnelMode {
-    DirectSsh,
-    Reverse,
-}
-
-fn default_tunnel_mode() -> RunnerTunnelMode {
-    RunnerTunnelMode::DirectSsh
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum RunnerSessionRole {
-    Controller,
-    Runner,
-}
-
-fn default_session_role() -> RunnerSessionRole {
-    RunnerSessionRole::Controller
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum RunnerSessionState {
-    Connected,
-    Disconnected,
-    Recorded,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerSession {
-    pub runner_id: String,
-    #[serde(default = "default_tunnel_mode")]
-    pub mode: RunnerTunnelMode,
-    #[serde(default = "default_session_role")]
-    pub role: RunnerSessionRole,
-    pub server_id: Option<String>,
-    #[serde(default)]
-    pub controller_id: Option<String>,
-    #[serde(default)]
-    pub broker_url: Option<String>,
-    #[serde(default)]
-    pub remote_daemon_address: Option<String>,
-    #[serde(default)]
-    pub local_port: Option<u16>,
-    #[serde(default)]
-    pub local_url: Option<String>,
-    pub tunnel_pid: Option<u32>,
-    pub remote_daemon_pid: Option<u32>,
-    pub homeboy_version: String,
-    pub connected_at: String,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum RunnerFailureKind {
-    SshFailure,
-    MissingRemoteHomeboy,
-    DaemonStartupFailure,
-    TunnelFailure,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct RunnerConnectReport {
-    pub runner_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mode: Option<RunnerTunnelMode>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub role: Option<RunnerSessionRole>,
-    pub connected: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub recorded: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub local_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub broker_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub controller_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub remote_daemon_address: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tunnel_pid: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub remote_daemon_pid: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub homeboy_version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub session_path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub failure_kind: Option<RunnerFailureKind>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub failure_message: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct RunnerStatusReport {
-    pub runner_id: String,
-    pub connected: bool,
-    pub state: RunnerSessionState,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub session: Option<RunnerSession>,
-    pub session_path: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct RunnerDisconnectReport {
-    pub runner_id: String,
-    pub disconnected: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub session: Option<RunnerSession>,
-    pub session_path: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ReverseRunnerConnectOptions {
-    pub controller_id: String,
-    pub runner_id: String,
-    pub broker_url: Option<String>,
-}
 
 #[derive(Debug, Clone, Deserialize)]
 struct CliEnvelope {

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -15,12 +15,53 @@ use crate::core::server::{self, Server, ServerAuthMode, SshClient};
 use super::{load, Runner, RunnerKind};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerTunnelMode {
+    DirectSsh,
+    Reverse,
+}
+
+fn default_tunnel_mode() -> RunnerTunnelMode {
+    RunnerTunnelMode::DirectSsh
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerSessionRole {
+    Controller,
+    Runner,
+}
+
+fn default_session_role() -> RunnerSessionRole {
+    RunnerSessionRole::Controller
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerSessionState {
+    Connected,
+    Disconnected,
+    Recorded,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunnerSession {
     pub runner_id: String,
+    #[serde(default = "default_tunnel_mode")]
+    pub mode: RunnerTunnelMode,
+    #[serde(default = "default_session_role")]
+    pub role: RunnerSessionRole,
     pub server_id: Option<String>,
-    pub remote_daemon_address: String,
-    pub local_port: u16,
-    pub local_url: String,
+    #[serde(default)]
+    pub controller_id: Option<String>,
+    #[serde(default)]
+    pub broker_url: Option<String>,
+    #[serde(default)]
+    pub remote_daemon_address: Option<String>,
+    #[serde(default)]
+    pub local_port: Option<u16>,
+    #[serde(default)]
+    pub local_url: Option<String>,
     pub tunnel_pid: Option<u32>,
     pub remote_daemon_pid: Option<u32>,
     pub homeboy_version: String,
@@ -39,9 +80,19 @@ pub enum RunnerFailureKind {
 #[derive(Debug, Clone, Serialize)]
 pub struct RunnerConnectReport {
     pub runner_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<RunnerTunnelMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<RunnerSessionRole>,
     pub connected: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub recorded: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub local_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub broker_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub controller_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remote_daemon_address: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -62,6 +113,7 @@ pub struct RunnerConnectReport {
 pub struct RunnerStatusReport {
     pub runner_id: String,
     pub connected: bool,
+    pub state: RunnerSessionState,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session: Option<RunnerSession>,
     pub session_path: String,
@@ -74,6 +126,13 @@ pub struct RunnerDisconnectReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session: Option<RunnerSession>,
     pub session_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReverseRunnerConnectOptions {
+    pub controller_id: String,
+    pub runner_id: String,
+    pub broker_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -93,7 +152,7 @@ pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
             runner_id,
             session_path,
             RunnerFailureKind::SshFailure,
-            "only SSH runners are supported by runner connect in this wave".to_string(),
+            "only SSH runners are supported by direct runner connect in this wave".to_string(),
         ));
     };
 
@@ -169,10 +228,14 @@ pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
 
     let session = RunnerSession {
         runner_id: runner.id.clone(),
+        mode: RunnerTunnelMode::DirectSsh,
+        role: RunnerSessionRole::Controller,
         server_id: Some(server_id),
-        remote_daemon_address: daemon.address,
-        local_port,
-        local_url: format!("http://127.0.0.1:{}", local_port),
+        controller_id: None,
+        broker_url: None,
+        remote_daemon_address: Some(daemon.address),
+        local_port: Some(local_port),
+        local_url: Some(format!("http://127.0.0.1:{}", local_port)),
         tunnel_pid: tunnel.pid,
         remote_daemon_pid: daemon.pid,
         homeboy_version: version,
@@ -183,12 +246,77 @@ pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
     Ok((
         RunnerConnectReport {
             runner_id: runner.id,
+            mode: Some(session.mode.clone()),
+            role: Some(session.role.clone()),
             connected: true,
-            local_url: Some(session.local_url.clone()),
-            remote_daemon_address: Some(session.remote_daemon_address.clone()),
+            recorded: None,
+            local_url: session.local_url.clone(),
+            broker_url: None,
+            controller_id: None,
+            remote_daemon_address: session.remote_daemon_address.clone(),
             tunnel_pid: session.tunnel_pid,
             remote_daemon_pid: session.remote_daemon_pid,
             homeboy_version: Some(session.homeboy_version.clone()),
+            session_path: Some(session_path.display().to_string()),
+            failure_kind: None,
+            failure_message: None,
+        },
+        0,
+    ))
+}
+
+pub fn connect_reverse(options: ReverseRunnerConnectOptions) -> Result<(RunnerConnectReport, i32)> {
+    if options.runner_id.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "runner",
+            "Reverse runner connect requires --reverse-runner <runner-id>",
+            None,
+            None,
+        ));
+    }
+    if options.controller_id.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "controller",
+            "Reverse runner connect requires a controller or broker ID",
+            None,
+            None,
+        ));
+    }
+
+    let runner = load(&options.runner_id)?;
+    let session_path = session_path(&runner.id)?;
+    let homeboy_version = env!("CARGO_PKG_VERSION").to_string();
+    let session = RunnerSession {
+        runner_id: runner.id.clone(),
+        mode: RunnerTunnelMode::Reverse,
+        role: RunnerSessionRole::Runner,
+        server_id: runner.server_id.clone(),
+        controller_id: Some(options.controller_id.clone()),
+        broker_url: options.broker_url.clone(),
+        remote_daemon_address: None,
+        local_port: None,
+        local_url: None,
+        tunnel_pid: None,
+        remote_daemon_pid: None,
+        homeboy_version,
+        connected_at: Utc::now().to_rfc3339(),
+    };
+    write_session(&session)?;
+
+    Ok((
+        RunnerConnectReport {
+            runner_id: runner.id,
+            mode: Some(RunnerTunnelMode::Reverse),
+            role: Some(RunnerSessionRole::Runner),
+            connected: false,
+            recorded: Some(true),
+            local_url: None,
+            broker_url: options.broker_url,
+            controller_id: Some(options.controller_id),
+            remote_daemon_address: None,
+            tunnel_pid: None,
+            remote_daemon_pid: None,
+            homeboy_version: Some(session.homeboy_version),
             session_path: Some(session_path.display().to_string()),
             failure_kind: None,
             failure_message: None,
@@ -201,13 +329,23 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     load(runner_id)?;
     let session_path = session_path(runner_id)?;
     let session = read_session(runner_id)?;
-    let connected = session.as_ref().is_some_and(session_is_live);
+    let state = session_state(session.as_ref());
+    let connected = state == RunnerSessionState::Connected;
     Ok(RunnerStatusReport {
         runner_id: runner_id.to_string(),
         connected,
+        state,
         session,
         session_path: session_path.display().to_string(),
     })
+}
+
+pub fn statuses() -> Result<Vec<RunnerStatusReport>> {
+    let mut reports = Vec::new();
+    for runner in super::list()? {
+        reports.push(status(&runner.id)?);
+    }
+    Ok(reports)
 }
 
 pub fn disconnect(runner_id: &str) -> Result<RunnerDisconnectReport> {
@@ -493,12 +631,26 @@ fn wait_for_tcp(port: u16, timeout: Duration) -> bool {
 }
 
 fn session_is_live(session: &RunnerSession) -> bool {
+    if session.mode != RunnerTunnelMode::DirectSsh {
+        return false;
+    }
     if let Some(pid) = session.tunnel_pid {
         if !crate::core::process::pid_is_running(pid) {
             return false;
         }
     }
-    wait_for_tcp(session.local_port, Duration::from_millis(200))
+    session
+        .local_port
+        .is_some_and(|port| wait_for_tcp(port, Duration::from_millis(200)))
+}
+
+fn session_state(session: Option<&RunnerSession>) -> RunnerSessionState {
+    match session {
+        Some(session) if session.mode == RunnerTunnelMode::Reverse => RunnerSessionState::Recorded,
+        Some(session) if session_is_live(session) => RunnerSessionState::Connected,
+        Some(_) => RunnerSessionState::Disconnected,
+        None => RunnerSessionState::Disconnected,
+    }
 }
 
 fn session_path(runner_id: &str) -> Result<PathBuf> {
@@ -548,8 +700,13 @@ fn failed_connect(
     (
         RunnerConnectReport {
             runner_id: runner_id.to_string(),
+            mode: None,
+            role: None,
             connected: false,
+            recorded: None,
             local_url: None,
+            broker_url: None,
+            controller_id: None,
             remote_daemon_address: None,
             tunnel_pid: None,
             remote_daemon_pid: None,
@@ -667,10 +824,14 @@ mod tests {
                 .expect("create runner");
             let session = RunnerSession {
                 runner_id: "lab-local".to_string(),
+                mode: RunnerTunnelMode::DirectSsh,
+                role: RunnerSessionRole::Controller,
                 server_id: None,
-                remote_daemon_address: "127.0.0.1:49152".to_string(),
-                local_port: 49153,
-                local_url: "http://127.0.0.1:49153".to_string(),
+                controller_id: None,
+                broker_url: None,
+                remote_daemon_address: Some("127.0.0.1:49152".to_string()),
+                local_port: Some(49153),
+                local_url: Some("http://127.0.0.1:49153".to_string()),
                 tunnel_pid: None,
                 remote_daemon_pid: None,
                 homeboy_version: "test".to_string(),
@@ -685,6 +846,65 @@ mod tests {
             assert!(report.disconnected);
             assert_eq!(report.session.expect("session").runner_id, "lab-local");
             assert!(!path.exists());
+        });
+    }
+
+    #[test]
+    fn records_reverse_runner_session_without_marking_transport_live() {
+        test_support::with_isolated_home(|_| {
+            crate::core::runner::create(
+                r#"{"id":"homeboy-lab","kind":"local","workspace_root":"/home/chubes/Developer"}"#,
+                false,
+            )
+            .expect("create runner");
+
+            let (report, exit_code) = connect_reverse(ReverseRunnerConnectOptions {
+                controller_id: "extra-chill".to_string(),
+                runner_id: "homeboy-lab".to_string(),
+                broker_url: Some("https://extrachill.com/homeboy/tunnel".to_string()),
+            })
+            .expect("record reverse session");
+
+            assert_eq!(exit_code, 0);
+            assert!(!report.connected);
+            assert_eq!(report.recorded, Some(true));
+            assert_eq!(report.mode, Some(RunnerTunnelMode::Reverse));
+            assert_eq!(report.role, Some(RunnerSessionRole::Runner));
+            assert_eq!(report.controller_id.as_deref(), Some("extra-chill"));
+
+            let status = status("homeboy-lab").expect("status");
+            assert!(!status.connected);
+            assert_eq!(status.state, RunnerSessionState::Recorded);
+            let session = status.session.expect("session");
+            assert_eq!(session.mode, RunnerTunnelMode::Reverse);
+            assert_eq!(session.role, RunnerSessionRole::Runner);
+            assert_eq!(session.controller_id.as_deref(), Some("extra-chill"));
+            assert_eq!(
+                session.broker_url.as_deref(),
+                Some("https://extrachill.com/homeboy/tunnel")
+            );
+            assert_eq!(session.local_url, None);
+            assert_eq!(session.local_port, None);
+        });
+    }
+
+    #[test]
+    fn status_lists_reverse_session_records() {
+        test_support::with_isolated_home(|_| {
+            crate::core::runner::create(r#"{"id":"homeboy-lab","kind":"local"}"#, false)
+                .expect("create runner");
+            connect_reverse(ReverseRunnerConnectOptions {
+                controller_id: "extra-chill".to_string(),
+                runner_id: "homeboy-lab".to_string(),
+                broker_url: None,
+            })
+            .expect("record reverse session");
+
+            let reports = statuses().expect("statuses");
+
+            assert_eq!(reports.len(), 1);
+            assert_eq!(reports[0].runner_id, "homeboy-lab");
+            assert_eq!(reports[0].state, RunnerSessionState::Recorded);
         });
     }
 }

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -103,20 +103,22 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
 
     if connected.connected {
         if let Some(session) = connected.session {
-            preflight_remote_runner_capabilities(
-                &runner,
-                options.capability_preflight.as_ref(),
-                &request_env,
-            )?;
-            return exec_via_daemon(
-                &runner,
-                &session.local_url,
-                cwd,
-                options.command,
-                request_env,
-                options.capture_patch,
-                options.source_snapshot,
-            );
+            if let Some(local_url) = session.local_url.as_deref() {
+                preflight_remote_runner_capabilities(
+                    &runner,
+                    options.capability_preflight.as_ref(),
+                    &request_env,
+                )?;
+                return exec_via_daemon(
+                    &runner,
+                    local_url,
+                    cwd,
+                    options.command,
+                    request_env,
+                    options.capture_patch,
+                    options.source_snapshot,
+                );
+            }
         }
     }
 
@@ -568,7 +570,17 @@ pub(crate) fn daemon_api_get(runner_id: &str, path: &str) -> Result<Value> {
         .timeout(Duration::from_secs(10))
         .build()
         .map_err(|err| Error::internal_unexpected(format!("build daemon HTTP client: {err}")))?;
-    daemon_get(&client, &session.local_url, path)
+    let Some(local_url) = session.local_url.as_deref() else {
+        return Err(Error::validation_invalid_argument(
+            "runner",
+            "runner session does not expose a local daemon URL yet",
+            Some(runner.id),
+            Some(vec![
+                "Reverse tunnel daemon routing is tracked in #2946 and #2948.".to_string(),
+            ]),
+        ));
+    };
+    daemon_get(&client, local_url, path)
 }
 
 fn result_event_data(events: &[JobEvent]) -> Option<Value> {

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -15,17 +15,14 @@ mod evidence;
 mod execution;
 mod offload_changed_since;
 mod offload_metadata;
+mod session;
 mod workspace;
 
 pub use apply::{
     apply_workspace_patch, RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput,
     RunnerWorkspaceApplyStatus,
 };
-pub use connection::{
-    connect, connect_reverse, disconnect, status, statuses, ReverseRunnerConnectOptions,
-    RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind, RunnerSession,
-    RunnerSessionRole, RunnerSessionState, RunnerStatusReport, RunnerTunnelMode,
-};
+pub use connection::{connect, connect_reverse, disconnect, status, statuses};
 pub use evidence::{
     download_remote_artifact, is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,
     is_retrievable_runner_artifact, reportable_artifact_evidence_path, RemoteArtifactDownload,
@@ -40,6 +37,10 @@ pub use offload_changed_since::{
     prepare_git_lab_offload_changed_since,
 };
 pub use offload_metadata::{capture_lab_offload_metadata, lab_offload_metadata};
+pub use session::{
+    ReverseRunnerConnectOptions, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
+    RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStatusReport, RunnerTunnelMode,
+};
 pub use workspace::{
     sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -22,8 +22,9 @@ pub use apply::{
     RunnerWorkspaceApplyStatus,
 };
 pub use connection::{
-    connect, disconnect, status, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
-    RunnerSession, RunnerStatusReport,
+    connect, connect_reverse, disconnect, status, statuses, ReverseRunnerConnectOptions,
+    RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind, RunnerSession,
+    RunnerSessionRole, RunnerSessionState, RunnerStatusReport, RunnerTunnelMode,
 };
 pub use evidence::{
     download_remote_artifact, is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,

--- a/src/core/runner/session.rs
+++ b/src/core/runner/session.rs
@@ -1,0 +1,122 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerTunnelMode {
+    DirectSsh,
+    Reverse,
+}
+
+fn default_tunnel_mode() -> RunnerTunnelMode {
+    RunnerTunnelMode::DirectSsh
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerSessionRole {
+    Controller,
+    Runner,
+}
+
+fn default_session_role() -> RunnerSessionRole {
+    RunnerSessionRole::Controller
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerSessionState {
+    Connected,
+    Disconnected,
+    Recorded,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerSession {
+    pub runner_id: String,
+    #[serde(default = "default_tunnel_mode")]
+    pub mode: RunnerTunnelMode,
+    #[serde(default = "default_session_role")]
+    pub role: RunnerSessionRole,
+    pub server_id: Option<String>,
+    #[serde(default)]
+    pub controller_id: Option<String>,
+    #[serde(default)]
+    pub broker_url: Option<String>,
+    #[serde(default)]
+    pub remote_daemon_address: Option<String>,
+    #[serde(default)]
+    pub local_port: Option<u16>,
+    #[serde(default)]
+    pub local_url: Option<String>,
+    pub tunnel_pid: Option<u32>,
+    pub remote_daemon_pid: Option<u32>,
+    pub homeboy_version: String,
+    pub connected_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerFailureKind {
+    SshFailure,
+    MissingRemoteHomeboy,
+    DaemonStartupFailure,
+    TunnelFailure,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RunnerConnectReport {
+    pub runner_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<RunnerTunnelMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<RunnerSessionRole>,
+    pub connected: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recorded: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub broker_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub controller_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_daemon_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tunnel_pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_daemon_pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub homeboy_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_kind: Option<RunnerFailureKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RunnerStatusReport {
+    pub runner_id: String,
+    pub connected: bool,
+    pub state: RunnerSessionState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session: Option<RunnerSession>,
+    pub session_path: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RunnerDisconnectReport {
+    pub runner_id: String,
+    pub disconnected: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session: Option<RunnerSession>,
+    pub session_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReverseRunnerConnectOptions {
+    pub controller_id: String,
+    pub runner_id: String,
+    pub broker_url: Option<String>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,9 +356,14 @@ fn connect_runner_for_offload(
             return Ok((
                 homeboy::core::runner::RunnerConnectReport {
                     runner_id: runner_id.to_string(),
+                    mode: Some(session.mode),
+                    role: Some(session.role),
                     connected: true,
-                    local_url: Some(session.local_url),
-                    remote_daemon_address: Some(session.remote_daemon_address),
+                    recorded: None,
+                    local_url: session.local_url,
+                    broker_url: session.broker_url,
+                    controller_id: session.controller_id,
+                    remote_daemon_address: session.remote_daemon_address,
                     tunnel_pid: session.tunnel_pid,
                     remote_daemon_pid: session.remote_daemon_pid,
                     homeboy_version: Some(session.homeboy_version),
@@ -389,8 +394,13 @@ fn connect_runner_for_offload(
     Ok((
         homeboy::core::runner::RunnerConnectReport {
             runner_id: runner_id.to_string(),
+            mode: None,
+            role: None,
             connected: false,
+            recorded: None,
             local_url: None,
+            broker_url: None,
+            controller_id: None,
             remote_daemon_address: None,
             tunnel_pid: None,
             remote_daemon_pid: None,
@@ -1244,6 +1254,7 @@ mod tests {
                 Ok(homeboy::core::runner::RunnerStatusReport {
                     runner_id: runner_id.to_string(),
                     connected: true,
+                    state: homeboy::core::runner::RunnerSessionState::Connected,
                     session: None,
                     session_path: "/tmp/lab.json".to_string(),
                 })
@@ -1268,6 +1279,7 @@ mod tests {
                 Ok(homeboy::core::runner::RunnerStatusReport {
                     runner_id: runner_id.to_string(),
                     connected: false,
+                    state: homeboy::core::runner::RunnerSessionState::Disconnected,
                     session: None,
                     session_path: "/tmp/lab.json".to_string(),
                 })
@@ -1276,8 +1288,13 @@ mod tests {
                 Ok((
                     homeboy::core::runner::RunnerConnectReport {
                         runner_id: runner_id.to_string(),
+                        mode: Some(homeboy::core::runner::RunnerTunnelMode::DirectSsh),
+                        role: Some(homeboy::core::runner::RunnerSessionRole::Controller),
                         connected: true,
+                        recorded: None,
                         local_url: Some("http://127.0.0.1:1234".to_string()),
+                        broker_url: None,
+                        controller_id: None,
                         remote_daemon_address: Some("127.0.0.1:5678".to_string()),
                         tunnel_pid: None,
                         remote_daemon_pid: Some(42),
@@ -1308,6 +1325,7 @@ mod tests {
                 Ok(homeboy::core::runner::RunnerStatusReport {
                     runner_id: runner_id.to_string(),
                     connected: false,
+                    state: homeboy::core::runner::RunnerSessionState::Disconnected,
                     session: None,
                     session_path: "/tmp/lab.json".to_string(),
                 })
@@ -1316,8 +1334,13 @@ mod tests {
                 Ok((
                     homeboy::core::runner::RunnerConnectReport {
                         runner_id: runner_id.to_string(),
+                        mode: None,
+                        role: None,
                         connected: false,
+                        recorded: None,
                         local_url: None,
+                        broker_url: None,
+                        controller_id: None,
                         remote_daemon_address: None,
                         tunnel_pid: None,
                         remote_daemon_pid: None,
@@ -1353,6 +1376,7 @@ mod tests {
                 Ok(homeboy::core::runner::RunnerStatusReport {
                     runner_id: runner_id.to_string(),
                     connected: false,
+                    state: homeboy::core::runner::RunnerSessionState::Disconnected,
                     session: None,
                     session_path: "/tmp/lab.json".to_string(),
                 })
@@ -1361,8 +1385,13 @@ mod tests {
                 Ok((
                     homeboy::core::runner::RunnerConnectReport {
                         runner_id: runner_id.to_string(),
+                        mode: None,
+                        role: None,
                         connected: false,
+                        recorded: None,
                         local_url: None,
+                        broker_url: None,
+                        controller_id: None,
                         remote_daemon_address: None,
                         tunnel_pid: None,
                         remote_daemon_pid: None,


### PR DESCRIPTION
## Summary
- Add runner session mode/role/state metadata so direct SSH sessions and reverse runner sessions can coexist.
- Add `homeboy runner connect <controller> --reverse --reverse-runner <runner-id> [--broker-url <url>]` to record the first runner-initiated reverse session substrate without changing existing SSH `runner connect` behavior.
- Let `homeboy runner status` and `homeboy runner list` surface persisted session state for inspection.
- Keep daemon execution on direct local daemon URLs only; reverse daemon routing remains follow-up work for #2946 and #2948.

Refs #2944.

## Verification
- `cargo test core::runner::connection`
- `cargo test`
- `target/debug/homeboy runner --help`
- `target/debug/homeboy runner connect --help`
- temp-home CLI smoke: add local runner, record reverse connect, inspect `runner status` and `runner list` JSON output

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the reverse runner session substrate, CLI changes, tests, and verification steps; Chris remains responsible for review and merge.