### PR TITLE
fix: clear Homeboy release blockers

### DIFF
--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -32,6 +32,7 @@ fn prepare_rig_bench_context(
     args: &BenchRunArgs,
 ) -> homeboy::core::Result<RigBenchContext> {
     let mut spec = rig::load(rig_id)?;
+    let declared_spec = spec.clone();
     apply_bench_path_override(&mut spec, args);
     let lease = rig::lease::acquire_active_run_lease(&spec, "bench")?;
     if let Some(prepare) = rig::run_bench_prepare(&spec)? {
@@ -43,7 +44,7 @@ fn prepare_rig_bench_context(
             ));
         }
     }
-    let snapshot = rig::snapshot_state(&spec);
+    let snapshot = rig::snapshot_state(&declared_spec);
     let package_root =
         rig::read_source_metadata(&spec.id).map(|metadata| PathBuf::from(metadata.package_path));
     Ok(RigBenchContext {

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -123,15 +123,13 @@ pub(super) fn prepare_component_deploy(
     let artifact_path = if is_git_deploy {
         None
     } else if is_file_deploy {
-        if let Err(result) = validate_preflight_file_artifact(
+        validate_preflight_file_artifact(
             component,
             base_path,
             build_exit_code,
             local_version.clone(),
             remote_version.clone(),
-        ) {
-            return Err(result);
-        }
+        )?;
         None
     } else {
         match resolve_preflight_artifact_path(
@@ -154,7 +152,7 @@ pub(super) fn prepare_component_deploy(
 
     Ok(PreparedComponentDeploy {
         component: component.clone(),
-        config: clone_config(config),
+        config: config.clone(),
         install_dir,
         local_version,
         remote_version,
@@ -199,24 +197,6 @@ pub(super) fn execute_preflighted_component_deploy(
     }
 
     execute_artifact_deploy(prepared, ctx, base_path, project)
-}
-
-fn clone_config(config: &DeployConfig) -> DeployConfig {
-    DeployConfig {
-        component_ids: config.component_ids.clone(),
-        all: config.all,
-        outdated: config.outdated,
-        behind_upstream: config.behind_upstream,
-        dry_run: config.dry_run,
-        check: config.check,
-        force: config.force,
-        skip_build: config.skip_build,
-        keep_deps: config.keep_deps,
-        expected_version: config.expected_version.clone(),
-        no_pull: config.no_pull,
-        head: config.head,
-        tagged: config.tagged,
-    }
 }
 
 fn should_try_download_release_artifact(
@@ -453,6 +433,18 @@ fn failed_file_deploy_result(
     )
 }
 
+fn failed_preflight_file_artifact_result(
+    component: &Component,
+    base_path: &str,
+    build_exit_code: Option<i32>,
+    local_version: Option<String>,
+    remote_version: Option<String>,
+    error: String,
+) -> ComponentDeployResult {
+    ComponentDeployResult::failed(component, base_path, local_version, remote_version, error)
+        .with_build_exit_code(build_exit_code)
+}
+
 fn validate_preflight_file_artifact(
     component: &Component,
     base_path: &str,
@@ -463,28 +455,28 @@ fn validate_preflight_file_artifact(
     let local_path = Path::new(&component.local_path);
 
     if !local_path.exists() {
-        return Err(ComponentDeployResult::failed(
+        return Err(failed_preflight_file_artifact_result(
             component,
             base_path,
+            build_exit_code,
             local_version,
             remote_version,
             format!("Source file does not exist: {}", component.local_path),
-        )
-        .with_build_exit_code(build_exit_code));
+        ));
     }
 
     if !local_path.is_file() {
-        return Err(ComponentDeployResult::failed(
+        return Err(failed_preflight_file_artifact_result(
             component,
             base_path,
+            build_exit_code,
             local_version,
             remote_version,
             format!(
                 "Component '{}' has deploy_strategy 'file' but local_path is not a file: {}",
                 component.id, component.local_path
             ),
-        )
-        .with_build_exit_code(build_exit_code));
+        ));
     }
 
     Ok(())

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -246,7 +246,7 @@ fn prepare_component_deployments(
 
     for component in components {
         let component = crate::core::project::apply_component_overrides(component, project);
-        let effective_config = clone_config(config);
+        let effective_config = config.clone();
 
         match prepare_component_deploy(
             &component,
@@ -758,25 +758,6 @@ fn check_unreleased_commits(
             "Use `deploy --force` to deploy the stale tag anyway".to_string(),
         ]),
     ))
-}
-
-/// Create a value copy of DeployConfig for per-component overrides.
-fn clone_config(config: &DeployConfig) -> DeployConfig {
-    DeployConfig {
-        component_ids: config.component_ids.clone(),
-        all: config.all,
-        outdated: config.outdated,
-        behind_upstream: config.behind_upstream,
-        dry_run: config.dry_run,
-        check: config.check,
-        force: config.force,
-        skip_build: config.skip_build,
-        keep_deps: config.keep_deps,
-        expected_version: config.expected_version.clone(),
-        no_pull: config.no_pull,
-        head: config.head,
-        tagged: config.tagged,
-    }
 }
 
 /// Verify that component versions match the expected version.

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -40,6 +40,7 @@ impl DeployResult {
     }
 }
 
+#[derive(Clone)]
 pub struct DeployConfig {
     pub component_ids: Vec<String>,
     pub all: bool,

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -421,7 +421,7 @@ fn run_lab_offload_inner(
         plan = with_step(
             plan,
             PlanStep::ready("lab.sync_rigs", "lab.sync_rigs")
-                .inputs(PlanValues::new().json("count", &synced_rigs))
+                .inputs(PlanValues::new().json("count", synced_rigs))
                 .build(),
         );
     }


### PR DESCRIPTION
## Summary
- Preserve the pre-override rig spec for bench snapshots so `declared_path` remains available when `--path` changes the effective component path.
- Remove duplicate deploy config cloning by deriving `Clone` for `DeployConfig` and using the shared implementation.
- Include the clippy cleanups generated by the release autofix branch and remove touched-scope deploy duplication.

## Verification
- `cargo fmt --check`
- `cargo test bench_rig_path_override --lib`
- `cargo test deploy --lib`
- `homeboy audit --path /Users/chubes/Developer/homeboy@fix-rig-path-override-recording --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the release-blocking regression and audit findings, drafted the fixes, and ran targeted verification; Chris remains responsible for review and merge.