### PR TITLE
Normalize bench budget findings

### DIFF
--- a/src/commands/report/failure_digest.rs
+++ b/src/commands/report/failure_digest.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 mod audit;
 mod bench;
+pub(super) mod budget_values;
 mod trace;
 
 use audit::render_audit_section;

--- a/src/commands/report/failure_digest/bench.rs
+++ b/src/commands/report/failure_digest/bench.rs
@@ -8,6 +8,8 @@ use super::{
 };
 use crate::commands::escape_markdown_table_cell;
 
+use super::budget_values;
+
 pub(super) fn render_bench_section(out: &mut String, output_dir: &Path, run_url: &str) {
     let (data, error) = super::envelope_parts(read_command_json(output_dir, "bench"));
 
@@ -85,19 +87,19 @@ fn render_budget_findings(out: &mut String, data: &Map<String, Value>) {
         let Some(finding) = finding.as_object() else {
             continue;
         };
-        let code = budget_string_value(finding, "code")
+        let code = budget_values::string_value(finding, "code")
             .or_else(|| string_value(finding, "rule"))
             .unwrap_or_else(|| "budget".to_string());
-        let subject = budget_string_value(finding, "subject")
-            .or_else(|| budget_string_value(finding, "context_label"))
+        let subject = budget_values::string_value(finding, "subject")
+            .or_else(|| budget_values::string_value(finding, "context_label"))
             .unwrap_or_else(|| "-".to_string());
-        let actual = budget_number_value(finding, "actual")
+        let actual = budget_values::number_value(finding, "actual")
             .map(format_report_number)
             .unwrap_or_else(|| "-".to_string());
-        let expected = budget_number_value(finding, "expected")
+        let expected = budget_values::number_value(finding, "expected")
             .map(format_report_number)
             .unwrap_or_else(|| "-".to_string());
-        let unit = budget_string_value(finding, "unit").unwrap_or_else(|| "-".to_string());
+        let unit = budget_values::string_value(finding, "unit").unwrap_or_else(|| "-".to_string());
         let message = string_value(finding, "message").unwrap_or_default();
         let _ = writeln!(
             out,
@@ -111,43 +113,6 @@ fn render_budget_findings(out: &mut String, data: &Map<String, Value>) {
         );
     }
     out.push('\n');
-}
-
-fn budget_string_value(finding: &Map<String, Value>, key: &str) -> Option<String> {
-    string_value(finding, key)
-        .or_else(|| {
-            object_value(finding, "metadata")
-                .get(key)
-                .and_then(value_to_string)
-        })
-        .or_else(|| {
-            object_value(finding, "raw")
-                .get(key)
-                .and_then(value_to_string)
-        })
-}
-
-fn budget_number_value(finding: &Map<String, Value>, key: &str) -> Option<f64> {
-    number_value(finding, key)
-        .or_else(|| {
-            object_value(finding, "metadata")
-                .get(key)
-                .and_then(Value::as_f64)
-        })
-        .or_else(|| {
-            object_value(finding, "raw")
-                .get(key)
-                .and_then(Value::as_f64)
-        })
-}
-
-fn value_to_string(value: &Value) -> Option<String> {
-    match value {
-        Value::String(s) if !s.is_empty() => Some(s.clone()),
-        Value::Number(n) => Some(n.to_string()),
-        Value::Bool(b) => Some(b.to_string()),
-        _ => None,
-    }
 }
 
 fn format_report_number(value: f64) -> String {

--- a/src/commands/report/failure_digest/bench.rs
+++ b/src/commands/report/failure_digest/bench.rs
@@ -85,17 +85,19 @@ fn render_budget_findings(out: &mut String, data: &Map<String, Value>) {
         let Some(finding) = finding.as_object() else {
             continue;
         };
-        let code = string_value(finding, "code").unwrap_or_else(|| "budget".to_string());
-        let subject = string_value(finding, "subject")
-            .or_else(|| string_value(finding, "context_label"))
+        let code = budget_string_value(finding, "code")
+            .or_else(|| string_value(finding, "rule"))
+            .unwrap_or_else(|| "budget".to_string());
+        let subject = budget_string_value(finding, "subject")
+            .or_else(|| budget_string_value(finding, "context_label"))
             .unwrap_or_else(|| "-".to_string());
-        let actual = number_value(finding, "actual")
+        let actual = budget_number_value(finding, "actual")
             .map(format_report_number)
             .unwrap_or_else(|| "-".to_string());
-        let expected = number_value(finding, "expected")
+        let expected = budget_number_value(finding, "expected")
             .map(format_report_number)
             .unwrap_or_else(|| "-".to_string());
-        let unit = string_value(finding, "unit").unwrap_or_else(|| "-".to_string());
+        let unit = budget_string_value(finding, "unit").unwrap_or_else(|| "-".to_string());
         let message = string_value(finding, "message").unwrap_or_default();
         let _ = writeln!(
             out,
@@ -109,6 +111,43 @@ fn render_budget_findings(out: &mut String, data: &Map<String, Value>) {
         );
     }
     out.push('\n');
+}
+
+fn budget_string_value(finding: &Map<String, Value>, key: &str) -> Option<String> {
+    string_value(finding, key)
+        .or_else(|| {
+            object_value(finding, "metadata")
+                .get(key)
+                .and_then(value_to_string)
+        })
+        .or_else(|| {
+            object_value(finding, "raw")
+                .get(key)
+                .and_then(value_to_string)
+        })
+}
+
+fn budget_number_value(finding: &Map<String, Value>, key: &str) -> Option<f64> {
+    number_value(finding, key)
+        .or_else(|| {
+            object_value(finding, "metadata")
+                .get(key)
+                .and_then(Value::as_f64)
+        })
+        .or_else(|| {
+            object_value(finding, "raw")
+                .get(key)
+                .and_then(Value::as_f64)
+        })
+}
+
+fn value_to_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(s) if !s.is_empty() => Some(s.clone()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
 }
 
 fn format_report_number(value: f64) -> String {

--- a/src/commands/report/failure_digest/budget_values.rs
+++ b/src/commands/report/failure_digest/budget_values.rs
@@ -1,0 +1,60 @@
+use serde_json::{Map, Value};
+
+pub(in crate::commands::report) fn string_value(
+    finding: &Map<String, Value>,
+    key: &str,
+) -> Option<String> {
+    direct_string_value(finding, key)
+        .or_else(|| nested_string_value(finding, "metadata", key))
+        .or_else(|| nested_string_value(finding, "raw", key))
+}
+
+pub(in crate::commands::report) fn number_value(
+    finding: &Map<String, Value>,
+    key: &str,
+) -> Option<f64> {
+    direct_number_value(finding, key)
+        .or_else(|| nested_number_value(finding, "metadata", key))
+        .or_else(|| nested_number_value(finding, "raw", key))
+}
+
+fn direct_string_value(finding: &Map<String, Value>, key: &str) -> Option<String> {
+    finding.get(key).and_then(value_to_string)
+}
+
+fn direct_number_value(finding: &Map<String, Value>, key: &str) -> Option<f64> {
+    finding.get(key).and_then(Value::as_f64)
+}
+
+fn nested_string_value(
+    finding: &Map<String, Value>,
+    object_key: &str,
+    value_key: &str,
+) -> Option<String> {
+    finding
+        .get(object_key)
+        .and_then(Value::as_object)
+        .and_then(|object| object.get(value_key))
+        .and_then(value_to_string)
+}
+
+fn nested_number_value(
+    finding: &Map<String, Value>,
+    object_key: &str,
+    value_key: &str,
+) -> Option<f64> {
+    finding
+        .get(object_key)
+        .and_then(Value::as_object)
+        .and_then(|object| object.get(value_key))
+        .and_then(Value::as_f64)
+}
+
+fn value_to_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(s) if !s.is_empty() => Some(s.clone()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}

--- a/src/commands/report/performance_digest.rs
+++ b/src/commands/report/performance_digest.rs
@@ -327,18 +327,57 @@ mod helpers {
             .filter_map(|value| {
                 let obj = value.as_object()?;
                 Some(BudgetFindingDigest {
-                    code: string_value(obj, "code").unwrap_or_else(|| "budget".to_string()),
-                    subject: string_value(obj, "subject")
-                        .or_else(|| string_value(obj, "context_label"))
+                    code: budget_string_value(obj, "code")
+                        .or_else(|| string_value(obj, "rule"))
+                        .unwrap_or_else(|| "budget".to_string()),
+                    subject: budget_string_value(obj, "subject")
+                        .or_else(|| budget_string_value(obj, "context_label"))
                         .unwrap_or_else(|| "-".to_string()),
-                    actual: number_value(obj, "actual"),
-                    expected: number_value(obj, "expected"),
-                    unit: string_value(obj, "unit").unwrap_or_else(|| "-".to_string()),
+                    actual: budget_number_value(obj, "actual"),
+                    expected: budget_number_value(obj, "expected"),
+                    unit: budget_string_value(obj, "unit").unwrap_or_else(|| "-".to_string()),
                     severity: string_value(obj, "severity").unwrap_or_else(|| "error".to_string()),
                     message: string_value(obj, "message").unwrap_or_default(),
                 })
             })
             .collect()
+    }
+
+    fn budget_string_value(finding: &Map<String, Value>, key: &str) -> Option<String> {
+        string_value(finding, key)
+            .or_else(|| {
+                object_value(finding, "metadata")
+                    .get(key)
+                    .and_then(value_to_string)
+            })
+            .or_else(|| {
+                object_value(finding, "raw")
+                    .get(key)
+                    .and_then(value_to_string)
+            })
+    }
+
+    fn budget_number_value(finding: &Map<String, Value>, key: &str) -> Option<f64> {
+        number_value(finding, key)
+            .or_else(|| {
+                object_value(finding, "metadata")
+                    .get(key)
+                    .and_then(Value::as_f64)
+            })
+            .or_else(|| {
+                object_value(finding, "raw")
+                    .get(key)
+                    .and_then(Value::as_f64)
+            })
+    }
+
+    fn value_to_string(value: &Value) -> Option<String> {
+        match value {
+            Value::String(s) if !s.is_empty() => Some(s.clone()),
+            Value::Number(n) => Some(n.to_string()),
+            Value::Bool(b) => Some(b.to_string()),
+            _ => None,
+        }
     }
 
     pub(super) fn collect_benchmark_memory(

--- a/src/commands/report/performance_digest.rs
+++ b/src/commands/report/performance_digest.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
+use super::failure_digest::budget_values;
 use crate::commands::escape_markdown_table_cell;
 use homeboy::core::engine::run_dir::files;
 
@@ -327,57 +328,21 @@ mod helpers {
             .filter_map(|value| {
                 let obj = value.as_object()?;
                 Some(BudgetFindingDigest {
-                    code: budget_string_value(obj, "code")
+                    code: budget_values::string_value(obj, "code")
                         .or_else(|| string_value(obj, "rule"))
                         .unwrap_or_else(|| "budget".to_string()),
-                    subject: budget_string_value(obj, "subject")
-                        .or_else(|| budget_string_value(obj, "context_label"))
+                    subject: budget_values::string_value(obj, "subject")
+                        .or_else(|| budget_values::string_value(obj, "context_label"))
                         .unwrap_or_else(|| "-".to_string()),
-                    actual: budget_number_value(obj, "actual"),
-                    expected: budget_number_value(obj, "expected"),
-                    unit: budget_string_value(obj, "unit").unwrap_or_else(|| "-".to_string()),
+                    actual: budget_values::number_value(obj, "actual"),
+                    expected: budget_values::number_value(obj, "expected"),
+                    unit: budget_values::string_value(obj, "unit")
+                        .unwrap_or_else(|| "-".to_string()),
                     severity: string_value(obj, "severity").unwrap_or_else(|| "error".to_string()),
                     message: string_value(obj, "message").unwrap_or_default(),
                 })
             })
             .collect()
-    }
-
-    fn budget_string_value(finding: &Map<String, Value>, key: &str) -> Option<String> {
-        string_value(finding, key)
-            .or_else(|| {
-                object_value(finding, "metadata")
-                    .get(key)
-                    .and_then(value_to_string)
-            })
-            .or_else(|| {
-                object_value(finding, "raw")
-                    .get(key)
-                    .and_then(value_to_string)
-            })
-    }
-
-    fn budget_number_value(finding: &Map<String, Value>, key: &str) -> Option<f64> {
-        number_value(finding, key)
-            .or_else(|| {
-                object_value(finding, "metadata")
-                    .get(key)
-                    .and_then(Value::as_f64)
-            })
-            .or_else(|| {
-                object_value(finding, "raw")
-                    .get(key)
-                    .and_then(Value::as_f64)
-            })
-    }
-
-    fn value_to_string(value: &Value) -> Option<String> {
-        match value {
-            Value::String(s) if !s.is_empty() => Some(s.clone()),
-            Value::Number(n) => Some(n.to_string()),
-            Value::Bool(b) => Some(b.to_string()),
-            _ => None,
-        }
     }
 
     pub(super) fn collect_benchmark_memory(

--- a/src/core/budget.rs
+++ b/src/core/budget.rs
@@ -6,6 +6,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::core::finding::{FindingSource, HomeboyFinding};
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BudgetFinding {
     #[serde(default = "budget_category")]
@@ -61,6 +63,27 @@ impl BudgetFinding {
             Some(subject) if !subject.is_empty() => format!("{}:{}", self.code, subject),
             _ => self.code.clone(),
         }
+    }
+
+    pub fn to_homeboy_finding(&self) -> HomeboyFinding {
+        let mut normalized = HomeboyFinding::builder("budget", self.message.clone())
+            .rule(self.code.clone())
+            .category(self.category.clone())
+            .severity(self.severity.clone())
+            .fingerprint(self.fingerprint())
+            .source(FindingSource::new("budget").label(self.context_label.clone()))
+            .metadata("code", self.code.clone())
+            .metadata("category", self.category.clone())
+            .metadata("context_label", self.context_label.clone())
+            .metadata("actual", self.actual)
+            .metadata("expected", self.expected)
+            .metadata("unit", self.unit.clone())
+            .metadata("subject", self.subject.clone())
+            .metadata("passed", self.passed)
+            .raw(self)
+            .build();
+        normalized.location.file = self.file.clone();
+        normalized
     }
 }
 

--- a/src/core/extension/bench/budget_findings.rs
+++ b/src/core/extension/bench/budget_findings.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Deserializer};
+
+use crate::core::budget::BudgetFinding;
+use crate::core::finding::HomeboyFinding;
+
+pub(crate) fn deserialize_budget_findings<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Vec<HomeboyFinding>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let values = Vec::<serde_json::Value>::deserialize(deserializer)?;
+    values
+        .into_iter()
+        .map(|value| {
+            if value.get("tool").is_some() {
+                serde_json::from_value::<HomeboyFinding>(value).map_err(serde::de::Error::custom)
+            } else {
+                serde_json::from_value::<BudgetFinding>(value)
+                    .map(|finding| finding.to_homeboy_finding())
+                    .map_err(serde::de::Error::custom)
+            }
+        })
+        .collect()
+}

--- a/src/core/extension/bench/gate.rs
+++ b/src/core/extension/bench/gate.rs
@@ -116,6 +116,7 @@ pub fn evaluate_gates(results: &mut BenchResults) -> Vec<String> {
                         "value",
                         Some(result.metric.clone()),
                     )
+                    .to_homeboy_finding()
                 }),
         );
         failures.extend(
@@ -129,10 +130,19 @@ pub fn evaluate_gates(results: &mut BenchResults) -> Vec<String> {
         results
             .budget_findings
             .iter()
-            .filter(|finding| finding.is_gate_failure())
+            .filter(|finding| is_budget_gate_failure(finding))
             .map(|finding| finding.message.clone()),
     );
     failures.sort();
     failures.dedup();
     failures
+}
+
+fn is_budget_gate_failure(finding: &crate::core::finding::HomeboyFinding) -> bool {
+    finding.severity.as_deref() == Some("error")
+        || finding
+            .metadata
+            .get("passed")
+            .and_then(serde_json::Value::as_bool)
+            == Some(false)
 }

