### PR TITLE
Remove no-op lint finding adapter

### DIFF
--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -17,11 +17,11 @@ pub use budget_findings::finding_records_from_budget;
 pub use records::{
     finding_record_from_audit, finding_record_from_lint, finding_records_from_annotation_file,
     finding_records_from_annotations_dir, finding_records_from_audit, finding_records_from_lint,
-    homeboy_finding_from_audit, homeboy_finding_from_lint, ArtifactCleanupCandidateRecord,
-    ArtifactCleanupFilter, ArtifactRecord, FindingListFilter, FindingRecord, NewFindingRecord,
-    NewRunRecord, NewRunRecordBuilder, NewTraceRunRecord, NewTraceRunRecordBuilder,
-    NewTraceSpanRecord, NewTraceSpanRecordBuilder, NewTriageItemRecord, RecordedHomeboyFinding,
-    RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord,
+    homeboy_finding_from_audit, ArtifactCleanupCandidateRecord, ArtifactCleanupFilter,
+    ArtifactRecord, FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord,
+    NewRunRecordBuilder, NewTraceRunRecord, NewTraceRunRecordBuilder, NewTraceSpanRecord,
+    NewTraceSpanRecordBuilder, NewTriageItemRecord, RecordedHomeboyFinding, RunListFilter,
+    RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord,
     TriagePullRequestSignals,
 };
 pub use store::{

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -262,12 +262,8 @@ struct AnnotationSidecarItem {
     extra: BTreeMap<String, Value>,
 }
 
-pub fn homeboy_finding_from_lint(finding: &HomeboyFinding) -> HomeboyFinding {
-    finding.clone()
-}
-
 pub fn finding_record_from_lint(run_id: &str, finding: &HomeboyFinding) -> NewFindingRecord {
-    NewFindingRecord::from_homeboy_finding(run_id, homeboy_finding_from_lint(finding))
+    NewFindingRecord::from_homeboy_finding(run_id, finding.clone())
 }
 
 pub fn finding_records_from_lint(


### PR DESCRIPTION
## Summary
- Remove the now-redundant `homeboy_finding_from_lint()` clone adapter.
- Persist canonical lint `HomeboyFinding` values directly through `NewFindingRecord::from_homeboy_finding()`.

Closes #3172

## Verification
- `cargo test test_finding_record_from_lint`
- `cargo test test_finding_records_from_lint`
- `cargo test core::observation::records`
- `homeboy audit --changed-since=origin/main`
- `homeboy lint --changed-since=origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Identified the redundant lint finding adapter, removed it, ran verification, and drafted this PR description; Chris remains responsible for review and merge.