### PR TITLE
Require canonical runner response envelopes

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -137,6 +137,25 @@ The broker exposes `POST /runner/jobs`, `POST /runner/jobs/claim`,
 controllers can queue work and reverse runners can claim, stream progress, and
 return results without inbound access to the lab machine.
 
+Daemon and broker HTTP responses use one canonical envelope. The outer response
+reports transport success and the endpoint payload always lives under
+`data.body`; runner clients require that shape and do not parse legacy direct
+`data` payloads.
+
+```json
+{
+  "success": true,
+  "data": {
+    "status": 200,
+    "endpoint": "runner.jobs.submit",
+    "body": {
+      "job": {},
+      "poll": {}
+    }
+  }
+}
+```
+
 For the generic controller-to-runner operator path, see
 [Controller to runner reverse-runner setup](../operators/controller-runner-reverse-runner.md).
 That guide is machine-agnostic and intentionally explicit about what is available
@@ -258,6 +277,7 @@ Path rules:
 - Omitting `--cwd` on an SSH runner uses the runner `workspace_root`.
 - `--project <id>` feeds the runner trust policy project allowlist check.
 - `--ssh` is the explicit diagnostic fallback when `connect` is unavailable; daemon execution is preferred because it records job metadata and supports artifact-oriented workflows.
+- Raw SSH execution remains intentionally explicit and should not be used as production Lab/offload evidence; use connected daemon or reverse broker execution for job/event/artifact-compatible output.
 
 Runner metrics:
 

--- a/docs/operators/controller-runner-reverse-runner.md
+++ b/docs/operators/controller-runner-reverse-runner.md
@@ -242,6 +242,11 @@ private smoke environment that provides equivalent branch builds.
 For PR or incident evidence, capture the command output plus the matching worker
 log lines showing the same `job_id`, claim, event, and finish result.
 
+The controller broker API wraps every successful response as
+`success: true` with endpoint data under `data.body`. Consumers should treat
+responses without `data.body` as malformed instead of falling back to direct
+`data` payload parsing.
+
 ## Troubleshooting
 
 | Symptom | Check | Likely fix |

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -256,15 +256,7 @@ where
             artifact: None,
         },
         ("POST", "/exec") => match enqueue_exec_job(body, job_store) {
-            Ok(body) => HttpResponse {
-                status_code: 200,
-                body: json!({
-                    "status": 200,
-                    "endpoint": "jobs.exec",
-                    "body": body,
-                }),
-                artifact: None,
-            },
+            Ok(body) => daemon_endpoint_response("jobs.exec", body),
             Err(err) => error_response(400, err),
         },
         ("GET", "/exec") => HttpResponse {

--- a/src/core/runner/broker_http.rs
+++ b/src/core/runner/broker_http.rs
@@ -33,7 +33,33 @@ pub(crate) fn post_json(
             envelope.error.unwrap_or(Value::Null)
         )));
     }
-    envelope
+    let data = envelope
         .data
