### PR TITLE
Flag stale deploy source checkouts

### DIFF
--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::process::Command;
 
 use crate::core::component::{self, Component};
 use crate::core::error::{Error, Result};
@@ -224,13 +225,90 @@ pub(super) fn calculate_component_status(
         }
     };
 
-    if matches!(version_status, ComponentStatus::UpToDate)
-        && component_is_behind_upstream(component)
-    {
-        ComponentStatus::BehindUpstream
-    } else {
-        version_status
+    if !matches!(version_status, ComponentStatus::UpToDate) {
+        return version_status;
     }
+
+    if component_is_behind_upstream(component) {
+        return ComponentStatus::BehindUpstream;
+    }
+
+    if component_is_behind_default_branch(component) {
+        return ComponentStatus::SourceStale;
+    }
+
+    version_status
+}
+
+fn component_is_behind_default_branch(component: &Component) -> bool {
+    if component.is_file_component() {
+        return false;
+    }
+
+    let path = Path::new(&component.local_path);
+    if git_output(path, &["rev-parse", "--abbrev-ref", "@{upstream}"]).is_some() {
+        return false;
+    }
+
+    fetch_origin(path);
+    let Some(default_branch) = default_remote_branch(path) else {
+        return false;
+    };
+
+    git_output(
+        path,
+        &[
+            "rev-list",
+            "--left-only",
+            "--count",
+            &format!("{default_branch}...HEAD"),
+        ],
+    )
+    .and_then(|value| value.parse::<u32>().ok())
+    .is_some_and(|count| count > 0)
+}
+
+fn fetch_origin(path: &Path) {
+    let _ = Command::new("git")
+        .args(["fetch", "--quiet", "origin"])
+        .current_dir(path)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+fn git_output(path: &Path, args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| {
+            let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            (!value.is_empty()).then_some(value)
+        })
+}
+
+fn default_remote_branch(path: &Path) -> Option<String> {
+    git_output(
+        path,
+        &[
+            "symbolic-ref",
+            "--quiet",
+            "--short",
+            "refs/remotes/origin/HEAD",
+        ],
+    )
+    .or_else(|| {
+        ["origin/main", "origin/trunk", "origin/master"]
+            .iter()
+            .find(|branch| git_output(path, &["rev-parse", "--verify", branch]).is_some())
+            .map(|branch| (*branch).to_string())
+    })
 }
 
 /// Calculate release state for a component.
@@ -491,6 +569,48 @@ mod tests {
         assert!(matches!(
             calculate_component_status(&stale, &remote_versions),
             ComponentStatus::BehindUpstream
+        ));
+    }
+
+    #[test]
+    fn component_status_reports_source_stale_for_detached_checkout_behind_default() {
+        let temp = TempDir::new().expect("temp dir");
+        let source = temp.path().join("source");
+        let local = temp.path().join("local");
+        std::fs::create_dir(&source).expect("source dir");
+
+        init_source_repo(&source);
+        clone_repo(&source, &local);
+        run_git(&local, &["checkout", "--detach", "HEAD"]);
+        commit_upstream_change(&source);
+
+        let stale = versioned_component("stale", &local, "1.0.0");
+        let remote_versions = HashMap::from([("stale".to_string(), "1.0.0".to_string())]);
+
+        assert!(matches!(
+            calculate_component_status(&stale, &remote_versions),
+            ComponentStatus::SourceStale
+        ));
+    }
+
+    #[test]
+    fn component_status_reports_source_stale_for_untracked_branch_behind_default() {
+        let temp = TempDir::new().expect("temp dir");
+        let source = temp.path().join("source");
+        let local = temp.path().join("local");
+        std::fs::create_dir(&source).expect("source dir");
+
+        init_source_repo(&source);
+        clone_repo(&source, &local);
+        run_git(&local, &["checkout", "-b", "configured-source"]);
+        commit_upstream_change(&source);
+
+        let stale = versioned_component("stale", &local, "1.0.0");
+        let remote_versions = HashMap::from([("stale".to_string(), "1.0.0".to_string())]);
+
+        assert!(matches!(
+            calculate_component_status(&stale, &remote_versions),
+            ComponentStatus::SourceStale
         ));
     }
 

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -91,6 +91,8 @@ pub enum ComponentStatus {
     BehindRemote,
     /// Local checkout is behind its upstream branch
     BehindUpstream,
+    /// Remote matches a configured source checkout that is stale or detached
+    SourceStale,
     /// Cannot determine status
     Unknown,
 }
