### PR TITLE
core: promote HomeboyFinding as shared finding contract

### DIFF
--- a/src/core/finding.rs
+++ b/src/core/finding.rs
@@ -1,0 +1,322 @@
+//! Shared typed finding substrate for Homeboy workflows.
+//!
+//! Domain-specific commands can keep their detailed sidecar contracts while
+//! adapting toward this shape before persistence, reporting, or issue grouping.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// A normalized finding emitted by lint, audit, test, bench, review, or custom
+/// extension producers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HomeboyFinding {
+    pub tool: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rule: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub severity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub column: Option<i64>,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fingerprint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fixable: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub producer: Option<FindingProducer>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<FindingSource>,
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub metadata: Map<String, Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw: Option<Value>,
+}
+
+impl HomeboyFinding {
+    pub fn builder(tool: impl Into<String>, message: impl Into<String>) -> HomeboyFindingBuilder {
+        HomeboyFindingBuilder::new(tool, message)
+    }
+
+    pub fn metadata_json(&self) -> Value {
+        let mut metadata = self.metadata.clone();
+        insert_option(&mut metadata, "category", self.category.clone());
+        insert_option(&mut metadata, "column", self.column);
+        insert_option_value(&mut metadata, "producer", &self.producer);
+        insert_option_value(&mut metadata, "source", &self.source);
+        if let Some(raw) = &self.raw {
+            metadata.insert("raw".to_string(), raw.clone());
+        }
+        Value::Object(metadata)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FindingProducer {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invocation: Option<String>,
+}
+
+impl FindingProducer {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            version: None,
+            invocation: None,
+        }
+    }
+
+    pub fn version(mut self, version: impl Into<String>) -> Self {
+        self.version = Some(version.into());
+        self
+    }
+
+    pub fn invocation(mut self, invocation: impl Into<String>) -> Self {
+        self.invocation = Some(invocation.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FindingSource {
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+impl FindingSource {
+    pub fn new(kind: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            label: None,
+            path: None,
+        }
+    }
+
+    pub fn label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    pub fn path(mut self, path: impl Into<String>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HomeboyFindingBuilder {
+    finding: HomeboyFinding,
+}
+
+impl HomeboyFindingBuilder {
+    fn new(tool: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            finding: HomeboyFinding {
+                tool: tool.into(),
+                rule: None,
+                category: None,
+                severity: None,
+                file: None,
+                line: None,
+                column: None,
+                message: message.into(),
+                fingerprint: None,
+                fixable: None,
+                producer: None,
+                source: None,
+                metadata: Map::new(),
+                raw: None,
+            },
+        }
+    }
+
+    pub fn rule(mut self, rule: impl Into<String>) -> Self {
+        self.finding.rule = Some(rule.into());
+        self
+    }
+
+    pub fn category(mut self, category: impl Into<String>) -> Self {
+        self.finding.category = Some(category.into());
+        self
+    }
+
+    pub fn severity(mut self, severity: impl Into<String>) -> Self {
+        self.finding.severity = Some(severity.into());
+        self
+    }
+
+    pub fn file(mut self, file: impl Into<String>) -> Self {
+        self.finding.file = Some(file.into());
+        self
+    }
+
+    pub fn line(mut self, line: impl Into<i64>) -> Self {
+        self.finding.line = Some(line.into());
+        self
+    }
+
+    pub fn column(mut self, column: impl Into<i64>) -> Self {
+        self.finding.column = Some(column.into());
+        self
+    }
+
+    pub fn fingerprint(mut self, fingerprint: impl Into<String>) -> Self {
+        self.finding.fingerprint = Some(fingerprint.into());
+        self
+    }
+
+    pub fn fixable(mut self, fixable: bool) -> Self {
+        self.finding.fixable = Some(fixable);
+        self
+    }
+
+    pub fn producer(mut self, producer: FindingProducer) -> Self {
+        self.finding.producer = Some(producer);
+        self
+    }
+
+    pub fn source(mut self, source: FindingSource) -> Self {
+        self.finding.source = Some(source);
+        self
+    }
+
+    pub fn metadata<T: Serialize>(mut self, key: impl Into<String>, value: T) -> Self {
+        self.finding.metadata.insert(
+            key.into(),
+            serde_json::to_value(value).unwrap_or(serde_json::Value::Null),
+        );
+        self
+    }
+
+    pub fn raw<T: Serialize>(mut self, raw: T) -> Self {
+        self.finding.raw = Some(serde_json::to_value(raw).unwrap_or(serde_json::Value::Null));
+        self
+    }
+
+    pub fn build(self) -> HomeboyFinding {
+        self.finding
+    }
+}
+
+fn insert_option<T: Serialize>(metadata: &mut Map<String, Value>, key: &str, value: Option<T>) {
+    if let Some(value) = value {
+        metadata.insert(
+            key.to_string(),
+            serde_json::to_value(value).unwrap_or(serde_json::Value::Null),
+        );
+    }
+}
+
+fn insert_option_value<T: Serialize>(
+    metadata: &mut Map<String, Value>,
+    key: &str,
+    value: &Option<T>,
+) {
+    if let Some(value) = value {
+        metadata.insert(
+            key.to_string(),
+            serde_json::to_value(value).unwrap_or(serde_json::Value::Null),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_covers_lint_shape() {
+        let finding = HomeboyFinding::builder("phpcs", "escape output")
+            .rule("WordPress.Security.EscapeOutput")
+            .category("security")
+            .severity("error")
+            .file("src/lib.php")
+            .line(12)
+            .column(8)
+            .fingerprint("src/lib.php:12:8:WordPress.Security.EscapeOutput")
+            .fixable(true)
+            .source(FindingSource::new("sidecar").path("lint-findings.json"))
+            .build();
+
+        assert_eq!(finding.category.as_deref(), Some("security"));
+        assert_eq!(finding.column, Some(8));
+        assert_eq!(
+            finding.metadata_json()["source"]["path"],
+            "lint-findings.json"
+        );
+    }
+
+    #[test]
+    fn builder_covers_audit_shape() {
+        let finding = HomeboyFinding::builder("audit", "Missing run function")
+            .rule("missing_method")
+            .category("command modules")
+            .severity("warning")
+            .file("src/commands/foo.rs")
+            .metadata("confidence", "structural")
+            .metadata("suggestion", "Add run()")
+            .build();
+
+        assert_eq!(finding.rule.as_deref(), Some("missing_method"));
+        assert_eq!(finding.metadata_json()["suggestion"], "Add run()");
+    }
+
+    #[test]
+    fn builder_covers_test_failure_shape() {
+        let finding = HomeboyFinding::builder("test", "Expected 200, got 500")
+            .rule("assertion_mismatch")
+            .category("test_failure")
+            .severity("error")
+            .file("tests/AuthTest.php")
+            .line(44)
+            .fingerprint("AuthTest::test_login:assertion_mismatch")
+            .metadata("test_name", "AuthTest::test_login")
+            .source(FindingSource::new("runner").label("phpunit"))
+            .build();
+
+        assert_eq!(finding.tool, "test");
+        assert_eq!(finding.metadata_json()["test_name"], "AuthTest::test_login");
+    }
+
+    #[test]
+    fn builder_covers_bench_budget_shape() {
+        let finding = HomeboyFinding::builder("budget", "Page ready time exceeded budget")
+            .rule("page.ready_ms")
+            .category("budget")
+            .severity("error")
+            .fingerprint("page.ready_ms:front-page")
+            .metadata("actual", 1200.0)
+            .metadata("expected", 1000.0)
+            .metadata("unit", "ms")
+            .build();
+
+        assert_eq!(finding.rule.as_deref(), Some("page.ready_ms"));
+        assert_eq!(finding.metadata_json()["unit"], "ms");
+    }
+
+    #[test]
+    fn builder_covers_annotation_shape() {
+        let finding = HomeboyFinding::builder("github-annotations", "escape output")
+            .rule("WordPress.Security.EscapeOutput")
+            .severity("warning")
+            .file("src/lib.php")
+            .line(12)
+            .source(FindingSource::new("annotation").path("phpcs.json"))
+            .metadata("github_level", "warning")
+            .build();
+
+        assert_eq!(finding.source.as_ref().unwrap().kind, "annotation");
+        assert_eq!(finding.metadata_json()["github_level"], "warning");
+    }
+}

--- a/src/core/finding.rs
+++ b/src/core/finding.rs
@@ -17,17 +17,13 @@ pub struct HomeboyFinding {
     pub category: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub severity: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub file: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub line: Option<i64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub column: Option<i64>,
+    #[serde(flatten)]
+    pub location: FindingLocation,
     pub message: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fingerprint: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub fixable: Option<bool>,
+    #[serde(flatten)]
+    pub fix: FindingFix,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub producer: Option<FindingProducer>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -46,7 +42,7 @@ impl HomeboyFinding {
     pub fn metadata_json(&self) -> Value {
         let mut metadata = self.metadata.clone();
         insert_option(&mut metadata, "category", self.category.clone());
-        insert_option(&mut metadata, "column", self.column);
+        insert_option(&mut metadata, "column", self.location.column);
         insert_option_value(&mut metadata, "producer", &self.producer);
         insert_option_value(&mut metadata, "source", &self.source);
         if let Some(raw) = &self.raw {
@@ -54,6 +50,22 @@ impl HomeboyFinding {
         }
         Value::Object(metadata)
     }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FindingLocation {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub column: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FindingFix {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fixable: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -127,12 +139,10 @@ impl HomeboyFindingBuilder {
                 rule: None,
                 category: None,
                 severity: None,
-                file: None,
-                line: None,
-                column: None,
+                location: FindingLocation::default(),
                 message: message.into(),
                 fingerprint: None,
-                fixable: None,
+                fix: FindingFix::default(),
                 producer: None,
                 source: None,
                 metadata: Map::new(),
@@ -157,17 +167,17 @@ impl HomeboyFindingBuilder {
     }
 
     pub fn file(mut self, file: impl Into<String>) -> Self {
-        self.finding.file = Some(file.into());
+        self.finding.location.file = Some(file.into());
         self
     }
 
     pub fn line(mut self, line: impl Into<i64>) -> Self {
-        self.finding.line = Some(line.into());
+        self.finding.location.line = Some(line.into());
         self
     }
 
     pub fn column(mut self, column: impl Into<i64>) -> Self {
-        self.finding.column = Some(column.into());
+        self.finding.location.column = Some(column.into());
         self
     }
 
@@ -177,7 +187,7 @@ impl HomeboyFindingBuilder {
     }
 
     pub fn fixable(mut self, fixable: bool) -> Self {
-        self.finding.fixable = Some(fixable);
+        self.finding.fix.fixable = Some(fixable);
         self
     }
 
@@ -250,7 +260,7 @@ mod tests {
             .build();
 
         assert_eq!(finding.category.as_deref(), Some("security"));
-        assert_eq!(finding.column, Some(8));
+        assert_eq!(finding.location.column, Some(8));
         assert_eq!(
             finding.metadata_json()["source"]["path"],
             "lint-findings.json"

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,6 +15,7 @@ pub mod engine;
 pub mod error;
 pub(crate) mod expand;
 pub mod extension;
+pub mod finding;
 pub mod fleet;
 pub mod git;
 pub mod http_api;

--- a/src/core/observation/budget_findings.rs
+++ b/src/core/observation/budget_findings.rs
@@ -1,29 +1,29 @@
 use crate::core::budget::BudgetFinding;
+use crate::core::finding::{FindingSource, HomeboyFinding};
 
 use super::records::NewFindingRecord;
 
+pub fn homeboy_finding_from_budget(finding: &BudgetFinding) -> HomeboyFinding {
+    let mut normalized = HomeboyFinding::builder("budget", finding.message.clone())
+        .rule(finding.code.clone())
+        .category(finding.category.clone())
+        .severity(finding.severity.clone())
+        .fingerprint(finding.fingerprint())
+        .source(FindingSource::new("budget").label(finding.context_label.clone()))
+        .metadata("context_label", finding.context_label.clone())
+        .metadata("actual", finding.actual)
+        .metadata("expected", finding.expected)
+        .metadata("unit", finding.unit.clone())
+        .metadata("subject", finding.subject.clone())
+        .metadata("passed", finding.passed)
+        .raw(finding)
+        .build();
+    normalized.file = finding.file.clone();
+    normalized
+}
+
 fn finding_record_from_budget(run_id: &str, finding: &BudgetFinding) -> NewFindingRecord {
-    NewFindingRecord {
-        run_id: run_id.to_string(),
-        tool: "budget".to_string(),
-        rule: Some(finding.code.clone()),
-        file: finding.file.clone(),
-        line: None,
-        severity: Some(finding.severity.clone()),
-        fingerprint: Some(finding.fingerprint()),
-        message: finding.message.clone(),
-        fixable: None,
-        metadata_json: serde_json::json!({
-            "category": finding.category,
-            "context_label": finding.context_label,
-            "actual": finding.actual,
-            "expected": finding.expected,
-            "unit": finding.unit,
-            "subject": finding.subject,
-            "passed": finding.passed,
-            "raw": finding,
-        }),
-    }
+    NewFindingRecord::from_homeboy_finding(run_id, homeboy_finding_from_budget(finding))
 }
 
 pub fn finding_records_from_budget(

--- a/src/core/observation/budget_findings.rs
+++ b/src/core/observation/budget_findings.rs
@@ -3,7 +3,7 @@ use crate::core::finding::{FindingSource, HomeboyFinding};
 
 use super::records::NewFindingRecord;
 
-pub fn homeboy_finding_from_budget(finding: &BudgetFinding) -> HomeboyFinding {
+fn homeboy_finding_from_budget(finding: &BudgetFinding) -> HomeboyFinding {
     let mut normalized = HomeboyFinding::builder("budget", finding.message.clone())
         .rule(finding.code.clone())
         .category(finding.category.clone())
@@ -18,7 +18,7 @@ pub fn homeboy_finding_from_budget(finding: &BudgetFinding) -> HomeboyFinding {
         .metadata("passed", finding.passed)
         .raw(finding)
         .build();
-    normalized.file = finding.file.clone();
+    normalized.location.file = finding.file.clone();
     normalized
 }
 

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -12,11 +12,12 @@ pub mod timeline;
 
 pub use lifecycle::{merge_metadata, run_owner_pid, running_status_note, ActiveObservation};
 
-pub use budget_findings::finding_records_from_budget;
+pub use budget_findings::{finding_records_from_budget, homeboy_finding_from_budget};
 pub use records::{
     finding_record_from_annotation, finding_record_from_audit, finding_record_from_lint,
     finding_records_from_annotation_file, finding_records_from_annotations_dir,
-    finding_records_from_audit, finding_records_from_lint, AnnotationFindingRecord,
+    finding_records_from_audit, finding_records_from_lint, homeboy_finding_from_annotation,
+    homeboy_finding_from_audit, homeboy_finding_from_lint, AnnotationFindingRecord,
     ArtifactCleanupCandidateRecord, ArtifactCleanupFilter, ArtifactRecord, FindingListFilter,
     FindingRecord, NewFindingRecord, NewRunRecord, NewRunRecordBuilder, NewTraceRunRecord,
     NewTraceRunRecordBuilder, NewTraceSpanRecord, NewTraceSpanRecordBuilder, NewTriageItemRecord,

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -12,7 +12,7 @@ pub mod timeline;
 
 pub use lifecycle::{merge_metadata, run_owner_pid, running_status_note, ActiveObservation};
 
-pub use budget_findings::{finding_records_from_budget, homeboy_finding_from_budget};
+pub use budget_findings::finding_records_from_budget;
 pub use records::{
     finding_record_from_annotation, finding_record_from_audit, finding_record_from_lint,
     finding_records_from_annotation_file, finding_records_from_annotations_dir,

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -4,6 +4,7 @@ use std::{collections::BTreeMap, path::Path};
 
 use crate::core::code_audit::{self, report::finding_kind_key};
 use crate::core::extension::lint::LintFinding;
+use crate::core::finding::{FindingSource, HomeboyFinding};
 
 mod run_builder;
 mod run_status;
@@ -114,6 +115,24 @@ pub struct NewFindingRecord {
     pub metadata_json: serde_json::Value,
 }
 
+impl NewFindingRecord {
+    pub fn from_homeboy_finding(run_id: impl Into<String>, finding: HomeboyFinding) -> Self {
+        let metadata_json = finding.metadata_json();
+        Self {
+            run_id: run_id.into(),
+            tool: finding.tool,
+            rule: finding.rule,
+            file: finding.file,
+            line: finding.line,
+            severity: finding.severity,
+            fingerprint: finding.fingerprint,
+            message: finding.message,
+            fixable: finding.fixable,
+            metadata_json,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FindingRecord {
     pub id: String,
@@ -152,23 +171,28 @@ pub struct AnnotationFindingRecord {
     pub extra: BTreeMap<String, Value>,
 }
 
+pub fn homeboy_finding_from_lint(finding: &LintFinding) -> HomeboyFinding {
+    let mut normalized = HomeboyFinding::builder(
+        finding.tool.clone().unwrap_or_else(|| "lint".to_string()),
+        finding.message.clone(),
+    )
+    .category(finding.category.clone())
+    .fingerprint(finding.id.clone())
+    .source(FindingSource::new("sidecar").label("lint-findings"))
+    .metadata("source_sidecar", "lint-findings")
+    .raw(finding)
+    .build();
+    normalized.rule = lint_extra_string(finding, "rule").or_else(|| Some(finding.category.clone()));
+    normalized.file = finding.file.clone();
+    normalized.line = lint_extra_i64(finding, "line");
+    normalized.column = lint_extra_i64(finding, "column");
+    normalized.severity = finding.severity.clone();
+    normalized.fixable = lint_extra_bool(finding, "fixable");
+    normalized
+}
+
 pub fn finding_record_from_lint(run_id: &str, finding: &LintFinding) -> NewFindingRecord {
-    NewFindingRecord {
-        run_id: run_id.to_string(),
-        tool: finding.tool.clone().unwrap_or_else(|| "lint".to_string()),
-        rule: lint_extra_string(finding, "rule").or_else(|| Some(finding.category.clone())),
-        file: finding.file.clone(),
-        line: lint_extra_i64(finding, "line"),
-        severity: finding.severity.clone(),
-        fingerprint: Some(finding.id.clone()),
-        message: finding.message.clone(),
-        fixable: lint_extra_bool(finding, "fixable"),
-        metadata_json: serde_json::json!({
-            "category": finding.category,
-            "source_sidecar": "lint-findings",
-            "raw": finding,
-        }),
-    }
+    NewFindingRecord::from_homeboy_finding(run_id, homeboy_finding_from_lint(finding))
 }
 
 pub fn finding_records_from_lint(run_id: &str, findings: &[LintFinding]) -> Vec<NewFindingRecord> {
@@ -178,27 +202,26 @@ pub fn finding_records_from_lint(run_id: &str, findings: &[LintFinding]) -> Vec<
         .collect()
 }
 
-pub fn finding_record_from_audit(run_id: &str, finding: &code_audit::Finding) -> NewFindingRecord {
+pub fn homeboy_finding_from_audit(finding: &code_audit::Finding) -> HomeboyFinding {
     let kind = finding_kind_key(&finding.kind);
-    NewFindingRecord {
-        run_id: run_id.to_string(),
-        tool: "audit".to_string(),
-        rule: Some(kind.clone()),
-        file: Some(finding.file.clone()),
-        line: None,
-        severity: Some(audit_severity_key(&finding.severity)),
-        fingerprint: Some(audit_finding_fingerprint(finding)),
-        message: finding.description.clone(),
-        fixable: None,
-        metadata_json: serde_json::json!({
-            "source_sidecar": "audit-findings",
-            "convention": finding.convention,
-            "suggestion": finding.suggestion,
-            "confidence": finding.kind.confidence(),
-            "kind": kind,
-            "raw": finding,
-        }),
-    }
+    HomeboyFinding::builder("audit", finding.description.clone())
+        .rule(kind.clone())
+        .category(finding.convention.clone())
+        .file(finding.file.clone())
+        .severity(audit_severity_key(&finding.severity))
+        .fingerprint(audit_finding_fingerprint(finding))
+        .source(FindingSource::new("sidecar").label("audit-findings"))
+        .metadata("source_sidecar", "audit-findings")
+        .metadata("convention", finding.convention.clone())
+        .metadata("suggestion", finding.suggestion.clone())
+        .metadata("confidence", finding.kind.confidence())
+        .metadata("kind", kind)
+        .raw(finding)
+        .build()
+}
+
+pub fn finding_record_from_audit(run_id: &str, finding: &code_audit::Finding) -> NewFindingRecord {
+    NewFindingRecord::from_homeboy_finding(run_id, homeboy_finding_from_audit(finding))
 }
 
 pub fn finding_records_from_audit(
@@ -306,26 +329,33 @@ pub fn finding_record_from_annotation(
     annotation: &AnnotationFindingRecord,
     source_file: &str,
 ) -> NewFindingRecord {
+    NewFindingRecord::from_homeboy_finding(
+        run_id,
+        homeboy_finding_from_annotation(annotation, source_file),
+    )
+}
+
+pub fn homeboy_finding_from_annotation(
+    annotation: &AnnotationFindingRecord,
+    source_file: &str,
+) -> HomeboyFinding {
     let tool = annotation
         .source
         .clone()
         .unwrap_or_else(|| annotation_file_stem(source_file));
-    NewFindingRecord {
-        run_id: run_id.to_string(),
-        tool,
-        rule: annotation.code.clone(),
-        file: annotation.file.clone(),
-        line: annotation.line,
-        severity: annotation.severity.clone(),
-        fingerprint: annotation_fingerprint(annotation),
-        message: annotation.message.clone(),
-        fixable: annotation.fixable,
-        metadata_json: serde_json::json!({
-            "source_sidecar": "annotations",
-            "annotation_file": source_file,
-            "raw": annotation,
-        }),
-    }
+    let mut normalized = HomeboyFinding::builder(tool, annotation.message.clone())
+        .source(FindingSource::new("annotation").path(source_file))
+        .metadata("source_sidecar", "annotations")
+        .metadata("annotation_file", source_file)
+        .raw(annotation)
+        .build();
+    normalized.rule = annotation.code.clone();
+    normalized.file = annotation.file.clone();
+    normalized.line = annotation.line;
+    normalized.severity = annotation.severity.clone();
+    normalized.fingerprint = annotation_fingerprint(annotation);
+    normalized.fixable = annotation.fixable;
+    normalized
 }
 
 fn annotation_file_stem(source_file: &str) -> String {

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -122,12 +122,12 @@ impl NewFindingRecord {
             run_id: run_id.into(),
             tool: finding.tool,
             rule: finding.rule,
-            file: finding.file,
-            line: finding.line,
+            file: finding.location.file,
+            line: finding.location.line,
             severity: finding.severity,
             fingerprint: finding.fingerprint,
             message: finding.message,
-            fixable: finding.fixable,
+            fixable: finding.fix.fixable,
             metadata_json,
         }
     }
@@ -183,11 +183,11 @@ pub fn homeboy_finding_from_lint(finding: &LintFinding) -> HomeboyFinding {
     .raw(finding)
     .build();
     normalized.rule = lint_extra_string(finding, "rule").or_else(|| Some(finding.category.clone()));
-    normalized.file = finding.file.clone();
-    normalized.line = lint_extra_i64(finding, "line");
-    normalized.column = lint_extra_i64(finding, "column");
+    normalized.location.file = finding.file.clone();
+    normalized.location.line = lint_extra_i64(finding, "line");
+    normalized.location.column = lint_extra_i64(finding, "column");
     normalized.severity = finding.severity.clone();
-    normalized.fixable = lint_extra_bool(finding, "fixable");
+    normalized.fix.fixable = lint_extra_bool(finding, "fixable");
     normalized
 }
 
@@ -350,11 +350,11 @@ pub fn homeboy_finding_from_annotation(
         .raw(annotation)
         .build();
     normalized.rule = annotation.code.clone();
-    normalized.file = annotation.file.clone();
-    normalized.line = annotation.line;
+    normalized.location.file = annotation.file.clone();
+    normalized.location.line = annotation.line;
     normalized.severity = annotation.severity.clone();
     normalized.fingerprint = annotation_fingerprint(annotation);
-    normalized.fixable = annotation.fixable;
+    normalized.fix.fixable = annotation.fixable;
     normalized
 }
 


### PR DESCRIPTION
## Summary
- Add `core::finding::HomeboyFinding` as the shared typed finding contract with builder-style construction, producer/source metadata, stable location fields, fingerprinting, fixability, metadata, and raw payload support.
- Route lint, audit, budget, and annotation observation adapters through `HomeboyFinding` before projecting to `NewFindingRecord`.
- Add focused model coverage showing the contract can represent lint, audit, test failure, bench budget, and annotation finding shapes.

Fixes #3069.
Part of #3074.

## Tests
- `cargo test core::finding`
- `cargo test core::observation`
- `cargo test`

## Follow-up notes
- #3070/#3071/#3072/#3073 can migrate command outputs and reporting toward `HomeboyFinding` without inventing new parallel finding shapes.
- Observation storage still persists the existing `findings` columns; richer fields like `category`, `column`, producer/source, and raw payloads project into `metadata_json` for now.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shared finding model, adapter projection changes, and focused tests; Chris remains responsible for review and merge decisions.