### PR TITLE
feat: clarify structured sidecar manifest contract

### DIFF
--- a/docs/schemas/extension-manifest-schema.md
+++ b/docs/schemas/extension-manifest-schema.md
@@ -16,7 +16,7 @@ Extension manifests define extension metadata, runtime behavior, platform behavi
   "deploy": {},
   "executable": {},
   "platform": {},
-  "structured_sidecars": [],
+  "structured_sidecars": {},
   "commands": {},
   "actions": {},
   "release_actions": {},
@@ -44,7 +44,7 @@ Extension manifests define extension metadata, runtime behavior, platform behavi
 - **`deploy`** (object): Deploy lifecycle — verifications, overrides, version patterns
 - **`executable`** (object): Standalone tool runtime, inputs, output schema
 - **`platform`** (object): Platform behavior definitions (database, deployment, version patterns)
-- **`structured_sidecars`** (array): Declares public machine-readable run-directory sidecar contracts
+- **`structured_sidecars`** (object): Declares public machine-readable run-directory sidecar contracts
 - **`commands`** (object): Additional CLI commands provided by extension
 - **`actions`** (object): Action definitions for `homeboy extension action`
 - **`release_actions`** (object): Release pipeline step definitions
@@ -126,35 +126,31 @@ Scripts that implement extension capabilities. Each script path is relative to t
 
 ## Structured Sidecar Declarations
 
-Extensions can declare which structured run-directory sidecars they emit and which schema version each sidecar follows. `structured_sidecars` is the only manifest field that declares sidecar contracts. Declarations are explicit contracts: if an entry is missing, the extension has not declared that structured sidecar.
+Extensions can declare which structured run-directory sidecars they emit. `structured_sidecars` is the only manifest field that declares sidecar contracts. Declarations are explicit contracts: if an entry is missing or set to `false`, the extension has not declared that structured sidecar.
 
 ```json
 {
-  "structured_sidecars": [
-    {
-      "name": "findings",
+  "structured_sidecars": {
+    "findings": {
       "path": "findings.json",
       "schema_version": "1"
     },
-    {
-      "name": "producer.summary",
+    "producer.summary": {
       "path": "producer-summary.json",
       "schema_version": "1"
     },
-    {
-      "name": "lint.findings",
-      "path": "lint-findings.json",
-      "schema_version": "1"
-    }
-  ]
+    "lint.findings": true,
+    "test.coverage": false
+  }
 }
 ```
 
 ### Sidecar Fields
 
-- **`structured_sidecars[].name`** (string): Stable logical sidecar name, for example `findings`, `producer.summary`, `lint.findings`, or `annotations`.
-- **`structured_sidecars[].path`** (string): Run-directory relative sidecar file or directory path.
-- **`structured_sidecars[].schema_version`** (string): Version of the sidecar payload contract.
+- **`structured_sidecars.<name>`** (boolean or object): Stable logical sidecar name, for example `findings`, `producer.summary`, `lint.findings`, or `annotations`. `true` declares the sidecar with its default run-dir path. `false` explicitly leaves it undeclared.
+- **`structured_sidecars.<name>.enabled`** (boolean): Optional object form enablement flag. Defaults to `true`.
+- **`structured_sidecars.<name>.path`** (string): Optional run-directory relative sidecar file or directory path. Known names such as `lint.findings`, `test.results`, `test.failures`, `bench.results`, and `annotations` have default paths.
+- **`structured_sidecars.<name>.schema_version`** (string): Optional version of the sidecar payload contract.
 
 The generic `findings` and `producer.summary` names are the preferred contracts for normalized finding output and producer summaries. Legacy producer-specific names such as `lint.findings` can be declared during migration, but they use the same top-level declaration shape.
 

--- a/docs/schemas/extension-manifest-schema.md
+++ b/docs/schemas/extension-manifest-schema.md
@@ -16,7 +16,7 @@ Extension manifests define extension metadata, runtime behavior, platform behavi
   "deploy": {},
   "executable": {},
   "platform": {},
