### PR TITLE
Refresh installed rig sources by package

### DIFF
--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -42,7 +42,7 @@ rig package / local spec
 | `runs <id>` | List persisted observation runs for the rig. |
 | `install <source>` | Install rigs from a local package path or git URL. |
 | `update [id]` | Pull and refresh git-backed installed rig packages. |
-| `sources ...` | Inspect or remove installed rig source packages. |
+| `sources ...` | Inspect, refresh, or remove installed rig source packages. |
 | `app ...` | Install, update, or remove a rig's desktop launcher. |
 
 All subcommands support `--output <path>` for structured JSON output in addition to stdout.
@@ -150,10 +150,12 @@ If the user replaced an installed config file with their own file, update preser
 
 ```sh
 homeboy rig sources list
+homeboy rig sources refresh
+homeboy rig sources refresh chubes4-homeboy-rigs
 homeboy rig sources remove chubes4-homeboy-rigs
 ```
 
-`sources list` groups installed rigs and stacks by package source, package path, revision, and ownership. `sources remove` removes Homeboy-owned config links and metadata for one source package; it also removes cloned git packages, while linked local package directories are left in place.
+`sources list` groups installed rigs and stacks by package source, package path, revision, and ownership. `sources refresh` pulls recorded git-backed package paths, refreshes Homeboy-owned installed rig and stack specs, and reports source, before/after revisions, installed config path, and source spec path. `sources remove` removes Homeboy-owned config links and metadata for one source package; it also removes cloned git packages, while linked local package directories are left in place.
 
 ## Stack Sync
 

--- a/src/commands/rig/output.rs
+++ b/src/commands/rig/output.rs
@@ -155,6 +155,7 @@ pub struct RigSourcesOutput {
 pub enum RigSourcesReport {
     List(rig::RigSourceListResult),
     Remove(rig::RigSourceRemoveResult),
+    Refresh(rig::RigSourceUpdateResult),
 }
 
 #[derive(Serialize)]

--- a/src/commands/rig/sources.rs
+++ b/src/commands/rig/sources.rs
@@ -14,12 +14,19 @@ pub(super) enum RigSourcesCommand {
         /// Source URL/path, package path, or package ID from `rig sources list`
         source: String,
     },
+    /// Refresh rigs installed from recorded source package paths
+    Refresh {
+        /// Source URL/path, package path, or package ID from `rig sources list`.
+        /// Omit to refresh every installed git-backed source package.
+        source: Option<String>,
+    },
 }
 
 pub(super) fn run(command: RigSourcesCommand) -> CmdResult<RigCommandOutput> {
     match command {
         RigSourcesCommand::List => list(),
         RigSourcesCommand::Remove { source } => remove(&source),
+        RigSourcesCommand::Refresh { source } => refresh(source.as_deref()),
     }
 }
 