--- a/src/core/extension/bench/mod.rs
+++ b/src/core/extension/bench/mod.rs
@@ -23,6 +23,7 @@ pub mod aggregation;
 pub mod artifact;
 pub(crate) mod artifact_validation;
 pub mod baseline;
+pub(crate) mod budget_findings;
 pub mod diagnostic;
 pub mod distribution;
 pub(crate) mod failure_diagnostic;

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -56,10 +56,11 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::core::budget::BudgetFinding;
 use crate::core::error::{Error, Result};
+use crate::core::finding::HomeboyFinding;
 use crate::core::observation::timeline::{
     reporting_timeline, summarize_spans, ObservationEvent, ObservationSpanDefinition,
     ObservationSpanResult,
@@ -98,13 +99,38 @@ pub struct BenchResults {
     pub span_definitions: BTreeMap<String, serde_json::Value>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub diagnostics: Vec<BenchDiagnostic>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub budget_findings: Vec<BudgetFinding>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_budget_findings",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub budget_findings: Vec<HomeboyFinding>,
     pub scenarios: Vec<BenchScenario>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub metric_policies: BTreeMap<String, BenchMetricPolicy>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub metric_policy_presets: BTreeMap<String, BenchMetricPolicyPreset>,
+}
+
+fn deserialize_budget_findings<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Vec<HomeboyFinding>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let values = Vec::<serde_json::Value>::deserialize(deserializer)?;
+    values
+        .into_iter()
+        .map(|value| {
+            if value.get("tool").is_some() {
+                serde_json::from_value::<HomeboyFinding>(value).map_err(serde::de::Error::custom)
+            } else {
+                serde_json::from_value::<BudgetFinding>(value)
+                    .map(|finding| finding.to_homeboy_finding())
+                    .map_err(serde::de::Error::custom)
+            }
+        })
+        .collect()
 }
 
 /// Homeboy-owned reproducibility metadata for a bench invocation.
