### PR TITLE
Refresh remaining Homeboy command and project docs

### DIFF
--- a/docs/architecture/rig-matrix-axis-composition.md
+++ b/docs/architecture/rig-matrix-axis-composition.md
@@ -2,6 +2,9 @@
 
 Design for deriving rig variants from one base rig plus explicit axis overlays.
 
+Status: design proposal. `homeboy rig matrix` and `--matrix` selectors are not
+part of the current CLI surface.
+
 Tracked by Extra-Chill/homeboy#1844.
 
 ## Problem
@@ -139,7 +142,7 @@ needs many changes.
 Use two surfaces: one for single derived variants and one for cartesian
 expansion.
 
-```bash
+```text
 # Single derived rig for normal rig verbs.
 homeboy rig check studio-agent --variant agent_runtime=pi --variant conversion=bfb
 homeboy rig up studio-agent --variant agent_runtime=pi --variant conversion=bfb
@@ -150,7 +153,7 @@ homeboy bench studio --rig studio-agent \
   --matrix agent_runtime=sdk,pi \
   --matrix conversion=none,bfb
 
-# Inspect the generated plan without running anything.
+# Proposed plan inspection without running anything.
 homeboy rig matrix studio-agent --matrix agent_runtime=sdk,pi --matrix conversion=none,bfb
 homeboy rig matrix studio-agent --variant agent_runtime=pi --variant conversion=bfb --json
 ```

--- a/docs/commands/component.md
+++ b/docs/commands/component.md
@@ -14,20 +14,26 @@ homeboy component [OPTIONS] <COMMAND>
 ### `create`
 
 ```sh
-homeboy component create [OPTIONS] --local-path <path> --remote-path <path> --build-artifact <path>
+homeboy component create [OPTIONS]
 ```
 
 The component ID comes from an existing `homeboy.json` `id` when present; otherwise it is derived from the `--local-path` directory name (lowercased). For example, `--local-path /path/to/extrachill-api` creates a component with ID `extrachill-api`.
 
 Options:
 
-- `--json <spec>`: JSON input spec for create/update (supports single or bulk)
-- `--skip-existing`: skip items that already exist (JSON mode only)
 - `--local-path <path>`: absolute path to local **source / git checkout** directory (required; ID derived from directory name; `~` is expanded). Must be a git repo — not the production deploy target (see [component schema](../schemas/component-schema.md#local_path-vs-remote_path))
-- `--remote-path <path>`: remote path relative to project `base_path` (required unless in `homeboy.json`)
-- `--build-artifact <path>`: build artifact path relative to `local_path` (required; must include a filename)
+- `--remote-path <path>`: remote path relative to project `base_path` (required for deployable components unless already present in `homeboy.json`)
+- `--build-artifact <path>`: build artifact path relative to `local_path` (required for artifact deploys; must include a filename)
 - `--version-target <TARGET>`: version target in format `file` or `file::pattern` (repeatable)
+- `--version-targets <JSON>`: version targets as a JSON array (supports `@file.json` and `-` for stdin)
 - `--extract-command <command>`: command to run after upload (optional; supports `{artifact}` and `{targetDir}`)
+- `--changelog-target <path>`: changelog path relative to `local_path`
+- `--extension <extension>`: extension this component uses (repeatable)
+- `--project <project>`: attach the component to a project after creation
+
+Legacy JSON bulk create flags are rejected. `component create` now initializes
+repo-owned `homeboy.json` from explicit flags, then registers the component for
+ID-based discovery.
 
 #### Extract Command Execution Context
 
@@ -202,24 +208,24 @@ This is useful for:
 
 ```json
 {
-  "command": "component.create|component.show|component.set|component.delete|component.rename|component.list|component.projects",
+  "command": "component.create|component.show|component.set|component.delete|component.rename|component.list|component.projects|component.shared|component.env|component.add-version-target|component.reconcile|component.artifacts",
   "component_id": "<id>|null",
   "success": true,
   "updated_fields": ["local_path", "remote_path"],
   "component": {},
   "components": [],
-  "import": null,
   "project_ids": ["project-1", "project-2"],
-  "projects": []
+  "projects": [],
+  "shared": {}
 }
 ```
 
 Notes:
 
-- In JSON import mode (`homeboy component create --json ...`), `command` is still `component.create` and `import` is populated.
-- `updated_fields` is empty for all actions except `set`/`rename`.
+- `updated_fields` is populated for mutations such as `set`, `rename`, `reconcile --apply`, and `artifacts --apply`.
 - `rename` does not include the old ID; capture it from your input if needed.
 - `project_ids` and `projects` are only populated for `component.projects`.
+- `shared` is only populated for `component.shared`.
 
 
 ## Related

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -1,0 +1,36 @@
+# `homeboy doctor`
+
+Read-only local diagnostics for Homeboy-adjacent work.
+
+## Synopsis
+
+```sh
+homeboy doctor <COMMAND>
+```
+
+## Subcommands
+
+### `resources`
+
+```sh
+homeboy doctor resources
+```
+
+Reports current machine pressure and Homeboy-adjacent hot processes. This is the
+same resource-policy signal Homeboy uses before hot commands such as benchmark,
+trace, and runner-heavy workflows.
+
+## JSON output
+
+Use the global `--output <PATH>` flag to persist the command-specific structured
+JSON payload to disk in addition to stdout:
+
+```sh
+homeboy --output doctor-resources.json doctor resources
+```
+
+## Related
+
+- [bench](bench.md)
+- [trace](trace.md)
+- [runner](runner.md)

--- a/docs/commands/project.md
+++ b/docs/commands/project.md
@@ -10,17 +10,17 @@ homeboy project [OPTIONS] <COMMAND>
 
 ### Linking Components to a Project
 
-After creating components, link them to a project:
+After creating a repo-owned component config, attach that checkout to a project:
 
 ```sh
