### PR TITLE
Share Cargo target dirs across Homeboy worktrees

### DIFF
--- a/src/core/cargo_target.rs
+++ b/src/core/cargo_target.rs
@@ -1,0 +1,123 @@
+use crate::core::component::Component;
+use crate::core::error::{Error, Result};
+use crate::core::paths;
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+pub(crate) const CARGO_TARGET_DIR_ENV: &str = "CARGO_TARGET_DIR";
+pub(crate) const HOMEBOY_CARGO_TARGET_DIR_ENV: &str = "HOMEBOY_CARGO_TARGET_DIR";
+
+/// Build Homeboy's default Cargo target env for Rust component commands.
+///
+/// The directory is keyed by stable component/repository identity instead of
+/// the checkout path, so primary checkouts and Homeboy-managed worktrees share
+/// one Cargo target cache. User-provided `CARGO_TARGET_DIR` always wins.
+pub(crate) fn env_vars(
+    component: &Component,
+    source_path: &Path,
+    existing_env: &[(String, String)],
+) -> Result<Vec<(String, String)>> {
+    if cargo_target_dir_is_set(existing_env) || !source_path.join("Cargo.toml").exists() {
+        return Ok(Vec::new());
+    }
+
+    let target_dir = target_dir(component, source_path)?;
+    let target_dir = target_dir.to_string_lossy().to_string();
+    Ok(vec![
+        (CARGO_TARGET_DIR_ENV.to_string(), target_dir.clone()),
+        (HOMEBOY_CARGO_TARGET_DIR_ENV.to_string(), target_dir),
+    ])
+}
+
+pub(crate) fn target_dir(component: &Component, source_path: &Path) -> Result<PathBuf> {
+    Ok(paths::homeboy_data()?
+        .join("cargo-targets")
+        .join(identity_segment(component, source_path)?))
+}
+
+fn cargo_target_dir_is_set(existing_env: &[(String, String)]) -> bool {
+    std::env::var_os(CARGO_TARGET_DIR_ENV).is_some()
+        || existing_env
+            .iter()
+            .any(|(key, _)| key == CARGO_TARGET_DIR_ENV)
+}
+
+fn identity_segment(component: &Component, source_path: &Path) -> Result<String> {
+    let identity = repository_identity(component, source_path)?;
+    let mut hasher = Sha256::new();
+    hasher.update(identity.as_bytes());
+    let hash = format!("{:x}", hasher.finalize());
+    let label = paths::sanitize_path_segment(&component.id)
+        .trim_matches('_')
+        .to_string();
+    let label = if label.is_empty() {
+        "component".to_string()
+    } else {
+        label
+    };
+    Ok(format!("{}-{}", label, &hash[..12]))
+}
+
+fn repository_identity(component: &Component, source_path: &Path) -> Result<String> {
+    if let Some(remote_url) = non_empty(component.remote_url.as_deref()) {
+        return Ok(normalize_repo_identity(remote_url));
+    }
+
+    if let Some(origin) = git_origin_url(source_path)? {
+        return Ok(normalize_repo_identity(&origin));
+    }
+
+    Ok(format!("component:{}", component.id))
+}
+
+fn git_origin_url(source_path: &Path) -> Result<Option<String>> {
+    if !source_path.exists() {
+        return Ok(None);
+    }
+
+    let output = std::process::Command::new("git")
+        .args(["config", "--get", "remote.origin.url"])
+        .current_dir(source_path)
+        .output()
+        .map_err(|e| {
+            Error::internal_io(e.to_string(), Some("git remote.origin.url".to_string()))
+        })?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(non_empty(Some(&value)).map(ToOwned::to_owned))
+}
+
+fn normalize_repo_identity(value: &str) -> String {
+    let mut value = value.trim().trim_end_matches('/').to_ascii_lowercase();
+    if let Some(rest) = value.strip_prefix("git@github.com:") {
+        value = format!("https://github.com/{rest}");
+    } else if let Some(rest) = value.strip_prefix("git@github.a8c.com:") {
+        value = format!("https://github.a8c.com/{rest}");
+    }
+    value.strip_suffix(".git").unwrap_or(&value).to_string()
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_common_git_remote_forms() {
+        assert_eq!(
+            normalize_repo_identity("git@github.com:Extra-Chill/homeboy.git"),
+            "https://github.com/extra-chill/homeboy"
+        );
+        assert_eq!(
+            normalize_repo_identity("https://github.com/Extra-Chill/homeboy.git/"),
+            "https://github.com/extra-chill/homeboy"
+        );
+    }
+}

