### PR TITLE
fix: surface refactor source extension failures

### DIFF
--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -73,7 +73,8 @@ pub use manifest::{
     VersionPatternConfig,
 };
 pub use refactor_protocol::{
-    run_refactor_script, AdjustedItem, ParsedItem, RelatedTests, ResolvedImports, RewrittenImport,
+    run_refactor_script, run_refactor_script_result, AdjustedItem, ParsedItem,
+    RefactorScriptRunError, RelatedTests, ResolvedImports, RewrittenImport,
 };
 pub use registry::{
     available_extension_ids, extension_path, find_extension_by_tool, find_extension_for_file_ext,

--- a/src/core/extension/refactor_protocol.rs
+++ b/src/core/extension/refactor_protocol.rs
@@ -1,5 +1,39 @@
 use super::manifest::ExtensionManifest;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefactorScriptRunError {
+    pub script_path: String,
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub io_error: Option<String>,
+}
+
+impl RefactorScriptRunError {
+    pub fn summary(&self) -> String {
+        let status = match self.exit_code {
+            Some(code) => format!("exit code {code}"),
+            None => "terminated by signal".to_string(),
+        };
+        let output = first_non_empty_excerpt([self.stderr.as_str(), self.stdout.as_str()]);
+
+        match (&self.io_error, output) {
+            (Some(io_error), Some(output)) => format!("{status}: {io_error}; {output}"),
+            (Some(io_error), None) => format!("{status}: {io_error}"),
+            (None, Some(output)) => format!("{status}: {output}"),
+            (None, None) => status,
+        }
+    }
+}
+
+fn first_non_empty_excerpt<'a>(values: impl IntoIterator<Item = &'a str>) -> Option<String> {
+    values
+        .into_iter()
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+        .map(|value| value.chars().take(500).collect())
+}
+
 // ============================================================================
 // Refactor Script Protocol
 // ============================================================================
@@ -20,13 +54,27 @@ pub fn run_refactor_script(
     extension: &ExtensionManifest,
     command: &serde_json::Value,
 ) -> Option<serde_json::Value> {
-    let extension_path = extension.extension_path.as_deref()?;
-    let script_rel = extension.refactor_script()?;
+    run_refactor_script_result(extension, command)
+        .ok()
+        .flatten()
+}
+
+pub fn run_refactor_script_result(
+    extension: &ExtensionManifest,
+    command: &serde_json::Value,
+) -> Result<Option<serde_json::Value>, RefactorScriptRunError> {
+    let Some(extension_path) = extension.extension_path.as_deref() else {
+        return Ok(None);
+    };
+    let Some(script_rel) = extension.refactor_script() else {
+        return Ok(None);
+    };
     let script_path = std::path::Path::new(extension_path).join(script_rel);
 
     if !script_path.exists() {
-        return None;
+        return Ok(None);
     }
+    let script_path_string = script_path.to_string_lossy().to_string();
 
     // Invoke the script directly so its shebang resolves the interpreter.
     // Wrapping with `sh -c <script>` bypasses `#!/usr/bin/env bash` and runs
@@ -36,25 +84,57 @@ pub fn run_refactor_script(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
-        .ok()
+        .map_err(|err| RefactorScriptRunError {
+            script_path: script_path_string.clone(),
+            exit_code: None,
+            stdout: String::new(),
+            stderr: String::new(),
+            io_error: Some(err.to_string()),
+        })
         .and_then(|mut child| {
             use std::io::Write;
             if let Some(ref mut stdin) = child.stdin {
                 let _ = stdin.write_all(command.to_string().as_bytes());
             }
-            child.wait_with_output().ok()
+            child
+                .wait_with_output()
+                .map_err(|err| RefactorScriptRunError {
+                    script_path: script_path_string.clone(),
+                    exit_code: None,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                    io_error: Some(err.to_string()),
+                })
         })?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
         if !stderr.is_empty() {
             crate::log_status!("refactor", "Extension script error: {}", stderr.trim());
         }
-        return None;
+        return Err(RefactorScriptRunError {
+            script_path: script_path_string,
+            exit_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr,
+            io_error: None,
+        });
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    serde_json::from_str(&stdout).ok()
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    if stdout.trim().is_empty() {
+        return Ok(None);
+    }
+
+    serde_json::from_str(&stdout)
+        .map(Some)
+        .map_err(|err| RefactorScriptRunError {
+            script_path: script_path_string,
+            exit_code: output.status.code(),
+            stdout,
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            io_error: Some(format!("invalid JSON output: {err}")),
+        })
 }
 
 /// Output from a `parse_items` refactor command.
@@ -145,6 +225,10 @@ mod tests {
         }))
         .unwrap();
         assert!(run_refactor_script(&manifest, &serde_json::json!({})).is_none());
