### PR TITLE
feat: render VPS broker deployment config

### DIFF
--- a/docs/architecture/headless-daemon-api.md
+++ b/docs/architecture/headless-daemon-api.md
@@ -64,8 +64,8 @@ does not need inbound ports:
 VPS systemd service
   homeboy daemon serve --addr 127.0.0.1:7421
           |
-          +-- ~/.config/homeboy/daemon/state.json
-          +-- ~/.config/homeboy/daemon/jobs.json
+          +-- /var/lib/homeboy/.config/homeboy/daemon/state.json
+          +-- /var/lib/homeboy/.config/homeboy/daemon/jobs.json
           |
 private tunnel / private network only
           |
@@ -123,11 +123,11 @@ safe for runners to mirror as evidence. The final result event carries the same
 structured result shape as the corresponding CLI command, including artifacts,
 findings, summaries, and CI context when a CI profile/job selector was used.
 
-The daemon durable job store is `~/.config/homeboy/daemon/jobs.json` for the
-account running the daemon. The store keeps bounded per-job events and supports
-restart recovery for queued broker jobs. It is operational state, not a durable
-audit archive; important evidence should still be persisted as Homeboy
-observations or artifacts.
+The packaged broker service sets `HOME=/var/lib/homeboy`, so the daemon durable
+job store is `/var/lib/homeboy/.config/homeboy/daemon/jobs.json`. The store keeps
+bounded per-job events and supports restart recovery for queued broker jobs. It
+is operational state, not a durable audit archive; important evidence should
+still be persisted as Homeboy observations or artifacts.
 
 Restart behavior:
 

--- a/docs/architecture/headless-daemon-api.md
+++ b/docs/architecture/headless-daemon-api.md
@@ -4,6 +4,12 @@ Homeboy is CLI-first, but the daemon is the stable local UI and automation
 surface for clients that should not shell out and parse terminal output. The
 daemon remains a local Homeboy engine, not a hosted control plane.
 
