### PR TITLE
fix: skip release artifacts for mutable deps

### DIFF
--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -160,8 +160,10 @@ fn should_try_download_release_artifact(
     !is_git_deploy
         && !is_file_deploy
         && !config.head
+        && !config.tagged
         && !config.skip_build
         && release_download::supports_release_deploy(component)
+        && !release_download::has_mutable_package_dependencies(component)
 }
 
 fn failed_component_deploy_result(
@@ -793,6 +795,115 @@ mod tests {
         };
 
         assert!(!should_try_download_release_artifact(
+            &component, &config, false, false
+        ));
+    }
+
+    #[test]
+    fn tagged_deploy_skips_release_artifact_download() {
+        let component = Component {
+            id: "example".to_string(),
+            remote_url: Some("https://github.com/example/example".to_string()),
+            build_artifact: Some("build/example.zip".to_string()),
+            ..Component::default()
+        };
+        let config = DeployConfig {
+            component_ids: Vec::new(),
+            all: false,
+            outdated: false,
+            behind_upstream: false,
+            dry_run: false,
+            check: false,
+            force: false,
+            skip_build: false,
+            keep_deps: false,
+            expected_version: None,
+            no_pull: false,
+            head: false,
+            tagged: true,
+        };
+
+        assert!(!should_try_download_release_artifact(
+            &component, &config, false, false
+        ));
+    }
+
+    #[test]
+    fn mutable_package_dependencies_skip_release_artifact_download() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            temp.path().join("package.json"),
+            r#"{
+                "dependencies": {
+                    "tokens": "github:Extra-Chill/extrachill-tokens#v0.7.2"
+                }
+            }"#,
+        )
+        .expect("write package.json");
+        let component = Component {
+            id: "example".to_string(),
+            local_path: temp.path().to_string_lossy().to_string(),
+            remote_url: Some("https://github.com/example/example".to_string()),
+            build_artifact: Some("build/example.zip".to_string()),
+            ..Component::default()
+        };
+        let config = DeployConfig {
+            component_ids: Vec::new(),
+            all: false,
+            outdated: false,
+            behind_upstream: false,
+            dry_run: false,
+            check: false,
+            force: false,
+            skip_build: false,
+            keep_deps: false,
+            expected_version: None,
+            no_pull: false,
+            head: false,
+            tagged: false,
+        };
+
+        assert!(!should_try_download_release_artifact(
+            &component, &config, false, false
+        ));
+    }
+
+    #[test]
+    fn registry_package_dependencies_allow_release_artifact_download() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            temp.path().join("package.json"),
+            r#"{
+                "dependencies": {
+                    "tokens": "^0.7.2"
+                }
+            }"#,
+        )
+        .expect("write package.json");
+        let component = Component {
+            id: "example".to_string(),
+            local_path: temp.path().to_string_lossy().to_string(),
+            remote_url: Some("https://github.com/example/example".to_string()),
+            build_artifact: Some("build/example.zip".to_string()),
+            ..Component::default()
+        };
+        let config = DeployConfig {
+            component_ids: Vec::new(),
+            all: false,
+            outdated: false,
+            behind_upstream: false,
+            dry_run: false,
+            check: false,
+            force: false,
+            skip_build: false,
+            keep_deps: false,
+            expected_version: None,
+            no_pull: false,
+            head: false,
+            tagged: false,
+        };
+
+        assert!(should_try_download_release_artifact(
             &component, &config, false, false
         ));
     }

--- a/src/core/deploy/release_download.rs
+++ b/src/core/deploy/release_download.rs
@@ -15,6 +15,25 @@ use std::path::{Path, PathBuf};
 use crate::core::component::Component;
 use crate::core::error::{Error, Result};
 
