### PR TITLE
Dispatch extension agent task providers

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -2,10 +2,10 @@ use clap::{Command, CommandFactory, Parser, Subcommand};
 use std::path::PathBuf;
 
 use crate::commands::{
-    api, audit, auth, bench, build, changelog, changes, ci, cleanup, component, config, daemon, db,
-    deploy, deps, doctor, extension, file, fleet, git, http, issues, lint, logs, observe, project,
-    refactor, refs, release, report, review, rig, runner, runs, self_cmd, server, ssh, stack,
-    status, test, trace, triage, tunnel, undo, upgrade, version,
+    agent_task, api, audit, auth, bench, build, changelog, changes, ci, cleanup, component, config,
+    daemon, db, deploy, deps, doctor, extension, file, fleet, git, http, issues, lint, logs,
+    observe, project, refactor, refs, release, report, review, rig, runner, runs, self_cmd, server,
+    ssh, stack, status, test, trace, triage, tunnel, undo, upgrade, version,
 };
 
 mod lab_contract;
@@ -45,6 +45,9 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Run generic agent task plans
+    #[command(name = "agent-task")]
+    AgentTask(agent_task::AgentTaskArgs),
     /// Manage project configuration
     Project(project::ProjectArgs),
     /// SSH into a project server or configured server
@@ -331,7 +334,8 @@ impl Commands {
                 output_file_mode,
                 CommandOutputContractKind::JsonEnvelope,
             ),