-# Add components to existing project
-homeboy project components add my-project component-1 component-2
+homeboy project components attach-path my-project /path/to/component-repo
 
-# Or set all components at once (replaces existing)
-homeboy project components set my-project component-1 component-2
+# Or replace all component attachments at once
+homeboy project components set my-project --json '[{"id":"component-1","local_path":"/repo/component-1","remote_path":"wp-content/plugins/component-1"}]'
 ```
 
-Components must exist (created via `homeboy component create`) before linking.
+`attach-path` discovers the component from the checkout's `homeboy.json` and
+adds a project attachment for that repo path.
 
 ## Subcommands
 
@@ -135,7 +135,7 @@ homeboy project create my-site my-site.local \
 
 All commands execute locally when no `server_id` is configured:
 
-- **CLI tools** (`homeboy wp`, `homeboy composer`) - execute in local shell
+- **Extension CLI tools** (`homeboy wp`, `homeboy cargo`, or extension-provided verbs) - execute in local shell
 - **Database** (`homeboy db`) - uses extension templates, executes locally
 - **Logs** (`homeboy logs`) - reads files from `base_path`
 - **Files** (`homeboy file`) - browses/edits files at `base_path`
@@ -247,13 +247,14 @@ JSON output:
 }
 ```
 
-#### `components add`
+#### `components attach-path`
 
 ```sh
-homeboy project components add <project_id> <component_id> [<component_id>...]
+homeboy project components attach-path <project_id> <local_path>
 ```
 
-Adds components to the project if they are not already present.
+Attaches a repo path for a project component discovered via that repo's
+`homeboy.json`.
 
 #### `components remove`
 
@@ -274,21 +275,23 @@ Removes all components from the project.
 #### `components set`
 
 ```sh
-homeboy project components set <project_id> <component_id> [<component_id>...]
+homeboy project components set <project_id> --json '<attachments-json>'
 ```
 
-Replaces the full `component_ids` list on the project (deduped, order-preserving). Component IDs must exist in `homeboy component list`.
+Replaces the full component attachment list on the project. The JSON payload is
+an array of attachments with fields such as `id`, `local_path`, and
+`remote_path`.
 
