### PR TITLE
Guard deploy archive core semantics

### DIFF
--- a/src/core/agent_task.rs
+++ b/src/core/agent_task.rs
@@ -1062,6 +1062,7 @@ mod tests {
                     artifacts: Vec::new(),
                     evidence_refs: Vec::new(),
                     diagnostics: Vec::new(),
+                    workflow: None,
                     follow_up: None,
                     metadata: json!({}),
                 })
@@ -1100,6 +1101,7 @@ mod tests {
                     artifacts: Vec::new(),
                     evidence_refs: Vec::new(),
                     diagnostics: Vec::new(),
+                    workflow: None,
                     follow_up: None,
                     metadata: json!({}),
                 })
@@ -1217,6 +1219,7 @@ mod tests {
                     artifacts: Vec::new(),
                     evidence_refs: Vec::new(),
                     diagnostics: Vec::new(),
+                    workflow: None,
                     follow_up: None,
                     metadata: json!({}),
                 })

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -437,6 +437,7 @@ impl AgentTaskScheduleSupport {
                 label: Some("scheduler cancellation".to_string()),
             }],
             diagnostics: Vec::new(),
+            workflow: None,
             follow_up: None,
             metadata: Value::Null,
         }
@@ -460,6 +461,7 @@ impl AgentTaskScheduleSupport {
                 message: format!("task exceeded timeout_ms={timeout_ms}"),
                 data: Value::Null,
             }],
+            workflow: None,
             follow_up: None,
             metadata: Value::Null,
         }
@@ -811,6 +813,7 @@ mod tests {
                 label: Some("task log".to_string()),
             }],
             diagnostics: Vec::new(),
+            workflow: None,
             follow_up: None,
             metadata: json!({}),
         }

--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -613,29 +613,29 @@ mod tests {
         zip.finish().expect("finish zip");
     }
 
