### PR TITLE
Reject unsupported component build_command

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -511,6 +511,8 @@ fn show(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
         })?,
     };
 
+    component.validate_supported_build_config()?;
+
     let resolved_id = component.id.clone();
     let drift_files = homeboy::core::component::drift::drift_file_paths(&component);
 
@@ -1185,6 +1187,26 @@ mod tests {
             .expect("portable id should be used");
 
         assert_eq!(id, "homeboy");
+    }
+
+    #[test]
+    fn component_show_rejects_legacy_build_command() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            temp.path().join("homeboy.json"),
+            r#"{
+                "id": "wp-codebox",
+                "build_artifact": "packages/wordpress-plugin/dist/wp-codebox.zip",
+                "build_command": "npm run package:wordpress-plugin"
+            }"#,
+        )
+        .expect("homeboy.json");
+
+        let err = show(None, Some(&temp.path().to_string_lossy()))
+            .expect_err("component show should reject legacy build_command");
+
+        assert!(err.message.contains("unsupported legacy build_command"));
+        assert!(err.message.contains("Use scripts.build instead"));
     }
 
     #[test]

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -544,6 +544,30 @@ impl Component {
         !self.script_commands(capability).is_empty()
     }
 
+    pub fn validate_supported_build_config(&self) -> crate::core::Result<()> {
+        let Some(command) = self
+            .build_command
+            .as_deref()
+            .map(str::trim)
+            .filter(|command| !command.is_empty())
+        else {
+            return Ok(());
+        };
+
+        Err(crate::core::Error::validation_invalid_argument(
+            "build_command",
+            format!(
+                "Component '{}' uses unsupported legacy build_command. Use scripts.build instead.",
+                self.id
+            ),
+            Some(command.to_string()),
+            Some(vec![
+                "Move the command into homeboy.json as: \"scripts\": { \"build\": [\"<command>\"] }".to_string(),
+                "Homeboy does not execute component-level build_command.".to_string(),
+            ]),
+        ))
+    }
+
     /// Ensure `remote_path` is populated. If empty, attempt auto-resolution.
     ///
     /// This should be called after all config layers (repo portable, project overrides)
