### PR TITLE
Expose target-adjacent deploy temp vars

### DIFF
--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -300,16 +300,16 @@ pub(super) fn deploy_with_override(
         })
         .unwrap_or("wp");
 
-    let mut vars = HashMap::new();
-    vars.insert("artifact".to_string(), artifact_filename.to_string());
-    vars.insert("stagingArtifact".to_string(), staging_artifact.clone());
-    vars.insert("targetDir".to_string(), remote_path.to_string());
-    vars.insert("siteRoot".to_string(), site_root.unwrap_or("").to_string());
-    vars.insert("cliPath".to_string(), cli_path.to_string());
-    vars.insert("domain".to_string(), domain.unwrap_or("").to_string());
-    vars.insert("allowRootFlag".to_string(), "--allow-root".to_string());
+    let vars = deploy_override_template_vars(
+        artifact_filename,
+        &staging_artifact,
+        remote_path,
+        site_root,
+        cli_path,
+        domain,
+    );
 
-    let install_cmd = render_install_command(&override_config.install_command, &vars);
+    let install_cmd = render_map(&override_config.install_command, &vars);
     log_status!("deploy", "Running install command: {}", install_cmd);
 
     let install_output = ssh_client.execute(&install_cmd);
@@ -368,37 +368,42 @@ pub(super) fn deploy_with_override(
     Ok(DeployResult::success(0))
 }
 
