### PR TITLE
Batch observation finding inserts

### DIFF
--- a/src/commands/report/performance_digest.rs
+++ b/src/commands/report/performance_digest.rs
@@ -359,6 +359,7 @@ mod helpers {
                     .get("memory")
                     .and_then(Value::as_object)
                     .and_then(|memory| u64_value(memory, "peak_bytes"))
+                    .or_else(|| max_run_peak_bytes(obj))
                     .or_else(|| {
                         obj.get("metrics")
                             .and_then(Value::as_object)
@@ -371,6 +372,18 @@ mod helpers {
                 })
             })
             .collect()
+    }
+
+    fn max_run_peak_bytes(scenario: &Map<String, Value>) -> Option<u64> {
+        array_value(scenario, "runs")
+            .into_iter()
+            .filter_map(|run| {
+                run.as_object()?
+                    .get("memory")?
+                    .as_object()
+                    .and_then(|memory| u64_value(memory, "peak_bytes"))
+            })
+            .max()
     }
 
     pub(super) fn collect_baseline_health(

--- a/src/core/observation/store/findings.rs
+++ b/src/core/observation/store/findings.rs
@@ -5,10 +5,52 @@ use super::*;
 
 impl ObservationStore {
     pub fn record_findings(&self, findings: &[NewFindingRecord]) -> Result<Vec<FindingRecord>> {
+        if findings.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let run_id = &findings[0].run_id;
+        validate_required("finding.run_id", run_id)?;
+        if self.get_run(run_id)?.is_none() {
+            return Err(Error::validation_invalid_argument(
+                "finding.run_id",
+                format!("referenced run record not found: {}", run_id),
+                Some(run_id.clone()),
+                None,
+            ));
+        }
+        for finding in findings {
+            validate_required("finding.run_id", &finding.run_id)?;
+            if finding.run_id != *run_id {
+                return Err(Error::validation_invalid_argument(
+                    "finding.run_id",
+                    "all batch findings must reference the same run record".to_string(),
+                    Some(finding.run_id.clone()),
+                    None,
+                ));
+            }
+            validate_required("finding.tool", &finding.tool)?;
+            validate_required("finding.message", &finding.message)?;
+        }
+
+        self.connection
+            .execute_batch("BEGIN IMMEDIATE TRANSACTION")
+            .map_err(sqlite_error("begin finding batch"))?;
+
         let mut records = Vec::with_capacity(findings.len());
         for finding in findings {
-            records.push(self.record_finding(finding)?);
+            match self.insert_finding_unchecked(finding) {
+                Ok(record) => records.push(record),
+                Err(error) => {
+                    let _ = self.connection.execute_batch("ROLLBACK");
+                    return Err(error);
+                }
+            }
         }
+
+        self.connection
+            .execute_batch("COMMIT")
+            .map_err(sqlite_error("commit finding batch"))?;
         Ok(records)
     }
 
@@ -25,6 +67,10 @@ impl ObservationStore {
             ));
         }
 
+        self.insert_finding_unchecked(finding)
+    }
+
+    fn insert_finding_unchecked(&self, finding: &NewFindingRecord) -> Result<FindingRecord> {
         let id = Uuid::new_v4().to_string();
         let created_at = chrono::Utc::now().to_rfc3339();
         let metadata_json = serialize_metadata(&finding.metadata_json)?;
@@ -57,10 +103,19 @@ impl ObservationStore {
             )
             .map_err(sqlite_error("insert finding record"))?;
 
-        self.get_finding(&id)?.ok_or_else(|| {
-            Error::internal_unexpected(format!(
-                "Inserted finding record {id} but could not read it back"
-            ))
+        Ok(FindingRecord {
+            id,
+            run_id: finding.run_id.clone(),
+            tool: finding.tool.clone(),
+            rule: finding.rule.clone(),
+            file: finding.file.clone(),
+            line: finding.line,
+            severity: finding.severity.clone(),
+            fingerprint: finding.fingerprint.clone(),
+            message: finding.message.clone(),
+            fixable: finding.fixable,
+            metadata_json: finding.metadata_json.clone(),
+            created_at,
         })
     }
 
@@ -310,6 +365,48 @@ mod tests {
                 .expect("findings");
 
             assert_eq!(findings.len(), 2);
+            assert_eq!(findings[0].rule.as_deref(), Some("security"));
+            assert_eq!(findings[1].rule.as_deref(), Some("i18n"));
+        });
+    }
+
+    #[test]
+    fn test_record_findings_rejects_unknown_run_before_insert() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+
+            let result = store.record_findings(&[
+                new_finding("missing-run", "security"),
+                new_finding("missing-run", "i18n"),
+            ]);
+
+            assert!(result.is_err());
+            let findings = store
+                .list_findings(FindingListFilter::default())
+                .expect("list");
+            assert!(findings.is_empty());
+        });
+    }
+
+    #[test]
+    fn test_record_findings_requires_one_run_per_batch() {
+        with_isolated_home(|_| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let first = store.start_run(new_run()).expect("first run");
+            let second = store.start_run(new_run()).expect("second run");
+
+            let result = store.record_findings(&[
+                new_finding(&first.id, "security"),
+                new_finding(&second.id, "i18n"),
+            ]);
+
+            assert!(result.is_err());
+            let findings = store
+                .list_findings(FindingListFilter::default())
+                .expect("list");
+            assert!(findings.is_empty());
         });
     }
 

