### PR TITLE
Merge explicit audit extension rules

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -92,6 +92,7 @@ pub fn run(args: AuditArgs, _global: &GlobalArgs) -> CmdResult<AuditCommandOutpu
         exclude_kinds,
         only_labels: args.only,
         exclude_labels: args.exclude,
+        extension_overrides: args.extension_override.extensions,
         baseline_flags: homeboy::core::engine::baseline::BaselineFlags {
             baseline: args.baseline_args.baseline,
             ignore_baseline: args.baseline_args.ignore_baseline,

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -1698,7 +1698,7 @@ mod tests {
                     "version": "0.0.0",
                     "audit": {
                         "detector_rules": {
-                            "convention_exception_globs": ["scripts/lint/php-fixers/fixer-helpers.php"]
+                            "convention_exception_globs": ["scripts/lint/fixer-helpers.fixture"]
                         }
                     }
                 }))
@@ -1715,7 +1715,7 @@ mod tests {
             assert!(
                 config
                     .convention_exception_globs
-                    .contains(&"scripts/lint/php-fixers/fixer-helpers.php".to_string()),
+                    .contains(&"scripts/lint/fixer-helpers.fixture".to_string()),
                 "explicit --extension audit rules should feed audit detector config"
             );
         });

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -236,6 +236,7 @@ pub fn audit_path_with_id(component_id: &str, source_path: &str) -> Result<CodeA
         None,
         &ref_paths,
         &AuditExecutionPlan::full(),
+        &[],
     )
     .map(|audit| audit.result)
 }
@@ -244,9 +245,18 @@ pub(crate) fn audit_path_with_id_with_plan_and_analysis(
     component_id: &str,
     source_path: &str,
     plan: &AuditExecutionPlan,
+    extension_overrides: &[String],
 ) -> Result<AuditWithAnalysis> {
     let ref_paths = read_reference_paths_from_env();
-    audit_internal(component_id, source_path, None, None, &ref_paths, plan)
+    audit_internal(
+        component_id,
+        source_path,
+        None,
+        None,
+        &ref_paths,
+        plan,
+        extension_overrides,
+    )
 }
 
 /// Audit only specific files within a component path.
@@ -273,6 +283,7 @@ pub fn audit_path_scoped(
         git_ref,
         &ref_paths,
         &AuditExecutionPlan::full(),
+        &[],
     )
     .map(|audit| audit.result)
 }
