### PR TITLE
Extract shared plan execution loop

### DIFF
--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -22,10 +22,11 @@ use std::process::Command;
 use homeboy::core::ci_profile::{self, CiRunOutput, CiRunSelection};
 use homeboy::core::code_audit::AuditCommandOutput;
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
+use homeboy::core::execution;
 use homeboy::core::extension::lint::LintCommandOutput;
 use homeboy::core::extension::test::TestCommandOutput;
 use homeboy::core::git;
-use homeboy::core::plan::HomeboyPlan;
+use homeboy::core::plan::{HomeboyPlan, PlanStep};
 use homeboy::core::quality::{build_quality_plan, QualityPlanOptions};
 use homeboy::core::ObservationOutputMetadata;
 
@@ -220,22 +221,14 @@ impl<Args, Output: Serialize> ReviewStageDescriptor<Args, Output> {
     }
 }
 
-fn review_stage_order(plan: &HomeboyPlan) -> Vec<String> {
-    plan.steps
-        .iter()
-        .filter(|step| step.status == homeboy::core::plan::PlanStepStatus::Ready)
-        .filter_map(|step| step.kind.strip_prefix("review.").map(str::to_string))
-        .collect()
-}
-
-fn execute_review_stage(
-    stage_name: &str,
+fn execute_review_plan_step(
+    step: &PlanStep,
     args: &ReviewArgs,
     global: &GlobalArgs,
     component_label: &str,
-) -> CmdResult<ReviewStageRun> {
-    match stage_name {
-        "audit" => {
+) -> homeboy::core::Result<Option<ReviewStageRun>> {
+    match step.kind.as_str() {
+        "review.audit" => {
             let descriptor = ReviewStageDescriptor {
                 name: "audit",
                 include_changed_only_scope: false,
@@ -243,11 +236,10 @@ fn execute_review_stage(
                 run: audit::run,
                 finding_count: audit_finding_count,
             };
-            descriptor
-                .execute(args, global, component_label)
-                .map(|(stage, exit_code)| (ReviewStageRun::Audit(stage, exit_code), exit_code))
+            let (stage, exit_code) = descriptor.execute(args, global, component_label)?;
+            Ok(Some(ReviewStageRun::Audit(stage, exit_code)))
         }
-        "lint" => {
+        "review.lint" => {
             let descriptor = ReviewStageDescriptor {
                 name: "lint",
                 include_changed_only_scope: true,
@@ -255,11 +247,10 @@ fn execute_review_stage(
                 run: lint::run,
                 finding_count: lint_finding_count,
             };
-            descriptor
-                .execute(args, global, component_label)
-                .map(|(stage, exit_code)| (ReviewStageRun::Lint(stage, exit_code), exit_code))
+            let (stage, exit_code) = descriptor.execute(args, global, component_label)?;
+            Ok(Some(ReviewStageRun::Lint(stage, exit_code)))
         }
-        "test" => {
+        "review.test" => {
             let descriptor = ReviewStageDescriptor {
                 name: "test",
                 include_changed_only_scope: false,
@@ -267,12 +258,11 @@ fn execute_review_stage(
                 run: test::run,
                 finding_count: test_finding_count,
             };
-            descriptor
-                .execute(args, global, component_label)
-                .map(|(stage, exit_code)| (ReviewStageRun::Test(stage, exit_code), exit_code))
+            let (stage, exit_code) = descriptor.execute(args, global, component_label)?;
+            Ok(Some(ReviewStageRun::Test(stage, exit_code)))
         }
         other => Err(homeboy::core::Error::internal_unexpected(format!(
-            "review quality plan contains unsupported stage '{other}'"
+            "review quality plan contains unsupported executable step '{other}'"
         ))),
     }
 }
@@ -396,16 +386,19 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
     let mut test_stage = None;
     let mut test_exit = 0;
 
-    for stage_name in review_stage_order(&quality_plan) {
-        let (stage_run, _stage_exit) =
-            match execute_review_stage(&stage_name, &args, global, &component_label) {
-                Ok(result) => result,
-                Err(error) => {
-                    observation::finish_error(review_observation, &error);
-                    return Err(error);
-                }
-            };
+    let stage_run = match execution::execute_plan_steps(
+        &quality_plan.steps,
+        |step| execute_review_plan_step(step, &args, global, &component_label),
+        |_| false,
+    ) {
+        Ok(run) => run,
+        Err(error) => {
+            observation::finish_error(review_observation, &error);
+            return Err(error);
+        }
+    };
 
+    for stage_run in stage_run.results {
         match stage_run {
             ReviewStageRun::Audit(stage, exit_code) => {
                 audit_stage = Some(stage);
@@ -1045,6 +1038,22 @@ mod tests {
     }
 
     #[test]
+    fn unsupported_review_plan_step_returns_consistent_error() {
+        let args = review_args_fixture();
+        let global = GlobalArgs {};
+        let step = PlanStep::ready("review.unknown", "review.unknown").build();
+
+        let err = match execute_review_plan_step(&step, &args, &global, "fixture") {
+            Ok(_) => panic!("unsupported executable review step should fail"),
+            Err(err) => err,
+        };
+
+        assert!(err
+            .to_string()
+            .contains("unsupported executable step 'review.unknown'"));
+    }
+
+    #[test]
     fn build_artifact_uses_review_schema_and_refs() {
         let command = ReviewArtifactCommand {
             name: "lint".to_string(),
@@ -1215,5 +1224,22 @@ mod tests {
         };
         assert_eq!(scope_flag_suffix(&args, true), "");
         assert_eq!(scope_flag_suffix(&args, false), "");
+    }
+
+    fn review_args_fixture() -> ReviewArgs {
+        ReviewArgs {
+            comp: PositionalComponentArgs {
+                component: Some("fixture".to_string()),
+                path: None,
+            },
+            extension_override: ExtensionOverrideArgs::default(),
+            changed_since: None,
+            changed_only: false,
+            summary: false,
+            ci_profile: None,
+            report: None,
+            banner: Vec::new(),
+            baseline_args: BaselineArgs::default(),
+        }
     }
 }

--- a/src/core/execution.rs
+++ b/src/core/execution.rs
@@ -13,7 +13,75 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::core::plan::{HomeboyPlan, PlanSubject};
+use crate::core::error::Result;
+use crate::core::plan::{HomeboyPlan, PlanStep, PlanStepStatus, PlanSubject};
+
+/// Result of walking executable plan steps through a workflow dispatcher.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlanExecutionRun<R> {
+    pub results: Vec<R>,
+    pub stopped: bool,
+}
+
+/// Execute plan steps with workflow-specific dispatch and stop semantics.
+///
+/// The shared loop owns generic plan behavior: disabled/skipped steps are not
+/// dispatched, caller-filtered steps are skipped, dispatcher `None` means the
+/// step was plan-only/non-executable, and `should_stop` decides whether a
+/// produced result blocks the rest of the plan.
+pub fn execute_plan_steps_filtered<R, Skip, Dispatch, Stop>(
+    steps: &[PlanStep],
+    should_skip_step: Skip,
+    mut dispatch: Dispatch,
+    should_stop: Stop,
+) -> Result<PlanExecutionRun<R>>
+where
+    Skip: Fn(&PlanStep) -> bool,
+    Dispatch: FnMut(&PlanStep) -> Result<Option<R>>,
+    Stop: Fn(&R) -> bool,
+{
+    let mut results = Vec::new();
+
+    for step in steps {
+        if should_skip_step(step)
+            || matches!(
+                step.status,
+                PlanStepStatus::Disabled | PlanStepStatus::Skipped
+            )
+        {
+            continue;
+        }
+
+        if let Some(result) = dispatch(step)? {
+            let stopped = should_stop(&result);
+            results.push(result);
+            if stopped {
+                return Ok(PlanExecutionRun {
+                    results,
+                    stopped: true,
+                });
+            }
+        }
+    }
+
+    Ok(PlanExecutionRun {
+        results,
+        stopped: false,
+    })
+}
+
+/// Execute all non-disabled plan steps through a workflow dispatcher.
+pub fn execute_plan_steps<R, Dispatch, Stop>(
+    steps: &[PlanStep],
+    dispatch: Dispatch,
+    should_stop: Stop,
+) -> Result<PlanExecutionRun<R>>
+where
+    Dispatch: FnMut(&PlanStep) -> Result<Option<R>>,
+    Stop: Fn(&R) -> bool,
+{
+    execute_plan_steps_filtered(steps, |_| false, dispatch, should_stop)
+}
 
 /// Normalized execution intent shared by CLI flags and extension adapters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -359,7 +427,7 @@ const fn publish_phase() -> ExecutionPhase {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::plan::{HomeboyPlan, PlanKind};
+    use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep};
     use crate::core::release::{
         ReleaseRun, ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus,
     };
@@ -628,6 +696,65 @@ mod tests {
         );
         assert_eq!(execution.artifacts[0].provenance.source, "release");
         assert_eq!(execution.warnings, vec!["signed artifact missing"]);
+    }
+
+    #[test]
+    fn shared_plan_executor_skips_disabled_steps() {
+        let steps = vec![
+            PlanStep::disabled_with_reason("skip", "demo.skip", "off").build(),
+            PlanStep::ready("run", "demo.run").build(),
+        ];
+        let mut dispatched = Vec::new();
+
+        let run = execute_plan_steps(
+            &steps,
+            |step| {
+                dispatched.push(step.id.clone());
+                Ok(Some(step.kind.clone()))
+            },
+            |_| false,
+        )
+        .expect("execute plan");
+
+        assert_eq!(dispatched, vec!["run"]);
+        assert_eq!(run.results, vec!["demo.run"]);
+        assert!(!run.stopped);
+    }
+
+    #[test]
+    fn shared_plan_executor_stops_after_blocking_result() {
+        let steps = vec![
+            PlanStep::ready("first", "demo.first").build(),
+            PlanStep::ready("second", "demo.second").build(),
+        ];
+
+        let run = execute_plan_steps(
+            &steps,
+            |step| Ok(Some(step.kind.clone())),
+            |result| result == "demo.first",
+        )
+        .expect("execute plan");
+
+        assert_eq!(run.results, vec!["demo.first"]);
+        assert!(run.stopped);
+    }
+
+    #[test]
+    fn shared_plan_executor_reports_dispatch_errors() {
+        let steps = vec![PlanStep::ready("bad", "demo.bad").build()];
+
+        let err = execute_plan_steps::<String, _, _>(
+            &steps,
+            |_| {
+                Err(crate::core::Error::internal_unexpected(
+                    "unsupported demo.bad",
+                ))
+            },
+            |_| false,
+        )
+        .expect_err("unsupported executable step should fail");
+
+        assert!(err.to_string().contains("unsupported demo.bad"));
     }
 
     fn patch_artifact() -> ChangeArtifact {

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -59,21 +59,15 @@ pub(super) fn execute_plan_steps(
         publish_failed: false,
     };
 
-    for step in steps {
-        if skip_step_ids.contains(step.id.as_str()) {
-            continue;
-        }
+    let run = crate::core::execution::execute_plan_steps_filtered(
+        steps,
+        |step| skip_step_ids.contains(step.id.as_str()),
+        |step| execute_release_plan_step(step, &mut context),
+        release_step_is_show_stopper,
+    )?;
+    results.extend(run.results);
 
-        if let Some(result) = execute_release_plan_step(step, &mut context)? {
-            let should_stop = release_step_is_show_stopper(&result);
-            results.push(result);
-            if should_stop {
-                return Ok(true);
-            }
-        }
-    }
-
-    Ok(false)
+    Ok(run.stopped)
 }
 
 fn initial_release_state(


### PR DESCRIPTION
## Summary
- Extracts a reusable `core::execution` plan-step loop that handles disabled/skipped steps, caller skip filters, workflow dispatch, result collection, and stop-on-result behavior.
- Routes release step execution through the shared loop while preserving release dispatch/result semantics.
- Routes review quality stage execution through the shared loop and keeps audit/lint/test output behavior stable.

Fixes #3087

## Testing
- `cargo test core::execution::tests`
- `cargo test core::release::execution_plan::tests`
- `cargo test commands::review::tests`
- `target/debug/homeboy review --changed-since origin/main --report=pr-comment`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the shared executor extraction, review/release migration, focused tests, and verification commands; Chris remains responsible for review and merge decisions.