### PR TITLE
Define agent task executor adapter contract

### DIFF
--- a/docs/architecture/agent-task-executor-adapter.md
+++ b/docs/architecture/agent-task-executor-adapter.md
@@ -1,0 +1,75 @@
+# Agent task executor adapter
+
+Agent task executor adapters are the boundary between Homeboy core and the
+systems that actually run agent work. Core owns the provider-neutral request,
+outcome, artifact, and lifecycle types in `src/core/agent_task.rs`; concrete
+backends own launch mechanics, credentials, process/session IDs, and provider
+payload parsing.
+
+## Contract
+
+Implement `AgentTaskExecutorAdapter` for a backend and pass that adapter to the
+scheduler or fan-out coordinator that dispatches an `AgentTaskRequest`.
+
+Adapters provide these operations:
+
+- `capabilities()` returns the backend name, selector, and supported lifecycle
+  features.
+- `validate(request)` checks backend-specific policy and required capabilities.
+- `prepare_workspace(request)` creates or resolves the workspace the backend can
+  operate on.
+- `start_task(request, workspace)` starts the work and may return an immediate
+  `AgentTaskOutcome` for synchronous backends.
+- `poll_progress(handle)` returns async progress, stream events, provider
+  payloads, or a terminal outcome.
+- `cancel_task(handle)` stops unfinished async work when the poll budget is
+  exhausted or a caller aborts the task.
+- `collect_artifacts(handle)` returns normalized `AgentTaskArtifact` records.
+- `normalize_outcome(request, handle, provider_payload)` converts backend output
+  into an `AgentTaskOutcome`.
+
+## Backend ownership
+
+Core should only see generic task types and adapter trait objects. Backend
+details stay with the component that knows how to run that backend.
+
+| Backend | Adapter owner | Core-facing backend string |
+|---------|---------------|----------------------------|
+| WP Codebox | Homeboy Extensions WordPress integration | `codebox` |
+| CLI/OpenCode session | Local CLI/session integration | `cli` or `opencode` |
+| Remote runner job | Runner/job integration | `runner` |
+
+The string values are selectors, not an enum in core. This keeps core open to
+new backends without adding provider-specific variants.
+
+## Registration
+
+Extensions register an adapter by exposing an implementation of
+`AgentTaskExecutorAdapter` to the scheduler or fan-out coordinator that owns the
+task batch. The coordinator selects an adapter by matching
+`AgentTaskRequest.executor.backend`, optional `selector`, and
+`required_capabilities` against `AgentTaskExecutorCapabilities`.
+
+Adapters should reject incompatible requests in `validate()` with
+`AgentTaskFailureClassification::CapabilityMissing`, `PolicyDenied`, or
+`InvalidInput` so callers get normalized failure classes.
+
+## Sync and async completion
+
+`start_task()` supports both execution styles:
+
+- Synchronous adapters return `AgentTaskStart { outcome: Some(...) }`.
+- Async adapters return a handle and expose progress through `poll_progress()`.
+
+When polling reaches a terminal state with a provider payload, the scheduler
+calls `normalize_outcome()` and appends `collect_artifacts()` output. If polling
+exceeds the scheduler's configured poll budget, the scheduler calls
+`cancel_task()` and returns that normalized cancellation outcome.
+
+## Provider payloads
+
+Provider payloads are intentionally opaque `serde_json::Value` objects until
+they reach the owning adapter. Core stores, forwards, and redacts generic task
+structures; adapters are responsible for interpreting backend-specific payloads
+and returning normalized Homeboy artifacts, diagnostics, evidence refs, and
+status values.

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ Internal system architecture and internals:
 - [Release pipeline system](architecture/release-pipeline.md) - Local release orchestration
 - [Planned change execution](architecture/planned-change-execution.md) - Core lifecycle vocabulary for plan, execute, artifact, approve, apply, and publish
 - [Apply and publish contract](architecture/apply-publish-contract.md) - Local apply boundary and post-apply publish semantics
+- [Agent task executor adapter](architecture/agent-task-executor-adapter.md) - Provider-neutral adapter boundary for Codebox, CLI/OpenCode, and runner backends
 - [Scope model](architecture/scope-model.md) - Components, targets/projects, rigs, fleets, workspace, and paths
 - [Execution context](architecture/execution-context.md) - Runtime context for extensions
 - [Rig matrix axis composition](architecture/rig-matrix-axis-composition.md) - Design for derived rig variants

