### PR TITLE
Preflight release packaging before mutation

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -37,7 +37,7 @@ pub(super) fn execute_release_plan_step(
             Ok(Some(run_changelog_bootstrap_preflight(step, context)))
         }
         "preflight.package" => Ok(Some(
-            executor::run_package_preflight(
+            executor::package_preflight::run_package_preflight(
                 context.extensions,
                 context.component_id,
                 &context.component.local_path,

--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -36,6 +36,14 @@ pub(super) fn execute_release_plan_step(
         "preflight.changelog_bootstrap" => {
             Ok(Some(run_changelog_bootstrap_preflight(step, context)))
         }
+        "preflight.package" => Ok(Some(
+            executor::run_package_preflight(
+                context.extensions,
+                context.component_id,
+                &context.component.local_path,
+            )
+            .unwrap_or_else(|err| failed_result("preflight.package", "preflight.package", err)),
+        )),
         "changelog.finalize" => {
             executor::changelog::run_changelog_finalize(step, context.component, &mut context.state)
                 .map(Some)
@@ -161,7 +169,8 @@ fn release_step_is_plan_only(step: &PlanStep) -> bool {
         && step.kind != "preflight.bump_policy"
         && step.kind != "preflight.lint"
         && step.kind != "preflight.test"
-        && step.kind != "preflight.changelog_bootstrap")
+        && step.kind != "preflight.changelog_bootstrap"
+        && step.kind != "preflight.package")
         || step.kind == "changelog.policy"
         || step.kind == "changelog.generate"
 }
@@ -372,6 +381,7 @@ pub(super) fn release_step_is_show_stopper(result: &ReleaseStepResult) -> bool {
             | "preflight.lint"
             | "preflight.test"
             | "preflight.changelog_bootstrap"
+            | "preflight.package"
             | "version"
             | "release.prepare"
             | "git.commit"
@@ -449,6 +459,7 @@ mod tests {
         assert!(!release_step_is_plan_only(&plan_step(
             "preflight.changelog_bootstrap"
         )));
+        assert!(!release_step_is_plan_only(&plan_step("preflight.package")));
         assert!(!release_step_is_plan_only(&plan_step("changelog.finalize")));
         assert!(!release_step_is_plan_only(&plan_step("deploy")));
     }
@@ -827,6 +838,7 @@ mod tests {
         let lint_failure = failed_step_result("preflight.lint");
         let test_failure = failed_step_result("preflight.test");
         let bootstrap_failure = failed_step_result("preflight.changelog_bootstrap");
+        let package_preflight_failure = failed_step_result("preflight.package");
         let changelog_failure = failed_step_result("changelog.finalize");
         let publish_failure = failed_step_result("publish.crates");
 
@@ -838,6 +850,7 @@ mod tests {
         assert!(release_step_is_show_stopper(&lint_failure));
         assert!(release_step_is_show_stopper(&test_failure));
         assert!(release_step_is_show_stopper(&bootstrap_failure));
+        assert!(release_step_is_show_stopper(&package_preflight_failure));
         assert!(release_step_is_show_stopper(&changelog_failure));
         assert!(!release_step_is_show_stopper(&publish_failure));
     }

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -20,6 +20,7 @@ use crate::core::extension::{self, ExtensionManifest};
 use crate::core::release::{changelog as release_changelog, version};
 
 use std::fmt::Write;
+use std::path::Path;
 
 use super::types::{ReleaseArtifact, ReleaseState, ReleaseStepResult, ReleaseStepStatus};
 use super::utils::{extract_latest_notes, parse_release_artifacts};
@@ -540,6 +541,152 @@ pub(crate) fn run_package(
     });
 
     Ok(step_success("package", "package", Some(data), Vec::new()))
+}
+
+/// Validate packaging against a temporary component copy before the release
+/// pipeline mutates changelog, version files, or git state.
+pub(crate) fn run_package_preflight(
+    extensions: &[ExtensionManifest],
+    component_id: &str,
+    component_local_path: &str,
+) -> Result<ReleaseStepResult> {
+    let temp = create_release_preflight_tempdir()?;
+    let temp_component_path = temp.join("component");
+    copy_release_preflight_tree(Path::new(component_local_path), &temp_component_path)?;
+
+    let mut state = ReleaseState::default();
+    let result = run_package(
+        extensions,
+        &mut state,
+        component_id,
+        &temp_component_path.to_string_lossy(),
+    );
+
+    let _ = std::fs::remove_dir_all(&temp);
+    let result = result?;
+
+    let data = serde_json::json!({
+        "component_path": component_local_path,
+        "validated_action": "release.package",
+        "artifacts": state.artifacts,
+        "package_result": result.data,
+    });
+    Ok(step_success(
+        "preflight.package",
+        "preflight.package",
+        Some(data),
+        Vec::new(),
+    ))
+}
+
+fn create_release_preflight_tempdir() -> Result<std::path::PathBuf> {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "homeboy-release-package-preflight-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default()
+    ));
+
+    std::fs::create_dir_all(&path).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to create package preflight tempdir: {}", e),
+            Some(path.display().to_string()),
+        )
+    })?;
+
+    Ok(path)
+}
+
+fn copy_release_preflight_tree(source: &Path, destination: &Path) -> Result<()> {
+    std::fs::create_dir_all(destination).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to create package preflight copy: {}", e),
+            Some(destination.display().to_string()),
+        )
+    })?;
+
+    for entry in std::fs::read_dir(source).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to read package preflight source: {}", e),
+            Some(source.display().to_string()),
+        )
+    })? {
+        let entry = entry.map_err(|e| {
+            Error::internal_io(
+                format!("Failed to read package preflight source entry: {}", e),
+                Some(source.display().to_string()),
+            )
+        })?;
+        let file_name = entry.file_name();
+        if file_name == std::ffi::OsStr::new(".git") {
+            continue;
+        }
+
+        let from = entry.path();
+        let to = destination.join(&file_name);
+        copy_release_preflight_entry(&from, &to)?;
+    }
+
+    Ok(())
+}
+
+fn copy_release_preflight_entry(source: &Path, destination: &Path) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(source).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to inspect package preflight entry: {}", e),
+            Some(source.display().to_string()),
+        )
+    })?;
+
+    if metadata.file_type().is_symlink() {
+        copy_release_preflight_symlink(source, destination)
+    } else if metadata.is_dir() {
+        copy_release_preflight_tree(source, destination)
+    } else if metadata.is_file() {
+        std::fs::copy(source, destination).map(|_| ()).map_err(|e| {
+            Error::internal_io(
+                format!("Failed to copy package preflight file: {}", e),
+                Some(source.display().to_string()),
+            )
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn copy_release_preflight_symlink(source: &Path, destination: &Path) -> Result<()> {
+    let target = std::fs::read_link(source).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to read package preflight symlink: {}", e),
+            Some(source.display().to_string()),
+        )
+    })?;
+
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(target, destination).map_err(|e| {
+            Error::internal_io(
+                format!("Failed to copy package preflight symlink: {}", e),
+                Some(source.display().to_string()),
+            )
+        })
+    }
+
+    #[cfg(not(unix))]
+    {
+        let target_path = if target.is_absolute() {
+            target
+        } else {
+            source
+                .parent()
+                .map(|parent| parent.join(&target))
+                .unwrap_or(target)
+        };
+        copy_release_preflight_entry(&target_path, destination)
+    }
 }
 
 /// Invoke the `release.publish` action on the named extension.

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -20,7 +20,6 @@ use crate::core::extension::{self, ExtensionManifest};
 use crate::core::release::{changelog as release_changelog, version};
 
 use std::fmt::Write;
