### PR TITLE
Add reusable bench settings matrix runner

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -7,6 +7,7 @@ deltas against a stored baseline.
 
 ```bash
 homeboy bench <component> [options] [-- <runner-args>]
+homeboy bench matrix [<component>] --setting-matrix <key=value[,value...]> [options] [-- <runner-args>]
 homeboy bench list <component> [options] [-- <runner-args>]
 homeboy bench history <component> [--scenario <id>] [--rig <id>] [--limit 20]
 homeboy bench distribution <component> --field <metadata.path> [--scenario <id>] [--rig <id>] [--status <status>] [--limit 20]
@@ -75,6 +76,10 @@ the other capabilities.
   multiple axes. When present, `homeboy bench` builds a generic
   `homeboy/agent-task-matrix-plan/v1`, dispatches cells through the generic
   scheduler, and returns both scheduler and matrix aggregate metadata.
+- `--setting-matrix <key=value[,value...]>`: For `homeboy bench matrix`, add a
+  local settings axis. The command expands the Cartesian product, runs one
+  normal child bench per cell, and aggregates child statuses, run IDs, and
+  numeric metric samples.
 - `--runner-pool <BACKEND>`: Executor backend string for matrix cells. Core keeps
   this as data so concrete backends such as Codebox remain extension-owned.
   Omit to use the local no-op executor for plan/scheduler smoke checks.
@@ -97,6 +102,28 @@ Arguments after `--` are passed verbatim to the extension's bench runner
 script.
 
 ## Matrix Fan-Out
+
+For local benchmark scale sweeps, `homeboy bench matrix` is the narrow reusable
+runner over existing bench execution. It supports zero or one rig, rejects
+baseline writes, and varies string settings via `--setting-matrix`:
+
+```bash
+homeboy bench matrix \
+  --rig gutenberg-rtc \
+  --scenario gutenberg-rtc-protocol-load \
+  --setting-matrix clients=10,100,500,1000 rounds=3 batch_size=1,10,25,100 \
+  --runs 3
+```
+
+The JSON output uses the `settings_matrix` bench variant and includes:
+
+- `cells`: one entry per expanded settings combination with status, exit code,
+  extracted child run ID, hints, and numeric metric samples.
+- `summary`: cell totals and collected child run IDs.
+- `follow_ups`: intentionally deferred pieces such as matrix-level observation
+  records, typed JSON axes, and cross-rig matrix aggregation.
+
+## Agent-Task Matrix Fan-Out
 
 Matrix fan-out is the operator-facing path over Homeboy's generic agent-task
 substrate. It is intentionally executor-neutral: the CLI turns product inputs

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -52,7 +52,7 @@ impl BenchArgs {
 #[derive(Subcommand)]
 enum BenchCommand {
     /// Run a local settings matrix and aggregate child bench runs
-    Matrix(BenchMatrixArgs),
+    Matrix(settings_matrix::BenchMatrixArgs),
     /// List declared benchmark scenarios without executing them
     List(BenchListArgs),
     /// List persisted benchmark runs for a component
@@ -61,21 +61,6 @@ enum BenchCommand {
     Distribution(BenchDistributionArgs),
     /// Compare two persisted benchmark runs
     Compare(BenchCompareArgs),
-}
-
-#[derive(Args)]
-struct BenchMatrixArgs {
-    #[command(flatten)]
-    run: BenchRunArgs,
-
-    /// Settings matrix axis in NAME=value,value form. Repeat the flag or pass
-    /// multiple axes after it, e.g. --setting-matrix clients=10,100 rounds=3.
-    #[arg(
-        long = "setting-matrix",
-        value_name = "NAME=VALUE[,VALUE...]",
-        num_args = 1..
-    )]
-    setting_matrix: Vec<String>,
 }
 
 #[derive(Args)]
@@ -339,10 +324,7 @@ pub fn run(mut args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> 
     if let Some(command) = &args.command {
         return match command {
             BenchCommand::Matrix(matrix_args) => {
-                let output = settings_matrix::run_settings_matrix(
-                    &matrix_args.run,
-                    &matrix_args.setting_matrix,
-                )?;
+                let output = settings_matrix::run_settings_matrix(matrix_args)?;
                 let exit = if output.summary.passed { 0 } else { 1 };
                 Ok((BenchOutput::SettingsMatrix(output), exit))
             }

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -24,6 +24,7 @@ use super::{runs, CmdResult, GlobalArgs};
 mod fanout;
 mod matrix;
 mod observation;
+mod settings_matrix;
 
 #[derive(Args)]
 pub struct BenchArgs {
@@ -50,6 +51,8 @@ impl BenchArgs {
 
 #[derive(Subcommand)]
 enum BenchCommand {
+    /// Run a local settings matrix and aggregate child bench runs
+    Matrix(BenchMatrixArgs),
     /// List declared benchmark scenarios without executing them
     List(BenchListArgs),
     /// List persisted benchmark runs for a component
@@ -58,6 +61,21 @@ enum BenchCommand {
     Distribution(BenchDistributionArgs),
     /// Compare two persisted benchmark runs
     Compare(BenchCompareArgs),
+}
+
+#[derive(Args)]
+struct BenchMatrixArgs {
+    #[command(flatten)]
+    run: BenchRunArgs,
+
+    /// Settings matrix axis in NAME=value,value form. Repeat the flag or pass
+    /// multiple axes after it, e.g. --setting-matrix clients=10,100 rounds=3.
+    #[arg(
+        long = "setting-matrix",
+        value_name = "NAME=VALUE[,VALUE...]",
+        num_args = 1..
+    )]
+    setting_matrix: Vec<String>,
 }
 
 #[derive(Args)]
@@ -131,7 +149,7 @@ struct BenchListArgs {
     args: Vec<String>,
 }
 
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct BenchRunArgs {
     #[command(flatten)]
     comp: PositionalComponentArgs,
@@ -312,6 +330,7 @@ pub enum BenchOutput {
     Comparison(BenchComparisonOutput),
     ComparisonSummary(BenchComparisonSummaryOutput),
     MatrixFanout(fanout::BenchMatrixFanoutOutput),
+    SettingsMatrix(settings_matrix::BenchSettingsMatrixOutput),
     List(BenchListWorkflowResult),
     Observation(runs::RunsOutput),
 }
@@ -319,6 +338,14 @@ pub enum BenchOutput {
 pub fn run(mut args: BenchArgs, _global: &GlobalArgs) -> CmdResult<BenchOutput> {
     if let Some(command) = &args.command {
         return match command {
+            BenchCommand::Matrix(matrix_args) => {
+                let output = settings_matrix::run_settings_matrix(
+                    &matrix_args.run,
+                    &matrix_args.setting_matrix,
+                )?;
+                let exit = if output.summary.passed { 0 } else { 1 };
+                Ok((BenchOutput::SettingsMatrix(output), exit))
+            }
             BenchCommand::List(list_args) => run_list(list_args),
             BenchCommand::History(history_args) => {
                 let (output, exit_code) = runs::bench_history(

--- a/src/commands/bench/settings_matrix.rs
+++ b/src/commands/bench/settings_matrix.rs
@@ -1,10 +1,26 @@
 use std::collections::BTreeMap;
 
+use clap::Args;
 use serde::Serialize;
 
 use homeboy::core::extension::bench::{BenchCommandOutput, BenchScenario};
 
 use super::{filter_homeboy_flags, matrix as bench_runner, BenchRunArgs};
+
+#[derive(Args)]
+pub(super) struct BenchMatrixArgs {
+    #[command(flatten)]
+    run: BenchRunArgs,
+
+    /// Settings matrix axis in NAME=value,value form. Repeat the flag or pass
+    /// multiple axes after it, e.g. --setting-matrix clients=10,100 rounds=3.
+    #[arg(
+        long = "setting-matrix",
+        value_name = "NAME=VALUE[,VALUE...]",
+        num_args = 1..
+    )]
+    setting_matrix: Vec<String>,
+}
 
 #[derive(Serialize)]
 pub struct BenchSettingsMatrixOutput {
@@ -55,9 +71,10 @@ pub struct BenchSettingsMatrixSummary {
 }
 
 pub(super) fn run_settings_matrix(
-    run_args: &BenchRunArgs,
-    raw_axes: &[String],
+    args: &BenchMatrixArgs,
 ) -> homeboy::core::Result<BenchSettingsMatrixOutput> {
+    let run_args = &args.run;
+    let raw_axes = &args.setting_matrix;
     if run_args.baseline_args.baseline || run_args.baseline_args.ratchet {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "setting-matrix",

--- a/src/commands/bench/settings_matrix.rs
+++ b/src/commands/bench/settings_matrix.rs
@@ -1,0 +1,336 @@
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use homeboy::core::extension::bench::{BenchCommandOutput, BenchScenario};
+
+use super::{filter_homeboy_flags, matrix as bench_runner, BenchRunArgs};
+
+#[derive(Serialize)]
+pub struct BenchSettingsMatrixOutput {
+    pub command: &'static str,
+    pub component: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub rigs: Vec<String>,
+    pub axes: Vec<BenchSettingsMatrixAxisOutput>,
+    pub cells: Vec<BenchSettingsMatrixCellOutput>,
+    pub summary: BenchSettingsMatrixSummary,
+    pub follow_ups: Vec<String>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct BenchSettingsMatrixAxisOutput {
+    pub name: String,
+    pub values: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct BenchSettingsMatrixCellOutput {
+    pub index: usize,
+    pub settings: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    pub passed: bool,
+    pub status: String,
+    pub exit_code: i32,
+    pub metrics: Vec<BenchSettingsMatrixMetricSample>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub hints: Vec<String>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct BenchSettingsMatrixMetricSample {
+    pub scenario_id: String,
+    pub metric: String,
+    pub value: f64,
+}
+
+#[derive(Serialize)]
+pub struct BenchSettingsMatrixSummary {
+    pub passed: bool,
+    pub cells: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+    pub child_run_ids: Vec<String>,
+}
+
+pub(super) fn run_settings_matrix(
+    run_args: &BenchRunArgs,
+    raw_axes: &[String],
+) -> homeboy::core::Result<BenchSettingsMatrixOutput> {
+    if run_args.baseline_args.baseline || run_args.baseline_args.ratchet {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "setting-matrix",
+            "bench matrix does not write baselines; run baseline or ratchet on selected cells separately",
+            None,
+            None,
+        ));
+    }
+    if run_args.rig.len() > 1 {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "rig",
+            "bench matrix currently supports zero or one --rig; use cross-rig comparison separately",
+            Some(run_args.rig.join(",")),
+            None,
+        ));
+    }
+
+    let axes = parse_setting_matrix_axes(raw_axes)?;
+    let cells = expand_setting_matrix_cells(&axes);
+    let passthrough_args = filter_homeboy_flags(&run_args.args);
+    let mut outputs = Vec::with_capacity(cells.len());
+
+    for (index, settings) in cells.into_iter().enumerate() {
+        let mut child_args = run_args.clone();
+        child_args.status_file = None;
+        child_args.setting_args.setting.extend(
+            settings
+                .iter()
+                .map(|(name, value)| (name.clone(), value.clone())),
+        );
+        let (output, exit_code) = match child_args.rig.first() {
+            Some(rig_id) => {
+                bench_runner::run_single_rig(&child_args, &passthrough_args, rig_id.clone())?
+            }
+            None => bench_runner::run_single(&child_args, &passthrough_args, None)?,
+        };
+        outputs.push(cell_output(index, settings, output, exit_code));
+    }
+
+    let child_run_ids = outputs
+        .iter()
+        .filter_map(|cell| cell.run_id.clone())
+        .collect::<Vec<_>>();
+    let succeeded = outputs.iter().filter(|cell| cell.passed).count();
+    let failed = outputs.len().saturating_sub(succeeded);
+    let component = run_args
+        .comp
+        .id()
+        .map(str::to_string)
+        .unwrap_or_else(|| "<auto>".to_string());
+
+    Ok(BenchSettingsMatrixOutput {
+        command: "bench.matrix",
+        component,
+        rigs: run_args.rig.clone(),
+        axes,
+        summary: BenchSettingsMatrixSummary {
+            passed: failed == 0,
+            cells: outputs.len(),
+            succeeded,
+            failed,
+            child_run_ids,
+        },
+        cells: outputs,
+        follow_ups: vec![
+            "Persisted matrix-level observation record that groups child run IDs.".to_string(),
+            "Add typed JSON setting matrix axes when a benchmark needs non-string settings."
+                .to_string(),
+            "Add cross-rig matrix aggregation after the single-rig surface has real users."
+                .to_string(),
+        ],
+    })
+}
+
+fn cell_output(
+    index: usize,
+    settings: BTreeMap<String, String>,
+    output: BenchCommandOutput,
+    exit_code: i32,
+) -> BenchSettingsMatrixCellOutput {
+    let hints = output.hints.clone().unwrap_or_default();
+    let metrics = collect_metric_samples(&output);
+    BenchSettingsMatrixCellOutput {
+        index,
+        settings,
+        run_id: extract_run_id(&hints),
+        passed: output.passed,
+        status: output.status,
+        exit_code,
+        metrics,
+        hints,
+    }
+}
+
+fn parse_setting_matrix_axes(
+    raw_axes: &[String],
+) -> homeboy::core::Result<Vec<BenchSettingsMatrixAxisOutput>> {
+    if raw_axes.is_empty() {
+        return Err(homeboy::core::Error::validation_missing_argument(vec![
+            "--setting-matrix NAME=value,value".to_string(),
+        ]));
+    }
+
+    raw_axes
+        .iter()
+        .map(|raw| {
+            let (name, raw_values) = raw.split_once('=').ok_or_else(|| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "setting-matrix",
+                    format!("setting matrix axis must be NAME=value,value; got '{raw}'"),
+                    Some(raw.clone()),
+                    None,
+                )
+            })?;
+            let values = raw_values
+                .split(',')
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            if name.is_empty() || values.is_empty() {
+                return Err(homeboy::core::Error::validation_invalid_argument(
+                    "setting-matrix",
+                    format!("setting matrix axis must include a name and at least one value; got '{raw}'"),
+                    Some(raw.clone()),
+                    None,
+                ));
+            }
+            Ok(BenchSettingsMatrixAxisOutput {
+                name: name.to_string(),
+                values,
+            })
+        })
+        .collect()
+}
+
+fn expand_setting_matrix_cells(
+    axes: &[BenchSettingsMatrixAxisOutput],
+) -> Vec<BTreeMap<String, String>> {
+    let mut cells = vec![BTreeMap::new()];
+    for axis in axes {
+        let mut next = Vec::with_capacity(cells.len() * axis.values.len());
+        for cell in &cells {
+            for value in &axis.values {
+                let mut expanded = cell.clone();
+                expanded.insert(axis.name.clone(), value.clone());
+                next.push(expanded);
+            }
+        }
+        cells = next;
+    }
+    cells
+}
+
+fn extract_run_id(hints: &[String]) -> Option<String> {
+    hints
+        .iter()
+        .find_map(|hint| hint.strip_prefix("Persisted benchmark run ID: "))
+        .map(str::to_string)
+}
+
+fn collect_metric_samples(output: &BenchCommandOutput) -> Vec<BenchSettingsMatrixMetricSample> {
+    output
+        .results
+        .as_ref()
+        .map(|results| {
+            results
+                .scenarios
+                .iter()
+                .flat_map(collect_scenario_metric_samples)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn collect_scenario_metric_samples(
+    scenario: &BenchScenario,
+) -> Vec<BenchSettingsMatrixMetricSample> {
+    let mut samples = Vec::new();
+    for (metric, value) in &scenario.metrics.values {
+        samples.push(BenchSettingsMatrixMetricSample {
+            scenario_id: scenario.id.clone(),
+            metric: metric.clone(),
+            value: *value,
+        });
+    }
+    for (group, metrics) in &scenario.metric_groups {
+        for (metric, value) in metrics {
+            samples.push(BenchSettingsMatrixMetricSample {
+                scenario_id: scenario.id.clone(),
+                metric: format!("{group}.{metric}"),
+                value: *value,
+            });
+        }
+    }
+    samples
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::bench::BenchArgs;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        bench: BenchArgs,
+    }
+
+    #[test]
+    fn bench_matrix_command_accepts_multiple_setting_axes() {
+        TestCli::try_parse_from([
+            "homeboy",
+            "matrix",
+            "--rig",
+            "gutenberg-rtc",
+            "--scenario",
+            "gutenberg-rtc-protocol-load",
+            "--setting-matrix",
+            "clients=10,100",
+            "rounds=3",
+            "batch_size=1,10",
+            "--runs",
+            "3",
+        ])
+        .expect("bench matrix CLI should parse");
+    }
+
+    #[test]
+    fn parses_setting_matrix_axes() {
+        let axes =
+            parse_setting_matrix_axes(&["clients=10,100".to_string(), "rounds=3".to_string()])
+                .expect("axes should parse");
+
+        assert_eq!(
+            axes,
+            vec![
+                BenchSettingsMatrixAxisOutput {
+                    name: "clients".to_string(),
+                    values: vec!["10".to_string(), "100".to_string()],
+                },
+                BenchSettingsMatrixAxisOutput {
+                    name: "rounds".to_string(),
+                    values: vec!["3".to_string()],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn expands_cartesian_setting_cells() {
+        let axes = parse_setting_matrix_axes(&[
+            "clients=10,100".to_string(),
+            "batch_size=1,25".to_string(),
+        ])
+        .expect("axes should parse");
+
+        let cells = expand_setting_matrix_cells(&axes);
+
+        assert_eq!(cells.len(), 4);
+        assert_eq!(cells[0]["clients"], "10");
+        assert_eq!(cells[0]["batch_size"], "1");
+        assert_eq!(cells[3]["clients"], "100");
+        assert_eq!(cells[3]["batch_size"], "25");
+    }
+
+    #[test]
+    fn extracts_child_run_id_from_hints() {
+        let run_id = extract_run_id(&[
+            "Persisted benchmark run ID: bench-123".to_string(),
+            "View this run: homeboy runs show bench-123".to_string(),
+        ]);
+
+        assert_eq!(run_id.as_deref(), Some("bench-123"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `homeboy bench matrix` as a narrow local settings-matrix runner over the existing bench execution path.
- Expands `--setting-matrix` axes into child bench runs, aggregates cell statuses, child run IDs, hints, and numeric metric samples.
- Documents current boundaries and follow-up slices for matrix-level observations, typed JSON axes, and cross-rig aggregation.

Closes #3259.

## Tests
- `cargo test settings_matrix --lib`
- `cargo test --test output_contracts_test runs_rig_and_bench_output_variants_have_unambiguous_contracts`
- `homeboy test --path . --extension rust --skip-lint -- settings_matrix`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the bench matrix command slice, drafted focused tests/docs, and ran verification. Chris remains responsible for review and merge.