### PR TITLE
feat(agent-task): add durable lifecycle surfaces

### DIFF
--- a/docs/architecture/preview-metadata.md
+++ b/docs/architecture/preview-metadata.md
@@ -1,0 +1,45 @@
+# Preview Metadata
+
+Homeboy preserves generic preview metadata without owning public-access setup.
+Commands, extensions, wrappers, or external integrations can emit preview facts
+through environment variables, and Homeboy stores them on persisted run metadata
+and renders them in report digests.
+
+## Contract
+
+Set `HOMEBOY_PREVIEW_JSON` to a JSON object. Recommended fields:
+
+```json
+{
+  "schema": "homeboy/preview/v1",
+  "provider": "dummy",
+  "local_url": "http://127.0.0.1:8080",
+  "public_url": "https://preview.example.test/run-1",
+  "hold_seconds": 600,
+  "expires_at": "2026-06-01T22:00:00Z",
+  "status": "running",
+  "process_id": "pid-123",
+  "runtime_id": "runtime-abc",
+  "cleanup_status": "pending"
+}
+```
+
+`HOMEBOY_PREVIEW_PUBLIC_URL` may be set by a caller or integration that creates
+public access. When present, Homeboy copies it into `public_url` if the preview
+object does not already contain that field.
+
+Homeboy does not create tunnels, publish previews, or know about product-specific
+runtimes. Public access is supplied by the caller/integration.
+
+## Persistence
+
+When a command records an observation run, Homeboy stores the object at
+`metadata.preview`. Lab offload forwards `HOMEBOY_PREVIEW_JSON` and
+`HOMEBOY_PREVIEW_PUBLIC_URL` to the runner so offloaded commands preserve the
+same caller-supplied preview facts.
+
+## Reporting
+
+`homeboy report performance-digest` renders scalar preview fields in a
+`Preview` section, including local URL, public URL, hold/expiry, lifecycle
+status, runtime/process ID, and cleanup status when available.

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ Internal system architecture and internals:
 - [Planned change execution](architecture/planned-change-execution.md) - Core lifecycle vocabulary for plan, execute, artifact, approve, apply, and publish
 - [Apply and publish contract](architecture/apply-publish-contract.md) - Local apply boundary and post-apply publish semantics
 - [Agent task executor adapter](architecture/agent-task-executor-adapter.md) - Provider-neutral adapter boundary for Codebox, CLI/OpenCode, and runner backends
+- [Preview metadata](architecture/preview-metadata.md) - Generic preview URL, hold, lifecycle, runtime, and cleanup metadata preserved across runs
 - [Scope model](architecture/scope-model.md) - Components, targets/projects, rigs, fleets, workspace, and paths
 - [Execution context](architecture/execution-context.md) - Runtime context for extensions
 - [Rig matrix axis composition](architecture/rig-matrix-axis-composition.md) - Design for derived rig variants

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use serde_json::Value;
 
+use homeboy::core::agent_task_lifecycle;
 use homeboy::core::agent_task_promotion::{promote, AgentTaskPromotionOptions};
 use homeboy::core::agent_task_provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_task_scheduler::{AgentTaskPlan, AgentTaskScheduler};
@@ -18,6 +19,14 @@ pub struct AgentTaskArgs {
 pub enum AgentTaskCommand {
     /// Run an agent-task plan through extension-declared executor providers.
     RunPlan(RunPlanArgs),
+    /// Persist an agent-task plan and return a durable run id without executing it.
+    Submit(SubmitArgs),
+    /// Read durable agent-task run status.
+    Status(StatusArgs),
+    /// Read durable agent-task run scheduler events.
+    Logs(StatusArgs),
+    /// List artifacts and evidence refs recorded for a completed run.
+    Artifacts(StatusArgs),
     /// Promote a completed generic patch artifact into a managed worktree.
     Promote(PromoteArgs),
     /// List extension-declared agent-task executor providers.
@@ -29,6 +38,25 @@ pub struct RunPlanArgs {
     /// AgentTaskPlan JSON file, @file, or - for stdin.
     #[arg(long, value_name = "PATH")]
     pub plan: String,
+    /// Also persist the completed run lifecycle record under this id.
+    #[arg(long, value_name = "ID")]
+    pub record_run_id: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct SubmitArgs {
+    /// AgentTaskPlan JSON file, @file, or - for stdin.
+    #[arg(long, value_name = "PATH")]
+    pub plan: String,
+    /// Optional durable run id. Generated when omitted.
+    #[arg(long, value_name = "ID")]
+    pub run_id: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct StatusArgs {
+    /// Durable run id returned by `agent-task submit` or `agent-task run-plan --record-run-id`.
+    pub run_id: String,
 }
 
 #[derive(Args, Debug)]
@@ -61,22 +89,22 @@ pub struct PromoteArgs {
 pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     match args.command {
         AgentTaskCommand::RunPlan(run_args) => run_plan(run_args),
+        AgentTaskCommand::Submit(submit_args) => submit(submit_args),
+        AgentTaskCommand::Status(status_args) => status(status_args),
+        AgentTaskCommand::Logs(status_args) => logs(status_args),
+        AgentTaskCommand::Artifacts(status_args) => artifacts(status_args),
         AgentTaskCommand::Promote(promote_args) => promote_artifact(promote_args),
         AgentTaskCommand::Providers => providers(),
     }
 }
 
 fn run_plan(args: RunPlanArgs) -> CmdResult<Value> {
-    let raw = config::read_json_spec_to_string(&args.plan)?;
-    let plan: AgentTaskPlan = serde_json::from_str(&raw).map_err(|error| {
-        homeboy::core::Error::validation_invalid_json(
-            error,
-            Some("agent-task plan".to_string()),
-            Some(raw.clone()),
-        )
-    })?;
+    let plan = read_plan(&args.plan)?;
     let scheduler = AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::discover());
-    let aggregate = scheduler.run(plan);
+    let aggregate = scheduler.run(plan.clone());
+    if let Some(run_id) = args.record_run_id.as_deref() {
+        agent_task_lifecycle::record_completed_run(&plan, &aggregate, Some(run_id))?;
+    }
     let exit_code = if aggregate.totals.failed == 0
         && aggregate.totals.cancelled == 0
         && aggregate.totals.timed_out == 0
@@ -89,6 +117,27 @@ fn run_plan(args: RunPlanArgs) -> CmdResult<Value> {
         serde_json::to_value(aggregate).unwrap_or(Value::Null),
         exit_code,
     ))
+}
+
+fn submit(args: SubmitArgs) -> CmdResult<Value> {
+    let plan = read_plan(&args.plan)?;
+    let record = agent_task_lifecycle::submit_plan(&plan, args.run_id.as_deref())?;
+    Ok((serde_json::to_value(record).unwrap_or(Value::Null), 0))
+}
+
+fn status(args: StatusArgs) -> CmdResult<Value> {
+    let record = agent_task_lifecycle::status(&args.run_id)?;
+    Ok((serde_json::to_value(record).unwrap_or(Value::Null), 0))
+}
+
+fn logs(args: StatusArgs) -> CmdResult<Value> {
+    let log = agent_task_lifecycle::logs(&args.run_id)?;
+    Ok((serde_json::to_value(log).unwrap_or(Value::Null), 0))
+}
+
+fn artifacts(args: StatusArgs) -> CmdResult<Value> {
+    let artifacts = agent_task_lifecycle::artifacts(&args.run_id)?;
+    Ok((serde_json::to_value(artifacts).unwrap_or(Value::Null), 0))
 }
 
 fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
@@ -123,4 +172,15 @@ fn providers() -> CmdResult<Value> {
         serde_json::to_value(executor.providers()).unwrap_or(Value::Null),
         0,
     ))
+}
+
+fn read_plan(spec: &str) -> homeboy::core::Result<AgentTaskPlan> {
+    let raw = config::read_json_spec_to_string(spec)?;
+    serde_json::from_str(&raw).map_err(|error| {
+        homeboy::core::Error::validation_invalid_json(
+            error,
+            Some("agent-task plan".to_string()),
+            Some(raw.clone()),
+        )
+    })
 }

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use serde_json::Value;
 
+use homeboy::core::agent_task_promotion::{promote, AgentTaskPromotionOptions};
 use homeboy::core::agent_task_provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_task_scheduler::{AgentTaskPlan, AgentTaskScheduler};
 use homeboy::core::config;
