### PR TITLE
Route reverse runner exec through broker

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -129,11 +129,13 @@ payload uses `command: "runner.connect"` and reports connection state such as
 the runner ID, tunnel endpoint, daemon endpoint, and persisted session metadata.
 
 Reverse runner connections record the runner-initiated session substrate and use
-the controller daemon as the broker. The broker exposes `POST /runner/jobs`,
-`POST /runner/jobs/claim`, `POST /runner/jobs/<job-id>/events`, and
-`POST /runner/jobs/<job-id>/finish` so controllers can queue work and reverse
-runners can claim, stream progress, and return results without inbound access to
-the lab machine.
+the controller daemon as the broker. A reverse runner can register itself with
+`POST /runner/sessions`; the controller then reports that runner as connected
+and routes `runner exec` through brokered jobs instead of a direct daemon URL.
+The broker exposes `POST /runner/jobs`, `POST /runner/jobs/claim`,
+`POST /runner/jobs/<job-id>/events`, and `POST /runner/jobs/<job-id>/finish` so
+controllers can queue work and reverse runners can claim, stream progress, and
+return results without inbound access to the lab machine.
 
 ### `status`
 

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -269,10 +269,12 @@ where
             body: json!({ "error": "method_not_allowed" }),
             artifact: None,
         },
