### PR TITLE
Normalize audit findings output

### DIFF
--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -18,7 +18,6 @@
 use std::fmt::Write as _;
 
 use homeboy::core::ci_profile::CiRunOutput;
-use homeboy::core::code_audit::report::AuditSummaryFinding;
 use homeboy::core::code_audit::{AuditCommandOutput, AuditFinding, Finding, Severity};
 use homeboy::core::extension::lint::LintCommandOutput;
 use homeboy::core::extension::test::TestCommandOutput;
@@ -214,14 +213,12 @@ fn render_audit_finding(out: &mut String, finding: &AuditFindingLine) {
     let _ = write!(
         out,
         "- `{}` — **{}**: {}",
-        finding.file,
-        audit_kind_label(&finding.kind),
-        finding.description
+        finding.file, finding.kind_label, finding.description
     );
     if !finding.suggestion.is_empty() {
         let _ = write!(out, "; {}", finding.suggestion);
     }
-    if matches!(finding.severity, Severity::Info) {
+    if finding.severity.as_deref() == Some("info") {
         let _ = write!(out, " _(info)_");
     }
     out.push('\n');
@@ -230,8 +227,8 @@ fn render_audit_finding(out: &mut String, finding: &AuditFindingLine) {
 #[derive(Clone)]
 struct AuditFindingLine {
     file: String,
-    kind: AuditFinding,
-    severity: Severity,
+    kind_label: String,
+    severity: Option<String>,
     description: String,
     suggestion: String,
 }
@@ -240,22 +237,37 @@ impl From<&Finding> for AuditFindingLine {
     fn from(finding: &Finding) -> Self {
         Self {
             file: finding.file.clone(),
-            kind: finding.kind.clone(),
-            severity: finding.severity.clone(),
+            kind_label: audit_kind_label(&finding.kind),
+            severity: Some(audit_severity_label(&finding.severity)),
             description: finding.description.clone(),
             suggestion: finding.suggestion.clone(),
         }
     }
 }
 
-impl From<&AuditSummaryFinding> for AuditFindingLine {
-    fn from(finding: &AuditSummaryFinding) -> Self {
+impl From<&HomeboyFinding> for AuditFindingLine {
+    fn from(finding: &HomeboyFinding) -> Self {
         Self {
-            file: finding.file.clone(),
-            kind: finding.kind.clone(),
+            file: finding.location.file.clone().unwrap_or_default(),
+            kind_label: finding
+                .rule
+                .as_deref()
+                .or_else(|| {
+                    finding
+                        .metadata
+                        .get("kind")
+                        .and_then(serde_json::Value::as_str)
+                })
+                .unwrap_or("audit")
+                .to_string(),
             severity: finding.severity.clone(),
-            description: finding.description.clone(),
-            suggestion: finding.suggestion.clone(),
+            description: finding.message.clone(),
+            suggestion: finding
+                .metadata
+                .get("suggestion")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
         }
     }
 }
@@ -285,6 +297,13 @@ fn audit_kind_label(kind: &AuditFinding) -> String {
         .ok()
         .and_then(|value| value.as_str().map(str::to_owned))
         .unwrap_or_else(|| format!("{:?}", kind).to_lowercase())
+}
+
+fn audit_severity_label(severity: &Severity) -> String {
+    serde_json::to_value(severity)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_owned))
+        .unwrap_or_else(|| format!("{severity:?}").to_lowercase())
 }
 
 /// Render the lint stage body — top sniff codes (by `category`) with counts.

--- a/src/core/code_audit/findings.rs
+++ b/src/core/code_audit/findings.rs
@@ -2,10 +2,13 @@
 
 use super::checks::{CheckResult, CheckStatus};
 use super::conventions::AuditFinding;
-use serde::ser::{SerializeStruct, Serializer};
+use crate::core::finding::{FindingSource, HomeboyFinding};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+use std::str::FromStr;
 
 /// An actionable finding from the code audit.
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Finding {
     /// The convention this finding relates to.
     pub convention: String,
@@ -26,15 +29,141 @@ impl serde::Serialize for Finding {
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("Finding", 7)?;
-        state.serialize_field("convention", &self.convention)?;
-        state.serialize_field("severity", &self.severity)?;
-        state.serialize_field("file", &self.file)?;
-        state.serialize_field("description", &self.description)?;
-        state.serialize_field("suggestion", &self.suggestion)?;
-        state.serialize_field("kind", &self.kind)?;
-        state.serialize_field("confidence", &self.kind.confidence())?;
-        state.end()
+        homeboy_finding_from_audit(self).serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Finding {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+
+        if let Ok(finding) = serde_json::from_value::<AuditFindingPayload>(value.clone()) {
+            return Ok(finding.into());
+        }
+
+        let normalized: HomeboyFinding =
+            serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        if let Some(raw) = normalized.raw.clone() {
+            if let Ok(finding) = serde_json::from_value::<AuditFindingPayload>(raw) {
+                return Ok(finding.into());
+            }
+        }
+
+        let kind = normalized
+            .rule
+            .as_deref()
+            .or_else(|| normalized.metadata.get("kind").and_then(Value::as_str))
+            .ok_or_else(|| serde::de::Error::custom("missing audit finding kind"))?;
+        let severity = normalized
+            .severity
+            .as_deref()
+            .map(severity_from_key)
+            .transpose()
+            .map_err(serde::de::Error::custom)?
+            .unwrap_or(Severity::Warning);
+
+        Ok(Finding {
+            convention: normalized
+                .metadata
+                .get("convention")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .or(normalized.category)
+                .unwrap_or_default(),
+            severity,
+            file: normalized.location.file.unwrap_or_default(),
+            description: normalized.message,
+            suggestion: normalized
+                .metadata
+                .get("suggestion")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            kind: AuditFinding::from_str(kind).map_err(serde::de::Error::custom)?,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct AuditFindingPayload {
+    convention: String,
+    severity: Severity,
+    file: String,
+    description: String,
+    suggestion: String,
+    kind: AuditFinding,
+}
+
+impl From<AuditFindingPayload> for Finding {
+    fn from(payload: AuditFindingPayload) -> Self {
+        Self {
+            convention: payload.convention,
+            severity: payload.severity,
+            file: payload.file,
+            description: payload.description,
+            suggestion: payload.suggestion,
+            kind: payload.kind,
+        }
+    }
+}
+
+pub fn homeboy_finding_from_audit(finding: &Finding) -> HomeboyFinding {
+    let kind = finding_kind_key(&finding.kind);
+    HomeboyFinding::builder("audit", finding.description.clone())
+        .rule(kind.clone())
+        .category(finding.convention.clone())
+        .file(finding.file.clone())
+        .severity(audit_severity_key(&finding.severity))
+        .fingerprint(audit_finding_fingerprint(finding))
+        .source(FindingSource::new("sidecar").label("audit-findings"))
+        .metadata("source_sidecar", "audit-findings")
+        .metadata("convention", finding.convention.clone())
+        .metadata("suggestion", finding.suggestion.clone())
+        .metadata("confidence", finding.kind.confidence())
+        .metadata("kind", kind)
+        .raw(AuditFindingPayload {
+            convention: finding.convention.clone(),
+            severity: finding.severity.clone(),
+            file: finding.file.clone(),
+            description: finding.description.clone(),
+            suggestion: finding.suggestion.clone(),
+            kind: finding.kind.clone(),
+        })
+        .build()
+}
+
+pub(crate) fn finding_kind_key(finding: &AuditFinding) -> String {
+    serde_json::to_value(finding)
+        .ok()
+        .and_then(|v| v.as_str().map(String::from))
+        .unwrap_or_else(|| format!("{:?}", finding).to_lowercase())
+}
+
+fn audit_finding_fingerprint(finding: &Finding) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        finding.file,
+        finding_kind_key(&finding.kind),
+        finding.convention,
+        finding.description
+    )
+}
+
+fn audit_severity_key(severity: &Severity) -> String {
+    serde_json::to_value(severity)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_string))
+        .unwrap_or_else(|| format!("{severity:?}").to_lowercase())
+}
+
+fn severity_from_key(value: &str) -> Result<Severity, String> {
+    match value {
+        "warning" => Ok(Severity::Warning),
+        "info" => Ok(Severity::Info),
+        other => Err(format!("unknown audit severity: {other}")),
     }
 }
 
@@ -287,7 +416,9 @@ mod tests {
 
         let json = serde_json::to_value(&finding).expect("serialize finding");
 
-        assert_eq!(json["confidence"], "structural");
+        assert_eq!(json["metadata"]["confidence"], "structural");
+        assert_eq!(json["rule"], "compiler_warning");
+        assert_eq!(json["message"], "unused import");
     }
 
     #[test]

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -65,7 +65,7 @@ pub use compare::{
 pub use conventions::{AuditFinding, Convention, Deviation, Language, Outlier};
 pub use duplication::DuplicateGroup;
 pub(crate) use execution_plan::AuditExecutionPlan;
-pub use findings::{Finding, FindingConfidence, Severity};
+pub use findings::{homeboy_finding_from_audit, Finding, FindingConfidence, Severity};
 pub use fingerprint::FileFingerprint;
 pub use report::AuditCommandOutput;
 pub use run::{run_main_audit_workflow, AuditRunWorkflowArgs, AuditRunWorkflowResult};

--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -8,9 +8,10 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use crate::core::code_audit::{
-    baseline, AuditFinding, CodeAuditResult, ConventionReport, DirectoryConvention,
-    FindingConfidence, Severity,
+    baseline, homeboy_finding_from_audit, AuditFinding, CodeAuditResult, ConventionReport,
+    DirectoryConvention, FindingConfidence, Severity,
 };
+use crate::core::finding::HomeboyFinding;
 use serde::Serialize;
 
 use super::run::AuditRunWorkflowResult;
@@ -26,7 +27,7 @@ pub struct AuditSummaryOutput {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub finding_groups: Vec<AuditSummaryGroup>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub top_findings: Vec<AuditSummaryFinding>,
+    pub top_findings: Vec<HomeboyFinding>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fixability: Option<AuditFixability>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -88,18 +89,6 @@ pub struct AuditBaselineFilteringSummary {
     pub resolved_findings: usize,
     pub drift_delta: i64,
     pub drift_increased: bool,
-}
-
-/// Individual finding in the summary.
-#[derive(Serialize)]
-pub struct AuditSummaryFinding {
-    pub file: String,
-    pub convention: String,
-    pub kind: AuditFinding,
-    pub confidence: FindingConfidence,
-    pub severity: Severity,
-    pub description: String,
-    pub suggestion: String,
 }
 
 /// Unified output envelope for the audit command.
@@ -204,15 +193,7 @@ pub fn build_audit_summary(result: &CodeAuditResult, exit_code: i32) -> AuditSum
     let top_findings = top_finding_refs
         .into_iter()
         .take(20)
-        .map(|f| AuditSummaryFinding {
-            file: f.file.clone(),
-            convention: f.convention.clone(),
-            kind: f.kind.clone(),
-            confidence: f.kind.confidence(),
-            severity: f.severity.clone(),
-            description: f.description.clone(),
-            suggestion: f.suggestion.clone(),
-        })
+        .map(homeboy_finding_from_audit)
         .collect();
     let finding_groups = build_finding_groups(result);
 
@@ -317,10 +298,7 @@ pub fn build_changed_since_summary(
 /// Using `format!("{:?}", ...)` would produce Debug PascalCase (e.g. `compilerwarning`)
 /// which doesn't match the serde output (`compiler_warning`).
 pub(crate) fn finding_kind_key(finding: &AuditFinding) -> String {
-    serde_json::to_value(finding)
-        .ok()
-        .and_then(|v| v.as_str().map(String::from))
-        .unwrap_or_else(|| format!("{:?}", finding).to_lowercase())
+    crate::core::code_audit::findings::finding_kind_key(finding)
 }
 
 /// Compute fixability metadata from an audit result without applying fixes.

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, path::Path};
 
-use crate::core::code_audit::{self, report::finding_kind_key};
+use crate::core::code_audit::{self, homeboy_finding_from_audit as audit_homeboy_finding};
 use crate::core::finding::{FindingProducer, FindingSource, HomeboyFinding};
 
 mod run_builder;
@@ -281,21 +281,7 @@ pub fn finding_records_from_lint(
 }
 
 pub fn homeboy_finding_from_audit(finding: &code_audit::Finding) -> HomeboyFinding {
-    let kind = finding_kind_key(&finding.kind);
-    HomeboyFinding::builder("audit", finding.description.clone())
-        .rule(kind.clone())
-        .category(finding.convention.clone())
-        .file(finding.file.clone())
-        .severity(audit_severity_key(&finding.severity))
-        .fingerprint(audit_finding_fingerprint(finding))
-        .source(FindingSource::new("sidecar").label("audit-findings"))
-        .metadata("source_sidecar", "audit-findings")
-        .metadata("convention", finding.convention.clone())
-        .metadata("suggestion", finding.suggestion.clone())
-        .metadata("confidence", finding.kind.confidence())
-        .metadata("kind", kind)
-        .raw(finding)
-        .build()
+    audit_homeboy_finding(finding)
 }
 
 pub fn finding_record_from_audit(run_id: &str, finding: &code_audit::Finding) -> NewFindingRecord {
@@ -310,23 +296,6 @@ pub fn finding_records_from_audit(
         .iter()
         .map(|finding| finding_record_from_audit(run_id, finding))
         .collect()
-}
-
-fn audit_finding_fingerprint(finding: &code_audit::Finding) -> String {
-    format!(
-        "{}:{}:{}:{}",
-        finding.file,
-        finding_kind_key(&finding.kind),
-        finding.convention,
-        finding.description
-    )
-}
-
-fn audit_severity_key(severity: &code_audit::Severity) -> String {
-    serde_json::to_value(severity)
-        .ok()
-        .and_then(|value| value.as_str().map(str::to_string))
-        .unwrap_or_else(|| format!("{severity:?}").to_lowercase())
 }
 
 pub fn finding_records_from_annotations_dir(

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -66,10 +66,10 @@ fn test_build_audit_summary_prioritizes_warnings_in_top_findings() {
 
     let summary = crate::core::code_audit::report::build_audit_summary(&result, 1);
 
-    assert_eq!(summary.top_findings[0].severity, Severity::Warning);
+    assert_eq!(summary.top_findings[0].severity.as_deref(), Some("warning"));
     assert_eq!(
-        summary.top_findings[0].kind,
-        AuditFinding::DuplicateFunction
+        summary.top_findings[0].rule.as_deref(),
+        Some("duplicate_function")
     );
 }
 
@@ -140,8 +140,8 @@ fn test_build_audit_summary_includes_finding_confidence() {
 
     assert_eq!(summary.top_findings.len(), 1);
     assert_eq!(
-        summary.top_findings[0].confidence,
-        FindingConfidence::Heuristic
+        summary.top_findings[0].metadata["confidence"],
+        serde_json::json!(FindingConfidence::Heuristic)
     );
 }
 

--- a/tests/fixtures/output_contracts/quality/audit-summary.json
+++ b/tests/fixtures/output_contracts/quality/audit-summary.json
@@ -22,13 +22,18 @@
     ],
     "top_findings": [
       {
-        "file": "src/large.rs",
-        "convention": "structural",
-        "kind": "god_file",
-        "confidence": "heuristic",
+        "tool": "audit",
+        "rule": "god_file",
+        "category": "structural",
         "severity": "warning",
-        "description": "File exceeds the size threshold",
-        "suggestion": "Split the module into focused pieces"
+        "file": "src/large.rs",
+        "message": "File exceeds the size threshold",
+        "metadata": {
+          "confidence": "heuristic",
+          "convention": "structural",
+          "kind": "god_file",
+          "suggestion": "Split the module into focused pieces"
+        }
       }
     ],
     "fixability": {

--- a/tests/output_contracts_test.rs
+++ b/tests/output_contracts_test.rs
@@ -9,10 +9,10 @@ use homeboy::commands::rig::RigCommandOutput;
 use homeboy::commands::runs::RunsOutput;
 use homeboy::commands::utils::response::cli_response_for_json_result;
 use homeboy::core::code_audit::report::{
-    AuditChangedSinceSummary, AuditCommandOutput, AuditFixability, AuditSummaryFinding,
-    AuditSummaryGroup, AuditSummaryOutput, FixabilityKindBreakdown,
+    AuditChangedSinceSummary, AuditCommandOutput, AuditFixability, AuditSummaryGroup,
+    AuditSummaryOutput, FixabilityKindBreakdown,
 };
-use homeboy::core::code_audit::{AuditFinding, FindingConfidence, Severity};
+use homeboy::core::code_audit::FindingConfidence;
 use homeboy::core::extension::lint::LintCommandOutput;
 use homeboy::core::extension::test::{
     RawTestOutput, TestCommandOutput, TestCounts, TestSummaryOutput,
@@ -463,15 +463,18 @@ fn audit_summary_output() -> AuditCommandOutput {
             sample_files: vec!["src/large.rs".to_string(), "src/also-large.rs".to_string()],
             drilldown_command: "homeboy audit fixture --only god_file".to_string(),
         }],
-        top_findings: vec![AuditSummaryFinding {
-            file: "src/large.rs".to_string(),
-            convention: "structural".to_string(),
-            kind: AuditFinding::GodFile,
-            confidence: FindingConfidence::Heuristic,
-            severity: Severity::Warning,
-            description: "File exceeds the size threshold".to_string(),
-            suggestion: "Split the module into focused pieces".to_string(),
-        }],
+        top_findings: vec![
+            HomeboyFinding::builder("audit", "File exceeds the size threshold")
+                .rule("god_file")
+                .category("structural")
+                .file("src/large.rs")
+                .severity("warning")
+                .metadata("convention", "structural")
+                .metadata("suggestion", "Split the module into focused pieces")
+                .metadata("confidence", FindingConfidence::Heuristic)
+                .metadata("kind", "god_file")
+                .build(),
+        ],
         fixability: Some(AuditFixability {
             fixable_count: 2,
             automated_count: 1,


### PR DESCRIPTION
## Summary
- Serialize audit findings through the shared `HomeboyFinding` contract while preserving audit-specific details in `metadata` and `raw`.
- Switch audit summary `top_findings` and review rendering away from the audit-only summary finding shape.
- Keep legacy audit finding deserialization so cached/baseline consumers can still read older audit output.

## Tests
- `cargo test -q --test output_contracts_test`
- `cargo test -q report_test`
- `cargo test -q --lib finding`
- `cargo test -q audit`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the audit output migration, updated focused fixtures/tests, and ran verification; Chris remains responsible for review and merge.