### PR TITLE
feat(agent-task): promote patch artifacts into worktrees

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use serde_json::Value;
 
+use homeboy::core::agent_task_promotion::{promote, AgentTaskPromotionOptions};
 use homeboy::core::agent_task_provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_task_scheduler::{AgentTaskPlan, AgentTaskScheduler};
 use homeboy::core::config;
@@ -17,6 +18,8 @@ pub struct AgentTaskArgs {
 pub enum AgentTaskCommand {
     /// Run an agent-task plan through extension-declared executor providers.
     RunPlan(RunPlanArgs),
+    /// Promote a completed generic patch artifact into a managed worktree.
+    Promote(PromoteArgs),
     /// List extension-declared agent-task executor providers.
     Providers,
 }
@@ -28,9 +31,37 @@ pub struct RunPlanArgs {
     pub plan: String,
 }
 
+#[derive(Args, Debug)]
+pub struct PromoteArgs {
+    /// AgentTaskOutcome or AgentTaskAggregate JSON file, @file, or - for stdin.
+    #[arg(value_name = "SOURCE")]
+    pub source: String,
+
+    /// Managed DMC worktree handle to apply into, e.g. repo@branch-slug.
+    #[arg(long, value_name = "HANDLE")]
+    pub to_worktree: String,
+
+    /// Outcome task id to select when SOURCE is an aggregate.
+    #[arg(long, value_name = "TASK_ID")]
+    pub task_id: Option<String>,
+
+    /// Patch artifact id to select when the outcome contains multiple patches.
+    #[arg(long, value_name = "ARTIFACT_ID")]
+    pub artifact_id: Option<String>,
+
+    /// Validate and report the selected promotion without creating/applying.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Verification command to run in the promoted worktree after apply.
+    #[arg(long = "verify", value_name = "COMMAND")]
+    pub verify: Vec<String>,
+}
+
 pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     match args.command {
         AgentTaskCommand::RunPlan(run_args) => run_plan(run_args),
+        AgentTaskCommand::Promote(promote_args) => promote_artifact(promote_args),
         AgentTaskCommand::Providers => providers(),
     }
 }
@@ -57,6 +88,32 @@ fn run_plan(args: RunPlanArgs) -> CmdResult<Value> {
     Ok((
         serde_json::to_value(aggregate).unwrap_or(Value::Null),
         exit_code,
+    ))
+}
+
+fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
+    let raw = config::read_json_spec_to_string(&args.source)?;
+    let source_path = source_spec_path(&args.source);
+    let report = promote(AgentTaskPromotionOptions {
+        source: raw,
+        source_path,
+        to_worktree: args.to_worktree,
+        task_id: args.task_id,
+        artifact_id: args.artifact_id,
+        dry_run: args.dry_run,
+        verify: args.verify,
+    })?;
+
+    Ok((serde_json::to_value(report).unwrap_or(Value::Null), 0))
+}
+
+fn source_spec_path(spec: &str) -> Option<std::path::PathBuf> {
+    if spec == "-" {
+        return None;
+    }
+
+    Some(std::path::PathBuf::from(
+        spec.strip_prefix('@').unwrap_or(spec),
     ))
 }
 

