### PR TITLE
Pass dependency stack constraints through providers

### DIFF
--- a/docs/commands/deps.md
+++ b/docs/commands/deps.md
@@ -11,10 +11,10 @@ homeboy deps <COMMAND>
 ## Subcommands
 
 - `status` — inspect dependency constraints and locked package versions
-- `update` — update one Composer package explicitly
+- `update` — update one package through its dependency provider
 - `stack status` — list declared dependency stack edges
 - `stack plan <upstream>` — plan downstream updates for a merged upstream component or repo
-- `stack apply <upstream> [--dry-run]` — run declared update, post-update, and test commands in dependency order
+- `stack apply <upstream> [--to <constraint>] [--dry-run]` — run declared update, post-update, and test commands in dependency order
 
 ## Dependency Stacks
 
@@ -46,6 +46,14 @@ When `update` is omitted, Homeboy uses:
 ```sh
 homeboy deps update <package> --path <downstream path>
 ```
+
+Pass `--to <constraint>` to `stack apply` when the default provider-backed update should set a new manifest constraint:
+
+```sh
+homeboy deps stack apply extrachill-components --to ^0.5.2
+```
+
+Custom `dependency_stack[].update` commands are executed as declared; include any constraint handling directly in the custom command when overriding the default provider-backed update.
 
 ## Related
 

