### PR TITLE
Normalize runs finding outputs

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -567,8 +567,8 @@ mod tests {
     use std::path::Path;
 
     use homeboy::core::observation::{
-        FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord, NewTraceSpanRecord,
-        RunRecord, RunStatus, TraceSpanRecord,
+        FindingListFilter, NewFindingRecord, NewRunRecord, NewTraceSpanRecord,
+        RecordedHomeboyFinding, RunRecord, RunStatus, TraceSpanRecord,
     };
     use homeboy::test_support::with_isolated_home;
     use serde::Deserialize;
@@ -870,14 +870,14 @@ mod tests {
             };
             assert_eq!(output.findings.len(), 1);
             assert_eq!(output.findings[0].id, recorded.id);
-            assert_eq!(output.findings[0].message, "Missing escaping");
+            assert_eq!(output.findings[0].finding.message, "Missing escaping");
 
             let (output, _) = findings::finding(&recorded.id).expect("show finding");
             let RunsOutput::Finding(output) = output else {
                 panic!("expected finding output");
             };
-            assert_eq!(output.finding.metadata_json["category"], "security");
-            assert_eq!(output.finding.fixable, Some(true));
+            assert_eq!(output.finding.finding.category.as_deref(), Some("security"));
+            assert_eq!(output.finding.finding.fix.fixable, Some(true));
         });
     }
 
@@ -971,7 +971,7 @@ mod tests {
             assert_eq!(output.command, "runs.latest-finding");
             assert_eq!(output.run.id, latest_run.id);
             assert_eq!(output.finding.id, latest_finding.id);
-            assert_eq!(output.finding.message, "Latest finding");
+            assert_eq!(output.finding.finding.message, "Latest finding");
         });
     }
 
@@ -1194,11 +1194,12 @@ mod tests {
             };
             assert_eq!(result.finding_count, 2);
             assert_eq!(result.test_failure_count, 1);
-            let findings: Vec<FindingRecord> = read_bundle_test_json(&output.join("findings.json"));
-            let test_failures: Vec<FindingRecord> =
+            let findings: Vec<RecordedHomeboyFinding> =
+                read_bundle_test_json(&output.join("findings.json"));
+            let test_failures: Vec<RecordedHomeboyFinding> =
                 read_bundle_test_json(&output.join("test_failures.json"));
-            assert_eq!(findings, vec![lint, failure.clone()]);
-            assert_eq!(test_failures, vec![failure]);
+            assert_eq!(findings, vec![lint.into(), failure.clone().into()]);
+            assert_eq!(test_failures, vec![failure.into()]);
         });
     }
 

--- a/src/commands/runs/bundle.rs
+++ b/src/commands/runs/bundle.rs
@@ -5,7 +5,8 @@ use clap::Args;
 use serde::{Deserialize, Serialize};
 
 use homeboy::core::observation::{
-    ArtifactRecord, FindingRecord, ObservationStore, RunRecord, TraceSpanRecord,
+    ArtifactRecord, FindingRecord, ObservationStore, RecordedHomeboyFinding, RunRecord,
+    TraceSpanRecord,
 };
 use homeboy::core::runner::is_reportable_artifact_evidence_path;
 use homeboy::core::Error;
