### PR TITLE
Refresh dependency installs after deps updates

### DIFF
--- a/docs/commands/refs.md
+++ b/docs/commands/refs.md
@@ -1,0 +1,36 @@
+# `homeboy refs`
+
+Find references to a symbol or term in one component or a small set of components.
+
+## Synopsis
+
+```sh
+homeboy refs <symbol> [--component <id>...] [--components <id,id>] [--path <path>]
+homeboy refs <symbol> [--scope code|config|all] [--context key|variable|parameter|all]
+```
+
+## Options
+
+- `--component <id>` — target a component by ID; repeat for multiple components.
+- `--components <id,id>` — target multiple components with a comma-separated list.
+- `--path <path>` — inspect a single checkout path directly.
+- `--scope <scope>` — limit the search to `code`, `config`, or `all`.
+- `--literal` — use exact string matching instead of boundary-aware variants.
+- `--files <glob>` — include only files matching a glob; repeatable.
+- `--exclude <glob>` — exclude files matching a glob; repeatable.
+- `--context <context>` — filter by syntactic context: `key`, `variable`, `parameter`, or `all`.
+
+## Examples
+
+```sh
+homeboy refs DependencyStackEdge --path /tmp/homeboy
+homeboy refs package_name --component data-machine --component homeboy --scope code
+homeboy refs old_config_key --components data-machine,homeboy --context key
+```
+
+The command exits with status `1` when no references are found, so scripts can treat an empty result as a failed lookup.
+
+## Related
+
+- [refactor](refactor.md)
+- [component](component.md)

--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -2,7 +2,7 @@ use clap::{Args, Subcommand};
 
 use homeboy::core::deps::{
     self, DependencyStackApplyResult, DependencyStackPlan, DependencyStackStatus, DependencyStatus,
-    DependencyUpdateResult,
+    DependencyUpdateOptions, DependencyUpdateResult,
 };
 
 use super::CmdResult;
@@ -28,9 +28,9 @@ enum DepsCommand {
         #[arg(long, value_name = "PATH")]
         path: Option<String>,
     },
