### PR TITLE
Surface refactor source extension execution failures

### DIFF
--- a/src/commands/utils/response.rs
+++ b/src/commands/utils/response.rs
@@ -150,6 +150,7 @@ fn exit_code_for_error(code: ErrorCode) -> i32 {
 
         ErrorCode::RemoteCommandFailed
         | ErrorCode::RemoteCommandTimeout
+        | ErrorCode::ExtensionExecutionFailed
         | ErrorCode::DeployNoComponentsConfigured
         | ErrorCode::DeployBuildFailed
         | ErrorCode::DeployUploadFailed

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -29,6 +29,7 @@ pub enum ErrorCode {
     FleetNotFound,
     ExtensionNotFound,
     ExtensionUnsupported,
+    ExtensionExecutionFailed,
     DocsTopicNotFound,
     RigNotFound,
     RunnerNotFound,
@@ -80,6 +81,7 @@ impl ErrorCode {
             ErrorCode::FleetNotFound => "fleet.not_found",
             ErrorCode::ExtensionNotFound => "extension.not_found",
             ErrorCode::ExtensionUnsupported => "extension.unsupported",
+            ErrorCode::ExtensionExecutionFailed => "extension.execution_failed",
             ErrorCode::DocsTopicNotFound => "docs.topic_not_found",
             ErrorCode::RigNotFound => "rig.not_found",
             ErrorCode::RunnerNotFound => "runner.not_found",
@@ -197,6 +199,26 @@ pub struct InvalidArgumentDetails {
     pub id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tried: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExtensionExecutionFailedDetails {
+    pub extension_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub script_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub io_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_error: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -346,6 +368,31 @@ impl Error {
         }
 
         Self::new(ErrorCode::ValidationInvalidJson, "Invalid JSON", details)
+    }
+
+    pub fn extension_execution_failed(
+        extension_id: impl Into<String>,
+        source: Option<String>,
+        command: impl Into<String>,
+        message: impl Into<String>,
+        details: ExtensionExecutionFailedDetails,
+    ) -> Self {
+        let extension_id = extension_id.into();
+        let command = command.into();
+        Self::new(
+            ErrorCode::ExtensionExecutionFailed,
+            format!(
+                "Extension '{}' failed {}{}: {}",
+                extension_id,
+                command,
+                source
+                    .as_deref()
+                    .map(|source| format!(" source '{}'", source))
+                    .unwrap_or_default(),
+                message.into()
+            ),
+            to_details(details),
+        )
     }
 
     pub fn validation_multiple_errors(errors: Vec<ValidationErrorItem>) -> Self {

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -73,7 +73,8 @@ pub use manifest::{
     VersionPatternConfig,
 };
 pub use refactor_protocol::{
-    run_refactor_script, AdjustedItem, ParsedItem, RelatedTests, ResolvedImports, RewrittenImport,
+    run_refactor_script, run_refactor_script_with_outcome, AdjustedItem, ParsedItem,
+    RefactorScriptFailure, RefactorScriptOutcome, RelatedTests, ResolvedImports, RewrittenImport,
 };
 pub use registry::{
     available_extension_ids, extension_path, find_extension_by_tool, find_extension_for_file_ext,

--- a/src/core/extension/refactor_protocol.rs
+++ b/src/core/extension/refactor_protocol.rs
@@ -1,5 +1,22 @@
 use super::manifest::ExtensionManifest;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefactorScriptFailure {
+    pub script_path: String,
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub io_error: Option<String>,
+    pub json_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RefactorScriptOutcome {
+    Missing,
+    Succeeded(serde_json::Value),
+    Failed(RefactorScriptFailure),
+}
+
 // ============================================================================
 // Refactor Script Protocol
 // ============================================================================
@@ -20,41 +37,107 @@ pub fn run_refactor_script(
     extension: &ExtensionManifest,
     command: &serde_json::Value,
 ) -> Option<serde_json::Value> {
-    let extension_path = extension.extension_path.as_deref()?;
-    let script_rel = extension.refactor_script()?;
+    match run_refactor_script_with_outcome(extension, command) {
+        RefactorScriptOutcome::Succeeded(value) => Some(value),
+        RefactorScriptOutcome::Missing => None,
+        RefactorScriptOutcome::Failed(failure) => {
+            if !failure.stderr.trim().is_empty() {
+                crate::log_status!(
+                    "refactor",
+                    "Extension script error: {}",
+                    failure.stderr.trim()
+                );
+            }
+            None
+        }
+    }
+}
+
+pub fn run_refactor_script_with_outcome(
+    extension: &ExtensionManifest,
+    command: &serde_json::Value,
+) -> RefactorScriptOutcome {
+    let Some(extension_path) = extension.extension_path.as_deref() else {
+        return RefactorScriptOutcome::Missing;
+    };
+    let Some(script_rel) = extension.refactor_script() else {
+        return RefactorScriptOutcome::Missing;
+    };
     let script_path = std::path::Path::new(extension_path).join(script_rel);
 
     if !script_path.exists() {
-        return None;
+        return RefactorScriptOutcome::Missing;
     }
 
     // Invoke the script directly so its shebang resolves the interpreter.
     // Wrapping with `sh -c <script>` bypasses `#!/usr/bin/env bash` and runs
     // under POSIX sh — which breaks scripts using bash-only features. See #1276.
-    let output = std::process::Command::new(&script_path)
+    let output = match std::process::Command::new(&script_path)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
-        .ok()
-        .and_then(|mut child| {
-            use std::io::Write;
-            if let Some(ref mut stdin) = child.stdin {
-                let _ = stdin.write_all(command.to_string().as_bytes());
-            }
-            child.wait_with_output().ok()
-        })?;
+    {
+        Ok(child) => child,
+        Err(err) => {
+            return RefactorScriptOutcome::Failed(RefactorScriptFailure {
+                script_path: script_path.to_string_lossy().to_string(),
+                exit_code: None,
+                stdout: String::new(),
+                stderr: String::new(),
+                io_error: Some(err.to_string()),
+                json_error: None,
+            });
+        }
+    };
+
+    let mut child = output;
+    let wait_result = {
+        use std::io::Write;
+        if let Some(ref mut stdin) = child.stdin {
+            let _ = stdin.write_all(command.to_string().as_bytes());
+        }
+        child.wait_with_output()
+    };
+    let output = match wait_result {
+        Ok(output) => output,
+        Err(err) => {
+            return RefactorScriptOutcome::Failed(RefactorScriptFailure {
+                script_path: script_path.to_string_lossy().to_string(),
+                exit_code: None,
+                stdout: String::new(),
+                stderr: String::new(),
+                io_error: Some(err.to_string()),
+                json_error: None,
+            });
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if !stderr.is_empty() {
-            crate::log_status!("refactor", "Extension script error: {}", stderr.trim());
-        }
-        return None;
+        return RefactorScriptOutcome::Failed(RefactorScriptFailure {
+            script_path: script_path.to_string_lossy().to_string(),
+            exit_code: output.status.code(),
+            stdout,
+            stderr,
+            io_error: None,
+            json_error: None,
+        });
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    serde_json::from_str(&stdout).ok()
+    match serde_json::from_str(&stdout) {
+        Ok(value) => RefactorScriptOutcome::Succeeded(value),
+        Err(err) => RefactorScriptOutcome::Failed(RefactorScriptFailure {
+            script_path: script_path.to_string_lossy().to_string(),
+            exit_code: output.status.code(),
+            stdout,
+            stderr,
+            io_error: None,
+            json_error: Some(err.to_string()),
+        }),
+    }
 }
 
 /// Output from a `parse_items` refactor command.

--- a/src/core/refactor/plan/sources/extension_source.rs
+++ b/src/core/refactor/plan/sources/extension_source.rs
@@ -19,6 +19,8 @@ struct ExtensionRefactorSourceResponse {
     fix_results: Vec<FixApplied>,
     #[serde(default)]
     warnings: Vec<String>,
+    #[serde(default)]
+    fatal_error: Option<String>,
 }
 
 pub(super) fn try_extension_refactor_source_stage<T: Serialize>(
@@ -43,20 +45,31 @@ pub(super) fn try_extension_refactor_source_stage<T: Serialize>(
         "write": write,
         "settings": settings.iter().cloned().collect::<std::collections::BTreeMap<_, _>>(),
     });
-    let Some(value) = extension::run_refactor_script(&manifest, &command) else {
-        return Err(Error::validation_invalid_argument(
-            setting_key.clone(),
-            format!(
-                "Extension '{}' did not handle refactor source '{}'",
-                extension_id, source
-            ),
-            None,
-            Some(vec![
-                "Remove the setting to use Homeboy's built-in refactor source".to_string(),
-                "Or update the extension refactor script to support command=refactor_source"
-                    .to_string(),
-            ]),
-        ));
+    let value = match extension::run_refactor_script_with_outcome(&manifest, &command) {
+        extension::RefactorScriptOutcome::Succeeded(value) => value,
+        extension::RefactorScriptOutcome::Missing => {
+            return Err(Error::validation_invalid_argument(
+                setting_key.clone(),
+                format!(
+                    "Extension '{}' did not handle refactor source '{}'",
+                    extension_id, source
+                ),
+                None,
+                Some(vec![
+                    "Remove the setting to use Homeboy's built-in refactor source".to_string(),
+                    "Or update the extension refactor script to support command=refactor_source"
+                        .to_string(),
+                ]),
+            ));
+        }
+        extension::RefactorScriptOutcome::Failed(failure) => {
+            return Err(refactor_source_failure_error(
+                extension_id,
+                source,
+                &failure,
+                Vec::new(),
+            ));
+        }
     };
     let response_value = unwrap_refactor_source_payload(value);
     let response: ExtensionRefactorSourceResponse = serde_json::from_value(response_value)
@@ -86,6 +99,38 @@ pub(super) fn try_extension_refactor_source_stage<T: Serialize>(
         ));
     }
 
+    if let Some(fatal_error) = response
+        .fatal_error
+        .as_deref()
+        .map(str::trim)
+        .filter(|message| !message.is_empty())
+    {
+        return Err(refactor_source_failure_error(
+            extension_id,
+            source,
+            &extension::RefactorScriptFailure {
+                script_path: manifest
+                    .extension_path
+                    .as_deref()
+                    .and_then(|extension_path| {
+                        manifest.refactor_script().map(|script| {
+                            Path::new(extension_path)
+                                .join(script)
+                                .to_string_lossy()
+                                .to_string()
+                        })
+                    })
+                    .unwrap_or_default(),
+                exit_code: Some(0),
+                stdout: String::new(),
+                stderr: fatal_error.to_string(),
+                io_error: None,
+                json_error: None,
+            },
+            response.warnings.clone(),
+        ));
+    }
+
     let fix_summary = if response.fix_results.is_empty() {
         None
     } else {
@@ -107,6 +152,77 @@ pub(super) fn try_extension_refactor_source_stage<T: Serialize>(
         },
         fix_results: response.fix_results,
     }))
+}
+
+fn refactor_source_failure_error(
+    extension_id: &str,
+    source: &str,
+    failure: &extension::RefactorScriptFailure,
+    warnings: Vec<String>,
+) -> Error {
+    let message = refactor_source_failure_message(failure);
+    Error::extension_execution_failed(
+        extension_id,
+        Some(source.to_string()),
+        "refactor_source",
+        message,
+        crate::core::error::ExtensionExecutionFailedDetails {
+            extension_id: extension_id.to_string(),
+            source: Some(source.to_string()),
+            command: "refactor_source".to_string(),
+            script_path: if failure.script_path.is_empty() {
+                None
+            } else {
+                Some(failure.script_path.clone())
+            },
+            exit_code: failure.exit_code,
+            stdout: failure.stdout.clone(),
+            stderr: failure.stderr.clone(),
+            io_error: failure.io_error.clone(),
+            json_error: failure.json_error.clone(),
+            warnings,
+        },
+    )
+}
+
+fn refactor_source_failure_message(failure: &extension::RefactorScriptFailure) -> String {
+    if let Some(error) = failure
+        .io_error
+        .as_deref()
+        .filter(|error| !error.is_empty())
+    {
+        return error.to_string();
+    }
+
+    if let Some(error) = failure
+        .json_error
+        .as_deref()
+        .filter(|error| !error.is_empty())
+    {
+        return format!("invalid JSON response: {error}");
+    }
+
+    let detail = failure
+        .stderr
+        .trim()
+        .lines()
+        .next()
+        .filter(|line| !line.is_empty())
+        .or_else(|| {
+            failure
+                .stdout
+                .trim()
+                .lines()
+                .next()
+                .filter(|line| !line.is_empty())
+        });
+
+    match (failure.exit_code, detail) {
+        (Some(code), Some(detail)) => format!("exit {code}: {detail}"),
+        (Some(code), None) => format!("exit {code}"),
+        (None, Some(detail)) => detail.to_string(),
+        (None, None) => "extension refactor script failed".to_string(),
+    }
 }
 
 fn unwrap_refactor_source_payload(value: serde_json::Value) -> serde_json::Value {
@@ -195,6 +311,38 @@ mod tests {
         }
     }
 
+    fn write_failing_refactor_source_extension(home: &Path, id: &str) {
+        let extension_dir = home.join(".config/homeboy/extensions").join(id);
+        fs::create_dir_all(&extension_dir).unwrap();
+        fs::write(
+            extension_dir.join(format!("{id}.json")),
+            serde_json::json!({
+                "name": "Failing Refactor Source Fixture",
+                "version": "0.0.0",
+                "scripts": {
+                    "refactor": "refactor-source.sh"
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        fs::write(
+            extension_dir.join("refactor-source.sh"),
+            "#!/bin/sh\nprintf '%s\n' 'WP Codebox audit fan-out failed: 7 of 11 task(s) failed' >&2\nprintf '%s\n' 'artifact: /tmp/homeboy-wp-codebox-audit-o7yqgh91/fanout-run.json' >&2\nexit 17\n",
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let script = extension_dir.join("refactor-source.sh");
+            let mut permissions = fs::metadata(&script).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(script, permissions).unwrap();
+        }
+    }
+
     #[test]
     fn extension_refactor_source_dispatch_uses_generic_source_result() {
         crate::test_support::with_isolated_home(|home| {
@@ -260,6 +408,51 @@ mod tests {
             assert_eq!(command["settings"]["extension.setting"], "value");
             assert_eq!(command["source_result"]["lint_findings"][0]["id"], "lint-1");
             assert!(command.get("audit_result").is_none());
+
+            let _ = fs::remove_dir_all(root);
+        });
+    }
+
+    #[test]
+    fn extension_refactor_source_failure_reports_execution_error() {
+        crate::test_support::with_isolated_home(|home| {
+            let root = tmp_dir("failing-extension-dispatch");
+            fs::create_dir_all(&root).unwrap();
+            write_failing_refactor_source_extension(home.path(), "generic");
+
+            let err = match try_extension_refactor_source_stage(
+                "audit",
+                &test_component(&root),
+                &root,
+                &serde_json::json!({
+                    "component_id": "component",
+                    "findings": []
+                }),
+                true,
+                &[(
+                    "refactor.audit.extension".to_string(),
+                    "generic".to_string(),
+                )],
+            ) {
+                Ok(_) => {
+                    panic!("non-zero handled extension failure should surface as execution failure")
+                }
+                Err(err) => err,
+            };
+
+            assert_eq!(err.code, crate::core::ErrorCode::ExtensionExecutionFailed);
+            assert!(err
+                .message
+                .contains("Extension 'generic' failed refactor_source source 'audit'"));
+            assert!(err.message.contains("WP Codebox audit fan-out failed"));
+            assert!(!err.message.contains("did not handle refactor source"));
+            assert_eq!(err.details["extension_id"], "generic");
+            assert_eq!(err.details["source"], "audit");
+            assert_eq!(err.details["exit_code"], 17);
+            assert!(err.details["stderr"]
+                .as_str()
+                .unwrap()
+                .contains("/tmp/homeboy-wp-codebox-audit-o7yqgh91/fanout-run.json"));
 
             let _ = fs::remove_dir_all(root);
         });


### PR DESCRIPTION
## Summary
- Distinguish missing refactor scripts from extension refactor scripts that execute and fail.
- Add an `extension.execution_failed` error that preserves extension id, source, command, script path, exit code, stdout, stderr, IO/JSON errors, and warnings when available.
- Teach extension refactor sources to surface non-zero/fatal extension results instead of reporting `did not handle refactor source`.
- Add focused coverage for a handled audit refactor source extension that exits non-zero after writing a WP Codebox-style fatal message and artifact path.

Fixes #2977.

## Tests
- `cargo fmt`
- `cargo test extension_refactor_source --lib`
- `cargo check --bins`
- `cargo clippy --bins --lib --tests -- -D warnings` fails on existing repo-wide clippy debt; after cleanup, the observed failures are unrelated pre-existing lints outside this patch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause investigation, implementation, focused Rust test coverage, and local verification commands for Chris to review.