--- a/src/core/extension/component_script.rs
+++ b/src/core/extension/component_script.rs
@@ -145,7 +145,7 @@ fn component_script_env(
     source_path: &Path,
     extra_env: &[(String, String)],
 ) -> Vec<(String, String)> {
-    let source_path = source_path.to_string_lossy().to_string();
+    let source_path_value = source_path.to_string_lossy().to_string();
     let mut env = vec![
         (
             exec_context::VERSION.to_string(),
@@ -157,12 +157,15 @@ fn component_script_env(
         ),
         (
             exec_context::EXTENSION_PATH.to_string(),
-            source_path.clone(),
+            source_path_value.clone(),
         ),
         (exec_context::COMPONENT_ID.to_string(), component.id.clone()),
-        (exec_context::COMPONENT_PATH.to_string(), source_path),
+        (exec_context::COMPONENT_PATH.to_string(), source_path_value),
         (exec_context::SETTINGS_JSON.to_string(), "{}".to_string()),
     ];
+    if let Ok(cargo_env) = crate::core::cargo_target::env_vars(component, source_path, extra_env) {
+        env.extend(cargo_env);
+    }
     env.extend(extra_env.iter().cloned());
     env
 }

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -744,6 +744,15 @@ fn build_exec_env(
                 }
             }
         };
+        if let Ok(component) =
+            component::resolve_effective(Some(cid), component_path_override, None)
+        {
+            if let Ok(cargo_env) =
+                crate::core::cargo_target::env_vars(&component, Path::new(&component_path), &env)
+            {
+                env.extend(cargo_env);
+            }
+        }
         env.push((exec_context::COMPONENT_PATH.to_string(), component_path));
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 pub mod config;
 pub mod api_jobs;
 pub mod budget;
+pub(crate) mod cargo_target;
 pub mod ci_profile;
 pub mod code_audit;
 pub mod component;

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -7,6 +7,7 @@ use crate::commands::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs,
 };
 use crate::commands::GlobalArgs;