--- a/src/core/agent_task.rs
+++ b/src/core/agent_task.rs
@@ -8,6 +8,215 @@ pub const AGENT_TASK_REQUEST_SCHEMA: &str = "homeboy/agent-task-request/v1";
 pub const AGENT_TASK_OUTCOME_SCHEMA: &str = "homeboy/agent-task-outcome/v1";
 pub const AGENT_TASK_ARTIFACT_SCHEMA: &str = "homeboy/agent-task-artifact/v1";
 
+/// Provider-neutral executor adapter contract for agent task backends.
+///
+/// Core owns the task and outcome schemas plus this lifecycle boundary. Runtime
+/// integrations provide concrete adapters that validate capabilities, prepare a
+/// workspace, start execution, poll async work, cancel in-flight handles, collect
+/// artifacts, and translate provider payloads into [`AgentTaskOutcome`].
+/// Extensions register adapters by exposing a value that implements this trait
+/// to the scheduler or fan-out coordinator that owns dispatch for a task batch.
+pub trait AgentTaskExecutorAdapter {
+    fn capabilities(&self) -> AgentTaskExecutorCapabilities;
+
+    fn validate(&self, request: &AgentTaskRequest) -> AgentTaskExecutorResult<()>;
+
+    fn prepare_workspace(
+        &mut self,
+        request: &AgentTaskRequest,
+    ) -> AgentTaskExecutorResult<AgentTaskPreparedWorkspace>;
+
+    fn start_task(
+        &mut self,
+        request: &AgentTaskRequest,
+        workspace: &AgentTaskPreparedWorkspace,
+    ) -> AgentTaskExecutorResult<AgentTaskStart>;
+
+    fn poll_progress(
+        &mut self,
+        handle: &AgentTaskExecutionHandle,
+    ) -> AgentTaskExecutorResult<AgentTaskProgress>;
+
+    fn cancel_task(
+        &mut self,
+        handle: &AgentTaskExecutionHandle,
+    ) -> AgentTaskExecutorResult<AgentTaskOutcome>;
+
+    fn collect_artifacts(
+        &mut self,
+        handle: &AgentTaskExecutionHandle,
+    ) -> AgentTaskExecutorResult<Vec<AgentTaskArtifact>>;
+
+    fn normalize_outcome(
+        &self,
+        request: &AgentTaskRequest,
+        handle: &AgentTaskExecutionHandle,
+        provider_payload: Value,
+    ) -> AgentTaskExecutorResult<AgentTaskOutcome>;
+}
+
+pub type AgentTaskExecutorResult<T> = std::result::Result<T, AgentTaskExecutorError>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskExecutorCapabilities {
+    pub backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub supports_sync_completion: bool,
+    #[serde(default)]
+    pub supports_async_polling: bool,
+    #[serde(default)]
+    pub supports_streaming: bool,
+    #[serde(default)]
+    pub supports_cancel: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskPreparedWorkspace {
+    pub mode: AgentTaskWorkspaceMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root: Option<String>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskExecutionHandle {
+    pub task_id: String,
+    pub backend: String,
+    pub run_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_uri: Option<String>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskStart {
+    pub handle: AgentTaskExecutionHandle,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<AgentTaskOutcome>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskProgress {
+    pub handle: AgentTaskExecutionHandle,
+    pub state: AgentTaskExecutionState,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub events: Vec<AgentTaskProgressEvent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_payload: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<AgentTaskOutcome>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskExecutionState {
+    Queued,
+    Running,
+    Waiting,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+impl AgentTaskExecutionState {
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Succeeded | Self::Failed | Self::Cancelled)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskProgressEvent {
+    pub kind: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub data: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskExecutorError {
+    pub classification: AgentTaskFailureClassification,
+    pub message: String,
+}
+
+impl AgentTaskExecutorError {
+    pub fn new(classification: AgentTaskFailureClassification, message: impl Into<String>) -> Self {
+        Self {
+            classification,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for AgentTaskExecutorError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}", self.message)
+    }
+}
+
+impl std::error::Error for AgentTaskExecutorError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg(test)]
+pub struct AgentTaskSchedulerOptions {
+    pub max_polls: usize,
+}
+
+#[cfg(test)]
+impl Default for AgentTaskSchedulerOptions {
+    fn default() -> Self {
+        Self { max_polls: 1 }
+    }
+}
+
+#[cfg(test)]
+fn execute_agent_task_with_adapter(
+    adapter: &mut dyn AgentTaskExecutorAdapter,
+    request: &AgentTaskRequest,
+    options: AgentTaskSchedulerOptions,
+) -> AgentTaskExecutorResult<AgentTaskOutcome> {
+    adapter.validate(request)?;
+    let workspace = adapter.prepare_workspace(request)?;
+    let start = adapter.start_task(request, &workspace)?;
+
+    if let Some(outcome) = start.outcome {
+        return Ok(outcome);
+    }
+
+    let mut handle = start.handle;
+
+    for _ in 0..options.max_polls {
+        let progress = adapter.poll_progress(&handle)?;
+        handle = progress.handle.clone();
+
+        if let Some(outcome) = progress.outcome {
+            return Ok(outcome);
+        }
+
+        if progress.state.is_terminal() {
+            if let Some(provider_payload) = progress.provider_payload {
+                let mut outcome = adapter.normalize_outcome(request, &handle, provider_payload)?;
+                let mut artifacts = adapter.collect_artifacts(&handle)?;
+                outcome.artifacts.append(&mut artifacts);
+                return Ok(outcome);
+            }
+
+            return Err(AgentTaskExecutorError::new(
+                AgentTaskFailureClassification::ExecutionFailed,
+                "executor reached a terminal state without an outcome",
+            ));
+        }
+    }
+
+    let outcome = adapter.cancel_task(&handle)?;
+    Ok(outcome)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskRequest {
     #[serde(default = "request_schema")]
@@ -481,5 +690,349 @@ mod tests {
         assert!(!redacted.to_string().contains("abc123"));
         assert!(!redacted.to_string().contains("session=secret"));
         assert_eq!(redacted["metadata"]["safe"], json!("value"));
+    }
+
+    #[test]
+    fn executor_contract_round_trips_provider_neutral_lifecycle_shapes() {
+        let capabilities = AgentTaskExecutorCapabilities {
+            backend: "local_session".to_string(),
+            selector: Some("default".to_string()),
+            capabilities: vec!["workspace_write".to_string(), "artifacts".to_string()],
+            supports_sync_completion: true,
+            supports_async_polling: true,
+            supports_streaming: true,
+            supports_cancel: true,
+        };
+
+        let handle = AgentTaskExecutionHandle {
+            task_id: "task-1".to_string(),
+            backend: capabilities.backend.clone(),
+            run_id: "run-1".to_string(),
+            stream_uri: Some("event://run-1".to_string()),
+            metadata: json!({ "attempt": 1 }),
+        };
+
+        let progress = AgentTaskProgress {
+            handle,
+            state: AgentTaskExecutionState::Running,
+            events: vec![AgentTaskProgressEvent {
+                kind: "log".to_string(),
+                message: "started".to_string(),
+                data: json!({ "sequence": 1 }),
+            }],
+            provider_payload: None,
+            outcome: None,
+        };
+
+        let encoded = serde_json::to_value((&capabilities, &progress)).expect("serialize");
+        let (decoded_capabilities, decoded_progress): (
+            AgentTaskExecutorCapabilities,
+            AgentTaskProgress,
+        ) = serde_json::from_value(encoded).expect("decode");
+
+        assert_eq!(decoded_capabilities, capabilities);
+        assert_eq!(decoded_progress, progress);
+        assert!(!decoded_progress.state.is_terminal());
+    }
+
+    #[test]
+    fn core_scheduler_uses_fake_adapter_for_async_task_completion() {
+        struct FakeAdapter {
+            polls: usize,
+        }
+
+        impl AgentTaskExecutorAdapter for FakeAdapter {
+            fn capabilities(&self) -> AgentTaskExecutorCapabilities {
+                AgentTaskExecutorCapabilities {
+                    backend: "fake".to_string(),
+                    selector: None,
+                    capabilities: vec!["workspace_write".to_string()],
+                    supports_sync_completion: false,
+                    supports_async_polling: true,
+                    supports_streaming: false,
+                    supports_cancel: true,
+                }
+            }
+
+            fn validate(&self, request: &AgentTaskRequest) -> AgentTaskExecutorResult<()> {
+                if request.executor.backend == self.capabilities().backend {
+                    Ok(())
+                } else {
+                    Err(AgentTaskExecutorError::new(
+                        AgentTaskFailureClassification::InvalidInput,
+                        "request targets a different backend",
+                    ))
+                }
+            }
+
+            fn prepare_workspace(
+                &mut self,
+                request: &AgentTaskRequest,
+            ) -> AgentTaskExecutorResult<AgentTaskPreparedWorkspace> {
+                Ok(AgentTaskPreparedWorkspace {
+                    mode: request.workspace.mode,
+                    root: request.workspace.root.clone(),
+                    metadata: json!({ "prepared": true }),
+                })
+            }
+
+            fn start_task(
+                &mut self,
+                request: &AgentTaskRequest,
+                _workspace: &AgentTaskPreparedWorkspace,
+            ) -> AgentTaskExecutorResult<AgentTaskStart> {
+                Ok(AgentTaskStart {
+                    handle: AgentTaskExecutionHandle {
+                        task_id: request.task_id.clone(),
+                        backend: request.executor.backend.clone(),
+                        run_id: "fake-run".to_string(),
+                        stream_uri: None,
+                        metadata: json!({}),
+                    },
+                    outcome: None,
+                })
+            }
+
+            fn poll_progress(
+                &mut self,
+                handle: &AgentTaskExecutionHandle,
+            ) -> AgentTaskExecutorResult<AgentTaskProgress> {
+                self.polls += 1;
+                let state = if self.polls == 1 {
+                    AgentTaskExecutionState::Running
+                } else {
+                    AgentTaskExecutionState::Succeeded
+                };
+
+                Ok(AgentTaskProgress {
+                    handle: handle.clone(),
+                    state,
+                    events: Vec::new(),
+                    provider_payload: state.is_terminal().then(|| json!({ "summary": "fixed" })),
+                    outcome: None,
+                })
+            }
+
+            fn cancel_task(
+                &mut self,
+                handle: &AgentTaskExecutionHandle,
+            ) -> AgentTaskExecutorResult<AgentTaskOutcome> {
+                Ok(AgentTaskOutcome {
+                    schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: handle.task_id.clone(),
+                    status: AgentTaskOutcomeStatus::Cancelled,
+                    summary: Some("cancelled after poll budget".to_string()),
+                    failure_classification: None,
+                    artifacts: Vec::new(),
+                    evidence_refs: Vec::new(),
+                    diagnostics: Vec::new(),
+                    follow_up: None,
+                    metadata: json!({}),
+                })
+            }
+
+            fn collect_artifacts(
+                &mut self,
+                _handle: &AgentTaskExecutionHandle,
+            ) -> AgentTaskExecutorResult<Vec<AgentTaskArtifact>> {
+                Ok(vec![AgentTaskArtifact {
+                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                    id: "patch".to_string(),
+                    kind: "patch".to_string(),
+                    name: Some("changes.patch".to_string()),
+                    path: Some("artifacts/changes.patch".to_string()),
+                    url: None,
+                    mime: Some("text/x-patch".to_string()),
+                    size_bytes: Some(42),
+                    sha256: None,
+                    metadata: json!({}),
+                }])
+            }
+
+            fn normalize_outcome(
+                &self,
+                request: &AgentTaskRequest,
+                _handle: &AgentTaskExecutionHandle,
+                provider_payload: Value,
+            ) -> AgentTaskExecutorResult<AgentTaskOutcome> {
+                Ok(AgentTaskOutcome {
+                    schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: request.task_id.clone(),
+                    status: AgentTaskOutcomeStatus::Succeeded,
+                    summary: provider_payload["summary"].as_str().map(str::to_string),
+                    failure_classification: None,
+                    artifacts: Vec::new(),
+                    evidence_refs: Vec::new(),
+                    diagnostics: Vec::new(),
+                    follow_up: None,
+                    metadata: json!({}),
+                })
+            }
+        }
+
+        let request = AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "task-async".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "fake".to_string(),
+                selector: None,
+                required_capabilities: Vec::new(),
+                model: None,
+                config: json!({}),
+            },
+            instructions: "Make the scoped change.".to_string(),
+            inputs: json!({}),
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace::default(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            metadata: json!({}),
+        };
+
+        let mut adapter = FakeAdapter { polls: 0 };
+        let outcome = execute_agent_task_with_adapter(
+            &mut adapter,
+            &request,
+            AgentTaskSchedulerOptions { max_polls: 2 },
+        )
+        .expect("task executes");
+
+        assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
+        assert_eq!(outcome.summary.as_deref(), Some("fixed"));
+        assert_eq!(outcome.artifacts.len(), 1);
+        assert_eq!(adapter.polls, 2);
+    }
+
+    #[test]
+    fn core_scheduler_cancels_when_async_poll_budget_is_exhausted() {
+        struct NeverFinishesAdapter;
+
+        impl AgentTaskExecutorAdapter for NeverFinishesAdapter {
+            fn capabilities(&self) -> AgentTaskExecutorCapabilities {
+                AgentTaskExecutorCapabilities {
+                    backend: "fake".to_string(),
+                    selector: None,
+                    capabilities: Vec::new(),
+                    supports_sync_completion: false,
+                    supports_async_polling: true,
+                    supports_streaming: false,
+                    supports_cancel: true,
+                }
+            }
+
+            fn validate(&self, _request: &AgentTaskRequest) -> AgentTaskExecutorResult<()> {
+                Ok(())
+            }
+
+            fn prepare_workspace(
+                &mut self,
+                _request: &AgentTaskRequest,
+            ) -> AgentTaskExecutorResult<AgentTaskPreparedWorkspace> {
+                Ok(AgentTaskPreparedWorkspace {
+                    mode: AgentTaskWorkspaceMode::Ephemeral,
+                    root: None,
+                    metadata: json!({}),
+                })
+            }
+
+            fn start_task(
+                &mut self,
+                request: &AgentTaskRequest,
+                _workspace: &AgentTaskPreparedWorkspace,
+            ) -> AgentTaskExecutorResult<AgentTaskStart> {
+                Ok(AgentTaskStart {
+                    handle: AgentTaskExecutionHandle {
+                        task_id: request.task_id.clone(),
+                        backend: request.executor.backend.clone(),
+                        run_id: "run".to_string(),
+                        stream_uri: None,
+                        metadata: json!({}),
+                    },
+                    outcome: None,
+                })
+            }
+
+            fn poll_progress(
+                &mut self,
+                handle: &AgentTaskExecutionHandle,
+            ) -> AgentTaskExecutorResult<AgentTaskProgress> {
+                Ok(AgentTaskProgress {
+                    handle: handle.clone(),
+                    state: AgentTaskExecutionState::Running,
+                    events: Vec::new(),
+                    provider_payload: None,
+                    outcome: None,
+                })
+            }
+
+            fn cancel_task(
+                &mut self,
+                handle: &AgentTaskExecutionHandle,
+            ) -> AgentTaskExecutorResult<AgentTaskOutcome> {
+                Ok(AgentTaskOutcome {
+                    schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: handle.task_id.clone(),
+                    status: AgentTaskOutcomeStatus::Cancelled,
+                    summary: Some("cancelled".to_string()),
+                    failure_classification: None,
+                    artifacts: Vec::new(),
+                    evidence_refs: Vec::new(),
+                    diagnostics: Vec::new(),
+                    follow_up: None,
+                    metadata: json!({}),
+                })
+            }
+
+            fn collect_artifacts(
+                &mut self,
+                _handle: &AgentTaskExecutionHandle,
+            ) -> AgentTaskExecutorResult<Vec<AgentTaskArtifact>> {
+                Ok(Vec::new())
+            }
+
+            fn normalize_outcome(
+                &self,
+                _request: &AgentTaskRequest,
+                _handle: &AgentTaskExecutionHandle,
+                _provider_payload: Value,
+            ) -> AgentTaskExecutorResult<AgentTaskOutcome> {
+                unreachable!("running progress should not normalize")
+            }
+        }
+
+        let request = AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "task-timeout".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "fake".to_string(),
+                selector: None,
+                required_capabilities: Vec::new(),
+                model: None,
+                config: json!({}),
+            },
+            instructions: "Run until cancelled.".to_string(),
+            inputs: json!({}),
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace::default(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            metadata: json!({}),
+        };
+
+        let mut adapter = NeverFinishesAdapter;
+        let outcome = execute_agent_task_with_adapter(
+            &mut adapter,
+            &request,
+            AgentTaskSchedulerOptions { max_polls: 1 },
+        )
+        .expect("task cancels");
+
+        assert_eq!(outcome.status, AgentTaskOutcomeStatus::Cancelled);
     }
 }


### PR DESCRIPTION
## Summary
- Define the provider-neutral `AgentTaskExecutorAdapter` contract and lifecycle data shapes for Codebox, CLI/OpenCode, and runner-style backends.
- Add fake-adapter scheduler tests covering async completion, artifact collection, cancellation, and lifecycle shape round-tripping.
- Document adapter ownership, registration, sync/async completion, and provider payload normalization.

Closes #3209.

## Testing
- `cargo fmt --check`
- `cargo check`
- `cargo test agent_task --lib`
- `homeboy audit --path . --changed-since origin/main --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Contract implementation, tests, documentation, and verification; Chris remains responsible for review and merge.