### PR TITLE
Capture audit-self subprocess memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 # Bench binaries follow the homeboy-extensions/rust convention:
 # any [[bin]] whose name starts with `bench-` is discoverable by
 # `homeboy bench homeboy`. See src/bin/bench-*.rs for the workload
-# contract (reads HOMEBOY_BENCH_ITERATIONS, emits {timings_ns: [...]}).
+# contract (reads HOMEBOY_BENCH_ITERATIONS, emits timings plus optional memory evidence).
 [[bin]]
 name = "bench-audit-self"
 path = "src/bin/bench-audit-self.rs"

--- a/src/bin/bench-audit-self.rs
+++ b/src/bin/bench-audit-self.rs
@@ -27,6 +27,9 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::Instant;
 
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
+
 fn main() {
     let iterations: usize = env::var("HOMEBOY_BENCH_ITERATIONS")
         .ok()
@@ -60,24 +63,14 @@ fn main() {
     );
 
     let mut timings_ns: Vec<u64> = Vec::with_capacity(iterations);
+    let mut peak_rss_bytes: Vec<u64> = Vec::with_capacity(iterations);
 
     for i in 0..iterations {
         let start = Instant::now();
-        let status = Command::new(&homeboy_bin)
-            .args([
-                "audit",
-                "homeboy", // positional component id required by audit subcommand
-                "--path",
-                &fixture_path,
-                "--ignore-baseline",
-                "--json-summary",
-            ])
-            .stdout(Stdio::null()) // we only care about timing, not output
-            .stderr(Stdio::null())
-            .status();
+        let output = run_audit_iteration(&homeboy_bin, &fixture_path);
         let elapsed = start.elapsed();
 
-        match status {
+        match output.status {
             Ok(s) if s.success() || s.code() == Some(1) => {
                 // exit 1 = audit found findings; that's a normal "I did work"
                 // outcome, not a bench failure. Anything else (panics,
@@ -104,11 +97,18 @@ fn main() {
         }
 
         timings_ns.push(elapsed.as_nanos() as u64);
+        if let Some(rss) = output.peak_rss_bytes {
+            peak_rss_bytes.push(rss);
+        }
         eprintln!(
-            "[bench-audit-self] iteration {}/{}: {:.2}ms",
+            "[bench-audit-self] iteration {}/{}: {:.2}ms, peak_rss={}",
             i + 1,
             iterations,
-            elapsed.as_secs_f64() * 1000.0
+            elapsed.as_secs_f64() * 1000.0,
+            output
+                .peak_rss_bytes
+                .map(|rss| rss.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
         );
     }
 
@@ -118,7 +118,95 @@ fn main() {
         .map(|t| t.to_string())
         .collect::<Vec<_>>()
         .join(",");
-    println!("{{\"timings_ns\":[{}]}}", csv);
+    println!("{}", result_json(&csv, &peak_rss_bytes));
+}
+
+fn result_json(timings_csv: &str, peak_rss_bytes: &[u64]) -> String {
+    let rss_csv: String = peak_rss_bytes
+        .iter()
+        .map(|rss| rss.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let max_peak_rss = peak_rss_bytes.iter().copied().max().unwrap_or(0);
+    format!(
+        "{{\"timings_ns\":[{}],\"peak_rss_bytes\":{},\"peak_rss_bytes_by_iteration\":[{}]}}",
+        timings_csv, max_peak_rss, rss_csv
+    )
+}
+
+struct AuditIterationOutput {
+    status: std::io::Result<std::process::ExitStatus>,
+    peak_rss_bytes: Option<u64>,
+}
+
+fn audit_command(homeboy_bin: &PathBuf, fixture_path: &str) -> Command {
+    let mut command = Command::new(homeboy_bin);
+    command
+        .args([
+            "audit",
+            "homeboy", // positional component id required by audit subcommand
+            "--path",
+            fixture_path,
+            "--ignore-baseline",
+            "--json-summary",
+        ])
+        .stdout(Stdio::null()) // we only care about timing, not output
+        .stderr(Stdio::null());
+    command
+}
+
+#[cfg(unix)]
+fn run_audit_iteration(homeboy_bin: &PathBuf, fixture_path: &str) -> AuditIterationOutput {
+    let child = match audit_command(homeboy_bin, fixture_path).spawn() {
+        Ok(child) => child,
+        Err(err) => {
+            return AuditIterationOutput {
+                status: Err(err),
+                peak_rss_bytes: None,
+            }
+        }
+    };
+
+    let mut raw_status = 0;
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    let waited = unsafe {
+        libc::wait4(
+            child.id() as libc::pid_t,
+            &mut raw_status,
+            0,
+            usage.as_mut_ptr(),
+        )
+    };
+    if waited < 0 {
+        return AuditIterationOutput {
+            status: Err(std::io::Error::last_os_error()),
+            peak_rss_bytes: None,
+        };
+    }
+
+    let usage = unsafe { usage.assume_init() };
+    AuditIterationOutput {
+        status: Ok(std::process::ExitStatus::from_raw(raw_status)),
+        peak_rss_bytes: Some(maxrss_to_bytes(usage.ru_maxrss)),
+    }
+}
+
+#[cfg(not(unix))]
+fn run_audit_iteration(homeboy_bin: &PathBuf, fixture_path: &str) -> AuditIterationOutput {
+    AuditIterationOutput {
+        status: audit_command(homeboy_bin, fixture_path).status(),
+        peak_rss_bytes: None,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn maxrss_to_bytes(maxrss: libc::c_long) -> u64 {
+    u64::try_from(maxrss).unwrap_or(0)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn maxrss_to_bytes(maxrss: libc::c_long) -> u64 {
+    u64::try_from(maxrss).unwrap_or(0).saturating_mul(1024)
 }
 
 fn ensure_release_homeboy(manifest_dir: &str, homeboy_bin: &PathBuf) {
@@ -172,4 +260,34 @@ fn stable_homeboy_copy(homeboy_bin: &PathBuf) -> PathBuf {
         std::process::exit(2);
     }
     stable_path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn result_json_includes_max_and_per_iteration_peak_rss() {
+        let value: serde_json::Value = serde_json::from_str(&result_json("10,20", &[4096, 8192]))
+            .expect("result payload should be valid JSON");
+
+        assert_eq!(value["timings_ns"], serde_json::json!([10, 20]));
+        assert_eq!(value["peak_rss_bytes"], serde_json::json!(8192));
+        assert_eq!(
+            value["peak_rss_bytes_by_iteration"],
+            serde_json::json!([4096, 8192])
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn maxrss_to_bytes_preserves_macos_byte_units() {
+        assert_eq!(maxrss_to_bytes(4096), 4096);
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn maxrss_to_bytes_converts_unix_kib_units() {
+        assert_eq!(maxrss_to_bytes(4), 4096);
+    }
 }

--- a/src/commands/report/performance_digest.rs
+++ b/src/commands/report/performance_digest.rs
@@ -43,6 +43,8 @@ pub struct PerformanceDigestReport {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub budget_findings: Vec<BudgetFindingDigest>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub benchmark_memory: Vec<BenchmarkMemoryDigest>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub baseline_health: Vec<BaselineHealthDiagnostic>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub host_pressure: Option<HostPressureDigest>,
@@ -91,6 +93,12 @@ pub struct BudgetFindingDigest {
     pub unit: String,
     pub severity: String,
     pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct BenchmarkMemoryDigest {
+    pub scenario: String,
+    pub peak_bytes: u64,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -165,9 +173,11 @@ pub fn performance_digest_from_args(
     });
 
     let budget_findings = collect_budget_findings(&bench_data);
+    let benchmark_memory = collect_benchmark_memory(&bench_data);
     let markdown = render_markdown(
         resource_summary.as_ref(),
         &budget_findings,
+        &benchmark_memory,
         &baseline_health,
         host_pressure.as_ref(),
         &lab_offload,
@@ -179,6 +189,7 @@ pub fn performance_digest_from_args(
         markdown,
         resource_summary,
         budget_findings,
+        benchmark_memory,
         baseline_health,
         host_pressure,
         lab_offload,
@@ -325,6 +336,38 @@ mod helpers {
                     unit: string_value(obj, "unit").unwrap_or_else(|| "-".to_string()),
                     severity: string_value(obj, "severity").unwrap_or_else(|| "error".to_string()),
                     message: string_value(obj, "message").unwrap_or_default(),
+                })
+            })
+            .collect()
+    }
+
+    pub(super) fn collect_benchmark_memory(
+        data: &Map<String, Value>,
+    ) -> Vec<BenchmarkMemoryDigest> {
+        let results = object_value(data, "results");
+        let mut scenarios = array_value(&results, "scenarios");
+        if scenarios.is_empty() {
+            scenarios = array_value(data, "scenarios");
+        }
+
+        scenarios
+            .into_iter()
+            .filter_map(|scenario| {
+                let obj = scenario.as_object()?;
+                let scenario = string_value(obj, "id").unwrap_or_else(|| "unknown".to_string());
+                let peak_bytes = obj
+                    .get("memory")
+                    .and_then(Value::as_object)
+                    .and_then(|memory| u64_value(memory, "peak_bytes"))
+                    .or_else(|| {
+                        obj.get("metrics")
+                            .and_then(Value::as_object)
+                            .and_then(|metrics| number_value(metrics, "peak_rss_bytes"))
+                            .map(|value| value.max(0.0) as u64)
+                    })?;
+                Some(BenchmarkMemoryDigest {
+                    scenario,
+                    peak_bytes,
                 })
             })
             .collect()
@@ -505,6 +548,7 @@ mod helpers {
     pub(super) fn render_markdown(
         resource_summary: Option<&ResourceSummaryDigest>,
         budget_findings: &[BudgetFindingDigest],
+        benchmark_memory: &[BenchmarkMemoryDigest],
         baseline_health: &[BaselineHealthDiagnostic],
         host_pressure: Option<&HostPressureDigest>,
         lab_offload: &BTreeMap<String, String>,
@@ -515,6 +559,7 @@ mod helpers {
         out.push_str("## Performance Digest\n\n");
         render_resource_summary(&mut out, resource_summary);
         render_budget_findings(&mut out, budget_findings);
+        render_benchmark_memory(&mut out, benchmark_memory);
         render_baseline_health(&mut out, baseline_health);
         render_host_pressure(&mut out, host_pressure);
         render_lab_offload(&mut out, lab_offload);
@@ -619,6 +664,26 @@ mod helpers {
                 escape_markdown_table_cell(&finding.unit),
                 escape_markdown_table_cell(&finding.severity),
                 escape_markdown_table_cell(&finding.message)
+            );
+        }
+        out.push('\n');
+    }
+
+    pub(super) fn render_benchmark_memory(out: &mut String, memory: &[BenchmarkMemoryDigest]) {
+        out.push_str("### Benchmark Memory\n");
+        if memory.is_empty() {
+            out.push_str("- No scenario-level memory evidence available.\n\n");
+            return;
+        }
+
+        out.push_str("| Scenario | Peak RSS |\n");
+        out.push_str("| --- | ---: |\n");
+        for entry in memory.iter().take(10) {
+            let _ = writeln!(
+                out,
+                "| `{}` | {} |",
+                escape_markdown_table_cell(&entry.scenario),
+                format_bytes(Some(entry.peak_bytes))
             );
         }
         out.push('\n');

--- a/tests/report_performance_digest_test.rs
+++ b/tests/report_performance_digest_test.rs
@@ -79,6 +79,7 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
                 "results": {
                     "scenarios": [{
                         "id": "fixture-scenario",
+                        "memory": { "peak_bytes": 8388608 },
                         "runs_summary": {
                             "elapsed_ms": { "n": 2, "mean": 100, "stdev": 25, "cv_pct": 25, "p50": 100, "p95": 130 }
                         }
@@ -118,6 +119,9 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
 
     assert!(report.resource_summary.is_some());
     assert_eq!(report.budget_findings.len(), 1);
+    assert_eq!(report.benchmark_memory.len(), 1);
+    assert_eq!(report.benchmark_memory[0].scenario, "fixture-scenario");
+    assert_eq!(report.benchmark_memory[0].peak_bytes, 8388608);
     assert!(report
         .baseline_health
         .iter()
@@ -149,6 +153,8 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
     assert!(report.markdown.contains("### Resource Summary"));
     assert!(report.markdown.contains("- Duration: **12345 ms**"));
     assert!(report.markdown.contains("fixture workload"));
+    assert!(report.markdown.contains("### Benchmark Memory"));
+    assert!(report.markdown.contains("| `fixture-scenario` | 8.0 MiB |"));
     assert!(report.markdown.contains("### Bench Budget Findings"));
     assert!(report.markdown.contains("| `metric.max_value` | fixture-subject | 42 | 20 | count | error | Metric exceeded budget |"));
     assert!(report.markdown.contains("### Baseline Health"));
@@ -196,6 +202,7 @@ fn reads_persisted_uuid_prefixed_artifacts() {
             }],
             "scenarios": [{
                 "id": "audit-self",
+                "metrics": { "peak_rss_bytes": 41943040 },
                 "runs_summary": {
                     "p95_ms": { "n": 3, "mean": 100, "stdev": 30, "cv_pct": 30, "p50": 100, "p95": 140 }
                 }
@@ -214,6 +221,9 @@ fn reads_persisted_uuid_prefixed_artifacts() {
         Some("persisted bench")
     );
     assert_eq!(report.budget_findings.len(), 1);
+    assert_eq!(report.benchmark_memory.len(), 1);
+    assert_eq!(report.benchmark_memory[0].scenario, "audit-self");
+    assert_eq!(report.benchmark_memory[0].peak_bytes, 41943040);
     assert!(report
         .baseline_health
         .iter()


### PR DESCRIPTION
## Summary
- Capture per-iteration `homeboy audit` subprocess peak RSS in `bench-audit-self` using `wait4` resource usage, while preserving the existing timing contract.
- Emit `peak_rss_bytes` plus `peak_rss_bytes_by_iteration` so the Rust bench runner stores scenario-level memory evidence.
- Render persisted scenario memory in `report performance-digest` under a `Benchmark Memory` table.

Fixes #3039

## Verification
- `cargo test --bin bench-audit-self`
- `cargo test --test report_performance_digest_test`
- `cargo run --bin homeboy -- bench --path . --extension rust --scenario audit-self --runs 1 --iterations 1 --warmup 0 --force-hot --json-summary`
- `cargo run --bin homeboy -- runs show 7cc9f133-2674-4333-929b-b1dc8fc5d322`
- `cargo run --bin homeboy -- report performance-digest --output-dir /Users/chubes/.local/share/homeboy/artifacts/7cc9f133-2674-4333-929b-b1dc8fc5d322`

## Notes
- The Data Machine Code workspace CLI could not clone/adopt from this site runtime because the PHP sandbox reported that `git` was unavailable. I used an isolated `/Users/chubes/Developer/homeboy@bench-subprocess-memory` worktree instead of editing the primary checkout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing subprocess RSS capture, performance digest rendering, tests, and local verification. Chris remains responsible for review and merge.