### PR TITLE
Support reverse runner hot offload selection

### DIFF
--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -208,7 +208,7 @@ pub fn connect_reverse(options: ReverseRunnerConnectOptions) -> Result<(RunnerCo
 }
 
 pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
-    let runner = load(runner_id)?;
+    load(runner_id)?;
     let session_path = session_path(runner_id)?;
     let session = read_session(runner_id)?;
     let state = session_state(session.as_ref());

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -17,7 +17,6 @@ use super::session::{
     RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStatusReport, RunnerTunnelMode,
 };
 use super::{load, Runner, RunnerKind};
-
 #[derive(Debug, Clone, Deserialize)]
 struct CliEnvelope {
     success: bool,

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -208,7 +208,7 @@ pub fn connect_reverse(options: ReverseRunnerConnectOptions) -> Result<(RunnerCo
 }
 
 pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
-    load(runner_id)?;
+    let runner = load(runner_id)?;
     let session_path = session_path(runner_id)?;
     let session = read_session(runner_id)?;
     let state = session_state(session.as_ref());

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -151,10 +151,15 @@ pub fn resolve_default_lab_runner() -> Result<Option<String>> {
             if runner.kind != RunnerKind::Ssh {
                 return None;
             }
-            let connected = status(&runner.id).ok()?.connected;
+            let status = status(&runner.id).ok()?;
+            let mode = status
+                .session
+                .as_ref()
+                .map_or(RunnerTunnelMode::DirectSsh, |session| session.mode.clone());
             Some(DefaultLabRunnerCandidate {
                 id: runner.id,
-                connected,
+                mode,
+                connected: status.connected,
             })
         }),
     ))
@@ -163,6 +168,7 @@ pub fn resolve_default_lab_runner() -> Result<Option<String>> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DefaultLabRunnerCandidate {
     id: String,
+    mode: RunnerTunnelMode,
     connected: bool,
 }
 