@@ -733,6 +757,24 @@ mod tests {
     fn validate_version_pattern_rejects_invalid_regex() {
         let result = validate_version_pattern(r"Version: (\d+\.\d+");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_supported_build_config_rejects_legacy_build_command() {
+        let component = Component {
+            id: "wp-codebox".to_string(),
+            build_command: Some("npm run package:wordpress-plugin".to_string()),
+            ..Default::default()
+        };
+
+        let err = component
+            .validate_supported_build_config()
+            .expect_err("legacy build_command should be unsupported");
+
+        assert!(err.message.contains("unsupported legacy build_command"));
+        assert!(err.message.contains("Use scripts.build instead"));
+        assert_eq!(err.details["field"].as_str(), Some("build_command"));
+        assert!(err.details["tried"].to_string().contains("scripts"));
     }
 
     #[test]

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -27,6 +27,7 @@ pub(super) fn deploy_components(
     base_path: &str,
 ) -> Result<DeployOrchestrationResult> {
     let loaded = load_project_components(project, &config.component_ids)?;
+    validate_supported_build_configs(&loaded.deployable)?;
     if loaded.deployable.is_empty() {
         let message = if loaded.skipped.is_empty() {
             "No components configured for project".to_string()
@@ -204,6 +205,14 @@ pub(super) fn deploy_components(
             skipped: 0,
         },
     })
+}
+
+fn validate_supported_build_configs(components: &[Component]) -> Result<()> {
+    for component in components {
+        component.validate_supported_build_config()?;
+    }
+
+    Ok(())
 }
 
 fn validate_effective_remote_paths(
@@ -820,6 +829,22 @@ mod tests {
             !message.contains("uncommitted changes"),
             "error must not conflate non-git with dirty git, got: {message}"
         );
+    }
+
+    #[test]
+    fn deploy_validation_rejects_legacy_build_command_before_artifact_checks() {
+        let dir = TempDir::new().expect("temp dir");
+        let mut component = make_component("wp-codebox", &dir.path().to_string_lossy());
+        component.build_artifact =
+            Some("packages/wordpress-plugin/dist/wp-codebox.zip".to_string());
+        component.build_command = Some("npm run package:wordpress-plugin".to_string());
+
+        let err = validate_supported_build_configs(&[component])
+            .expect_err("legacy build_command should fail deploy preflight");
+
+        assert!(err.message.contains("unsupported legacy build_command"));
+        assert!(err.message.contains("Use scripts.build instead"));
+        assert_eq!(err.details["field"].as_str(), Some("build_command"));
     }
 
     #[test]

--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -205,29 +205,6 @@ pub(crate) fn build_component(component: &component::Component) -> (Option<i32>,
     }
 }
 
-fn execute_explicit_build_command(comp: &Component, build_cmd: &str) -> Result<(BuildOutput, i32)> {
-    let validated_path = component::validate_local_path(comp)?;
-    let local_path_str = validated_path.to_string_lossy().to_string();
-
-    permissions::fix_local_permissions(&local_path_str);
-
-    let env = [("HOMEBOY_PLUGIN_PATH", comp.local_path.as_str())];
-    let output = execute_local_command_in_dir(build_cmd, Some(&local_path_str), Some(&env));
-    let success = output.success;
-    let exit_code = output.exit_code;
-
-    Ok((
-        BuildOutput {
-            command: "build.run".to_string(),
-            component_id: comp.id.clone(),
-            build_command: build_cmd.to_string(),
-            output: CapturedOutput::new(output.stdout, output.stderr),
-            success,
-        },
-        exit_code,
-    ))
-}
-
 /// Format a build error message with context from stderr/stdout.
 /// Only includes universal POSIX exit code hints - Homeboy is technology-agnostic.
 fn format_build_error(
@@ -353,9 +330,7 @@ fn execute_build(component_id: &str, path_override: Option<&str>) -> Result<(Bui
 }
 
 fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
-    if let Some(command) = artifact_build_command(comp) {
-        return execute_explicit_build_command(comp, command);
-    }
+    comp.validate_supported_build_config()?;
 
     // Validate required extensions are installed before resolving build commands.
     // Without this, missing extensions cause vague "no build command" errors.
@@ -446,16 +421,6 @@ fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
     ))
 }
 
-fn artifact_build_command(component: &Component) -> Option<&str> {
-    component.build_artifact.as_ref()?;
-
-    component
-        .build_command
-        .as_deref()
-        .map(str::trim)
-        .filter(|command| !command.is_empty())
-}
-
 /// Run pre-build scripts from all configured extensions.
 /// Returns Some((exit_code, stderr)) if any script fails, None if all pass or no scripts.
 fn run_pre_build_scripts(
@@ -534,15 +499,13 @@ mod tests {
             hint.message
                 .contains("homeboy component set plain-package --extension")
         }));
-        assert!(err.hints.iter().any(|hint| {
-            hint.message.contains(
-                "component-level `build_command` is only used for artifact-producing builds",
-            )
-        }));
+        assert!(err.hints.iter().any(|hint| hint
+            .message
+            .contains("Use `scripts.build` for component-owned build commands")));
     }
 
     #[test]
