### PR TITLE
fix: add core artifact manifest substrate

### DIFF
--- a/src/core/artifact_manifest.rs
+++ b/src/core/artifact_manifest.rs
@@ -1,0 +1,552 @@
+//! Product-neutral artifact manifest validation.
+//!
+//! Domain-specific workloads decide which artifacts matter. Core only defines
+//! the portable file-entry shape and confines declared paths to an artifact root.
+
+use crate::core::error::{Error, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+pub const ARTIFACT_MANIFEST_FILE: &str = "homeboy-artifact-manifest.json";
+pub const ARTIFACT_MANIFEST_SCHEMA: &str = "homeboy/artifact-manifest/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactManifest {
+    #[serde(default = "default_schema")]
+    pub schema: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<ArtifactManifestEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactManifestEntry {
+    pub path: String,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redaction: Option<ArtifactRedactionState>,
+    #[serde(
+        default = "default_metadata",
+        skip_serializing_if = "is_empty_metadata"
+    )]
+    pub metadata: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactRedactionState {
+    Unspecified,
+    Raw,
+    Redacted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedArtifactManifestEntry {
+    pub entry: ArtifactManifestEntry,
+    pub absolute_path: PathBuf,
+}
+
+impl ArtifactManifest {
+    pub fn new(artifacts: Vec<ArtifactManifestEntry>) -> Self {
+        Self {
+            schema: ARTIFACT_MANIFEST_SCHEMA.to_string(),
+            artifacts,
+        }
+    }
+
+    pub fn read(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let raw = fs::read_to_string(path).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("read artifact manifest {}", path.display())),
+            )
+        })?;
+        serde_json::from_str(&raw).map_err(|e| {
+            Error::validation_invalid_json(
+                e,
+                Some(format!("artifact manifest {}", path.display())),
+                Some(raw),
+            )
+        })
+    }
+
+    pub fn write(&self, path: impl AsRef<Path>) -> Result<()> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                Error::internal_io(
+                    e.to_string(),
+                    Some(format!("create artifact manifest dir {}", parent.display())),
+                )
+            })?;
+        }
+        let raw = serde_json::to_string_pretty(self).map_err(|e| {
+            Error::internal_json(
+                e.to_string(),
+                Some("serialize artifact manifest".to_string()),
+            )
+        })?;
+        fs::write(path, format!("{raw}\n")).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("write artifact manifest {}", path.display())),
+            )
+        })
+    }
+
+    pub fn validate_under(
+        &self,
+        root: impl AsRef<Path>,
+    ) -> Result<Vec<ValidatedArtifactManifestEntry>> {
+        if self.schema != ARTIFACT_MANIFEST_SCHEMA {
+            return Err(Error::validation_invalid_argument(
+                "schema",
+                format!("expected {ARTIFACT_MANIFEST_SCHEMA}"),
+                Some(self.schema.clone()),
+                None,
+            ));
+        }
+
+        let root = root.as_ref();
+        let root_canonical = canonicalize_existing_dir(root, "artifact_root")?;
+        let mut validated = Vec::with_capacity(self.artifacts.len());
+        for entry in &self.artifacts {
+            let mut entry = entry.clone();
+            validate_entry_shape(&entry)?;
+            let absolute_path = confined_existing_file(&root_canonical, &entry.path)?;
+            let metadata = fs::metadata(&absolute_path).map_err(|e| {
+                Error::internal_io(
+                    e.to_string(),
+                    Some(format!(
+                        "read artifact metadata {}",
+                        absolute_path.display()
+                    )),
+                )
+            })?;
+            let actual_size = metadata.len();
+            if let Some(expected_size) = entry.size_bytes {
+                if expected_size != actual_size {
+                    return Err(Error::validation_invalid_argument(
+                        "size_bytes",
+                        format!(
+                            "declared size for '{}' is {}, actual size is {}",
+                            entry.path, expected_size, actual_size
+                        ),
+                        Some(entry.path.clone()),
+                        None,
+                    ));
+                }
+            } else {
+                entry.size_bytes = Some(actual_size);
+            }
+
+            let actual_sha256 = sha256_file(&absolute_path)?;
+            if let Some(expected_sha256) = &entry.sha256 {
+                if expected_sha256 != &actual_sha256 {
+                    return Err(Error::validation_invalid_argument(
+                        "sha256",
+                        format!(
+                            "declared sha256 for '{}' does not match file bytes",
+                            entry.path
+                        ),
+                        Some(entry.path.clone()),
+                        None,
+                    ));
+                }
+            } else {
+                entry.sha256 = Some(actual_sha256);
+            }
+
+            if entry.content_type.is_none() {
+                entry.content_type = mime_from_path(&absolute_path);
+            }
+
+            validated.push(ValidatedArtifactManifestEntry {
+                entry,
+                absolute_path,
+            });
+        }
+        Ok(validated)
+    }
+}
+
+pub fn manifest_path(root: impl AsRef<Path>) -> PathBuf {
+    root.as_ref().join(ARTIFACT_MANIFEST_FILE)
+}
+
+pub fn manifest_exists(root: impl AsRef<Path>) -> bool {
+    manifest_path(root).is_file()
+}
+
+pub fn read_manifest_from_root(root: impl AsRef<Path>) -> Result<ArtifactManifest> {
+    ArtifactManifest::read(manifest_path(root))
+}
+
+pub fn write_manifest_to_root(root: impl AsRef<Path>, manifest: &ArtifactManifest) -> Result<()> {
+    manifest.write(manifest_path(root))
+}
+
+pub fn manifest_for_existing_files(root: impl AsRef<Path>) -> Result<ArtifactManifest> {
+    let root = root.as_ref();
+    let root_canonical = canonicalize_existing_dir(root, "artifact_root")?;
+    let mut artifacts = Vec::new();
+    collect_manifest_entries(&root_canonical, &root_canonical, &mut artifacts)?;
+    artifacts.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(ArtifactManifest::new(artifacts))
+}
+
+fn collect_manifest_entries(
+    root: &Path,
+    current: &Path,
+    artifacts: &mut Vec<ArtifactManifestEntry>,
+) -> Result<()> {
+    for entry in fs::read_dir(current).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("read artifact directory {}", current.display())),
+        )
+    })? {
+        let entry = entry.map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!(
+                    "read artifact directory entry {}",
+                    current.display()
+                )),
+            )
+        })?;
+        let path = entry.path();
+        let metadata = entry.metadata().map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("read artifact metadata {}", path.display())),
+            )
+        })?;
+        if metadata.is_dir() {
+            collect_manifest_entries(root, &path, artifacts)?;
+        } else if metadata.is_file() {
+            let relative = slash_path(path.strip_prefix(root).map_err(|e| {
+                Error::internal_unexpected(format!(
+                    "artifact path {} escaped root {}: {e}",
+                    path.display(),
+                    root.display()
+                ))
+            })?);
+            if relative == ARTIFACT_MANIFEST_FILE {
+                continue;
+            }
+            artifacts.push(ArtifactManifestEntry {
+                kind: "file".to_string(),
+                label: None,
+                content_type: mime_from_path(&path),
+                size_bytes: Some(metadata.len()),
+                sha256: Some(sha256_file(&path)?),
+                redaction: None,
+                metadata: serde_json::Value::Object(serde_json::Map::new()),
+                path: relative,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_entry_shape(entry: &ArtifactManifestEntry) -> Result<()> {
+    validate_non_empty("path", &entry.path)?;
+    validate_non_empty("kind", &entry.kind)?;
+    if let Some(label) = &entry.label {
+        validate_non_empty("label", label)?;
+    }
+    if let Some(content_type) = &entry.content_type {
+        validate_non_empty("content_type", content_type)?;
+    }
+    if let Some(sha256) = &entry.sha256 {
+        if sha256.len() != 64 || !sha256.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return Err(Error::validation_invalid_argument(
+                "sha256",
+                "must be a 64-character hex digest",
+                Some(entry.path.clone()),
+                None,
+            ));
+        }
+    }
+    if !entry.metadata.is_object() {
+        return Err(Error::validation_invalid_argument(
+            "metadata",
+            "must be an object",
+            Some(entry.path.clone()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn validate_non_empty(field: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            field,
+            "value cannot be empty",
+            None,
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn confined_existing_file(root_canonical: &Path, relative: &str) -> Result<PathBuf> {
+    let relative_path = Path::new(relative);
+    if relative_path.is_absolute() || relative_path.components().any(disallowed_component) {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "artifact path must be relative and stay within the artifact root",
+            Some(relative.to_string()),
+            None,
+        ));
+    }
+
+    let candidate = root_canonical.join(relative_path);
+    let canonical = candidate.canonicalize().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            return Error::validation_invalid_argument(
+                "path",
+                format!("artifact file not found: {relative}"),
+                Some(relative.to_string()),
+                None,
+            );
+        }
+        Error::internal_io(
+            e.to_string(),
+            Some(format!(
+                "canonicalize artifact path {}",
+                candidate.display()
+            )),
+        )
+    })?;
+    if !canonical.starts_with(root_canonical) {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "artifact path resolves outside the artifact root",
+            Some(relative.to_string()),
+            None,
+        ));
+    }
+    if !canonical.is_file() {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "artifact manifest entries must reference files",
+            Some(relative.to_string()),
+            None,
+        ));
+    }
+    Ok(canonical)
+}
+
+fn disallowed_component(component: Component<'_>) -> bool {
+    matches!(
+        component,
+        Component::Prefix(_) | Component::RootDir | Component::ParentDir | Component::CurDir
+    )
+}
+
+fn canonicalize_existing_dir(path: &Path, field: &str) -> Result<PathBuf> {
+    let canonical = path.canonicalize().map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("canonicalize artifact root {}", path.display())),
+        )
+    })?;
+    if !canonical.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            field,
+            "must be an existing directory",
+            Some(path.to_string_lossy().to_string()),
+            None,
+        ));
+    }
+    Ok(canonical)
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let bytes = fs::read(path).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("read artifact bytes {}", path.display())),
+        )
+    })?;
+    Ok(format!("{:x}", Sha256::digest(&bytes)))
+}
+
+fn mime_from_path(path: &Path) -> Option<String> {
+    let extension = path.extension()?.to_string_lossy().to_ascii_lowercase();
+    let mime = match extension.as_str() {
+        "json" => "application/json",
+        "md" | "markdown" => "text/markdown",
+        "html" | "htm" => "text/html",
+        "txt" | "log" => "text/plain",
+        "csv" => "text/csv",
+        "xml" => "application/xml",
+        "zip" => "application/zip",
+        "gz" => "application/gzip",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "svg" => "image/svg+xml",
+        _ => return None,
+    };
+    Some(mime.to_string())
+}
+
+fn slash_path(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(part) => Some(part.to_string_lossy().to_string()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn default_schema() -> String {
+    ARTIFACT_MANIFEST_SCHEMA.to_string()
+}
+
+fn default_metadata() -> serde_json::Value {
+    serde_json::Value::Object(serde_json::Map::new())
+}
+
+fn is_empty_metadata(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(|object| object.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn validates_confined_relative_file_entries() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::create_dir_all(dir.path().join("logs")).expect("mkdir");
+        fs::write(dir.path().join("logs/output.log"), "hello").expect("write artifact");
+        let manifest = ArtifactManifest::new(vec![ArtifactManifestEntry {
+            path: "logs/output.log".to_string(),
+            kind: "log".to_string(),
+            label: Some("Output log".to_string()),
+            content_type: None,
+            size_bytes: None,
+            sha256: None,
+            redaction: Some(ArtifactRedactionState::Redacted),
+            metadata: json!({ "phase": "test" }),
+        }]);
+
+        let entries = manifest.validate_under(dir.path()).expect("valid manifest");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].entry.size_bytes, Some(5));
+        assert_eq!(entries[0].entry.content_type.as_deref(), Some("text/plain"));
+        assert_eq!(
+            entries[0].entry.sha256.as_deref(),
+            Some("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+        );
+        assert!(entries[0].absolute_path.ends_with("logs/output.log"));
+    }
+
+    #[test]
+    fn rejects_parent_path_escape_before_touching_filesystem() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manifest = ArtifactManifest::new(vec![ArtifactManifestEntry {
+            path: "../secret.txt".to_string(),
+            kind: "log".to_string(),
+            label: None,
+            content_type: None,
+            size_bytes: None,
+            sha256: None,
+            redaction: None,
+            metadata: json!({}),
+        }]);
+
+        let err = manifest
+            .validate_under(dir.path())
+            .expect_err("escape should fail");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("path"));
+        assert!(err.details.to_string().contains("../secret.txt"));
+    }
+
+    #[test]
+    fn missing_metadata_defaults_to_empty_object() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("output.txt"), "hello").expect("write artifact");
+        let manifest: ArtifactManifest = serde_json::from_value(json!({
+            "schema": ARTIFACT_MANIFEST_SCHEMA,
+            "artifacts": [{
+                "path": "output.txt",
+                "kind": "log"
+            }]
+        }))
+        .expect("parse manifest");
+
+        let entries = manifest.validate_under(dir.path()).expect("valid manifest");
+
+        assert_eq!(entries[0].entry.metadata, json!({}));
+    }
+
+    #[test]
+    fn rejects_symlink_escape() {
+        #[cfg(unix)]
+        {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let outside = tempfile::tempdir().expect("outside tempdir");
+            let outside_file = outside.path().join("secret.txt");
+            fs::write(&outside_file, "secret").expect("write outside");
+            std::os::unix::fs::symlink(&outside_file, dir.path().join("link.txt"))
+                .expect("symlink");
+            let manifest = ArtifactManifest::new(vec![ArtifactManifestEntry {
+                path: "link.txt".to_string(),
+                kind: "log".to_string(),
+                label: None,
+                content_type: None,
+                size_bytes: None,
+                sha256: None,
+                redaction: None,
+                metadata: json!({}),
+            }]);
+
+            let err = manifest
+                .validate_under(dir.path())
+                .expect_err("symlink escape should fail");
+
+            assert_eq!(err.code.as_str(), "validation.invalid_argument");
+            assert!(err.message.contains("resolves outside"));
+        }
+    }
+
+    #[test]
+    fn generates_manifest_for_existing_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::create_dir_all(dir.path().join("nested")).expect("mkdir");
+        fs::write(dir.path().join("nested/result.json"), r#"{"ok":true}"#).expect("write result");
+        fs::write(dir.path().join(ARTIFACT_MANIFEST_FILE), "{}").expect("write manifest");
+
+        let manifest = manifest_for_existing_files(dir.path()).expect("manifest");
+
+        assert_eq!(manifest.schema, ARTIFACT_MANIFEST_SCHEMA);
+        assert_eq!(manifest.artifacts.len(), 1);
+        assert_eq!(manifest.artifacts[0].path, "nested/result.json");
+        assert_eq!(manifest.artifacts[0].kind, "file");
+        assert_eq!(
+            manifest.artifacts[0].content_type.as_deref(),
+            Some("application/json")
+        );
+    }
+}

