### PR TITLE
Fence SSH runner exec as diagnostic

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -268,7 +268,7 @@ homeboy runner exec <runner-id> --project <project-id> --cwd /runner/workspace/p
 homeboy runner exec <runner-id> --ssh --cwd /runner/workspace/project -- <command...>
 ```
 
-`exec` submits the command to the connected runner daemon when `homeboy runner connect <runner-id>` has established a live loopback tunnel. If no daemon session is connected, local runners execute directly and SSH runners require explicit `--ssh`. SSH runner raw exec is policy-denied by default until `policy.allow_raw_exec` is explicitly true.
+`exec` submits the command to the connected runner daemon when `homeboy runner connect <runner-id>` has established a live loopback tunnel. If no daemon session is connected, local runners execute directly and SSH runners require explicit diagnostic `--ssh`. SSH runner raw exec is policy-denied by default until `policy.allow_raw_exec` is explicitly true.
 
 Path rules:
 
@@ -277,6 +277,7 @@ Path rules:
 - Omitting `--cwd` on an SSH runner uses the runner `workspace_root`.
 - `--project <id>` feeds the runner trust policy project allowlist check.
 - `--ssh` is the explicit diagnostic fallback when `connect` is unavailable; daemon execution is preferred because it records job metadata and supports artifact-oriented workflows.
+- Diagnostic SSH output serializes as `mode: "diagnostic_ssh"` and does not include job/event evidence.
 - Raw SSH execution remains intentionally explicit and should not be used as production Lab/offload evidence; use connected daemon or reverse broker execution for job/event/artifact-compatible output.
 
 Runner metrics:

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -253,7 +253,7 @@ enum RunnerCommand {
         #[arg(long)]
         project: Option<String>,
 
-        /// Allow explicit SSH command execution when no daemon session is connected
+        /// Allow diagnostic-only SSH command execution when no daemon session is connected
         #[arg(long)]
         ssh: bool,
 
@@ -744,7 +744,7 @@ fn exec(
     runner_id: &str,
     cwd: Option<String>,
     project_id: Option<String>,
-    allow_ssh: bool,
+    allow_diagnostic_ssh: bool,
     capture_patch: bool,
     command: Vec<String>,
 ) -> CmdResult<RunnerExecOutput> {
@@ -753,7 +753,7 @@ fn exec(
         runner::RunnerExecOptions {
             cwd,
             project_id,
-            allow_ssh,
+            allow_diagnostic_ssh,
             command,
             env: Default::default(),
             capture_patch,

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -25,7 +25,7 @@ use policy::{validate_runner_policy, RunnerPolicyRequest};
 pub struct RunnerExecOptions {
     pub cwd: Option<String>,
     pub project_id: Option<String>,
-    pub allow_ssh: bool,
+    pub allow_diagnostic_ssh: bool,
     pub command: Vec<String>,
     pub env: HashMap<String, String>,
     pub capture_patch: bool,
@@ -41,7 +41,7 @@ pub enum RunnerExecMode {
     Daemon,
     Local,
     ReverseBroker,
-    Ssh,
+    DiagnosticSsh,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -146,13 +146,13 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
 
     match runner.kind {
         RunnerKind::Local => exec_local(&runner, cwd, options.command, options.env),
-        RunnerKind::Ssh if options.allow_ssh => {
+        RunnerKind::Ssh if options.allow_diagnostic_ssh => {
             preflight_runner_capability_plan(
                 &runner,
                 options.capability_preflight.as_ref(),
                 &request_env,
             )?;
-            exec_ssh(&runner, cwd, options.command, request_env)
+            exec_diagnostic_ssh(&runner, cwd, options.command, request_env)
         }
         RunnerKind::Ssh => Err(Error::validation_invalid_argument(
             "runner",
@@ -636,7 +636,7 @@ fn exec_local(
     ))
 }
 
-fn exec_ssh(
+fn exec_diagnostic_ssh(
     runner: &Runner,
     cwd: String,
     command: Vec<String>,
@@ -668,7 +668,7 @@ fn exec_ssh(
         SourceSnapshot::existing_remote(&runner.id, &cwd, runner.workspace_root.as_deref());
     Ok(exec_output(
         runner,
-        RunnerExecMode::Ssh,
+        RunnerExecMode::DiagnosticSsh,
         cwd,
         command,
         ProcessOutput {
@@ -807,7 +807,7 @@ fn string_field(value: &Value, key: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::server::{RunnerPolicy, RunnerSettings};
+    use crate::core::server::{self, RunnerPolicy, RunnerSettings};
 
     fn ssh_runner() -> Runner {
         Runner {
@@ -858,7 +858,7 @@ mod tests {
                 RunnerExecOptions {
                     cwd: None,
                     project_id: None,
-                    allow_ssh: false,
+                    allow_diagnostic_ssh: false,
                     command: vec!["sh".to_string(), "-c".to_string(), "printf ok".to_string()],
                     env: Default::default(),
                     capture_patch: false,
@@ -895,6 +895,55 @@ mod tests {
     }
 
     #[test]
+    fn test_exec_rejects_disconnected_ssh_runner_without_diagnostic_fallback() {
+        crate::test_support::with_isolated_home(|_| {
+            server::create(
+                r#"{"id":"lab-server","host":"192.168.86.63","user":"chubes"}"#,
+                false,
+            )
+            .expect("create server");
+
+            super::super::create(
+                r#"{"id":"lab-server","kind":"ssh","server_id":"lab-server","workspace_root":"/srv/homeboy"}"#,
+                false,
+            )
+            .expect("create ssh runner");
+
+            let err = exec(
+                "lab-server",
+                RunnerExecOptions {
+                    cwd: Some("/srv/homeboy/project".to_string()),
+                    project_id: None,
+                    allow_diagnostic_ssh: false,
+                    command: vec!["homeboy".to_string(), "test".to_string()],
+                    env: Default::default(),
+                    capture_patch: false,
+                    raw_exec: false,
+                    source_snapshot: None,
+                    capability_preflight: None,
+                    required_extensions: Vec::new(),
+                },
+            )
+            .expect_err("disconnected ssh runner needs daemon or diagnostic fallback");
+
+            assert_eq!(err.code.as_str(), "validation.invalid_argument");
+            assert!(err.message.contains("connected to a daemon"));
+            let tried = err.details["tried"].as_array().expect("tried details");
+            assert!(tried.iter().any(|detail| detail
+                .as_str()
+                .is_some_and(|detail| detail.contains("job metadata"))));
+        });
+    }
+
+    #[test]
+    fn test_diagnostic_ssh_mode_serializes_as_diagnostic_ssh() {
+        assert_eq!(
+            serde_json::to_value(RunnerExecMode::DiagnosticSsh).expect("mode json"),
+            json!("diagnostic_ssh")
+        );
+    }
+
+    #[test]
     fn test_required_extensions_for_command_reads_extension_flags() {
         let command = vec![
             "homeboy".to_string(),
@@ -920,7 +969,7 @@ mod tests {
         let options = RunnerExecOptions {
             cwd: Some("/srv/homeboy/project".to_string()),
             project_id: Some("extrachill".to_string()),
-            allow_ssh: true,
+            allow_diagnostic_ssh: true,
             command: vec!["sh".to_string()],
             env: Default::default(),
             capture_patch: false,
@@ -952,7 +1001,7 @@ mod tests {
         let allowed = RunnerExecOptions {
             cwd: Some("/srv/homeboy/extrachill/homeboy".to_string()),
             project_id: Some("extrachill".to_string()),
-            allow_ssh: true,
+            allow_diagnostic_ssh: true,
             command: vec!["cargo".to_string(), "test".to_string()],
             env: Default::default(),
             capture_patch: false,

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -453,7 +453,7 @@ fn run_lab_offload_inner(
         RunnerExecOptions {
             cwd: Some(remote_cwd),
             project_id: None,
-            allow_ssh: false,
+            allow_diagnostic_ssh: false,
             command,
             env,
             capture_patch: request.capture_patch,

--- a/src/core/runner/rig_materialization.rs
+++ b/src/core/runner/rig_materialization.rs
@@ -48,7 +48,7 @@ pub(super) fn sync_lab_offload_rigs(
             RunnerExecOptions {
                 cwd: Some(remote_cwd.to_string()),
                 project_id: None,
-                allow_ssh: false,
+                allow_diagnostic_ssh: false,
                 command: vec![
                     homeboy_path.to_string(),
                     "rig".to_string(),

--- a/src/core/runner/worker.rs
+++ b/src/core/runner/worker.rs
@@ -75,7 +75,7 @@ pub fn run_reverse_worker(
         RunnerExecOptions {
             cwd: claim.request.cwd.clone(),
             project_id: claim.request.project_id.clone(),
-            allow_ssh: false,
+            allow_diagnostic_ssh: false,
             command: claim.request.command.clone(),
             env: claim.request.env.clone(),
             capture_patch: claim.request.capture_patch,

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -159,7 +159,7 @@ fn runner_exec_options(runner: &Runner, command: Vec<String>) -> RunnerExecOptio
     RunnerExecOptions {
         cwd: None,
         project_id: None,
-        allow_ssh: true,
+        allow_diagnostic_ssh: true,
         command,
         env: runner.env.clone(),
         capture_patch: false,
@@ -222,7 +222,7 @@ mod tests {
             commands.push((
                 runner_id.to_string(),
                 options.command.clone(),
-                options.allow_ssh,
+                options.allow_diagnostic_ssh,
             ));
             let stdout = match commands.len() {
                 1 => "homeboy 0.199.1\n",
@@ -327,7 +327,7 @@ mod tests {
         RunnerExecOutput {
             command: "runner.exec",
             runner_id: runner_id.to_string(),
-            mode: RunnerExecMode::Ssh,
+            mode: RunnerExecMode::DiagnosticSsh,
             argv,
             remote_cwd: "/home/chubes/workspace".to_string(),
             exit_code,


### PR DESCRIPTION
## Summary
- Rename raw SSH runner execution plumbing to diagnostic SSH and serialize its mode as `diagnostic_ssh`.
- Keep normal Lab, rig materialization, and reverse-worker execution paths on daemon/broker-compatible execution by leaving diagnostic SSH disabled.
- Document that `--ssh` is diagnostic-only and lacks job/event evidence.

Closes #3199.

## Testing
- `cargo fmt --check`
- `cargo check`
- `cargo test runner::execution --lib`
- `cargo test upgrade::runners --lib`
- `homeboy audit --path . --changed-since origin/main --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation, targeted tests, documentation updates, and verification; Chris remains responsible for review and merge.