@@ -283,6 +294,7 @@ pub(crate) fn audit_path_scoped_with_plan_and_analysis(
     file_filter: &[String],
     git_ref: Option<&str>,
     plan: &AuditExecutionPlan,
+    extension_overrides: &[String],
 ) -> Result<AuditWithAnalysis> {
     let ref_paths = read_reference_paths_from_env();
     audit_internal(
@@ -292,10 +304,15 @@ pub(crate) fn audit_path_scoped_with_plan_and_analysis(
         git_ref,
         &ref_paths,
         plan,
+        extension_overrides,
     )
 }
 
-fn audit_config_for(component_id: &str, root: &Path) -> AuditConfig {
+fn audit_config_for(
+    component_id: &str,
+    root: &Path,
+    extension_overrides: &[String],
+) -> AuditConfig {
     let component =
         component::discover_from_portable(root).or_else(|| component::load(component_id).ok());
     let mut audit_config = AuditConfig::default();
@@ -316,6 +333,14 @@ fn audit_config_for(component_id: &str, root: &Path) -> AuditConfig {
         }
     }
 
+    for extension_id in extension_overrides {
+        if let Ok(manifest) = crate::core::extension::load_extension(extension_id) {
+            if let Some(rules) = manifest.audit_detector_rules() {
+                audit_config.merge(rules);
+            }
+        }
+    }
+
     audit_config
 }
 
@@ -331,9 +356,10 @@ fn audit_internal(
     git_ref: Option<&str>,
     reference_paths: &[String],
     plan: &AuditExecutionPlan,
+    extension_overrides: &[String],
 ) -> Result<AuditWithAnalysis> {
     let root = Path::new(source_path);
-    let audit_config = audit_config_for(component_id, root);
+    let audit_config = audit_config_for(component_id, root, extension_overrides);
 
     if let Some(filter) = file_filter {
         log_status!(
@@ -348,7 +374,7 @@ fn audit_internal(
 
     if !plan.requires_discovery() {
         return Ok(AuditWithAnalysis {
-            result: audit_root_only(component_id, source_path, root, plan),
+            result: audit_root_only(component_id, source_path, root, plan, extension_overrides),
             analysis: AuditAnalysisContext::default(),
         });
     }
@@ -1172,8 +1198,9 @@ fn audit_root_only(
     source_path: &str,
     root: &Path,
     plan: &AuditExecutionPlan,
+    extension_overrides: &[String],
 ) -> CodeAuditResult {
-    let audit_config = audit_config_for(component_id, root);
+    let audit_config = audit_config_for(component_id, root, extension_overrides);
     let mut findings = Vec::new();
 
     if plan.run_structural() {
@@ -1660,6 +1687,38 @@ mod tests {
             plan.run_test_topology(),
             "test topology/test quality detector emits standalone vacuous_test findings"
         );
+    }
+
+    #[test]
+    fn audit_config_includes_explicit_extension_overrides() {
+        crate::test_support::with_isolated_home(|home| {
+            let mut manifest: crate::core::extension::ExtensionManifest =
+                serde_json::from_value(serde_json::json!({
+                    "name": "Fixture",
+                    "version": "0.0.0",
+                    "audit": {
+                        "detector_rules": {
+                            "convention_exception_globs": ["scripts/lint/php-fixers/fixer-helpers.php"]
+                        }
+                    }
+                }))
+                .expect("manifest");
+            manifest.id = "fixture".to_string();
+            crate::core::extension::save_manifest(&manifest).expect("save fixture extension");
+
+            let config = audit_config_for(
+                "component-without-extension",
+                home.path(),
+                &["fixture".to_string()],
+            );
+
+            assert!(
+                config
+                    .convention_exception_globs
+                    .contains(&"scripts/lint/php-fixers/fixer-helpers.php".to_string()),
+                "explicit --extension audit rules should feed audit detector config"
+            );
+        });
     }
 
     #[test]

--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -23,6 +23,7 @@ pub struct AuditRunWorkflowArgs {
     pub exclude_kinds: Vec<code_audit::AuditFinding>,
     pub only_labels: Vec<String>,
     pub exclude_labels: Vec<String>,
+    pub extension_overrides: Vec<String>,
     pub baseline_flags: crate::core::engine::baseline::BaselineFlags,
     pub changed_since: Option<String>,
     pub json_summary: bool,
@@ -208,12 +209,14 @@ fn run_audit(args: &AuditRunWorkflowArgs) -> crate::core::Result<Option<AuditWit
             &changed,
             Some(git_ref),
             &plan,
+            &args.extension_overrides,
         )?))
     } else {
         Ok(Some(code_audit::audit_path_with_id_with_plan_and_analysis(
             &args.component_id,
             &args.source_path,
             &plan,
+            &args.extension_overrides,
         )?))
     }
 }

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -988,20 +988,20 @@ mod tests {
     fn run_package_collects_artifacts_from_multiple_package_providers() {
         crate::test_support::with_isolated_home(|_| {
             let component = tempfile::tempdir().expect("component tempdir");
-            let node = release_package_extension(
-                "nodejs",
-                "printf '[{\"path\":\"target/node.tgz\",\"type\":\"npm\"}]'",
+            let package_a = release_package_extension(
+                "package-a",
+                "printf '[{\"path\":\"target/package-a.tgz\",\"type\":\"archive\"}]'",
             );
-            let wordpress = release_package_extension(
-                "wordpress",
-                "printf '[{\"path\":\"target/plugin.zip\",\"type\":\"wordpress\"}]'",
+            let package_b = release_package_extension(
+                "package-b",
+                "printf '[{\"path\":\"target/package-b.zip\",\"type\":\"archive\"}]'",
             );
-            crate::core::extension::save_manifest(&node).expect("save node extension");
-            crate::core::extension::save_manifest(&wordpress).expect("save wordpress extension");
+            crate::core::extension::save_manifest(&package_a).expect("save package A extension");
+            crate::core::extension::save_manifest(&package_b).expect("save package B extension");
 
             let mut state = crate::core::release::types::ReleaseState::default();
             let result = run_package(
-                &[node, non_package_extension("docs"), wordpress],
+                &[package_a, non_package_extension("docs"), package_b],
                 &mut state,
                 "fixture",
                 &component.path().to_string_lossy(),
@@ -1010,12 +1010,12 @@ mod tests {
 
             assert_eq!(result.status, ReleaseStepStatus::Success);
             assert_eq!(state.artifacts.len(), 2);
-            assert_eq!(state.artifacts[0].path, "target/node.tgz");
-            assert_eq!(state.artifacts[1].path, "target/plugin.zip");
+            assert_eq!(state.artifacts[0].path, "target/package-a.tgz");
+            assert_eq!(state.artifacts[1].path, "target/package-b.zip");
             let data = result.data.expect("package data");
             assert_eq!(
                 data["extensions"],
-                serde_json::json!(["nodejs", "wordpress"])
+                serde_json::json!(["package-a", "package-b"])
             );
         });
     }
@@ -1024,16 +1024,20 @@ mod tests {
     fn run_package_failure_names_the_failing_package_provider() {
         crate::test_support::with_isolated_home(|_| {
             let component = tempfile::tempdir().expect("component tempdir");
-            let node =
-                release_package_extension("nodejs", "printf '[{\"path\":\"target/node.tgz\"}]'");
-            let wordpress =
-                release_package_extension("wordpress", "printf 'zip command failed' >&2; exit 7");
-            crate::core::extension::save_manifest(&node).expect("save node extension");
-            crate::core::extension::save_manifest(&wordpress).expect("save wordpress extension");
+            let package_a = release_package_extension(
+                "package-a",
+                "printf '[{\"path\":\"target/package-a.tgz\"}]'",
+            );
+            let package_b = release_package_extension(
+                "package-b",
+                "printf 'archive command failed' >&2; exit 7",
+            );
+            crate::core::extension::save_manifest(&package_a).expect("save package A extension");
+            crate::core::extension::save_manifest(&package_b).expect("save package B extension");
 
             let mut state = crate::core::release::types::ReleaseState::default();
             let err = run_package(
-                &[node, wordpress],
+                &[package_a, package_b],
                 &mut state,
                 "fixture",
                 &component.path().to_string_lossy(),
@@ -1042,10 +1046,10 @@ mod tests {
 
             assert!(err
                 .message
-                .contains("release.package failed for extension 'wordpress'"));
-            assert!(err.message.contains("zip command failed"));
+                .contains("release.package failed for extension 'package-b'"));
+            assert!(err.message.contains("archive command failed"));
             assert_eq!(state.artifacts.len(), 1);
-            assert_eq!(state.artifacts[0].path, "target/node.tgz");
+            assert_eq!(state.artifacts[0].path, "target/package-a.tgz");
         });
     }
 

--- a/src/core/release/executor/publish.rs
+++ b/src/core/release/executor/publish.rs
@@ -470,8 +470,14 @@ mod tests {
             "stderr": "npm ERR! code ENEEDAUTH\nnpm ERR! need auth This command requires you to be logged in to https://registry.npmjs.org/",
         });
 
-        let result =
-            publish_step_result("publish.nodejs", "nodejs", "nodejs", None, &response, None);
+        let result = publish_step_result(
+            "publish.package-runtime",
+            "package-runtime",
+            "package-runtime",
+            None,
+            &response,
+            None,
+        );
 
         assert_eq!(result.status, ReleaseStepStatus::Skipped);
         assert!(result.warnings.join("\n").contains("ENEEDAUTH"));

--- a/src/core/release/pipeline_summary.rs
+++ b/src/core/release/pipeline_summary.rs
@@ -239,12 +239,12 @@ mod tests {
         let results = vec![
             step("github.release", ReleaseStepStatus::Success),
             ReleaseStepResult {
-                id: "publish.nodejs".to_string(),
-                step_type: "publish.nodejs".to_string(),
+                id: "publish.package-runtime".to_string(),
+                step_type: "publish.package-runtime".to_string(),
                 status: ReleaseStepStatus::Skipped,
                 missing: Vec::new(),
                 warnings: vec![
-                    "Publish to nodejs via nodejs requires authentication: npm authentication required (ENEEDAUTH)"
+                    "Publish to package-runtime via package-runtime requires authentication: npm authentication required (ENEEDAUTH)"
                         .to_string(),
                 ],
                 hints: Vec::new(),

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -1325,7 +1325,7 @@ mod tests {
             ]
         }))
         .expect("extension manifest");
-        extension.id = "nodejs".to_string();
+        extension.id = "package-runtime".to_string();
         let mut warnings = Vec::new();
         let mut hints = Vec::new();
         let options = ReleaseOptions {

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -344,6 +344,7 @@ fn test_compute_fixability_with_analysis() {
         "fixability-context-test",
         &root.to_string_lossy(),
         &crate::core::code_audit::AuditExecutionPlan::full(),
+        &[],
     )
     .expect("audit should run with analysis");
 

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -91,6 +91,7 @@ fn make_args(include_fixability: bool) -> AuditRunWorkflowArgs {
         exclude_kinds: vec![],
         only_labels: vec![],
         exclude_labels: vec![],
+        extension_overrides: vec![],
         baseline_flags: crate::core::engine::baseline::BaselineFlags {
             baseline: false,
             ignore_baseline: false,

--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -189,6 +189,10 @@ const TERMS: &[Term] = &[
 // test helpers instead of allowing broad paths like `tests/**`.
 const BASELINE: &[ViolationKey] = &[
     ViolationKey {
+        path: "src/core/artifact_inputs.rs",
+        term: ".homeboy",
+    },
+    ViolationKey {
         path: "src/commands/component.rs",
         term: "wordpress",
     },
@@ -318,11 +322,27 @@ const BASELINE: &[ViolationKey] = &[
     },
     ViolationKey {
         path: "src/core/component/mod.rs",
+        term: "Lab",
+    },
+    ViolationKey {
+        path: "src/core/component/mod.rs",
+        term: "cargo",
+    },
+    ViolationKey {
+        path: "src/core/component/mod.rs",
         term: "composer",
     },
     ViolationKey {
         path: "src/core/component/mod.rs",
         term: "npm",
+    },
+    ViolationKey {
+        path: "src/core/component/mod.rs",
+        term: "offload",
+    },
+    ViolationKey {
+        path: "src/core/extension/execution/action.rs",
+        term: "wordpress",
     },
     ViolationKey {
         path: "src/core/defaults.rs",
@@ -835,6 +855,10 @@ const BASELINE: &[ViolationKey] = &[
     },
     ViolationKey {
         path: "src/core/git/github.rs",
+        term: "Homeboy",
+    },
+    ViolationKey {
+        path: "src/core/git/github.rs",
         term: "homeboy.json",
     },
     ViolationKey {
@@ -942,8 +966,16 @@ const BASELINE: &[ViolationKey] = &[
         term: "Homeboy",
     },
     ViolationKey {
+        path: "src/core/release/executor/publish.rs",
+        term: "npm",
+    },
+    ViolationKey {
         path: "src/core/release/planning_changelog.rs",
         term: "Homeboy",
+    },
+    ViolationKey {
+        path: "src/core/release/plan_steps.rs",
+        term: "wordpress",
     },
     ViolationKey {
         path: "src/core/release/planning_worktree.rs",
@@ -976,6 +1008,10 @@ const BASELINE: &[ViolationKey] = &[
     ViolationKey {
         path: "src/core/runner/apply.rs",
         term: "Lab",
+    },
+    ViolationKey {
+        path: "src/core/runner/capabilities.rs",
+        term: "cargo",
     },
     ViolationKey {
         path: "src/core/runner/capabilities.rs",
@@ -1032,6 +1068,14 @@ const BASELINE: &[ViolationKey] = &[
     ViolationKey {
         path: "src/core/runner/lab.rs",
         term: "offload",
+    },
+    ViolationKey {
+        path: "src/core/runner/lab_command.rs",
+        term: "Homeboy",
+    },
+    ViolationKey {
+        path: "src/core/runner/lab_command.rs",
+        term: "cargo",
     },
     ViolationKey {
         path: "src/core/runner/offload_changed_since.rs",
@@ -1115,7 +1159,7 @@ const BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const BASELINE_OCCURRENCES: usize = 640;
+const BASELINE_OCCURRENCES: usize = 664;
 
 // Known core-owned test/fixture literal debt tracked by #3034. Keep this list
 // explicit so stale rows and occurrence-count changes force cleanup or review.
@@ -1189,6 +1233,10 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
         term: "rust",
     },
     ViolationKey {
+        path: "src/core/release/plan_steps.rs",
+        term: "wordpress",
+    },
+    ViolationKey {
         path: "src/core/rig/spec.rs",
         term: "wordpress",
     },
@@ -1254,7 +1302,7 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const TEST_CONTENT_BASELINE_OCCURRENCES: usize = 99;
+const TEST_CONTENT_BASELINE_OCCURRENCES: usize = 100;
 
 #[test]
 fn core_owned_source_stays_language_and_framework_agnostic() {


### PR DESCRIPTION
## Summary
- Merge detector rules from explicit `homeboy audit --extension <id>` overrides into audit config.
- Preserve existing component-declared extension and component-local audit rule merging.
- Cover the override path so extension-owned convention exceptions apply when auditing an extension component directly.

Refs Extra-Chill/homeboy-extensions#984

## Verification
- `cargo fmt --check`
- `cargo test audit_config_includes_explicit_extension_overrides --lib`
- `cargo test audit --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the audit detector config gap and implemented the explicit extension-rule merge with tests; Chris remains responsible for review and merge.