+        assert_eq!(
+            run_refactor_script_result(&manifest, &serde_json::json!({})).unwrap(),
+            None
+        );
     }
 
     #[test]

--- a/src/core/refactor/plan/sources/extension_source.rs
+++ b/src/core/refactor/plan/sources/extension_source.rs
@@ -1,7 +1,7 @@
 use crate::core::component::Component;
 use crate::core::extension;
 use crate::core::refactor::auto::{self, FixApplied};
-use crate::core::Error;
+use crate::core::{Error, ErrorCode};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -19,6 +19,12 @@ struct ExtensionRefactorSourceResponse {
     fix_results: Vec<FixApplied>,
     #[serde(default)]
     warnings: Vec<String>,
+    #[serde(default)]
+    fatal: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
 }
 
 pub(super) fn try_extension_refactor_source_stage<T: Serialize>(
@@ -43,23 +49,34 @@ pub(super) fn try_extension_refactor_source_stage<T: Serialize>(
         "write": write,
         "settings": settings.iter().cloned().collect::<std::collections::BTreeMap<_, _>>(),
     });
-    let Some(value) = extension::run_refactor_script(&manifest, &command) else {
-        return Err(Error::validation_invalid_argument(
-            setting_key.clone(),
-            format!(
-                "Extension '{}' did not handle refactor source '{}'",
-                extension_id, source
-            ),
-            None,
-            Some(vec![
-                "Remove the setting to use Homeboy's built-in refactor source".to_string(),
-                "Or update the extension refactor script to support command=refactor_source"
-                    .to_string(),
-            ]),
-        ));
+    let value = match extension::run_refactor_script_result(&manifest, &command) {
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            return Err(Error::validation_invalid_argument(
+                setting_key.clone(),
+                format!(
+                    "Extension '{}' did not handle refactor source '{}'",
+                    extension_id, source
+                ),
+                None,
+                Some(vec![
+                    "Remove the setting to use Homeboy's built-in refactor source".to_string(),
+                    "Or update the extension refactor script to support command=refactor_source"
+                        .to_string(),
+                ]),
+            ));
+        }
+        Err(err) => {
+            return Err(extension_refactor_source_execution_error(
+                &setting_key,
+                extension_id,
+                source,
+                &err,
+            ));
+        }
     };
     let response_value = unwrap_refactor_source_payload(value);
-    let response: ExtensionRefactorSourceResponse = serde_json::from_value(response_value)
+    let response: ExtensionRefactorSourceResponse = serde_json::from_value(response_value.clone())
         .map_err(|err| {
             Error::validation_invalid_argument(
                 setting_key.clone(),
@@ -86,6 +103,16 @@ pub(super) fn try_extension_refactor_source_stage<T: Serialize>(
         ));
     }
 
+    if let Some(reason) = response_fatal_reason(&response) {
+        return Err(extension_refactor_source_fatal_response_error(
+            &setting_key,
+            extension_id,
+            source,
+            &reason,
+            response_value,
+        ));
+    }
+
     let fix_summary = if response.fix_results.is_empty() {
         None
     } else {
@@ -107,6 +134,76 @@ pub(super) fn try_extension_refactor_source_stage<T: Serialize>(
         },
         fix_results: response.fix_results,
     }))
