### PR TITLE
docs: add agent-task command index entry

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -1,6 +1,7 @@
 # Commands index
 
 - [api](api.md)
+- [agent-task](agent-task.md)
 - [audit](audit.md) — code convention drift and structural analysis
 - [auth](auth.md)
 - [bench](bench.md) — performance benchmarks + p95 regression ratchet


### PR DESCRIPTION
## Summary
- Add the new `agent-task` top-level command to the commands index so the command-surface docs test matches the current CLI.

## Verification
- `cargo test --test command_surface_test -- --nocapture`
- `cargo check`