@@ -1067,12 +1093,15 @@ mod tests {
         assert!(failures[0].contains("assistant_message_count gte 1"));
         assert_eq!(scenario.gate_results[0].actual, Some(0.0));
         assert_eq!(parsed.budget_findings.len(), 1);
-        assert_eq!(parsed.budget_findings[0].category, "budget");
         assert_eq!(
-            parsed.budget_findings[0].code,
-            "bench.gate.assistant_message_count"
+            parsed.budget_findings[0].category.as_deref(),
+            Some("budget")
         );
-        assert!(!parsed.budget_findings[0].passed);
+        assert_eq!(
+            parsed.budget_findings[0].rule.as_deref(),
+            Some("bench.gate.assistant_message_count")
+        );
+        assert_eq!(parsed.budget_findings[0].metadata["passed"], false);
     }
 
     #[test]
@@ -1100,9 +1129,9 @@ mod tests {
         let failures = evaluate_gates(&mut parsed);
 
         assert_eq!(failures, vec!["REST response exceeded 250 KB budget"]);
-        assert_eq!(parsed.budget_findings[0].actual, Some(4378195.0));
-        assert_eq!(parsed.budget_findings[0].expected, 250000.0);
-        assert_eq!(parsed.budget_findings[0].unit, "bytes");
+        assert_eq!(parsed.budget_findings[0].metadata["actual"], 4378195.0);
+        assert_eq!(parsed.budget_findings[0].metadata["expected"], 250000.0);
+        assert_eq!(parsed.budget_findings[0].metadata["unit"], "bytes");
     }
 
     #[test]
