### PR TITLE
Normalize lab runner command PATH

### DIFF
--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -13,7 +13,7 @@ use crate::core::error::{Error, RemoteCommandFailedDetails, Result, TargetDetail
 use crate::core::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
 use crate::core::paths;
 use crate::core::process::pid_is_running;
-use crate::core::runner::measured_command_output;
+use crate::core::runner::{measured_command_output, normalize_runner_command_env};
 use crate::core::source_snapshot::SourceSnapshot;
 
 mod artifact_download;
@@ -362,10 +362,12 @@ fn enqueue_exec_job(
             } else {
                 None
             };
+            let mut env = request.env.clone();
+            normalize_runner_command_env(&mut env);
             let mut command = Command::new(&request.command[0]);
             command
                 .args(&request.command[1..])
-                .envs(request.env.iter())
+                .envs(env.iter())
                 .current_dir(&request.cwd);
             if let Some(snapshot) = &source_snapshot {
                 command.env(

--- a/src/core/runner/command_path.rs
+++ b/src/core/runner/command_path.rs
@@ -1,0 +1,153 @@
+use std::collections::{HashMap, HashSet};
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const HOME_BIN_DIRS: &[&str] = &[".local/bin", ".cargo/bin", ".kimaki/bin"];
+const ABSOLUTE_BIN_DIRS: &[&str] = &[
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+];
+
+pub(crate) fn normalize_runner_command_env(env: &mut HashMap<String, String>) {
+    if env.contains_key("PATH") {
+        return;
+    }
+    if let Some(path) = local_runner_command_path() {
+        env.insert("PATH".to_string(), path.to_string_lossy().to_string());
+    }
+}
+
+pub(crate) fn remote_shell_path_preamble() -> &'static str {
+    "export PATH=\"$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.kimaki/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}\"; for d in \"$HOME\"/.local/opt/node-*/bin \"$HOME\"/.nvm/versions/node/*/bin; do [ -d \"$d\" ] && PATH=\"$d:$PATH\"; done; export PATH"
+}
+
+fn local_runner_command_path() -> Option<OsString> {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let existing_path = std::env::var_os("PATH");
+    build_runner_command_path(home.as_deref(), existing_path.as_deref())
+}
+
+fn build_runner_command_path(
+    home: Option<&Path>,
+    existing_path: Option<&OsStr>,
+) -> Option<OsString> {
+    let mut seen = HashSet::new();
+    let mut paths = Vec::new();
+
+    if let Some(home) = home {
+        for rel in HOME_BIN_DIRS {
+            push_existing_path(&mut paths, &mut seen, home.join(rel));
+        }
+        push_node_bins(&mut paths, &mut seen, &home.join(".local/opt"), "node-");
+        push_node_bins(&mut paths, &mut seen, &home.join(".nvm/versions/node"), "");
+    }
+
+    for path in ABSOLUTE_BIN_DIRS {
+        push_existing_path(&mut paths, &mut seen, PathBuf::from(path));
+    }
+
+    if let Some(existing_path) = existing_path {
+        for path in std::env::split_paths(existing_path) {
+            push_path(&mut paths, &mut seen, path);
+        }
+    }
+
+    if paths.is_empty() {
+        None
+    } else {
+        std::env::join_paths(paths).ok()
+    }
+}
+
+fn push_node_bins(
+    paths: &mut Vec<PathBuf>,
+    seen: &mut HashSet<PathBuf>,
+    versions_dir: &Path,
+    prefix: &str,
+) {
+    let Ok(entries) = fs::read_dir(versions_dir) else {
+        return;
+    };
+
+    let mut bins = entries
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| {
+            prefix.is_empty()
+                || path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with(prefix))
+        })
+        .map(|path| path.join("bin"))
+        .filter(|path| path.exists())
+        .collect::<Vec<_>>();
+    bins.sort();
+    bins.reverse();
+
+    for bin in bins {
+        push_path(paths, seen, bin);
+    }
+}
+
+fn push_existing_path(paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>, path: PathBuf) {
+    if path.exists() {
+        push_path(paths, seen, path);
+    }
+}
+
+fn push_path(paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>, path: PathBuf) {
+    if seen.insert(path.clone()) {
+        paths.push(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    #[test]
+    fn runner_command_path_prepends_common_user_tool_dirs() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let home = tmp.path().join("home");
+        let local_bin = home.join(".local/bin");
+        let local_node = home.join(".local/opt/node-v24.13.1-linux-x64/bin");
+        let nvm_node = home.join(".nvm/versions/node/v20.0.0/bin");
+        fs::create_dir_all(&local_bin).expect("local bin");
+        fs::create_dir_all(&local_node).expect("local node");
+        fs::create_dir_all(&nvm_node).expect("nvm node");
+
+        let path = build_runner_command_path(Some(&home), Some(&OsString::from("/usr/bin:/bin")))
+            .expect("path");
+        let parts = std::env::split_paths(&path).collect::<Vec<_>>();
+
+        assert_eq!(parts[0], local_bin);
+        assert!(parts.contains(&local_node));
+        assert!(parts.contains(&nvm_node));
+        assert!(parts.contains(&PathBuf::from("/usr/bin")));
+        assert!(parts.contains(&PathBuf::from("/bin")));
+    }
+
+    #[test]
+    fn runner_env_keeps_explicit_path() {
+        let mut env = HashMap::from([("PATH".to_string(), "/custom/bin".to_string())]);
+
+        normalize_runner_command_env(&mut env);
+
+        assert_eq!(env.get("PATH").map(String::as_str), Some("/custom/bin"));
+    }
+
+    #[test]
+    fn remote_shell_path_preamble_includes_local_opt_node_glob() {
+        let preamble = remote_shell_path_preamble();
+
+        assert!(preamble.contains("$HOME/.local/bin"));
+        assert!(preamble.contains("$HOME\"/.local/opt/node-*/bin"));
+        assert!(preamble.contains("$HOME\"/.nvm/versions/node/*/bin"));
+    }
+}

--- a/src/core/runner/command_path.rs
+++ b/src/core/runner/command_path.rs
@@ -26,6 +26,21 @@ pub(crate) fn remote_shell_path_preamble() -> &'static str {
     "export PATH=\"$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.kimaki/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}\"; for d in \"$HOME\"/.local/opt/node-*/bin \"$HOME\"/.nvm/versions/node/*/bin; do [ -d \"$d\" ] && PATH=\"$d:$PATH\"; done; export PATH"
 }
 