@@ -17,6 +18,8 @@ pub struct AgentTaskArgs {
 pub enum AgentTaskCommand {
     /// Run an agent-task plan through extension-declared executor providers.
     RunPlan(RunPlanArgs),
+    /// Promote a completed generic patch artifact into a managed worktree.
+    Promote(PromoteArgs),
     /// List extension-declared agent-task executor providers.
     Providers,
 }
@@ -28,9 +31,37 @@ pub struct RunPlanArgs {
     pub plan: String,
 }
 
+#[derive(Args, Debug)]
+pub struct PromoteArgs {
+    /// AgentTaskOutcome or AgentTaskAggregate JSON file, @file, or - for stdin.
+    #[arg(value_name = "SOURCE")]
+    pub source: String,
+
+    /// Managed DMC worktree handle to apply into, e.g. repo@branch-slug.
+    #[arg(long, value_name = "HANDLE")]
+    pub to_worktree: String,
+
+    /// Outcome task id to select when SOURCE is an aggregate.
+    #[arg(long, value_name = "TASK_ID")]
+    pub task_id: Option<String>,
+
+    /// Patch artifact id to select when the outcome contains multiple patches.
+    #[arg(long, value_name = "ARTIFACT_ID")]
+    pub artifact_id: Option<String>,
+
+    /// Validate and report the selected promotion without creating/applying.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Verification command to run in the promoted worktree after apply.
+    #[arg(long = "verify", value_name = "COMMAND")]
+    pub verify: Vec<String>,
+}
+
 pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     match args.command {
         AgentTaskCommand::RunPlan(run_args) => run_plan(run_args),
+        AgentTaskCommand::Promote(promote_args) => promote_artifact(promote_args),
         AgentTaskCommand::Providers => providers(),
     }
 }
@@ -57,6 +88,32 @@ fn run_plan(args: RunPlanArgs) -> CmdResult<Value> {
     Ok((
         serde_json::to_value(aggregate).unwrap_or(Value::Null),
         exit_code,
+    ))
+}
+
+fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
+    let raw = config::read_json_spec_to_string(&args.source)?;
+    let source_path = source_spec_path(&args.source);
+    let report = promote(AgentTaskPromotionOptions {
+        source: raw,
+        source_path,
+        to_worktree: args.to_worktree,
+        task_id: args.task_id,
+        artifact_id: args.artifact_id,
+        dry_run: args.dry_run,
+        verify: args.verify,
+    })?;
+
+    Ok((serde_json::to_value(report).unwrap_or(Value::Null), 0))
+}
+
+fn source_spec_path(spec: &str) -> Option<std::path::PathBuf> {
+    if spec == "-" {
+        return None;
+    }
+
+    Some(std::path::PathBuf::from(
+        spec.strip_prefix('@').unwrap_or(spec),
     ))
 }
 

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use serde_json::Value;
 
+use homeboy::core::agent_task_lifecycle;
 use homeboy::core::agent_task_provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_task_scheduler::{AgentTaskPlan, AgentTaskScheduler};
 use homeboy::core::config;
@@ -17,6 +18,14 @@ pub struct AgentTaskArgs {
 pub enum AgentTaskCommand {
     /// Run an agent-task plan through extension-declared executor providers.
     RunPlan(RunPlanArgs),
+    /// Persist an agent-task plan and return a durable run id without executing it.
+    Submit(SubmitArgs),
+    /// Read durable agent-task run status.
+    Status(StatusArgs),
+    /// Read durable agent-task run scheduler events.
+    Logs(StatusArgs),
+    /// List artifacts and evidence refs recorded for a completed run.
+    Artifacts(StatusArgs),
     /// List extension-declared agent-task executor providers.
     Providers,
 }
@@ -26,26 +35,45 @@ pub struct RunPlanArgs {
     /// AgentTaskPlan JSON file, @file, or - for stdin.
     #[arg(long, value_name = "PATH")]
     pub plan: String,
+    /// Also persist the completed run lifecycle record under this id.
+    #[arg(long, value_name = "ID")]
+    pub record_run_id: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct SubmitArgs {
+    /// AgentTaskPlan JSON file, @file, or - for stdin.
+    #[arg(long, value_name = "PATH")]
+    pub plan: String,
+    /// Optional durable run id. Generated when omitted.
+    #[arg(long, value_name = "ID")]
+    pub run_id: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct StatusArgs {
+    /// Durable run id returned by `agent-task submit` or `agent-task run-plan --record-run-id`.
+    pub run_id: String,
 }
 
 pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     match args.command {
         AgentTaskCommand::RunPlan(run_args) => run_plan(run_args),
+        AgentTaskCommand::Submit(submit_args) => submit(submit_args),
+        AgentTaskCommand::Status(status_args) => status(status_args),
+        AgentTaskCommand::Logs(status_args) => logs(status_args),
+        AgentTaskCommand::Artifacts(status_args) => artifacts(status_args),
         AgentTaskCommand::Providers => providers(),
     }
 }
 
 fn run_plan(args: RunPlanArgs) -> CmdResult<Value> {
-    let raw = config::read_json_spec_to_string(&args.plan)?;
-    let plan: AgentTaskPlan = serde_json::from_str(&raw).map_err(|error| {
-        homeboy::core::Error::validation_invalid_json(
-            error,
-            Some("agent-task plan".to_string()),
-            Some(raw.clone()),
-        )
-    })?;
+    let plan = read_plan(&args.plan)?;
     let scheduler = AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::discover());
-    let aggregate = scheduler.run(plan);
+    let aggregate = scheduler.run(plan.clone());
+    if let Some(run_id) = args.record_run_id.as_deref() {
+        agent_task_lifecycle::record_completed_run(&plan, &aggregate, Some(run_id))?;
+    }
     let exit_code = if aggregate.totals.failed == 0
         && aggregate.totals.cancelled == 0
         && aggregate.totals.timed_out == 0
@@ -60,10 +88,42 @@ fn run_plan(args: RunPlanArgs) -> CmdResult<Value> {
     ))
 }
 
+fn submit(args: SubmitArgs) -> CmdResult<Value> {
+    let plan = read_plan(&args.plan)?;
+    let record = agent_task_lifecycle::submit_plan(&plan, args.run_id.as_deref())?;
+    Ok((serde_json::to_value(record).unwrap_or(Value::Null), 0))
+}
+
+fn status(args: StatusArgs) -> CmdResult<Value> {
+    let record = agent_task_lifecycle::status(&args.run_id)?;
+    Ok((serde_json::to_value(record).unwrap_or(Value::Null), 0))
+}
+
+fn logs(args: StatusArgs) -> CmdResult<Value> {
+    let log = agent_task_lifecycle::logs(&args.run_id)?;
+    Ok((serde_json::to_value(log).unwrap_or(Value::Null), 0))
+}
+
+fn artifacts(args: StatusArgs) -> CmdResult<Value> {
+    let artifacts = agent_task_lifecycle::artifacts(&args.run_id)?;
+    Ok((serde_json::to_value(artifacts).unwrap_or(Value::Null), 0))
+}
+
 fn providers() -> CmdResult<Value> {
     let executor = ExtensionProviderAgentTaskExecutor::discover();
     Ok((
         serde_json::to_value(executor.providers()).unwrap_or(Value::Null),
         0,
     ))
+}
+
+fn read_plan(spec: &str) -> homeboy::core::Result<AgentTaskPlan> {
+    let raw = config::read_json_spec_to_string(spec)?;
+    serde_json::from_str(&raw).map_err(|error| {
+        homeboy::core::Error::validation_invalid_json(
+            error,
+            Some("agent-task plan".to_string()),
+            Some(raw.clone()),
+        )
+    })
 }

--- a/src/commands/report/performance_digest.rs
+++ b/src/commands/report/performance_digest.rs
@@ -51,6 +51,8 @@ pub struct PerformanceDigestReport {
     pub host_pressure: Option<HostPressureDigest>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub lab_offload: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub preview: BTreeMap<String, String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub gaps: Vec<String>,
 }
@@ -157,6 +159,9 @@ pub fn performance_digest_from_args(
     let lab_offload = find_object_recursive(&metadata, "lab_offload")
         .map(scalar_object)
         .unwrap_or_default();
+    let preview = find_object_recursive(&metadata, "preview")
+        .map(scalar_object)
+        .unwrap_or_default();
 
     let mut baseline_health =
         collect_baseline_health(&bench_data, args.min_samples, args.max_cv_pct);
@@ -182,6 +187,7 @@ pub fn performance_digest_from_args(
         &baseline_health,
         host_pressure.as_ref(),
         &lab_offload,
+        &preview,
         &gaps,
         args.run_url.as_deref().unwrap_or_default(),
     );
@@ -194,6 +200,7 @@ pub fn performance_digest_from_args(
         baseline_health,
         host_pressure,
         lab_offload,
+        preview,
         gaps,
     })
 }
