### PR TITLE
Use GitHub generated release notes

### DIFF
--- a/src/core/git/commits.rs
+++ b/src/core/git/commits.rs
@@ -327,6 +327,50 @@ pub fn get_latest_tag_with_prefix(path: &str, tag_prefix: Option<&str>) -> Resul
         .map(|(tag, _)| tag))
 }
 
+/// Get the previous release tag reachable from `current_tag`.
+///
+/// In monorepos, `tag_prefix` scopes the search to the component tag namespace.
+pub fn get_previous_tag_before_with_prefix(
+    path: &str,
+    current_tag: &str,
+    tag_prefix: Option<&str>,
+) -> Result<Option<String>> {
+    let Some(current_version) = exact_release_version_from_tag(current_tag, tag_prefix) else {
+        return Ok(None);
+    };
+
+    let Some(tags) = command::run_in_optional(
+        path,
+        "git",
+        &[
+            "tag",
+            "--merged",
+            current_tag,
+            "--sort=-v:refname",
+            "--list",
+        ],
+    ) else {
+        return Ok(None);
+    };
+
+    Ok(tags
+        .lines()
+        .filter_map(|tag| {
+            let tag = tag.trim();
+            if tag == current_tag {
+                return None;
+            }
+            let version = exact_release_version_from_tag(tag, tag_prefix)?;
+            if version < current_version {
+                Some((tag.to_string(), version))
+            } else {
+                None
+            }
+        })
+        .max_by(|(_, a), (_, b)| a.cmp(b))
+        .map(|(tag, _)| tag))
+}
+
 fn exact_release_version_from_tag(tag: &str, tag_prefix: Option<&str>) -> Option<Version> {
     let tag = match tag_prefix {
         Some(prefix) => tag.strip_prefix(&format!("{}-", prefix))?,
@@ -1084,6 +1128,23 @@ mod tests {
         assert_eq!(
             get_latest_tag_with_prefix(&path, Some("wordpress")).unwrap(),
             Some("wordpress-v1.4.0".to_string())
+        );
+    }
+
+    #[test]
+    fn previous_tag_before_current_respects_component_prefix() {
+        let (dir, path) = init_repo();
+        git(&path, &["tag", "wordpress-v1.0.0"]);
+        git(&path, &["tag", "api-v9.9.9"]);
+        commit_file(&dir, &path, "one.txt", "one\n", "fix: one");
+        git(&path, &["tag", "wordpress-v1.1.0"]);
+        commit_file(&dir, &path, "two.txt", "two\n", "fix: two");
+        git(&path, &["tag", "wordpress-v1.2.0"]);
+
+        assert_eq!(
+            get_previous_tag_before_with_prefix(&path, "wordpress-v1.2.0", Some("wordpress"))
+                .unwrap(),
+            Some("wordpress-v1.1.0".to_string())
         );
     }
 

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -23,8 +23,8 @@ pub(crate) use commits::extract_version_from_tag;
 pub use commits::{
     categorize_commits, find_version_commit, find_version_release_commit, get_commits_since_tag,
     get_commits_since_tag_for_path, get_last_n_commits, get_latest_tag, get_latest_tag_with_prefix,
-    recommended_bump_from_commits, strip_conventional_prefix, CommitCategory, CommitCounts,
-    CommitInfo, MonorepoContext, SemverBump,
+    get_previous_tag_before_with_prefix, recommended_bump_from_commits, strip_conventional_prefix,
+    CommitCategory, CommitCounts, CommitInfo, MonorepoContext, SemverBump,
 };
 pub use github::{
     gh_probe_succeeds, issue_close, issue_comment, issue_create, issue_edit, issue_find, pr_create,

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -771,35 +771,11 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_tag_for_filename_preserves_safe_chars() {
-        assert_eq!(
-            github_release::sanitize_tag_for_filename("v1.2.3"),
-            "v1.2.3"
-        );
-        assert_eq!(
-            github_release::sanitize_tag_for_filename("data-machine-v0.70.2"),
-            "data-machine-v0.70.2"
-        );
-    }
-
-    #[test]
-    fn sanitize_tag_for_filename_strips_unsafe_chars() {
-        assert_eq!(
-            github_release::sanitize_tag_for_filename("v1.2.3 rc1"),
-            "v1.2.3-rc1"
-        );
-        assert_eq!(
-            github_release::sanitize_tag_for_filename("feat/foo@1"),
-            "feat-foo-1"
-        );
-    }
-
-    #[test]
     fn fallback_gh_command_includes_tag_twice() {
         let cmd = github_release::fallback_gh_command("v1.2.3");
         assert!(cmd.contains("gh release create v1.2.3"));
         assert!(cmd.contains("--title v1.2.3"));
-        assert!(cmd.contains("--notes-file"));
+        assert!(cmd.contains("--generate-notes"));
     }
 
     #[test]

--- a/src/core/release/executor/github_release.rs
+++ b/src/core/release/executor/github_release.rs
@@ -174,19 +174,7 @@ pub(crate) fn run_github_release(
     } else {
         notes
     };
-
-    let tmp_dir = crate::core::engine::temp::runtime_temp_dir("github-release")?;
-    let notes_path = tmp_dir.join(format!("notes-{}.md", sanitize_tag_for_filename(&tag)));
-    std::fs::write(&notes_path, &notes_body).map_err(|e| {
-        Error::internal_io(
-            format!("Failed to write release notes file: {}", e),
-            Some(notes_path.display().to_string()),
-        )
-    })?;
-
-    let notes_path_str = notes_path.to_str().ok_or_else(|| {
-        Error::internal_unexpected("github.release: notes-file path is not valid UTF-8".to_string())
-    })?;
+    let notes_start_tag = github_generated_notes_start_tag(component, &tag)?;
 
     log_status!(
         "release",
@@ -205,11 +193,15 @@ pub(crate) fn run_github_release(
         &tag,
         "--title",
         &tag,
-        "--notes-file",
-        notes_path_str,
+        "--generate-notes",
+        "--notes",
+        &notes_body,
         "-R",
         &repo_flag,
     ];
+    if let Some(previous_tag) = notes_start_tag.as_deref() {
+        create_args.extend_from_slice(&["--notes-start-tag", previous_tag]);
+    }
     for path in &artifact_paths {
         create_args.push(path);
     }
@@ -260,9 +252,20 @@ pub(crate) fn run_github_release(
             "repo": github.repo,
             "url": url,
             "artifact_count": artifact_paths.len(),
+            "generated_notes": true,
+            "notes_start_tag": notes_start_tag,
         })),
         Vec::new(),
     ))
