### PR TITLE
fix: clarify lint changed-since help

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -69,11 +69,7 @@ pub struct LintArgs {
     #[arg(long)]
     pub category: Option<String>,
 
-    /// Apply auto-fixable lint findings in place.
-    ///
-    /// Thin alias for `homeboy refactor <component> --from lint --write` —
-    /// dispatches to the existing fixer pipeline so a single ergonomic flag
-    /// resolves the auto-fix CTA without re-typing the canonical invocation.
+    /// Apply auto-fixable lint findings in place using the lint fixer pipeline.
     #[arg(long)]
     pub fix: bool,
 
@@ -337,7 +333,7 @@ fn run_fix(
 #[cfg(test)]
 mod tests {
     use super::LintArgs;
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
     use homeboy::core::component::Component;
     use homeboy::core::extension::lint as extension_lint;
     use homeboy::core::extension::lint::baseline as lint_baseline;
@@ -385,6 +381,27 @@ mod tests {
             .expect("lint should parse --ci-job");
 
         assert_eq!(cli.lint.ci_job.as_deref(), Some("lint-typecheck"));
+    }
+
+    #[test]
+    fn lint_help_documents_changed_since_once_as_read_only_scope() {
+        let help = TestCli::command().render_long_help().to_string();
+
+        assert_eq!(help.matches("--changed-since").count(), 1, "{help}");
+        assert!(
+            help.contains("Lint only files changed since a git ref (branch, tag, or SHA)"),
+            "{help}"
+        );
+        assert!(
+            help.contains(
+                "Apply auto-fixable lint findings in place using the lint fixer pipeline"
+            ),
+            "{help}"
+        );
+        assert!(
+            !help.contains("--from lint --write"),
+            "lint --help should not describe --changed-since or --fix as a refactor --write alias: {help}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Clarify `homeboy lint --help` so `--changed-since` remains documented once as a read-only changed-file scope.
- Remove the adjacent `--from lint --write` alias wording from `--fix` help to avoid confusing it with `--changed-since` semantics.
- Add a regression test covering the lint help output.

Closes https://github.com/Extra-Chill/homeboy/issues/3119

## Verification
- `cargo fmt --check`
- `cargo test lint_help_documents_changed_since_once_as_read_only_scope`
- `cargo test commands::lint::tests`
- `cargo run --quiet --bin homeboy -- lint --help`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused CLI help/test change and ran local verification; Chris remains responsible for review and merge.