-    fn deploy_build_uses_explicit_command_when_artifact_is_required() {
+    fn deploy_build_rejects_legacy_build_command_before_fallback() {
         let temp = tempfile::tempdir().expect("tempdir");
         let component = Component {
             id: "artifact-component".to_string(),
@@ -560,17 +523,19 @@ mod tests {
 
         let (exit_code, error) = build_component(&component);
 
-        assert_eq!(exit_code, Some(0));
-        assert_eq!(error, None);
-        assert_eq!(
-            std::fs::read_to_string(temp.path().join("dist/component.zip")).unwrap(),
-            "explicit"
+        assert_eq!(exit_code, Some(1));
+        let error = error.expect("legacy build_command should fail");
+        assert!(
+            error.contains("unsupported legacy build_command"),
+            "{error}"
         );
+        assert!(error.contains("Use scripts.build instead"), "{error}");
+        assert!(!temp.path().join("dist/component.zip").exists());
         assert!(!temp.path().join("dist/generic.zip").exists());
     }
 
     #[test]
-    fn build_run_uses_explicit_command_when_artifact_is_required() {
+    fn build_run_rejects_legacy_build_command_before_fallback() {
         let temp = tempfile::tempdir().expect("tempdir");
         let component = Component {
             id: "artifact-component".to_string(),
@@ -586,22 +551,14 @@ mod tests {
             ..Default::default()
         };
 
-        let (result, exit_code) = run_component(&component).expect("build should run");
+        let err = run_component(&component).expect_err("legacy build_command should fail");
 
-        let BuildResult::Single(output) = result else {
-            panic!("expected single build result");
-        };
-        assert_eq!(exit_code, 0);
-        assert!(output.success);
-        assert_eq!(output.build_command, component.build_command.unwrap());
-        assert_eq!(
-            std::fs::read_to_string(
-                temp.path()
-                    .join("packages/content-plugin/dist/component.zip")
-            )
-            .unwrap(),
-            "artifact"
-        );
+        assert!(err.message.contains("unsupported legacy build_command"));
+        assert!(err.message.contains("Use scripts.build instead"));
+        assert!(!temp
+            .path()
+            .join("packages/content-plugin/dist/component.zip")
+            .exists());
         assert!(!temp.path().join("dist/generic.zip").exists());
     }
 }

--- a/src/core/extension/capability.rs
+++ b/src/core/extension/capability.rs
@@ -216,7 +216,7 @@ pub(crate) fn extension_guidance_hints(
         link_hint,
         "List installed extensions: homeboy extension list".to_string(),
         "The component path resolved correctly; the requested command needs an extension provider.".to_string(),
-        "For one-off shell builds or checks without `build_artifact`, model the workflow as a rig `command` step; component-level `build_command` is only used for artifact-producing builds.".to_string(),
+        "Use `scripts.build` for component-owned build commands; component-level `build_command` is unsupported.".to_string(),
     ]
 }
 

--- a/src/core/extension/tests.rs
+++ b/src/core/extension/tests.rs
@@ -261,9 +261,9 @@ fn extension_guidance_hints_point_to_supported_paths() {
     assert!(hints
         .iter()
         .any(|hint| { hint.contains("homeboy component set plain-package --extension") }));
-    assert!(hints.iter().any(|hint| {
-        hint.contains("component-level `build_command` is only used for artifact-producing builds")
-    }));
+    assert!(hints
+        .iter()
+        .any(|hint| { hint.contains("Use `scripts.build` for component-owned build commands") }));
     assert!(hints
         .iter()
         .any(|hint| hint.contains("homeboy extension list")));


### PR DESCRIPTION
## Summary
- Reject component-level `build_command` with a clear validation error directing users to `scripts.build`.
- Run the validation before build fallback, deploy planning, and `component show` output so bad configs fail at inspection/preflight time.
- Update tests that previously expected `build_command` execution to prove no fallback build or missing-artifact path runs first.

Fixes #3058.

## Tests
- `cargo test build_command`
- `cargo test component_show_rejects_legacy_build_command`
- `cargo test extension_guidance_hints_point_to_supported_paths`
- `cargo test test_write_to_run_dir`
- `cargo test test_run_main_bench_workflow`
- `cargo test build_exec_env_includes_runtime_runner_helper_path`
- `cargo test --lib -- --test-threads=1`

## Notes
- `cargo test --lib` with default parallelism had three transient failures in unrelated run-dir/helper tests; each failing test passed when rerun individually, and the serial library suite passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the validation change, updated tests, and ran verification; Chris remains responsible for review and merge.