### PR TITLE
fix(audit): keep structural complexity review-only

### DIFF
--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -354,7 +354,16 @@ fn build_comparison_output(
             });
         retain_new_items_for_changed_files(&mut comparison, &changed);
     }
-    let exit_code = if comparison.drift_increased { 1 } else { 0 };
+    let drift_increased = if args.changed_since.is_none() && !uses_finding_filters(args) {
+        comparison
+            .new_items
+            .iter()
+            .any(|item| !is_structural_complexity_fingerprint(&item.fingerprint))
+    } else {
+        comparison.drift_increased
+    };
+    comparison.drift_increased = drift_increased;
+    let exit_code = if drift_increased { 1 } else { 0 };
     let changed_since_summary = args
         .changed_since
         .as_ref()
@@ -454,11 +463,34 @@ fn default_audit_exit_code(result: &CodeAuditResult, is_scoped: bool) -> i32 {
         } else {
             1
         }
-    } else if result.summary.outliers_found > 0 {
+    } else if result.findings.iter().any(is_blocking_full_audit_finding) {
         1
     } else {
         0
     }
+}
+
+fn is_blocking_full_audit_finding(finding: &code_audit::Finding) -> bool {
+    !matches!(
+        finding.kind,
+        code_audit::AuditFinding::GodFile
+            | code_audit::AuditFinding::HighItemCount
+            | code_audit::AuditFinding::DirectorySprawl
+    )
+}
+
+fn uses_finding_filters(args: &AuditRunWorkflowArgs) -> bool {
+    !args.only_kinds.is_empty()
+        || !args.exclude_kinds.is_empty()
+        || !args.only_labels.is_empty()
+        || !args.exclude_labels.is_empty()
+}
+
+fn is_structural_complexity_fingerprint(fingerprint: &str) -> bool {
+    fingerprint.starts_with("structural::")
+        && (fingerprint.ends_with("::GodFile")
+            || fingerprint.ends_with("::HighItemCount")
+            || fingerprint.ends_with("::DirectorySprawl"))
 }
 
 #[cfg(test)]

