### PR TITLE
Remove legacy CLI aliases

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -46,12 +46,10 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Commands {
     /// Manage project configuration
-    #[command(visible_alias = "projects")]
     Project(project::ProjectArgs),
     /// SSH into a project server or configured server
     Ssh(ssh::SshArgs),
     /// Manage SSH server configurations
-    #[command(visible_alias = "servers")]
     Server(server::ServerArgs),
     /// Run tests for a component
     Test(test::TestArgs),
@@ -66,7 +64,6 @@ pub enum Commands {
     /// Database operations
     Db(db::DbArgs),
     /// Manage component dependencies
-    #[command(visible_alias = "dependencies")]
     Deps(deps::DepsArgs),
     /// Inspect CI reproduction profiles and discovered CI surfaces
     Ci(ci::CiArgs),
@@ -75,7 +72,6 @@ pub enum Commands {
     /// Remote file operations
     File(file::FileArgs),
     /// Manage fleets (groups of projects)
-    #[command(visible_alias = "fleets")]
     Fleet(fleet::FleetArgs),
     /// Remote log viewing
     Logs(logs::LogsArgs),
@@ -84,14 +80,12 @@ pub enum Commands {
     /// Deploy components to remote server
     Deploy(deploy::DeployArgs),
     /// Manage standalone component configurations
-    #[command(visible_alias = "components")]
     Component(component::ComponentArgs),
     /// Manage global Homeboy configuration
     Config(config::ConfigArgs),
     /// Run the local-only HTTP API daemon
     Daemon(daemon::DaemonArgs),
     /// Execute CLI-compatible extensions
-    #[command(visible_alias = "extensions")]
     Extension(extension::ExtensionArgs),
     /// Actionable component status overview
     Status(status::StatusArgs),
@@ -122,10 +116,8 @@ pub enum Commands {
     /// Read-only reference discovery for a symbol or term
     Refs(refs::RefsArgs),
     /// Manage local dev rigs (reproducible multi-component environments)
-    #[command(visible_alias = "rigs")]
     Rig(rig::RigArgs),
     /// Manage local and SSH execution runners
-    #[command(visible_alias = "runners")]
     Runner(runner::RunnerArgs),
     /// Manage private service tunnel declarations
     Tunnel(tunnel::TunnelArgs),
@@ -135,7 +127,6 @@ pub enum Commands {
     #[command(name = "self")]
     SelfCmd(self_cmd::SelfArgs),
     /// Manage stacks (combined-fixes branches built from base + cherry-picked PRs)
-    #[command(visible_alias = "stacks")]
     Stack(stack::StackArgs),
     /// Undo the last write operation (audit fix, refactor, etc.)
     Undo(undo::UndoArgs),

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -72,7 +72,6 @@ enum ComponentCommand {
     ///
     /// Supports dedicated flags for common fields (e.g., --local-path, --changelog-target)
     /// as well as --json/--base64 for arbitrary object updates.
-    #[command(visible_aliases = ["edit", "merge"])]
     Set {
         #[command(flatten)]
         args: DynamicSetArgs,

--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -71,7 +71,7 @@ enum ExtensionCommand {
         #[arg(long)]
         id: Option<String>,
         /// Git ref to check out for URL installs (branch, tag, or commit)
-        #[arg(long = "ref", alias = "revision")]
+        #[arg(long = "ref")]
         revision: Option<String>,
         /// Replace an existing extension install/link
         #[arg(long)]
@@ -134,7 +134,6 @@ enum ExtensionCommand {
         args: Vec<String>,
     },
     /// Update extension manifest fields
-    #[command(visible_aliases = ["edit", "merge"])]
     Set {
         /// Extension ID (optional if provided in JSON body)
         extension_id: Option<String>,

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -40,7 +40,6 @@ enum FleetCommand {
         id: String,
     },
     /// Update fleet configuration
-    #[command(visible_aliases = ["edit", "merge"])]
     Set {
         #[command(flatten)]
         args: DynamicSetArgs,

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -44,7 +44,6 @@ enum ProjectCommand {
         table_prefix: Option<String>,
     },
     /// Update project configuration fields
-    #[command(visible_aliases = ["edit", "merge"])]
     Set {
         #[command(flatten)]
         args: super::DynamicSetArgs,

--- a/src/commands/refactor.rs
+++ b/src/commands/refactor.rs
@@ -172,10 +172,10 @@ enum RefactorCommand {
     /// Scans the codebase for instantiations of the named struct, detects which fields
     /// are missing, and inserts them with sensible defaults (None, vec![], false, etc.).
     ///
-    /// Example: `refactor propagate --struct FileFingerprint --component homeboy`
+    /// Example: `refactor propagate --struct-name FileFingerprint --component homeboy`
     Propagate {
         /// Name of the struct to propagate fields for
-        #[arg(long, value_name = "NAME", alias = "struct")]
+        #[arg(long, value_name = "NAME")]
         struct_name: String,
 
         /// File containing the struct definition (auto-detected if omitted)

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -130,7 +130,6 @@ enum RunnerCommand {
         id: String,
     },
     /// Modify runner settings
-    #[command(visible_aliases = ["edit", "merge"])]
     Set {
         #[command(flatten)]
         args: DynamicSetArgs,

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -74,7 +74,6 @@ enum ServerCommand {
         server_id: String,
     },
     /// Modify server settings
-    #[command(visible_aliases = ["edit", "merge"])]
     Set {
         #[command(flatten)]
         args: DynamicSetArgs,

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -162,7 +162,7 @@ pub struct TraceArgs {
     pub stale: bool,
 
     /// Remove stale trace overlay locks even when touched files are dirty.
-    #[arg(long, alias = "force-stale-lock-cleanup")]
+    #[arg(long)]
     pub force: bool,
 }
 

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -97,7 +97,6 @@ enum TunnelServiceCommand {
         id: String,
     },
     /// Modify a private service tunnel declaration
-    #[command(visible_aliases = ["edit", "merge"])]
     Set {
         #[command(flatten)]
         args: DynamicSetArgs,

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -386,6 +386,45 @@ mod normalize_tests {
     }
 
     #[test]
+    fn legacy_cli_aliases_are_rejected() {
+        let cases = [
+            &["homeboy", "components", "list"][..],
+            &["homeboy", "component", "edit", "example", "--json", "{}"][..],
+            &["homeboy", "component", "merge", "example", "--json", "{}"][..],
+            &[
+                "homeboy",
+                "extension",
+                "install",
+                "https://example.test/ext.git",
+                "--revision",
+                "main",
+            ][..],
+            &[
+                "homeboy",
+                "refactor",
+                "propagate",
+                "--struct",
+                "FileFingerprint",
+            ][..],
+            &[
+                "homeboy",
+                "trace",
+                "overlay-locks",
+                "cleanup",
+                "--stale",
+                "--force-stale-lock-cleanup",
+            ][..],
+        ];
+
+        for case in cases {
+            assert!(
+                Cli::try_parse_from(normalize(argv(case))).is_err(),
+                "legacy alias should be rejected: {case:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_owned_flag_after_component_and_explicit_passthrough_stay_distinct() {
         let input = argv(&[
             "homeboy",

--- a/src/core/refactor/propagate.rs
+++ b/src/core/refactor/propagate.rs
@@ -291,7 +291,7 @@ fn find_struct_definition(struct_name: &str, root: &Path) -> Result<PathBuf, Err
         ),
         None,
         Some(vec![format!(
-            "homeboy refactor propagate --struct {} --definition src/path/to/file.rs",
+            "homeboy refactor propagate --struct-name {} --definition src/path/to/file.rs",
             struct_name
         )]),
     ))

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -43,13 +43,13 @@ fn includes_first_level_subcommands() {
 }
 
 #[test]
-fn includes_visible_aliases() {
+fn excludes_removed_cli_aliases() {
     let surface = current_command_surface();
 
-    assert!(surface.contains_path(&["components"]));
-    assert!(surface.contains_path(&["dependencies"]));
-    assert!(surface.contains_path(&["rigs"]));
-    assert!(surface.contains_path(&["stacks", "inspect"]));
+    assert!(!surface.contains_path(&["components"]));
+    assert!(!surface.contains_path(&["dependencies"]));
+    assert!(!surface.contains_path(&["rigs"]));
+    assert!(!surface.contains_path(&["stacks", "inspect"]));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Removes non-canonical CLI command aliases from the public Clap surface so canonical command names are required.
- Removes alternate flag spellings for extension install refs, refactor propagate struct names, and stale trace overlay cleanup.
- Updates parser/surface tests to assert legacy alias rejection and canonical-only command surface entries.

## Provenance classification
| Surface | History reviewed | Classification | Decision |
|---|---|---:|---|
| Root plural aliases: `projects`, `servers`, `fleets`, `components`, `extensions`, `rigs`, `stacks` | `88480cc9`, `4201ed0b`, `1ff1ef6b`, `3c2ae423` | remove | Alternate plural spellings were visible Clap aliases for singular canonical root commands; issue #2918 identifies these as non-canonical compatibility surface and no separate migration contract requires retaining them. |
| Root plural aliases: `dependencies`, `runners` | `06028d4c`, `87d5e807` | remove | Added as visible alternates alongside canonical `deps` and `runner`; no persisted/external contract requires them, and the CLI surface should require canonical root command names. |
| `set` subcommand aliases `edit`/`merge` for component/project/server/fleet/runner/extension/tunnel | `3c2ae423`, `1ff1ef6b`, `4201ed0b`, `87d5e807`, `464e250e`/`ec7ab589` | remove | These expose alternate mutation verbs for the canonical `set` operation. Current parser tests now require `set` only. |
| `extension install --revision` alias for `--ref` | `c71c4aa0` | remove | `--ref` is the canonical git ref flag; `--revision` was an alternate spelling accepted by Clap and is removed from the parser. |
| `refactor propagate --struct` alias for `--struct-name` | `781cc688` | remove | The field/canonical long flag is `--struct-name`; the shorter alias and stale examples are removed. |
| `trace overlay-locks cleanup --force-stale-lock-cleanup` alias for `--force` | `e0f487d6` | remove | The alias encoded a command-specific compatibility spelling for the canonical force flag; parser now accepts `--force` only. |
| `normalize_version_show` | `0573fe9a`, `12473273`/`948ddce2` | already removed | Reviewed for provenance; #2934 already removed this compatibility rewrite, so this PR leaves the current canonical behavior intact and adds regression coverage around alias rejection. |
| `normalize_trace_compare_variant_scenario` | `08f504c9`, `12473273`/`948ddce2` | already removed | Reviewed for provenance; #2934 already removed the flag-to-positional rewrite, so this PR preserves current canonical parsing. |
| `normalize_trailing_flags` | `0573fe9a`, `12473273`/`948ddce2` | already reduced | Reviewed for provenance; the broad auto-insertion compatibility behavior was already removed. The remaining explicit passthrough sentinel is retained because it only preserves user-specified `--` boundaries for runner args. |

## Tests
- `cargo test --test command_surface_test`
- `cargo test normalize_tests`
- `cargo check`

## Quality notes
- `cargo clippy --all-targets -- -D warnings` was attempted and fails on broad pre-existing repository warnings unrelated to this CLI alias diff (large enum variants, existing sort_by_key suggestions, type complexity, etc.). Focused CLI parser/surface tests and `cargo check` pass.

Fixes #2918

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Provenance review, CLI alias cleanup implementation, test updates, and PR description drafting. Chris remains responsible for review and merge decisions.