### PR TITLE
Fail release when registry publish is unverified

### DIFF
--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -19,6 +19,8 @@ use crate::core::error::{Error, Result};
 use crate::core::extension::{self, ExtensionManifest};
 use crate::core::release::{changelog as release_changelog, version};
 
+use std::fmt::Write;
+
 use super::types::{ReleaseArtifact, ReleaseState, ReleaseStepResult, ReleaseStepStatus};
 use super::utils::{extract_latest_notes, parse_release_artifacts};
 
@@ -594,6 +596,7 @@ pub(crate) fn run_publish(
         &extension.id,
         Some(data),
         &response,
+        state.version.as_deref(),
     ))
 }
 
@@ -603,13 +606,19 @@ fn publish_step_result(
     extension_id: &str,
     data: Option<serde_json::Value>,
     response: &serde_json::Value,
+    expected_version: Option<&str>,
 ) -> ReleaseStepResult {
-    if response
-        .get("success")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(true)
-    {
-        return step_success(step_id, step_id, data, Vec::new());
+    if let Some(reason) = extension_blocking_publish_reason(response) {
+        return step_failed(
+            step_id,
+            step_id,
+            data,
+            Some(format!(
+                "Publish to {} via {} was not completed: {}",
+                target, extension_id, reason
+            )),
+            Vec::new(),
+        );
     }
 
     if let Some(reason) = extension_skip_reason(response) {
@@ -624,6 +633,18 @@ fn publish_step_result(
         );
     }
 
+    if response
+        .get("success")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true)
+    {
+        if let Some(failure) = verify_publish_response(target, response, expected_version) {
+            return step_failed(step_id, step_id, data, Some(failure), Vec::new());
+        }
+
+        return step_success(step_id, step_id, data, Vec::new());
+    }
+
     step_failed(
         step_id,
         step_id,
@@ -633,12 +654,25 @@ fn publish_step_result(
     )
 }
 
-fn extension_skip_reason(response: &serde_json::Value) -> Option<String> {
+fn extension_blocking_publish_reason(response: &serde_json::Value) -> Option<String> {
     let status = response.get("status").and_then(|v| v.as_str())?;
-    if !matches!(status, "skipped" | "missing_secret" | "auth_required") {
+    if !matches!(status, "missing_secret" | "auth_required") {
         return None;
     }
 
+    publish_response_reason(response).or_else(|| Some(status.replace('_', " ")))
+}
+
+fn extension_skip_reason(response: &serde_json::Value) -> Option<String> {
+    let status = response.get("status").and_then(|v| v.as_str())?;
+    if status != "skipped" {
+        return None;
+    }
+
+    publish_response_reason(response).or_else(|| Some(status.replace('_', " ")))
+}
+
+fn publish_response_reason(response: &serde_json::Value) -> Option<String> {
     response
         .get("reason")
         .or_else(|| response.get("message"))
@@ -651,7 +685,140 @@ fn extension_skip_reason(response: &serde_json::Value) -> Option<String> {
             let detail = output.trim();
             (!detail.is_empty()).then(|| detail.to_string())
         })
-        .or_else(|| Some(status.replace('_', " ")))
+}
+
+fn verify_publish_response(
+    target: &str,
+    response: &serde_json::Value,
+    expected_version: Option<&str>,
+) -> Option<String> {
+    let verification = publish_registry_verification(response, expected_version)?;
+    let client = match reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+    {
+        Ok(client) => client,
+        Err(err) => {
+            return Some(format!(
+                "Registry verification setup failed for {}: {}",
+                target, err
+            ));
+        }
+    };
+
+    let http_response = match client.get(&verification.url).send() {
+        Ok(response) => response,
+        Err(err) => {
+            return Some(format!(
+                "Registry verification failed for {} {}: {}",
+                verification.package_name, verification.version, err
+            ));
+        }
+    };
+
+    let status = http_response.status();
+    if !status.is_success() {
+        return Some(format!(
+            "Registry verification failed for {} {}: registry returned {}",
+            verification.package_name, verification.version, status
+        ));
+    }
+
+    let body = match http_response.text() {
+        Ok(body) => body,
+        Err(err) => {
+            return Some(format!(
+                "Registry verification failed for {} {}: could not read response: {}",
+                verification.package_name, verification.version, err
+            ));
+        }
+    };
+
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
+        if let Some(actual_version) = json.get("version").and_then(|value| value.as_str()) {
+            if actual_version != verification.version {
+                return Some(format!(
+                    "Registry verification failed for {}: expected version {}, registry returned {}",
+                    verification.package_name, verification.version, actual_version
+                ));
+            }
+        }
+    }
+
+    None
+}
+
+#[derive(Debug)]
+struct PublishRegistryVerification {
+    package_name: String,
+    version: String,
+    url: String,
+}
+
+fn publish_registry_verification(
+    response: &serde_json::Value,
+    expected_version: Option<&str>,
+) -> Option<PublishRegistryVerification> {
+    let source = response
+        .get("registry_verification")
+        .or_else(|| response.get("registryVerification"))
+        .unwrap_or(response);
+
+    let package_name = string_field(source, &["package_name", "packageName", "package", "name"])?;
+    let version = string_field(
+        source,
+        &["version", "published_version", "publishedVersion"],
+    )
+    .or(expected_version)
+    .map(str::to_string)?;
+    let url = string_field(source, &["version_url", "versionUrl", "url"])
+        .map(str::to_string)
+        .or_else(|| {
+            let registry_url = string_field(source, &["registry_url", "registryUrl"])?;
+            Some(package_registry_version_url(
+                registry_url,
+                package_name,
+                &version,
+            ))
+        })?;
+
+    Some(PublishRegistryVerification {
+        package_name: package_name.to_string(),
+        version,
+        url,
+    })
+}
+
+fn string_field<'a>(value: &'a serde_json::Value, names: &[&str]) -> Option<&'a str> {
+    names
+        .iter()
+        .find_map(|name| value.get(*name).and_then(|value| value.as_str()))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn package_registry_version_url(registry_url: &str, package_name: &str, version: &str) -> String {
+    format!(
+        "{}/{}/{}",
+        registry_url.trim_end_matches('/'),
+        percent_encode_path_segment(package_name),
+        percent_encode_path_segment(version)
+    )
+}
+
+fn percent_encode_path_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char)
+            }
+            _ => {
+                let _ = write!(&mut encoded, "%{:02X}", byte);
+            }
+        }
+    }
+    encoded
 }
 
 fn publish_response_output(response: &serde_json::Value) -> String {
@@ -1157,7 +1324,14 @@ mod tests {
     use super::{github_release, publish_step_result, run_git_push, store_artifacts_from_output};
     use crate::core::component::Component;
     use crate::core::release::ReleaseStepStatus;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
     use std::process::Command;
+
+    struct RegistryServer {
+        registry_url: String,
+        handle: std::thread::JoinHandle<String>,
+    }
 
     fn git(path: &std::path::Path, args: &[&str]) {
         let output = Command::new("git")
@@ -1171,6 +1345,36 @@ mod tests {
             args,
             String::from_utf8_lossy(&output.stderr)
         );
+    }
+
+    fn registry_server(status: u16, body: &'static str) -> RegistryServer {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind registry server");
+        let port = listener.local_addr().expect("registry server addr").port();
+        let registry_url = format!("http://127.0.0.1:{}", port);
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept registry request");
+            let mut buffer = [0; 1024];
+            let bytes_read = stream.read(&mut buffer).expect("read registry request");
+            let request = String::from_utf8_lossy(&buffer[..bytes_read]).to_string();
+            let request_line = request.lines().next().unwrap_or_default().to_string();
+            let reason = if status == 200 { "OK" } else { "Not Found" };
+            let response = format!(
+                "HTTP/1.1 {} {}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                status,
+                reason,
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write registry response");
+            request_line
+        });
+
+        RegistryServer {
+            registry_url,
+            handle,
+        }
     }
 
     #[test]
@@ -1286,7 +1490,7 @@ mod tests {
     }
 
     #[test]
-    fn publish_step_skips_when_extension_reports_missing_secret() {
+    fn publish_step_fails_when_extension_reports_missing_secret() {
         let response = serde_json::json!({
             "success": false,
             "status": "missing_secret",
@@ -1302,27 +1506,39 @@ mod tests {
             "registry",
             Some(data),
             &response,
+            None,
         );
 
-        assert_eq!(result.status, ReleaseStepStatus::Skipped);
-        assert!(result.error.is_none());
-        assert_eq!(result.warnings.len(), 1);
-        assert!(result.warnings[0].contains("registry token is not configured"));
+        assert_eq!(result.status, ReleaseStepStatus::Failed);
+        assert!(result
+            .error
+            .unwrap()
+            .contains("registry token is not configured"));
+        assert!(result.warnings.is_empty());
     }
 
     #[test]
-    fn publish_step_skips_when_extension_reports_auth_required() {
+    fn publish_step_fails_when_extension_reports_auth_required() {
         let response = serde_json::json!({
             "success": false,
             "status": "auth_required",
             "message": "run the extension login command",
         });
 
-        let result =
-            publish_step_result("publish.registry", "registry", "registry", None, &response);
+        let result = publish_step_result(
+            "publish.registry",
+            "registry",
+            "registry",
+            None,
+            &response,
+            None,
+        );
 
-        assert_eq!(result.status, ReleaseStepStatus::Skipped);
-        assert!(result.warnings[0].contains("run the extension login command"));
+        assert_eq!(result.status, ReleaseStepStatus::Failed);
+        assert!(result
+            .error
+            .unwrap()
+            .contains("run the extension login command"));
     }
 
     #[test]
@@ -1333,11 +1549,65 @@ mod tests {
             "stderr": "error: failed to upload package: 500 server error",
         });
 
-        let result =
-            publish_step_result("publish.registry", "registry", "registry", None, &response);
+        let result = publish_step_result(
+            "publish.registry",
+            "registry",
+            "registry",
+            None,
+            &response,
+            None,
+        );
 
         assert_eq!(result.status, ReleaseStepStatus::Failed);
         assert!(result.error.unwrap().contains("500 server error"));
+    }
+
+    #[test]
+    fn publish_step_fails_when_registry_version_is_missing() {
+        let server = registry_server(404, r#"{"error":"not found"}"#);
+        let response = serde_json::json!({
+            "success": true,
+            "registry_verification": {
+                "registry_url": server.registry_url,
+                "package_name": "@extrachill/components",
+                "version": "0.5.2"
+            }
+        });
+
+        let result =
+            publish_step_result("publish.npm", "npm", "npm", None, &response, Some("0.5.2"));
+
+        assert_eq!(result.status, ReleaseStepStatus::Failed);
+        assert!(result
+            .error
+            .unwrap()
+            .contains("registry returned 404 Not Found"));
+        assert_eq!(
+            server.handle.join().expect("server request"),
+            "GET /%40extrachill%2Fcomponents/0.5.2 HTTP/1.1"
+        );
+    }
+
+    #[test]
+    fn publish_step_succeeds_when_registry_version_is_present() {
+        let server = registry_server(200, r#"{"version":"0.5.2"}"#);
+        let response = serde_json::json!({
+            "success": true,
+            "registry_verification": {
+                "registry_url": server.registry_url,
+                "package_name": "@extrachill/components",
+                "version": "0.5.2"
+            }
+        });
+
+        let result =
+            publish_step_result("publish.npm", "npm", "npm", None, &response, Some("0.5.2"));
+
+        assert_eq!(result.status, ReleaseStepStatus::Success);
+        assert_eq!(
+            server.handle.join().expect("server request"),
+            "GET /%40extrachill%2Fcomponents/0.5.2 HTTP/1.1"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Treat `missing_secret` and `auth_required` publish responses as failed release steps instead of skipped warnings, preventing green release summaries when publish did not happen.
- Add optional post-publish registry verification when an extension response includes registry/package/version metadata; missing or mismatched registry versions fail the publish step.
- Cover npm-style scoped package verification with unit tests using a local registry fixture.

Closes #3077.

## Tests
- `cargo test core::release::executor::tests::publish_step -- --nocapture`
- `cargo test core::release::pipeline_summary::tests`
- `cargo test core_agnostic`
- `cargo test`
- `cargo test core::source_snapshot::tests::test_collect_local -- --nocapture`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-release-publish-verification`

## Caveats
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-release-publish-verification` still fails `core::source_snapshot::tests::test_collect_local` under the Homeboy wrapper, while direct `cargo test` and the isolated direct test pass. An earlier parallel run also showed `core::extension::trace::run::tests::rig_save_baseline_does_not_write_component_homeboy_json` once, but it did not recur when rerun alone.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigated issue #3077, implemented the focused release publish verification change, added tests, and ran verification commands for Chris to review.