### PR TITLE
Normalize lint sidecar findings

### DIFF
--- a/src/core/extension/bench/budget_findings.rs
+++ b/src/core/extension/bench/budget_findings.rs
@@ -70,21 +70,21 @@ mod tests {
                     "category": "budget",
                     "severity": "error",
                     "message": "REST response exceeded 250 KB budget",
-                    "fingerprint": "rest.max_response_bytes:/wp-json/datamachine/v1/pipelines?per_page=100",
-                    "source": { "kind": "budget", "label": "profile:wordpress-rest" },
+                    "fingerprint": "rest.max_response_bytes:/api/example/v1/items?per_page=100",
+                    "source": { "kind": "budget", "label": "profile:example-rest" },
                     "metadata": {
                         "code": "rest.max_response_bytes",
                         "category": "budget",
-                        "context_label": "profile:wordpress-rest",
+                        "context_label": "profile:example-rest",
                         "actual": 4378195,
                         "expected": 250000,
                         "unit": "bytes",
-                        "subject": "/wp-json/datamachine/v1/pipelines?per_page=100",
+                        "subject": "/api/example/v1/items?per_page=100",
                         "passed": false
                     }
                 }
             ],
-            "scenarios": [{ "id": "wordpress-rest", "iterations": 1, "metrics": { "p95_ms": 50.0 } }]
+            "scenarios": [{ "id": "example-rest", "iterations": 1, "metrics": { "p95_ms": 50.0 } }]
         }"#;
 
         let mut parsed = parse_bench_results_str(raw).unwrap();

