### PR TITLE
Follow up lint finding record ownership

### DIFF
--- a/src/core/observation/finding_records.rs
+++ b/src/core/observation/finding_records.rs
@@ -167,8 +167,8 @@ pub(crate) struct AnnotationSidecarItem {
     pub(crate) extra: BTreeMap<String, Value>,
 }
 
-pub fn finding_record_from_lint(run_id: &str, finding: &HomeboyFinding) -> NewFindingRecord {
-    NewFindingRecord::from_homeboy_finding(run_id, finding.clone())
+pub fn finding_record_from_lint(run_id: &str, finding: HomeboyFinding) -> NewFindingRecord {
+    NewFindingRecord::from_homeboy_finding(run_id, finding)
 }
 
 pub fn finding_records_from_lint(
@@ -177,6 +177,7 @@ pub fn finding_records_from_lint(
 ) -> Vec<NewFindingRecord> {
     findings
         .iter()
+        .cloned()
         .map(|finding| finding_record_from_lint(run_id, finding))
         .collect()
 }

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -183,7 +183,7 @@ mod tests {
             .metadata("source_sidecar", "lint-findings")
             .build();
 
-        let record = finding_record_from_lint("run-1", &finding);
+        let record = finding_record_from_lint("run-1", finding);
 
         assert_eq!(record.run_id, "run-1");
         assert_eq!(record.tool, "phpcs");


### PR DESCRIPTION
## Summary
- Follow up #3177 by moving the remaining clone to the slice-to-records boundary.
- Make `finding_record_from_lint()` consume canonical `HomeboyFinding` directly, matching `NewFindingRecord::from_homeboy_finding()` ownership.

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo test finding_record_from_lint`
- `cargo test finding_records_from_lint`

Historical note before the rebase: `homeboy test` with default lab offload failed before running tests because the remote Linux linker crashed with `ld terminated with signal 7 [Bus error]`; the same Homeboy test path passed locally with `--force-hot`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the by-value lint finding record follow-up, rebased after #3177, ran verification, and drafted this PR description for Chris to review.