-        ("POST", "/runner/jobs") | ("POST", "/runner/jobs/claim") => {
-            remote_runner::route(method, path, body, job_store)
+        ("POST", "/runner/sessions")
+        | ("POST", "/runner/jobs")
+        | ("POST", "/runner/jobs/claim") => remote_runner::route(method, path, body, job_store),
+        ("GET", "/runner/sessions") | ("GET", "/runner/jobs") | ("GET", "/runner/jobs/claim") => {
+            method_not_allowed()
         }
-        ("GET", "/runner/jobs") | ("GET", "/runner/jobs/claim") => method_not_allowed(),
         ("POST", path) if path.starts_with("/runner/jobs/") => {
             remote_runner::route(method, path, body, job_store)
         }

--- a/src/core/daemon/remote_runner.rs
+++ b/src/core/daemon/remote_runner.rs
@@ -7,6 +7,8 @@ use crate::core::api_jobs::{
     JobEventKind, JobStore, RemoteRunnerJobRequest, RemoteRunnerJobResult,
 };
 use crate::core::error::{Error, Result};
+use crate::core::paths;
+use crate::core::runner::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
 
 #[derive(Debug, Clone, Deserialize)]
 struct ClaimRequest {
@@ -33,6 +35,16 @@ struct FinishRequest {
     result: RemoteRunnerJobResult,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct SessionRequest {
+    runner_id: String,
+    controller_id: String,
+    #[serde(default)]
+    broker_url: Option<String>,
+    #[serde(default)]
+    homeboy_version: Option<String>,
+}
+
 pub(super) fn route(
     method: &str,
     path: &str,
@@ -40,6 +52,10 @@ pub(super) fn route(
     job_store: &JobStore,
 ) -> HttpResponse {
     match (method, path) {
+        ("POST", "/runner/sessions") => match register_session(body) {
+            Ok(body) => daemon_endpoint_response("runner.sessions.register", body),
+            Err(err) => error_response(400, err),
+        },
         ("POST", "/runner/jobs") => match enqueue(body, job_store) {
             Ok(body) => daemon_endpoint_response("runner.jobs.submit", body),
             Err(err) => error_response(400, err),
@@ -58,10 +74,74 @@ pub(super) fn route(
                 Some(vec![
                     "Use /runner/jobs, /runner/jobs/claim, /runner/jobs/<job-id>/events, or /runner/jobs/<job-id>/finish."
                         .to_string(),
+                    "Use /runner/sessions to register reverse runner sessions.".to_string(),
                 ]),
             ),
         ),
     }
+}
+
+fn register_session(body: Option<Value>) -> Result<Value> {
+    let request: SessionRequest = parse_body(body, "remote runner session request")?;
+    if request.runner_id.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "runner_id",
+            "remote runner session requires a runner id",
+            None,
+            None,
+        ));
+    }
+    if request.controller_id.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "controller_id",
+            "remote runner session requires a controller id",
+            None,
+            None,
+        ));
+    }
+
+    let session = RunnerSession {
+        runner_id: request.runner_id.clone(),
+        mode: RunnerTunnelMode::Reverse,
+        role: RunnerSessionRole::Controller,
+        server_id: None,
+        controller_id: Some(request.controller_id.clone()),
+        broker_url: request.broker_url.clone(),
+        remote_daemon_address: None,
+        local_port: None,
+        local_url: None,
+        tunnel_pid: None,
+        remote_daemon_pid: None,
+        homeboy_version: request
+            .homeboy_version
+            .clone()
+            .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string()),
+        connected_at: chrono::Utc::now().to_rfc3339(),
+    };
+    let path = paths::runner_session_file(&session.runner_id)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+    }
+    let serialized = serde_json::to_string_pretty(&session).map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("serialize runner session".to_string()),
+        )
+    })?;
+    std::fs::write(&path, serialized).map_err(|err| {
+        Error::internal_io(err.to_string(), Some(format!("write {}", path.display())))
+    })?;
+
+    Ok(json!({
+        "command": "api.runner.sessions.register",
+        "session": session,
+        "session_path": path.display().to_string(),
+    }))
 }
 
 fn enqueue(body: Option<Value>, job_store: &JobStore) -> Result<Value> {

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -4,6 +4,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
+use reqwest::blocking::Client;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -184,13 +185,17 @@ pub fn connect_reverse(options: ReverseRunnerConnectOptions) -> Result<(RunnerCo
         connected_at: Utc::now().to_rfc3339(),
     };
     write_session(&session)?;
+    let broker_registered = match session.broker_url.as_deref() {
+        Some(broker_url) => register_reverse_session_with_broker(broker_url, &session)?,
+        None => false,
+    };
 
     Ok((
         RunnerConnectReport {
             runner_id: runner.id,
             mode: Some(RunnerTunnelMode::Reverse),
             role: Some(RunnerSessionRole::Runner),
-            connected: false,
+            connected: broker_registered,
             recorded: Some(true),
             local_url: None,
             broker_url: options.broker_url,
@@ -205,6 +210,42 @@ pub fn connect_reverse(options: ReverseRunnerConnectOptions) -> Result<(RunnerCo
         },
         0,
     ))
+}
+
+fn register_reverse_session_with_broker(broker_url: &str, session: &RunnerSession) -> Result<bool> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|err| Error::internal_unexpected(format!("build broker HTTP client: {err}")))?;
+    let response = client
+        .post(format!(
+            "{}/runner/sessions",
+            broker_url.trim_end_matches('/')
+        ))
+        .json(&serde_json::json!({
+            "runner_id": session.runner_id,
+            "controller_id": session.controller_id,
+            "broker_url": session.broker_url,
+            "homeboy_version": session.homeboy_version,
+        }))
+        .send()
+        .map_err(|err| {
+            Error::internal_unexpected(format!("register reverse runner session: {err}"))
+        })?;
+    let status_code = response.status().as_u16();
+    let envelope: CliEnvelope = response.json().map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("parse reverse runner session registration response".to_string()),
+        )
+    })?;
+    if status_code >= 400 || !envelope.success {
+        return Err(Error::internal_unexpected(format!(
+            "reverse runner session registration failed: {}",
+            envelope.error.unwrap_or(Value::Null)
+        )));
+    }
+    Ok(true)
 }
 
 pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
