### PR TITLE
Run rig bench_prepare before benchmark workloads

### DIFF
--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -30,6 +30,15 @@ struct RigBenchContext {
 fn prepare_rig_bench_context(rig_id: &str) -> homeboy::core::Result<RigBenchContext> {
     let spec = rig::load(rig_id)?;
     let lease = rig::lease::acquire_active_run_lease(&spec, "bench")?;
+    if let Some(prepare) = rig::run_bench_prepare(&spec)? {
+        if !prepare.success {
+            return Err(homeboy::core::Error::rig_pipeline_failed(
+                &spec.id,
+                "bench_prepare",
+                "rig bench preparation failed; refusing to run bench workload",
+            ));
+        }
+    }
     let snapshot = rig::snapshot_state(&spec);
     let package_root =
         rig::read_source_metadata(&spec.id).map(|metadata| PathBuf::from(metadata.package_path));

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -1487,6 +1487,9 @@ mod bench_default_baseline_dispatch_test;
 #[path = "../../../tests/core/rig/bench_default_baseline_output_test.rs"]
 mod bench_default_baseline_output_test;
 #[cfg(test)]
+#[path = "../../../tests/core/rig/bench_prepare_pipeline_test.rs"]
+mod bench_prepare_pipeline_test;
+#[cfg(test)]
 #[path = "../../../tests/core/rig/bench_resource_lease_test.rs"]
 mod bench_resource_lease_test;
 #[cfg(test)]

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -42,9 +42,9 @@ pub use install::{
 pub use lease::{acquire_active_run_lease, active_run_leases, ActiveRigRunLease, RigRunLease};
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use runner::{
-    head_sha_and_branch, run_check, run_check_groups, run_down, run_repair, run_status, run_up,
-    snapshot_state, CheckReport, DownReport, RepairReport, RepairResourceReport, RigStatusReport,
-    SymlinkStatusReport, SymlinkStatusState, UpReport,
+    head_sha_and_branch, run_bench_prepare, run_check, run_check_groups, run_down, run_repair,
+    run_status, run_up, snapshot_state, BenchPrepareReport, CheckReport, DownReport, RepairReport,
+    RepairResourceReport, RigStatusReport, SymlinkStatusReport, SymlinkStatusState, UpReport,
 };
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use source::{

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -39,6 +39,14 @@ pub struct CheckReport {
     pub success: bool,
 }
 
+/// Report from a bench preparation pipeline.
+#[derive(Debug, Clone, Serialize)]
+pub struct BenchPrepareReport {
+    pub rig_id: String,
+    pub pipeline: PipelineOutcome,
+    pub success: bool,
+}
+
 /// Report from `rig down`.
 #[derive(Debug, Clone, Serialize)]
 pub struct DownReport {
@@ -197,6 +205,24 @@ pub fn run_check_groups(rig: &RigSpec, groups: &[String]) -> Result<CheckReport>
         success: outcome.is_success(),
         pipeline: outcome,
     })
+}
+
+/// Run rig-owned setup required before timed bench workloads.
+///
+/// Missing `bench_prepare` pipelines are a no-op so existing rigs keep their
+/// previous bench behavior. Declared steps fail fast because workload timing
+/// must not start when dependency/bootstrap preparation is incomplete.
+pub fn run_bench_prepare(rig: &RigSpec) -> Result<Option<BenchPrepareReport>> {
+    if !rig.pipeline.contains_key("bench_prepare") {
+        return Ok(None);
+    }
+
+    let outcome = run_pipeline(rig, "bench_prepare", true)?;
+    Ok(Some(BenchPrepareReport {
+        rig_id: rig.id.clone(),
+        success: outcome.is_success(),
+        pipeline: outcome,
+    }))
 }
 
 /// Tear down a rig. Runs the `down` pipeline if defined, then stops every

--- a/tests/core/rig/bench_prepare_pipeline_test.rs
+++ b/tests/core/rig/bench_prepare_pipeline_test.rs
@@ -1,0 +1,203 @@
+use super::*;
+use crate::test_support::with_isolated_home;
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use tempfile::TempDir;
+
+fn write_logging_bench_extension(home: &TempDir, log_path: &std::path::Path) {
+    let extension_dir = home
+        .path()
+        .join(".config")
+        .join("homeboy")
+        .join("extensions")
+        .join("nodejs");
+    fs::create_dir_all(&extension_dir).expect("mkdir extension");
+    fs::write(
+        extension_dir.join("nodejs.json"),
+        r#"{"name":"Node.js","version":"0.0.0","bench":{"extension_script":"bench-runner.sh"}}"#,
+    )
+    .expect("write extension manifest");
+
+    let script_path = extension_dir.join("bench-runner.sh");
+    fs::write(
+        &script_path,
+        format!(
+            r#"#!/bin/sh
+if [ "$HOMEBOY_BENCH_LIST_ONLY" != "1" ]; then
+  printf 'workload
+' >> '{}'
+fi
+cat > "$HOMEBOY_BENCH_RESULTS_FILE" <<JSON
+{{"component_id":"$HOMEBOY_COMPONENT_ID","iterations":${{HOMEBOY_BENCH_ITERATIONS:-0}},"scenarios":[{{"id":"ordered","iterations":${{HOMEBOY_BENCH_ITERATIONS:-0}},"metrics":{{"p95_ms":1.0}}}}],"metric_policies":{{"p95_ms":{{"direction":"lower_is_better"}}}}}}
+JSON
+"#,
+            log_path.display()
+        ),
+    )
+    .expect("write bench script");
+
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&script_path)
+            .expect("script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("chmod script");
+    }
+}
+
+fn write_pipeline_rig(
+    home: &TempDir,
+    rig_id: &str,
+    component_path: &std::path::Path,
+    log_path: &std::path::Path,
+    bench_prepare_command: Option<String>,
+) {
+    let rig_dir = home.path().join(".config").join("homeboy").join("rigs");
+    fs::create_dir_all(&rig_dir).expect("mkdir rigs");
+
+    let mut pipeline = serde_json::Map::new();
+    if let Some(command) = bench_prepare_command {
+        pipeline.insert(
+            "bench_prepare".to_string(),
+            serde_json::json!([{ "kind": "command", "label": "bench prep", "command": command }]),
+        );
+    }
+    pipeline.insert(
+        "check".to_string(),
+        serde_json::json!([{
+            "kind": "command",
+            "label": "check rig",
+            "command": format!("printf 'check\\n' >> '{}'", log_path.display())
+        }]),
+    );
+
+    let spec = serde_json::json!({
+        "components": {
+            "studio": {
+                "path": component_path,
+                "extensions": { "nodejs": {} }
+            }
+        },
+        "bench": { "default_component": "studio" },
+        "pipeline": pipeline
+    });
+    fs::write(
+        rig_dir.join(format!("{rig_id}.json")),
+        serde_json::to_string(&spec).expect("serialize rig"),
+    )
+    .expect("write rig");
+}
+
+fn log_lines(log_path: &std::path::Path) -> Vec<String> {
+    fs::read_to_string(log_path)
+        .unwrap_or_default()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+#[test]
+fn bench_prepare_runs_before_check_and_workload() {
+    with_isolated_home(|home| {
+        let component = tempfile::TempDir::new().expect("component");
+        let log_dir = tempfile::TempDir::new().expect("log dir");
+        let log_path = log_dir.path().join("order.log");
+        write_logging_bench_extension(home, &log_path);
+        write_pipeline_rig(
+            home,
+            "bench-prep-rig",
+            component.path(),
+            &log_path,
+            Some(format!("printf 'prepare\\n' >> '{}'", log_path.display())),
+        );
+
+        let (_output, exit_code) = run(
+            run_args(None, vec!["bench-prep-rig".to_string()], Vec::new()),
+            &GlobalArgs {},
+        )
+        .expect("bench should run");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(log_lines(&log_path), vec!["prepare", "check", "workload"]);
+    });
+}
+
+#[test]
+fn rig_without_bench_prepare_preserves_existing_check_then_workload_flow() {
+    with_isolated_home(|home| {
+        let component = tempfile::TempDir::new().expect("component");
+        let log_dir = tempfile::TempDir::new().expect("log dir");
+        let log_path = log_dir.path().join("order.log");
+        write_logging_bench_extension(home, &log_path);
+        write_pipeline_rig(home, "plain-rig", component.path(), &log_path, None);
+
+        let (_output, exit_code) = run(
+            run_args(None, vec!["plain-rig".to_string()], Vec::new()),
+            &GlobalArgs {},
+        )
+        .expect("bench should run");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(log_lines(&log_path), vec!["check", "workload"]);
+    });
+}
+
+#[test]
+fn failing_bench_prepare_aborts_before_check_and_workload() {
+    with_isolated_home(|home| {
+        let component = tempfile::TempDir::new().expect("component");
+        let log_dir = tempfile::TempDir::new().expect("log dir");
+        let log_path = log_dir.path().join("order.log");
+        write_logging_bench_extension(home, &log_path);
+        write_pipeline_rig(
+            home,
+            "failing-prep-rig",
+            component.path(),
+            &log_path,
+            Some(format!(
+                "printf 'prepare\\n' >> '{}'; exit 7",
+                log_path.display()
+            )),
+        );
+
+        let error = match run(
+            run_args(None, vec!["failing-prep-rig".to_string()], Vec::new()),
+            &GlobalArgs {},
+        ) {
+            Ok(_) => panic!("bench should fail before workload"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("bench_prepare"));
+        assert_eq!(log_lines(&log_path), vec!["prepare"]);
+    });
+}
+
+#[test]
+fn bench_list_rig_does_not_run_bench_prepare() {
+    with_isolated_home(|home| {
+        let component = tempfile::TempDir::new().expect("component");
+        let log_dir = tempfile::TempDir::new().expect("log dir");
+        let log_path = log_dir.path().join("order.log");
+        write_logging_bench_extension(home, &log_path);
+        write_pipeline_rig(
+            home,
+            "list-rig",
+            component.path(),
+            &log_path,
+            Some(format!("printf 'prepare\\n' >> '{}'", log_path.display())),
+        );
+
+        let mut args = run_args(None, Vec::new(), Vec::new());
+        args.command = Some(BenchCommand::List(list_args(
+            None,
+            vec!["list-rig".to_string()],
+        )));
+        let (_output, exit_code) = run(args, &GlobalArgs {}).expect("bench list should run");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(log_lines(&log_path), vec!["check"]);
+    });
+}


### PR DESCRIPTION
## Summary
- Add an optional rig-owned `bench_prepare` pipeline that runs before rig bench checks and timed workload execution.
- Keep rigs without `bench_prepare` on the existing behavior path, and leave `homeboy bench list --rig` non-mutating for prep.
- Add bench command coverage for prepare/check/workload ordering, no-hook behavior, failure aborts, and list behavior.

Fixes #3053.

## Tests
- `cargo fmt`
- `cargo test bench_prepare --lib`
- `cargo test commands::bench::tests:: --lib`

## Caveats
- `cargo clippy --lib -- -D warnings` still fails on existing repository-wide clippy warnings unrelated to this change, including large enum variants and style lints in daemon/issues/refactor/report/review/rig/runner/status/code_audit/engine/extension/git/keychain/release/server/triage modules.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing generic bench prepare hook and tests.