-use std::path::Path;
 
 use super::types::{ReleaseArtifact, ReleaseState, ReleaseStepResult, ReleaseStepStatus};
 use super::utils::{extract_latest_notes, parse_release_artifacts};
@@ -28,6 +27,7 @@ use super::utils::{extract_latest_notes, parse_release_artifacts};
 pub(crate) mod artifacts;
 pub(crate) mod changelog;
 mod github_release;
+pub(crate) mod package_preflight;
 pub(crate) mod prepare;
 mod version_targets;
 
@@ -541,152 +541,6 @@ pub(crate) fn run_package(
     });
 
     Ok(step_success("package", "package", Some(data), Vec::new()))
-}
-
-/// Validate packaging against a temporary component copy before the release
-/// pipeline mutates changelog, version files, or git state.
-pub(crate) fn run_package_preflight(
-    extensions: &[ExtensionManifest],
-    component_id: &str,
-    component_local_path: &str,
-) -> Result<ReleaseStepResult> {
-    let temp = create_release_preflight_tempdir()?;
-    let temp_component_path = temp.join("component");
-    copy_release_preflight_tree(Path::new(component_local_path), &temp_component_path)?;
-
-    let mut state = ReleaseState::default();
-    let result = run_package(
-        extensions,
-        &mut state,
-        component_id,
-        &temp_component_path.to_string_lossy(),
-    );
-
-    let _ = std::fs::remove_dir_all(&temp);
-    let result = result?;
-
-    let data = serde_json::json!({
-        "component_path": component_local_path,
-        "validated_action": "release.package",
-        "artifacts": state.artifacts,
-        "package_result": result.data,
-    });
-    Ok(step_success(
-        "preflight.package",
-        "preflight.package",
-        Some(data),
-        Vec::new(),
-    ))
-}
-
-fn create_release_preflight_tempdir() -> Result<std::path::PathBuf> {
-    let mut path = std::env::temp_dir();
-    path.push(format!(
-        "homeboy-release-package-preflight-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|duration| duration.as_nanos())
-            .unwrap_or_default()
-    ));
-
-    std::fs::create_dir_all(&path).map_err(|e| {
-        Error::internal_io(
-            format!("Failed to create package preflight tempdir: {}", e),
-            Some(path.display().to_string()),
-        )
-    })?;
-
-    Ok(path)
-}
-
-fn copy_release_preflight_tree(source: &Path, destination: &Path) -> Result<()> {
-    std::fs::create_dir_all(destination).map_err(|e| {
-        Error::internal_io(
-            format!("Failed to create package preflight copy: {}", e),
-            Some(destination.display().to_string()),
-        )
-    })?;
-
-    for entry in std::fs::read_dir(source).map_err(|e| {
-        Error::internal_io(
-            format!("Failed to read package preflight source: {}", e),
-            Some(source.display().to_string()),
-        )
-    })? {
-        let entry = entry.map_err(|e| {
-            Error::internal_io(
-                format!("Failed to read package preflight source entry: {}", e),
-                Some(source.display().to_string()),
-            )
-        })?;
-        let file_name = entry.file_name();
-        if file_name == std::ffi::OsStr::new(".git") {
-            continue;
-        }
-
-        let from = entry.path();
-        let to = destination.join(&file_name);
-        copy_release_preflight_entry(&from, &to)?;
-    }
-
-    Ok(())
-}
-
-fn copy_release_preflight_entry(source: &Path, destination: &Path) -> Result<()> {
-    let metadata = std::fs::symlink_metadata(source).map_err(|e| {
-        Error::internal_io(
-            format!("Failed to inspect package preflight entry: {}", e),
-            Some(source.display().to_string()),
-        )
-    })?;
-
-    if metadata.file_type().is_symlink() {
-        copy_release_preflight_symlink(source, destination)
-    } else if metadata.is_dir() {
-        copy_release_preflight_tree(source, destination)
-    } else if metadata.is_file() {
-        std::fs::copy(source, destination).map(|_| ()).map_err(|e| {
-            Error::internal_io(
-                format!("Failed to copy package preflight file: {}", e),
-                Some(source.display().to_string()),
-            )
-        })
-    } else {
-        Ok(())
-    }
-}
-
-fn copy_release_preflight_symlink(source: &Path, destination: &Path) -> Result<()> {
-    let target = std::fs::read_link(source).map_err(|e| {
-        Error::internal_io(
-            format!("Failed to read package preflight symlink: {}", e),
-            Some(source.display().to_string()),
-        )
-    })?;
-
-    #[cfg(unix)]
-    {
-        std::os::unix::fs::symlink(target, destination).map_err(|e| {
-            Error::internal_io(
-                format!("Failed to copy package preflight symlink: {}", e),
-                Some(source.display().to_string()),
-            )
-        })
-    }
-
-    #[cfg(not(unix))]
-    {
-        let target_path = if target.is_absolute() {
-            target
-        } else {
-            source
-                .parent()
-                .map(|parent| parent.join(&target))
-                .unwrap_or(target)
-        };
-        copy_release_preflight_entry(&target_path, destination)
-    }
 }
 
 /// Invoke the `release.publish` action on the named extension.