@@ -528,6 +569,12 @@ fn session_is_live(session: &RunnerSession) -> bool {
 
 fn session_state(session: Option<&RunnerSession>) -> RunnerSessionState {
     match session {
+        Some(session)
+            if session.mode == RunnerTunnelMode::Reverse
+                && session.role == RunnerSessionRole::Controller =>
+        {
+            RunnerSessionState::Connected
+        }
         Some(session) if session.mode == RunnerTunnelMode::Reverse => RunnerSessionState::Recorded,
         Some(session) if session_is_live(session) => RunnerSessionState::Connected,
         Some(_) => RunnerSessionState::Disconnected,
@@ -743,7 +790,7 @@ mod tests {
             let (report, exit_code) = connect_reverse(ReverseRunnerConnectOptions {
                 controller_id: "extra-chill".to_string(),
                 runner_id: "homeboy-lab".to_string(),
-                broker_url: Some("https://extrachill.com/homeboy/tunnel".to_string()),
+                broker_url: None,
             })
             .expect("record reverse session");
 
@@ -761,10 +808,7 @@ mod tests {
             assert_eq!(session.mode, RunnerTunnelMode::Reverse);
             assert_eq!(session.role, RunnerSessionRole::Runner);
             assert_eq!(session.controller_id.as_deref(), Some("extra-chill"));
-            assert_eq!(
-                session.broker_url.as_deref(),
-                Some("https://extrachill.com/homeboy/tunnel")
-            );
+            assert_eq!(session.broker_url, None);
             assert_eq!(session.local_url, None);
             assert_eq!(session.local_port, None);
         });

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -5,7 +5,7 @@ use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::core::api_jobs::{Job, JobEvent, JobStatus};
+use crate::core::api_jobs::{Job, JobEvent, JobStatus, RemoteRunnerJobRequest};
 use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
 use crate::core::server::{self, SshClient};
@@ -13,7 +13,7 @@ use crate::core::source_snapshot::SourceSnapshot;
 
 use super::capabilities::{runner_capability_snapshot, validate_runner_capability_preflight};
 use super::evidence::mirror_daemon_evidence;
-use super::{load, status, Runner, RunnerCapabilityPreflight, RunnerKind};
+use super::{load, status, Runner, RunnerCapabilityPreflight, RunnerKind, RunnerTunnelMode};
 
 mod policy;
 use policy::{validate_runner_policy, RunnerPolicyRequest};
@@ -36,6 +36,7 @@ pub struct RunnerExecOptions {
 pub enum RunnerExecMode {
     Daemon,
     Local,
+    ReverseBroker,
     Ssh,
 }
 
@@ -98,12 +99,12 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
 
     if connected.connected {
         if let Some(session) = connected.session {
+            preflight_runner_capability_plan(
+                &runner,
+                options.capability_preflight.as_ref(),
+                &request_env,
+            )?;
             if let Some(local_url) = session.local_url.as_deref() {
-                preflight_runner_capability_plan(
-                    &runner,
-                    options.capability_preflight.as_ref(),
-                    &request_env,
-                )?;
                 return exec_via_daemon(
                     &runner,
                     local_url,
@@ -113,6 +114,20 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
                     options.capture_patch,
                     options.source_snapshot,
                 );
+            }
+            if session.mode == RunnerTunnelMode::Reverse {
+                if let Some(broker_url) = session.broker_url.as_deref() {
+                    return exec_via_reverse_broker(
+                        &runner,
+                        broker_url,
+                        cwd,
+                        options.project_id,
+                        options.command,
+                        request_env,
+                        options.capture_patch,
+                        options.source_snapshot,
+                    );
+                }
             }
         }
     }
@@ -137,6 +152,111 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
             ]),
         )),
     }