@@ -38,6 +45,16 @@ fn remove(source: &str) -> CmdResult<RigCommandOutput> {
         RigCommandOutput::Sources(RigSourcesOutput {
             command: "rig.sources.remove",
             report: RigSourcesReport::Remove(rig::remove_source(source)?),
+        }),
+        0,
+    ))
+}
+
+fn refresh(source: Option<&str>) -> CmdResult<RigCommandOutput> {
+    Ok((
+        RigCommandOutput::Sources(RigSourcesOutput {
+            command: "rig.sources.refresh",
+            report: RigSourcesReport::Refresh(rig::update_source(source)?),
         }),
         0,
     ))

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -48,7 +48,7 @@ pub use runner::{
 };
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use source::{
-    list_sources, remove_source, update_all_sources, update_source_for_rig,
+    list_sources, remove_source, update_all_sources, update_source, update_source_for_rig,
     InvalidRigSourceMetadata, RemovedRigSourceRig, RemovedRigSourceStack, RigSourceGroup,
     RigSourceListResult, RigSourceRemoveResult, RigSourceRig, RigSourceStack,
     RigSourceUpdateResult, RigSourceUpdatedRig, RigSourceUpdatedStack, SkippedRigSourceRig,

--- a/src/core/rig/source.rs
+++ b/src/core/rig/source.rs
@@ -212,6 +212,69 @@ pub fn update_all_sources() -> Result<RigSourceUpdateResult> {
     Ok(aggregate)
 }
 
+pub fn update_source(selector: Option<&str>) -> Result<RigSourceUpdateResult> {
+    let Some(selector) = selector else {
+        return update_all_sources();
+    };
+
+    let matches = list_sources()?
+        .sources
+        .into_iter()
+        .filter(|source| source_matches(source, selector))
+        .collect::<Vec<_>>();
+
+    if matches.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            format!("No installed rig source matches '{}'", selector),
+            Some(selector.to_string()),
+            None,
+        ));
+    }
+    if matches.len() > 1 {
+        let tried = matches
+            .iter()
+            .map(|source| source.package_id.clone())
+            .collect::<Vec<_>>();
+        return Err(Error::validation_invalid_argument(
+            "source",
+            format!(
+                "Selector '{}' matches multiple rig sources; use the full source or package path",
+                selector
+            ),
+            Some(selector.to_string()),
+            Some(tried),
+        ));
+    }
+
+    let source = matches.into_iter().next().expect("checked non-empty");
+    if source.linked {
+        let mut skipped = Vec::new();
+        for rig in source.rigs {
+            skipped.push(SkippedRigSourceUpdate {
+                id: rig.id,
+                source: source.source.clone(),
+                reason: "linked local sources are updated in place outside homeboy".to_string(),
+            });
+        }
+        for stack in source.stacks {
+            skipped.push(SkippedRigSourceUpdate {
+                id: stack.id,
+                source: source.source.clone(),
+                reason: "linked local sources are updated in place outside homeboy".to_string(),
+            });
+        }
+        return Ok(RigSourceUpdateResult {
+            updated: Vec::new(),
+            updated_stacks: Vec::new(),
+            skipped,
+            failed: Vec::new(),
+        });
+    }
+
+    update_group(source)
+}
+
 fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
     let package_path = PathBuf::from(&source.package_path);
     if !package_path.exists() {

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -1,7 +1,7 @@
 //! Rig source lifecycle tests. Covers `src/core/rig/source.rs`.
 
 use crate::core::rig::{
-    install, list_sources, remove_source, update_all_sources, update_source_for_rig,
+    install, list_sources, remove_source, update_all_sources, update_source, update_source_for_rig,
 };
 use crate::test_support::HomeGuard;
 use std::fs;
@@ -339,6 +339,83 @@ fn update_all_reports_broken_sources_and_continues() {
     let installed = fs::read_to_string(crate::core::paths::rig_config("good").unwrap())
         .expect("installed good rig");
     assert!(installed.contains("good rig updated"));
+}
+
+#[test]
+fn refresh_source_selector_updates_recorded_package() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    let source_rig = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    let bare = create_bare_source(package.path());
+    let source = bare
+        .path()
+        .join("rig-package.git")
+        .to_string_lossy()
+        .to_string();
+
+    install(&source, None, false).expect("install");
+    let before = crate::core::rig::read_source_metadata("alpha")
+        .expect("metadata")
+        .source_revision;
+
+    fs::write(
+        &source_rig,
+        minimal_rig("alpha").replace("alpha rig", "alpha rig refreshed"),
+    )
+    .expect("update rig");
+    commit_package(package.path(), "refresh alpha");
+    run_git(package.path(), &["push", &source, "HEAD:main"]);
+
+    let package_id = list_sources().expect("sources").sources[0]
+        .package_id
+        .clone();
+    let result = update_source(Some(&package_id)).expect("refresh source");
+
+    assert_eq!(result.updated.len(), 1);
+    assert_eq!(result.updated[0].id, "alpha");
+    assert_eq!(result.updated[0].source, source);
+    assert_eq!(
+        result.updated[0].path,
+        crate::core::paths::rig_config("alpha")
+            .unwrap()
+            .to_string_lossy()
+    );
+    assert_eq!(result.updated[0].previous_revision, before);
+    assert_ne!(result.updated[0].source_revision, before);
+    assert!(
+        fs::read_to_string(crate::core::paths::rig_config("alpha").unwrap())
+            .expect("installed rig")
+            .contains("alpha rig refreshed")
+    );
+}
+
+#[test]
+fn refresh_without_selector_updates_all_sources() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    let source_rig = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    let bare = create_bare_source(package.path());
+    let source = bare
+        .path()
+        .join("rig-package.git")
+        .to_string_lossy()
+        .to_string();
+
+    install(&source, None, false).expect("install");
+    fs::write(
+        &source_rig,
+        minimal_rig("alpha").replace("alpha rig", "alpha rig refreshed"),
+    )
+    .expect("update rig");
+    commit_package(package.path(), "refresh alpha");
+    run_git(package.path(), &["push", &source, "HEAD:main"]);
+
+    let result = update_source(None).expect("refresh all sources");
+
+    assert_eq!(result.updated.len(), 1);
+    assert_eq!(result.updated[0].id, "alpha");
+    assert!(result.skipped.is_empty());
+    assert!(result.failed.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `homeboy rig sources refresh [source]` to refresh installed rigs/stacks from recorded git-backed source package paths.
- Reuse source selectors from `rig sources list` and report refreshed source, before/after revisions, installed config paths, and source spec paths through the existing source update payload.
- Document the new refresh flow and cover selector/all-source refresh behavior in rig source lifecycle tests.

Closes #3261

## Tests
- `cargo fmt --check`
- `cargo test refresh_source_selector_updates_recorded_package`
- `cargo test refresh_without_selector_updates_all_sources`
- `cargo test --lib core::rig::source::source_test`
- `cargo test --test command_surface_test`
- `cargo test --test output_contracts_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, docs, and PR description; Chris remains responsible for review and merge.