@@ -304,15 +306,36 @@ impl ComponentDeployResult {
         self.local_path = Some(component.local_path.clone());
         self.git_branch = git_output(path, &["branch", "--show-current"]);
         self.git_head = git_output(path, &["rev-parse", "HEAD"]);
-        self.upstream_branch = git_output(path, &["rev-parse", "--abbrev-ref", "@{upstream}"]);
-        self.upstream_head = git_output(path, &["rev-parse", "@{upstream}"]);
+        self.upstream_branch = git_output(path, &["rev-parse", "--abbrev-ref", "@{upstream}"])
+            .or_else(|| default_remote_branch(path));
+        self.upstream_head = self
+            .upstream_branch
+            .as_deref()
+            .and_then(|upstream| git_output(path, &["rev-parse", upstream]));
         self.is_worktree = detect_linked_worktree(path);
-        self.behind_upstream = git_output(
-            path,
-            &["rev-list", "--left-only", "--count", "@{upstream}...HEAD"],
-        )
-        .and_then(|value| value.parse::<u32>().ok())
-        .filter(|count| *count > 0);
+        self.behind_upstream = self
+            .upstream_branch
+            .as_deref()
+            .and_then(|upstream| {
+                git_output(
+                    path,
+                    &[
+                        "rev-list",
+                        "--left-only",
+                        "--count",
+                        &format!("{upstream}...HEAD"),
+                    ],
+                )
+            })
+            .and_then(|value| value.parse::<u32>().ok())
+            .filter(|count| *count > 0);
+
+        if self.git_head.is_some() && self.git_branch.is_none() {
+            self.warnings.push(
+                "configured_source_detached: source checkout is detached; deploy readiness is comparing against the remote default branch"
+                    .to_string(),
+            );
+        }
 
         if head_deploy && self.is_worktree == Some(true) {
             self.warnings.push(
@@ -321,9 +344,10 @@ impl ComponentDeployResult {
             );
         }
 
-        if let (true, Some(count)) = (head_deploy, self.behind_upstream) {
+        if let Some(count) = self.behind_upstream {
             self.warnings.push(format!(
-                "--head deploy source is {count} commit(s) behind its upstream branch"
+                "configured_source_behind_upstream: source checkout is {count} commit(s) behind {}",
+                self.upstream_branch.as_deref().unwrap_or("upstream")
             ));
         }
 
@@ -353,6 +377,24 @@ fn detect_linked_worktree(path: &Path) -> Option<bool> {
         &["rev-parse", "--path-format=absolute", "--git-common-dir"],
     )?;
     Some(git_dir != common_dir)
+}
+
+fn default_remote_branch(path: &Path) -> Option<String> {
+    git_output(
+        path,
+        &[
+            "symbolic-ref",
+            "--quiet",
+            "--short",
+            "refs/remotes/origin/HEAD",
+        ],
+    )
+    .or_else(|| {
+        ["origin/main", "origin/trunk", "origin/master"]
+            .iter()
+            .find(|branch| git_output(path, &["rev-parse", "--verify", branch]).is_some())
+            .map(|branch| (*branch).to_string())
+    })
 }
 
 #[cfg(test)]
@@ -612,6 +654,40 @@ mod tests {
             .warnings
             .iter()
             .any(|warning| warning.contains("non-primary git worktree")));
+    }
+
+    #[test]
+    fn test_with_source_identity_warns_for_detached_source() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir(&repo).expect("repo dir");
+        std::fs::write(repo.join("README.md"), "fixture\n").expect("fixture file");
+
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+        run_git(&repo, &["add", "README.md"]);
+        run_git(
+            &repo,
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=homeboy@example.test",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        );
+        run_git(&repo, &["checkout", "--detach", "HEAD"]);
+
+        let mut component = component();
+        component.local_path = repo.to_string_lossy().to_string();
+        let result = deploy_result().with_source_identity(&component, false);
+
+        assert!(result.git_branch.is_none());
+        assert!(result
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("configured_source_detached")));
     }
 
     fn run_git(path: &std::path::Path, args: &[&str]) {

--- a/src/core/fleet/check.rs
+++ b/src/core/fleet/check.rs
@@ -70,12 +70,13 @@ pub fn collect_check(
                         Some(deploy::ComponentStatus::NeedsUpdate) => "needs_update",
                         Some(deploy::ComponentStatus::BehindRemote) => "behind_remote",
                         Some(deploy::ComponentStatus::BehindUpstream) => "behind_upstream",
+                        Some(deploy::ComponentStatus::SourceStale) => "source_stale",
                         Some(deploy::ComponentStatus::Unknown) | None => "unknown",
                     };
 
                     match status_str {
                         "up_to_date" => summary.components_up_to_date += 1,
-                        "needs_update" | "behind_remote" | "behind_upstream" => {
+                        "needs_update" | "behind_remote" | "behind_upstream" | "source_stale" => {
                             summary.components_needs_update += 1
                         }
                         _ => summary.components_unknown += 1,

--- a/src/core/fleet/status.rs
+++ b/src/core/fleet/status.rs
@@ -373,6 +373,7 @@ fn resolve_component_drift(
         Some(deploy::ComponentStatus::NeedsUpdate) => FleetComponentDrift::NeedsUpdate,
         Some(deploy::ComponentStatus::BehindRemote) => FleetComponentDrift::BehindRemote,
         Some(deploy::ComponentStatus::BehindUpstream) => FleetComponentDrift::BehindUpstream,
+        Some(deploy::ComponentStatus::SourceStale) => FleetComponentDrift::BehindUpstream,
         Some(deploy::ComponentStatus::Unknown) | None => FleetComponentDrift::Unknown,
     };
 


### PR DESCRIPTION
## Summary
- Adds a `source_stale` deploy-check component status when the remote version matches a configured source checkout that is detached or otherwise lacks an upstream and is behind the remote default branch.
- Emits source readiness warnings such as `configured_source_detached` and `configured_source_behind_upstream` in deploy check/dry-run source identity output.
- Treats `source_stale` as not up-to-date in fleet check summaries so stale configured sources do not look clean.

Closes #3213.

## Verification
- `cargo check`
- `cargo test core::deploy::planning::tests`
- `cargo test core::deploy::types::tests`
- `cargo test --test output_contracts_test`

## Notes
- `cargo clippy --all-targets -- -D warnings` was attempted and fails on existing repository-wide lint debt unrelated to this change, including `large_enum_variant`, `unnecessary_sort_by`, `needless_range_loop`, and other pre-existing warnings across code audit, runner, refactor, and extension modules.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the deploy readiness source-staleness implementation, tests, verification run, commit, and PR description for Chris to review.