### PR TITLE
Add declarative rig file guards

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -253,6 +253,22 @@ Runs via the platform shell. `cwd`, `command`, and `env` values support variable
 
 Prefer typed `build`, `git`, `stack`, `check`, and `service` steps when they fit; generic commands are the escape hatch.
 
+### `command-if-missing`
+
+```jsonc
+{
+  "kind": "command-if-missing",
+  "missing": "node_modules/.bin/wp-env",
+  "command": "npm install",
+  "cwd": "${components.gutenberg.path}",
+  "label": "install dependencies when wp-env is missing"
+}
+```
+
+Runs the shell command only when `missing` does not exist. Relative `missing` paths resolve against `cwd` when set, otherwise against the current process directory. `cwd`, `missing`, `command`, and `env` values support variable expansion.
+
+Use this for generic idempotent bootstrap guards such as “install dependencies when the expected tool binary is missing” without embedding shell conditionals in rig JSON.
+
 ### `symlink`
 
 ```jsonc
@@ -306,6 +322,19 @@ Issues a `GET` with a 5s timeout. `expect_status` defaults to `200`.
 ```
 
 Checks that the file exists and optionally contains a substring.
+
+### Any File Exists Probe
+
+```jsonc
+{
+  "any_file_exists": [
+    "${components.gutenberg.path}/lib/compat/wordpress-7.1/class-wp-http-polling-sync-server.php",
+    "${components.gutenberg.path}/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php"
+  ]
+}
+```
+
+Passes when at least one candidate path exists. This covers versioned compatibility-file checks without shelling out to `test -f A || test -f B`.
 
 ### Command Probe
 

--- a/src/core/rig/check.rs
+++ b/src/core/rig/check.rs
@@ -1,8 +1,7 @@
 //! Declarative check evaluation.
 //!
-//! A `CheckSpec` has optional `http` / `file` / `command` fields. Exactly one
-//! should be set per spec. `evaluate` returns `Ok(())` on pass, a structured
-//! `Error` on fail.
+//! A `CheckSpec` has optional probe fields. Exactly one should be set per spec.
+//! `evaluate` returns `Ok(())` on pass, a structured `Error` on fail.
 //!
 //! Kept deliberately small — no retries, no fancy wait-for semantics. A
 //! failing check means fix-the-env, not poll-until-it-works.