--- a/src/core/artifact_manifest.rs
+++ b/src/core/artifact_manifest.rs
@@ -5,7 +5,6 @@
 
 use crate::core::error::{Error, Result};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 
@@ -150,7 +149,7 @@ impl ArtifactManifest {
                 entry.size_bytes = Some(actual_size);
             }
 
-            let actual_sha256 = sha256_file(&absolute_path)?;
+            let actual_sha256 = crate::core::artifact_metadata::sha256_file(&absolute_path)?;
             if let Some(expected_sha256) = &entry.sha256 {
                 if expected_sha256 != &actual_sha256 {
                     return Err(Error::validation_invalid_argument(
@@ -168,7 +167,8 @@ impl ArtifactManifest {
             }
 
             if entry.content_type.is_none() {
-                entry.content_type = mime_from_path(&absolute_path);
+                entry.content_type =
+                    crate::core::artifact_metadata::content_type_from_path(&absolute_path);
             }
 
             validated.push(ValidatedArtifactManifestEntry {
@@ -180,12 +180,8 @@ impl ArtifactManifest {
     }
 }
 
-pub fn manifest_path(root: impl AsRef<Path>) -> PathBuf {
+fn manifest_path(root: impl AsRef<Path>) -> PathBuf {
     root.as_ref().join(ARTIFACT_MANIFEST_FILE)
-}
-
-pub fn manifest_exists(root: impl AsRef<Path>) -> bool {
-    manifest_path(root).is_file()
 }
 
 pub fn read_manifest_from_root(root: impl AsRef<Path>) -> Result<ArtifactManifest> {
@@ -248,9 +244,9 @@ fn collect_manifest_entries(
             artifacts.push(ArtifactManifestEntry {
                 kind: "file".to_string(),
                 label: None,
-                content_type: mime_from_path(&path),
+                content_type: crate::core::artifact_metadata::content_type_from_path(&path),
                 size_bytes: Some(metadata.len()),
-                sha256: Some(sha256_file(&path)?),
+                sha256: Some(crate::core::artifact_metadata::sha256_file(&path)?),
                 redaction: None,
                 metadata: serde_json::Value::Object(serde_json::Map::new()),
                 path: relative,
@@ -373,36 +369,6 @@ fn canonicalize_existing_dir(path: &Path, field: &str) -> Result<PathBuf> {
         ));
     }
     Ok(canonical)
-}
-
-fn sha256_file(path: &Path) -> Result<String> {
-    let bytes = fs::read(path).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!("read artifact bytes {}", path.display())),
-        )
-    })?;
-    Ok(format!("{:x}", Sha256::digest(&bytes)))
-}
-
-fn mime_from_path(path: &Path) -> Option<String> {
-    let extension = path.extension()?.to_string_lossy().to_ascii_lowercase();
-    let mime = match extension.as_str() {
-        "json" => "application/json",
-        "md" | "markdown" => "text/markdown",
-        "html" | "htm" => "text/html",
-        "txt" | "log" => "text/plain",
-        "csv" => "text/csv",
-        "xml" => "application/xml",
-        "zip" => "application/zip",
-        "gz" => "application/gzip",
-        "png" => "image/png",
-        "jpg" | "jpeg" => "image/jpeg",
-        "gif" => "image/gif",
-        "svg" => "image/svg+xml",
-        _ => return None,
-    };
-    Some(mime.to_string())
 }
 
 fn slash_path(path: &Path) -> String {

--- a/src/core/artifact_metadata.rs
+++ b/src/core/artifact_metadata.rs
@@ -1,0 +1,33 @@
+use crate::core::error::{Error, Result};
+use sha2::{Digest, Sha256};
+use std::path::Path;
+
+pub(crate) fn sha256_file(path: &Path) -> Result<String> {
+    let bytes = std::fs::read(path).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("read artifact bytes {}", path.display())),
+        )
+    })?;
+    Ok(format!("{:x}", Sha256::digest(&bytes)))
+}
+
+pub(crate) fn content_type_from_path(path: &Path) -> Option<String> {
+    let extension = path.extension()?.to_string_lossy().to_ascii_lowercase();
+    let mime = match extension.as_str() {
+        "json" => "application/json",
+        "md" | "markdown" => "text/markdown",
+        "html" | "htm" => "text/html",
+        "txt" | "log" => "text/plain",
+        "csv" => "text/csv",
+        "xml" => "application/xml",
+        "zip" => "application/zip",
+        "gz" => "application/gzip",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "svg" => "image/svg+xml",
+        _ => return None,
+    };
+    Some(mime.to_string())
+}