+For reverse runner work, a VPS can run the daemon as a broker service while
+still keeping the daemon itself on loopback. Use `homeboy daemon broker-config`
+to render the `systemd` unit and private tunnel/proxy scaffolding. Public broker
+exposure remains blocked until the broker auth/pairing work in
+[#2990](https://github.com/Extra-Chill/homeboy/issues/2990) lands.
+
 ## Scope
 
 The daemon owns a loopback-only HTTP contract for:
@@ -13,6 +19,18 @@ The daemon owns a loopback-only HTTP contract for:
 - long-running lint, test, audit, and bench jobs
 - structured job events and final results
 - future mutating operations behind explicit capabilities and confirmations
+
+Reverse runner broker routes add a private controller/runner job exchange:
+
+- `POST /runner/sessions` for runner-initiated session registration
+- `POST /runner/jobs` for the controller to enqueue work
+- `POST /runner/jobs/claim` for a reverse runner to claim queued work
+- `POST /runner/jobs/:id/events` for runner progress events
+- `POST /runner/jobs/:id/finish` for terminal runner results
+
+These routes are not safe as an unauthenticated public service. Until #2990 is
+available, deploy them only on loopback plus private SSH/VPN/Zero Trust tunnel
+access.
 
 The CLI remains usable without the daemon. Daemon routes reuse Homeboy core and
 command adapters so desktop, web, agent, and CLI workflows do not fork product
@@ -29,7 +47,7 @@ homeboy daemon start
         +-- binds 127.0.0.1:<port>
         +-- writes pid/address/token metadata to the daemon state file
         |
-homeboy daemon status --format=json
+homeboy daemon status
         |
         +-- returns the current loopback address and process state
 ```
@@ -37,6 +55,29 @@ homeboy daemon status --format=json
 Remote runner clients use `homeboy runner connect <runner-id>` to create an SSH
 loopback tunnel to a runner daemon. The client still talks to a local loopback
 URL; Homeboy owns the SSH tunnel and rejects non-loopback daemon addresses.
+
+Reverse runners invert that flow. The controller/VPS runs `homeboy daemon serve`
+as a loopback broker, and the lab connects out to a private broker URL so the lab
+does not need inbound ports:
+
+```text
+VPS systemd service
+  homeboy daemon serve --addr 127.0.0.1:7421
+          |
+          +-- ~/.config/homeboy/daemon/state.json
+          +-- ~/.config/homeboy/daemon/jobs.json
+          |
+private tunnel / private network only
+          |
+Homeboy Lab reverse runner
+  POST /runner/sessions
+  POST /runner/jobs/claim
+  POST /runner/jobs/:id/events
+  POST /runner/jobs/:id/finish
+```
+
+Use `homeboy daemon broker-config` on the target VPS to render the
+service unit, proxy snippets, safe exposure state, and operational commands.
 
 ## Minimum Dashboard Surface
 
@@ -81,6 +122,19 @@ Events are append-only records. They are safe for UIs to render incrementally an
 safe for runners to mirror as evidence. The final result event carries the same
 structured result shape as the corresponding CLI command, including artifacts,
 findings, summaries, and CI context when a CI profile/job selector was used.
+
+The daemon durable job store is `~/.config/homeboy/daemon/jobs.json` for the
+account running the daemon. The store keeps bounded per-job events and supports
+restart recovery for queued broker jobs. It is operational state, not a durable
+audit archive; important evidence should still be persisted as Homeboy
+observations or artifacts.
+
+Restart behavior:
+
+- queued remote-runner jobs stay queued across daemon restart
+- broker-owned running jobs are marked failed as stale when the store is reopened
+- active reverse-runner claims remain lease-scoped until expiry
+- runners should retry claim after lease expiry when the broker restarts mid-job
 
 ## Client Replacement Order
 
@@ -147,6 +201,7 @@ another.
 ## Default-Deny Rules
 
 - Bind to loopback by default.
+- Keep VPS broker services on a stable loopback port and expose them only through private tunnels until broker auth/pairing lands.
 - Treat daemon tokens/capabilities as local secrets.
 - Reject mutating routes until they declare required capabilities.
 - Require preview/apply for high-risk writes.

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -14,6 +14,7 @@ homeboy daemon <COMMAND>
 - `serve` — run the daemon in the foreground
 - `stop` — stop the background daemon recorded in the state file
 - `status` — show daemon state and selected local address
+- `broker-config` — render a deployable reverse-runner broker service recipe
 
 ## Local HTTP API
 
@@ -23,6 +24,49 @@ address and PID to the daemon state file so headless clients can discover it via
 
 Always treat the API as a local UI contract. It is not a hosted or remote
 multi-user service.
+
+## VPS Reverse Runner Broker
+
+`homeboy daemon broker-config` renders the code-backed deployment shape for a
+VPS-hosted reverse runner broker. The safe default is a durable `systemd`
+service that keeps the daemon on a stable loopback port:
+
+```sh
+homeboy daemon broker-config --listen-addr 127.0.0.1:7421
+```
+
+The JSON output includes:
+
+- `systemd_unit` for a `homeboy-broker` service running `homeboy daemon serve`
+- `private_tunnel_examples` for SSH, Cloudflare, or tailnet-only access
+- optional `nginx_site` and `caddy_site` snippets when `--domain` is supplied
+- `daemon_state_path` and `daemon_jobs_path` operational state locations
+- status and log commands for day-two operations
+- restart, retention, and claim caveats
+
+The service config intentionally requires a stable loopback address. Broker
+routes are currently suitable for private loopback or private tunnel access only.
+Public Internet exposure through Nginx or Caddy is blocked until broker
+auth/pairing from [#2990](https://github.com/Extra-Chill/homeboy/issues/2990)
+lands. The rendered proxy snippets include that warning and should stay disabled
+or protected by private network controls until the auth model is available.
+
+Extra Chill-compatible private setup:
+
+1. Install Homeboy on the VPS at the binary path used in `broker-config`.
+2. Create the service user/group named in the generated output.
+3. Install the rendered `systemd_unit` as `/etc/systemd/system/homeboy-broker.service`.
+4. Run `systemctl daemon-reload && systemctl enable --now homeboy-broker`.
+5. Verify with `systemctl status homeboy-broker`, `homeboy daemon status`, and `curl -fsS http://127.0.0.1:7421/health` on the VPS.
+6. Reach the broker from Homeboy Lab through a private SSH tunnel or private network URL, then use reverse runner connection commands against that private broker URL.
+
+Operational caveats:
+
+- The daemon job store lives at `~/.config/homeboy/daemon/jobs.json` for the service user.
+- Queued reverse-runner jobs survive daemon restart.
+- Broker-owned running jobs are marked failed as stale when the durable store is reopened after restart.
+- Active reverse-runner claims are lease-scoped; runners should retry claim after the lease expires.
+- The job store has bounded per-job event retention and is not a long-term audit archive. Persist important evidence through Homeboy observations/artifacts.
 
 ### Built-in Endpoints
 
@@ -56,6 +100,11 @@ contract and return the same JSON envelope shape as other daemon responses.
 - `GET /jobs/:id`
 - `GET /jobs/:id/events`
 - `POST /jobs/:id/cancel`
+- `POST /runner/sessions`
+- `POST /runner/jobs`
+- `POST /runner/jobs/claim`
+- `POST /runner/jobs/:id/events`
+- `POST /runner/jobs/:id/finish`
 
 The run readers expose persisted observation-store evidence from previous
 analysis runs. They do not start audit, lint, test, bench, rig, or stack work.

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -40,7 +40,7 @@ The JSON output includes:
 - `systemd_unit` for a `homeboy-broker` service running `homeboy daemon serve`
 - `private_tunnel_examples` for SSH, Cloudflare, or tailnet-only access
 - optional `nginx_site` and `caddy_site` snippets when `--domain` is supplied
-- `daemon_state_path` and `daemon_jobs_path` operational state locations
+- `daemon_state_path` and `daemon_jobs_path` service-owned operational state locations
 - status and log commands for day-two operations
 - restart, retention, and claim caveats
 
@@ -62,7 +62,7 @@ Extra Chill-compatible private setup:
 
 Operational caveats:
 
-- The daemon job store lives at `~/.config/homeboy/daemon/jobs.json` for the service user.
+- The systemd service sets `HOME=/var/lib/homeboy`, so daemon state lives under `/var/lib/homeboy/.config/homeboy/daemon/` instead of the service user's login home.
 - Queued reverse-runner jobs survive daemon restart.
 - Broker-owned running jobs are marked failed as stale when the durable store is reopened after restart.
 - Active reverse-runner claims are lease-scoped; runners should retry claim after the lease expires.

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -4,7 +4,9 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use homeboy::core::daemon::{self, DaemonStartResult, DaemonStatus, DaemonStopResult};
+use homeboy::core::daemon::{
+    self, BrokerConfig, BrokerConfigOptions, DaemonStartResult, DaemonStatus, DaemonStopResult,
+};
 use homeboy::core::http_api::{AnalysisJobRunOutput, AnalysisJobRunner};
 
 use super::CmdResult;
@@ -33,6 +35,24 @@ enum DaemonCommand {
     Stop,
     /// Show daemon state and selected local address
     Status,
+    /// Render deployable reverse-runner broker service configuration
+    BrokerConfig {
+        /// Stable loopback address for the VPS service.
+        #[arg(long, default_value = "127.0.0.1:7421")]
+        listen_addr: String,
+        /// Homeboy binary path used by the service unit.
+        #[arg(long, default_value = "/usr/local/bin/homeboy")]
+        binary_path: String,
+        /// System user that runs the broker service.
+        #[arg(long, default_value = "homeboy")]
+        user: String,
+        /// System group that runs the broker service.
+        #[arg(long, default_value = "homeboy")]
+        group: String,
+        /// Optional public hostname to render disabled Nginx/Caddy examples.
+        #[arg(long)]
+        domain: Option<String>,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -42,6 +62,7 @@ pub enum DaemonOutput {
     Serve(DaemonStartResult),
     Stop(DaemonStopResult),
     Status(DaemonStatus),
+    BrokerConfig(BrokerConfig),
 }
 
 pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<DaemonOutput> {
@@ -50,6 +71,22 @@ pub fn run(args: DaemonArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
         DaemonCommand::Serve { addr } => serve(&addr),
         DaemonCommand::Stop => Ok((DaemonOutput::Stop(daemon::stop()?), 0)),
         DaemonCommand::Status => Ok((DaemonOutput::Status(daemon::read_status()?), 0)),
+        DaemonCommand::BrokerConfig {
+            listen_addr,
+            binary_path,
+            user,
+            group,
+            domain,
+        } => Ok((
+            DaemonOutput::BrokerConfig(daemon::render_broker_config(BrokerConfigOptions {
+                listen_addr,
+                binary_path,
+                service_user: user,
+                service_group: group,
+                domain,
+            })?),
+            0,
+        )),
     }
 }
 

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -16,9 +16,11 @@ use crate::core::process::pid_is_running;
 use crate::core::source_snapshot::SourceSnapshot;
 
 mod artifact_download;
+mod broker_config;
 mod patch_capture;
 mod remote_runner;
 pub use artifact_download::ArtifactDownload;
+pub use broker_config::{render_broker_config, BrokerConfig, BrokerConfigOptions};
 use patch_capture::{capture_baseline, capture_patch_report};
 
 pub const DEFAULT_ADDR: &str = "127.0.0.1:0";

--- a/src/core/daemon/broker_config.rs
+++ b/src/core/daemon/broker_config.rs
@@ -72,8 +72,8 @@ pub fn render_broker_config(options: BrokerConfigOptions) -> Result<BrokerConfig
         service_user: options.service_user.clone(),
         service_group: options.service_group.clone(),
         binary_path: options.binary_path.clone(),
-        daemon_state_path: "~/.config/homeboy/daemon/state.json".to_string(),
-        daemon_jobs_path: "~/.config/homeboy/daemon/jobs.json".to_string(),
+        daemon_state_path: "/var/lib/homeboy/.config/homeboy/daemon/state.json".to_string(),
+        daemon_jobs_path: "/var/lib/homeboy/.config/homeboy/daemon/jobs.json".to_string(),
         safe_exposure: BrokerExposure {
             loopback_only: true,
             private_tunnel_safe: true,
@@ -102,7 +102,7 @@ pub fn render_broker_config(options: BrokerConfigOptions) -> Result<BrokerConfig
             "homeboy runner status <runner-id>".to_string(),
         ],
         restart_caveats: vec![
-            "The durable job store is reopened from ~/.config/homeboy/daemon/jobs.json after restart.".to_string(),
+            "The durable job store is reopened from /var/lib/homeboy/.config/homeboy/daemon/jobs.json after restart.".to_string(),
             "Queued remote-runner jobs survive daemon restart; running broker-owned jobs are marked failed as stale.".to_string(),
             "Active reverse-runner claims remain claim-scoped until their lease expires; runners should reclaim after the lease window.".to_string(),
             "Use systemctl restart homeboy-broker only when runners can tolerate lease expiry or retry.".to_string(),
@@ -110,7 +110,7 @@ pub fn render_broker_config(options: BrokerConfigOptions) -> Result<BrokerConfig
         retention_expectations: vec![
             "Job events are retained in the daemon durable job store with Homeboy's bounded per-job event retention.".to_string(),
             "The store is operational state, not an audit archive; mirror important run evidence into Homeboy observations/artifacts.".to_string(),
-            "Back up ~/.config/homeboy/daemon/jobs.json before broker maintenance if in-flight jobs matter.".to_string(),
+            "Back up /var/lib/homeboy/.config/homeboy/daemon/jobs.json before broker maintenance if in-flight jobs matter.".to_string(),
         ],
     })
 }
@@ -139,6 +139,8 @@ Wants=network-online.target
 Type=simple
 User={user}
 Group={group}
+Environment=HOME=/var/lib/homeboy
+Environment=XDG_DATA_HOME=/var/lib/homeboy/.local/share
 ExecStart={binary} daemon serve --addr {listen_addr}
 Restart=on-failure
 RestartSec=5s

--- a/src/core/daemon/broker_config.rs
+++ b/src/core/daemon/broker_config.rs
@@ -1,0 +1,246 @@
+use serde::Serialize;
+
+use crate::core::error::{Error, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrokerConfigOptions {
+    pub listen_addr: String,
+    pub binary_path: String,
+    pub service_user: String,
+    pub service_group: String,
+    pub domain: Option<String>,
+}
+
+impl Default for BrokerConfigOptions {
+    fn default() -> Self {
+        Self {
+            listen_addr: "127.0.0.1:7421".to_string(),
+            binary_path: "/usr/local/bin/homeboy".to_string(),
+            service_user: "homeboy".to_string(),
+            service_group: "homeboy".to_string(),
+            domain: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BrokerConfig {
+    pub command: String,
+    pub listen_addr: String,
+    pub service_name: String,
+    pub service_user: String,
+    pub service_group: String,
+    pub binary_path: String,
+    pub daemon_state_path: String,
+    pub daemon_jobs_path: String,
+    pub safe_exposure: BrokerExposure,
+    pub systemd_unit: String,
+    pub private_tunnel_examples: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nginx_site: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub caddy_site: Option<String>,
+    pub operational_commands: Vec<String>,
+    pub restart_caveats: Vec<String>,
+    pub retention_expectations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BrokerExposure {
+    pub loopback_only: bool,
+    pub private_tunnel_safe: bool,
+    pub public_reverse_proxy_blocked_by: String,
+    pub reason: String,
+}
+
+pub fn render_broker_config(options: BrokerConfigOptions) -> Result<BrokerConfig> {
+    let listen = parse_loopback_addr(&options.listen_addr)?;
+    let host = listen
+        .split_once(':')
+        .map(|(host, _)| host)
+        .unwrap_or(options.listen_addr.as_str());
+    let port = listen
+        .rsplit_once(':')
+        .map(|(_, port)| port)
+        .unwrap_or("7421");
+    let domain = options.domain.clone();
+
+    Ok(BrokerConfig {
+        command: "daemon.broker_config".to_string(),
+        listen_addr: listen.to_string(),
+        service_name: "homeboy-broker".to_string(),
+        service_user: options.service_user.clone(),
+        service_group: options.service_group.clone(),
+        binary_path: options.binary_path.clone(),
+        daemon_state_path: "~/.config/homeboy/daemon/state.json".to_string(),
+        daemon_jobs_path: "~/.config/homeboy/daemon/jobs.json".to_string(),
+        safe_exposure: BrokerExposure {
+            loopback_only: true,
+            private_tunnel_safe: true,
+            public_reverse_proxy_blocked_by: "https://github.com/Extra-Chill/homeboy/issues/2990".to_string(),
+            reason: "Current broker routes do not enforce production auth/pairing, so keep the service on loopback and reach it through a private tunnel until #2990 lands.".to_string(),
+        },
+        systemd_unit: render_systemd_unit(&options, &listen),
+        private_tunnel_examples: vec![
+            format!(
+                "ssh -N -L {port}:{host}:{port} <vps-user>@<vps-host>"
+            ),
+            format!(
+                "cloudflared tunnel --url http://{listen} # protect with Zero Trust before use"
+            ),
+            format!(
+                "tailscale funnel is not recommended until #2990; use tailnet-only access to http://{listen}"
+            ),
+        ],
+        nginx_site: domain.as_ref().map(|domain| render_nginx_site(domain, &listen)),
+        caddy_site: domain.as_ref().map(|domain| render_caddy_site(domain, &listen)),
+        operational_commands: vec![
+            "systemctl status homeboy-broker".to_string(),
+            "journalctl -u homeboy-broker -f".to_string(),
+            "homeboy daemon status".to_string(),
+            format!("curl -fsS http://{listen}/health"),
+            "homeboy runner status <runner-id>".to_string(),
+        ],
+        restart_caveats: vec![
+            "The durable job store is reopened from ~/.config/homeboy/daemon/jobs.json after restart.".to_string(),
+            "Queued remote-runner jobs survive daemon restart; running broker-owned jobs are marked failed as stale.".to_string(),
+            "Active reverse-runner claims remain claim-scoped until their lease expires; runners should reclaim after the lease window.".to_string(),
+            "Use systemctl restart homeboy-broker only when runners can tolerate lease expiry or retry.".to_string(),
+        ],
+        retention_expectations: vec![
+            "Job events are retained in the daemon durable job store with Homeboy's bounded per-job event retention.".to_string(),
+            "The store is operational state, not an audit archive; mirror important run evidence into Homeboy observations/artifacts.".to_string(),
+            "Back up ~/.config/homeboy/daemon/jobs.json before broker maintenance if in-flight jobs matter.".to_string(),
+        ],
+    })
+}
+
+fn parse_loopback_addr(addr: &str) -> Result<String> {
+    let parsed = super::parse_bind_addr(addr)?;
+    if parsed.port() == 0 {
+        return Err(Error::validation_invalid_argument(
+            "listen_addr",
+            "broker service config requires a stable loopback port",
+            Some(addr.to_string()),
+            Some(vec!["Use a value like 127.0.0.1:7421".to_string()]),
+        ));
+    }
+    Ok(parsed.to_string())
+}
+
+fn render_systemd_unit(options: &BrokerConfigOptions, listen_addr: &str) -> String {
+    format!(
+        r#"[Unit]
+Description=Homeboy reverse runner broker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={user}
+Group={group}
+ExecStart={binary} daemon serve --addr {listen_addr}
+Restart=on-failure
+RestartSec=5s
+StateDirectory=homeboy
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=read-only
+
+[Install]
+WantedBy=multi-user.target
+"#,
+        user = options.service_user,
+        group = options.service_group,
+        binary = options.binary_path,
+    )
+}
+
+fn render_nginx_site(domain: &str, listen_addr: &str) -> String {
+    format!(
+        r#"# Blocked for public Internet use until Homeboy broker auth/pairing lands in #2990.
+# Use only behind private network controls or keep this site disabled.
+server {{
+    listen 443 ssl http2;
+    server_name {domain};
+
+    location / {{
+        proxy_pass http://{listen_addr};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }}
+}}
+"#
+    )
+}
+
+fn render_caddy_site(domain: &str, listen_addr: &str) -> String {
+    format!(
+        r#"# Blocked for public Internet use until Homeboy broker auth/pairing lands in #2990.
+# Use only behind private network controls or keep this site disabled.
+{domain} {{
+    reverse_proxy http://{listen_addr}
+}}
+"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn broker_config_renders_loopback_systemd_service() {
+        let config = render_broker_config(BrokerConfigOptions::default()).expect("config");
+
+        assert_eq!(config.listen_addr, "127.0.0.1:7421");
+        assert!(config
+            .systemd_unit
+            .contains("ExecStart=/usr/local/bin/homeboy daemon serve --addr 127.0.0.1:7421"));
+        assert!(config.systemd_unit.contains("Restart=on-failure"));
+        assert!(config.safe_exposure.loopback_only);
+        assert!(config
+            .safe_exposure
+            .public_reverse_proxy_blocked_by
+            .ends_with("/2990"));
+        assert!(config.nginx_site.is_none());
+    }
+
+    #[test]
+    fn broker_config_renders_proxy_snippets_as_blocked_until_auth() {
+        let config = render_broker_config(BrokerConfigOptions {
+            domain: Some("broker.example.com".to_string()),
+            ..BrokerConfigOptions::default()
+        })
+        .expect("config");
+
+        let nginx = config.nginx_site.expect("nginx");
+        let caddy = config.caddy_site.expect("caddy");
+
+        assert!(nginx.contains("broker.example.com"));
+        assert!(nginx.contains("proxy_pass http://127.0.0.1:7421"));
+        assert!(nginx.contains("#2990"));
+        assert!(caddy.contains("reverse_proxy http://127.0.0.1:7421"));
+        assert!(caddy.contains("#2990"));
+    }
+
+    #[test]
+    fn broker_config_rejects_ephemeral_or_public_binds() {
+        let ephemeral = render_broker_config(BrokerConfigOptions {
+            listen_addr: "127.0.0.1:0".to_string(),
+            ..BrokerConfigOptions::default()
+        })
+        .expect_err("ephemeral port rejected");
+        assert!(ephemeral.message.contains("stable loopback port"));
+
+        let public = render_broker_config(BrokerConfigOptions {
+            listen_addr: "0.0.0.0:7421".to_string(),
+            ..BrokerConfigOptions::default()
+        })
+        .expect_err("public bind rejected");
+        assert!(public.message.contains("loopback"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `homeboy daemon broker-config` to render a loopback-only VPS reverse-runner broker deployment recipe.
- Generate a systemd unit, private tunnel examples, optional Nginx/Caddy snippets, operational commands, retention expectations, and restart/claim caveats.
- Document the Extra Chill-compatible private setup and keep public proxy exposure explicitly blocked by #2990.

Refs #2992.
Refs #2950.
Blocked public exposure by #2990.

## Verification
- `cargo test broker_config --all-targets`
- `cargo test --all-targets` (one daemon listener test failed once, passed on direct rerun)
- `cargo test core::daemon::daemon_test::test_serve_writes_state_and_routes_health_requests --lib`
- `cargo run --quiet --bin homeboy -- daemon broker-config --domain broker.example.com`
- `homeboy audit --force-hot --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the broker config renderer, tests, docs, and verification commands for Chris to review.