@@ -1460,7 +1489,10 @@ mod tests {
         assert_eq!(parsed.scenarios[0].gates.len(), 1);
         assert_eq!(parsed.scenarios[0].gates[0].op, BenchGateOp::Lte);
         assert!(!failures.is_empty());
-        assert_eq!(parsed.budget_findings[0].code, "bench.gate.peak_rss_bytes");
+        assert_eq!(
+            parsed.budget_findings[0].rule.as_deref(),
+            Some("bench.gate.peak_rss_bytes")
+        );
     }
 
     #[test]

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -56,9 +56,8 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
-use crate::core::budget::BudgetFinding;
 use crate::core::error::{Error, Result};
 use crate::core::finding::HomeboyFinding;
 use crate::core::observation::timeline::{
@@ -101,7 +100,7 @@ pub struct BenchResults {
     pub diagnostics: Vec<BenchDiagnostic>,
     #[serde(
         default,
-        deserialize_with = "deserialize_budget_findings",
+        deserialize_with = "super::budget_findings::deserialize_budget_findings",
         skip_serializing_if = "Vec::is_empty"
     )]
     pub budget_findings: Vec<HomeboyFinding>,
@@ -110,27 +109,6 @@ pub struct BenchResults {
     pub metric_policies: BTreeMap<String, BenchMetricPolicy>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub metric_policy_presets: BTreeMap<String, BenchMetricPolicyPreset>,
-}
-
-fn deserialize_budget_findings<'de, D>(
-    deserializer: D,
-) -> std::result::Result<Vec<HomeboyFinding>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let values = Vec::<serde_json::Value>::deserialize(deserializer)?;
-    values
-        .into_iter()
-        .map(|value| {
-            if value.get("tool").is_some() {
-                serde_json::from_value::<HomeboyFinding>(value).map_err(serde::de::Error::custom)
-            } else {
-                serde_json::from_value::<BudgetFinding>(value)
-                    .map(|finding| finding.to_homeboy_finding())
-                    .map_err(serde::de::Error::custom)
-            }
-        })
-        .collect()
 }
 
 /// Homeboy-owned reproducibility metadata for a bench invocation.