-fn render_install_command(template: &str, vars: &HashMap<String, String>) -> String {
-    let rendered = render_map(template, vars);
-    normalize_legacy_wordpress_plugin_install_tempdir(
-        &rendered,
-        vars.get("targetDir").map(String::as_str),
-    )
-}
-
-fn normalize_legacy_wordpress_plugin_install_tempdir(
-    command: &str,
-    target_dir: Option<&str>,
-) -> String {
-    let Some(target_dir) = target_dir else {
-        return command.to_string();
+fn deploy_override_template_vars(
+    artifact_filename: &str,
+    staging_artifact: &str,
+    target_dir: &str,
+    site_root: Option<&str>,
+    cli_path: &str,
+    domain: Option<&str>,
+) -> HashMap<String, String> {
+    let target_parent_dir = target_dir
+        .trim_end_matches('/')
+        .rsplit_once('/')
+        .map(|(parent, _)| parent)
+        .unwrap_or("");
+    let target_adjacent_temp_pattern = if target_parent_dir.is_empty() {
+        String::new()
+    } else {
+        format!("{}/.homeboy-install.XXXXXX", target_parent_dir)
     };
 
-    const LEGACY_TMP_PATTERN: &str = "mktemp -d /tmp/homeboy-install.XXXXXX";
-    if !command.contains(LEGACY_TMP_PATTERN) || !command.contains("mv \"$extracted\"") {
-        return command.to_string();
-    }
-
-    let Some((target_parent, _)) = target_dir.trim_end_matches('/').rsplit_once('/') else {
-        return command.to_string();
-    };
-    if target_parent.is_empty() {
-        return command.to_string();
-    }
-
-    let safe_tmp_dir = format!("{}/.homeboy-install.XXXXXX", target_parent);
-    let safe_tmp_pattern = format!("mktemp -d {}", shell::quote_path(&safe_tmp_dir));
-    command.replace(LEGACY_TMP_PATTERN, &safe_tmp_pattern)
+    HashMap::from([
+        ("artifact".to_string(), artifact_filename.to_string()),
+        ("stagingArtifact".to_string(), staging_artifact.to_string()),
+        (TemplateVars::TARGET_DIR.to_string(), target_dir.to_string()),
+        (
+            TemplateVars::TARGET_PARENT_DIR.to_string(),
+            target_parent_dir.to_string(),
+        ),
+        (
+            TemplateVars::TARGET_ADJACENT_TEMP_PATTERN.to_string(),
+            target_adjacent_temp_pattern,
+        ),
+        ("siteRoot".to_string(), site_root.unwrap_or("").to_string()),
+        ("cliPath".to_string(), cli_path.to_string()),
+        ("domain".to_string(), domain.unwrap_or("").to_string()),
+        ("allowRootFlag".to_string(), "--allow-root".to_string()),
+    ])
 }
 
 /// Build template variables and run `post:deploy` hooks remotely via SSH.
@@ -596,46 +601,32 @@ mod tests {
     }
 
     #[test]
-    fn test_render_install_command_stages_legacy_plugin_replace_next_to_target() {
-        let template = r#"cd {{siteRoot}} && tmp_dir=$(mktemp -d /tmp/homeboy-install.XXXXXX) && unzip -q {{stagingArtifact}} -d "$tmp_dir" && extracted="$tmp_dir/$zip_root" && mv "$extracted" {{targetDir}} && rm -rf "$tmp_dir""#;
-        let vars = HashMap::from([
-            ("siteRoot".to_string(), "/srv/htdocs".to_string()),
-            (
-                "stagingArtifact".to_string(),
-                "/tmp/homeboy-staging/plugin.zip".to_string(),
-            ),
-            (
-                "targetDir".to_string(),
-                "/srv/htdocs/wp-content/plugins/wp-codebox".to_string(),
-            ),
-        ]);
-
-        let command = render_install_command(template, &vars);
-
-        assert!(
-            command.contains("mktemp -d '/srv/htdocs/wp-content/plugins/.homeboy-install.XXXXXX'")
+    fn test_deploy_override_template_vars_include_target_adjacent_temp_pattern() {
+        let vars = deploy_override_template_vars(
+            "artifact.zip",
+            "/tmp/homeboy-staging/artifact.zip",
+            "/srv/htdocs/wp-content/plugins/wp-codebox",
+            Some("/srv/htdocs"),
+            "wp",
+            Some("example.com"),
         );
-        assert!(!command.contains("mktemp -d /tmp/homeboy-install.XXXXXX"));
-    }
-
-    #[test]
-    fn test_render_install_command_leaves_unrelated_tempdirs_unchanged() {
-        let template =
-            "tmp_dir=$(mktemp -d /tmp/other.XXXXXX) && cp {{stagingArtifact}} {{targetDir}}";
-        let vars = HashMap::from([
-            (
-                "stagingArtifact".to_string(),
-                "/tmp/homeboy-staging/plugin.zip".to_string(),
-            ),
-            (
-                "targetDir".to_string(),
-                "/srv/htdocs/wp-content/plugins/wp-codebox".to_string(),
-            ),
-        ]);
 
         assert_eq!(
-            render_install_command(template, &vars),
-            "tmp_dir=$(mktemp -d /tmp/other.XXXXXX) && cp /tmp/homeboy-staging/plugin.zip /srv/htdocs/wp-content/plugins/wp-codebox"
+            vars.get(TemplateVars::TARGET_PARENT_DIR)
+                .map(String::as_str),
+            Some("/srv/htdocs/wp-content/plugins")
+        );
+        assert_eq!(
+            vars.get(TemplateVars::TARGET_ADJACENT_TEMP_PATTERN)
+                .map(String::as_str),
+            Some("/srv/htdocs/wp-content/plugins/.homeboy-install.XXXXXX")
+        );
+        assert_eq!(
+            render_map(
+                "mktemp -d {{targetAdjacentTempPattern}} && cp {{stagingArtifact}} {{targetDir}}/installed.zip",
+                &vars,
+            ),
+            "mktemp -d /srv/htdocs/wp-content/plugins/.homeboy-install.XXXXXX && cp /tmp/homeboy-staging/artifact.zip /srv/htdocs/wp-content/plugins/wp-codebox/installed.zip"
         );
     }
 }

--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -309,7 +309,7 @@ pub(super) fn deploy_with_override(
     vars.insert("domain".to_string(), domain.unwrap_or("").to_string());
     vars.insert("allowRootFlag".to_string(), "--allow-root".to_string());
 
-    let install_cmd = render_map(&override_config.install_command, &vars);
+    let install_cmd = render_install_command(&override_config.install_command, &vars);
     log_status!("deploy", "Running install command: {}", install_cmd);
 
     let install_output = ssh_client.execute(&install_cmd);
@@ -366,6 +366,39 @@ pub(super) fn deploy_with_override(
     }
 
     Ok(DeployResult::success(0))
+}
+
+fn render_install_command(template: &str, vars: &HashMap<String, String>) -> String {
+    let rendered = render_map(template, vars);
+    normalize_legacy_wordpress_plugin_install_tempdir(
+        &rendered,
+        vars.get("targetDir").map(String::as_str),
+    )
+}
+
+fn normalize_legacy_wordpress_plugin_install_tempdir(
+    command: &str,
+    target_dir: Option<&str>,
+) -> String {
+    let Some(target_dir) = target_dir else {
+        return command.to_string();
+    };
+
+    const LEGACY_TMP_PATTERN: &str = "mktemp -d /tmp/homeboy-install.XXXXXX";
+    if !command.contains(LEGACY_TMP_PATTERN) || !command.contains("mv \"$extracted\"") {
+        return command.to_string();
+    }
+
+    let Some((target_parent, _)) = target_dir.trim_end_matches('/').rsplit_once('/') else {
+        return command.to_string();
+    };
+    if target_parent.is_empty() {
+        return command.to_string();
+    }
+
+    let safe_tmp_dir = format!("{}/.homeboy-install.XXXXXX", target_parent);
+    let safe_tmp_pattern = format!("mktemp -d {}", shell::quote_path(&safe_tmp_dir));
+    command.replace(LEGACY_TMP_PATTERN, &safe_tmp_pattern)
 }
 
 /// Build template variables and run `post:deploy` hooks remotely via SSH.
@@ -559,6 +592,50 @@ mod tests {
         assert_eq!(
             fs::read_to_string(target.join("installed.zip")).expect("installed artifact"),
             "artifact bytes"
+        );
+    }
+
+    #[test]
+    fn test_render_install_command_stages_legacy_plugin_replace_next_to_target() {
+        let template = r#"cd {{siteRoot}} && tmp_dir=$(mktemp -d /tmp/homeboy-install.XXXXXX) && unzip -q {{stagingArtifact}} -d "$tmp_dir" && extracted="$tmp_dir/$zip_root" && mv "$extracted" {{targetDir}} && rm -rf "$tmp_dir""#;
+        let vars = HashMap::from([
+            ("siteRoot".to_string(), "/srv/htdocs".to_string()),
+            (
+                "stagingArtifact".to_string(),
+                "/tmp/homeboy-staging/plugin.zip".to_string(),
+            ),
+            (
+                "targetDir".to_string(),
+                "/srv/htdocs/wp-content/plugins/wp-codebox".to_string(),
+            ),
+        ]);
+
+        let command = render_install_command(template, &vars);
+
+        assert!(
+            command.contains("mktemp -d '/srv/htdocs/wp-content/plugins/.homeboy-install.XXXXXX'")
+        );
+        assert!(!command.contains("mktemp -d /tmp/homeboy-install.XXXXXX"));
+    }
+
+    #[test]
+    fn test_render_install_command_leaves_unrelated_tempdirs_unchanged() {
+        let template =
+            "tmp_dir=$(mktemp -d /tmp/other.XXXXXX) && cp {{stagingArtifact}} {{targetDir}}";
+        let vars = HashMap::from([
+            (
+                "stagingArtifact".to_string(),
+                "/tmp/homeboy-staging/plugin.zip".to_string(),
+            ),
+            (
+                "targetDir".to_string(),
+                "/srv/htdocs/wp-content/plugins/wp-codebox".to_string(),
+            ),
+        ]);
+
+        assert_eq!(
+            render_install_command(template, &vars),
+            "tmp_dir=$(mktemp -d /tmp/other.XXXXXX) && cp /tmp/homeboy-staging/plugin.zip /srv/htdocs/wp-content/plugins/wp-codebox"
         );
     }
 }

--- a/src/core/engine/template.rs
+++ b/src/core/engine/template.rs
@@ -14,6 +14,8 @@ impl TemplateVars {
     pub const QUERY: &'static str = "query";
     pub const FORMAT: &'static str = "format";
     pub const TARGET_DIR: &'static str = "targetDir";
+    pub const TARGET_PARENT_DIR: &'static str = "targetParentDir";
+    pub const TARGET_ADJACENT_TEMP_PATTERN: &'static str = "targetAdjacentTempPattern";
     pub const DB_HOST: &'static str = "db_host";
     pub const DB_PORT: &'static str = "db_port";
     pub const DB_NAME: &'static str = "db_name";


### PR DESCRIPTION
## Summary
- Refs #3027 by adding generic deploy override template variables for target-adjacent staging: `{{targetParentDir}}` and `{{targetAdjacentTempPattern}}`.
- Lets extension manifests stage extraction/replacement temp directories beside the deploy target, keeping final directory replacement on the same filesystem without hardcoding WordPress/plugin behavior into Homeboy core.
- Adds focused deploy override tests for the new template variables.

## Tests
- `cargo fmt --check`
- `cargo test core::deploy::version_overrides::tests --lib`
- `cargo test deploy --lib`

## Follow-up
- The WordPress extension manifest should switch its plugin installer from `/tmp/homeboy-install.XXXXXX` to `{{targetAdjacentTempPattern}}` so WP Cloud plugin replacement avoids cross-filesystem `mv` fallback behavior.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the deploy override path, drafted the generic Homeboy template-variable change and tests, and ran focused verification. Chris remains responsible for review and merge.