### PR TITLE
refactor: centralize finding and plan payload adapters

### DIFF
--- a/src/core/code_audit/findings.rs
+++ b/src/core/code_audit/findings.rs
@@ -29,7 +29,7 @@ impl serde::Serialize for Finding {
     where
         S: Serializer,
     {
-        homeboy_finding_from_audit(self).serialize(serializer)
+        HomeboyFinding::from(self).serialize(serializer)
     }
 }
 
@@ -78,20 +78,26 @@ impl<'de> serde::Deserialize<'de> for Finding {
 }
 
 pub fn homeboy_finding_from_audit(finding: &Finding) -> HomeboyFinding {
-    let kind = finding_kind_key(&finding.kind);
-    HomeboyFinding::builder("audit", finding.description.clone())
-        .rule(kind.clone())
-        .category(finding.convention.clone())
-        .file(finding.file.clone())
-        .severity(audit_severity_key(&finding.severity))
-        .fingerprint(audit_finding_fingerprint(finding))
-        .source(FindingSource::new("sidecar").label("audit-findings"))
-        .metadata("source_sidecar", "audit-findings")
-        .metadata("convention", finding.convention.clone())
-        .metadata("suggestion", finding.suggestion.clone())
-        .metadata("confidence", finding.kind.confidence())
-        .metadata("kind", kind)
-        .build()
+    HomeboyFinding::from(finding)
+}
+
+impl From<&Finding> for HomeboyFinding {
+    fn from(finding: &Finding) -> Self {
+        let kind = finding_kind_key(&finding.kind);
+        HomeboyFinding::builder("audit", finding.description.clone())
+            .rule(kind.clone())
+            .category(finding.convention.clone())
+            .file(finding.file.clone())
+            .severity(audit_severity_key(&finding.severity))
+            .fingerprint(audit_finding_fingerprint(finding))
+            .source(FindingSource::new("sidecar").label("audit-findings"))
+            .metadata("source_sidecar", "audit-findings")
+            .metadata("convention", finding.convention.clone())
+            .metadata("suggestion", finding.suggestion.clone())
+            .metadata("confidence", finding.kind.confidence())
+            .metadata("kind", kind)
+            .build()
+    }
 }
 
 pub(crate) fn finding_kind_key(finding: &AuditFinding) -> String {

--- a/src/core/code_audit/report.rs
+++ b/src/core/code_audit/report.rs
@@ -8,8 +8,8 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use crate::core::code_audit::{
-    baseline, homeboy_finding_from_audit, AuditFinding, CodeAuditResult, ConventionReport,
-    DirectoryConvention, FindingConfidence, Severity,
+    baseline, AuditFinding, CodeAuditResult, ConventionReport, DirectoryConvention,
+    FindingConfidence, Severity,
 };
 use crate::core::finding::HomeboyFinding;
 use serde::Serialize;
@@ -193,7 +193,7 @@ pub fn build_audit_summary(result: &CodeAuditResult, exit_code: i32) -> AuditSum
     let top_findings = top_finding_refs
         .into_iter()
         .take(20)
-        .map(homeboy_finding_from_audit)
+        .map(HomeboyFinding::from)
         .collect();
     let finding_groups = build_finding_groups(result);
 

--- a/src/core/deps/stack.rs
+++ b/src/core/deps/stack.rs
@@ -361,8 +361,7 @@ fn stack_step(step: &DependencyStackPlanStep) -> PlanStep {
 fn stack_steps_from_plan(plan: &HomeboyPlan) -> Vec<DependencyStackPlanStep> {
     plan.steps
         .iter()
-        .filter_map(|step| step.inputs.get("stack_step"))
-        .filter_map(|value| serde_json::from_value(value.clone()).ok())
+        .filter_map(|step| step.input_as("stack_step"))
         .collect()
 }
 

--- a/src/core/issues/plan.rs
+++ b/src/core/issues/plan.rs
@@ -217,8 +217,7 @@ impl ReconcilePlan {
 fn actions_from_plan(plan: &HomeboyPlan) -> Vec<ReconcileAction> {
     plan.steps
         .iter()
-        .filter_map(|step| step.inputs.get("action"))
-        .filter_map(|value| serde_json::from_value(value.clone()).ok())
+        .filter_map(|step| step.input_as("action"))
         .collect()
 }
 

--- a/src/core/observation/budget_findings.rs
+++ b/src/core/observation/budget_findings.rs
@@ -1,7 +1,8 @@
 use crate::core::finding::HomeboyFinding;
 
-use super::records::NewFindingRecord;
+use super::records::{finding_records_from_homeboy_findings, NewFindingRecord};
 
+#[cfg(test)]
 fn finding_record_from_budget(run_id: &str, finding: &HomeboyFinding) -> NewFindingRecord {
     NewFindingRecord::from_homeboy_finding(run_id, finding.clone())
 }
@@ -10,10 +11,7 @@ pub fn finding_records_from_budget(
     run_id: &str,
     findings: &[HomeboyFinding],
 ) -> Vec<NewFindingRecord> {
-    findings
-        .iter()
-        .map(|finding| finding_record_from_budget(run_id, finding))
-        .collect()
+    finding_records_from_homeboy_findings(run_id, findings.iter().cloned())
 }
 
 #[cfg(test)]

--- a/src/core/observation/finding_records.rs
+++ b/src/core/observation/finding_records.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::BTreeMap, path::Path};
 
-use crate::core::code_audit::{self, homeboy_finding_from_audit as audit_homeboy_finding};
+use crate::core::code_audit;
 use crate::core::finding::{FindingProducer, FindingSource, HomeboyFinding};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -35,6 +35,17 @@ impl NewFindingRecord {
             metadata_json,
         }
     }
+}
+
+pub fn finding_records_from_homeboy_findings(
+    run_id: &str,
+    findings: impl IntoIterator<Item = HomeboyFinding>,
+) -> Vec<NewFindingRecord> {
+    let run_id = run_id.to_string();
+    findings
+        .into_iter()
+        .map(|finding| NewFindingRecord::from_homeboy_finding(run_id.clone(), finding))
+        .collect()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -175,15 +186,11 @@ pub fn finding_records_from_lint(
     run_id: &str,
     findings: &[HomeboyFinding],
 ) -> Vec<NewFindingRecord> {
-    findings
-        .iter()
-        .cloned()
-        .map(|finding| finding_record_from_lint(run_id, finding))
-        .collect()
+    finding_records_from_homeboy_findings(run_id, findings.iter().cloned())
 }
 
 pub fn homeboy_finding_from_audit(finding: &code_audit::Finding) -> HomeboyFinding {
-    audit_homeboy_finding(finding)
+    HomeboyFinding::from(finding)
 }
 
 pub fn finding_record_from_audit(run_id: &str, finding: &code_audit::Finding) -> NewFindingRecord {
@@ -241,10 +248,10 @@ pub fn finding_records_from_annotation_file(
     run_id: &str,
     path: &Path,
 ) -> crate::core::error::Result<Vec<NewFindingRecord>> {
-    Ok(homeboy_findings_from_annotation_file(path)?
-        .into_iter()
-        .map(|finding| NewFindingRecord::from_homeboy_finding(run_id, finding))
-        .collect())
+    Ok(finding_records_from_homeboy_findings(
+        run_id,
+        homeboy_findings_from_annotation_file(path)?,
+    ))
 }
 
 fn homeboy_findings_from_annotation_file(

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -16,13 +16,13 @@ pub use lifecycle::{merge_metadata, run_owner_pid, running_status_note, ActiveOb
 pub use budget_findings::finding_records_from_budget;
 pub use records::{
     finding_record_from_audit, finding_record_from_lint, finding_records_from_annotation_file,
-    finding_records_from_annotations_dir, finding_records_from_audit, finding_records_from_lint,
-    homeboy_finding_from_audit, ArtifactCleanupCandidateRecord, ArtifactCleanupFilter,
-    ArtifactRecord, FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord,
-    NewRunRecordBuilder, NewTraceRunRecord, NewTraceRunRecordBuilder, NewTraceSpanRecord,
-    NewTraceSpanRecordBuilder, NewTriageItemRecord, RecordedHomeboyFinding, RunListFilter,
-    RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord,
-    TriagePullRequestSignals,
+    finding_records_from_annotations_dir, finding_records_from_audit,
+    finding_records_from_homeboy_findings, finding_records_from_lint, homeboy_finding_from_audit,
+    ArtifactCleanupCandidateRecord, ArtifactCleanupFilter, ArtifactRecord, FindingListFilter,
+    FindingRecord, NewFindingRecord, NewRunRecord, NewRunRecordBuilder, NewTraceRunRecord,
+    NewTraceRunRecordBuilder, NewTraceSpanRecord, NewTraceSpanRecordBuilder, NewTriageItemRecord,
+    RecordedHomeboyFinding, RunListFilter, RunRecord, RunStatus, TraceRunRecord, TraceSpanRecord,
+    TriageItemRecord, TriagePullRequestSignals,
 };
 pub use store::{
     ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION, LAB_OFFLOAD_METADATA_ENV,

--- a/src/core/observation/test_findings.rs
+++ b/src/core/observation/test_findings.rs
@@ -3,7 +3,7 @@ use crate::core::extension::test::{
 };
 use crate::core::finding::{FindingSource, HomeboyFinding};
 
-use super::records::NewFindingRecord;
+use super::records::{finding_records_from_homeboy_findings, NewFindingRecord};
 
 pub(crate) fn homeboy_finding_from_test_failure(failure: &TestFailure) -> HomeboyFinding {
     let mut normalized = HomeboyFinding::builder("test", test_failure_message(failure))
@@ -41,19 +41,14 @@ pub(crate) fn homeboy_findings_from_test_analysis_input(
     )
 }
 
-fn finding_record_from_test_failure(run_id: &str, failure: &TestFailure) -> NewFindingRecord {
-    NewFindingRecord::from_homeboy_finding(run_id, homeboy_finding_from_test_failure(failure))
-}
-
 pub(crate) fn finding_records_from_test_analysis_input(
     run_id: &str,
     input: &TestAnalysisInput,
 ) -> Vec<NewFindingRecord> {
-    input
-        .failures
-        .iter()
-        .map(|failure| finding_record_from_test_failure(run_id, failure))
-        .collect()
+    finding_records_from_homeboy_findings(
+        run_id,
+        input.failures.iter().map(homeboy_finding_from_test_failure),
+    )
 }
 
 fn homeboy_finding_from_failure_cluster(cluster: &FailureCluster) -> HomeboyFinding {
@@ -76,6 +71,7 @@ fn homeboy_finding_from_failure_cluster(cluster: &FailureCluster) -> HomeboyFind
     normalized
 }
 
+#[cfg(test)]
 fn finding_record_from_failure_cluster(run_id: &str, cluster: &FailureCluster) -> NewFindingRecord {
     NewFindingRecord::from_homeboy_finding(run_id, homeboy_finding_from_failure_cluster(cluster))
 }
@@ -84,10 +80,10 @@ pub(crate) fn finding_records_from_failure_clusters(
     run_id: &str,
     clusters: &[FailureCluster],
 ) -> Vec<NewFindingRecord> {
-    clusters
-        .iter()
-        .map(|cluster| finding_record_from_failure_cluster(run_id, cluster))
-        .collect()
+    finding_records_from_homeboy_findings(
+        run_id,
+        clusters.iter().map(homeboy_finding_from_failure_cluster),
+    )
 }
 
 fn test_failure_message(failure: &TestFailure) -> String {

--- a/src/core/plan.rs
+++ b/src/core/plan.rs
@@ -5,7 +5,7 @@
 //! why it will run, whether it blocks progress, and what artifacts/results are
 //! expected.
 
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -267,6 +267,12 @@ impl PlanStep {
         Self::disabled(id, kind)
             .input_value("reason", serde_json::Value::String(reason.clone()))
             .skip_reason(reason)
+    }
+
+    pub(crate) fn input_as<T: DeserializeOwned>(&self, key: &str) -> Option<T> {
+        self.inputs
+            .get(key)
+            .and_then(|value| serde_json::from_value(value.clone()).ok())
     }
 }
 
@@ -741,6 +747,21 @@ mod tests {
             step.inputs.get("reason"),
             Some(&serde_json::json!("manual"))
         );
+    }
+
+    #[test]
+    fn test_input_as() {
+        let step = PlanStep::ready("refactor", "refactor.decompose")
+            .input_value("items", serde_json::json!(["first", "second"]))
+            .build();
+
+        let items: Option<Vec<String>> = step.input_as("items");
+        let missing: Option<Vec<String>> = step.input_as("missing");
+        let wrong_type: Option<bool> = step.input_as("items");
+
+        assert_eq!(items, Some(vec!["first".to_string(), "second".to_string()]));
+        assert_eq!(missing, None);
+        assert_eq!(wrong_type, None);
     }
 
     #[test]

--- a/src/core/refactor/decompose.rs
+++ b/src/core/refactor/decompose.rs
@@ -150,8 +150,7 @@ impl DecomposePlan {
 fn decompose_groups_from_plan(plan: &HomeboyPlan) -> Vec<DecomposeGroup> {
     plan.steps
         .iter()
-        .filter_map(|step| step.inputs.get("group_payload"))
-        .filter_map(|value| serde_json::from_value(value.clone()).ok())
+        .filter_map(|step| step.input_as("group_payload"))
         .collect()
 }
 


### PR DESCRIPTION
## Summary
- Centralize `HomeboyFinding` to observation-record conversion through a shared batch adapter.
- Add `From<&code_audit::Finding> for HomeboyFinding` and route audit serialization/summary/persistence through it.
- Add `PlanStep::input_as<T>()` and use it for typed plan payload reads in issue reconciliation, refactor decompose, and dependency stack plans.

## Testing
- `cargo fmt --check`
- `cargo test core::plan`
- `cargo test issues::plan`
- `cargo test decompose`
- `cargo test deps`
- `cargo test code_audit`
- `cargo test observation::records`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing the adapter refactor, running verification, and preparing the PR; Chris remains responsible for review and merge.