@@ -1092,15 +1070,6 @@ mod tests {
         assert_eq!(failures.len(), 1);
         assert!(failures[0].contains("assistant_message_count gte 1"));
         assert_eq!(scenario.gate_results[0].actual, Some(0.0));
-        assert_eq!(parsed.budget_findings.len(), 1);
-        assert_eq!(
-            parsed.budget_findings[0].category.as_deref(),
-            Some("budget")
-        );
-        assert_eq!(
-            parsed.budget_findings[0].rule.as_deref(),
-            Some("bench.gate.assistant_message_count")
-        );
         assert_eq!(parsed.budget_findings[0].metadata["passed"], false);
     }
 

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -7,8 +7,8 @@ use super::baseline::BenchBaselineComparison;
 use super::diagnostic::BenchDiagnostic;
 use super::parsing::BenchResults;
 use super::run::{BenchRunFailure, BenchRunWorkflowResult};
-use crate::core::budget::BudgetFinding;
 use crate::core::ci_profile::CiContext;
+use crate::core::finding::HomeboyFinding;
 use crate::core::rig::RigStateSnapshot;
 use crate::core::runner::reportable_artifact_evidence_path;
 
@@ -28,7 +28,7 @@ pub struct BenchCommandOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub results: Option<BenchResults>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub budget_findings: Vec<BudgetFinding>,
+    pub budget_findings: Vec<HomeboyFinding>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub gate_failures: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/core/observation/budget_findings.rs
+++ b/src/core/observation/budget_findings.rs
@@ -1,34 +1,14 @@
-use crate::core::budget::BudgetFinding;
-use crate::core::finding::{FindingSource, HomeboyFinding};
+use crate::core::finding::HomeboyFinding;
 
 use super::records::NewFindingRecord;
 
