### PR TITLE
Add npm dependency provider

### DIFF
--- a/src/core/deps.rs
+++ b/src/core/deps.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 mod stack;
 
 use crate::extensions::deps_provider as provider;
-pub use crate::extensions::deps_provider::{composer_command_args, ComposerAction};
 pub use stack::{
     stack_apply, stack_plan, stack_plan_from_components, stack_status, DependencyStackApplyResult,
     DependencyStackApplyStep, DependencyStackCommandResult, DependencyStackEdgeStatus,

--- a/src/extensions/deps_provider.rs
+++ b/src/extensions/deps_provider.rs
@@ -2,12 +2,15 @@ use crate::core::component::Component;
 use crate::core::deps::{DependencyCommandResult, DependencyPackage, DependencyUpdateResult};
 use crate::core::extension::{self, ExtensionCapability, ExtensionExecutionContext};
 use crate::core::{Error, Result};
+use crate::extensions::npm_deps_provider::NpmDependencyProvider;
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
+
+pub use crate::extensions::npm_deps_provider::npm_command_args;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ComposerAction {
@@ -57,7 +60,7 @@ impl DependencyProvider {
     pub(crate) fn handles_package(&self, path: &Path, package: &str) -> Result<bool> {
         match self {
             DependencyProvider::Composer(provider) => provider.handles_package(path, package),
-            DependencyProvider::Npm(provider) => provider.handles_package(path, package),
+            DependencyProvider::Npm(provider) => provider.manages_package(path, package),
             DependencyProvider::Extension(_) => Ok(true),
             DependencyProvider::ComponentScript(_) => Ok(true),
         }
@@ -175,13 +178,6 @@ pub(crate) fn dependency_provider_snapshot(
     Ok(snapshot)
 }
 
-pub fn npm_command_args(package: &str, constraint: Option<&str>) -> Vec<String> {
-    match constraint {
-        Some(constraint) => vec!["install".to_string(), format!("{package}@{constraint}")],
-        None => vec!["update".to_string(), package.to_string()],
-    }
-}
-
 pub fn composer_command_args(package: &str, action: &ComposerAction) -> Vec<String> {
     match action {
         ComposerAction::Require { constraint } => vec![
@@ -196,85 +192,6 @@ pub fn composer_command_args(package: &str, action: &ComposerAction) -> Vec<Stri
             "--with-dependencies".to_string(),
             "--no-interaction".to_string(),
         ],
-    }
-}
-
-pub(crate) struct NpmDependencyProvider;
-
-impl NpmDependencyProvider {
-    fn supports(path: &Path) -> bool {
-        path.join("package.json").is_file()
-    }
-
-    fn status(
-        &self,
-        path: &Path,
-        package_filter: Option<&str>,
-    ) -> Result<ProviderDependencyStatus> {
-        Ok(ProviderDependencyStatus {
-            package_manager: "npm".to_string(),
-            dependency_identities: Vec::new(),
-            packages: read_npm_packages(path, package_filter)?,
-        })
-    }
-
-    fn handles_package(&self, path: &Path, package: &str) -> Result<bool> {
-        Ok(npm_package_snapshot(path, package)?.is_some())
-    }
-
-    fn update(
-        &self,
-        component: &Component,
-        path: &Path,
-        package: &str,
-        constraint: Option<&str>,
-    ) -> Result<DependencyUpdateResult> {
-        let before = npm_package_snapshot(path, package)?;
-        let args = npm_command_args(package, constraint);
-        let output = Command::new("npm")
-            .args(&args)
-            .current_dir(path)
-            .output()
-            .map_err(|e| {
-                Error::internal_io(e.to_string(), Some("run dependency provider".to_string()))
-            })?;
-
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-
-        if !output.status.success() {
-            return Err(Error::validation_invalid_argument(
-                "dependency_provider",
-                format!(
-                    "Dependency provider command failed with status {}: {}",
-                    output.status,
-                    first_non_empty_line(&stderr)
-                        .or_else(|| first_non_empty_line(&stdout))
-                        .unwrap_or("no output")
-                ),
-                None,
-                Some(vec![format!(
-                    "Run manually in {}: npm {}",
-                    path.display(),
-                    args.join(" ")
-                )]),
-            ));
-        }
-
-        let after = npm_package_snapshot(path, package)?;
-
-        Ok(DependencyUpdateResult {
-            component_id: component.id.clone(),
-            component_path: path.display().to_string(),
-            package_manager: "npm".to_string(),
-            package: package.to_string(),
-            requested_constraint: constraint.map(str::to_string),
-            command: std::iter::once("npm".to_string()).chain(args).collect(),
-            before,
-            after,
-            stdout,
-            stderr,
-        })
     }
 }
 
@@ -603,55 +520,6 @@ fn composer_identities(path: &Path) -> Result<Vec<String>> {
         .unwrap_or_default())
 }
 
-fn npm_package_snapshot(path: &Path, package: &str) -> Result<Option<DependencyPackage>> {
-    Ok(read_npm_packages(path, Some(package))?.into_iter().next())
-}
-
-fn read_npm_packages(path: &Path, package_filter: Option<&str>) -> Result<Vec<DependencyPackage>> {
-    let manifest = read_json_file(&path.join("package.json"))?;
-    let lock = read_optional_json_file(&path.join("package-lock.json"))?;
-    let mut direct = BTreeMap::new();
-
-    for section in [
-        "dependencies",
-        "devDependencies",
-        "optionalDependencies",
-        "peerDependencies",
-    ] {
-        collect_manifest_section(&manifest, section, &mut direct);
-    }
-
-    let locked = lock
-        .as_ref()
-        .map(collect_npm_locked_packages)
-        .unwrap_or_default();
-
-    let mut names: BTreeSet<String> = direct.keys().cloned().collect();
-    names.extend(locked.keys().cloned());
-
-    let packages = names
-        .into_iter()
-        .filter(|name| package_filter.map(|filter| filter == name).unwrap_or(true))
-        .map(|name| {
-            let (manifest_section, constraint) = direct
-                .get(&name)
-                .cloned()
-                .map(|(section, constraint)| (Some(section), Some(constraint)))
-                .unwrap_or((None, None));
-            let locked = locked.get(&name);
-            DependencyPackage {
-                name,
-                manifest_section,
-                constraint,
-                locked_version: locked.and_then(|p| p.version.clone()),
-                locked_reference: locked.and_then(|p| p.reference.clone()),
-            }
-        })
-        .collect();
-
-    Ok(packages)
-}
-
 fn read_composer_packages(
     path: &Path,
     package_filter: Option<&str>,
@@ -713,22 +581,6 @@ fn collect_composer_manifest_section(
     }
 }
 
-fn collect_manifest_section(
-    manifest: &Value,
-    section: &str,
-    direct: &mut BTreeMap<String, (String, String)>,
-) {
-    let Some(entries) = manifest.get(section).and_then(Value::as_object) else {
-        return;
-    };
-
-    for (name, constraint) in entries {
-        if let Some(constraint) = constraint.as_str() {
-            direct.insert(name.clone(), (section.to_string(), constraint.to_string()));
-        }
-    }
-}
-
 #[derive(Debug, Clone, Default)]
 struct LockedPackage {
     version: Option<String>,
@@ -763,67 +615,6 @@ fn collect_locked_packages(lock: &Value) -> BTreeMap<String, LockedPackage> {
     }
 
     packages
-}
-
-fn collect_npm_locked_packages(lock: &Value) -> BTreeMap<String, LockedPackage> {
-    let mut packages = BTreeMap::new();
-
-    if let Some(entries) = lock.get("packages").and_then(Value::as_object) {
-        for (path, entry) in entries {
-            let Some(name) = npm_lock_package_name(path, entry) else {
-                continue;
-            };
-            packages.insert(name, npm_locked_package(entry, entries));
-        }
-    }
-
-    if let Some(entries) = lock.get("dependencies").and_then(Value::as_object) {
-        for (name, entry) in entries {
-            packages
-                .entry(name.to_string())
-                .or_insert_with(|| npm_locked_package(entry, &serde_json::Map::new()));
-        }
-    }
-
-    packages
-}
-
-fn npm_lock_package_name(path: &str, entry: &Value) -> Option<String> {
-    if path.is_empty() {
-        return None;
-    }
-    entry
-        .get("name")
-        .and_then(Value::as_str)
-        .map(str::to_string)
-        .or_else(|| {
-            path.strip_prefix("node_modules/")
-                .or_else(|| {
-                    path.rsplit_once("/node_modules/")
-                        .map(|(_, package)| package)
-                })
-                .map(str::to_string)
-        })
-}
-
-fn npm_locked_package(entry: &Value, packages: &serde_json::Map<String, Value>) -> LockedPackage {
-    let resolved_entry = entry
-        .get("resolved")
-        .and_then(Value::as_str)
-        .and_then(|resolved| packages.get(resolved));
-
-    LockedPackage {
-        version: entry
-            .get("version")
-            .or_else(|| resolved_entry.and_then(|entry| entry.get("version")))
-            .and_then(Value::as_str)
-            .map(str::to_string),
-        reference: entry
-            .get("resolved")
-            .or_else(|| entry.get("integrity"))
-            .and_then(Value::as_str)
-            .map(str::to_string),
-    }
 }
 
 fn read_json_file(path: &Path) -> Result<Value> {

--- a/src/extensions/deps_provider.rs
+++ b/src/extensions/deps_provider.rs
@@ -96,6 +96,7 @@ impl DependencyProvider {
     ) -> Result<Option<DependencyCommandResult>> {
         match self {
             DependencyProvider::Composer(provider) => provider.install(component, path),
+            DependencyProvider::Npm(provider) => provider.install(component, path),
             DependencyProvider::ComponentScript(provider) => provider.install(component, path),
             DependencyProvider::Extension(provider) => provider.install(component, path),
         }

--- a/src/extensions/deps_provider.rs
+++ b/src/extensions/deps_provider.rs
@@ -30,6 +30,7 @@ pub(crate) struct DependencyProviderSnapshot {
 
 pub(crate) enum DependencyProvider {
     Composer(ComposerDependencyProvider),
+    Npm(NpmDependencyProvider),
     Extension(ExtensionDependencyProvider),
     ComponentScript(ComponentScriptDependencyProvider),
 }
@@ -43,6 +44,7 @@ impl DependencyProvider {
     ) -> Result<ProviderDependencyStatus> {
         match self {
             DependencyProvider::Composer(provider) => provider.status(path, package_filter),
+            DependencyProvider::Npm(provider) => provider.status(path, package_filter),
             DependencyProvider::Extension(provider) => {
                 provider.status(component, path, package_filter)
             }
@@ -55,6 +57,7 @@ impl DependencyProvider {
     pub(crate) fn handles_package(&self, path: &Path, package: &str) -> Result<bool> {
         match self {
             DependencyProvider::Composer(provider) => provider.handles_package(path, package),
+            DependencyProvider::Npm(provider) => provider.handles_package(path, package),
             DependencyProvider::Extension(_) => Ok(true),
             DependencyProvider::ComponentScript(_) => Ok(true),
         }
@@ -69,6 +72,9 @@ impl DependencyProvider {
     ) -> Result<DependencyUpdateResult> {
         match self {
             DependencyProvider::Composer(provider) => {
+                provider.update(component, path, package, constraint)
+            }
+            DependencyProvider::Npm(provider) => {
                 provider.update(component, path, package, constraint)
             }
             DependencyProvider::Extension(provider) => {
@@ -107,6 +113,10 @@ pub(crate) fn resolve_dependency_providers(
         providers.push(DependencyProvider::ComponentScript(
             ComponentScriptDependencyProvider,
         ));
+    }
+
+    if NpmDependencyProvider::supports(path) {
+        providers.push(DependencyProvider::Npm(NpmDependencyProvider));
     }
 
     if component
@@ -165,6 +175,13 @@ pub(crate) fn dependency_provider_snapshot(
     Ok(snapshot)
 }
 
+pub fn npm_command_args(package: &str, constraint: Option<&str>) -> Vec<String> {
+    match constraint {
+        Some(constraint) => vec!["install".to_string(), format!("{package}@{constraint}")],
+        None => vec!["update".to_string(), package.to_string()],
+    }
+}
+
 pub fn composer_command_args(package: &str, action: &ComposerAction) -> Vec<String> {
     match action {
         ComposerAction::Require { constraint } => vec![
@@ -179,6 +196,85 @@ pub fn composer_command_args(package: &str, action: &ComposerAction) -> Vec<Stri
             "--with-dependencies".to_string(),
             "--no-interaction".to_string(),
         ],
+    }
+}
+
+pub(crate) struct NpmDependencyProvider;
+
+impl NpmDependencyProvider {
+    fn supports(path: &Path) -> bool {
+        path.join("package.json").is_file()
+    }
+
+    fn status(
+        &self,
+        path: &Path,
+        package_filter: Option<&str>,
+    ) -> Result<ProviderDependencyStatus> {
+        Ok(ProviderDependencyStatus {
+            package_manager: "npm".to_string(),
+            dependency_identities: Vec::new(),
+            packages: read_npm_packages(path, package_filter)?,
+        })
+    }
+
+    fn handles_package(&self, path: &Path, package: &str) -> Result<bool> {
+        Ok(npm_package_snapshot(path, package)?.is_some())
+    }
+
+    fn update(
+        &self,
+        component: &Component,
+        path: &Path,
+        package: &str,
+        constraint: Option<&str>,
+    ) -> Result<DependencyUpdateResult> {
+        let before = npm_package_snapshot(path, package)?;
+        let args = npm_command_args(package, constraint);
+        let output = Command::new("npm")
+            .args(&args)
+            .current_dir(path)
+            .output()
+            .map_err(|e| {
+                Error::internal_io(e.to_string(), Some("run dependency provider".to_string()))
+            })?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        if !output.status.success() {
+            return Err(Error::validation_invalid_argument(
+                "dependency_provider",
+                format!(
+                    "Dependency provider command failed with status {}: {}",
+                    output.status,
+                    first_non_empty_line(&stderr)
+                        .or_else(|| first_non_empty_line(&stdout))
+                        .unwrap_or("no output")
+                ),
+                None,
+                Some(vec![format!(
+                    "Run manually in {}: npm {}",
+                    path.display(),
+                    args.join(" ")
+                )]),
+            ));
+        }
+
+        let after = npm_package_snapshot(path, package)?;
+
+        Ok(DependencyUpdateResult {
+            component_id: component.id.clone(),
+            component_path: path.display().to_string(),
+            package_manager: "npm".to_string(),
+            package: package.to_string(),
+            requested_constraint: constraint.map(str::to_string),
+            command: std::iter::once("npm".to_string()).chain(args).collect(),
+            before,
+            after,
+            stdout,
+            stderr,
+        })
     }
 }
 
@@ -507,6 +603,55 @@ fn composer_identities(path: &Path) -> Result<Vec<String>> {
         .unwrap_or_default())
 }
 
+fn npm_package_snapshot(path: &Path, package: &str) -> Result<Option<DependencyPackage>> {
+    Ok(read_npm_packages(path, Some(package))?.into_iter().next())
+}
+
+fn read_npm_packages(path: &Path, package_filter: Option<&str>) -> Result<Vec<DependencyPackage>> {
+    let manifest = read_json_file(&path.join("package.json"))?;
+    let lock = read_optional_json_file(&path.join("package-lock.json"))?;
+    let mut direct = BTreeMap::new();
+
+    for section in [
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+        "peerDependencies",
+    ] {
+        collect_manifest_section(&manifest, section, &mut direct);
+    }
+
+    let locked = lock
+        .as_ref()
+        .map(collect_npm_locked_packages)
+        .unwrap_or_default();
+
+    let mut names: BTreeSet<String> = direct.keys().cloned().collect();
+    names.extend(locked.keys().cloned());
+
+    let packages = names
+        .into_iter()
+        .filter(|name| package_filter.map(|filter| filter == name).unwrap_or(true))
+        .map(|name| {
+            let (manifest_section, constraint) = direct
+                .get(&name)
+                .cloned()
+                .map(|(section, constraint)| (Some(section), Some(constraint)))
+                .unwrap_or((None, None));
+            let locked = locked.get(&name);
+            DependencyPackage {
+                name,
+                manifest_section,
+                constraint,
+                locked_version: locked.and_then(|p| p.version.clone()),
+                locked_reference: locked.and_then(|p| p.reference.clone()),
+            }
+        })
+        .collect();
+
+    Ok(packages)
+}
+
 fn read_composer_packages(
     path: &Path,
     package_filter: Option<&str>,
@@ -515,8 +660,8 @@ fn read_composer_packages(
     let lock = read_optional_json_file(&path.join("composer.lock"))?;
     let mut direct = BTreeMap::new();
 
-    collect_manifest_section(&manifest, "require", &mut direct);
-    collect_manifest_section(&manifest, "require-dev", &mut direct);
+    collect_composer_manifest_section(&manifest, "require", &mut direct);
+    collect_composer_manifest_section(&manifest, "require-dev", &mut direct);
 
     let locked = lock
         .as_ref()
@@ -549,7 +694,7 @@ fn read_composer_packages(
     Ok(packages)
 }
 
-fn collect_manifest_section(
+fn collect_composer_manifest_section(
     manifest: &Value,
     section: &str,
     direct: &mut BTreeMap<String, (String, String)>,
@@ -562,6 +707,22 @@ fn collect_manifest_section(
         if name == "php" || name.starts_with("ext-") {
             continue;
         }
+        if let Some(constraint) = constraint.as_str() {
+            direct.insert(name.clone(), (section.to_string(), constraint.to_string()));
+        }
+    }
+}
+
+fn collect_manifest_section(
+    manifest: &Value,
+    section: &str,
+    direct: &mut BTreeMap<String, (String, String)>,
+) {
+    let Some(entries) = manifest.get(section).and_then(Value::as_object) else {
+        return;
+    };
+
+    for (name, constraint) in entries {
         if let Some(constraint) = constraint.as_str() {
             direct.insert(name.clone(), (section.to_string(), constraint.to_string()));
         }
@@ -602,6 +763,67 @@ fn collect_locked_packages(lock: &Value) -> BTreeMap<String, LockedPackage> {
     }
 
     packages
+}
+
+fn collect_npm_locked_packages(lock: &Value) -> BTreeMap<String, LockedPackage> {
+    let mut packages = BTreeMap::new();
+
+    if let Some(entries) = lock.get("packages").and_then(Value::as_object) {
+        for (path, entry) in entries {
+            let Some(name) = npm_lock_package_name(path, entry) else {
+                continue;
+            };
+            packages.insert(name, npm_locked_package(entry, entries));
+        }
+    }
+
+    if let Some(entries) = lock.get("dependencies").and_then(Value::as_object) {
+        for (name, entry) in entries {
+            packages
+                .entry(name.to_string())
+                .or_insert_with(|| npm_locked_package(entry, &serde_json::Map::new()));
+        }
+    }
+
+    packages
+}
+
+fn npm_lock_package_name(path: &str, entry: &Value) -> Option<String> {
+    if path.is_empty() {
+        return None;
+    }
+    entry
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            path.strip_prefix("node_modules/")
+                .or_else(|| {
+                    path.rsplit_once("/node_modules/")
+                        .map(|(_, package)| package)
+                })
+                .map(str::to_string)
+        })
+}
+
+fn npm_locked_package(entry: &Value, packages: &serde_json::Map<String, Value>) -> LockedPackage {
+    let resolved_entry = entry
+        .get("resolved")
+        .and_then(Value::as_str)
+        .and_then(|resolved| packages.get(resolved));
+
+    LockedPackage {
+        version: entry
+            .get("version")
+            .or_else(|| resolved_entry.and_then(|entry| entry.get("version")))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        reference: entry
+            .get("resolved")
+            .or_else(|| entry.get("integrity"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+    }
 }
 
 fn read_json_file(path: &Path) -> Result<Value> {

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1,1 +1,2 @@
 pub mod deps_provider;
+pub mod npm_deps_provider;

--- a/src/extensions/npm_deps_provider.rs
+++ b/src/extensions/npm_deps_provider.rs
@@ -1,5 +1,5 @@
 use crate::core::component::Component;
-use crate::core::deps::{DependencyPackage, DependencyUpdateResult};
+use crate::core::deps::{DependencyCommandResult, DependencyPackage, DependencyUpdateResult};
 use crate::core::{Error, Result};
 use crate::extensions::deps_provider::ProviderDependencyStatus;
 use serde_json::Value;
@@ -90,7 +90,17 @@ impl NpmDependencyProvider {
             after,
             stdout,
             stderr,
+            install: None,
+            rebuild: None,
         })
+    }
+
+    pub(crate) fn install(
+        &self,
+        _component: &Component,
+        _path: &Path,
+    ) -> Result<Option<DependencyCommandResult>> {
+        Ok(None)
     }
 }
 

--- a/src/extensions/npm_deps_provider.rs
+++ b/src/extensions/npm_deps_provider.rs
@@ -1,0 +1,254 @@
+use crate::core::component::Component;
+use crate::core::deps::{DependencyPackage, DependencyUpdateResult};
+use crate::core::{Error, Result};
+use crate::extensions::deps_provider::ProviderDependencyStatus;
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+pub fn npm_command_args(package: &str, constraint: Option<&str>) -> Vec<String> {
+    match constraint {
+        Some(constraint) => vec!["install".to_string(), format!("{package}@{constraint}")],
+        None => vec!["update".to_string(), package.to_string()],
+    }
+}
+
+pub(crate) struct NpmDependencyProvider;
+
+impl NpmDependencyProvider {
+    pub(crate) fn supports(path: &Path) -> bool {
+        path.join("package.json").is_file()
+    }
+
+    pub(crate) fn status(
+        &self,
+        path: &Path,
+        package_filter: Option<&str>,
+    ) -> Result<ProviderDependencyStatus> {
+        Ok(ProviderDependencyStatus {
+            package_manager: "npm".to_string(),
+            dependency_identities: npm_identities(path)?,
+            packages: read_npm_packages(path, package_filter)?,
+        })
+    }
+
+    pub(crate) fn manages_package(&self, path: &Path, package: &str) -> Result<bool> {
+        Ok(npm_package_snapshot(path, package)?.is_some())
+    }
+
+    pub(crate) fn update(
+        &self,
+        component: &Component,
+        path: &Path,
+        package: &str,
+        constraint: Option<&str>,
+    ) -> Result<DependencyUpdateResult> {
+        let before = npm_package_snapshot(path, package)?;
+        let args = npm_command_args(package, constraint);
+        let output = Command::new("npm")
+            .args(&args)
+            .current_dir(path)
+            .output()
+            .map_err(|e| {
+                Error::internal_io(e.to_string(), Some("run dependency provider".to_string()))
+            })?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        if !output.status.success() {
+            return Err(Error::validation_invalid_argument(
+                "dependency_provider",
+                format!(
+                    "Dependency provider command failed with status {}: {}",
+                    output.status,
+                    first_non_empty_line(&stderr)
+                        .or_else(|| first_non_empty_line(&stdout))
+                        .unwrap_or("no output")
+                ),
+                None,
+                Some(vec![format!(
+                    "Run manually in {}: npm {}",
+                    path.display(),
+                    args.join(" ")
+                )]),
+            ));
+        }
+
+        let after = npm_package_snapshot(path, package)?;
+
+        Ok(DependencyUpdateResult {
+            component_id: component.id.clone(),
+            component_path: path.display().to_string(),
+            package_manager: "npm".to_string(),
+            package: package.to_string(),
+            requested_constraint: constraint.map(str::to_string),
+            command: std::iter::once("npm".to_string()).chain(args).collect(),
+            before,
+            after,
+            stdout,
+            stderr,
+        })
+    }
+}
+
+fn npm_package_snapshot(path: &Path, package: &str) -> Result<Option<DependencyPackage>> {
+    Ok(read_npm_packages(path, Some(package))?.into_iter().next())
+}
+
+fn npm_identities(path: &Path) -> Result<Vec<String>> {
+    let manifest = read_json_file(&path.join("package.json"))?;
+    Ok(manifest
+        .get("name")
+        .and_then(Value::as_str)
+        .map(|name| vec![name.to_string()])
+        .unwrap_or_default())
+}
+
+fn read_npm_packages(path: &Path, package_filter: Option<&str>) -> Result<Vec<DependencyPackage>> {
+    let manifest = read_json_file(&path.join("package.json"))?;
+    let lock = read_optional_json_file(&path.join("package-lock.json"))?;
+    let mut direct = BTreeMap::new();
+
+    for section in [
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+        "peerDependencies",
+    ] {
+        collect_manifest_section(&manifest, section, &mut direct);
+    }
+
+    let locked = lock
+        .as_ref()
+        .map(collect_npm_locked_packages)
+        .unwrap_or_default();
+
+    let mut names: BTreeSet<String> = direct.keys().cloned().collect();
+    names.extend(locked.keys().cloned());
+
+    let packages = names
+        .into_iter()
+        .filter(|name| package_filter.map(|filter| filter == name).unwrap_or(true))
+        .map(|name| {
+            let (manifest_section, constraint) = direct
+                .get(&name)
+                .cloned()
+                .map(|(section, constraint)| (Some(section), Some(constraint)))
+                .unwrap_or((None, None));
+            let locked = locked.get(&name);
+            DependencyPackage {
+                name,
+                manifest_section,
+                constraint,
+                locked_version: locked.and_then(|p| p.version.clone()),
+                locked_reference: locked.and_then(|p| p.reference.clone()),
+            }
+        })
+        .collect();
+
+    Ok(packages)
+}
+
+fn collect_manifest_section(
+    manifest: &Value,
+    section: &str,
+    direct: &mut BTreeMap<String, (String, String)>,
+) {
+    let Some(entries) = manifest.get(section).and_then(Value::as_object) else {
+        return;
+    };
+
+    for (name, constraint) in entries {
+        if let Some(constraint) = constraint.as_str() {
+            direct.insert(name.clone(), (section.to_string(), constraint.to_string()));
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct LockedPackage {
+    version: Option<String>,
+    reference: Option<String>,
+}
+
+fn collect_npm_locked_packages(lock: &Value) -> BTreeMap<String, LockedPackage> {
+    let mut packages = BTreeMap::new();
+
+    if let Some(entries) = lock.get("packages").and_then(Value::as_object) {
+        for (path, entry) in entries {
+            let Some(name) = npm_lock_package_name(path, entry) else {
+                continue;
+            };
+            packages.insert(name, npm_locked_package(entry, entries));
+        }
+    }
+
+    if let Some(entries) = lock.get("dependencies").and_then(Value::as_object) {
+        for (name, entry) in entries {
+            packages
+                .entry(name.to_string())
+                .or_insert_with(|| npm_locked_package(entry, &serde_json::Map::new()));
+        }
+    }
+
+    packages
+}
+
+fn npm_lock_package_name(path: &str, entry: &Value) -> Option<String> {
+    if path.is_empty() {
+        return None;
+    }
+    entry
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            path.strip_prefix("node_modules/")
+                .or_else(|| {
+                    path.rsplit_once("/node_modules/")
+                        .map(|(_, package)| package)
+                })
+                .map(str::to_string)
+        })
+}
+
+fn npm_locked_package(entry: &Value, packages: &serde_json::Map<String, Value>) -> LockedPackage {
+    let resolved_entry = entry
+        .get("resolved")
+        .and_then(Value::as_str)
+        .and_then(|resolved| packages.get(resolved));
+
+    LockedPackage {
+        version: entry
+            .get("version")
+            .or_else(|| resolved_entry.and_then(|entry| entry.get("version")))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        reference: entry
+            .get("resolved")
+            .or_else(|| entry.get("integrity"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+    }
+}
+
+fn read_json_file(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))?;
+    serde_json::from_str(&raw)
+        .map_err(|e| Error::validation_invalid_json(e, Some(path.display().to_string()), Some(raw)))
+}
+
+fn read_optional_json_file(path: &Path) -> Result<Option<Value>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    read_json_file(path).map(Some)
+}
+
+fn first_non_empty_line(output: &str) -> Option<&str> {
+    output.lines().find(|line| !line.trim().is_empty())
+}

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -180,6 +180,7 @@ fn stack_plan_walks_declared_downstream_edges_in_order() {
                 downstream: "block-format-bridge".to_string(),
                 package: "chubes4/html-to-blocks-converter".to_string(),
                 update: None,
+                rebuild: false,
                 post_update: vec!["composer build".to_string()],
                 test: vec!["homeboy test --path . --extension wordpress".to_string()],
             }],
@@ -192,6 +193,7 @@ fn stack_plan_walks_declared_downstream_edges_in_order() {
                 downstream: "static-site-importer".to_string(),
                 package: "chubes4/block-format-bridge".to_string(),
                 update: Some("composer update chubes4/block-format-bridge".to_string()),
+                rebuild: false,
                 post_update: Vec::new(),
                 test: vec!["homeboy test --path . --extension wordpress".to_string()],
             }],
@@ -282,6 +284,7 @@ fn stack_plan_keeps_explicit_edge_config_when_provider_edge_matches() {
         downstream: "downstream".to_string(),
         package: "fixture/upstream".to_string(),
         update: Some("fixture-provider update fixture/upstream".to_string()),
+        rebuild: false,
         post_update: vec!["fixture-provider build".to_string()],
         test: vec!["fixture-provider test".to_string()],
     };

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -180,7 +180,6 @@ fn stack_plan_walks_declared_downstream_edges_in_order() {
                 downstream: "block-format-bridge".to_string(),
                 package: "chubes4/html-to-blocks-converter".to_string(),
                 update: None,
-                rebuild: false,
                 post_update: vec!["composer build".to_string()],
                 test: vec!["homeboy test --path . --extension wordpress".to_string()],
             }],
@@ -193,7 +192,6 @@ fn stack_plan_walks_declared_downstream_edges_in_order() {
                 downstream: "static-site-importer".to_string(),
                 package: "chubes4/block-format-bridge".to_string(),
                 update: Some("composer update chubes4/block-format-bridge".to_string()),
-                rebuild: false,
                 post_update: Vec::new(),
                 test: vec!["homeboy test --path . --extension wordpress".to_string()],
             }],
@@ -284,7 +282,6 @@ fn stack_plan_keeps_explicit_edge_config_when_provider_edge_matches() {
         downstream: "downstream".to_string(),
         package: "fixture/upstream".to_string(),
         update: Some("fixture-provider update fixture/upstream".to_string()),
-        rebuild: false,
         post_update: vec!["fixture-provider build".to_string()],
         test: vec!["fixture-provider test".to_string()],
     };

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -1,5 +1,6 @@
 use homeboy::core::component::{Component, ComponentScriptsConfig, DependencyStackEdge};
-use homeboy::core::deps::{self, ComposerAction, DependencyUpdateOptions};
+use homeboy::core::deps::{self, DependencyUpdateOptions};
+use homeboy::extensions::deps_provider::{self, ComposerAction};
 use std::fs;
 use tempfile::tempdir;
 
@@ -143,7 +144,7 @@ fn status_filters_to_one_package() {
 #[test]
 fn test_composer_command_args() {
     assert_eq!(
-        deps::composer_command_args(
+        deps_provider::composer_command_args(
             "fixture/package",
             &ComposerAction::Require {
                 constraint: "^2.0".to_string(),
@@ -158,7 +159,7 @@ fn test_composer_command_args() {
     );
 
     assert_eq!(
-        deps::composer_command_args("fixture/package", &ComposerAction::Update),
+        deps_provider::composer_command_args("fixture/package", &ComposerAction::Update),
         vec![
             "update",
             "fixture/package",
@@ -437,7 +438,13 @@ esac
 fn deps_orchestration_stays_package_manager_agnostic() {
     let source = fs::read_to_string("src/core/deps.rs").unwrap();
 
-    for forbidden in ["composer.json", "composer.lock", "Command::new", "npm", "Cargo"] {
+    for forbidden in [
+        "composer",
+        "composer.json",
+        "composer.lock",
+        "Command::new",
+        "Cargo",
+    ] {
         assert!(
             !source.contains(forbidden),
             "core deps orchestration must not contain package-manager literal {forbidden:?}"

--- a/tests/deps_npm_provider_test.rs
+++ b/tests/deps_npm_provider_test.rs
@@ -1,4 +1,4 @@
-use homeboy::core::deps;
+use homeboy::core::deps::{self, DependencyUpdateOptions};
 use homeboy::extensions::deps_provider;
 use std::fs;
 use tempfile::tempdir;
@@ -212,6 +212,10 @@ fn npm_update_with_constraint_changes_manifest_and_lock_for_local_path_package()
         Some(&root_path),
         "fixture-package",
         Some("file:../package-v2"),
+        DependencyUpdateOptions {
+            install: false,
+            rebuild: false,
+        },
     )
     .unwrap();
 

--- a/tests/deps_npm_provider_test.rs
+++ b/tests/deps_npm_provider_test.rs
@@ -1,0 +1,230 @@
+use homeboy::core::deps;
+use homeboy::extensions::deps_provider;
+use std::fs;
+use tempfile::tempdir;
+
+fn write_file(path: &std::path::Path, contents: &str) {
+    fs::write(path, contents).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+}
+
+#[test]
+fn status_reads_npm_direct_constraints_and_lock_details() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    let root_path = root.display().to_string();
+
+    write_file(
+        &root.join("package.json"),
+        r#"{
+            "name": "fixture-root",
+            "dependencies": {
+                "fixture-prod": "^1.0.0"
+            },
+            "devDependencies": {
+                "fixture-dev": "^2.0.0"
+            }
+        }"#,
+    );
+    write_file(
+        &root.join("package-lock.json"),
+        r#"{
+            "name": "fixture-root",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "dependencies": { "fixture-prod": "^1.0.0" },
+                    "devDependencies": { "fixture-dev": "^2.0.0" }
+                },
+                "node_modules/fixture-prod": {
+                    "version": "1.2.3",
+                    "resolved": "https://registry.npmjs.org/fixture-prod/-/fixture-prod-1.2.3.tgz"
+                },
+                "node_modules/fixture-transitive": {
+                    "version": "0.1.0",
+                    "integrity": "sha512-transitive"
+                },
+                "node_modules/fixture-dev": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/fixture-dev/-/fixture-dev-2.1.0.tgz"
+                }
+            }
+        }"#,
+    );
+
+    let status = deps::status(Some("fixture"), Some(&root_path), None).unwrap();
+
+    assert_eq!(status.component_id, "fixture");
+    assert_eq!(status.package_manager, "npm");
+    assert_eq!(status.packages.len(), 3);
+
+    let prod = status
+        .packages
+        .iter()
+        .find(|package| package.name == "fixture-prod")
+        .unwrap();
+    assert_eq!(prod.manifest_section.as_deref(), Some("dependencies"));
+    assert_eq!(prod.constraint.as_deref(), Some("^1.0.0"));
+    assert_eq!(prod.locked_version.as_deref(), Some("1.2.3"));
+    assert_eq!(
+        prod.locked_reference.as_deref(),
+        Some("https://registry.npmjs.org/fixture-prod/-/fixture-prod-1.2.3.tgz")
+    );
+
+    let dev = status
+        .packages
+        .iter()
+        .find(|package| package.name == "fixture-dev")
+        .unwrap();
+    assert_eq!(dev.manifest_section.as_deref(), Some("devDependencies"));
+    assert_eq!(dev.locked_version.as_deref(), Some("2.1.0"));
+
+    let transitive = status
+        .packages
+        .iter()
+        .find(|package| package.name == "fixture-transitive")
+        .unwrap();
+    assert_eq!(transitive.manifest_section, None);
+    assert_eq!(transitive.constraint, None);
+    assert_eq!(
+        transitive.locked_reference.as_deref(),
+        Some("sha512-transitive")
+    );
+}
+
+#[test]
+fn status_combines_composer_and_npm_providers_generically() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    let root_path = root.display().to_string();
+
+    write_file(
+        &root.join("composer.json"),
+        r#"{ "require": { "fixture/composer": "^1.0" } }"#,
+    );
+    write_file(
+        &root.join("package.json"),
+        r#"{ "dependencies": { "fixture-npm": "^2.0.0" } }"#,
+    );
+
+    let status = deps::status(Some("fixture"), Some(&root_path), None).unwrap();
+
+    assert_eq!(status.package_manager, "composer,npm");
+    assert!(status
+        .packages
+        .iter()
+        .any(|package| package.name == "fixture/composer"));
+    assert!(status
+        .packages
+        .iter()
+        .any(|package| package.name == "fixture-npm"));
+}
+
+#[test]
+fn test_npm_command_args() {
+    assert_eq!(
+        deps_provider::npm_command_args("fixture-package", Some("^2.0.0")),
+        vec!["install", "fixture-package@^2.0.0"]
+    );
+
+    assert_eq!(
+        deps_provider::npm_command_args("@fixture/package", Some("^2.0.0")),
+        vec!["install", "@fixture/package@^2.0.0"]
+    );
+
+    assert_eq!(
+        deps_provider::npm_command_args("fixture-package", None),
+        vec!["update", "fixture-package"]
+    );
+}
+
+#[test]
+fn core_deps_orchestration_stays_package_manager_agnostic() {
+    let source = fs::read_to_string("src/core/deps.rs").unwrap();
+
+    for forbidden in [
+        "composer",
+        "composer.json",
+        "composer.lock",
+        "package.json",
+        "package-lock.json",
+        "Command::new",
+        "npm",
+        "Cargo",
+    ] {
+        assert!(
+            !source.contains(forbidden),
+            "core deps orchestration must not contain package-manager literal {forbidden:?}"
+        );
+    }
+}
+
+#[test]
+fn npm_update_with_constraint_changes_manifest_and_lock_for_local_path_package() {
+    if std::process::Command::new("npm")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("npm not found; skipping integration-ish deps update test");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let root = dir.path().join("root");
+    let package_v1 = dir.path().join("package-v1");
+    let package_v2 = dir.path().join("package-v2");
+    fs::create_dir_all(&root).unwrap();
+    fs::create_dir_all(&package_v1).unwrap();
+    fs::create_dir_all(&package_v2).unwrap();
+
+    write_file(
+        &package_v1.join("package.json"),
+        r#"{ "name": "fixture-package", "version": "1.0.0" }"#,
+    );
+    write_file(
+        &package_v2.join("package.json"),
+        r#"{ "name": "fixture-package", "version": "1.1.0" }"#,
+    );
+    write_file(
+        &root.join("package.json"),
+        r#"{
+            "name": "fixture-root",
+            "version": "1.0.0",
+            "dependencies": { "fixture-package": "file:../package-v1" }
+        }"#,
+    );
+
+    let initial = std::process::Command::new("npm")
+        .args(["install", "--ignore-scripts"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    assert!(
+        initial.status.success(),
+        "initial npm install failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&initial.stdout),
+        String::from_utf8_lossy(&initial.stderr)
+    );
+
+    let root_path = root.display().to_string();
+    let result = deps::update(
+        Some("fixture"),
+        Some(&root_path),
+        "fixture-package",
+        Some("file:../package-v2"),
+    )
+    .unwrap();
+
+    assert_eq!(result.package_manager, "npm");
+    assert_eq!(
+        result.before.unwrap().locked_version.as_deref(),
+        Some("1.0.0")
+    );
+    let after = result.after.unwrap();
+    assert_eq!(after.constraint.as_deref(), Some("file:../package-v2"));
+    assert_eq!(after.locked_version.as_deref(), Some("1.1.0"));
+    assert_eq!(
+        result.command,
+        vec!["npm", "install", "fixture-package@file:../package-v2"]
+    );
+}


### PR DESCRIPTION
## Summary
- Adds an npm dependency provider for `homeboy deps status` and `homeboy deps update` while keeping package-manager behavior outside core orchestration.
- Preserves Composer provider behavior and reports multi-provider components generically as combined provider status.
- Covers npm status, npm lock parsing, scoped package command args, npm manifest/lock updates, combined provider status, and core agnosticism.

Fixes #3080.

## Testing
- `cargo fmt --check`
- `cargo test --test deps_test`
- `cargo test --test deps_npm_provider_test`
- `cargo test --test core_agnostic_test`
- `cargo test --test architecture_core_agnostic_test`
- `./target/debug/homeboy audit --path . --extension rust --changed-since origin/main --ignore-baseline --json-summary`

## Follow-ups
- #3078 still needs dependency stack edge declaration/derivation so `deps stack status/plan/apply` can discover downstream consumers.
- #3079 still needs provider-owned install/reinstall semantics to be paired with optional rebuild behavior for asset-bundling consumers.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the npm dependency provider, tests, and PR preparation; Chris remains responsible for review and merge.