### PR TITLE
fix: preserve Composer vendor in lab snapshots

### DIFF
--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -39,8 +39,6 @@ const DEFAULT_EXCLUDES: &[&str] = &[
     ".turbo/**",
     ".cache",
     ".cache/**",
-    "vendor",
-    "vendor/**",
 ];
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -603,7 +601,7 @@ mod tests {
     }
 
     #[test]
-    fn default_excludes_filter_dependencies_and_secrets() {
+    fn default_excludes_filter_generated_outputs_and_secrets() {
         let root = Path::new("/repo");
 
         assert!(is_excluded(
@@ -631,6 +629,11 @@ mod tests {
             Path::new("/repo/src/main.rs"),
             DEFAULT_EXCLUDES
         ));
+        assert!(!is_excluded(
+            root,
+            Path::new("/repo/vendor/autoload.php"),
+            DEFAULT_EXCLUDES
+        ));
     }
 
     #[test]
@@ -640,12 +643,14 @@ mod tests {
             let runner_root = tempfile::tempdir().expect("runner root tempdir");
             fs::create_dir_all(source.path().join("src")).expect("src dir");
             fs::create_dir_all(source.path().join("build")).expect("root build dir");
+            fs::create_dir_all(source.path().join("vendor")).expect("vendor dir");
             fs::create_dir_all(source.path().join("wordpress/scripts/build"))
                 .expect("extension scripts build dir");
             fs::create_dir_all(source.path().join(".git")).expect("git dir");
             fs::create_dir_all(source.path().join("target/debug")).expect("target dir");
             fs::write(source.path().join("src/main.rs"), "fn main() {}\n").expect("source file");
             fs::write(source.path().join("build/bundle.js"), "artifact").expect("build file");
+            fs::write(source.path().join("vendor/autoload.php"), "<?php\n").expect("vendor file");
             fs::write(
                 source.path().join("wordpress/scripts/build/setup.sh"),
                 "#!/bin/sh\n",
@@ -678,8 +683,11 @@ mod tests {
 
             assert_eq!(exit_code, 0);
             assert_eq!(output.sync_mode, RunnerWorkspaceSyncMode::Snapshot);
-            assert_eq!(output.files, 3);
+            assert_eq!(output.files, 4);
             assert!(Path::new(&output.remote_path).join("src/main.rs").exists());
+            assert!(Path::new(&output.remote_path)
+                .join("vendor/autoload.php")
+                .exists());
             assert!(Path::new(&output.remote_path)
                 .join("wordpress/scripts/build/setup.sh")
                 .exists());


### PR DESCRIPTION
## Summary
- keep Composer `vendor/` files in snapshot-mode Lab workspace syncs
- update runner workspace sync tests to assert `vendor/autoload.php` is preserved
- keep generated/heavy outputs and secrets excluded from snapshots

## Repro
- `homeboy test --path /Users/chubes/Developer/data-machine --extension wordpress`
- Auto-selected lab runner `lab`
- Offloaded WP Codebox bootstrap failed before PHPUnit because `/wordpress/wp-content/plugins/data-machine/vendor/autoload.php` was missing in the remote snapshot

## Verification
- `cargo test core::runner::workspace::tests`
- `cargo check --release`
- `cargo run --bin homeboy -- test --path /Users/chubes/Developer/data-machine --extension wordpress` passed locally: 1305 tests, 1302 passed, 3 skipped

## Notes
- Explicit offload verification from the worktree was blocked by local config shape drift: current source saw `lab` as a missing server/runner while the installed Homeboy binary still resolves it. The failing path is covered by the snapshot sync unit test that now materializes `vendor/autoload.php`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Reproduced the lab offload bootstrap failure, traced snapshot excludes, drafted the one-file fix and tests, and ran verification commands. Chris remains responsible for review and merge.