-    fn plugin_archive_policy(staging_path: String) -> DeployArchiveInstallPolicy {
+    fn package_archive_policy(staging_path: String) -> DeployArchiveInstallPolicy {
         DeployArchiveInstallPolicy {
-            path_pattern: "/wp-content/plugins/".to_string(),
+            path_pattern: "/packages/".to_string(),
             staging_path,
             root_must_match_target_basename: true,
             required_header: Some(DeployRequiredHeader {
                 file: None,
-                file_glob: Some("*.php".to_string()),
-                contains: "Plugin Name:".to_string(),
+                file_glob: Some("*.manifest".to_string()),
+                contains: "Package Name:".to_string(),
             }),
             skip_permissions_fix: true,
         }
     }
 
-    fn theme_archive_policy(staging_path: String) -> DeployArchiveInstallPolicy {
+    fn bundle_archive_policy(staging_path: String) -> DeployArchiveInstallPolicy {
         DeployArchiveInstallPolicy {
-            path_pattern: "/wp-content/themes/".to_string(),
+            path_pattern: "/bundles/".to_string(),
             staging_path,
             root_must_match_target_basename: true,
             required_header: Some(DeployRequiredHeader {
-                file: Some("style.css".to_string()),
+                file: Some("bundle.manifest".to_string()),
                 file_glob: None,
-                contains: "Theme Name:".to_string(),
+                contains: "Bundle Name:".to_string(),
             }),
             skip_permissions_fix: true,
         }
@@ -785,19 +785,16 @@ mod tests {
         let temp = tempfile::tempdir().expect("temp dir");
         let artifact = temp.path().join("fixture.zip");
         let staging = temp.path().join("staging");
-        let target = temp.path().join("wp-content/plugins/fixture");
+        let target = temp.path().join("packages/fixture");
 
         fs::create_dir_all(&target).expect("target dir");
         fs::write(target.join("stale.php"), "stale").expect("stale file");
         write_zip(
             &artifact,
-            &[(
-                "fixture/fixture.php",
-                "<?php\n/*\nPlugin Name: Fixture\n*/\n",
-            )],
+            &[("fixture/fixture.manifest", "Package Name: Fixture\n")],
         );
 
-        let policy = plugin_archive_policy(staging.to_string_lossy().to_string());
+        let policy = package_archive_policy(staging.to_string_lossy().to_string());
         let override_config = archive_install_override(&policy);
         let verification = archive_install_verification(&policy).expect("verification");
 
@@ -816,7 +813,7 @@ mod tests {
         .expect("deploy result");
 
         assert!(result.success, "deploy failed: {:?}", result.error);
-        assert!(target.join("fixture.php").exists());
+        assert!(target.join("fixture.manifest").exists());
         assert!(!target.join("stale.php").exists());
         assert!(!staging.join("fixture.zip").exists());
     }
@@ -824,19 +821,19 @@ mod tests {
     #[test]
     fn test_archive_install_policy_verifies_required_file_header() {
         let temp = tempfile::tempdir().expect("temp dir");
-        let artifact = temp.path().join("fixture-theme.zip");
+        let artifact = temp.path().join("fixture-bundle.zip");
         let staging = temp.path().join("staging");
-        let target = temp.path().join("wp-content/themes/fixture-theme");
+        let target = temp.path().join("bundles/fixture-bundle");
 
         write_zip(
             &artifact,
             &[(
-                "fixture-theme/style.css",
-                "/*\nTheme Name: Fixture Theme\n*/\n",
+                "fixture-bundle/bundle.manifest",
+                "Bundle Name: Fixture Bundle\n",
             )],
         );
 
-        let policy = theme_archive_policy(staging.to_string_lossy().to_string());
+        let policy = bundle_archive_policy(staging.to_string_lossy().to_string());
         let override_config = archive_install_override(&policy);
         let verification = archive_install_verification(&policy).expect("verification");
 
@@ -855,7 +852,7 @@ mod tests {
         .expect("deploy result");
 
         assert!(result.success, "deploy failed: {:?}", result.error);
-        assert!(target.join("style.css").exists());
+        assert!(target.join("bundle.manifest").exists());
     }
 
     #[test]
@@ -863,14 +860,14 @@ mod tests {
         let temp = tempfile::tempdir().expect("temp dir");
         let artifact = temp.path().join("fixture.zip");
         let staging = temp.path().join("staging");
-        let target = temp.path().join("wp-content/plugins/fixture");
+        let target = temp.path().join("packages/fixture");
 
         write_zip(
             &artifact,
-            &[("other/fixture.php", "<?php\n/*\nPlugin Name: Fixture\n*/\n")],
+            &[("other/fixture.manifest", "Package Name: Fixture\n")],
         );
 
-        let policy = plugin_archive_policy(staging.to_string_lossy().to_string());
+        let policy = package_archive_policy(staging.to_string_lossy().to_string());
         let override_config = archive_install_override(&policy);
         let verification = archive_install_verification(&policy).expect("verification");
 

--- a/tests/architecture_core_agnostic_test.rs
+++ b/tests/architecture_core_agnostic_test.rs
@@ -318,7 +318,7 @@ fn deploy_archive_core_stays_free_of_wordpress_header_semantics() {
     let scanned_roots = ["src/core/deploy", "tests/commands/deploy_test.rs"];
 
     for relative_path in scanned_roots {
-        scan_files_for_forbidden_literals(
+        validate_files_for_forbidden_literals(
             root,
             &root.join(relative_path),
             &forbidden,
@@ -333,7 +333,7 @@ fn deploy_archive_core_stays_free_of_wordpress_header_semantics() {
     );
 }
 
-fn scan_files_for_forbidden_literals(
+fn validate_files_for_forbidden_literals(
     root: &std::path::Path,
     path: &std::path::Path,
     forbidden: &[&str],
@@ -342,7 +342,7 @@ fn scan_files_for_forbidden_literals(
     if path.is_dir() {
         for entry in std::fs::read_dir(path).expect("read source directory") {
             let entry = entry.expect("read source entry");
-            scan_files_for_forbidden_literals(root, &entry.path(), forbidden, violations);
+            validate_files_for_forbidden_literals(root, &entry.path(), forbidden, violations);
         }
         return;
     }

--- a/tests/architecture_core_agnostic_test.rs
+++ b/tests/architecture_core_agnostic_test.rs
@@ -302,6 +302,67 @@ fn source_file(relative_path: &str) -> String {
 }
 
 #[test]
+fn deploy_archive_core_stays_free_of_wordpress_header_semantics() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut violations = Vec::new();
+    let forbidden = [
+        "Plugin Name",
+        "Theme Name",
+        "Text Domain",
+        "Requires at least",
+        "Requires PHP",
+        "Tested up to",
+        "Stable tag",
+        "style.css",
+    ];
+    let scanned_roots = ["src/core/deploy", "tests/commands/deploy_test.rs"];
+
+    for relative_path in scanned_roots {
+        scan_files_for_forbidden_literals(
+            root,
+            &root.join(relative_path),
+            &forbidden,
+            &mut violations,
+        );
+    }
+
+    assert!(
+        violations.is_empty(),
+        "core deploy/archive implementation and tests must not bake in WordPress plugin/theme header semantics. Keep domain-specific archive verification in extension-owned config. Violations:\n{}",
+        violations.join("\n")
+    );
+}
+
+fn scan_files_for_forbidden_literals(
+    root: &std::path::Path,
+    path: &std::path::Path,
+    forbidden: &[&str],
+    violations: &mut Vec<String>,
+) {
+    if path.is_dir() {
+        for entry in std::fs::read_dir(path).expect("read source directory") {
+            let entry = entry.expect("read source entry");
+            scan_files_for_forbidden_literals(root, &entry.path(), forbidden, violations);
+        }
+        return;
+    }
+
+    if path.extension().is_none_or(|extension| extension != "rs") {
+        return;
+    }
+
+    let relative = relative_source_path(root, path);
+    let content = std::fs::read_to_string(path).expect("read source file");
+    for (index, line) in content.lines().enumerate() {
+        for term in forbidden {
+            if line.contains(term) {
+                violations.push(format!("{relative}:{} contains `{term}`", index + 1));
+            }
+        }
+    }
+}
+
+#[test]
 fn core_source_does_not_depend_on_command_layer() {
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let core_root = root.join("src/core");


### PR DESCRIPTION
## Summary
- Add a focused architecture guard that scans core deploy/archive implementation and deploy command tests for WordPress plugin/theme header semantics.
- Convert core archive install test fixtures from WordPress plugin/theme examples to neutral package/bundle examples so extension config remains the owner of domain-specific verification.
- Fill missing `AgentTaskOutcome.workflow` fields in existing test helpers so the focused checks compile on current `main`.

## Tests
- `cargo fmt`
- `cargo test --test architecture_core_agnostic_test deploy_archive_core_stays_free_of_wordpress_header_semantics`
- `cargo test test_archive_install_policy`

## Regression caught
This prevents core deploy/archive code and core-owned tests from baking in WordPress plugin/theme verification concepts such as `Plugin Name`, `Theme Name`, `Text Domain`, `Requires PHP`, `Stable tag`, and `style.css`. Those semantics must stay in extension-owned deploy archive install configuration.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the architecture guard, neutralized fixture semantics, ran focused tests, and drafted this PR description for Chris to review.