@@ -26,6 +25,9 @@ pub fn evaluate(rig: &RigSpec, check: &CheckSpec) -> Result<()> {
     if check.file.is_some() {
         set += 1;
     }
+    if !check.any_file_exists.is_empty() {
+        set += 1;
+    }
     if check.command.is_some() {
         set += 1;
     }
@@ -36,7 +38,7 @@ pub fn evaluate(rig: &RigSpec, check: &CheckSpec) -> Result<()> {
     if set == 0 {
         return Err(Error::validation_invalid_argument(
             "check",
-            "Check must specify one of `http`, `file`, `command`, or `newer_than`",
+            "Check must specify one of `http`, `file`, `any_file_exists`, `command`, or `newer_than`",
             None,
             None,
         ));
@@ -44,7 +46,7 @@ pub fn evaluate(rig: &RigSpec, check: &CheckSpec) -> Result<()> {
     if set > 1 {
         return Err(Error::validation_invalid_argument(
             "check",
-            "Check must specify exactly one of `http`, `file`, `command`, or `newer_than`",
+            "Check must specify exactly one of `http`, `file`, `any_file_exists`, `command`, or `newer_than`",
             None,
             None,
         ));
@@ -55,6 +57,9 @@ pub fn evaluate(rig: &RigSpec, check: &CheckSpec) -> Result<()> {
     }
     if let Some(path) = &check.file {
         return file_check(rig, path, check.contains.as_deref());
+    }
+    if !check.any_file_exists.is_empty() {
+        return any_file_exists_check(rig, &check.any_file_exists);
     }
     if let Some(cmd) = &check.command {
         return command_check(rig, cmd, check.expect_exit.unwrap_or(0));
@@ -160,6 +165,24 @@ fn file_check(rig: &RigSpec, path: &str, contains: Option<&str>) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn any_file_exists_check(rig: &RigSpec, paths: &[String]) -> Result<()> {
+    let resolved = paths
+        .iter()
+        .map(|path| expand_vars(rig, path))
+        .collect::<Vec<_>>();
+
+    if resolved.iter().any(|path| PathBuf::from(path).exists()) {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "check.any_file_exists",
+        format!("None of the candidate files exist: {}", resolved.join(", ")),
+        None,
+        None,
+    ))
 }
 
 fn command_check(rig: &RigSpec, cmd: &str, expect_exit: i32) -> Result<()> {

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -175,6 +175,14 @@ fn run_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {
             label: _,
             ..
         } => run_command_step(rig, cmd, cwd.as_deref(), env),
+        PipelineStep::CommandIfMissing {
+            missing,
+            cmd,
+            cwd,
+            env,
+            label: _,
+            ..
+        } => run_command_if_missing_step(rig, missing, cmd, cwd.as_deref(), env),
         PipelineStep::Symlink { op, .. } => run_symlink_step(rig, *op),
         PipelineStep::SharedPath { op, .. } => run_shared_path_step(rig, *op),
         PipelineStep::Patch {
@@ -287,6 +295,7 @@ fn step_id(step: &PipelineStep) -> Option<&str> {
         | PipelineStep::Git { step_id, .. }
         | PipelineStep::Stack { step_id, .. }
         | PipelineStep::Command { step_id, .. }
+        | PipelineStep::CommandIfMissing { step_id, .. }
         | PipelineStep::Symlink { step_id, .. }
         | PipelineStep::SharedPath { step_id, .. }
         | PipelineStep::Patch { step_id, .. }
@@ -302,6 +311,7 @@ fn step_dependencies(step: &PipelineStep) -> &[String] {
         | PipelineStep::Git { depends_on, .. }
         | PipelineStep::Stack { depends_on, .. }
         | PipelineStep::Command { depends_on, .. }
+        | PipelineStep::CommandIfMissing { depends_on, .. }
         | PipelineStep::Symlink { depends_on, .. }
         | PipelineStep::SharedPath { depends_on, .. }
         | PipelineStep::Patch { depends_on, .. }
@@ -592,6 +602,30 @@ fn run_command_step(
         ));
     }
     Ok(())
+}
+
+fn run_command_if_missing_step(
+    rig: &RigSpec,
+    missing: &str,
+    cmd: &str,
+    cwd: Option<&str>,
+    env: &HashMap<String, String>,
+) -> Result<()> {
+    let expanded_missing = expand_vars(rig, missing);
+    let missing_path = PathBuf::from(&expanded_missing);
+    let resolved_missing = if missing_path.is_absolute() {
+        missing_path
+    } else if let Some(cwd) = cwd {
+        PathBuf::from(expand_vars(rig, cwd)).join(missing_path)
+    } else {
+        missing_path
+    };
+
+    if resolved_missing.exists() {
+        return Ok(());
+    }
+
+    run_command_step(rig, cmd, cwd, env)
 }
 
 #[cfg(unix)]
@@ -1058,6 +1092,7 @@ fn step_kind(step: &PipelineStep) -> &'static str {
         PipelineStep::Git { .. } => "git",
         PipelineStep::Stack { .. } => "stack",
         PipelineStep::Command { .. } => "command",
+        PipelineStep::CommandIfMissing { .. } => "command-if-missing",
         PipelineStep::Symlink { .. } => "symlink",
         PipelineStep::SharedPath { .. } => "shared-path",
         PipelineStep::Patch { .. } => "patch",
@@ -1110,6 +1145,9 @@ fn step_label(rig: &RigSpec, step: &PipelineStep, idx: usize) -> String {
             )
         }),
         PipelineStep::Command { cmd, label, .. } => label
+            .clone()
+            .unwrap_or_else(|| truncate(&expand_vars(rig, cmd), 80)),
+        PipelineStep::CommandIfMissing { cmd, label, .. } => label
             .clone()
             .unwrap_or_else(|| truncate(&expand_vars(rig, cmd), 80)),
         PipelineStep::Symlink { op, .. } => format!("symlink {}", serialize_symlink_op(*op)),

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -168,21 +168,9 @@ fn run_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {
             dry_run,
             ..
         } => run_stack_step(rig, component, *op, *dry_run),
-        PipelineStep::Command {
-            cmd,
-            cwd,
-            env,
-            label: _,
-            ..
-        } => run_command_step(rig, cmd, cwd.as_deref(), env),
-        PipelineStep::CommandIfMissing {
-            missing,
-            cmd,
-            cwd,
-            env,
-            label: _,
-            ..
-        } => run_command_if_missing_step(rig, missing, cmd, cwd.as_deref(), env),
+        PipelineStep::Command { .. } | PipelineStep::CommandIfMissing { .. } => {
+            run_command_pipeline_step(rig, step)
+        }
         PipelineStep::Symlink { op, .. } => run_symlink_step(rig, *op),
         PipelineStep::SharedPath { op, .. } => run_shared_path_step(rig, *op),
         PipelineStep::Patch {
@@ -602,6 +590,22 @@ fn run_command_step(
         ));
     }
     Ok(())
+}
+
+fn run_command_pipeline_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {
+    match step {
+        PipelineStep::Command { cmd, cwd, env, .. } => {
+            run_command_step(rig, cmd, cwd.as_deref(), env)
+        }
+        PipelineStep::CommandIfMissing {
+            missing,
+            cmd,
+            cwd,
+            env,
+            ..
+        } => run_command_if_missing_step(rig, missing, cmd, cwd.as_deref(), env),
+        _ => unreachable!("command pipeline helper only accepts command steps"),
+    }
 }
 
 fn run_command_if_missing_step(

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -1080,6 +1080,34 @@ pub enum PipelineStep {
         label: Option<String>,
     },
 
+    /// Run a shell command only when a filesystem path is missing.
+    ///
+    /// This keeps common bootstrap guards declarative without teaching Homeboy
+    /// package-manager-specific install semantics.
+    CommandIfMissing {
+        /// Optional stable node ID for dependency-aware pipeline ordering.
+        #[serde(default, rename = "id", skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
+        /// Step IDs that must run before this step.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
+        /// Path whose absence triggers the command. Relative paths resolve
+        /// against `cwd` when set, otherwise against the process cwd.
+        missing: String,
+        /// Shell command to execute when `missing` does not exist.
+        #[serde(rename = "command")]
+        cmd: String,
+        /// Working directory. Supports variable expansion.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cwd: Option<String>,
+        /// Env vars (merged over inherited environment).
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        env: HashMap<String, String>,
+        /// Human-readable label shown during execution. If absent, `cmd` is used.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+    },
+
     /// Ensure a declared symlink exists (or verify it in `check` pipelines).
     Symlink {
         /// Optional stable node ID for dependency-aware pipeline ordering.
@@ -1259,7 +1287,8 @@ pub enum PatchOp {
 }
 
 /// A single declarative check. One-of semantics — exactly one of the
-/// probe fields (`http`, `file`, `command`, `newer_than`) should be set.
+/// probe fields (`http`, `file`, `any_file_exists`, `command`, `newer_than`)
+/// should be set.
 /// Validated at check-time, not parse-time, because serde flattening
 /// across tagged enums is awkward and explicit-field checks keep the
 /// spec readable.
@@ -1281,6 +1310,10 @@ pub struct CheckSpec {
     /// this substring. Cheap probe for verifying drop-ins / generated files.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub contains: Option<String>,
+
+    /// File paths — passes when at least one path exists.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub any_file_exists: Vec<String>,
 
     /// Shell command — passes if exit code matches `expect_exit` (default 0).
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/tests/core/rig/check_test.rs
+++ b/tests/core/rig/check_test.rs
@@ -41,11 +41,46 @@ fn test_evaluate_rejects_multiple_probes() {
     let rig = minimal_rig();
     let spec = CheckSpec {
         http: Some("http://example.com".to_string()),
-        file: Some("/tmp/x".to_string()),
+        any_file_exists: vec!["/tmp/x".to_string()],
         ..Default::default()
     };
     let err = evaluate(&rig, &spec).expect_err("multiple probes rejected");
     assert!(err.message.contains("must specify exactly one of"));
+}
+
+#[test]
+fn test_evaluate_any_file_exists_passes_when_one_candidate_exists() {
+    let tmp_dir = tempfile::tempdir().expect("tmpdir");
+    let missing = tmp_dir.path().join("missing.php");
+    let existing = tmp_dir.path().join("existing.php");
+    std::fs::write(&existing, "<?php\n").expect("write");
+
+    let rig = minimal_rig();
+    let spec = CheckSpec {
+        any_file_exists: vec![
+            missing.to_string_lossy().into_owned(),
+            existing.to_string_lossy().into_owned(),
+        ],
+        ..Default::default()
+    };
+
+    evaluate(&rig, &spec).expect("one existing candidate passes");
+}
+
+#[test]
+fn test_evaluate_any_file_exists_fails_when_all_candidates_are_missing() {
+    let tmp_dir = tempfile::tempdir().expect("tmpdir");
+    let rig = minimal_rig();
+    let spec = CheckSpec {
+        any_file_exists: vec![
+            tmp_dir.path().join("a.php").to_string_lossy().into_owned(),
+            tmp_dir.path().join("b.php").to_string_lossy().into_owned(),
+        ],
+        ..Default::default()
+    };
+
+    let err = evaluate(&rig, &spec).expect_err("all missing candidates fail");
+    assert!(err.message.contains("None of the candidate files exist"));
 }
 
 #[test]

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -105,7 +105,7 @@ fn test_command_if_missing_runs_when_path_is_missing() {
                 "bench_prepare": [{{
                     "kind": "command-if-missing",
                     "cwd": "{}",
-                    "missing": "node_modules/.bin/wp-env",
+                    "missing": "node_modules/.bin/project-env",
                     "command": "printf installed > {}"
                 }}]
             }}
@@ -125,9 +125,9 @@ fn test_command_if_missing_runs_when_path_is_missing() {
 #[test]
 fn test_command_if_missing_skips_when_path_exists() {
     let tmp = tempfile::tempdir().expect("tmpdir");
-    let wp_env = tmp.path().join("node_modules/.bin/wp-env");
-    std::fs::create_dir_all(wp_env.parent().expect("parent")).expect("mkdir");
-    std::fs::write(&wp_env, "#!/bin/sh\n").expect("write");
+    let tool_bin = tmp.path().join("node_modules/.bin/project-env");
+    std::fs::create_dir_all(tool_bin.parent().expect("parent")).expect("mkdir");
+    std::fs::write(&tool_bin, "#!/bin/sh\n").expect("write");
     let marker = tmp.path().join("installed.txt");
     let marker_arg = marker.to_string_lossy();
     let cwd_arg = tmp.path().to_string_lossy();
@@ -138,7 +138,7 @@ fn test_command_if_missing_skips_when_path_exists() {
                 "bench_prepare": [{{
                     "kind": "command-if-missing",
                     "cwd": "{}",
-                    "missing": "node_modules/.bin/wp-env",
+                    "missing": "node_modules/.bin/project-env",
                     "command": "printf installed > {}"
                 }}]
             }}

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -4,7 +4,9 @@
 //! and are covered by the manual smoke documented in #1468. Scope here is
 //! the public outcome types — shape, serialization, `is_success` contract.
 
-use crate::core::rig::pipeline::{run_pipeline_check_groups, PipelineOutcome, PipelineStepOutcome};
+use crate::core::rig::pipeline::{
+    run_pipeline, run_pipeline_check_groups, PipelineOutcome, PipelineStepOutcome,
+};
 use crate::core::rig::spec::RigSpec;
 
 fn step(status: &str) -> PipelineStepOutcome {
@@ -88,6 +90,66 @@ fn test_run_pipeline_check_groups() {
     assert!(outcome.is_success());
     assert_eq!(outcome.steps.len(), 1);
     assert_eq!(outcome.steps[0].label, "selected");
+}
+
+#[test]
+fn test_command_if_missing_runs_when_path_is_missing() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let marker = tmp.path().join("installed.txt");
+    let marker_arg = marker.to_string_lossy();
+    let cwd_arg = tmp.path().to_string_lossy();
+    let rig: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "command-if-missing-run",
+            "pipeline": {{
+                "bench_prepare": [{{
+                    "kind": "command-if-missing",
+                    "cwd": "{}",
+                    "missing": "node_modules/.bin/wp-env",
+                    "command": "printf installed > {}"
+                }}]
+            }}
+        }}"#,
+        cwd_arg, marker_arg
+    ))
+    .expect("parse rig");
+
+    let out = run_pipeline(&rig, "bench_prepare", true).expect("pipeline runs");
+    assert!(out.is_success(), "outcomes: {:?}", out.steps);
+    assert_eq!(
+        std::fs::read_to_string(marker).expect("marker"),
+        "installed"
+    );
+}
+
+#[test]
+fn test_command_if_missing_skips_when_path_exists() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let wp_env = tmp.path().join("node_modules/.bin/wp-env");
+    std::fs::create_dir_all(wp_env.parent().expect("parent")).expect("mkdir");
+    std::fs::write(&wp_env, "#!/bin/sh\n").expect("write");
+    let marker = tmp.path().join("installed.txt");
+    let marker_arg = marker.to_string_lossy();
+    let cwd_arg = tmp.path().to_string_lossy();
+    let rig: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "command-if-missing-skip",
+            "pipeline": {{
+                "bench_prepare": [{{
+                    "kind": "command-if-missing",
+                    "cwd": "{}",
+                    "missing": "node_modules/.bin/wp-env",
+                    "command": "printf installed > {}"
+                }}]
+            }}
+        }}"#,
+        cwd_arg, marker_arg
+    ))
+    .expect("parse rig");
+
+    let out = run_pipeline(&rig, "bench_prepare", true).expect("pipeline runs");
+    assert!(out.is_success(), "outcomes: {:?}", out.steps);
+    assert!(!marker.exists(), "guarded command should not run");
 }
 
 // ---- Dependency-aware ordering ---------------------------------------------

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -98,11 +98,8 @@ fn test_spec_pipeline_steps_discriminate_correctly() {
 
     let check = spec.pipeline.get("check").unwrap();
     assert!(matches!(check[3], PipelineStep::Check { .. }));
-}
 