-            Commands::Project(_)
+            Commands::AgentTask(_)
+            | Commands::Project(_)
             | Commands::Component(_)
             | Commands::Config(_)
             | Commands::Extension(_)

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -1,0 +1,69 @@
+use clap::{Args, Subcommand};
+use serde_json::Value;
+
+use homeboy::core::agent_task_provider::ExtensionProviderAgentTaskExecutor;
+use homeboy::core::agent_task_scheduler::{AgentTaskPlan, AgentTaskScheduler};
+use homeboy::core::config;
+
+use super::{CmdResult, GlobalArgs};
+
+#[derive(Args, Debug)]
+pub struct AgentTaskArgs {
+    #[command(subcommand)]
+    pub command: AgentTaskCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AgentTaskCommand {
+    /// Run an agent-task plan through extension-declared executor providers.
+    RunPlan(RunPlanArgs),
+    /// List extension-declared agent-task executor providers.
+    Providers,
+}
+
+#[derive(Args, Debug)]
+pub struct RunPlanArgs {
+    /// AgentTaskPlan JSON file, @file, or - for stdin.
+    #[arg(long, value_name = "PATH")]
+    pub plan: String,
+}
+
+pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
+    match args.command {
+        AgentTaskCommand::RunPlan(run_args) => run_plan(run_args),
+        AgentTaskCommand::Providers => providers(),
+    }
+}
+
+fn run_plan(args: RunPlanArgs) -> CmdResult<Value> {
+    let raw = config::read_json_spec_to_string(&args.plan)?;
+    let plan: AgentTaskPlan = serde_json::from_str(&raw).map_err(|error| {
+        homeboy::core::Error::validation_invalid_json(
+            error,
+            Some("agent-task plan".to_string()),
+            Some(raw.clone()),
+        )
+    })?;
+    let scheduler = AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::discover());
+    let aggregate = scheduler.run(plan);
+    let exit_code = if aggregate.totals.failed == 0
+        && aggregate.totals.cancelled == 0
+        && aggregate.totals.timed_out == 0
+    {
+        0
+    } else {
+        1
+    };
+    Ok((
+        serde_json::to_value(aggregate).unwrap_or(Value::Null),
+        exit_code,
+    ))
+}
+
+fn providers() -> CmdResult<Value> {
+    let executor = ExtensionProviderAgentTaskExecutor::discover();
+    Ok((
+        serde_json::to_value(executor.providers()).unwrap_or(Value::Null),
+        0,
+    ))
+}

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -2,12 +2,13 @@ use crate::cli_surface::Commands;
 
 use super::{map, JsonRun};
 use crate::commands::{
-    build, changelog, changes, cleanup, component, config, docs, extension, project, refactor,
-    refs, release, report, rig, runner, runs, stack, tunnel, undo, version, GlobalArgs,
+    agent_task, build, changelog, changes, cleanup, component, config, docs, extension, project,
+    refactor, refs, release, report, rig, runner, runs, stack, tunnel, undo, version, GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
     match command {
+        Commands::AgentTask(args) => map(agent_task::run(args, global)),
         Commands::Project(args) => map(project::run(args, global)),
         Commands::Component(args) => map(component::run(args, global)),
         Commands::Config(args) => map(config::run(args, global)),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -165,6 +165,7 @@ pub fn finalize_set_spec(
     Ok((json_string, replace_fields))
 }
 
+pub mod agent_task;
 pub mod api;
 pub mod audit;
 pub mod auth;

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -1,0 +1,407 @@
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::core::agent_task::{
+    AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskFailureClassification, AgentTaskOutcome,
+    AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_OUTCOME_SCHEMA,
+};
+use crate::core::agent_task_scheduler::{AgentTaskExecutionContext, AgentTaskExecutorAdapter};
+use crate::core::extension::load_all_extensions;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskExecutorProvider {
+    pub schema: String,
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub backend: String,
+    pub command: String,
+    pub request_schema: String,
+    pub outcome_schema: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extension_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extension_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ExtensionProviderAgentTaskExecutor {
+    providers: Vec<AgentTaskExecutorProvider>,
+}
+
+impl ExtensionProviderAgentTaskExecutor {
+    pub fn discover() -> Self {
+        Self {
+            providers: discover_agent_task_executor_providers(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_providers(providers: Vec<AgentTaskExecutorProvider>) -> Self {
+        Self { providers }
+    }
+
+    pub fn providers(&self) -> &[AgentTaskExecutorProvider] {
+        &self.providers
+    }
+}
+
+impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
+    fn execute(
+        &self,
+        request: AgentTaskRequest,
+        _context: AgentTaskExecutionContext,
+    ) -> AgentTaskOutcome {
+        let Some(provider) = select_provider(&self.providers, &request) else {
+            return failure_outcome(
+                &request,
+                AgentTaskOutcomeStatus::Failed,
+                AgentTaskFailureClassification::CapabilityMissing,
+                "agent_task.provider_missing",
+                format!(
+                    "no extension agent-task provider found for backend '{}'",
+                    request.executor.backend
+                ),
+                json!({ "backend": request.executor.backend }),
+            );
+        };
+
+        let missing_capabilities: Vec<String> = request
+            .executor
+            .required_capabilities
+            .iter()
+            .filter(|capability| !provider.capabilities.contains(capability))
+            .cloned()
+            .collect();
+        if !missing_capabilities.is_empty() {
+            return failure_outcome(
+                &request,
+                AgentTaskOutcomeStatus::Failed,
+                AgentTaskFailureClassification::CapabilityMissing,
+                "agent_task.capability_missing",
+                format!(
+                    "provider '{}' is missing required capabilities: {}",
+                    provider.id,
+                    missing_capabilities.join(", ")
+                ),
+                json!({ "provider": provider.id, "missing_capabilities": missing_capabilities }),
+            );
+        }
+
+        run_provider_command(&request, provider)
+    }
+}
+
+pub fn discover_agent_task_executor_providers() -> Vec<AgentTaskExecutorProvider> {
+    let mut providers = Vec::new();
+    for manifest in load_all_extensions().unwrap_or_default() {
+        let Some(value) = manifest.extra.get("agent_task_executors") else {
+            continue;
+        };
+        let Ok(mut extension_providers) =
+            serde_json::from_value::<Vec<AgentTaskExecutorProvider>>(value.clone())
+        else {
+            continue;
+        };
+        for provider in &mut extension_providers {
+            provider.extension_id = Some(manifest.id.clone());
+            provider.extension_path = manifest.extension_path.clone();
+        }
+        providers.extend(extension_providers);
+    }
+    providers
+}
+
+fn select_provider<'a>(
+    providers: &'a [AgentTaskExecutorProvider],
+    request: &AgentTaskRequest,
+) -> Option<&'a AgentTaskExecutorProvider> {
+    providers.iter().find(|provider| {
+        provider.backend == request.executor.backend
+            && request
+                .executor
+                .selector
+                .as_ref()
+                .is_none_or(|selector| provider.id == *selector)
+    })
+}
+
+fn run_provider_command(
+    request: &AgentTaskRequest,
+    provider: &AgentTaskExecutorProvider,
+) -> AgentTaskOutcome {
+    let command = render_provider_command(provider);
+    let Some((program, args)) = provider_command_parts(&command) else {
+        return failure_outcome(
+            request,
+            AgentTaskOutcomeStatus::ProviderError,
+            AgentTaskFailureClassification::Provider,
+            "agent_task.provider_command_empty",
+            format!("provider '{}' has an empty command", provider.id),
+            json!({ "provider": provider.id }),
+        );
+    };
+    let timeout = request
+        .limits
+        .timeout_ms
+        .or(request.limits.max_runtime_ms)
+        .map(Duration::from_millis);
+    let input = match serde_json::to_vec(request) {
+        Ok(input) => input,
+        Err(error) => {
+            return failure_outcome(
+                request,
+                AgentTaskOutcomeStatus::Failed,
+                AgentTaskFailureClassification::InvalidInput,
+                "agent_task.request_encode_failed",
+                error.to_string(),
+                json!({ "provider": provider.id }),
+            )
+        }
+    };
+
+    let mut child = match Command::new(&program)
+        .args(&args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(error) => {
+            return failure_outcome(
+                request,
+                AgentTaskOutcomeStatus::ProviderError,
+                AgentTaskFailureClassification::Provider,
+                "agent_task.provider_spawn_failed",
+                error.to_string(),
+                json!({ "provider": provider.id, "command": command }),
+            )
+        }
+    };
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = std::io::Write::write_all(&mut stdin, &input);
+    }
+
+    let output = if let Some(timeout) = timeout {
+        let started = Instant::now();
+        loop {
+            match child.try_wait() {
+                Ok(Some(_status)) => break child.wait_with_output(),
+                Ok(None) if started.elapsed() >= timeout => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return failure_outcome(
+                        request,
+                        AgentTaskOutcomeStatus::Timeout,
+                        AgentTaskFailureClassification::Timeout,
+                        "agent_task.provider_timeout",
+                        format!(
+                            "provider '{}' exceeded timeout_ms={}",
+                            provider.id,
+                            timeout.as_millis()
+                        ),
+                        json!({ "provider": provider.id, "command": command, "timeout_ms": timeout.as_millis() }),
+                    );
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+                Err(error) => break Err(error),
+            }
+        }
+    } else {
+        child.wait_with_output()
+    };
+
+    let Ok(output) = output else {
+        return failure_outcome(
+            request,
+            AgentTaskOutcomeStatus::ProviderError,
+            AgentTaskFailureClassification::Provider,
+            "agent_task.provider_io_failed",
+            "provider command failed while collecting output".to_string(),
+            json!({ "provider": provider.id, "command": command }),
+        );
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if stdout.is_empty() {
+        return failure_outcome(
+            request,
+            AgentTaskOutcomeStatus::ProviderError,
+            AgentTaskFailureClassification::Provider,
+            "agent_task.provider_empty_stdout",
+            format!("provider '{}' produced no JSON outcome", provider.id),
+            json!({ "provider": provider.id, "command": command, "exit_code": output.status.code(), "stderr": stderr }),
+        );
+    }
+
+    let parsed: Result<AgentTaskOutcome, _> = serde_json::from_str(&stdout);
+    match parsed {
+        Ok(mut outcome) => {
+            if outcome.schema != AGENT_TASK_OUTCOME_SCHEMA {
+                outcome.schema = AGENT_TASK_OUTCOME_SCHEMA.to_string();
+            }
+            outcome
+        }
+        Err(error) => failure_outcome(
+            request,
+            AgentTaskOutcomeStatus::ProviderError,
+            AgentTaskFailureClassification::Provider,
+            "agent_task.provider_malformed_json",
+            format!(
+                "provider '{}' returned malformed JSON: {error}",
+                provider.id
+            ),
+            json!({ "provider": provider.id, "command": command, "exit_code": output.status.code(), "stderr": stderr, "stdout": stdout }),
+        ),
+    }
+}
+
+fn render_provider_command(provider: &AgentTaskExecutorProvider) -> String {
+    let extension_path = provider.extension_path.as_deref().unwrap_or_default();
+    provider
+        .command
+        .replace("{{extension_path}}", extension_path)
+}
+
+fn provider_command_parts(command: &str) -> Option<(String, Vec<String>)> {
+    let mut parts = command.split_whitespace().map(str::to_string);
+    let program = parts.next()?;
+    Some((program, parts.collect()))
+}
+
+fn failure_outcome(
+    request: &AgentTaskRequest,
+    status: AgentTaskOutcomeStatus,
+    classification: AgentTaskFailureClassification,
+    diagnostic_class: &str,
+    message: String,
+    data: Value,
+) -> AgentTaskOutcome {
+    AgentTaskOutcome {
+        schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+        task_id: request.task_id.clone(),
+        status,
+        summary: Some(message.clone()),
+        failure_classification: Some(classification),
+        artifacts: Vec::new(),
+        evidence_refs: vec![AgentTaskEvidenceRef {
+            kind: "agent-task-provider".to_string(),
+            uri: format!("homeboy://agent-task/{}", diagnostic_class),
+            label: Some("agent task provider dispatch".to_string()),
+        }],
+        diagnostics: vec![AgentTaskDiagnostic {
+            class: diagnostic_class.to_string(),
+            message,
+            data,
+        }],
+        workflow: None,
+        follow_up: None,
+        metadata: Value::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::agent_task::{
+        AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskWorkspace,
+        AGENT_TASK_REQUEST_SCHEMA,
+    };
+    use crate::core::agent_task_scheduler::{AgentTaskPlan, AgentTaskScheduler};
+    use std::fs;
+
+    fn script(body: &str) -> String {
+        let path = std::env::temp_dir().join(format!(
+            "homeboy-agent-task-provider-{}-{}.js",
+            std::process::id(),
+            body.len()
+        ));
+        fs::write(&path, body).expect("script written");
+        path.to_string_lossy().to_string()
+    }
+
+    fn request(task_id: &str, command: String) -> (AgentTaskRequest, AgentTaskExecutorProvider) {
+        let provider = AgentTaskExecutorProvider {
+            schema: "homeboy/agent-task-executor-provider/v1".to_string(),
+            id: "test.provider".to_string(),
+            label: None,
+            backend: "test".to_string(),
+            command,
+            request_schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            outcome_schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            capabilities: vec!["structured_outcome".to_string()],
+            extension_id: None,
+            extension_path: None,
+        };
+        let request = AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: task_id.to_string(),
+            group_key: None,
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "test".to_string(),
+                selector: None,
+                required_capabilities: Vec::new(),
+                model: None,
+                config: Value::Null,
+            },
+            instructions: "run".to_string(),
+            inputs: Value::Null,
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace::default(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            metadata: Value::Null,
+        };
+        (request, provider)
+    }
+
+    #[test]
+    fn scheduler_dispatches_extension_provider_command() {
+        let command = format!(
+            "node {}",
+            script("let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'succeeded',summary:'ok'}));")
+        );
+        let (request, provider) = request("task-a", command);
+        let scheduler =
+            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+                provider,
+            ]));
+
+        let aggregate = scheduler.run(AgentTaskPlan::new("plan-a", vec![request]));
+
+        assert_eq!(aggregate.totals.succeeded, 1);
+        assert_eq!(
+            aggregate.outcomes[0].status,
+            AgentTaskOutcomeStatus::Succeeded
+        );
+    }
+
+    #[test]
+    fn provider_timeout_returns_structured_outcome() {
+        let command = format!("node {}", script("setInterval(() => {}, 1000);"));
+        let (mut request, provider) = request("task-timeout", command);
+        request.limits.timeout_ms = Some(50);
+        let scheduler =
+            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+                provider,
+            ]));
+
+        let aggregate = scheduler.run(AgentTaskPlan::new("plan-timeout", vec![request]));
+
+        assert_eq!(aggregate.totals.timed_out, 1);
+        assert_eq!(
+            aggregate.outcomes[0].failure_classification,
+            Some(AgentTaskFailureClassification::Timeout)
+        );
+    }
+}

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -42,7 +42,7 @@ impl ExtensionProviderAgentTaskExecutor {
     }
 
     #[cfg(test)]
