### PR TITLE
Consume normalized review findings

### DIFF
--- a/src/commands/review/artifact_findings.rs
+++ b/src/commands/review/artifact_findings.rs
@@ -1,0 +1,31 @@
+use serde_json::Value;
+
+use homeboy::core::ci_profile::CiRunOutput;
+use homeboy::core::code_audit::AuditCommandOutput;
+use homeboy::core::extension::lint::LintCommandOutput;
+use homeboy::core::extension::test::TestCommandOutput;
+use homeboy::core::finding::HomeboyFinding;
+
+pub(super) trait ReviewArtifactFindings {
+    fn review_artifact_findings(&self) -> Vec<HomeboyFinding> {
+        Vec::new()
+    }
+}
+
+impl ReviewArtifactFindings for AuditCommandOutput {}
+
+impl ReviewArtifactFindings for LintCommandOutput {
+    fn review_artifact_findings(&self) -> Vec<HomeboyFinding> {
+        self.findings.clone().unwrap_or_default()
+    }
+}
+
+impl ReviewArtifactFindings for TestCommandOutput {
+    fn review_artifact_findings(&self) -> Vec<HomeboyFinding> {
+        self.findings.clone().unwrap_or_default()
+    }
+}
+
+impl ReviewArtifactFindings for CiRunOutput {}
+
+impl ReviewArtifactFindings for Value {}

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -35,9 +35,12 @@ use super::parse_key_val;
 use super::utils::args::{BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs};
 use super::{audit, lint, test, CmdResult, GlobalArgs};
 
+mod artifact_findings;
 mod observation;
 pub(super) mod raw_output;
 mod render;