-#[test]
-fn test_spec_parses_declarative_rig_primitives() {
-    let spec: RigSpec = serde_json::from_str(
+    let declarative_spec: RigSpec = serde_json::from_str(
         r#"{
             "id": "declarative-primitives",
             "pipeline": {
@@ -110,15 +107,15 @@ fn test_spec_parses_declarative_rig_primitives() {
                     {
                         "kind": "check",
                         "label": "compat server exists",
-                        "any_file_exists": ["lib/compat/wordpress-7.1/server.php", "lib/compat/wordpress-7.0/server.php"]
+                        "any_file_exists": ["lib/compat/runtime-v2/server.txt", "lib/compat/runtime-v1/server.txt"]
                     }
                 ],
                 "bench_prepare": [
                     {
                         "kind": "command-if-missing",
-                        "label": "Install npm dependencies when wp-env is missing",
+                        "label": "Install dependencies when project-env is missing",
                         "cwd": "/tmp/project",
-                        "missing": "node_modules/.bin/wp-env",
+                        "missing": "node_modules/.bin/project-env",
                         "command": "npm install"
                     }
                 ]
@@ -127,13 +124,16 @@ fn test_spec_parses_declarative_rig_primitives() {
     )
     .expect("parse declarative primitives");
 
-    let check = spec.pipeline.get("check").expect("check pipeline");
-    match &check[0] {
+    let declarative_check = declarative_spec
+        .pipeline
+        .get("check")
+        .expect("check pipeline");
+    match &declarative_check[0] {
         PipelineStep::Check { spec, .. } => assert_eq!(spec.any_file_exists.len(), 2),
         other => panic!("expected check step, got {other:?}"),
     }
 
-    let prepare = spec
+    let prepare = declarative_spec
         .pipeline
         .get("bench_prepare")
         .expect("prepare pipeline");
@@ -141,7 +141,7 @@ fn test_spec_parses_declarative_rig_primitives() {
         PipelineStep::CommandIfMissing {
             missing, cmd, cwd, ..
         } => {
-            assert_eq!(missing, "node_modules/.bin/wp-env");
+            assert_eq!(missing, "node_modules/.bin/project-env");
             assert_eq!(cmd, "npm install");
             assert_eq!(cwd.as_deref(), Some("/tmp/project"));
         }

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -101,6 +101,55 @@ fn test_spec_pipeline_steps_discriminate_correctly() {
 }
 
 #[test]
+fn test_spec_parses_declarative_rig_primitives() {
+    let spec: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "declarative-primitives",
+            "pipeline": {
+                "check": [
+                    {
+                        "kind": "check",
+                        "label": "compat server exists",
+                        "any_file_exists": ["lib/compat/wordpress-7.1/server.php", "lib/compat/wordpress-7.0/server.php"]
+                    }
+                ],
+                "bench_prepare": [
+                    {
+                        "kind": "command-if-missing",
+                        "label": "Install npm dependencies when wp-env is missing",
+                        "cwd": "/tmp/project",
+                        "missing": "node_modules/.bin/wp-env",
+                        "command": "npm install"
+                    }
+                ]
+            }
+        }"#,
+    )
+    .expect("parse declarative primitives");
+
+    let check = spec.pipeline.get("check").expect("check pipeline");
+    match &check[0] {
+        PipelineStep::Check { spec, .. } => assert_eq!(spec.any_file_exists.len(), 2),
+        other => panic!("expected check step, got {other:?}"),
+    }
+
+    let prepare = spec
+        .pipeline
+        .get("bench_prepare")
+        .expect("prepare pipeline");
+    match &prepare[0] {
+        PipelineStep::CommandIfMissing {
+            missing, cmd, cwd, ..
+        } => {
+            assert_eq!(missing, "node_modules/.bin/wp-env");
+            assert_eq!(cmd, "npm install");
+            assert_eq!(cwd.as_deref(), Some("/tmp/project"));
+        }
+        other => panic!("expected command-if-missing step, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_spec_symlink_fields_parse() {
     let spec: RigSpec = serde_json::from_str(STUDIO_PLAYGROUND_SPEC).expect("parse");
     let link: &SymlinkSpec = &spec.symlinks[0];


### PR DESCRIPTION
## Summary
- Add an `any_file_exists` check probe for versioned fallback-file checks without shell `test -f A || test -f B` commands.
- Add a generic `command-if-missing` pipeline step for idempotent bootstrap commands such as installing dependencies when a tool binary is absent.
- Document both primitives and cover serde parsing plus check/pipeline execution behavior.

## Tests
- `cargo fmt --check && cargo test check_test && cargo test pipeline_test && cargo test spec_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the narrow rig primitive implementation, docs, tests, commit, and PR body for Chris to review.