--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -73,6 +73,10 @@ enum DepsStackCommand {
         /// Upstream component or repository identifier from dependency_stack[].upstream.
         upstream: String,
 
+        /// New manifest constraint to pass to provider-backed default update steps.
+        #[arg(long, value_name = "CONSTRAINT")]
+        to: Option<String>,
+
         /// Print the command plan without running commands.
         #[arg(long)]
         dry_run: bool,
@@ -161,12 +165,13 @@ pub fn run(args: DepsArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<s
             }
             DepsStackCommand::Apply {
                 upstream,
+                to,
                 dry_run,
                 no_install,
                 rebuild,
             } => {
                 let output: DependencyStackApplyResult =
-                    deps::stack_apply(&upstream, dry_run, !no_install, rebuild)?;
+                    deps::stack_apply(&upstream, to.as_deref(), dry_run, !no_install, rebuild)?;
                 Ok((
                     serde_json::to_value(output).map_err(|e| {
                         homeboy::core::Error::internal_json(

--- a/src/core/deps.rs
+++ b/src/core/deps.rs
@@ -8,9 +8,9 @@ mod stack;
 
 use crate::extensions::deps_provider as provider;
 pub use stack::{
-    stack_apply, stack_plan, stack_plan_from_components, stack_status, DependencyStackApplyResult,
-    DependencyStackApplyStep, DependencyStackCommandResult, DependencyStackEdgeStatus,
-    DependencyStackPlan, DependencyStackPlanStep, DependencyStackStatus,
+    stack_apply, stack_apply_plan, stack_plan, stack_plan_from_components, stack_status,
+    DependencyStackApplyResult, DependencyStackApplyStep, DependencyStackCommandResult,
+    DependencyStackEdgeStatus, DependencyStackPlan, DependencyStackPlanStep, DependencyStackStatus,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/deps/stack.rs
+++ b/src/core/deps/stack.rs
@@ -101,17 +101,30 @@ pub fn stack_plan(upstream: &str) -> Result<DependencyStackPlan> {
 
 pub fn stack_apply(
     upstream: &str,
+    constraint: Option<&str>,
     dry_run: bool,
     install: bool,
     rebuild: bool,
 ) -> Result<DependencyStackApplyResult> {
     let plan = stack_plan(upstream)?;
+    stack_apply_plan(plan, constraint, dry_run, install, rebuild)
+}
+
+pub fn stack_apply_plan(
+    plan: DependencyStackPlan,
+    constraint: Option<&str>,
+    dry_run: bool,
+    install: bool,
+    rebuild: bool,
+) -> Result<DependencyStackApplyResult> {
     let mut steps = Vec::new();
 
     for step in plan.planned_steps() {
         let mut command_results = Vec::new();
         if step.uses_default_update_command() {
-            command_results.push(run_default_update_step(&step, dry_run, install)?);
+            command_results.push(run_default_update_step(
+                &step, constraint, dry_run, install,
+            )?);
         } else {
             command_results.push(run_stack_command(
                 "update",
@@ -379,15 +392,24 @@ fn update_command(edge: &DependencyStackEdge, downstream_path: &str) -> String {
 }
 
 fn update_command_for(package: &str, downstream_path: &str) -> String {
-    update_command_for_options(package, downstream_path, true)
+    update_command_for_options(package, downstream_path, None, true)
 }
 
-fn update_command_for_options(package: &str, downstream_path: &str, install: bool) -> String {
+fn update_command_for_options(
+    package: &str,
+    downstream_path: &str,
+    constraint: Option<&str>,
+    install: bool,
+) -> String {
     let mut command = format!(
         "homeboy deps update {} --path {}",
         shell_word(package),
         shell_word(downstream_path)
     );
+    if let Some(constraint) = constraint {
+        command.push_str(" --to ");
+        command.push_str(&shell_word(constraint));
+    }
     if !install {
         command.push_str(" --no-install");
     }
@@ -404,10 +426,12 @@ fn rebuild_command(step: &DependencyStackPlanStep) -> String {
 
 fn run_default_update_step(
     step: &DependencyStackPlanStep,
+    constraint: Option<&str>,
     dry_run: bool,
     install: bool,
 ) -> Result<DependencyStackCommandResult> {
-    let command = update_command_for_options(&step.package, &step.downstream_path, install);
+    let command =
+        update_command_for_options(&step.package, &step.downstream_path, constraint, install);
     if dry_run {
         return Ok(DependencyStackCommandResult {
             phase: "update".to_string(),
@@ -423,7 +447,7 @@ fn run_default_update_step(
         Some(&step.downstream),
         Some(&step.downstream_path),
         &step.package,
-        None,
+        constraint,
         DependencyUpdateOptions {
             install,
             rebuild: false,

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -272,34 +272,6 @@ fn stack_plan_derives_edges_from_provider_reported_dependency_identities() {
 }
 
 #[test]
-fn stack_apply_dry_run_passes_constraint_to_default_provider_update() {
-    let plan = deps::DependencyStackPlan::new(
-        "upstream",
-        vec![deps::DependencyStackPlanStep {
-            sequence: 1,
-            declaring_component_id: "downstream".to_string(),
-            upstream: "upstream".to_string(),
-            downstream: "downstream".to_string(),
-            downstream_path: "/tmp/downstream path".to_string(),
-            package: "fixture/upstream".to_string(),
-            update_command: "homeboy deps update fixture/upstream --path '/tmp/downstream path'"
-                .to_string(),
-            rebuild: false,
-            post_update: Vec::new(),
-            test: Vec::new(),
-        }],
-    );
-
-    let result = deps::stack_apply_plan(plan, Some("^2.0"), true, false, false).unwrap();
-
-    assert_eq!(result.step_count, 1);
-    assert_eq!(
-        result.steps[0].command_results[0].command,
-        "homeboy deps update fixture/upstream --path '/tmp/downstream path' --to '^2.0' --no-install"
-    );
-}
-
-#[test]
 fn stack_plan_keeps_explicit_edge_config_when_provider_edge_matches() {
     let dir = tempdir().unwrap();
     let upstream_path = dir.path().join("upstream");

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -272,6 +272,34 @@ fn stack_plan_derives_edges_from_provider_reported_dependency_identities() {
 }
 
 #[test]
+fn stack_apply_dry_run_passes_constraint_to_default_provider_update() {
+    let plan = deps::DependencyStackPlan::new(
+        "upstream",
+        vec![deps::DependencyStackPlanStep {
+            sequence: 1,
+            declaring_component_id: "downstream".to_string(),
+            upstream: "upstream".to_string(),
+            downstream: "downstream".to_string(),
+            downstream_path: "/tmp/downstream path".to_string(),
+            package: "fixture/upstream".to_string(),
+            update_command: "homeboy deps update fixture/upstream --path '/tmp/downstream path'"
+                .to_string(),
+            rebuild: false,
+            post_update: Vec::new(),
+            test: Vec::new(),
+        }],
+    );
+
+    let result = deps::stack_apply_plan(plan, Some("^2.0"), true, false, false).unwrap();
+
+    assert_eq!(result.step_count, 1);
+    assert_eq!(
+        result.steps[0].command_results[0].command,
+        "homeboy deps update fixture/upstream --path '/tmp/downstream path' --to '^2.0' --no-install"
+    );
+}
+
+#[test]
 fn stack_plan_keeps_explicit_edge_config_when_provider_edge_matches() {
     let dir = tempdir().unwrap();
     let upstream_path = dir.path().join("upstream");

--- a/tests/deps_test.rs
+++ b/tests/deps_test.rs
@@ -1,1 +1,29 @@
 include!("core/deps_test.rs");
+
+#[test]
+fn stack_apply_dry_run_passes_constraint_to_default_provider_update() {
+    let plan = deps::DependencyStackPlan::new(
+        "upstream",
+        vec![deps::DependencyStackPlanStep {
+            sequence: 1,
+            declaring_component_id: "downstream".to_string(),
+            upstream: "upstream".to_string(),
+            downstream: "downstream".to_string(),
+            downstream_path: "/tmp/downstream path".to_string(),
+            package: "fixture/upstream".to_string(),
+            update_command: "homeboy deps update fixture/upstream --path '/tmp/downstream path'"
+                .to_string(),
+            rebuild: false,
+            post_update: Vec::new(),
+            test: Vec::new(),
+        }],
+    );
+
+    let result = deps::stack_apply_plan(plan, Some("^2.0"), true, false, false).unwrap();
+
+    assert_eq!(result.step_count, 1);
+    assert_eq!(
+        result.steps[0].command_results[0].command,
+        "homeboy deps update fixture/upstream --path '/tmp/downstream path' --to '^2.0' --no-install"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `--to <constraint>` to `homeboy deps stack apply` so default stack updates pass the requested constraint into provider-backed `deps update` calls.
- Keeps stack orchestration package-manager agnostic: custom edge commands still run as declared, while default commands dispatch through dependency providers.
- Updates deps command docs to describe provider-backed updates and stack constraint propagation.

## Issue
- Closes https://github.com/Extra-Chill/homeboy/issues/3076

## Tests
- `cargo test --test deps_npm_provider_test --test deps_test`
- `homeboy lint --path . --extension rust`

## Residual risk
- `homeboy test --path . --extension rust` is not green on current `origin/main`; observed failures were outside this dependency slice (`core::deploy::version_overrides::tests::test_archive_install_policy_rejects_wrong_root`, `core::extension::execution::tests::test_execute_capability_script_supports_stderr_only_passthrough`, and several `core::extension::lifecycle::*` tests). The focused deps tests pass.
- Explicit `dependency_stack[].update` commands do not receive `--to`; they remain fully caller-owned by design and docs now call this out.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, tests, docs, and PR description; Chris remains responsible for review and merge.