### PR TITLE
Add generic execution contracts

### DIFF
--- a/src/core/execution.rs
+++ b/src/core/execution.rs
@@ -1,0 +1,360 @@
+//! Generic execution, change artifact, and apply contracts.
+//!
+//! `HomeboyPlan` remains the planning substrate: it describes what can run and
+//! why. These contracts describe what was requested, what ran, which proposed
+//! change artifacts were produced, and how those artifacts were applied.
+//! Domain commands and extensions should project their existing output into
+//! these ecosystem-agnostic shapes when they need a shared execution boundary.
+//!
+//! Publishing is intentionally left as a follow-up seam. The first shared layer
+//! models request/run/artifact/apply because those are the common contracts that
+//! runner, refactor, release, and extension workflows already overlap on.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::core::plan::{HomeboyPlan, PlanSubject};
+
+/// Normalized execution intent shared by CLI flags and extension adapters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionMode {
+    /// Build or inspect a plan without executing its steps.
+    Plan,
+    /// Run enough to preview effects without writing durable changes.
+    DryRun,
+    /// Execute and capture a proposed change artifact for review/approval.
+    CapturePatch,
+    /// Apply an approved or otherwise permitted change artifact.
+    Apply,
+    /// Execute the requested workflow directly.
+    Execute,
+}
+
+impl ExecutionMode {
+    /// Normalize common CLI spellings into the shared mode names.
+    pub(crate) fn from_cli_value(value: &str) -> Option<Self> {
+        match value {
+            "plan" | "preview" => Some(Self::Plan),
+            "dry-run" | "dry_run" => Some(Self::DryRun),
+            "capture-patch" | "capture_patch" => Some(Self::CapturePatch),
+            "apply" | "write" => Some(Self::Apply),
+            "execute" | "run" => Some(Self::Execute),
+            _ => None,
+        }
+    }
+}
+
+impl std::str::FromStr for ExecutionMode {
+    type Err = String;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        Self::from_cli_value(value).ok_or_else(|| format!("unknown execution mode: {value}"))
+    }
+}
+
+/// High-level request to execute a plan or command-shaped workflow.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionRequest {
+    pub id: String,
+    pub mode: ExecutionMode,
+    pub subject: PlanSubject,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan: Option<HomeboyPlan>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval_scope: Option<ApprovalScope>,
+    #[serde(flatten)]
+    pub controls: ExecutionControls,
+}
+
+/// Shared arbitrary input/policy payload for execution and apply requests.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionControls {
+    #[serde(default, rename = "inputs", skip_serializing_if = "HashMap::is_empty")]
+    pub execution_inputs: HashMap<String, serde_json::Value>,
+    #[serde(default, rename = "policy", skip_serializing_if = "HashMap::is_empty")]
+    pub execution_policy: HashMap<String, serde_json::Value>,
+}
+
+/// Result of executing a request.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionRun {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    pub mode: ExecutionMode,
+    pub subject: PlanSubject,
+    pub status: ExecutionStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub steps: Vec<ExecutionStepResult>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<ChangeArtifact>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+/// Shared lifecycle status for execution runs, steps, and apply results.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionStatus {
+    Pending,
+    Running,
+    AwaitingApproval,
+    ArtifactProduced,
+    Approved,
+    Applied,
+    Published,
+    Success,
+    PartialSuccess,
+    Skipped,
+    Missing,
+    Failed,
+}
+
+/// Result for one executed step.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionStepResult {
+    pub id: String,
+    pub kind: String,
+    pub status: ExecutionStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// A proposed or captured change that can be approved and applied later.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChangeArtifact {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub artifact_type: String,
+    pub provenance: ChangeArtifactProvenance,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diff: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval_scope: Option<ApprovalScope>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+/// Where a change artifact came from.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangeArtifactProvenance {
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub step_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub captured_at: Option<String>,
+}
+
+/// Approval boundary for a request or produced artifact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "scope")]
+pub enum ApprovalScope {
+    Step { step_id: String },
+    Artifact { artifact_id: String },
+    Run { run_id: String },
+    External { id: String },
+}
+
+/// Request to apply a captured change artifact.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApplyRequest {
+    pub id: String,
+    pub artifact: ChangeArtifact,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval_scope: Option<ApprovalScope>,
+    #[serde(flatten)]
+    pub controls: ExecutionControls,
+}
+
+/// Result of applying a captured change artifact.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApplyResult {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    pub status: ExecutionStatus,
+    pub applied: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files_changed: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<ChangeArtifact>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::plan::{HomeboyPlan, PlanKind};
+    use crate::core::release::{
+        ReleaseRun, ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus,
+    };
+
+    #[test]
+    fn execution_mode_normalizes_cli_spellings() {
+        assert_eq!(
+            ExecutionMode::from_cli_value("dry-run"),
+            Some(ExecutionMode::DryRun)
+        );
+        assert_eq!(
+            ExecutionMode::from_cli_value("write"),
+            Some(ExecutionMode::Apply)
+        );
+        assert_eq!(
+            ExecutionMode::from_cli_value("execute"),
+            Some(ExecutionMode::Execute)
+        );
+        assert_eq!(ExecutionMode::from_cli_value("unknown"), None);
+    }
+
+    #[test]
+    fn request_round_trips_with_plan() {
+        let plan = HomeboyPlan::for_component(PlanKind::Refactor, "homeboy");
+        let request = ExecutionRequest {
+            id: "exec-1".to_string(),
+            mode: ExecutionMode::CapturePatch,
+            subject: plan.subject.clone(),
+            plan: Some(plan),
+            approval_scope: Some(ApprovalScope::Run {
+                run_id: "run-1".to_string(),
+            }),
+            controls: ExecutionControls::default(),
+        };
+
+        let json = serde_json::to_string(&request).expect("serialize request");
+        let parsed: ExecutionRequest = serde_json::from_str(&json).expect("parse request");
+
+        assert_eq!(parsed.mode, ExecutionMode::CapturePatch);
+        assert_eq!(parsed.subject.component_id.as_deref(), Some("homeboy"));
+        assert!(matches!(
+            parsed.approval_scope,
+            Some(ApprovalScope::Run { .. })
+        ));
+    }
+
+    #[test]
+    fn change_artifact_round_trips_with_provenance() {
+        let artifact = ChangeArtifact {
+            id: "patch-1".to_string(),
+            artifact_type: "patch".to_string(),
+            provenance: ChangeArtifactProvenance {
+                source: "refactor".to_string(),
+                run_id: Some("run-1".to_string()),
+                step_id: Some("collect".to_string()),
+                command: Some("homeboy refactor --dry-run".to_string()),
+                captured_at: Some("2026-05-30T00:00:00Z".to_string()),
+            },
+            title: Some("Refactor preview".to_string()),
+            summary: Some("One file would change".to_string()),
+            path: Some("artifacts/refactor.patch".to_string()),
+            files: vec!["src/lib.rs".to_string()],
+            diff: None,
+            approval_scope: Some(ApprovalScope::Artifact {
+                artifact_id: "patch-1".to_string(),
+            }),
+            metadata: HashMap::new(),
+        };
+
+        let value = serde_json::to_value(&artifact).expect("serialize artifact");
+
+        assert_eq!(value["type"], "patch");
+        assert_eq!(value["provenance"]["source"], "refactor");
+        assert_eq!(value["approval_scope"]["scope"], "artifact");
+        let parsed: ChangeArtifact = serde_json::from_value(value).expect("parse artifact");
+        assert_eq!(parsed.files, vec!["src/lib.rs"]);
+    }
+
+    #[test]
+    fn apply_result_round_trips() {
+        let result = ApplyResult {
+            id: "apply-1".to_string(),
+            request_id: Some("request-1".to_string()),
+            status: ExecutionStatus::Applied,
+            applied: true,
+            files_changed: vec!["src/lib.rs".to_string()],
+            artifacts: Vec::new(),
+            warnings: Vec::new(),
+            error: None,
+            metadata: HashMap::new(),
+        };
+
+        let json = serde_json::to_string(&result).expect("serialize apply result");
+        let parsed: ApplyResult = serde_json::from_str(&json).expect("parse apply result");
+
+        assert!(parsed.applied);
+        assert_eq!(parsed.status, ExecutionStatus::Applied);
+        assert_eq!(parsed.files_changed, vec!["src/lib.rs"]);
+    }
+
+    #[test]
+    fn release_run_projects_into_execution_run() {
+        let release = ReleaseRun {
+            component_id: "homeboy".to_string(),
+            enabled: true,
+            result: ReleaseRunResult {
+                steps: vec![ReleaseStepResult {
+                    id: "package".to_string(),
+                    step_type: "release.package".to_string(),
+                    status: ReleaseStepStatus::Success,
+                    missing: Vec::new(),
+                    warnings: Vec::new(),
+                    hints: Vec::new(),
+                    data: Some(serde_json::json!([
+                        {
+                            "path": "artifacts/homeboy.tar.gz",
+                            "artifact_type": "archive",
+                            "platform": "darwin"
+                        }
+                    ])),
+                    error: None,
+                }],
+                status: ReleaseStepStatus::Success,
+                warnings: vec!["signed artifact missing".to_string()],
+                summary: None,
+            },
+        };
+
+        let execution = ExecutionRun::from(&release);
+
+        assert_eq!(execution.id, "release.homeboy");
+        assert_eq!(execution.mode, ExecutionMode::Execute);
+        assert_eq!(execution.status, ExecutionStatus::Success);
+        assert_eq!(execution.steps[0].status, ExecutionStatus::Success);
+        assert_eq!(execution.steps[0].artifacts, vec!["package.artifact.1"]);
+        assert_eq!(execution.artifacts.len(), 1);
+        assert_eq!(execution.artifacts[0].artifact_type, "archive");
+        assert_eq!(
+            execution.artifacts[0].path.as_deref(),
+            Some("artifacts/homeboy.tar.gz")
+        );
+        assert_eq!(execution.artifacts[0].provenance.source, "release");
+        assert_eq!(execution.warnings, vec!["signed artifact missing"]);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -13,6 +13,7 @@ pub mod deploy;
 pub mod deps;
 pub mod engine;
 pub mod error;
+pub mod execution;
 pub(crate) mod expand;
 pub mod extension;
 pub mod finding;

--- a/src/core/release/execution_projection.rs
+++ b/src/core/release/execution_projection.rs
@@ -1,0 +1,130 @@
+use std::collections::HashMap;
+
+use crate::core::execution::{
+    ChangeArtifact, ChangeArtifactProvenance, ExecutionMode, ExecutionRun, ExecutionStatus,
+    ExecutionStepResult,
+};
+use crate::core::plan::PlanSubject;
+
+use super::types::{ReleaseArtifact, ReleaseRun, ReleaseStepResult, ReleaseStepStatus};
+
+impl From<&ReleaseRun> for ExecutionRun {
+    fn from(run: &ReleaseRun) -> Self {
+        let run_id = format!("release.{}", run.component_id);
+
+        Self {
+            id: run_id.clone(),
+            request_id: None,
+            mode: ExecutionMode::Execute,
+            subject: PlanSubject {
+                component_id: Some(run.component_id.clone()),
+                ..PlanSubject::default()
+            },
+            status: release_status_to_execution_status(&run.result.status),
+            steps: run
+                .result
+                .steps
+                .iter()
+                .map(ExecutionStepResult::from)
+                .collect(),
+            artifacts: release_artifacts_from_run(&run_id, &run.result.steps),
+            warnings: run.result.warnings.clone(),
+            metadata: HashMap::from([("enabled".to_string(), serde_json::json!(run.enabled))]),
+        }
+    }
+}
+
+impl From<&ReleaseStepResult> for ExecutionStepResult {
+    fn from(step: &ReleaseStepResult) -> Self {
+        Self {
+            id: step.id.clone(),
+            kind: step.step_type.clone(),
+            status: release_status_to_execution_status(&step.status),
+            summary: None,
+            artifacts: release_artifact_ids(&step.id, step.data.as_ref()),
+            warnings: step.warnings.clone(),
+            data: step.data.clone(),
+            error: step.error.clone(),
+        }
+    }
+}
+
+fn release_status_to_execution_status(status: &ReleaseStepStatus) -> ExecutionStatus {
+    match status {
+        ReleaseStepStatus::Success => ExecutionStatus::Success,
+        ReleaseStepStatus::PartialSuccess => ExecutionStatus::PartialSuccess,
+        ReleaseStepStatus::Failed => ExecutionStatus::Failed,
+        ReleaseStepStatus::Skipped => ExecutionStatus::Skipped,
+        ReleaseStepStatus::Missing => ExecutionStatus::Missing,
+    }
+}
+
+fn release_artifacts_from_run(run_id: &str, steps: &[ReleaseStepResult]) -> Vec<ChangeArtifact> {
+    steps
+        .iter()
+        .flat_map(|step| release_artifacts_from_step(run_id, step))
+        .collect()
+}
+
+fn release_artifacts_from_step(run_id: &str, step: &ReleaseStepResult) -> Vec<ChangeArtifact> {
+    let Some(data) = step.data.as_ref() else {
+        return Vec::new();
+    };
+
+    let Ok(artifacts) = serde_json::from_value::<Vec<ReleaseArtifact>>(data.clone()) else {
+        return Vec::new();
+    };
+
+    artifacts
+        .into_iter()
+        .enumerate()
+        .map(|(index, artifact)| {
+            let ReleaseArtifact {
+                path: release_artifact_path,
+                artifact_type,
+                platform,
+            } = artifact;
+            let id = format!("{}.artifact.{}", step.id, index + 1);
+            let artifact_type = artifact_type.unwrap_or_else(|| "release_artifact".to_string());
+            let mut metadata = HashMap::new();
+            if let Some(platform) = platform {
+                metadata.insert("platform".to_string(), serde_json::Value::String(platform));
+            }
+
+            ChangeArtifact {
+                id,
+                artifact_type,
+                provenance: ChangeArtifactProvenance {
+                    source: "release".to_string(),
+                    run_id: Some(run_id.to_string()),
+                    step_id: Some(step.id.clone()),
+                    command: None,
+                    captured_at: None,
+                },
+                title: None,
+                summary: None,
+                path: Some(release_artifact_path),
+                files: Vec::new(),
+                diff: None,
+                approval_scope: None,
+                metadata,
+            }
+        })
+        .collect()
+}
+
+fn release_artifact_ids(step_id: &str, data: Option<&serde_json::Value>) -> Vec<String> {
+    let Some(data) = data else {
+        return Vec::new();
+    };
+
+    let Ok(artifacts) = serde_json::from_value::<Vec<ReleaseArtifact>>(data.clone()) else {
+        return Vec::new();
+    };
+
+    artifacts
+        .iter()
+        .enumerate()
+        .map(|(index, _)| format!("{}.artifact.{}", step_id, index + 1))
+        .collect()
+}

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -3,6 +3,7 @@ mod context;
 mod deployment;
 mod execution_dispatch;
 mod execution_plan;
+mod execution_projection;
 mod executor;
 mod orchestrator;
 mod pipeline;


### PR DESCRIPTION
## Summary
- Adds a generic `core::execution` contract layer for execution requests/runs, change artifacts, approvals, and apply results.
- Keeps `HomeboyPlan` as the planning substrate while giving runner/refactor/release/extension flows a shared execution boundary.
- Projects release run output into the new execution run/artifact shape without adding ecosystem-specific semantics.

Fixes #3089.

## Verification
- `cargo fmt`
- `cargo test core::execution`
- `cargo test release_run_projects_into_execution_run`
- `cargo test --lib -- --test-threads=1`
- `homeboy lint --path . --extension rust` passed with existing clippy warnings.
- `homeboy audit --path . --extension rust` reports existing baseline findings outside the new execution contract files.

## Follow-up
- `homeboy-extensions#883` can migrate to these contracts separately once this core seam lands.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the generic execution contract implementation and release projection adapter; Chris remains responsible for review and merge decisions.