@@ -83,8 +84,8 @@ struct ObservationBundle {
     runs: Vec<RunRecord>,
     artifacts: Vec<ArtifactRecord>,
     trace_spans: Vec<TraceSpanRecord>,
-    findings: Vec<FindingRecord>,
-    test_failures: Vec<FindingRecord>,
+    findings: Vec<RecordedHomeboyFinding>,
+    test_failures: Vec<RecordedHomeboyFinding>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -190,7 +191,7 @@ pub(super) fn import_runs(args: RunsImportArgs) -> CmdResult<RunsOutput> {
         store.import_trace_span(span)?;
     }
     for finding in bundle.findings.iter().chain(bundle.test_failures.iter()) {
-        store.import_finding(finding)?;
+        store.import_finding(&FindingRecord::from(finding.clone()))?;
     }
 
     Ok((
@@ -265,7 +266,12 @@ fn build_bundle(
                 .map(portable_bundle_artifact_record),
         );
         trace_spans.extend(store.list_trace_spans(&run.id)?);
-        findings.extend(store.list_findings_for_run(&run.id)?);
+        findings.extend(
+            store
+                .list_findings_for_run(&run.id)?
+                .into_iter()
+                .map(RecordedHomeboyFinding::from),
+        );
     }
     let test_failures = findings
         .iter()
@@ -366,8 +372,9 @@ fn read_bundle_dir(path: &Path) -> homeboy::core::Result<ObservationBundle> {
     let runs: Vec<RunRecord> = read_json(path.join("runs.json"))?;
     let artifacts: Vec<ArtifactRecord> = read_json(path.join("artifacts.json"))?;
     let trace_spans: Vec<TraceSpanRecord> = read_json(path.join("trace_spans.json"))?;
-    let mut findings: Vec<FindingRecord> = read_optional_json(path.join("findings.json"))?;
-    let test_failures: Vec<FindingRecord> = read_optional_json(path.join("test_failures.json"))?;
+    let mut findings: Vec<RecordedHomeboyFinding> = read_optional_json(path.join("findings.json"))?;
+    let test_failures: Vec<RecordedHomeboyFinding> =
+        read_optional_json(path.join("test_failures.json"))?;
     for test_failure in &test_failures {
         if !findings.iter().any(|finding| finding.id == test_failure.id) {
             findings.push(test_failure.clone());
@@ -396,15 +403,14 @@ fn read_bundle_dir(path: &Path) -> homeboy::core::Result<ObservationBundle> {
     })
 }
 
-fn is_test_failure_finding(finding: &FindingRecord) -> bool {
-    finding.tool == "test"
-        && (finding
-            .metadata_json
+fn is_test_failure_finding(finding: &RecordedHomeboyFinding) -> bool {
+    let metadata_json = finding.finding.metadata_json();
+    finding.finding.tool == "test"
+        && (metadata_json
             .get("record_kind")
             .and_then(|value| value.as_str())
             == Some("failure")
-            || finding
-                .metadata_json
+            || metadata_json
                 .get("source_sidecar")
                 .and_then(|value| value.as_str())
                 == Some("test-failures"))

--- a/src/commands/runs/findings.rs
+++ b/src/commands/runs/findings.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use serde::Serialize;
 
-use homeboy::core::observation::{FindingListFilter, FindingRecord, ObservationStore};
+use homeboy::core::observation::{FindingListFilter, ObservationStore, RecordedHomeboyFinding};
 use homeboy::core::Error;
 
 use crate::commands::{
@@ -56,25 +56,29 @@ pub struct RunsLatestFindingArgs {
 pub struct RunsFindingsOutput {
     pub command: &'static str,
     pub run_id: String,
-    pub findings: Vec<FindingRecord>,
+    pub findings: Vec<RecordedHomeboyFinding>,
 }
 
 #[derive(Serialize)]
 pub struct RunsFindingOutput {
     pub command: &'static str,
-    pub finding: FindingRecord,
+    pub finding: RecordedHomeboyFinding,
 }
 
 pub fn findings(args: RunsFindingsArgs) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
     require_run(&store, &args.run_id)?;
-    let findings = store.list_findings(FindingListFilter {
-        run_id: Some(args.run_id.clone()),
-        tool: args.tool,
-        file: args.file,
-        fingerprint: args.fingerprint,
-        limit: Some(args.limit),
-    })?;
+    let findings = store
+        .list_findings(FindingListFilter {
+            run_id: Some(args.run_id.clone()),
+            tool: args.tool,
+            file: args.file,
+            fingerprint: args.fingerprint,
+            limit: Some(args.limit),
+        })?
+        .into_iter()
+        .map(RecordedHomeboyFinding::from)
+        .collect();
 
     Ok((
         RunsOutput::Findings(RunsFindingsOutput {
@@ -100,7 +104,7 @@ pub fn finding(finding_id: &str) -> CmdResult<RunsOutput> {
     Ok((
         RunsOutput::Finding(RunsFindingOutput {
             command: "runs.finding",
-            finding,
+            finding: RecordedHomeboyFinding::from(finding),
         }),
         0,
     ))
@@ -137,7 +141,7 @@ pub fn latest_finding(args: RunsLatestFindingArgs) -> CmdResult<RunsOutput> {
         RunsOutput::LatestFinding(RunsLatestFindingOutput {
             command: "runs.latest-finding",
             run: run_summary(run),
-            finding,
+            finding: RecordedHomeboyFinding::from(finding),
         }),
         0,
     ))

--- a/src/commands/runs/latest.rs
+++ b/src/commands/runs/latest.rs
@@ -1,7 +1,9 @@
 use clap::Args;
 use serde::Serialize;
 
-use homeboy::core::observation::{FindingRecord, ObservationStore, RunListFilter, RunRecord};
+use homeboy::core::observation::{
+    ObservationStore, RecordedHomeboyFinding, RunListFilter, RunRecord,
+};
 use homeboy::core::Error;
 
 use crate::commands::{
@@ -35,7 +37,7 @@ pub struct RunsLatestRunOutput {
 pub struct RunsLatestFindingOutput {
     pub command: &'static str,
     pub run: RunSummary,
-    pub finding: FindingRecord,
+    pub finding: RecordedHomeboyFinding,
 }
 
 pub fn latest_run(args: RunsLatestRunArgs) -> CmdResult<RunsOutput> {

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -22,8 +22,8 @@ pub use records::{
     ArtifactCleanupCandidateRecord, ArtifactCleanupFilter, ArtifactRecord, FindingListFilter,
     FindingRecord, NewFindingRecord, NewRunRecord, NewRunRecordBuilder, NewTraceRunRecord,
     NewTraceRunRecordBuilder, NewTraceSpanRecord, NewTraceSpanRecordBuilder, NewTriageItemRecord,
-    RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord,
-    TriagePullRequestSignals,
+    RecordedHomeboyFinding, RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord,
+    TriageItemRecord, TriagePullRequestSignals,
 };
 pub use store::{
     ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION, LAB_OFFLOAD_METADATA_ENV,

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 use std::{collections::BTreeMap, path::Path};
 
 use crate::core::code_audit::{self, report::finding_kind_key};
-use crate::core::finding::{FindingSource, HomeboyFinding};
+use crate::core::finding::{FindingProducer, FindingSource, HomeboyFinding};
 
 mod run_builder;
 mod run_status;
@@ -146,6 +146,98 @@ pub struct FindingRecord {
     pub fixable: Option<bool>,
     pub metadata_json: serde_json::Value,
     pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RecordedHomeboyFinding {
+    pub id: String,
+    pub run_id: String,
+    #[serde(flatten)]
+    pub finding: HomeboyFinding,
+    pub created_at: String,
+}
+
+impl From<FindingRecord> for RecordedHomeboyFinding {
+    fn from(record: FindingRecord) -> Self {
+        let mut metadata = record
+            .metadata_json
+            .as_object()
+            .cloned()
+            .unwrap_or_default();
+        let category = take_optional_string(&mut metadata, "category");
+        let column = take_optional_i64(&mut metadata, "column");
+        let producer = take_optional_json::<FindingProducer>(&mut metadata, "producer");
+        let source = take_optional_json::<FindingSource>(&mut metadata, "source");
+        let raw = metadata.remove("raw");
+        let finding = HomeboyFinding {
+            tool: record.tool,
+            rule: record.rule,
+            category,
+            severity: record.severity,
+            location: crate::core::finding::FindingLocation {
+                file: record.file,
+                line: record.line,
+                column,
+            },
+            message: record.message,
+            fingerprint: record.fingerprint,
+            fix: crate::core::finding::FindingFix {
+                fixable: record.fixable,
+            },
+            producer,
+            source,
+            metadata,
+            raw,
+        };
+        Self {
+            id: record.id,
+            run_id: record.run_id,
+            finding,
+            created_at: record.created_at,
+        }
+    }
+}
+
+impl From<RecordedHomeboyFinding> for FindingRecord {
+    fn from(recorded: RecordedHomeboyFinding) -> Self {
+        let metadata_json = recorded.finding.metadata_json();
+        Self {
+            id: recorded.id,
+            run_id: recorded.run_id,
+            tool: recorded.finding.tool,
+            rule: recorded.finding.rule,
+            file: recorded.finding.location.file,
+            line: recorded.finding.location.line,
+            severity: recorded.finding.severity,
+            fingerprint: recorded.finding.fingerprint,
+            message: recorded.finding.message,
+            fixable: recorded.finding.fix.fixable,
+            metadata_json,
+            created_at: recorded.created_at,
+        }
+    }
+}
+
+fn take_optional_string(
+    metadata: &mut serde_json::Map<String, Value>,
+    key: &str,
+) -> Option<String> {
+    metadata
+        .remove(key)
+        .and_then(|value| value.as_str().map(str::to_string))
+}
+
+fn take_optional_i64(metadata: &mut serde_json::Map<String, Value>, key: &str) -> Option<i64> {
+    metadata.remove(key).and_then(|value| value.as_i64())
+}
+
+fn take_optional_json<T: for<'de> Deserialize<'de>>(
+    metadata: &mut serde_json::Map<String, Value>,
+    key: &str,
+) -> Option<T> {
+    metadata
+        .remove(key)
+        .and_then(|value| serde_json::from_value(value).ok())
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -598,6 +690,37 @@ mod tests {
         assert_eq!(record.severity.as_deref(), Some("notice"));
         assert_eq!(record.fingerprint.as_deref(), Some("custom-id"));
         assert_eq!(record.fixable, Some(false));
+    }
+
+    #[test]
+    fn recorded_homeboy_finding_projects_normalized_shape() {
+        let record = FindingRecord {
+            id: "finding-1".to_string(),
+            run_id: "run-1".to_string(),
+            tool: "phpcs".to_string(),
+            rule: Some("WordPress.Security".to_string()),
+            file: Some("src/lib.php".to_string()),
+            line: Some(12),
+            severity: Some("warning".to_string()),
+            fingerprint: Some("src/lib.php:12:WordPress.Security".to_string()),
+            message: "escape output".to_string(),
+            fixable: Some(true),
+            metadata_json: serde_json::json!({
+                "category": "security",
+                "column": 4,
+                "source_sidecar": "lint-findings",
+                "source": { "kind": "sidecar", "path": "lint-findings.json" }
+            }),
+            created_at: "2026-05-30T16:00:00Z".to_string(),
+        };
+
+        let recorded = RecordedHomeboyFinding::from(record.clone());
+
+        assert_eq!(recorded.id, "finding-1");
+        assert_eq!(recorded.finding.category.as_deref(), Some("security"));
+        assert_eq!(recorded.finding.location.column, Some(4));
+        assert_eq!(recorded.finding.metadata["source_sidecar"], "lint-findings");
+        assert_eq!(FindingRecord::from(recorded), record);
     }
 
     fn lint_finding(id: &str, category: &str, tool: Option<&str>) -> HomeboyFinding {


### PR DESCRIPTION
## Summary
- Adds `RecordedHomeboyFinding` as the normalized reporting/export projection for persisted findings.
- Switches `runs.findings`, `runs.finding`, `runs.latest-finding`, and observation bundle finding exports to emit the normalized Homeboy finding shape.
- Preserves bundle import/storage by converting normalized exported findings back to `FindingRecord` before persistence.

Closes #3074.

## Testing
- `cargo fmt`
- `cargo test finding`
- `cargo test export`
- `homeboy audit homeboy --path /Users/chubes/Developer/homeboy@issue-3074-normalized-reporting --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the normalized finding projection, updated command/export surfaces, and ran focused verification. Chris remains responsible for review and acceptance.