-        .ok_or_else(|| Error::internal_unexpected("broker response missing data"))
+        .ok_or_else(|| Error::internal_unexpected("broker response missing data"))?;
+    canonical_broker_body(&data)
+}
+
+fn canonical_broker_body(data: &Value) -> Result<Value> {
+    data.get("body")
+        .cloned()
+        .ok_or_else(|| Error::internal_unexpected("broker response missing canonical data.body"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn canonical_broker_body_requires_data_body() {
+        let err = canonical_broker_body(&json!({ "job": {} })).expect_err("reject legacy data");
+        assert!(err.message.contains("data.body"));
+    }
+
+    #[test]
+    fn canonical_broker_body_returns_nested_body() {
+        let body =
+            canonical_broker_body(&json!({ "body": { "job": { "id": "job-1" } } })).expect("body");
+        assert_eq!(body["job"]["id"], "job-1");
+    }
 }

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -9,7 +9,7 @@ use crate::core::error::{Error, Result};
 use crate::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
 use crate::core::paths;
 
-use super::execution::daemon_api_get;
+use super::execution::{canonical_daemon_body, daemon_api_get};
 use super::Runner;
 
 pub fn is_remote_runner_artifact_path(path: &str) -> bool {
@@ -47,7 +47,7 @@ pub fn download_remote_artifact(
             encode_component(&token.artifact_id)
         ),
     )?;
-    let body = data.get("body").unwrap_or(&data);
+    let body = canonical_daemon_body(&data, "runner artifact response")?;
     let content_base64 = body
         .get("content_base64")
         .and_then(Value::as_str)
@@ -267,7 +267,7 @@ fn mirror_remote_observation_runs(
     job: &Job,
 ) -> Result<()> {
     let data = daemon_api_get(&runner.id, "/runs?limit=100")?;
-    let body = data.get("body").unwrap_or(&data);
+    let body = canonical_daemon_body(&data, "runner runs response")?;
     let Some(remote_runs) = body.get("runs").and_then(Value::as_array) else {
         return Ok(());
     };
@@ -280,7 +280,7 @@ fn mirror_remote_observation_runs(
         }
         let detail_data =
             daemon_api_get(&runner.id, &format!("/runs/{}", encode_component(run_id)))?;
-        let detail_body = detail_data.get("body").unwrap_or(&detail_data);
+        let detail_body = canonical_daemon_body(&detail_data, "runner run detail response")?;
         let Some(detail) = detail_body.get("run") else {
             continue;
         };

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -333,8 +333,7 @@ fn exec_via_reverse_broker(
         })?,
         "submit reverse runner job",
     )?;
-    let body = data.get("body").unwrap_or(&data);
-    let job_value = body
+    let job_value = data
         .get("job")
         .ok_or_else(|| Error::internal_unexpected("reverse broker submit returned no job"))?;
     let mut job: Job = serde_json::from_value(job_value.clone()).map_err(|err| {
@@ -448,7 +447,7 @@ fn exec_via_daemon(
     let data = envelope
         .data
         .ok_or_else(|| Error::internal_unexpected("daemon exec returned no data"))?;
-    let body = data.get("body").unwrap_or(&data);
+    let body = canonical_daemon_body(&data, "daemon exec response")?;
     let job_value = body
         .get("job")
         .ok_or_else(|| Error::internal_unexpected("daemon exec returned no job"))?;
@@ -534,15 +533,22 @@ fn preflight_runner_capability_plan(
 
 fn fetch_daemon_job(client: &Client, local_url: &str, job_id: &str) -> Result<Job> {
     let data = daemon_get(client, local_url, &format!("/jobs/{job_id}"))?;
-    serde_json::from_value(data["body"]["job"].clone())
+    let body = canonical_daemon_body(&data, "daemon job response")?;
+    serde_json::from_value(body["job"].clone())
         .map_err(|err| Error::internal_json(err.to_string(), Some("parse daemon job".to_string())))
 }
 
 fn fetch_daemon_events(client: &Client, local_url: &str, job_id: &str) -> Result<Vec<JobEvent>> {
     let data = daemon_get(client, local_url, &format!("/jobs/{job_id}/events"))?;
-    serde_json::from_value(data["body"]["events"].clone()).map_err(|err| {
+    let body = canonical_daemon_body(&data, "daemon job events response")?;
+    serde_json::from_value(body["events"].clone()).map_err(|err| {
         Error::internal_json(err.to_string(), Some("parse daemon job events".to_string()))
     })
+}
+
+pub(crate) fn canonical_daemon_body<'a>(data: &'a Value, context: &str) -> Result<&'a Value> {
+    data.get("body")
+        .ok_or_else(|| Error::internal_unexpected(format!("{context} missing canonical data.body")))
 }
 
 fn daemon_get(client: &Client, local_url: &str, path: &str) -> Result<Value> {
@@ -1019,6 +1025,20 @@ mod tests {
             assert_eq!(err.code.as_str(), "validation.invalid_argument");
             assert!(err.message.contains("connected to a daemon"));
         });
+    }
+
+    #[test]
+    fn canonical_daemon_body_requires_nested_body() {
+        let err = canonical_daemon_body(&json!({ "job": {} }), "daemon exec response")
+            .expect_err("reject legacy direct data");
+        assert!(err.message.contains("data.body"));
+    }
+
+    #[test]
+    fn canonical_daemon_body_returns_nested_body() {
+        let data = json!({ "body": { "job": { "id": "job-1" } } });
+        let body = canonical_daemon_body(&data, "daemon exec response").expect("body");
+        assert_eq!(body["job"]["id"], "job-1");
     }
 
     #[test]

--- a/src/core/runner/worker.rs
+++ b/src/core/runner/worker.rs
@@ -131,7 +131,7 @@ fn claim_job(
         }),
         "claim reverse runner job",
     )?;
-    let claim = data["body"]["claim"].clone();
+    let claim = data["claim"].clone();
     if claim.is_null() {
         return Ok(None);
     }
@@ -175,7 +175,7 @@ fn finish_job(
         }),
         "finish reverse runner job",
     )?;
-    serde_json::from_value(data["body"]["job"].clone()).map_err(|err| {
+    serde_json::from_value(data["job"].clone()).map_err(|err| {
         Error::internal_json(
             err.to_string(),
             Some("parse finished reverse runner job".to_string()),


### PR DESCRIPTION
## Summary
- Require daemon and broker runner clients to parse the canonical `success` + `data.body` envelope instead of falling back to direct `data` payloads.
- Normalize `/exec` daemon responses through the shared daemon endpoint helper and update reverse worker parsing to consume the canonical broker body.
- Document the envelope contract and add unit coverage proving legacy direct payloads are rejected.

Closes #3198.

## Residual work
- #3199 should split: `runner upgrade` still uses explicit direct SSH runner execution for maintenance, so retiring raw SSH as diagnostic-only needs a separate decision about maintenance/job/evidence contracts rather than a partial rename in this PR.

## Tests
- `cargo fmt`
- `cargo test canonical_broker_body`
- `cargo test canonical_daemon_body`
- `cargo test reverse_broker_exec_submits_job_and_polls_result`
- `cargo test reverse_worker_executes_claimed_job_and_finishes_it`
- `cargo test runner:: -- --test-threads=1`

## Notes
- `cargo test runner::` with default parallelism had one connection-refused race in `reverse_broker_exec_submits_job_and_polls_result`; the focused rerun passed and the serial runner-module pass passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner envelope parsing changes, docs, tests, and verification commands under Chris's requested scope.