### PR TITLE
Add annotation sidecar writer helpers

### DIFF
--- a/src/core/extension/runtime/sidecar-writer.sh
+++ b/src/core/extension/runtime/sidecar-writer.sh
@@ -3,7 +3,7 @@
 # Shared JSON sidecar writer for extension runner scripts.
 #
 # The helper owns the common "sidecar is a JSON array" file mechanics used by
-# lint findings, test failures, and fix results. Callers still build the
+# lint findings, test failures, fix results, and annotation files. Callers still build the
 # domain-specific JSON object; this helper validates it, writes atomically, and
 # keeps empty/missing target env vars as no-ops for legacy compatibility.
 #
@@ -12,6 +12,7 @@
 #   homeboy_sidecar_append_json "$HOMEBOY_LINT_FINDINGS_FILE" '{"message":"..."}'
 #   homeboy_sidecar_write_json_array "$HOMEBOY_TEST_FAILURES_FILE" "$failure_json"
 #   homeboy_sidecar_merge_json_array "$HOMEBOY_FIX_RESULTS_FILE" "$tmp_results"
+#   homeboy_write_annotations "phpcs" "$annotation_json"
 
 homeboy_sidecar_python() {
     if command -v python3 >/dev/null 2>&1; then
@@ -156,6 +157,18 @@ except Exception:
 PYEOF
 }
 
+homeboy_annotation_file() {
+    local source="${1:-}"
+    local dir="${HOMEBOY_ANNOTATIONS_DIR:-}"
+
+    if [ -z "$dir" ] || [ -z "$source" ]; then
+        return 0
+    fi
+
+    source="$(printf '%s' "$source" | tr -c 'A-Za-z0-9_.-' '-')"
+    printf '%s/%s.json\n' "$dir" "$source"
+}
+
 homeboy_write_lint_findings() {
     homeboy_sidecar_write_json_array "${HOMEBOY_LINT_FINDINGS_FILE:-}" "$@"
 }
@@ -190,4 +203,31 @@ homeboy_append_fix_result() {
 
 homeboy_merge_fix_results() {
     homeboy_sidecar_merge_json_array "${HOMEBOY_FIX_RESULTS_FILE:-}" "$1"
+}
+
+homeboy_write_annotations() {
+    local source="${1:-}"
+    shift || true
+
+    local target
+    target="$(homeboy_annotation_file "$source")"
+    homeboy_sidecar_write_json_array "$target" "$@"
+}
+
+homeboy_append_annotation() {
+    local source="${1:-}"
+    local item="${2:-}"
+
+    local target
+    target="$(homeboy_annotation_file "$source")"
+    homeboy_sidecar_append_json "$target" "$item"
+}
+
+homeboy_merge_annotations() {
+    local source="${1:-}"
+    local file="${2:-}"
+
+    local target
+    target="$(homeboy_annotation_file "$source")"
+    homeboy_sidecar_merge_json_array "$target" "$file"
 }

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -107,6 +107,40 @@ fn sidecar_writer_supports_test_failure_and_fix_result_wrappers() {
 }
 
 #[test]
+fn sidecar_writer_supports_annotation_source_files() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("sidecar-writer.sh");
+    let annotations_dir = dir.path().join("annotations");
+    let source_path = dir.path().join("phpstan-extra.json");
+    std::fs::write(&helper_path, assets::SIDECAR_WRITER_SH).expect("write helper");
+    std::fs::write(&source_path, r#"[{"file":"b.php","line":2}]"#).expect("source");
+
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {}; HOMEBOY_ANNOTATIONS_DIR={}; homeboy_write_annotations phpcs '{{\"file\":\"a.php\",\"line\":1}}'; homeboy_merge_annotations phpstan {}; printf '%s\n%s' \"$(cat {}/phpcs.json)\" \"$(cat {}/phpstan.json)\"",
+            helper_path.display(),
+            annotations_dir.display(),
+            source_path.display(),
+            annotations_dir.display(),
+            annotations_dir.display()
+        ))
+        .output()
+        .expect("run bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        r#"[{"file":"a.php","line":1}]
+[{"file":"b.php","line":2}]"#
+    );
+}
+
+#[test]
 fn ensure_all_helpers_writes_legacy_bench_fallbacks() {
     with_isolated_home(|home| {
         ensure_all_helpers().expect("all helpers should be written");


### PR DESCRIPTION
## Summary
- Adds generic annotation sidecar helpers to the shared extension runtime sidecar writer.
- Keeps annotation payload construction in extension scripts while centralizing the JSON array file mechanics and source-file naming.
- Adds runtime helper test coverage for per-source annotation files.

## Verification
- `cargo test core::extension::runtime_helper`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the runtime helper change and targeted tests; Chris remains responsible for review and merge.