### PR TITLE
Preserve generic preview metadata

### DIFF
--- a/docs/architecture/preview-metadata.md
+++ b/docs/architecture/preview-metadata.md
@@ -1,0 +1,45 @@
+# Preview Metadata
+
+Homeboy preserves generic preview metadata without owning public-access setup.
+Commands, extensions, wrappers, or external integrations can emit preview facts
+through environment variables, and Homeboy stores them on persisted run metadata
+and renders them in report digests.
+
+## Contract
+
+Set `HOMEBOY_PREVIEW_JSON` to a JSON object. Recommended fields:
+
+```json
+{
+  "schema": "homeboy/preview/v1",
+  "provider": "dummy",
+  "local_url": "http://127.0.0.1:8080",
+  "public_url": "https://preview.example.test/run-1",
+  "hold_seconds": 600,
+  "expires_at": "2026-06-01T22:00:00Z",
+  "status": "running",
+  "process_id": "pid-123",
+  "runtime_id": "runtime-abc",
+  "cleanup_status": "pending"
+}
+```
+
+`HOMEBOY_PREVIEW_PUBLIC_URL` may be set by a caller or integration that creates
+public access. When present, Homeboy copies it into `public_url` if the preview
+object does not already contain that field.
+
+Homeboy does not create tunnels, publish previews, or know about product-specific
+runtimes. Public access is supplied by the caller/integration.
+
+## Persistence
+
+When a command records an observation run, Homeboy stores the object at
+`metadata.preview`. Lab offload forwards `HOMEBOY_PREVIEW_JSON` and
+`HOMEBOY_PREVIEW_PUBLIC_URL` to the runner so offloaded commands preserve the
+same caller-supplied preview facts.
+
+## Reporting
+
+`homeboy report performance-digest` renders scalar preview fields in a
+`Preview` section, including local URL, public URL, hold/expiry, lifecycle
+status, runtime/process ID, and cleanup status when available.

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ Internal system architecture and internals:
 - [Planned change execution](architecture/planned-change-execution.md) - Core lifecycle vocabulary for plan, execute, artifact, approve, apply, and publish
 - [Apply and publish contract](architecture/apply-publish-contract.md) - Local apply boundary and post-apply publish semantics
 - [Agent task executor adapter](architecture/agent-task-executor-adapter.md) - Provider-neutral adapter boundary for Codebox, CLI/OpenCode, and runner backends
+- [Preview metadata](architecture/preview-metadata.md) - Generic preview URL, hold, lifecycle, runtime, and cleanup metadata preserved across runs
 - [Scope model](architecture/scope-model.md) - Components, targets/projects, rigs, fleets, workspace, and paths
 - [Execution context](architecture/execution-context.md) - Runtime context for extensions
 - [Rig matrix axis composition](architecture/rig-matrix-axis-composition.md) - Design for derived rig variants

--- a/src/commands/report/performance_digest.rs
+++ b/src/commands/report/performance_digest.rs
@@ -51,6 +51,8 @@ pub struct PerformanceDigestReport {
     pub host_pressure: Option<HostPressureDigest>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub lab_offload: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub preview: BTreeMap<String, String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub gaps: Vec<String>,
 }
@@ -157,6 +159,9 @@ pub fn performance_digest_from_args(
     let lab_offload = find_object_recursive(&metadata, "lab_offload")
         .map(scalar_object)
         .unwrap_or_default();
+    let preview = find_object_recursive(&metadata, "preview")
+        .map(scalar_object)
+        .unwrap_or_default();
 
     let mut baseline_health =
         collect_baseline_health(&bench_data, args.min_samples, args.max_cv_pct);
@@ -182,6 +187,7 @@ pub fn performance_digest_from_args(
         &baseline_health,
         host_pressure.as_ref(),
         &lab_offload,
+        &preview,
         &gaps,
         args.run_url.as_deref().unwrap_or_default(),
     );
@@ -194,6 +200,7 @@ pub fn performance_digest_from_args(
         baseline_health,
         host_pressure,
         lab_offload,
+        preview,
         gaps,
     })
 }
