### PR TITLE
test: keep build command fixtures core agnostic

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -1195,9 +1195,9 @@ mod tests {
         fs::write(
             temp.path().join("homeboy.json"),
             r#"{
-                "id": "wp-codebox",
-                "build_artifact": "packages/wordpress-plugin/dist/wp-codebox.zip",
-                "build_command": "npm run package:wordpress-plugin"
+                "id": "sample-codebox",
+                "build_artifact": "packages/browser-extension/dist/sample-codebox.zip",
+                "build_command": "npm run package:browser-extension"
             }"#,
         )
         .expect("homeboy.json");

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -763,8 +763,8 @@ mod tests {
     #[test]
     fn validate_supported_build_config_rejects_legacy_build_command() {
         let component = Component {
-            id: "wp-codebox".to_string(),
-            build_command: Some("npm run package:wordpress-plugin".to_string()),
+            id: "sample-codebox".to_string(),
+            build_command: Some("npm run package:browser-extension".to_string()),
             ..Default::default()
         };
 

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -880,10 +880,10 @@ mod tests {
     #[test]
     fn deploy_validation_rejects_legacy_build_command_before_artifact_checks() {
         let dir = TempDir::new().expect("temp dir");
-        let mut component = make_component("wp-codebox", &dir.path().to_string_lossy());
+        let mut component = make_component("sample-codebox", &dir.path().to_string_lossy());
         component.build_artifact =
-            Some("packages/wordpress-plugin/dist/wp-codebox.zip".to_string());
-        component.build_command = Some("npm run package:wordpress-plugin".to_string());
+            Some("packages/browser-extension/dist/sample-codebox.zip".to_string());
+        component.build_command = Some("npm run package:browser-extension".to_string());
 
         let err = validate_supported_build_configs(&[component])
             .expect_err("legacy build_command should fail deploy preflight");


### PR DESCRIPTION
## Summary
- Rename legacy build-command test fixtures away from WordPress-specific package names.
- Keep the core-owned fixture coverage while satisfying the core-agnostic content guard.

## Verification
- `cargo fmt --check`
- `cargo test --test core_agnostic_test core_owned_test_content_stays_language_and_framework_agnostic`
- `homeboy audit --path /Users/chubes/Developer/homeboy@fix-core-agnostic-fixtures --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the release test failure, renamed fixtures, and ran targeted verification; Chris remains responsible for review and merge.