### PR TITLE
fix(rig): refresh broken installed symlinks

### DIFF
--- a/src/core/deploy/safety_and_artifact.rs
+++ b/src/core/deploy/safety_and_artifact.rs
@@ -643,12 +643,7 @@ mod tests {
 
         let archive = temp.join(archive_name);
         let status = std::process::Command::new("zip")
-            .args([
-                "-q",
-                "-r",
-                archive.to_str().expect("archive path"),
-                top_dir,
-            ])
+            .args(["-q", "-r", archive.to_str().expect("archive path"), top_dir])
             .current_dir(&staging)
             .status()
             .expect("run zip");
@@ -776,7 +771,10 @@ mod tests {
 
         let result = flatten_double_nested_dir(&local_client(), target.to_str().expect("target"))
             .expect("ok");
-        assert!(result.is_none(), "flatten should be a no-op on a flat layout");
+        assert!(
+            result.is_none(),
+            "flatten should be a no-op on a flat layout"
+        );
         assert!(target.join("plugin.php").is_file());
     }
 

--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -9,6 +9,7 @@ use crate::core::error::{Error, Result};
 use crate::core::{extension, git, paths, stack};
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize)]
@@ -172,8 +173,16 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
 }
 
 fn ensure_rig_refreshable(rig: &DiscoveredRig, target: &Path) -> Result<()> {
-    let content = fs::read_to_string(target)
-        .map_err(|e| Error::internal_io(e.to_string(), Some("read existing rig spec".into())))?;
+    let content = match fs::read_to_string(target) {
+        Ok(content) => content,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some("read existing rig spec".into()),
+            ));
+        }
+    };
     let mut spec: super::RigSpec = serde_json::from_str(&content).map_err(|e| {
         Error::validation_invalid_json(
             e,

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -201,6 +201,27 @@ fn install_refreshes_existing_matching_local_rig_without_metadata() {
 }
 
 #[test]
+#[cfg(unix)]
+fn install_refreshes_existing_broken_rig_symlink() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    let refreshed = minimal_rig("alpha").replace("alpha rig", "alpha rig refreshed");
+    let source = write_rig(package.path(), "alpha", &refreshed);
+
+    fs::create_dir_all(crate::core::paths::rigs().expect("rigs dir")).expect("rigs dir");
+    let installed = crate::core::paths::rig_config("alpha").expect("alpha rig path");
+    std::os::unix::fs::symlink(package.path().join("missing-rig.json"), &installed)
+        .expect("broken rig symlink");
+
+    let result = install(package.path().to_str().unwrap(), None, false).expect("refresh");
+
+    assert_eq!(result.installed.len(), 1);
+    assert_eq!(fs::read_link(&installed).expect("updated symlink"), source);
+    let installed_content = fs::read_to_string(&installed).expect("installed rig");
+    assert!(installed_content.contains("alpha rig refreshed"));
+}
+
+#[test]
 fn install_rejects_existing_rig_with_different_declared_id() {
     let _home = HomeGuard::new();
     let package = tempfile::tempdir().expect("package");


### PR DESCRIPTION
## Summary
- Allow `homeboy rig install` to refresh an existing installed rig entry when the old config path is a broken symlink.
- Preserve the declared-ID collision guard for readable existing rig specs.
- Add regression coverage for reinstalling over a stale broken rig symlink.

## Verification
- `cargo test install_refreshes_existing_broken_rig_symlink`
- Used the patched binary to reinstall the Gutenberg RTC rig after a stale installed spec path had reproduced `read existing rig spec` / `No such file or directory`.

## Note
- `cargo fmt --check` currently reports formatting diffs in pre-existing `src/core/deploy/safety_and_artifact.rs` lines unrelated to this change; touched files were formatted with `rustfmt`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Isolated the stale symlink install failure, implemented the targeted recovery, and added the regression test; Chris remains responsible for review and merge.