+pub(crate) fn quote_runner_env_value(key: &str, value: &str) -> String {
+    if key == "PATH" {
+        return format!("\"{}\"", escape_double_quoted_env_value(value));
+    }
+
+    crate::core::engine::shell::quote_arg(value)
+}
+
+fn escape_double_quoted_env_value(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('`', "\\`")
+}
+
 fn local_runner_command_path() -> Option<OsString> {
     let home = std::env::var_os("HOME").map(PathBuf::from);
     let existing_path = std::env::var_os("PATH");
@@ -149,5 +164,21 @@ mod tests {
         assert!(preamble.contains("$HOME/.local/bin"));
         assert!(preamble.contains("$HOME\"/.local/opt/node-*/bin"));
         assert!(preamble.contains("$HOME\"/.nvm/versions/node/*/bin"));
+    }
+
+    #[test]
+    fn path_env_value_allows_existing_path_expansion() {
+        assert_eq!(
+            quote_runner_env_value("PATH", "$PATH:/custom/bin"),
+            "\"$PATH:/custom/bin\""
+        );
+    }
+
+    #[test]
+    fn non_path_env_value_uses_shell_quoting() {
+        assert_eq!(
+            quote_runner_env_value("TOKEN", "hello world"),
+            "'hello world'"
+        );
     }
 }

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -15,6 +15,7 @@ use crate::core::source_snapshot::SourceSnapshot;
 use super::broker_http;
 use super::capabilities::{runner_capability_snapshot, validate_runner_capability_preflight};
 use super::evidence::mirror_daemon_evidence;
+use super::normalize_runner_command_env;
 use super::resource_metrics::{measured_command_output, RunnerResourceMetrics};
 use super::{load, status, Runner, RunnerCapabilityPreflight, RunnerKind, RunnerTunnelMode};
 
@@ -104,6 +105,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
     let connected = status(runner_id)?;
     let mut request_env = runner.env.clone();
     request_env.extend(options.env.clone());
+    normalize_runner_command_env(&mut request_env);
     let required_extensions =
         required_extensions_for_command(&options.command, &options.required_extensions);
 