-You can also do this via `project set` by merging `component_ids`:
+You can also do this via `project set` by merging `components`:
 
 ```sh
-homeboy project set <project_id> --json '{"component_ids":["chubes-theme","chubes-blocks"]}'
+homeboy project set <project_id> --json '{"components":[{"id":"chubes-theme","local_path":"/repo/chubes-theme","remote_path":"wp-content/themes/chubes-theme"}]}'
 ```
 
 Example:
 
 ```sh
-homeboy project components set chubes chubes-theme chubes-blocks chubes-contact chubes-docs chubes-games
+homeboy project components set chubes --json '[{"id":"chubes-theme","local_path":"/repo/chubes-theme","remote_path":"wp-content/themes/chubes-theme"}]'
 ```
 
 JSON output:
@@ -303,9 +306,35 @@ JSON output:
     "component_ids": ["<component_id>", "<component_id>"],
     "components": [ { } ]
   },
-  "updated": ["component_ids"]
+  "updated": ["components"]
 }
 ```
+
+### `delete`
+
+```sh
+homeboy project delete <project_id>
+```
+
+Deletes a project configuration.
+
+### `init`
+
+```sh
+homeboy project init <project_id>
+```
+
+Initializes the configured project directory.
+
+### `status`
+
+```sh
+homeboy project status <project_id>
+homeboy project status <project_id> --health-only
+```
+
+Shows live server health and component versions for a project. Use
+`--health-only` to skip component version checks.
 
 ### `pin`
 

--- a/docs/commands/project.md
+++ b/docs/commands/project.md
@@ -169,7 +169,7 @@ Options:
 Notes:
 
 - `set` no longer supports individual field flags; use `--json` and provide the fields you want to update.
-- Use `null` in JSON to clear a field (for example, `{"component_ids": null}`).
+- Use `null` in JSON to clear a field (for example, `{"server_id": null}`).
 
 JSON output:
 
@@ -457,12 +457,13 @@ Options:
 - `--json <JSON>`: JSON object to remove from config (supports `@file` and `-` for stdin)
 
 Note: Use this to remove specific fields or array items from project configuration.
+Use `project components remove` for component attachments.
 
 Example:
 
 ```sh
-# Remove a component
-homeboy project remove my-project --json '{"component_ids": ["component-id"]}'
+# Remove a shared table entry
+homeboy project remove my-project --json '{"shared_tables": ["wp_users"]}'
 ```
 
 JSON output:
@@ -471,7 +472,7 @@ JSON output:
 {
   "command": "project.remove",
   "project_id": "<project_id>",
-  "removed": ["component_ids"],
+  "removed": ["shared_tables"],
   "project": {}
 }
 ```

--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -160,10 +160,11 @@ With `--dry-run`:
 
 ### CI / bot semver recommendation example
 
-For automation, run dry-run JSON and consume:
+For automation, run a dry-run and persist the structured payload with the global
+`--output <PATH>` flag:
 
 ```sh
-homeboy release <component_id> --dry-run --json
+homeboy --output release-plan.json release <component_id> --dry-run
 ```
 
 Semver recommendation is exposed at:

--- a/docs/developer-guide/config-directory.md
+++ b/docs/developer-guide/config-directory.md
@@ -90,10 +90,12 @@ Each project is a separate JSON file named after the project ID.
 ```json
 {
   "id": "extrachill",
-  "name": "Extra Chill",
   "domain": "extrachill.com",
   "server_id": "production",
-  "component_ids": ["theme", "api"]
+  "components": [
+    { "id": "theme", "local_path": "/repo/theme", "remote_path": "wp-content/themes/theme" },
+    { "id": "api", "local_path": "/repo/api", "remote_path": "wp-content/plugins/api" }
+  ]
 }
 ```
 

