### PR TITLE
Remove residual lint finding adapter

### DIFF
--- a/src/core/observation/finding_records.rs
+++ b/src/core/observation/finding_records.rs
@@ -167,12 +167,8 @@ pub(crate) struct AnnotationSidecarItem {
     pub(crate) extra: BTreeMap<String, Value>,
 }
 
-pub fn homeboy_finding_from_lint(finding: &HomeboyFinding) -> HomeboyFinding {
-    finding.clone()
-}
-
 pub fn finding_record_from_lint(run_id: &str, finding: &HomeboyFinding) -> NewFindingRecord {
-    NewFindingRecord::from_homeboy_finding(run_id, homeboy_finding_from_lint(finding))
+    NewFindingRecord::from_homeboy_finding(run_id, finding.clone())
 }
 
 pub fn finding_records_from_lint(


### PR DESCRIPTION
## Summary
- Remove the remaining clone-only `homeboy_finding_from_lint()` adapter from finding record conversion.
- Convert lint `HomeboyFinding` values directly into `NewFindingRecord`.

Closes #3176

## Verification
- `cargo fmt --check`
- `cargo test finding_records_from_lint`
- `homeboy audit --changed-since=origin/main`
- `homeboy lint --changed-since=origin/main`
- Grep confirmed no remaining `homeboy_finding_from_lint` or legacy finding reader symbols in Rust sources.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Removed the residual pass-through adapter, ran verification, and drafted this PR description; Chris remains responsible for review and merge.