### PR TITLE
Fix release deploy handoff to tagged release

### DIFF
--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -75,7 +75,7 @@ pub(super) fn deploy_components(
     validate_effective_remote_paths(&components, &project, base_path)?;
 
     // Gather versions
-    let local_versions: HashMap<String, String> = components
+    let mut local_versions: HashMap<String, String> = components
         .iter()
         .filter_map(|c| version::get_component_version(c).map(|v| (c.id.clone(), v)))
         .collect();
@@ -138,6 +138,11 @@ pub(super) fn deploy_components(
     if let Some(ref expected) = config.expected_version {
         verify_expected_version(&components, expected)?;
     }
+
+    local_versions = components
+        .iter()
+        .filter_map(|c| version::get_component_version(c).map(|v| (c.id.clone(), v)))
+        .collect();
 
     // Execute deployments
     let mut results: Vec<ComponentDeployResult> = vec![];
@@ -721,13 +726,16 @@ fn verify_expected_version(components: &[Component], expected: &str) -> Result<(
     let mut mismatches = Vec::new();
 
     for component in components {
-        if let Some(local_version) = version::get_component_version(component) {
-            if local_version != expected {
-                mismatches.push(format!(
-                    "'{}': local version is {} (expected {})",
-                    component.id, local_version, expected
-                ));
-            }
+        match version::get_component_version(component) {
+            Some(local_version) if local_version == expected => {}
+            Some(local_version) => mismatches.push(format!(
+                "'{}': local version is {} (expected {})",
+                component.id, local_version, expected
+            )),
+            None => mismatches.push(format!(
+                "'{}': local version could not be read (expected {})",
+                component.id, expected
+            )),
         }
     }
 
@@ -865,6 +873,29 @@ mod tests {
             .expect_err("default tag deploy should still require an explicit override");
         assert!(
             err.message.contains("HEAD has unreleased commits"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn expected_version_rejects_stale_component_worktree() {
+        let dir = TempDir::new().expect("temp dir");
+        let package_json = dir.path().join("package.json");
+        std::fs::write(&package_json, r#"{"version":"1.0.0"}"#).expect("write package.json");
+
+        let mut component = make_component("demo", &dir.path().to_string_lossy());
+        component.version_targets = Some(vec![crate::core::component::VersionTarget {
+            file: "package.json".to_string(),
+            pattern: Some(r#""version"\s*:\s*"([^"]+)""#.to_string()),
+        }]);
+
+        let err = verify_expected_version(&[component], "1.0.1")
+            .expect_err("stale registered worktree must not pass release deploy preflight");
+
+        assert!(
+            err.message
+                .contains("local version is 1.0.0 (expected 1.0.1)"),
             "unexpected error: {}",
             err.message
         );

--- a/src/core/release/deployment.rs
+++ b/src/core/release/deployment.rs
@@ -27,8 +27,12 @@ pub(super) fn plan_deployment(component_id: &str) -> ReleaseDeploymentResult {
     }
 }
 
-pub(super) fn run_deployment_step(component_id: &str, local_path: &str) -> ReleaseStepResult {
-    let deployment = execute_deployment(component_id, local_path);
+pub(super) fn run_deployment_step(
+    component_id: &str,
+    local_path: &str,
+    expected_version: Option<&str>,
+) -> ReleaseStepResult {
+    let deployment = execute_deployment(component_id, local_path, expected_version);
     let deploy_failed = deployment.summary.failed > 0;
 
     ReleaseStepResult {
@@ -57,7 +61,11 @@ pub(super) fn extract_deployment_from_run(run: &ReleaseRun) -> Option<ReleaseDep
         .and_then(|deployment| serde_json::from_value(deployment.clone()).ok())
 }
 
-fn execute_deployment(component_id: &str, local_path: &str) -> ReleaseDeploymentResult {
+fn execute_deployment(
+    component_id: &str,
+    local_path: &str,
+    expected_version: Option<&str>,
+) -> ReleaseDeploymentResult {
     let projects = release_deploy_targets(component_id);
 
     if projects.is_empty() {
@@ -74,21 +82,7 @@ fn execute_deployment(component_id: &str, local_path: &str) -> ReleaseDeployment
         projects.len()
     );
 
-    let config = DeployConfig {
-        component_ids: vec![component_id.to_string()],
-        all: false,
-        outdated: false,
-        behind_upstream: false,
-        dry_run: false,
-        check: false,
-        force: true,
-        skip_build: false,
-        keep_deps: false,
-        expected_version: None,
-        no_pull: true,
-        head: true,
-        tagged: true,
-    };
+    let config = release_deployment_config(component_id, expected_version);
 
     let deployment = match deploy::run_multi(&projects, &[component_id.to_string()], &config) {
         Ok(result) => ReleaseDeploymentResult {
@@ -133,6 +127,24 @@ fn execute_deployment(component_id: &str, local_path: &str) -> ReleaseDeployment
 
     cleanup_release_artifacts(local_path);
     deployment
+}
+
+fn release_deployment_config(component_id: &str, expected_version: Option<&str>) -> DeployConfig {
+    DeployConfig {
+        component_ids: vec![component_id.to_string()],
+        all: false,
+        outdated: false,
+        behind_upstream: false,
+        dry_run: false,
+        check: false,
+        force: true,
+        skip_build: false,
+        keep_deps: false,
+        expected_version: expected_version.map(str::to_string),
+        no_pull: false,
+        head: false,
+        tagged: true,
+    }
 }
 
 fn release_deploy_targets(component_id: &str) -> Vec<String> {
@@ -184,7 +196,7 @@ mod tests {
 
     #[test]
     fn test_run_deployment_step() {
-        let result = super::run_deployment_step("definitely-not-used-by-projects", "/tmp");
+        let result = super::run_deployment_step("definitely-not-used-by-projects", "/tmp", None);
 
         assert_eq!(result.id, "deploy");
         assert_eq!(result.status, ReleaseStepStatus::Success);
@@ -217,5 +229,25 @@ mod tests {
 
         let extracted = extract_deployment_from_run(&run).expect("deployment result");
         assert_eq!(extracted.summary.total_projects, 0);
+    }
+
+    #[test]
+    fn release_deploy_config_uses_tagged_release_version() {
+        let config = super::release_deployment_config("demo", Some("1.2.3"));
+
+        assert_eq!(config.component_ids, vec!["demo".to_string()]);
+        assert_eq!(config.expected_version, Some("1.2.3".to_string()));
+        assert!(
+            config.tagged,
+            "release deploy must use tagged deploy semantics"
+        );
+        assert!(
+            !config.head,
+            "release deploy must not deploy the registered worktree HEAD"
+        );
+        assert!(
+            !config.no_pull,
+            "release deploy must fetch/pull before checking out the released tag"
+        );
     }
 }

--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -123,6 +123,7 @@ pub(super) fn execute_release_plan_step(
         "deploy" => Ok(Some(super::deployment::run_deployment_step(
             context.component_id,
             &context.component.local_path,
+            context.state.version.as_deref(),
         ))),
         step_kind if step_kind.starts_with("publish.") => {
             let target = step_kind.strip_prefix("publish.").unwrap_or_default();


### PR DESCRIPTION
## Summary
- Fixes release `--deploy` so the deploy step uses tagged deploy semantics instead of the registered component worktree HEAD.
- Passes the just-released version into deploy as `expected_version`, allowing stale or unreadable deploy worktrees to fail before deployment.
- Rereads local component versions after sync/tag checkout so deploy output reflects the ref that is actually being deployed.

Fixes #3047.

## Verification
- `cargo test core::release::deployment`
- `cargo test core::deploy::orchestration`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-release-deploy-tag-ref-3047 --extension rust --changed-since origin/main`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the release/deploy handoff, drafted the Rust fix and regression tests, and ran verification; Chris remains responsible for review and merge.