### PR TITLE
Add bounded sandbox tool API

### DIFF
--- a/docs/architecture/headless-daemon-api.md
+++ b/docs/architecture/headless-daemon-api.md
@@ -17,6 +17,7 @@ The daemon owns a loopback-only HTTP contract for:
 - local client discovery and health checks
 - read-only component, rig, stack, run, artifact, and finding inspection
 - long-running lint, test, audit, and bench jobs
+- typed, allowlisted sandbox-agent Homeboy tool jobs
 - structured job events and final results
 - future mutating operations behind explicit capabilities and confirmations
 
@@ -97,6 +98,8 @@ A useful headless UI can be built from this read/query surface:
 - `GET /audit/runs` and `GET /bench/runs` for analysis-specific run history
 - `GET /jobs`, `GET /jobs/:id`, `GET /jobs/:id/events`, and
   `POST /jobs/:id/cancel` for long-running work
+- `GET /tools`, `GET /tools/:id`, and `POST /tools/:id/run` for sandbox agents
+  that need typed Homeboy tool execution without arbitrary shell access
 
 This is enough for a dashboard that lists components, shows selected checkout
 state, displays rigs/stacks, starts analysis jobs, streams progress, and renders
@@ -122,6 +125,42 @@ Events are append-only records. They are safe for UIs to render incrementally an
 safe for runners to mirror as evidence. The final result event carries the same
 structured result shape as the corresponding CLI command, including artifacts,
 findings, summaries, and CI context when a CI profile/job selector was used.
+
+## Sandbox Tool Surface
+
+Sandbox agents use `/tools` instead of `/exec`. The surface is an allowlist, not a
+shell command proxy.
+
+```text
+GET /tools
+        |
+        +-- [{ id, command, required_capability, risk, runs_as_job,
+              allowed_arguments }]
+
+POST /tools/homeboy.review/run
+        |
+        +-- validates the tool id and JSON body fields
+        +-- enqueues a daemon job
+        +-- returns poll links for /jobs/:id and /jobs/:id/events
+```
+
+The first bounded slice exposes these executable tool IDs:
+
+- `homeboy.audit` with `run:audit`
+- `homeboy.lint` with `run:lint`
+- `homeboy.test` with `run:test`
+- `homeboy.bench` with `run:bench`
+- `homeboy.build` with `run:build`
+- `homeboy.review` with `run:review`
+
+Each tool accepts only its declared JSON arguments. Mutating or operator-shaped
+fields such as lint `fix`, baseline writes, ratchets, free-form build JSON,
+review markdown report output, and review banners are rejected. Non-allowlisted
+tool IDs such as deploy, release, SSH, auth, keychain, and DB operations are
+rejected before any job starts.
+
+`POST /exec` remains a daemon-internal structured execution route for existing
+runner plumbing. It is not the sandbox-agent contract.
 
 The packaged broker service sets `HOME=/var/lib/homeboy`, so the daemon durable
 job store is `/var/lib/homeboy/.config/homeboy/daemon/jobs.json`. The store keeps

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -100,6 +100,9 @@ contract and return the same JSON envelope shape as other daemon responses.
 - `GET /jobs/:id`
 - `GET /jobs/:id/events`
 - `POST /jobs/:id/cancel`
+- `GET /tools`
+- `GET /tools/:id`
+- `POST /tools/:id/run`
 - `POST /runner/sessions`
 - `POST /runner/jobs`
 - `POST /runner/jobs/claim`
@@ -118,6 +121,18 @@ logic in the HTTP API contract.
 The analysis entry points `POST /audit`, `POST /lint`, `POST /test`, and
 `POST /bench` enqueue daemon jobs. Clients inspect those jobs through
 `GET /jobs/:id` and `GET /jobs/:id/events` instead of parsing terminal output.