+}
+
+fn response_fatal_reason(response: &ExtensionRefactorSourceResponse) -> Option<String> {
+    response
+        .fatal
+        .as_deref()
+        .or(response.error.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| {
+            response
+                .status
+                .as_deref()
+                .map(str::trim)
+                .filter(|status| status.eq_ignore_ascii_case("failed"))
+                .map(|status| format!("extension reported status {status}"))
+        })
+}
+
+fn extension_refactor_source_fatal_response_error(
+    setting_key: &str,
+    extension_id: &str,
+    source: &str,
+    reason: &str,
+    response: serde_json::Value,
+) -> Error {
+    Error::new(
+        ErrorCode::ValidationInvalidArgument,
+        format!(
+            "Invalid argument '{}': Extension '{}' failed while handling refactor source '{}': {}",
+            setting_key, extension_id, source, reason
+        ),
+        serde_json::json!({
+            "field": setting_key,
+            "problem": "extension_refactor_source_failed",
+            "extension_id": extension_id,
+            "source": source,
+            "response": response,
+        }),
+    )
+}
+
+fn extension_refactor_source_execution_error(
+    setting_key: &str,
+    extension_id: &str,
+    source: &str,
+    err: &extension::RefactorScriptRunError,
+) -> Error {
+    Error::new(
+        ErrorCode::ValidationInvalidArgument,
+        format!(
+            "Invalid argument '{}': Extension '{}' failed while handling refactor source '{}': {}",
+            setting_key,
+            extension_id,
+            source,
+            err.summary()
+        ),
+        serde_json::json!({
+            "field": setting_key,
+            "problem": "extension_refactor_source_failed",
+            "extension_id": extension_id,
+            "source": source,
+            "script_path": err.script_path,
+            "exit_code": err.exit_code,
+            "stdout": err.stdout,
+            "stderr": err.stderr,
+            "io_error": err.io_error,
+        }),
+    )
 }
 
 fn unwrap_refactor_source_payload(value: serde_json::Value) -> serde_json::Value {
@@ -195,6 +292,79 @@ mod tests {
         }
     }
 