@@ -632,10 +638,12 @@ mod tests {
             vec![
                 DefaultLabRunnerCandidate {
                     id: "lab-a".to_string(),
+                    mode: RunnerTunnelMode::DirectSsh,
                     connected: true,
                 },
                 DefaultLabRunnerCandidate {
                     id: "lab-b".to_string(),
+                    mode: RunnerTunnelMode::Reverse,
                     connected: true,
                 },
             ],
@@ -651,10 +659,12 @@ mod tests {
             vec![
                 DefaultLabRunnerCandidate {
                     id: "lab-a".to_string(),
+                    mode: RunnerTunnelMode::DirectSsh,
                     connected: false,
                 },
                 DefaultLabRunnerCandidate {
                     id: "lab-b".to_string(),
+                    mode: RunnerTunnelMode::Reverse,
                     connected: true,
                 },
             ],
@@ -666,6 +676,7 @@ mod tests {
             None,
             vec![DefaultLabRunnerCandidate {
                 id: "lab-a".to_string(),
+                mode: RunnerTunnelMode::DirectSsh,
                 connected: false,
             }],
         );
@@ -680,10 +691,12 @@ mod tests {
             vec![
                 DefaultLabRunnerCandidate {
                     id: "lab-a".to_string(),
+                    mode: RunnerTunnelMode::DirectSsh,
                     connected: false,
                 },
                 DefaultLabRunnerCandidate {
                     id: "lab-b".to_string(),
+                    mode: RunnerTunnelMode::Reverse,
                     connected: false,
                 },
             ],
@@ -693,10 +706,12 @@ mod tests {
             vec![
                 DefaultLabRunnerCandidate {
                     id: "lab-a".to_string(),
+                    mode: RunnerTunnelMode::DirectSsh,
                     connected: true,
                 },
                 DefaultLabRunnerCandidate {
                     id: "lab-b".to_string(),
+                    mode: RunnerTunnelMode::Reverse,
                     connected: true,
                 },
             ],
@@ -712,10 +727,25 @@ mod tests {
             Some("lab-a"),
             vec![DefaultLabRunnerCandidate {
                 id: "lab-a".to_string(),
+                mode: RunnerTunnelMode::Reverse,
                 connected: false,
             }],
         );
 
         assert_eq!(selected.as_deref(), Some("lab-a"));
+    }
+
+    #[test]
+    fn default_lab_runner_can_select_connected_reverse_runner() {
+        let selected = resolve_default_lab_runner_from_candidates(
+            None,
+            vec![DefaultLabRunnerCandidate {
+                id: "homeboy-lab".to_string(),
+                mode: RunnerTunnelMode::Reverse,
+                connected: true,
+            }],
+        );
+
+        assert_eq!(selected.as_deref(), Some("homeboy-lab"));
     }
 }

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -735,7 +735,6 @@ mod tests {
         assert_eq!(selected.as_deref(), Some("lab-a"));
     }
 
-    #[test]
     fn default_lab_runner_can_select_connected_reverse_runner() {
         let selected = resolve_default_lab_runner_from_candidates(
             None,

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -735,6 +735,7 @@ mod tests {
         assert_eq!(selected.as_deref(), Some("lab-a"));
     }
 
+    #[test]
     fn default_lab_runner_can_select_connected_reverse_runner() {
         let selected = resolve_default_lab_runner_from_candidates(
             None,

--- a/src/core/runner/offload_metadata.rs
+++ b/src/core/runner/offload_metadata.rs
@@ -1,6 +1,7 @@
 pub fn lab_offload_metadata(
     source: &str,
     runner_id: Option<&str>,
+    runner_mode: Option<&str>,
     status: &str,
     remote_workspace: Option<&str>,
     fallback_reason: Option<&str>,
@@ -9,6 +10,7 @@ pub fn lab_offload_metadata(
         "source": source,
         "status": status,
         "runner_id": runner_id,
+        "runner_mode": runner_mode,
         "remote_workspace": remote_workspace,
         "fallback_reason": fallback_reason,
     })
@@ -29,6 +31,7 @@ mod tests {
         let explicit = lab_offload_metadata(
             "explicit",
             Some("lab-explicit"),
+            Some("direct_ssh"),
             "offloaded",
             Some("/srv/homeboy/project"),
             None,
@@ -36,12 +39,14 @@ mod tests {
         assert_eq!(explicit["source"], "explicit");
         assert_eq!(explicit["status"], "offloaded");
         assert_eq!(explicit["runner_id"], "lab-explicit");
+        assert_eq!(explicit["runner_mode"], "direct_ssh");
         assert_eq!(explicit["remote_workspace"], "/srv/homeboy/project");
         assert!(explicit["fallback_reason"].is_null());
 
         let fallback = lab_offload_metadata(
             "automatic",
             Some("lab"),
+            Some("reverse"),
             "fallback",
             None,
             Some("runner connect timed out after 3s"),
@@ -56,6 +61,7 @@ mod tests {
 
         let skipped = lab_offload_metadata(
             "automatic",
+            None,
             None,
             "skipped",
             None,

--- a/src/core/runner/session.rs
+++ b/src/core/runner/session.rs
@@ -7,6 +7,23 @@ pub enum RunnerTunnelMode {
     Reverse,
 }
 
+impl RunnerTunnelMode {
+    pub fn label(&self) -> &'static str {
+        self.labels().0
+    }
+
+    pub fn metadata_value(&self) -> &'static str {
+        self.labels().1
+    }
+
+    fn labels(&self) -> (&'static str, &'static str) {
+        match self {
+            RunnerTunnelMode::DirectSsh => ("direct SSH", "direct_ssh"),
+            RunnerTunnelMode::Reverse => ("reverse-connected", "reverse"),
+        }
+    }
+}
+
 fn default_tunnel_mode() -> RunnerTunnelMode {
     RunnerTunnelMode::DirectSsh
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ use homeboy::commands::utils::{args, entity_suggest, resource_policy, response a
 use homeboy::core::extension::load_all_extensions;
 
 mod lab_offload_extension_parity;
+#[cfg(test)]
+mod reverse_lab_offload_tests;
 
 struct ExtensionCliCommand {
     tool: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1039,24 +1039,6 @@ mod tests {
         }
     }
 
-    fn reverse_runner_session(runner_id: &str) -> homeboy::core::runner::RunnerSession {
-        homeboy::core::runner::RunnerSession {
-            runner_id: runner_id.to_string(),
-            mode: homeboy::core::runner::RunnerTunnelMode::Reverse,
-            role: homeboy::core::runner::RunnerSessionRole::Runner,
-            server_id: None,
-            controller_id: Some("controller".to_string()),
-            broker_url: None,
-            remote_daemon_address: None,
-            local_port: None,
-            local_url: None,
-            tunnel_pid: None,
-            remote_daemon_pid: None,
-            homeboy_version: "test".to_string(),
-            connected_at: "2026-05-27T00:00:00Z".to_string(),
-        }
-    }
-
     #[test]
     fn rewrites_lab_offload_path_and_strips_runner_flag_before_remote_exec() {
         let args = vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -1442,64 +1442,6 @@ mod tests {
     }
 
     #[test]
-    fn lab_runner_preparation_falls_back_for_disconnected_default_reverse_runner_without_connecting(
-    ) {
-        let selection = LabRunnerSelection {
-            runner_id: "lab".to_string(),
-            source: LabRunnerSelectionSource::Default,
-            mode: homeboy::core::runner::RunnerTunnelMode::Reverse,
-        };
-
-        let prepared = prepare_lab_runner_for_offload_with(
-            &selection,
-            |runner_id| {
-                Ok(homeboy::core::runner::RunnerStatusReport {
-                    runner_id: runner_id.to_string(),
-                    connected: false,
-                    state: homeboy::core::runner::RunnerSessionState::Recorded,
-                    session: Some(reverse_runner_session(runner_id)),
-                    session_path: "/tmp/lab.json".to_string(),
-                })
-            },
-            |_| panic!("reverse runner sessions are supplied by the reverse substrate"),
-        )
-        .expect("prepared");
-
-        assert_eq!(
-            prepared,
-            LabRunnerPreparation::FallBackLocal {
-                reason: "reverse-connected runner `lab` is not currently connected".to_string()
-            }
-        );
-    }
-
-    #[test]
-    fn lab_runner_preparation_errors_for_disconnected_explicit_reverse_runner() {
-        let selection = LabRunnerSelection {
-            runner_id: "lab".to_string(),
-            source: LabRunnerSelectionSource::Explicit,
-            mode: homeboy::core::runner::RunnerTunnelMode::Reverse,
-        };
-
-        let err = prepare_lab_runner_for_offload_with(
-            &selection,
-            |runner_id| {
-                Ok(homeboy::core::runner::RunnerStatusReport {
-                    runner_id: runner_id.to_string(),
-                    connected: false,
-                    state: homeboy::core::runner::RunnerSessionState::Recorded,
-                    session: Some(reverse_runner_session(runner_id)),
-                    session_path: "/tmp/lab.json".to_string(),
-                })
-            },
-            |_| panic!("reverse runner sessions are supplied by the reverse substrate"),
-        )
-        .expect_err("explicit reverse runner should error");
-
-        assert!(err.message.contains("requires reverse runner `lab`"));
-    }
-
-    #[test]
     fn lab_runner_preparation_errors_for_unreachable_explicit_runner() {
         let selection = LabRunnerSelection {
             runner_id: "lab".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,8 @@ fn main() -> std::process::ExitCode {
         Ok(Some(selection)) => {
             if matches!(selection.source, LabRunnerSelectionSource::Default) {
                 eprintln!(
-                    "Lab offload: auto-selected default runner `{}`.",
+                    "Lab offload: auto-selected default {} runner `{}`.",
+                    selection.mode.label(),
                     selection.runner_id
                 );
             }
@@ -199,6 +200,7 @@ fn main() -> std::process::ExitCode {
                                 LabRunnerSelectionSource::Default => "automatic",
                             },
                             Some(&selection.runner_id),
+                            Some(selection.mode.metadata_value()),
                             "fallback",
                             None,
                             Some(&reason),
@@ -218,6 +220,7 @@ fn main() -> std::process::ExitCode {
                 homeboy::core::runner::capture_lab_offload_metadata(
                     homeboy::core::runner::lab_offload_metadata(
                         "automatic",
+                        None,
                         None,
                         "skipped",
                         None,
@@ -309,6 +312,7 @@ enum LabRunnerSelectionSource {
 struct LabRunnerSelection {
     runner_id: String,
     source: LabRunnerSelectionSource,
+    mode: homeboy::core::runner::RunnerTunnelMode,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -327,10 +331,10 @@ fn prepare_lab_runner_for_offload(
     if runner.kind != homeboy::core::runner::RunnerKind::Ssh {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "runner",
-            "Lab offload requires a remote SSH runner; local runners would execute on this machine",
+            "Lab offload requires a remote direct SSH or reverse-connected runner; local runners would execute on this machine",
             Some(runner.id),
             Some(vec![
-                "Register an SSH runner before using Lab offload.".to_string()
+                "Register a direct SSH runner or configure a reverse-connected runner before using Lab offload.".to_string()
             ]),
         ));
     }
@@ -468,11 +472,37 @@ fn prepare_lab_runner_for_offload_with(
 ) -> homeboy::core::Result<LabRunnerPreparation> {
     let status = status_fn(&selection.runner_id)?;
     if status.connected {
+        eprintln!(
+            "Lab offload: runner `{}` is connected via {} mode.",
+            selection.runner_id,
+            status_tunnel_mode(&status).label()
+        );
         return Ok(LabRunnerPreparation::Ready);
     }
 
+    if status_tunnel_mode(&status) == homeboy::core::runner::RunnerTunnelMode::Reverse {
+        let reason = format!(
+            "reverse-connected runner `{}` is not currently connected",
+            selection.runner_id
+        );
+        return match selection.source {
+            LabRunnerSelectionSource::Default => Ok(LabRunnerPreparation::FallBackLocal { reason }),
+            LabRunnerSelectionSource::Explicit => {
+                Err(homeboy::core::Error::validation_invalid_argument(
+                    "runner",
+                    format!("Lab offload requires reverse runner `{}` to have an active reverse session", selection.runner_id),
+                    Some(selection.runner_id.clone()),
+                    Some(vec![
+                        "Start the reverse runner session on the Lab machine before using --runner.".to_string(),
+                        "Use --force-hot to run the command locally instead of offloading.".to_string(),
+                    ]),
+                ))
+            }
+        };
+    }
+
     eprintln!(
-        "Lab offload: runner `{}` is not connected; attempting connection.",
+        "Lab offload: direct SSH runner `{}` is not connected; attempting connection.",
         selection.runner_id
     );
     let (report, _) = connect_fn(&selection.runner_id)?;
@@ -545,6 +575,7 @@ fn resolve_lab_runner_selection_from_default(
         return Ok(Some(LabRunnerSelection {
             runner_id: runner_id.to_string(),
             source: LabRunnerSelectionSource::Explicit,
+            mode: runner_status_tunnel_mode(runner_id),
         }));
     }
 
@@ -552,10 +583,31 @@ fn resolve_lab_runner_selection_from_default(
         return Ok(None);
     }
 
-    Ok(default_runner.map(|runner_id| LabRunnerSelection {
-        runner_id,
-        source: LabRunnerSelectionSource::Default,
-    }))
+    default_runner
+        .map(|runner_id| {
+            Ok(LabRunnerSelection {
+                mode: runner_status_tunnel_mode(&runner_id),
+                runner_id,
+                source: LabRunnerSelectionSource::Default,
+            })
+        })
+        .transpose()
+}
+
+fn runner_status_tunnel_mode(runner_id: &str) -> homeboy::core::runner::RunnerTunnelMode {
+    homeboy::core::runner::status(runner_id).map_or(
+        homeboy::core::runner::RunnerTunnelMode::DirectSsh,
+        |status| status_tunnel_mode(&status),
+    )
+}
+
+fn status_tunnel_mode(
+    status: &homeboy::core::runner::RunnerStatusReport,
+) -> homeboy::core::runner::RunnerTunnelMode {
+    status.session.as_ref().map_or(
+        homeboy::core::runner::RunnerTunnelMode::DirectSsh,
+        |session| session.mode.clone(),
+    )
 }
 
 fn exit_code_to_u8(code: i32) -> u8 {
@@ -614,26 +666,29 @@ fn run_lab_offload_inner(
     capture_patch: bool,
 ) -> homeboy::core::Result<i32> {
     let runner = homeboy::core::runner::load(runner_id)?;
+    let status = homeboy::core::runner::status(runner_id)?;
     if runner.kind != homeboy::core::runner::RunnerKind::Ssh {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "runner",
-            "Lab offload requires a remote SSH runner; local runners would execute on this machine",
+            "Lab offload requires a remote direct SSH or reverse-connected runner; local runners would execute on this machine",
             Some(runner.id),
             Some(vec![
-                "Register an SSH runner and run `homeboy runner connect <runner-id>` first."
+                "Register a direct SSH runner or configure a reverse-connected runner first."
                     .to_string(),
             ]),
         ));
     }
 
-    let status = homeboy::core::runner::status(runner_id)?;
     if !status.connected {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "runner",
-            "Lab offload requires a connected runner daemon",
+            format!(
+                "Lab offload requires a connected {} runner daemon",
+                status_tunnel_mode(&status).label()
+            ),
             Some(runner_id.to_string()),
             Some(vec![format!(
-                "Run `homeboy runner connect {runner_id}` before using --runner."
+                "Connect runner `{runner_id}` before using --runner."
             )]),
         ));
     }
@@ -708,6 +763,7 @@ fn run_lab_offload_inner(
             LabRunnerSelectionSource::Default => "automatic",
         },
         Some(runner_id),
+        Some(status_tunnel_mode(&status).metadata_value()),
         "offloaded",
         Some(&remote_cwd),
         None,
@@ -983,6 +1039,24 @@ mod tests {
         }
     }
 
+    fn reverse_runner_session(runner_id: &str) -> homeboy::core::runner::RunnerSession {
+        homeboy::core::runner::RunnerSession {
+            runner_id: runner_id.to_string(),
+            mode: homeboy::core::runner::RunnerTunnelMode::Reverse,
+            role: homeboy::core::runner::RunnerSessionRole::Runner,
+            server_id: None,
+            controller_id: Some("controller".to_string()),
+            broker_url: None,
+            remote_daemon_address: None,
+            local_port: None,
+            local_url: None,
+            tunnel_pid: None,
+            remote_daemon_pid: None,
+            homeboy_version: "test".to_string(),
+            connected_at: "2026-05-27T00:00:00Z".to_string(),
+        }
+    }
+
     #[test]
     fn rewrites_lab_offload_path_and_strips_runner_flag_before_remote_exec() {
         let args = vec![
@@ -1247,6 +1321,7 @@ mod tests {
         let selection = LabRunnerSelection {
             runner_id: "lab".to_string(),
             source: LabRunnerSelectionSource::Default,
+            mode: homeboy::core::runner::RunnerTunnelMode::DirectSsh,
         };
 
         let prepared = prepare_lab_runner_for_offload_with(
@@ -1272,6 +1347,7 @@ mod tests {
         let selection = LabRunnerSelection {
             runner_id: "lab".to_string(),
             source: LabRunnerSelectionSource::Default,
+            mode: homeboy::core::runner::RunnerTunnelMode::DirectSsh,
         };
 
         let prepared = prepare_lab_runner_for_offload_with(
@@ -1318,6 +1394,7 @@ mod tests {
         let selection = LabRunnerSelection {
             runner_id: "lab".to_string(),
             source: LabRunnerSelectionSource::Default,
+            mode: homeboy::core::runner::RunnerTunnelMode::DirectSsh,
         };
 
         let prepared = prepare_lab_runner_for_offload_with(
@@ -1365,10 +1442,69 @@ mod tests {
     }
 
     #[test]
+    fn lab_runner_preparation_falls_back_for_disconnected_default_reverse_runner_without_connecting(
+    ) {
+        let selection = LabRunnerSelection {
+            runner_id: "lab".to_string(),
+            source: LabRunnerSelectionSource::Default,
+            mode: homeboy::core::runner::RunnerTunnelMode::Reverse,
+        };
+
+        let prepared = prepare_lab_runner_for_offload_with(
+            &selection,
+            |runner_id| {
+                Ok(homeboy::core::runner::RunnerStatusReport {
+                    runner_id: runner_id.to_string(),
+                    connected: false,
+                    state: homeboy::core::runner::RunnerSessionState::Recorded,
+                    session: Some(reverse_runner_session(runner_id)),
+                    session_path: "/tmp/lab.json".to_string(),
+                })
+            },
+            |_| panic!("reverse runner sessions are supplied by the reverse substrate"),
+        )
+        .expect("prepared");
+
+        assert_eq!(
+            prepared,
+            LabRunnerPreparation::FallBackLocal {
+                reason: "reverse-connected runner `lab` is not currently connected".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn lab_runner_preparation_errors_for_disconnected_explicit_reverse_runner() {
+        let selection = LabRunnerSelection {
+            runner_id: "lab".to_string(),
+            source: LabRunnerSelectionSource::Explicit,
+            mode: homeboy::core::runner::RunnerTunnelMode::Reverse,
+        };
+
+        let err = prepare_lab_runner_for_offload_with(
+            &selection,
+            |runner_id| {
+                Ok(homeboy::core::runner::RunnerStatusReport {
+                    runner_id: runner_id.to_string(),
+                    connected: false,
+                    state: homeboy::core::runner::RunnerSessionState::Recorded,
+                    session: Some(reverse_runner_session(runner_id)),
+                    session_path: "/tmp/lab.json".to_string(),
+                })
+            },
+            |_| panic!("reverse runner sessions are supplied by the reverse substrate"),
+        )
+        .expect_err("explicit reverse runner should error");
+
+        assert!(err.message.contains("requires reverse runner `lab`"));
+    }
+
+    #[test]
     fn lab_runner_preparation_errors_for_unreachable_explicit_runner() {
         let selection = LabRunnerSelection {
             runner_id: "lab".to_string(),
             source: LabRunnerSelectionSource::Explicit,
+            mode: homeboy::core::runner::RunnerTunnelMode::DirectSsh,
         };
 
         let err = prepare_lab_runner_for_offload_with(

--- a/src/reverse_lab_offload_tests.rs
+++ b/src/reverse_lab_offload_tests.rs
@@ -1,0 +1,79 @@
+use super::{
+    prepare_lab_runner_for_offload_with, LabRunnerPreparation, LabRunnerSelection,
+    LabRunnerSelectionSource,
+};
+
+fn reverse_runner_session(runner_id: &str) -> homeboy::core::runner::RunnerSession {
+    homeboy::core::runner::RunnerSession {
+        runner_id: runner_id.to_string(),
+        mode: homeboy::core::runner::RunnerTunnelMode::Reverse,
+        role: homeboy::core::runner::RunnerSessionRole::Runner,
+        server_id: None,
+        controller_id: Some("controller".to_string()),
+        broker_url: None,
+        remote_daemon_address: None,
+        local_port: None,
+        local_url: None,
+        tunnel_pid: None,
+        remote_daemon_pid: None,
+        homeboy_version: "test".to_string(),
+        connected_at: "2026-05-27T00:00:00Z".to_string(),
+    }
+}
+
+#[test]
+fn lab_runner_preparation_falls_back_for_disconnected_default_reverse_runner_without_connecting() {
+    let selection = LabRunnerSelection {
+        runner_id: "lab".to_string(),
+        source: LabRunnerSelectionSource::Default,
+        mode: homeboy::core::runner::RunnerTunnelMode::Reverse,
+    };
+
+    let prepared = prepare_lab_runner_for_offload_with(
+        &selection,
+        |runner_id| {
+            Ok(homeboy::core::runner::RunnerStatusReport {
+                runner_id: runner_id.to_string(),
+                connected: false,
+                state: homeboy::core::runner::RunnerSessionState::Recorded,
+                session: Some(reverse_runner_session(runner_id)),
+                session_path: "/tmp/lab.json".to_string(),
+            })
+        },
+        |_| panic!("reverse runner sessions are supplied by the reverse substrate"),
+    )
+    .expect("prepared");
+
+    assert_eq!(
+        prepared,
+        LabRunnerPreparation::FallBackLocal {
+            reason: "reverse-connected runner `lab` is not currently connected".to_string()
+        }
+    );
+}
+
+#[test]
+fn lab_runner_preparation_errors_for_disconnected_explicit_reverse_runner() {
+    let selection = LabRunnerSelection {
+        runner_id: "lab".to_string(),
+        source: LabRunnerSelectionSource::Explicit,
+        mode: homeboy::core::runner::RunnerTunnelMode::Reverse,
+    };
+
+    let err = prepare_lab_runner_for_offload_with(
+        &selection,
+        |runner_id| {
+            Ok(homeboy::core::runner::RunnerStatusReport {
+                runner_id: runner_id.to_string(),
+                connected: false,
+                state: homeboy::core::runner::RunnerSessionState::Recorded,
+                session: Some(reverse_runner_session(runner_id)),
+                session_path: "/tmp/lab.json".to_string(),
+            })
+        },
+        |_| panic!("reverse runner sessions are supplied by the reverse substrate"),
+    )
+    .expect_err("explicit reverse runner should error");
+
+    assert!(err.message.contains("requires reverse runner `lab`"));
+}


### PR DESCRIPTION
## Summary
- add runner connection modes so status can distinguish local, direct SSH, and reverse-connected runners
- allow default Lab runner resolution and explicit --runner preparation to use reverse-connected status without attempting direct SSH connect
- include runner_mode in Lab offload metadata for offloaded and fallback paths

Fixes #2948

## Testing
- cargo test lab_runner --bin homeboy
- cargo test default_lab_runner --lib
- cargo test status_reports_reverse_runner_from_config_stub --lib
- cargo test lab_offload_metadata --lib
- cargo test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and tests for reverse runner offload selection/status paths; Chris to review and validate before merge.
