### PR TITLE
Fix release context test fixture id

### DIFF
--- a/src/core/release/context.rs
+++ b/src/core/release/context.rs
@@ -40,6 +40,7 @@ mod tests {
         std::fs::write(
             homeboy_json,
             r#"{
+                "id": "fixture",
                 "components": {
                     "fixture": {
                         "type": "nodejs",


### PR DESCRIPTION
## Summary
- add the required top-level id to the release context test fixture
- keep the fixture aligned with explicit portable component ids

## Testing
- cargo test core::release::context::tests::test_load_component --lib
- cargo check --all-targets
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the failing CI test and made the one-line test fixture correction; Chris remains responsible for review and merge.