--- a/src/core/engine/invocation.rs
+++ b/src/core/engine/invocation.rs
@@ -259,8 +259,24 @@ impl InvocationGuard {
             "invocation.artifacts.preserve",
             crate::core::io::EntryPolicy::CopyRegularFilesOnly,
         )?;
+        preserve_artifact_manifest(&self.env.artifact_dir, &target)?;
         Ok(Some(target))
     }
+}
+
+fn preserve_artifact_manifest(source: &Path, target: &Path) -> Result<()> {
+    let manifest = if crate::core::artifact_manifest::manifest_exists(source) {
+        let manifest = crate::core::artifact_manifest::read_manifest_from_root(source)?;
+        // Validate against the copied target so the manifest describes the
+        // preserved artifact tree, not only the pre-copy invocation directory.
+        let entries = manifest.validate_under(target)?;
+        crate::core::artifact_manifest::ArtifactManifest::new(
+            entries.into_iter().map(|entry| entry.entry).collect(),
+        )
+    } else {
+        crate::core::artifact_manifest::manifest_for_existing_files(target)?
+    };
+    crate::core::artifact_manifest::write_manifest_to_root(target, &manifest)
 }
 
 impl Drop for InvocationGuard {

--- a/src/core/engine/invocation.rs
+++ b/src/core/engine/invocation.rs
@@ -259,24 +259,28 @@ impl InvocationGuard {
             "invocation.artifacts.preserve",
             crate::core::io::EntryPolicy::CopyRegularFilesOnly,
         )?;
-        preserve_artifact_manifest(&self.env.artifact_dir, &target)?;
+        self.preserve_artifact_manifest(&target)?;
         Ok(Some(target))
     }