-fn homeboy_finding_from_budget(finding: &BudgetFinding) -> HomeboyFinding {
-    let mut normalized = HomeboyFinding::builder("budget", finding.message.clone())
-        .rule(finding.code.clone())
-        .category(finding.category.clone())
-        .severity(finding.severity.clone())
-        .fingerprint(finding.fingerprint())
-        .source(FindingSource::new("budget").label(finding.context_label.clone()))
-        .metadata("context_label", finding.context_label.clone())
-        .metadata("actual", finding.actual)
-        .metadata("expected", finding.expected)
-        .metadata("unit", finding.unit.clone())
-        .metadata("subject", finding.subject.clone())
-        .metadata("passed", finding.passed)
-        .raw(finding)
-        .build();
-    normalized.location.file = finding.file.clone();
-    normalized
-}
-
-fn finding_record_from_budget(run_id: &str, finding: &BudgetFinding) -> NewFindingRecord {
-    NewFindingRecord::from_homeboy_finding(run_id, homeboy_finding_from_budget(finding))
+fn finding_record_from_budget(run_id: &str, finding: &HomeboyFinding) -> NewFindingRecord {
+    NewFindingRecord::from_homeboy_finding(run_id, finding.clone())
 }
 
 pub fn finding_records_from_budget(
     run_id: &str,
-    findings: &[BudgetFinding],
+    findings: &[HomeboyFinding],
 ) -> Vec<NewFindingRecord> {
     findings
         .iter()
@@ -39,6 +19,7 @@ pub fn finding_records_from_budget(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::budget::BudgetFinding;
 
     #[test]
     fn test_finding_record_from_budget() {
@@ -52,7 +33,8 @@ mod tests {
             Some("/wp-json/datamachine/v1/pipelines?per_page=100".to_string()),
         );
 
-        let record = finding_record_from_budget("run-1", &finding);
+        let normalized = finding.to_homeboy_finding();
+        let record = finding_record_from_budget("run-1", &normalized);
 
         assert_eq!(record.tool, "budget");
         assert_eq!(record.rule.as_deref(), Some("rest.max_response_bytes"));
@@ -74,7 +56,8 @@ mod tests {
             1000.0,
             "ms",
             Some("front-page".to_string()),
-        )];
+        )
+        .to_homeboy_finding()];
 
         let records = finding_records_from_budget("run-1", &findings);
 

--- a/tests/report_failure_digest_test.rs
+++ b/tests/report_failure_digest_test.rs
@@ -78,16 +78,34 @@ fn bench_json() -> &'static str {
             "iterations": 5,
             "budget_findings": [
                 {
+                    "tool": "budget",
+                    "rule": "rest.max_response_bytes",
                     "category": "budget",
-                    "code": "rest.max_response_bytes",
                     "severity": "error",
-                    "context_label": "profile:wordpress-rest",
                     "message": "REST response exceeded 250 KB budget",
-                    "actual": 4378195,
-                    "expected": 250000,
-                    "unit": "bytes",
-                    "subject": "/wp-json/datamachine/v1/pipelines?per_page=100",
-                    "passed": false
+                    "fingerprint": "rest.max_response_bytes:/wp-json/datamachine/v1/pipelines?per_page=100",
+                    "source": { "kind": "budget", "label": "profile:wordpress-rest" },
+                    "metadata": {
+                        "code": "rest.max_response_bytes",
+                        "context_label": "profile:wordpress-rest",
+                        "actual": 4378195,
+                        "expected": 250000,
+                        "unit": "bytes",
+                        "subject": "/wp-json/datamachine/v1/pipelines?per_page=100",
+                        "passed": false
+                    },
+                    "raw": {
+                        "category": "budget",
+                        "code": "rest.max_response_bytes",
+                        "severity": "error",
+                        "context_label": "profile:wordpress-rest",
+                        "message": "REST response exceeded 250 KB budget",
+                        "actual": 4378195,
+                        "expected": 250000,
+                        "unit": "bytes",
+                        "subject": "/wp-json/datamachine/v1/pipelines?per_page=100",
+                        "passed": false
+                    }
                 }
             ],
             "artifacts": [

--- a/tests/report_failure_digest_test.rs
+++ b/tests/report_failure_digest_test.rs
@@ -94,18 +94,7 @@ fn bench_json() -> &'static str {
                         "subject": "/wp-json/datamachine/v1/pipelines?per_page=100",
                         "passed": false
                     },
-                    "raw": {
-                        "category": "budget",
-                        "code": "rest.max_response_bytes",
-                        "severity": "error",
-                        "context_label": "profile:wordpress-rest",
-                        "message": "REST response exceeded 250 KB budget",
-                        "actual": 4378195,
-                        "expected": 250000,
-                        "unit": "bytes",
-                        "subject": "/wp-json/datamachine/v1/pipelines?per_page=100",
-                        "passed": false
-                    }
+                    "raw": { "category": "budget" }
                 }
             ],
             "artifacts": [

--- a/tests/report_performance_digest_test.rs
+++ b/tests/report_performance_digest_test.rs
@@ -66,15 +66,34 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
             "success": true,
             "data": {
                 "budget_findings": [{
-                    "code": "metric.max_value",
+                    "tool": "budget",
+                    "rule": "metric.max_value",
+                    "category": "budget",
                     "severity": "error",
-                    "context_label": "profile:generic",
                     "message": "Metric exceeded budget",
-                    "actual": 42,
-                    "expected": 20,
-                    "unit": "count",
-                    "subject": "fixture-subject",
-                    "passed": false
+                    "fingerprint": "metric.max_value:fixture-subject",
+                    "source": { "kind": "budget", "label": "profile:generic" },
+                    "metadata": {
+                        "code": "metric.max_value",
+                        "context_label": "profile:generic",
+                        "actual": 42,
+                        "expected": 20,
+                        "unit": "count",
+                        "subject": "fixture-subject",
+                        "passed": false
+                    },
+                    "raw": {
+                        "category": "budget",
+                        "code": "metric.max_value",
+                        "severity": "error",
+                        "context_label": "profile:generic",
+                        "message": "Metric exceeded budget",
+                        "actual": 42,
+                        "expected": 20,
+                        "unit": "count",
+                        "subject": "fixture-subject",
+                        "passed": false
+                    }
                 }],
                 "results": {
                     "scenarios": [{


### PR DESCRIPTION
## Summary
- Normalize bench `budget_findings` in `BenchResults` and `BenchCommandOutput` to `HomeboyFinding` while accepting legacy runner-emitted `BudgetFinding` payloads.
- Preserve budget-specific details (`code`, `category`, `context_label`, `actual`, `expected`, `unit`, `subject`, `passed`) in finding metadata/raw and keep digest renderers compatible with both shapes.
- Update bench parsing, observation projection, performance digest, and failure digest coverage for the normalized contract.

## Tests
- `cargo fmt && cargo test parsing::tests && cargo test --test report_performance_digest_test && cargo test --test report_failure_digest_test && cargo test --test output_contracts_test quality_command_golden_json_contract_fixtures_match_typed_payloads`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused bench budget finding migration, updated tests, and ran verification; Chris remains responsible for review and merge.