### PR TITLE
fix: render deploy artifact templates

### DIFF
--- a/src/core/deploy/safety_and_artifact.rs
+++ b/src/core/deploy/safety_and_artifact.rs
@@ -294,7 +294,7 @@ pub(super) fn deploy_artifact(
 }
 
 fn render_extract_command(template: &str, vars: &HashMap<String, String>) -> String {
-    let mut result = template.to_string();
+    let mut result = render_map(template, vars);
     for (key, value) in vars {
         result = result.replace(&format!("{{{}}}", key), value);
     }
@@ -340,6 +340,25 @@ mod tests {
         assert_eq!(
             render_extract_command("unzip {archive} -d {target}", &vars),
             "unzip artifact.zip -d /srv/site/plugin"
+        );
+    }
+
+    #[test]
+    fn test_deploy_artifact_extract_command_template_replaces_double_brace_vars() {
+        let vars = std::collections::HashMap::from([
+            (
+                "artifact".to_string(),
+                ".homeboy-data-machine-events.zip".to_string(),
+            ),
+            (
+                "targetDir".to_string(),
+                "/srv/site/wp-content/plugins/data-machine-events".to_string(),
+            ),
+        ]);
+
+        assert_eq!(
+            render_extract_command("unzip -o {{artifact}} && rm {{artifact}}", &vars),
+            "unzip -o .homeboy-data-machine-events.zip && rm .homeboy-data-machine-events.zip"
         );
     }
 


### PR DESCRIPTION
## Summary
- Render deploy `extract_command` templates with the shared double-brace renderer so documented `{{artifact}}` placeholders resolve before extraction.
- Preserve existing single-brace placeholder compatibility for current commands.
- Add a regression test for the failing `unzip -o {{artifact}} && rm {{artifact}}` form from #3226.

Fixes #3226.

## Testing
- `cargo test deploy_artifact_extract_command_template`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the deploy template rendering bug, drafted the minimal code change and regression test, rebased the branch, and ran verification. Chris remains responsible for review and merge.