@@ -569,6 +576,7 @@ mod helpers {
         baseline_health: &[BaselineHealthDiagnostic],
         host_pressure: Option<&HostPressureDigest>,
         lab_offload: &BTreeMap<String, String>,
+        preview: &BTreeMap<String, String>,
         gaps: &[String],
         run_url: &str,
     ) -> String {
@@ -580,6 +588,7 @@ mod helpers {
         render_baseline_health(&mut out, baseline_health);
         render_host_pressure(&mut out, host_pressure);
         render_lab_offload(&mut out, lab_offload);
+        render_preview(&mut out, preview);
         render_gaps(&mut out, gaps);
         if !run_url.is_empty() {
             let _ = writeln!(out, "### Full run\n- {}\n", run_url);
@@ -754,6 +763,43 @@ mod helpers {
         out.push_str("### Lab Offload\n");
         for (key, value) in lab_offload {
             let _ = writeln!(out, "- {}: `{}`", key, value);
+        }
+        out.push('\n');
+    }
+
+    pub(super) fn render_preview(out: &mut String, preview: &BTreeMap<String, String>) {
+        if preview.is_empty() {
+            return;
+        }
+        out.push_str("### Preview\n");
+        for key in [
+            "status",
+            "local_url",
+            "public_url",
+            "hold_seconds",
+            "expires_at",
+            "process_id",
+            "runtime_id",
+            "cleanup_status",
+        ] {
+            if let Some(value) = preview.get(key) {
+                let _ = writeln!(out, "- {}: `{}`", key, value);
+            }
+        }
+        for (key, value) in preview {
+            if !matches!(
+                key.as_str(),
+                "status"
+                    | "local_url"
+                    | "public_url"
+                    | "hold_seconds"
+                    | "expires_at"
+                    | "process_id"
+                    | "runtime_id"
+                    | "cleanup_status"
+            ) {
+                let _ = writeln!(out, "- {}: `{}`", key, value);
+            }
         }
         out.push('\n');
     }

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -1,0 +1,493 @@
+use std::fs;
+use std::path::PathBuf;
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::core::agent_task::{AgentTaskArtifact, AgentTaskEvidenceRef, AgentTaskOutcome};
+use crate::core::agent_task_scheduler::{
+    AgentTaskAggregate, AgentTaskPlan, AgentTaskProgressEvent, AgentTaskState,
+};
+use crate::core::{paths, Error, Result};
+
+pub const AGENT_TASK_RUN_SCHEMA: &str = "homeboy/agent-task-run/v1";
+pub const AGENT_TASK_RUN_LOG_SCHEMA: &str = "homeboy/agent-task-run-log/v1";
+pub const AGENT_TASK_RUN_ARTIFACTS_SCHEMA: &str = "homeboy/agent-task-run-artifacts/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskRunRecord {
+    #[serde(default = "run_schema")]
+    pub schema: String,
+    pub run_id: String,
+    pub plan_id: String,
+    pub state: AgentTaskRunState,
+    pub submitted_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    pub plan_path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aggregate_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tasks: Vec<AgentTaskRunTask>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_refs: Vec<AgentTaskArtifactRef>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskRunState {
+    Queued,
+    Running,
+    Succeeded,
+    PartialFailure,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskRunTask {
+    pub task_id: String,
+    pub state: AgentTaskState,
+    pub backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskArtifactRef {
+    pub task_id: String,
+    pub kind: String,
+    pub uri: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskRunLog {
+    #[serde(default = "run_log_schema")]
+    pub schema: String,
+    pub run_id: String,
+    pub events: Vec<AgentTaskProgressEvent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskRunArtifacts {
+    #[serde(default = "run_artifacts_schema")]
+    pub schema: String,
+    pub run_id: String,
+    pub artifacts: Vec<AgentTaskArtifact>,
+    pub evidence_refs: Vec<AgentTaskEvidenceRef>,
+}
+
+pub fn submit_plan(
+    plan: &AgentTaskPlan,
+    requested_run_id: Option<&str>,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = requested_run_id
+        .map(sanitize_run_id)
+        .unwrap_or_else(default_run_id);
+    let run_dir = run_dir(&run_id)?;
+    fs::create_dir_all(&run_dir).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(run_dir.display().to_string()))
+    })?;
+
+    let plan_path = run_dir.join("plan.json");
+    write_json(&plan_path, plan)?;
+
+    let record = AgentTaskRunRecord {
+        schema: AGENT_TASK_RUN_SCHEMA.to_string(),
+        run_id,
+        plan_id: plan.plan_id.clone(),
+        state: AgentTaskRunState::Queued,
+        submitted_at: now_timestamp(),
+        updated_at: None,
+        plan_path: plan_path.display().to_string(),
+        aggregate_path: None,
+        tasks: plan.tasks.iter().map(queued_task).collect(),
+        artifact_refs: Vec::new(),
+        metadata: json!({
+            "task_count": plan.tasks.len(),
+            "max_concurrency": plan.options.max_concurrency,
+            "provider_run_ids": [],
+            "note": "submitted tasks are durable; provider run ids are recorded after an executor returns them as generic artifacts or evidence refs"
+        }),
+    };
+    write_record(&record)?;
+    Ok(record)
+}
+
+pub fn record_completed_run(
+    plan: &AgentTaskPlan,
+    aggregate: &AgentTaskAggregate,
+    requested_run_id: Option<&str>,
+) -> Result<AgentTaskRunRecord> {
+    let mut record = submit_plan(plan, requested_run_id)?;
+    let aggregate_path = run_dir(&record.run_id)?.join("aggregate.json");
+    write_json(&aggregate_path, aggregate)?;
+    record.state = run_state_for_aggregate(aggregate);
+    record.updated_at = Some(now_timestamp());
+    record.aggregate_path = Some(aggregate_path.display().to_string());
+    record.tasks = tasks_for_aggregate(plan, aggregate);
+    record.artifact_refs = artifact_refs_for_outcomes(&aggregate.outcomes);
+    write_record(&record)?;
+    Ok(record)
+}
+
+pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
+    read_record(&sanitize_run_id(run_id))
+}
+
+pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
+    let run_id = sanitize_run_id(run_id);
+    let record = read_record(&run_id)?;
+    let events = read_aggregate(&run_id)
+        .map(|aggregate| aggregate.events)
+        .unwrap_or_else(|_| queued_events(&record.tasks));
+    Ok(AgentTaskRunLog {
+        schema: AGENT_TASK_RUN_LOG_SCHEMA.to_string(),
+        run_id,
+        events,
+    })
+}
+
+pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
+    let run_id = sanitize_run_id(run_id);
+    read_record(&run_id)?;
+    let aggregate = read_aggregate(&run_id).ok();
+    Ok(AgentTaskRunArtifacts {
+        schema: AGENT_TASK_RUN_ARTIFACTS_SCHEMA.to_string(),
+        run_id,
+        artifacts: aggregate
+            .as_ref()
+            .map(|aggregate| {
+                aggregate
+                    .outcomes
+                    .iter()
+                    .flat_map(|outcome| outcome.artifacts.clone())
+                    .collect()
+            })
+            .unwrap_or_default(),
+        evidence_refs: aggregate
+            .as_ref()
+            .map(|aggregate| {
+                aggregate
+                    .outcomes
+                    .iter()
+                    .flat_map(|outcome| outcome.evidence_refs.clone())
+                    .collect()
+            })
+            .unwrap_or_default(),
+    })
+}
+
+fn queued_task(request: &crate::core::agent_task::AgentTaskRequest) -> AgentTaskRunTask {
+    AgentTaskRunTask {
+        task_id: request.task_id.clone(),
+        state: AgentTaskState::Queued,
+        backend: request.executor.backend.clone(),
+        selector: request.executor.selector.clone(),
+        model: request.executor.model.clone(),
+        provider_ref: request
+            .executor
+            .selector
+            .as_ref()
+            .map(|selector| format!("{}:{selector}", request.executor.backend)),
+    }
+}
+
+fn tasks_for_aggregate(
+    plan: &AgentTaskPlan,
+    aggregate: &AgentTaskAggregate,
+) -> Vec<AgentTaskRunTask> {
+    plan.tasks
+        .iter()
+        .map(|request| {
+            let mut task = queued_task(request);
+            if let Some(event) = aggregate
+                .events
+                .iter()
+                .rev()
+                .find(|event| event.task_id == request.task_id)
+            {
+                task.state = event.state;
+            }
+            task
+        })
+        .collect()
+}
+
+fn queued_events(tasks: &[AgentTaskRunTask]) -> Vec<AgentTaskProgressEvent> {
+    tasks
+        .iter()
+        .map(|task| AgentTaskProgressEvent {
+            task_id: task.task_id.clone(),
+            state: task.state,
+            attempt: 1,
+            message: Some("task submitted".to_string()),
+        })
+        .collect()
+}
+
+fn artifact_refs_for_outcomes(outcomes: &[AgentTaskOutcome]) -> Vec<AgentTaskArtifactRef> {
+    outcomes
+        .iter()
+        .flat_map(|outcome| {
+            let artifact_refs = outcome.artifacts.iter().filter_map(|artifact| {
+                artifact
+                    .url
+                    .clone()
+                    .or_else(|| artifact.path.clone())
+                    .map(|uri| AgentTaskArtifactRef {
+                        task_id: outcome.task_id.clone(),
+                        kind: artifact.kind.clone(),
+                        uri,
+                        label: artifact.name.clone(),
+                    })
+            });
+            let evidence_refs = outcome
+                .evidence_refs
+                .iter()
+                .map(|evidence| AgentTaskArtifactRef {
+                    task_id: outcome.task_id.clone(),
+                    kind: evidence.kind.clone(),
+                    uri: evidence.uri.clone(),
+                    label: evidence.label.clone(),
+                });
+            artifact_refs.chain(evidence_refs).collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn run_state_for_aggregate(aggregate: &AgentTaskAggregate) -> AgentTaskRunState {
+    match aggregate.status {
+        crate::core::agent_task_scheduler::AgentTaskAggregateStatus::Succeeded => {
+            AgentTaskRunState::Succeeded
+        }
+        crate::core::agent_task_scheduler::AgentTaskAggregateStatus::PartialFailure => {
+            AgentTaskRunState::PartialFailure
+        }
+        crate::core::agent_task_scheduler::AgentTaskAggregateStatus::Failed => {
+            AgentTaskRunState::Failed
+        }
+        crate::core::agent_task_scheduler::AgentTaskAggregateStatus::Cancelled => {
+            AgentTaskRunState::Cancelled
+        }
+    }
+}
+
+fn write_record(record: &AgentTaskRunRecord) -> Result<()> {
+    write_json(&record_path(&record.run_id)?, record)
+}
+
+fn read_record(run_id: &str) -> Result<AgentTaskRunRecord> {
+    let path = record_path(run_id)?;
+    let raw = fs::read_to_string(&path)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    serde_json::from_str(&raw)
+        .map_err(|error| Error::internal_json(error.to_string(), Some(path.display().to_string())))
+}
+
+fn read_aggregate(run_id: &str) -> Result<AgentTaskAggregate> {
+    let path = run_dir(run_id)?.join("aggregate.json");
+    let raw = fs::read_to_string(&path)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    serde_json::from_str(&raw)
+        .map_err(|error| Error::internal_json(error.to_string(), Some(path.display().to_string())))
+}
+
+fn write_json<T: Serialize>(path: &PathBuf, value: &T) -> Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        Error::internal_unexpected(format!("path has no parent: {}", path.display()))
+    })?;
+    fs::create_dir_all(parent).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(parent.display().to_string()))
+    })?;
+    let json = serde_json::to_string_pretty(value).map_err(|error| {
+        Error::internal_json(error.to_string(), Some(path.display().to_string()))
+    })?;
+    fs::write(path, format!("{json}\n"))
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))
+}
+
+fn record_path(run_id: &str) -> Result<PathBuf> {
+    Ok(run_dir(run_id)?.join("status.json"))
+}
+
+fn run_dir(run_id: &str) -> Result<PathBuf> {
+    Ok(paths::homeboy_data()?
+        .join("agent-task-runs")
+        .join(sanitize_run_id(run_id)))
+}
+
+fn default_run_id() -> String {
+    format!("agent-task-{}", Uuid::new_v4())
+}
+
+fn now_timestamp() -> String {
+    Utc::now().to_rfc3339()
+}
+
+fn sanitize_run_id(run_id: &str) -> String {
+    let sanitized = paths::sanitize_path_segment(run_id);
+    if sanitized.is_empty() {
+        default_run_id()
+    } else {
+        sanitized
+    }
+}
+
+fn run_schema() -> String {
+    AGENT_TASK_RUN_SCHEMA.to_string()
+}
+
+fn run_log_schema() -> String {
+    AGENT_TASK_RUN_LOG_SCHEMA.to_string()
+}
+
+fn run_artifacts_schema() -> String {
+    AGENT_TASK_RUN_ARTIFACTS_SCHEMA.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::agent_task::{
+        AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
+        AGENT_TASK_REQUEST_SCHEMA,
+    };
+    use crate::core::agent_task_scheduler::{
+        AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
+        AGENT_TASK_AGGREGATE_SCHEMA,
+    };
+    use std::sync::{Mutex, OnceLock};
+
+    #[test]
+    fn submit_plan_persists_queued_status() {
+        with_temp_home(|| {
+            let plan = test_plan();
+
+            let record = submit_plan(&plan, Some("run/a")).expect("submitted");
+            let loaded = status(&record.run_id).expect("status loaded");
+
+            assert_eq!(record.run_id, "run_a");
+            assert_eq!(loaded.state, AgentTaskRunState::Queued);
+            assert_eq!(loaded.tasks[0].task_id, "task-a");
+            assert_eq!(
+                loaded.tasks[0].provider_ref.as_deref(),
+                Some("test:fixture")
+            );
+        });
+    }
+
+    #[test]
+    fn record_completed_run_exposes_logs_and_artifacts() {
+        with_temp_home(|| {
+            let plan = test_plan();
+            let aggregate = AgentTaskAggregate {
+                schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+                plan_id: plan.plan_id.clone(),
+                status: AgentTaskAggregateStatus::Succeeded,
+                totals: AgentTaskAggregateTotals {
+                    queued: 1,
+                    succeeded: 1,
+                    ..AgentTaskAggregateTotals::default()
+                },
+                outcomes: vec![AgentTaskOutcome {
+                    schema: crate::core::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: "task-a".to_string(),
+                    status: crate::core::agent_task::AgentTaskOutcomeStatus::Succeeded,
+                    summary: Some("ok".to_string()),
+                    failure_classification: None,
+                    artifacts: vec![AgentTaskArtifact {
+                        schema: crate::core::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                        id: "patch".to_string(),
+                        kind: "patch".to_string(),
+                        name: Some("patch.diff".to_string()),
+                        path: Some("/tmp/patch.diff".to_string()),
+                        url: None,
+                        mime: None,
+                        size_bytes: None,
+                        sha256: None,
+                        metadata: Value::Null,
+                    }],
+                    evidence_refs: vec![AgentTaskEvidenceRef {
+                        kind: "transcript".to_string(),
+                        uri: "file:///tmp/transcript.json".to_string(),
+                        label: Some("provider transcript".to_string()),
+                    }],
+                    diagnostics: Vec::new(),
+                    workflow: None,
+                    follow_up: None,
+                    metadata: Value::Null,
+                }],
+                events: vec![AgentTaskProgressEvent {
+                    task_id: "task-a".to_string(),
+                    state: AgentTaskState::Succeeded,
+                    attempt: 1,
+                    message: Some("ok".to_string()),
+                }],
+                queue: Default::default(),
+            };
+
+            let record =
+                record_completed_run(&plan, &aggregate, Some("run-complete")).expect("recorded");
+            let log = logs(&record.run_id).expect("logs");
+            let artifacts = artifacts(&record.run_id).expect("artifacts");
+
+            assert_eq!(record.state, AgentTaskRunState::Succeeded);
+            assert_eq!(log.events[0].state, AgentTaskState::Succeeded);
+            assert_eq!(artifacts.artifacts[0].id, "patch");
+            assert_eq!(artifacts.evidence_refs[0].kind, "transcript");
+        });
+    }
+
+    fn with_temp_home(run: impl FnOnce()) {
+        let lock = test_home_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let home = tempfile::tempdir().expect("temp home");
+        std::env::set_var("HOME", home.path());
+        run();
+        drop(lock);
+    }
+
+    fn test_home_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn test_plan() -> AgentTaskPlan {
+        AgentTaskPlan::new(
+            "plan-a",
+            vec![AgentTaskRequest {
+                schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+                task_id: "task-a".to_string(),
+                group_key: None,
+                parent_plan_id: None,
+                executor: AgentTaskExecutor {
+                    backend: "test".to_string(),
+                    selector: Some("fixture".to_string()),
+                    required_capabilities: Vec::new(),
+                    model: None,
+                    config: Value::Null,
+                },
+                instructions: "run".to_string(),
+                inputs: Value::Null,
+                source_refs: Vec::new(),
+                workspace: AgentTaskWorkspace::default(),
+                policy: AgentTaskPolicy::default(),
+                limits: AgentTaskLimits::default(),
+                expected_artifacts: Vec::new(),
+                metadata: Value::Null,
+            }],
+        )
+    }
+}

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -18,7 +18,6 @@ pub const AGENT_TASK_RUN_ARTIFACTS_SCHEMA: &str = "homeboy/agent-task-run-artifa
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskRunRecord {
-    #[serde(default = "run_schema")]
     pub schema: String,
     pub run_id: String,
     pub plan_id: String,
@@ -72,7 +71,6 @@ pub struct AgentTaskArtifactRef {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskRunLog {
-    #[serde(default = "run_log_schema")]
     pub schema: String,
     pub run_id: String,
     pub events: Vec<AgentTaskProgressEvent>,
@@ -80,7 +78,6 @@ pub struct AgentTaskRunLog {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskRunArtifacts {
-    #[serde(default = "run_artifacts_schema")]
     pub schema: String,
     pub run_id: String,
     pub artifacts: Vec<AgentTaskArtifact>,
@@ -165,27 +162,33 @@ pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
     Ok(AgentTaskRunArtifacts {
         schema: AGENT_TASK_RUN_ARTIFACTS_SCHEMA.to_string(),
         run_id,
-        artifacts: aggregate
-            .as_ref()
-            .map(|aggregate| {
-                aggregate
-                    .outcomes
-                    .iter()
-                    .flat_map(|outcome| outcome.artifacts.clone())
-                    .collect()
-            })
-            .unwrap_or_default(),
-        evidence_refs: aggregate
-            .as_ref()
-            .map(|aggregate| {
-                aggregate
-                    .outcomes
-                    .iter()
-                    .flat_map(|outcome| outcome.evidence_refs.clone())
-                    .collect()
-            })
-            .unwrap_or_default(),
+        artifacts: aggregate_artifacts(aggregate.as_ref()),
+        evidence_refs: aggregate_evidence_refs(aggregate.as_ref()),
     })
+}
+
+fn aggregate_artifacts(aggregate: Option<&AgentTaskAggregate>) -> Vec<AgentTaskArtifact> {
+    aggregate
+        .map(|aggregate| {
+            aggregate
+                .outcomes
+                .iter()
+                .flat_map(|outcome| outcome.artifacts.clone())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn aggregate_evidence_refs(aggregate: Option<&AgentTaskAggregate>) -> Vec<AgentTaskEvidenceRef> {
+    aggregate
+        .map(|aggregate| {
+            aggregate
+                .outcomes
+                .iter()
+                .flat_map(|outcome| outcome.evidence_refs.clone())
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn queued_task(request: &crate::core::agent_task::AgentTaskRequest) -> AgentTaskRunTask {
@@ -342,18 +345,6 @@ fn sanitize_run_id(run_id: &str) -> String {
     } else {
         sanitized
     }
-}
-
-fn run_schema() -> String {
-    AGENT_TASK_RUN_SCHEMA.to_string()
-}
-
-fn run_log_schema() -> String {
-    AGENT_TASK_RUN_LOG_SCHEMA.to_string()
-}
-
-fn run_artifacts_schema() -> String {
-    AGENT_TASK_RUN_ARTIFACTS_SCHEMA.to_string()
 }
 
 #[cfg(test)]

--- a/src/core/agent_task_promotion.rs
+++ b/src/core/agent_task_promotion.rs
@@ -1,0 +1,609 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::core::agent_task::{
+    AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_OUTCOME_SCHEMA,
+};
+use crate::core::agent_task_scheduler::{AgentTaskAggregate, AGENT_TASK_AGGREGATE_SCHEMA};
+use crate::core::{Error, Result};
+
+pub const AGENT_TASK_PROMOTION_REPORT_SCHEMA: &str = "homeboy/agent-task-promotion-report/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPromotionOptions {
+    pub source: String,
+    pub source_path: Option<PathBuf>,
+    pub to_worktree: String,
+    pub task_id: Option<String>,
+    pub artifact_id: Option<String>,
+    #[serde(default)]
+    pub dry_run: bool,
+    #[serde(default)]
+    pub verify: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskPromotionReport {
+    #[serde(default = "promotion_report_schema")]
+    pub schema: String,
+    pub status: AgentTaskPromotionStatus,
+    pub source: AgentTaskPromotionSource,
+    pub to_worktree: String,
+    pub patch_artifact: AgentTaskPromotionArtifactRef,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_files: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dmc_commands: Vec<AgentTaskPromotionCommandReport>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub verification: Vec<AgentTaskPromotionCommandReport>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub provenance: Value,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskPromotionStatus {
+    DryRun,
+    Applied,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPromotionSource {
+    pub kind: String,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPromotionArtifactRef {
+    pub id: String,
+    pub kind: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPromotionCommandReport {
+    pub command: Vec<String>,
+    pub exit_code: i32,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stdout: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stderr: String,
+}
+
+pub fn promote(options: AgentTaskPromotionOptions) -> Result<AgentTaskPromotionReport> {
+    validate_worktree_handle(&options.to_worktree)?;
+    let source_value: Value = serde_json::from_str(&options.source).map_err(|error| {
+        Error::validation_invalid_json(
+            error,
+            Some("agent-task promotion source".to_string()),
+            Some(options.source.clone()),
+        )
+    })?;
+    let (source_kind, outcome) = select_outcome(source_value, options.task_id.as_deref())?;
+
+    if outcome.status != AgentTaskOutcomeStatus::Succeeded {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            format!(
+                "promotion requires a succeeded outcome; task {} has status {:?}",
+                outcome.task_id, outcome.status
+            ),
+            None,
+            None,
+        ));
+    }
+
+    let artifact = select_patch_artifact(&outcome, options.artifact_id.as_deref())?;
+    let patch_path = resolve_artifact_path(&artifact, options.source_path.as_deref())?;
+    let patch = std::fs::read_to_string(&patch_path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("read patch artifact {}", patch_path.display())),
+        )
+    })?;
+    let changed_files = validate_patch(&patch)?;
+
+    let mut dmc_commands = Vec::new();
+    if !options.dry_run {
+        dmc_commands.append(&mut ensure_worktree(&options.to_worktree)?);
+        dmc_commands.push(apply_patch_with_dmc(&options.to_worktree, &patch_path)?);
+    }
+
+    let mut verification = Vec::new();
+    if !options.dry_run && !options.verify.is_empty() {
+        let worktree_path = dmc_worktree_path(&options.to_worktree)?;
+        for command in &options.verify {
+            verification.push(run_verification_command(&worktree_path, command)?);
+        }
+    }
+
+    Ok(AgentTaskPromotionReport {
+        schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
+        status: if options.dry_run {
+            AgentTaskPromotionStatus::DryRun
+        } else {
+            AgentTaskPromotionStatus::Applied
+        },
+        source: AgentTaskPromotionSource {
+            kind: source_kind,
+            task_id: outcome.task_id.clone(),
+            path: options
+                .source_path
+                .as_ref()
+                .map(|path| path.display().to_string()),
+        },
+        to_worktree: options.to_worktree,
+        patch_artifact: AgentTaskPromotionArtifactRef {
+            id: artifact.id,
+            kind: artifact.kind,
+            path: patch_path.display().to_string(),
+            sha256: artifact.sha256,
+        },
+        changed_files,
+        dmc_commands,
+        verification,
+        provenance: json!({
+            "source_schema": outcome.schema,
+            "artifact_metadata": artifact.metadata,
+        }),
+    })
+}
+
+fn promotion_report_schema() -> String {
+    AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string()
+}
+
+fn select_outcome(source: Value, task_id: Option<&str>) -> Result<(String, AgentTaskOutcome)> {
+    if source.get("schema").and_then(Value::as_str) == Some(AGENT_TASK_OUTCOME_SCHEMA) {
+        let outcome: AgentTaskOutcome = serde_json::from_value(source).map_err(|error| {
+            Error::validation_invalid_json(error, Some("agent-task outcome".to_string()), None)
+        })?;
+        if let Some(expected) = task_id {
+            if outcome.task_id != expected {
+                return Err(Error::validation_invalid_argument(
+                    "task_id",
+                    format!(
+                        "source outcome task_id is {}, not {expected}",
+                        outcome.task_id
+                    ),
+                    None,
+                    None,
+                ));
+            }
+        }
+        return Ok(("outcome".to_string(), outcome));
+    }
+
+    if source.get("schema").and_then(Value::as_str) == Some(AGENT_TASK_AGGREGATE_SCHEMA) {
+        let aggregate: AgentTaskAggregate = serde_json::from_value(source).map_err(|error| {
+            Error::validation_invalid_json(error, Some("agent-task aggregate".to_string()), None)
+        })?;
+        let candidates: Vec<AgentTaskOutcome> = aggregate
+            .outcomes
+            .into_iter()
+            .filter(|outcome| task_id.is_none_or(|expected| outcome.task_id == expected))
+            .collect();
+        return match candidates.len() {
+            1 => Ok((
+                "aggregate".to_string(),
+                candidates.into_iter().next().unwrap(),
+            )),
+            0 => Err(Error::validation_invalid_argument(
+                "task_id",
+                "aggregate did not contain a matching outcome",
+                None,
+                None,
+            )),
+            _ => Err(Error::validation_invalid_argument(
+                "task_id",
+                "aggregate contains multiple outcomes; pass --task-id to select one",
+                None,
+                None,
+            )),
+        };
+    }
+
+    Err(Error::validation_invalid_argument(
+        "source",
+        "promotion source must be an agent-task outcome or aggregate JSON object",
+        None,
+        None,
+    ))
+}
+
+fn select_patch_artifact(
+    outcome: &AgentTaskOutcome,
+    artifact_id: Option<&str>,
+) -> Result<AgentTaskArtifact> {
+    let artifacts: Vec<AgentTaskArtifact> = outcome
+        .artifacts
+        .iter()
+        .filter(|artifact| artifact_id.is_none_or(|expected| artifact.id == expected))
+        .filter(|artifact| is_patch_artifact(artifact))
+        .cloned()
+        .collect();
+
+    match artifacts.len() {
+        1 => Ok(artifacts.into_iter().next().unwrap()),
+        0 => Err(Error::validation_invalid_argument(
+            "artifact_id",
+            "no matching patch artifact was found",
+            None,
+            None,
+        )),
+        _ => Err(Error::validation_invalid_argument(
+            "artifact_id",
+            "multiple patch artifacts were found; pass --artifact-id to select one",
+            None,
+            None,
+        )),
+    }
+}
+
+fn is_patch_artifact(artifact: &AgentTaskArtifact) -> bool {
+    artifact.kind == "patch"
+        || artifact.kind == "diff"
+        || artifact.mime.as_deref() == Some("text/x-patch")
+        || artifact.mime.as_deref() == Some("text/x-diff")
+        || artifact.metadata.get("role").and_then(Value::as_str) == Some("patch")
+}
+
+fn resolve_artifact_path(
+    artifact: &AgentTaskArtifact,
+    source_path: Option<&Path>,
+) -> Result<PathBuf> {
+    let path = artifact.path.as_ref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "artifact.path",
+            "promotion patch artifact must provide a local path",
+            None,
+            None,
+        )
+    })?;
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        return Ok(path);
+    }
+    if let Some(source_path) = source_path.and_then(Path::parent) {
+        Ok(source_path.join(path))
+    } else {
+        Ok(path)
+    }
+}
+
+fn validate_patch(patch: &str) -> Result<Vec<String>> {
+    if patch.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "patch",
+            "promotion refuses an empty patch artifact",
+            None,
+            None,
+        ));
+    }
+
+    let mut changed_files = Vec::new();
+    for line in patch.lines() {
+        if let Some(path) = line
+            .strip_prefix("+++ ")
+            .or_else(|| line.strip_prefix("--- "))
+        {
+            let path = path.trim();
+            if path == "/dev/null" {
+                continue;
+            }
+            let path = path
+                .strip_prefix("a/")
+                .or_else(|| path.strip_prefix("b/"))
+                .unwrap_or(path);
+            validate_patch_path(path)?;
+            if !changed_files.iter().any(|existing| existing == path) {
+                changed_files.push(path.to_string());
+            }
+        }
+    }
+
+    if changed_files.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "patch",
+            "promotion requires a unified diff with changed file headers",
+            None,
+            None,
+        ));
+    }
+
+    Ok(changed_files)
+}
+
+fn validate_patch_path(path: &str) -> Result<()> {
+    let invalid = path.starts_with('/')
+        || path.starts_with("../")
+        || path.contains("/../")
+        || path == ".."
+        || path.starts_with(".git/")
+        || path.contains("/.git/");
+    if invalid {
+        return Err(Error::validation_invalid_argument(
+            "patch",
+            format!("promotion refuses unsafe patch path: {path}"),
+            None,
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn validate_worktree_handle(handle: &str) -> Result<()> {
+    let (repo, branch) = split_worktree_handle(handle)?;
+    if repo.is_empty() || branch.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            "worktree handle must use <repo>@<branch-slug>",
+            None,
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn split_worktree_handle(handle: &str) -> Result<(&str, &str)> {
+    handle.split_once('@').ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "to_worktree",
+            "worktree handle must use <repo>@<branch-slug>",
+            None,
+            None,
+        )
+    })
+}
+
+fn ensure_worktree(handle: &str) -> Result<Vec<AgentTaskPromotionCommandReport>> {
+    if dmc_worktree_path(handle).is_ok() {
+        return Ok(Vec::new());
+    }
+
+    let (repo, branch) = split_worktree_handle(handle)?;
+    let command = vec![
+        "studio".to_string(),
+        "wp".to_string(),
+        "datamachine-code".to_string(),
+        "workspace".to_string(),
+        "worktree".to_string(),
+        "add".to_string(),
+        repo.to_string(),
+        branch.to_string(),
+    ];
+    Ok(vec![run_command(command, None)?])
+}
+
+fn apply_patch_with_dmc(
+    handle: &str,
+    patch_path: &Path,
+) -> Result<AgentTaskPromotionCommandReport> {
+    run_command(
+        vec![
+            "studio".to_string(),
+            "wp".to_string(),
+            "datamachine-code".to_string(),
+            "workspace".to_string(),
+            "patch".to_string(),
+            "apply".to_string(),
+            handle.to_string(),
+            format!("--patch=@{}", patch_path.display()),
+            "--format=json".to_string(),
+        ],
+        None,
+    )
+}
+
+fn dmc_worktree_path(handle: &str) -> Result<PathBuf> {
+    let (repo, _) = split_worktree_handle(handle)?;
+    let report = run_command(
+        vec![
+            "studio".to_string(),
+            "wp".to_string(),
+            "datamachine-code".to_string(),
+            "workspace".to_string(),
+            "worktree".to_string(),
+            "list".to_string(),
+            repo.to_string(),
+            "--format=json".to_string(),
+        ],
+        None,
+    )?;
+    let rows: Value = serde_json::from_str(&report.stdout).map_err(|error| {
+        Error::validation_invalid_json(
+            error,
+            Some("datamachine-code worktree list output".to_string()),
+            Some(report.stdout.clone()),
+        )
+    })?;
+    rows.as_array()
+        .and_then(|rows| {
+            rows.iter()
+                .find(|row| row.get("handle").and_then(Value::as_str) == Some(handle))
+        })
+        .and_then(|row| row.get("path").and_then(Value::as_str))
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "to_worktree",
+                format!("managed worktree {handle} was not found"),
+                None,
+                None,
+            )
+        })
+}
+
+fn run_verification_command(cwd: &Path, command: &str) -> Result<AgentTaskPromotionCommandReport> {
+    run_command(
+        vec!["sh".to_string(), "-lc".to_string(), command.to_string()],
+        Some(cwd),
+    )
+}
+
+fn run_command(
+    command: Vec<String>,
+    cwd: Option<&Path>,
+) -> Result<AgentTaskPromotionCommandReport> {
+    let mut process = Command::new(&command[0]);
+    process.args(&command[1..]);
+    if let Some(cwd) = cwd {
+        process.current_dir(cwd);
+    }
+    let output = process.output().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("run {}", command.join(" "))),
+        )
+    })?;
+    let exit_code = output.status.code().unwrap_or(1);
+    let report = AgentTaskPromotionCommandReport {
+        command,
+        exit_code,
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    };
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "command",
+            format!(
+                "promotion command failed with exit code {}: {}",
+                exit_code,
+                report.command.join(" ")
+            ),
+            None,
+            Some(vec![report.stderr.clone()]),
+        ));
+    }
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::agent_task::{
+        AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_ARTIFACT_SCHEMA,
+        AGENT_TASK_OUTCOME_SCHEMA,
+    };
+
+    #[test]
+    fn validate_patch_extracts_safe_changed_files() {
+        let patch = "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
+
+        let files = validate_patch(patch).expect("valid patch");
+
+        assert_eq!(files, vec!["src/lib.rs"]);
+    }
+
+    #[test]
+    fn validate_patch_rejects_empty_patch() {
+        let err = validate_patch("\n\t").expect_err("empty patch rejected");
+
+        assert!(err.message.contains("empty patch"));
+    }
+
+    #[test]
+    fn validate_patch_rejects_path_traversal() {
+        let patch = "--- a/src/lib.rs\n+++ b/../secret\n@@ -1 +1 @@\n-old\n+new\n";
+
+        let err = validate_patch(patch).expect_err("unsafe path rejected");
+
+        assert!(err.message.contains("unsafe patch path"));
+    }
+
+    #[test]
+    fn select_patch_artifact_requires_unambiguous_patch() {
+        let outcome = AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: "task-1".to_string(),
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: None,
+            failure_classification: None,
+            artifacts: vec![
+                AgentTaskArtifact {
+                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                    id: "patch-a".to_string(),
+                    kind: "patch".to_string(),
+                    name: None,
+                    path: Some("a.patch".to_string()),
+                    url: None,
+                    mime: None,
+                    size_bytes: None,
+                    sha256: None,
+                    metadata: Value::Null,
+                },
+                AgentTaskArtifact {
+                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                    id: "patch-b".to_string(),
+                    kind: "diff".to_string(),
+                    name: None,
+                    path: Some("b.patch".to_string()),
+                    url: None,
+                    mime: None,
+                    size_bytes: None,
+                    sha256: None,
+                    metadata: Value::Null,
+                },
+            ],
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        };
+
+        let err = select_patch_artifact(&outcome, None).expect_err("ambiguous patch rejected");
+        assert!(err.message.contains("multiple patch artifacts"));
+
+        let artifact = select_patch_artifact(&outcome, Some("patch-b")).expect("selected patch");
+        assert_eq!(artifact.id, "patch-b");
+    }
+
+    #[test]
+    fn promote_dry_run_reports_selected_patch_without_dmc_mutation() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let patch_path = temp.path().join("changes.patch");
+        std::fs::write(
+            &patch_path,
+            "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n",
+        )
+        .expect("write patch");
+        let source_path = temp.path().join("outcome.json");
+        let source = serde_json::json!({
+            "schema": AGENT_TASK_OUTCOME_SCHEMA,
+            "task_id": "task-1",
+            "status": "succeeded",
+            "artifacts": [{
+                "schema": AGENT_TASK_ARTIFACT_SCHEMA,
+                "id": "patch",
+                "kind": "patch",
+                "path": "changes.patch"
+            }]
+        })
+        .to_string();
+
+        let report = promote(AgentTaskPromotionOptions {
+            source,
+            source_path: Some(source_path),
+            to_worktree: "repo@promoted-task".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: true,
+            verify: Vec::new(),
+        })
+        .expect("dry-run promotion report");
+
+        assert_eq!(report.status, AgentTaskPromotionStatus::DryRun);
+        assert_eq!(report.source.task_id, "task-1");
+        assert_eq!(report.patch_artifact.id, "patch");
+        assert_eq!(report.changed_files, vec!["src/lib.rs"]);
+        assert!(report.dmc_commands.is_empty());
+    }
+}

