### PR TITLE
Add artifact retention cleanup command

### DIFF
--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -1,0 +1,23 @@
+# cleanup
+
+Remove or inspect reconstructable artifacts that Homeboy can safely recreate.
+
+## `homeboy cleanup artifacts`
+
+Scans the current repository and its managed Git worktrees for declared artifact paths. The command defaults to dry-run JSON output and only removes files when `--apply` is passed.
+
+Built-in artifact paths:
+
+- `target/` for Rust build output
+- `node_modules/` for Node dependencies
+- `dist/` for generated distribution output
+
+Projects can add repo-relative paths with `artifact_cleanup_paths` in `homeboy.json`.
+
+```bash
+homeboy cleanup artifacts
+homeboy cleanup artifacts --path /path/to/checkout
+homeboy cleanup artifacts --apply
+```
+
+The JSON output includes worktree identity, candidate paths, estimated bytes, skipped reasons, and applied rows. Cleanup refuses unsafe path declarations and skips artifact paths that contain tracked or staged source changes.

--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -6,11 +6,11 @@ Remove or inspect reconstructable artifacts that Homeboy can safely recreate.
 
 Scans the current repository and its managed Git worktrees for declared artifact paths. The command defaults to dry-run JSON output and only removes files when `--apply` is passed.
 
-Built-in artifact paths:
+Built-in artifact names:
 
-- `target/` for Rust build output
-- `node_modules/` for Node dependencies
-- `dist/` for generated distribution output
+- `target` for Rust build output
+- `node_modules` for Node dependencies
+- `dist` for generated distribution output
 
 Projects can add repo-relative paths with `artifact_cleanup_paths` in `homeboy.json`.
 

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -9,6 +9,7 @@
 - [changelog](changelog.md)
 - [changes](changes.md)
 - [ci](ci.md) — CI reproduction profiles and shallow CI surface discovery
+- [cleanup](cleanup.md) — declared reconstructable artifact cleanup across managed worktrees
 - [component](component.md)
 - [config](config.md)
 - [daemon](daemon.md) — local-only HTTP API daemon

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -2,8 +2,8 @@ use clap::{Command, CommandFactory, Parser, Subcommand};
 use std::path::PathBuf;
 
 use crate::commands::{
-    api, audit, auth, bench, build, changelog, changes, ci, component, config, daemon, db, deploy,
-    deps, doctor, extension, file, fleet, git, http, issues, lint, logs, observe, project,
+    api, audit, auth, bench, build, changelog, changes, ci, cleanup, component, config, daemon, db,
+    deploy, deps, doctor, extension, file, fleet, git, http, issues, lint, logs, observe, project,
     refactor, refs, release, report, review, rig, runner, runs, self_cmd, server, ssh, stack,
     status, test, trace, triage, tunnel, undo, upgrade, version,
 };