@@ -569,6 +576,7 @@ mod helpers {
         baseline_health: &[BaselineHealthDiagnostic],
         host_pressure: Option<&HostPressureDigest>,
         lab_offload: &BTreeMap<String, String>,
+        preview: &BTreeMap<String, String>,
         gaps: &[String],
         run_url: &str,
     ) -> String {
@@ -580,6 +588,7 @@ mod helpers {
         render_baseline_health(&mut out, baseline_health);
         render_host_pressure(&mut out, host_pressure);
         render_lab_offload(&mut out, lab_offload);
+        render_preview(&mut out, preview);
         render_gaps(&mut out, gaps);
         if !run_url.is_empty() {
             let _ = writeln!(out, "### Full run\n- {}\n", run_url);
@@ -754,6 +763,43 @@ mod helpers {
         out.push_str("### Lab Offload\n");
         for (key, value) in lab_offload {
             let _ = writeln!(out, "- {}: `{}`", key, value);
+        }
+        out.push('\n');
+    }
+
+    pub(super) fn render_preview(out: &mut String, preview: &BTreeMap<String, String>) {
+        if preview.is_empty() {
+            return;
+        }
+        out.push_str("### Preview\n");
+        for key in [
+            "status",
+            "local_url",
+            "public_url",
+            "hold_seconds",
+            "expires_at",
+            "process_id",
+            "runtime_id",
+            "cleanup_status",
+        ] {
+            if let Some(value) = preview.get(key) {
+                let _ = writeln!(out, "- {}: `{}`", key, value);
+            }
+        }
+        for (key, value) in preview {
+            if !matches!(
+                key.as_str(),
+                "status"
+                    | "local_url"
+                    | "public_url"
+                    | "hold_seconds"
+                    | "expires_at"
+                    | "process_id"
+                    | "runtime_id"
+                    | "cleanup_status"
+            ) {
+                let _ = writeln!(out, "- {}: `{}`", key, value);
+            }
         }
         out.push('\n');
     }

--- a/src/core/observation/context.rs
+++ b/src/core/observation/context.rs
@@ -2,6 +2,8 @@ use serde::Serialize;
 
 pub const SOURCE_SNAPSHOT_METADATA_ENV: &str = "HOMEBOY_SOURCE_SNAPSHOT_JSON";
 pub const LAB_OFFLOAD_METADATA_ENV: &str = "HOMEBOY_LAB_OFFLOAD_JSON";
+pub const PREVIEW_METADATA_ENV: &str = "HOMEBOY_PREVIEW_JSON";
+pub const PREVIEW_PUBLIC_URL_ENV: &str = "HOMEBOY_PREVIEW_PUBLIC_URL";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RunContext {
@@ -21,6 +23,7 @@ impl RunContext {
         Self::from_provenance(RunProvenance {
             source_snapshot: env_json(SOURCE_SNAPSHOT_METADATA_ENV),
             lab_offload: env_json(LAB_OFFLOAD_METADATA_ENV),
+            preview: preview_metadata_from_env(),
             artifact_mirror: None,
         })
     }
@@ -35,6 +38,7 @@ impl RunContext {
 pub struct RunProvenance {
     pub source_snapshot: Option<serde_json::Value>,
     pub lab_offload: Option<serde_json::Value>,
+    pub preview: Option<serde_json::Value>,
     pub artifact_mirror: Option<serde_json::Value>,
 }
 
@@ -46,6 +50,11 @@ impl RunProvenance {
 
     pub fn with_lab_offload(mut self, lab_offload: impl Serialize) -> Self {
         self.lab_offload = serde_json::to_value(lab_offload).ok();
+        self
+    }
+
+    pub fn with_preview(mut self, preview: impl Serialize) -> Self {
+        self.preview = serde_json::to_value(preview).ok();
         self
     }
 
@@ -61,6 +70,9 @@ impl RunProvenance {
         if self.lab_offload.is_none() {
             self.lab_offload = fallback.lab_offload;
         }
+        if self.preview.is_none() {
+            self.preview = fallback.preview;
+        }
         if self.artifact_mirror.is_none() {
             self.artifact_mirror = fallback.artifact_mirror;
         }
@@ -72,4 +84,50 @@ fn env_json(name: &str) -> Option<serde_json::Value> {
     std::env::var(name)
         .ok()
         .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+}
+
+fn preview_metadata_from_env() -> Option<serde_json::Value> {
+    let mut preview = env_json(PREVIEW_METADATA_ENV)?;
+    if let Ok(public_url) = std::env::var(PREVIEW_PUBLIC_URL_ENV) {
+        if !public_url.trim().is_empty() {
+            if let Some(object) = preview.as_object_mut() {
+                object
+                    .entry("public_url")
+                    .or_insert_with(|| serde_json::Value::String(public_url));
+            }
+        }
+    }
+    Some(preview)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RunContext, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
+
+    #[test]
+    fn subprocess_context_reads_generic_preview_metadata_with_public_url_overlay() {
+        std::env::set_var(
+            PREVIEW_METADATA_ENV,
+            r#"{"schema":"homeboy/preview/v1","local_url":"http://127.0.0.1:8080","hold_seconds":600,"expires_at":"2026-06-01T22:00:00Z","status":"running","process_id":"pid-123","runtime_id":"runtime-abc","cleanup_status":"pending"}"#,
+        );
+        std::env::set_var(PREVIEW_PUBLIC_URL_ENV, "https://preview.example.test/run-1");
+
+        let context = RunContext::subprocess_compatibility_from_env();
+        let preview = context
+            .provenance
+            .preview
+            .expect("preview metadata should be captured");
+
+        assert_eq!(preview["schema"], "homeboy/preview/v1");
+        assert_eq!(preview["local_url"], "http://127.0.0.1:8080");
+        assert_eq!(preview["public_url"], "https://preview.example.test/run-1");
+        assert_eq!(preview["hold_seconds"], 600);
+        assert_eq!(preview["status"], "running");
+        assert_eq!(preview["process_id"], "pid-123");
+        assert_eq!(preview["runtime_id"], "runtime-abc");
+        assert_eq!(preview["cleanup_status"], "pending");
+
+        std::env::remove_var(PREVIEW_METADATA_ENV);
+        std::env::remove_var(PREVIEW_PUBLIC_URL_ENV);
+    }
 }

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -28,7 +28,7 @@ pub use records::{
 };
 pub use store::{
     ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION, LAB_OFFLOAD_METADATA_ENV,
-    SOURCE_SNAPSHOT_METADATA_ENV,
+    PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV, SOURCE_SNAPSHOT_METADATA_ENV,
 };
 pub(crate) use test_findings::{
     finding_records_from_failure_clusters, finding_records_from_test_analysis_input,

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -10,7 +10,10 @@ mod schema;
 mod triage_items;
 
 use super::context::RunContext;
-pub use super::context::{LAB_OFFLOAD_METADATA_ENV, SOURCE_SNAPSHOT_METADATA_ENV};
+pub use super::context::{
+    LAB_OFFLOAD_METADATA_ENV, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV,
+    SOURCE_SNAPSHOT_METADATA_ENV,
+};
 use super::records::{
     ArtifactCleanupCandidateRecord, ArtifactCleanupFilter, ArtifactRecord, FindingListFilter,
     FindingRecord, NewFindingRecord, NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord,
@@ -883,6 +886,9 @@ fn with_run_context_metadata(
     }
     if let Some(lab_offload) = &context.provenance.lab_offload {
         additions.push(("lab_offload".to_string(), lab_offload.clone()));
+    }
+    if let Some(preview) = &context.provenance.preview {
+        additions.push(("preview".to_string(), preview.clone()));
     }
     if let Some(artifact_mirror) = &context.provenance.artifact_mirror {
         additions.push(("artifact_mirror".to_string(), artifact_mirror.clone()));

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use crate::core::observation::LAB_OFFLOAD_METADATA_ENV;
+use crate::core::observation::{
+    LAB_OFFLOAD_METADATA_ENV, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV,
+};
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, Result};
@@ -448,6 +450,8 @@ fn run_lab_offload_inner(
         LAB_OFFLOAD_METADATA_ENV.to_string(),
         serde_json::to_string(&lab_metadata).unwrap_or_default(),
     );
+    forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
+    forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
     let (exec_output, exit_code) = exec(
         runner_id,
         RunnerExecOptions {
@@ -491,6 +495,14 @@ fn run_lab_offload_inner(
         stderr,
         exit_code,
     })
+}
+
+fn forward_env_if_present(env: &mut HashMap<String, String>, name: &str) {
+    if let Ok(value) = std::env::var(name) {
+        if !value.trim().is_empty() {
+            env.insert(name.to_string(), value);
+        }
+    }
 }
 
 fn base_lab_plan(command: Option<&LabOffloadCommand>) -> HomeboyPlan {

--- a/tests/report_performance_digest_test.rs
+++ b/tests/report_performance_digest_test.rs
@@ -130,6 +130,18 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
                 "mode": "remote",
                 "status": "completed",
                 "fallback_reason": ""
+            },
+            "preview": {
+                "schema": "homeboy/preview/v1",
+                "provider": "dummy",
+                "local_url": "http://127.0.0.1:8080",
+                "public_url": "https://preview.example.test/run-1",
+                "hold_seconds": 600,
+                "expires_at": "2026-06-01T22:00:00Z",
+                "status": "running",
+                "process_id": "pid-123",
+                "runtime_id": "runtime-abc",
+                "cleanup_status": "pending"
             }
         }"#,
     );
@@ -168,6 +180,10 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
         report.lab_offload.get("runner_id"),
         Some(&"lab-a".to_string())
     );
+    assert_eq!(
+        report.preview.get("public_url"),
+        Some(&"https://preview.example.test/run-1".to_string())
+    );
     assert!(report.markdown.contains("## Performance Digest"));
     assert!(report.markdown.contains("### Resource Summary"));
     assert!(report.markdown.contains("- Duration: **12345 ms**"));
@@ -181,6 +197,20 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
     assert!(report.markdown.contains("### Host Pressure"));
     assert!(report.markdown.contains("- Severity: **hot**"));
     assert!(report.markdown.contains("### Lab Offload"));
+    assert!(report.markdown.contains("### Preview"));
+    assert!(report
+        .markdown
+        .contains("- local_url: `http://127.0.0.1:8080`"));
+    assert!(report
+        .markdown
+        .contains("- public_url: `https://preview.example.test/run-1`"));
+    assert!(report.markdown.contains("- hold_seconds: `600`"));
+    assert!(report
+        .markdown
+        .contains("- expires_at: `2026-06-01T22:00:00Z`"));
+    assert!(report.markdown.contains("- process_id: `pid-123`"));
+    assert!(report.markdown.contains("- runtime_id: `runtime-abc`"));
+    assert!(report.markdown.contains("- cleanup_status: `pending`"));
 
     let _ = fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary
- Add generic `HOMEBOY_PREVIEW_JSON` provenance support with optional caller-supplied `HOMEBOY_PREVIEW_PUBLIC_URL` overlay.
- Persist preview metadata on observation runs and forward the generic preview env through Lab offload without adding public-access or product-specific runtime coupling.
- Render preview lifecycle/access fields in performance digests and document the generic contract with a dummy provider example.

Closes #3281.

## Tests
- `cargo test core::observation::context::tests::subprocess_context_reads_generic_preview_metadata_with_public_url_overlay`
- `cargo test --test report_performance_digest_test renders_resource_summary_budget_findings_and_baseline_health`
- `cargo test core::runner::lab::tests::plan_records_skipped_auto_offload`
- `cargo test --test architecture_core_agnostic_test`
- `cargo test --test report_performance_digest_test`
- `homeboy lint --path . --extension rust`

## Known check issue
- `homeboy test --path . --extension rust` was run and reached `3706 passed; 5 failed; 18 ignored`. The failures appear unrelated to this preview metadata change: missing local `zip` binary in deploy archive tests, an existing temp rig baseline path issue, source snapshot workspace-root assumption, and a reverse broker localhost connection race.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic preview metadata contract, tests, docs, and verification commands for Chris to review.