### PR TITLE
Refresh stale Homeboy architecture docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,7 +133,7 @@ the higher-level system model and core/extension boundary, see
 
 ### `RuntimeConfig`
 
-- `runtime_type` — Desktop app runtime type (python/shell/cli). CLI ignores this field.
+- `runtime_type` — Legacy UI/runtime hint (python/shell/cli). CLI ignores this field.
 - `run_command` — Shell command to execute when running the extension. Template variables: {{entrypoint}}, {{args}}, {{extensionPath}}, plus project context vars.
 - `setup_command` — Shell command to set up the extension (e.g., create venv, install deps).
 - `ready_check` — Shell command to check if extension is ready. Exit 0 = ready.
@@ -141,8 +141,8 @@ the higher-level system model and core/extension boundary, see
 - `entrypoint` — Entry point file (used in template substitution).
 - `args` — Default args template (used in template substitution).
 - `default_site` — Default site for this extension (used by some CLI extensions).
-- `dependencies` — Desktop app: Python dependencies to install.
-- `playwright_browsers` — Desktop app: Playwright browsers to install.
+- `dependencies` — Legacy UI/runtime hint for Python dependencies to install.
+- `playwright_browsers` — Legacy UI/runtime hint for Playwright browsers to install.
 
 ### `InputConfig`
 
@@ -172,7 +172,7 @@ the higher-level system model and core/extension boundary, see
 - `requires_auth`
 - `payload`
 - `command`
-- `builtin` — Builtin action type (Desktop app only). CLI parses but does not execute.
+- `builtin` — Legacy UI action type. CLI parses but does not execute.
 - `column` — Column identifier for copy-column builtin action.
 
 ### `SettingConfig`

--- a/docs/architecture/api-client.md
+++ b/docs/architecture/api-client.md
@@ -10,7 +10,7 @@ Homeboy projects can configure an API client for making HTTP requests to project
 - Template-based URL and header construction
 - Keychain-stored authentication tokens
 - JSON request/response handling
-- Bulk request operations
+- Project-scoped `get`, `post`, `put`, `patch`, and `delete` requests
 
 ## Configuration
 
@@ -88,65 +88,33 @@ Authentication header templates use `{{var}}` placeholders.
 ### Make Request
 
 ```bash
-homeboy api <project_id> <method> <endpoint> [options]
+homeboy api <project_id> <command> <endpoint> [options]
 ```
 
 **Arguments:**
 - `<project_id>`: Project identifier
-- `<method>`: HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`)
+- `<command>`: Request command (`get`, `post`, `put`, `patch`, `delete`)
 - `<endpoint>`: API endpoint path (appended to `base_url`)
 
 **Options:**
-- `--data <json>`: Request body (JSON)
-- `--params <key=value>`: Query parameters (repeatable)
-- `--header <key=value>`: Request headers (repeatable)
-- `--output <path>`: Save response to file
-- `--json`: Return response as JSON (when applicable)
+- `--body <json>`: Request body for `post`, `put`, and `patch`
+- `--form <key=value>`: Form field for `post`, `put`, and `patch` (repeatable)
+- `--output <path>`: Write the structured JSON envelope to a file
 
 **Examples:**
 
 ```bash
 # GET request
-homeboy api myproject GET /posts
+homeboy api myproject get /posts
 
-# POST with data
-homeboy api myproject POST /posts --data '{"title": "Hello", "content": "World"}'
+# POST with JSON body
+homeboy api myproject post /posts --body '{"title": "Hello", "content": "World"}'
 
-# With query parameters
-homeboy api myproject GET /posts --params page=1 --params per_page=10
+# POST with form fields
+homeboy api myproject post /posts --form title=Hello --form status=draft
 
-# Custom header
-homeboy api myproject GET /posts --header "Authorization: Bearer {{token}}"
-
-# Save response
-homeboy api myproject GET /posts --output /tmp/posts.json
-```
-
-### Bulk Requests
-
-```bash
-homeboy api --json <spec>
-```
-
-**JSON Spec Format:**
-
-```json
-{
-  "project_id": "myproject",
-  "requests": [
-    {
-      "method": "GET",
-      "endpoint": "/posts",
-      "params": {"page": 1, "per_page": 10},
-      "output": "/tmp/posts.json"
-    },
-    {
-      "method": "POST",
-      "endpoint": "/posts",
-      "data": {"title": "New Post", "content": "Content"}
-    }
-  ]
-}
+# Write structured response to a file
+homeboy --output /tmp/posts.json api myproject get /posts
 ```
 
 ## Extension Integration
@@ -234,10 +202,10 @@ All API commands return responses wrapped in the global JSON envelope:
 
 ```bash
 # List posts
-homeboy api myproject GET /wp/v2/posts
+homeboy api myproject get /wp/v2/posts
 
 # Create post
-homeboy api myproject POST /wp/v2/posts --data '{"title": "New Post"}'
+homeboy api myproject post /wp/v2/posts --body '{"title": "New Post"}'
 ```
 
 ### Custom API
@@ -253,7 +221,7 @@ homeboy api myproject POST /wp/v2/posts --data '{"title": "New Post"}'
 
 ```bash
 # Make authenticated request
