### PR TITLE
Add shared runner prelude runtime helper

### DIFF
--- a/src/core/extension/runtime/runner-prelude.sh
+++ b/src/core/extension/runtime/runner-prelude.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+# Shared bootstrap for shell-based Homeboy extension runners.
+#
+# Runner scripts source this file, then call homeboy_runner_init with the
+# runtime pieces they need:
+#   homeboy_runner_init --bash 4 --component-alias PLUGIN_PATH --steps --failure-trap
+
+homeboy_runtime_dir() {
+    cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
+}
+
+homeboy_require_bash_version() {
+    local required_major="$1"
+
+    if [ -z "${BASH_VERSION:-}" ] || ((BASH_VERSINFO[0] < required_major)); then
+        echo "ERROR: bash ${required_major}.0+ required (found ${BASH_VERSION:-non-bash shell})" >&2
+        case "$(uname -s)" in
+            Darwin)
+                echo "macOS ships with bash 3.2. Install newer bash: brew install bash" >&2
+                echo "Then restart your terminal so Homebrew bash takes priority on PATH." >&2
+                ;;
+            Linux)
+                echo "Update bash via your package manager (apt, dnf, pacman, etc.)" >&2
+                ;;
+            MINGW*|MSYS*|CYGWIN*)
+                echo "Update Git Bash or use WSL with a modern bash version" >&2
+                ;;
+            *)
+                echo "Install bash ${required_major}.0 or later for your platform" >&2
+                ;;
+        esac
+        exit 1
+    fi
+}
+
+homeboy_source_runtime_helper() {
+    local env_var="$1"
+    local fallback="$2"
+    local required="${3:-required}"
+    local helper="${!env_var:-}"
+
+    if [ -z "$helper" ]; then
+        helper="$fallback"
+    fi
+
+    if [ -n "$helper" ] && [ -f "$helper" ]; then
+        # shellcheck source=/dev/null
+        source "$helper"
+        return 0
+    fi
+
+    if [ "$required" = "optional" ]; then
+        return 0
+    fi
+
+    echo "homeboy_runner_init: missing runtime helper for ${env_var}: ${helper}" >&2
+    return 2
+}
+
+homeboy_runner_init() {
+    local required_bash=""
+    local project_alias="PROJECT_PATH"
+    local component_alias=""
+    local load_steps=0
+    local load_failure_trap=0
+    local load_sidecar_writer=0
+    local runtime_dir
+    runtime_dir="$(homeboy_runtime_dir)"
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --bash)
+                required_bash="${2:-}"
+                shift 2
+                ;;
+            --project-alias)
+                project_alias="${2:-}"
+                shift 2
+                ;;
+            --component-alias)
+                component_alias="${2:-}"
+                shift 2
+                ;;
+            --steps)
+                load_steps=1
+                shift
+                ;;
+            --failure-trap)
+                load_failure_trap=1
+                shift
+                ;;
+            --sidecar-writer)
+                load_sidecar_writer=1
+                shift
+                ;;
+            *)
+                echo "homeboy_runner_init: unknown argument: $1" >&2
+                return 2
+                ;;
+        esac
+    done
+
+    if [ -n "$required_bash" ]; then
+        homeboy_require_bash_version "$required_bash"
+    fi
+
+    homeboy_source_runtime_helper HOMEBOY_RUNTIME_RESOLVE_CONTEXT "${runtime_dir}/resolve-context.sh"
+    homeboy_resolve_context --project-alias "$project_alias" --component-alias "$component_alias"
+
+    if [ "$load_steps" -eq 1 ]; then
+        homeboy_source_runtime_helper HOMEBOY_RUNTIME_RUNNER_STEPS "${runtime_dir}/runner-steps.sh"
+    fi
+
+    if [ "$load_sidecar_writer" -eq 1 ]; then
+        homeboy_source_runtime_helper HOMEBOY_RUNTIME_SIDECAR_WRITER "${runtime_dir}/sidecar-writer.sh" optional
+    fi
+
+    if [ "$load_failure_trap" -eq 1 ]; then
+        if homeboy_source_runtime_helper HOMEBOY_RUNTIME_FAILURE_TRAP "${runtime_dir}/failure-trap.sh" optional; then
+            if type homeboy_init_failure_trap >/dev/null 2>&1; then
+                homeboy_init_failure_trap
+            else
+                FAILED_STEP=""
+                FAILURE_OUTPUT=""
+                FAILURE_REPLAY_MODE="full"
+            fi
+        fi
+    fi
+}

--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 mod assets;
 
 pub const RUNNER_STEPS_ENV: &str = "HOMEBOY_RUNTIME_RUNNER_STEPS";
+pub const RUNNER_PRELUDE_ENV: &str = "HOMEBOY_RUNTIME_RUNNER_PRELUDE";
 pub const FAILURE_TRAP_ENV: &str = "HOMEBOY_RUNTIME_FAILURE_TRAP";
 pub const WRITE_TEST_RESULTS_ENV: &str = "HOMEBOY_RUNTIME_WRITE_TEST_RESULTS";
 pub const SIDECAR_WRITER_ENV: &str = "HOMEBOY_RUNTIME_SIDECAR_WRITER";
