### PR TITLE
fix: bound command output capture

### DIFF
--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -14,6 +14,8 @@ use crate::commands::version;
 
 use super::CmdResult;
 
+const BODY_STDIN_LIMIT_BYTES: u64 = 256 * 1024;
+
 #[derive(Args)]
 pub struct GitArgs {
     #[command(subcommand)]
@@ -1240,10 +1242,27 @@ fn resolve_body(
 
     if path == "-" {
         use std::io::Read;
-        let mut buf = String::new();
-        std::io::stdin().read_to_string(&mut buf).map_err(|e| {
+        let mut bytes = Vec::new();
+        std::io::stdin()
+            .take(BODY_STDIN_LIMIT_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|e| {
+                homeboy::core::Error::internal_io(
+                    format!("Failed to read body from stdin: {}", e),
+                    Some("stdin".into()),
+                )
+            })?;
+        if bytes.len() > BODY_STDIN_LIMIT_BYTES as usize {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "body_file",
+                "stdin body exceeds the retained byte limit",
+                Some(format!("limit_bytes={BODY_STDIN_LIMIT_BYTES}")),
+                None,
+            ));
+        }
+        let buf = String::from_utf8(bytes).map_err(|e| {
             homeboy::core::Error::internal_io(
-                format!("Failed to read body from stdin: {}", e),
+                format!("Failed to decode body from stdin as UTF-8: {}", e),
                 Some("stdin".into()),
             )
         })?;

--- a/src/commands/observe.rs
+++ b/src/commands/observe.rs
@@ -25,6 +25,7 @@ use super::{CmdResult, GlobalArgs};
 const DEFAULT_DURATION: &str = "30s";
 const DEFAULT_PROCESS_WATCH_INTERVAL: &str = "1s";
 const POLL_INTERVAL: Duration = Duration::from_millis(250);
+const TAIL_LOG_POLL_LIMIT_BYTES: u64 = 256 * 1024;
 
 #[derive(Args, Clone)]
 pub struct ObserveArgs {
@@ -349,13 +350,21 @@ fn poll_tail_log(state: &mut TailLogState, t_ms: u64) -> homeboy::core::Result<V
     file.seek(SeekFrom::Start(state.offset)).map_err(|e| {
         Error::internal_io(e.to_string(), Some("observe.tail_log.seek".to_string()))
     })?;
-    let mut content = String::new();
-    file.read_to_string(&mut content).map_err(|e| {
-        Error::internal_io(e.to_string(), Some("observe.tail_log.read".to_string()))
-    })?;
+    let mut bytes = Vec::new();
+    file.take(TAIL_LOG_POLL_LIMIT_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|e| {
+            Error::internal_io(e.to_string(), Some("observe.tail_log.read".to_string()))
+        })?;
+    let truncated = bytes.len() > TAIL_LOG_POLL_LIMIT_BYTES as usize;
+    if truncated {
+        let overflow = bytes.len() - TAIL_LOG_POLL_LIMIT_BYTES as usize;
+        bytes.drain(..overflow);
+    }
     state.offset = len;
+    let content = String::from_utf8_lossy(&bytes);
 
-    Ok(content
+    let mut events = content
         .lines()
         .filter(|line| {
             state
@@ -375,7 +384,22 @@ fn poll_tail_log(state: &mut TailLogState, t_ms: u64) -> homeboy::core::Result<V
                 ],
             )
         })
-        .collect())
+        .collect::<Vec<_>>();
+    if truncated {
+        events.insert(
+            0,
+            event(
+                t_ms,
+                "log",
+                "truncated",
+                [
+                    ("path", state.path.to_string_lossy().to_string()),
+                    ("byte_limit", TAIL_LOG_POLL_LIMIT_BYTES.to_string()),
+                ],
+            ),
+        );
+    }
+    Ok(events)
 }
 
 fn poll_process_watch(

--- a/src/core/code_audit/detectors/test_topology.rs
+++ b/src/core/code_audit/detectors/test_topology.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
 use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use crate::core::engine::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
 use crate::core::extension::{self, ExtensionManifest};
 
 #[path = "../test_quality.rs"]
@@ -201,7 +202,7 @@ fn run_topology_script(
                 let payload = serde_json::to_vec(input).ok()?;
                 let _ = stdin.write_all(&payload);
             }
-            child.wait_with_output().ok()
+            wait_with_bounded_output(child, DEFAULT_CAPTURE_LIMIT_BYTES).ok()
         });
 
     let Some(output) = output else {

--- a/src/core/engine/command.rs
+++ b/src/core/engine/command.rs
@@ -1,9 +1,13 @@
 //! Command execution primitives with consistent error handling.
 
-use std::process::{Command, Output};
+use std::io::{self, Read};
+use std::process::{Child, Command, ExitStatus, Output};
+use std::thread;
 
 use crate::core::error::{Error, Result};
 use serde::Serialize;
+
+pub const DEFAULT_CAPTURE_LIMIT_BYTES: usize = 64 * 1024;
 
 pub fn run(program: &str, args: &[&str], context: &str) -> Result<String> {
     let output = Command::new(program).args(args).output().map_err(|e| {
@@ -93,6 +97,147 @@ pub fn require_success(success: bool, stderr: &str, operation: &str) -> Result<(
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, Serialize, PartialEq, Eq)]
+pub struct CaptureMetadata {
+    pub bytes_seen: u64,
+    pub bytes_retained: usize,
+    pub byte_limit: usize,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub struct CommandCaptureMetadata {
+    pub stdout: CaptureMetadata,
+    pub stderr: CaptureMetadata,
+}
+
+#[derive(Debug)]
+pub struct BoundedCommandOutput {
+    pub status: ExitStatus,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub capture: CommandCaptureMetadata,
+}
+
+impl BoundedCommandOutput {
+    pub fn into_output(self) -> Output {
+        Output {
+            status: self.status,
+            stdout: self.stdout,
+            stderr: self.stderr,
+        }
+    }
+}
+
+pub fn wait_with_bounded_output(
+    mut child: Child,
+    byte_limit: usize,
+) -> io::Result<BoundedCommandOutput> {
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let stdout_handle =
+        stdout.map(|stream| thread::spawn(move || capture_tail(stream, byte_limit)));
+    let stderr_handle =
+        stderr.map(|stream| thread::spawn(move || capture_tail(stream, byte_limit)));
+
+    let status = child.wait()?;
+    let stdout = join_capture(stdout_handle)?;
+    let stderr = join_capture(stderr_handle)?;
+
+    Ok(BoundedCommandOutput {
+        status,
+        stdout: stdout.bytes,
+        stderr: stderr.bytes,
+        capture: CommandCaptureMetadata {
+            stdout: stdout.metadata,
+            stderr: stderr.metadata,
+        },
+    })
+}
+
+#[derive(Debug)]
+struct BoundedStreamCapture {
+    bytes: Vec<u8>,
+    metadata: CaptureMetadata,
+}
+
+fn join_capture(
+    handle: Option<thread::JoinHandle<io::Result<BoundedStreamCapture>>>,
+) -> io::Result<BoundedStreamCapture> {
+    match handle {
+        Some(handle) => handle
+            .join()
+            .map_err(|_| io::Error::other("capture thread panicked"))?,
+        None => Ok(BoundedStreamCapture {
+            bytes: Vec::new(),
+            metadata: CaptureMetadata::default(),
+        }),
+    }
+}
+
+fn capture_tail(mut stream: impl Read, byte_limit: usize) -> io::Result<BoundedStreamCapture> {
+    let mut capture = TailCapture::new(byte_limit);
+    let mut buf = [0_u8; 8192];
+    loop {
+        let n = stream.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        capture.push(&buf[..n]);
+    }
+    Ok(capture.finish())
+}
+
+struct TailCapture {
+    bytes: Vec<u8>,
+    bytes_seen: u64,
+    byte_limit: usize,
+}
+
+impl TailCapture {
+    fn new(byte_limit: usize) -> Self {
+        Self {
+            bytes: Vec::new(),
+            bytes_seen: 0,
+            byte_limit,
+        }
+    }
+
+    fn push(&mut self, chunk: &[u8]) {
+        self.bytes_seen = self
+            .bytes_seen
+            .saturating_add(chunk.len().try_into().unwrap_or(u64::MAX));
+        if self.byte_limit == 0 {
+            self.bytes.clear();
+            return;
+        }
+        if chunk.len() >= self.byte_limit {
+            self.bytes.clear();
+            self.bytes
+                .extend_from_slice(&chunk[chunk.len() - self.byte_limit..]);
+            return;
+        }
+        self.bytes.extend_from_slice(chunk);
+        let overflow = self.bytes.len().saturating_sub(self.byte_limit);
+        if overflow > 0 {
+            self.bytes.drain(..overflow);
+        }
+    }
+
+    fn finish(self) -> BoundedStreamCapture {
+        let bytes_retained = self.bytes.len();
+        BoundedStreamCapture {
+            bytes: self.bytes,
+            metadata: CaptureMetadata {
+                bytes_seen: self.bytes_seen,
+                bytes_retained,
+                byte_limit: self.byte_limit,
+                truncated: self.bytes_seen > bytes_retained as u64,
+            },
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct CapturedOutput {
     #[serde(skip_serializing_if = "String::is_empty")]
@@ -108,5 +253,38 @@ impl CapturedOutput {
 
     pub fn is_empty(&self) -> bool {
         self.stdout.is_empty() && self.stderr.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tail_capture_retains_last_bytes_and_marks_truncated() {
+        let mut capture = TailCapture::new(5);
+        capture.push(b"hello");
+        capture.push(b" world");
+
+        let captured = capture.finish();
+
+        assert_eq!(captured.bytes, b"world");
+        assert_eq!(captured.metadata.bytes_seen, 11);
+        assert_eq!(captured.metadata.bytes_retained, 5);
+        assert_eq!(captured.metadata.byte_limit, 5);
+        assert!(captured.metadata.truncated);
+    }
+
+    #[test]
+    fn tail_capture_reports_untruncated_stream() {
+        let mut capture = TailCapture::new(10);
+        capture.push(b"ok");
+
+        let captured = capture.finish();
+
+        assert_eq!(captured.bytes, b"ok");
+        assert_eq!(captured.metadata.bytes_seen, 2);
+        assert_eq!(captured.metadata.bytes_retained, 2);
+        assert!(!captured.metadata.truncated);
     }
 }

--- a/src/core/extension/compiler_warning_contract.rs
+++ b/src/core/extension/compiler_warning_contract.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use crate::core::engine::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
+
 use super::ExtensionManifest;
 
 #[derive(Debug, Clone, Copy)]
@@ -79,7 +81,7 @@ pub(crate) fn run_compiler_warning_contract_script(
             if let Some(ref mut stdin) = child.stdin {
                 let _ = stdin.write_all(input.to_string().as_bytes());
             }
-            child.wait_with_output().ok()
+            wait_with_bounded_output(child, DEFAULT_CAPTURE_LIMIT_BYTES).ok()
         })
     else {
         return Err(format!(

--- a/src/core/extension/fingerprint.rs
+++ b/src/core/extension/fingerprint.rs
@@ -1,4 +1,5 @@
 use super::manifest::ExtensionManifest;
+use crate::core::engine::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
 
 /// Run a extension's fingerprint script on file content.
 ///
@@ -50,7 +51,7 @@ pub fn run_fingerprint_script(
             if let Some(ref mut stdin) = child.stdin {
                 let _ = stdin.write_all(input.to_string().as_bytes());
             }
-            child.wait_with_output().ok()
+            wait_with_bounded_output(child, DEFAULT_CAPTURE_LIMIT_BYTES).ok()
         })?;
 
     if !output.status.success() {

--- a/src/core/extension/refactor_protocol.rs
+++ b/src/core/extension/refactor_protocol.rs
@@ -1,4 +1,5 @@
 use super::manifest::ExtensionManifest;
+use crate::core::engine::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
 
 #[derive(Debug, Clone)]
 pub struct RefactorScriptFailure {
@@ -95,15 +96,15 @@ pub fn run_refactor_script_result(
             if let Some(ref mut stdin) = child.stdin {
                 let _ = stdin.write_all(command.to_string().as_bytes());
             }
-            child
-                .wait_with_output()
-                .map_err(|err| RefactorScriptFailure {
+            wait_with_bounded_output(child, DEFAULT_CAPTURE_LIMIT_BYTES).map_err(|err| {
+                RefactorScriptFailure {
                     kind: RefactorScriptFailureKind::SpawnFailed,
                     exit_code: None,
                     stdout: String::new(),
                     stderr: err.to_string(),
                     parsed_stdout: None,
-                })
+                }
+            })
         })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();

--- a/src/core/project/files.rs
+++ b/src/core/project/files.rs
@@ -20,6 +20,8 @@ use std::process::Command;
 
 mod edit;
 
+const STDIN_CONTENT_LIMIT_BYTES: u64 = 1024 * 1024;
+
 pub use edit::{
     edit_append, edit_delete_line, edit_delete_lines, edit_delete_pattern, edit_insert_after_line,
     edit_insert_before_line, edit_prepend, edit_replace_line, edit_replace_pattern, EditResult,
@@ -130,10 +132,27 @@ fn parse_ls_line(line: &str, base_path: &str) -> Option<FileEntry> {
 
 /// Read content from stdin, stripping trailing newline.
 pub fn read_stdin() -> Result<String> {
-    let mut content = String::new();
-    io::stdin().read_to_string(&mut content).map_err(|e| {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take(STDIN_CONTENT_LIMIT_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|e| {
+            Error::internal_io(
+                format!("Failed to read stdin: {}", e),
+                Some("read stdin".to_string()),
+            )
+        })?;
+    if bytes.len() > STDIN_CONTENT_LIMIT_BYTES as usize {
+        return Err(Error::validation_invalid_argument(
+            "stdin",
+            "stdin content exceeds the retained byte limit",
+            Some(format!("limit_bytes={STDIN_CONTENT_LIMIT_BYTES}")),
+            None,
+        ));
+    }
+    let mut content = String::from_utf8(bytes).map_err(|e| {
         Error::internal_io(
-            format!("Failed to read stdin: {}", e),
+            format!("Failed to decode stdin as UTF-8: {}", e),
             Some("read stdin".to_string()),
         )
     })?;

--- a/src/core/runner/apply.rs
+++ b/src/core/runner/apply.rs
@@ -6,6 +6,7 @@ use std::process::{Command, Stdio};
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 
+use crate::core::engine::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
 use crate::core::error::{Error, Result};
 use crate::core::source_snapshot::SourceSnapshot;
 
@@ -200,8 +201,7 @@ fn run_git_with_stdin(local_path: &Path, args: &[&str], stdin: &str) -> Result<S
         .ok_or_else(|| Error::internal_unexpected("git stdin unavailable"))?
         .write_all(stdin.as_bytes())
         .map_err(|err| Error::internal_io(err.to_string(), Some("write git stdin".to_string())))?;
-    let output = child
-        .wait_with_output()
+    let output = wait_with_bounded_output(child, DEFAULT_CAPTURE_LIMIT_BYTES)
         .map_err(|err| Error::internal_io(err.to_string(), Some("wait for git".to_string())))?;
     if output.status.success() {
         return Ok(String::from_utf8_lossy(&output.stdout).to_string());

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::core::api_jobs::{Job, JobEvent, JobStatus, RemoteRunnerJobRequest};
+use crate::core::engine::command::CommandCaptureMetadata;
 use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
 use crate::core::server::{self, SshClient};
@@ -67,6 +68,8 @@ pub struct RunnerExecOutput {
     pub patch: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metrics: Option<RunnerResourceMetrics>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capture: Option<CommandCaptureMetadata>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -392,6 +395,7 @@ fn exec_via_reverse_broker(
             mirror_run_id: None,
             patch: None,
             metrics,
+            capture: None,
         },
         exit_code,
     ))
@@ -506,6 +510,7 @@ fn exec_via_daemon(
             mirror_run_id: mirror.map(|evidence| evidence.run.id),
             patch,
             metrics,
+            capture: None,
         },
         exit_code,
     ))
@@ -665,6 +670,7 @@ fn exec_ssh(
             stderr: output.stderr,
             exit_code: output.exit_code,
             metrics: None,
+            capture: None,
         },
         Some(source_snapshot),
     ))
@@ -675,6 +681,7 @@ struct ProcessOutput {
     stderr: String,
     exit_code: i32,
     metrics: Option<RunnerResourceMetrics>,
+    capture: Option<CommandCaptureMetadata>,
 }
 
 fn command_output(command: &mut std::process::Command) -> Result<ProcessOutput> {
@@ -685,6 +692,7 @@ fn command_output(command: &mut std::process::Command) -> Result<ProcessOutput> 
         stderr: String::from_utf8_lossy(&output.stderr).to_string(),
         exit_code: output.status.code().unwrap_or(1),
         metrics: Some(measured.metrics),
+        capture: Some(measured.capture),
     })
 }
 
@@ -714,6 +722,7 @@ fn exec_output(
             mirror_run_id: None,
             patch: None,
             metrics: output.metrics,
+            capture: output.capture,
         },
         exit_code,
     )

--- a/src/core/runner/resource_metrics.rs
+++ b/src/core/runner/resource_metrics.rs
@@ -5,6 +5,9 @@ use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
+use crate::core::engine::command::{
+    wait_with_bounded_output, CommandCaptureMetadata, DEFAULT_CAPTURE_LIMIT_BYTES,
+};
 use crate::core::error::{Error, Result};
 
 const SAMPLE_INTERVAL: Duration = Duration::from_millis(1000);
@@ -27,6 +30,7 @@ pub struct RunnerResourceMetrics {
 #[derive(Debug)]
 pub(crate) struct MeasuredOutput {
     pub output: Output,
+    pub capture: CommandCaptureMetadata,
     pub metrics: RunnerResourceMetrics,
 }
 
@@ -47,11 +51,18 @@ pub(crate) fn measured_command_output(command: &mut Command) -> Result<MeasuredO
     })?;
     let pid = child.id();
     let collector = ResourceMetricsCollector::start(pid);
-    let output = child.wait_with_output().map_err(|err| {
-        Error::internal_io(err.to_string(), Some("wait for runner command".to_string()))
-    })?;
+    let bounded_output =
+        wait_with_bounded_output(child, DEFAULT_CAPTURE_LIMIT_BYTES).map_err(|err| {
+            Error::internal_io(err.to_string(), Some("wait for runner command".to_string()))
+        })?;
+    let capture = bounded_output.capture.clone();
+    let output = bounded_output.into_output();
     let metrics = collector.finish(started.elapsed());
-    Ok(MeasuredOutput { output, metrics })
+    Ok(MeasuredOutput {
+        output,
+        capture,
+        metrics,
+    })
 }
 
 struct ResourceMetricsCollector {

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -340,6 +340,7 @@ mod tests {
             mirror_run_id: None,
             patch: None,
             metrics: None,
+            capture: None,
         }
     }
 }

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -3,6 +3,8 @@ use crate::core::api_jobs::{JobEventKind, JobStatus, JobStore};
 use crate::core::observation::{NewRunRecord, ObservationStore};
 use crate::test_support::HomeGuard;
 
+const DAEMON_TEST_RESPONSE_LIMIT_BYTES: u64 = 64 * 1024;
+
 #[test]
 fn parse_bind_addr_defaults_to_loopback_shape() {
     let addr = parse_bind_addr(DEFAULT_ADDR).expect("parse default");
@@ -106,8 +108,13 @@ fn test_serve_writes_state_and_routes_health_requests() {
     stream
         .write_all(b"GET /health HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
         .expect("write request");
-    let mut response = String::new();
-    stream.read_to_string(&mut response).expect("read response");
+    let mut response_bytes = Vec::new();
+    stream
+        .take(DAEMON_TEST_RESPONSE_LIMIT_BYTES + 1)
+        .read_to_end(&mut response_bytes)
+        .expect("read response");
+    assert!(response_bytes.len() <= DAEMON_TEST_RESPONSE_LIMIT_BYTES as usize);
+    let response = String::from_utf8_lossy(&response_bytes);
 
     let status = read_status().expect("status");
 


### PR DESCRIPTION
## Summary
- Adds a shared bounded tail-capture primitive for child process stdout/stderr with bytes seen, retained bytes, byte limit, and truncation metadata.
- Routes local runner execution and extension script command captures through the bounded capture path.
- Caps nearby stdin/log/test reads that the audit detector grouped with command-output capture, leaving reporter row-cap findings for a follow-up slice.

## Verification
- `cargo test tail_capture`
- `cargo test test_run_refactor_script`
- `cargo test test_serve_writes_state_and_routes_health_requests`
- `cargo test core::rig::check::check_test::test_http_check_exhausts_budget_when_nothing_ever_listens`
- `cargo run --bin homeboy -- audit --path . --extension rust --only unbounded_output_capture --ignore-baseline --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-3011-audit.json` clears command-output capture findings and leaves 9 reporter detail-cap findings.

## Notes
- A full `cargo test` run had one transient timing failure in `core::rig::check::check_test::test_http_check_exhausts_budget_when_nothing_ever_listens`; rerunning that exact test passed.
- Data Machine Code worktree creation failed locally with `EADDRINUSE`, so this branch was created as a direct git worktree under `/Users/chubes/Developer` to avoid mutating the primary checkout.

Closes the command-output-capture slice of #3011; reporter row caps remain for a follow-up PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the bounded command-output capture slice, ran focused verification, and drafted this PR description for Chris to review.