### PR TITLE
Keep archive header verification core-agnostic

### DIFF
--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -280,6 +280,7 @@ fn archive_install_override(policy: &DeployArchiveInstallPolicy) -> DeployOverri
 
 fn archive_install_verification(policy: &DeployArchiveInstallPolicy) -> Option<DeployVerification> {
     let header = policy.required_header.as_ref()?;
+    let contains = shell::quote_arg(&header.contains);
     let selector = if let Some(file) = header.file.as_deref() {
         format!(
             "candidate=$(printf '%s\\n' \"$entries\" | awk -v required={} '{{ slash = index($0, \"/\"); rel = slash ? substr($0, slash + 1) : $0; if (rel == required) {{ print $0; exit }} }}')",
@@ -288,8 +289,9 @@ fn archive_install_verification(policy: &DeployArchiveInstallPolicy) -> Option<D
     } else if let Some(file_glob) = header.file_glob.as_deref() {
         let file_regex = glob_to_awk_regex(file_glob);
         format!(
-            "candidate=$(printf '%s\\n' \"$entries\" | awk -v pattern={} '{{ slash = index($0, \"/\"); rel = slash ? substr($0, slash + 1) : $0; count = split(rel, parts, \"/\"); base = parts[count]; if (base ~ pattern) {{ print $0; exit }} }}')",
-            shell::quote_arg(&file_regex)
+            "candidate=$(printf '%s\\n' \"$entries\" | awk -v pattern={} '{{ slash = index($0, \"/\"); rel = slash ? substr($0, slash + 1) : $0; count = split(rel, parts, \"/\"); base = parts[count]; if (base ~ pattern) {{ print $0 }} }}' | while IFS= read -r entry; do unzip -p \"{{{{stagingArtifact}}}}\" \"$entry\" 2>/dev/null | grep -F -q {} && {{ printf '%s\\n' \"$entry\"; break; }}; done)",
+            shell::quote_arg(&file_regex),
+            contains
         )
     } else {
         return None;
@@ -300,8 +302,6 @@ fn archive_install_verification(policy: &DeployArchiveInstallPolicy) -> Option<D
     } else {
         ""
     };
-    let contains = shell::quote_arg(&header.contains);
-
     Some(DeployVerification {
         path_pattern: policy.path_pattern.clone(),
         verify_command: Some(format!(
@@ -819,6 +819,56 @@ mod tests {
         assert!(target.join("fixture.php").exists());
         assert!(!target.join("stale.php").exists());
         assert!(!staging.join("fixture.zip").exists());
+    }
+
+    #[test]
+    fn test_archive_install_policy_finds_plugin_header_after_nested_php() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let artifact = temp.path().join("fixture.zip");
+        let staging = temp.path().join("staging");
+        let target = temp.path().join("wp-content/plugins/fixture");
+
+        write_zip(
+            &artifact,
+            &[
+                (
+                    "fixture/inc/helpers.php",
+                    "<?php
+function fixture_helper() {}
+",
+                ),
+                (
+                    "fixture/fixture.php",
+                    "<?php
+/*
+Plugin Name: Fixture
+*/
+",
+                ),
+            ],
+        );
+
+        let policy = plugin_archive_policy(staging.to_string_lossy().to_string());
+        let override_config = archive_install_override(&policy);
+        let verification = archive_install_verification(&policy).expect("verification");
+
+        let result = deploy_with_override(
+            &local_client(),
+            &artifact,
+            target.to_str().expect("target path"),
+            &override_config,
+            &extension(),
+            Some(&verification),
+            Some(temp.path().to_str().expect("site root")),
+            None,
+            None,
+            None,
+        )
+        .expect("deploy result");
+
+        assert!(result.success, "deploy failed: {:?}", result.error);
+        assert!(target.join("fixture.php").exists());
+        assert!(target.join("inc/helpers.php").exists());
     }
 
     #[test]

--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -280,7 +280,6 @@ fn archive_install_override(policy: &DeployArchiveInstallPolicy) -> DeployOverri
 
 fn archive_install_verification(policy: &DeployArchiveInstallPolicy) -> Option<DeployVerification> {
     let header = policy.required_header.as_ref()?;
-    let contains = shell::quote_arg(&header.contains);
     let selector = if let Some(file) = header.file.as_deref() {
         format!(
             "candidate=$(printf '%s\\n' \"$entries\" | awk -v required={} '{{ slash = index($0, \"/\"); rel = slash ? substr($0, slash + 1) : $0; if (rel == required) {{ print $0; exit }} }}')",
@@ -289,9 +288,8 @@ fn archive_install_verification(policy: &DeployArchiveInstallPolicy) -> Option<D
     } else if let Some(file_glob) = header.file_glob.as_deref() {
         let file_regex = glob_to_awk_regex(file_glob);
         format!(
-            "candidate=$(printf '%s\\n' \"$entries\" | awk -v pattern={} '{{ slash = index($0, \"/\"); rel = slash ? substr($0, slash + 1) : $0; count = split(rel, parts, \"/\"); base = parts[count]; if (base ~ pattern) {{ print $0 }} }}' | while IFS= read -r entry; do unzip -p \"{{{{stagingArtifact}}}}\" \"$entry\" 2>/dev/null | grep -F -q {} && {{ printf '%s\\n' \"$entry\"; break; }}; done)",
-            shell::quote_arg(&file_regex),
-            contains
+            "candidate=$(printf '%s\\n' \"$entries\" | awk -v pattern={} '{{ slash = index($0, \"/\"); rel = slash ? substr($0, slash + 1) : $0; count = split(rel, parts, \"/\"); base = parts[count]; if (base ~ pattern) {{ print $0; exit }} }}')",
+            shell::quote_arg(&file_regex)
         )
     } else {
         return None;
@@ -302,6 +300,8 @@ fn archive_install_verification(policy: &DeployArchiveInstallPolicy) -> Option<D
     } else {
         ""
     };
+    let contains = shell::quote_arg(&header.contains);
+
     Some(DeployVerification {
         path_pattern: policy.path_pattern.clone(),
         verify_command: Some(format!(
@@ -483,6 +483,11 @@ fn deploy_override_template_vars(
         .rsplit_once('/')
         .map(|(parent, _)| parent)
         .unwrap_or("");
+    let target_basename = target_dir
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .unwrap_or("");
     let target_adjacent_temp_pattern = if target_parent_dir.is_empty() {
         String::new()
     } else {
@@ -493,6 +498,10 @@ fn deploy_override_template_vars(
         ("artifact".to_string(), artifact_filename.to_string()),
         ("stagingArtifact".to_string(), staging_artifact.to_string()),
         (TemplateVars::TARGET_DIR.to_string(), target_dir.to_string()),
+        (
+            TemplateVars::TARGET_BASENAME.to_string(),
+            target_basename.to_string(),
+        ),
         (
             TemplateVars::TARGET_PARENT_DIR.to_string(),
             target_parent_dir.to_string(),
@@ -619,8 +628,8 @@ mod tests {
             staging_path,
             root_must_match_target_basename: true,
             required_header: Some(DeployRequiredHeader {
-                file: None,
-                file_glob: Some("*.php".to_string()),
+                file: Some("{{targetBasename}}.php".to_string()),
+                file_glob: None,
                 contains: "Plugin Name:".to_string(),
             }),
             skip_permissions_fix: true,
@@ -688,7 +697,7 @@ mod tests {
                     pattern: Some(r#""version":\s*"([0-9.]+)""#.to_string()),
                 },
                 VersionTarget {
-                    file: "packages/wordpress-plugin/fixture.php".to_string(),
+                    file: "packages/component/fixture.php".to_string(),
                     pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
                 },
             ]),
@@ -970,6 +979,10 @@ Plugin Name: Fixture
             vars.get(TemplateVars::TARGET_ADJACENT_TEMP_PATTERN)
                 .map(String::as_str),
             Some("/srv/htdocs/wp-content/plugins/.homeboy-install.XXXXXX")
+        );
+        assert_eq!(
+            vars.get(TemplateVars::TARGET_BASENAME).map(String::as_str),
+            Some("wp-codebox")
         );
         assert_eq!(
             render_map(

--- a/src/core/engine/template.rs
+++ b/src/core/engine/template.rs
@@ -14,6 +14,7 @@ impl TemplateVars {
     pub const QUERY: &'static str = "query";
     pub const FORMAT: &'static str = "format";
     pub const TARGET_DIR: &'static str = "targetDir";
+    pub const TARGET_BASENAME: &'static str = "targetBasename";
     pub const TARGET_PARENT_DIR: &'static str = "targetParentDir";
     pub const TARGET_ADJACENT_TEMP_PATTERN: &'static str = "targetAdjacentTempPattern";
     pub const DB_HOST: &'static str = "db_host";


### PR DESCRIPTION
## Summary
- Adds a generic deploy template variable, `{{targetBasename}}`, for archive install policies that need target-derived filenames.
- Keeps Homeboy core archive verification generic: `file` and `file_glob` select configured archive entries, while `contains` only verifies the selected installed file.
- Moves the WordPress plugin header selector to the WordPress extension config in companion PR Extra-Chill/homeboy-extensions#970.

## Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo test core::deploy::version_overrides`
- `cargo test --test core_agnostic_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Reworked the archive verification fix to preserve the core-agnostic boundary, updated targeted tests, and ran focused validation. Chris remains responsible for review and merge.