### PR TITLE
fix: bound remaining output detail reporting

### DIFF
--- a/src/core/code_audit/detectors/unbounded_output_capture.rs
+++ b/src/core/code_audit/detectors/unbounded_output_capture.rs
@@ -16,7 +16,9 @@ pub(in crate::core::code_audit) fn run(fingerprints: &[&FileFingerprint]) -> Vec
             continue;
         }
 
-        if has_unbounded_capture_shape(&fp.content) {
+        let detector_content = strip_test_modules(&strip_string_literals(&fp.content));
+
+        if has_unbounded_capture_shape(&detector_content) {
             findings.push(Finding {
                 convention: "output_capture".to_string(),
                 severity: Severity::Warning,
@@ -27,7 +29,7 @@ pub(in crate::core::code_audit) fn run(fingerprints: &[&FileFingerprint]) -> Vec
             });
         }
 
-        if has_unbounded_detail_output_shape(&fp.content) {
+        if has_unbounded_detail_output_shape(&detector_content) {
             findings.push(Finding {
                 convention: "output_capture".to_string(),
                 severity: Severity::Warning,
@@ -41,6 +43,83 @@ pub(in crate::core::code_audit) fn run(fingerprints: &[&FileFingerprint]) -> Vec
 
     findings.sort_by(|a, b| a.file.cmp(&b.file));
     findings
+}
+
+fn strip_string_literals(content: &str) -> String {
+    let mut stripped = String::with_capacity(content.len());
+    let chars = content.chars();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for ch in chars {
+        if in_string {
+            if escaped {
+                escaped = false;
+                stripped.push(' ');
+                continue;
+            }
+            match ch {
+                '\\' => {
+                    escaped = true;
+                    stripped.push(' ');
+                }
+                '"' => {
+                    in_string = false;
+                    stripped.push('"');
+                }
+                '\n' => stripped.push('\n'),
+                _ => stripped.push(' '),
+            }
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+        }
+        stripped.push(ch);
+    }
+
+    stripped
+}
+
+fn strip_test_modules(content: &str) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut stripped = String::new();
+    let mut index = 0;
+
+    while index < lines.len() {
+        if lines[index].trim() == "#[cfg(test)]" {
+            let mut skip_until = index + 1;
+            while skip_until < lines.len() && !lines[skip_until].contains('{') {
+                skip_until += 1;
+            }
+            if skip_until < lines.len() {
+                let mut depth = 0_i32;
+                for (offset, line) in lines[skip_until..].iter().enumerate() {
+                    for ch in line.chars() {
+                        match ch {
+                            '{' => depth += 1,
+                            '}' => depth -= 1,
+                            _ => {}
+                        }
+                    }
+                    if depth <= 0 && offset > 0 {
+                        index = skip_until + offset + 1;
+                        break;
+                    }
+                }
+                if index > skip_until {
+                    continue;
+                }
+            }
+        }
+
+        stripped.push_str(lines[index]);
+        stripped.push('\n');
+        index += 1;
+    }
+
+    stripped
 }
 
 fn has_unbounded_capture_shape(content: &str) -> bool {
@@ -69,43 +148,49 @@ fn has_unbounded_capture_shape(content: &str) -> bool {
 }
 
 fn has_unbounded_detail_output_shape(content: &str) -> bool {
-    let emits_text = content.contains("println!")
-        || content.contains("eprintln!")
-        || content.contains("writeln!")
-        || content.contains("push_str(&format!")
-        || content.contains("push_str(format!");
-    if !emits_text {
-        return false;
-    }
-
-    let has_detail_loop = content.lines().any(|line| {
+    let lines: Vec<&str> = content.lines().collect();
+    lines.iter().enumerate().any(|(index, line)| {
         let line = line.trim();
         if !line.starts_with("for ") || !line.contains(" in ") {
             return false;
         }
 
         let lower = line.to_ascii_lowercase();
-        [
+        let detail_loop = [
             "matches", "findings", "files", "details", "entries", "items",
         ]
         .iter()
-        .any(|needle| lower.contains(needle))
-    });
-    if !has_detail_loop {
-        return false;
-    }
+        .any(|needle| lower.contains(needle));
+        if !detail_loop {
+            return false;
+        }
 
-    let has_bound = content.contains(".take(")
+        let window_end = lines.len().min(index + 24);
+        let window = lines[index..window_end].join("\n");
+        emits_text(&window) && !has_detail_bound(&window)
+    })
+}
+
+fn emits_text(content: &str) -> bool {
+    content.contains("println!")
+        || content.contains("eprintln!")
+        || content.contains("writeln!")
+        || content.contains("push_str(&format!")
+        || content.contains("push_str(format!")
+}
+
+fn has_detail_bound(content: &str) -> bool {
+    content.contains(".take(")
         || content.contains(".truncate(")
         || content.contains("omitted")
         || content.contains("remaining")
+        || content.contains("remainder")
         || content.contains("detail_limit")
         || content.contains("DETAIL_LIMIT")
         || content.contains("MAX_DETAIL")
         || content.contains("max_detail")
-        || content.contains("summary");
-
-    !has_bound
+        || content.contains("TOP_N")
+        || content.contains("summary")
 }
 
 #[cfg(test)]
@@ -195,6 +280,42 @@ mod tests {
                 if omitted > 0 {
                     out.push_str(&format!("... {omitted} omitted\n"));
                 }
+            }
+            "#,
+        );
+
+        assert!(run(&[&file]).is_empty());
+    }
+
+    #[test]
+    fn ignores_detail_shapes_inside_test_modules() {
+        let file = fp(
+            "src/report.rs",
+            r#"
+            fn production() {}
+
+            #[cfg(test)]
+            mod tests {
+                fn sample() {
+                    let matches = vec!["a", "b"];
+                    for item in matches {
+                        println!("{item}");
+                    }
+                }
+            }
+            "#,
+        );
+
+        assert!(run(&[&file]).is_empty());
+    }
+
+    #[test]
+    fn ignores_detail_shapes_inside_string_literals() {
+        let file = fp(
+            "src/report.rs",
+            r#"
+            fn sample_fixture() -> &'static str {
+                "for item in items { println!(\"{item}\"); }"
             }
             "#,
         );

--- a/src/core/engine/detail_output.rs
+++ b/src/core/engine/detail_output.rs
@@ -1,0 +1,60 @@
+//! Helpers for rendering bounded per-item detail output.
+
+use serde::Serialize;
+
+pub const DEFAULT_DETAIL_ITEM_LIMIT: usize = 100;
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct DetailOutputMetadata {
+    pub items_seen: usize,
+    pub items_rendered: usize,
+    pub item_limit: usize,
+    pub omitted_item_count: usize,
+    pub truncated: bool,
+}
+
+pub fn bounded_items<T>(items: &[T], item_limit: usize) -> (&[T], DetailOutputMetadata) {
+    let items_rendered = items.len().min(item_limit);
+    let omitted_item_count = items.len().saturating_sub(items_rendered);
+    (
+        &items[..items_rendered],
+        DetailOutputMetadata {
+            items_seen: items.len(),
+            items_rendered,
+            item_limit,
+            omitted_item_count,
+            truncated: omitted_item_count > 0,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_items_reports_omitted_metadata() {
+        let items = [1, 2, 3, 4];
+        let (shown, metadata) = bounded_items(&items, 2);
+
+        assert_eq!(shown, &[1, 2]);
+        assert_eq!(metadata.items_seen, 4);
+        assert_eq!(metadata.items_rendered, 2);
+        assert_eq!(metadata.item_limit, 2);
+        assert_eq!(metadata.omitted_item_count, 2);
+        assert!(metadata.truncated);
+    }
+
+    #[test]
+    fn bounded_items_handles_zero_limit() {
+        let items = [1, 2, 3];
+        let (shown, metadata) = bounded_items(&items, 0);
+
+        assert!(shown.is_empty());
+        assert_eq!(metadata.items_seen, 3);
+        assert_eq!(metadata.items_rendered, 0);
+        assert_eq!(metadata.item_limit, 0);
+        assert_eq!(metadata.omitted_item_count, 3);
+        assert!(metadata.truncated);
+    }
+}

--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -6,6 +6,7 @@ pub mod baseline;
 pub mod cli_tool;
 pub mod codebase_scan;
 pub mod command;
+pub mod detail_output;
 pub mod edit_op;
 pub mod edit_op_apply;
 pub mod execution_context;

--- a/src/core/extension/trace/overlay.rs
+++ b/src/core/extension/trace/overlay.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::core::engine::detail_output::{bounded_items, DEFAULT_DETAIL_ITEM_LIMIT};
 use crate::core::engine::run_dir::RunDir;
 use crate::core::error::{Error, Result};
 
@@ -168,8 +169,18 @@ fn print_trace_overlay(action: &str, patch_path: &Path, touched_files: &[String]
         return;
     }
     eprintln!("  touched files:");
-    for file in touched_files {
+    let (visible_files, metadata) = bounded_items(touched_files, DEFAULT_DETAIL_ITEM_LIMIT);
+    for file in visible_files {
         eprintln!("    - {file}");
+    }
+    if metadata.truncated {
+        eprintln!(
+            "    ... {} touched file(s) omitted (shown: {}, total: {}, limit: {})",
+            metadata.omitted_item_count,
+            metadata.items_rendered,
+            metadata.items_seen,
+            metadata.item_limit
+        );
     }
 }
 

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -9,6 +9,7 @@ use super::parsing::{
     TraceArtifact, TraceAssertionStatus, TraceList, TraceResults, TraceSpanStatus,
 };
 use super::run::{TraceOverlay, TraceRunWorkflowResult};
+use crate::core::engine::detail_output::{bounded_items, DEFAULT_DETAIL_ITEM_LIMIT};
 use crate::core::rig::RigStateSnapshot;
 use crate::core::runner::is_reportable_artifact_evidence_path;
 
@@ -457,7 +458,8 @@ pub fn render_markdown(results: &TraceResults, overlays: &[TraceOverlay]) -> Str
         out.push_str("\n## Spans\n\n");
         out.push_str("| Span | From | To | Duration | Status |\n");
         out.push_str("|---|---|---|---:|---|\n");
-        for span in &results.span_results {
+        let (spans, metadata) = bounded_items(&results.span_results, DEFAULT_DETAIL_ITEM_LIMIT);
+        for span in spans {
             let duration = span
                 .duration_ms
                 .map(|ms| format!("{}ms", ms))
@@ -474,11 +476,13 @@ pub fn render_markdown(results: &TraceResults, overlays: &[TraceOverlay]) -> Str
                 span.id, span.from, span.to, duration, status
             ));
         }
+        push_omitted_detail_line(&mut out, "span(s)", &metadata);
     }
 
     if !results.assertions.is_empty() {
         out.push_str("\n## Assertions\n\n");
-        for assertion in &results.assertions {
+        let (assertions, metadata) = bounded_items(&results.assertions, DEFAULT_DETAIL_ITEM_LIMIT);
+        for assertion in assertions {
             let status = match assertion.status {
                 TraceAssertionStatus::Pass => "pass",
                 TraceAssertionStatus::Fail => "fail",
@@ -492,24 +496,29 @@ pub fn render_markdown(results: &TraceResults, overlays: &[TraceOverlay]) -> Str
                 None => out.push_str(&format!("- `{}`: **{}**\n", assertion.id, status)),
             }
         }
+        push_omitted_detail_line(&mut out, "assertion(s)", &metadata);
     }
 
     let artifacts = reportable_trace_artifacts(&results.artifacts);
     if !artifacts.is_empty() {
         out.push_str("\n## Artifacts\n\n");
-        for artifact in &artifacts {
+        let (artifacts, metadata) = bounded_items(&artifacts, DEFAULT_DETAIL_ITEM_LIMIT);
+        for artifact in artifacts {
             out.push_str(&format!("- **{}:** `{}`\n", artifact.label, artifact.path));
         }
+        push_omitted_detail_line(&mut out, "artifact(s)", &metadata);
     }
 
     if !results.timeline.is_empty() {
         out.push_str("\n## Timeline\n\n");
-        for event in &results.timeline {
+        let (events, metadata) = bounded_items(&results.timeline, DEFAULT_DETAIL_ITEM_LIMIT);
+        for event in events {
             out.push_str(&format!(
                 "- `{}ms` `{}.{}`\n",
                 event.t_ms, event.source, event.event
             ));
         }
+        push_omitted_detail_line(&mut out, "timeline event(s)", &metadata);
     }
 
     out
@@ -548,10 +557,47 @@ pub fn push_overlay_markdown(out: &mut String, overlays: &[TraceOverlay]) {
             out.push_str("  - Touched files: none reported by `git apply --numstat`\n");
         } else {
             out.push_str("  - Touched files:\n");
-            for file in &overlay.touched_files {
+            let (files, metadata) =
+                bounded_items(&overlay.touched_files, DEFAULT_DETAIL_ITEM_LIMIT);
+            for file in files {
                 out.push_str(&format!("    - `{}`\n", file));
             }
+            push_indented_omitted_detail_line(out, "touched file(s)", &metadata);
         }
+    }
+}
+
+fn push_omitted_detail_line(
+    out: &mut String,
+    label: &str,
+    metadata: &crate::core::engine::detail_output::DetailOutputMetadata,
+) {
+    if metadata.truncated {
+        out.push_str(&format!(
+            "- _... {} more {} omitted (shown: {}, total: {}, limit: {})_\n",
+            metadata.omitted_item_count,
+            label,
+            metadata.items_rendered,
+            metadata.items_seen,
+            metadata.item_limit
+        ));
+    }
+}
+
+fn push_indented_omitted_detail_line(
+    out: &mut String,
+    label: &str,
+    metadata: &crate::core::engine::detail_output::DetailOutputMetadata,
+) {
+    if metadata.truncated {
+        out.push_str(&format!(
+            "    - _... {} more {} omitted (shown: {}, total: {}, limit: {})_\n",
+            metadata.omitted_item_count,
+            label,
+            metadata.items_rendered,
+            metadata.items_seen,
+            metadata.item_limit
+        ));
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds a shared bounded detail-output helper with rendered/omitted item metadata.
- Bounds trace overlay and trace markdown detail lists so large touched-file/span/assertion/artifact/timeline reports include explicit omitted-count metadata.
- Tightens the output-capture audit detector to inspect scoped reporter loops and ignore test fixtures/string literals that are not production detail output.

Closes #3152.

## Verification
- `cargo fmt --check`
- `cargo test detail_output`
- `cargo test unbounded_output_capture`
- `cargo test trace::report`
- `cargo run --bin homeboy -- audit --force-hot --path . --extension rust --only unbounded_output_capture --ignore-baseline --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-3152-final-audit.json`
- `homeboy lint --force-hot --path . --extension rust --changed-since origin/main`
- `homeboy test --force-hot --path . --extension rust --changed-since origin/main`

## Notes
- The focused output-capture audit now reports `findings: []` and `passed: true`.
- `homeboy test --changed-since origin/main` selected zero impacted tests, so the targeted Rust tests above cover the changed code paths.
- `homeboy lint --changed-since origin/main` passed; the repository still emits existing clippy warnings outside this slice.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the bounded detail-output helper, migrated trace/reporting output paths, refined the audit detector, ran verification, and drafted this PR description for Chris to review.