### PR TITLE
feat(agent-task): run submitted lifecycle records

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -18,6 +18,8 @@ pub struct AgentTaskArgs {
 pub enum AgentTaskCommand {
     /// Run an agent-task plan through extension-declared executor providers.
     RunPlan(RunPlanArgs),
+    /// Execute a previously submitted durable agent-task run.
+    Run(StatusArgs),
     /// Persist an agent-task plan and return a durable run id without executing it.
     Submit(SubmitArgs),
     /// Read durable agent-task run status.
@@ -59,6 +61,7 @@ pub struct StatusArgs {
 pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     match args.command {
         AgentTaskCommand::RunPlan(run_args) => run_plan(run_args),
+        AgentTaskCommand::Run(status_args) => run_submitted(status_args),
         AgentTaskCommand::Submit(submit_args) => submit(submit_args),
         AgentTaskCommand::Status(status_args) => status(status_args),
         AgentTaskCommand::Logs(status_args) => logs(status_args),
@@ -74,6 +77,26 @@ fn run_plan(args: RunPlanArgs) -> CmdResult<Value> {
     if let Some(run_id) = args.record_run_id.as_deref() {
         agent_task_lifecycle::record_completed_run(&plan, &aggregate, Some(run_id))?;
     }
+    let exit_code = if aggregate.totals.failed == 0
+        && aggregate.totals.cancelled == 0
+        && aggregate.totals.timed_out == 0
+    {
+        0
+    } else {
+        1
+    };
+    Ok((
+        serde_json::to_value(aggregate).unwrap_or(Value::Null),
+        exit_code,
+    ))
+}
+
+fn run_submitted(args: StatusArgs) -> CmdResult<Value> {
+    let plan = agent_task_lifecycle::load_plan(&args.run_id)?;
+    agent_task_lifecycle::mark_running(&args.run_id)?;
+    let scheduler = AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::discover());
+    let aggregate = scheduler.run(plan.clone());
+    agent_task_lifecycle::record_run_aggregate(&args.run_id, &plan, &aggregate)?;
     let exit_code = if aggregate.totals.failed == 0
         && aggregate.totals.cancelled == 0
         && aggregate.totals.timed_out == 0

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -130,6 +130,41 @@ pub fn record_completed_run(
     requested_run_id: Option<&str>,
 ) -> Result<AgentTaskRunRecord> {
     let mut record = submit_plan(plan, requested_run_id)?;
+    record_aggregate(&mut record, plan, aggregate)
+}
+
+pub fn load_plan(run_id: &str) -> Result<AgentTaskPlan> {
+    let record = read_record(&sanitize_run_id(run_id))?;
+    read_plan_path(&PathBuf::from(record.plan_path))
+}
+
+pub fn mark_running(run_id: &str) -> Result<AgentTaskRunRecord> {
+    let mut record = read_record(&sanitize_run_id(run_id))?;
+    record.state = AgentTaskRunState::Running;
+    record.updated_at = Some(now_timestamp());
+    for task in &mut record.tasks {
+        if task.state == AgentTaskState::Queued {
+            task.state = AgentTaskState::Running;
+        }
+    }
+    write_record(&record)?;
+    Ok(record)
+}
+
+pub fn record_run_aggregate(
+    run_id: &str,
+    plan: &AgentTaskPlan,
+    aggregate: &AgentTaskAggregate,
+) -> Result<AgentTaskRunRecord> {
+    let mut record = read_record(&sanitize_run_id(run_id))?;
+    record_aggregate(&mut record, plan, aggregate)
+}
+
+fn record_aggregate(
+    record: &mut AgentTaskRunRecord,
+    plan: &AgentTaskPlan,
+    aggregate: &AgentTaskAggregate,
+) -> Result<AgentTaskRunRecord> {
     let aggregate_path = run_dir(&record.run_id)?.join("aggregate.json");
     write_json(&aggregate_path, aggregate)?;
     record.state = run_state_for_aggregate(aggregate);
@@ -138,7 +173,7 @@ pub fn record_completed_run(
     record.tasks = tasks_for_aggregate(plan, aggregate);
     record.artifact_refs = artifact_refs_for_outcomes(&aggregate.outcomes);
     write_record(&record)?;
-    Ok(record)
+    Ok(record.clone())
 }
 
 pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
@@ -297,6 +332,17 @@ fn read_record(run_id: &str) -> Result<AgentTaskRunRecord> {
 
 fn read_aggregate(run_id: &str) -> Result<AgentTaskAggregate> {
     let path = run_dir(run_id)?.join("aggregate.json");
+    read_aggregate_path(&path)
+}
+
+fn read_plan_path(path: &PathBuf) -> Result<AgentTaskPlan> {
+    let raw = fs::read_to_string(path)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    serde_json::from_str(&raw)
+        .map_err(|error| Error::internal_json(error.to_string(), Some(path.display().to_string())))
+}
+
+fn read_aggregate_path(path: &PathBuf) -> Result<AgentTaskAggregate> {
     let raw = fs::read_to_string(&path)
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
     serde_json::from_str(&raw)
@@ -446,6 +492,57 @@ mod tests {
             assert_eq!(log.events[0].state, AgentTaskState::Succeeded);
             assert_eq!(artifacts.artifacts[0].id, "patch");
             assert_eq!(artifacts.evidence_refs[0].kind, "transcript");
+        });
+    }
+
+    #[test]
+    fn submitted_run_can_be_loaded_marked_running_and_completed() {
+        with_temp_home(|| {
+            let plan = test_plan();
+            submit_plan(&plan, Some("run-execute")).expect("submitted");
+
+            let loaded_plan = load_plan("run-execute").expect("plan loaded");
+            let running = mark_running("run-execute").expect("marked running");
+            let aggregate = AgentTaskAggregate {
+                schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+                plan_id: loaded_plan.plan_id.clone(),
+                status: AgentTaskAggregateStatus::Succeeded,
+                totals: AgentTaskAggregateTotals {
+                    queued: 1,
+                    succeeded: 1,
+                    ..AgentTaskAggregateTotals::default()
+                },
+                outcomes: vec![AgentTaskOutcome {
+                    schema: crate::core::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: "task-a".to_string(),
+                    status: crate::core::agent_task::AgentTaskOutcomeStatus::Succeeded,
+                    summary: Some("ok".to_string()),
+                    failure_classification: None,
+                    artifacts: Vec::new(),
+                    evidence_refs: Vec::new(),
+                    diagnostics: Vec::new(),
+                    workflow: None,
+                    follow_up: None,
+                    metadata: Value::Null,
+                }],
+                events: vec![AgentTaskProgressEvent {
+                    task_id: "task-a".to_string(),
+                    state: AgentTaskState::Succeeded,
+                    attempt: 1,
+                    message: Some("ok".to_string()),
+                }],
+                queue: Default::default(),
+            };
+
+            let completed =
+                record_run_aggregate("run-execute", &loaded_plan, &aggregate).expect("completed");
+
+            assert_eq!(loaded_plan.plan_id, "plan-a");
+            assert_eq!(running.state, AgentTaskRunState::Running);
+            assert_eq!(running.tasks[0].state, AgentTaskState::Running);
+            assert_eq!(completed.state, AgentTaskRunState::Succeeded);
+            assert_eq!(completed.tasks[0].state, AgentTaskState::Succeeded);
+            assert!(completed.aggregate_path.is_some());
         });
     }
 


### PR DESCRIPTION
## Summary
- Adds `agent-task run <run_id>` to execute a previously submitted durable lifecycle record without needing the original plan path.
- Marks submitted records `running` before dispatch and records the final aggregate, events, outcomes, artifacts, and evidence refs back to the same run id.
- Keeps execution routed through the existing provider-generic scheduler and extension provider adapter.

## Stack
- Stacked on #3284.
- Follows #3285.

## Tests
- `cargo test agent_task_lifecycle`
- `cargo test agent_task_scheduler`
- `cargo test agent_task_provider`
- `cargo test command_surface`
- `cargo run --bin homeboy -- agent-task --help`

Refs #3285

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the submitted-run execution slice, ran targeted verification, and drafted this PR description; Chris remains responsible for review and acceptance.