--- a/docs/schemas/project-schema.md
+++ b/docs/schemas/project-schema.md
@@ -11,22 +11,17 @@ matter when the workflow needs environment context.
 ```json
 {
   "id": "string",
-  "name": "string",
+  "aliases": [],
   "domain": "string",
   "server_id": "string",
   "base_path": "string",
-  "project_type": "string",
-  "component_ids": [],
+  "path_roots": {},
   "api": {},
   "database": {},
-  "local_environment": {},
   "remote_files": {},
   "remote_logs": {},
   "table_prefix": "string",
-  "protected_table_patterns": [],
-  "unlocked_table_patterns": [],
   "shared_tables": [],
-  "table_groupings": [],
   "sub_targets": [],
   "components": [
     {
@@ -35,8 +30,10 @@ matter when the workflow needs environment context.
       "remote_path": "string"
     }
   ],
-  "component_groupings": [],
   "component_overrides": {},
+  "services": [],
+  "changelog_next_section_label": "string",
+  "changelog_next_section_aliases": [],
   "cli_path": "string",
   "tools": {},
   "extensions": {}
@@ -47,16 +44,15 @@ matter when the workflow needs environment context.
 
 ### Required Fields
 
-- **`id`** (string): Unique project identifier
-- **`name`** (string): Human-readable project name
-- **`domain`** (string): Project domain name
-- **`server_id`** (string): ID of linked server configuration
-- **`base_path`** (string): Remote server base path for project files
+- **`id`** (string): Unique project identifier. The ID is the filename key and is not serialized inside the stored project object.
 
 ### Optional Fields
 
-- **`project_type`** (string): Project type identifier (e.g., `"wordpress"`)
-- **`component_ids`** (array): List of component IDs linked to this project
+- **`aliases`** (array): Alternate IDs accepted for project lookup
+- **`domain`** (string): Project domain name
+- **`server_id`** (string): ID of linked server configuration
+- **`base_path`** (string): Local or remote base path for project files
+- **`path_roots`** (object): Named path roots used by deploy/path resolution
 - **`api`** (object): API client configuration
   - **`base_url`** (string): API base URL
   - **`enabled`** (boolean): Whether API client is enabled
@@ -70,9 +66,6 @@ matter when the workflow needs environment context.
   - **`user`** (string): Database user
   - **`password`** (string): Database password (stored in keychain)
   - **`use_ssh_tunnel`** (boolean): Connect via SSH tunnel
-- **`local_environment`** (object): Local development environment
-  - **`domain`** (string): Local domain
-  - **`site_path`** (string): Local site path
 - **`remote_files`** (object): Remote file management
   - **`pinned_files`** (array): List of frequently accessed files
     - **`id`** (string): Unique identifier
@@ -83,22 +76,13 @@ matter when the workflow needs environment context.
     - **`path`** (string): Log path relative to base_path
     - **`tail_lines`** (number): Default line count for tail
 - **`table_prefix`** (string): Database table prefix (e.g., `"wp_"`)
-- **`protected_table_patterns`** (array): Patterns for protected tables (cannot be deleted)
-- **`unlocked_table_patterns`** (array): Patterns for unlocked tables (allow dangerous operations)
 - **`shared_tables`** (array): List of shared table names across multi-site installations
-- **`table_groupings`** (array): Groupings for organizing tables
-  - **`id`** (string): Unique grouping identifier
-  - **`name`** (string): Grouping name
-  - **`patterns`** (array): Glob patterns matching tables in this group
-  - **`member_ids`** (array): Explicit table IDs in this group
-  - **`sort_order`** (number): Display sort order
 - **`sub_targets`** (array): Sub-target paths for multi-component sites
 - **`components`** (array): Project-attached component checkouts. Each entry requires `id` and `local_path`; optional `remote_path` overrides the repo-owned component `remote_path` for this project so the same component can deploy to projects with different filesystem layouts.
-- **`component_groupings`** (array): Groupings for organizing components
-  - **`id`** (string): Unique grouping identifier
-  - **`name`** (string): Grouping name
-  - **`member_ids`** (array): Component IDs in this group
 - **`component_overrides`** (object): Per-component project overrides keyed by component ID. These remain the most-specific deploy overrides and take precedence over `components[].remote_path`.
+- **`services`** (array): Service names checked by project/fleet health status
+- **`changelog_next_section_label`** (string): Project-level changelog next-section label override
+- **`changelog_next_section_aliases`** (array): Additional labels accepted for the next changelog section
 - **`cli_path`** (string): Project-scoped CLI path used by extension deploy install steps. On any given site the WP-CLI entrypoint is fixed (`wp`, `studio wp`, a Lando wrapper, etc.) and shared by every component deployed there, so this lives at the project layer instead of being repeated per component. Component-level `component_overrides[id].cli_path` still wins as the most-specific escape hatch. If unset, the deploy resolver auto-detects Studio sites (projects whose `base_path` is under `~/Studio/`) and defaults them to `"studio wp"`.
 - **`tools`** (object): Project-specific tool configurations
   - Keys are tool identifiers (e.g., `"newsletter"`, `"bandcamp_scraper"`)
@@ -112,14 +96,20 @@ matter when the workflow needs environment context.
 ```json
 {
   "id": "extrachill",
-  "name": "Extra Chill",
   "domain": "extrachill.com",
   "server_id": "production",
   "base_path": "/var/www/extrachill",
-  "project_type": "wordpress",
-  "component_ids": [
-    "extrachill-theme",
-    "extrachill-api"
+  "components": [
+    {
+      "id": "extrachill-theme",
+      "local_path": "/Users/dev/Developer/extrachill-theme",
+      "remote_path": "wp-content/themes/extrachill-theme"
+    },
+    {
+      "id": "extrachill-api",
+      "local_path": "/Users/dev/Developer/extrachill-api",
+      "remote_path": "wp-content/plugins/extrachill-api"
+    }
   ],
   "api": {
     "base_url": "https://extrachill.com/wp-json",
@@ -141,10 +131,6 @@ matter when the workflow needs environment context.
     "user": "extrachill_user",
     "use_ssh_tunnel": true
   },
-  "local_environment": {
-    "domain": "extrachill.local",
-    "site_path": "/Users/dev/Sites/extrachill"
-  },
   "remote_files": {
     "pinned_files": [
       {
@@ -163,15 +149,7 @@ matter when the workflow needs environment context.
     ]
   },
   "table_prefix": "wp_",
-  "table_groupings": [
-    {
-      "id": "wordpress-core",
-      "name": "WordPress Core",
-      "patterns": ["wp_*"],
-      "member_ids": [],
-      "sort_order": 0
-    }
-  ],
+  "services": ["nginx", "php8.4-fpm"],
   "extensions": {
     "wordpress": {
       "wp_cli_path": "/usr/local/bin/wp"

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -20,12 +20,12 @@ pub struct ComponentArgs {
 enum ComponentCommand {
     /// Initialize portable component config for a repo
     Create {
-        /// JSON input spec for create/update (supports single or bulk)
-        #[arg(long)]
+        /// Legacy JSON input spec. Hidden because create now writes repo-owned homeboy.json from flags.
+        #[arg(long, hide = true)]
         json: Option<String>,
 
-        /// Skip items that already exist (JSON mode only)
-        #[arg(long)]
+        /// Legacy JSON-mode flag. Hidden because JSON bulk create is no longer supported.
+        #[arg(long, hide = true)]
         skip_existing: bool,
 
         /// Absolute path to local source directory (writes homeboy.json there)


### PR DESCRIPTION
## Summary
- Recover the docs command-surface cleanup commit that missed the already-merged #3118 branch.
- Align project component workflow docs with `attach-path` and JSON attachment arrays.
- Refresh project schema/config examples to the current `components` attachment model and mark rig matrix docs as a proposal.

## Verification
- `cargo build --bin homeboy`
- `cargo check --bin homeboy`
- `cargo fmt --check`
- `git diff --check`
- `target/debug/homeboy audit --changed-since origin/main --only broken_doc_reference --only undocumented_feature --only stale_doc_reference --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-docs-followup-2-audit.json`
- Rendered `homeboy docs schemas/project-schema` and `homeboy docs developer-guide/config-directory`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Auditing current docs against CLI help/source, drafting documentation updates, running verification, and preparing this PR. Chris remains responsible for review and merge.