+
+use artifact_findings::ReviewArtifactFindings;
 
 #[derive(Args, Debug, Clone)]
 pub struct ReviewArgs {
@@ -176,30 +179,6 @@ pub struct ReviewArtifactCommand {
     pub findings: Vec<HomeboyFinding>,
     pub artifacts: Vec<Value>,
 }
-
-pub(super) trait ReviewArtifactFindings {
-    fn review_artifact_findings(&self) -> Vec<HomeboyFinding> {
-        Vec::new()
-    }
-}
-
-impl ReviewArtifactFindings for AuditCommandOutput {}
-
-impl ReviewArtifactFindings for LintCommandOutput {
-    fn review_artifact_findings(&self) -> Vec<HomeboyFinding> {
-        self.findings.clone().unwrap_or_default()
-    }
-}
-
-impl ReviewArtifactFindings for TestCommandOutput {
-    fn review_artifact_findings(&self) -> Vec<HomeboyFinding> {
-        self.findings.clone().unwrap_or_default()
-    }
-}
-
-impl ReviewArtifactFindings for CiRunOutput {}
-
-impl ReviewArtifactFindings for Value {}
 
 struct ReviewStageDescriptor<Args, Output: Serialize + ReviewArtifactFindings> {
     name: &'static str,

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -25,6 +25,7 @@ use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::execution;
 use homeboy::core::extension::lint::LintCommandOutput;
 use homeboy::core::extension::test::TestCommandOutput;
+use homeboy::core::finding::HomeboyFinding;
 use homeboy::core::git;
 use homeboy::core::plan::{HomeboyPlan, PlanStep};
 use homeboy::core::quality::{build_quality_plan, QualityPlanOptions};
@@ -172,11 +173,35 @@ pub struct ReviewArtifactCommand {
     pub status: String,
     pub exit_code: i32,
     pub summary: String,
-    pub findings: Vec<Value>,
+    pub findings: Vec<HomeboyFinding>,
     pub artifacts: Vec<Value>,
 }
 
-struct ReviewStageDescriptor<Args, Output: Serialize> {
+pub(super) trait ReviewArtifactFindings {
+    fn review_artifact_findings(&self) -> Vec<HomeboyFinding> {
+        Vec::new()
+    }
+}
+
+impl ReviewArtifactFindings for AuditCommandOutput {}
+
+impl ReviewArtifactFindings for LintCommandOutput {
+    fn review_artifact_findings(&self) -> Vec<HomeboyFinding> {
+        self.findings.clone().unwrap_or_default()
+    }
+}
+
+impl ReviewArtifactFindings for TestCommandOutput {
+    fn review_artifact_findings(&self) -> Vec<HomeboyFinding> {
+        self.findings.clone().unwrap_or_default()
+    }
+}
+
+impl ReviewArtifactFindings for CiRunOutput {}
+
+impl ReviewArtifactFindings for Value {}
+
+struct ReviewStageDescriptor<Args, Output: Serialize + ReviewArtifactFindings> {
     name: &'static str,
     include_changed_only_scope: bool,
     build_args: fn(&ReviewArgs) -> Args,
@@ -190,7 +215,7 @@ enum ReviewStageRun {
     Test(ReviewStage<TestCommandOutput>, i32),
 }
 
-impl<Args, Output: Serialize> ReviewStageDescriptor<Args, Output> {
+impl<Args, Output: Serialize + ReviewArtifactFindings> ReviewStageDescriptor<Args, Output> {
     fn execute(
         &self,
         review_args: &ReviewArgs,
@@ -646,7 +671,9 @@ fn build_artifact(
     }
 }
 
-fn artifact_command<T: Serialize>(stage: &ReviewStage<T>) -> ReviewArtifactCommand {
+fn artifact_command<T: Serialize + ReviewArtifactFindings>(
+    stage: &ReviewStage<T>,
+) -> ReviewArtifactCommand {
     ReviewArtifactCommand {
         name: stage.stage.clone(),
         status: if !stage.ran {
@@ -670,7 +697,11 @@ fn artifact_command<T: Serialize>(stage: &ReviewStage<T>) -> ReviewArtifactComma
                 if stage.passed { "passed" } else { "failed" }
             )
         },
-        findings: Vec::new(),
+        findings: stage
+            .output
+            .as_ref()
+            .map(ReviewArtifactFindings::review_artifact_findings)
+            .unwrap_or_default(),
         artifacts: Vec::new(),
     }
 }

--- a/src/commands/review/observation.rs
+++ b/src/commands/review/observation.rs
@@ -4,7 +4,9 @@ use homeboy::core::git::short_head_revision_at;
 use homeboy::core::observation::{merge_metadata, ActiveObservation, NewRunRecord, RunStatus};
 use homeboy::core::ObservationOutputMetadata;
 
-use super::{artifact_command, ReviewArgs, ReviewCommandOutput, ReviewStage};
+use super::{
+    artifact_command, ReviewArgs, ReviewArtifactFindings, ReviewCommandOutput, ReviewStage,
+};
 
 pub(super) struct ReviewObservation(ActiveObservation);
 
@@ -156,7 +158,9 @@ pub(super) fn review_observation_finish_metadata(
     )
 }
 
-fn stage_observation<T: serde::Serialize>(stage: &ReviewStage<T>) -> serde_json::Value {
+fn stage_observation<T: serde::Serialize + ReviewArtifactFindings>(
+    stage: &ReviewStage<T>,
+) -> serde_json::Value {
     let command = artifact_command(stage);
     serde_json::json!({
         "name": command.name,

--- a/src/core/issues/render.rs
+++ b/src/core/issues/render.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::core::code_audit::FindingConfidence;
+use crate::core::finding::HomeboyFinding;
 
 /// Canonical input shape consumed by `homeboy issues reconcile`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -70,6 +71,11 @@ pub fn build_findings_from_native_output(
 }
 
 fn render_audit(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsInput {
+    let normalized_findings = normalized_findings(data);
+    if !normalized_findings.is_empty() {
+        return render_normalized_findings("audit", normalized_findings, context);
+    }
+
     let mut by_kind: BTreeMap<String, Vec<&Value>> = BTreeMap::new();
     let findings = data
         .get("findings")
@@ -148,6 +154,11 @@ fn render_audit_body(
 }
 
 fn render_lint(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsInput {
+    let normalized_findings = normalized_findings(data);
+    if !normalized_findings.is_empty() {
+        return render_normalized_findings("lint", normalized_findings, context);
+    }
+
     let mut by_category: BTreeMap<String, Vec<&Value>> = BTreeMap::new();
     if let Some(findings) = data.get("findings").and_then(Value::as_array) {
         for finding in findings {
@@ -290,6 +301,11 @@ fn render_lint_body(
 }
 
 fn render_test(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsInput {
+    let normalized_findings = normalized_findings(data);
+    if !normalized_findings.is_empty() {
+        return render_normalized_findings("test", normalized_findings, context);
+    }
+
     let mut groups = BTreeMap::new();
 
     if let Some(clusters) = data.pointer("/analysis/clusters").and_then(Value::as_array) {
@@ -338,6 +354,108 @@ fn render_test(data: &Value, context: &IssueRenderContext) -> ReconcileFindingsI
         command: "test".to_string(),
         groups,
     }
+}
+
+fn normalized_findings(data: &Value) -> Vec<HomeboyFinding> {
+    let Some(findings) = data.get("findings").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    let parsed: Vec<HomeboyFinding> = findings
+        .iter()
+        .filter_map(|finding| serde_json::from_value(finding.clone()).ok())
+        .collect();
+    if parsed.len() == findings.len() {
+        parsed
+    } else {
+        Vec::new()
+    }
+}
+
+fn render_normalized_findings(
+    command: &str,
+    findings: Vec<HomeboyFinding>,
+    context: &IssueRenderContext,
+) -> ReconcileFindingsInput {
+    let mut by_category: BTreeMap<String, Vec<HomeboyFinding>> = BTreeMap::new();
+    for finding in findings {
+        let category = finding_category(command, &finding);
+        by_category.entry(category).or_default().push(finding);
+    }
+
+    let mut groups = BTreeMap::new();
+    for (category, findings) in by_category {
+        groups.insert(
+            category.clone(),
+            RenderedIssueGroup {
+                count: findings.len(),
+                label: labelize(&category),
+                body: render_normalized_findings_body(command, &category, &findings, context),
+                confidence: None,
+            },
+        );
+    }
+
+    ReconcileFindingsInput {
+        command: command.to_string(),
+        groups,
+    }
+}
+
+fn finding_category(command: &str, finding: &HomeboyFinding) -> String {
+    finding
+        .category
+        .clone()
+        .or_else(|| finding.rule.clone())
+        .unwrap_or_else(|| format!("{}_finding", command))
+}
+
+fn render_normalized_findings_body(
+    command: &str,
+    category: &str,
+    findings: &[HomeboyFinding],
+    context: &IssueRenderContext,
+) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "## {}", labelize(category));
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "{} {} finding(s) in this category.",
+        findings.len(),
+        command
+    );
+    if let Some(url) = context.run_url.as_deref() {
+        let _ = writeln!(out, "\nRun: {}", url);
+    }
+    let _ = writeln!(out, "\n### Findings");
+    for finding in findings.iter().take(20) {
+        render_normalized_finding_line(&mut out, finding);
+    }
+    if findings.len() > 20 {
+        let _ = writeln!(out, "- _... {} more finding(s)_", findings.len() - 20);
+    }
+    out
+}
+
+fn render_normalized_finding_line(out: &mut String, finding: &HomeboyFinding) {
+    let label = finding
+        .fingerprint
+        .as_deref()
+        .or(finding.rule.as_deref())
+        .or(finding.location.file.as_deref())
+        .unwrap_or(&finding.tool);
+    let _ = write!(out, "- `{}` — {}", label, finding.message);
+    if let Some(file) = finding.location.file.as_deref() {
+        if label != file {
+            let _ = write!(out, " (`{}", file);
+            if let Some(line) = finding.location.line {
+                let _ = write!(out, ":{}", line);
+            }
+            let _ = write!(out, "`)");
+        }
+    }
+    out.push('\n');
 }
 
 fn render_test_cluster_body(

--- a/tests/core/issues/render_test.rs
+++ b/tests/core/issues/render_test.rs
@@ -133,6 +133,37 @@ fn renders_lint_output_grouped_by_category() {
 }
 
 #[test]
+fn renders_normalized_lint_findings() {
+    let output = json!({
+        "data": {
+            "passed": false,
+            "status": "failed",
+            "exit_code": 1,
+            "findings": [
+                {
+                    "tool": "lint",
+                    "category": "style",
+                    "message": "trailing whitespace",
+                    "fingerprint": "lint-1",
+                    "file": "src/lib.rs",
+                    "line": 12
+                }
+            ]
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("lint", output, &IssueRenderContext::default()).unwrap();
+
+    let group = rendered.groups.get("style").unwrap();
+    assert_eq!(group.count, 1);
+    assert!(group.body.contains("1 lint finding(s) in this category."));
+    assert!(group
+        .body
+        .contains("- `lint-1` — trailing whitespace (`src/lib.rs:12`)"));
+}
+
+#[test]
 fn renders_lint_aggregate_fallback_when_findings_are_missing() {
     let output = json!({
         "data": {
@@ -248,6 +279,37 @@ fn renders_test_analysis_clusters_by_category() {
         .contains("**Pattern:** undefined method Widget::render"));
     assert!(group.body.contains("- `tests/widget.rs`"));
     assert!(group.body.contains("- `widget_renders`"));
+}
+
+#[test]
+fn renders_normalized_test_findings() {
+    let output = json!({
+        "data": {
+            "passed": false,
+            "status": "failed",
+            "exit_code": 1,
+            "findings": [
+                {
+                    "tool": "test",
+                    "category": "assertion_failure",
+                    "message": "expected 200, got 500",
+                    "fingerprint": "test-1",
+                    "file": "tests/http.rs",
+                    "line": 44
+                }
+            ]
+        }
+    });
+
+    let rendered =
+        build_findings_from_native_output("test", output, &IssueRenderContext::default()).unwrap();
+
+    let group = rendered.groups.get("assertion_failure").unwrap();
+    assert_eq!(group.count, 1);
+    assert!(group.body.contains("1 test finding(s) in this category."));
+    assert!(group
+        .body
+        .contains("- `test-1` — expected 200, got 500 (`tests/http.rs:44`)"));
 }
 
 #[test]

--- a/tests/fixtures/output_contracts/quality/review-artifact.json
+++ b/tests/fixtures/output_contracts/quality/review-artifact.json
@@ -24,8 +24,9 @@
           "summary": "1 lint finding(s) detected",
           "findings": [
             {
-              "id": "lint:src/lib.rs:12:trailing-whitespace",
-              "message": "Trailing whitespace"
+              "tool": "lint",
+              "message": "Trailing whitespace",
+              "fingerprint": "lint:src/lib.rs:12:trailing-whitespace"
             }
           ],
           "artifacts": []

--- a/tests/output_contracts_test.rs
+++ b/tests/output_contracts_test.rs
@@ -620,10 +620,9 @@ fn review_artifact_output() -> ReviewCommandOutput {
                 status: "fail".to_string(),
                 exit_code: 1,
                 summary: "1 lint finding(s) detected".to_string(),
-                findings: vec![json!({
-                    "id": "lint:src/lib.rs:12:trailing-whitespace",
-                    "message": "Trailing whitespace"
-                })],
+                findings: vec![HomeboyFinding::builder("lint", "Trailing whitespace")
+                    .fingerprint("lint:src/lib.rs:12:trailing-whitespace")
+                    .build()],
                 artifacts: Vec::new(),
             }],
         },


### PR DESCRIPTION
## Summary
- Populate review artifact command findings with typed `HomeboyFinding` values for stages that already emit them.
- Teach issue reconcile rendering to consume canonical `HomeboyFinding` arrays before falling back to existing command-specific shapes.
- Update the review artifact golden fixture and focused issue-render tests for normalized lint/test findings.

## Verification
- `cargo fmt`
- `cargo test core::issues::render`
- `cargo test commands::review`
- `cargo test --test output_contracts_test`

## Residual risk
- Audit output still uses the existing ad-hoc audit shape on current main unless a command emits canonical `HomeboyFinding` entries; this PR intentionally avoids a broad audit/bench migration.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the bounded code/test changes and ran focused verification; Chris remains responsible for review and merge.