### PR TITLE
Fix component set source config dirtiness

### DIFF
--- a/src/core/component/inventory.rs
+++ b/src/core/component/inventory.rs
@@ -135,21 +135,9 @@ fn load_standalone_components() -> Result<Vec<Component>> {
         // (it's the source of truth for version_targets, extensions, etc.)
         // and merge the standalone file's fields as fallback.
         if local_dir.exists() {
-            if let Some(mut discovered) = discover_from_portable(local_dir) {
-                // The portable config is authoritative, but the standalone file
-                // may have fields the portable config doesn't (e.g., remote_path
-                // for deploy, settings that were set via `component set`).
-                if discovered.remote_path.is_empty() {
-                    if let Some(rp) = json.get("remote_path").and_then(|v| v.as_str()) {
-                        if !rp.is_empty() {
-                            discovered.remote_path = rp.to_string();
-                        }
-                    }
-                }
-
-                // Ensure the ID matches the filename (canonical source)
-                discovered.id = id;
-                components.push(discovered);
+            if let Some(discovered) = discover_from_portable(local_dir) {
+                let component = overlay_standalone_registration(&id, discovered, json);
+                components.push(component);
                 continue;
             }
         } else if let Some(parent) = local_dir.parent() {
@@ -175,6 +163,33 @@ fn load_standalone_components() -> Result<Vec<Component>> {
     }
 
     Ok(components)
+}
+
+fn overlay_standalone_registration(
+    id: &str,
+    discovered: Component,
+    standalone: serde_json::Value,
+) -> Component {
+    let mut merged = serde_json::to_value(&discovered).unwrap_or_else(|_| serde_json::json!({}));
+
+    if let (Some(base), Some(overrides)) = (merged.as_object_mut(), standalone.as_object()) {
+        for (key, value) in overrides {
+            if key == "id" || value.is_null() {
+                continue;
+            }
+            base.insert(key.clone(), value.clone());
+        }
+    }
+
+    if let Some(obj) = merged.as_object_mut() {
+        obj.insert("id".to_string(), serde_json::Value::String(id.to_string()));
+    }
+
+    serde_json::from_value::<Component>(merged).unwrap_or_else(|_| {
+        let mut fallback = discovered;
+        fallback.id = id.to_string();
+        fallback
+    })
 }
 
 /// Discover sibling repos when a standalone registration points at a path that
@@ -508,6 +523,47 @@ pub fn write_standalone_registration(component: &Component) -> Result<()> {
         &path,
         &content,
         &format!("write standalone registration {}", path.display()),
+    )
+}
+
+/// Write the effective component config to the standalone registry without
+/// mutating the repo-owned portable `homeboy.json`.
+pub fn write_standalone_component_config(component: &Component) -> Result<()> {
+    if component.id.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "id",
+            "Cannot write standalone component config with a blank component ID",
+            None,
+            None,
+        ));
+    }
+
+    let dir = crate::core::paths::components()?;
+    crate::core::engine::local_files::local().ensure_dir(&dir)?;
+    let path = dir.join(format!("{}.json", component.id));
+
+    let mut json = serde_json::to_value(component).map_err(|error| {
+        Error::validation_invalid_argument(
+            "component",
+            "Failed to serialize component registration",
+            Some(error.to_string()),
+            None,
+        )
+    })?;
+    if let Some(obj) = json.as_object_mut() {
+        obj.remove("id");
+        obj.insert(
+            "local_path".to_string(),
+            serde_json::Value::String(component.local_path.clone()),
+        );
+    }
+
+    crate::core::component::portable::validate_component_remote_urls(&json)?;
+    let content = crate::core::config::to_string_pretty(&json)?;
+    crate::core::engine::local_files::write_file_atomic(
+        &path,
+        &content,
+        &format!("write standalone component config {}", path.display()),
     )
 }
 

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -23,7 +23,8 @@ pub use audit::{
 };
 pub use inventory::{
     exists, extension_provides_artifact_pattern, inventory, list, list_ids, load,
-    reconcile_standalone_registration, write_standalone_registration, ComponentReconcileReport,
+    reconcile_standalone_registration, write_standalone_component_config,
+    write_standalone_registration, ComponentReconcileReport,
 };
 pub use mutations::{delete_safe, merge, rename};
 pub use portable::{

--- a/src/core/component/mutations.rs
+++ b/src/core/component/mutations.rs
@@ -1,5 +1,5 @@
 use crate::core::component::{
-    associated_projects, inventory, mutate_portable, rename_component, resolve_effective, Component,
+    associated_projects, inventory, rename_component, resolve_effective, Component,
 };
 use crate::core::config;
 use crate::core::error::{Error, Result};
@@ -44,41 +44,30 @@ pub fn merge(id: Option<&str>, json_spec: &str, replace_fields: &[String]) -> Re
         map.remove("id");
     }
 
