### PR TITLE
fix: isolate runtime env tests

### DIFF
--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -793,15 +793,17 @@ mod tests {
 
     #[test]
     fn build_exec_env_includes_runtime_runner_helper_path() {
-        let env = build_exec_env("rust", None, None, "{}", Some("/tmp/ext"), None, None, None);
+        crate::test_support::with_isolated_home(|_| {
+            let env = build_exec_env("rust", None, None, "{}", Some("/tmp/ext"), None, None, None);
 
-        let helper = env
-            .iter()
-            .find(|(k, _)| k == runtime_helper::RUNNER_STEPS_ENV)
-            .map(|(_, v)| v.clone());
+            let helper = env
+                .iter()
+                .find(|(k, _)| k == runtime_helper::RUNNER_STEPS_ENV)
+                .map(|(_, v)| v.clone());
 
-        assert!(helper.is_some());
-        assert!(helper.unwrap().ends_with("runner-steps.sh"));
+            assert!(helper.is_some());
+            assert!(helper.unwrap().ends_with("runner-steps.sh"));
+        });
     }
 
     #[test]

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -976,24 +976,26 @@ mod tests {
 
     #[test]
     fn test_run_trace_list_workflow() {
-        let temp = tempfile::tempdir().unwrap();
-        let component = test_component(temp.path());
-        let run_dir = RunDir::create().unwrap();
-        let list = run_trace_list_workflow(
-            &component,
-            TraceListWorkflowArgs {
-                component_label: "example".to_string(),
-                component_id: "example".to_string(),
-                path_override: Some(temp.path().to_string_lossy().to_string()),
-                settings: Vec::new(),
-                runner_inputs: TraceRunnerInputs::default(),
-                rig_id: None,
-            },
-            &run_dir,
-        )
-        .unwrap();
-        assert!(list.scenarios.is_empty());
-        run_dir.cleanup();
+        crate::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().unwrap();
+            let component = test_component(temp.path());
+            let run_dir = RunDir::create().unwrap();
+            let list = run_trace_list_workflow(
+                &component,
+                TraceListWorkflowArgs {
+                    component_label: "example".to_string(),
+                    component_id: "example".to_string(),
+                    path_override: Some(temp.path().to_string_lossy().to_string()),
+                    settings: Vec::new(),
+                    runner_inputs: TraceRunnerInputs::default(),
+                    rig_id: None,
+                },
+                &run_dir,
+            )
+            .unwrap();
+            assert!(list.scenarios.is_empty());
+            run_dir.cleanup();
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Isolate the runtime helper env test with the existing test home guard so it no longer reads helper paths from a shared process environment.
- Isolate the trace list workflow test before creating runtime temp dirs, avoiding collisions with other tests that mutate Homeboy runtime env vars.

## Verification
- `cargo test core::extension::execution::tests::build_exec_env_includes_runtime_runner_helper_path`
- `cargo test core::extension::trace::run::tests::test_run_trace_list_workflow`
- `homeboy lint homeboy --path . --changed-since origin/main`
- `homeboy test homeboy --path . --changed-since origin/main`
- `cargo test` was attempted locally; it timed out after 15 minutes with long-running full-suite tests, while the reported tests passed when rerun directly.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Root-cause investigation, drafting the focused test-isolation patch, and running local verification. Chris remains responsible for review and merge.