### PR TITLE
Fix lint checkout consistency from worktrees

### DIFF
--- a/src/core/component/resolution.rs
+++ b/src/core/component/resolution.rs
@@ -169,7 +169,48 @@ fn prefer_cwd_for_component(component_id: &str) -> Option<Component> {
         }
     }
 
+    let mut registered = load(component_id).ok()?;
+    let registered_path = PathBuf::from(shellexpand::tilde(&registered.local_path).into_owned());
+    let cwd_git_root = detect_git_root(&cwd)?;
+    if same_git_common_dir(&registered_path, &cwd_git_root) {
+        registered.local_path = cwd_git_root.to_string_lossy().to_string();
+        registered.resolve_remote_path();
+        return Some(registered);
+    }
+
     None
+}
+
+fn same_git_common_dir(a: &Path, b: &Path) -> bool {
+    match (git_common_dir(a), git_common_dir(b)) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    }
+}
+
+fn git_common_dir(dir: &Path) -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .current_dir(dir)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if raw.is_empty() {
+        return None;
+    }
+
+    let path = PathBuf::from(raw);
+    let absolute = if path.is_absolute() {
+        path
+    } else {
+        dir.join(path)
+    };
+    absolute.canonicalize().ok()
 }
 
 fn synthetic_component_for_path(path: &str) -> Component {
@@ -474,6 +515,20 @@ mod tests {
         .expect("standalone registration");
     }
 
+    fn git(path: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("git command should run");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
     #[test]
     fn test_resolve_artifact() {
         let explicit = Component {
@@ -642,6 +697,38 @@ mod tests {
             assert_eq!(target.component_id, "registered");
             assert_eq!(target.source_path, repo);
             assert!(!target.synthetic);
+        });
+    }
+
+    #[test]
+    fn target_spec_prefers_cwd_worktree_for_registered_component() {
+        crate::test_support::with_isolated_home(|home| {
+            let dir = tempfile::tempdir().expect("temp dir");
+            let primary = dir.path().join("primary");
+            let worktree = dir.path().join("component-worktree");
+            std::fs::create_dir_all(&primary).expect("primary dir");
+            git(&primary, &["init"]);
+            git(&primary, &["config", "user.email", "test@example.com"]);
+            git(&primary, &["config", "user.name", "Test User"]);
+            std::fs::write(primary.join("README.md"), "fixture\n").expect("readme");
+            git(&primary, &["add", "README.md"]);
+            git(&primary, &["commit", "-m", "Initial commit"]);
+            git(&primary, &["worktree", "add", worktree.to_str().unwrap()]);
+            write_standalone_registration(home.path(), "registered", &primary);
+
+            with_cwd(&worktree, || {
+                let target = resolve_target(TargetSpec::new(Some("registered"), None))
+                    .expect("registered worktree target");
+                let canonical_worktree = worktree.canonicalize().expect("canonical worktree");
+
+                assert_eq!(target.component_id, "registered");
+                assert_eq!(target.source_path, canonical_worktree);
+                assert_eq!(
+                    target.component.local_path,
+                    target.source_path.to_string_lossy()
+                );
+                assert!(!target.synthetic);
+            });
         });
     }
 


### PR DESCRIPTION
## Summary
- Prefer the current git worktree when a registered component command is run from a checkout sharing the same git common directory as the registered path.
- Preserve registered component metadata while resolving `local_path` to the CWD worktree root so `lint` read and `lint --fix` verify against the same checkout.
- Add regression coverage for a registered primary checkout plus git worktree without relying on WordPress-specific assumptions.

Fixes #3121.

## Verification
- `cargo test core::component::resolution::tests::target_spec_prefers_cwd_worktree_for_registered_component`
- `cargo test core::component::resolution::tests`
- `cargo test core::engine::execution_context::tests`
- `cargo test --test core_agnostic_test`
- `homeboy lint homeboy --path . --changed-since origin/main`
- `homeboy test homeboy --path . --changed-since origin/main`

## Notes
- Full `cargo test` was attempted twice. Each run completed 3,575 passing tests before hitting a different transient test failure; each failed test passed when rerun directly:
  - `core::extension::execution::tests::build_exec_env_includes_runtime_runner_helper_path`
  - `core::extension::trace::run::tests::test_run_trace_list_workflow`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigating the checkout-resolution mismatch, drafting the resolver fix and regression test, running verification, and preparing the PR. Chris remains responsible for review and merge.