### PR TITLE
Add generic agent task schemas

### DIFF
--- a/src/core/agent_task.rs
+++ b/src/core/agent_task.rs
@@ -1,0 +1,485 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[cfg(test)]
+use crate::core::redaction::RedactionPolicy;
+
+pub const AGENT_TASK_REQUEST_SCHEMA: &str = "homeboy/agent-task-request/v1";
+pub const AGENT_TASK_OUTCOME_SCHEMA: &str = "homeboy/agent-task-outcome/v1";
+pub const AGENT_TASK_ARTIFACT_SCHEMA: &str = "homeboy/agent-task-artifact/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskRequest {
+    #[serde(default = "request_schema")]
+    pub schema: String,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_plan_id: Option<String>,
+    pub executor: AgentTaskExecutor,
+    pub instructions: String,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub inputs: Value,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_refs: Vec<AgentTaskSourceRef>,
+    #[serde(default)]
+    pub workspace: AgentTaskWorkspace,
+    #[serde(default)]
+    pub policy: AgentTaskPolicy,
+    #[serde(default)]
+    pub limits: AgentTaskLimits,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expected_artifacts: Vec<String>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[cfg(test)]
+impl AgentTaskRequest {
+    pub(crate) fn redacted(&self) -> Self {
+        let policy = RedactionPolicy::default();
+        let mut redacted = self.clone();
+        redacted.instructions = policy.redact_string(&redacted.instructions);
+        redacted.inputs = policy.redact_json(&redacted.inputs);
+        redacted.executor.config = policy.redact_json(&redacted.executor.config);
+        redacted.workspace.materialization =
+            policy.redact_json(&redacted.workspace.materialization);
+        redacted.metadata = policy.redact_json(&redacted.metadata);
+        redacted
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskExecutor {
+    pub backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_capabilities: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub config: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskSourceRef {
+    pub kind: String,
+    pub uri: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskWorkspace {
+    #[serde(default)]
+    pub mode: AgentTaskWorkspaceMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root: Option<String>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub materialization: Value,
+}
+
+impl Default for AgentTaskWorkspace {
+    fn default() -> Self {
+        Self {
+            mode: AgentTaskWorkspaceMode::Ephemeral,
+            root: None,
+            materialization: Value::Null,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskWorkspaceMode {
+    Ephemeral,
+    Existing,
+    Materialized,
+}
+
+impl Default for AgentTaskWorkspaceMode {
+    fn default() -> Self {
+        Self::Ephemeral
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPolicy {
+    #[serde(default = "default_read_policy")]
+    pub read: String,
+    #[serde(default = "default_write_policy")]
+    pub write: String,
+    #[serde(default = "default_apply_policy")]
+    pub apply: String,
+}
+
+impl Default for AgentTaskPolicy {
+    fn default() -> Self {
+        Self {
+            read: default_read_policy(),
+            write: default_write_policy(),
+            apply: default_apply_policy(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskLimits {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_runtime_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_output_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskOutcome {
+    #[serde(default = "outcome_schema")]
+    pub schema: String,
+    pub task_id: String,
+    pub status: AgentTaskOutcomeStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_classification: Option<AgentTaskFailureClassification>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<AgentTaskArtifact>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence_refs: Vec<AgentTaskEvidenceRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<AgentTaskDiagnostic>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub follow_up: Option<AgentTaskFollowUp>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[cfg(test)]
+impl AgentTaskOutcome {
+    pub(crate) fn redacted(&self) -> Self {
+        let policy = RedactionPolicy::default();
+        let mut redacted = self.clone();
+        redacted.summary = redacted.summary.map(|value| policy.redact_string(&value));
+        redacted.artifacts = redacted
+            .artifacts
+            .into_iter()
+            .map(|artifact| artifact.redacted_with(&policy))
+            .collect();
+        redacted.diagnostics = redacted
+            .diagnostics
+            .into_iter()
+            .map(|diagnostic| diagnostic.redacted_with(&policy))
+            .collect();
+        redacted.metadata = policy.redact_json(&redacted.metadata);
+        redacted
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskOutcomeStatus {
+    Succeeded,
+    NoOp,
+    UnableToRemediate,
+    ProviderError,
+    Timeout,
+    Failed,
+    FollowUpIssue,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskFailureClassification {
+    Provider,
+    Timeout,
+    PolicyDenied,
+    CapabilityMissing,
+    InvalidInput,
+    ExecutionFailed,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskArtifact {
+    #[serde(default = "artifact_schema")]
+    pub schema: String,
+    pub id: String,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[cfg(test)]
+impl AgentTaskArtifact {
+    fn redacted_with(mut self, policy: &RedactionPolicy) -> Self {
+        self.name = self.name.map(|value| policy.redact_string(&value));
+        self.path = self.path.map(|value| policy.redact_string(&value));
+        self.url = self.url.map(|value| policy.redact_url(&value));
+        self.metadata = policy.redact_json(&self.metadata);
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskEvidenceRef {
+    pub kind: String,
+    pub uri: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskDiagnostic {
+    pub class: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub data: Value,
+}
+
+#[cfg(test)]
+impl AgentTaskDiagnostic {
+    fn redacted_with(mut self, policy: &RedactionPolicy) -> Self {
+        self.message = policy.redact_string(&self.message);
+        self.data = policy.redact_json(&self.data);
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskFollowUp {
+    pub kind: String,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uri: Option<String>,
+}
+
+fn request_schema() -> String {
+    AGENT_TASK_REQUEST_SCHEMA.to_string()
+}
+
+fn outcome_schema() -> String {
+    AGENT_TASK_OUTCOME_SCHEMA.to_string()
+}
+
+fn artifact_schema() -> String {
+    AGENT_TASK_ARTIFACT_SCHEMA.to_string()
+}
+
+fn default_read_policy() -> String {
+    "workspace".to_string()
+}
+
+fn default_write_policy() -> String {
+    "artifacts_only".to_string()
+}
+
+fn default_apply_policy() -> String {
+    "propose_only".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn request_round_trips_generic_agent_task_shape() {
+        let request = AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "task-1".to_string(),
+            group_key: Some("audit-batch".to_string()),
+            parent_plan_id: Some("plan-1".to_string()),
+            executor: AgentTaskExecutor {
+                backend: "browser_sandbox".to_string(),
+                selector: Some("lab-a".to_string()),
+                required_capabilities: vec!["structured_output".to_string()],
+                model: Some("quality-model".to_string()),
+                config: json!({ "account": "team-a" }),
+            },
+            instructions: "Fix the scoped finding and return artifacts.".to_string(),
+            inputs: json!({ "finding_id": "finding-1" }),
+            source_refs: vec![AgentTaskSourceRef {
+                kind: "git".to_string(),
+                uri: "https://example.test/repo.git".to_string(),
+                revision: Some("abc123".to_string()),
+            }],
+            workspace: AgentTaskWorkspace {
+                mode: AgentTaskWorkspaceMode::Materialized,
+                root: Some("/workspace/repo".to_string()),
+                materialization: json!({ "component": "repo" }),
+            },
+            policy: AgentTaskPolicy {
+                read: "workspace".to_string(),
+                write: "workspace".to_string(),
+                apply: "propose_only".to_string(),
+            },
+            limits: AgentTaskLimits {
+                timeout_ms: Some(300_000),
+                max_runtime_ms: Some(240_000),
+                max_output_bytes: Some(1_000_000),
+            },
+            expected_artifacts: vec!["patch".to_string(), "report".to_string()],
+            metadata: json!({ "batch": 1 }),
+        };
+
+        let encoded = serde_json::to_string(&request).expect("serialize request");
+        let decoded: AgentTaskRequest = serde_json::from_str(&encoded).expect("decode request");
+
+        assert_eq!(decoded, request);
+        assert_eq!(decoded.schema, AGENT_TASK_REQUEST_SCHEMA);
+    }
+
+    #[test]
+    fn outcome_round_trips_success_noop_timeout_and_follow_up_shapes() {
+        let statuses = [
+            AgentTaskOutcomeStatus::Succeeded,
+            AgentTaskOutcomeStatus::NoOp,
+            AgentTaskOutcomeStatus::UnableToRemediate,
+            AgentTaskOutcomeStatus::ProviderError,
+            AgentTaskOutcomeStatus::Timeout,
+            AgentTaskOutcomeStatus::FollowUpIssue,
+        ];
+
+        for status in statuses {
+            let outcome = AgentTaskOutcome {
+                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: "task-1".to_string(),
+                status,
+                summary: Some("completed".to_string()),
+                failure_classification: match status {
+                    AgentTaskOutcomeStatus::ProviderError => {
+                        Some(AgentTaskFailureClassification::Provider)
+                    }
+                    AgentTaskOutcomeStatus::Timeout => {
+                        Some(AgentTaskFailureClassification::Timeout)
+                    }
+                    _ => None,
+                },
+                artifacts: vec![AgentTaskArtifact {
+                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                    id: "artifact-1".to_string(),
+                    kind: "patch".to_string(),
+                    name: Some("fix.patch".to_string()),
+                    path: Some("artifacts/fix.patch".to_string()),
+                    url: None,
+                    mime: Some("text/x-patch".to_string()),
+                    size_bytes: Some(128),
+                    sha256: Some("sha256:abc".to_string()),
+                    metadata: json!({}),
+                }],
+                evidence_refs: vec![AgentTaskEvidenceRef {
+                    kind: "log".to_string(),
+                    uri: "artifact://run/log".to_string(),
+                    label: Some("runner log".to_string()),
+                }],
+                diagnostics: vec![AgentTaskDiagnostic {
+                    class: "provider".to_string(),
+                    message: "provider returned retryable error".to_string(),
+                    data: json!({}),
+                }],
+                follow_up: Some(AgentTaskFollowUp {
+                    kind: "issue_report".to_string(),
+                    title: "Needs human decision".to_string(),
+                    body: Some("The requested fix needs product direction.".to_string()),
+                    uri: None,
+                }),
+                metadata: json!({}),
+            };
+
+            let value = serde_json::to_value(&outcome).expect("serialize outcome");
+            let decoded: AgentTaskOutcome = serde_json::from_value(value).expect("decode outcome");
+
+            assert_eq!(decoded, outcome);
+            assert_eq!(decoded.schema, AGENT_TASK_OUTCOME_SCHEMA);
+            assert_eq!(decoded.artifacts[0].schema, AGENT_TASK_ARTIFACT_SCHEMA);
+        }
+    }
+
+    #[test]
+    fn redacted_request_removes_sensitive_fields() {
+        let request = AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "task-secret".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "cli_agent".to_string(),
+                selector: None,
+                required_capabilities: Vec::new(),
+                model: None,
+                config: json!({ "api_key": "secret-value" }),
+            },
+            instructions: "Use token=abc123 while testing.".to_string(),
+            inputs: json!({ "authorization": "Bearer abc123", "safe": "value" }),
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace::default(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            metadata: json!({ "refresh_token": "secret-refresh" }),
+        };
+
+        let redacted = serde_json::to_value(request.redacted()).expect("redacted json");
+
+        assert!(!redacted.to_string().contains("secret-value"));
+        assert!(!redacted.to_string().contains("abc123"));
+        assert!(!redacted.to_string().contains("secret-refresh"));
+        assert_eq!(redacted["inputs"]["safe"], json!("value"));
+    }
+
+    #[test]
+    fn redacted_outcome_removes_sensitive_artifact_and_diagnostic_data() {
+        let outcome = AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: "task-secret".to_string(),
+            status: AgentTaskOutcomeStatus::Failed,
+            summary: Some("failed with password=hunter2".to_string()),
+            failure_classification: Some(AgentTaskFailureClassification::ExecutionFailed),
+            artifacts: vec![AgentTaskArtifact {
+                schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                id: "log".to_string(),
+                kind: "log".to_string(),
+                name: None,
+                path: None,
+                url: Some("https://example.test/log?token=abc123".to_string()),
+                mime: None,
+                size_bytes: None,
+                sha256: None,
+                metadata: json!({ "cookie": "session=secret" }),
+            }],
+            evidence_refs: Vec::new(),
+            diagnostics: vec![AgentTaskDiagnostic {
+                class: "provider".to_string(),
+                message: "Authorization: Bearer abc123".to_string(),
+                data: json!({ "client_secret": "secret" }),
+            }],
+            follow_up: None,
+            metadata: json!({ "safe": "value", "password": "hunter2" }),
+        };
+
+        let redacted = serde_json::to_value(outcome.redacted()).expect("redacted json");
+
+        assert!(!redacted.to_string().contains("hunter2"));
+        assert!(!redacted.to_string().contains("abc123"));
+        assert!(!redacted.to_string().contains("session=secret"));
+        assert_eq!(redacted["metadata"]["safe"], json!("value"));
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,7 @@
 // Public extensions (config first — exports entity_crud! macro used by entity extensions)
 #[macro_use]
 pub mod config;
+pub mod agent_task;
 pub mod api_jobs;
 pub mod artifact_manifest;
 pub(crate) mod artifact_metadata;


### PR DESCRIPTION
## Summary
- Add core-owned `agent_task` request, outcome, and artifact schema constants/types for provider-agnostic fan-out work.
- Cover executor selection, capabilities, instructions, source refs, workspace materialization, read/write/apply policy, limits, expected artifacts, evidence, diagnostics, failure classifications, and follow-up issue outcomes.
- Add round-trip tests plus sensitive-field redaction tests for request/outcome shapes.

Closes #3207.

## Testing
- `cargo fmt --check`
- `cargo check`
- `cargo test agent_task --lib`
- `homeboy audit --path . --changed-since origin/main --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Schema implementation, tests, and verification; Chris remains responsible for review and merge.