--- a/src/core/release/executor/package_preflight.rs
+++ b/src/core/release/executor/package_preflight.rs
@@ -1,0 +1,153 @@
+use std::path::{Path, PathBuf};
+
+use crate::core::error::{Error, Result};
+use crate::core::extension::ExtensionManifest;
+use crate::core::release::types::{ReleaseState, ReleaseStepResult};
+
+use super::{run_package, step_success};
+
+/// Validate packaging against a temporary component copy before the release
+/// pipeline mutates changelog, version files, or git state.
+pub(crate) fn run_package_preflight(
+    extensions: &[ExtensionManifest],
+    component_id: &str,
+    component_local_path: &str,
+) -> Result<ReleaseStepResult> {
+    let temp = create_release_preflight_tempdir()?;
+    let temp_component_path = temp.join("component");
+    copy_release_preflight_tree(Path::new(component_local_path), &temp_component_path)?;
+
+    let mut state = ReleaseState::default();
+    let result = run_package(
+        extensions,
+        &mut state,
+        component_id,
+        &temp_component_path.to_string_lossy(),
+    );
+
+    let _ = std::fs::remove_dir_all(&temp);
+    let result = result?;
+
+    let data = serde_json::json!({
+        "component_path": component_local_path,
+        "validated_action": "release.package",
+        "artifacts": state.artifacts,
+        "package_result": result.data,
+    });
+    Ok(step_success(
+        "preflight.package",
+        "preflight.package",
+        Some(data),
+        Vec::new(),
+    ))
+}
+
+fn create_release_preflight_tempdir() -> Result<PathBuf> {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "homeboy-release-package-preflight-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default()
+    ));
+
+    std::fs::create_dir_all(&path).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to create package preflight tempdir: {}", e),
+            Some(path.display().to_string()),
+        )
+    })?;
+
+    Ok(path)
+}
+
+fn copy_release_preflight_tree(source: &Path, destination: &Path) -> Result<()> {
+    std::fs::create_dir_all(destination).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to create package preflight copy: {}", e),
+            Some(destination.display().to_string()),
+        )
+    })?;
+
+    for entry in std::fs::read_dir(source).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to read package preflight source: {}", e),
+            Some(source.display().to_string()),
+        )
+    })? {
+        let entry = entry.map_err(|e| {
+            Error::internal_io(
+                format!("Failed to read package preflight source entry: {}", e),
+                Some(source.display().to_string()),
+            )
+        })?;
+        let file_name = entry.file_name();
+        if file_name == std::ffi::OsStr::new(".git") {
+            continue;
+        }
+
+        let from = entry.path();
+        let to = destination.join(&file_name);
+        copy_release_preflight_entry(&from, &to)?;
+    }
+
+    Ok(())
+}
+
+fn copy_release_preflight_entry(source: &Path, destination: &Path) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(source).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to inspect package preflight entry: {}", e),
+            Some(source.display().to_string()),
+        )
+    })?;
+
+    if metadata.file_type().is_symlink() {
+        copy_release_preflight_symlink(source, destination)
+    } else if metadata.is_dir() {
+        copy_release_preflight_tree(source, destination)
+    } else if metadata.is_file() {
+        std::fs::copy(source, destination).map(|_| ()).map_err(|e| {
+            Error::internal_io(
+                format!("Failed to copy package preflight file: {}", e),
+                Some(source.display().to_string()),
+            )
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn copy_release_preflight_symlink(source: &Path, destination: &Path) -> Result<()> {
+    let target = std::fs::read_link(source).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to read package preflight symlink: {}", e),
+            Some(source.display().to_string()),
+        )
+    })?;
+
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(target, destination).map_err(|e| {
+            Error::internal_io(
+                format!("Failed to copy package preflight symlink: {}", e),
+                Some(source.display().to_string()),
+            )
+        })
+    }
+
+    #[cfg(not(unix))]
+    {
+        let target_path = if target.is_absolute() {
+            target
+        } else {
+            source
+                .parent()
+                .map(|parent| parent.join(&target))
+                .unwrap_or(target)
+        };
+        copy_release_preflight_entry(&target_path, destination)
+    }
+}

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -233,10 +233,21 @@ pub(super) fn build_release_steps(
         );
     }
 
