### PR TITLE
fix(deploy): prevent plugin dir double-nesting + correct extract-command placeholder hint (closes #3243)

### DIFF
--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -568,7 +568,7 @@ fn resolve_preflight_artifact_path(
             remote_version,
             format!(
                 "Archive artifact '{}' requires an extractCommand. \
-                 Add one with: homeboy component set <id> --json '{{\"extract_command\": \"unzip -o {{{{artifact}}}} && rm {{{{artifact}}}}\"}}'",
+                 Add one with: homeboy component set <id> --json '{{\"extract_command\": \"unzip -o {{artifact}} && rm {{artifact}}\"}}'",
                 artifact_path.display()
             ),
         )

--- a/src/core/deploy/safety_and_artifact.rs
+++ b/src/core/deploy/safety_and_artifact.rs
@@ -258,6 +258,30 @@ pub(super) fn deploy_artifact(
                 ));
             }
 
+            // Step 2b: Flatten an accidental single top-level directory.
+            //
+            // Build ZIPs commonly contain a single top-level directory named after
+            // the component (e.g. `extrachill-users/extrachill-users.php`). When the
+            // component's remote_path already points AT that directory
+            // (`wp-content/plugins/extrachill-users`), extracting in place produces a
+            // double-nested layout (`.../extrachill-users/extrachill-users/...`) that
+            // WordPress cannot load. Detect that signature and lift the inner
+            // directory's contents up one level so the artifact lands flat.
+            if let Some(result) = flatten_double_nested_dir(ssh_client, remote_path)? {
+                return Ok(result);
+            }
+
+            // Step 2c: Fail loudly if the layout is still double-nested.
+            //
+            // This is independent of the optional user-configured `verification`
+            // step below. A false success on a broken layout is the worst symptom:
+            // it silently breaks the install while reporting `success: true`. If the
+            // double-nest directory still exists after the flatten attempt, refuse to
+            // report success.
+            if let Some(result) = ensure_not_double_nested(ssh_client, remote_path) {
+                return Ok(result);
+            }
+
             // Fix file permissions after extraction
             log_status!("deploy", "Fixing file permissions");
             permissions::fix_deployed_permissions(ssh_client, remote_path, remote_owner)?;
@@ -293,6 +317,137 @@ pub(super) fn deploy_artifact(
     Ok(DeployResult::success(0))
 }
 