-    pub fn with_providers(providers: Vec<AgentTaskExecutorProvider>) -> Self {
+    fn with_providers(providers: Vec<AgentTaskExecutorProvider>) -> Self {
         Self { providers }
     }
 
@@ -97,7 +97,7 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
     }
 }
 
-pub fn discover_agent_task_executor_providers() -> Vec<AgentTaskExecutorProvider> {
+fn discover_agent_task_executor_providers() -> Vec<AgentTaskExecutorProvider> {
     let mut providers = Vec::new();
     for manifest in load_all_extensions().unwrap_or_default() {
         let Some(value) = manifest.extra.get("agent_task_executors") else {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 pub mod config;
 pub mod agent_task;
 pub mod agent_task_aggregate;
+pub mod agent_task_provider;
 pub mod agent_task_scheduler;
 pub mod api_jobs;
 pub mod artifact_manifest;


### PR DESCRIPTION
## Summary
- Add a generic `agent-task` command that can list extension-declared executor providers and run an `AgentTaskPlan` through the core scheduler.
- Add an extension-provider scheduler adapter that discovers `agent_task_executors`, matches request backends/capabilities, invokes provider commands via stdin, and normalizes missing provider, capability, timeout, and malformed-output failures.
- Preserve Codebox/WordPress as extension-owned behavior; core only handles generic provider dispatch.

Refs #3235
Refs #3234

## Verification
- `cargo fmt --check`
- `cargo test agent_task_provider --lib`
- `cargo check`
- Live validation with a 2-cell `homeboy agent-task run-plan` against the patched WordPress Codebox provider returned structured per-cell timeout outcomes and preflight evidence refs instead of hanging.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic provider dispatcher, CLI wiring, tests, and live validation commands; Chris remains responsible for review and merge.