### PR TITLE
Add reverse runner worker

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -137,6 +137,23 @@ The broker exposes `POST /runner/jobs`, `POST /runner/jobs/claim`,
 controllers can queue work and reverse runners can claim, stream progress, and
 return results without inbound access to the lab machine.
 
+### `work`
+
+```sh
+homeboy runner work <runner-id> --broker-url <url>
+homeboy runner work <runner-id> --broker-url <url> --project extrachill --lease-ms 30000
+```
+
+Claims one brokered reverse-runner job for the runner, executes it on the runner
+machine under the runner's local policy, streams a progress event, and finishes
+the broker job with stdout, stderr, and exit code. This is the runner-side half
+of reverse `runner exec`; it uses outbound HTTP from the lab to the controller
+broker and does not require inbound SSH or a public listening port on the lab.
+
+The command exits `0` when no job is available, with `claimed: false` in the JSON
+payload. When a job is claimed, the process exit code matches the executed
+command's exit code.
+
 ### `status`
 
 ```sh

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -5,8 +5,9 @@ use serde::Serialize;
 use serde_json::Value;
 
 use homeboy::core::runner::{
-    self, ReverseRunnerConnectOptions, Runner, RunnerConnectReport, RunnerDisconnectReport,
-    RunnerExecOutput, RunnerKind, RunnerStatusReport,
+    self, ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput,
+    Runner, RunnerConnectReport, RunnerDisconnectReport, RunnerExecOutput, RunnerKind,
+    RunnerStatusReport,
 };
 use homeboy::core::server::{RunnerPolicy, RunnerSettings};
 use homeboy::core::{EntityCrudOutput, MergeOutput};
@@ -43,6 +44,7 @@ pub enum RunnerCommandOutput {
     Registry(RunnerOutput),
     Doctor(doctor::RunnerDoctorOutput),
     Execution(RunnerExecOutput),
+    Worker(ReverseRunnerWorkerOutput),
     Workspace(workspace::RunnerWorkspaceOutput),
 }
 
@@ -264,6 +266,23 @@ enum RunnerCommand {
         #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
         command: Vec<String>,
     },
+    /// Claim and execute one brokered reverse-runner job from this machine
+    Work {
+        /// Runner ID on this machine
+        runner_id: String,
+
+        /// Controller/broker daemon URL
+        #[arg(long)]
+        broker_url: String,
+
+        /// Optional project filter for claimed jobs
+        #[arg(long)]
+        project: Option<String>,
+
+        /// Claim lease duration in milliseconds
+        #[arg(long, default_value_t = 30_000)]
+        lease_ms: u64,
+    },
     /// Materialize local workspaces on a configured runner
     Workspace {
         #[command(subcommand)]
@@ -404,6 +423,17 @@ pub fn run(
             capture_patch,
             command,
         } => map_execution(exec(&id, cwd, project, ssh, capture_patch, command)),
+        RunnerCommand::Work {
+            runner_id,
+            broker_url,
+            project,
+            lease_ms,
+        } => map_worker(runner::run_reverse_worker(ReverseRunnerWorkerOptions {
+            runner_id,
+            broker_url,
+            project_id: project,
+            lease_ms,
+        })),
         RunnerCommand::Workspace { command } => workspace::run(command)
             .map(|(output, exit_code)| (RunnerCommandOutput::Workspace(output), exit_code)),
     }
@@ -438,6 +468,10 @@ fn map_doctor(result: CmdResult<doctor::RunnerDoctorOutput>) -> CmdResult<Runner
 
 fn map_execution(result: CmdResult<RunnerExecOutput>) -> CmdResult<RunnerCommandOutput> {
     result.map(|(output, exit_code)| (RunnerCommandOutput::Execution(output), exit_code))
+}
+
+fn map_worker(result: CmdResult<ReverseRunnerWorkerOutput>) -> CmdResult<RunnerCommandOutput> {
+    result.map(|(output, exit_code)| (RunnerCommandOutput::Worker(output), exit_code))
 }
 
 struct RunnerAddInput {

--- a/src/core/code_audit/baseline.rs
+++ b/src/core/code_audit/baseline.rs
@@ -146,7 +146,7 @@ pub fn save_baseline_scoped(
 ///
 /// Audit fingerprints have the format `convention::file::kind`.
 /// The file path is the middle segment between the first `::` and the last `::`.
-fn file_from_audit_fingerprint(fingerprint: &str) -> Option<String> {
+pub fn file_from_audit_fingerprint(fingerprint: &str) -> Option<String> {
     let first = fingerprint.find("::")?;
     let rest = &fingerprint[first + 2..];
     let last = rest.rfind("::")?;

--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -342,7 +342,18 @@ fn build_comparison_output(
     existing_baseline: baseline::AuditBaseline,
     args: &AuditRunWorkflowArgs,
 ) -> crate::core::Result<AuditRunWorkflowResult> {
-    let comparison = baseline::compare(&result, &existing_baseline);
+    let mut comparison = baseline::compare(&result, &existing_baseline);
+    if let Some(ref git_ref) = args.changed_since {
+        let changed =
+            git::get_files_changed_since(&args.source_path, git_ref).unwrap_or_else(|_| {
+                result
+                    .findings
+                    .iter()
+                    .map(|finding| finding.file.clone())
+                    .collect()
+            });
+        retain_new_items_for_changed_files(&mut comparison, &changed);
+    }
     let exit_code = if comparison.drift_increased { 1 } else { 0 };
     let changed_since_summary = args
         .changed_since
@@ -410,6 +421,19 @@ fn build_comparison_output(
             findings,
         })
     }
+}
+
+fn retain_new_items_for_changed_files(
+    comparison: &mut baseline::BaselineComparison,
+    changed_files: &[String],
+) {
+    let changed_files: HashSet<&str> = changed_files.iter().map(String::as_str).collect();
+
+    comparison.new_items.retain(|item| {
+        baseline::file_from_audit_fingerprint(&item.fingerprint)
+            .is_some_and(|file| changed_files.contains(file.as_str()))
+    });
+    comparison.drift_increased = !comparison.new_items.is_empty();
 }
 
 fn compute_fixability_if_requested(

--- a/src/core/runner/broker_http.rs
+++ b/src/core/runner/broker_http.rs
@@ -1,0 +1,39 @@
+use reqwest::blocking::Client;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::core::error::{Error, Result};
+
+#[derive(Debug, Deserialize)]
+struct BrokerEnvelope {
+    success: bool,
+    data: Option<Value>,
+    error: Option<Value>,
+}
+
+pub(crate) fn post_json(
+    client: &Client,
+    base_url: &str,
+    path: &str,
+    body: Value,
+    action: &str,
+) -> Result<Value> {
+    let response = client
+        .post(format!("{}{}", base_url.trim_end_matches('/'), path))
+        .json(&body)
+        .send()
+        .map_err(|err| Error::internal_unexpected(format!("{action}: {err}")))?;
+    let status_code = response.status().as_u16();
+    let envelope: BrokerEnvelope = response.json().map_err(|err| {
+        Error::internal_json(err.to_string(), Some("parse broker response".to_string()))
+    })?;
+    if status_code >= 400 || !envelope.success {
+        return Err(Error::internal_unexpected(format!(
+            "broker request failed: {}",
+            envelope.error.unwrap_or(Value::Null)
+        )));
+    }
+    envelope
+        .data
+        .ok_or_else(|| Error::internal_unexpected("broker response missing data"))
+}

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -11,6 +11,7 @@ use crate::core::error::{Error, Result};
 use crate::core::server::{self, SshClient};
 use crate::core::source_snapshot::SourceSnapshot;
 
+use super::broker_http;
 use super::capabilities::{runner_capability_snapshot, validate_runner_capability_preflight};
 use super::evidence::mirror_daemon_evidence;
 use super::{load, status, Runner, RunnerCapabilityPreflight, RunnerKind, RunnerTunnelMode};
@@ -184,7 +185,7 @@ fn exec_via_reverse_broker(
             "transport": "reverse_broker",
         })),
     };
-    let data = daemon_post(
+    let data = broker_http::post_json(
         &client,
         broker_url,
         "/runner/jobs",
@@ -407,33 +408,6 @@ fn daemon_get(client: &Client, local_url: &str, path: &str) -> Result<Value> {
         Error::internal_json(err.to_string(), Some("parse daemon response".to_string()))
     })?;
     if !envelope.success {
-        return Err(Error::internal_unexpected(format!(
-            "daemon request failed: {}",
-            envelope.error.unwrap_or(Value::Null)
-        )));
-    }
-    envelope
-        .data
-        .ok_or_else(|| Error::internal_unexpected("daemon response missing data"))
-}
-
-fn daemon_post(
-    client: &Client,
-    local_url: &str,
-    path: &str,
-    body: Value,
-    action: &str,
-) -> Result<Value> {
-    let response = client
-        .post(format!("{}{}", local_url.trim_end_matches('/'), path))
-        .json(&body)
-        .send()
-        .map_err(|err| Error::internal_unexpected(format!("{action}: {err}")))?;
-    let status_code = response.status().as_u16();
-    let envelope: DaemonEnvelope = response.json().map_err(|err| {
-        Error::internal_json(err.to_string(), Some("parse daemon response".to_string()))
-    })?;
-    if status_code >= 400 || !envelope.success {
         return Err(Error::internal_unexpected(format!(
             "daemon request failed: {}",
             envelope.error.unwrap_or(Value::Null)

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -10,6 +10,7 @@ use crate::core::output::{BatchResult, CreateOutput, CreateResult, MergeOutput, 
 use crate::core::server::{self, RunnerPolicy, RunnerSettings, ServerRunner};
 
 mod apply;
+mod broker_http;
 mod capabilities;
 mod connection;
 mod evidence;
@@ -18,6 +19,7 @@ mod lab;
 mod offload_changed_since;
 mod offload_metadata;
 mod session;
+mod worker;
 mod workspace;
 
 pub use apply::{
@@ -49,6 +51,7 @@ pub use session::{
     ReverseRunnerConnectOptions, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
     RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStatusReport, RunnerTunnelMode,
 };
+pub use worker::{run_reverse_worker, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput};
 pub use workspace::{
     sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };

--- a/src/core/runner/worker.rs
+++ b/src/core/runner/worker.rs
@@ -1,0 +1,390 @@
+use std::time::Duration;
+
+use reqwest::blocking::Client;
+use serde::Serialize;
+use serde_json::json;
+
+use crate::core::api_jobs::{Job, RemoteRunnerJobClaim, RemoteRunnerJobResult};
+use crate::core::error::{Error, Result};
+
+use super::broker_http;
+use super::execution::{exec, RunnerExecOptions};
+
+#[derive(Debug, Clone)]
+pub struct ReverseRunnerWorkerOptions {
+    pub runner_id: String,
+    pub broker_url: String,
+    pub project_id: Option<String>,
+    pub lease_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ReverseRunnerWorkerOutput {
+    pub command: &'static str,
+    pub runner_id: String,
+    pub broker_url: String,
+    pub claimed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job: Option<Job>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+}
+
+pub fn run_reverse_worker(
+    options: ReverseRunnerWorkerOptions,
+) -> Result<(ReverseRunnerWorkerOutput, i32)> {
+    if options.runner_id.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "runner_id",
+            "reverse runner worker requires a runner id",
+            None,
+            None,
+        ));
+    }
+    if options.broker_url.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "broker_url",
+            "reverse runner worker requires a broker URL",
+            None,
+            None,
+        ));
+    }
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|err| Error::internal_unexpected(format!("build broker HTTP client: {err}")))?;
+    let claim = claim_job(&client, &options)?;
+    let Some(claim) = claim else {
+        return Ok((
+            ReverseRunnerWorkerOutput {
+                command: "runner.work",
+                runner_id: options.runner_id,
+                broker_url: options.broker_url,
+                claimed: false,
+                job: None,
+                exit_code: None,
+            },
+            0,
+        ));
+    };
+
+    append_progress(&client, &options.broker_url, &options.runner_id, &claim.job)?;
+    let (exec_output, exit_code) = exec(
+        &options.runner_id,
+        RunnerExecOptions {
+            cwd: claim.request.cwd.clone(),
+            project_id: claim.request.project_id.clone(),
+            allow_ssh: false,
+            command: claim.request.command.clone(),
+            env: claim.request.env.clone(),
+            capture_patch: claim.request.capture_patch,
+            raw_exec: false,
+            source_snapshot: claim.request.source_snapshot.clone(),
+            capability_preflight: None,
+        },
+    )?;
+    let job = finish_job(
+        &client,
+        &options.broker_url,
+        &options.runner_id,
+        &claim.job,
+        RemoteRunnerJobResult {
+            exit_code,
+            stdout: Some(exec_output.stdout),
+            stderr: Some(exec_output.stderr),
+            data: Some(json!({
+                "mode": exec_output.mode,
+                "remote_cwd": exec_output.remote_cwd,
+            })),
+            artifacts: Vec::new(),
+        },
+    )?;
+
+    Ok((
+        ReverseRunnerWorkerOutput {
+            command: "runner.work",
+            runner_id: options.runner_id,
+            broker_url: options.broker_url,
+            claimed: true,
+            job: Some(job),
+            exit_code: Some(exit_code),
+        },
+        exit_code,
+    ))
+}
+
+fn claim_job(
+    client: &Client,
+    options: &ReverseRunnerWorkerOptions,
+) -> Result<Option<RemoteRunnerJobClaim>> {
+    let data = broker_http::post_json(
+        client,
+        &options.broker_url,
+        "/runner/jobs/claim",
+        json!({
+            "runner_id": options.runner_id,
+            "project_id": options.project_id,
+            "lease_ms": options.lease_ms.max(1),
+        }),
+        "claim reverse runner job",
+    )?;
+    let claim = data["body"]["claim"].clone();
+    if claim.is_null() {
+        return Ok(None);
+    }
+    serde_json::from_value(claim).map(Some).map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("parse reverse runner job claim".to_string()),
+        )
+    })
+}
+
+fn append_progress(client: &Client, broker_url: &str, runner_id: &str, job: &Job) -> Result<()> {
+    broker_http::post_json(
+        client,
+        broker_url,
+        &format!("/runner/jobs/{}/events", job.id),
+        json!({
+            "runner_id": runner_id,
+            "kind": "progress",
+            "message": "reverse runner worker started execution",
+        }),
+        "append reverse runner progress event",
+    )?;
+    Ok(())
+}
+
+fn finish_job(
+    client: &Client,
+    broker_url: &str,
+    runner_id: &str,
+    job: &Job,
+    result: RemoteRunnerJobResult,
+) -> Result<Job> {
+    let data = broker_http::post_json(
+        client,
+        broker_url,
+        &format!("/runner/jobs/{}/finish", job.id),
+        json!({
+            "runner_id": runner_id,
+            "result": result,
+        }),
+        "finish reverse runner job",
+    )?;
+    serde_json::from_value(data["body"]["job"].clone()).map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("parse finished reverse runner job".to_string()),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+
+    use super::*;
+    use crate::core::api_jobs::{JobEventKind, JobStatus, JobStore, RemoteRunnerJobRequest};
+    use crate::core::server::RunnerPolicy;
+    use crate::test_support;
+    use serde_json::Value;
+
+    #[test]
+    fn reverse_worker_executes_claimed_job_and_finishes_it() {
+        test_support::with_isolated_home(|_| {
+            crate::core::runner::create(
+                r#"{"id":"lab","kind":"local","workspace_root":"/tmp"}"#,
+                false,
+            )
+            .expect("create runner");
+            crate::core::runner::merge(
+                Some("lab"),
+                &serde_json::json!({
+                    "policy": RunnerPolicy {
+                        allow_raw_exec: Some(true),
+                        workspace_roots: vec!["/tmp".to_string()],
+                        allowed_commands: vec!["sh".to_string()],
+                        ..Default::default()
+                    }
+                })
+                .to_string(),
+                &[],
+            )
+            .expect("set policy");
+            let store = JobStore::default();
+            store
+                .submit_remote_runner_job(RemoteRunnerJobRequest {
+                    runner_id: "lab".to_string(),
+                    project_id: None,
+                    operation: "runner.exec".to_string(),
+                    command: vec![
+                        "sh".to_string(),
+                        "-c".to_string(),
+                        "printf worker-ok".to_string(),
+                    ],
+                    cwd: Some("/tmp".to_string()),
+                    env: Default::default(),
+                    capture_patch: false,
+                    source_snapshot: None,
+                    metadata: None,
+                })
+                .expect("submit job");
+            let (broker_url, handle) = spawn_mock_broker(store.clone(), 3);
+
+            let (output, exit_code) = run_reverse_worker(ReverseRunnerWorkerOptions {
+                runner_id: "lab".to_string(),
+                broker_url: broker_url.clone(),
+                project_id: None,
+                lease_ms: 30_000,
+            })
+            .expect("run worker");
+
+            assert_eq!(exit_code, 0);
+            assert!(output.claimed);
+            let job = output.job.expect("job");
+            assert_eq!(job.status, JobStatus::Succeeded);
+            handle.join().expect("mock broker joins");
+            let events = store.events(job.id).expect("events");
+            assert!(events.iter().any(|event| {
+                event.kind == JobEventKind::Result
+                    && event.data.as_ref().expect("result data")["stdout"]
+                        == serde_json::json!("worker-ok")
+            }));
+        });
+    }
+
+    fn spawn_mock_broker(
+        store: JobStore,
+        expected_requests: usize,
+    ) -> (String, std::thread::JoinHandle<()>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let addr = listener.local_addr().expect("addr");
+        let handle = std::thread::spawn(move || {
+            for _ in 0..expected_requests {
+                let (mut stream, _) = listener.accept().expect("accept request");
+                let request = read_request(&mut stream);
+                let response = handle_request(&store, &request);
+                write_response(&mut stream, response);
+            }
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    struct MockRequest {
+        path: String,
+        body: Value,
+    }
+
+    fn read_request(stream: &mut std::net::TcpStream) -> MockRequest {
+        let mut buffer = Vec::new();
+        let mut temp = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut temp).expect("read request");
+            assert_ne!(read, 0, "request closed before headers");
+            buffer.extend_from_slice(&temp[..read]);
+            if let Some(index) = find_header_end(&buffer) {
+                break index;
+            }
+        };
+        let headers = String::from_utf8_lossy(&buffer[..header_end]).to_string();
+        let path = headers
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .expect("request path")
+            .to_string();
+        let content_length = headers
+            .lines()
+            .find_map(|line| line.strip_prefix("content-length: "))
+            .or_else(|| {
+                headers
+                    .lines()
+                    .find_map(|line| line.strip_prefix("Content-Length: "))
+            })
+            .and_then(|value| value.trim().parse::<usize>().ok())
+            .unwrap_or(0);
+        let body_start = header_end + 4;
+        while buffer.len() < body_start + content_length {
+            let read = stream.read(&mut temp).expect("read body");
+            assert_ne!(read, 0, "request closed before body");
+            buffer.extend_from_slice(&temp[..read]);
+        }
+        let body = if content_length == 0 {
+            Value::Null
+        } else {
+            serde_json::from_slice(&buffer[body_start..body_start + content_length])
+                .expect("request json")
+        };
+        MockRequest { path, body }
+    }
+
+    fn find_header_end(buffer: &[u8]) -> Option<usize> {
+        buffer.windows(4).position(|window| window == b"\r\n\r\n")
+    }
+
+    fn handle_request(store: &JobStore, request: &MockRequest) -> Value {
+        if request.path == "/runner/jobs/claim" {
+            let claim = store
+                .claim_remote_runner_job("lab", None, 30_000)
+                .expect("claim job");
+            return serde_json::json!({
+                "success": true,
+                "data": { "body": { "claim": claim } }
+            });
+        }
+        if let Some(job_id) = request
+            .path
+            .strip_prefix("/runner/jobs/")
+            .and_then(|tail| tail.strip_suffix("/events"))
+        {
+            let job_id = uuid::Uuid::parse_str(job_id).expect("event job id");
+            let event = store
+                .append_remote_runner_event(
+                    job_id,
+                    "lab",
+                    JobEventKind::Progress,
+                    request.body["message"].as_str().map(ToString::to_string),
+                    None,
+                )
+                .expect("append event");
+            return serde_json::json!({
+                "success": true,
+                "data": { "body": { "event": event } }
+            });
+        }
+        if let Some(job_id) = request
+            .path
+            .strip_prefix("/runner/jobs/")
+            .and_then(|tail| tail.strip_suffix("/finish"))
+        {
+            let job_id = uuid::Uuid::parse_str(job_id).expect("finish job id");
+            let result: RemoteRunnerJobResult =
+                serde_json::from_value(request.body["result"].clone()).expect("finish result");
+            let job = store
+                .finish_remote_runner_job(job_id, "lab", result)
+                .expect("finish job");
+            return serde_json::json!({
+                "success": true,
+                "data": { "body": { "job": job } }
+            });
+        }
+        serde_json::json!({
+            "success": false,
+            "error": { "message": "unknown mock path" }
+        })
+    }
+
+    fn write_response(stream: &mut std::net::TcpStream, body: Value) {
+        let body = body.to_string();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write response");
+    }
+}


### PR DESCRIPTION
## Summary
- Add one-shot reverse runner worker command for claiming brokered jobs over outbound HTTP
- Share broker JSON POST handling between brokered exec and the worker
- Tighten changed-since audit comparison so unrelated contextual findings do not block scoped ratchets
- Document runner work usage and exit behavior

Refs #2944

## Verification
- cargo fmt --check
- cargo test core::runner::worker::tests::reverse_worker_executes_claimed_job_and_finishes_it --all-targets
- cargo test core::runner --all-targets
- cargo test --test command_surface_test --all-targets
- cargo test --all-targets
- target/debug/homeboy audit --force-hot --changed-since origin/main
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the reverse worker implementation, tests, docs, and verification updates for Chris to review and validate.