+    fn write_failing_refactor_source_extension(home: &Path, id: &str, artifact_file: &Path) {
+        let extension_dir = home.join(".config/homeboy/extensions").join(id);
+        fs::create_dir_all(&extension_dir).unwrap();
+        fs::write(
+            extension_dir.join(format!("{id}.json")),
+            serde_json::json!({
+                "name": "Failing Refactor Source Fixture",
+                "version": "0.0.0",
+                "scripts": {
+                    "refactor": "refactor-source.sh"
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        fs::write(
+            extension_dir.join("refactor-source.sh"),
+            format!(
+                "#!/bin/sh
+cat > /dev/null
+printf '%s\n' '{{\"variant\":\"refactor_source\",\"payload\":{{\"handled\":true,\"fatal\":\"fanout failed\",\"artifact\":\"{}\"}}}}'
+printf '%s\n' 'fatal: WP Codebox fanout failed; artifact={}' >&2
+exit 42
+",
+                artifact_file.display(),
+                artifact_file.display()
+            ),
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let script = extension_dir.join("refactor-source.sh");
+            let mut permissions = fs::metadata(&script).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(script, permissions).unwrap();
+        }
+    }
+
+    fn write_fatal_response_refactor_source_extension(home: &Path, id: &str) {
+        let extension_dir = home.join(".config/homeboy/extensions").join(id);
+        fs::create_dir_all(&extension_dir).unwrap();
+        fs::write(
+            extension_dir.join(format!("{id}.json")),
+            serde_json::json!({
+                "name": "Fatal Response Refactor Source Fixture",
+                "version": "0.0.0",
+                "scripts": {
+                    "refactor": "refactor-source.sh"
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        fs::write(
+            extension_dir.join("refactor-source.sh"),
+            "#!/bin/sh\ncat > /dev/null\nprintf '%s' '{\"variant\":\"refactor_source\",\"payload\":{\"handled\":true,\"fatal\":\"fanout failed after handling\",\"warnings\":[\"artifact=/tmp/fanout-run.json\"]}}'\n",
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let script = extension_dir.join("refactor-source.sh");
+            let mut permissions = fs::metadata(&script).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(script, permissions).unwrap();
+        }
+    }
+
     #[test]
     fn extension_refactor_source_dispatch_uses_generic_source_result() {
         crate::test_support::with_isolated_home(|home| {
@@ -260,6 +430,99 @@ mod tests {
             assert_eq!(command["settings"]["extension.setting"], "value");
             assert_eq!(command["source_result"]["lint_findings"][0]["id"], "lint-1");
             assert!(command.get("audit_result").is_none());
+
+            let _ = fs::remove_dir_all(root);
+        });
+    }
+
+    #[test]
+    fn extension_refactor_source_preserves_handled_failure_output() {
+        crate::test_support::with_isolated_home(|home| {
+            let root = tmp_dir("generic-extension-fatal");
+            fs::create_dir_all(&root).unwrap();
+            let artifact_file = root.join("fanout-run.json");
+            write_failing_refactor_source_extension(home.path(), "fatal-source", &artifact_file);
+
+            let result = try_extension_refactor_source_stage(
+                "audit",
+                &test_component(&root),
+                &root,
+                &serde_json::json!({
+                    "component_id": "component",
+                    "findings": []
+                }),
+                true,
+                &[(
+                    "refactor.audit.extension".to_string(),
+                    "fatal-source".to_string(),
+                )],
+            );
+            let err = match result {
+                Ok(_) => panic!("fatal extension result should fail the source stage"),
+                Err(err) => err,
+            };
+
+            let message = err.to_string();
+            assert!(message.contains(
+                "Extension 'fatal-source' failed while handling refactor source 'audit'"
+            ));
+            assert!(message.contains("exit code 42"));
+            assert!(message.contains("WP Codebox fanout failed"));
+            assert!(!message.contains("did not handle refactor source"));
+
+            assert_eq!(err.details["extension_id"], "fatal-source");
+            assert_eq!(err.details["source"], "audit");
+            assert_eq!(err.details["exit_code"], 42);
+            assert!(err.details["stderr"]
+                .as_str()
+                .unwrap()
+                .contains(artifact_file.to_string_lossy().as_ref()));
+            assert!(err.details["stdout"]
+                .as_str()
+                .unwrap()
+                .contains("\"handled\":true"));
+
+            let _ = fs::remove_dir_all(root);
+        });
+    }
+
+    #[test]
+    fn extension_refactor_source_reports_handled_fatal_response() {
+        crate::test_support::with_isolated_home(|home| {
+            let root = tmp_dir("generic-extension-fatal-response");
+            fs::create_dir_all(&root).unwrap();
+            write_fatal_response_refactor_source_extension(home.path(), "fatal-response");
+
+            let result = try_extension_refactor_source_stage(
+                "audit",
+                &test_component(&root),
+                &root,
+                &serde_json::json!({
+                    "component_id": "component",
+                    "findings": []
+                }),
+                true,
+                &[(
+                    "refactor.audit.extension".to_string(),
+                    "fatal-response".to_string(),
+                )],
+            );
+            let err = match result {
+                Ok(_) => panic!("handled fatal extension response should fail the source stage"),
+                Err(err) => err,
+            };
+
+            let message = err.to_string();
+            assert!(message.contains(
+                "Extension 'fatal-response' failed while handling refactor source 'audit'"
+            ));
+            assert!(message.contains("fanout failed after handling"));
+            assert!(!message.contains("did not handle refactor source"));
+            assert_eq!(err.details["response"]["handled"], true);
+            assert_eq!(
+                err.details["response"]["warnings"][0],
+                "artifact=/tmp/fanout-run.json"
+            );
 
             let _ = fs::remove_dir_all(root);
         });


### PR DESCRIPTION
## Summary
- Keep missing refactor scripts/unhandled sources on the existing `did not handle refactor source` path.
- Add a refactor script runner result that preserves non-zero execution failures with extension id, source, script path, exit code, stdout, stderr, and IO/JSON errors.
- Treat handled fatal refactor source responses (`fatal`, `error`, or `status: failed`) as real extension failures instead of successful empty stages.
- Add focused coverage for non-zero handled failures and handled fatal responses preserving artifact/warning output.

Fixes #2977.

## Tests
- `cargo test extension_source`
- `cargo test run_refactor_script`
- `cargo check`

## Notes
- `cargo clippy --all-targets -- -D warnings` was attempted, but the repo currently fails on existing unrelated Clippy warnings such as `duplicate_mod`, `large_enum_variant`, `too_many_arguments`, and other pre-existing lint debt outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the refactor extension failure path, drafted the Homeboy core fix and focused tests, and ran local verification. Chris remains responsible for review and merge.
