### PR TITLE
Remove legacy finding readers

### DIFF
--- a/src/core/code_audit/findings.rs
+++ b/src/core/code_audit/findings.rs
@@ -3,7 +3,7 @@
 use super::checks::{CheckResult, CheckStatus};
 use super::conventions::AuditFinding;
 use crate::core::finding::{FindingSource, HomeboyFinding};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserializer, Serializer};
 use serde_json::Value;
 use std::str::FromStr;
 
@@ -40,18 +40,8 @@ impl<'de> serde::Deserialize<'de> for Finding {
     {
         let value = Value::deserialize(deserializer)?;
 
-        if let Ok(finding) = serde_json::from_value::<AuditFindingPayload>(value.clone()) {
-            return Ok(finding.into());
-        }
-
         let normalized: HomeboyFinding =
             serde_json::from_value(value).map_err(serde::de::Error::custom)?;
-        if let Some(raw) = normalized.raw.clone() {
-            if let Ok(finding) = serde_json::from_value::<AuditFindingPayload>(raw) {
-                return Ok(finding.into());
-            }
-        }
-
         let kind = normalized
             .rule
             .as_deref()
@@ -84,30 +74,6 @@ impl<'de> serde::Deserialize<'de> for Finding {
                 .to_string(),
             kind: AuditFinding::from_str(kind).map_err(serde::de::Error::custom)?,
         })
-    }
-}
-
-// Legacy typed audit payload accepted when reading older saved audit JSON.
-#[derive(Serialize, Deserialize)]
-struct AuditFindingPayload {
-    convention: String,
-    severity: Severity,
-    file: String,
-    description: String,
-    suggestion: String,
-    kind: AuditFinding,
-}
-
-impl From<AuditFindingPayload> for Finding {
-    fn from(payload: AuditFindingPayload) -> Self {
-        Self {
-            convention: payload.convention,
-            severity: payload.severity,
-            file: payload.file,
-            description: payload.description,
-            suggestion: payload.suggestion,
-            kind: payload.kind,
-        }
     }
 }
 
@@ -414,7 +380,7 @@ mod tests {
         assert_eq!(json["message"], "unused import");
         assert!(
             json.get("raw").is_none(),
-            "canonical audit findings should not serialize the legacy typed payload"
+            "canonical audit findings should not serialize a typed raw payload"
         );
     }
 
@@ -440,23 +406,6 @@ mod tests {
         assert_eq!(finding.file, "src/lib.rs");
         assert_eq!(finding.description, "unused import");
         assert_eq!(finding.suggestion, "remove it");
-    }
-
-    #[test]
-    fn finding_deserializes_legacy_payloads() {
-        let value = serde_json::json!({
-            "convention": "compiler",
-            "severity": "warning",
-            "file": "src/lib.rs",
-            "description": "unused import",
-            "suggestion": "remove it",
-            "kind": "compiler_warning"
-        });
-
-        let finding: Finding = serde_json::from_value(value).expect("deserialize finding");
-
-        assert_eq!(finding.kind, AuditFinding::CompilerWarning);
-        assert_eq!(finding.description, "unused import");
     }
 
     #[test]

--- a/src/core/extension/lint/baseline.rs
+++ b/src/core/extension/lint/baseline.rs
@@ -6,32 +6,15 @@
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use std::collections::BTreeMap;
 
 use crate::core::engine::baseline::{self as generic, BaselineConfig, Fingerprintable};
