### PR TITLE
Stabilize Lab offload metadata contract

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -55,7 +55,7 @@ Hot commands that support Lab offload (`audit`, full `lint`, `test`, `bench run`
 - If the auto-selected runner is disconnected, Homeboy attempts a short bounded `runner connect` before execution. Connection failure prints the reason and falls back to local execution.
 - Explicit `--runner <id>` also attempts to connect a disconnected runner, but connection failure remains a command error instead of falling back silently.
 
-Observation metadata records the routing decision under `metadata.lab_offload` when an observed run is created. `source` is `automatic` or `explicit`; `status` is `offloaded`, `skipped`, or `fallback`; and successful offloads include `runner_id` plus `remote_workspace`. Local fallback records the runner and `fallback_reason`, while skipped local execution records why no automatic offload was used, such as `force_hot` or `no_default_runner`.
+Observation metadata records the routing decision under `metadata.lab_offload` when an observed run is created. The stable contract is `schema: "homeboy/lab-offload/v1"` and keeps the existing top-level compatibility fields: `source` is `automatic` or `explicit`; `status` is `offloaded`, `skipped`, or `fallback`; successful offloads include `runner_id` plus `remote_workspace`; local fallback records the runner and `fallback_reason`; skipped local execution records why no automatic offload was used, such as `force_hot` or `no_default_runner`. The same object also carries `plan_id` and plan-derived phase fields including `sync_mode`, `capability_preflight`, `extension_parity`, and `patch_captured`.
 
 Lab offload support is intentionally command-specific:
 

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -151,8 +151,8 @@ pub fn execute_lab_offload(
             .build(),
         );
         return Ok(LabOffloadOutcome::RunLocal {
-            plan,
             metadata: Some(lab_offload_metadata(
+                &plan,
                 "automatic",
                 None,
                 None,
@@ -160,6 +160,7 @@ pub fn execute_lab_offload(
                 None,
                 Some(reason),
             )),
+            plan,
             messages: Vec::new(),
         });
     };
@@ -204,8 +205,8 @@ pub fn execute_lab_offload(
                 .build(),
             );
             return Ok(LabOffloadOutcome::RunLocal {
-                plan,
                 metadata: Some(lab_offload_metadata(
+                    &plan,
                     selection.source.metadata_value(),
                     Some(&selection.runner_id),
                     Some(selection.mode.metadata_value()),
@@ -213,6 +214,7 @@ pub fn execute_lab_offload(
                     None,
                     Some(&reason),
                 )),
+                plan,
                 messages: vec![format!("Lab offload: {reason}; running locally.")],
             });
         }
@@ -429,6 +431,7 @@ fn run_lab_offload_inner(
         remote_cwd
     );
     let lab_metadata = lab_offload_metadata(
+        &plan,
         selection.source.metadata_value(),
         Some(runner_id),
         Some(status_tunnel_mode(&runner_status).metadata_value()),
@@ -513,8 +516,8 @@ fn automatic_capability_fallback(
     reason: String,
 ) -> LabOffloadOutcome {
     LabOffloadOutcome::RunLocal {
-        plan,
         metadata: Some(lab_offload_metadata(
+            &plan,
             "automatic",
             Some(runner_id),
             Some(status_tunnel_mode(runner_status).metadata_value()),
@@ -522,6 +525,7 @@ fn automatic_capability_fallback(
             None,
             Some(&reason),
         )),
+        plan,
         messages: vec![format!("Lab offload: {reason}; running locally.")],
     }
 }

--- a/src/core/runner/offload_metadata.rs
+++ b/src/core/runner/offload_metadata.rs
@@ -1,4 +1,9 @@
+use crate::core::plan::{HomeboyPlan, PlanStepStatus};
+
+pub const LAB_OFFLOAD_METADATA_SCHEMA: &str = "homeboy/lab-offload/v1";
+
 pub fn lab_offload_metadata(
+    plan: &HomeboyPlan,
     source: &str,
     runner_id: Option<&str>,
     runner_mode: Option<&str>,
@@ -6,14 +11,50 @@ pub fn lab_offload_metadata(
     remote_workspace: Option<&str>,
     fallback_reason: Option<&str>,
 ) -> serde_json::Value {
+    let sync_mode = plan_step_input_string(plan, "lab.sync_workspace", "mode");
     serde_json::json!({
+        "schema": LAB_OFFLOAD_METADATA_SCHEMA,
+        "plan_id": plan.id,
         "source": source,
         "status": status,
         "runner_id": runner_id,
         "runner_mode": runner_mode,
         "remote_workspace": remote_workspace,
+        "sync_mode": sync_mode,
         "fallback_reason": fallback_reason,
+        "capability_preflight": plan_step_status(plan, "lab.capability_preflight"),
+        "extension_parity": plan_step_status(plan, "lab.extension_parity"),
+        "patch_captured": plan_has_step(plan, "lab.apply_patch"),
     })
+}
+
+fn plan_step_status(plan: &HomeboyPlan, step_id: &str) -> Option<&'static str> {
+    plan.steps
+        .iter()
+        .find(|step| step.id == step_id)
+        .map(|step| match step.status {
+            PlanStepStatus::Ready => "ready",
+            PlanStepStatus::Missing => "missing",
+            PlanStepStatus::Disabled => "disabled",
+            PlanStepStatus::Skipped => "skipped",
+            PlanStepStatus::Running => "running",
+            PlanStepStatus::Success => "success",
+            PlanStepStatus::PartialSuccess => "partial_success",
+            PlanStepStatus::Failed => "failed",
+        })
+}
+
+fn plan_step_input_string(plan: &HomeboyPlan, step_id: &str, key: &str) -> Option<String> {
+    plan.steps
+        .iter()
+        .find(|step| step.id == step_id)
+        .and_then(|step| step.inputs.get(key))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+}
+
+fn plan_has_step(plan: &HomeboyPlan, step_id: &str) -> bool {
+    plan.steps.iter().any(|step| step.id == step_id)
 }
 
 pub fn capture_lab_offload_metadata(metadata: serde_json::Value) {
@@ -24,11 +65,44 @@ pub fn capture_lab_offload_metadata(metadata: serde_json::Value) {
 
 #[cfg(test)]
 mod tests {
-    use super::lab_offload_metadata;
+    use super::{lab_offload_metadata, LAB_OFFLOAD_METADATA_SCHEMA};
+    use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
+
+    fn lab_plan() -> HomeboyPlan {
+        let mut plan = HomeboyPlan::builder_for_description(PlanKind::LabOffload, "test")
+            .mode("lab_offload")
+            .build();
+        plan.steps.push(
+            PlanStep::ready("lab.sync_workspace", "lab.sync_workspace")
+                .inputs(PlanValues::new().string("mode", "snapshot"))
+                .build(),
+        );
+        plan.steps.push(
+            PlanStep::builder(
+                "lab.capability_preflight",
+                "lab.capability_preflight",
+                PlanStepStatus::Success,
+            )
+            .build(),
+        );
+        plan.steps
+            .push(PlanStep::ready("lab.extension_parity", "lab.extension_parity").build());
+        plan.steps.push(
+            PlanStep::builder(
+                "lab.apply_patch",
+                "lab.apply_patch",
+                PlanStepStatus::Success,
+            )
+            .build(),
+        );
+        plan
+    }
 
     #[test]
     fn lab_offload_metadata_records_explicit_auto_skipped_and_fallback_states() {
+        let plan = lab_plan();
         let explicit = lab_offload_metadata(
+            &plan,
             "explicit",
             Some("lab-explicit"),
             Some("direct_ssh"),
@@ -36,14 +110,21 @@ mod tests {
             Some("/srv/homeboy/project"),
             None,
         );
+        assert_eq!(explicit["schema"], LAB_OFFLOAD_METADATA_SCHEMA);
+        assert_eq!(explicit["plan_id"], "lab_offload.test");
         assert_eq!(explicit["source"], "explicit");
         assert_eq!(explicit["status"], "offloaded");
         assert_eq!(explicit["runner_id"], "lab-explicit");
         assert_eq!(explicit["runner_mode"], "direct_ssh");
         assert_eq!(explicit["remote_workspace"], "/srv/homeboy/project");
+        assert_eq!(explicit["sync_mode"], "snapshot");
+        assert_eq!(explicit["capability_preflight"], "success");
+        assert_eq!(explicit["extension_parity"], "ready");
+        assert_eq!(explicit["patch_captured"], true);
         assert!(explicit["fallback_reason"].is_null());
 
         let fallback = lab_offload_metadata(
+            &plan,
             "automatic",
             Some("lab"),
             Some("reverse"),
@@ -60,6 +141,7 @@ mod tests {
         );
 
         let skipped = lab_offload_metadata(
+            &plan,
             "automatic",
             None,
             None,


### PR DESCRIPTION
## Summary
- Add the stable `homeboy/lab-offload/v1` schema to Lab offload metadata while preserving existing top-level compatibility fields.
- Derive contract details from the Lab `HomeboyPlan`, including `plan_id`, `sync_mode`, capability preflight status, extension parity status, and patch capture status.
- Document the versioned `metadata.lab_offload` contract in runner docs.

Fixes #2971.

## Verification
- `cargo fmt --check`
- `cargo test core::runner::offload_metadata::tests --all-targets`
- `cargo test core::runner::lab::tests --all-targets`
- `cargo test --all-targets`
- `git diff --check`
- `homeboy audit --force-hot --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the metadata contract implementation, focused tests, docs update, and verification loop; Chris remains responsible for review and final merge.