-}
 
-fn preserve_artifact_manifest(source: &Path, target: &Path) -> Result<()> {
-    let manifest = if crate::core::artifact_manifest::manifest_exists(source) {
-        let manifest = crate::core::artifact_manifest::read_manifest_from_root(source)?;
-        // Validate against the copied target so the manifest describes the
-        // preserved artifact tree, not only the pre-copy invocation directory.
-        let entries = manifest.validate_under(target)?;
-        crate::core::artifact_manifest::ArtifactManifest::new(
-            entries.into_iter().map(|entry| entry.entry).collect(),
-        )
-    } else {
-        crate::core::artifact_manifest::manifest_for_existing_files(target)?
-    };
-    crate::core::artifact_manifest::write_manifest_to_root(target, &manifest)
+    fn preserve_artifact_manifest(&self, target: &Path) -> Result<()> {
+        let source = &self.env.artifact_dir;
+        let manifest = if source
+            .join(crate::core::artifact_manifest::ARTIFACT_MANIFEST_FILE)
+            .is_file()
+        {
+            let manifest = crate::core::artifact_manifest::read_manifest_from_root(source)?;
+            // Validate against the copied target so the manifest describes the
+            // preserved artifact tree, not only the pre-copy invocation directory.
+            let entries = manifest.validate_under(target)?;
+            crate::core::artifact_manifest::ArtifactManifest::new(
+                entries.into_iter().map(|entry| entry.entry).collect(),
+            )
+        } else {
+            crate::core::artifact_manifest::manifest_for_existing_files(target)?
+        };
+        crate::core::artifact_manifest::write_manifest_to_root(target, &manifest)
+    }
 }
 
 impl Drop for InvocationGuard {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,7 @@
 #[macro_use]
 pub mod config;
 pub mod api_jobs;
+pub mod artifact_manifest;
 pub mod budget;
 pub mod ci_profile;
 pub mod code_audit;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 pub mod config;
 pub mod api_jobs;
 pub mod artifact_manifest;
+pub(crate) mod artifact_metadata;
 pub mod budget;
 pub mod ci_profile;
 pub mod code_audit;

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 mod findings;
@@ -360,8 +359,8 @@ impl ObservationStore {
         let id = Uuid::new_v4().to_string();
         let created_at = chrono::Utc::now().to_rfc3339();
         let size_bytes = i64::try_from(metadata.len()).ok();
-        let sha256 = Some(sha256_file(path)?);
-        let mime = mime_from_path(path);
+        let sha256 = Some(crate::core::artifact_metadata::sha256_file(path)?);
+        let mime = crate::core::artifact_metadata::content_type_from_path(path);
         let stored_path = persisted_artifact_path(run_id, &id, path)?;
         copy_artifact_file(path, &stored_path)?;
         let path_string = stored_path.to_string_lossy().to_string();
@@ -987,16 +986,6 @@ fn collect_rows<T>(
     Ok(records)
 }
 
-fn sha256_file(path: &Path) -> Result<String> {
-    let bytes = fs::read(path).map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some(format!("read artifact bytes {}", path.display())),
-        )
-    })?;
-    Ok(format!("{:x}", Sha256::digest(&bytes)))
-}
-
 fn persisted_artifact_path(run_id: &str, artifact_id: &str, source: &Path) -> Result<PathBuf> {
     let file_name = source
         .file_name()
@@ -1069,26 +1058,6 @@ fn copy_artifact_directory(source: &Path, target: &Path) -> Result<()> {
         }
     }
     Ok(())