-  "annotations_schema_version": "string",
+  "structured_sidecars": [],
   "commands": {},
   "actions": {},
   "release_actions": {},
@@ -44,7 +44,7 @@ Extension manifests define extension metadata, runtime behavior, platform behavi
 - **`deploy`** (object): Deploy lifecycle — verifications, overrides, version patterns
 - **`executable`** (object): Standalone tool runtime, inputs, output schema
 - **`platform`** (object): Platform behavior definitions (database, deployment, version patterns)
-- **`annotations_schema_version`** (string): Schema version for structured files emitted under the run-dir annotations sidecar
+- **`structured_sidecars`** (array): Declares public machine-readable run-directory sidecar contracts
 - **`commands`** (object): Additional CLI commands provided by extension
 - **`actions`** (object): Action definitions for `homeboy extension action`
 - **`release_actions`** (object): Release pipeline step definitions
@@ -126,33 +126,41 @@ Scripts that implement extension capabilities. Each script path is relative to t
 
 ## Structured Sidecar Declarations
 
-Extensions can declare which well-known structured sidecars they emit and which schema version each sidecar follows. Declarations are explicit contracts: if a field is missing, the extension has not declared that structured sidecar.
+Extensions can declare which structured run-directory sidecars they emit and which schema version each sidecar follows. `structured_sidecars` is the only manifest field that declares sidecar contracts. Declarations are explicit contracts: if an entry is missing, the extension has not declared that structured sidecar.
 
 ```json
 {
-  "lint": {
-    "extension_script": "scripts/lint.sh",
-    "findings_schema_version": "1"
-  },
-  "test": {
-    "extension_script": "scripts/test.sh",
-    "results_schema_version": "1",
-    "failures_schema_version": "1"
-  },
-  "annotations_schema_version": "1"
+  "structured_sidecars": [
+    {
+      "name": "findings",
+      "path": "findings.json",
+      "schema_version": "1"
+    },
+    {
+      "name": "producer.summary",
+      "path": "producer-summary.json",
+      "schema_version": "1"
+    },
+    {
+      "name": "lint.findings",
+      "path": "lint-findings.json",
+      "schema_version": "1"
+    }
+  ]
 }
 ```
 
 ### Sidecar Fields
 
-- **`lint.findings_schema_version`** (string): Declares structured `lint-findings.json` output in the run directory.
-- **`test.results_schema_version`** (string): Declares structured `test-results.json` output in the run directory.
-- **`test.failures_schema_version`** (string): Declares structured `test-failures.json` output in the run directory.
-- **`annotations_schema_version`** (string): Declares structured annotation files under the run directory's annotations sidecar subdirectory.
+- **`structured_sidecars[].name`** (string): Stable logical sidecar name, for example `findings`, `producer.summary`, `lint.findings`, or `annotations`.
+- **`structured_sidecars[].path`** (string): Run-directory relative sidecar file or directory path.
+- **`structured_sidecars[].schema_version`** (string): Version of the sidecar payload contract.
+
+The generic `findings` and `producer.summary` names are the preferred contracts for normalized finding output and producer summaries. Legacy producer-specific names such as `lint.findings` can be declared during migration, but they use the same top-level declaration shape.
 
 ### Inspection Behavior
 
-Core exposes declared sidecars through manifest inspection. Consumers that need machine-readable output should require the matching declaration before relying on a sidecar.
+Core exposes declared sidecars through manifest inspection, including `homeboy extension show <id>` JSON output. Consumers that need machine-readable output should require the matching declaration before relying on a sidecar.
 
 ## Audit Configuration
 

--- a/src/core/code_audit/detectors/test_topology.rs
+++ b/src/core/code_audit/detectors/test_topology.rs
@@ -385,7 +385,7 @@ JSON
             test: None,
             bench: None,
             trace: None,
-            structured_sidecars: vec![],
+            structured_sidecars: std::collections::BTreeMap::new(),
             actions: vec![],
             hooks: std::collections::HashMap::new(),
             settings: vec![],

