### PR TITLE
Fix Lab offload for rig benchmarks

### DIFF
--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -27,8 +27,12 @@ struct RigBenchContext {
     _lease: Option<ActiveRigRunLease>,
 }
 
-fn prepare_rig_bench_context(rig_id: &str) -> homeboy::core::Result<RigBenchContext> {
-    let spec = rig::load(rig_id)?;
+fn prepare_rig_bench_context(
+    rig_id: &str,
+    args: &BenchRunArgs,
+) -> homeboy::core::Result<RigBenchContext> {
+    let mut spec = rig::load(rig_id)?;
+    apply_bench_path_override(&mut spec, args);
     let lease = rig::lease::acquire_active_run_lease(&spec, "bench")?;
     if let Some(prepare) = rig::run_bench_prepare(&spec)? {
         if !prepare.success {
@@ -49,6 +53,23 @@ fn prepare_rig_bench_context(rig_id: &str) -> homeboy::core::Result<RigBenchCont
         snapshot,
         _lease: lease,
     })
+}
+
+fn apply_bench_path_override(spec: &mut RigSpec, args: &BenchRunArgs) {
+    let Some(path) = args.comp.path.as_ref() else {
+        return;
+    };
+    let component_id = args.comp.id().map(str::to_string).or_else(|| {
+        spec.bench
+            .as_ref()
+            .and_then(|bench| bench_component_ids(bench).into_iter().next())
+    });
+    let Some(component_id) = component_id else {
+        return;
+    };
+    if let Some(component) = spec.components.get_mut(&component_id) {
+        component.path = path.clone();
+    }
 }
 
 pub(super) fn bench_component_ids(bench: &BenchSpec) -> Vec<String> {
@@ -311,7 +332,7 @@ pub(super) fn run_single_rig(
     passthrough_args: &[String],
     rig_id: String,
 ) -> CmdResult<BenchCommandOutput> {
-    let context = prepare_rig_bench_context(&rig_id)?;
+    let context = prepare_rig_bench_context(&rig_id, args)?;
     let matrix_components = if let Some(explicit) = args.comp.id() {
         vec![explicit.to_string()]
     } else {
@@ -407,7 +428,7 @@ pub(super) fn run_single(
 ) -> CmdResult<BenchCommandOutput> {
     let rig_context = match rig_id_override.as_deref() {
         None => None,
-        Some(rig_id) => Some(prepare_rig_bench_context(rig_id)?),
+        Some(rig_id) => Some(prepare_rig_bench_context(rig_id, args)?),
     };
     run_component_with_rig_context(args, passthrough_args, rig_context.as_ref(), None, None)
 }
@@ -658,6 +679,35 @@ mod tests {
         .expect("write extension manifest");
     }
 
+    fn bench_args(component: Option<&str>, path: Option<&str>) -> BenchRunArgs {
+        BenchRunArgs {
+            comp: PositionalComponentArgs {
+                component: component.map(str::to_string),
+                path: path.map(str::to_string),
+            },
+            extension_override: ExtensionOverrideArgs::default(),
+            iterations: 1,
+            warmup: None,
+            runs: 1,
+            shared_state: None,
+            concurrency: 1,
+            baseline_args: BaselineArgs::default(),
+            regression_threshold: 5.0,
+            setting_args: SettingArgs::default(),
+            args: Vec::new(),
+            json_summary: false,
+            status_file: None,
+            report: Vec::new(),
+            rig: vec!["rig".to_string()],
+            rig_order: crate::commands::bench::BenchRigOrder::Input,
+            rig_concurrency: 1,
+            scenario_ids: Vec::new(),
+            profile: None,
+            ci_profile: None,
+            ignore_default_baseline: false,
+        }
+    }
+
     #[test]
     fn rig_bench_components_prefers_matrix_over_default_component() {
         let rig_spec: RigSpec = serde_json::from_str(
@@ -692,32 +742,8 @@ mod tests {
 
     #[test]
     fn component_shared_state_uses_subdirs_for_matrix_only() {
-        let mut args = BenchRunArgs {
-            comp: PositionalComponentArgs {
-                component: None,
-                path: None,
-            },
-            extension_override: ExtensionOverrideArgs::default(),
-            iterations: 1,
-            warmup: None,
-            runs: 1,
-            shared_state: Some(PathBuf::from("/tmp/shared")),
-            concurrency: 1,
-            baseline_args: BaselineArgs::default(),
-            regression_threshold: 5.0,
-            setting_args: SettingArgs::default(),
-            args: Vec::new(),
-            json_summary: false,
-            status_file: None,
-            report: Vec::new(),
-            rig: vec!["rig".to_string()],
-            rig_order: crate::commands::bench::BenchRigOrder::Input,
-            rig_concurrency: 1,
-            scenario_ids: Vec::new(),
-            profile: None,
-            ci_profile: None,
-            ignore_default_baseline: false,
-        };
+        let mut args = bench_args(None, None);
+        args.shared_state = Some(PathBuf::from("/tmp/shared"));
 
         assert_eq!(
             component_shared_state(&args, "mdi-primary", 3),
@@ -730,6 +756,52 @@ mod tests {
 
         args.shared_state = None;
         assert_eq!(component_shared_state(&args, "mdi-primary", 3), None);
+    }
+
+    #[test]
+    fn bench_path_override_updates_rig_component_before_prepare() {
+        let mut rig_spec: RigSpec = serde_json::from_str(
+            r#"{
+                "id": "gutenberg-rtc",
+                "components": {
+                    "gutenberg": { "path": "~/Developer/gutenberg" }
+                },
+                "bench": { "default_component": "gutenberg" }
+            }"#,
+        )
+        .expect("parse rig spec");
+        let args = bench_args(
+            None,
+            Some("/home/chubes/Developer/_lab_workspaces/gutenberg"),
+        );
+
+        apply_bench_path_override(&mut rig_spec, &args);
+
+        assert_eq!(
+            rig_spec.components["gutenberg"].path,
+            "/home/chubes/Developer/_lab_workspaces/gutenberg"
+        );
+    }
+
+    #[test]
+    fn bench_path_override_prefers_explicit_component() {
+        let mut rig_spec: RigSpec = serde_json::from_str(
+            r#"{
+                "id": "dual",
+                "components": {
+                    "primary": { "path": "/src/primary" },
+                    "candidate": { "path": "/src/candidate" }
+                },
+                "bench": { "default_component": "primary" }
+            }"#,
+        )
+        .expect("parse rig spec");
+        let args = bench_args(Some("candidate"), Some("/tmp/candidate"));
+
+        apply_bench_path_override(&mut rig_spec, &args);
+
+        assert_eq!(rig_spec.components["primary"].path, "/src/primary");
+        assert_eq!(rig_spec.components["candidate"].path, "/tmp/candidate");
     }
 
     #[test]

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -6,17 +6,16 @@ use std::time::Duration;
 
 use crate::core::observation::LAB_OFFLOAD_METADATA_ENV;
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
-use crate::core::rig;
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, Result};
 
 use super::{
     evaluate_lab_runner_capabilities_for_runner, exec, lab_offload_changed_since_ref,
     lab_offload_metadata, lab_runner_capability_plan, load, preflight_lab_offload_changed_since,
-    prepare_git_lab_offload_changed_since, status, sync_workspace, LabRunnerCapabilityContract,
-    LabRunnerGateDecision, LabRunnerGateMode, RunnerCapabilityPreflight, RunnerConnectReport,
-    RunnerExecOptions, RunnerRequiredTool, RunnerStatusReport, RunnerTunnelMode,
-    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+    prepare_git_lab_offload_changed_since, rig_materialization, status, sync_workspace,
+    LabRunnerCapabilityContract, LabRunnerGateDecision, LabRunnerGateMode,
+    RunnerCapabilityPreflight, RunnerConnectReport, RunnerExecOptions, RunnerRequiredTool,
+    RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -412,7 +411,7 @@ fn run_lab_offload_inner(
         );
     }
 
-    let synced_rigs = sync_lab_offload_rigs(
+    let synced_rigs = rig_materialization::sync_lab_offload_rigs(
         runner_id,
         homeboy_path,
         &remote_cwd,
@@ -929,113 +928,6 @@ fn rewrite_lab_offload_args(args: &[String], remote_path: &str) -> Vec<String> {
     stripped
 }
 
-fn sync_lab_offload_rigs(
-    runner_id: &str,
-    homeboy_path: &str,
-    remote_cwd: &str,
-    args: &[String],
-) -> Result<usize> {
-    let rig_ids = lab_offload_rig_ids(args);
-    if rig_ids.is_empty() {
-        return Ok(0);
-    }
-
-    for rig_id in &rig_ids {
-        let metadata = rig::read_source_metadata(rig_id).ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "rig",
-                format!(
-                    "Lab offload cannot materialize rig `{rig_id}` on the runner because it has no installed source metadata"
-                ),
-                Some(rig_id.clone()),
-                Some(vec![
-                    format!("Reinstall rig `{rig_id}` from a rig package before using --runner."),
-                    "Run `homeboy rig sources` to inspect installed rig sources.".to_string(),
-                ]),
-            )
-        })?;
-        let synced = sync_workspace(
-            runner_id,
-            RunnerWorkspaceSyncOptions {
-                path: metadata.package_path,
-                mode: RunnerWorkspaceSyncMode::Snapshot,
-                changed_since_base: None,
-            },
-        )?
-        .0;
-        let (output, exit_code) = exec(
-            runner_id,
-            RunnerExecOptions {
-                cwd: Some(remote_cwd.to_string()),
-                project_id: None,
-                allow_ssh: false,
-                command: vec![
-                    homeboy_path.to_string(),
-                    "rig".to_string(),
-                    "install".to_string(),
-                    synced.remote_path,
-                    "--id".to_string(),
-                    rig_id.clone(),
-                ],
-                env: HashMap::new(),
-                capture_patch: false,
-                raw_exec: false,
-                source_snapshot: None,
-                capability_preflight: None,
-            },
-        )?;
-        if exit_code != 0 {
-            return Err(Error::validation_invalid_argument(
-                "rig",
-                format!("Lab offload could not install rig `{rig_id}` on runner `{runner_id}`"),
-                Some(rig_id.clone()),
-                Some(vec![
-                    output.stderr.trim().to_string(),
-                    "Run the command with --force-hot to execute locally while investigating runner rig setup.".to_string(),
-                ]),
-            ));
-        }
-    }
-
-    Ok(rig_ids.len())
-}
-
-fn lab_offload_rig_ids(args: &[String]) -> Vec<String> {
-    let mut rig_ids = Vec::new();
-    let is_bench = args.iter().any(|arg| arg == "bench");
-    if !is_bench {
-        return rig_ids;
-    }
-
-    let mut iter = args.iter().peekable();
-    let mut passthrough = false;
-    while let Some(arg) = iter.next() {
-        if passthrough {
-            continue;
-        }
-        if arg == "--" {
-            passthrough = true;
-            continue;
-        }
-        let raw = if arg == "--rig" {
-            iter.next().map(String::as_str)
-        } else {
-            arg.strip_prefix("--rig=")
-        };
-        if let Some(raw) = raw {
-            for rig_id in raw
-                .split(',')
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-            {
-                push_unique(&mut rig_ids, rig_id.to_string());
-            }
-        }
-    }
-
-    rig_ids
-}
-
 fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
     if !items.contains(&item) {
         items.push(item);
@@ -1165,44 +1057,6 @@ mod tests {
                 "/home/chubes/Developer/project".to_string(),
             ]
         );
-    }
-
-    #[test]
-    fn extracts_unique_bench_rig_ids_for_lab_materialization() {
-        let args = vec![
-            "homeboy".to_string(),
-            "bench".to_string(),
-            "--rig".to_string(),
-            "baseline,candidate".to_string(),
-            "--scenario".to_string(),
-            "smoke".to_string(),
-            "--rig=candidate".to_string(),
-        ];
-
-        assert_eq!(
-            lab_offload_rig_ids(&args),
-            vec!["baseline".to_string(), "candidate".to_string()]
-        );
-    }
-
-    #[test]
-    fn ignores_non_bench_and_passthrough_rig_args_for_lab_materialization() {
-        let non_bench = vec![
-            "homeboy".to_string(),
-            "test".to_string(),
-            "--rig".to_string(),
-            "candidate".to_string(),
-        ];
-        assert!(lab_offload_rig_ids(&non_bench).is_empty());
-
-        let passthrough = vec![
-            "homeboy".to_string(),
-            "bench".to_string(),
-            "--".to_string(),
-            "--rig".to_string(),
-            "candidate".to_string(),
-        ];
-        assert!(lab_offload_rig_ids(&passthrough).is_empty());
     }
 
     #[test]

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use crate::core::observation::LAB_OFFLOAD_METADATA_ENV;
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
+use crate::core::rig;
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, Result};
 
@@ -408,6 +409,21 @@ fn run_lab_offload_inner(
         plan = with_step(
             plan,
             PlanStep::ready("lab.extension_parity", "lab.extension_parity").build(),
+        );
+    }
+
+    let synced_rigs = sync_lab_offload_rigs(
+        runner_id,
+        homeboy_path,
+        &remote_cwd,
+        &changed_since_preflight.args,
+    )?;
+    if synced_rigs > 0 {
+        plan = with_step(
+            plan,
+            PlanStep::ready("lab.sync_rigs", "lab.sync_rigs")
+                .inputs(PlanValues::new().json("count", &synced_rigs))
+                .build(),
         );
     }
 
@@ -913,6 +929,113 @@ fn rewrite_lab_offload_args(args: &[String], remote_path: &str) -> Vec<String> {
     stripped
 }
 
+fn sync_lab_offload_rigs(
+    runner_id: &str,
+    homeboy_path: &str,
+    remote_cwd: &str,
+    args: &[String],
+) -> Result<usize> {
+    let rig_ids = lab_offload_rig_ids(args);
+    if rig_ids.is_empty() {
+        return Ok(0);
+    }
+
+    for rig_id in &rig_ids {
+        let metadata = rig::read_source_metadata(rig_id).ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "rig",
+                format!(
+                    "Lab offload cannot materialize rig `{rig_id}` on the runner because it has no installed source metadata"
+                ),
+                Some(rig_id.clone()),
+                Some(vec![
+                    format!("Reinstall rig `{rig_id}` from a rig package before using --runner."),
+                    "Run `homeboy rig sources` to inspect installed rig sources.".to_string(),
+                ]),
+            )
+        })?;
+        let synced = sync_workspace(
+            runner_id,
+            RunnerWorkspaceSyncOptions {
+                path: metadata.package_path,
+                mode: RunnerWorkspaceSyncMode::Snapshot,
+                changed_since_base: None,
+            },
+        )?
+        .0;
+        let (output, exit_code) = exec(
+            runner_id,
+            RunnerExecOptions {
+                cwd: Some(remote_cwd.to_string()),
+                project_id: None,
+                allow_ssh: false,
+                command: vec![
+                    homeboy_path.to_string(),
+                    "rig".to_string(),
+                    "install".to_string(),
+                    synced.remote_path,
+                    "--id".to_string(),
+                    rig_id.clone(),
+                ],
+                env: HashMap::new(),
+                capture_patch: false,
+                raw_exec: false,
+                source_snapshot: None,
+                capability_preflight: None,
+            },
+        )?;
+        if exit_code != 0 {
+            return Err(Error::validation_invalid_argument(
+                "rig",
+                format!("Lab offload could not install rig `{rig_id}` on runner `{runner_id}`"),
+                Some(rig_id.clone()),
+                Some(vec![
+                    output.stderr.trim().to_string(),
+                    "Run the command with --force-hot to execute locally while investigating runner rig setup.".to_string(),
+                ]),
+            ));
+        }
+    }
+
+    Ok(rig_ids.len())
+}
+
+fn lab_offload_rig_ids(args: &[String]) -> Vec<String> {
+    let mut rig_ids = Vec::new();
+    let is_bench = args.iter().any(|arg| arg == "bench");
+    if !is_bench {
+        return rig_ids;
+    }
+
+    let mut iter = args.iter().peekable();
+    let mut passthrough = false;
+    while let Some(arg) = iter.next() {
+        if passthrough {
+            continue;
+        }
+        if arg == "--" {
+            passthrough = true;
+            continue;
+        }
+        let raw = if arg == "--rig" {
+            iter.next().map(String::as_str)
+        } else {
+            arg.strip_prefix("--rig=")
+        };
+        if let Some(raw) = raw {
+            for rig_id in raw
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                push_unique(&mut rig_ids, rig_id.to_string());
+            }
+        }
+    }
+
+    rig_ids
+}
+
 fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
     if !items.contains(&item) {
         items.push(item);
@@ -1042,6 +1165,44 @@ mod tests {
                 "/home/chubes/Developer/project".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn extracts_unique_bench_rig_ids_for_lab_materialization() {
+        let args = vec![
+            "homeboy".to_string(),
+            "bench".to_string(),
+            "--rig".to_string(),
+            "baseline,candidate".to_string(),
+            "--scenario".to_string(),
+            "smoke".to_string(),
+            "--rig=candidate".to_string(),
+        ];
+
+        assert_eq!(
+            lab_offload_rig_ids(&args),
+            vec!["baseline".to_string(), "candidate".to_string()]
+        );
+    }
+
+    #[test]
+    fn ignores_non_bench_and_passthrough_rig_args_for_lab_materialization() {
+        let non_bench = vec![
+            "homeboy".to_string(),
+            "test".to_string(),
+            "--rig".to_string(),
+            "candidate".to_string(),
+        ];
+        assert!(lab_offload_rig_ids(&non_bench).is_empty());
+
+        let passthrough = vec![
+            "homeboy".to_string(),
+            "bench".to_string(),
+            "--".to_string(),
+            "--rig".to_string(),
+            "candidate".to_string(),
+        ];
+        assert!(lab_offload_rig_ids(&passthrough).is_empty());
     }
 
     #[test]

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -19,6 +19,7 @@ mod lab;
 mod offload_changed_since;
 mod offload_metadata;
 mod resource_metrics;
+mod rig_materialization;
 mod session;
 mod worker;
 mod workspace;

--- a/src/core/runner/rig_materialization.rs
+++ b/src/core/runner/rig_materialization.rs
@@ -1,0 +1,167 @@
+use std::collections::HashMap;
+
+use crate::core::rig;
+use crate::core::{Error, Result};
+
+use super::{
+    exec, sync_workspace, RunnerExecOptions, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+};
+
+pub(super) fn sync_lab_offload_rigs(
+    runner_id: &str,
+    homeboy_path: &str,
+    remote_cwd: &str,
+    args: &[String],
+) -> Result<usize> {
+    let rig_ids = lab_offload_rig_ids(args);
+    if rig_ids.is_empty() {
+        return Ok(0);
+    }
+
+    for rig_id in &rig_ids {
+        let metadata = rig::read_source_metadata(rig_id).ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "rig",
+                format!(
+                    "Lab offload cannot materialize rig `{rig_id}` on the runner because it has no installed source metadata"
+                ),
+                Some(rig_id.clone()),
+                Some(vec![
+                    format!("Reinstall rig `{rig_id}` from a rig package before using --runner."),
+                    "Run `homeboy rig sources` to inspect installed rig sources.".to_string(),
+                ]),
+            )
+        })?;
+
+        let synced = sync_workspace(
+            runner_id,
+            RunnerWorkspaceSyncOptions {
+                path: metadata.package_path,
+                mode: RunnerWorkspaceSyncMode::Snapshot,
+                changed_since_base: None,
+            },
+        )?
+        .0;
+
+        let (output, exit_code) = exec(
+            runner_id,
+            RunnerExecOptions {
+                cwd: Some(remote_cwd.to_string()),
+                project_id: None,
+                allow_ssh: false,
+                command: vec![
+                    homeboy_path.to_string(),
+                    "rig".to_string(),
+                    "install".to_string(),
+                    synced.remote_path,
+                    "--id".to_string(),
+                    rig_id.clone(),
+                ],
+                env: HashMap::new(),
+                capture_patch: false,
+                raw_exec: false,
+                source_snapshot: None,
+                capability_preflight: None,
+            },
+        )?;
+
+        if exit_code != 0 {
+            return Err(Error::validation_invalid_argument(
+                "rig",
+                format!("Lab offload could not install rig `{rig_id}` on runner `{runner_id}`"),
+                Some(rig_id.clone()),
+                Some(vec![
+                    output.stderr.trim().to_string(),
+                    "Run the command with --force-hot to execute locally while investigating runner rig setup.".to_string(),
+                ]),
+            ));
+        }
+    }
+
+    Ok(rig_ids.len())
+}
+
+fn lab_offload_rig_ids(args: &[String]) -> Vec<String> {
+    let mut rig_ids = Vec::new();
+    let is_bench = args.iter().any(|arg| arg == "bench");
+    if !is_bench {
+        return rig_ids;
+    }
+
+    let mut iter = args.iter().peekable();
+    let mut passthrough = false;
+    while let Some(arg) = iter.next() {
+        if passthrough {
+            continue;
+        }
+        if arg == "--" {
+            passthrough = true;
+            continue;
+        }
+        let raw = if arg == "--rig" {
+            iter.next().map(String::as_str)
+        } else {
+            arg.strip_prefix("--rig=")
+        };
+        if let Some(raw) = raw {
+            for rig_id in raw
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                push_unique(&mut rig_ids, rig_id.to_string());
+            }
+        }
+    }
+
+    rig_ids
+}
+
+fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
+    if !items.contains(&item) {
+        items.push(item);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_unique_bench_rig_ids_for_lab_materialization() {
+        let args = vec![
+            "homeboy".to_string(),
+            "bench".to_string(),
+            "--rig".to_string(),
+            "baseline,candidate".to_string(),
+            "--scenario".to_string(),
+            "smoke".to_string(),
+            "--rig=candidate".to_string(),
+        ];
+
+        assert_eq!(
+            lab_offload_rig_ids(&args),
+            vec!["baseline".to_string(), "candidate".to_string()]
+        );
+    }
+
+    #[test]
+    fn ignores_non_bench_and_passthrough_rig_args_for_lab_materialization() {
+        let non_bench = vec![
+            "homeboy".to_string(),
+            "test".to_string(),
+            "--rig".to_string(),
+            "candidate".to_string(),
+        ];
+        assert!(lab_offload_rig_ids(&non_bench).is_empty());
+
+        let passthrough = vec![
+            "homeboy".to_string(),
+            "bench".to_string(),
+            "--".to_string(),
+            "--rig".to_string(),
+            "candidate".to_string(),
+        ];
+        assert!(lab_offload_rig_ids(&passthrough).is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Materialize `--rig` benchmark packages on the Lab runner before dispatching an offloaded bench run.
- Apply `--path` overrides to the rig bench context before leases and `bench_prepare`, so runner snapshots are used during preparation.
- Add targeted coverage for rig-id extraction and pre-prepare path overrides.

Fixes #3059.

## Testing
- `cargo fmt --check`
- `cargo test lab_materialization --lib`
- `cargo test bench_path_override --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Lab rig offload failures, drafted the Homeboy fix and tests, and ran targeted verification. Chris remains responsible for review and merge.