### PR TITLE
Honor explicit deploy build commands

### DIFF
--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -172,6 +172,7 @@ pub struct Component {
     pub local_path: String,
     pub remote_path: String,
     pub build_artifact: Option<String>,
+    pub build_command: Option<String>,
     pub extensions: Option<HashMap<String, ScopedExtensionConfig>>,
     pub version_targets: Option<Vec<VersionTarget>>,
     pub changelog_target: Option<String>,
@@ -243,6 +244,8 @@ struct RawComponent {
     )]
     build_artifact: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    build_command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     extensions: Option<HashMap<String, ScopedExtensionConfig>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     version_targets: Option<Vec<VersionTarget>>,
@@ -298,6 +301,7 @@ impl From<RawComponent> for Component {
             local_path: raw.local_path,
             remote_path: raw.remote_path,
             build_artifact: raw.build_artifact,
+            build_command: raw.build_command,
             extensions: raw.extensions,
             version_targets: raw.version_targets,
             changelog_target: raw.changelog_target,
@@ -333,6 +337,7 @@ impl From<Component> for RawComponent {
             local_path: c.local_path,
             remote_path: c.remote_path,
             build_artifact: c.build_artifact,
+            build_command: c.build_command,
             extensions: c.extensions,
             version_targets: c.version_targets,
             changelog_target: c.changelog_target,
@@ -408,6 +413,7 @@ impl Component {
             local_path,
             remote_path,
             build_artifact,
+            build_command: None,
             extensions: None,
             version_targets: None,
             changelog_target: None,

--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -181,7 +181,19 @@ pub fn run(input: &str) -> Result<(BuildResult, i32)> {
 /// Thin wrapper around `execute_build_component` that adapts the return type
 /// for the deploy pipeline's error handling convention.
 pub(crate) fn build_component(component: &component::Component) -> (Option<i32>, Option<String>) {
-    match execute_build_component(component) {
+    let result = if component.build_artifact.is_some() {
+        component
+            .build_command
+            .as_deref()
+            .map(str::trim)
+            .filter(|command| !command.is_empty())
+            .map(|command| execute_explicit_build_command(component, command))
+            .unwrap_or_else(|| execute_build_component(component))
+    } else {
+        execute_build_component(component)
+    };
+
+    match result {
         Ok((output, exit_code)) => {
             if output.success {
                 (Some(exit_code), None)
@@ -201,6 +213,29 @@ pub(crate) fn build_component(component: &component::Component) -> (Option<i32>,
         }
         Err(e) => (Some(1), Some(e.to_string())),
     }
+}
+
+fn execute_explicit_build_command(comp: &Component, build_cmd: &str) -> Result<(BuildOutput, i32)> {
+    let validated_path = component::validate_local_path(comp)?;
+    let local_path_str = validated_path.to_string_lossy().to_string();
+
+    permissions::fix_local_permissions(&local_path_str);
+
+    let env = [("HOMEBOY_PLUGIN_PATH", comp.local_path.as_str())];
+    let output = execute_local_command_in_dir(build_cmd, Some(&local_path_str), Some(&env));
+    let success = output.success;
+    let exit_code = output.exit_code;
+
+    Ok((
+        BuildOutput {
+            command: "build.run".to_string(),
+            component_id: comp.id.clone(),
+            build_command: build_cmd.to_string(),
+            output: CapturedOutput::new(output.stdout, output.stderr),
+            success,
+        },
+        exit_code,
+    ))
 }
 
 /// Format a build error message with context from stderr/stdout.
@@ -470,6 +505,7 @@ fn run_pre_build_scripts(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::component::ComponentScriptsConfig;
 
     #[test]
     fn is_json_input_detects_json() {
@@ -498,5 +534,33 @@ mod tests {
             hint.message
                 .contains("component-level `build_command` is not supported")
         }));
+    }
+
+    #[test]
+    fn deploy_build_uses_explicit_command_when_artifact_is_required() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let component = Component {
+            id: "wp-codebox".to_string(),
+            local_path: temp.path().to_string_lossy().to_string(),
+            build_artifact: Some("dist/wp-codebox.zip".to_string()),
+            build_command: Some(
+                "mkdir -p dist && printf explicit > dist/wp-codebox.zip".to_string(),
+            ),
+            scripts: Some(ComponentScriptsConfig {
+                build: vec!["mkdir -p dist && printf generic > dist/generic.zip".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let (exit_code, error) = build_component(&component);
+
+        assert_eq!(exit_code, Some(0));
+        assert_eq!(error, None);
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("dist/wp-codebox.zip")).unwrap(),
+            "explicit"
+        );
+        assert!(!temp.path().join("dist/generic.zip").exists());
     }
 }


### PR DESCRIPTION
## Summary
- Parse component-level `build_command` so deploy can see explicit artifact build commands.
- When deploy needs a configured `build_artifact`, run the component `build_command` before falling back to generic build resolution.
- Add regression coverage where the generic build produces the wrong artifact and the explicit deploy command produces the required ZIP.

Fixes #3041

## Tests
- `cargo fmt --check`
- `cargo test core::extension::build::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated deploy build-command selection, implemented the narrow fix, added regression coverage, and ran focused verification. Chris remains responsible for review and merge.