+use crate::core::cargo_target::CARGO_TARGET_DIR_ENV;
 use crate::core::component::{Component, ComponentScriptsConfig};
 use crate::core::engine::run_dir::RunDir;
 use crate::core::extension::component_script::{
@@ -69,6 +70,34 @@ fn script_component(root: &Path, command: &str) -> Component {
     component
 }
 
+fn rust_script_component(root: &Path, command: &str) -> Component {
+    let mut component = script_component(root, command);
+    component.remote_url = Some("https://github.com/Extra-Chill/homeboy.git".to_string());
+    component
+}
+
+fn without_process_cargo_target_dir<R>(body: impl FnOnce() -> R) -> R {
+    let prior = std::env::var(CARGO_TARGET_DIR_ENV).ok();
+    std::env::remove_var(CARGO_TARGET_DIR_ENV);
+    let result = body();
+    match prior {
+        Some(value) => std::env::set_var(CARGO_TARGET_DIR_ENV, value),
+        None => std::env::remove_var(CARGO_TARGET_DIR_ENV),
+    }
+    result
+}
+
+fn with_process_cargo_target_dir<R>(value: &Path, body: impl FnOnce() -> R) -> R {
+    let prior = std::env::var(CARGO_TARGET_DIR_ENV).ok();
+    std::env::set_var(CARGO_TARGET_DIR_ENV, value);
+    let result = body();
+    match prior {
+        Some(value) => std::env::set_var(CARGO_TARGET_DIR_ENV, value),
+        None => std::env::remove_var(CARGO_TARGET_DIR_ENV),
+    }
+    result
+}
+
 #[test]
 fn test_run_component_scripts() {
     let dir = tempfile::tempdir().expect("temp dir");
@@ -99,6 +128,138 @@ fn test_run_component_scripts_with_env() {
 
     assert!(output.success);
     assert_eq!(fs::read_to_string(dir.path().join("marker")).unwrap(), "ok");
+}
+
+#[test]
+fn rust_component_scripts_default_to_shared_cargo_target_dir() {
+    with_isolated_home(|home| {
+        without_process_cargo_target_dir(|| {
+            let primary = tempfile::tempdir().expect("primary temp dir");
+            let worktree = tempfile::tempdir().expect("worktree temp dir");
+            fs::write(
+                primary.path().join("Cargo.toml"),
+                "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\n",
+            )
+            .expect("primary Cargo.toml");
+            fs::write(
+                worktree.path().join("Cargo.toml"),
+                "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\n",
+            )
+            .expect("worktree Cargo.toml");
+
+            let primary_component = rust_script_component(
+                primary.path(),
+                "printf '%s' \"$CARGO_TARGET_DIR\" > cargo-target",
+            );
+            let worktree_component = rust_script_component(
+                worktree.path(),
+                "printf '%s' \"$CARGO_TARGET_DIR\" > cargo-target",
+            );
+
+            let primary_output = run_component_scripts(
+                &primary_component,
+                ExtensionCapability::Test,
+                primary.path(),
+                false,
+            )
+            .expect("primary component script should run");
+            let worktree_output = run_component_scripts(
+                &worktree_component,
+                ExtensionCapability::Test,
+                worktree.path(),
+                false,
+            )
+            .expect("worktree component script should run");
+
+            assert!(primary_output.success);
+            assert!(worktree_output.success);
+            let primary_target = fs::read_to_string(primary.path().join("cargo-target")).unwrap();
+            let worktree_target = fs::read_to_string(worktree.path().join("cargo-target")).unwrap();
+
+            assert_eq!(primary_target, worktree_target);
+            assert!(
+                primary_target.starts_with(
+                    &home
+                        .path()
+                        .join(".local/share/homeboy/cargo-targets")
+                        .to_string_lossy()
+                        .to_string()
+                ),
+                "target dir should live under Homeboy data dir: {primary_target}"
+            );
+            assert!(
+                primary_target.contains("fixture-"),
+                "target dir should include component identity label: {primary_target}"
+            );
+        });
+    });
+}
+
+#[test]
+fn rust_component_scripts_respect_explicit_cargo_target_dir() {
+    with_isolated_home(|_| {
+        without_process_cargo_target_dir(|| {
+            let dir = tempfile::tempdir().expect("temp dir");
+            fs::write(
+                dir.path().join("Cargo.toml"),
+                "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\n",
+            )
+            .expect("Cargo.toml");
+            let explicit = dir.path().join("custom-target");
+            let component = rust_script_component(
+                dir.path(),
+                "printf '%s' \"$CARGO_TARGET_DIR\" > cargo-target",
+            );
+
+            let output = run_component_scripts_with_env(
+                &component,
+                ExtensionCapability::Test,
+                dir.path(),
+                false,
+                &[(
+                    CARGO_TARGET_DIR_ENV.to_string(),
+                    explicit.to_string_lossy().to_string(),
+                )],
+                &[],
+            )
+            .expect("component script should run");
+
+            assert!(output.success);
+            assert_eq!(
+                fs::read_to_string(dir.path().join("cargo-target")).unwrap(),
+                explicit.to_string_lossy()
+            );
+        });
+    });
+}
+
+#[test]
+fn rust_component_scripts_respect_process_cargo_target_dir() {
+    with_isolated_home(|_| {
+        let dir = tempfile::tempdir().expect("temp dir");
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\n",
+        )
+        .expect("Cargo.toml");
+        let explicit = dir.path().join("process-target");
+        with_process_cargo_target_dir(&explicit, || {
+            let component = rust_script_component(
+                dir.path(),
+                "printf '%s' \"$CARGO_TARGET_DIR\" > cargo-target",
+            );
+
+            let output =
+                run_component_scripts(&component, ExtensionCapability::Test, dir.path(), false)
+                    .expect("component script should run");
+
+            assert!(output.success);
+            assert_eq!(
+                fs::read_to_string(dir.path().join("cargo-target")).unwrap(),
+                explicit.to_string_lossy()
+            );
+        });
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add a shared Cargo target directory resolver keyed by stable component/repository identity instead of checkout path.
- Inject `CARGO_TARGET_DIR` and `HOMEBOY_CARGO_TARGET_DIR` for Homeboy-managed Rust component/extension commands when no user `CARGO_TARGET_DIR` is set.
- Cover primary/worktree sharing plus explicit env override behavior in component script tests.

Fixes #3022

## Tests
- `CARGO_TARGET_DIR=/Users/chubes/.local/share/homeboy/cargo-targets/homeboy-dev cargo test core::cargo_target -- --nocapture`
- `CARGO_TARGET_DIR=/Users/chubes/.local/share/homeboy/cargo-targets/homeboy-dev cargo test core::extension::component_script::component_script_test -- --nocapture`
- `CARGO_TARGET_DIR=/Users/chubes/.local/share/homeboy/cargo-targets/homeboy-dev homeboy lint --path /Users/chubes/Developer/homeboy@fix-issue-3022-shared-cargo-target --changed-since origin/main --summary`
- `CARGO_TARGET_DIR=/Users/chubes/.local/share/homeboy/cargo-targets/homeboy-dev homeboy test --path /Users/chubes/Developer/homeboy@fix-issue-3022-shared-cargo-target --changed-since origin/main --json-summary`

## Notes
- Raw `cargo clippy --all-targets -- -D warnings` still fails on existing repository-wide clippy debt unrelated to this change. The Homeboy lint gate passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Implemented the shared Cargo target directory plumbing, tests, verification commands, and PR drafting; Chris remains responsible for review and merge.