### PR TITLE
Preserve execution context component overrides

### DIFF
--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -33,8 +33,8 @@ pub use portable::{
 };
 pub use relationships::{associated_projects, projects_using, rename_component, shared_components};
 pub use resolution::{
-    resolve, resolve_artifact, resolve_effective, resolve_target, validate_local_path,
-    ResolvedTarget, TargetSpec,
+    resolve, resolve_artifact, resolve_effective, resolve_target, resolve_target_from_component,
+    validate_local_path, ResolvedTarget, TargetSpec,
 };
 pub use scope::{resolve_component_scope, EffectiveScope, ScopeCommand};
 pub use versioning::{

--- a/src/core/component/resolution.rs
+++ b/src/core/component/resolution.rs
@@ -60,6 +60,37 @@ pub struct ResolvedTarget {
     pub synthetic: bool,
 }
 
+fn resolved_target_from_component(mut component: Component, synthetic: bool) -> ResolvedTarget {
+    let source_path = PathBuf::from(shellexpand::tilde(&component.local_path).into_owned());
+    let git_root = detect_git_root(&source_path);
+    component.resolve_remote_path();
+
+    ResolvedTarget {
+        component_id: component.id.clone(),
+        component,
+        source_path,
+        git_root,
+        extension_id: None,
+        synthetic,
+    }
+}
+
+/// Resolve target path details from an already-authoritative component.
+///
+/// This preserves caller-supplied in-memory component fields while sharing the
+/// same path expansion, git-root detection, and remote-path normalization used
+/// by [`resolve_target`].
+pub fn resolve_target_from_component(
+    mut component: Component,
+    path_override: Option<&str>,
+) -> ResolvedTarget {
+    if let Some(path) = path_override {
+        component.local_path = path.to_string();
+    }
+
+    resolved_target_from_component(component, false)
+}
+
 pub fn resolve_artifact(component: &Component) -> Option<String> {
     if let Some(ref artifact) = component.build_artifact {
         return Some(artifact.clone());
@@ -319,7 +350,7 @@ pub fn resolve_target(spec: TargetSpec<'_>) -> Result<ResolvedTarget> {
         ));
     }
 
-    let mut component = resolve_effective_inner(
+    let component = resolve_effective_inner(
         spec.component_id,
         spec.path_override,
         spec.project,
@@ -344,24 +375,15 @@ pub fn resolve_target(spec: TargetSpec<'_>) -> Result<ResolvedTarget> {
         ));
     }
 
-    let source_path = PathBuf::from(shellexpand::tilde(&component.local_path).into_owned());
-    let git_root = detect_git_root(&source_path);
     let extension_id = if let Some(capability) = spec.capability {
         Some(extension::resolve_execution_context(&component, capability)?.extension_id)
     } else {
         None
     };
 
-    component.resolve_remote_path();
-
-    Ok(ResolvedTarget {
-        component_id: component.id.clone(),
-        component,
-        source_path,
-        git_root,
-        extension_id,
-        synthetic,
-    })
+    let mut target = resolved_target_from_component(component, synthetic);
+    target.extension_id = extension_id;
+    Ok(target)
 }
 
 /// Find the git root directory for a given path.

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -221,33 +221,25 @@ pub fn resolve_with_component(
     component_override: Option<Component>,
 ) -> Result<ExecutionContext> {
     // 1. Resolve component
-    let mut component = if let Some(mut component) = component_override {
-        if let Some(path) = options.path_override.as_deref() {
-            component.local_path = path.to_string();
-        }
-        component
+    let target = if let Some(component) = component_override {
+        component::resolve_target_from_component(component, options.path_override.as_deref())
     } else {
         component::resolve_target(component::TargetSpec::new(
             options.component_id.as_deref(),
             options.path_override.as_deref(),
         ))?
-        .component
     };
+    let component::ResolvedTarget {
+        mut component,
+        source_path,
+        git_root,
+        ..
+    } = target;
 
     let declared_extension_ids = declared_extension_ids(&component);
     apply_extension_overrides(&mut component, &options.extension_overrides);
 
-    // 2. Resolve source path
-    let target = component::resolve_target(component::TargetSpec::new(
-        Some(&component.id),
-        Some(&component.local_path),
-    ))?;
-    let source_path = target.source_path;
-
-    // 3. Detect git root
-    let git_root = target.git_root;
-
-    // 4. Optionally resolve extension context
+    // 2. Optionally resolve extension context
     let (extension_id, extension_path, settings) = if let Some(capability) = options.capability {
         let ext_context =
             extension::resolve_execution_context(&component, capability).map_err(|err| {
@@ -492,6 +484,114 @@ mod tests {
         assert_eq!(ctx.component_id, "rig-owned");
         assert_eq!(ctx.source_path, root);
         assert!(ctx.extension_id.is_none());
+    }
+
+    #[test]
+    fn resolve_with_component_preserves_in_memory_extension_config() {
+        with_isolated_home(|home| {
+            write_extension(
+                home,
+                "rig-node",
+                r#""lint": { "extension_script": "lint.sh" }"#,
+            );
+            write_extension(
+                home,
+                "portable-node",
+                r#""lint": { "extension_script": "lint.sh" }"#,
+            );
+            let dir = TempDir::new().expect("temp dir");
+            let root = dir.path();
+            fs::write(
+                root.join("homeboy.json"),
+                r#"{"id":"rig-owned","extensions":{"portable-node":{"marker":"portable"}}}"#,
+            )
+            .expect("write portable config");
+            let extensions = HashMap::from([(
+                "rig-node".to_string(),
+                ScopedExtensionConfig {
+                    settings: HashMap::from([(
+                        "marker".to_string(),
+                        serde_json::json!("in-memory"),
+                    )]),
+                    ..ScopedExtensionConfig::default()
+                },
+            )]);
+            let component = Component {
+                id: "rig-owned".to_string(),
+                local_path: root.to_string_lossy().to_string(),
+                extensions: Some(extensions),
+                ..Component::default()
+            };
+            let options = ResolveOptions::with_capability(
+                "rig-owned",
+                None,
+                ExtensionCapability::Lint,
+                Vec::new(),
+            );
+
+            let ctx = resolve_with_component(&options, Some(component))
+                .expect("in-memory component should stay authoritative");
+
+            assert_eq!(ctx.extension_id.as_deref(), Some("rig-node"));
+            assert!(ctx
+                .component
+                .extensions
+                .as_ref()
+                .is_some_and(|extensions| extensions.contains_key("rig-node")
+                    && !extensions.contains_key("portable-node")));
+            assert!(ctx
+                .settings
+                .iter()
+                .any(|(key, value)| key == "marker" && value == "in-memory"));
+        });
+    }
+
+    #[test]
+    fn resolve_with_component_applies_path_override_without_rediscovery() {
+        with_isolated_home(|home| {
+            write_extension(
+                home,
+                "rig-node",
+                r#""lint": { "extension_script": "lint.sh" }"#,
+            );
+            let dir = TempDir::new().expect("temp dir");
+            let original = dir.path().join("original");
+            let override_path = dir.path().join("override");
+            fs::create_dir_all(&original).expect("create original");
+            fs::create_dir_all(&override_path).expect("create override");
+            fs::write(
+                override_path.join("homeboy.json"),
+                r#"{"id":"rig-owned","extensions":{"portable-node":{}}}"#,
+            )
+            .expect("write portable config");
+            let extensions =
+                HashMap::from([("rig-node".to_string(), ScopedExtensionConfig::default())]);
+            let component = Component {
+                id: "rig-owned".to_string(),
+                local_path: original.to_string_lossy().to_string(),
+                extensions: Some(extensions),
+                ..Component::default()
+            };
+            let options = ResolveOptions::with_capability(
+                "rig-owned",
+                Some(override_path.to_string_lossy().to_string()),
+                ExtensionCapability::Lint,
+                Vec::new(),
+            );
+
+            let ctx = resolve_with_component(&options, Some(component))
+                .expect("path override should not trigger portable rediscovery");
+
+            assert_eq!(ctx.source_path, override_path);
+            assert_eq!(ctx.component.local_path, override_path.to_string_lossy());
+            assert_eq!(ctx.extension_id.as_deref(), Some("rig-node"));
+            assert!(ctx
+                .component
+                .extensions
+                .as_ref()
+                .is_some_and(|extensions| extensions.contains_key("rig-node")
+                    && !extensions.contains_key("portable-node")));
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a component-derived target resolver that reuses path expansion, git-root detection, and remote-path normalization without rediscovering the component.
- Update `ExecutionContext::resolve_with_component()` to preserve caller-supplied in-memory `Component` fields, including extension config, while still honoring `path_override`.
- Cover portable-config collision cases so rig/dispatcher-owned component overrides remain authoritative.

Closes #3267.

## Verification
- `cargo fmt --check`
- `cargo test resolve_with_component`
- `cargo test target_spec`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-issue-3267-preserve-component-override --extension rust`

## Known check caveat
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-issue-3267-preserve-component-override --extension rust` ran the broader suite and failed on existing/environment failures unrelated to this change:
  - `core::deploy::safety_and_artifact::tests::test_deploy_artifact_flattens_double_nested_plugin_zip`: missing `zip` binary (`Os { code: 2, kind: NotFound }`)
  - `core::deploy::safety_and_artifact::tests::test_deploy_artifact_leaves_flat_archive_untouched`: missing `zip` binary (`Os { code: 2, kind: NotFound }`)
  - `core::source_snapshot::tests::test_collect_local`: `snapshot.workspace_root.is_some()` assertion failed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the targeted execution-context resolver fix, adding regression tests, and running verification; Chris remains responsible for review and merge.