### PR TITLE
Add agent task matrix fan-out plan

### DIFF
--- a/docs/architecture/rig-matrix-axis-composition.md
+++ b/docs/architecture/rig-matrix-axis-composition.md
@@ -174,6 +174,14 @@ Rules:
   to one base rig at a time; mixing explicit cross-rig lists with cartesian
   expansion is a later design if a real use case appears.
 
+For agent-runner fan-out, matrix expansion should also be representable as a
+generic `core::agent_task` plan. The plan-only shape is
+`homeboy/agent-task-matrix-plan/v1`: each cartesian cell becomes an
+`AgentTaskRequest` with stable `task_id`, `parent_plan_id`, `group_key`, and
+matrix axis metadata. Once the generic scheduler and executor adapter contracts
+from #3208 and #3209 exist, that same plan is the handoff boundary for executing
+cells without adding a bench-specific scheduler.
+
 ## Derived Rig Identity
 
 Derived rigs are ephemeral values, but they need stable ids for output, state,

--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -70,6 +70,10 @@ the other capabilities.
 - `--rig-concurrency <N>`: For multi-rig comparisons, run up to `N` rigs
   concurrently. Default `1` preserves sequential CI behavior. Values greater
   than `1` are opt-in and preserve output ordering by the selected rig order.
+- Future `--matrix <axis=value[,value...]>` expansion should use the generic
+  `core::agent_task` matrix plan schema for plan inspection and fan-out. The
+  scheduler/executor pieces are tracked separately so bench does not grow its
+  own task runner.
 - `--scenario <SCENARIO_ID>`: Run or list only the exact scenario id. May
   be repeated. Homeboy validates selected ids against discovery before
   execution and forwards the comma-separated selector to runners via

--- a/src/core/agent_task.rs
+++ b/src/core/agent_task.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
+use std::collections::{BTreeMap, BTreeSet};
 
 #[cfg(test)]
 use crate::core::redaction::RedactionPolicy;
@@ -8,6 +9,8 @@ pub const AGENT_TASK_REQUEST_SCHEMA: &str = "homeboy/agent-task-request/v1";
 pub const AGENT_TASK_OUTCOME_SCHEMA: &str = "homeboy/agent-task-outcome/v1";
 pub const AGENT_TASK_ARTIFACT_SCHEMA: &str = "homeboy/agent-task-artifact/v1";
 pub const AGENT_TASK_WORKFLOW_SCHEMA: &str = "homeboy/agent-task-workflow/v1";
+pub const AGENT_TASK_MATRIX_PLAN_SCHEMA: &str = "homeboy/agent-task-matrix-plan/v1";
+pub const AGENT_TASK_MATRIX_AGGREGATE_SCHEMA: &str = "homeboy/agent-task-matrix-aggregate/v1";
 
 /// Provider-neutral executor adapter contract for agent task backends.
 ///
