### PR TITLE
Clarify structured sidecar manifest contract

### DIFF
--- a/docs/schemas/extension-manifest-schema.md
+++ b/docs/schemas/extension-manifest-schema.md
@@ -150,7 +150,23 @@ Extensions can declare which structured run-directory sidecars they emit. `struc
 - **`structured_sidecars.<name>.path`** (string): Optional run-directory relative sidecar file or directory path. Known names such as `lint.findings`, `test.results`, `test.failures`, `bench.results`, and `annotations` have default paths.
 - **`structured_sidecars.<name>.schema_version`** (string): Optional version of the sidecar payload contract.
 
-The generic `findings` and `producer.summary` names are the preferred contracts for normalized finding output and producer summaries. Legacy producer-specific names such as `lint.findings` can be declared during migration, but they use the same top-level declaration shape.
+The generic `findings` and `producer.summary` names are the preferred contracts for normalized finding output and producer summaries. Legacy producer-specific names such as `lint.findings` can be declared during migration, but they use the same top-level declaration shape. Schema versions are read only from `structured_sidecars.<name>.schema_version`; nested producer fields such as `lint.findings_schema_version` do not declare sidecar contracts.
+
+Known sidecar names default to these run-directory paths when `path` is omitted:
+
+| Name | Default path |
+| --- | --- |
+| `findings` | `findings.json` |
+| `producer.summary` | `producer-summary.json` |
+| `lint.findings` | `lint-findings.json` |
+| `lint.producers` | `lint-producers.json` |
+| `test.results` | `test-results.json` |
+| `test.failures` | `test-failures.json` |
+| `test.coverage` | `coverage.json` |
+| `bench.results` | `bench-results.json` |
+| `trace.results` | `trace.json` |
+| `resource.summary` | `resource-summary.json` |
+| `annotations` | `annotations` |
 
 ### Inspection Behavior
 

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -606,6 +606,19 @@ impl ExtensionManifest {
             .collect()
     }
 
+    /// Schema version declared by the canonical `structured_sidecars` manifest
+    /// section for a logical sidecar name.
+    pub fn structured_sidecar_schema_version(&self, name: &str) -> Option<&str> {
+        self.structured_sidecars
+            .get(name)
+            .and_then(|contract| match contract {
+                StructuredSidecarContract::Detail(detail) if detail.enabled => {
+                    detail.schema_version.as_deref()
+                }
+                _ => None,
+            })
+    }
+
     /// Convenience: get deploy verifications (empty if no deploy capability).
     pub fn deploy_verifications(&self) -> &[DeployVerification] {
         self.deploy

--- a/src/core/extension/manifest_sidecar.rs
+++ b/src/core/extension/manifest_sidecar.rs
@@ -53,10 +53,15 @@ fn default_true() -> bool {
 fn default_structured_sidecar_path(name: &str) -> String {
     match name {
         "lint.findings" => run_dir::files::LINT_FINDINGS,
+        "lint.producers" => run_dir::files::LINT_PRODUCERS,
         "test.results" => run_dir::files::TEST_RESULTS,
         "test.failures" => run_dir::files::TEST_FAILURES,
         "test.coverage" => run_dir::files::COVERAGE,
         "bench.results" => run_dir::files::BENCH_RESULTS,
+        "trace.results" => run_dir::files::TRACE_RESULTS,
+        "resource.summary" => run_dir::files::RESOURCE_SUMMARY,
+        "producer.summary" => "producer-summary.json",
+        "findings" => "findings.json",
         "annotations" => run_dir::files::ANNOTATIONS_DIR,
         _ => name,
     }

--- a/src/core/extension/tests.rs
+++ b/src/core/extension/tests.rs
@@ -77,25 +77,64 @@ fn manifest_parses_declared_structured_sidecars() {
                 "schema_version": "1"
             },
             "producer.summary": {
-                "path": "producer-summary.json",
                 "schema_version": "1"
             },
             "lint.findings": true,
+            "lint.producers": true,
+            "trace.results": true,
             "test.coverage": false
         }
     }))
     .unwrap();
 
     let sidecars = manifest.structured_sidecars();
-    assert_eq!(sidecars.len(), 3);
+    assert_eq!(sidecars.len(), 5);
     assert_eq!(sidecars[0].name, "findings");
     assert_eq!(sidecars[0].path, "findings.json");
     assert_eq!(sidecars[0].schema_version.as_deref(), Some("1"));
     assert_eq!(sidecars[1].name, "lint.findings");
     assert_eq!(sidecars[1].path, "lint-findings.json");
     assert_eq!(sidecars[1].schema_version, None);
-    assert_eq!(sidecars[2].name, "producer.summary");
-    assert_eq!(sidecars[2].path, "producer-summary.json");
+    assert_eq!(sidecars[2].name, "lint.producers");
+    assert_eq!(sidecars[2].path, "lint-producers.json");
+    assert_eq!(sidecars[3].name, "producer.summary");
+    assert_eq!(sidecars[3].path, "producer-summary.json");
+    assert_eq!(sidecars[4].name, "trace.results");
+    assert_eq!(sidecars[4].path, "trace.json");
+}
+
+#[test]
+fn structured_sidecar_schema_versions_come_from_top_level_contract() {
+    let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+        "name": "Example",
+        "version": "0.0.0",
+        "structured_sidecars": {
+            "findings": {
+                "path": "findings.json",
+                "schema_version": "2"
+            },
+            "lint.findings": true,
+            "test.failures": false
+        },
+        "lint": {
+            "extension_script": "lint.sh",
+            "findings_schema_version": "1"
+        }
+    }))
+    .unwrap();
+
+    assert_eq!(
+        manifest.structured_sidecar_schema_version("findings"),
+        Some("2")
+    );
+    assert_eq!(
+        manifest.structured_sidecar_schema_version("lint.findings"),
+        None
+    );
+    assert_eq!(
+        manifest.structured_sidecar_schema_version("test.failures"),
+        None
+    );
 }
 
 #[test]

--- a/tests/output_contracts_test.rs
+++ b/tests/output_contracts_test.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use homeboy::cli_surface::current_command_surface;
 use homeboy::commands::bench::BenchOutput;
+use homeboy::commands::extension::{ExtensionDetail, ExtensionOutput};
 use homeboy::commands::review::{
     ReviewArtifact, ReviewArtifactCommand, ReviewCommandOutput, ReviewStage, ReviewSummary,
 };
@@ -18,7 +19,8 @@ use homeboy::core::extension::test::{
     RawTestOutput, TestCommandOutput, TestCounts, TestSummaryOutput,
 };
 use homeboy::core::extension::{
-    PhaseFailure, PhaseFailureCategory, PhaseReport, PhaseStatus, VerificationPhase,
+    PhaseFailure, PhaseFailureCategory, PhaseReport, PhaseStatus, StructuredSidecarDeclaration,
+    VerificationPhase,
 };
 use homeboy::core::finding::{FindingProducerSummary, FindingSource, HomeboyFinding};
 use homeboy::core::plan::HomeboyPlan;
@@ -325,6 +327,47 @@ fn runs_rig_and_bench_output_variants_have_unambiguous_contracts() {
             variant_contract("observation", json!({ "command": "runs.list", "runs": [] })),
         ],
     );
+}
+
+#[test]
+fn extension_show_output_contracts_use_top_level_structured_sidecars() {
+    let output = typed_output_value(ExtensionOutput::Show {
+        extension: ExtensionDetail {
+            id: "wordpress".to_string(),
+            name: "WordPress".to_string(),
+            version: "1.0.0".to_string(),
+            description: None,
+            author: None,
+            homepage: None,
+            source_url: None,
+            runtime: "platform".to_string(),
+            runtime_requirements: None,
+            has_setup: None,
+            has_ready_check: None,
+            ready: true,
+            ready_reason: None,
+            ready_detail: None,
+            linked: false,
+            path: "/extensions/wordpress".to_string(),
+            source_revision: None,
+            cli: None,
+            actions: Vec::new(),
+            inputs: Vec::new(),
+            settings: Vec::new(),
+            structured_sidecars: vec![StructuredSidecarDeclaration {
+                name: "findings".to_string(),
+                path: "findings.json".to_string(),
+                schema_version: Some("1".to_string()),
+            }],
+            requires: None,
+        },
+    });
+
+    assert_eq!(
+        output["extension"]["structured_sidecars"],
+        json!([{ "name": "findings", "path": "findings.json", "schema_version": "1" }])
+    );
+    assert_eq!(output["extension"].get("lint"), None);
 }
 
 fn quality_output_contract_scenarios() -> Vec<OutputContractScenario> {


### PR DESCRIPTION
## Summary
- Clarifies `structured_sidecars` as the authoritative extension manifest contract for structured sidecar declarations and schema versions.
- Expands default path discovery for unified findings, producer summaries, lint producer summaries, trace results, resource summaries, and other structured outputs.
- Adds focused parser and output-contract coverage for top-level sidecar declarations and schema-version access.

## Testing
- `cargo fmt`
- `cargo test extension`
- `cargo test output_contracts`
- `git diff --check`

## Linked issue
- Closes https://github.com/Extra-Chill/homeboy/issues/3072

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing this structured sidecar contract cleanup and verification; Chris remains responsible for review and merge.