### PR TITLE
Refactor refactor script spawn failure handling

### DIFF
--- a/src/core/extension/refactor_protocol.rs
+++ b/src/core/extension/refactor_protocol.rs
@@ -84,27 +84,14 @@ pub fn run_refactor_script_result(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
-        .map_err(|err| RefactorScriptFailure {
-            kind: RefactorScriptFailureKind::SpawnFailed,
-            exit_code: None,
-            stdout: String::new(),
-            stderr: err.to_string(),
-            parsed_stdout: None,
-        })
+        .map_err(RefactorScriptFailure::spawn_failed)
         .and_then(|mut child| {
             use std::io::Write;
             if let Some(ref mut stdin) = child.stdin {
                 let _ = stdin.write_all(command.to_string().as_bytes());
             }
-            wait_with_bounded_output(child, DEFAULT_CAPTURE_LIMIT_BYTES).map_err(|err| {
-                RefactorScriptFailure {
-                    kind: RefactorScriptFailureKind::SpawnFailed,
-                    exit_code: None,
-                    stdout: String::new(),
-                    stderr: err.to_string(),
-                    parsed_stdout: None,
-                }
-            })
+            wait_with_bounded_output(child, DEFAULT_CAPTURE_LIMIT_BYTES)
+                .map_err(RefactorScriptFailure::spawn_failed)
         })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
@@ -131,6 +118,16 @@ pub fn run_refactor_script_result(
 }
 
 impl RefactorScriptFailure {
+    fn spawn_failed(error: std::io::Error) -> Self {
+        Self {
+            kind: RefactorScriptFailureKind::SpawnFailed,
+            exit_code: None,
+            stdout: String::new(),
+            stderr: error.to_string(),
+            parsed_stdout: None,
+        }
+    }
+
     fn new(kind: RefactorScriptFailureKind) -> Self {
         Self {
             kind,


### PR DESCRIPTION
## Summary
- Extract the duplicated refactor script spawn-failure construction into a single private constructor.
- Preserve existing failure kind, stderr message, exit-code, stdout, and parsed-stdout behavior while resolving the intra-method duplication audit finding.

Closes #3151.

## Tests
- `cargo fmt --check`
- `cargo test refactor_protocol`
- `homeboy lint`
- `homeboy audit --changed-since origin/main`
- `homeboy test --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the small refactor, ran focused verification, and prepared this PR for Chris to review.