+/// Return the final path segment of `remote_path` (its basename), if any.
+///
+/// e.g. `wp-content/plugins/extrachill-users` -> `extrachill-users`.
+fn remote_basename(remote_path: &str) -> Option<&str> {
+    remote_path
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|segment| !segment.is_empty())
+}
+
+/// Detect and repair the classic double-nested layout produced when a build ZIP
+/// has a single top-level directory equal to the deploy target's own basename.
+///
+/// The signature we repair is: after extraction, `remote_path` contains exactly
+/// one entry, and that entry is a directory whose name equals `basename(remote_path)`
+/// (e.g. `.../extrachill-users/extrachill-users/`). When that holds, the inner
+/// directory's contents (including dotfiles) are lifted up into `remote_path` and
+/// the now-empty inner directory is removed.
+///
+/// Returns `Ok(Some(failure))` only if the flatten was attempted but failed, so the
+/// caller can short-circuit and report failure. Returns `Ok(None)` when there was
+/// nothing to flatten or the flatten succeeded.
+fn flatten_double_nested_dir(
+    ssh_client: &SshClient,
+    remote_path: &str,
+) -> Result<Option<DeployResult>> {
+    let Some(basename) = remote_basename(remote_path) else {
+        return Ok(None);
+    };
+
+    let normalized = remote_path.trim_end_matches('/');
+    let nested_dir = format!("{}/{}", normalized, basename);
+
+    // Only flatten when the nested directory is the *sole* entry in remote_path.
+    // This avoids clobbering a legitimate same-named subdirectory that lives
+    // alongside other top-level files (which would not be a double-nest artifact).
+    //
+    // `entries` counts the non-hidden + hidden top-level entries; we require it to be
+    // exactly the nested directory and nothing else.
+    let detect_cmd = format!(
+        "test -d {nested} && [ \"$(cd {target} && ls -A | wc -l)\" = \"1\" ] && \
+         [ \"$(cd {target} && ls -A)\" = {basename_arg} ] && echo NESTED || echo OK",
+        nested = shell::quote_path(&nested_dir),
+        target = shell::quote_path(normalized),
+        basename_arg = shell::quote_arg(basename),
+    );
+    let detect_output = ssh_client.execute(&detect_cmd);
+    if !detect_output.success {
+        // Detection is best-effort; if we cannot determine the layout, let the
+        // mandatory sanity check below decide.
+        return Ok(None);
+    }
+    if detect_output.stdout.trim() != "NESTED" {
+        return Ok(None);
+    }
+
+    log_status!(
+        "deploy",
+        "Detected double-nested directory '{}'; flattening into '{}'",
+        nested_dir,
+        normalized
+    );
+
+    // Move the inner directory aside, then lift its contents (including dotfiles)
+    // up into remote_path, then remove the now-empty staging directory.
+    //
+    // Using a temp staging name avoids the "cannot move a directory into itself"
+    // problem when the inner dir shares the basename with its parent.
+    let staging = format!("{}/.homeboy-flatten-staging", normalized);
+    let flatten_cmd = format!(
+        "cd {target} && rm -rf {staging} && mv {nested} {staging} && \
+         find {staging} -mindepth 1 -maxdepth 1 -exec mv -t {target} {{}} + && \
+         rmdir {staging}",
+        target = shell::quote_path(normalized),
+        nested = shell::quote_path(&nested_dir),
+        staging = shell::quote_path(&staging),
+    );
+    let flatten_output = ssh_client.execute(&flatten_cmd);
+    if !flatten_output.success {
+        let error_detail = if flatten_output.stderr.is_empty() {
+            flatten_output.stdout.clone()
+        } else {
+            flatten_output.stderr.clone()
+        };
+        return Ok(Some(DeployResult::failure(
+            flatten_output.exit_code,
+            format!(
+                "Failed to flatten double-nested directory '{}' (exit {}): {}",
+                nested_dir, flatten_output.exit_code, error_detail
+            ),
+        )));
+    }
+
+    Ok(None)
+}
+
+/// Mandatory post-extract sanity check: fail the deploy if the artifact landed
+/// double-nested (`remote_path/<basename(remote_path)>/` still exists).
+///
+/// This guards against silently reporting `success: true` while the install is
+/// broken on disk. Returns `Some(failure)` when the broken layout is detected.
+fn ensure_not_double_nested(ssh_client: &SshClient, remote_path: &str) -> Option<DeployResult> {
+    let basename = remote_basename(remote_path)?;
+    let normalized = remote_path.trim_end_matches('/');
+    let nested_dir = format!("{}/{}", normalized, basename);
+
+    let check_cmd = format!(
+        "test -d {} && echo NESTED || echo OK",
+        shell::quote_path(&nested_dir)
+    );
+    let check_output = ssh_client.execute(&check_cmd);
+    if check_output.stdout.trim() == "NESTED" {
+        return Some(DeployResult::failure(
+            1,
+            format!(
+                "Deploy produced a double-nested layout: '{nested}' exists, so the artifact \
+                 landed at '{nested}/...' instead of '{target}/...'. WordPress (and most \
+                 frameworks) cannot load a plugin/theme nested one level too deep. Refusing to \
+                 report success. Set the component's remote_path to the parent directory, or \
+                 adjust the build so the archive does not contain a redundant top-level '{base}/' \
+                 directory.",
+                nested = nested_dir,
+                target = normalized,
+                base = basename,
+            ),
+        ));
+    }
+    None
+}
+
 fn render_extract_command(template: &str, vars: &HashMap<String, String>) -> String {
     let mut result = render_map(template, vars);
     for (key, value) in vars {
@@ -303,7 +458,10 @@ fn render_extract_command(template: &str, vars: &HashMap<String, String>) -> Str
 
 #[cfg(test)]
 mod tests {
-    use super::{deploy_artifact, render_extract_command, DANGEROUS_PATH_SUFFIXES};
+    use super::{
+        deploy_artifact, ensure_not_double_nested, flatten_double_nested_dir, remote_basename,
+        render_extract_command, DANGEROUS_PATH_SUFFIXES,
+    };
     use crate::core::extension::DeployVerification;
     use crate::core::server::SshClient;
     use std::collections::HashMap;
@@ -446,5 +604,211 @@ mod tests {
         assert!(error.contains("Failed to clean target directory before extraction"));
         assert!(error.contains("exit 42"));
         assert!(error.contains("cleanup denied"));
+    }
+
+    #[test]
+    fn test_remote_basename_extracts_final_segment() {
+        assert_eq!(
+            remote_basename("wp-content/plugins/extrachill-users"),
+            Some("extrachill-users")
+        );
+        assert_eq!(
+            remote_basename("wp-content/plugins/extrachill-users/"),
+            Some("extrachill-users")
+        );
+        assert_eq!(remote_basename("plugin"), Some("plugin"));
+        assert_eq!(remote_basename(""), None);
+        assert_eq!(remote_basename("/"), None);
+    }
+
+    /// Build a zip whose sole top-level entry is a directory `<name>/` containing
+    /// the given relative files. Returns the path to the created archive.
+    #[cfg(unix)]
+    fn make_zip_with_top_level_dir(
+        temp: &std::path::Path,
+        archive_name: &str,
+        top_dir: &str,
+        files: &[(&str, &str)],
+    ) -> std::path::PathBuf {
+        let staging = temp.join("zip-staging");
+        let root = staging.join(top_dir);
+        fs::create_dir_all(&root).expect("staging root");
+        for (rel, contents) in files {
+            let path = root.join(rel);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("file parent");
+            }
+            fs::write(&path, contents).expect("staged file");
+        }
+
+        let archive = temp.join(archive_name);
+        let status = std::process::Command::new("zip")
+            .args([
+                "-q",
+                "-r",
+                archive.to_str().expect("archive path"),
+                top_dir,
+            ])
+            .current_dir(&staging)
+            .status()
+            .expect("run zip");
+        assert!(status.success(), "zip command failed");
+        archive
+    }
+
+    /// End-to-end: a build ZIP with a top-level dir equal to the target basename,
+    /// deployed with the real-world `unzip -o {artifact} && rm {artifact}` command,
+    /// must land FLAT (no double-nesting) and report success.
+    #[test]
+    #[cfg(unix)]
+    fn test_deploy_artifact_flattens_double_nested_plugin_zip() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let plugin = "extrachill-users";
+        let archive = make_zip_with_top_level_dir(
+            temp.path(),
+            "build.zip",
+            plugin,
+            &[
+                ("extrachill-users.php", "<?php // plugin main"),
+                ("src/loader.php", "<?php // loader"),
+                (".gitkeep", ""),
+            ],
+        );
+
+        // remote_path points AT the plugin dir (the prod misconfiguration that
+        // triggers double-nesting).
+        let target = temp.path().join("wp-content/plugins").join(plugin);
+
+        let result = deploy_artifact(
+            &local_client(),
+            &archive,
+            target.to_str().expect("target path"),
+            Some("unzip -o {artifact} && rm {artifact}"),
+            None,
+            None,
+        )
+        .expect("deploy result");
+
+        assert!(result.success, "deploy should succeed: {:?}", result.error);
+        // Flat layout: main file directly under remote_path.
+        assert!(
+            target.join("extrachill-users.php").is_file(),
+            "plugin main file must land flat at remote_path"
+        );
+        assert!(target.join("src/loader.php").is_file());
+        assert!(target.join(".gitkeep").is_file());
+        // No double-nesting.
+        assert!(
+            !target.join(plugin).exists(),
+            "double-nested directory must not exist after flatten"
+        );
+        // Extract artifact and flatten staging cleaned up.
+        assert!(!target.join(".homeboy-flatten-staging").exists());
+    }
+
+    /// A normal (non-nested) archive must extract in place untouched.
+    #[test]
+    #[cfg(unix)]
+    fn test_deploy_artifact_leaves_flat_archive_untouched() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let staging = temp.path().join("flat-staging");
+        fs::create_dir_all(&staging).expect("flat staging");
+        fs::write(staging.join("plugin.php"), "<?php // main").expect("main file");
+        fs::write(staging.join("readme.txt"), "readme").expect("readme");
+
+        let archive = temp.path().join("flat.zip");
+        let status = std::process::Command::new("zip")
+            .args(["-q", "-r", archive.to_str().expect("archive"), "."])
+            .current_dir(&staging)
+            .status()
+            .expect("run zip");
+        assert!(status.success());
+
+        let target = temp.path().join("wp-content/plugins/flat-plugin");
+        let result = deploy_artifact(
+            &local_client(),
+            &archive,
+            target.to_str().expect("target path"),
+            Some("unzip -o {artifact} && rm {artifact}"),
+            None,
+            None,
+        )
+        .expect("deploy result");
+
+        assert!(result.success, "deploy should succeed: {:?}", result.error);
+        assert!(target.join("plugin.php").is_file());
+        assert!(target.join("readme.txt").is_file());
+        // No spurious nested dir matching the target basename.
+        assert!(!target.join("flat-plugin").exists());
+    }
+
+    /// The mandatory sanity check must report failure when a double-nested layout
+    /// remains (e.g. an extract path the flatten heuristic could not repair).
+    #[test]
+    #[cfg(unix)]
+    fn test_ensure_not_double_nested_detects_broken_layout() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let plugin = "extrachill-users";
+        let target = temp.path().join(plugin);
+        let nested = target.join(plugin);
+        fs::create_dir_all(&nested).expect("nested dir");
+        fs::write(nested.join("extrachill-users.php"), "<?php").expect("nested main");
+        // Also place a sibling file so the auto-flatten heuristic would NOT trigger
+        // (more than one top-level entry), but the broken layout still exists.
+        fs::write(target.join("stray.txt"), "stray").expect("stray");
+
+        let result = ensure_not_double_nested(&local_client(), target.to_str().expect("target"));
+        let result = result.expect("should detect broken layout");
+        assert!(!result.success);
+        let error = result.error.expect("error message");
+        assert!(error.contains("double-nested layout"));
+        assert!(error.contains(plugin));
+    }
+
+    /// The flatten helper is a no-op (returns Ok(None)) when there is nothing nested.
+    #[test]
+    #[cfg(unix)]
+    fn test_flatten_double_nested_dir_noop_when_flat() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let target = temp.path().join("flat-plugin");
+        fs::create_dir_all(&target).expect("target");
+        fs::write(target.join("plugin.php"), "<?php").expect("main");
+
+        let result = flatten_double_nested_dir(&local_client(), target.to_str().expect("target"))
+            .expect("ok");
+        assert!(result.is_none(), "flatten should be a no-op on a flat layout");
+        assert!(target.join("plugin.php").is_file());
+    }
+
+    /// The "requires an extractCommand" hint must use single-brace `{artifact}`
+    /// placeholders so a copy-paste of the JSON works (render_extract_command +
+    /// render_map both resolve `{artifact}` correctly).
+    #[test]
+    fn test_archive_without_extract_command_hint_uses_single_brace_placeholder() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let archive = temp.path().join("plugin.zip");
+        fs::write(&archive, "zip bytes").expect("archive");
+        let target = temp.path().join("wp-content/plugins/plugin");
+
+        let result = deploy_artifact(
+            &local_client(),
+            &archive,
+            target.to_str().expect("target"),
+            None,
+            None,
+            None,
+        )
+        .expect("deploy result");
+
+        assert!(!result.success);
+        let error = result.error.expect("hint error");
+        assert!(
+            error.contains("{artifact}"),
+            "hint must contain single-brace placeholder: {error}"
+        );
+        assert!(
+            !error.contains("{{artifact}}"),
+            "hint must NOT contain double-brace placeholder: {error}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the critical `homeboy deploy` bug where WordPress plugin directories were **double-nested** on the remote, breaking the install while still reporting `success: true` — and corrects the misleading extract-command placeholder hint. `Closes #3243`.

## Bug 1 (critical) — plugin dir double-nesting + silent false-success

### Root cause
Build ZIPs contain a single **top-level directory** named after the component (e.g. `extrachill-users/extrachill-users.php`). When a component's `remote_path` points **at** that directory (`wp-content/plugins/extrachill-users`), the deploy uploads the archive into `remote_path` and runs `unzip` there. Because the ZIP already has its own `extrachill-users/` top dir, the result is:

```
wp-content/plugins/extrachill-users/extrachill-users/extrachill-users.php   ← double-nested (broken)
```

WordPress can't find the plugin main file → network-activated plugin outage. Worse, `deploy` returned **`success: true`** because the layout was never checked (the optional user `verification` step didn't cover placement).