-use crate::core::finding::{FindingProducer, FindingSource, HomeboyFinding};
+use crate::core::finding::{FindingSource, HomeboyFinding};
 
 const BASELINE_KEY: &str = "lint";
 
 #[cfg(test)]
 #[path = "../../../../tests/core/lint_baseline_test.rs"]
 mod lint_baseline_test;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct LegacyLintSidecarFinding {
-    pub id: String,
-    pub message: String,
-    pub category: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tool: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub file: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub severity: Option<String>,
-    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub extra: BTreeMap<String, Value>,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LintBaselineMetadata {
@@ -83,23 +66,17 @@ pub fn parse_findings_file(path: &Path) -> crate::core::error::Result<Vec<Homebo
         return Ok(Vec::new());
     }
 
-    let findings: Vec<Value> = serde_json::from_str(&content).map_err(|e| {
+    let findings: Vec<HomeboyFinding> = serde_json::from_str(&content).map_err(|e| {
         crate::core::Error::internal_io(
             format!("Malformed lint findings JSON in {}: {}", path.display(), e),
             Some("lint.baseline.parse".to_string()),
         )
     })?;
 
-    findings
+    Ok(findings
         .into_iter()
-        .map(|finding| parse_sidecar_finding(finding, path))
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| {
-            crate::core::Error::internal_io(
-                format!("Malformed lint findings JSON in {}: {}", path.display(), e),
-                Some("lint.baseline.parse".to_string()),
-            )
-        })
+        .map(|finding| normalize_sidecar_finding(finding, path))
+        .collect())
 }
 
 pub fn save_baseline(
@@ -142,72 +119,6 @@ fn normalize_sidecar_finding(mut finding: HomeboyFinding, path: &Path) -> Homebo
         .entry("source_sidecar_path".to_string())
         .or_insert_with(|| serde_json::json!(path.display().to_string()));
     finding
-}
-
-fn parse_sidecar_finding(value: Value, path: &Path) -> Result<HomeboyFinding, serde_json::Error> {
-    if is_legacy_lint_sidecar_finding(&value) {
-        return serde_json::from_value::<LegacyLintSidecarFinding>(value)
-            .map(|finding| legacy_finding_from_sidecar(finding, path));
-    }
-
-    match serde_json::from_value::<HomeboyFinding>(value.clone()) {
-        Ok(finding) => Ok(normalize_sidecar_finding(finding, path)),
-        Err(canonical_error) => serde_json::from_value::<LegacyLintSidecarFinding>(value)
-            .map(|finding| legacy_finding_from_sidecar(finding, path))
-            .map_err(|_| canonical_error),
-    }
-}
-
-fn is_legacy_lint_sidecar_finding(value: &Value) -> bool {
-    value
-        .as_object()
-        .is_some_and(|object| object.contains_key("id") && !object.contains_key("fingerprint"))
-}
-
-fn legacy_finding_from_sidecar(finding: LegacyLintSidecarFinding, path: &Path) -> HomeboyFinding {
-    let tool = finding.tool.clone().unwrap_or_else(|| "lint".to_string());
-    let mut builder = HomeboyFinding::builder(tool.clone(), finding.message.clone())
-        .category(finding.category.clone())
-        .fingerprint(finding.id.clone())
-        .producer(FindingProducer::new(tool.clone()))
-        .source(
-            FindingSource::new("sidecar")
-                .label("lint-findings")
-                .path(path.display().to_string()),
-        )
-        .metadata("source_sidecar", "lint-findings")
-        .metadata("source_sidecar_path", path.display().to_string())
-        .raw(&finding);
-
-    if let Some(file) = finding.file.clone() {
-        builder = builder.file(file);
-    }
-    if let Some(severity) = finding.severity.clone() {
-        builder = builder.severity(severity);
-    }
-    if let Some(rule) = finding.extra.get("rule").and_then(|value| value.as_str()) {
-        builder = builder.rule(rule.to_string());
-    } else {
-        builder = builder.rule(finding.category.clone());
-    }
-    if let Some(line) = finding.extra.get("line").and_then(|value| value.as_i64()) {
-        builder = builder.line(line);
-    }
-    if let Some(column) = finding.extra.get("column").and_then(|value| value.as_i64()) {
-        builder = builder.column(column);
-    }
-    if let Some(fixable) = finding
-        .extra
-        .get("fixable")
-        .and_then(|value| value.as_bool())
-    {
-        builder = builder.fixable(fixable);
-    }
-    for (key, value) in finding.extra {
-        builder = builder.metadata(key, value);
-    }
-
-    normalize_sidecar_finding(builder.build(), path)
 }
 
 #[cfg(test)]

--- a/tests/core/lint_baseline_test.rs
+++ b/tests/core/lint_baseline_test.rs
@@ -71,28 +71,6 @@ fn test_parse_findings_file() {
 }
 
 #[test]
-fn test_parse_findings_file_keeps_legacy_shape_compatibility() {
-    let dir = tempfile::tempdir().expect("temp dir");
-    let file = dir.path().join("lint-findings.json");
-    std::fs::write(
-        &file,
-        r#"[{"id":"a","tool":"phpcs","message":"m1","category":"cat1"}]"#,
-    )
-    .expect("should write JSON");
-
-    let parsed = lint_baseline::parse_findings_file(&file).expect("should parse findings");
-
-    assert_eq!(parsed.len(), 1);
-    assert_eq!(parsed[0].tool, "phpcs");
-    assert_eq!(parsed[0].fingerprint.as_deref(), Some("a"));
-    assert_eq!(parsed[0].rule.as_deref(), Some("cat1"));
-    assert_eq!(
-        parsed[0].source.as_ref().unwrap().label.as_deref(),
-        Some("lint-findings")
-    );
-}
-
-#[test]
 fn test_parse_findings_file_missing() {
     let parsed = lint_baseline::parse_findings_file(Path::new(
         "/tmp/definitely-missing-lint-baseline-test.json",


### PR DESCRIPTION
## Summary
- Remove the legacy `id`-based lint sidecar DTO and fallback parser.
- Remove the legacy typed audit finding payload deserializer.
- Keep lint and audit finding readers on canonical `HomeboyFinding` shapes only.

Closes #3174

## Verification
- `cargo test core::extension::lint::baseline`
- `cargo test lint_baseline_test`
- `cargo test core::code_audit::findings::tests`
- `cargo test core::code_audit::report_test`
- `cargo test --test output_contracts_test`
- `homeboy audit --changed-since=origin/main`
- `homeboy lint --changed-since=origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Removed the remaining finding compatibility readers, updated tests, ran verification, and drafted this PR description; Chris remains responsible for review and merge.