+}
+
+fn github_generated_notes_start_tag(component: &Component, tag: &str) -> Result<Option<String>> {
+    let monorepo = crate::core::git::MonorepoContext::detect(&component.local_path, &component.id);
+    let (git_root, tag_prefix) = match monorepo.as_ref() {
+        Some(ctx) => (ctx.git_root.as_str(), Some(ctx.tag_prefix.as_str())),
+        None => (component.local_path.as_str(), None),
+    };
+    crate::core::git::get_previous_tag_before_with_prefix(git_root, tag, tag_prefix)
 }
 
 pub(super) fn skipped_result(
@@ -342,19 +345,7 @@ pub(super) fn gh_release_exists(tag: &str, repo_flag: &str) -> bool {
 
 pub(super) fn fallback_gh_command(tag: &str) -> String {
     format!(
-        "gh release create {} --title {} --notes-file <path-to-release-notes>",
+        "gh release create {} --title {} --generate-notes --notes <release-notes>",
         tag, tag
     )
-}
-
-pub(super) fn sanitize_tag_for_filename(tag: &str) -> String {
-    tag.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
-                c
-            } else {
-                '-'
-            }
-        })
-        .collect()
 }


### PR DESCRIPTION
## Summary
- Use GitHub's generated release notes when Homeboy creates GitHub Releases so native contributor credit is included.
- Preserve Homeboy's changelog notes as prepended release notes via `--notes`.
- Add a git primitive for resolving the previous release tag, including component-prefixed monorepo tags, so generated notes can start from the right tag.

## Verification
- `cargo fmt`
- `cargo test core::git::commits`
- `cargo test release`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the release-note wiring and focused tests; Chris reviewed the direction and corrected it to use GitHub-native contributors.