+    let package_preflight_step_id = add_package_preflight_step(
+        &mut steps,
+        extensions,
+        &publish_targets,
+        options,
+        "preflight.changelog_bootstrap",
+    );
+
     steps.extend(build_changelog_steps(
         changelog_plan,
         current_version,
         new_version,
+        package_preflight_step_id
+            .as_deref()
+            .unwrap_or("preflight.changelog_bootstrap"),
     ));
 
     let version_config = StepConfig::new()
@@ -526,6 +537,31 @@ fn build_head_release_steps(
     steps
 }
 
+fn add_package_preflight_step(
+    steps: &mut Vec<PlanStep>,
+    extensions: &[ExtensionManifest],
+    publish_targets: &[String],
+    options: &ReleaseOptions,
+    needs: &str,
+) -> Option<String> {
+    if publish_targets.is_empty()
+        || options.pipeline.skip_publish
+        || !has_package_capability(extensions)
+    {
+        return None;
+    }
+
+    let step_id = "preflight.package".to_string();
+    steps.push(ready_step(
+        &step_id,
+        "preflight.package",
+        "Validate package tooling",
+        vec![needs.to_string()],
+        StepConfig::new(),
+    ));
+    Some(step_id)
+}
+
 fn add_release_extension_diagnostics(
     component: &Component,
     extensions: &[ExtensionManifest],
@@ -594,6 +630,7 @@ fn build_changelog_steps(
     changelog_plan: &ReleaseChangelogPlan,
     current_version: &str,
     new_version: &str,
+    initial_need: &str,
 ) -> Vec<PlanStep> {
     let policy_config = StepConfig::new()
         .string("policy", changelog_plan.policy.clone())
@@ -617,7 +654,7 @@ fn build_changelog_steps(
             "changelog.policy",
             "changelog.policy",
             "Resolve changelog policy",
-            vec!["preflight.changelog_bootstrap".to_string()],
+            vec![initial_need.to_string()],
             policy_config,
         ),
         ready_step(
@@ -972,6 +1009,76 @@ mod tests {
         assert_eq!(steps[version_index].needs, vec!["changelog.finalize"]);
         assert_eq!(steps[prepare_index].needs, vec!["version"]);
         assert_eq!(steps[commit_index].needs, vec!["release.prepare"]);
+    }
+
+    #[test]
+    fn release_plan_runs_package_preflight_before_mutating_release_steps() {
+        let mut component = fixture_component();
+        component.extensions = Some(std::collections::HashMap::from([(
+            "fixture-packager".to_string(),
+            ScopedExtensionConfig::default(),
+        )]));
+        let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "Fixture Packager",
+            "version": "1.0.0",
+            "actions": [
+                {
+                    "id": "release.package",
+                    "label": "Package release",
+                    "type": "command",
+                    "command": "true"
+                },
+                {
+                    "id": "release.publish",
+                    "label": "Publish release",
+                    "type": "command",
+                    "command": "true"
+                }
+            ]
+        }))
+        .expect("extension manifest");
+        extension.id = "fixture-packager".to_string();
+        let mut warnings = Vec::new();
+        let mut hints = Vec::new();
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            ..Default::default()
+        };
+
+        let steps = build_release_steps(
+            &component,
+            &[extension],
+            "1.0.0",
+            "1.0.1",
+            &fixture_changelog_plan(),
+            &options,
+            None,
+            &mut warnings,
+            &mut hints,
+        )
+        .expect("steps");
+
+        let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
+        let package_preflight_index = step_index(&ids, "preflight.package");
+        let changelog_finalize_index = step_index(&ids, "changelog.finalize");
+        let version_index = step_index(&ids, "version");
+        let commit_index = step_index(&ids, "git.commit");
+
+        assert!(package_preflight_index < changelog_finalize_index);
+        assert!(package_preflight_index < version_index);
+        assert!(package_preflight_index < commit_index);
+
+        let package_preflight = &steps[package_preflight_index];
+        assert_eq!(
+            package_preflight.needs,
+            vec!["preflight.changelog_bootstrap"]
+        );
+
+        let changelog_policy = steps
+            .iter()
+            .find(|step| step.id == "changelog.policy")
+            .expect("changelog policy step");
+        assert_eq!(changelog_policy.needs, vec!["preflight.package"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add an executable `preflight.package` release step for releases that will package and publish artifacts.
- Run the existing `release.package` action against a temporary component copy before changelog/version/git mutation steps, so missing package tooling fails before leaving a half-release commit behind.
- Mark package preflight failures as release show-stoppers and pin the plan ordering with focused tests.

Closes https://github.com/Extra-Chill/homeboy/issues/3179

## Testing
- `cargo fmt --check`
- `cargo test release`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing this focused release preflight fix and verification; Chris remains responsible for review and merge.