--- a/src/core/deploy/safety_and_artifact.rs
+++ b/src/core/deploy/safety_and_artifact.rs
@@ -260,13 +260,12 @@ pub(super) fn deploy_artifact(
 
             // Step 2b: Flatten an accidental single top-level directory.
             //
-            // Build ZIPs commonly contain a single top-level directory named after
-            // the component (e.g. `extrachill-users/extrachill-users.php`). When the
-            // component's remote_path already points AT that directory
-            // (`wp-content/plugins/extrachill-users`), extracting in place produces a
-            // double-nested layout (`.../extrachill-users/extrachill-users/...`) that
-            // WordPress cannot load. Detect that signature and lift the inner
-            // directory's contents up one level so the artifact lands flat.
+            // Build archives commonly contain a single top-level directory named
+            // after the component. When the component's remote_path already points
+            // at that directory, extracting in place produces a double-nested layout
+            // (`.../component/component/...`) that runtimes cannot load. Detect that
+            // signature and lift the inner directory's contents up one level so the
+            // artifact lands flat.
             if let Some(result) = flatten_double_nested_dir(ssh_client, remote_path)? {
                 return Ok(result);
             }
@@ -319,7 +318,7 @@ pub(super) fn deploy_artifact(
 
 /// Return the final path segment of `remote_path` (its basename), if any.
 ///
-/// e.g. `wp-content/plugins/extrachill-users` -> `extrachill-users`.
+/// For example, `/srv/app/components/example` -> `example`.
 fn remote_basename(remote_path: &str) -> Option<&str> {
     remote_path
         .trim_end_matches('/')
@@ -333,7 +332,7 @@ fn remote_basename(remote_path: &str) -> Option<&str> {
 ///
 /// The signature we repair is: after extraction, `remote_path` contains exactly
 /// one entry, and that entry is a directory whose name equals `basename(remote_path)`
-/// (e.g. `.../extrachill-users/extrachill-users/`). When that holds, the inner
+/// (e.g. `.../component/component/`). When that holds, the inner
 /// directory's contents (including dotfiles) are lifted up into `remote_path` and
 /// the now-empty inner directory is removed.
 ///
@@ -382,11 +381,10 @@ fn flatten_double_nested_dir(
     );
 
     // Move the inner directory aside, then lift its contents (including dotfiles)
-    // up into remote_path, then remove the now-empty staging directory.
-    //
-    // Using a temp staging name avoids the "cannot move a directory into itself"
-    // problem when the inner dir shares the basename with its parent.
-    let staging = format!("{}/.homeboy-flatten-staging", normalized);
+    // up into remote_path, then remove the now-empty staging directory. Using a
+    // temp staging name avoids the "cannot move a directory into itself" problem
+    // when the inner dir shares the basename with its parent.
+    let staging = format!("{}/.artifact-flatten-staging", normalized);
     let flatten_cmd = format!(
         "cd {target} && rm -rf {staging} && mv {nested} {staging} && \
          find {staging} -mindepth 1 -maxdepth 1 -exec mv -t {target} {{}} + && \
@@ -434,8 +432,8 @@ fn ensure_not_double_nested(ssh_client: &SshClient, remote_path: &str) -> Option
             1,
             format!(
                 "Deploy produced a double-nested layout: '{nested}' exists, so the artifact \
-                 landed at '{nested}/...' instead of '{target}/...'. WordPress (and most \
-                 frameworks) cannot load a plugin/theme nested one level too deep. Refusing to \
+                 landed at '{nested}/...' instead of '{target}/...'. Runtimes generally cannot \
+                 load a component nested one level too deep. Refusing to \
                  report success. Set the component's remote_path to the parent directory, or \
                  adjust the build so the archive does not contain a redundant top-level '{base}/' \
                  directory.",
@@ -698,7 +696,7 @@ mod tests {
             "double-nested directory must not exist after flatten"
         );
         // Extract artifact and flatten staging cleaned up.
-        assert!(!target.join(".homeboy-flatten-staging").exists());
+        assert!(!target.join(".artifact-flatten-staging").exists());
     }
 
     /// A normal (non-nested) archive must extract in place untouched.

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -4,7 +4,7 @@
 
 use super::{
     apply_finding_filters, build_comparison_output, compute_fixability_if_requested,
-    scope_convention_outliers_to_findings, AuditRunWorkflowArgs,
+    default_audit_exit_code, scope_convention_outliers_to_findings, AuditRunWorkflowArgs,
 };
 use crate::core::code_audit::checks::CheckStatus;
 use crate::core::code_audit::conventions::{Deviation, Outlier};
@@ -217,6 +217,59 @@ fn only_with_no_matches_leaves_zero_findings_and_clean_exit() {
 
     assert!(result.findings.is_empty());
     assert_eq!(result.summary.outliers_found, 0);
+}
+
+mod full_audit_structural_complexity_tests {
+    use super::*;
+
+    #[test]
+    fn full_audit_keeps_structural_complexity_findings_review_only() {
+        let result = make_result(vec![
+            make_finding(AuditFinding::GodFile, "src/large.rs"),
+            make_finding(AuditFinding::HighItemCount, "src/items.rs"),
+            make_finding(AuditFinding::DirectorySprawl, "src/flat"),
+        ]);
+
+        assert_eq!(default_audit_exit_code(&result, false), 0);
+    }
+
+    #[test]
+    fn full_audit_still_blocks_on_non_structural_complexity_findings() {
+        let result = make_result(vec![make_finding(
+            AuditFinding::UnreferencedExport,
+            "src/dead.rs",
+        )]);
+
+        assert_eq!(default_audit_exit_code(&result, false), 1);
+    }
+
+    #[test]
+    fn full_audit_baseline_comparison_keeps_structural_complexity_review_only() {
+        let mut result = make_result(vec![make_finding(
+            AuditFinding::DirectorySprawl,
+            "src/commands",
+        )]);
+        result.findings[0].convention = "structural".to_string();
+        let baseline = make_baseline(vec![]);
+
+        let workflow =
+            build_comparison_output(result, &make_analysis(), baseline, &make_args(false))
+                .expect("comparison output builds");
+
+        assert_eq!(workflow.exit_code, 0);
+        match workflow.output {
+            crate::core::code_audit::report::AuditCommandOutput::Compared {
+                passed,
+                baseline_comparison,
+                ..
+            } => {
+                assert!(passed);
+                assert!(!baseline_comparison.drift_increased);
+                assert_eq!(baseline_comparison.new_items.len(), 1);
+            }
+            _ => panic!("expected compared output"),
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Keeps full-scope audit structural complexity findings (`god_file`, `high_item_count`, `directory_sprawl`) visible as review findings without failing release/main audit gates by themselves.
- Preserves blocking behavior for scoped/filtered audit runs and non-structural findings.
- Removes newly introduced core-specific deploy artifact wording that tripped the core-agnostic test in the failed release run.

## Verification
- `cargo fmt --check`
- `cargo test core::code_audit::run_test`
- `cargo test --test core_agnostic_test`
- `cargo run --bin homeboy -- --force-hot audit --path /Users/chubes/Developer/homeboy@fix-release-audit-structural-findings --extension rust --ignore-baseline --exclude non_portable_artifact_path`

## Notes
- Local full audit without excluding `non_portable_artifact_path` still reports pre-existing workstation observation metadata with local-only paths; that was not part of the failed release run's structural blocker.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the release audit blocker, drafted the targeted audit policy change and tests, and ran local verification. Chris remains responsible for review and merge.