-homeboy api myproject GET /users
+homeboy api myproject get /users
 ```
 
 ## Security Considerations

--- a/docs/architecture/api-client.md
+++ b/docs/architecture/api-client.md
@@ -157,17 +157,16 @@ Extensions can define API actions in their manifest for automated API interactio
 
 ```json
 {
-  "actions": {
-    "sync_posts": {
+  "actions": [
+    {
+      "id": "sync_posts",
+      "label": "Sync posts from API",
       "type": "api",
-      "description": "Sync posts from API",
-      "config": {
-        "method": "GET",
-        "endpoint": "/posts",
-        "params": {"per_page": 100}
-      }
+      "method": "GET",
+      "endpoint": "/posts",
+      "payload": {"per_page": 100}
     }
-  }
+  ]
 }
 ```
 
@@ -177,12 +176,10 @@ Extension API actions can use template variables:
 
 ```json
 {
-  "config": {
-    "method": "POST",
-    "endpoint": "/posts/{{postId}}/comments",
-    "template": {
-      "content": "{{payload.comment}}"
-    }
+  "method": "POST",
+  "endpoint": "/posts/{{postId}}/comments",
+  "payload": {
+    "content": "{{payload.comment}}"
   }
 }
 ```

--- a/docs/architecture/keychain-secrets.md
+++ b/docs/architecture/keychain-secrets.md
@@ -47,7 +47,7 @@ Stored for project API authentication.
 homeboy auth set --project <project_id> token
 
 # Token is automatically retrieved during API requests
-homeboy api <project_id> GET /posts
+homeboy api <project_id> get /posts
 ```
 
 ### Database Passwords

--- a/docs/architecture/output-system.md
+++ b/docs/architecture/output-system.md
@@ -22,7 +22,8 @@ summary artifact.
 
 ## Top-level envelope
 
-In JSON mode, Homeboy prints a `CliResponse<T>` (implemented in the `homeboy-cli` crate) where `T` is the **command-specific output struct**.
+In JSON mode, Homeboy prints a `CliResponse<T>` where `T` is the
+**command-specific output struct**.
 
 Success:
 
@@ -86,7 +87,7 @@ The `summary` object provides counts for quick overview:
 {
   "summary": {
     "total_components": 24,
-    "by_module": { "wordpress": 21, "rust": 2, "swift": 1 },
+    "by_extension": { "wordpress": 21, "rust": 2, "swift": 1 },
     "by_status": { "clean": 5, "uncommitted": 8, "needs_release": 11 }
   }
 }
@@ -127,7 +128,7 @@ The `next_steps` array contains context-aware actionable guidance based on the c
 
 ## Error fields
 
-`error` is a `CliError` (implemented in the `homeboy-cli` crate).
+`error` is a `CliError`.
 
 - `code` (string): stable error code (see `homeboy::error::ErrorCode::as_str()`).
 - `message` (string): human-readable message.

--- a/docs/architecture/release-pipeline.md
+++ b/docs/architecture/release-pipeline.md
@@ -1,385 +1,115 @@
 # Release Pipeline System
 
-The release pipeline provides configurable, local orchestration for managing component releases without CI/CD systems.
+Homeboy release automation is a local-first planner/executor for component
+releases. It turns component metadata, conventional commits, extension release
+actions, and git state into a reviewable release plan.
 
-## Overview
+## Current Model
 
-Homeboy's release pipeline is a local-first alternative to CI/CD, allowing developers to:
-- Define release workflows as configuration
-- Plan and review releases before execution
-- Integrate custom extension actions
-- Run releases from local development environment
+The release command is intentionally not a generic shell workflow runner. Core
+owns the release graph and safety checks; extensions contribute domain-specific
+prepare, package, and publish behavior through release actions declared in their
+manifests.
 
-## Pipeline Configuration
-
-Release pipelines are defined in component configuration:
-
-```json
-{
-  "release": {
-    "enabled": true,
-    "steps": [],
-    "settings": {}
-  }
-}
+```text
+component config + git history
+        |
+        v
+release planner
+        |
+        +-- core steps: preflight, changelog, version, git, deploy, cleanup
+        |
+        +-- extension actions: prepare, package, publish.<target>
+        v
+structured release plan + execution results
 ```
 
-### Release Fields
+## Core Step Kinds
 
-- **`enabled`** (boolean): Whether release pipeline is active
-- **`steps`** (array): Ordered list of release steps
-- **`settings`** (object): Pipeline-level settings
+Common executable step kinds include:
 
-## Step Types
+- `preflight.default_branch`
+- `preflight.git_identity`
+- `preflight.working_tree`
+- `preflight.remote_sync`
+- `preflight.bump_policy`
+- `preflight.lint`
+- `preflight.test`
+- `preflight.changelog_bootstrap`
+- `changelog.finalize`
+- `version`
+- `git.commit`
+- `package`
+- `artifacts.inventory`
+- `git.tag`
+- `git.push`
+- `github.release`
+- `deploy`
+- `cleanup`
+- `post_release`
+- `publish.<target>`
 
-### Built-in Step Types
+Some preflight and changelog planning steps are plan-only. They appear in the
+release plan for visibility but are not executed as mutating steps.
 
-#### `build`
+## Extension Boundary
 
-Build the component using its linked extension's build support.
+Extensions should own ecosystem-specific release semantics:
 
-```json
-{
-  "id": "build",
-  "type": "build",
-  "label": "Build",
-  "needs": [],
-  "config": {}
-}
-```
+- how to package a Rust crate, WordPress plugin, Node project, or Swift artifact
+- how to publish to GitHub, Homebrew, crates.io, npm, or another registry
+- how to run platform-specific prepare checks before packaging
+- how to report skipped or auth-blocked publish attempts in a structured way
 
-**Config options:** None (uses linked extension build configuration)
+Core should own generic sequencing, state, git operations, output contracts, and
+failure handling.
 
-#### `version_bump`
+## Commands
 
-Increment component version.
-
-```json
-{
-  "id": "bump",
-  "type": "version_bump",
-  "label": "Bump Version",
-  "needs": [],
-  "config": {
-    "bump_type": "patch|minor|major"
-  }
-}
-```
-
-**Config options:**
-- **`bump_type`** (string): Version increment type (`patch`, `minor`, `major`)
-
-#### `git_commit`
-
-Create a git commit.
-
-```json
-{
-  "id": "commit",
-  "type": "git_commit",
-  "label": "Commit Changes",
-  "needs": ["build"],
-  "config": {
-    "message": "Release {version}",
-    "add_all": false,
-    "add_staged": true
-  }
-}
-```
-
-**Config options:**
-- **`message`** (string): Commit message (supports `{{version}}` variable)
-- **`add_all`** (boolean): Stage all changes before committing
-- **`add_staged`** (boolean): Commit only staged changes
-
-#### `git_tag`
-
-Create a git tag for the version.
-
-```json
-{
-  "id": "tag",
-  "type": "git_tag",
-  "label": "Create Tag",
-  "needs": ["bump"],
-  "config": {
-    "tag_format": "v{version}",
-    "push": true
-  }
-}
-```
-
-**Config options:**
-- **`tag_format`** (string): Tag format string (supports `{{version}}`)
-- **`push`** (boolean): Push tags to remote
-
-#### `git_push`
-
-Push commits and tags to remote.
-
-```json
-{
-  "id": "push",
-  "type": "git_push",
-  "label": "Push to Remote",
-  "needs": ["tag"],
-  "config": {
-    "push_tags": true
-  }
-}
-```
-
-**Config options:**
-- **`push_tags`** (boolean): Push tags along with commits
-
-#### `extension_run`
-
-Execute a extension runtime command.
-
-```json
-{
-  "id": "test",
-  "type": "extension_run",
-  "label": "Run Tests",
-  "needs": ["build"],
-  "config": {
-    "extension": "rust",
-    "command": "test",
-    "inputs": [
-      {"id": "release", "value": "true"}
-    ]
-  }
-}
-```
-
-**Config options:**
-- **`extension`** (string): Extension ID to execute
-- **`command`** (string): Command to pass to extension
-- **`inputs`** (array): Input arguments for extension
-
-#### `extension_action`
-
-Execute a extension action.
-
-```json
-{
-  "id": "publish",
-  "type": "extension_action",
-  "label": "Publish Release",
-  "needs": ["push"],
-  "config": {
-    "extension": "github",
-    "action": "create_release",
-    "data": {}
-  }
-}
-```
-
-**Config options:**
-- **`extension`** (string): Extension ID providing the action
-- **`action`** (string): Action ID to execute
-- **`data`** (object): Data to pass to action
-
-## Step Dependencies
-
-The `needs` field defines step execution order:
-
-```json
-{
-  "steps": [
-    {"id": "test", "type": "extension_run", "needs": []},
-    {"id": "build", "type": "build", "needs": []},
-    {"id": "bump", "type": "version_bump", "needs": ["test", "build"]},
-    {"id": "commit", "type": "git_commit", "needs": ["bump"]},
-    {"id": "push", "type": "git_push", "needs": ["commit"]}
-  ]
-}
-```
-
-Steps with empty `needs` arrays run first. Steps wait for all dependencies to complete successfully before executing.
-
-## Extension Actions in Pipelines
-
-Extensions can define `release_actions` in their manifest for pipeline integration:
-
-```json
-{
-  "release_actions": {
-    "publish": {
-      "type": "extension_run",
-      "config": {
-        "extension": "github",
-        "inputs": [
-          {"id": "create_release", "value": "true"}
-        ]
-      }
-    }
-  }
-}
-```
-
-These can be referenced in pipeline steps:
-
-```json
-{
-  "id": "publish",
-  "type": "extension.run",
-  "label": "Publish",
-  "needs": ["push"],
-  "config": {}
-}
-```
-
-## Pipeline Commands
-
-### Plan Release
-
-Review what a release pipeline will do without executing:
+Preview a release without executing mutating steps:
 
 ```bash
-homeboy release plan <component_id>
+homeboy release --dry-run <component_id>
 ```
 
-Shows:
-- Pipeline steps in execution order
-- Dependency graph
-- Current version
-- Next version after bump
-- Configuration validation
-
-### Run Release
-
-Execute the release pipeline:
+Execute the release plan:
 
 ```bash
-homeboy release run <component_id>
+homeboy release <component_id>
 ```
 
-Execution:
-1. Validates pipeline configuration
-2. Executes steps in dependency order
-3. Stops on first failure
-4. Reports status for each step
+Useful companion commands:
 
-## Complete Example
-
-```json
-{
-  "release": {
-    "enabled": true,
-    "steps": [
-      {
-        "id": "lint",
-        "type": "extension_run",
-        "label": "Lint Code",
-        "needs": [],
-        "config": {
-          "extension": "rust",
-          "command": "clippy"
-        }
-      },
-      {
-        "id": "test",
-        "type": "extension_run",
-        "label": "Run Tests",
-        "needs": [],
-        "config": {
-          "extension": "rust",
-          "command": "test"
-        }
-      },
-      {
-        "id": "build",
-        "type": "build",
-        "label": "Build Artifact",
-        "needs": ["lint", "test"],
-        "config": {}
-      },
-      {
-        "id": "bump",
-        "type": "version_bump",
-        "label": "Bump Version",
-        "needs": ["build"],
-        "config": {
-          "bump_type": "patch"
-        }
-      },
-      {
-        "id": "commit",
-        "type": "git_commit",
-        "label": "Commit Release",
-        "needs": ["bump"],
-        "config": {
-          "message": "Release {{version}}",
-          "add_staged": true
-        }
-      },
-      {
-        "id": "tag",
-        "type": "git_tag",
-        "label": "Create Tag",
-        "needs": ["bump"],
-        "config": {
-          "tag_format": "v{{version}}",
-          "push": true
-        }
-      },
-      {
-        "id": "push",
-        "type": "git_push",
-        "label": "Push to Remote",
-        "needs": ["commit", "tag"],
-        "config": {
-          "push_tags": true
-        }
-      },
-      {
-        "id": "publish",
-        "type": "extension_action",
-        "label": "Create GitHub Release",
-        "needs": ["push"],
-        "config": {
-          "extension": "github",
-          "action": "create_release"
-        }
-      }
-    ]
-  }
-}
+```bash
+homeboy changes <component_id>
+homeboy version show <component_id>
+homeboy changelog show <component_id>
 ```
 
-## Pipeline Settings
+## Execution Behavior
 
-Release pipeline supports global settings:
+Release execution:
 
-```json
-{
-  "release": {
-    "enabled": true,
-    "steps": [],
-    "settings": {
-      "distTarget": "homeboy",
-      "dryRun": false
-    }
-  }
-}
-```
+1. Resolves the component and extension context.
+2. Builds a release plan from git history, component metadata, and extension
+   capabilities.
+3. Runs executable steps in dependency order.
+4. Stops on failure and returns structured step results.
+5. Leaves plan-only steps visible for review without executing them.
 
-**Available settings:**
-- **`distTarget`** (string): Distribution target identifier
-- **`dryRun`** (boolean): Preview pipeline execution without making changes
+Release requires a clean working tree except for files the release process owns,
+such as version targets and changelog targets.
 
-## Error Handling
+## Historical Terminology
 
-Pipeline execution stops on first failure. Failed steps are reported with:
-- Step ID and label
-- Error message
-- Exit code (for extension steps)
-
-Resume from a specific step is not supported. Rerun the entire pipeline after fixing issues.
+Older docs and changelog entries may mention `extension_run`,
+`extension_action`, or generic `extension.run` release steps. Treat those as
+historical terminology unless the current release planner emits those step kinds.
+Current release execution is built around known core step kinds and declared
+extension release actions.
 
 ## Related
 
-- [Release command](../commands/release.md) - Plan and run releases
-- [Component schema](../schemas/component-schema.md) - Release configuration structure
-- [Extension manifest schema](../schemas/extension-manifest-schema.md) - Extension action definitions
+- [Release command](../commands/release.md)
+- [Component schema](../schemas/component-schema.md)
+- [Extension manifest schema](../schemas/extension-manifest-schema.md)

--- a/docs/cli/homeboy-root-command.md
+++ b/docs/cli/homeboy-root-command.md
@@ -8,7 +8,9 @@ homeboy [OPTIONS] <COMMAND>
 
 ## Description
 
-`homeboy` is a CLI tool for development and deployment automation.
+`homeboy` is headless automation for agentic software engineering workflows. It
+keeps local developers, CI, scheduled jobs, and coding agents on the same
+component-aware command surface and structured evidence contract.
 
 ## Global flags
 
@@ -18,6 +20,8 @@ These are provided by clap:
 - `--help` / `-h`: print help and exit
 - `--output <PATH>`: write the structured JSON envelope to a file in addition to stdout
 - `--force-hot`: suppress resource policy warnings for intentionally hot commands
+- `--artifact-root <DIR>`: copy persisted run artifacts to a specific directory
+- `--runner <RUNNER_ID>`: offload supported hot commands to a connected Homeboy Lab runner
 
 `--output` is a global flag, so pass it before the subcommand:
 

--- a/docs/commands/api.md
+++ b/docs/commands/api.md
@@ -23,19 +23,19 @@ homeboy api <project_id> get <endpoint>
 ### `post`
 
 ```sh
-homeboy api <project_id> post <endpoint> [--body <json>]
+homeboy api <project_id> post <endpoint> [--body <json>] [--form <key=value>]...
 ```
 
 ### `put`
 
 ```sh
-homeboy api <project_id> put <endpoint> [--body <json>]
+homeboy api <project_id> put <endpoint> [--body <json>] [--form <key=value>]...
 ```
 
 ### `patch`
 
 ```sh
-homeboy api <project_id> patch <endpoint> [--body <json>]
+homeboy api <project_id> patch <endpoint> [--body <json>] [--form <key=value>]...
 ```
 
 ### `delete`
@@ -48,7 +48,8 @@ homeboy api <project_id> delete <endpoint>
 
 - `<endpoint>` is passed through as provided (example: `/wp/v2/posts`).
 - `--body` is parsed as JSON. If parsing fails, the request is sent with `body: null`.
-- If `--body` is omitted, `body` is `null`.
+- `--form key=value` may be repeated for `post`, `put`, and `patch`; form fields take precedence over `--body`.
+- If `--body` and `--form` are omitted, `body` is `null`.
 
 ## Output
 

--- a/docs/commands/docs.md
+++ b/docs/commands/docs.md
@@ -113,6 +113,5 @@ If a component does not exist for `map`, the command fails with a component not 
 
 - [audit](audit.md) — code-level convention auditing, including documentation-reference findings when enabled by the audit implementation
 - [commands index](commands-index.md)
-- [audit](audit.md) — code-level convention auditing, including documentation-reference findings when enabled by the audit implementation
 - [changelog](changelog.md)
 - [JSON output contract](../architecture/output-system.md)

--- a/docs/commands/extension.md
+++ b/docs/commands/extension.md
@@ -43,7 +43,7 @@ homeboy extension set [extension_id] --json <JSON> [--replace <field>]...
 homeboy extension set [extension_id] --json '<JSON>'
 ```
 
-Updates a extension manifest by merging a JSON object into the extension config.
+Updates an extension manifest by merging a JSON object into the extension config.
 
 Options:
 
@@ -66,7 +66,7 @@ homeboy extension setup <extension_id>
 homeboy extension install <source> [--id <extension_id>] [--ref <git-ref>] [--revision <git-ref>] [--replace]
 ```
 
-Installs a extension into Homeboy's extensions directory.
+Installs an extension into Homeboy's extensions directory.
 
 - If `<source>` is a git URL, Homeboy clones it and writes `sourceUrl` into the installed extension's `<extension_id>.json` manifest.
 - For git URL installs, `--ref` (alias `--revision`) checks out a branch, tag, or commit after cloning. The installed metadata still records the resolved `source_revision` SHA.
@@ -99,7 +99,7 @@ Updates a git-cloned extension.
 homeboy extension uninstall <extension_id>
 ```
 
-Uninstalls a extension.
+Uninstalls an extension.
 
 - If the extension is **symlinked**, Homeboy removes the symlink (the source directory is preserved).
 - If the extension is **git-cloned**, Homeboy deletes the extension directory.
@@ -130,7 +130,7 @@ Homeboy builds an **effective settings** map for each extension by merging setti
 1. Project (`projects/<project_id>.json`): `extensions.<extension_id>.settings`
 2. Component (`components/<component_id>.json`): `extensions.<extension_id>.settings`
 
-When running a extension, Homeboy passes an execution context via environment variables:
+When running an extension, Homeboy passes an execution context via environment variables:
 
 - `HOMEBOY_EXEC_CONTEXT_VERSION`: currently `2`
 - `HOMEBOY_EXTENSION_ID`
@@ -148,7 +148,10 @@ Extensions can define additional environment variables via `runtime.env` in thei
 
 Extension settings validation happens during extension execution and may also be checked by other commands.
 
-`homeboy extension run` requires the extension to be installed/linked under the Homeboy extensions directory (discovered by scanning `<config dir>/homeboy/extensions/<extension_id>/<extension_id>.json`). There is no separate "installedModules in global config" requirement.
+`homeboy extension run` requires the extension to be installed or linked under
+the Homeboy extensions directory, discovered by scanning
+`~/.config/homeboy/extensions/<extension_id>/<extension_id>.json`. There is no
+separate `installedModules` requirement in global config.
 
 ## Runtime Configuration
 
@@ -225,7 +228,7 @@ Discover what’s available on your machine:
 homeboy docs list
 ```
 
-Render a extension-provided topic:
+Render an extension-provided topic:
 
 ```sh
 homeboy docs <topic>

--- a/docs/commands/extension.md
+++ b/docs/commands/extension.md
@@ -205,9 +205,9 @@ Extension entry (`extensions[]`):
 - `runtime`: `executable` (has runtime config) or `platform` (no runtime config)
 - `compatible` (with optional `--project`)
 - `ready` (runtime readiness based on `ready_check`)
-- `configured`: currently always `true` for discovered extensions (reserved for future richer config state)
 - `linked`: whether the extension is symlinked
 - `path`: extension directory path (may be empty if unknown)
+- Optional fields include `ready_reason`, `ready_detail`, `error`, `symlink_target`, `source_revision`, `cli_tool`, `cli_display_name`, `actions`, `has_setup`, and `has_ready_check`.
 
 Extension detail (`extension.show`):
 

--- a/docs/commands/extension.md
+++ b/docs/commands/extension.md
@@ -204,7 +204,7 @@ Extension entry (`extensions[]`):
 - `id`, `name`, `version`, `description`
 - `runtime`: `executable` (has runtime config) or `platform` (no runtime config)
 - `compatible` (with optional `--project`)
-- `ready` (runtime readiness based on `readyCheck`)
+- `ready` (runtime readiness based on `ready_check`)
 - `configured`: currently always `true` for discovered extensions (reserved for future richer config state)
 - `linked`: whether the extension is symlinked
 - `path`: extension directory path (may be empty if unknown)
@@ -215,8 +215,8 @@ Extension detail (`extension.show`):
 
 ## Exit code
 
-- `extension.run`: exit code of the executed extension's `runCommand`.
-- `extension.setup`: `0` on success; if no `setupCommand` defined, returns `0` without action.
+- `extension.run`: exit code of the executed extension's `run_command`.
+- `extension.setup`: `0` on success; if no `setup_command` is defined, returns `0` without action.
 
 ## Extension-provided commands and docs
 

--- a/docs/commands/fleet.md
+++ b/docs/commands/fleet.md
@@ -10,12 +10,13 @@ homeboy fleet <COMMAND>
 
 ## Overview
 
-Fleets enable cloud version management by grouping projects that share components. Use fleets to:
+Fleets group projects that share components or operational policies. Use fleets
+to:
 
-- Deploy updates to multiple sites simultaneously
-- Check version drift across your network
-- Coordinate deployments between staging/production environments
-- Keep shared plugins/themes in sync across a WordPress multisite network
+- Inspect status and version drift across a project group
+- Coordinate deployments between staging and production environments
+- Keep shared components in sync across multiple sites, apps, or servers
+- Produce read-only attention reports for a group of environments
 
 **Hierarchy:**
 - **Component** → versioned thing (plugin, CLI tool, extension)

--- a/docs/commands/fleet.md
+++ b/docs/commands/fleet.md
@@ -107,11 +107,15 @@ Useful for understanding which components are shared and where they're deployed.
 
 ```sh
 homeboy fleet status <id>
+homeboy fleet status <id> --cached
+homeboy fleet status <id> --health-only
 ```
 
-Show component versions for each project in the fleet. Reads local configuration only (no SSH).
+Show live component versions and server health for each project in the fleet via SSH.
 
-Use `fleet check` for drift detection that compares local vs remote versions.
+- `--cached`: use locally cached versions instead of a live SSH check.
+- `--health-only`: skip component versions and report only server health.
+- Use `fleet check` for drift detection that compares local vs remote versions.
 
 ### `check`
 
@@ -140,16 +144,6 @@ homeboy fleet exec <id> -- <command>
 ```
 
 Runs a command across projects in the fleet via each project's configured SSH connection. `fleet exec` participates in resource-policy warnings because it can create heavy remote work, but it intentionally stays local for Lab offload: the command depends on local fleet, project, and server configuration before opening those SSH sessions, and runner-side config parity is not guaranteed.
-
-### `sync` (deprecated)
-
-> **Deprecated.** Use `homeboy deploy` to sync files across servers instead. Register shared configs as components and deploy them like any other component. See [#101](https://github.com/Extra-Chill/homeboy/issues/101).
-
-```sh
-# Instead of: homeboy fleet sync fleet-servers
-# Use:
-homeboy deploy my-config --fleet fleet-servers
-```
 
 ## Fleet Deployment
 
@@ -210,7 +204,7 @@ Top-level fields:
 - `fleets`: list for `list` command
 - `projects`: project details for `projects` command
 - `components`: component usage map for `components` command
-- `status`: version info per project for `status` command
+- `status`: live or cached version and health info per project for `status` command
 - `check`: drift detection results for `check` command
 - `summary`: aggregate counts for `check` command
 
@@ -221,13 +215,6 @@ Check result fields:
 Summary fields:
 - `total_projects`, `projects_checked`, `projects_failed`
 - `components_up_to_date`, `components_needs_update`, `components_unknown`
-
-Sync result fields:
-- `leader_project_id`: source of truth server
-- `dry_run`: whether this was a preview run
-- `projects[]`: per-project results with `project_id`, `server_id`, `status`, `error`
-- `projects[].categories[]`: per-category results with `category`, `status`, `error`, `files_synced`
-- `summary`: `total_projects`, `projects_synced`, `projects_failed`, `projects_skipped`, `total_categories`, `categories_synced`, `categories_failed`
 
 ## Related
 

--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -63,7 +63,7 @@ The release command coordinates versioning, committing, tagging, and pushing.
 Release pipelines support two step types:
 
 - **Core steps**: `build`, `changes`, `version`, `git.commit`, `git.tag`, `git.push`
-- **Extension-backed steps**: any custom step type implemented as a extension action named `release.<step_type>`
+- **Extension-backed steps**: publish/package/prepare behavior implemented by extension release actions such as `release.prepare`, `release.package`, or `release.publish.<target>`
 
 ### Core step: `git.commit`
 
@@ -95,26 +95,16 @@ These files are modified during the release anyway and included in the release c
 
 Any other uncommitted changes will cause the release to fail with guidance to commit first.
 
-### Pipeline step: `extension.run`
+### Extension-backed release behavior
 
-Use `extension.run` to execute a extension runtime command as part of the release pipeline.
+Older release docs may mention generic `extension.run` steps. Current release
+execution is intentionally narrower: the executable release plan is built from
+known core steps plus extension-backed release actions declared in extension
+manifests.
 
-Example step configuration:
-
-```json
-{
-  "id": "scrape",
-  "type": "extension.run",
-  "needs": ["build"],
-  "config": {
-    "extension": "bandcamp-scraper",
-    "inputs": [
-      { "id": "artist", "value": "some-artist" }
-    ],
-    "args": ["--verbose"]
-  }
-}
-```
+Use extension manifests for release-specific prepare, package, and publish
+actions. Core keeps the release graph generic; extensions own platform-specific
+work.
 
 - `config.extension` is required.
 - `config.inputs` is optional; each entry must include `id` and `value`.

--- a/docs/developer-guide/architecture-overview.md
+++ b/docs/developer-guide/architecture-overview.md
@@ -195,8 +195,8 @@ Local orchestration system:
 - Execute with error handling
 
 Step types:
-- Built-in: build, version_bump, git_commit, git_tag, git_push
-- Extension: extension_run, extension_action
+- Core: preflight, changelog, version, git, deploy, cleanup, and artifact steps
+- Extension-backed: prepare, package, and publish actions declared by extensions
 
 ### Code Audit
 
@@ -233,11 +233,11 @@ Documentation verification:
 
 **Location:** `src/core/fleet/`
 
-Fleet management for cloud version management:
+Fleet management for grouped environments:
 - Named groups of projects
 - Shared component detection
-- Fleet-wide operations (status, check, deploy)
-- Coordinated deployments across multiple servers
+- Fleet-wide status, triage, and deploy operations
+- Coordinated operations across multiple servers or local environments
 
 Config entities:
 - **Fleets**: Named groups of projects for batch operations
@@ -329,11 +329,10 @@ Extensions are loaded from:
 
 ### Extension Execution
 
-Two execution paths:
-1. **Direct execution**: `homeboy extension run <extension_id>`
-2. **Pipeline step**: `extension.run` step in release pipeline
-
-Both paths use the same execution context builder and template resolver.
+Direct extension execution uses `homeboy extension run <extension_id>`. Other
+Homeboy command families, such as lint, test, build, bench, trace, release, and
+deploy, can also invoke extension-owned scripts or actions through their own
+typed contracts.
 
 ## Error Handling
 

--- a/docs/developer-guide/architecture-overview.md
+++ b/docs/developer-guide/architecture-overview.md
@@ -83,8 +83,6 @@ File-based storage for configurations:
 - Handles atomic operations for safety
 - Cross-platform paths (macOS, Linux, Windows)
 
-**Future:** Storage abstraction trait for database backends (see `storage-system-decoupling-plan.md`)
-
 ### Template System
 
 **Location:** `src/core/engine/template.rs`

--- a/docs/developer-guide/architecture-overview.md
+++ b/docs/developer-guide/architecture-overview.md
@@ -298,7 +298,7 @@ Embedded documentation:
 
 ### Release Pipeline Flow
 
-1. CLI parses `homeboy release run <component>`
+1. CLI parses `homeboy release <component>`
 2. Load component configuration
 3. Parse release pipeline steps
 4. Validate step dependencies

--- a/docs/developer-guide/config-directory.md
+++ b/docs/developer-guide/config-directory.md
@@ -1,6 +1,10 @@
 # Config Directory Structure
 
-> **Important:** Homeboy uses centralized configuration only. There is no repo-local config file (no .homeboy.toml or .homeboy directory). All configuration lives in `~/.config/homeboy/`.
+> **Important:** Portable component configuration can live in a repo-level
+> `homeboy.json`. Reusable machine-local configuration, state, installed
+> extensions, projects, servers, fleets, rigs, and stacks live in
+> `~/.config/homeboy/`. There is no repo-local dotfile or hidden Homeboy config
+> directory.
 
 Homeboy stores all configuration in a universal directory location across operating systems.
 
@@ -32,8 +36,7 @@ Typically: `C:\Users\<username>\AppData\Roaming\homeboy\`
 
 ```
 ~/.config/homeboy/
-├── homeboy/
-│   └── homeboy.json           # Global app configuration
+├── homeboy.json               # Global app configuration
 ├── projects/
 │   ├── <project_id>.json       # Project configurations
 │   └── ...
@@ -69,10 +72,12 @@ Contains global Homeboy settings. Created automatically on first run with defaul
 
 ```json
 {
-  "storage": "builtin-filesystem",
-  "installedModules": []
+  "storage": "builtin-filesystem"
 }
 ```
+
+Installed extensions are discovered from `~/.config/homeboy/extensions/`, not a
+global `installedModules` list.
 
 ### Project Configurations
 
@@ -114,6 +119,8 @@ Each server is a separate JSON file named after the server ID.
 **Directory:** `~/.config/homeboy/components/`
 
 Each component is a separate JSON file named after the component ID.
+Components can also be declared portably in a repository's `homeboy.json`; the
+standalone config directory is for reusable registrations outside the checkout.
 
 **Example:** `~/.config/homeboy/components/theme.json`
 
@@ -172,15 +179,15 @@ Configuration backups created by Homeboy (optional). Created before destructive 
 
 ## File Operations
 
-Homeboy does not write to directories outside the config directory:
-- **No repo-local config files**: Configuration is centralized
-- **No .homeboy directories**: Avoids repo contamination
-- **Cross-repo compatibility**: Multiple repos can reference the same configurations
+Homeboy keeps machine-local state under the config directory:
+- **Portable repo config**: A repository can opt into `homeboy.json` for local and CI loops
+- **No hidden repo state directory**: Homeboy avoids creating hidden state directories in source checkouts
+- **Cross-repo compatibility**: Multiple repos can reference the same reusable configurations
 
 ## Auto-creation
 
 Directories are created automatically when needed:
-- homeboy/ — First run
+- homeboy.json — First run or first global config update
 - projects/ — First project created
 - servers/ — First server created
 - components/ — First component created

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ repository.
 
 JSON configuration schemas for components, projects, servers, fleets, and extensions:
 
-- [Component schema](schemas/component-schema.md) - Buildable/deployable units
+- [Component schema](schemas/component-schema.md) - Buildable, testable, reviewable units
 - [Project schema](schemas/project-schema.md) - Deployable environments
 - [Server schema](schemas/server-schema.md) - SSH connection settings
 - [Fleet schema](schemas/fleet-schema.md) - Named groups of projects

--- a/docs/schemas/component-schema.md
+++ b/docs/schemas/component-schema.md
@@ -151,12 +151,9 @@ Setting `local_path` to the same directory as the deploy target is a misconfigur
     "enabled": true,
     "steps": [
       {
-        "id": "test",
-        "type": "extension.run",
-        "label": "Run Tests",
-        "config": {
-          "extension": "rust"
-        }
+        "id": "preflight.test",
+        "type": "preflight.test",
+        "label": "Run Tests"
       }
     ]
   }

--- a/docs/schemas/extension-manifest-schema.md
+++ b/docs/schemas/extension-manifest-schema.md
@@ -18,8 +18,7 @@ Extension manifests define extension metadata, runtime behavior, platform behavi
   "platform": {},
   "structured_sidecars": {},
   "commands": {},
-  "actions": {},
-  "release_actions": {},
+  "actions": [],
   "hooks": {},
   "docs": [],
   "capabilities": [],
@@ -46,8 +45,7 @@ Extension manifests define extension metadata, runtime behavior, platform behavi
 - **`platform`** (object): Platform behavior definitions (database, deployment, version patterns)
 - **`structured_sidecars`** (object): Declares public machine-readable run-directory sidecar contracts
 - **`commands`** (object): Additional CLI commands provided by extension
-- **`actions`** (object): Action definitions for `homeboy extension action`
-- **`release_actions`** (object): Release pipeline step definitions
+- **`actions`** (array): Action definitions for `homeboy extension action`; release actions are normal actions whose IDs start with `release.`
 - **`hooks`** (object): Lifecycle hooks (pre/post version bump, deploy, release)
 - **`docs`** (array): Documentation topic paths
 - **`capabilities`** (array): Capabilities provided by extension (e.g., `["storage"]`)
@@ -74,7 +72,7 @@ Declares what file types and capabilities this extension handles. Used by the au
 
 - **`file_extensions`** (array): File extensions this extension can process (e.g., `["php", "inc"]`, `["rs"]`)
 - **`capabilities`** (array): Capabilities this extension supports (e.g., `["fingerprint", "refactor"]`)
-- **`discovery_markers`** (array): Component-root marker rules used by `homeboy context` gap reporting to suggest an extension without core knowing ecosystem-specific files.
+- **`discovery_markers`** (array): Component-root marker rules used by diagnostics and gap reporting to suggest an extension without core knowing ecosystem-specific files.
 
 Each `discovery_markers` rule supports:
 
@@ -415,38 +413,44 @@ Extensions can register additional top-level CLI commands.
 ## Actions Configuration
 
 Actions define executable operations accessible via `homeboy extension action`.
+They are an array of typed action objects.
 
 ```json
 {
-  "actions": {
-    "<action_id>": {
-      "type": "cli|api",
-      "description": "string",
-      "config": {}
+  "actions": [
+    {
+      "id": "sync",
+      "label": "Sync data",
+      "type": "command",
+      "command": "scripts/sync.sh"
     }
-  }
+  ]
 }
 ```
 
 ### Action Fields
 
-- **`type`** (string): `"cli"` or `"api"`
-- **`description`** (string): Action description
-- **`config`** (object): Action-specific configuration
+- **`id`** (string): Stable action identifier
+- **`label`** (string): Human-readable action label
+- **`type`** (string): `"command"`, `"api"`, or `"builtin"`
+- **`command`** (string): Command to execute for `command` actions
+- **`endpoint`** (string): Endpoint for `api` actions
+- **`method`** (string): HTTP method for `api` actions
+- **`payload`** (object): Optional payload template for `api` actions
+- **`builtin`** (string): Legacy UI action type for `builtin` actions
 
-#### CLI Action
+#### Command Action
 
 ```json
 {
-  "actions": {
-    "sync": {
-      "type": "cli",
-      "description": "Sync data",
-      "config": {
-        "command": "sync --output {{format}}"
-      }
+  "actions": [
+    {
+      "id": "sync",
+      "label": "Sync data",
+      "type": "command",
+      "command": "scripts/sync.sh"
     }
-  }
+  ]
 }
 ```
 
@@ -454,43 +458,47 @@ Actions define executable operations accessible via `homeboy extension action`.
 
 ```json
 {
-  "actions": {
-    "create_release": {
+  "actions": [
+    {
+      "id": "create_release",
+      "label": "Create GitHub release",
       "type": "api",
-      "description": "Create GitHub release",
-      "config": {
-        "method": "POST",
-        "path": "/repos/{owner}/{repo}/releases",
-        "template": {
-          "tag_name": "{{release.tag}}",
-          "name": "{{release.name}}",
-          "body": "{{release.notes}}"
-        }
+      "method": "POST",
+      "endpoint": "/repos/{owner}/{repo}/releases",
+      "payload": {
+        "tag_name": "{{release.tag}}",
+        "name": "{{release.name}}",
+        "body": "{{release.notes}}"
       }
     }
-  }
+  ]
 }
 ```
 
 ## Release Actions Configuration
 
-Release actions define steps for release pipelines.
+Release actions are normal extension `actions` whose IDs start with
+`release.`. Core release planning detects configured extensions with release
+actions and routes prepare/package/publish behavior through those actions.
 
 ```json
 {
-  "release_actions": {
-    "<step_type>": {
-      "type": "extension.run|extension.action",
-      "config": {}
+  "actions": [
+    {
+      "id": "release.publish.github",
+      "label": "Publish GitHub release",
+      "type": "command",
+      "command": "scripts/publish-github-release.sh"
     }
-  }
+  ]
 }
 ```
 
 ### Release Action Types
 
-- **`extension.run`**: Execute extension runtime command
-- **`extension.action`**: Execute extension action
+- **`command`**: Execute an extension-owned command.
+- **`api`**: Execute an API request configured by the extension action.
+- **`builtin`**: Legacy UI action type parsed by the CLI but not executed.
 
 ### Release Action Output Contract
 
@@ -515,17 +523,14 @@ For skipped or authentication-related results, include **`reason`** or **`messag
 
 ```json
 {
-  "release_actions": {
-    "publish": {
-      "type": "extension.run",
-      "config": {
-        "extension": "github",
-        "inputs": [
-          {"id": "create_release", "value": "true"}
-        ]
-      }
+  "actions": [
+    {
+      "id": "release.publish.github",
+      "label": "Publish GitHub release",
+      "type": "command",
+      "command": "scripts/publish-github-release.sh"
     }
-  }
+  ]
 }
 ```
 

--- a/docs/schemas/fleet-schema.md
+++ b/docs/schemas/fleet-schema.md
@@ -96,8 +96,12 @@ homeboy fleet remove production --project old-site
 ### Check Fleet Status
 
 ```bash
-# Local version info
+# Live version and health info via SSH
 homeboy fleet status production
+homeboy fleet status production --health-only
+
+# Cached version info
+homeboy fleet status production --cached
 
 # Drift detection (compares local vs remote via SSH)
 homeboy fleet check production

--- a/docs/schemas/project-schema.md
+++ b/docs/schemas/project-schema.md
@@ -1,6 +1,10 @@
 # Project Schema
 
-Project configuration defines deployable environments stored in `projects/<id>.json`.
+Project configuration defines environment-specific context stored in
+`projects/<id>.json`: server bindings, domains, local paths, remote paths,
+project-scoped CLI settings, API settings, database settings, and component
+attachments. Components can run local quality loops without a project; projects
+matter when the workflow needs environment context.
 
 ## Schema
 


### PR DESCRIPTION
## Summary
- Replaces stale release-pipeline architecture docs that still described older generic `extension_run` / `git_commit` style steps.
- Updates extension action and release-action examples to match the current action-array shape and `release.*` action IDs.
- Clarifies config-directory, root command, project/fleet, API, and output docs against the current Homeboy command and architecture model.

## Verification
- `cargo build --bin homeboy`
- `cargo fmt --check`
- `target/debug/homeboy audit --changed-since origin/main --only broken_doc_reference --only undocumented_feature --only stale_doc_reference --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-docs-followup-audit.json`
- `target/debug/homeboy docs architecture/release-pipeline`
- `target/debug/homeboy docs schemas/extension-manifest-schema`

## Context
- Follow-up to #3109. That PR landed before this second-pass cleanup was pushed to its source branch, so this branch was recreated from current `main` and contains only the follow-up docs cleanup.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing stale docs against current code, drafting updates, resolving the post-merge branch situation, and running verification. Chris remains responsible for review and merge decisions.