+}
+
+fn exec_via_reverse_broker(
+    runner: &Runner,
+    broker_url: &str,
+    cwd: String,
+    project_id: Option<String>,
+    command: Vec<String>,
+    env: HashMap<String, String>,
+    capture_patch: bool,
+    source_snapshot_override: Option<SourceSnapshot>,
+) -> Result<(RunnerExecOutput, i32)> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|err| Error::internal_unexpected(format!("build broker HTTP client: {err}")))?;
+    let source_snapshot = source_snapshot_override.unwrap_or_else(|| {
+        SourceSnapshot::existing_remote(&runner.id, &cwd, runner.workspace_root.as_deref())
+    });
+    let request = RemoteRunnerJobRequest {
+        runner_id: runner.id.clone(),
+        project_id,
+        operation: "runner.exec".to_string(),
+        command: command.clone(),
+        cwd: Some(cwd.clone()),
+        env,
+        capture_patch,
+        source_snapshot: Some(source_snapshot.clone()),
+        metadata: Some(json!({
+            "transport": "reverse_broker",
+        })),
+    };
+    let data = daemon_post(
+        &client,
+        broker_url,
+        "/runner/jobs",
+        serde_json::to_value(&request).map_err(|err| {
+            Error::internal_json(
+                err.to_string(),
+                Some("serialize reverse runner job request".to_string()),
+            )
+        })?,
+        "submit reverse runner job",
+    )?;
+    let body = data.get("body").unwrap_or(&data);
+    let job_value = body
+        .get("job")
+        .ok_or_else(|| Error::internal_unexpected("reverse broker submit returned no job"))?;
+    let mut job: Job = serde_json::from_value(job_value.clone()).map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("parse reverse broker job".to_string()),
+        )
+    })?;
+
+    let deadline = Instant::now() + Duration::from_secs(60 * 60);
+    while !matches!(
+        job.status,
+        JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
+    ) {
+        if Instant::now() >= deadline {
+            return Err(Error::internal_unexpected(format!(
+                "reverse runner job {} did not finish before timeout",
+                job.id
+            )));
+        }
+        std::thread::sleep(Duration::from_millis(200));
+        job = fetch_daemon_job(&client, broker_url, &job.id.to_string())?;
+    }
+    let events = fetch_daemon_events(&client, broker_url, &job.id.to_string())?;
+
+    let result = result_event_data(&events).unwrap_or_else(|| json!({}));
+    let stdout = string_field(&result, "stdout");
+    let stderr = string_field(&result, "stderr");
+    let exit_code = result
+        .get("exit_code")
+        .and_then(Value::as_i64)
+        .and_then(|code| i32::try_from(code).ok())
+        .unwrap_or_else(|| {
+            if job.status == JobStatus::Succeeded {
+                0
+            } else {
+                1
+            }
+        });
+
+    Ok((
+        RunnerExecOutput {
+            command: "runner.exec",
+            runner_id: runner.id.clone(),
+            mode: RunnerExecMode::ReverseBroker,
+            argv: command,
+            remote_cwd: cwd,
+            exit_code,
+            stdout,
+            stderr,
+            source_snapshot: Some(source_snapshot),
+            job_id: Some(job.id.to_string()),
+            job: Some(job),
+            job_events: Some(events),
+            mirror_run_id: None,
+            patch: None,
+        },
+        exit_code,
+    ))
 }
 
 fn exec_via_daemon(
@@ -287,6 +407,33 @@ fn daemon_get(client: &Client, local_url: &str, path: &str) -> Result<Value> {
         Error::internal_json(err.to_string(), Some("parse daemon response".to_string()))
     })?;
     if !envelope.success {
+        return Err(Error::internal_unexpected(format!(
+            "daemon request failed: {}",
+            envelope.error.unwrap_or(Value::Null)
+        )));
+    }
+    envelope
+        .data
+        .ok_or_else(|| Error::internal_unexpected("daemon response missing data"))
+}
+
+fn daemon_post(
+    client: &Client,
+    local_url: &str,
+    path: &str,
+    body: Value,
+    action: &str,
+) -> Result<Value> {
+    let response = client
+        .post(format!("{}{}", local_url.trim_end_matches('/'), path))
+        .json(&body)
+        .send()
+        .map_err(|err| Error::internal_unexpected(format!("{action}: {err}")))?;
+    let status_code = response.status().as_u16();
+    let envelope: DaemonEnvelope = response.json().map_err(|err| {
+        Error::internal_json(err.to_string(), Some("parse daemon response".to_string()))
+    })?;
+    if status_code >= 400 || !envelope.success {
         return Err(Error::internal_unexpected(format!(
             "daemon request failed: {}",
             envelope.error.unwrap_or(Value::Null)
@@ -709,6 +856,95 @@ mod tests {
             let err = daemon_api_get("lab-local", "/runs").expect_err("requires daemon");
             assert_eq!(err.code.as_str(), "validation.invalid_argument");
             assert!(err.message.contains("connected to a daemon"));
+        });
+    }
+
+    #[test]
+    fn reverse_broker_exec_submits_job_and_polls_result() {
+        crate::test_support::with_isolated_home(|_| {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+            let addr = listener.local_addr().expect("addr");
+            drop(listener);
+            std::thread::spawn(move || {
+                let _ = crate::core::daemon::serve(addr);
+            });
+            for _ in 0..100 {
+                if std::net::TcpStream::connect(addr).is_ok() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            let broker_url = format!("http://{addr}");
+            let worker_broker_url = broker_url.clone();
+            let worker = std::thread::spawn(move || {
+                let client = Client::builder()
+                    .timeout(Duration::from_secs(10))
+                    .build()
+                    .expect("client");
+                let claim = loop {
+                    let response: Value = client
+                        .post(format!("{}/runner/jobs/claim", worker_broker_url))
+                        .json(&json!({
+                            "runner_id": "lab",
+                            "lease_ms": 30_000,
+                        }))
+                        .send()
+                        .expect("claim response")
+                        .json()
+                        .expect("claim json");
+                    let claim = response["data"]["body"]["claim"].clone();
+                    if !claim.is_null() {
+                        break claim;
+                    }
+                    std::thread::sleep(Duration::from_millis(20));
+                };
+                let job_id = claim["job"]["id"].as_str().expect("job id").to_string();
+                client
+                    .post(format!("{}/runner/jobs/{job_id}/events", worker_broker_url))
+                    .json(&json!({
+                        "runner_id": "lab",
+                        "kind": "progress",
+                        "message": "running test worker"
+                    }))
+                    .send()
+                    .expect("event response");
+                client
+                    .post(format!("{}/runner/jobs/{job_id}/finish", worker_broker_url))
+                    .json(&json!({
+                        "runner_id": "lab",
+                        "result": {
+                            "exit_code": 0,
+                            "stdout": "reverse ok",
+                            "stderr": ""
+                        }
+                    }))
+                    .send()
+                    .expect("finish response");
+            });
+
+            let (output, exit_code) = exec_via_reverse_broker(
+                &ssh_runner(),
+                &broker_url,
+                "/srv/homeboy/project".to_string(),
+                Some("extrachill".to_string()),
+                vec!["homeboy".to_string(), "test".to_string()],
+                Default::default(),
+                false,
+                None,
+            )
+            .expect("reverse broker exec");
+            worker.join().expect("worker joins");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(output.mode, RunnerExecMode::ReverseBroker);
+            assert_eq!(output.stdout, "reverse ok");
+            assert_eq!(output.runner_id, "lab");
+            assert!(output.job_id.is_some());
+            assert!(output
+                .job_events
+                .expect("events")
+                .iter()
+                .any(|event| { event.kind == crate::core::api_jobs::JobEventKind::Progress }));
         });
     }
 }

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -330,6 +330,49 @@ fn routes_remote_runner_job_broker_lifecycle() {
 }
 
 #[test]
+fn routes_remote_runner_session_registration() {
+    let _home = HomeGuard::new();
+    crate::core::runner::create(
+        r#"{"id":"homeboy-lab","kind":"local","workspace_root":"/home/chubes/Developer"}"#,
+        false,
+    )
+    .expect("create runner");
+    let store = JobStore::default();
+
+    let response = route_with_job_store_and_body(
+        "POST",
+        "/runner/sessions",
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "controller_id": "extra-chill",
+            "broker_url": "http://127.0.0.1:49152",
+            "homeboy_version": "test-version"
+        })),
+        &store,
+    );
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.body["endpoint"], "runner.sessions.register");
+    assert_eq!(
+        response.body["body"]["session"]["role"],
+        serde_json::json!("controller")
+    );
+
+    let status = crate::core::runner::status("homeboy-lab").expect("runner status");
+    assert!(status.connected);
+    assert_eq!(
+        status.state,
+        crate::core::runner::RunnerSessionState::Connected
+    );
+    let session = status.session.expect("session");
+    assert_eq!(session.controller_id.as_deref(), Some("extra-chill"));
+    assert_eq!(
+        session.broker_url.as_deref(),
+        Some("http://127.0.0.1:49152")
+    );
+}
+
+#[test]
 fn routes_json_body_to_analysis_enqueue() {
     let store = JobStore::default();
     let response = route_with_job_store_and_body(


### PR DESCRIPTION
## Summary
- Register reverse runner sessions through the controller daemon broker so controller-side status can see reverse runners as connected.
- Route `runner exec` through brokered remote-runner jobs when a connected reverse session has a broker URL.
- Cover broker session registration and reverse broker exec polling with tests, and document the session registration endpoint.

Refs #2944.

## Verification
- `cargo fmt --check`
- `cargo test core::runner::connection::tests::records_reverse_runner_session_without_marking_transport_live --all-targets`
- `cargo test core::daemon::daemon_test::routes_remote_runner_session_registration --all-targets`
- `cargo test core::runner::execution::tests::reverse_broker_exec_submits_job_and_polls_result --all-targets`
- `cargo test core::daemon --all-targets`
- `cargo test core::runner --all-targets`
- `cargo test --all-targets`
- `git diff --check`
- `homeboy audit --force-hot --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the reverse runner session registration, brokered exec routing, tests, docs, and verification loop; Chris remains responsible for review and merge.