+const PACKAGE_DEPENDENCY_FIELDS: &[&str] = &[
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+];
+
+const MUTABLE_DEPENDENCY_PREFIXES: &[&str] = &[
+    "file:",
+    "link:",
+    "git+",
+    "github:",
+    "git://",
+    "git@",
+    "ssh://git@",
+    "https://github.com/",
+    "http://github.com/",
+];
+
 /// Parsed GitHub owner/repo from a remote URL.
 #[derive(Debug, Clone)]
 pub struct GitHubRepo {
@@ -199,6 +218,39 @@ pub fn supports_release_deploy(component: &Component) -> bool {
     has_remote && has_artifact
 }
 
+/// Detect package dependency specs that are resolved from mutable sources.
+///
+/// Release artifacts are safe to reuse when dependencies resolve from immutable
+/// package registry versions. Local paths and Git refs can change independently
+/// of the component tag, so deploy should rebuild locally instead.
+pub fn has_mutable_package_dependencies(component: &Component) -> bool {
+    let package_json_path = Path::new(&component.local_path).join("package.json");
+    let Ok(raw) = std::fs::read_to_string(package_json_path) else {
+        return false;
+    };
+    let Ok(package_json) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return false;
+    };
+
+    PACKAGE_DEPENDENCY_FIELDS.iter().any(|field| {
+        package_json
+            .get(field)
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(|dependencies| {
+                dependencies
+                    .values()
+                    .any(|spec| spec.as_str().is_some_and(is_mutable_dependency_spec))
+            })
+    })
+}
+
+fn is_mutable_dependency_spec(spec: &str) -> bool {
+    let spec = spec.trim().to_ascii_lowercase();
+    MUTABLE_DEPENDENCY_PREFIXES
+        .iter()
+        .any(|prefix| spec.starts_with(prefix))
+}
+
 /// Auto-detect the git remote URL from a local repository.
 ///
 /// Runs `git remote get-url origin` in the given directory.
@@ -369,5 +421,58 @@ mod tests {
         // No build_artifact → false
         comp.build_artifact = None;
         assert!(!supports_release_deploy(&comp));
+    }
+
+    #[test]
+    fn mutable_package_dependencies_detects_git_and_file_specs() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            temp.path().join("package.json"),
+            r#"{
+                "dependencies": {
+                    "registry-only": "^1.2.3",
+                    "tokens": "github:Extra-Chill/extrachill-tokens#v0.7.2"
+                },
+                "devDependencies": {
+                    "components": "file:../components"
+                }
+            }"#,
+        )
+        .expect("write package.json");
+        let comp = Component::new(
+            "test".to_string(),
+            temp.path().to_string_lossy().to_string(),
+            "/remote".to_string(),
+            Some("test.zip".to_string()),
+        );
+
+        assert!(has_mutable_package_dependencies(&comp));
+    }
+
+    #[test]
+    fn mutable_package_dependencies_allows_registry_specs() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            temp.path().join("package.json"),
+            r#"{
+                "dependencies": {
+                    "serde": "1.0.0",
+                    "react": "^19.0.0",
+                    "private-registry": "npm:@scope/pkg@1.2.3"
+                },
+                "optionalDependencies": {
+                    "optional": "~2.0.0"
+                }
+            }"#,
+        )
+        .expect("write package.json");
+        let comp = Component::new(
+            "test".to_string(),
+            temp.path().to_string_lossy().to_string(),
+            "/remote".to_string(),
+            Some("test.zip".to_string()),
+        );
+
+        assert!(!has_mutable_package_dependencies(&comp));
     }
 }


### PR DESCRIPTION
## Summary
- Skip release artifact reuse when `--tagged` is set so the flag matches its documented behavior.
- Detect mutable package dependency specs (`github:`, `git+`, `file:`, `link:`, GitHub URLs, SSH git refs) and force deploy to rebuild locally instead of using a potentially stale release artifact.
- Preserve release artifact reuse for registry-only package dependencies.

Fixes #2961.

## Tests
- `cargo fmt --check`
- `cargo test core::deploy::release_download`
- `cargo test core::deploy::execution`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the artifact-reuse guard and focused tests; Chris remains responsible for review and validation.