+
+Sandbox agents should prefer the typed tool surface over command-shaped routes:
+
+- `GET /tools` returns the bounded Homeboy tool allowlist.
+- Each tool declares its required capability, risk category, job behavior, and
+  accepted JSON request fields.
+- `POST /tools/homeboy.audit/run`, `POST /tools/homeboy.lint/run`,
+  `POST /tools/homeboy.test/run`, `POST /tools/homeboy.bench/run`,
+  `POST /tools/homeboy.build/run`, and `POST /tools/homeboy.review/run` enqueue
+  jobs through the same job/event/result contract.
+- Tool IDs that are not in the allowlist, including deploy, release, SSH, auth,
+  keychain, and DB operations, are rejected before execution.
 
 Mutating operations such as deploy, release, rig up/down, stack apply, git
 writes, and SSH execution are not exposed by this daemon slice.

--- a/src/core/agent_task.rs
+++ b/src/core/agent_task.rs
@@ -1062,6 +1062,7 @@ mod tests {
                     artifacts: Vec::new(),
                     evidence_refs: Vec::new(),
                     diagnostics: Vec::new(),
+                    workflow: None,
                     follow_up: None,
                     metadata: json!({}),
                 })
@@ -1100,6 +1101,7 @@ mod tests {
                     artifacts: Vec::new(),
                     evidence_refs: Vec::new(),
                     diagnostics: Vec::new(),
+                    workflow: None,
                     follow_up: None,
                     metadata: json!({}),
                 })
@@ -1217,6 +1219,7 @@ mod tests {
                     artifacts: Vec::new(),
                     evidence_refs: Vec::new(),
                     diagnostics: Vec::new(),
+                    workflow: None,
                     follow_up: None,
                     metadata: json!({}),
                 })

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -437,6 +437,7 @@ impl AgentTaskScheduleSupport {
                 label: Some("scheduler cancellation".to_string()),
             }],
             diagnostics: Vec::new(),
+            workflow: None,
             follow_up: None,
             metadata: Value::Null,
         }
@@ -460,6 +461,7 @@ impl AgentTaskScheduleSupport {
                 message: format!("task exceeded timeout_ms={timeout_ms}"),
                 data: Value::Null,
             }],
+            workflow: None,
             follow_up: None,
             metadata: Value::Null,
         }
@@ -811,6 +813,7 @@ mod tests {
                 label: Some("task log".to_string()),
             }],
             diagnostics: Vec::new(),
+            workflow: None,
             follow_up: None,
             metadata: json!({}),
         }

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -18,6 +18,7 @@ use crate::core::observation::{
 use crate::core::{component, git, rig, stack};
 
 mod analysis_job_runner;
+mod sandbox_tools;
 
 pub use analysis_job_runner::{
     AnalysisJobRunOutput, AnalysisJobRunner, UnsupportedAnalysisJobRunner,
@@ -69,6 +70,9 @@ pub enum HttpEndpoint {
     JobEvents { id: String },
     JobCancel { id: String },
     JobReadyRun { kind: JobReadyRunKind },
+    SandboxTools,
+    SandboxTool { id: String },
+    SandboxToolRun { id: String },
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -103,6 +107,8 @@ pub enum JobReadyRunKind {
     Lint,
     Test,
     Bench,
+    Build,
+    Review,
 }
 
 impl HttpEndpoint {
@@ -130,6 +136,9 @@ impl HttpEndpoint {
             Self::JobEvents { .. } => "jobs.events",
             Self::JobCancel { .. } => "jobs.cancel",
             Self::JobReadyRun { .. } => "jobs.required",
+            Self::SandboxTools => "tools.list",
+            Self::SandboxTool { .. } => "tools.show",
+            Self::SandboxToolRun { .. } => "tools.run",
         }
     }
 }
@@ -203,6 +212,13 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
         (HttpMethod::Post, ["bench"]) => Ok(HttpEndpoint::JobReadyRun {
             kind: JobReadyRunKind::Bench,
         }),
+        (HttpMethod::Get, ["tools"]) => Ok(HttpEndpoint::SandboxTools),
+        (HttpMethod::Get, ["tools", id]) => Ok(HttpEndpoint::SandboxTool {
+            id: (*id).to_string(),
+        }),
+        (HttpMethod::Post, ["tools", id, "run"]) => Ok(HttpEndpoint::SandboxToolRun {
+            id: (*id).to_string(),
+        }),
         _ => Err(Error::validation_invalid_argument(
             "path",
             format!(
@@ -229,6 +245,9 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
                 "GET /jobs/:id".to_string(),
                 "GET /jobs/:id/events".to_string(),
                 "POST /jobs/:id/cancel".to_string(),
+                "GET /tools".to_string(),
+                "GET /tools/:id".to_string(),
+                "POST /tools/:id/run".to_string(),
             ]),
         )),
     }
