### PR TITLE
Refactor requested detector language matching

### DIFF
--- a/src/core/code_audit/detectors/requested_detectors.rs
+++ b/src/core/code_audit/detectors/requested_detectors.rs
@@ -587,14 +587,19 @@ fn language_matches(rule: &RequestedDetectorRule, fp: &FileFingerprint) -> bool 
     let Some(language) = &rule.language else {
         return true;
     };
-    match language.trim().to_ascii_lowercase().as_str() {
-        "php" => fp.language == Language::Php,
-        "rust" => fp.language == Language::Rust,
-        "javascript" | "js" => fp.language == Language::JavaScript,
-        "typescript" | "ts" => fp.language == Language::TypeScript,
-        "unknown" => fp.language == Language::Unknown,
-        _ => false,
-    }
+    expected_language(language)
+        .as_ref()
+        .is_some_and(|expected| fp.language == *expected)
+}
+
+fn expected_language(language: &str) -> Option<Language> {
+    let normalized = language.trim().to_ascii_lowercase();
+    serde_json::from_value::<Language>(serde_json::Value::String(normalized.clone()))
+        .ok()
+        .or_else(|| {
+            let language = Language::from_extension(&normalized);
+            (language != Language::Unknown).then_some(language)
+        })
 }
 
 fn finding_from_captures(
@@ -781,6 +786,16 @@ mod tests {
             requested_detectors: vec![rule],
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn language_filter_uses_generic_language_names_and_extensions() {
+        assert_eq!(expected_language("javascript"), Some(Language::JavaScript));
+        assert_eq!(expected_language("js"), Some(Language::JavaScript));
+        assert_eq!(expected_language("typescript"), Some(Language::TypeScript));
+        assert_eq!(expected_language("ts"), Some(Language::TypeScript));
+        assert_eq!(expected_language("unknown"), Some(Language::Unknown));
+        assert_eq!(expected_language("not-a-language"), None);
     }
 
     #[test]

--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -234,14 +234,6 @@ const BASELINE: &[ViolationKey] = &[
         term: "php",
     },
     ViolationKey {
-        path: "src/core/code_audit/detectors/requested_detectors.rs",
-        term: "php",
-    },
-    ViolationKey {
-        path: "src/core/code_audit/detectors/requested_detectors.rs",
-        term: "rust",
-    },
-    ViolationKey {
         path: "src/core/code_audit/requirements.rs",
         term: "composer",
     },
@@ -475,7 +467,7 @@ const BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const BASELINE_OCCURRENCES: usize = 142;
+const BASELINE_OCCURRENCES: usize = 140;
 
 // Known core-owned test/fixture literal debt tracked by #3034. Keep this list
 // explicit so stale rows and occurrence-count changes force cleanup or review.


### PR DESCRIPTION
## Summary
- Replaces requested detector language matching's detector-local ecosystem branch with generic `Language` parsing plus the existing extension-based alias helper.
- Removes the stale `requested_detectors.rs` `php`/`rust` rows from the #2240 core-agnostic baseline.

Closes part of #2240.
Related child lane: #2842.

## Testing
- `cargo test core_agnostic`
- `cargo test --test core_agnostic_test`
- `cargo test language_filter_uses_generic_language_names_and_extensions`
- `cargo test requested_detectors`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing this core-agnostic cleanup and verification; Chris remains responsible for review and merge.