### PR TITLE
fix: hide runtime temp root helper

### DIFF
--- a/src/core/engine/temp.rs
+++ b/src/core/engine/temp.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, SystemTime};
 
 const HOMEBOY_RUNTIME_TMPDIR_ENV: &str = "HOMEBOY_RUNTIME_TMPDIR";
 
-pub fn runtime_root() -> Result<PathBuf> {
+fn runtime_root() -> Result<PathBuf> {
     if let Ok(override_dir) = env::var(HOMEBOY_RUNTIME_TMPDIR_ENV) {
         let trimmed = override_dir.trim();
         if !trimmed.is_empty() {


### PR DESCRIPTION
## Summary
- Makes the runtime temp root helper private because it is only used inside `src/core/engine/temp.rs`.
- Resolves Extra-Chill/homeboy#3150 by removing the public unreferenced export surface while preserving runtime temp behavior.

## Tests
- `cargo test core::engine::temp::tests`
- `cargo fmt --check`
- `homeboy lint --path . --extension rust`
- `homeboy test --path . --extension rust --changed-since=origin/main`
- `homeboy audit --path . --extension rust` confirmed `dead_code::src/core/engine/temp.rs::UnreferencedExport` is in `resolved_fingerprints`; the command still reports unrelated existing audit findings.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the audit finding, made the minimal Rust visibility change, ran checks, and drafted this PR description for Chris to review.