--- a/tests/report_performance_digest_test.rs
+++ b/tests/report_performance_digest_test.rs
@@ -269,3 +269,33 @@ fn missing_optional_artifacts_degrade_gracefully() {
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn renders_max_peak_rss_from_multi_run_memory() {
+    let dir = tmp_dir("multi-run-memory");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    write_fixture_file(
+        &dir,
+        "bench-results.json",
+        r#"{
+            "component_id": "homeboy",
+            "scenarios": [{
+                "id": "audit-self",
+                "runs": [
+                    { "memory": { "peak_bytes": 1048576 }, "metrics": { "p95_ms": 10 } },
+                    { "memory": { "peak_bytes": 33554432 }, "metrics": { "p95_ms": 12 } },
+                    { "memory": { "peak_bytes": 16777216 }, "metrics": { "p95_ms": 11 } }
+                ]
+            }]
+        }"#,
+    );
+
+    let report = performance_digest_from_args(&args(&dir)).expect("digest should render");
+
+    assert_eq!(report.benchmark_memory.len(), 1);
+    assert_eq!(report.benchmark_memory[0].scenario, "audit-self");
+    assert_eq!(report.benchmark_memory[0].peak_bytes, 33554432);
+    assert!(report.markdown.contains("| `audit-self` | 32.0 MiB |"));
+
+    let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Summary
- Batch `ObservationStore::record_findings` inserts in one SQLite transaction after validating the shared run once.
- Preserve single-finding behavior while avoiding per-finding run lookups and readbacks in the batch path.
- Render benchmark memory from multi-run `runs[].memory` evidence so normal `audit-self` runs show peak RSS in performance digests.

Fixes #3042.

## Testing
- `cargo fmt --check`
- `cargo test core::observation::store::findings --lib`
- `cargo test --test report_performance_digest_test`
- `cargo check`
- `target/debug/homeboy bench --path . --extension rust --scenario audit-self --runs 3 --iterations 10 --warmup 1 --force-hot --json-summary --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-batch-findings-bench.json`
- `target/debug/homeboy report performance-digest --output-dir /Users/chubes/.local/share/homeboy/artifacts/d69fb4d4-2eca-46c3-aa7a-dcc2aac9cc0b --format markdown`

## Benchmark notes
- Baseline run on current main before this branch: `10a94536-f709-4d70-88dd-509cded8c6b5`, median `p95_ms` about `8356 ms`, load before `12.91 / 12.63 / 10.90`.
- Candidate run: `d69fb4d4-2eca-46c3-aa7a-dcc2aac9cc0b`, median `p95_ms` about `9088 ms`, load before `39.16 / 25.67 / 17.84`.
- The end-to-end benchmark was too noisy/hot to claim a wall-time win. The code change removes repeated SQLite round trips from audit observation persistence and the digest now correctly exposes the memory evidence needed for later comparisons.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identifying the observation persistence hot path, implementing the batch insert and memory digest fixes, and running focused tests/bench verification. Chris remains responsible for review and merge.