@@ -364,6 +383,17 @@ where
         HttpEndpoint::JobReadyRun { kind } => {
             enqueue_analysis_job(job_store, *kind, request.body, analysis_runner)?
         }
+        HttpEndpoint::SandboxTools => json!({
+            "command": "api.tools.list",
+            "tools": sandbox_tools::all(),
+        }),
+        HttpEndpoint::SandboxTool { id } => json!({
+            "command": "api.tools.show",
+            "tool": sandbox_tools::get(id)?,
+        }),
+        HttpEndpoint::SandboxToolRun { id } => {
+            enqueue_sandbox_tool_job(job_store, id, request.body, analysis_runner)?
+        }
     };
 
     Ok(HttpApiResponse {
@@ -371,6 +401,25 @@ where
         endpoint: endpoint.name().to_string(),
         body,
     })
+}
+
+fn enqueue_sandbox_tool_job(
+    job_store: &JobStore,
+    id: &str,
+    body: Option<Value>,
+    analysis_runner: impl AnalysisJobRunner,
+) -> Result<Value> {
+    let tool = sandbox_tools::get(id)?;
+    let kind = sandbox_tools::kind(tool.id)?;
+    let mut response = enqueue_analysis_job(job_store, kind, body, analysis_runner)?;
+    if let Value::Object(ref mut fields) = response {
+        fields.insert("command".to_string(), json!("api.tools.run.enqueue"));
+        fields.insert(
+            "tool".to_string(),
+            serde_json::to_value(tool).unwrap_or(Value::Null),
+        );
+    }
+    Ok(response)
 }
 
 fn artifact_content(run_id: &str, artifact_id: &str) -> Result<Value> {
@@ -545,12 +594,11 @@ impl AnalysisJobRequest {
         let mut parser = AnalysisBodyParser::new(body)?;
         let mut args = vec![job_ready_slug(kind).to_string()];
 
-        parser.push_optional_string("component", &mut args)?;
-        parser.push_optional_flag_value("path", "--path", &mut args)?;
-        parser.push_bool_flag("json_summary", "--json-summary", &mut args)?;
-
         match kind {
             JobReadyRunKind::Audit => {
+                parser.push_optional_string("component", &mut args)?;
+                parser.push_optional_flag_value("path", "--path", &mut args)?;
+                parser.push_bool_flag("json_summary", "--json-summary", &mut args)?;
                 parser.push_bool_flag("conventions", "--conventions", &mut args)?;
                 parser.push_string_array("only", "--only", &mut args)?;
                 parser.push_string_array("exclude", "--exclude", &mut args)?;
@@ -558,6 +606,9 @@ impl AnalysisJobRequest {
                 parser.push_bool_flag("fixability", "--fixability", &mut args)?;
             }
             JobReadyRunKind::Lint => {
+                parser.push_optional_string("component", &mut args)?;
+                parser.push_optional_flag_value("path", "--path", &mut args)?;
+                parser.push_bool_flag("json_summary", "--json-summary", &mut args)?;
                 parser.push_bool_flag("summary", "--summary", &mut args)?;
                 parser.push_optional_flag_value("file", "--file", &mut args)?;
                 parser.push_optional_flag_value("glob", "--glob", &mut args)?;
@@ -570,6 +621,9 @@ impl AnalysisJobRequest {
                 parser.reject_present("fix", "POST /lint jobs do not expose mutating --fix")?;
             }
             JobReadyRunKind::Test => {
+                parser.push_optional_string("component", &mut args)?;
+                parser.push_optional_flag_value("path", "--path", &mut args)?;
+                parser.push_bool_flag("json_summary", "--json-summary", &mut args)?;
                 parser.push_bool_flag("skip_lint", "--skip-lint", &mut args)?;
                 parser.push_bool_flag("coverage", "--coverage", &mut args)?;
                 parser.push_optional_number("coverage_min", "--coverage-min", &mut args)?;
@@ -581,6 +635,9 @@ impl AnalysisJobRequest {
                 parser.reject_present("write", "POST /test jobs do not expose mutating --write")?;
             }
             JobReadyRunKind::Bench => {
+                parser.push_optional_string("component", &mut args)?;
+                parser.push_optional_flag_value("path", "--path", &mut args)?;
+                parser.push_bool_flag("json_summary", "--json-summary", &mut args)?;
                 parser.push_optional_u64("iterations", "--iterations", &mut args)?;
                 parser.push_optional_u64("warmup", "--warmup", &mut args)?;
                 parser.push_optional_u64("runs", "--runs", &mut args)?;
@@ -599,6 +656,23 @@ impl AnalysisJobRequest {
                     &mut args,
                 )?;
                 parser.push_passthrough_args(&mut args)?;
+            }
+            JobReadyRunKind::Build => {
+                parser.push_optional_string("component", &mut args)?;
+                parser.push_string_array_values("component_ids", &mut args)?;
+                parser.push_optional_flag_value("path", "--path", &mut args)?;
+                parser.push_bool_flag("all", "--all", &mut args)?;
+                parser.reject_present("json", "sandbox build jobs do not expose --json")?;
+            }
+            JobReadyRunKind::Review => {
+                parser.push_optional_string("component", &mut args)?;
+                parser.push_optional_flag_value("path", "--path", &mut args)?;
+                parser.push_optional_flag_value("changed_since", "--changed-since", &mut args)?;
+                parser.push_bool_flag("changed_only", "--changed-only", &mut args)?;
+                parser.push_bool_flag("summary", "--summary", &mut args)?;
+                parser.push_optional_flag_value("ci_profile", "--ci-profile", &mut args)?;
+                parser.reject_present("report", "sandbox review jobs keep JSON output")?;
+                parser.reject_present("banner", "sandbox review jobs do not expose --banner")?;
             }
         }
 
@@ -707,6 +781,25 @@ impl AnalysisBodyParser {
                     args.push(flag.to_string());
                     args.push(value);
                 }
+                Value::Null => {}
+                other => return Err(invalid_body_type(key, "string or array of strings", &other)),
+            }
+        }
+        Ok(())
+    }
+
+    fn push_string_array_values(&mut self, key: &str, args: &mut Vec<String>) -> Result<()> {
+        if let Some(value) = self.take(key) {
+            match value {
+                Value::Array(values) => {
+                    for value in values {
+                        let Some(value) = value.as_str() else {
+                            return Err(invalid_body_type(key, "array of strings", &value));
+                        };
+                        args.push(value.to_string());
+                    }
+                }
+                Value::String(value) => args.push(value),
                 Value::Null => {}
                 other => return Err(invalid_body_type(key, "string or array of strings", &other)),
             }
@@ -882,6 +975,8 @@ fn job_ready_slug(kind: JobReadyRunKind) -> &'static str {
         JobReadyRunKind::Lint => "lint",
         JobReadyRunKind::Test => "test",
         JobReadyRunKind::Bench => "bench",
+        JobReadyRunKind::Build => "build",
+        JobReadyRunKind::Review => "review",
     }
 }
 

--- a/src/core/http_api/sandbox_tools.rs
+++ b/src/core/http_api/sandbox_tools.rs
@@ -1,0 +1,160 @@
+use serde::Serialize;
+
+use super::JobReadyRunKind;
+use crate::core::error::{Error, Result};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SandboxToolDescriptor {
+    pub id: &'static str,
+    pub command: &'static str,
+    pub required_capability: &'static str,
+    pub risk: &'static str,
+    pub runs_as_job: bool,
+    pub allowed_arguments: &'static [&'static str],
+}
+
+const SANDBOX_TOOLS: &[SandboxToolDescriptor] = &[
+    SandboxToolDescriptor {
+        id: "homeboy.audit",
+        command: "homeboy audit",
+        required_capability: "run:audit",
+        risk: "bounded_local_run",
+        runs_as_job: true,
+        allowed_arguments: &[
+            "component",
+            "path",
+            "json_summary",
+            "conventions",
+            "only",
+            "exclude",
+            "changed_since",
+            "fixability",
+        ],
+    },
+    SandboxToolDescriptor {
+        id: "homeboy.lint",
+        command: "homeboy lint",
+        required_capability: "run:lint",
+        risk: "bounded_local_run",
+        runs_as_job: true,
+        allowed_arguments: &[
+            "component",
+            "path",
+            "json_summary",
+            "summary",
+            "file",
+            "glob",
+            "changed_only",
+            "changed_since",
+            "errors_only",
+            "sniffs",
+            "exclude_sniffs",
+            "category",
+        ],
+    },
+    SandboxToolDescriptor {
+        id: "homeboy.test",
+        command: "homeboy test",
+        required_capability: "run:test",
+        risk: "bounded_local_run",
+        runs_as_job: true,
+        allowed_arguments: &[
+            "component",
+            "path",
+            "json_summary",
+            "skip_lint",
+            "coverage",
+            "coverage_min",
+            "analyze",
+            "drift",
+            "since",
+            "changed_since",
+            "args",
+        ],
+    },
+    SandboxToolDescriptor {
+        id: "homeboy.bench",
+        command: "homeboy bench",
+        required_capability: "run:bench",
+        risk: "bounded_local_run",
+        runs_as_job: true,
+        allowed_arguments: &[
+            "component",
+            "path",
+            "json_summary",
+            "iterations",
+            "warmup",
+            "runs",
+            "concurrency",
+            "rig",
+            "scenario",
+            "profile",
+            "regression_threshold",
+            "ignore_default_baseline",
+            "args",
+        ],
+    },
+    SandboxToolDescriptor {
+        id: "homeboy.build",
+        command: "homeboy build",
+        required_capability: "run:build",
+        risk: "bounded_local_run",
+        runs_as_job: true,
+        allowed_arguments: &["component", "component_ids", "path", "all"],
+    },
+    SandboxToolDescriptor {
+        id: "homeboy.review",
+        command: "homeboy review",
+        required_capability: "run:review",
+        risk: "bounded_local_run",
+        runs_as_job: true,
+        allowed_arguments: &[
+            "component",
+            "path",
+            "changed_since",
+            "changed_only",
+            "summary",
+            "ci_profile",
+        ],
+    },
+];
+
+pub fn all() -> &'static [SandboxToolDescriptor] {
+    SANDBOX_TOOLS
+}
+
+pub fn get(id: &str) -> Result<&'static SandboxToolDescriptor> {
+    SANDBOX_TOOLS
+        .iter()
+        .find(|tool| tool.id == id)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "tool_id",
+                format!("sandbox tool is not allowlisted: {id}"),
+                Some(id.to_string()),
+                Some(
+                    SANDBOX_TOOLS
+                        .iter()
+                        .map(|tool| tool.id.to_string())
+                        .collect(),
+                ),
+            )
+        })
+}
+
+pub fn kind(id: &str) -> Result<JobReadyRunKind> {
+    match id {
+        "homeboy.audit" => Ok(JobReadyRunKind::Audit),
+        "homeboy.lint" => Ok(JobReadyRunKind::Lint),
+        "homeboy.test" => Ok(JobReadyRunKind::Test),
+        "homeboy.bench" => Ok(JobReadyRunKind::Bench),
+        "homeboy.build" => Ok(JobReadyRunKind::Build),
+        "homeboy.review" => Ok(JobReadyRunKind::Review),
+        _ => Err(Error::validation_invalid_argument(
+            "tool_id",
+            format!("sandbox tool is not executable: {id}"),
+            Some(id.to_string()),
+            None,
+        )),
+    }
+}

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -143,6 +143,26 @@ fn routes_job_ready_analysis_endpoints_without_executing_them() {
 }
 
 #[test]
