### PR TITLE
Fix runner metrics build

### DIFF
--- a/src/core/runner/resource_metrics.rs
+++ b/src/core/runner/resource_metrics.rs
@@ -148,7 +148,7 @@ fn process_tree_snapshot(root_pid: u32) -> Option<ProcessSnapshot> {
     let root_pid = root_pid as i32;
     stats.get(&root_pid)?;
 
-    let mut children: HashMap<i32, Vec<i32>> = HashMap::new();
+    let mut children: std::collections::HashMap<i32, Vec<i32>> = std::collections::HashMap::new();
     for stat in stats.values() {
         children.entry(stat.ppid).or_default().push(stat.pid);
     }


### PR DESCRIPTION
## Summary
- Qualify the `HashMap` type used while building Linux runner process-tree metrics.
- Restores the build after #2997 merged with the missing import.

## Tests
- `cargo build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified the merged build failure and applied the minimal compile fix.