### PR TITLE
Record runner process metrics

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -253,6 +253,12 @@ Path rules:
 - `--project <id>` feeds the runner trust policy project allowlist check.
 - `--ssh` is the explicit diagnostic fallback when `connect` is unavailable; daemon execution is preferred because it records job metadata and supports artifact-oriented workflows.
 
+Runner metrics:
+
+- Local runner execution, connected daemon jobs, and reverse-runner worker results include a `metrics` object with `duration_ms`, `sample_count`, and lightweight resource fields when available.
+- On Linux runners, metrics are sampled from `/proc` for the command process tree and include `peak_rss_bytes`, `child_process_count_peak`, `cpu_user_ms`, and `cpu_system_ms`.
+- CPU accounting is sampled and can miss very short-lived child processes between samples; duration is always recorded, and non-Linux runners report `source: "duration_only"`.
+
 ### `workspace sync`
 
 ```sh

--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -1115,6 +1115,7 @@ mod tests {
                         sha256: Some("abc123".to_string()),
                         metadata: Some(json!({ "kind": "test_report" })),
                     }],
+                    metrics: None,
                 },
             )
             .expect("runner completes job");
@@ -1157,6 +1158,7 @@ mod tests {
                     stderr: Some("nope".to_string()),
                     data: None,
                     artifacts: Vec::new(),
+                    metrics: None,
                 },
             )
             .expect("runner fails job");

--- a/src/core/api_jobs/remote_runner.rs
+++ b/src/core/api_jobs/remote_runner.rs
@@ -8,6 +8,7 @@ use super::{
     job_not_found, timestamp_ms, Job, JobEvent, JobEventKind, JobStatus, JobStore, StoredJob,
 };
 use crate::core::error::{Error, Result};
+use crate::core::runner::RunnerResourceMetrics;
 use crate::core::source_snapshot::SourceSnapshot;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -66,6 +67,8 @@ pub struct RemoteRunnerJobResult {
     pub data: Option<Value>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifacts: Vec<JobArtifactMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metrics: Option<RunnerResourceMetrics>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -13,6 +13,7 @@ use crate::core::error::{Error, RemoteCommandFailedDetails, Result, TargetDetail
 use crate::core::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
 use crate::core::paths;
 use crate::core::process::pid_is_running;
+use crate::core::runner::measured_command_output;
 use crate::core::source_snapshot::SourceSnapshot;
 
 mod artifact_download;
@@ -380,12 +381,9 @@ fn enqueue_exec_job(
                     serde_json::to_string(snapshot).unwrap_or_default(),
                 );
             }
-            let output = command.output().map_err(|err| {
-                Error::internal_io(
-                    err.to_string(),
-                    Some("execute daemon runner command".to_string()),
-                )
-            })?;
+            let measured = measured_command_output(&mut command)?;
+            let output = measured.output;
+            let metrics = measured.metrics;
             let stdout = String::from_utf8_lossy(&output.stdout).to_string();
             let stderr = String::from_utf8_lossy(&output.stderr).to_string();
             let exit_code = output.status.code().unwrap_or(1);
@@ -398,6 +396,7 @@ fn enqueue_exec_job(
             job.progress(json!({
                 "phase": "finished",
                 "exit_code": exit_code,
+                "metrics": metrics.clone(),
             }))?;
             let patch = if let Some(baseline) = baseline {
                 Some(capture_patch_report(
@@ -421,6 +420,7 @@ fn enqueue_exec_job(
                 "stderr": stderr,
                 "source_snapshot": source_snapshot,
                 "patch": patch,
+                "metrics": metrics,
             });
             if exit_code != 0 {
                 job.result(result.clone())?;

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -14,6 +14,7 @@ use crate::core::source_snapshot::SourceSnapshot;
 use super::broker_http;
 use super::capabilities::{runner_capability_snapshot, validate_runner_capability_preflight};
 use super::evidence::mirror_daemon_evidence;
+use super::resource_metrics::{measured_command_output, RunnerResourceMetrics};
 use super::{load, status, Runner, RunnerCapabilityPreflight, RunnerKind, RunnerTunnelMode};
 
 mod policy;
@@ -63,6 +64,8 @@ pub struct RunnerExecOutput {
     pub mirror_run_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub patch: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metrics: Option<RunnerResourceMetrics>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -227,6 +230,9 @@ fn exec_via_reverse_broker(
     let result = result_event_data(&events).unwrap_or_else(|| json!({}));
     let stdout = string_field(&result, "stdout");
     let stderr = string_field(&result, "stderr");
+    let metrics = result
+        .get("metrics")
+        .and_then(|value| serde_json::from_value(value.clone()).ok());
     let exit_code = result
         .get("exit_code")
         .and_then(Value::as_i64)
@@ -255,6 +261,7 @@ fn exec_via_reverse_broker(
             job_events: Some(events),
             mirror_run_id: None,
             patch: None,
+            metrics,
         },
         exit_code,
     ))
@@ -334,6 +341,9 @@ fn exec_via_daemon(
     let result = result_event_data(&events).unwrap_or_else(|| json!({}));
     let stdout = string_field(&result, "stdout");
     let stderr = string_field(&result, "stderr");
+    let metrics = result
+        .get("metrics")
+        .and_then(|value| serde_json::from_value(value.clone()).ok());
     let exit_code = result
         .get("exit_code")
         .and_then(Value::as_i64)
@@ -365,6 +375,7 @@ fn exec_via_daemon(
             job_events: Some(events),
             mirror_run_id: mirror.map(|evidence| evidence.run.id),
             patch,
+            metrics,
         },
         exit_code,
     ))
@@ -523,6 +534,7 @@ fn exec_ssh(
             stdout: output.stdout,
             stderr: output.stderr,
             exit_code: output.exit_code,
+            metrics: None,
         },
         Some(source_snapshot),
     ))
@@ -532,16 +544,17 @@ struct ProcessOutput {
     stdout: String,
     stderr: String,
     exit_code: i32,
+    metrics: Option<RunnerResourceMetrics>,
 }
 
 fn command_output(command: &mut std::process::Command) -> Result<ProcessOutput> {
-    let output = command.output().map_err(|err| {
-        Error::internal_io(err.to_string(), Some("execute runner command".to_string()))
-    })?;
+    let measured = measured_command_output(command)?;
+    let output = measured.output;
     Ok(ProcessOutput {
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),
         stderr: String::from_utf8_lossy(&output.stderr).to_string(),
         exit_code: output.status.code().unwrap_or(1),
+        metrics: Some(measured.metrics),
     })
 }
 
@@ -570,6 +583,7 @@ fn exec_output(
             job_events: None,
             mirror_run_id: None,
             patch: None,
+            metrics: output.metrics,
         },
         exit_code,
     )
@@ -714,6 +728,17 @@ mod tests {
             assert_eq!(output.runner_id, "lab-local");
             assert_eq!(output.mode, RunnerExecMode::Local);
             assert_eq!(output.stdout, "ok");
+            let metrics = output.metrics.expect("local exec metrics");
+            assert!(metrics.duration_ms < 60_000);
+            if cfg!(target_os = "linux") {
+                assert_eq!(metrics.source, "linux_procfs_process_tree");
+                assert!(metrics.sample_count > 0);
+                assert!(metrics.peak_rss_bytes.unwrap_or(0) > 0);
+                assert!(metrics.child_process_count_peak.is_some());
+            } else {
+                assert_eq!(metrics.source, "duration_only");
+                assert_eq!(metrics.sample_count, 0);
+            }
             let source_snapshot = output.source_snapshot.expect("source snapshot");
             assert_eq!(source_snapshot.runner_id, "lab-local");
             assert_eq!(source_snapshot.sync_mode, "existing_remote");

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -18,6 +18,7 @@ mod execution;
 mod lab;
 mod offload_changed_since;
 mod offload_metadata;
+mod resource_metrics;
 mod session;
 mod worker;
 mod workspace;
@@ -47,6 +48,8 @@ pub use offload_changed_since::{
     prepare_git_lab_offload_changed_since,
 };
 pub use offload_metadata::{capture_lab_offload_metadata, lab_offload_metadata};
+pub(crate) use resource_metrics::measured_command_output;
+pub use resource_metrics::RunnerResourceMetrics;
 pub use session::{
     ReverseRunnerConnectOptions, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
     RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStatusReport, RunnerTunnelMode,

--- a/src/core/runner/resource_metrics.rs
+++ b/src/core/runner/resource_metrics.rs
@@ -1,0 +1,250 @@
+use std::process::{Command, Output, Stdio};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::error::{Error, Result};
+
+const SAMPLE_INTERVAL: Duration = Duration::from_millis(1000);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerResourceMetrics {
+    pub duration_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_user_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_system_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peak_rss_bytes: Option<u64>,
+    pub sample_count: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_process_count_peak: Option<u64>,
+    pub source: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct MeasuredOutput {
+    pub output: Output,
+    pub metrics: RunnerResourceMetrics,
+}
+
+#[derive(Debug, Default)]
+struct MetricsState {
+    sample_count: u64,
+    peak_rss_bytes: u64,
+    child_process_count_peak: u64,
+    cpu_user_ms: u64,
+    cpu_system_ms: u64,
+}
+
+pub(crate) fn measured_command_output(command: &mut Command) -> Result<MeasuredOutput> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let started = Instant::now();
+    let child = command.spawn().map_err(|err| {
+        Error::internal_io(err.to_string(), Some("execute runner command".to_string()))
+    })?;
+    let pid = child.id();
+    let collector = ResourceMetricsCollector::start(pid);
+    let output = child.wait_with_output().map_err(|err| {
+        Error::internal_io(err.to_string(), Some("wait for runner command".to_string()))
+    })?;
+    let metrics = collector.finish(started.elapsed());
+    Ok(MeasuredOutput { output, metrics })
+}
+
+struct ResourceMetricsCollector {
+    supported: bool,
+    stop: Option<mpsc::Sender<()>>,
+    state: Arc<Mutex<MetricsState>>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl ResourceMetricsCollector {
+    fn start(root_pid: u32) -> Self {
+        let supported = cfg!(target_os = "linux") && std::path::Path::new("/proc").exists();
+        let state = Arc::new(Mutex::new(MetricsState::default()));
+        if !supported {
+            return Self {
+                supported,
+                stop: None,
+                state,
+                handle: None,
+            };
+        }
+
+        let (stop, stop_rx) = mpsc::channel();
+        let thread_state = Arc::clone(&state);
+        let handle = thread::spawn(move || loop {
+            sample(root_pid, &thread_state);
+            if stop_rx.recv_timeout(SAMPLE_INTERVAL).is_ok() {
+                break;
+            }
+        });
+
+        Self {
+            supported,
+            stop: Some(stop),
+            state,
+            handle: Some(handle),
+        }
+    }
+
+    fn finish(mut self, duration: Duration) -> RunnerResourceMetrics {
+        if let Some(stop) = self.stop.take() {
+            let _ = stop.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+        let state = self.state.lock().expect("resource metrics mutex poisoned");
+        RunnerResourceMetrics {
+            duration_ms: duration.as_millis().try_into().unwrap_or(u64::MAX),
+            cpu_user_ms: (state.sample_count > 0).then_some(state.cpu_user_ms),
+            cpu_system_ms: (state.sample_count > 0).then_some(state.cpu_system_ms),
+            peak_rss_bytes: (state.sample_count > 0).then_some(state.peak_rss_bytes),
+            sample_count: state.sample_count,
+            child_process_count_peak: (state.sample_count > 0)
+                .then_some(state.child_process_count_peak),
+            source: if self.supported {
+                "linux_procfs_process_tree".to_string()
+            } else {
+                "duration_only".to_string()
+            },
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn sample(root_pid: u32, state: &Arc<Mutex<MetricsState>>) {
+    if let Some(snapshot) = process_tree_snapshot(root_pid) {
+        let mut state = state.lock().expect("resource metrics mutex poisoned");
+        state.sample_count += 1;
+        state.peak_rss_bytes = state.peak_rss_bytes.max(snapshot.rss_bytes);
+        state.child_process_count_peak = state
+            .child_process_count_peak
+            .max(snapshot.process_count.saturating_sub(1));
+        state.cpu_user_ms = state.cpu_user_ms.max(snapshot.cpu_user_ms);
+        state.cpu_system_ms = state.cpu_system_ms.max(snapshot.cpu_system_ms);
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn sample(_root_pid: u32, _state: &Arc<Mutex<MetricsState>>) {}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+struct ProcessSnapshot {
+    process_count: u64,
+    rss_bytes: u64,
+    cpu_user_ms: u64,
+    cpu_system_ms: u64,
+}
+
+#[cfg(target_os = "linux")]
+fn process_tree_snapshot(root_pid: u32) -> Option<ProcessSnapshot> {
+    let stats = read_process_stats();
+    let root_pid = root_pid as i32;
+    stats.get(&root_pid)?;
+
+    let mut children: HashMap<i32, Vec<i32>> = HashMap::new();
+    for stat in stats.values() {
+        children.entry(stat.ppid).or_default().push(stat.pid);
+    }
+
+    let mut queue = std::collections::VecDeque::from([root_pid]);
+    let mut seen = std::collections::HashSet::new();
+    let mut rss_bytes = 0_u64;
+    let mut user_ticks = 0_u64;
+    let mut system_ticks = 0_u64;
+
+    while let Some(pid) = queue.pop_front() {
+        if !seen.insert(pid) {
+            continue;
+        }
+        if let Some(stat) = stats.get(&pid) {
+            rss_bytes = rss_bytes.saturating_add(stat.rss_bytes);
+            user_ticks = user_ticks.saturating_add(stat.user_ticks);
+            system_ticks = system_ticks.saturating_add(stat.system_ticks);
+            if let Some(child_pids) = children.get(&pid) {
+                queue.extend(child_pids);
+            }
+        }
+    }
+
+    let clock_ticks = clock_ticks_per_second().max(1);
+    Some(ProcessSnapshot {
+        process_count: seen.len().try_into().unwrap_or(u64::MAX),
+        rss_bytes,
+        cpu_user_ms: user_ticks.saturating_mul(1000) / clock_ticks,
+        cpu_system_ms: system_ticks.saturating_mul(1000) / clock_ticks,
+    })
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+struct ProcessStat {
+    pid: i32,
+    ppid: i32,
+    user_ticks: u64,
+    system_ticks: u64,
+    rss_bytes: u64,
+}
+
+#[cfg(target_os = "linux")]
+fn read_process_stats() -> std::collections::HashMap<i32, ProcessStat> {
+    let mut stats = std::collections::HashMap::new();
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return stats;
+    };
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(pid_text) = file_name.to_str() else {
+            continue;
+        };
+        let Ok(pid) = pid_text.parse::<i32>() else {
+            continue;
+        };
+        if let Some(stat) = read_process_stat(pid) {
+            stats.insert(pid, stat);
+        }
+    }
+    stats
+}
+
+#[cfg(target_os = "linux")]
+fn read_process_stat(pid: i32) -> Option<ProcessStat> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let end_command = stat.rfind(')')?;
+    let fields: Vec<&str> = stat[end_command + 2..].split_whitespace().collect();
+    let ppid = fields.get(1)?.parse().ok()?;
+    let user_ticks = fields.get(11).and_then(|v| v.parse().ok()).unwrap_or(0)
+        + fields.get(13).and_then(|v| v.parse().ok()).unwrap_or(0);
+    let system_ticks = fields.get(12).and_then(|v| v.parse().ok()).unwrap_or(0)
+        + fields.get(14).and_then(|v| v.parse().ok()).unwrap_or(0);
+    let rss_pages: u64 = fields.get(21).and_then(|v| v.parse().ok()).unwrap_or(0);
+    Some(ProcessStat {
+        pid,
+        ppid,
+        user_ticks,
+        system_ticks,
+        rss_bytes: rss_pages.saturating_mul(page_size_bytes()),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn clock_ticks_per_second() -> u64 {
+    command_u64("getconf", &["CLK_TCK"]).unwrap_or(100)
+}
+
+#[cfg(target_os = "linux")]
+fn page_size_bytes() -> u64 {
+    command_u64("getconf", &["PAGESIZE"]).unwrap_or(4096)
+}
+
+#[cfg(target_os = "linux")]
+fn command_u64(command: &str, args: &[&str]) -> Option<u64> {
+    let output = Command::new(command).args(args).output().ok()?;
+    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+}

--- a/src/core/runner/worker.rs
+++ b/src/core/runner/worker.rs
@@ -98,6 +98,7 @@ pub fn run_reverse_worker(
                 "remote_cwd": exec_output.remote_cwd,
             })),
             artifacts: Vec::new(),
+            metrics: exec_output.metrics.clone(),
         },
     )?;
 
@@ -252,6 +253,19 @@ mod tests {
                     && event.data.as_ref().expect("result data")["stdout"]
                         == serde_json::json!("worker-ok")
             }));
+            let result = events
+                .iter()
+                .find(|event| event.kind == JobEventKind::Result)
+                .and_then(|event| event.data.as_ref())
+                .expect("result event data");
+            assert!(result["metrics"]["duration_ms"].as_u64().is_some());
+            if cfg!(target_os = "linux") {
+                assert_eq!(
+                    result["metrics"]["source"],
+                    serde_json::json!("linux_procfs_process_tree")
+                );
+                assert!(result["metrics"]["sample_count"].as_u64().unwrap_or(0) > 0);
+            }
         });
     }
 

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -338,6 +338,7 @@ mod tests {
             job_events: None,
             mirror_run_id: None,
             patch: None,
+            metrics: None,
         }
     }
 }

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -485,6 +485,12 @@ fn exec_applies_request_env_to_daemon_command() {
         .and_then(|event| event.data.as_ref())
         .expect("result event");
     assert_eq!(result["stdout"], "ok");
+    assert!(result["metrics"]["duration_ms"].as_u64().is_some());
+    if cfg!(target_os = "linux") {
+        assert_eq!(result["metrics"]["source"], "linux_procfs_process_tree");
+        assert!(result["metrics"]["sample_count"].as_u64().unwrap_or(0) > 0);
+        assert!(result["metrics"]["peak_rss_bytes"].as_u64().unwrap_or(0) > 0);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add lightweight runner command metrics for local exec, daemon exec jobs, and reverse-runner worker results.
- Sample Linux `/proc` process trees for peak RSS, child process count peak, and CPU time, with duration-only fallback elsewhere.
- Document metrics availability and sampling limitations for runner exec.

Closes https://github.com/Extra-Chill/homeboy/issues/2996

## Tests
- `cargo test core::runner::execution::tests::test_exec_runs_local_runner_command`
- `cargo test core::runner::worker::tests::reverse_worker_executes_claimed_job_and_finishes_it`
- `cargo test exec_applies_request_env_to_daemon_command`
- `cargo test --test output_contracts_test`
- `cargo test core::api_jobs::tests::remote_runner_job_result_records_terminal_state_and_artifacts`
- `cargo test core::api_jobs::tests::remote_runner_job_failed_result_records_error_and_terminal_state`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner metrics sampler, wired it into runner job outputs, updated tests/docs, and verified targeted coverage.