### PR TITLE
feat: add core HomeboyFinding contract

### DIFF
--- a/docs/architecture/finding-contract.md
+++ b/docs/architecture/finding-contract.md
@@ -14,7 +14,7 @@ Common fields stay stable across producers:
 - `category`: broad grouping such as `security`, `code_audit`, `test_failure`, or `budget`.
 - `severity`: producer severity as a string so extensions can preserve their own taxonomy.
 - `fingerprint`: stable identity used for baselines, dedupe, and trend tracking.
-- `file`, `line`, `column`: optional source location.
+- `location.file`, `location.line`, `location.column`: optional source location.
 - `message`: human-facing summary.
 - `fixable`: whether automated or guided remediation is available.
 - `producer`: command, extension, step, sidecar, and artifact provenance.

--- a/docs/architecture/finding-contract.md
+++ b/docs/architecture/finding-contract.md
@@ -1,0 +1,62 @@
+# Homeboy Finding Contract
+
+`HomeboyFinding` is the shared typed finding model for Homeboy commands,
+extensions, reports, and agents. It is analogous to `HomeboyPlan`: producers
+build one normalized shape first, then storage and output layers project it into
+their local representation.
+
+## Core Shape
+
+Common fields stay stable across producers:
+
+- `tool`: producer tool family such as `lint`, `audit`, `test`, or `budget`.
+- `rule`: machine-readable rule, sniff, audit kind, test cluster, or budget code.
+- `category`: broad grouping such as `security`, `code_audit`, `test_failure`, or `budget`.
+- `severity`: producer severity as a string so extensions can preserve their own taxonomy.
+- `fingerprint`: stable identity used for baselines, dedupe, and trend tracking.
+- `file`, `line`, `column`: optional source location.
+- `message`: human-facing summary.
+- `fixable`: whether automated or guided remediation is available.
+- `producer`: command, extension, step, sidecar, and artifact provenance.
+- `metadata`: structured source-specific common details.
+- `raw`: lossless source payload when the producer has richer native data.
+
+## Storage Projection
+
+`NewFindingRecord` and `FindingRecord` are observation-store records. They are
+not the producer contract. Use `NewFindingRecord::from_homeboy_finding()` when a
+finding needs to be persisted.
+
+The projection stores high-value query fields as SQLite columns:
+
+- `tool`, `rule`, `file`, `line`, `severity`, `fingerprint`, `message`, `fixable`
+
+The projection stores remaining normalized evidence in `metadata_json`:
+
+- `category`
+- `producer`
+- `source_sidecar`
+- `source_artifact`
+- source-specific `metadata`
+- `raw`
+
+This keeps existing run queries stable while making the upstream contract clear.
+
+## Representative Producers
+
+The contract can represent current finding dialects without forcing one PR to
+migrate every producer:
+
+- lint findings map sniffs/rules, category, source file, severity, fixability,
+  and `lint-findings` sidecar provenance.
+- audit findings map audit kind, convention, confidence, file, suggestion, and
+  `audit-findings` sidecar provenance.
+- test failures map failed test name, source location, failure category, cluster,
+  and error type into `metadata`.
+- bench budget findings map budget code, actual/expected/unit, subject,
+  severity, and gate status.
+- annotation sidecars map source, code, location, severity, fixability, and raw
+  annotation payloads.
+
+Follow-up PRs should migrate producers incrementally to emit `HomeboyFinding`
+directly at their command/output boundary.