@@ -99,6 +99,8 @@ pub enum Commands {
     Docs(crate::commands::docs::DocsArgs),
     /// Changelog operations
     Changelog(changelog::ChangelogArgs),
+    /// Remove declared reconstructable artifacts from managed worktrees
+    Cleanup(cleanup::CleanupArgs),
     /// Git operations for components
     Git(git::GitArgs),
     /// Reconcile findings against an issue tracker
@@ -343,6 +345,7 @@ impl Commands {
             | Commands::Config(_)
             | Commands::Extension(_)
             | Commands::Changelog(_)
+            | Commands::Cleanup(_)
             | Commands::Version(_)
             | Commands::Build(_)
             | Commands::Changes(_)

--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -1,0 +1,39 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+use homeboy::core::cleanup::{self, ArtifactCleanupOptions, ArtifactCleanupOutput};
+
+use super::CmdResult;
+
+#[derive(Args)]
+pub struct CleanupArgs {
+    #[command(subcommand)]
+    pub command: CleanupCommand,
+}
+
+#[derive(Subcommand)]
+pub enum CleanupCommand {
+    /// Inspect or remove declared reconstructable artifacts across repo worktrees
+    Artifacts(CleanupArtifactsArgs),
+}
+
+#[derive(Args)]
+pub struct CleanupArtifactsArgs {
+    /// Apply cleanup. Omit for dry-run output.
+    #[arg(long)]
+    pub apply: bool,
+
+    /// Resolve managed worktrees from this checkout instead of the current directory.
+    #[arg(long, value_name = "PATH")]
+    pub path: Option<PathBuf>,
+}
+
+pub fn run(args: CleanupArgs, _global: &super::GlobalArgs) -> CmdResult<ArtifactCleanupOutput> {
+    match args.command {
+        CleanupCommand::Artifacts(args) => cleanup::cleanup_artifacts(ArtifactCleanupOptions {
+            path: args.path,
+            apply: args.apply,
+        })
+        .map(|output| (output, 0)),
+    }
+}

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -2,8 +2,8 @@ use crate::cli_surface::Commands;
 
 use super::{map, JsonRun};
 use crate::commands::{
-    build, changelog, changes, component, config, docs, extension, project, refactor, refs,
-    release, report, rig, runner, runs, stack, tunnel, undo, version, GlobalArgs,
+    build, changelog, changes, cleanup, component, config, docs, extension, project, refactor,
+    refs, release, report, rig, runner, runs, stack, tunnel, undo, version, GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
@@ -14,6 +14,7 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Extension(args) => map(extension::run(args, global)),
         Commands::Docs(args) => map(docs::run(args, global)),
         Commands::Changelog(args) => map(changelog::run(args, global)),
+        Commands::Cleanup(args) => map(cleanup::run(args, global)),
         Commands::Version(args) => map(version::run(args, global)),
         Commands::Build(args) => map(build::run(args, global)),
         Commands::Changes(args) => map(changes::run(args, global)),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -173,6 +173,7 @@ pub mod build;
 pub mod changelog;
 pub mod changes;
 pub mod ci;
+pub mod cleanup;
 pub mod cli;
 pub mod component;
 pub mod config;

--- a/src/core/cleanup.rs
+++ b/src/core/cleanup.rs
@@ -1,0 +1,559 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Serialize;
+
+use crate::core::{Error, Result};
+
+const BUILTIN_ARTIFACT_PATHS: &[(&str, &str)] = &[
+    ("target", "rust_target"),
+    ("node_modules", "node_modules"),
+    ("dist", "generated_dist"),
+];
+
+#[derive(Debug, Clone, Default)]
+pub struct ArtifactCleanupOptions {
+    pub path: Option<PathBuf>,
+    pub apply: bool,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct ArtifactCleanupOutput {
+    pub command: &'static str,
+    pub mode: &'static str,
+    pub root: String,
+    pub worktree_count: usize,
+    pub candidate_count: usize,
+    pub skipped_count: usize,
+    pub applied_count: usize,
+    pub estimated_bytes: u64,
+    pub reclaimed_bytes: u64,
+    pub candidates: Vec<ArtifactCleanupCandidate>,
+    pub skipped: Vec<ArtifactCleanupSkipped>,
+    pub applied: Vec<ArtifactCleanupApplied>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ArtifactCleanupCandidate {
+    pub worktree: String,
+    pub path: String,
+    pub relative_path: String,
+    pub kind: String,
+    pub declared_by: String,
+    pub size_bytes: u64,
+    pub source_dirty: bool,
+    pub unpushed_commits: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ArtifactCleanupSkipped {
+    pub worktree: String,
+    pub path: String,
+    pub relative_path: String,
+    pub kind: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ArtifactCleanupApplied {
+    pub worktree: String,
+    pub path: String,
+    pub relative_path: String,
+    pub kind: String,
+    pub size_bytes: u64,
+    pub removed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WorktreeInfo {
+    path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ArtifactDeclaration {
+    relative_path: String,
+    kind: String,
+    declared_by: String,
+}
+
+#[derive(Debug, Default)]
+struct GitSafety {
+    source_dirty: bool,
+    unpushed_commits: bool,
+    dirty_paths: Vec<String>,
+}
+
+pub fn cleanup_artifacts(options: ArtifactCleanupOptions) -> Result<ArtifactCleanupOutput> {
+    let root = resolve_root(options.path.as_deref())?;
+    let worktrees = discover_worktrees(&root)?;
+    let mut candidates = Vec::new();
+    let mut skipped = Vec::new();
+    let mut applied = Vec::new();
+
+    for worktree in &worktrees {
+        let safety = git_safety(&worktree.path)?;
+        for declaration in artifact_declarations(&worktree.path)? {
+            let artifact_path = worktree.path.join(&declaration.relative_path);
+            let display_path = artifact_path.to_string_lossy().to_string();
+            if !artifact_path.exists() {
+                continue;
+            }
+            if !is_safe_artifact_path(&declaration.relative_path) {
+                skipped.push(skip_row(
+                    worktree,
+                    &declaration,
+                    display_path,
+                    "declared artifact path is not a safe repo-relative path",
+                ));
+                continue;
+            }
+            if has_tracked_changes_under(&safety.dirty_paths, &declaration.relative_path) {
+                skipped.push(skip_row(
+                    worktree,
+                    &declaration,
+                    display_path,
+                    "artifact path contains tracked or staged source changes",
+                ));
+                continue;
+            }
+
+            let size_bytes = path_size(&artifact_path)?;
+            let candidate = ArtifactCleanupCandidate {
+                worktree: worktree.path.to_string_lossy().to_string(),
+                path: display_path.clone(),
+                relative_path: declaration.relative_path.clone(),
+                kind: declaration.kind.clone(),
+                declared_by: declaration.declared_by.clone(),
+                size_bytes,
+                source_dirty: safety.source_dirty,
+                unpushed_commits: safety.unpushed_commits,
+            };
+
+            if options.apply {
+                remove_artifact_path(&artifact_path)?;
+                applied.push(ArtifactCleanupApplied {
+                    worktree: candidate.worktree.clone(),
+                    path: candidate.path.clone(),
+                    relative_path: candidate.relative_path.clone(),
+                    kind: candidate.kind.clone(),
+                    size_bytes,
+                    removed: true,
+                });
+            }
+
+            candidates.push(candidate);
+        }
+    }
+
+    let estimated_bytes = candidates.iter().map(|row| row.size_bytes).sum();
+    let reclaimed_bytes = applied.iter().map(|row| row.size_bytes).sum();
+
+    Ok(ArtifactCleanupOutput {
+        command: "cleanup.artifacts",
+        mode: if options.apply { "apply" } else { "dry_run" },
+        root: root.to_string_lossy().to_string(),
+        worktree_count: worktrees.len(),
+        candidate_count: candidates.len(),
+        skipped_count: skipped.len(),
+        applied_count: applied.len(),
+        estimated_bytes,
+        reclaimed_bytes,
+        candidates,
+        skipped,
+        applied,
+    })
+}
+
+fn resolve_root(path: Option<&Path>) -> Result<PathBuf> {
+    let start = match path {
+        Some(path) => path.to_path_buf(),
+        None => std::env::current_dir().map_err(|e| {
+            Error::internal_io(e.to_string(), Some("read current directory".to_string()))
+        })?,
+    };
+    git_root(&start)
+}
+
+fn discover_worktrees(root: &Path) -> Result<Vec<WorktreeInfo>> {
+    let output = git_output(root, &["worktree", "list", "--porcelain"])?;
+    let mut worktrees = Vec::new();
+    for line in output.lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            worktrees.push(WorktreeInfo {
+                path: PathBuf::from(path),
+            });
+        }
+    }
+    if worktrees.is_empty() {
+        worktrees.push(WorktreeInfo {
+            path: root.to_path_buf(),
+        });
+    }
+    Ok(worktrees)
+}
+
+fn artifact_declarations(worktree: &Path) -> Result<Vec<ArtifactDeclaration>> {
+    let mut declarations = Vec::new();
+    for (relative_path, kind) in BUILTIN_ARTIFACT_PATHS {
+        declarations.push(ArtifactDeclaration {
+            relative_path: (*relative_path).to_string(),
+            kind: (*kind).to_string(),
+            declared_by: "builtin".to_string(),
+        });
+    }
+
+    let config_path = worktree.join("homeboy.json");
+    if config_path.exists() {
+        let raw = fs::read_to_string(&config_path).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("read {}", config_path.display())),
+            )
+        })?;
+        let value: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
+            Error::internal_json(
+                e.to_string(),
+                Some(format!("parse {}", config_path.display())),
+            )
+        })?;
+        for path in value
+            .get("artifact_cleanup_paths")
+            .and_then(serde_json::Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(serde_json::Value::as_str)
+        {
+            declarations.push(ArtifactDeclaration {
+                relative_path: path.to_string(),
+                kind: "declared_artifact".to_string(),
+                declared_by: "homeboy.json:artifact_cleanup_paths".to_string(),
+            });
+        }
+    }
+
+    let mut seen = HashSet::new();
+    declarations.retain(|row| seen.insert(row.relative_path.clone()));
+    Ok(declarations)
+}
+
+fn git_safety(worktree: &Path) -> Result<GitSafety> {
+    let status = git_output(worktree, &["status", "--porcelain=v1"])?;
+    let mut dirty_paths = Vec::new();
+    let mut source_dirty = false;
+    for line in status.lines() {
+        if line.len() < 4 || line.starts_with("?? ") || line.starts_with("!! ") {
+            continue;
+        }
+        let path = status_path(line);
+        if !path.is_empty() {
+            source_dirty = true;
+            dirty_paths.push(path);
+        }
+    }
+
+    let unpushed_commits = match git_output(worktree, &["rev-list", "--count", "@{upstream}..HEAD"])
+    {
+        Ok(count) => count.trim().parse::<u32>().unwrap_or(0) > 0,
+        Err(_) => false,
+    };
+
+    Ok(GitSafety {
+        source_dirty,
+        unpushed_commits,
+        dirty_paths,
+    })
+}
+
+fn status_path(line: &str) -> String {
+    let raw = line.get(3..).unwrap_or_default();
+    raw.rsplit(" -> ")
+        .next()
+        .unwrap_or(raw)
+        .trim_matches('"')
+        .to_string()
+}
+
+fn has_tracked_changes_under(dirty_paths: &[String], relative_path: &str) -> bool {
+    let prefix = format!("{}/", relative_path.trim_end_matches('/'));
+    dirty_paths
+        .iter()
+        .any(|path| path == relative_path || path.starts_with(&prefix))
+}
+
+fn skip_row(
+    worktree: &WorktreeInfo,
+    declaration: &ArtifactDeclaration,
+    path: String,
+    reason: &str,
+) -> ArtifactCleanupSkipped {
+    ArtifactCleanupSkipped {
+        worktree: worktree.path.to_string_lossy().to_string(),
+        path,
+        relative_path: declaration.relative_path.clone(),
+        kind: declaration.kind.clone(),
+        reason: reason.to_string(),
+    }
+}
+
+fn is_safe_artifact_path(relative_path: &str) -> bool {
+    let path = Path::new(relative_path);
+    !relative_path.is_empty()
+        && relative_path != "."
+        && !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, std::path::Component::Normal(_)))
+}
+
+fn path_size(path: &Path) -> Result<u64> {
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(format!("stat {}", path.display()))))?;
+    if metadata.is_file() || metadata.file_type().is_symlink() {
+        return Ok(metadata.len());
+    }
+
+    let mut total = metadata.len();
+    for entry in fs::read_dir(path).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("read directory {}", path.display())),
+        )
+    })? {
+        let entry = entry.map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("read directory entry {}", path.display())),
+            )
+        })?;
+        total += path_size(&entry.path())?;
+    }
+    Ok(total)
+}
+
+fn remove_artifact_path(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(format!("stat {}", path.display()))))?;
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        fs::remove_dir_all(path).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("remove directory {}", path.display())),
+            )
+        })
+    } else {
+        fs::remove_file(path).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("remove file {}", path.display())),
+            )
+        })
+    }
+}
+
+fn git_root(path: &Path) -> Result<PathBuf> {
+    let output = git_output(path, &["rev-parse", "--show-toplevel"])?;
+    Ok(PathBuf::from(output.trim()))
+}
+
+fn git_output(path: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .map_err(|e| {
+            Error::internal_io(e.to_string(), Some(format!("run git {}", args.join(" "))))
+        })?;
+    if !output.status.success() {
+        return Err(Error::git_command_failed(format!(
+            "git {} failed in {}: {}",
+            args.join(" "),
+            path.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    String::from_utf8(output.stdout)
+        .map_err(|e| Error::internal_unexpected(format!("git output was not UTF-8: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn safe_artifact_paths_are_repo_relative() {
+        assert!(is_safe_artifact_path("target"));
+        assert!(is_safe_artifact_path("runtime/generated-fixture"));
+        assert!(!is_safe_artifact_path(""));
+        assert!(!is_safe_artifact_path("."));
+        assert!(!is_safe_artifact_path("./target"));
+        assert!(!is_safe_artifact_path("../target"));
+        assert!(!is_safe_artifact_path("/tmp/target"));
+    }
+
+    #[test]
+    fn tracked_changes_under_artifact_path_are_detected() {
+        let dirty = vec!["target/generated.rs".to_string(), "src/lib.rs".to_string()];
+        assert!(has_tracked_changes_under(&dirty, "target"));
+        assert!(!has_tracked_changes_under(&dirty, "node_modules"));
+    }
+
+    #[test]
+    fn declared_artifact_paths_are_loaded_from_homeboy_json() {
+        let tmp = TempDir::new().expect("tempdir");
+        fs::write(
+            tmp.path().join("homeboy.json"),
+            r#"{"artifact_cleanup_paths":["runtime/generated-fixture","dist"]}"#,
+        )
+        .expect("write config");
+
+        let declarations = artifact_declarations(tmp.path()).expect("declarations");
+
+        assert!(declarations.iter().any(|row| row.relative_path == "target"));
+        assert!(declarations
+            .iter()
+            .any(|row| row.relative_path == "runtime/generated-fixture"));
+        assert_eq!(
+            declarations
+                .iter()
+                .filter(|row| row.relative_path == "dist")
+                .count(),
+            1,
+            "declared paths should not duplicate builtins"
+        );
+    }
+
+    #[test]
+    fn dry_run_reports_artifact_candidates_across_worktrees() {
+        let repo = git_repo();
+        let sibling_parent = TempDir::new().expect("sibling parent");
+        let sibling = sibling_parent.path().join("artifact-worktree");
+        git(repo.path(), &["worktree", "add", sibling.to_str().unwrap()]);
+        write_file(&repo.path().join("target/debug/app"), "primary artifact");
+        write_file(
+            &sibling.join("node_modules/pkg/index.js"),
+            "dependency artifact",
+        );
+
+        let output = cleanup_artifacts(ArtifactCleanupOptions {
+            path: Some(repo.path().to_path_buf()),
+            apply: false,
+        })
+        .expect("dry-run cleanup");
+
+        assert_eq!(output.mode, "dry_run");
+        assert_eq!(output.applied_count, 0);
+        assert!(output.candidates.iter().any(|row| row
+            .worktree
+            .ends_with(repo.path().file_name().unwrap().to_str().unwrap())
+            && row.relative_path == "target"));
+        assert!(output
+            .candidates
+            .iter()
+            .any(|row| row.worktree.ends_with("artifact-worktree")
+                && row.relative_path == "node_modules"));
+        assert!(repo.path().join("target/debug/app").exists());
+        assert!(sibling.join("node_modules/pkg/index.js").exists());
+    }
+
+    #[test]
+    fn apply_removes_declared_artifacts_only_and_preserves_dirty_source() {
+        let repo = git_repo();
+        write_file(&repo.path().join("target/debug/app"), "artifact");
+        write_file(&repo.path().join("src/lib.rs"), "changed source");
+
+        let output = cleanup_artifacts(ArtifactCleanupOptions {
+            path: Some(repo.path().to_path_buf()),
+            apply: true,
+        })
+        .expect("apply cleanup");
+
+        assert_eq!(output.mode, "apply");
+        assert_eq!(output.applied_count, 1);
+        assert!(!repo.path().join("target").exists());
+        assert_eq!(
+            fs::read_to_string(repo.path().join("src/lib.rs")).expect("read source"),
+            "changed source"
+        );
+        assert!(output.candidates.iter().any(|row| row.source_dirty));
+    }
+
+    #[test]
+    fn apply_skips_artifact_path_with_tracked_source_changes() {
+        let repo = git_repo();
+        write_file(
+            &repo.path().join("target/generated.rs"),
+            "tracked artifact source",
+        );
+        git(repo.path(), &["add", "target/generated.rs"]);
+        git(
+            repo.path(),
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=homeboy@example.test",
+                "commit",
+                "-m",
+                "track generated source",
+            ],
+        );
+        write_file(
+            &repo.path().join("target/generated.rs"),
+            "modified tracked source",
+        );
+
+        let output = cleanup_artifacts(ArtifactCleanupOptions {
+            path: Some(repo.path().to_path_buf()),
+            apply: true,
+        })
+        .expect("apply cleanup");
+
+        assert_eq!(output.applied_count, 0);
+        assert!(repo.path().join("target/generated.rs").exists());
+        assert!(output.skipped.iter().any(|row| {
+            row.relative_path == "target" && row.reason.contains("tracked or staged source changes")
+        }));
+    }
+
+    fn git_repo() -> TempDir {
+        let repo = TempDir::new().expect("repo tempdir");
+        git(repo.path(), &["init", "-b", "main"]);
+        write_file(&repo.path().join("src/lib.rs"), "source");
+        git(repo.path(), &["add", "src/lib.rs"]);
+        git(
+            repo.path(),
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=homeboy@example.test",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        );
+        repo
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        fs::create_dir_all(path.parent().expect("parent")).expect("mkdir parent");
+        fs::write(path, content).expect("write file");
+    }
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod api_jobs;
 pub mod budget;
 pub mod ci_profile;
+pub mod cleanup;
 pub mod code_audit;
 pub mod component;
 pub mod context;


### PR DESCRIPTION
## Summary
- Adds `homeboy cleanup artifacts` for dry-run or applied cleanup of declared reconstructable artifacts across managed Git worktrees.
- Reports candidate paths, size estimates, worktree identity, dirty/unpushed flags, skipped reasons, and applied rows in JSON output.
- Documents the command and wires it into the top-level command surface.

Fixes #3023

## Testing
- `cargo fmt --check`
- `cargo test --lib core::cleanup`
- `cargo test --test command_surface_test`
- `cargo run --bin homeboy -- cleanup artifacts --path .`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Recovered the existing worktree, completed implementation/docs, resolved rebase conflicts, ran focused tests, and drafted this PR body.