--- a/src/core/extension/lint/baseline.rs
+++ b/src/core/extension/lint/baseline.rs
@@ -18,8 +18,8 @@ const BASELINE_KEY: &str = "lint";
 #[path = "../../../../tests/core/lint_baseline_test.rs"]
 mod lint_baseline_test;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-struct LintSidecarFinding {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LegacyLintSidecarFinding {
     pub id: String,
     pub message: String,
     pub category: String,
@@ -83,17 +83,23 @@ pub fn parse_findings_file(path: &Path) -> crate::core::error::Result<Vec<Homebo
         return Ok(Vec::new());
     }
 
-    let findings: Vec<LintSidecarFinding> = serde_json::from_str(&content).map_err(|e| {
+    let findings: Vec<Value> = serde_json::from_str(&content).map_err(|e| {
         crate::core::Error::internal_io(
             format!("Malformed lint findings JSON in {}: {}", path.display(), e),
             Some("lint.baseline.parse".to_string()),
         )
     })?;
 
-    Ok(findings
+    findings
         .into_iter()
-        .map(|finding| homeboy_finding_from_sidecar(finding, path))
-        .collect())
+        .map(|finding| parse_sidecar_finding(finding, path))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| {
+            crate::core::Error::internal_io(
+                format!("Malformed lint findings JSON in {}: {}", path.display(), e),
+                Some("lint.baseline.parse".to_string()),
+            )
+        })
 }
 
 pub fn save_baseline(
@@ -119,7 +125,46 @@ pub fn compare(findings: &[HomeboyFinding], baseline: &LintBaseline) -> Baseline
     generic::compare(&items, baseline)
 }
 
-fn homeboy_finding_from_sidecar(finding: LintSidecarFinding, path: &Path) -> HomeboyFinding {
+fn normalize_sidecar_finding(mut finding: HomeboyFinding, path: &Path) -> HomeboyFinding {
+    if finding.source.is_none() {
+        finding.source = Some(
+            FindingSource::new("sidecar")
+                .label("lint-findings")
+                .path(path.display().to_string()),
+        );
+    }
+    finding
+        .metadata
+        .entry("source_sidecar".to_string())
+        .or_insert_with(|| serde_json::json!("lint-findings"));
+    finding
+        .metadata
+        .entry("source_sidecar_path".to_string())
+        .or_insert_with(|| serde_json::json!(path.display().to_string()));
+    finding
+}
+
+fn parse_sidecar_finding(value: Value, path: &Path) -> Result<HomeboyFinding, serde_json::Error> {
+    if is_legacy_lint_sidecar_finding(&value) {
+        return serde_json::from_value::<LegacyLintSidecarFinding>(value)
+            .map(|finding| legacy_finding_from_sidecar(finding, path));
+    }
+
+    match serde_json::from_value::<HomeboyFinding>(value.clone()) {
+        Ok(finding) => Ok(normalize_sidecar_finding(finding, path)),
+        Err(canonical_error) => serde_json::from_value::<LegacyLintSidecarFinding>(value)
+            .map(|finding| legacy_finding_from_sidecar(finding, path))
+            .map_err(|_| canonical_error),
+    }
+}
+
+fn is_legacy_lint_sidecar_finding(value: &Value) -> bool {
+    value
+        .as_object()
+        .is_some_and(|object| object.contains_key("id") && !object.contains_key("fingerprint"))
+}
+
+fn legacy_finding_from_sidecar(finding: LegacyLintSidecarFinding, path: &Path) -> HomeboyFinding {
     let tool = finding.tool.clone().unwrap_or_else(|| "lint".to_string());
     let mut builder = HomeboyFinding::builder(tool.clone(), finding.message.clone())
         .category(finding.category.clone())
@@ -162,7 +207,7 @@ fn homeboy_finding_from_sidecar(finding: LintSidecarFinding, path: &Path) -> Hom
         builder = builder.metadata(key, value);
     }
 
-    builder.build()
+    normalize_sidecar_finding(builder.build(), path)
 }
 
 #[cfg(test)]
@@ -246,7 +291,7 @@ mod tests {
         let path = dir.path().join("lint-findings.json");
         std::fs::write(
             &path,
-            r#"[{"id":"id-1","message":"message","category":"security","file":"src/lib.rs"}]"#,
+            r#"[{"tool":"lint","message":"message","category":"security","fingerprint":"id-1","file":"src/lib.rs"}]"#,
         )
         .expect("findings file written");
 

--- a/src/core/extension/runtime/sidecar-writer.sh
+++ b/src/core/extension/runtime/sidecar-writer.sh
@@ -9,7 +9,7 @@
 #
 # Usage:
 #   source "${HOMEBOY_RUNTIME_SIDECAR_WRITER}"
-#   homeboy_sidecar_emit lint.finding '{"message":"..."}'
+#   homeboy_sidecar_emit lint.finding '{"tool":"eslint","message":"...","fingerprint":"..."}'
 #   homeboy_sidecar_write test.failures "$failure_json"
 #   homeboy_sidecar_merge annotation.phpcs "$tmp_annotations"
 

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -114,12 +114,16 @@ fn sidecar_writer_appends_and_merges_json_arrays() {
     let target_path = dir.path().join("lint-findings.json");
     let source_path = dir.path().join("extra-findings.json");
     std::fs::write(&helper_path, assets::SIDECAR_WRITER_SH).expect("write helper");
-    std::fs::write(&source_path, r#"[{"id":"third","message":"three"}]"#).expect("source");
+    std::fs::write(
+        &source_path,
+        r#"[{"tool":"lint","message":"three","fingerprint":"third"}]"#,
+    )
+    .expect("source");
 
     let output = std::process::Command::new("bash")
         .arg("-c")
         .arg(format!(
-            "source {}; HOMEBOY_LINT_FINDINGS_FILE={}; homeboy_append_lint_finding '{{\"id\":\"first\",\"message\":\"one\"}}'; homeboy_append_lint_finding '{{\"id\":\"second\",\"message\":\"two\"}}'; homeboy_merge_lint_findings {}; cat {}",
+            "source {}; HOMEBOY_LINT_FINDINGS_FILE={}; homeboy_append_lint_finding '{{\"tool\":\"lint\",\"message\":\"one\",\"fingerprint\":\"first\"}}'; homeboy_append_lint_finding '{{\"tool\":\"lint\",\"message\":\"two\",\"fingerprint\":\"second\"}}'; homeboy_merge_lint_findings {}; cat {}",
             helper_path.display(),
             target_path.display(),
             source_path.display(),
@@ -135,7 +139,7 @@ fn sidecar_writer_appends_and_merges_json_arrays() {
     );
     assert_eq!(
         String::from_utf8_lossy(&output.stdout),
-        r#"[{"id":"first","message":"one"},{"id":"second","message":"two"},{"id":"third","message":"three"}]
+        r#"[{"tool":"lint","message":"one","fingerprint":"first"},{"tool":"lint","message":"two","fingerprint":"second"},{"tool":"lint","message":"three","fingerprint":"third"}]
 "#
     );
 }

--- a/tests/core/lint_baseline_test.rs
+++ b/tests/core/lint_baseline_test.rs
@@ -51,12 +51,45 @@ fn test_compare() {
 fn test_parse_findings_file() {
     let dir = tempfile::tempdir().expect("temp dir");
     let file = dir.path().join("lint-findings.json");
-    std::fs::write(&file, r#"[{"id":"a","message":"m1","category":"cat1"}]"#)
+    std::fs::write(
+        &file,
+        r#"[{"tool":"eslint","message":"m1","category":"cat1","fingerprint":"a","file":"src/lib.rs","line":12,"source":{"kind":"sidecar","label":"custom","path":"custom.json"}}]"#,
+    )
         .expect("should write JSON");
 
     let parsed = lint_baseline::parse_findings_file(&file).expect("should parse findings");
     assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0].tool, "eslint");
     assert_eq!(parsed[0].fingerprint.as_deref(), Some("a"));
+    assert_eq!(parsed[0].location.file.as_deref(), Some("src/lib.rs"));
+    assert_eq!(parsed[0].location.line, Some(12));
+    assert_eq!(
+        parsed[0].source.as_ref().unwrap().label.as_deref(),
+        Some("custom")
+    );
+    assert_eq!(parsed[0].metadata["source_sidecar"], "lint-findings");
+}
+
+#[test]
+fn test_parse_findings_file_keeps_legacy_shape_compatibility() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let file = dir.path().join("lint-findings.json");
+    std::fs::write(
+        &file,
+        r#"[{"id":"a","tool":"phpcs","message":"m1","category":"cat1"}]"#,
+    )
+    .expect("should write JSON");
+
+    let parsed = lint_baseline::parse_findings_file(&file).expect("should parse findings");
+
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0].tool, "phpcs");
+    assert_eq!(parsed[0].fingerprint.as_deref(), Some("a"));
+    assert_eq!(parsed[0].rule.as_deref(), Some("cat1"));
+    assert_eq!(
+        parsed[0].source.as_ref().unwrap().label.as_deref(),
+        Some("lint-findings")
+    );
 }
 
 #[test]

--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -481,10 +481,6 @@ const BASELINE_OCCURRENCES: usize = 142;
 // explicit so stale rows and occurrence-count changes force cleanup or review.
 const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
     ViolationKey {
-        path: "src/core/budget.rs",
-        term: "wordpress",
-    },
-    ViolationKey {
         path: "src/core/code_audit/core_fingerprint.rs",
         term: "rust",
     },
@@ -519,10 +515,6 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
     ViolationKey {
         path: "src/core/engine/symbol_graph.rs",
         term: "php",
-    },
-    ViolationKey {
-        path: "src/core/extension/bench/parsing.rs",
-        term: "wordpress",
     },
     ViolationKey {
         path: "src/core/extension/bench/run_metadata.rs",
@@ -638,7 +630,7 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const TEST_CONTENT_BASELINE_OCCURRENCES: usize = 109;
+const TEST_CONTENT_BASELINE_OCCURRENCES: usize = 105;
 
 #[test]
 fn core_owned_source_stays_language_and_framework_agnostic() {


### PR DESCRIPTION
## Summary
- Parse lint findings sidecars as canonical `HomeboyFinding` values first, while preserving a narrow fallback for legacy `id`-based lint sidecar objects.
- Stamp sidecar source metadata for parsed findings when missing so producer summaries, baselines, and command JSON output keep their current behavior.
- Update sidecar helper examples/tests to emit canonical lint findings.

Closes #3162

## Verification
- `cargo test core::extension::lint::baseline`
- `cargo test lint_baseline_test`
- `cargo test --test output_contracts_test`
- `cargo test lint_scope`
- `homeboy audit --changed-since=origin/main`
- `homeboy lint --changed-since=origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the lint sidecar parsing migration, adjusted focused tests, and ran verification; Chris remains responsible for review and merge.