-}
-
-fn mime_from_path(path: &Path) -> Option<String> {
-    let extension = path.extension()?.to_string_lossy().to_ascii_lowercase();
-    let mime = match extension.as_str() {
-        "json" => "application/json",
-        "md" | "markdown" => "text/markdown",
-        "html" | "htm" => "text/html",
-        "txt" | "log" => "text/plain",
-        "csv" => "text/csv",
-        "xml" => "application/xml",
-        "zip" => "application/zip",
-        "gz" => "application/gzip",
-        "png" => "image/png",
-        "jpg" | "jpeg" => "image/jpeg",
-        "gif" => "image/gif",
-        "svg" => "image/svg+xml",
-        _ => return None,
-    };
-    Some(mime.to_string())
 }
 
 fn sqlite_error(context: impl Into<String>) -> impl FnOnce(rusqlite::Error) -> Error {

--- a/tests/core/engine/invocation_test.rs
+++ b/tests/core/engine/invocation_test.rs
@@ -413,6 +413,82 @@ fn invocation_drop_cleans_up_root_directory() {
     });
 }
 
+#[test]
+fn preserve_artifacts_emits_manifest_for_invocation_files() {
+    with_isolated_home(|_| {
+        let run_dir = RunDir::create().expect("run dir");
+        let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())
+            .expect("invocation guard");
+        let artifact = std::path::PathBuf::from(value_for(
+            &guard.env_vars(),
+            "HOMEBOY_INVOCATION_ARTIFACT_DIR",
+        ));
+        std::fs::create_dir_all(artifact.join("nested")).expect("mkdir artifact nested");
+        std::fs::write(artifact.join("nested/result.json"), r#"{"ok":true}"#)
+            .expect("write artifact");
+
+        let preserved = guard
+            .preserve_artifacts(&run_dir)
+            .expect("preserve artifacts")
+            .expect("artifact path");
+        let manifest = homeboy::core::artifact_manifest::read_manifest_from_root(&preserved)
+            .expect("read manifest");
+
+        assert_eq!(manifest.artifacts.len(), 1);
+        assert_eq!(manifest.artifacts[0].path, "nested/result.json");
+        assert_eq!(manifest.artifacts[0].kind, "file");
+        assert_eq!(
+            manifest.artifacts[0].content_type.as_deref(),
+            Some("application/json")
+        );
+
+        run_dir.cleanup();
+    });
+}
+
+#[test]
+fn preserve_artifacts_normalizes_existing_manifest() {
+    with_isolated_home(|_| {
+        let run_dir = RunDir::create().expect("run dir");
+        let guard = InvocationGuard::acquire(&run_dir, &InvocationRequirements::default())
+            .expect("invocation guard");
+        let artifact = std::path::PathBuf::from(value_for(
+            &guard.env_vars(),
+            "HOMEBOY_INVOCATION_ARTIFACT_DIR",
+        ));
+        std::fs::write(artifact.join("declared.log"), "hello").expect("write artifact");
+        let manifest = homeboy::core::artifact_manifest::ArtifactManifest::new(vec![
+            homeboy::core::artifact_manifest::ArtifactManifestEntry {
+                path: "declared.log".to_string(),
+                kind: "runner-log".to_string(),
+                label: Some("Runner log".to_string()),
+                content_type: None,
+                size_bytes: None,
+                sha256: None,
+                redaction: Some(homeboy::core::artifact_manifest::ArtifactRedactionState::Raw),
+                metadata: serde_json::json!({ "source": "test" }),
+            },
+        ]);
+        homeboy::core::artifact_manifest::write_manifest_to_root(&artifact, &manifest)
+            .expect("write source manifest");
+
+        let preserved = guard
+            .preserve_artifacts(&run_dir)
+            .expect("preserve artifacts")
+            .expect("artifact path");
+        let manifest = homeboy::core::artifact_manifest::read_manifest_from_root(&preserved)
+            .expect("read manifest");
+
+        assert_eq!(manifest.artifacts.len(), 1);
+        assert_eq!(manifest.artifacts[0].path, "declared.log");
+        assert_eq!(manifest.artifacts[0].kind, "runner-log");
+        assert_eq!(manifest.artifacts[0].size_bytes, Some(5));
+        assert!(manifest.artifacts[0].sha256.is_some());
+
+        run_dir.cleanup();
+    });
+}
+
 // --- followup: STATE_DIR is the leaf the workload owns ---------------------
 
 #[test]


### PR DESCRIPTION
## Summary
- Add a product-neutral `homeboy/artifact-manifest/v1` schema for invocation artifact file entries.
- Validate manifest paths through relative-path checks, canonical root confinement, file existence, size, sha256, content type, redaction state, and object metadata shape.
- Teach invocation artifact preservation to normalize an existing manifest or emit one for preserved files without adding domain semantics or observation-store import/storage wiring.

Closes #3134.

## Verification
- `cargo fmt --check` — passed
- `cargo test artifact_manifest` — passed, 5 tests
- `cargo test preserve_artifacts` — passed, 3 tests
- `cargo test test_record_artifact` — passed, 4 tests
- `cargo test --test core_agnostic_test` — passed, 3 tests
- `cargo check` — passed
- `git diff --check` — passed
- `homeboy audit --path . --extension rust --changed-since origin/main` — passed, 0 introduced findings, 2 contextual findings already known in touched scope

## Scope cut
- This PR intentionally stops at the core manifest substrate plus invocation preservation consume/emit support.
- It does not add storage/import integration, remote artifact import behavior, or Node/WordPress/Playwright/WP Codebox-specific artifact semantics.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused Rust manifest substrate, tests, verification, commit, and PR body; Chris remains responsible for review and final merge decisions.