### PR TITLE
Honor artifact build commands

### DIFF
--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -181,17 +181,7 @@ pub fn run(input: &str) -> Result<(BuildResult, i32)> {
 /// Thin wrapper around `execute_build_component` that adapts the return type
 /// for the deploy pipeline's error handling convention.
 pub(crate) fn build_component(component: &component::Component) -> (Option<i32>, Option<String>) {
-    let result = if component.build_artifact.is_some() {
-        component
-            .build_command
-            .as_deref()
-            .map(str::trim)
-            .filter(|command| !command.is_empty())
-            .map(|command| execute_explicit_build_command(component, command))
-            .unwrap_or_else(|| execute_build_component(component))
-    } else {
-        execute_build_component(component)
-    };
+    let result = execute_build_component(component);
 
     match result {
         Ok((output, exit_code)) => {
@@ -363,6 +353,10 @@ fn execute_build(component_id: &str, path_override: Option<&str>) -> Result<(Bui
 }
 
 fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
+    if let Some(command) = artifact_build_command(comp) {
+        return execute_explicit_build_command(comp, command);
+    }
+
     // Validate required extensions are installed before resolving build commands.
     // Without this, missing extensions cause vague "no build command" errors.
     extension::validate_required_extensions(comp)?;
@@ -452,6 +446,18 @@ fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
     ))
 }
 
+fn artifact_build_command(component: &Component) -> Option<&str> {
+    if component.build_artifact.is_none() {
+        return None;
+    }
+
+    component
+        .build_command
+        .as_deref()
+        .map(str::trim)
+        .filter(|command| !command.is_empty())
+}
+
 /// Run pre-build scripts from all configured extensions.
 /// Returns Some((exit_code, stderr)) if any script fails, None if all pass or no scripts.
 fn run_pre_build_scripts(
@@ -531,8 +537,9 @@ mod tests {
                 .contains("homeboy component set plain-package --extension")
         }));
         assert!(err.hints.iter().any(|hint| {
-            hint.message
-                .contains("component-level `build_command` is not supported")
+            hint.message.contains(
+                "component-level `build_command` is only used for artifact-producing builds",
+            )
         }));
     }
 
@@ -560,6 +567,42 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(temp.path().join("dist/wp-codebox.zip")).unwrap(),
             "explicit"
+        );
+        assert!(!temp.path().join("dist/generic.zip").exists());
+    }
+
+    #[test]
+    fn build_run_uses_explicit_command_when_artifact_is_required() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let component = Component {
+            id: "wp-codebox".to_string(),
+            local_path: temp.path().to_string_lossy().to_string(),
+            build_artifact: Some("packages/wordpress-plugin/dist/wp-codebox.zip".to_string()),
+            build_command: Some(
+                "mkdir -p packages/wordpress-plugin/dist && printf artifact > packages/wordpress-plugin/dist/wp-codebox.zip".to_string(),
+            ),
+            scripts: Some(ComponentScriptsConfig {
+                build: vec!["mkdir -p dist && printf generic > dist/generic.zip".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let (result, exit_code) = run_component(&component).expect("build should run");
+
+        let BuildResult::Single(output) = result else {
+            panic!("expected single build result");
+        };
+        assert_eq!(exit_code, 0);
+        assert!(output.success);
+        assert_eq!(output.build_command, component.build_command.unwrap());
+        assert_eq!(
+            std::fs::read_to_string(
+                temp.path()
+                    .join("packages/wordpress-plugin/dist/wp-codebox.zip")
+            )
+            .unwrap(),
+            "artifact"
         );
         assert!(!temp.path().join("dist/generic.zip").exists());
     }

--- a/src/core/extension/capability.rs
+++ b/src/core/extension/capability.rs
@@ -216,7 +216,7 @@ pub(crate) fn extension_guidance_hints(
         link_hint,
         "List installed extensions: homeboy extension list".to_string(),
         "The component path resolved correctly; the requested command needs an extension provider.".to_string(),
-        "For one-off shell builds or checks, model the workflow as a rig `command` step; component-level `build_command` is not supported.".to_string(),
+        "For one-off shell builds or checks without `build_artifact`, model the workflow as a rig `command` step; component-level `build_command` is only used for artifact-producing builds.".to_string(),
     ]
 }
 

--- a/src/core/extension/tests.rs
+++ b/src/core/extension/tests.rs
@@ -261,9 +261,9 @@ fn extension_guidance_hints_point_to_supported_paths() {
     assert!(hints
         .iter()
         .any(|hint| { hint.contains("homeboy component set plain-package --extension") }));
-    assert!(hints
-        .iter()
-        .any(|hint| { hint.contains("component-level `build_command` is not supported") }));
+    assert!(hints.iter().any(|hint| {
+        hint.contains("component-level `build_command` is only used for artifact-producing builds")
+    }));
     assert!(hints
         .iter()
         .any(|hint| hint.contains("homeboy extension list")));


### PR DESCRIPTION
## Summary
- Fixes `homeboy build` and deploy-time builds for artifact-producing components so an explicit component `build_command` runs before extension default build resolution when `build_artifact` is configured.
- Keeps extension/script build behavior unchanged for components without an artifact-producing `build_command`.
- Updates guidance text to clarify component `build_command` is supported for artifact-producing builds.

Fixes #3048.

## Verification
- `cargo fmt`
- `cargo test core::extension::build::tests`
- `cargo test core::extension::tests::extension_guidance_hints_point_to_supported_paths`
- `git diff --check`
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-3048-build-command-artifact --extension rust` ran the full suite and failed in existing/unrelated harness tests:
  - `core::extension::trace::run::tests::rig_save_baseline_does_not_write_component_homeboy_json`
  - `core::source_snapshot::tests::test_collect_local`
  - `core::runner::execution::tests::reverse_broker_exec_submits_job_and_polls_result`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the build/deploy path, drafted the fix and regression tests, ran verification, and prepared this PR summary for Chris to review.