-    let updates_standalone_registration = patch
-        .as_object()
-        .map(|obj| obj.contains_key("local_path") || obj.contains_key("remote_path"))
-        .unwrap_or(false);
-
-    let component = mutate_portable(id, |component| {
-        let fields = config::merge_config(component, patch.clone(), replace_fields)?;
-        if fields.updated_fields.is_empty() {
-            return Err(Error::validation_invalid_argument(
-                "merge",
-                "Merge patch cannot be empty",
-                None,
-                None,
-            ));
-        }
-        Ok(())
-    })?;
-
-    if updates_standalone_registration {
-        inventory::write_standalone_registration(&component)?;
+    let mut component = resolve_effective(Some(id), None, None)?;
+    let fields = config::merge_config(&mut component, patch.clone(), replace_fields)?;
+    if fields.updated_fields.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "merge",
+            "Merge patch cannot be empty",
+            None,
+            None,
+        ));
     }
+
+    if component.id.trim().is_empty() {
+        component.id = id.to_string();
+    }
+
+    inventory::write_standalone_component_config(&component)?;
 
     if let Some(local_path) = patch.get("local_path").and_then(|value| value.as_str()) {
         update_project_attachment_local_paths(id, local_path)?;
     }
 
-    let updated_fields = match patch {
-        Value::Object(obj) => obj.keys().cloned().collect(),
-        _ => vec![],
-    };
-
-    let _ = component;
     Ok(MergeOutput::Single(MergeResult {
         id: id.to_string(),
-        updated_fields,
+        updated_fields: fields.updated_fields,
     }))
 }
 
@@ -243,6 +232,64 @@ mod tests {
                     .get("local_path")
                     .and_then(|value| value.as_str()),
                 Some(new_repo.to_string_lossy().as_ref())
+            );
+        });
+    }
+
+    #[test]
+    fn merge_writes_registry_without_rewriting_portable_config() {
+        crate::test_support::with_isolated_home(|home| {
+            let repo = home.path().join("codebox");
+            fs::create_dir_all(&repo).expect("repo dir");
+            let portable = r#"{"id":"codebox","remote_path":"deploy/codebox"}"#;
+            fs::write(repo.join("homeboy.json"), portable).expect("homeboy.json");
+
+            let component = Component::new(
+                "codebox".to_string(),
+                repo.to_string_lossy().to_string(),
+                "deploy/codebox".to_string(),
+                None,
+            );
+            inventory::write_standalone_registration(&component)
+                .expect("write initial standalone registration");
+
+            let patch = serde_json::json!({
+                "scripts": {
+                    "build": ["npm run package"]
+                }
+            })
+            .to_string();
+            let result = merge(Some("codebox"), &patch, &[]).expect("component merge");
+            let MergeOutput::Single(result) = result else {
+                panic!("expected single merge result");
+            };
+            assert_eq!(result.updated_fields, vec!["scripts".to_string()]);
+
+            assert_eq!(
+                fs::read_to_string(repo.join("homeboy.json")).expect("read portable config"),
+                portable,
+                "component set must not rewrite repo-owned homeboy.json by default"
+            );
+
+            let loaded = crate::core::component::load("codebox").expect("load component");
+            assert_eq!(
+                loaded.scripts.expect("scripts should be registered").build,
+                vec!["npm run package".to_string()]
+            );
+
+            let registration_path = home.path().join(".config/homeboy/components/codebox.json");
+            let registration: serde_json::Value = serde_json::from_str(
+                &fs::read_to_string(registration_path).expect("read registration"),
+            )
+            .expect("parse registration");
+            assert_eq!(
+                registration
+                    .get("scripts")
+                    .and_then(|value| value.get("build"))
+                    .and_then(|value| value.as_array())
+                    .and_then(|commands| commands.first())
+                    .and_then(|command| command.as_str()),
+                Some("npm run package")
             );
         });
     }


### PR DESCRIPTION
## Summary
- Change `component set` to write merged component updates to the standalone registry instead of mutating repo-owned `homeboy.json` by default.
- Overlay standalone registry fields onto portable-discovered components so registry-only updates remain effective.
- Add a regression test proving a source `homeboy.json` remains byte-for-byte unchanged after setting component scripts.

Fixes #3057

## Tests
- `cargo test core::component::mutations`
- `cargo test core::component`
- `cargo test component_set`
- `cargo test core_owned_test_content_stays_language_and_framework_agnostic --test core_agnostic_test`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the registry-only component mutation path, added the regression test, and ran verification; Chris remains responsible for review and merge.