### PR TITLE
Fix GitHub Actions artifact import by run ID

### DIFF
--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -14,6 +14,8 @@ homeboy runs artifact cleanup-downloads [--runner <runner-id>] [--run-id <run-id
 homeboy runs export --run <run-id> --output <dir>
 homeboy runs export --since <duration> --output <dir>
 homeboy runs import <dir>
+homeboy runs import --from-gh-actions --component <id> --repo <owner/repo> --workflow <workflow.yml> --artifact-glob <glob>
+homeboy runs import --from-gh-actions --component <id> --repo <owner/repo> --run-id <gh-run-id> --artifact-glob <glob>
 ```
 
 ## Description
@@ -73,3 +75,17 @@ homeboy-observations/
 The v1 bundle is metadata-only: artifact records are exported, but artifact file bytes are not copied. Imported local file and directory artifacts are stored as `metadata-only` records with portable labels rather than source-machine paths. `homeboy runs query` reports these rows as skipped evidence, and `homeboy runs artifact get` explains that bytes are unavailable. `findings.json` contains normalized observation findings, and `test_failures.json` is an additive subset of findings where test commands recorded individual failures. Zip output is intentionally out of scope for v1; pass a directory path to `--output`.
 
 `homeboy runs import` is idempotent. Existing identical records are accepted, while conflicting records with the same primary key fail clearly.
+
+## GitHub Actions Artifacts
+
+`homeboy runs import --from-gh-actions` imports JSON files from matching GitHub Actions artifacts into the local observation store. Use `--workflow` to scan recent workflow runs, or `--run-id` when triage starts from an exact GitHub Actions run URL or ID and the workflow filename is irrelevant.
+
+The structured output includes stable Homeboy run/artifact IDs and persisted local artifact paths under `artifacts[]`, so agents can read the copied JSON directly without searching temporary download directories.
+
+```bash
+homeboy runs import --from-gh-actions \
+  --component wp-site-generator \
+  --repo chubes4/wp-site-generator \
+  --run-id 26731420339 \
+  --artifact-glob 'php-transformer-iterator-transcript-*'
+```

--- a/src/commands/runs/bundle.rs
+++ b/src/commands/runs/bundle.rs
@@ -36,9 +36,9 @@ pub(super) struct RunsImportArgs {
     /// using `--from-gh-actions`. Mutually exclusive with `--from-gh-actions`.
     pub input: Option<PathBuf>,
 
-    /// Ingest artifacts directly from a GitHub Actions workflow instead of
-    /// from a portable bundle directory. When set, all of `--component`,
-    /// `--repo`, `--workflow`, and `--artifact-glob` are required.
+    /// Ingest artifacts directly from GitHub Actions instead of from a
+    /// portable bundle directory. When set, `--component`, `--repo`,
+    /// `--artifact-glob`, and one of `--workflow` or `--run-id` are required.
     #[arg(long, default_value_t = false)]
     pub from_gh_actions: bool,
 
@@ -51,6 +51,9 @@ pub(super) struct RunsImportArgs {
     /// Workflow filename or display name (gh-actions mode).
     #[arg(long)]
     pub workflow: Option<String>,
+    /// Exact GitHub Actions run id (gh-actions mode).
+    #[arg(long = "run-id")]
+    pub run_id: Option<u64>,
     /// Glob filter for artifact names (gh-actions mode). Examples:
     /// `'design-distribution-*'`, `'*.json'`.
     #[arg(long = "artifact-glob")]
@@ -231,7 +234,12 @@ fn portable_artifact_label(path: &str, fallback: &str) -> String {
 fn import_via_gh_actions(args: RunsImportArgs) -> CmdResult<RunsOutput> {
     let component_id = require_gh_arg(args.component_id.clone(), "component")?;
     let repo = require_gh_arg(args.repo.clone(), "repo")?;
-    let workflow = require_gh_arg(args.workflow.clone(), "workflow")?;
+    let workflow = args.workflow.clone().filter(|v| !v.trim().is_empty());
+    if workflow.is_none() && args.run_id.is_none() {
+        return Err(Error::validation_missing_argument(vec![
+            "--workflow or --run-id".to_string(),
+        ]));
+    }
     let artifact_glob = require_gh_arg(args.artifact_glob.clone(), "artifact-glob")?;
     let since = args.since.clone().unwrap_or_else(|| "30d".to_string());
 
@@ -239,6 +247,7 @@ fn import_via_gh_actions(args: RunsImportArgs) -> CmdResult<RunsOutput> {
         component_id,
         repo,
         workflow,
+        run_id: args.run_id,
         artifact_glob,
         since,
         limit: args.limit,

--- a/src/commands/runs/corpus_tests.rs
+++ b/src/commands/runs/corpus_tests.rs
@@ -199,7 +199,7 @@ fn runs_drift_reports_dominant_value_above_threshold() {
 fn import_from_gh_actions_requires_gh_specific_arguments() {
     with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();
-        // Without --component, --repo, --workflow, --artifact-glob, the
+        // Without --component, --repo, --workflow/--run-id, --artifact-glob, the
         // gh-actions branch must reject with a missing-argument error.
         let err = import_runs(RunsImportArgs {
             input: None,
@@ -208,6 +208,24 @@ fn import_from_gh_actions_requires_gh_specific_arguments() {
         })
         .err()
         .expect("must fail without required gh-actions args");
+        assert_eq!(err.code.as_str(), "validation.missing_argument");
+    });
+}
+
+#[test]
+fn import_from_gh_actions_requires_workflow_or_run_id() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let err = import_runs(RunsImportArgs {
+            input: None,
+            from_gh_actions: true,
+            component_id: Some("wp-site-generator".into()),
+            repo: Some("chubes4/wp-site-generator".into()),
+            artifact_glob: Some("php-transformer-iterator-transcript-*".into()),
+            ..RunsImportArgs::default()
+        })
+        .err()
+        .expect("must fail without workflow or run id");
         assert_eq!(err.code.as_str(), "validation.missing_argument");
     });
 }

--- a/src/commands/runs/gh_actions.rs
+++ b/src/commands/runs/gh_actions.rs
@@ -20,7 +20,7 @@
 //! `runs drift` primitives project arbitrary JSONPath expressions over the
 //! resulting artifact corpus.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::fs;
 use std::io::{Cursor, Read};
 use std::path::PathBuf;
@@ -61,7 +61,10 @@ pub struct GhActionsImportArgs {
     pub repo: String,
     /// Workflow filename (e.g. `static-site-validation.yml`) or workflow name.
     #[arg(long)]
-    pub workflow: String,
+    pub workflow: Option<String>,
+    /// Exact GitHub Actions run id.
+    #[arg(long = "run-id")]
+    pub run_id: Option<u64>,
     /// Artifact name glob — matched against the GitHub artifact name.
     /// Examples: `'design-distribution-*'`, `'*.json'`, `'ssi-validation-*'`.
     #[arg(long = "artifact-glob")]
@@ -79,7 +82,8 @@ pub struct GhActionsImportOutput {
     pub command: &'static str,
     pub component_id: String,
     pub repo: String,
-    pub workflow: String,
+    pub workflow: Option<String>,
+    pub run_id: Option<u64>,
     pub artifact_glob: String,
     pub runs_inspected: usize,
     pub runs_imported: usize,
@@ -88,6 +92,26 @@ pub struct GhActionsImportOutput {
     pub artifacts_skipped_existing: usize,
     pub artifacts_skipped_non_json: usize,
     pub etag_cache_hit: bool,
+    pub artifacts: Vec<GhActionsImportedArtifact>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct GhActionsImportedArtifact {
+    pub run_id: String,
+    pub gh_run_id: u64,
+    pub artifact_id: String,
+    pub gh_artifact_id: u64,
+    pub artifact_name: String,
+    pub file_name: String,
+    pub path: String,
+    pub status: GhActionsImportedArtifactStatus,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GhActionsImportedArtifactStatus {
+    Imported,
+    Existing,
 }
 
 pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput> {
@@ -103,7 +127,14 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
     let store = ObservationStore::open_initialized()?;
     let pattern = compile_glob(&args.artifact_glob)?;
 
-    let (runs, etag_cache_hit) = list_workflow_runs(&args.repo, &args.workflow, &args.since)?;
+    let (runs, etag_cache_hit) = if let Some(run_id) = args.run_id {
+        (vec![get_workflow_run(&args.repo, run_id)?], false)
+    } else {
+        let workflow = args.workflow.as_deref().ok_or_else(|| {
+            Error::validation_missing_argument(vec!["--workflow or --run-id".to_string()])
+        })?;
+        list_workflow_runs(&args.repo, workflow, &args.since)?
+    };
     let runs_inspected = runs.len().min(args.limit);
     let runs_to_process: Vec<&GhWorkflowRun> = runs.iter().take(args.limit).collect();
 
@@ -112,6 +143,7 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
     let mut artifacts_imported = 0usize;
     let mut artifacts_skipped_existing = 0usize;
     let mut artifacts_skipped_non_json = 0usize;
+    let mut artifact_rows = Vec::new();
 
     for gh_run in runs_to_process {
         let homeboy_run_id = deterministic_run_id(&args.repo, gh_run.id);
@@ -130,10 +162,10 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
         // ingested. Existing artifact rows are detected via deterministic
         // (run_id, gh_artifact_id, file_name) IDs.
         let artifacts = list_run_artifacts(&args.repo, gh_run.id)?;
-        let existing_artifact_ids: HashSet<String> = store
+        let existing_artifacts: HashMap<String, homeboy::core::observation::ArtifactRecord> = store
             .list_artifacts(&homeboy_run_id)?
             .into_iter()
-            .map(|a| a.id)
+            .map(|a| (a.id.clone(), a))
             .collect();
 
         for artifact in artifacts {
@@ -158,8 +190,18 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
                 }
                 let artifact_id =
                     deterministic_artifact_id(&homeboy_run_id, artifact.id, &file_name);
-                if existing_artifact_ids.contains(&artifact_id) {
+                if let Some(existing) = existing_artifacts.get(&artifact_id) {
                     artifacts_skipped_existing += 1;
+                    artifact_rows.push(GhActionsImportedArtifact {
+                        run_id: homeboy_run_id.clone(),
+                        gh_run_id: gh_run.id,
+                        artifact_id,
+                        gh_artifact_id: artifact.id,
+                        artifact_name: artifact.name.clone(),
+                        file_name,
+                        path: existing.path.clone(),
+                        status: GhActionsImportedArtifactStatus::Existing,
+                    });
                     continue;
                 }
 
@@ -180,6 +222,16 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
                     created_at: chrono::Utc::now().to_rfc3339(),
                 };
                 store.import_artifact(&artifact_record)?;
+                artifact_rows.push(GhActionsImportedArtifact {
+                    run_id: homeboy_run_id.clone(),
+                    gh_run_id: gh_run.id,
+                    artifact_id: artifact_record.id.clone(),
+                    gh_artifact_id: artifact.id,
+                    artifact_name: artifact.name.clone(),
+                    file_name,
+                    path: artifact_record.path.clone(),
+                    status: GhActionsImportedArtifactStatus::Imported,
+                });
                 artifacts_imported += 1;
             }
         }
@@ -191,6 +243,7 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
             component_id: args.component_id,
             repo: args.repo,
             workflow: args.workflow,
+            run_id: args.run_id,
             artifact_glob: args.artifact_glob,
             runs_inspected,
             runs_imported,
@@ -199,6 +252,7 @@ pub fn import_from_gh_actions(args: GhActionsImportArgs) -> CmdResult<RunsOutput
             artifacts_skipped_existing,
             artifacts_skipped_non_json,
             etag_cache_hit,
+            artifacts: artifact_rows,
         }),
         0,
     ))
@@ -246,8 +300,8 @@ fn build_run_record(
         finished_at: gh_run.updated_at.clone(),
         status: map_gh_conclusion_to_status(gh_run),
         command: Some(format!(
-            "homeboy runs import --from-gh-actions --repo {repo} --workflow {}",
-            gh_run.workflow_name.clone().unwrap_or_default()
+            "homeboy runs import --from-gh-actions --repo {repo} --run-id {}",
+            gh_run.id
         )),
         cwd: None,
         homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
@@ -274,6 +328,25 @@ fn map_gh_conclusion_to_status(gh_run: &GhWorkflowRun) -> String {
 }
 
 // ── GitHub API listing (via `gh` CLI) ───────────────────────────────────────
+
+fn get_workflow_run(repo: &str, run_id: u64) -> homeboy::core::Result<GhWorkflowRun> {
+    let api_path = format!("repos/{repo}/actions/runs/{run_id}");
+    let output = Command::new("gh")
+        .args(["api", &api_path])
+        .output()
+        .map_err(|e| Error::internal_io(format!("Failed to invoke gh: {e}"), Some("gh".into())))?;
+    if !output.status.success() {
+        return Err(Error::internal_io(
+            format!(
+                "gh api workflow run failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+            Some(format!("gh api {api_path}")),
+        ));
+    }
+
+    parse_run_payload(&output.stdout)
+}
 
 /// One GitHub Actions workflow run, projected to the fields we persist.
 #[derive(Debug, Clone, Deserialize)]
@@ -509,6 +582,12 @@ fn parse_runs_payload(body: &[u8]) -> homeboy::core::Result<Vec<GhWorkflowRun>> 
         runs.extend(page.workflow_runs.into_iter().map(GhWorkflowRun::from));
     }
     Ok(runs)
+}
+
+fn parse_run_payload(body: &[u8]) -> homeboy::core::Result<GhWorkflowRun> {
+    let raw: GhWorkflowRunRaw = serde_json::from_slice(body)
+        .map_err(|e| Error::internal_json(e.to_string(), Some("parse workflow run".into())))?;
+    Ok(GhWorkflowRun::from(raw))
 }
 
 /// Drop runs whose `created_at` is older than the `--since` window.
@@ -831,6 +910,36 @@ mod tests {
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].id, 100);
         assert_eq!(runs[0].pull_request_numbers, vec![98]);
+    }
+
+    #[test]
+    fn parse_run_payload_handles_single_run_response() {
+        let raw = serde_json::to_vec(&serde_json::json!({
+            "id": 26731420339u64,
+            "run_number": 42,
+            "name": "Static site validation iterator",
+            "workflow_id": 123,
+            "head_branch": "main",
+            "head_sha": "deadbeef",
+            "event": "workflow_dispatch",
+            "status": "completed",
+            "conclusion": "failure",
+            "run_started_at": "2026-05-31T10:00:00Z",
+            "created_at": "2026-05-31T09:59:00Z",
+            "updated_at": "2026-05-31T10:05:00Z",
+            "run_attempt": 1,
+            "pull_requests": []
+        }))
+        .unwrap();
+
+        let run = parse_run_payload(&raw).expect("parse run");
+        assert_eq!(run.id, 26731420339);
+        assert_eq!(
+            run.workflow_name.as_deref(),
+            Some("Static site validation iterator")
+        );
+        assert_eq!(run.workflow_id, Some(123));
+        assert_eq!(map_gh_conclusion_to_status(&run), "fail");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `--run-id` support to `homeboy runs import --from-gh-actions` so callers can import artifacts from an exact GitHub Actions run without knowing the workflow filename.
- Include imported/existing artifact rows in structured output with stable Homeboy IDs and persisted local paths.
- Document the run-ID import flow and keep the existing workflow-based import path intact.

Fixes #3237.

## Testing
- `cargo test commands::runs::gh_actions::tests`
- `cargo test import_from_gh_actions`
- `cargo test command_surface`
- Live smoke: `XDG_DATA_HOME=$(mktemp -d)/.local/share ./target/debug/homeboy runs import --from-gh-actions --component wp-site-generator --repo chubes4/wp-site-generator --run-id 26731420339 --artifact-glob 'php-transformer-iterator-transcript-*'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the run-ID artifact import path, updated tests/docs, and ran targeted verification. Chris remains responsible for review and merge.