### Strategy chosen — **A (auto-flatten on extract) + mandatory fail-on-broken-layout**
I picked **Strategy A** (post-extract flatten) over Strategy B (extract into the parent) because:

- It is **least surprising**: it does not require changing every component's `remote_path` config or touching the dangerous "clean target directory" step (which deletes everything in `remote_path` except the artifact — moving the extract to the parent would force that cleanup to operate on a shared parent, exactly the `DANGEROUS_PATH_SUFFIXES` hazard the code already guards against).
- It is **general**: it repairs the broken layout for ALL components hitting this signature without per-component config changes, and is a no-op for correctly-structured archives.
- It keeps the existing pre-extract cleanup logic intact and correct.

**What it does:** after the extract command succeeds, `flatten_double_nested_dir()` detects the precise double-nest signature — `remote_path` contains **exactly one** entry, and that entry is a directory whose name equals `basename(remote_path)` (e.g. `.../extrachill-users/extrachill-users/`). When detected, it lifts the inner directory's contents (including dotfiles) up one level via a temp staging dir (avoids the "move a dir into itself" problem when inner == parent basename) and removes the empty inner dir. It is a strict no-op when the archive is not nested or has other top-level entries.

### Bug 1b — mandatory post-extract verification that FAILS on broken layout
Independent of the optional user-configured `verification`, `ensure_not_double_nested()` runs after the flatten attempt: if `remote_path/<basename>/` still exists, the deploy returns `DeployResult::failure(...)` with a descriptive error instead of `success`. **A false success on a broken deploy is the worst symptom**, so we now refuse to report success when the artifact didn't land at the expected path.