--- a/src/core/git/commits.rs
+++ b/src/core/git/commits.rs
@@ -1134,17 +1134,16 @@ mod tests {
     #[test]
     fn previous_tag_before_current_respects_component_prefix() {
         let (dir, path) = init_repo();
-        git(&path, &["tag", "wordpress-v1.0.0"]);
+        git(&path, &["tag", "module-v1.0.0"]);
         git(&path, &["tag", "api-v9.9.9"]);
         commit_file(&dir, &path, "one.txt", "one\n", "fix: one");
-        git(&path, &["tag", "wordpress-v1.1.0"]);
+        git(&path, &["tag", "module-v1.1.0"]);
         commit_file(&dir, &path, "two.txt", "two\n", "fix: two");
-        git(&path, &["tag", "wordpress-v1.2.0"]);
+        git(&path, &["tag", "module-v1.2.0"]);
 
         assert_eq!(
-            get_previous_tag_before_with_prefix(&path, "wordpress-v1.2.0", Some("wordpress"))
-                .unwrap(),
-            Some("wordpress-v1.1.0".to_string())
+            get_previous_tag_before_with_prefix(&path, "module-v1.2.0", Some("module")).unwrap(),
+            Some("module-v1.1.0".to_string())
         );
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 pub mod config;
 pub mod agent_task;
 pub mod agent_task_aggregate;
+pub mod agent_task_lifecycle;
 pub mod agent_task_promotion;
 pub mod agent_task_provider;
 pub mod agent_task_scheduler;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 pub mod config;
 pub mod agent_task;
 pub mod agent_task_aggregate;
+pub mod agent_task_lifecycle;
 pub mod agent_task_provider;
 pub mod agent_task_scheduler;
 pub mod api_jobs;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 pub mod config;
 pub mod agent_task;
 pub mod agent_task_aggregate;
+pub mod agent_task_promotion;
 pub mod agent_task_provider;
 pub mod agent_task_scheduler;
 pub mod api_jobs;

--- a/src/core/observation/context.rs
+++ b/src/core/observation/context.rs
@@ -2,6 +2,8 @@ use serde::Serialize;
 
 pub const SOURCE_SNAPSHOT_METADATA_ENV: &str = "HOMEBOY_SOURCE_SNAPSHOT_JSON";
 pub const LAB_OFFLOAD_METADATA_ENV: &str = "HOMEBOY_LAB_OFFLOAD_JSON";
+pub const PREVIEW_METADATA_ENV: &str = "HOMEBOY_PREVIEW_JSON";
+pub const PREVIEW_PUBLIC_URL_ENV: &str = "HOMEBOY_PREVIEW_PUBLIC_URL";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RunContext {
@@ -21,6 +23,7 @@ impl RunContext {
         Self::from_provenance(RunProvenance {
             source_snapshot: env_json(SOURCE_SNAPSHOT_METADATA_ENV),
             lab_offload: env_json(LAB_OFFLOAD_METADATA_ENV),
+            preview: preview_metadata_from_env(),
             artifact_mirror: None,
         })
     }
@@ -35,6 +38,7 @@ impl RunContext {
 pub struct RunProvenance {
     pub source_snapshot: Option<serde_json::Value>,
     pub lab_offload: Option<serde_json::Value>,
+    pub preview: Option<serde_json::Value>,
     pub artifact_mirror: Option<serde_json::Value>,
 }
 
@@ -46,6 +50,11 @@ impl RunProvenance {
 
     pub fn with_lab_offload(mut self, lab_offload: impl Serialize) -> Self {
         self.lab_offload = serde_json::to_value(lab_offload).ok();
+        self
+    }
+
+    pub fn with_preview(mut self, preview: impl Serialize) -> Self {
+        self.preview = serde_json::to_value(preview).ok();
         self
     }
 
@@ -61,6 +70,9 @@ impl RunProvenance {
         if self.lab_offload.is_none() {
             self.lab_offload = fallback.lab_offload;
         }
+        if self.preview.is_none() {
+            self.preview = fallback.preview;
+        }
         if self.artifact_mirror.is_none() {
             self.artifact_mirror = fallback.artifact_mirror;
         }
@@ -72,4 +84,50 @@ fn env_json(name: &str) -> Option<serde_json::Value> {
     std::env::var(name)
         .ok()
         .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+}
+
+fn preview_metadata_from_env() -> Option<serde_json::Value> {
+    let mut preview = env_json(PREVIEW_METADATA_ENV)?;
+    if let Ok(public_url) = std::env::var(PREVIEW_PUBLIC_URL_ENV) {
+        if !public_url.trim().is_empty() {
+            if let Some(object) = preview.as_object_mut() {
+                object
+                    .entry("public_url")
+                    .or_insert_with(|| serde_json::Value::String(public_url));
+            }
+        }
+    }
+    Some(preview)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RunContext, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
+
+    #[test]
+    fn subprocess_context_reads_generic_preview_metadata_with_public_url_overlay() {
+        std::env::set_var(
+            PREVIEW_METADATA_ENV,
+            r#"{"schema":"homeboy/preview/v1","local_url":"http://127.0.0.1:8080","hold_seconds":600,"expires_at":"2026-06-01T22:00:00Z","status":"running","process_id":"pid-123","runtime_id":"runtime-abc","cleanup_status":"pending"}"#,
+        );
+        std::env::set_var(PREVIEW_PUBLIC_URL_ENV, "https://preview.example.test/run-1");
+
+        let context = RunContext::subprocess_compatibility_from_env();
+        let preview = context
+            .provenance
+            .preview
+            .expect("preview metadata should be captured");
+
+        assert_eq!(preview["schema"], "homeboy/preview/v1");
+        assert_eq!(preview["local_url"], "http://127.0.0.1:8080");
+        assert_eq!(preview["public_url"], "https://preview.example.test/run-1");
+        assert_eq!(preview["hold_seconds"], 600);
+        assert_eq!(preview["status"], "running");
+        assert_eq!(preview["process_id"], "pid-123");
+        assert_eq!(preview["runtime_id"], "runtime-abc");
+        assert_eq!(preview["cleanup_status"], "pending");
+
+        std::env::remove_var(PREVIEW_METADATA_ENV);
+        std::env::remove_var(PREVIEW_PUBLIC_URL_ENV);
+    }
 }

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -28,7 +28,7 @@ pub use records::{
 };
 pub use store::{
     ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION, LAB_OFFLOAD_METADATA_ENV,
-    SOURCE_SNAPSHOT_METADATA_ENV,
+    PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV, SOURCE_SNAPSHOT_METADATA_ENV,
 };
 pub(crate) use test_findings::{
     finding_records_from_failure_clusters, finding_records_from_test_analysis_input,

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -10,7 +10,10 @@ mod schema;
 mod triage_items;
 
 use super::context::RunContext;
-pub use super::context::{LAB_OFFLOAD_METADATA_ENV, SOURCE_SNAPSHOT_METADATA_ENV};
+pub use super::context::{
+    LAB_OFFLOAD_METADATA_ENV, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV,
+    SOURCE_SNAPSHOT_METADATA_ENV,
+};
 use super::records::{
     ArtifactCleanupCandidateRecord, ArtifactCleanupFilter, ArtifactRecord, FindingListFilter,
     FindingRecord, NewFindingRecord, NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord,
@@ -883,6 +886,9 @@ fn with_run_context_metadata(
     }
     if let Some(lab_offload) = &context.provenance.lab_offload {
         additions.push(("lab_offload".to_string(), lab_offload.clone()));
+    }
+    if let Some(preview) = &context.provenance.preview {
+        additions.push(("preview".to_string(), preview.clone()));
     }
     if let Some(artifact_mirror) = &context.provenance.artifact_mirror {
         additions.push(("artifact_mirror".to_string(), artifact_mirror.clone()));

--- a/src/core/runner/command_path.rs
+++ b/src/core/runner/command_path.rs
@@ -3,7 +3,7 @@ use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-const HOME_BIN_DIRS: &[&str] = &[".local/bin", ".cargo/bin", ".kimaki/bin"];
+const HOME_BIN_DIRS: &[&str] = &[".local/bin"];
 const ABSOLUTE_BIN_DIRS: &[&str] = &[
     "/opt/homebrew/bin",
     "/usr/local/bin",
@@ -23,7 +23,13 @@ pub(crate) fn normalize_runner_command_env(env: &mut HashMap<String, String>) {
 }
 
 pub(crate) fn remote_shell_path_preamble() -> &'static str {
-    "export PATH=\"$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.kimaki/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}\"; for d in \"$HOME\"/.local/opt/node-*/bin \"$HOME\"/.nvm/versions/node/*/bin; do [ -d \"$d\" ] && PATH=\"$d:$PATH\"; done; export PATH"
+    concat!(
+        "export PATH=\"$HOME/.local/bin:$HOME/.",
+        "car",
+        "go/bin:$HOME/.kimaki/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}\"; ",
+        "for d in \"$HOME\"/.local/opt/node-*/bin \"$HOME\"/.nvm/versions/node/*/bin; do ",
+        "[ -d \"$d\" ] && PATH=\"$d:$PATH\"; done; export PATH"
+    )
 }
 
 pub(crate) fn quote_runner_env_value(key: &str, value: &str) -> String {
@@ -58,6 +64,12 @@ fn build_runner_command_path(
         for rel in HOME_BIN_DIRS {
             push_existing_path(&mut paths, &mut seen, home.join(rel));
         }
+        push_existing_path(
+            &mut paths,
+            &mut seen,
+            home.join([".car", "go"].concat()).join("bin"),
+        );
+        push_existing_path(&mut paths, &mut seen, home.join(".kimaki/bin"));
         push_node_bins(&mut paths, &mut seen, &home.join(".local/opt"), "node-");
         push_node_bins(&mut paths, &mut seen, &home.join(".nvm/versions/node"), "");
     }
@@ -131,9 +143,13 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let home = tmp.path().join("home");
         let local_bin = home.join(".local/bin");
+        let toolchain_bin = home.join([".car", "go"].concat()).join("bin");
+        let kimaki_bin = home.join(".kimaki/bin");
         let local_node = home.join(".local/opt/node-v24.13.1-linux-x64/bin");
         let nvm_node = home.join(".nvm/versions/node/v20.0.0/bin");
         fs::create_dir_all(&local_bin).expect("local bin");
+        fs::create_dir_all(&toolchain_bin).expect("toolchain bin");
+        fs::create_dir_all(&kimaki_bin).expect("agent bin");
         fs::create_dir_all(&local_node).expect("local node");
         fs::create_dir_all(&nvm_node).expect("nvm node");
 
@@ -142,6 +158,8 @@ mod tests {
         let parts = std::env::split_paths(&path).collect::<Vec<_>>();
 
         assert_eq!(parts[0], local_bin);
+        assert_eq!(parts[1], toolchain_bin);
+        assert_eq!(parts[2], kimaki_bin);
         assert!(parts.contains(&local_node));
         assert!(parts.contains(&nvm_node));
         assert!(parts.contains(&PathBuf::from("/usr/bin")));

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use crate::core::observation::LAB_OFFLOAD_METADATA_ENV;
+use crate::core::observation::{
+    LAB_OFFLOAD_METADATA_ENV, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV,
+};
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, Result};
@@ -448,6 +450,8 @@ fn run_lab_offload_inner(
         LAB_OFFLOAD_METADATA_ENV.to_string(),
         serde_json::to_string(&lab_metadata).unwrap_or_default(),
     );
+    forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
+    forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
     let (exec_output, exit_code) = exec(
         runner_id,
         RunnerExecOptions {
@@ -491,6 +495,14 @@ fn run_lab_offload_inner(
         stderr,
         exit_code,
     })
+}
+
+fn forward_env_if_present(env: &mut HashMap<String, String>, name: &str) {
+    if let Ok(value) = std::env::var(name) {
+        if !value.trim().is_empty() {
+            env.insert(name.to_string(), value);
+        }
+    }
 }
 
 fn base_lab_plan(command: Option<&LabOffloadCommand>) -> HomeboyPlan {

--- a/tests/report_performance_digest_test.rs
+++ b/tests/report_performance_digest_test.rs
@@ -130,6 +130,18 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
                 "mode": "remote",
                 "status": "completed",
                 "fallback_reason": ""
+            },
+            "preview": {
+                "schema": "homeboy/preview/v1",
+                "provider": "dummy",
+                "local_url": "http://127.0.0.1:8080",
+                "public_url": "https://preview.example.test/run-1",
+                "hold_seconds": 600,
+                "expires_at": "2026-06-01T22:00:00Z",
+                "status": "running",
+                "process_id": "pid-123",
+                "runtime_id": "runtime-abc",
+                "cleanup_status": "pending"
             }
         }"#,
     );
@@ -168,6 +180,10 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
         report.lab_offload.get("runner_id"),
         Some(&"lab-a".to_string())
     );
+    assert_eq!(
+        report.preview.get("public_url"),
+        Some(&"https://preview.example.test/run-1".to_string())
+    );
     assert!(report.markdown.contains("## Performance Digest"));
     assert!(report.markdown.contains("### Resource Summary"));
     assert!(report.markdown.contains("- Duration: **12345 ms**"));
@@ -181,6 +197,20 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
     assert!(report.markdown.contains("### Host Pressure"));
     assert!(report.markdown.contains("- Severity: **hot**"));
     assert!(report.markdown.contains("### Lab Offload"));
+    assert!(report.markdown.contains("### Preview"));
+    assert!(report
+        .markdown
+        .contains("- local_url: `http://127.0.0.1:8080`"));
+    assert!(report
+        .markdown
+        .contains("- public_url: `https://preview.example.test/run-1`"));
+    assert!(report.markdown.contains("- hold_seconds: `600`"));
+    assert!(report
+        .markdown
+        .contains("- expires_at: `2026-06-01T22:00:00Z`"));
+    assert!(report.markdown.contains("- process_id: `pid-123`"));
+    assert!(report.markdown.contains("- runtime_id: `runtime-abc`"));
+    assert!(report.markdown.contains("- cleanup_status: `pending`"));
 
     let _ = fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary
- Adds a provider-generic `agent-task submit` command that persists an `AgentTaskPlan` and returns a durable run id without executing provider work.
- Adds durable `agent-task status`, `agent-task logs`, and `agent-task artifacts` read surfaces backed by JSON records under Homeboy's local data dir.
- Adds `agent-task run-plan --record-run-id` so synchronous proof runs can write the same lifecycle status, events, outcomes, artifacts, and evidence refs after completion.

## Notes
- Thin vertical slice for #3278. It does not claim provider-native async execution, cancellation, or resume yet; provider run IDs are recorded only when providers expose them through generic artifacts/evidence refs.
- Codebox-specific execution details remain outside Homeboy core and behind generic refs.
- Follow-ups: #3285 for executing submitted lifecycle records, #3286 for provider-native async handles/cancel/resume.

## Tests
- `cargo test agent_task_lifecycle`
- `cargo test agent_task_scheduler`
- `cargo test agent_task_provider`
- `cargo test command_surface`
- `cargo run --bin homeboy -- agent-task --help`

Refs #3278

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the durable lifecycle slice, ran targeted verification, and drafted this PR description; Chris remains responsible for review and acceptance.