### PR TITLE
Declare Lab command contracts

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -196,6 +196,43 @@ pub struct CommandDescriptor {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LabCommandContract {
+    pub hot_label: &'static str,
+    pub portability: LabCommandPortability,
+    pub source_path_mode: LabSourcePathMode,
+    pub workspace_mode_policy: LabWorkspaceModePolicy,
+    pub mutation_flag: Option<&'static str>,
+    pub requires_extension_parity: bool,
+    pub extra_required_tools: &'static [LabCommandRequiredTool],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabCommandPortability {
+    Portable,
+    LocalOnly(&'static str),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabSourcePathMode {
+    CwdOrPathFlag,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabWorkspaceModePolicy {
+    ChangedSinceGitElseSnapshot,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabCommandRequiredTool {
+    Playwright,
+}
+
+const LAB_TRACE_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[LabCommandRequiredTool::Playwright];
+const LAB_NO_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[];
+const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.";
+const FLEET_EXEC_LAB_UNSUPPORTED_REASON: &str = "`fleet exec` stays local because it depends on local fleet, project, and server configuration before opening SSH sessions to each project; runner-side config parity is not guaranteed.";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PublicOutputVariantContract {
     pub command: &'static str,
     pub variant: &'static str,
@@ -211,6 +248,55 @@ pub struct CommandResponsePlan {
 }
 
 impl Commands {
+    pub fn lab_contract(&self) -> Option<LabCommandContract> {
+        let contract = match self {
+            Commands::Audit(args) if args.changed_since.is_none() && !args.conventions => {
+                lab_portable_contract("audit", None, true, LAB_NO_EXTRA_TOOLS)
+            }
+            Commands::Bench(args) if args.is_run_command() => lab_portable_contract(
+                "bench",
+                args.lab_offload_writes_local_state()
+                    .then_some("--baseline/--ratchet"),
+                true,
+                LAB_NO_EXTRA_TOOLS,
+            ),
+            Commands::Fleet(args) if args.is_hot_resource_command() => {
+                lab_local_only_contract("fleet exec", FLEET_EXEC_LAB_UNSUPPORTED_REASON)
+            }
+            Commands::Lint(args) if args.is_full_workspace_run() => lab_portable_contract(
+                "lint",
+                args.fix.then_some("--fix"),
+                true,
+                LAB_NO_EXTRA_TOOLS,
+            ),
+            Commands::Refactor(args) if args.is_hot_resource_command() => lab_portable_contract(
+                "refactor",
+                args.lab_offload_writes_local_state()
+                    .then_some("--write/--commit"),
+                false,
+                LAB_NO_EXTRA_TOOLS,
+            ),
+            Commands::Rig(args) if args.is_hot_resource_command() => {
+                lab_local_only_contract("rig up", RIG_UP_LAB_UNSUPPORTED_REASON)
+            }
+            Commands::Test(args) if args.changed_since.is_none() => lab_portable_contract(
+                "test",
+                args.write.then_some("--write"),
+                true,
+                LAB_NO_EXTRA_TOOLS,
+            ),
+            Commands::Trace(args) => lab_portable_contract(
+                "trace",
+                args.keep_overlay.then_some("--keep-overlay"),
+                false,
+                LAB_TRACE_EXTRA_TOOLS,
+            ),
+            _ => return None,
+        };
+
+        Some(contract)
+    }
+
     pub fn descriptor(&self, has_output_file: bool) -> CommandDescriptor {
         let output_file_mode = if !has_output_file {
             CommandOutputFileMode::None
@@ -224,7 +310,7 @@ impl Commands {
             }
         };
 
-        match self {
+        let mut descriptor = match self {
             Commands::Ssh(args) if args.subcommand.is_none() && args.command.is_empty() => {
                 raw_ops_descriptor(CommandRawOutputMode::InteractivePassthrough, output_file_mode)
             }
@@ -383,7 +469,10 @@ impl Commands {
                 ),
             ),
             Commands::Triage(_) => ops_json_descriptor(output_file_mode, None),
-        }
+        };
+
+        apply_lab_contract_to_descriptor(&mut descriptor, self.lab_contract());
+        descriptor
     }
 
     pub fn response_plan(&self, has_output_file: bool) -> CommandResponsePlan {
@@ -399,15 +488,21 @@ impl Commands {
     }
 
     pub fn supports_lab_runner(&self) -> bool {
-        self.descriptor(false).supports_lab_runner
+        self.lab_contract()
+            .is_some_and(|contract| matches!(contract.portability, LabCommandPortability::Portable))
     }
 
     pub fn lab_runner_unsupported_reason(&self) -> Option<&'static str> {
-        self.descriptor(false).lab_runner_unsupported_reason
+        self.lab_contract()
+            .and_then(|contract| match contract.portability {
+                LabCommandPortability::Portable => None,
+                LabCommandPortability::LocalOnly(reason) => Some(reason),
+            })
     }
 
     pub fn lab_offload_mutation_flag(&self) -> Option<&'static str> {
-        self.descriptor(false).lab_offload_mutation_flag
+        self.lab_contract()
+            .and_then(|contract| contract.mutation_flag)
     }
 
     pub fn response_mode(&self, has_output_file: bool) -> CommandResponseMode {
@@ -416,6 +511,49 @@ impl Commands {
 
     pub fn output_file_mode(&self, has_output_file: bool) -> CommandOutputFileMode {
         self.descriptor(has_output_file).output_file_mode
+    }
+}
+
+fn apply_lab_contract_to_descriptor(
+    descriptor: &mut CommandDescriptor,
+    contract: Option<LabCommandContract>,
+) {
+    descriptor.supports_lab_runner = contract
+        .is_some_and(|contract| matches!(contract.portability, LabCommandPortability::Portable));
+    descriptor.lab_runner_unsupported_reason =
+        contract.and_then(|contract| match contract.portability {
+            LabCommandPortability::Portable => None,
+            LabCommandPortability::LocalOnly(reason) => Some(reason),
+        });
+    descriptor.lab_offload_mutation_flag = contract.and_then(|contract| contract.mutation_flag);
+}
+
+fn lab_portable_contract(
+    hot_label: &'static str,
+    mutation_flag: Option<&'static str>,
+    requires_extension_parity: bool,
+    extra_required_tools: &'static [LabCommandRequiredTool],
+) -> LabCommandContract {
+    LabCommandContract {
+        hot_label,
+        portability: LabCommandPortability::Portable,
+        source_path_mode: LabSourcePathMode::CwdOrPathFlag,
+        workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+        mutation_flag,
+        requires_extension_parity,
+        extra_required_tools,
+    }
+}
+
+fn lab_local_only_contract(hot_label: &'static str, reason: &'static str) -> LabCommandContract {
+    LabCommandContract {
+        hot_label,
+        portability: LabCommandPortability::LocalOnly(reason),
+        source_path_mode: LabSourcePathMode::CwdOrPathFlag,
+        workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+        mutation_flag: None,
+        requires_extension_parity: false,
+        extra_required_tools: LAB_NO_EXTRA_TOOLS,
     }
 }
 
@@ -1042,6 +1180,68 @@ mod tests {
         let cli = parsed_cli(&["homeboy", "lint", "--runner", "lab-a"]);
         assert_eq!(cli.runner.as_deref(), Some("lab-a"));
         assert!(cli.command.supports_lab_runner());
+    }
+
+    #[test]
+    fn test_lab_command_contracts_cover_hot_commands() {
+        let supported = [
+            (parsed_command(&["homeboy", "lint"]), "lint"),
+            (parsed_command(&["homeboy", "test"]), "test"),
+            (parsed_command(&["homeboy", "audit"]), "audit"),
+            (parsed_command(&["homeboy", "bench"]), "bench"),
+            (parsed_command(&["homeboy", "trace"]), "trace"),
+            (
+                parsed_command(&["homeboy", "refactor", "--from", "audit"]),
+                "refactor",
+            ),
+        ];
+
+        for (command, label) in supported {
+            let contract = command.lab_contract().expect("hot contract");
+            assert_eq!(contract.hot_label, label);
+            assert_eq!(contract.portability, LabCommandPortability::Portable);
+            assert_eq!(contract.source_path_mode, LabSourcePathMode::CwdOrPathFlag);
+            assert_eq!(
+                contract.workspace_mode_policy,
+                LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot
+            );
+        }
+
+        let trace = parsed_command(&["homeboy", "trace"])
+            .lab_contract()
+            .expect("trace contract");
+        assert_eq!(trace.extra_required_tools, LAB_TRACE_EXTRA_TOOLS);
+        assert!(!trace.requires_extension_parity);
+
+        let lint = parsed_command(&["homeboy", "lint"])
+            .lab_contract()
+            .expect("lint contract");
+        assert!(lint.requires_extension_parity);
+
+        let rig = parsed_command(&["homeboy", "rig", "up", "studio"])
+            .lab_contract()
+            .expect("rig up contract");
+        assert_eq!(rig.hot_label, "rig up");
+        assert!(matches!(
+            rig.portability,
+            LabCommandPortability::LocalOnly(reason) if reason.contains("single-workspace Lab snapshot")
+        ));
+
+        let fleet = parsed_command(&["homeboy", "fleet", "exec", "prod", "wp", "plugin", "list"])
+            .lab_contract()
+            .expect("fleet exec contract");
+        assert_eq!(fleet.hot_label, "fleet exec");
+        assert!(matches!(
+            fleet.portability,
+            LabCommandPortability::LocalOnly(reason) if reason.contains("config parity")
+        ));
+
+        assert!(parsed_command(&["homeboy", "status"])
+            .lab_contract()
+            .is_none());
+        assert!(parsed_command(&["homeboy", "bench", "list"])
+            .lab_contract()
+            .is_none());
     }
 
     #[test]

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -8,6 +8,12 @@ use crate::commands::{
     test, trace, triage, tunnel, undo, upgrade, version,
 };
 
+mod lab_contract;
+pub use lab_contract::{
+    LabCommandContract, LabCommandPortability, LabCommandRequiredTool, LabSourcePathMode,
+    LabWorkspaceModePolicy, LAB_TRACE_EXTRA_TOOLS,
+};
+
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Parser)]
@@ -196,43 +202,6 @@ pub struct CommandDescriptor {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct LabCommandContract {
-    pub hot_label: &'static str,
-    pub portability: LabCommandPortability,
-    pub source_path_mode: LabSourcePathMode,
-    pub workspace_mode_policy: LabWorkspaceModePolicy,
-    pub mutation_flag: Option<&'static str>,
-    pub requires_extension_parity: bool,
-    pub extra_required_tools: &'static [LabCommandRequiredTool],
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LabCommandPortability {
-    Portable,
-    LocalOnly(&'static str),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LabSourcePathMode {
-    CwdOrPathFlag,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LabWorkspaceModePolicy {
-    ChangedSinceGitElseSnapshot,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LabCommandRequiredTool {
-    Playwright,
-}
-
-const LAB_TRACE_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[LabCommandRequiredTool::Playwright];
-const LAB_NO_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[];
-const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.";
-const FLEET_EXEC_LAB_UNSUPPORTED_REASON: &str = "`fleet exec` stays local because it depends on local fleet, project, and server configuration before opening SSH sessions to each project; runner-side config parity is not guaranteed.";
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PublicOutputVariantContract {
     pub command: &'static str,
     pub variant: &'static str,
@@ -248,55 +217,6 @@ pub struct CommandResponsePlan {
 }
 
 impl Commands {
-    pub fn lab_contract(&self) -> Option<LabCommandContract> {
-        let contract = match self {
-            Commands::Audit(args) if args.changed_since.is_none() && !args.conventions => {
-                lab_portable_contract("audit", None, true, LAB_NO_EXTRA_TOOLS)
-            }
-            Commands::Bench(args) if args.is_run_command() => lab_portable_contract(
-                "bench",
-                args.lab_offload_writes_local_state()
-                    .then_some("--baseline/--ratchet"),
-                true,
-                LAB_NO_EXTRA_TOOLS,
-            ),
-            Commands::Fleet(args) if args.is_hot_resource_command() => {
-                lab_local_only_contract("fleet exec", FLEET_EXEC_LAB_UNSUPPORTED_REASON)
-            }
-            Commands::Lint(args) if args.is_full_workspace_run() => lab_portable_contract(
-                "lint",
-                args.fix.then_some("--fix"),
-                true,
-                LAB_NO_EXTRA_TOOLS,
-            ),
-            Commands::Refactor(args) if args.is_hot_resource_command() => lab_portable_contract(
-                "refactor",
-                args.lab_offload_writes_local_state()
-                    .then_some("--write/--commit"),
-                false,
-                LAB_NO_EXTRA_TOOLS,
-            ),
-            Commands::Rig(args) if args.is_hot_resource_command() => {
-                lab_local_only_contract("rig up", RIG_UP_LAB_UNSUPPORTED_REASON)
-            }
-            Commands::Test(args) if args.changed_since.is_none() => lab_portable_contract(
-                "test",
-                args.write.then_some("--write"),
-                true,
-                LAB_NO_EXTRA_TOOLS,
-            ),
-            Commands::Trace(args) => lab_portable_contract(
-                "trace",
-                args.keep_overlay.then_some("--keep-overlay"),
-                false,
-                LAB_TRACE_EXTRA_TOOLS,
-            ),
-            _ => return None,
-        };
-
-        Some(contract)
-    }
-
     pub fn descriptor(&self, has_output_file: bool) -> CommandDescriptor {
         let output_file_mode = if !has_output_file {
             CommandOutputFileMode::None
@@ -471,7 +391,7 @@ impl Commands {
             Commands::Triage(_) => ops_json_descriptor(output_file_mode, None),
         };
 
-        apply_lab_contract_to_descriptor(&mut descriptor, self.lab_contract());
+        lab_contract::apply_lab_contract_to_descriptor(&mut descriptor, self.lab_contract());
         descriptor
     }
 
@@ -511,49 +431,6 @@ impl Commands {
 
     pub fn output_file_mode(&self, has_output_file: bool) -> CommandOutputFileMode {
         self.descriptor(has_output_file).output_file_mode
-    }
-}
-
-fn apply_lab_contract_to_descriptor(
-    descriptor: &mut CommandDescriptor,
-    contract: Option<LabCommandContract>,
-) {
-    descriptor.supports_lab_runner = contract
-        .is_some_and(|contract| matches!(contract.portability, LabCommandPortability::Portable));
-    descriptor.lab_runner_unsupported_reason =
-        contract.and_then(|contract| match contract.portability {
-            LabCommandPortability::Portable => None,
-            LabCommandPortability::LocalOnly(reason) => Some(reason),
-        });
-    descriptor.lab_offload_mutation_flag = contract.and_then(|contract| contract.mutation_flag);
-}
-
-fn lab_portable_contract(
-    hot_label: &'static str,
-    mutation_flag: Option<&'static str>,
-    requires_extension_parity: bool,
-    extra_required_tools: &'static [LabCommandRequiredTool],
-) -> LabCommandContract {
-    LabCommandContract {
-        hot_label,
-        portability: LabCommandPortability::Portable,
-        source_path_mode: LabSourcePathMode::CwdOrPathFlag,
-        workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
-        mutation_flag,
-        requires_extension_parity,
-        extra_required_tools,
-    }
-}
-
-fn lab_local_only_contract(hot_label: &'static str, reason: &'static str) -> LabCommandContract {
-    LabCommandContract {
-        hot_label,
-        portability: LabCommandPortability::LocalOnly(reason),
-        source_path_mode: LabSourcePathMode::CwdOrPathFlag,
-        workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
-        mutation_flag: None,
-        requires_extension_parity: false,
-        extra_required_tools: LAB_NO_EXTRA_TOOLS,
     }
 }
 

--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -1,0 +1,132 @@
+use super::{CommandDescriptor, Commands};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LabCommandContract {
+    pub hot_label: &'static str,
+    pub portability: LabCommandPortability,
+    pub source_path_mode: LabSourcePathMode,
+    pub workspace_mode_policy: LabWorkspaceModePolicy,
+    pub mutation_flag: Option<&'static str>,
+    pub requires_extension_parity: bool,
+    pub extra_required_tools: &'static [LabCommandRequiredTool],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabCommandPortability {
+    Portable,
+    LocalOnly(&'static str),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabSourcePathMode {
+    CwdOrPathFlag,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabWorkspaceModePolicy {
+    ChangedSinceGitElseSnapshot,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabCommandRequiredTool {
+    Playwright,
+}
+
+pub const LAB_TRACE_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[LabCommandRequiredTool::Playwright];
+const LAB_NO_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[];
+const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.";
+const FLEET_EXEC_LAB_UNSUPPORTED_REASON: &str = "`fleet exec` stays local because it depends on local fleet, project, and server configuration before opening SSH sessions to each project; runner-side config parity is not guaranteed.";
+
+impl Commands {
+    pub fn lab_contract(&self) -> Option<LabCommandContract> {
+        let contract = match self {
+            Commands::Audit(args) if args.changed_since.is_none() && !args.conventions => {
+                lab_portable_contract("audit", None, true, LAB_NO_EXTRA_TOOLS)
+            }
+            Commands::Bench(args) if args.is_run_command() => lab_portable_contract(
+                "bench",
+                args.lab_offload_writes_local_state()
+                    .then_some("--baseline/--ratchet"),
+                true,
+                LAB_NO_EXTRA_TOOLS,
+            ),
+            Commands::Fleet(args) if args.is_hot_resource_command() => {
+                lab_local_only_contract("fleet exec", FLEET_EXEC_LAB_UNSUPPORTED_REASON)
+            }
+            Commands::Lint(args) if args.is_full_workspace_run() => lab_portable_contract(
+                "lint",
+                args.fix.then_some("--fix"),
+                true,
+                LAB_NO_EXTRA_TOOLS,
+            ),
+            Commands::Refactor(args) if args.is_hot_resource_command() => lab_portable_contract(
+                "refactor",
+                args.lab_offload_writes_local_state()
+                    .then_some("--write/--commit"),
+                false,
+                LAB_NO_EXTRA_TOOLS,
+            ),
+            Commands::Rig(args) if args.is_hot_resource_command() => {
+                lab_local_only_contract("rig up", RIG_UP_LAB_UNSUPPORTED_REASON)
+            }
+            Commands::Test(args) if args.changed_since.is_none() => lab_portable_contract(
+                "test",
+                args.write.then_some("--write"),
+                true,
+                LAB_NO_EXTRA_TOOLS,
+            ),
+            Commands::Trace(args) => lab_portable_contract(
+                "trace",
+                args.keep_overlay.then_some("--keep-overlay"),
+                false,
+                LAB_TRACE_EXTRA_TOOLS,
+            ),
+            _ => return None,
+        };
+
+        Some(contract)
+    }
+}
+
+pub(super) fn apply_lab_contract_to_descriptor(
+    descriptor: &mut CommandDescriptor,
+    contract: Option<LabCommandContract>,
+) {
+    descriptor.supports_lab_runner = contract
+        .is_some_and(|contract| matches!(contract.portability, LabCommandPortability::Portable));
+    descriptor.lab_runner_unsupported_reason =
+        contract.and_then(|contract| match contract.portability {
+            LabCommandPortability::Portable => None,
+            LabCommandPortability::LocalOnly(reason) => Some(reason),
+        });
+    descriptor.lab_offload_mutation_flag = contract.and_then(|contract| contract.mutation_flag);
+}
+
+fn lab_portable_contract(
+    hot_label: &'static str,
+    mutation_flag: Option<&'static str>,
+    requires_extension_parity: bool,
+    extra_required_tools: &'static [LabCommandRequiredTool],
+) -> LabCommandContract {
+    LabCommandContract {
+        hot_label,
+        portability: LabCommandPortability::Portable,
+        source_path_mode: LabSourcePathMode::CwdOrPathFlag,
+        workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+        mutation_flag,
+        requires_extension_parity,
+        extra_required_tools,
+    }
+}
+
+fn lab_local_only_contract(hot_label: &'static str, reason: &'static str) -> LabCommandContract {
+    LabCommandContract {
+        hot_label,
+        portability: LabCommandPortability::LocalOnly(reason),
+        source_path_mode: LabSourcePathMode::CwdOrPathFlag,
+        workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+        mutation_flag: None,
+        requires_extension_parity: false,
+        extra_required_tools: LAB_NO_EXTRA_TOOLS,
+    }
+}

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -3,7 +3,7 @@ use std::sync::RwLock;
 
 use serde::{Deserialize, Serialize};
 
-use crate::cli_surface::Commands;
+use crate::cli_surface::{Commands, LabCommandPortability, LabCommandRequiredTool};
 
 use crate::commands::doctor::resources::{DoctorOutput, ResourceRecommendation};
 use crate::commands::runner::doctor::RunnerDoctorOutput;
@@ -271,24 +271,13 @@ pub fn reset_captured_context_for_test() {
 }
 
 pub fn hot_command(command: &Commands) -> Option<HotCommand> {
-    let label = match command {
-        Commands::Bench(args) if args.is_run_command() => "bench",
-        Commands::Rig(args) if args.is_hot_resource_command() => "rig up",
-        Commands::Fleet(args) if args.is_hot_resource_command() => "fleet exec",
-        Commands::Refactor(args) if args.is_hot_resource_command() => "refactor",
-        Commands::Audit(args) if args.changed_since.is_none() && !args.conventions => "audit",
-        Commands::Lint(args) if args.is_full_workspace_run() => "lint",
-        Commands::Test(args) if args.changed_since.is_none() => "test",
-        _ => return None,
-    };
+    let contract = command.lab_contract()?;
 
-    if command.supports_lab_runner() {
-        Some(HotCommand::lab_supported(label))
-    } else {
-        Some(HotCommand::local_only(
-            label,
-            command.lab_runner_unsupported_reason(),
-        ))
+    match contract.portability {
+        LabCommandPortability::Portable => Some(HotCommand::lab_supported(contract.hot_label)),
+        LabCommandPortability::LocalOnly(reason) => {
+            Some(HotCommand::local_only(contract.hot_label, Some(reason)))
+        }
     }
 }
 
@@ -296,6 +285,7 @@ pub fn lab_runner_capability_plan(
     command: &Commands,
     source_path: &Path,
 ) -> Option<LabRunnerCapabilityPlan> {
+    let contract = command.lab_contract()?;
     let hot_command = hot_command(command)?;
     let mut required_tools = vec![LabRunnerTool::Git];
 
@@ -318,14 +308,20 @@ pub fn lab_runner_capability_plan(
         push_unique(&mut required_tools, LabRunnerTool::Docker);
     }
 
-    if matches!(command, Commands::Trace(_)) {
-        push_unique(&mut required_tools, LabRunnerTool::Playwright);
+    for tool in contract.extra_required_tools {
+        push_unique(&mut required_tools, lab_runner_tool(*tool));
     }
 
     Some(LabRunnerCapabilityPlan {
         command: hot_command.label,
         required_tools,
     })
+}
+
+fn lab_runner_tool(tool: LabCommandRequiredTool) -> LabRunnerTool {
+    match tool {
+        LabCommandRequiredTool::Playwright => LabRunnerTool::Playwright,
+    }
 }
 
 pub fn evaluate_lab_runner_capabilities(

--- a/src/lab_offload_extension_parity.rs
+++ b/src/lab_offload_extension_parity.rs
@@ -17,6 +17,13 @@ pub fn preflight(
     remote_cwd: &str,
     _capability_plan_preflight: LabOffloadCapabilityPlanPreflight,
 ) -> homeboy::core::Result<()> {
+    if !command
+        .lab_contract()
+        .is_some_and(|contract| contract.requires_extension_parity)
+    {
+        return Ok(());
+    }
+
     let extension_ids = parity_extension_ids(command)?;
     for extension_id in extension_ids {
         let (output, exit_code) = homeboy::core::runner::exec(


### PR DESCRIPTION
## Summary
- Add a typed `LabCommandContract` on the command surface for hot labels, portability, source/workspace policy, mutation flags, extension parity, and command-specific extra tools.
- Keep existing `supports_lab_runner()`, `lab_runner_unsupported_reason()`, and `lab_offload_mutation_flag()` helpers as compatibility shims backed by the contract.
- Route resource-policy hot command mapping and extension parity gating through the contract without moving capability planning out of `resource_policy`.

Fixes #2969.
Unblocks #2968 by giving the future Lab plan-backed primitive a typed command contract instead of scattered descriptor booleans and resource-policy command matching.

## Verification
- `cargo fmt --check`
- `cargo test lab_command_contracts_cover_hot_commands && cargo test test_command_descriptor_drives_behavioral_routing && cargo test test_supports_lab_runner && cargo test test_lab_runner_unsupported_hot_command_reasons && cargo test test_lab_offload_mutation_flag && cargo test lab_runner_capability_plan_detects_project_tool_needs && cargo test parity_includes_lint_selector`
- `cargo test core::refactor::auto::verify::tests::passing_verify_leaves_files_and_chunks_alone -- --nocapture`
- `cargo test` passed lib/main/integration coverage on rerun except an existing unrelated baseline failure in `tests/core_agnostic_test.rs::core_owned_source_stays_language_and_framework_agnostic`, reporting `src/core/deploy/release_download.rs: package.json` under known issue #2240 baseline debt. This PR does not touch that file.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the typed Lab command contract, compatibility shims, targeted tests, and PR preparation; Chris remains responsible for review and merge.