--- a/src/core/code_audit/detectors/test_topology.rs
+++ b/src/core/code_audit/detectors/test_topology.rs
@@ -385,7 +385,7 @@ JSON
             test: None,
             bench: None,
             trace: None,
-            annotations_schema_version: None,
+            structured_sidecars: vec![],
             actions: vec![],
             hooks: std::collections::HashMap::new(),
             settings: vec![],

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -1,6 +1,5 @@
 use crate::core::component::AuditConfig;
 use crate::core::config::ConfigEntity;
-use crate::core::engine::run_dir;
 use crate::core::error::{Error, Result};
 use crate::core::paths;
 use serde::{Deserialize, Serialize};
@@ -20,6 +19,7 @@ pub use super::manifest_config::{
     RemotePathInferenceRule, RemotePathRootRule, RequirementsConfig, SinceTagConfig, TestConfig,
     TraceConfig, VersionPatternConfig,
 };
+pub use super::manifest_sidecar::{StructuredSidecarContract, StructuredSidecarDeclaration};
 
 /// Type of action that can be executed by a extension.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -805,75 +805,4 @@ pub struct RuntimeRequirementsConfig {
 #[serde(deny_unknown_fields)]
 pub struct RuntimeRequirementConfig {
     pub version: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum StructuredSidecarContract {
-    Enabled(bool),
-    Detail(StructuredSidecarDetail),
-}
-
-impl StructuredSidecarContract {
-    fn declaration(&self, name: &str) -> Option<StructuredSidecarDeclaration> {
-        match self {
-            StructuredSidecarContract::Enabled(true) => Some(StructuredSidecarDeclaration {
-                name: name.to_string(),
-                path: default_structured_sidecar_path(name),
-                schema_version: None,
-            }),
-            StructuredSidecarContract::Enabled(false) => None,
-            StructuredSidecarContract::Detail(detail) => {
-                if !detail.enabled {
-                    return None;
-                }
-
-                Some(StructuredSidecarDeclaration {
-                    name: name.to_string(),
-                    path: detail
-                        .path
-                        .clone()
-                        .unwrap_or_else(|| default_structured_sidecar_path(name)),
-                    schema_version: detail.schema_version.clone(),
-                })
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct StructuredSidecarDetail {
-    #[serde(default = "default_true")]
-    pub enabled: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub schema_version: Option<String>,
-}
-
-fn default_true() -> bool {
-    true
-}
-
-fn default_structured_sidecar_path(name: &str) -> String {
-    match name {
-        "lint.findings" => run_dir::files::LINT_FINDINGS,
-        "test.results" => run_dir::files::TEST_RESULTS,
-        "test.failures" => run_dir::files::TEST_FAILURES,
-        "test.coverage" => run_dir::files::COVERAGE,
-        "bench.results" => run_dir::files::BENCH_RESULTS,
-        "annotations" => run_dir::files::ANNOTATIONS_DIR,
-        _ => name,
-    }
-    .to_string()
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct StructuredSidecarDeclaration {
-    pub name: String,
-    pub path: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub schema_version: Option<String>,
 }

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -1,5 +1,6 @@
 use crate::core::component::AuditConfig;
 use crate::core::config::ConfigEntity;
+use crate::core::engine::run_dir;
 use crate::core::error::{Error, Result};
 use crate::core::paths;
 use serde::{Deserialize, Serialize};
@@ -452,8 +453,8 @@ pub struct ExtensionManifest {
     pub autofix_verify: Option<AutofixVerifyConfig>,
     /// Structured run-directory sidecars this extension declares as a public
     /// machine-readable contract.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub structured_sidecars: Vec<StructuredSidecarDeclaration>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub structured_sidecars: BTreeMap<String, StructuredSidecarContract>,
 
     // Actions (cross-cutting: used by both platform and executable extensions)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -580,7 +581,10 @@ impl ExtensionManifest {
     /// Missing declarations mean the extension has no structured sidecar
     /// contract for that output.
     pub fn structured_sidecars(&self) -> Vec<StructuredSidecarDeclaration> {
-        self.structured_sidecars.clone()
+        self.structured_sidecars
+            .iter()
+            .filter_map(|(name, contract)| contract.declaration(name))
+            .collect()
     }
 
     /// Convenience: get deploy verifications (empty if no deploy capability).
@@ -804,9 +808,72 @@ pub struct RuntimeRequirementConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum StructuredSidecarContract {
+    Enabled(bool),
+    Detail(StructuredSidecarDetail),
+}
+
+impl StructuredSidecarContract {
+    fn declaration(&self, name: &str) -> Option<StructuredSidecarDeclaration> {
+        match self {
+            StructuredSidecarContract::Enabled(true) => Some(StructuredSidecarDeclaration {
+                name: name.to_string(),
+                path: default_structured_sidecar_path(name),
+                schema_version: None,
+            }),
+            StructuredSidecarContract::Enabled(false) => None,
+            StructuredSidecarContract::Detail(detail) => {
+                if !detail.enabled {
+                    return None;
+                }
+
+                Some(StructuredSidecarDeclaration {
+                    name: name.to_string(),
+                    path: detail
+                        .path
+                        .clone()
+                        .unwrap_or_else(|| default_structured_sidecar_path(name)),
+                    schema_version: detail.schema_version.clone(),
+                })
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct StructuredSidecarDetail {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_structured_sidecar_path(name: &str) -> String {
+    match name {
+        "lint.findings" => run_dir::files::LINT_FINDINGS,
+        "test.results" => run_dir::files::TEST_RESULTS,
+        "test.failures" => run_dir::files::TEST_FAILURES,
+        "test.coverage" => run_dir::files::COVERAGE,
+        "bench.results" => run_dir::files::BENCH_RESULTS,
+        "annotations" => run_dir::files::ANNOTATIONS_DIR,
+        _ => name,
+    }
+    .to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct StructuredSidecarDeclaration {
     pub name: String,
     pub path: String,
-    pub schema_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<String>,
 }

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -1,6 +1,5 @@
 use crate::core::component::AuditConfig;
 use crate::core::config::ConfigEntity;
-use crate::core::engine::run_dir;
 use crate::core::error::{Error, Result};
 use crate::core::paths;
 use serde::{Deserialize, Serialize};
@@ -451,10 +450,10 @@ pub struct ExtensionManifest {
     /// are reverted and the fixes are reclassified as declined. See #1167.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub autofix_verify: Option<AutofixVerifyConfig>,
-    /// Schema version for structured CI annotations emitted under the
-    /// `annotations/` run-dir sidecar.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations_schema_version: Option<String>,
+    /// Structured run-directory sidecars this extension declares as a public
+    /// machine-readable contract.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub structured_sidecars: Vec<StructuredSidecarDeclaration>,
 
     // Actions (cross-cutting: used by both platform and executable extensions)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -578,63 +577,10 @@ impl ExtensionManifest {
     }
 
     /// Structured sidecars this extension explicitly declares.
-    ///
     /// Missing declarations mean the extension has no structured sidecar
     /// contract for that output.
     pub fn structured_sidecars(&self) -> Vec<StructuredSidecarDeclaration> {
-        let mut sidecars = Vec::new();
-
-        if let Some(schema_version) = self.lint_findings_schema_version() {
-            sidecars.push(StructuredSidecarDeclaration {
-                name: "lint.findings".to_string(),
-                path: run_dir::files::LINT_FINDINGS.to_string(),
-                schema_version: schema_version.to_string(),
-            });
-        }
-
-        if let Some(schema_version) = self.test_results_schema_version() {
-            sidecars.push(StructuredSidecarDeclaration {
-                name: "test.results".to_string(),
-                path: run_dir::files::TEST_RESULTS.to_string(),
-                schema_version: schema_version.to_string(),
-            });
-        }
-
-        if let Some(schema_version) = self.test_failures_schema_version() {
-            sidecars.push(StructuredSidecarDeclaration {
-                name: "test.failures".to_string(),
-                path: run_dir::files::TEST_FAILURES.to_string(),
-                schema_version: schema_version.to_string(),
-            });
-        }
-
-        if let Some(schema_version) = self.annotations_schema_version.as_deref() {
-            sidecars.push(StructuredSidecarDeclaration {
-                name: "annotations".to_string(),
-                path: run_dir::files::ANNOTATIONS_DIR.to_string(),
-                schema_version: schema_version.to_string(),
-            });
-        }
-
-        sidecars
-    }
-
-    pub fn lint_findings_schema_version(&self) -> Option<&str> {
-        self.lint
-            .as_ref()
-            .and_then(|lint| lint.findings_schema_version.as_deref())
-    }
-
-    pub fn test_results_schema_version(&self) -> Option<&str> {
-        self.test
-            .as_ref()
-            .and_then(|test| test.results_schema_version.as_deref())
-    }
-
-    pub fn test_failures_schema_version(&self) -> Option<&str> {
-        self.test
-            .as_ref()
-            .and_then(|test| test.failures_schema_version.as_deref())
+        self.structured_sidecars.clone()
     }
 
     /// Convenience: get deploy verifications (empty if no deploy capability).
@@ -858,6 +804,7 @@ pub struct RuntimeRequirementConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct StructuredSidecarDeclaration {
     pub name: String,
     pub path: String,

--- a/src/core/extension/manifest_config.rs
+++ b/src/core/extension/manifest_config.rs
@@ -187,12 +187,6 @@ pub struct LintConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extension_script: Option<String>,
 
-    /// Schema version for the structured `lint-findings.json` sidecar emitted
-    /// by this extension. Absent means the extension has no declared findings
-    /// sidecar contract.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub findings_schema_version: Option<String>,
-
     /// Changed-file routing rules for split lint runners.
     ///
     /// When present, changed-file lint scopes files to the matching runner step
@@ -221,16 +215,6 @@ pub struct TestConfig {
     pub extension_script: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result_parse: Option<ParseSpec>,
-    /// Schema version for the structured `test-results.json` sidecar emitted
-    /// by this extension. Absent means the extension has no declared results
-    /// sidecar contract.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub results_schema_version: Option<String>,
-    /// Schema version for the structured `test-failures.json` sidecar emitted
-    /// by this extension. Absent means the extension has no declared failures
-    /// sidecar contract.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub failures_schema_version: Option<String>,
     /// Source/test selection contract used by changed-test and drift workflows.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub drift: Option<TestDriftConfig>,

--- a/src/core/extension/manifest_sidecar.rs
+++ b/src/core/extension/manifest_sidecar.rs
@@ -1,0 +1,73 @@
+use crate::core::engine::run_dir;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum StructuredSidecarContract {
+    Enabled(bool),
+    Detail(StructuredSidecarDetail),
+}
+
+impl StructuredSidecarContract {
+    pub(super) fn declaration(&self, name: &str) -> Option<StructuredSidecarDeclaration> {
+        match self {
+            StructuredSidecarContract::Enabled(true) => Some(StructuredSidecarDeclaration {
+                name: name.to_string(),
+                path: default_structured_sidecar_path(name),
+                schema_version: None,
+            }),
+            StructuredSidecarContract::Enabled(false) => None,
+            StructuredSidecarContract::Detail(detail) => {
+                if !detail.enabled {
+                    return None;
+                }
+
+                Some(StructuredSidecarDeclaration {
+                    name: name.to_string(),
+                    path: detail
+                        .path
+                        .clone()
+                        .unwrap_or_else(|| default_structured_sidecar_path(name)),
+                    schema_version: detail.schema_version.clone(),
+                })
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct StructuredSidecarDetail {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_structured_sidecar_path(name: &str) -> String {
+    match name {
+        "lint.findings" => run_dir::files::LINT_FINDINGS,
+        "test.results" => run_dir::files::TEST_RESULTS,
+        "test.failures" => run_dir::files::TEST_FAILURES,
+        "test.coverage" => run_dir::files::COVERAGE,
+        "bench.results" => run_dir::files::BENCH_RESULTS,
+        "annotations" => run_dir::files::ANNOTATIONS_DIR,
+        _ => name,
+    }
+    .to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct StructuredSidecarDeclaration {
+    pub name: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<String>,
+}

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -15,6 +15,7 @@ mod maintenance;
 mod manifest;
 mod manifest_action_config;
 mod manifest_config;
+mod manifest_sidecar;
 mod refactor_protocol;
 mod registry;
 mod repair;

--- a/src/core/extension/tests.rs
+++ b/src/core/extension/tests.rs
@@ -69,23 +69,18 @@ fn manifest_parses_declared_structured_sidecars() {
     let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
         "name": "Example",
         "version": "0.0.0",
-        "structured_sidecars": [
-            {
-                "name": "findings",
+        "structured_sidecars": {
+            "findings": {
                 "path": "findings.json",
                 "schema_version": "1"
             },
-            {
-                "name": "producer.summary",
+            "producer.summary": {
                 "path": "producer-summary.json",
                 "schema_version": "1"
             },
-            {
-                "name": "lint.findings",
-                "path": "lint-findings.json",
-                "schema_version": "1"
-            }
-        ]
+            "lint.findings": true,
+            "test.coverage": false
+        }
     }))
     .unwrap();
 
@@ -93,11 +88,12 @@ fn manifest_parses_declared_structured_sidecars() {
     assert_eq!(sidecars.len(), 3);
     assert_eq!(sidecars[0].name, "findings");
     assert_eq!(sidecars[0].path, "findings.json");
-    assert_eq!(sidecars[0].schema_version, "1");
-    assert_eq!(sidecars[1].name, "producer.summary");
-    assert_eq!(sidecars[1].path, "producer-summary.json");
-    assert_eq!(sidecars[2].name, "lint.findings");
-    assert_eq!(sidecars[2].path, "lint-findings.json");
+    assert_eq!(sidecars[0].schema_version.as_deref(), Some("1"));
+    assert_eq!(sidecars[1].name, "lint.findings");
+    assert_eq!(sidecars[1].path, "lint-findings.json");
+    assert_eq!(sidecars[1].schema_version, None);
+    assert_eq!(sidecars[2].name, "producer.summary");
+    assert_eq!(sidecars[2].path, "producer-summary.json");
 }
 
 #[test]
@@ -139,18 +135,17 @@ fn structured_sidecar_declarations_reject_unknown_fields() {
     let err = serde_json::from_value::<ExtensionManifest>(serde_json::json!({
         "name": "Example",
         "version": "0.0.0",
-        "structured_sidecars": [
-            {
-                "name": "findings",
+        "structured_sidecars": {
+            "findings": {
                 "path": "findings.json",
                 "schema_version": "1",
                 "legacy": true
             }
-        ]
+        }
     }))
     .expect_err("sidecar declarations should have one explicit shape");
 
-    assert!(err.to_string().contains("legacy"));
+    assert!(err.to_string().contains("data did not match"));
 }
 
 #[test]

--- a/src/core/extension/tests.rs
+++ b/src/core/extension/tests.rs
@@ -65,7 +65,56 @@ fn extension_capability_owns_labels_and_scripts() {
 }
 
 #[test]
-fn manifest_parses_declared_structured_sidecar_schema_versions() {
+fn manifest_parses_declared_structured_sidecars() {
+    let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+        "name": "Example",
+        "version": "0.0.0",
+        "structured_sidecars": [
+            {
+                "name": "findings",
+                "path": "findings.json",
+                "schema_version": "1"
+            },
+            {
+                "name": "producer.summary",
+                "path": "producer-summary.json",
+                "schema_version": "1"
+            },
+            {
+                "name": "lint.findings",
+                "path": "lint-findings.json",
+                "schema_version": "1"
+            }
+        ]
+    }))
+    .unwrap();
+
+    let sidecars = manifest.structured_sidecars();
+    assert_eq!(sidecars.len(), 3);
+    assert_eq!(sidecars[0].name, "findings");
+    assert_eq!(sidecars[0].path, "findings.json");
+    assert_eq!(sidecars[0].schema_version, "1");
+    assert_eq!(sidecars[1].name, "producer.summary");
+    assert_eq!(sidecars[1].path, "producer-summary.json");
+    assert_eq!(sidecars[2].name, "lint.findings");
+    assert_eq!(sidecars[2].path, "lint-findings.json");
+}
+
+#[test]
+fn missing_sidecar_declarations_have_no_structured_contract() {
+    let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+        "name": "Example",
+        "version": "0.0.0",
+        "lint": { "extension_script": "lint.sh" },
+        "test": { "extension_script": "test.sh" }
+    }))
+    .unwrap();
+
+    assert!(manifest.structured_sidecars().is_empty());
+}
+
+#[test]
+fn legacy_sidecar_schema_fields_do_not_declare_structured_contracts() {
     let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
         "name": "Example",
         "version": "0.0.0",
@@ -82,36 +131,26 @@ fn manifest_parses_declared_structured_sidecar_schema_versions() {
     }))
     .unwrap();
 
-    assert_eq!(manifest.lint_findings_schema_version(), Some("1"));
-    assert_eq!(manifest.test_results_schema_version(), Some("1"));
-    assert_eq!(manifest.test_failures_schema_version(), Some("1"));
-
-    let sidecars = manifest.structured_sidecars();
-    assert_eq!(sidecars.len(), 4);
-    assert_eq!(sidecars[0].name, "lint.findings");
-    assert_eq!(sidecars[0].path, "lint-findings.json");
-    assert_eq!(sidecars[1].name, "test.results");
-    assert_eq!(sidecars[1].path, "test-results.json");
-    assert_eq!(sidecars[2].name, "test.failures");
-    assert_eq!(sidecars[2].path, "test-failures.json");
-    assert_eq!(sidecars[3].name, "annotations");
-    assert_eq!(sidecars[3].path, "annotations");
+    assert!(manifest.structured_sidecars().is_empty());
 }
 
 #[test]
-fn missing_sidecar_declarations_have_no_structured_contract() {
-    let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+fn structured_sidecar_declarations_reject_unknown_fields() {
+    let err = serde_json::from_value::<ExtensionManifest>(serde_json::json!({
         "name": "Example",
         "version": "0.0.0",
-        "lint": { "extension_script": "lint.sh" },
-        "test": { "extension_script": "test.sh" }
+        "structured_sidecars": [
+            {
+                "name": "findings",
+                "path": "findings.json",
+                "schema_version": "1",
+                "legacy": true
+            }
+        ]
     }))
-    .unwrap();
+    .expect_err("sidecar declarations should have one explicit shape");
 
-    assert_eq!(manifest.lint_findings_schema_version(), None);
-    assert_eq!(manifest.test_results_schema_version(), None);
-    assert_eq!(manifest.test_failures_schema_version(), None);
-    assert!(manifest.structured_sidecars().is_empty());
+    assert!(err.to_string().contains("legacy"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Replaces synthesized nested sidecar schema-version fields with one authoritative top-level `structured_sidecars` manifest contract.
- Allows extensions to declare normalized `findings` and `producer.summary` sidecars alongside producer-specific sidecars during migration.
- Updates manifest docs and parser tests for declared, missing, legacy, and malformed sidecar declarations.

## Verification
- `cargo fmt`
- `cargo test core::extension::tests`
- `cargo test --lib` *(fails in existing audit/code-audit tests: `commands::audit::tests::audit_detects_outliers_in_convention_group`, `core::code_audit::report::report_test::test_compute_fixability_with_analysis`)*

## Notes
- Tracker context: Extra-Chill/homeboy#3074 lists #3073 as the sidecar cleanup workstream, though the current #3073 issue title/body on GitHub describes the broader core finding-contract work.
- Follow-up for Extra-Chill/homeboy-extensions#879: update extension manifests, including WordPress, to declare `structured_sidecars` at the top level with `findings` and `producer.summary` entries once producers emit those files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the manifest parser cleanup, updating tests/docs, and running verification. Chris remains responsible for review and acceptance.