--- a/src/core/agent_task_promotion.rs
+++ b/src/core/agent_task_promotion.rs
@@ -1,0 +1,609 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::core::agent_task::{
+    AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_OUTCOME_SCHEMA,
+};
+use crate::core::agent_task_scheduler::{AgentTaskAggregate, AGENT_TASK_AGGREGATE_SCHEMA};
+use crate::core::{Error, Result};
+
+pub const AGENT_TASK_PROMOTION_REPORT_SCHEMA: &str = "homeboy/agent-task-promotion-report/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPromotionOptions {
+    pub source: String,
+    pub source_path: Option<PathBuf>,
+    pub to_worktree: String,
+    pub task_id: Option<String>,
+    pub artifact_id: Option<String>,
+    #[serde(default)]
+    pub dry_run: bool,
+    #[serde(default)]
+    pub verify: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskPromotionReport {
+    #[serde(default = "promotion_report_schema")]
+    pub schema: String,
+    pub status: AgentTaskPromotionStatus,
+    pub source: AgentTaskPromotionSource,
+    pub to_worktree: String,
+    pub patch_artifact: AgentTaskPromotionArtifactRef,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_files: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dmc_commands: Vec<AgentTaskPromotionCommandReport>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub verification: Vec<AgentTaskPromotionCommandReport>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub provenance: Value,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskPromotionStatus {
+    DryRun,
+    Applied,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPromotionSource {
+    pub kind: String,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPromotionArtifactRef {
+    pub id: String,
+    pub kind: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPromotionCommandReport {
+    pub command: Vec<String>,
+    pub exit_code: i32,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stdout: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stderr: String,
+}
+
+pub fn promote(options: AgentTaskPromotionOptions) -> Result<AgentTaskPromotionReport> {
+    validate_worktree_handle(&options.to_worktree)?;
+    let source_value: Value = serde_json::from_str(&options.source).map_err(|error| {
+        Error::validation_invalid_json(
+            error,
+            Some("agent-task promotion source".to_string()),
+            Some(options.source.clone()),
+        )
+    })?;
+    let (source_kind, outcome) = select_outcome(source_value, options.task_id.as_deref())?;
+
+    if outcome.status != AgentTaskOutcomeStatus::Succeeded {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            format!(
+                "promotion requires a succeeded outcome; task {} has status {:?}",
+                outcome.task_id, outcome.status
+            ),
+            None,
+            None,
+        ));
+    }
+
+    let artifact = select_patch_artifact(&outcome, options.artifact_id.as_deref())?;
+    let patch_path = resolve_artifact_path(&artifact, options.source_path.as_deref())?;
+    let patch = std::fs::read_to_string(&patch_path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("read patch artifact {}", patch_path.display())),
+        )
+    })?;
+    let changed_files = validate_patch(&patch)?;
+
+    let mut dmc_commands = Vec::new();
+    if !options.dry_run {
+        dmc_commands.append(&mut ensure_worktree(&options.to_worktree)?);
+        dmc_commands.push(apply_patch_with_dmc(&options.to_worktree, &patch_path)?);
+    }
+
+    let mut verification = Vec::new();
+    if !options.dry_run && !options.verify.is_empty() {
+        let worktree_path = dmc_worktree_path(&options.to_worktree)?;
+        for command in &options.verify {
+            verification.push(run_verification_command(&worktree_path, command)?);
+        }
+    }
+
+    Ok(AgentTaskPromotionReport {
+        schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
+        status: if options.dry_run {
+            AgentTaskPromotionStatus::DryRun
+        } else {
+            AgentTaskPromotionStatus::Applied
+        },
+        source: AgentTaskPromotionSource {
+            kind: source_kind,
+            task_id: outcome.task_id.clone(),
+            path: options
+                .source_path
+                .as_ref()
+                .map(|path| path.display().to_string()),
+        },
+        to_worktree: options.to_worktree,
+        patch_artifact: AgentTaskPromotionArtifactRef {
+            id: artifact.id,
+            kind: artifact.kind,
+            path: patch_path.display().to_string(),
+            sha256: artifact.sha256,
+        },
+        changed_files,
+        dmc_commands,
+        verification,
+        provenance: json!({
+            "source_schema": outcome.schema,
+            "artifact_metadata": artifact.metadata,
+        }),
+    })
+}
+
+fn promotion_report_schema() -> String {
+    AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string()
+}
+
+fn select_outcome(source: Value, task_id: Option<&str>) -> Result<(String, AgentTaskOutcome)> {
+    if source.get("schema").and_then(Value::as_str) == Some(AGENT_TASK_OUTCOME_SCHEMA) {
+        let outcome: AgentTaskOutcome = serde_json::from_value(source).map_err(|error| {
+            Error::validation_invalid_json(error, Some("agent-task outcome".to_string()), None)
+        })?;
+        if let Some(expected) = task_id {
+            if outcome.task_id != expected {
+                return Err(Error::validation_invalid_argument(
+                    "task_id",
+                    format!(
+                        "source outcome task_id is {}, not {expected}",
+                        outcome.task_id
+                    ),
+                    None,
+                    None,
+                ));
+            }
+        }
+        return Ok(("outcome".to_string(), outcome));
+    }
+
+    if source.get("schema").and_then(Value::as_str) == Some(AGENT_TASK_AGGREGATE_SCHEMA) {
+        let aggregate: AgentTaskAggregate = serde_json::from_value(source).map_err(|error| {
+            Error::validation_invalid_json(error, Some("agent-task aggregate".to_string()), None)
+        })?;
+        let candidates: Vec<AgentTaskOutcome> = aggregate
+            .outcomes
+            .into_iter()
+            .filter(|outcome| task_id.is_none_or(|expected| outcome.task_id == expected))
+            .collect();
+        return match candidates.len() {
+            1 => Ok((
+                "aggregate".to_string(),
+                candidates.into_iter().next().unwrap(),
+            )),
+            0 => Err(Error::validation_invalid_argument(
+                "task_id",
+                "aggregate did not contain a matching outcome",
+                None,
+                None,
+            )),
+            _ => Err(Error::validation_invalid_argument(
+                "task_id",
+                "aggregate contains multiple outcomes; pass --task-id to select one",
+                None,
+                None,
+            )),
+        };
+    }
+
+    Err(Error::validation_invalid_argument(
+        "source",
+        "promotion source must be an agent-task outcome or aggregate JSON object",
+        None,
+        None,
+    ))
+}
+
+fn select_patch_artifact(
+    outcome: &AgentTaskOutcome,
+    artifact_id: Option<&str>,
+) -> Result<AgentTaskArtifact> {
+    let artifacts: Vec<AgentTaskArtifact> = outcome
+        .artifacts
+        .iter()
+        .filter(|artifact| artifact_id.is_none_or(|expected| artifact.id == expected))
+        .filter(|artifact| is_patch_artifact(artifact))
+        .cloned()
+        .collect();
+
+    match artifacts.len() {
+        1 => Ok(artifacts.into_iter().next().unwrap()),
+        0 => Err(Error::validation_invalid_argument(
+            "artifact_id",
+            "no matching patch artifact was found",
+            None,
+            None,
+        )),
+        _ => Err(Error::validation_invalid_argument(
+            "artifact_id",
+            "multiple patch artifacts were found; pass --artifact-id to select one",
+            None,
+            None,
+        )),
+    }
+}
+
+fn is_patch_artifact(artifact: &AgentTaskArtifact) -> bool {
+    artifact.kind == "patch"
+        || artifact.kind == "diff"
+        || artifact.mime.as_deref() == Some("text/x-patch")
+        || artifact.mime.as_deref() == Some("text/x-diff")
+        || artifact.metadata.get("role").and_then(Value::as_str) == Some("patch")
+}
+
+fn resolve_artifact_path(
+    artifact: &AgentTaskArtifact,
+    source_path: Option<&Path>,
+) -> Result<PathBuf> {
+    let path = artifact.path.as_ref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "artifact.path",
+            "promotion patch artifact must provide a local path",
+            None,
+            None,
+        )
+    })?;
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        return Ok(path);
+    }
+    if let Some(source_path) = source_path.and_then(Path::parent) {
+        Ok(source_path.join(path))
+    } else {
+        Ok(path)
+    }
+}
+
+fn validate_patch(patch: &str) -> Result<Vec<String>> {
+    if patch.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "patch",
+            "promotion refuses an empty patch artifact",
+            None,
+            None,
+        ));
+    }
+
+    let mut changed_files = Vec::new();
+    for line in patch.lines() {
+        if let Some(path) = line
+            .strip_prefix("+++ ")
+            .or_else(|| line.strip_prefix("--- "))
+        {
+            let path = path.trim();
+            if path == "/dev/null" {
+                continue;
+            }
+            let path = path
+                .strip_prefix("a/")
+                .or_else(|| path.strip_prefix("b/"))
+                .unwrap_or(path);
+            validate_patch_path(path)?;
+            if !changed_files.iter().any(|existing| existing == path) {
+                changed_files.push(path.to_string());
+            }
+        }
+    }
+
+    if changed_files.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "patch",
+            "promotion requires a unified diff with changed file headers",
+            None,
+            None,
+        ));
+    }
+
+    Ok(changed_files)
+}
+
+fn validate_patch_path(path: &str) -> Result<()> {
+    let invalid = path.starts_with('/')
+        || path.starts_with("../")
+        || path.contains("/../")
+        || path == ".."
+        || path.starts_with(".git/")
+        || path.contains("/.git/");
+    if invalid {
+        return Err(Error::validation_invalid_argument(
+            "patch",
+            format!("promotion refuses unsafe patch path: {path}"),
+            None,
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn validate_worktree_handle(handle: &str) -> Result<()> {
+    let (repo, branch) = split_worktree_handle(handle)?;
+    if repo.is_empty() || branch.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            "worktree handle must use <repo>@<branch-slug>",
+            None,
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn split_worktree_handle(handle: &str) -> Result<(&str, &str)> {
+    handle.split_once('@').ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "to_worktree",
+            "worktree handle must use <repo>@<branch-slug>",
+            None,
+            None,
+        )
+    })
+}
+
+fn ensure_worktree(handle: &str) -> Result<Vec<AgentTaskPromotionCommandReport>> {
+    if dmc_worktree_path(handle).is_ok() {
+        return Ok(Vec::new());
+    }
+
+    let (repo, branch) = split_worktree_handle(handle)?;
+    let command = vec![
+        "studio".to_string(),
+        "wp".to_string(),
+        "datamachine-code".to_string(),
+        "workspace".to_string(),
+        "worktree".to_string(),
+        "add".to_string(),
+        repo.to_string(),
+        branch.to_string(),
+    ];
+    Ok(vec![run_command(command, None)?])
+}
+
+fn apply_patch_with_dmc(
+    handle: &str,
+    patch_path: &Path,
+) -> Result<AgentTaskPromotionCommandReport> {
+    run_command(
+        vec![
+            "studio".to_string(),
+            "wp".to_string(),
+            "datamachine-code".to_string(),
+            "workspace".to_string(),
+            "patch".to_string(),
+            "apply".to_string(),
+            handle.to_string(),
+            format!("--patch=@{}", patch_path.display()),
+            "--format=json".to_string(),
+        ],
+        None,
+    )
+}
+
+fn dmc_worktree_path(handle: &str) -> Result<PathBuf> {
+    let (repo, _) = split_worktree_handle(handle)?;
+    let report = run_command(
+        vec![
+            "studio".to_string(),
+            "wp".to_string(),
+            "datamachine-code".to_string(),
+            "workspace".to_string(),
+            "worktree".to_string(),
+            "list".to_string(),
+            repo.to_string(),
+            "--format=json".to_string(),
+        ],
+        None,
+    )?;
+    let rows: Value = serde_json::from_str(&report.stdout).map_err(|error| {
+        Error::validation_invalid_json(
+            error,
+            Some("datamachine-code worktree list output".to_string()),
+            Some(report.stdout.clone()),
+        )
+    })?;
+    rows.as_array()
+        .and_then(|rows| {
+            rows.iter()
+                .find(|row| row.get("handle").and_then(Value::as_str) == Some(handle))
+        })
+        .and_then(|row| row.get("path").and_then(Value::as_str))
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "to_worktree",
+                format!("managed worktree {handle} was not found"),
+                None,
+                None,
+            )
+        })
+}
+
+fn run_verification_command(cwd: &Path, command: &str) -> Result<AgentTaskPromotionCommandReport> {
+    run_command(
+        vec!["sh".to_string(), "-lc".to_string(), command.to_string()],
+        Some(cwd),
+    )
+}
+
+fn run_command(
+    command: Vec<String>,
+    cwd: Option<&Path>,
+) -> Result<AgentTaskPromotionCommandReport> {
+    let mut process = Command::new(&command[0]);
+    process.args(&command[1..]);
+    if let Some(cwd) = cwd {
+        process.current_dir(cwd);
+    }
+    let output = process.output().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("run {}", command.join(" "))),
+        )
+    })?;
+    let exit_code = output.status.code().unwrap_or(1);
+    let report = AgentTaskPromotionCommandReport {
+        command,
+        exit_code,
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    };
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "command",
+            format!(
+                "promotion command failed with exit code {}: {}",
+                exit_code,
+                report.command.join(" ")
+            ),
+            None,
+            Some(vec![report.stderr.clone()]),
+        ));
+    }
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::agent_task::{
+        AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_ARTIFACT_SCHEMA,
+        AGENT_TASK_OUTCOME_SCHEMA,
+    };
+
+    #[test]
+    fn validate_patch_extracts_safe_changed_files() {
+        let patch = "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
+
+        let files = validate_patch(patch).expect("valid patch");
+
+        assert_eq!(files, vec!["src/lib.rs"]);
+    }
+
+    #[test]
+    fn validate_patch_rejects_empty_patch() {
+        let err = validate_patch("\n\t").expect_err("empty patch rejected");
+
+        assert!(err.message.contains("empty patch"));
+    }
+
+    #[test]
+    fn validate_patch_rejects_path_traversal() {
+        let patch = "--- a/src/lib.rs\n+++ b/../secret\n@@ -1 +1 @@\n-old\n+new\n";
+
+        let err = validate_patch(patch).expect_err("unsafe path rejected");
+
+        assert!(err.message.contains("unsafe patch path"));
+    }
+
+    #[test]
+    fn select_patch_artifact_requires_unambiguous_patch() {
+        let outcome = AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: "task-1".to_string(),
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: None,
+            failure_classification: None,
+            artifacts: vec![
+                AgentTaskArtifact {
+                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                    id: "patch-a".to_string(),
+                    kind: "patch".to_string(),
+                    name: None,
+                    path: Some("a.patch".to_string()),
+                    url: None,
+                    mime: None,
+                    size_bytes: None,
+                    sha256: None,
+                    metadata: Value::Null,
+                },
+                AgentTaskArtifact {
+                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                    id: "patch-b".to_string(),
+                    kind: "diff".to_string(),
+                    name: None,
+                    path: Some("b.patch".to_string()),
+                    url: None,
+                    mime: None,
+                    size_bytes: None,
+                    sha256: None,
+                    metadata: Value::Null,
+                },
+            ],
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        };
+
+        let err = select_patch_artifact(&outcome, None).expect_err("ambiguous patch rejected");
+        assert!(err.message.contains("multiple patch artifacts"));
+
+        let artifact = select_patch_artifact(&outcome, Some("patch-b")).expect("selected patch");
+        assert_eq!(artifact.id, "patch-b");
+    }
+
+    #[test]
+    fn promote_dry_run_reports_selected_patch_without_dmc_mutation() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let patch_path = temp.path().join("changes.patch");
+        std::fs::write(
+            &patch_path,
+            "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n",
+        )
+        .expect("write patch");
+        let source_path = temp.path().join("outcome.json");
+        let source = serde_json::json!({
+            "schema": AGENT_TASK_OUTCOME_SCHEMA,
+            "task_id": "task-1",
+            "status": "succeeded",
+            "artifacts": [{
+                "schema": AGENT_TASK_ARTIFACT_SCHEMA,
+                "id": "patch",
+                "kind": "patch",
+                "path": "changes.patch"
+            }]
+        })
+        .to_string();
+
+        let report = promote(AgentTaskPromotionOptions {
+            source,
+            source_path: Some(source_path),
+            to_worktree: "repo@promoted-task".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: true,
+            verify: Vec::new(),
+        })
+        .expect("dry-run promotion report");
+
+        assert_eq!(report.status, AgentTaskPromotionStatus::DryRun);
+        assert_eq!(report.source.task_id, "task-1");
+        assert_eq!(report.patch_artifact.id, "patch");
+        assert_eq!(report.changed_files, vec!["src/lib.rs"]);
+        assert!(report.dmc_commands.is_empty());
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 pub mod config;
 pub mod agent_task;
 pub mod agent_task_aggregate;
+pub mod agent_task_promotion;
 pub mod agent_task_provider;
 pub mod agent_task_scheduler;
 pub mod api_jobs;


### PR DESCRIPTION
## Summary
- Adds `homeboy agent-task promote` for applying a generic succeeded outcome or aggregate patch artifact into a managed DMC worktree.
- Keeps provider-specific artifact internals behind generic `AgentTaskArtifact` fields and delegates worktree creation/patch application to `datamachine-code workspace` commands.
- Emits a structured promotion report with selected artifact, changed files, provenance, DMC command evidence, and optional verification command results.

## Verification
- `cargo test agent_task_promotion --lib`
- `cargo test agent_task --lib`
- `cargo check --bin homeboy`

## Notes
- Full async task/run-id lookup remains blocked on the durable lifecycle/registry work in #3278. This PR intentionally accepts explicit outcome/aggregate JSON sources instead of inventing a local registry.
- `cargo clippy --lib -- -D warnings` is not currently a useful gate on `main`; it fails on existing repository-wide lints unrelated to this change.

Closes #3279.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the provider-neutral promotion command, added targeted tests, ran verification, and drafted this PR description; Chris remains responsible for review and merge.