## Bug 2 (medium) — extract-command placeholder hint

`render_extract_command()` / `render_map()` resolve `{artifact}` (single brace). The "requires an extractCommand" hint in `execution.rs` printed **double braces** (`{{artifact}}`) via `{{{{artifact}}}}` in the Rust format literal — copy-pasting it produced a config that the extract path expanded inconsistently and could leave a literal `{.homeboy-*.zip}` filename. Fixed to print single-brace `{artifact}`.

Note: the sibling hint in `safety_and_artifact.rs` was already correct (its `{{artifact}}` in the format literal escapes to a printed `{artifact}`); verified and left as-is. Added a test asserting the rendered hint contains `{artifact}` and **not** `{{artifact}}`.

## Bug 3 (low) — composer.lock churn

Investigated. `composer install` is run inside the WP plugin build scripts ("universal build.sh"), not by homeboy's Rust — there is no central homeboy-side build/cleanup hook that owns `composer.lock` where it could be safely removed without risking deletion of a legitimately committed lockfile. **Recommend fixing this per-component by gitignoring the build-generated `composer.lock`** (the build already restores dev deps). Left out of this PR to avoid touching unrelated build flow.

## Tests (run output below)

Extended `#[cfg(test)] mod tests` in `safety_and_artifact.rs`. New tests use the local `SshClient` (`is_local: true`) so they exercise real `zip`/`unzip`/`mv` end-to-end:

- `test_deploy_artifact_flattens_double_nested_plugin_zip` — builds a ZIP with a top-level `extrachill-users/` dir, deploys into `.../plugins/extrachill-users` with the real `unzip -o {artifact} && rm {artifact}` command, asserts the main file lands FLAT and no double-nest dir remains.
- `test_deploy_artifact_leaves_flat_archive_untouched` — non-nested archive extracts in place untouched.
- `test_ensure_not_double_nested_detects_broken_layout` — mandatory check returns failure on a residual double-nested layout.
- `test_flatten_double_nested_dir_noop_when_flat` — flatten is a no-op on a flat layout.
- `test_remote_basename_extracts_final_segment` — basename helper edge cases.
- `test_archive_without_extract_command_hint_uses_single_brace_placeholder` — hint contains `{artifact}`, not `{{artifact}}`.
- Existing tests (including `test_deploy_artifact_extract_command_template_replaces_vars`) still pass.

```
cargo build                              → Finished (compiles clean)
cargo test --lib deploy::safety_and_artifact → 11 passed; 0 failed
cargo test --lib deploy::execution           → 11 passed; 0 failed
```

`rustfmt`/`clippy` toolchain components are not installed on the build host (no rustup); CI (`.github/workflows/ci.yml`) gates only on `cargo build --release`. Added lines were manually kept under 100 cols to match house style.

Closes #3243