@@ -28,6 +29,12 @@ const HELPERS: &[RuntimeHelper] = &[
         filename: "runner-steps.sh",
         content: assets::RUNNER_STEPS_SH,
         env_var: RUNNER_STEPS_ENV,
+        legacy_fallback: false,
+    },
+    RuntimeHelper {
+        filename: "runner-prelude.sh",
+        content: assets::RUNNER_PRELUDE_SH,
+        env_var: RUNNER_PRELUDE_ENV,
         legacy_fallback: false,
     },
     RuntimeHelper {

--- a/src/core/extension/runtime_helper/assets.rs
+++ b/src/core/extension/runtime_helper/assets.rs
@@ -1,4 +1,5 @@
 pub(super) const RUNNER_STEPS_SH: &str = include_str!("../runtime/runner-steps.sh");
+pub(super) const RUNNER_PRELUDE_SH: &str = include_str!("../runtime/runner-prelude.sh");
 pub(super) const FAILURE_TRAP_SH: &str = include_str!("../runtime/failure-trap.sh");
 pub(super) const WRITE_TEST_RESULTS_SH: &str = include_str!("../runtime/write-test-results.sh");
 pub(super) const SIDECAR_WRITER_SH: &str = include_str!("../runtime/sidecar-writer.sh");
@@ -15,6 +16,7 @@ mod tests {
     fn embedded_runtime_helpers_are_present() {
         for content in [
             RUNNER_STEPS_SH,
+            RUNNER_PRELUDE_SH,
             FAILURE_TRAP_SH,
             WRITE_TEST_RESULTS_SH,
             SIDECAR_WRITER_SH,

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -18,6 +18,10 @@ fn ensure_all_helpers_writes_all_files() {
             "failure trap helper should be in pairs"
         );
         assert!(
+            pairs.iter().any(|(k, _)| k == RUNNER_PRELUDE_ENV),
+            "runner prelude helper should be in pairs"
+        );
+        assert!(
             pairs.iter().any(|(k, _)| k == WRITE_TEST_RESULTS_ENV),
             "write test results helper should be in pairs"
         );
@@ -38,6 +42,45 @@ fn ensure_all_helpers_writes_all_files() {
             "bench PHP helper should be in pairs"
         );
     });
+}
+
+#[test]
+fn runner_prelude_initializes_context_steps_trap_and_sidecar() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let runtime_dir = dir.path().join("runtime");
+    std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+    std::fs::write(runtime_dir.join("runner-prelude.sh"), assets::RUNNER_PRELUDE_SH)
+        .expect("write prelude");
+    std::fs::write(runtime_dir.join("resolve-context.sh"), assets::RESOLVE_CONTEXT_SH)
+        .expect("write resolve context");
+    std::fs::write(runtime_dir.join("runner-steps.sh"), assets::RUNNER_STEPS_SH)
+        .expect("write runner steps");
+    std::fs::write(runtime_dir.join("failure-trap.sh"), assets::FAILURE_TRAP_SH)
+        .expect("write failure trap");
+    std::fs::write(runtime_dir.join("sidecar-writer.sh"), assets::SIDECAR_WRITER_SH)
+        .expect("write sidecar writer");
+
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {}; homeboy_runner_init --bash 4 --component-alias PLUGIN_PATH --steps --failure-trap --sidecar-writer; should_run_step test; type homeboy_append_lint_finding >/dev/null; printf '%s|%s|%s|%s' \"$EXTENSION_PATH\" \"$COMPONENT_PATH\" \"$PLUGIN_PATH\" \"$FAILED_STEP\"",
+            runtime_dir.join("runner-prelude.sh").display()
+        ))
+        .env("HOMEBOY_EXTENSION_PATH", "/tmp/ext")
+        .env("HOMEBOY_COMPONENT_PATH", "/tmp/project")
+        .env("HOMEBOY_COMPONENT_ID", "demo")
+        .output()
+        .expect("run bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "/tmp/ext|/tmp/project|/tmp/project|"
+    );
 }
 
 #[test]

--- a/tests/core/extension/runtime_helper_test.rs
+++ b/tests/core/extension/runtime_helper_test.rs
@@ -20,4 +20,8 @@ fn test_ensure_all_helpers() {
         RUNTIME_HELPER_RS.contains("HOMEBOY_RUNTIME_SIDECAR_WRITER"),
         "extension env should expose the shared sidecar writer helper"
     );
+    assert!(
+        RUNTIME_HELPER_RS.contains("HOMEBOY_RUNTIME_RUNNER_PRELUDE"),
+        "extension env should expose the shared runner prelude helper"
+    );
 }


### PR DESCRIPTION
## Summary
- Adds a core-provided `HOMEBOY_RUNTIME_RUNNER_PRELUDE` helper for shell runner bootstrap.
- Centralizes Bash version checks, context resolution, optional step filtering, failure trap setup, and sidecar helper sourcing behind `homeboy_runner_init`.
- Covers helper materialization and prelude initialization in runtime helper tests.

## Verification
- `cargo test runtime_helper`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the runtime helper extraction, tests, and verification flow; Chris remains responsible for review and merge.