-    /// Update one Composer package explicitly
+    /// Update one package through its dependency provider
     Update {
-        /// Composer package name, e.g. chubes4/block-format-bridge.
+        /// Package name, e.g. chubes4/block-format-bridge.
         package: String,
 
         /// Component ID. When omitted, auto-detected from CWD.
@@ -43,6 +43,14 @@ enum DepsCommand {
         /// Workspace path to operate on directly.
         #[arg(long, value_name = "PATH")]
         path: Option<String>,
+
+        /// Skip provider-owned install/lockfile refresh after the manifest update.
+        #[arg(long)]
+        no_install: bool,
+
+        /// Rebuild the component through its generic build capability after updating.
+        #[arg(long)]
+        rebuild: bool,
     },
     /// Work with declared downstream dependency stacks
     Stack {
@@ -68,6 +76,14 @@ enum DepsStackCommand {
         /// Print the command plan without running commands.
         #[arg(long)]
         dry_run: bool,
+
+        /// Skip provider-owned install/lockfile refresh after each manifest update.
+        #[arg(long)]
+        no_install: bool,
+
+        /// Rebuild each downstream component through its generic build capability.
+        #[arg(long)]
+        rebuild: bool,
     },
 }
 
@@ -95,12 +111,18 @@ pub fn run(args: DepsArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<s
             component,
             to,
             path,
+            no_install,
+            rebuild,
         } => {
             let output: DependencyUpdateResult = deps::update(
                 component.as_deref(),
                 path.as_deref(),
                 &package,
                 to.as_deref(),
+                DependencyUpdateOptions {
+                    install: !no_install,
+                    rebuild,
+                },
             )?;
             Ok((
                 serde_json::to_value(output).map_err(|e| {
@@ -137,8 +159,14 @@ pub fn run(args: DepsArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<s
                     0,
                 ))
             }
-            DepsStackCommand::Apply { upstream, dry_run } => {
-                let output: DependencyStackApplyResult = deps::stack_apply(&upstream, dry_run)?;
+            DepsStackCommand::Apply {
+                upstream,
+                dry_run,
+                no_install,
+                rebuild,
+            } => {
+                let output: DependencyStackApplyResult =
+                    deps::stack_apply(&upstream, dry_run, !no_install, rebuild)?;
                 Ok((
                     serde_json::to_value(output).map_err(|e| {
                         homeboy::core::Error::internal_json(

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -152,6 +152,8 @@ pub struct DependencyStackEdge {
     pub package: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub update: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub rebuild: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub post_update: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -401,6 +403,9 @@ fn is_default_remote(s: &str) -> bool {
 }
 fn is_default_branch(s: &str) -> bool {
     s == "main"
+}
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 impl Component {

--- a/src/core/deps.rs
+++ b/src/core/deps.rs
@@ -1,4 +1,5 @@
 use crate::core::component::{self, Component};
+use crate::core::extension::build;
 use crate::core::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -49,6 +50,35 @@ pub struct DependencyUpdateResult {
     pub after: Option<DependencyPackage>,
     pub stdout: String,
     pub stderr: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub install: Option<DependencyCommandResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rebuild: Option<DependencyCommandResult>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DependencyCommandResult {
+    pub command: Vec<String>,
+    pub skipped: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DependencyUpdateOptions {
+    pub install: bool,
+    pub rebuild: bool,
+}
+
+impl Default for DependencyUpdateOptions {
+    fn default() -> Self {
+        Self {
+            install: true,
+            rebuild: false,
+        }
+    }
 }
 
 pub fn status(
@@ -72,13 +102,21 @@ pub fn update(
     path_override: Option<&str>,
     package: &str,
     constraint: Option<&str>,
+    options: DependencyUpdateOptions,
 ) -> Result<DependencyUpdateResult> {
     let (component, path) = resolve_component_path(component_id, path_override)?;
     let providers = provider::resolve_dependency_providers(&component, &path)?;
 
     for provider in providers {
         if provider.handles_package(&path, package)? {
-            return provider.update(&component, &path, package, constraint);
+            let mut result = provider.update(&component, &path, package, constraint)?;
+            if options.install {
+                result.install = provider.install(&component, &path)?;
+            }
+            if options.rebuild {
+                result.rebuild = Some(rebuild_component(&component, &path)?);
+            }
+            return Ok(result);
         }
     }
 
@@ -91,6 +129,42 @@ pub fn update(
         Some(package.to_string()),
         None,
     ))
+}
+
+fn rebuild_component(component: &Component, path: &Path) -> Result<DependencyCommandResult> {
+    let mut build_component = component.clone();
+    build_component.local_path = path.display().to_string();
+    let (result, exit_code) = build::run_component(&build_component)?;
+    let stdout = serde_json::to_string(&result).map_err(|e| {
+        Error::internal_json(e.to_string(), Some("serialize deps rebuild".to_string()))
+    })?;
+    let command = vec![
+        "homeboy".to_string(),
+        "build".to_string(),
+        component.id.clone(),
+        "--path".to_string(),
+        path.display().to_string(),
+    ];
+
+    if exit_code != 0 {
+        return Err(Error::validation_invalid_argument(
+            "rebuild",
+            format!(
+                "Dependency update rebuild failed for '{}' with status {}",
+                component.id, exit_code
+            ),
+            Some(component.id.clone()),
+            Some(vec![format!("Run manually: {}", command.join(" "))]),
+        ));
+    }
+
+    Ok(DependencyCommandResult {
+        command,
+        skipped: false,
+        status: Some(exit_code),
+        stdout,
+        stderr: String::new(),
+    })
 }
 
 fn resolve_component_path(

--- a/src/core/deps/stack.rs
+++ b/src/core/deps/stack.rs
@@ -1,4 +1,5 @@
 use crate::core::component::{self, Component, DependencyStackEdge};
+use crate::core::deps::{update, DependencyUpdateOptions};
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
 use crate::core::{Error, Result};
 use crate::extensions::deps_provider;
@@ -20,6 +21,7 @@ pub struct DependencyStackEdgeStatus {
     pub downstream: String,
     pub package: String,
     pub update_command: String,
+    pub rebuild: bool,
     pub post_update: Vec<String>,
     pub test: Vec<String>,
 }
@@ -42,6 +44,7 @@ pub struct DependencyStackPlanStep {
     pub downstream_path: String,
     pub package: String,
     pub update_command: String,
+    pub rebuild: bool,
     pub post_update: Vec<String>,
     pub test: Vec<String>,
 }
@@ -96,18 +99,35 @@ pub fn stack_plan(upstream: &str) -> Result<DependencyStackPlan> {
     stack_plan_from_components(upstream, &components)
 }
 
-pub fn stack_apply(upstream: &str, dry_run: bool) -> Result<DependencyStackApplyResult> {
+pub fn stack_apply(
+    upstream: &str,
+    dry_run: bool,
+    install: bool,
+    rebuild: bool,
+) -> Result<DependencyStackApplyResult> {
     let plan = stack_plan(upstream)?;
     let mut steps = Vec::new();
 
     for step in plan.planned_steps() {
         let mut command_results = Vec::new();
-        command_results.push(run_stack_command(
-            "update",
-            &step.update_command,
-            &step.downstream_path,
-            dry_run,
-        )?);
+        if step.uses_default_update_command() {
+            command_results.push(run_default_update_step(&step, dry_run, install)?);
+        } else {
+            command_results.push(run_stack_command(
+                "update",
+                &step.update_command,
+                &step.downstream_path,
+                dry_run,
+            )?);
+        }
+        if rebuild || step.rebuild {
+            command_results.push(run_stack_command(
+                "rebuild",
+                &rebuild_command(&step),
+                &step.downstream_path,
+                dry_run,
+            )?);
+        }
         for command in &step.post_update {
             command_results.push(run_stack_command(
                 "post_update",
@@ -194,6 +214,7 @@ pub fn stack_plan_from_components(
                 downstream_path: downstream_path.clone(),
                 package: edge.package.clone(),
                 update_command: update_command(edge, downstream_path),
+                rebuild: edge.rebuild,
                 post_update: edge.post_update.clone(),
                 test: edge.test.clone(),
             });
@@ -315,6 +336,7 @@ fn stack_step(step: &DependencyStackPlanStep) -> PlanStep {
             .string("downstream_path", step.downstream_path.clone())
             .string("package", step.package.clone())
             .string("update_command", step.update_command.clone())
+            .json("rebuild", &step.rebuild)
             .json("post_update", &step.post_update)
             .json("test", &step.test)
             .json("stack_step", step),
@@ -337,18 +359,89 @@ fn edge_status(component: &Component, edge: &DependencyStackEdge) -> DependencyS
         downstream: edge.downstream.clone(),
         package: edge.package.clone(),
         update_command: update_command(edge, &component.local_path),
+        rebuild: edge.rebuild,
         post_update: edge.post_update.clone(),
         test: edge.test.clone(),
     }
 }
 
+impl DependencyStackPlanStep {
+    fn uses_default_update_command(&self) -> bool {
+        self.update_command == update_command_for(&self.package, &self.downstream_path)
+    }
+}
+
 fn update_command(edge: &DependencyStackEdge, downstream_path: &str) -> String {
-    edge.update.clone().unwrap_or_else(|| {
-        format!(
-            "homeboy deps update {} --path {}",
-            shell_word(&edge.package),
-            shell_word(downstream_path)
+    edge.update
+        .clone()
+        .unwrap_or_else(|| update_command_for(&edge.package, downstream_path))
+}
+
+fn update_command_for(package: &str, downstream_path: &str) -> String {
+    update_command_for_options(package, downstream_path, true)
+}
+
+fn update_command_for_options(package: &str, downstream_path: &str, install: bool) -> String {
+    let mut command = format!(
+        "homeboy deps update {} --path {}",
+        shell_word(package),
+        shell_word(downstream_path)
+    );
+    if !install {
+        command.push_str(" --no-install");
+    }
+    command
+}
+
+fn rebuild_command(step: &DependencyStackPlanStep) -> String {
+    format!(
+        "homeboy build {} --path {}",
+        shell_word(&step.downstream),
+        shell_word(&step.downstream_path)
+    )
+}
+
+fn run_default_update_step(
+    step: &DependencyStackPlanStep,
+    dry_run: bool,
+    install: bool,
+) -> Result<DependencyStackCommandResult> {
+    let command = update_command_for_options(&step.package, &step.downstream_path, install);
+    if dry_run {
+        return Ok(DependencyStackCommandResult {
+            phase: "update".to_string(),
+            command,
+            skipped: true,
+            status: None,
+            stdout: String::new(),
+            stderr: String::new(),
+        });
+    }
+
+    let result = update(
+        Some(&step.downstream),
+        Some(&step.downstream_path),
+        &step.package,
+        None,
+        DependencyUpdateOptions {
+            install,
+            rebuild: false,
+        },
+    )?;
+    let stdout = serde_json::to_string(&result).map_err(|e| {
+        Error::internal_json(
+            e.to_string(),
+            Some("serialize deps stack update".to_string()),
         )
+    })?;
+
+    Ok(DependencyStackCommandResult {
+        phase: "update".to_string(),
+        command,
+        skipped: false,
+        status: Some(0),
+        stdout,
+        stderr: String::new(),
     })
 }
 

--- a/src/core/deps/stack.rs
+++ b/src/core/deps/stack.rs
@@ -272,6 +272,7 @@ fn stack_edges_from_components(
                 downstream: component.id.clone(),
                 package: package.name.clone(),
                 update: None,
+                rebuild: false,
                 post_update: Vec::new(),
                 test: Vec::new(),
             };

--- a/src/extensions/deps_provider.rs
+++ b/src/extensions/deps_provider.rs
@@ -1,5 +1,5 @@
 use crate::core::component::Component;
-use crate::core::deps::{DependencyPackage, DependencyUpdateResult};
+use crate::core::deps::{DependencyCommandResult, DependencyPackage, DependencyUpdateResult};
 use crate::core::extension::{self, ExtensionCapability, ExtensionExecutionContext};
 use crate::core::{Error, Result};
 use serde::Deserialize;
@@ -77,6 +77,18 @@ impl DependencyProvider {
             DependencyProvider::ComponentScript(provider) => {
                 provider.update(component, path, package, constraint)
             }
+        }
+    }
+
+    pub(crate) fn install(
+        &self,
+        component: &Component,
+        path: &Path,
+    ) -> Result<Option<DependencyCommandResult>> {
+        match self {
+            DependencyProvider::Composer(provider) => provider.install(component, path),
+            DependencyProvider::ComponentScript(provider) => provider.install(component, path),
+            DependencyProvider::Extension(provider) => provider.install(component, path),
         }
     }
 }
@@ -253,7 +265,82 @@ impl ComposerDependencyProvider {
             after,
             stdout,
             stderr,
+            install: None,
+            rebuild: None,
         })
+    }
+
+    fn install(
+        &self,
+        _component: &Component,
+        _path: &Path,
+    ) -> Result<Option<DependencyCommandResult>> {
+        Ok(None)
+    }
+}
+
+pub(crate) struct ComponentScriptDependencyProvider;
+
+impl ComponentScriptDependencyProvider {
+    fn status(
+        &self,
+        component: &Component,
+        path: &Path,
+        package_filter: Option<&str>,
+    ) -> Result<ProviderDependencyStatus> {
+        let mut args = vec!["status".to_string()];
+        if let Some(package_filter) = package_filter {
+            args.push(package_filter.to_string());
+        }
+        let output = run_component_deps_script(component, path, &args)?;
+        let status: ExtensionStatusOutput = parse_extension_output(&output.stdout, "deps status")?;
+
+        Ok(ProviderDependencyStatus {
+            package_manager: status.package_manager,
+            dependency_identities: status.dependency_identities,
+            packages: status.packages,
+        })
+    }
+
+    fn update(
+        &self,
+        component: &Component,
+        path: &Path,
+        package: &str,
+        constraint: Option<&str>,
+    ) -> Result<DependencyUpdateResult> {
+        let mut args = vec!["update".to_string(), package.to_string()];
+        if let Some(constraint) = constraint {
+            args.push(constraint.to_string());
+        }
+        let output = run_component_deps_script(component, path, &args)?;
+        let mut result: DependencyUpdateResult =
+            parse_extension_output(&output.stdout, "deps update")?;
+        result.component_id = component.id.clone();
+        result.component_path = path.display().to_string();
+        result.package = package.to_string();
+        result.requested_constraint = constraint.map(str::to_string);
+        result.stdout = output.stdout;
+        result.stderr = output.stderr;
+        result.install = None;
+        result.rebuild = None;
+        Ok(result)
+    }
+
+    fn install(
+        &self,
+        component: &Component,
+        path: &Path,
+    ) -> Result<Option<DependencyCommandResult>> {
+        let args = vec!["install".to_string()];
+        let output = run_component_deps_script(component, path, &args)?;
+        Ok(Some(DependencyCommandResult {
+            command: component_deps_script_command(component, &args),
+            skipped: false,
+            status: Some(output.exit_code),
+            stdout: output.stdout,
+            stderr: output.stderr,
+        }))
     }
 }
 
@@ -302,7 +389,25 @@ impl ExtensionDependencyProvider {
         result.requested_constraint = constraint.map(str::to_string);
         result.stdout = output.stdout;
         result.stderr = output.stderr;
+        result.install = None;
+        result.rebuild = None;
         Ok(result)
+    }
+
+    fn install(
+        &self,
+        component: &Component,
+        path: &Path,
+    ) -> Result<Option<DependencyCommandResult>> {
+        let args = vec!["install".to_string()];
+        let output = self.run(component, path, &args)?;
+        Ok(Some(DependencyCommandResult {
+            command: extension_deps_command(&args),
+            skipped: false,
+            status: Some(output.exit_code),
+            stdout: output.stdout,
+            stderr: output.stderr,
+        }))
     }
 
     fn run(
@@ -321,68 +426,55 @@ impl ExtensionDependencyProvider {
     }
 }
 
-pub(crate) struct ComponentScriptDependencyProvider;
-
-impl ComponentScriptDependencyProvider {
-    fn status(
-        &self,
-        component: &Component,
-        path: &Path,
-        package_filter: Option<&str>,
-    ) -> Result<ProviderDependencyStatus> {
-        let mut args = vec!["status".to_string()];
-        if let Some(package_filter) = package_filter {
-            args.push(package_filter.to_string());
-        }
-        let output = self.run(component, path, &args)?;
-        let status: ExtensionStatusOutput = parse_extension_output(&output.stdout, "deps status")?;
-
-        Ok(ProviderDependencyStatus {
-            package_manager: status.package_manager,
-            dependency_identities: status.dependency_identities,
-            packages: status.packages,
-        })
+fn run_component_deps_script(
+    component: &Component,
+    path: &Path,
+    args: &[String],
+) -> Result<crate::core::extension::component_script::ComponentScriptOutput> {
+    let output = crate::core::extension::component_script::run_component_scripts_with_env(
+        component,
+        ExtensionCapability::Deps,
+        path,
+        false,
+        &[],
+        args,
+    )?;
+    if !output.success {
+        return Err(Error::validation_invalid_argument(
+            "dependency_provider",
+            format!(
+                "Dependency provider command failed with status {}: {}",
+                output.exit_code,
+                first_non_empty_line(&output.stderr)
+                    .or_else(|| first_non_empty_line(&output.stdout))
+                    .unwrap_or("no output")
+            ),
+            None,
+            Some(vec![format!(
+                "Run the component deps script manually in {}",
+                path.display()
+            )]),
+        ));
     }
+    Ok(output)
+}
 
-    fn update(
-        &self,
-        component: &Component,
-        path: &Path,
-        package: &str,
-        constraint: Option<&str>,
-    ) -> Result<DependencyUpdateResult> {
-        let mut args = vec!["update".to_string(), package.to_string()];
-        if let Some(constraint) = constraint {
-            args.push(constraint.to_string());
-        }
-        let output = self.run(component, path, &args)?;
-        let mut result: DependencyUpdateResult =
-            parse_extension_output(&output.stdout, "deps update")?;
-        result.component_id = component.id.clone();
-        result.component_path = path.display().to_string();
-        result.package = package.to_string();
-        result.requested_constraint = constraint.map(str::to_string);
-        result.stdout = output.stdout;
-        result.stderr = output.stderr;
-        Ok(result)
-    }
+fn component_deps_script_command(component: &Component, args: &[String]) -> Vec<String> {
+    let mut command = vec!["scripts.deps".to_string()];
+    command.extend(
+        component
+            .script_commands(ExtensionCapability::Deps)
+            .iter()
+            .cloned(),
+    );
+    command.extend(args.iter().cloned());
+    command
+}
 
-    fn run(
-        &self,
-        component: &Component,
-        path: &Path,
-        args: &[String],
-    ) -> Result<crate::core::extension::RunnerOutput> {
-        let output = crate::core::extension::component_script::run_component_scripts_with_env(
-            component,
-            ExtensionCapability::Deps,
-            path,
-            false,
-            &[],
-            args,
-        )?;
-        Ok(output.into())
-    }
+fn extension_deps_command(args: &[String]) -> Vec<String> {
+    let mut command = vec!["extension.deps".to_string()];
+    command.extend(args.iter().cloned());
+    command
 }
 
 #[derive(Debug, Deserialize)]

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -283,6 +283,7 @@ fn stack_plan_keeps_explicit_edge_config_when_provider_edge_matches() {
         downstream: "downstream".to_string(),
         package: "fixture/upstream".to_string(),
         update: Some("fixture-provider update fixture/upstream".to_string()),
+        rebuild: false,
         post_update: vec!["fixture-provider build".to_string()],
         test: vec!["fixture-provider test".to_string()],
     };

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -1,5 +1,5 @@
 use homeboy::core::component::{Component, ComponentScriptsConfig, DependencyStackEdge};
-use homeboy::core::deps::{self, ComposerAction};
+use homeboy::core::deps::{self, ComposerAction, DependencyUpdateOptions};
 use std::fs;
 use tempfile::tempdir;
 
@@ -179,6 +179,7 @@ fn stack_plan_walks_declared_downstream_edges_in_order() {
                 downstream: "block-format-bridge".to_string(),
                 package: "chubes4/html-to-blocks-converter".to_string(),
                 update: None,
+                rebuild: false,
                 post_update: vec!["composer build".to_string()],
                 test: vec!["homeboy test --path . --extension wordpress".to_string()],
             }],
@@ -191,6 +192,7 @@ fn stack_plan_walks_declared_downstream_edges_in_order() {
                 downstream: "static-site-importer".to_string(),
                 package: "chubes4/block-format-bridge".to_string(),
                 update: Some("composer update chubes4/block-format-bridge".to_string()),
+                rebuild: false,
                 post_update: Vec::new(),
                 test: vec!["homeboy test --path . --extension wordpress".to_string()],
             }],
@@ -331,6 +333,7 @@ fn stack_plan_dedupes_cycles_by_edge_identity() {
                 downstream: "b".to_string(),
                 package: "fixture/b".to_string(),
                 update: None,
+                rebuild: false,
                 post_update: Vec::new(),
                 test: Vec::new(),
             }],
@@ -343,6 +346,7 @@ fn stack_plan_dedupes_cycles_by_edge_identity() {
                 downstream: "a".to_string(),
                 package: "fixture/a".to_string(),
                 update: None,
+                rebuild: false,
                 post_update: Vec::new(),
                 test: Vec::new(),
             }],
@@ -366,6 +370,66 @@ fn non_composer_component_returns_clear_unsupported_error() {
     assert_eq!(err.code.as_str(), "validation.invalid_argument");
     assert!(err.message.contains("dependency provider"));
     assert!(err.message.contains("No dependency provider found"));
+}
+
+#[test]
+fn update_runs_component_provider_install_and_optional_rebuild() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    fs::create_dir_all(root.join("scripts")).unwrap();
+    write_file(
+        &root.join("homeboy.json"),
+        r#"{
+            "id": "fixture",
+            "scripts": {
+                "deps": ["sh scripts/deps.sh"],
+                "build": ["sh scripts/build.sh"]
+            }
+        }"#,
+    );
+    write_file(
+        &root.join("scripts/deps.sh"),
+        r#"#!/bin/sh
+case "$1" in
+  update)
+    printf '{"component_id":"ignored","component_path":"ignored","package_manager":"fixture","package":"ignored","requested_constraint":"ignored","command":["fixture-provider","update"],"stdout":"provider update","stderr":""}'
+    ;;
+  install)
+    printf 'installed' > provider-install-marker
+    printf 'provider install'
+    ;;
+  *)
+    printf 'unknown deps action' >&2
+    exit 2
+    ;;
+esac
+"#,
+    );
+    write_file(
+        &root.join("scripts/build.sh"),
+        "#!/bin/sh\nprintf 'rebuilt' > build-marker\nprintf 'provider build'\n",
+    );
+
+    let root_path = root.display().to_string();
+    let result = deps::update(
+        Some("fixture"),
+        Some(&root_path),
+        "fixture/package",
+        Some("^2.0"),
+        DependencyUpdateOptions {
+            install: true,
+            rebuild: true,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(result.package_manager, "fixture");
+    assert_eq!(result.package, "fixture/package");
+    assert_eq!(result.requested_constraint.as_deref(), Some("^2.0"));
+    assert!(result.install.is_some());
+    assert!(result.rebuild.is_some());
+    assert_eq!(fs::read_to_string(root.join("provider-install-marker")).unwrap(), "installed");
+    assert_eq!(fs::read_to_string(root.join("build-marker")).unwrap(), "rebuilt");
 }
 
 #[test]
@@ -447,6 +511,10 @@ fn update_with_constraint_changes_manifest_and_lock_for_local_path_package() {
         Some(&root_path),
         "fixture/package",
         Some("1.1.0"),
+        DependencyUpdateOptions {
+            install: true,
+            rebuild: false,
+        },
     )
     .unwrap();
 

--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -395,10 +395,6 @@ const BASELINE: &[ViolationKey] = &[
     },
     ViolationKey {
         path: "src/core/extension/test/mod.rs",
-        term: "cargo",
-    },
-    ViolationKey {
-        path: "src/core/extension/test/mod.rs",
         term: "php",
     },
     ViolationKey {
@@ -479,7 +475,7 @@ const BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const BASELINE_OCCURRENCES: usize = 146;
+const BASELINE_OCCURRENCES: usize = 142;
 
 // Known core-owned test/fixture literal debt tracked by #3034. Keep this list
 // explicit so stale rows and occurrence-count changes force cleanup or review.
@@ -541,31 +537,11 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
         term: "wordpress",
     },
     ViolationKey {
-        path: "src/core/extension/runtime_helper/tests.rs",
-        term: "phpstan",
-    },
-    ViolationKey {
-        path: "src/core/extension/runtime_helper/tests.rs",
-        term: "rust",
-    },
-    ViolationKey {
-        path: "src/core/extension/test/mod.rs",
-        term: "rust",
-    },
-    ViolationKey {
-        path: "src/core/extension/test/mod.rs",
-        term: "wordpress",
-    },
-    ViolationKey {
         path: "src/core/extension/test/parsing.rs",
         term: "cargo",
     },
     ViolationKey {
         path: "src/core/extension/test/report.rs",
-        term: "wordpress",
-    },
-    ViolationKey {
-        path: "src/core/extension/tests.rs",
         term: "wordpress",
     },
     ViolationKey {
@@ -662,7 +638,7 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const TEST_CONTENT_BASELINE_OCCURRENCES: usize = 119;
+const TEST_CONTENT_BASELINE_OCCURRENCES: usize = 109;
 
 #[test]
 fn core_owned_source_stays_language_and_framework_agnostic() {

--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -395,6 +395,10 @@ const BASELINE: &[ViolationKey] = &[
     },
     ViolationKey {
         path: "src/core/extension/test/mod.rs",
+        term: "cargo",
+    },
+    ViolationKey {
+        path: "src/core/extension/test/mod.rs",
         term: "php",
     },
     ViolationKey {
@@ -475,7 +479,7 @@ const BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const BASELINE_OCCURRENCES: usize = 142;
+const BASELINE_OCCURRENCES: usize = 146;
 
 // Known core-owned test/fixture literal debt tracked by #3034. Keep this list
 // explicit so stale rows and occurrence-count changes force cleanup or review.
@@ -537,11 +541,31 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
         term: "wordpress",
     },
     ViolationKey {
+        path: "src/core/extension/runtime_helper/tests.rs",
+        term: "phpstan",
+    },
+    ViolationKey {
+        path: "src/core/extension/runtime_helper/tests.rs",
+        term: "rust",
+    },
+    ViolationKey {
+        path: "src/core/extension/test/mod.rs",
+        term: "rust",
+    },
+    ViolationKey {
+        path: "src/core/extension/test/mod.rs",
+        term: "wordpress",
+    },
+    ViolationKey {
         path: "src/core/extension/test/parsing.rs",
         term: "cargo",
     },
     ViolationKey {
         path: "src/core/extension/test/report.rs",
+        term: "wordpress",
+    },
+    ViolationKey {
+        path: "src/core/extension/tests.rs",
         term: "wordpress",
     },
     ViolationKey {
@@ -638,7 +662,7 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const TEST_CONTENT_BASELINE_OCCURRENCES: usize = 109;
+const TEST_CONTENT_BASELINE_OCCURRENCES: usize = 119;
 
 #[test]
 fn core_owned_source_stays_language_and_framework_agnostic() {


### PR DESCRIPTION
## Summary
- Runs provider-owned install/lockfile refresh after `deps update` by default, with `--no-install` for callers that need the previous update-only behavior.
- Adds optional rebuild support through existing generic build behavior via `deps update --rebuild`, `deps stack apply --rebuild`, or declared `dependency_stack[].rebuild`.
- Keeps package-manager behavior behind dependency providers and adds generic component-script provider coverage for install + rebuild.

Fixes #3079.

## Tests
- `cargo fmt --check`
- `cargo test --test deps_test`
- `cargo test --test architecture_core_agnostic_test`

## Caveats
- `fix/deps-npm-provider` / PR #3080 was not available when this branch was cut, so this PR does not add npm-specific integration coverage.
- `cargo test --test core_agnostic_test` currently fails on pre-existing baseline drift outside this change (`src/core/extension/test/mod.rs`, runtime helper tests, etc.).
- `cargo test --test command_surface_test` currently fails because `docs/commands/commands-index.md` is missing the pre-existing top-level `refs` command.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic deps install/rebuild implementation, tests, and PR description; Chris remains responsible for review and acceptance.