### PR TITLE
Fix performance digest persisted artifact lookup

### DIFF
--- a/src/commands/report/performance_digest.rs
+++ b/src/commands/report/performance_digest.rs
@@ -6,6 +6,7 @@ use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
 use crate::commands::escape_markdown_table_cell;
+use homeboy::core::engine::run_dir::files;
 
 #[derive(Args, Debug, Clone)]
 pub struct PerformanceDigestArgs {
@@ -129,13 +130,13 @@ pub fn performance_digest_from_args(
     let output_dir = PathBuf::from(&args.output_dir);
     let mut gaps = Vec::new();
 
-    let resource_summary = read_json_file(&output_dir.join("resource-summary.json"))
+    let resource_summary = read_json_artifact(&output_dir, &[files::RESOURCE_SUMMARY])
         .and_then(|value| resource_summary_digest(&value));
     if resource_summary.is_none() {
         gaps.push("resource-summary.json not found or not parseable".to_string());
     }
 
-    let bench_json = read_json_file(&output_dir.join("bench.json"));
+    let bench_json = read_json_artifact(&output_dir, &["bench.json", files::BENCH_RESULTS]);
     if bench_json.is_none() {
         gaps.push("bench.json not found or not parseable".to_string());
     }
@@ -191,6 +192,38 @@ mod helpers {
     pub(super) fn read_json_file(path: &Path) -> Option<Value> {
         let raw = std::fs::read_to_string(path).ok()?;
         serde_json::from_str(&raw).ok()
+    }
+
+    pub(super) fn read_json_artifact(output_dir: &Path, filenames: &[&str]) -> Option<Value> {
+        for filename in filenames {
+            if let Some(value) = read_json_file(&output_dir.join(filename)) {
+                return Some(value);
+            }
+        }
+
+        let mut candidates = std::fs::read_dir(output_dir)
+            .ok()?
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| path.is_file())
+            .collect::<Vec<_>>();
+        candidates.sort();
+
+        for filename in filenames {
+            let suffix = format!("-{filename}");
+            for path in &candidates {
+                let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                    continue;
+                };
+                if name.ends_with(&suffix) {
+                    if let Some(value) = read_json_file(path) {
+                        return Some(value);
+                    }
+                }
+            }
+        }
+
+        None
     }
 
     pub(super) fn read_json_spec_value(spec: &str, context: &str) -> homeboy::core::Result<Value> {
@@ -304,7 +337,11 @@ mod helpers {
     ) -> Vec<BaselineHealthDiagnostic> {
         let mut diagnostics = Vec::new();
         let results = object_value(data, "results");
-        for scenario in array_value(&results, "scenarios") {
+        let mut scenarios = array_value(&results, "scenarios");
+        if scenarios.is_empty() {
+            scenarios = array_value(data, "scenarios");
+        }
+        for scenario in scenarios {
             let Some(scenario_obj) = scenario.as_object() else {
                 continue;
             };

--- a/tests/report_performance_digest_test.rs
+++ b/tests/report_performance_digest_test.rs
@@ -161,6 +161,74 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
 }
 
 #[test]
+fn reads_persisted_uuid_prefixed_artifacts() {
+    let dir = tmp_dir("persisted");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    write_fixture_file(
+        &dir,
+        "123-resource-summary.json",
+        r#"{
+            "label": "persisted bench",
+            "duration_ms": 54321,
+            "platform": "macos",
+            "extension_children": [],
+            "warnings": []
+        }"#,
+    );
+    write_fixture_file(
+        &dir,
+        "456-bench-results.json",
+        r#"{
+            "component_id": "homeboy",
+            "iterations": 3,
+            "metadata": {
+                "warmup_iterations": 0
+            },
+            "budget_findings": [{
+                "code": "metric.max_value",
+                "severity": "error",
+                "message": "Metric exceeded budget",
+                "actual": 42,
+                "expected": 20,
+                "unit": "count",
+                "subject": "persisted-subject",
+                "passed": false
+            }],
+            "scenarios": [{
+                "id": "audit-self",
+                "runs_summary": {
+                    "p95_ms": { "n": 3, "mean": 100, "stdev": 30, "cv_pct": 30, "p50": 100, "p95": 140 }
+                }
+            }]
+        }"#,
+    );
+
+    let report = performance_digest_from_args(&args(&dir)).expect("digest should render");
+
+    assert!(report.gaps.is_empty());
+    assert_eq!(
+        report
+            .resource_summary
+            .as_ref()
+            .and_then(|summary| summary.label.as_deref()),
+        Some("persisted bench")
+    );
+    assert_eq!(report.budget_findings.len(), 1);
+    assert!(report
+        .baseline_health
+        .iter()
+        .any(|diagnostic| diagnostic.code == "baseline.high_variance"));
+    assert!(report
+        .baseline_health
+        .iter()
+        .any(|diagnostic| diagnostic.code == "baseline.missing_warmup"));
+    assert!(report.markdown.contains("- Duration: **54321 ms**"));
+    assert!(report.markdown.contains("persisted-subject"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn missing_optional_artifacts_degrade_gracefully() {
     let dir = tmp_dir("missing");
     fs::create_dir_all(&dir).expect("temp dir should exist");


### PR DESCRIPTION
## Summary
- Resolve performance digest artifacts by exact runtime filenames and persisted UUID-prefixed artifact filenames.
- Accept `bench-results.json` as bench evidence in addition to legacy `bench.json`.
- Cover persisted artifact directories with a regression test.

Closes #3037.

## Testing
- `cargo test --test report_performance_digest_test`
- `cargo check`
- `target/debug/homeboy report performance-digest --output-dir /Users/chubes/.local/share/homeboy/artifacts/3300c5be-b7f8-4d8b-a787-26b95e7bfa1e --format markdown`
- `target/debug/homeboy report performance-digest --output-dir /Users/chubes/.config/homeboy/runtime/tmp/homeboy-run-a4c3bb77-c37a-4600-bfc2-71038ef40851-1780073211697212000 --format markdown`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the released benchmark/reporting artifact mismatch, implementing the resolver/test change, and running verification commands. Chris remains responsible for review and merge.