### PR TITLE
Pass agent task provider config env

### DIFF
--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -164,9 +164,14 @@ fn run_provider_command(
             )
         }
     };
+    let env = provider_command_env(request, provider);
 
     let mut child = match Command::new(&program)
         .args(&args)
+        .envs(
+            env.iter()
+                .map(|(key, value)| (key.as_str(), value.as_str())),
+        )
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -275,6 +280,30 @@ fn provider_command_parts(command: &str) -> Option<(String, Vec<String>)> {
     let mut parts = command.split_whitespace().map(str::to_string);
     let program = parts.next()?;
     Some((program, parts.collect()))
+}
+
+fn provider_command_env(
+    request: &AgentTaskRequest,
+    provider: &AgentTaskExecutorProvider,
+) -> Vec<(String, String)> {
+    vec![
+        (
+            "HOMEBOY_AGENT_TASK_PROVIDER_ID".to_string(),
+            provider.id.clone(),
+        ),
+        (
+            "HOMEBOY_AGENT_TASK_EXECUTOR_CONFIG_JSON".to_string(),
+            serde_json::to_string(&request.executor.config).unwrap_or_else(|_| "null".to_string()),
+        ),
+        (
+            "HOMEBOY_EXTENSION_ID".to_string(),
+            provider.extension_id.clone().unwrap_or_default(),
+        ),
+        (
+            "HOMEBOY_EXTENSION_PATH".to_string(),
+            provider.extension_path.clone().unwrap_or_default(),
+        ),
+    ]
 }
 
 fn failure_outcome(
@@ -402,6 +431,30 @@ mod tests {
         assert_eq!(
             aggregate.outcomes[0].failure_classification,
             Some(AgentTaskFailureClassification::Timeout)
+        );
+    }
+
+    #[test]
+    fn provider_command_receives_executor_config_env() {
+        let command = format!(
+            "node {}",
+            script("let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); let config=JSON.parse(process.env.HOMEBOY_AGENT_TASK_EXECUTOR_CONFIG_JSON); process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:config.marker==='configured'?'succeeded':'failed',summary:process.env.HOMEBOY_AGENT_TASK_PROVIDER_ID}));")
+        );
+        let (mut request, mut provider) = request("task-config", command);
+        request.executor.config = json!({ "marker": "configured" });
+        provider.extension_id = Some("wordpress".to_string());
+        provider.extension_path = Some("/tmp/homeboy-extension".to_string());
+        let scheduler =
+            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+                provider,
+            ]));
+
+        let aggregate = scheduler.run(AgentTaskPlan::new("plan-config", vec![request]));
+
+        assert_eq!(aggregate.totals.succeeded, 1);
+        assert_eq!(
+            aggregate.outcomes[0].summary.as_deref(),
+            Some("test.provider")
         );
     }
 }


### PR DESCRIPTION
## Summary
- Pass generic provider/task execution metadata into extension agent-task provider commands via environment variables.
- Add coverage proving provider commands can read structured executor config during scheduler dispatch.

## Validation
- `cargo fmt --check`
- `cargo test provider_command_receives_executor_config_env --lib`
- `cargo test scheduler_dispatches_extension_provider_command --lib`
- `cargo test provider_timeout_returns_structured_outcome --lib`

## Follow-up evidence
- Stacked with Extra-Chill/homeboy-extensions#986, `agent-task run-plan` executed the two-cell Codebox proof for #3234 through scheduler -> extension provider -> WP Codebox recipe-run and returned two structured succeeded outcomes with artifact directories.

Closes #3246.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Isolated the provider config gap, drafted the implementation and tests, and ran local validation; Chris remains responsible for review and merge.