### PR TITLE
Add reverse runner broker routes

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -119,6 +119,7 @@ Lab offload selection.
 
 ```sh
 homeboy runner connect <runner-id>
+homeboy runner connect <controller-id> --reverse --reverse-runner <runner-id> --broker-url <url>
 ```
 
 Starts a loopback-only Homeboy daemon on the runner and opens an SSH tunnel to
@@ -126,6 +127,13 @@ it. This is the preferred Lab execution path because later `runner exec` calls
 can use the daemon session instead of ad-hoc SSH command execution. The JSON
 payload uses `command: "runner.connect"` and reports connection state such as
 the runner ID, tunnel endpoint, daemon endpoint, and persisted session metadata.
+
+Reverse runner connections record the runner-initiated session substrate and use
+the controller daemon as the broker. The broker exposes `POST /runner/jobs`,
+`POST /runner/jobs/claim`, `POST /runner/jobs/<job-id>/events`, and
+`POST /runner/jobs/<job-id>/finish` so controllers can queue work and reverse
+runners can claim, stream progress, and return results without inbound access to
+the lab machine.
 
 ### `status`
 

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -17,6 +17,7 @@ use crate::core::source_snapshot::SourceSnapshot;
 
 mod artifact_download;
 mod patch_capture;
+mod remote_runner;
 pub use artifact_download::ArtifactDownload;
 use patch_capture::{capture_baseline, capture_patch_report};
 
@@ -268,7 +269,34 @@ where
             body: json!({ "error": "method_not_allowed" }),
             artifact: None,
         },
+        ("POST", "/runner/jobs") | ("POST", "/runner/jobs/claim") => {
+            remote_runner::route(method, path, body, job_store)
+        }
+        ("GET", "/runner/jobs") | ("GET", "/runner/jobs/claim") => method_not_allowed(),
+        ("POST", path) if path.starts_with("/runner/jobs/") => {
+            remote_runner::route(method, path, body, job_store)
+        }
         _ => route_read_only_api(method, path, body, job_store, analysis_runner),
+    }
+}
+
+pub(super) fn daemon_endpoint_response(endpoint: &str, body: serde_json::Value) -> HttpResponse {
+    HttpResponse {
+        status_code: 200,
+        body: json!({
+            "status": 200,
+            "endpoint": endpoint,
+            "body": body,
+        }),
+        artifact: None,
+    }
+}
+
+fn method_not_allowed() -> HttpResponse {
+    HttpResponse {
+        status_code: 405,
+        body: json!({ "error": "method_not_allowed" }),
+        artifact: None,
     }
 }
 