+fn routes_sandbox_tool_endpoints() {
+    assert_eq!(
+        http_api::route(HttpMethod::Get, "/tools").expect("route"),
+        HttpEndpoint::SandboxTools
+    );
+    assert_eq!(
+        http_api::route(HttpMethod::Get, "/tools/homeboy.audit").expect("route"),
+        HttpEndpoint::SandboxTool {
+            id: "homeboy.audit".to_string()
+        }
+    );
+    assert_eq!(
+        http_api::route(HttpMethod::Post, "/tools/homeboy.review/run").expect("route"),
+        HttpEndpoint::SandboxToolRun {
+            id: "homeboy.review".to_string()
+        }
+    );
+}
+
+#[test]
 fn routes_observation_run_readers() {
     assert_eq!(
         http_api::route(HttpMethod::Get, "/runs?kind=bench").expect("route"),
@@ -362,6 +382,84 @@ fn rejects_mutating_endpoint_shapes() {
     assert!(http_api::route(HttpMethod::Post, "/stacks/studio/apply").is_err());
     assert!(http_api::route(HttpMethod::Post, "/deploy").is_err());
     assert!(http_api::route(HttpMethod::Post, "/release").is_err());
+}
+
+#[test]
+fn sandbox_tools_declare_capabilities_and_allowed_arguments() {
+    let response = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Get,
+            path: "/tools".to_string(),
+            body: None,
+        },
+        &JobStore::default(),
+    )
+    .expect("list tools");
+
+    assert_eq!(response.endpoint, "tools.list");
+    let tools = response.body["tools"].as_array().expect("tools");
+    assert!(tools.iter().any(|tool| {
+        tool["id"] == "homeboy.review"
+            && tool["required_capability"] == "run:review"
+            && tool["risk"] == "bounded_local_run"
+    }));
+    assert!(tools.iter().all(|tool| {
+        !tool["required_capability"]
+            .as_str()
+            .unwrap_or_default()
+            .starts_with("operator:")
+    }));
+}
+
+#[test]
+fn sandbox_tool_run_enqueues_allowlisted_job() {
+    let store = JobStore::default();
+    let response = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Post,
+            path: "/tools/homeboy.build/run".to_string(),
+            body: Some(serde_json::json!({
+                "component": "missing-component",
+                "path": "/tmp/homeboy-missing-component"
+            })),
+        },
+        &store,
+    )
+    .expect("build tool job enqueued");
+
+    assert_eq!(response.endpoint, "tools.run");
+    assert_eq!(response.body["command"], "api.tools.run.enqueue");
+    assert_eq!(response.body["tool"]["id"], "homeboy.build");
+    assert_eq!(response.body["request"]["kind"], "build");
+    let args = response.body["request"]["args"].as_array().expect("args");
+    assert!(args.iter().any(|arg| arg == "build"));
+    assert!(args.iter().any(|arg| arg == "--path"));
+    assert_eq!(store.list().len(), 1);
+}
+
+#[test]
+fn sandbox_tool_run_rejects_unallowlisted_tool_and_arguments() {
+    let unknown = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Post,
+            path: "/tools/homeboy.deploy/run".to_string(),
+            body: Some(serde_json::json!({})),
+        },
+        &JobStore::default(),
+    )
+    .expect_err("deploy tool is not allowlisted");
+    assert!(unknown.to_string().contains("not allowlisted"));
+
+    let mutating = http_api::handle_with_jobs(
+        HttpApiRequest {
+            method: HttpMethod::Post,
+            path: "/tools/homeboy.review/run".to_string(),
+            body: Some(serde_json::json!({ "report": "pr-comment" })),
+        },
+        &JobStore::default(),
+    )
+    .expect_err("review report output is rejected");
+    assert!(mutating.to_string().contains("JSON output"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds a typed `/tools` daemon surface for sandbox agents with explicit Homeboy tool IDs, capabilities, risk labels, and allowed JSON arguments.
- Routes allowlisted tool runs through the existing daemon job/event/result substrate instead of exposing arbitrary shell/operator execution.
- Documents the sandbox-agent contract and covers allowlist metadata, job enqueueing, and rejected unsafe fields/tools.

Fixes #3224

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo test http_api -- --nocapture`
- `homeboy audit --path . --changed-since origin/main --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and implemented the bounded daemon tool API, tests, docs, and verification pass; Chris remains responsible for review and merge.