@@ -590,6 +593,160 @@ impl AgentTaskWorkflowStepSuggestion {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskMatrixAxis {
+    pub name: String,
+    pub values: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskMatrixPlan {
+    #[serde(default = "matrix_plan_schema")]
+    pub schema: String,
+    pub plan_id: String,
+    pub axes: Vec<AgentTaskMatrixAxis>,
+    pub cells: Vec<AgentTaskMatrixCell>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskMatrixCell {
+    pub cell_id: String,
+    pub axes: BTreeMap<String, String>,
+    pub task: AgentTaskRequest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskMatrixAggregate {
+    #[serde(default = "matrix_aggregate_schema")]
+    pub schema: String,
+    pub plan_id: String,
+    pub passed: bool,
+    pub cells: Vec<AgentTaskMatrixAggregateCell>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskMatrixAggregateCell {
+    pub cell_id: String,
+    pub task_id: String,
+    pub axes: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<AgentTaskOutcomeStatus>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<AgentTaskArtifact>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence_refs: Vec<AgentTaskEvidenceRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<AgentTaskDiagnostic>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentTaskMatrixError {
+    pub message: String,
+}
+
+impl AgentTaskMatrixError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for AgentTaskMatrixError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for AgentTaskMatrixError {}
+
+pub(crate) fn expand_agent_task_matrix(
+    plan_id: impl Into<String>,
+    axes: Vec<AgentTaskMatrixAxis>,
+    template: AgentTaskRequest,
+) -> Result<AgentTaskMatrixPlan, AgentTaskMatrixError> {
+    let plan_id = plan_id.into();
+    validate_matrix_id("plan id", &plan_id)?;
+    validate_axes(&axes)?;
+
+    let mut combinations = Vec::new();
+    collect_matrix_combinations(&axes, 0, &mut BTreeMap::new(), &mut combinations);
+
+    let cells = combinations
+        .into_iter()
+        .map(|selection| {
+            let cell_id = matrix_cell_id(&plan_id, &axes, &selection);
+            let mut task = template.clone();
+            task.task_id = cell_id.clone();
+            task.parent_plan_id = Some(plan_id.clone());
+            task.group_key.get_or_insert_with(|| plan_id.clone());
+            task.metadata = metadata_with_matrix(task.metadata, &cell_id, &selection);
+            AgentTaskMatrixCell {
+                cell_id,
+                axes: selection,
+                task,
+            }
+        })
+        .collect();
+
+    Ok(AgentTaskMatrixPlan {
+        schema: AGENT_TASK_MATRIX_PLAN_SCHEMA.to_string(),
+        plan_id,
+        axes,
+        cells,
+    })
+}
+
+impl AgentTaskMatrixAggregate {
+    pub(crate) fn from_outcomes(plan: &AgentTaskMatrixPlan, outcomes: &[AgentTaskOutcome]) -> Self {
+        let outcomes_by_task: BTreeMap<&str, &AgentTaskOutcome> = outcomes
+            .iter()
+            .map(|outcome| (outcome.task_id.as_str(), outcome))
+            .collect();
+        let mut passed = true;
+        let cells = plan
+            .cells
+            .iter()
+            .map(|cell| {
+                let outcome = outcomes_by_task.get(cell.task.task_id.as_str()).copied();
+                if !matches!(
+                    outcome.map(|outcome| outcome.status),
+                    Some(AgentTaskOutcomeStatus::Succeeded | AgentTaskOutcomeStatus::NoOp)
+                ) {
+                    passed = false;
+                }
+                AgentTaskMatrixAggregateCell {
+                    cell_id: cell.cell_id.clone(),
+                    task_id: cell.task.task_id.clone(),
+                    axes: cell.axes.clone(),
+                    status: outcome.map(|outcome| outcome.status),
+                    artifacts: outcome
+                        .map(|outcome| outcome.artifacts.clone())
+                        .unwrap_or_default(),
+                    evidence_refs: outcome
+                        .map(|outcome| outcome.evidence_refs.clone())
+                        .unwrap_or_default(),
+                    diagnostics: outcome
+                        .map(|outcome| outcome.diagnostics.clone())
+                        .unwrap_or_default(),
+                    metadata: outcome
+                        .map(|outcome| outcome.metadata.clone())
+                        .unwrap_or(Value::Null),
+                }
+            })
+            .collect();
+
+        Self {
+            schema: AGENT_TASK_MATRIX_AGGREGATE_SCHEMA.to_string(),
+            plan_id: plan.plan_id.clone(),
+            passed,
+            cells,
+        }
+    }
+}
+
 fn request_schema() -> String {
     AGENT_TASK_REQUEST_SCHEMA.to_string()
 }
@@ -606,6 +763,14 @@ fn workflow_schema() -> String {
     AGENT_TASK_WORKFLOW_SCHEMA.to_string()
 }
 
+fn matrix_plan_schema() -> String {
+    AGENT_TASK_MATRIX_PLAN_SCHEMA.to_string()
+}
+
+fn matrix_aggregate_schema() -> String {
+    AGENT_TASK_MATRIX_AGGREGATE_SCHEMA.to_string()
+}
+
 fn default_read_policy() -> String {
     "workspace".to_string()
 }
@@ -616,6 +781,123 @@ fn default_write_policy() -> String {
 
 fn default_apply_policy() -> String {
     "propose_only".to_string()
+}
+
+fn validate_axes(axes: &[AgentTaskMatrixAxis]) -> Result<(), AgentTaskMatrixError> {
+    if axes.is_empty() {
+        return Err(AgentTaskMatrixError::new(
+            "matrix expansion requires at least one axis",
+        ));
+    }
+
+    let mut names = BTreeSet::new();
+    for axis in axes {
+        validate_matrix_id("axis", &axis.name)?;
+        if !names.insert(axis.name.as_str()) {
+            return Err(AgentTaskMatrixError::new(format!(
+                "duplicate matrix axis '{}'",
+                axis.name
+            )));
+        }
+        if axis.values.is_empty() {
+            return Err(AgentTaskMatrixError::new(format!(
+                "matrix axis '{}' requires at least one value",
+                axis.name
+            )));
+        }
+        let mut values = BTreeSet::new();
+        for value in &axis.values {
+            validate_matrix_id("axis value", value)?;
+            if !values.insert(value.as_str()) {
+                return Err(AgentTaskMatrixError::new(format!(
+                    "duplicate value '{}' for matrix axis '{}'",
+                    value, axis.name
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_matrix_id(label: &str, value: &str) -> Result<(), AgentTaskMatrixError> {
+    if value.is_empty() {
+        return Err(AgentTaskMatrixError::new(format!(
+            "matrix {label} cannot be empty"
+        )));
+    }
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b'/'))
+    {
+        return Err(AgentTaskMatrixError::new(format!(
+            "matrix {label} '{value}' must contain only ASCII letters, numbers, '.', '_', '-', or '/'"
+        )));
+    }
+
+    Ok(())
+}
+
+fn collect_matrix_combinations(
+    axes: &[AgentTaskMatrixAxis],
+    index: usize,
+    current: &mut BTreeMap<String, String>,
+    combinations: &mut Vec<BTreeMap<String, String>>,
+) {
+    if index == axes.len() {
+        combinations.push(current.clone());
+        return;
+    }
+
+    let axis = &axes[index];
+    for value in &axis.values {
+        current.insert(axis.name.clone(), value.clone());
+        collect_matrix_combinations(axes, index + 1, current, combinations);
+    }
+    current.remove(&axis.name);
+}
+
+fn matrix_cell_id(
+    plan_id: &str,
+    axes: &[AgentTaskMatrixAxis],
+    selection: &BTreeMap<String, String>,
+) -> String {
+    let pairs = axes
+        .iter()
+        .map(|axis| {
+            let value = selection
+                .get(&axis.name)
+                .expect("selection populated from axis values");
+            format!("{}={}", axis.name, value)
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("{plan_id}[{pairs}]")
+}
+
+fn metadata_with_matrix(
+    metadata: Value,
+    cell_id: &str,
+    selection: &BTreeMap<String, String>,
+) -> Value {
+    let mut object = match metadata {
+        Value::Object(object) => object,
+        Value::Null => Map::new(),
+        other => {
+            let mut object = Map::new();
+            object.insert("base".to_string(), other);
+            object
+        }
+    };
+    object.insert(
+        "matrix_cell_id".to_string(),
+        Value::String(cell_id.to_string()),
+    );
+    object.insert(
+        "matrix".to_string(),
+        serde_json::to_value(selection).expect("matrix selection serializes"),
+    );
+    Value::Object(object)
 }
 
 #[cfg(test)]
@@ -1270,5 +1552,204 @@ mod tests {
         .expect("task cancels");
 
         assert_eq!(outcome.status, AgentTaskOutcomeStatus::Cancelled);
+    }
+
+    #[test]
+    fn matrix_expansion_builds_cartesian_agent_task_plan() {
+        let plan = expand_agent_task_matrix(
+            "bench/studio-web",
+            vec![
+                AgentTaskMatrixAxis {
+                    name: "model".to_string(),
+                    values: vec!["gpt-5.5".to_string(), "claude".to_string()],
+                },
+                AgentTaskMatrixAxis {
+                    name: "prompt".to_string(),
+                    values: vec!["site-a".to_string(), "site-b".to_string()],
+                },
+            ],
+            template_request(),
+        )
+        .expect("expand matrix");
+
+        assert_eq!(plan.schema, AGENT_TASK_MATRIX_PLAN_SCHEMA);
+        assert_eq!(plan.cells.len(), 4);
+        assert_eq!(
+            plan.cells
+                .iter()
+                .map(|cell| cell.cell_id.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "bench/studio-web[model=gpt-5.5,prompt=site-a]",
+                "bench/studio-web[model=gpt-5.5,prompt=site-b]",
+                "bench/studio-web[model=claude,prompt=site-a]",
+                "bench/studio-web[model=claude,prompt=site-b]",
+            ]
+        );
+        assert!(plan
+            .cells
+            .iter()
+            .all(|cell| cell.task.parent_plan_id.as_deref() == Some("bench/studio-web")));
+        assert_eq!(plan.cells[2].task.metadata["matrix"]["model"], "claude");
+        assert_eq!(plan.cells[2].task.metadata["matrix"]["prompt"], "site-a");
+    }
+
+    #[test]
+    fn matrix_expansion_rejects_invalid_axes() {
+        let error = expand_agent_task_matrix(
+            "bench-plan",
+            vec![AgentTaskMatrixAxis {
+                name: "bad,axis".to_string(),
+                values: vec!["site-a".to_string()],
+            }],
+            template_request(),
+        )
+        .expect_err("invalid axis fails");
+
+        assert!(error.message.contains("bad,axis"));
+
+        let error = expand_agent_task_matrix(
+            "bench-plan",
+            vec![AgentTaskMatrixAxis {
+                name: "prompt".to_string(),
+                values: Vec::new(),
+            }],
+            template_request(),
+        )
+        .expect_err("empty values fail");
+
+        assert!(error.message.contains("requires at least one value"));
+    }
+
+    #[test]
+    fn matrix_cell_ids_are_stable_across_input_order_noise() {
+        let first = expand_agent_task_matrix(
+            "bench-plan",
+            vec![
+                AgentTaskMatrixAxis {
+                    name: "model".to_string(),
+                    values: vec!["gpt".to_string(), "claude".to_string()],
+                },
+                AgentTaskMatrixAxis {
+                    name: "prompt".to_string(),
+                    values: vec!["site".to_string()],
+                },
+            ],
+            template_request(),
+        )
+        .expect("expand first");
+        let second = expand_agent_task_matrix(
+            "bench-plan",
+            vec![
+                AgentTaskMatrixAxis {
+                    name: "model".to_string(),
+                    values: vec!["gpt".to_string(), "claude".to_string()],
+                },
+                AgentTaskMatrixAxis {
+                    name: "prompt".to_string(),
+                    values: vec!["site".to_string()],
+                },
+            ],
+            template_request(),
+        )
+        .expect("expand second");
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn matrix_aggregate_preserves_partial_task_failure() {
+        let plan = expand_agent_task_matrix(
+            "bench-plan",
+            vec![AgentTaskMatrixAxis {
+                name: "model".to_string(),
+                values: vec!["gpt".to_string(), "claude".to_string()],
+            }],
+            template_request(),
+        )
+        .expect("expand matrix");
+
+        let aggregate = AgentTaskMatrixAggregate::from_outcomes(
+            &plan,
+            &[
+                AgentTaskOutcome {
+                    schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: plan.cells[0].task.task_id.clone(),
+                    status: AgentTaskOutcomeStatus::Succeeded,
+                    summary: Some("ok".to_string()),
+                    failure_classification: None,
+                    artifacts: vec![AgentTaskArtifact {
+                        schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                        id: "metrics".to_string(),
+                        kind: "json".to_string(),
+                        name: None,
+                        path: Some("artifacts/metrics.json".to_string()),
+                        url: None,
+                        mime: Some("application/json".to_string()),
+                        size_bytes: Some(64),
+                        sha256: None,
+                        metadata: json!({ "metric": "p95_ms" }),
+                    }],
+                    evidence_refs: Vec::new(),
+                    diagnostics: Vec::new(),
+                    follow_up: None,
+                    metadata: json!({ "p95_ms": 1200 }),
+                },
+                AgentTaskOutcome {
+                    schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: plan.cells[1].task.task_id.clone(),
+                    status: AgentTaskOutcomeStatus::Failed,
+                    summary: Some("runner failed".to_string()),
+                    failure_classification: Some(AgentTaskFailureClassification::ExecutionFailed),
+                    artifacts: Vec::new(),
+                    evidence_refs: Vec::new(),
+                    diagnostics: vec![AgentTaskDiagnostic {
+                        class: "runner".to_string(),
+                        message: "exit 1".to_string(),
+                        data: json!({}),
+                    }],
+                    follow_up: None,
+                    metadata: json!({}),
+                },
+            ],
+        );
+
+        assert_eq!(aggregate.schema, AGENT_TASK_MATRIX_AGGREGATE_SCHEMA);
+        assert!(!aggregate.passed);
+        assert_eq!(
+            aggregate.cells[0].status,
+            Some(AgentTaskOutcomeStatus::Succeeded)
+        );
+        assert_eq!(aggregate.cells[0].artifacts[0].id, "metrics");
+        assert_eq!(
+            aggregate.cells[1].status,
+            Some(AgentTaskOutcomeStatus::Failed)
+        );
+        assert_eq!(aggregate.cells[1].axes["model"], "claude");
+        assert_eq!(aggregate.cells[1].diagnostics[0].class, "runner");
+    }
+
+    fn template_request() -> AgentTaskRequest {
+        AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "template".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "runner".to_string(),
+                selector: Some("homeboy-lab".to_string()),
+                required_capabilities: vec!["bench".to_string()],
+                model: None,
+                config: json!({}),
+            },
+            instructions: "Run the selected bench cell.".to_string(),
+            inputs: json!({ "component": "studio-web" }),
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace::default(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: vec!["bench-results".to_string()],
+            metadata: json!({ "report": "side-by-side" }),
+        }
     }
 }

--- a/src/core/agent_task.rs
+++ b/src/core/agent_task.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
-use std::collections::{BTreeMap, BTreeSet};
+use serde_json::Value;
 
 #[cfg(test)]
 use crate::core::redaction::RedactionPolicy;
@@ -11,6 +10,14 @@ pub const AGENT_TASK_ARTIFACT_SCHEMA: &str = "homeboy/agent-task-artifact/v1";
 pub const AGENT_TASK_WORKFLOW_SCHEMA: &str = "homeboy/agent-task-workflow/v1";
 pub const AGENT_TASK_MATRIX_PLAN_SCHEMA: &str = "homeboy/agent-task-matrix-plan/v1";
 pub const AGENT_TASK_MATRIX_AGGREGATE_SCHEMA: &str = "homeboy/agent-task-matrix-aggregate/v1";
+
+mod matrix;
+
+pub(crate) use matrix::expand_agent_task_matrix;
+pub use matrix::{
+    AgentTaskMatrixAggregate, AgentTaskMatrixAggregateCell, AgentTaskMatrixAxis,
+    AgentTaskMatrixCell, AgentTaskMatrixError, AgentTaskMatrixPlan,
+};
 
 /// Provider-neutral executor adapter contract for agent task backends.
 ///
@@ -593,160 +600,6 @@ impl AgentTaskWorkflowStepSuggestion {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AgentTaskMatrixAxis {
-    pub name: String,
-    pub values: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct AgentTaskMatrixPlan {
-    #[serde(default = "matrix_plan_schema")]
-    pub schema: String,
-    pub plan_id: String,
-    pub axes: Vec<AgentTaskMatrixAxis>,
-    pub cells: Vec<AgentTaskMatrixCell>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct AgentTaskMatrixCell {
-    pub cell_id: String,
-    pub axes: BTreeMap<String, String>,
-    pub task: AgentTaskRequest,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct AgentTaskMatrixAggregate {
-    #[serde(default = "matrix_aggregate_schema")]
-    pub schema: String,
-    pub plan_id: String,
-    pub passed: bool,
-    pub cells: Vec<AgentTaskMatrixAggregateCell>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct AgentTaskMatrixAggregateCell {
-    pub cell_id: String,
-    pub task_id: String,
-    pub axes: BTreeMap<String, String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub status: Option<AgentTaskOutcomeStatus>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub artifacts: Vec<AgentTaskArtifact>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub evidence_refs: Vec<AgentTaskEvidenceRef>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub diagnostics: Vec<AgentTaskDiagnostic>,
-    #[serde(default, skip_serializing_if = "Value::is_null")]
-    pub metadata: Value,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AgentTaskMatrixError {
-    pub message: String,
-}
-
-impl AgentTaskMatrixError {
-    fn new(message: impl Into<String>) -> Self {
-        Self {
-            message: message.into(),
-        }
-    }
-}
-
-impl std::fmt::Display for AgentTaskMatrixError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(&self.message)
-    }
-}
-
-impl std::error::Error for AgentTaskMatrixError {}
-
-pub(crate) fn expand_agent_task_matrix(
-    plan_id: impl Into<String>,
-    axes: Vec<AgentTaskMatrixAxis>,
-    template: AgentTaskRequest,
-) -> Result<AgentTaskMatrixPlan, AgentTaskMatrixError> {
-    let plan_id = plan_id.into();
-    validate_matrix_id("plan id", &plan_id)?;
-    validate_axes(&axes)?;
-
-    let mut combinations = Vec::new();
-    collect_matrix_combinations(&axes, 0, &mut BTreeMap::new(), &mut combinations);
-
-    let cells = combinations
-        .into_iter()
-        .map(|selection| {
-            let cell_id = matrix_cell_id(&plan_id, &axes, &selection);
-            let mut task = template.clone();
-            task.task_id = cell_id.clone();
-            task.parent_plan_id = Some(plan_id.clone());
-            task.group_key.get_or_insert_with(|| plan_id.clone());
-            task.metadata = metadata_with_matrix(task.metadata, &cell_id, &selection);
-            AgentTaskMatrixCell {
-                cell_id,
-                axes: selection,
-                task,
-            }
-        })
-        .collect();
-
-    Ok(AgentTaskMatrixPlan {
-        schema: AGENT_TASK_MATRIX_PLAN_SCHEMA.to_string(),
-        plan_id,
-        axes,
-        cells,
-    })
-}
-
-impl AgentTaskMatrixAggregate {
-    pub(crate) fn from_outcomes(plan: &AgentTaskMatrixPlan, outcomes: &[AgentTaskOutcome]) -> Self {
-        let outcomes_by_task: BTreeMap<&str, &AgentTaskOutcome> = outcomes
-            .iter()
-            .map(|outcome| (outcome.task_id.as_str(), outcome))
-            .collect();
-        let mut passed = true;
-        let cells = plan
-            .cells
-            .iter()
-            .map(|cell| {
-                let outcome = outcomes_by_task.get(cell.task.task_id.as_str()).copied();
-                if !matches!(
-                    outcome.map(|outcome| outcome.status),
-                    Some(AgentTaskOutcomeStatus::Succeeded | AgentTaskOutcomeStatus::NoOp)
-                ) {
-                    passed = false;
-                }
-                AgentTaskMatrixAggregateCell {
-                    cell_id: cell.cell_id.clone(),
-                    task_id: cell.task.task_id.clone(),
-                    axes: cell.axes.clone(),
-                    status: outcome.map(|outcome| outcome.status),
-                    artifacts: outcome
-                        .map(|outcome| outcome.artifacts.clone())
-                        .unwrap_or_default(),
-                    evidence_refs: outcome
-                        .map(|outcome| outcome.evidence_refs.clone())
-                        .unwrap_or_default(),
-                    diagnostics: outcome
-                        .map(|outcome| outcome.diagnostics.clone())
-                        .unwrap_or_default(),
-                    metadata: outcome
-                        .map(|outcome| outcome.metadata.clone())
-                        .unwrap_or(Value::Null),
-                }
-            })
-            .collect();
-
-        Self {
-            schema: AGENT_TASK_MATRIX_AGGREGATE_SCHEMA.to_string(),
-            plan_id: plan.plan_id.clone(),
-            passed,
-            cells,
-        }
-    }
-}
-
 fn request_schema() -> String {
     AGENT_TASK_REQUEST_SCHEMA.to_string()
 }
@@ -763,14 +616,6 @@ fn workflow_schema() -> String {
     AGENT_TASK_WORKFLOW_SCHEMA.to_string()
 }
 
-fn matrix_plan_schema() -> String {
-    AGENT_TASK_MATRIX_PLAN_SCHEMA.to_string()
-}
-
-fn matrix_aggregate_schema() -> String {
-    AGENT_TASK_MATRIX_AGGREGATE_SCHEMA.to_string()
-}
-
 fn default_read_policy() -> String {
     "workspace".to_string()
 }
@@ -781,123 +626,6 @@ fn default_write_policy() -> String {
 
 fn default_apply_policy() -> String {
     "propose_only".to_string()
-}
-
-fn validate_axes(axes: &[AgentTaskMatrixAxis]) -> Result<(), AgentTaskMatrixError> {
-    if axes.is_empty() {
-        return Err(AgentTaskMatrixError::new(
-            "matrix expansion requires at least one axis",
-        ));
-    }
-
-    let mut names = BTreeSet::new();
-    for axis in axes {
-        validate_matrix_id("axis", &axis.name)?;
-        if !names.insert(axis.name.as_str()) {
-            return Err(AgentTaskMatrixError::new(format!(
-                "duplicate matrix axis '{}'",
-                axis.name
-            )));
-        }
-        if axis.values.is_empty() {
-            return Err(AgentTaskMatrixError::new(format!(
-                "matrix axis '{}' requires at least one value",
-                axis.name
-            )));
-        }
-        let mut values = BTreeSet::new();
-        for value in &axis.values {
-            validate_matrix_id("axis value", value)?;
-            if !values.insert(value.as_str()) {
-                return Err(AgentTaskMatrixError::new(format!(
-                    "duplicate value '{}' for matrix axis '{}'",
-                    value, axis.name
-                )));
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn validate_matrix_id(label: &str, value: &str) -> Result<(), AgentTaskMatrixError> {
-    if value.is_empty() {
-        return Err(AgentTaskMatrixError::new(format!(
-            "matrix {label} cannot be empty"
-        )));
-    }
-    if !value
-        .bytes()
-        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b'/'))
-    {
-        return Err(AgentTaskMatrixError::new(format!(
-            "matrix {label} '{value}' must contain only ASCII letters, numbers, '.', '_', '-', or '/'"
-        )));
-    }
-
-    Ok(())
-}
-
-fn collect_matrix_combinations(
-    axes: &[AgentTaskMatrixAxis],
-    index: usize,
-    current: &mut BTreeMap<String, String>,
-    combinations: &mut Vec<BTreeMap<String, String>>,
-) {
-    if index == axes.len() {
-        combinations.push(current.clone());
-        return;
-    }
-
-    let axis = &axes[index];
-    for value in &axis.values {
-        current.insert(axis.name.clone(), value.clone());
-        collect_matrix_combinations(axes, index + 1, current, combinations);
-    }
-    current.remove(&axis.name);
-}
-
-fn matrix_cell_id(
-    plan_id: &str,
-    axes: &[AgentTaskMatrixAxis],
-    selection: &BTreeMap<String, String>,
-) -> String {
-    let pairs = axes
-        .iter()
-        .map(|axis| {
-            let value = selection
-                .get(&axis.name)
-                .expect("selection populated from axis values");
-            format!("{}={}", axis.name, value)
-        })
-        .collect::<Vec<_>>()
-        .join(",");
-    format!("{plan_id}[{pairs}]")
-}
-
-fn metadata_with_matrix(
-    metadata: Value,
-    cell_id: &str,
-    selection: &BTreeMap<String, String>,
-) -> Value {
-    let mut object = match metadata {
-        Value::Object(object) => object,
-        Value::Null => Map::new(),
-        other => {
-            let mut object = Map::new();
-            object.insert("base".to_string(), other);
-            object
-        }
-    };
-    object.insert(
-        "matrix_cell_id".to_string(),
-        Value::String(cell_id.to_string()),
-    );
-    object.insert(
-        "matrix".to_string(),
-        serde_json::to_value(selection).expect("matrix selection serializes"),
-    );
-    Value::Object(object)
 }
 
 #[cfg(test)]
@@ -1344,6 +1072,7 @@ mod tests {
                     artifacts: Vec::new(),
                     evidence_refs: Vec::new(),
                     diagnostics: Vec::new(),
+                    workflow: None,
                     follow_up: None,
                     metadata: json!({}),
                 })
@@ -1382,6 +1111,7 @@ mod tests {
                     artifacts: Vec::new(),
                     evidence_refs: Vec::new(),
                     diagnostics: Vec::new(),
+                    workflow: None,
                     follow_up: None,
                     metadata: json!({}),
                 })
@@ -1499,6 +1229,7 @@ mod tests {
                     artifacts: Vec::new(),
                     evidence_refs: Vec::new(),
                     diagnostics: Vec::new(),
+                    workflow: None,
                     follow_up: None,
                     metadata: json!({}),
                 })
@@ -1552,204 +1283,5 @@ mod tests {
         .expect("task cancels");
 
         assert_eq!(outcome.status, AgentTaskOutcomeStatus::Cancelled);
-    }
-
-    #[test]
-    fn matrix_expansion_builds_cartesian_agent_task_plan() {
-        let plan = expand_agent_task_matrix(
-            "bench/studio-web",
-            vec![
-                AgentTaskMatrixAxis {
-                    name: "model".to_string(),
-                    values: vec!["gpt-5.5".to_string(), "claude".to_string()],
-                },
-                AgentTaskMatrixAxis {
-                    name: "prompt".to_string(),
-                    values: vec!["site-a".to_string(), "site-b".to_string()],
-                },
-            ],
-            template_request(),
-        )
-        .expect("expand matrix");
-
-        assert_eq!(plan.schema, AGENT_TASK_MATRIX_PLAN_SCHEMA);
-        assert_eq!(plan.cells.len(), 4);
-        assert_eq!(
-            plan.cells
-                .iter()
-                .map(|cell| cell.cell_id.as_str())
-                .collect::<Vec<_>>(),
-            vec![
-                "bench/studio-web[model=gpt-5.5,prompt=site-a]",
-                "bench/studio-web[model=gpt-5.5,prompt=site-b]",
-                "bench/studio-web[model=claude,prompt=site-a]",
-                "bench/studio-web[model=claude,prompt=site-b]",
-            ]
-        );
-        assert!(plan
-            .cells
-            .iter()
-            .all(|cell| cell.task.parent_plan_id.as_deref() == Some("bench/studio-web")));
-        assert_eq!(plan.cells[2].task.metadata["matrix"]["model"], "claude");
-        assert_eq!(plan.cells[2].task.metadata["matrix"]["prompt"], "site-a");
-    }
-
-    #[test]
-    fn matrix_expansion_rejects_invalid_axes() {
-        let error = expand_agent_task_matrix(
-            "bench-plan",
-            vec![AgentTaskMatrixAxis {
-                name: "bad,axis".to_string(),
-                values: vec!["site-a".to_string()],
-            }],
-            template_request(),
-        )
-        .expect_err("invalid axis fails");
-
-        assert!(error.message.contains("bad,axis"));
-
-        let error = expand_agent_task_matrix(
-            "bench-plan",
-            vec![AgentTaskMatrixAxis {
-                name: "prompt".to_string(),
-                values: Vec::new(),
-            }],
-            template_request(),
-        )
-        .expect_err("empty values fail");
-
-        assert!(error.message.contains("requires at least one value"));
-    }
-
-    #[test]
-    fn matrix_cell_ids_are_stable_across_input_order_noise() {
-        let first = expand_agent_task_matrix(
-            "bench-plan",
-            vec![
-                AgentTaskMatrixAxis {
-                    name: "model".to_string(),
-                    values: vec!["gpt".to_string(), "claude".to_string()],
-                },
-                AgentTaskMatrixAxis {
-                    name: "prompt".to_string(),
-                    values: vec!["site".to_string()],
-                },
-            ],
-            template_request(),
-        )
-        .expect("expand first");
-        let second = expand_agent_task_matrix(
-            "bench-plan",
-            vec![
-                AgentTaskMatrixAxis {
-                    name: "model".to_string(),
-                    values: vec!["gpt".to_string(), "claude".to_string()],
-                },
-                AgentTaskMatrixAxis {
-                    name: "prompt".to_string(),
-                    values: vec!["site".to_string()],
-                },
-            ],
-            template_request(),
-        )
-        .expect("expand second");
-
-        assert_eq!(first, second);
-    }
-
-    #[test]
-    fn matrix_aggregate_preserves_partial_task_failure() {
-        let plan = expand_agent_task_matrix(
-            "bench-plan",
-            vec![AgentTaskMatrixAxis {
-                name: "model".to_string(),
-                values: vec!["gpt".to_string(), "claude".to_string()],
-            }],
-            template_request(),
-        )
-        .expect("expand matrix");
-
-        let aggregate = AgentTaskMatrixAggregate::from_outcomes(
-            &plan,
-            &[
-                AgentTaskOutcome {
-                    schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
-                    task_id: plan.cells[0].task.task_id.clone(),
-                    status: AgentTaskOutcomeStatus::Succeeded,
-                    summary: Some("ok".to_string()),
-                    failure_classification: None,
-                    artifacts: vec![AgentTaskArtifact {
-                        schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-                        id: "metrics".to_string(),
-                        kind: "json".to_string(),
-                        name: None,
-                        path: Some("artifacts/metrics.json".to_string()),
-                        url: None,
-                        mime: Some("application/json".to_string()),
-                        size_bytes: Some(64),
-                        sha256: None,
-                        metadata: json!({ "metric": "p95_ms" }),
-                    }],
-                    evidence_refs: Vec::new(),
-                    diagnostics: Vec::new(),
-                    follow_up: None,
-                    metadata: json!({ "p95_ms": 1200 }),
-                },
-                AgentTaskOutcome {
-                    schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
-                    task_id: plan.cells[1].task.task_id.clone(),
-                    status: AgentTaskOutcomeStatus::Failed,
-                    summary: Some("runner failed".to_string()),
-                    failure_classification: Some(AgentTaskFailureClassification::ExecutionFailed),
-                    artifacts: Vec::new(),
-                    evidence_refs: Vec::new(),
-                    diagnostics: vec![AgentTaskDiagnostic {
-                        class: "runner".to_string(),
-                        message: "exit 1".to_string(),
-                        data: json!({}),
-                    }],
-                    follow_up: None,
-                    metadata: json!({}),
-                },
-            ],
-        );
-
-        assert_eq!(aggregate.schema, AGENT_TASK_MATRIX_AGGREGATE_SCHEMA);
-        assert!(!aggregate.passed);
-        assert_eq!(
-            aggregate.cells[0].status,
-            Some(AgentTaskOutcomeStatus::Succeeded)
-        );
-        assert_eq!(aggregate.cells[0].artifacts[0].id, "metrics");
-        assert_eq!(
-            aggregate.cells[1].status,
-            Some(AgentTaskOutcomeStatus::Failed)
-        );
-        assert_eq!(aggregate.cells[1].axes["model"], "claude");
-        assert_eq!(aggregate.cells[1].diagnostics[0].class, "runner");
-    }
-
-    fn template_request() -> AgentTaskRequest {
-        AgentTaskRequest {
-            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
-            task_id: "template".to_string(),
-            group_key: None,
-            parent_plan_id: None,
-            executor: AgentTaskExecutor {
-                backend: "runner".to_string(),
-                selector: Some("homeboy-lab".to_string()),
-                required_capabilities: vec!["bench".to_string()],
-                model: None,
-                config: json!({}),
-            },
-            instructions: "Run the selected bench cell.".to_string(),
-            inputs: json!({ "component": "studio-web" }),
-            source_refs: Vec::new(),
-            workspace: AgentTaskWorkspace::default(),
-            policy: AgentTaskPolicy::default(),
-            limits: AgentTaskLimits::default(),
-            expected_artifacts: vec!["bench-results".to_string()],
-            metadata: json!({ "report": "side-by-side" }),
-        }
     }
 }

--- a/src/core/agent_task/matrix.rs
+++ b/src/core/agent_task/matrix.rs
@@ -1,0 +1,500 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{
+    AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskOutcome,
+    AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_MATRIX_AGGREGATE_SCHEMA,
+    AGENT_TASK_MATRIX_PLAN_SCHEMA,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskMatrixAxis {
+    pub name: String,
+    pub values: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskMatrixPlan {
+    #[serde(default = "matrix_plan_schema")]
+    pub schema: String,
+    pub plan_id: String,
+    pub axes: Vec<AgentTaskMatrixAxis>,
+    pub cells: Vec<AgentTaskMatrixCell>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskMatrixCell {
+    pub cell_id: String,
+    pub axes: BTreeMap<String, String>,
+    pub task: AgentTaskRequest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskMatrixAggregate {
+    #[serde(default = "matrix_aggregate_schema")]
+    pub schema: String,
+    pub plan_id: String,
+    pub passed: bool,
+    pub cells: Vec<AgentTaskMatrixAggregateCell>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskMatrixAggregateCell {
+    pub cell_id: String,
+    pub task_id: String,
+    pub axes: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<AgentTaskOutcomeStatus>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<AgentTaskArtifact>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence_refs: Vec<AgentTaskEvidenceRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<AgentTaskDiagnostic>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentTaskMatrixError {
+    pub message: String,
+}
+
+impl AgentTaskMatrixError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for AgentTaskMatrixError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for AgentTaskMatrixError {}
+
+pub(crate) fn expand_agent_task_matrix(
+    plan_id: impl Into<String>,
+    axes: Vec<AgentTaskMatrixAxis>,
+    template: AgentTaskRequest,
+) -> Result<AgentTaskMatrixPlan, AgentTaskMatrixError> {
+    let plan_id = plan_id.into();
+    validate_matrix_id("plan id", &plan_id)?;
+    validate_axes(&axes)?;
+
+    let mut combinations = Vec::new();
+    collect_matrix_combinations(&axes, 0, &mut BTreeMap::new(), &mut combinations);
+
+    let cells = combinations
+        .into_iter()
+        .map(|selection| {
+            let cell_id = matrix_cell_id(&plan_id, &axes, &selection);
+            let mut task = template.clone();
+            task.task_id = cell_id.clone();
+            task.parent_plan_id = Some(plan_id.clone());
+            task.group_key.get_or_insert_with(|| plan_id.clone());
+            task.metadata = metadata_with_matrix(task.metadata, &cell_id, &selection);
+            AgentTaskMatrixCell {
+                cell_id,
+                axes: selection,
+                task,
+            }
+        })
+        .collect();
+
+    Ok(AgentTaskMatrixPlan {
+        schema: AGENT_TASK_MATRIX_PLAN_SCHEMA.to_string(),
+        plan_id,
+        axes,
+        cells,
+    })
+}
+
+impl AgentTaskMatrixAggregate {
+    pub(crate) fn from_outcomes(plan: &AgentTaskMatrixPlan, outcomes: &[AgentTaskOutcome]) -> Self {
+        let outcomes_by_task: BTreeMap<&str, &AgentTaskOutcome> = outcomes
+            .iter()
+            .map(|outcome| (outcome.task_id.as_str(), outcome))
+            .collect();
+        let mut passed = true;
+        let cells = plan
+            .cells
+            .iter()
+            .map(|cell| {
+                let outcome = outcomes_by_task.get(cell.task.task_id.as_str()).copied();
+                if !matches!(
+                    outcome.map(|outcome| outcome.status),
+                    Some(AgentTaskOutcomeStatus::Succeeded | AgentTaskOutcomeStatus::NoOp)
+                ) {
+                    passed = false;
+                }
+                AgentTaskMatrixAggregateCell {
+                    cell_id: cell.cell_id.clone(),
+                    task_id: cell.task.task_id.clone(),
+                    axes: cell.axes.clone(),
+                    status: outcome.map(|outcome| outcome.status),
+                    artifacts: outcome
+                        .map(|outcome| outcome.artifacts.clone())
+                        .unwrap_or_default(),
+                    evidence_refs: outcome
+                        .map(|outcome| outcome.evidence_refs.clone())
+                        .unwrap_or_default(),
+                    diagnostics: outcome
+                        .map(|outcome| outcome.diagnostics.clone())
+                        .unwrap_or_default(),
+                    metadata: outcome
+                        .map(|outcome| outcome.metadata.clone())
+                        .unwrap_or(Value::Null),
+                }
+            })
+            .collect();
+
+        Self {
+            schema: AGENT_TASK_MATRIX_AGGREGATE_SCHEMA.to_string(),
+            plan_id: plan.plan_id.clone(),
+            passed,
+            cells,
+        }
+    }
+}
+
+fn matrix_plan_schema() -> String {
+    AGENT_TASK_MATRIX_PLAN_SCHEMA.to_string()
+}
+
+fn matrix_aggregate_schema() -> String {
+    AGENT_TASK_MATRIX_AGGREGATE_SCHEMA.to_string()
+}
+
+fn validate_axes(axes: &[AgentTaskMatrixAxis]) -> Result<(), AgentTaskMatrixError> {
+    if axes.is_empty() {
+        return Err(AgentTaskMatrixError::new(
+            "matrix expansion requires at least one axis",
+        ));
+    }
+
+    let mut names = BTreeSet::new();
+    for axis in axes {
+        validate_matrix_id("axis", &axis.name)?;
+        if !names.insert(axis.name.as_str()) {
+            return Err(AgentTaskMatrixError::new(format!(
+                "duplicate matrix axis '{}'",
+                axis.name
+            )));
+        }
+        if axis.values.is_empty() {
+            return Err(AgentTaskMatrixError::new(format!(
+                "matrix axis '{}' requires at least one value",
+                axis.name
+            )));
+        }
+        let mut values = BTreeSet::new();
+        for value in &axis.values {
+            validate_matrix_id("axis value", value)?;
+            if !values.insert(value.as_str()) {
+                return Err(AgentTaskMatrixError::new(format!(
+                    "duplicate value '{}' for matrix axis '{}'",
+                    value, axis.name
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_matrix_id(label: &str, value: &str) -> Result<(), AgentTaskMatrixError> {
+    if value.is_empty() {
+        return Err(AgentTaskMatrixError::new(format!(
+            "matrix {label} cannot be empty"
+        )));
+    }
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b'/'))
+    {
+        return Err(AgentTaskMatrixError::new(format!(
+            "matrix {label} '{value}' must contain only ASCII letters, numbers, '.', '_', '-', or '/'"
+        )));
+    }
+
+    Ok(())
+}
+
+fn collect_matrix_combinations(
+    axes: &[AgentTaskMatrixAxis],
+    index: usize,
+    current: &mut BTreeMap<String, String>,
+    combinations: &mut Vec<BTreeMap<String, String>>,
+) {
+    if index == axes.len() {
+        combinations.push(current.clone());
+        return;
+    }
+
+    let axis = &axes[index];
+    for value in &axis.values {
+        current.insert(axis.name.clone(), value.clone());
+        collect_matrix_combinations(axes, index + 1, current, combinations);
+    }
+    current.remove(&axis.name);
+}
+
+fn matrix_cell_id(
+    plan_id: &str,
+    axes: &[AgentTaskMatrixAxis],
+    selection: &BTreeMap<String, String>,
+) -> String {
+    let pairs = axes
+        .iter()
+        .map(|axis| {
+            let value = selection
+                .get(&axis.name)
+                .expect("selection populated from axis values");
+            format!("{}={}", axis.name, value)
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("{plan_id}[{pairs}]")
+}
+
+fn metadata_with_matrix(
+    metadata: Value,
+    cell_id: &str,
+    selection: &BTreeMap<String, String>,
+) -> Value {
+    let mut object = match metadata {
+        Value::Object(object) => object,
+        Value::Null => Map::new(),
+        other => {
+            let mut object = Map::new();
+            object.insert("base".to_string(), other);
+            object
+        }
+    };
+    object.insert(
+        "matrix_cell_id".to_string(),
+        Value::String(cell_id.to_string()),
+    );
+    object.insert(
+        "matrix".to_string(),
+        serde_json::to_value(selection).expect("matrix selection serializes"),
+    );
+    Value::Object(object)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::agent_task::{
+        AgentTaskExecutor, AgentTaskFailureClassification, AgentTaskLimits, AgentTaskPolicy,
+        AgentTaskWorkspace, AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA,
+        AGENT_TASK_REQUEST_SCHEMA,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn matrix_expansion_builds_cartesian_agent_task_plan() {
+        let plan = expand_agent_task_matrix(
+            "bench/studio-web",
+            vec![
+                AgentTaskMatrixAxis {
+                    name: "model".to_string(),
+                    values: vec!["gpt-5.5".to_string(), "claude".to_string()],
+                },
+                AgentTaskMatrixAxis {
+                    name: "prompt".to_string(),
+                    values: vec!["site-a".to_string(), "site-b".to_string()],
+                },
+            ],
+            template_request(),
+        )
+        .expect("expand matrix");
+
+        assert_eq!(plan.schema, AGENT_TASK_MATRIX_PLAN_SCHEMA);
+        assert_eq!(plan.cells.len(), 4);
+        assert_eq!(
+            plan.cells
+                .iter()
+                .map(|cell| cell.cell_id.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "bench/studio-web[model=gpt-5.5,prompt=site-a]",
+                "bench/studio-web[model=gpt-5.5,prompt=site-b]",
+                "bench/studio-web[model=claude,prompt=site-a]",
+                "bench/studio-web[model=claude,prompt=site-b]",
+            ]
+        );
+        assert!(plan
+            .cells
+            .iter()
+            .all(|cell| cell.task.parent_plan_id.as_deref() == Some("bench/studio-web")));
+        assert_eq!(plan.cells[2].task.metadata["matrix"]["model"], "claude");
+        assert_eq!(plan.cells[2].task.metadata["matrix"]["prompt"], "site-a");
+    }
+
+    #[test]
+    fn matrix_expansion_rejects_invalid_axes() {
+        let error = expand_agent_task_matrix(
+            "bench-plan",
+            vec![AgentTaskMatrixAxis {
+                name: "bad,axis".to_string(),
+                values: vec!["site-a".to_string()],
+            }],
+            template_request(),
+        )
+        .expect_err("invalid axis fails");
+
+        assert!(error.message.contains("bad,axis"));
+
+        let error = expand_agent_task_matrix(
+            "bench-plan",
+            vec![AgentTaskMatrixAxis {
+                name: "prompt".to_string(),
+                values: Vec::new(),
+            }],
+            template_request(),
+        )
+        .expect_err("empty values fail");
+
+        assert!(error.message.contains("requires at least one value"));
+    }
+
+    #[test]
+    fn matrix_cell_ids_are_stable_across_input_order_noise() {
+        let first = expand_agent_task_matrix(
+            "bench-plan",
+            vec![
+                AgentTaskMatrixAxis {
+                    name: "model".to_string(),
+                    values: vec!["gpt".to_string(), "claude".to_string()],
+                },
+                AgentTaskMatrixAxis {
+                    name: "prompt".to_string(),
+                    values: vec!["site".to_string()],
+                },
+            ],
+            template_request(),
+        )
+        .expect("expand first");
+        let second = expand_agent_task_matrix(
+            "bench-plan",
+            vec![
+                AgentTaskMatrixAxis {
+                    name: "model".to_string(),
+                    values: vec!["gpt".to_string(), "claude".to_string()],
+                },
+                AgentTaskMatrixAxis {
+                    name: "prompt".to_string(),
+                    values: vec!["site".to_string()],
+                },
+            ],
+            template_request(),
+        )
+        .expect("expand second");
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn matrix_aggregate_preserves_partial_task_failure() {
+        let plan = expand_agent_task_matrix(
+            "bench-plan",
+            vec![AgentTaskMatrixAxis {
+                name: "model".to_string(),
+                values: vec!["gpt".to_string(), "claude".to_string()],
+            }],
+            template_request(),
+        )
+        .expect("expand matrix");
+
+        let aggregate = AgentTaskMatrixAggregate::from_outcomes(
+            &plan,
+            &[
+                AgentTaskOutcome {
+                    schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: plan.cells[0].task.task_id.clone(),
+                    status: AgentTaskOutcomeStatus::Succeeded,
+                    summary: Some("ok".to_string()),
+                    failure_classification: None,
+                    artifacts: vec![AgentTaskArtifact {
+                        schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                        id: "metrics".to_string(),
+                        kind: "json".to_string(),
+                        name: None,
+                        path: Some("artifacts/metrics.json".to_string()),
+                        url: None,
+                        mime: Some("application/json".to_string()),
+                        size_bytes: Some(64),
+                        sha256: None,
+                        metadata: json!({ "metric": "p95_ms" }),
+                    }],
+                    evidence_refs: Vec::new(),
+                    diagnostics: Vec::new(),
+                    workflow: None,
+                    follow_up: None,
+                    metadata: json!({ "p95_ms": 1200 }),
+                },
+                AgentTaskOutcome {
+                    schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: plan.cells[1].task.task_id.clone(),
+                    status: AgentTaskOutcomeStatus::Failed,
+                    summary: Some("runner failed".to_string()),
+                    failure_classification: Some(AgentTaskFailureClassification::ExecutionFailed),
+                    artifacts: Vec::new(),
+                    evidence_refs: Vec::new(),
+                    diagnostics: vec![AgentTaskDiagnostic {
+                        class: "runner".to_string(),
+                        message: "exit 1".to_string(),
+                        data: json!({}),
+                    }],
+                    workflow: None,
+                    follow_up: None,
+                    metadata: json!({}),
+                },
+            ],
+        );
+
+        assert_eq!(aggregate.schema, AGENT_TASK_MATRIX_AGGREGATE_SCHEMA);
+        assert!(!aggregate.passed);
+        assert_eq!(
+            aggregate.cells[0].status,
+            Some(AgentTaskOutcomeStatus::Succeeded)
+        );
+        assert_eq!(aggregate.cells[0].artifacts[0].id, "metrics");
+        assert_eq!(
+            aggregate.cells[1].status,
+            Some(AgentTaskOutcomeStatus::Failed)
+        );
+        assert_eq!(aggregate.cells[1].axes["model"], "claude");
+        assert_eq!(aggregate.cells[1].diagnostics[0].class, "runner");
+    }
+
+    fn template_request() -> AgentTaskRequest {
+        AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "template".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "runner".to_string(),
+                selector: Some("homeboy-lab".to_string()),
+                required_capabilities: vec!["bench".to_string()],
+                model: None,
+                config: json!({}),
+            },
+            instructions: "Run the selected bench cell.".to_string(),
+            inputs: json!({ "component": "studio-web" }),
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace::default(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: vec!["bench-results".to_string()],
+            metadata: json!({ "report": "side-by-side" }),
+        }
+    }
+}

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -596,7 +596,6 @@ impl AgentTaskScheduleSupport {
             }],
             workflow: None,
             follow_up: None,
-            workflow: None,
             metadata: Value::Null,
         }
     }

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -437,6 +437,7 @@ impl AgentTaskScheduleSupport {
                 label: Some("scheduler cancellation".to_string()),
             }],
             diagnostics: Vec::new(),
+            workflow: None,
             follow_up: None,
             metadata: Value::Null,
         }
@@ -460,6 +461,7 @@ impl AgentTaskScheduleSupport {
                 message: format!("task exceeded timeout_ms={timeout_ms}"),
                 data: Value::Null,
             }],
+            workflow: None,
             follow_up: None,
             metadata: Value::Null,
         }
@@ -811,6 +813,7 @@ mod tests {
                 label: Some("task log".to_string()),
             }],
             diagnostics: Vec::new(),
+            workflow: None,
             follow_up: None,
             metadata: json!({}),
         }

--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -688,7 +688,7 @@ mod tests {
                     pattern: Some(r#""version":\s*"([0-9.]+)""#.to_string()),
                 },
                 VersionTarget {
-                    file: "packages/wordpress-plugin/fixture.php".to_string(),
+                    file: "packages/packaged-plugin/fixture.php".to_string(),
                     pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
                 },
             ]),

--- a/src/core/extension/bench/report/comparison.rs
+++ b/src/core/extension/bench/report/comparison.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use serde_json::{json, Value};
+
 mod types;
 
 pub use types::{
@@ -10,6 +12,12 @@ pub use types::{
     RigBenchEntry,
 };
 
+use crate::core::agent_task::{
+    expand_agent_task_matrix, AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskExecutor,
+    AgentTaskLimits, AgentTaskMatrixAggregate, AgentTaskMatrixAxis, AgentTaskMatrixPlan,
+    AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest,
+    AgentTaskWorkspace, AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
+};
 use crate::core::extension::bench::diagnostic::BenchDiagnostic;
 use crate::core::extension::bench::distribution::BenchRunDistribution;
 use crate::core::extension::bench::parsing::{BenchResults, BenchScenario};
@@ -315,6 +323,8 @@ pub fn aggregate_comparison_with_axes(
         }
     };
     let axis_diffs = build_axis_diffs(&entries, axes_by_rig);
+    let agent_task_matrix =
+        build_agent_task_matrix_summary(&component, iterations, &entries, axes_by_rig);
     let summary = BenchScenarioComparisonSummary::build(&entries);
     let side_by_side = build_side_by_side_report(&component, iterations, &entries);
 
@@ -373,6 +383,8 @@ pub fn aggregate_comparison_with_axes(
             rigs: entries,
             diff,
             axis_diffs,
+            agent_task_plan: agent_task_matrix.as_ref().map(|(plan, _)| plan.clone()),
+            agent_task_aggregate: agent_task_matrix.map(|(_, aggregate)| aggregate),
             summary,
             failures,
             diagnostic_classes,
@@ -382,6 +394,153 @@ pub fn aggregate_comparison_with_axes(
         },
         exit_code,
     )
+}
+
+fn build_agent_task_matrix_summary(
+    component: &str,
+    iterations: u64,
+    entries: &[RigBenchEntry],
+    axes_by_rig: &BTreeMap<String, BTreeMap<String, String>>,
+) -> Option<(AgentTaskMatrixPlan, AgentTaskMatrixAggregate)> {
+    if axes_by_rig.is_empty() {
+        return None;
+    }
+
+    let axes = agent_task_axes(axes_by_rig);
+    if axes.is_empty() {
+        return None;
+    }
+
+    let plan = expand_agent_task_matrix(
+        format!("bench/{component}"),
+        axes,
+        AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "template".to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "homeboy.bench".to_string(),
+                selector: None,
+                required_capabilities: vec!["bench".to_string()],
+                model: None,
+                config: Value::Null,
+            },
+            instructions: "Run the selected bench matrix cell.".to_string(),
+            inputs: json!({
+                "component": component,
+                "iterations": iterations,
+            }),
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace::default(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: vec!["bench-results".to_string()],
+            metadata: json!({ "source": "bench.comparison" }),
+        },
+    )
+    .ok()?;
+
+    let outcomes = entries
+        .iter()
+        .filter_map(|entry| agent_task_outcome_for_entry(entry, axes_by_rig, &plan))
+        .collect::<Vec<_>>();
+    let aggregate = AgentTaskMatrixAggregate::from_outcomes(&plan, &outcomes);
+
+    Some((plan, aggregate))
+}
+
+fn agent_task_axes(
+    axes_by_rig: &BTreeMap<String, BTreeMap<String, String>>,
+) -> Vec<AgentTaskMatrixAxis> {
+    let mut values_by_axis: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for axes in axes_by_rig.values() {
+        for (axis, value) in axes {
+            let values = values_by_axis.entry(axis.clone()).or_default();
+            if !values.contains(value) {
+                values.push(value.clone());
+            }
+        }
+    }
+
+    values_by_axis
+        .into_iter()
+        .map(|(name, values)| AgentTaskMatrixAxis { name, values })
+        .collect()
+}
+
+fn agent_task_outcome_for_entry(
+    entry: &RigBenchEntry,
+    axes_by_rig: &BTreeMap<String, BTreeMap<String, String>>,
+    plan: &AgentTaskMatrixPlan,
+) -> Option<AgentTaskOutcome> {
+    let axes = axes_by_rig.get(&entry.rig_id)?;
+    let task_id = plan
+        .cells
+        .iter()
+        .find(|cell| &cell.axes == axes)
+        .map(|cell| cell.task.task_id.clone())?;
+
+    Some(AgentTaskOutcome {
+        schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+        task_id,
+        status: if entry.passed {
+            AgentTaskOutcomeStatus::Succeeded
+        } else {
+            AgentTaskOutcomeStatus::Failed
+        },
+        summary: Some(entry.status.clone()),
+        failure_classification: None,
+        artifacts: entry
+            .artifacts
+            .iter()
+            .enumerate()
+            .map(|(index, artifact)| AgentTaskArtifact {
+                id: format!("{}:{}", entry.rig_id, index),
+                kind: artifact
+                    .kind
+                    .clone()
+                    .or_else(|| artifact.artifact_type.clone())
+                    .unwrap_or_else(|| "bench_artifact".to_string()),
+                name: Some(artifact.name.clone()),
+                path: artifact.path.clone(),
+                url: artifact.url.clone(),
+                mime: None,
+                size_bytes: None,
+                sha256: None,
+                metadata: json!({
+                    "scenario_id": artifact.scenario_id,
+                    "run_index": artifact.run_index,
+                    "label": artifact.label,
+                }),
+                schema: crate::core::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            })
+            .collect(),
+        evidence_refs: Vec::new(),
+        diagnostics: entry
+            .diagnostics
+            .iter()
+            .map(agent_task_diagnostic)
+            .collect(),
+        workflow: None,
+        follow_up: None,
+        metadata: json!({
+            "rig_id": entry.rig_id,
+            "status": entry.status,
+            "exit_code": entry.exit_code,
+        }),
+    })
+}
+
+fn agent_task_diagnostic(diagnostic: &BenchDiagnostic) -> AgentTaskDiagnostic {
+    AgentTaskDiagnostic {
+        class: diagnostic.class.clone(),
+        message: diagnostic.message.clone().unwrap_or_default(),
+        data: json!({
+            "source": diagnostic.source,
+            "metadata": diagnostic.metadata,
+        }),
+    }
 }
 
 fn summarize_diagnostic_classes(entries: &[RigBenchEntry]) -> Vec<BenchDiagnosticClassSummary> {

--- a/src/core/extension/bench/report/comparison/types.rs
+++ b/src/core/extension/bench/report/comparison/types.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 
 use super::super::BenchArtifactRef;
+use crate::core::agent_task::{AgentTaskMatrixAggregate, AgentTaskMatrixPlan};
 use crate::core::extension::bench::diagnostic::BenchDiagnostic;
 use crate::core::extension::bench::parsing::{BenchMetricPhase, BenchMetricPolicy, BenchResults};
 use crate::core::extension::bench::run::BenchRunFailure;
@@ -50,6 +51,13 @@ pub struct BenchComparisonOutput {
     /// declared axis while all other axis values match.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub axis_diffs: Vec<BenchAxisComparison>,
+    /// Generic agent-task fan-out plan for matrix-shaped rig comparisons.
+    /// Present when compared rigs declare `bench.axes` metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_task_plan: Option<AgentTaskMatrixPlan>,
+    /// Generic aggregate envelope keyed by the matrix plan's cell ids.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_task_aggregate: Option<AgentTaskMatrixAggregate>,
     /// Per-scenario run summary table. Promotes the variance-aware data
     /// already present under each scenario's `runs_summary` into a direct
     /// cross-rig comparison shape.

--- a/tests/core/extension/bench/report_comparison_test.rs
+++ b/tests/core/extension/bench/report_comparison_test.rs
@@ -367,6 +367,32 @@ fn axis_diffs_cover_two_by_two_rig_matrix() {
     let (out, _) = aggregate_comparison_with_axes("studio".into(), 10, entries, &axes_by_rig);
 
     assert_eq!(out.axis_diffs.len(), 4);
+    let agent_task_plan = out.agent_task_plan.as_ref().expect("agent task plan");
+    assert_eq!(agent_task_plan.plan_id, "bench/studio");
+    assert_eq!(agent_task_plan.cells.len(), 4);
+    let sdk_standard_cell = agent_task_plan
+        .cells
+        .iter()
+        .find(|cell| {
+            cell.axes.get("runtime").map(String::as_str) == Some("sdk")
+                && cell.axes.get("substrate").map(String::as_str) == Some("standard")
+        })
+        .expect("sdk standard agent task cell");
+    assert_eq!(
+        sdk_standard_cell.task.parent_plan_id.as_deref(),
+        Some("bench/studio")
+    );
+    assert_eq!(sdk_standard_cell.task.metadata["matrix"]["runtime"], "sdk");
+    let agent_task_aggregate = out
+        .agent_task_aggregate
+        .as_ref()
+        .expect("agent task aggregate");
+    assert!(agent_task_aggregate.passed);
+    assert_eq!(agent_task_aggregate.cells.len(), 4);
+    assert_eq!(
+        agent_task_aggregate.cells[0].status,
+        Some(crate::core::agent_task::AgentTaskOutcomeStatus::Succeeded)
+    );
     let sdk_substrate = out
         .axis_diffs
         .iter()


### PR DESCRIPTION
## Summary
- Add generic `core::agent_task` matrix plan and aggregate schemas for cartesian task fan-out.
- Emit plan/aggregate metadata from existing bench cross-rig axis comparisons when rigs declare `bench.axes`.
- Document the bench/matrix handoff boundary so future scheduler/executor work uses generic agent-task fan-out instead of a bench-specific runner.

## Dependency note
- #3208 and #3209 are still open, so this PR lands the independent preparatory slice: plan generation and aggregation are wired into existing bench matrix output, while actual scheduler/executor dispatch remains delegated to those follow-ups.

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo test core::agent_task`
- `cargo test axis_diffs_cover_two_by_two_rig_matrix`
- `homeboy audit --path . --changed-since origin/main --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, docs, and verification loop; Chris remains responsible for review and merge.

Refs #3210