--- a/src/core/daemon/remote_runner.rs
+++ b/src/core/daemon/remote_runner.rs
@@ -1,0 +1,167 @@
+use serde::Deserialize;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use super::{daemon_endpoint_response, error_response, HttpResponse};
+use crate::core::api_jobs::{
+    JobEventKind, JobStore, RemoteRunnerJobRequest, RemoteRunnerJobResult,
+};
+use crate::core::error::{Error, Result};
+
+#[derive(Debug, Clone, Deserialize)]
+struct ClaimRequest {
+    runner_id: String,
+    #[serde(default)]
+    project_id: Option<String>,
+    #[serde(default)]
+    lease_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct EventRequest {
+    runner_id: String,
+    kind: JobEventKind,
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    data: Option<Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FinishRequest {
+    runner_id: String,
+    result: RemoteRunnerJobResult,
+}
+
+pub(super) fn route(
+    method: &str,
+    path: &str,
+    body: Option<Value>,
+    job_store: &JobStore,
+) -> HttpResponse {
+    match (method, path) {
+        ("POST", "/runner/jobs") => match enqueue(body, job_store) {
+            Ok(body) => daemon_endpoint_response("runner.jobs.submit", body),
+            Err(err) => error_response(400, err),
+        },
+        ("POST", "/runner/jobs/claim") => match claim(body, job_store) {
+            Ok(body) => daemon_endpoint_response("runner.jobs.claim", body),
+            Err(err) => error_response(400, err),
+        },
+        ("POST", path) if path.starts_with("/runner/jobs/") => update(path, body, job_store),
+        _ => error_response(
+            404,
+            Error::validation_invalid_argument(
+                "path",
+                "unknown remote runner broker path",
+                Some(path.to_string()),
+                Some(vec![
+                    "Use /runner/jobs, /runner/jobs/claim, /runner/jobs/<job-id>/events, or /runner/jobs/<job-id>/finish."
+                        .to_string(),
+                ]),
+            ),
+        ),
+    }
+}
+
+fn enqueue(body: Option<Value>, job_store: &JobStore) -> Result<Value> {
+    let request: RemoteRunnerJobRequest = parse_body(body, "remote runner job request")?;
+    let job = job_store.submit_remote_runner_job(request.clone())?;
+    Ok(json!({
+        "command": "api.runner.jobs.submit",
+        "job": job,
+        "poll": {
+            "job": format!("/jobs/{}", job.id),
+            "events": format!("/jobs/{}/events", job.id),
+        },
+        "request": request,
+    }))
+}
+
+fn claim(body: Option<Value>, job_store: &JobStore) -> Result<Value> {
+    let request: ClaimRequest = parse_body(body, "remote runner claim request")?;
+    let claim = job_store.claim_remote_runner_job(
+        &request.runner_id,
+        request.project_id.as_deref(),
+        request.lease_ms.unwrap_or(30_000),
+    )?;
+    Ok(json!({
+        "command": "api.runner.jobs.claim",
+        "claim": claim,
+    }))
+}
+
+fn update(path: &str, body: Option<Value>, job_store: &JobStore) -> HttpResponse {
+    let Some((job_id, operation)) = job_path(path) else {
+        return error_response(
+            404,
+            Error::validation_invalid_argument(
+                "path",
+                "unknown remote runner job path",
+                Some(path.to_string()),
+                Some(vec![
+                    "Use /runner/jobs/<job-id>/events or /runner/jobs/<job-id>/finish.".to_string(),
+                ]),
+            ),
+        );
+    };
+
+    match operation {
+        "events" => match append_event(job_id, body, job_store) {
+            Ok(body) => daemon_endpoint_response("runner.jobs.events.append", body),
+            Err(err) => error_response(400, err),
+        },
+        "finish" => match finish(job_id, body, job_store) {
+            Ok(body) => daemon_endpoint_response("runner.jobs.finish", body),
+            Err(err) => error_response(400, err),
+        },
+        _ => error_response(
+            404,
+            Error::validation_invalid_argument(
+                "path",
+                "unknown remote runner job operation",
+                Some(operation.to_string()),
+                Some(vec![
+                    "Supported operations are events and finish.".to_string()
+                ]),
+            ),
+        ),
+    }
+}
+
+fn job_path(path: &str) -> Option<(Uuid, &str)> {
+    let tail = path.strip_prefix("/runner/jobs/")?;
+    let (job_id, operation) = tail.split_once('/')?;
+    let job_id = Uuid::parse_str(job_id).ok()?;
+    Some((job_id, operation))
+}
+
+fn append_event(job_id: Uuid, body: Option<Value>, job_store: &JobStore) -> Result<Value> {
+    let request: EventRequest = parse_body(body, "remote runner event request")?;
+    let event = job_store.append_remote_runner_event(
+        job_id,
+        &request.runner_id,
+        request.kind,
+        request.message,
+        request.data,
+    )?;
+    Ok(json!({
+        "command": "api.runner.jobs.events.append",
+        "event": event,
+    }))
+}
+
+fn finish(job_id: Uuid, body: Option<Value>, job_store: &JobStore) -> Result<Value> {
+    let request: FinishRequest = parse_body(body, "remote runner finish request")?;
+    let job = job_store.finish_remote_runner_job(job_id, &request.runner_id, request.result)?;
+    Ok(json!({
+        "command": "api.runner.jobs.finish",
+        "job": job,
+    }))
+}
+
+fn parse_body<T: for<'de> Deserialize<'de>>(body: Option<Value>, label: &str) -> Result<T> {
+    serde_json::from_value(body.unwrap_or_else(|| json!({}))).map_err(|err| {
+        Error::validation_invalid_argument("body", format!("invalid {label}: {err}"), None, None)
+    })
+}

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -254,6 +254,82 @@ fn routes_job_inspection_against_daemon_job_store() {
 }
 
 #[test]
+fn routes_remote_runner_job_broker_lifecycle() {
+    let store = JobStore::default();
+    let submit = route_with_job_store_and_body(
+        "POST",
+        "/runner/jobs",
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "project_id": "extrachill",
+            "command": ["homeboy", "test", "data-machine"],
+            "cwd": "/home/chubes/Developer/data-machine"
+        })),
+        &store,
+    );
+
+    assert_eq!(submit.status_code, 200);
+    assert_eq!(submit.body["endpoint"], "runner.jobs.submit");
+    assert_eq!(submit.body["body"]["command"], "api.runner.jobs.submit");
+    let job_id = submit.body["body"]["job"]["id"]
+        .as_str()
+        .expect("job id")
+        .to_string();
+
+    let claim = route_with_job_store_and_body(
+        "POST",
+        "/runner/jobs/claim",
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "project_id": "extrachill",
+            "lease_ms": 30000
+        })),
+        &store,
+    );
+
+    assert_eq!(claim.status_code, 200);
+    assert_eq!(claim.body["endpoint"], "runner.jobs.claim");
+    assert_eq!(claim.body["body"]["claim"]["job"]["id"], job_id);
+    assert_eq!(
+        claim.body["body"]["claim"]["request"]["command"],
+        serde_json::json!(["homeboy", "test", "data-machine"])
+    );
+
+    let event = route_with_job_store_and_body(
+        "POST",
+        &format!("/runner/jobs/{job_id}/events"),
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "kind": "progress",
+            "data": { "phase": "running" }
+        })),
+        &store,
+    );
+
+    assert_eq!(event.status_code, 200);
+    assert_eq!(event.body["endpoint"], "runner.jobs.events.append");
+    assert_eq!(event.body["body"]["event"]["kind"], "progress");
+
+    let finish = route_with_job_store_and_body(
+        "POST",
+        &format!("/runner/jobs/{job_id}/finish"),
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "result": {
+                "exit_code": 0,
+                "stdout": "ok",
+                "stderr": ""
+            }
+        })),
+        &store,
+    );
+
+    assert_eq!(finish.status_code, 200);
+    assert_eq!(finish.body["endpoint"], "runner.jobs.finish");
+    assert_eq!(finish.body["body"]["job"]["status"], "succeeded");
+}
+
+#[test]
 fn routes_json_body_to_analysis_enqueue() {
     let store = JobStore::default();
     let response = route_with_job_store_and_body(


### PR DESCRIPTION
## Summary
- Add controller daemon broker routes for reverse runner job submit, claim, event append, and finish.
- Keep broker routing in a focused daemon submodule backed by existing remote runner JobStore primitives.
- Document the reverse runner broker endpoint contract and cover the full broker lifecycle in daemon tests.

Refs #2944.

## Verification
- cargo fmt --check
- cargo test core::daemon::daemon_test::routes_remote_runner_job_broker_lifecycle
- cargo test core::daemon
- cargo test core::api_jobs
- cargo test --all-targets
- git diff --check
- homeboy audit --force-hot --changed-since origin/main

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused daemon broker route implementation, tests, docs, and verification loop; Chris remains responsible for review and merge.