--- a/src/core/finding.rs
+++ b/src/core/finding.rs
@@ -20,12 +20,8 @@ pub struct HomeboyFinding {
     pub severity: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fingerprint: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub file: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub line: Option<i64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub column: Option<i64>,
+    #[serde(default, skip_serializing_if = "HomeboyFindingLocation::is_empty")]
+    pub location: HomeboyFindingLocation,
     pub message: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fixable: Option<bool>,
@@ -40,6 +36,23 @@ pub struct HomeboyFinding {
 impl HomeboyFinding {
     pub fn builder(tool: impl Into<String>, message: impl Into<String>) -> HomeboyFindingBuilder {
         HomeboyFindingBuilder::new(tool, message)
+    }
+}
+
+/// Optional source location for a finding.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HomeboyFindingLocation {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub column: Option<i64>,
+}
+
+impl HomeboyFindingLocation {
+    pub fn is_empty(&self) -> bool {
+        self.file.is_none() && self.line.is_none() && self.column.is_none()
     }
 }
 
@@ -83,9 +96,7 @@ impl HomeboyFindingBuilder {
                 category: None,
                 severity: None,
                 fingerprint: None,
-                file: None,
-                line: None,
-                column: None,
+                location: HomeboyFindingLocation::default(),
                 message: message.into(),
                 fixable: None,
                 producer: HomeboyFindingProducer::default(),
@@ -121,17 +132,17 @@ impl HomeboyFindingBuilder {
     }
 
     pub fn file(mut self, value: impl Into<String>) -> Self {
-        self.finding.file = Some(value.into());
+        self.finding.location.file = Some(value.into());
         self
     }
 
     pub fn line(mut self, value: impl Into<i64>) -> Self {
-        self.finding.line = Some(value.into());
+        self.finding.location.line = Some(value.into());
         self
     }
 
     pub fn column(mut self, value: impl Into<i64>) -> Self {
-        self.finding.column = Some(value.into());
+        self.finding.location.column = Some(value.into());
         self
     }
 
@@ -254,6 +265,7 @@ mod tests {
 
         assert_eq!(finding.tool, "test");
         assert_eq!(finding.category.as_deref(), Some("test_failure"));
+        assert_eq!(finding.location.line, Some(44));
         assert_eq!(finding.metadata["test_name"], "ExampleTest::test_save");
     }
 
@@ -289,7 +301,7 @@ mod tests {
             .source_artifact("compiler-warnings.json")
             .build();
 
-        assert_eq!(finding.column, Some(13));
+        assert_eq!(finding.location.column, Some(13));
         assert_eq!(
             finding.producer.source_artifact.as_deref(),
             Some("compiler-warnings.json")

--- a/src/core/finding.rs
+++ b/src/core/finding.rs
@@ -1,0 +1,298 @@
+//! Shared typed finding contract for Homeboy producers.
+//!
+//! `HomeboyFinding` is the command/extension/reporting shape. Observation
+//! storage records are a projection of this model, not the generic contract
+//! producers should build first.
+
+use serde::{Deserialize, Serialize};
+
+/// A normalized finding emitted by a Homeboy command, extension, or report step.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HomeboyFinding {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub tool: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rule: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub severity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fingerprint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub column: Option<i64>,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fixable: Option<bool>,
+    #[serde(default, skip_serializing_if = "HomeboyFindingProducer::is_empty")]
+    pub producer: HomeboyFindingProducer,
+    #[serde(default, skip_serializing_if = "is_empty_json_object")]
+    pub metadata: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw: Option<serde_json::Value>,
+}
+
+impl HomeboyFinding {
+    pub fn builder(tool: impl Into<String>, message: impl Into<String>) -> HomeboyFindingBuilder {
+        HomeboyFindingBuilder::new(tool, message)
+    }
+}
+
+/// Provenance for the producer that created a finding.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HomeboyFindingProducer {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extension: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_sidecar: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_artifact: Option<String>,
+}
+
+impl HomeboyFindingProducer {
+    pub fn is_empty(&self) -> bool {
+        self.command.is_none()
+            && self.extension.is_none()
+            && self.step.is_none()
+            && self.source_sidecar.is_none()
+            && self.source_artifact.is_none()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HomeboyFindingBuilder {
+    finding: HomeboyFinding,
+}
+
+impl HomeboyFindingBuilder {
+    pub fn new(tool: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            finding: HomeboyFinding {
+                id: None,
+                tool: tool.into(),
+                rule: None,
+                category: None,
+                severity: None,
+                fingerprint: None,
+                file: None,
+                line: None,
+                column: None,
+                message: message.into(),
+                fixable: None,
+                producer: HomeboyFindingProducer::default(),
+                metadata: serde_json::json!({}),
+                raw: None,
+            },
+        }
+    }
+
+    pub fn id(mut self, value: impl Into<String>) -> Self {
+        self.finding.id = Some(value.into());
+        self
+    }
+
+    pub fn rule(mut self, value: impl Into<String>) -> Self {
+        self.finding.rule = Some(value.into());
+        self
+    }
+
+    pub fn category(mut self, value: impl Into<String>) -> Self {
+        self.finding.category = Some(value.into());
+        self
+    }
+
+    pub fn severity(mut self, value: impl Into<String>) -> Self {
+        self.finding.severity = Some(value.into());
+        self
+    }
+
+    pub fn fingerprint(mut self, value: impl Into<String>) -> Self {
+        self.finding.fingerprint = Some(value.into());
+        self
+    }
+
+    pub fn file(mut self, value: impl Into<String>) -> Self {
+        self.finding.file = Some(value.into());
+        self
+    }
+
+    pub fn line(mut self, value: impl Into<i64>) -> Self {
+        self.finding.line = Some(value.into());
+        self
+    }
+
+    pub fn column(mut self, value: impl Into<i64>) -> Self {
+        self.finding.column = Some(value.into());
+        self
+    }
+
+    pub fn fixable(mut self, value: bool) -> Self {
+        self.finding.fixable = Some(value);
+        self
+    }
+
+    pub fn producer(mut self, producer: HomeboyFindingProducer) -> Self {
+        self.finding.producer = producer;
+        self
+    }
+
+    pub fn command(mut self, value: impl Into<String>) -> Self {
+        self.finding.producer.command = Some(value.into());
+        self
+    }
+
+    pub fn extension(mut self, value: impl Into<String>) -> Self {
+        self.finding.producer.extension = Some(value.into());
+        self
+    }
+
+    pub fn step(mut self, value: impl Into<String>) -> Self {
+        self.finding.producer.step = Some(value.into());
+        self
+    }
+
+    pub fn source_sidecar(mut self, value: impl Into<String>) -> Self {
+        self.finding.producer.source_sidecar = Some(value.into());
+        self
+    }
+
+    pub fn source_artifact(mut self, value: impl Into<String>) -> Self {
+        self.finding.producer.source_artifact = Some(value.into());
+        self
+    }
+
+    pub fn metadata(mut self, value: serde_json::Value) -> Self {
+        self.finding.metadata = value;
+        self
+    }
+
+    pub fn raw<T: Serialize>(mut self, value: T) -> Self {
+        self.finding.raw = Some(serde_json::to_value(value).unwrap_or(serde_json::Value::Null));
+        self
+    }
+
+    pub fn build(self) -> HomeboyFinding {
+        self.finding
+    }
+}
+
+fn is_empty_json_object(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(serde_json::Map::is_empty)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn represents_lint_finding_data() {
+        let finding = HomeboyFinding::builder("phpcs", "escape output")
+            .rule("WordPress.Security.EscapeOutput")
+            .category("security")
+            .severity("error")
+            .fingerprint("src/foo.php:12:WordPress.Security.EscapeOutput")
+            .file("src/foo.php")
+            .line(12)
+            .fixable(true)
+            .command("homeboy lint")
+            .source_sidecar("lint-findings")
+            .raw(serde_json::json!({ "sniff": "WordPress.Security.EscapeOutput" }))
+            .build();
+
+        assert_eq!(finding.tool, "phpcs");
+        assert_eq!(finding.category.as_deref(), Some("security"));
+        assert_eq!(finding.fixable, Some(true));
+        assert_eq!(
+            finding.producer.source_sidecar.as_deref(),
+            Some("lint-findings")
+        );
+    }
+
+    #[test]
+    fn represents_audit_finding_data() {
+        let finding = HomeboyFinding::builder("audit", "unused parameter")
+            .rule("unused_parameter")
+            .category("code_audit")
+            .severity("warning")
+            .file("src/core/foo.rs")
+            .fingerprint("src/core/foo.rs:unused_parameter")
+            .metadata(serde_json::json!({
+                "convention": "parameter use",
+                "confidence": "graph",
+                "suggestion": "Remove the parameter or wire it into behavior"
+            }))
+            .build();
+
+        assert_eq!(finding.rule.as_deref(), Some("unused_parameter"));
+        assert_eq!(finding.metadata["confidence"], "graph");
+    }
+
+    #[test]
+    fn represents_test_failure_data() {
+        let finding = HomeboyFinding::builder("test", "ExampleTest::test_save failed")
+            .rule("assertion_mismatch")
+            .category("test_failure")
+            .severity("error")
+            .file("tests/example_test.rs")
+            .line(44)
+            .fingerprint("tests/example_test.rs:ExampleTest::test_save")
+            .metadata(serde_json::json!({
+                "test_name": "ExampleTest::test_save",
+                "error_type": "AssertionFailed",
+                "cluster": "assertion_mismatch"
+            }))
+            .build();
+
+        assert_eq!(finding.tool, "test");
+        assert_eq!(finding.category.as_deref(), Some("test_failure"));
+        assert_eq!(finding.metadata["test_name"], "ExampleTest::test_save");
+    }
+
+    #[test]
+    fn represents_bench_budget_data() {
+        let finding = HomeboyFinding::builder("budget", "Page ready time exceeded budget")
+            .rule("page.ready_ms")
+            .category("budget")
+            .severity("error")
+            .fingerprint("page.ready_ms:front-page")
+            .metadata(serde_json::json!({
+                "actual": 1200.0,
+                "expected": 1000.0,
+                "unit": "ms",
+                "subject": "front-page"
+            }))
+            .build();
+
+        assert_eq!(finding.tool, "budget");
+        assert_eq!(finding.metadata["unit"], "ms");
+    }
+
+    #[test]
+    fn represents_annotation_data() {
+        let finding = HomeboyFinding::builder("compiler", "unused variable")
+            .rule("unused_variables")
+            .category("annotation")
+            .severity("warning")
+            .file("src/main.rs")
+            .line(8)
+            .column(13)
+            .source_sidecar("annotations")
+            .source_artifact("compiler-warnings.json")
+            .build();
+
+        assert_eq!(finding.column, Some(13));
+        assert_eq!(
+            finding.producer.source_artifact.as_deref(),
+            Some("compiler-warnings.json")
+        );
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,6 +15,7 @@ pub mod engine;
 pub mod error;
 pub(crate) mod expand;
 pub mod extension;
+pub mod finding;
 pub mod fleet;
 pub mod git;
 pub mod http_api;

--- a/src/core/observation/budget_findings.rs
+++ b/src/core/observation/budget_findings.rs
@@ -1,29 +1,29 @@
 use crate::core::budget::BudgetFinding;
+use crate::core::finding::HomeboyFinding;
 
 use super::records::NewFindingRecord;
 
 fn finding_record_from_budget(run_id: &str, finding: &BudgetFinding) -> NewFindingRecord {
-    NewFindingRecord {
-        run_id: run_id.to_string(),
-        tool: "budget".to_string(),
-        rule: Some(finding.code.clone()),
-        file: finding.file.clone(),
-        line: None,
-        severity: Some(finding.severity.clone()),
-        fingerprint: Some(finding.fingerprint()),
-        message: finding.message.clone(),
-        fixable: None,
-        metadata_json: serde_json::json!({
-            "category": finding.category,
+    let mut builder = HomeboyFinding::builder("budget", finding.message.clone())
+        .rule(finding.code.clone())
+        .category(finding.category.clone())
+        .severity(finding.severity.clone())
+        .fingerprint(finding.fingerprint())
+        .metadata(serde_json::json!({
             "context_label": finding.context_label,
             "actual": finding.actual,
             "expected": finding.expected,
             "unit": finding.unit,
             "subject": finding.subject,
             "passed": finding.passed,
-            "raw": finding,
-        }),
+        }))
+        .raw(finding);
+
+    if let Some(file) = &finding.file {
+        builder = builder.file(file.clone());
     }
+
+    NewFindingRecord::from_homeboy_finding(run_id, &builder.build())
 }
 
 pub fn finding_records_from_budget(

--- a/src/core/observation/finding_adapters.rs
+++ b/src/core/observation/finding_adapters.rs
@@ -1,0 +1,257 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{collections::BTreeMap, path::Path};
+
+use crate::core::code_audit::{self, report::finding_kind_key};
+use crate::core::extension::lint::LintFinding;
+use crate::core::finding::HomeboyFinding;
+
+use super::records::NewFindingRecord;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AnnotationFindingRecord {
+    pub file: Option<String>,
+    pub line: Option<i64>,
+    pub message: String,
+    pub source: Option<String>,
+    pub severity: Option<String>,
+    pub code: Option<String>,
+    pub fixable: Option<bool>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+pub fn finding_record_from_lint(run_id: &str, finding: &LintFinding) -> NewFindingRecord {
+    let mut builder = HomeboyFinding::builder(
+        finding.tool.clone().unwrap_or_else(|| "lint".to_string()),
+        finding.message.clone(),
+    )
+    .category(finding.category.clone())
+    .fingerprint(finding.id.clone())
+    .source_sidecar("lint-findings")
+    .raw(finding);
+
+    if let Some(rule) =
+        lint_extra_string(finding, "rule").or_else(|| Some(finding.category.clone()))
+    {
+        builder = builder.rule(rule);
+    }
+    if let Some(file) = &finding.file {
+        builder = builder.file(file.clone());
+    }
+    if let Some(line) = lint_extra_i64(finding, "line") {
+        builder = builder.line(line);
+    }
+    if let Some(severity) = &finding.severity {
+        builder = builder.severity(severity.clone());
+    }
+    if let Some(fixable) = lint_extra_bool(finding, "fixable") {
+        builder = builder.fixable(fixable);
+    }
+
+    NewFindingRecord::from_homeboy_finding(run_id, &builder.build())
+}
+
+pub fn finding_records_from_lint(run_id: &str, findings: &[LintFinding]) -> Vec<NewFindingRecord> {
+    findings
+        .iter()
+        .map(|finding| finding_record_from_lint(run_id, finding))
+        .collect()
+}
+
+pub fn finding_record_from_audit(run_id: &str, finding: &code_audit::Finding) -> NewFindingRecord {
+    let kind = finding_kind_key(&finding.kind);
+    let normalized = HomeboyFinding::builder("audit", finding.description.clone())
+        .rule(kind.clone())
+        .category("code_audit")
+        .file(finding.file.clone())
+        .severity(audit_severity_key(&finding.severity))
+        .fingerprint(audit_finding_fingerprint(finding))
+        .source_sidecar("audit-findings")
+        .metadata(serde_json::json!({
+            "convention": finding.convention,
+            "suggestion": finding.suggestion,
+            "confidence": finding.kind.confidence(),
+            "kind": kind,
+        }))
+        .raw(finding)
+        .build();
+
+    NewFindingRecord::from_homeboy_finding(run_id, &normalized)
+}
+
+pub fn finding_records_from_audit(
+    run_id: &str,
+    findings: &[code_audit::Finding],
+) -> Vec<NewFindingRecord> {
+    findings
+        .iter()
+        .map(|finding| finding_record_from_audit(run_id, finding))
+        .collect()
+}
+
+fn audit_finding_fingerprint(finding: &code_audit::Finding) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        finding.file,
+        finding_kind_key(&finding.kind),
+        finding.convention,
+        finding.description
+    )
+}
+
+fn audit_severity_key(severity: &code_audit::Severity) -> String {
+    serde_json::to_value(severity)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_string))
+        .unwrap_or_else(|| format!("{severity:?}").to_lowercase())
+}
+
+pub fn finding_records_from_annotations_dir(
+    run_id: &str,
+    annotations_dir: &Path,
+) -> crate::core::error::Result<Vec<NewFindingRecord>> {
+    if !annotations_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = std::fs::read_dir(annotations_dir)
+        .map_err(|e| annotation_dir_error("read", annotations_dir, e))?
+        .collect::<std::io::Result<Vec<_>>>()
+        .map_err(|e| annotation_dir_error("list", annotations_dir, e))?;
+    entries.sort_by_key(|entry| entry.path());
+
+    let mut records = Vec::new();
+    for entry in entries {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        records.extend(finding_records_from_annotation_file(run_id, &path)?);
+    }
+    Ok(records)
+}
+
+fn annotation_dir_error(action: &str, path: &Path, error: std::io::Error) -> crate::core::Error {
+    crate::core::Error::internal_io(
+        format!(
+            "Failed to {} annotations dir {}: {}",
+            action,
+            path.display(),
+            error
+        ),
+        Some("observation.findings.annotations".to_string()),
+    )
+}
+
+pub fn finding_records_from_annotation_file(
+    run_id: &str,
+    path: &Path,
+) -> crate::core::error::Result<Vec<NewFindingRecord>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let content = std::fs::read_to_string(path).map_err(|e| {
+        crate::core::Error::internal_io(
+            format!("Failed to read annotations file {}: {}", path.display(), e),
+            Some("observation.findings.annotations".to_string()),
+        )
+    })?;
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let annotations: Vec<AnnotationFindingRecord> =
+        serde_json::from_str(&content).map_err(|e| {
+            crate::core::Error::internal_io(
+                format!("Malformed annotations JSON in {}: {}", path.display(), e),
+                Some("observation.findings.annotations".to_string()),
+            )
+        })?;
+    let source_file = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("annotations.json");
+
+    Ok(annotations
+        .iter()
+        .map(|annotation| finding_record_from_annotation(run_id, annotation, source_file))
+        .collect())
+}
+
+pub fn finding_record_from_annotation(
+    run_id: &str,
+    annotation: &AnnotationFindingRecord,
+    source_file: &str,
+) -> NewFindingRecord {
+    let tool = annotation
+        .source
+        .clone()
+        .unwrap_or_else(|| annotation_file_stem(source_file));
+    let mut builder = HomeboyFinding::builder(tool, annotation.message.clone())
+        .category("annotation")
+        .source_sidecar("annotations")
+        .source_artifact(source_file)
+        .metadata(serde_json::json!({ "annotation_file": source_file }))
+        .raw(annotation);
+
+    if let Some(rule) = &annotation.code {
+        builder = builder.rule(rule.clone());
+    }
+    if let Some(file) = &annotation.file {
+        builder = builder.file(file.clone());
+    }
+    if let Some(line) = annotation.line {
+        builder = builder.line(line);
+    }
+    if let Some(severity) = &annotation.severity {
+        builder = builder.severity(severity.clone());
+    }
+    if let Some(fingerprint) = annotation_fingerprint(annotation) {
+        builder = builder.fingerprint(fingerprint);
+    }
+    if let Some(fixable) = annotation.fixable {
+        builder = builder.fixable(fixable);
+    }
+
+    NewFindingRecord::from_homeboy_finding(run_id, &builder.build())
+}
+
+fn annotation_file_stem(source_file: &str) -> String {
+    Path::new(source_file)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("annotations")
+        .to_string()
+}
+
+fn annotation_fingerprint(annotation: &AnnotationFindingRecord) -> Option<String> {
+    if let Some(id) = annotation.extra.get("id").and_then(Value::as_str) {
+        return Some(id.to_string());
+    }
+    Some(format!(
+        "{}:{}:{}:{}:{}",
+        annotation.file.as_deref().unwrap_or_default(),
+        annotation.line.unwrap_or_default(),
+        annotation.source.as_deref().unwrap_or_default(),
+        annotation.code.as_deref().unwrap_or_default(),
+        annotation.message
+    ))
+}
+
+fn lint_extra_string(finding: &LintFinding, key: &str) -> Option<String> {
+    finding.extra.get(key)?.as_str().map(str::to_string)
+}
+
+fn lint_extra_i64(finding: &LintFinding, key: &str) -> Option<i64> {
+    finding.extra.get(key)?.as_i64()
+}
+
+fn lint_extra_bool(finding: &LintFinding, key: &str) -> Option<bool> {
+    match finding.extra.get(key)? {
+        Value::Bool(value) => Some(*value),
+        Value::String(value) => value.parse().ok(),
+        _ => None,
+    }
+}

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -5,6 +5,7 @@
 //! generated artifacts. This module only provides the storage substrate.
 
 mod budget_findings;
+mod finding_adapters;
 mod lifecycle;
 pub mod records;
 pub mod store;
@@ -13,10 +14,12 @@ pub mod timeline;
 pub use lifecycle::{merge_metadata, run_owner_pid, running_status_note, ActiveObservation};
 
 pub use budget_findings::finding_records_from_budget;
-pub use records::{
+pub use finding_adapters::{
     finding_record_from_annotation, finding_record_from_audit, finding_record_from_lint,
     finding_records_from_annotation_file, finding_records_from_annotations_dir,
     finding_records_from_audit, finding_records_from_lint, AnnotationFindingRecord,
+};
+pub use records::{
     ArtifactCleanupCandidateRecord, ArtifactCleanupFilter, ArtifactRecord, FindingListFilter,
     FindingRecord, NewFindingRecord, NewRunRecord, NewRunRecordBuilder, NewTraceRunRecord,
     NewTraceRunRecordBuilder, NewTraceSpanRecord, NewTraceSpanRecordBuilder, NewTriageItemRecord,

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -1,10 +1,5 @@
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use std::{collections::BTreeMap, path::Path};
-
-use crate::core::code_audit::{self, report::finding_kind_key};
-use crate::core::extension::lint::LintFinding;
 use crate::core::finding::HomeboyFinding;
+use serde::{Deserialize, Serialize};
 
 mod run_builder;
 mod run_status;
@@ -163,8 +158,8 @@ impl NewFindingRecord {
             run_id: run_id.into(),
             tool: finding.tool.clone(),
             rule: finding.rule.clone(),
-            file: finding.file.clone(),
-            line: finding.line,
+            file: finding.location.file.clone(),
+            line: finding.location.line,
             severity: finding.severity.clone(),
             fingerprint: finding.fingerprint.clone().or_else(|| finding.id.clone()),
             message: finding.message.clone(),
@@ -197,254 +192,6 @@ pub struct FindingListFilter {
     pub file: Option<String>,
     pub fingerprint: Option<String>,
     pub limit: Option<i64>,
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AnnotationFindingRecord {
-    pub file: Option<String>,
-    pub line: Option<i64>,
-    pub message: String,
-    pub source: Option<String>,
-    pub severity: Option<String>,
-    pub code: Option<String>,
-    pub fixable: Option<bool>,
-    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub extra: BTreeMap<String, Value>,
-}
-
-pub fn finding_record_from_lint(run_id: &str, finding: &LintFinding) -> NewFindingRecord {
-    let mut builder = HomeboyFinding::builder(
-        finding.tool.clone().unwrap_or_else(|| "lint".to_string()),
-        finding.message.clone(),
-    )
-    .category(finding.category.clone())
-    .fingerprint(finding.id.clone())
-    .source_sidecar("lint-findings")
-    .raw(finding);
-
-    if let Some(rule) =
-        lint_extra_string(finding, "rule").or_else(|| Some(finding.category.clone()))
-    {
-        builder = builder.rule(rule);
-    }
-    if let Some(file) = &finding.file {
-        builder = builder.file(file.clone());
-    }
-    if let Some(line) = lint_extra_i64(finding, "line") {
-        builder = builder.line(line);
-    }
-    if let Some(severity) = &finding.severity {
-        builder = builder.severity(severity.clone());
-    }
-    if let Some(fixable) = lint_extra_bool(finding, "fixable") {
-        builder = builder.fixable(fixable);
-    }
-
-    NewFindingRecord::from_homeboy_finding(run_id, &builder.build())
-}
-
-pub fn finding_records_from_lint(run_id: &str, findings: &[LintFinding]) -> Vec<NewFindingRecord> {
-    findings
-        .iter()
-        .map(|finding| finding_record_from_lint(run_id, finding))
-        .collect()
-}
-
-pub fn finding_record_from_audit(run_id: &str, finding: &code_audit::Finding) -> NewFindingRecord {
-    let kind = finding_kind_key(&finding.kind);
-    let normalized = HomeboyFinding::builder("audit", finding.description.clone())
-        .rule(kind.clone())
-        .category("code_audit")
-        .file(finding.file.clone())
-        .severity(audit_severity_key(&finding.severity))
-        .fingerprint(audit_finding_fingerprint(finding))
-        .source_sidecar("audit-findings")
-        .metadata(serde_json::json!({
-            "convention": finding.convention,
-            "suggestion": finding.suggestion,
-            "confidence": finding.kind.confidence(),
-            "kind": kind,
-        }))
-        .raw(finding)
-        .build();
-
-    NewFindingRecord::from_homeboy_finding(run_id, &normalized)
-}
-
-pub fn finding_records_from_audit(
-    run_id: &str,
-    findings: &[code_audit::Finding],
-) -> Vec<NewFindingRecord> {
-    findings
-        .iter()
-        .map(|finding| finding_record_from_audit(run_id, finding))
-        .collect()
-}
-
-fn audit_finding_fingerprint(finding: &code_audit::Finding) -> String {
-    format!(
-        "{}:{}:{}:{}",
-        finding.file,
-        finding_kind_key(&finding.kind),
-        finding.convention,
-        finding.description
-    )
-}
-
-fn audit_severity_key(severity: &code_audit::Severity) -> String {
-    serde_json::to_value(severity)
-        .ok()
-        .and_then(|value| value.as_str().map(str::to_string))
-        .unwrap_or_else(|| format!("{severity:?}").to_lowercase())
-}
-
-pub fn finding_records_from_annotations_dir(
-    run_id: &str,
-    annotations_dir: &Path,
-) -> crate::core::error::Result<Vec<NewFindingRecord>> {
-    if !annotations_dir.exists() {
-        return Ok(Vec::new());
-    }
-
-    let mut entries = std::fs::read_dir(annotations_dir)
-        .map_err(|e| annotation_dir_error("read", annotations_dir, e))?
-        .collect::<std::io::Result<Vec<_>>>()
-        .map_err(|e| annotation_dir_error("list", annotations_dir, e))?;
-    entries.sort_by_key(|entry| entry.path());
-
-    let mut records = Vec::new();
-    for entry in entries {
-        let path = entry.path();
-        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
-            continue;
-        }
-        records.extend(finding_records_from_annotation_file(run_id, &path)?);
-    }
-    Ok(records)
-}
-
-fn annotation_dir_error(action: &str, path: &Path, error: std::io::Error) -> crate::core::Error {
-    crate::core::Error::internal_io(
-        format!(
-            "Failed to {} annotations dir {}: {}",
-            action,
-            path.display(),
-            error
-        ),
-        Some("observation.findings.annotations".to_string()),
-    )
-}
-
-pub fn finding_records_from_annotation_file(
-    run_id: &str,
-    path: &Path,
-) -> crate::core::error::Result<Vec<NewFindingRecord>> {
-    if !path.exists() {
-        return Ok(Vec::new());
-    }
-
-    let content = std::fs::read_to_string(path).map_err(|e| {
-        crate::core::Error::internal_io(
-            format!("Failed to read annotations file {}: {}", path.display(), e),
-            Some("observation.findings.annotations".to_string()),
-        )
-    })?;
-    if content.trim().is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let annotations: Vec<AnnotationFindingRecord> =
-        serde_json::from_str(&content).map_err(|e| {
-            crate::core::Error::internal_io(
-                format!("Malformed annotations JSON in {}: {}", path.display(), e),
-                Some("observation.findings.annotations".to_string()),
-            )
-        })?;
-    let source_file = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("annotations.json");
-
-    Ok(annotations
-        .iter()
-        .map(|annotation| finding_record_from_annotation(run_id, annotation, source_file))
-        .collect())
-}
-
-pub fn finding_record_from_annotation(
-    run_id: &str,
-    annotation: &AnnotationFindingRecord,
-    source_file: &str,
-) -> NewFindingRecord {
-    let tool = annotation
-        .source
-        .clone()
-        .unwrap_or_else(|| annotation_file_stem(source_file));
-    let mut builder = HomeboyFinding::builder(tool, annotation.message.clone())
-        .category("annotation")
-        .source_sidecar("annotations")
-        .source_artifact(source_file)
-        .metadata(serde_json::json!({ "annotation_file": source_file }))
-        .raw(annotation);
-
-    if let Some(rule) = &annotation.code {
-        builder = builder.rule(rule.clone());
-    }
-    if let Some(file) = &annotation.file {
-        builder = builder.file(file.clone());
-    }
-    if let Some(line) = annotation.line {
-        builder = builder.line(line);
-    }
-    if let Some(severity) = &annotation.severity {
-        builder = builder.severity(severity.clone());
-    }
-    if let Some(fingerprint) = annotation_fingerprint(annotation) {
-        builder = builder.fingerprint(fingerprint);
-    }
-    if let Some(fixable) = annotation.fixable {
-        builder = builder.fixable(fixable);
-    }
-
-    NewFindingRecord::from_homeboy_finding(run_id, &builder.build())
-}
-
-fn annotation_file_stem(source_file: &str) -> String {
-    Path::new(source_file)
-        .file_stem()
-        .and_then(|stem| stem.to_str())
-        .unwrap_or("annotations")
-        .to_string()
-}
-
-fn annotation_fingerprint(annotation: &AnnotationFindingRecord) -> Option<String> {
-    if let Some(id) = annotation.extra.get("id").and_then(Value::as_str) {
-        return Some(id.to_string());
-    }
-    Some(format!(
-        "{}:{}:{}:{}:{}",
-        annotation.file.as_deref().unwrap_or_default(),
-        annotation.line.unwrap_or_default(),
-        annotation.source.as_deref().unwrap_or_default(),
-        annotation.code.as_deref().unwrap_or_default(),
-        annotation.message
-    ))
-}
-
-fn lint_extra_string(finding: &LintFinding, key: &str) -> Option<String> {
-    finding.extra.get(key)?.as_str().map(str::to_string)
-}
-
-fn lint_extra_i64(finding: &LintFinding, key: &str) -> Option<i64> {
-    finding.extra.get(key)?.as_i64()
-}
-
-fn lint_extra_bool(finding: &LintFinding, key: &str) -> Option<bool> {
-    match finding.extra.get(key)? {
-        Value::Bool(value) => Some(*value),
-        Value::String(value) => value.parse().ok(),
-        _ => None,
-    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -506,6 +253,14 @@ pub struct TraceSpanRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::code_audit;
+    use crate::core::extension::lint::LintFinding;
+    use crate::core::observation::finding_adapters::{
+        finding_record_from_annotation, finding_record_from_audit, finding_record_from_lint,
+        finding_records_from_annotation_file, finding_records_from_annotations_dir,
+        finding_records_from_audit, finding_records_from_lint, AnnotationFindingRecord,
+    };
+    use std::collections::BTreeMap;
 
     #[test]
     fn test_builder() {

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -4,6 +4,7 @@ use std::{collections::BTreeMap, path::Path};
 
 use crate::core::code_audit::{self, report::finding_kind_key};
 use crate::core::extension::lint::LintFinding;
+use crate::core::finding::HomeboyFinding;
 
 mod run_builder;
 mod run_status;
@@ -114,6 +115,65 @@ pub struct NewFindingRecord {
     pub metadata_json: serde_json::Value,
 }
 
+impl NewFindingRecord {
+    /// Project the shared finding contract into the observation-store schema.
+    ///
+    /// Storage keeps a stable queryable subset as columns. Producer provenance,
+    /// source category, raw payloads, and source-specific metadata stay in the
+    /// JSON column so the persisted record remains lossless for consumers that
+    /// need the original evidence.
+    pub fn from_homeboy_finding(run_id: impl Into<String>, finding: &HomeboyFinding) -> Self {
+        let mut metadata = serde_json::Map::new();
+        if let Some(category) = &finding.category {
+            metadata.insert("category".to_string(), serde_json::json!(category));
+        }
+        if !finding.producer.is_empty() {
+            metadata.insert("producer".to_string(), serde_json::json!(finding.producer));
+            if let Some(source_sidecar) = &finding.producer.source_sidecar {
+                metadata.insert(
+                    "source_sidecar".to_string(),
+                    serde_json::json!(source_sidecar),
+                );
+            }
+            if let Some(source_artifact) = &finding.producer.source_artifact {
+                metadata.insert(
+                    "source_artifact".to_string(),
+                    serde_json::json!(source_artifact),
+                );
+            }
+        }
+        if !finding
+            .metadata
+            .as_object()
+            .is_some_and(serde_json::Map::is_empty)
+        {
+            if let Some(object) = finding.metadata.as_object() {
+                for (key, value) in object {
+                    metadata.insert(key.clone(), value.clone());
+                }
+            } else {
+                metadata.insert("metadata".to_string(), finding.metadata.clone());
+            }
+        }
+        if let Some(raw) = &finding.raw {
+            metadata.insert("raw".to_string(), raw.clone());
+        }
+
+        Self {
+            run_id: run_id.into(),
+            tool: finding.tool.clone(),
+            rule: finding.rule.clone(),
+            file: finding.file.clone(),
+            line: finding.line,
+            severity: finding.severity.clone(),
+            fingerprint: finding.fingerprint.clone().or_else(|| finding.id.clone()),
+            message: finding.message.clone(),
+            fixable: finding.fixable,
+            metadata_json: serde_json::Value::Object(metadata),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FindingRecord {
     pub id: String,
@@ -153,22 +213,34 @@ pub struct AnnotationFindingRecord {
 }
 
 pub fn finding_record_from_lint(run_id: &str, finding: &LintFinding) -> NewFindingRecord {
-    NewFindingRecord {
-        run_id: run_id.to_string(),
-        tool: finding.tool.clone().unwrap_or_else(|| "lint".to_string()),
-        rule: lint_extra_string(finding, "rule").or_else(|| Some(finding.category.clone())),
-        file: finding.file.clone(),
-        line: lint_extra_i64(finding, "line"),
-        severity: finding.severity.clone(),
-        fingerprint: Some(finding.id.clone()),
-        message: finding.message.clone(),
-        fixable: lint_extra_bool(finding, "fixable"),
-        metadata_json: serde_json::json!({
-            "category": finding.category,
-            "source_sidecar": "lint-findings",
-            "raw": finding,
-        }),
+    let mut builder = HomeboyFinding::builder(
+        finding.tool.clone().unwrap_or_else(|| "lint".to_string()),
+        finding.message.clone(),
+    )
+    .category(finding.category.clone())
+    .fingerprint(finding.id.clone())
+    .source_sidecar("lint-findings")
+    .raw(finding);
+
+    if let Some(rule) =
+        lint_extra_string(finding, "rule").or_else(|| Some(finding.category.clone()))
+    {
+        builder = builder.rule(rule);
     }
+    if let Some(file) = &finding.file {
+        builder = builder.file(file.clone());
+    }
+    if let Some(line) = lint_extra_i64(finding, "line") {
+        builder = builder.line(line);
+    }
+    if let Some(severity) = &finding.severity {
+        builder = builder.severity(severity.clone());
+    }
+    if let Some(fixable) = lint_extra_bool(finding, "fixable") {
+        builder = builder.fixable(fixable);
+    }
+
+    NewFindingRecord::from_homeboy_finding(run_id, &builder.build())
 }
 
 pub fn finding_records_from_lint(run_id: &str, findings: &[LintFinding]) -> Vec<NewFindingRecord> {
@@ -180,25 +252,23 @@ pub fn finding_records_from_lint(run_id: &str, findings: &[LintFinding]) -> Vec<
 
 pub fn finding_record_from_audit(run_id: &str, finding: &code_audit::Finding) -> NewFindingRecord {
     let kind = finding_kind_key(&finding.kind);
-    NewFindingRecord {
-        run_id: run_id.to_string(),
-        tool: "audit".to_string(),
-        rule: Some(kind.clone()),
-        file: Some(finding.file.clone()),
-        line: None,
-        severity: Some(audit_severity_key(&finding.severity)),
-        fingerprint: Some(audit_finding_fingerprint(finding)),
-        message: finding.description.clone(),
-        fixable: None,
-        metadata_json: serde_json::json!({
-            "source_sidecar": "audit-findings",
+    let normalized = HomeboyFinding::builder("audit", finding.description.clone())
+        .rule(kind.clone())
+        .category("code_audit")
+        .file(finding.file.clone())
+        .severity(audit_severity_key(&finding.severity))
+        .fingerprint(audit_finding_fingerprint(finding))
+        .source_sidecar("audit-findings")
+        .metadata(serde_json::json!({
             "convention": finding.convention,
             "suggestion": finding.suggestion,
             "confidence": finding.kind.confidence(),
             "kind": kind,
-            "raw": finding,
-        }),
-    }
+        }))
+        .raw(finding)
+        .build();
+
+    NewFindingRecord::from_homeboy_finding(run_id, &normalized)
 }
 
 pub fn finding_records_from_audit(
@@ -310,22 +380,33 @@ pub fn finding_record_from_annotation(
         .source
         .clone()
         .unwrap_or_else(|| annotation_file_stem(source_file));
-    NewFindingRecord {
-        run_id: run_id.to_string(),
-        tool,
-        rule: annotation.code.clone(),
-        file: annotation.file.clone(),
-        line: annotation.line,
-        severity: annotation.severity.clone(),
-        fingerprint: annotation_fingerprint(annotation),
-        message: annotation.message.clone(),
-        fixable: annotation.fixable,
-        metadata_json: serde_json::json!({
-            "source_sidecar": "annotations",
-            "annotation_file": source_file,
-            "raw": annotation,
-        }),
+    let mut builder = HomeboyFinding::builder(tool, annotation.message.clone())
+        .category("annotation")
+        .source_sidecar("annotations")
+        .source_artifact(source_file)
+        .metadata(serde_json::json!({ "annotation_file": source_file }))
+        .raw(annotation);
+
+    if let Some(rule) = &annotation.code {
+        builder = builder.rule(rule.clone());
     }
+    if let Some(file) = &annotation.file {
+        builder = builder.file(file.clone());
+    }
+    if let Some(line) = annotation.line {
+        builder = builder.line(line);
+    }
+    if let Some(severity) = &annotation.severity {
+        builder = builder.severity(severity.clone());
+    }
+    if let Some(fingerprint) = annotation_fingerprint(annotation) {
+        builder = builder.fingerprint(fingerprint);
+    }
+    if let Some(fixable) = annotation.fixable {
+        builder = builder.fixable(fixable);
+    }
+
+    NewFindingRecord::from_homeboy_finding(run_id, &builder.build())
 }
 
 fn annotation_file_stem(source_file: &str) -> String {
@@ -432,6 +513,44 @@ mod tests {
 
         assert_eq!(record.kind, "lint");
         assert_eq!(record.metadata_json, serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_new_finding_record_projects_homeboy_finding() {
+        let finding = HomeboyFinding::builder("test", "ExampleTest failed")
+            .rule("assertion_mismatch")
+            .category("test_failure")
+            .severity("error")
+            .fingerprint("tests/example.rs:ExampleTest::test_save")
+            .file("tests/example.rs")
+            .line(42)
+            .column(7)
+            .fixable(false)
+            .command("homeboy test")
+            .extension("rust")
+            .step("unit")
+            .source_artifact("junit.json")
+            .metadata(serde_json::json!({
+                "test_name": "ExampleTest::test_save",
+                "error_type": "AssertionFailed"
+            }))
+            .raw(serde_json::json!({ "runner": "cargo test" }))
+            .build();
+
+        let record = NewFindingRecord::from_homeboy_finding("run-1", &finding);
+
+        assert_eq!(record.run_id, "run-1");
+        assert_eq!(record.tool, "test");
+        assert_eq!(record.rule.as_deref(), Some("assertion_mismatch"));
+        assert_eq!(record.file.as_deref(), Some("tests/example.rs"));
+        assert_eq!(record.line, Some(42));
+        assert_eq!(record.severity.as_deref(), Some("error"));
+        assert_eq!(record.fixable, Some(false));
+        assert_eq!(record.metadata_json["category"], "test_failure");
+        assert_eq!(record.metadata_json["producer"]["command"], "homeboy test");
+        assert_eq!(record.metadata_json["source_artifact"], "junit.json");
+        assert_eq!(record.metadata_json["test_name"], "ExampleTest::test_save");
+        assert_eq!(record.metadata_json["raw"]["runner"], "cargo test");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Introduces `core::finding::HomeboyFinding` with a builder, stable common finding fields, producer provenance, metadata, and raw payload support.
- Makes observation storage an explicit projection via `NewFindingRecord::from_homeboy_finding()` while preserving the existing SQLite/query shape.
- Routes representative lint, audit, budget, and annotation projections through the shared contract and documents how lint/audit/test/bench/annotation data fit without migrating every producer in this PR.

Closes #3073.
Part of #3074.

## Tests
- `cargo test core::finding`
- `cargo test core::observation::records`
- `cargo test core::observation::budget_findings`
- `cargo test`

## Notes
- `cargo clippy --all-targets -- -D warnings` is not green on current `main`; it fails on existing unrelated Clippy debt such as large enum variants, sort_by_key suggestions, ptr_arg, and result_large_err. No Clippy errors were reported in the new `core::finding` module or touched finding projection code before the broader existing failures stopped the run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the core finding model, projection adapter, docs, tests, and PR description; Chris remains responsible for review and merge.