@@ -145,7 +147,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
     }
 
     match runner.kind {
-        RunnerKind::Local => exec_local(&runner, cwd, options.command, options.env),
+        RunnerKind::Local => exec_local(&runner, cwd, options.command, request_env),
         RunnerKind::Ssh if options.allow_diagnostic_ssh => {
             preflight_runner_capability_plan(
                 &runner,

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -12,6 +12,7 @@ use crate::core::server::{self, RunnerPolicy, RunnerSettings, ServerRunner};
 mod apply;
 mod broker_http;
 mod capabilities;
+mod command_path;
 mod connection;
 mod evidence;
 mod execution;
@@ -33,6 +34,7 @@ pub use capabilities::{
     lab_runner_capability_preflight, LabRunnerCapabilityContract, LabRunnerCapabilityPlan,
     LabRunnerGateDecision, LabRunnerGateMode, RunnerCapabilityPreflight, RunnerRequiredTool,
 };
+pub(crate) use command_path::{normalize_runner_command_env, remote_shell_path_preamble};
 pub use connection::{connect, connect_reverse, disconnect, status, statuses};
 pub use evidence::{
     download_remote_artifact, is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -34,7 +34,9 @@ pub use capabilities::{
     lab_runner_capability_preflight, LabRunnerCapabilityContract, LabRunnerCapabilityPlan,
     LabRunnerGateDecision, LabRunnerGateMode, RunnerCapabilityPreflight, RunnerRequiredTool,
 };
-pub(crate) use command_path::{normalize_runner_command_env, remote_shell_path_preamble};
+pub(crate) use command_path::{
+    normalize_runner_command_env, quote_runner_env_value, remote_shell_path_preamble,
+};
 pub use connection::{connect, connect_reverse, disconnect, status, statuses};
 pub use evidence::{
     download_remote_artifact, is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -9,6 +9,7 @@ use crate::core::engine::invocation;
 use crate::core::engine::resource::{ChildProcessIdentity, ExtensionChildResourceSummary};
 use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
+use crate::core::runner::remote_shell_path_preamble;
 use chrono::Utc;
 
 use super::{
@@ -43,6 +44,21 @@ pub struct CommandOutput {
     pub success: bool,
     pub exit_code: i32,
     pub child_resource: Option<ExtensionChildResourceSummary>,
+}
+
+fn quote_env_value(key: &str, value: &str) -> String {
+    if key == "PATH" {
+        return format!("\"{}\"", escape_double_quoted_env_value(value));
+    }
+
+    shell::quote_arg(value)
+}
+
+fn escape_double_quoted_env_value(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('`', "\\`")
 }
 
 impl SshClient {
@@ -310,17 +326,16 @@ impl SshClient {
         self.execute_with_stdin(&effective, None)
     }
 
-    /// Build an env preamble that sets configured variables via `export`.
-    /// Values are quoted but allow shell expansion (e.g. `$PATH`).
+    /// Build an env preamble that normalizes runner command lookup and sets
+    /// configured variables via `export`. PATH values allow shell expansion
+    /// so configs can append/prepend `$PATH`.
     fn prepend_env(&self, command: &str) -> String {
-        if self.env.is_empty() {
-            return command.to_string();
-        }
-        let exports: Vec<String> = self
-            .env
-            .iter()
-            .map(|(k, v)| format!("export {}={}", k, shell::quote_arg(v)))
-            .collect();
+        let mut exports = vec![remote_shell_path_preamble().to_string()];
+        exports.extend(
+            self.env
+                .iter()
+                .map(|(k, v)| format!("export {}={}", k, quote_env_value(k, v))),
+        );
         format!("{} && {}", exports.join(" && "), command)
     }
 
@@ -1180,6 +1195,43 @@ fn is_transient_ssh_error(output: &CommandOutput) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ssh_command_prepends_runner_tool_path() {
+        let client = SshClient {
+            host: "runner.example.test".to_string(),
+            user: "tester".to_string(),
+            port: 22,
+            identity_file: None,
+            auth: None,
+            is_local: false,
+            env: HashMap::new(),
+        };
+
+        let command = client.prepend_env("command -v node");
+
+        assert!(command.starts_with("export PATH=\"$HOME/.local/bin"));
+        assert!(command.contains("$HOME\"/.local/opt/node-*/bin"));
+        assert!(command.contains("$HOME\"/.nvm/versions/node/*/bin"));
+        assert!(command.ends_with("&& command -v node"));
+    }
+
+    #[test]
+    fn ssh_command_allows_configured_path_to_expand_existing_path() {
+        let client = SshClient {
+            host: "runner.example.test".to_string(),
+            user: "tester".to_string(),
+            port: 22,
+            identity_file: None,
+            auth: None,
+            is_local: false,
+            env: HashMap::from([("PATH".to_string(), "$PATH:/custom/bin".to_string())]),
+        };
+
+        let command = client.prepend_env("command -v homeboy");
+
+        assert!(command.contains("export PATH=\"$PATH:/custom/bin\""));
+    }
 
     #[test]
     fn test_non_local_hosts() {

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -9,7 +9,7 @@ use crate::core::engine::invocation;
 use crate::core::engine::resource::{ChildProcessIdentity, ExtensionChildResourceSummary};
 use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
-use crate::core::runner::remote_shell_path_preamble;
+use crate::core::runner::{quote_runner_env_value, remote_shell_path_preamble};
 use chrono::Utc;
 
 use super::{
@@ -44,21 +44,6 @@ pub struct CommandOutput {
     pub success: bool,
     pub exit_code: i32,
     pub child_resource: Option<ExtensionChildResourceSummary>,
-}
-
-fn quote_env_value(key: &str, value: &str) -> String {
-    if key == "PATH" {
-        return format!("\"{}\"", escape_double_quoted_env_value(value));
-    }
-
-    shell::quote_arg(value)
-}
-
-fn escape_double_quoted_env_value(value: &str) -> String {
-    value
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('`', "\\`")
 }
 
 impl SshClient {
@@ -334,7 +319,7 @@ impl SshClient {
         exports.extend(
             self.env
                 .iter()
-                .map(|(k, v)| format!("export {}={}", k, quote_env_value(k, v))),
+                .map(|(k, v)| format!("export {}={}", k, quote_runner_env_value(k, v))),
         );
         format!("{} && {}", exports.join(" && "), command)
     }
@@ -1195,43 +1180,6 @@ fn is_transient_ssh_error(output: &CommandOutput) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn ssh_command_prepends_runner_tool_path() {
-        let client = SshClient {
-            host: "runner.example.test".to_string(),
-            user: "tester".to_string(),
-            port: 22,
-            identity_file: None,
-            auth: None,
-            is_local: false,
-            env: HashMap::new(),
-        };
-
-        let command = client.prepend_env("command -v node");
-
-        assert!(command.starts_with("export PATH=\"$HOME/.local/bin"));
-        assert!(command.contains("$HOME\"/.local/opt/node-*/bin"));
-        assert!(command.contains("$HOME\"/.nvm/versions/node/*/bin"));
-        assert!(command.ends_with("&& command -v node"));
-    }
-
-    #[test]
-    fn ssh_command_allows_configured_path_to_expand_existing_path() {
-        let client = SshClient {
-            host: "runner.example.test".to_string(),
-            user: "tester".to_string(),
-            port: 22,
-            identity_file: None,
-            auth: None,
-            is_local: false,
-            env: HashMap::from([("PATH".to_string(), "$PATH:/custom/bin".to_string())]),
-        };
-
-        let command = client.prepend_env("command -v homeboy");
-
-        assert!(command.contains("export PATH=\"$PATH:/custom/bin\""));
-    }
 
     #[test]
     fn test_non_local_hosts() {


### PR DESCRIPTION
## Summary
- Normalize runner command envs with common user tool paths when no explicit `PATH` is configured.
- Add SSH command preamble support for non-login shells, including `$HOME/.local/bin`, `$HOME/.local/opt/node-*/bin`, and nvm node bins.
- Preserve explicit runner `PATH` overrides while allowing `$PATH` expansion for SSH env config.

Closes https://github.com/Extra-Chill/homeboy/issues/3256

## Tests
- `cargo fmt --check`
- `cargo test command_path --lib`
- `cargo test runner_command_path --lib`
- `cargo test ssh_command_ --lib`
- `cargo test runner_env_keeps_explicit_path --lib`
- `cargo test test_exec_runs_local_runner_command --lib`
- `cargo test runner_capability_preflight --lib`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner PATH normalization fix, added focused tests, and ran verification; Chris remains responsible for review and merge.