### PR TITLE
Ship Lab dependency workspaces

### DIFF
--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -1,9 +1,12 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
+use serde::Serialize;
+
+use crate::core::component::{self, TargetSpec};
 use crate::core::observation::{
     LAB_OFFLOAD_METADATA_ENV, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV,
 };
@@ -13,12 +16,17 @@ use crate::core::{Error, Result};
 
 use super::{
     evaluate_lab_runner_capabilities_for_runner, exec, lab_offload_changed_since_ref,
-    lab_offload_metadata, lab_runner_capability_plan, load, preflight_lab_offload_changed_since,
-    prepare_git_lab_offload_changed_since, rig_materialization, status, sync_workspace,
-    LabRunnerCapabilityContract, LabRunnerGateDecision, LabRunnerGateMode,
-    RunnerCapabilityPreflight, RunnerConnectReport, RunnerExecOptions, RunnerRequiredTool,
-    RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+    lab_offload_metadata, lab_offload_metadata_with_workspace_mapping, lab_runner_capability_plan,
+    load, preflight_lab_offload_changed_since, prepare_git_lab_offload_changed_since,
+    rig_materialization, status, sync_workspace, LabRunnerCapabilityContract,
+    LabRunnerGateDecision, LabRunnerGateMode, RunnerCapabilityPreflight, RunnerConnectReport,
+    RunnerExecOptions, RunnerRequiredTool, RunnerStatusReport, RunnerTunnelMode,
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
+
+const LAB_EXTRA_WORKSPACES_ENV: &str = "HOMEBOY_LAB_EXTRA_WORKSPACES";
+const LAB_EXTRA_WORKSPACES_JSON_ENV: &str = "HOMEBOY_LAB_EXTRA_WORKSPACES_JSON";
+const LAB_WORKSPACE_MAPPING_SCHEMA: &str = "homeboy/workspace-map/v1";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LabRunnerSelectionSource {
@@ -91,6 +99,21 @@ pub enum LabOffloadOutcome {
         stderr: String,
         exit_code: i32,
     },
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct LabWorkspaceMappingEntry {
+    role: String,
+    local_path: String,
+    remote_path: String,
+    sync_mode: String,
+    snapshot_identity: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ExtraLabWorkspace {
+    role: String,
+    path: PathBuf,
 }
 
 pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadOutcome> {
@@ -360,6 +383,7 @@ fn run_lab_offload_inner(
     } else {
         preflight_lab_offload_changed_since(request.normalized_args, sync_mode)?
     };
+    let extra_workspaces = lab_extra_workspaces(&source_path)?;
     let synced = sync_workspace(
         runner_id,
         RunnerWorkspaceSyncOptions {
@@ -369,7 +393,8 @@ fn run_lab_offload_inner(
         },
     )?
     .0;
-    let remote_cwd = synced.remote_path;
+    let remote_cwd = synced.remote_path.clone();
+    let mut workspace_mapping = vec![workspace_mapping_entry("primary", &synced)];
     plan = with_step(
         plan,
         PlanStep::ready("lab.sync_workspace", "lab.sync_workspace")
@@ -387,6 +412,25 @@ fn run_lab_offload_inner(
             )
             .build(),
     );
+
+    let synced_extra_workspaces = sync_extra_lab_workspaces(
+        runner_id,
+        &synced.local_path,
+        extra_workspaces,
+        &mut workspace_mapping,
+    )?;
+    if !synced_extra_workspaces.is_empty() {
+        plan = with_step(
+            plan,
+            PlanStep::ready("lab.sync_extra_workspaces", "lab.sync_extra_workspaces")
+                .inputs(
+                    PlanValues::new()
+                        .json("count", synced_extra_workspaces.len())
+                        .json("workspaces", &synced_extra_workspaces),
+                )
+                .build(),
+        );
+    }
 
     let source_snapshot = SourceSnapshot::collect_local(
         runner_id,
@@ -436,7 +480,8 @@ fn run_lab_offload_inner(
         runner_id,
         remote_cwd
     );
-    let lab_metadata = lab_offload_metadata(
+    let workspace_mapping_metadata = lab_workspace_mapping_metadata(&workspace_mapping);
+    let lab_metadata = lab_offload_metadata_with_workspace_mapping(
         &plan,
         selection.source.metadata_value(),
         Some(runner_id),
@@ -444,12 +489,9 @@ fn run_lab_offload_inner(
         "offloaded",
         Some(&remote_cwd),
         None,
+        Some(&workspace_mapping_metadata),
     );
-    let mut env = HashMap::new();
-    env.insert(
-        LAB_OFFLOAD_METADATA_ENV.to_string(),
-        serde_json::to_string(&lab_metadata).unwrap_or_default(),
-    );
+    let mut env = build_lab_offload_env(&lab_metadata);
     forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
     forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
     let (exec_output, exit_code) = exec(
@@ -503,6 +545,201 @@ fn forward_env_if_present(env: &mut HashMap<String, String>, name: &str) {
             env.insert(name.to_string(), value);
         }
     }
+}
+
+fn build_lab_offload_env(lab_metadata: &serde_json::Value) -> HashMap<String, String> {
+    HashMap::from([(
+        LAB_OFFLOAD_METADATA_ENV.to_string(),
+        serde_json::to_string(lab_metadata).unwrap_or_default(),
+    )])
+}
+
+fn sync_extra_lab_workspaces(
+    runner_id: &str,
+    primary_local_path: &str,
+    extra_workspaces: Vec<ExtraLabWorkspace>,
+    workspace_mapping: &mut Vec<LabWorkspaceMappingEntry>,
+) -> Result<Vec<LabWorkspaceMappingEntry>> {
+    let primary = canonical_existing_dir(primary_local_path, "path")?;
+    let mut seen = HashSet::from([primary]);
+    let mut synced_entries = Vec::new();
+
+    for extra in extra_workspaces {
+        let local_path = canonical_existing_dir(&extra.path.display().to_string(), "workspace")?;
+        if !seen.insert(local_path.clone()) {
+            continue;
+        }
+        let synced = sync_workspace(
+            runner_id,
+            RunnerWorkspaceSyncOptions {
+                path: local_path.display().to_string(),
+                mode: RunnerWorkspaceSyncMode::Snapshot,
+                changed_since_base: None,
+            },
+        )?
+        .0;
+        let entry = workspace_mapping_entry(&extra.role, &synced);
+        workspace_mapping.push(entry.clone());
+        synced_entries.push(entry);
+    }
+
+    Ok(synced_entries)
+}
+
+fn workspace_mapping_entry(
+    role: impl Into<String>,
+    synced: &RunnerWorkspaceSyncOutput,
+) -> LabWorkspaceMappingEntry {
+    LabWorkspaceMappingEntry {
+        role: role.into(),
+        local_path: synced.local_path.clone(),
+        remote_path: synced.remote_path.clone(),
+        sync_mode: match synced.sync_mode {
+            RunnerWorkspaceSyncMode::Snapshot => "snapshot".to_string(),
+            RunnerWorkspaceSyncMode::Git => "git".to_string(),
+        },
+        snapshot_identity: synced.snapshot_identity.clone(),
+    }
+}
+
+fn lab_workspace_mapping_metadata(
+    workspace_mapping: &[LabWorkspaceMappingEntry],
+) -> serde_json::Value {
+    let local_to_remote = workspace_mapping
+        .iter()
+        .map(|entry| {
+            (
+                entry.local_path.clone(),
+                serde_json::Value::String(entry.remote_path.clone()),
+            )
+        })
+        .collect::<serde_json::Map<_, _>>();
+    serde_json::json!({
+        "schema": LAB_WORKSPACE_MAPPING_SCHEMA,
+        "workspaces": workspace_mapping,
+        "local_to_remote": local_to_remote,
+    })
+}
+
+fn lab_extra_workspaces(source_path: &Path) -> Result<Vec<ExtraLabWorkspace>> {
+    let mut workspaces = accepted_extra_lab_workspaces()?;
+    workspaces.extend(discovered_validation_dependency_workspaces(source_path)?);
+    Ok(workspaces)
+}
+
+fn accepted_extra_lab_workspaces() -> Result<Vec<ExtraLabWorkspace>> {
+    let mut paths = Vec::new();
+    if let Ok(raw) = std::env::var(LAB_EXTRA_WORKSPACES_JSON_ENV) {
+        if !raw.trim().is_empty() {
+            let parsed: Vec<String> = serde_json::from_str(&raw).map_err(|err| {
+                Error::validation_invalid_argument(
+                    LAB_EXTRA_WORKSPACES_JSON_ENV,
+                    format!("{LAB_EXTRA_WORKSPACES_JSON_ENV} must be a JSON array of paths: {err}"),
+                    Some(raw.clone()),
+                    None,
+                )
+            })?;
+            paths.extend(parsed);
+        }
+    }
+    if let Ok(raw) = std::env::var(LAB_EXTRA_WORKSPACES_ENV) {
+        paths.extend(
+            raw.lines()
+                .flat_map(|line| line.split(','))
+                .map(str::trim)
+                .filter(|path| !path.is_empty())
+                .map(str::to_string),
+        );
+    }
+
+    paths
+        .into_iter()
+        .map(|path| {
+            Ok(ExtraLabWorkspace {
+                role: "extra".to_string(),
+                path: canonical_existing_dir(&path, "extra_workspace")?,
+            })
+        })
+        .collect()
+}
+
+fn discovered_validation_dependency_workspaces(
+    source_path: &Path,
+) -> Result<Vec<ExtraLabWorkspace>> {
+    let source_path_string = source_path.display().to_string();
+    let Ok(target) = component::resolve_target(TargetSpec {
+        component_id: None,
+        path_override: Some(&source_path_string),
+        project: None,
+        capability: None,
+        allow_synthetic: true,
+        accept_bare_directory: true,
+    }) else {
+        return Ok(Vec::new());
+    };
+    let Some(extensions) = target.component.extensions.as_ref() else {
+        return Ok(Vec::new());
+    };
+
+    let mut workspaces = Vec::new();
+    for config in extensions.values() {
+        let Some(dependencies) = config.settings.get("validation_dependencies") else {
+            continue;
+        };
+        let Some(dependencies) = dependencies.as_array() else {
+            continue;
+        };
+        for dependency in dependencies.iter().filter_map(|value| value.as_str()) {
+            let path = resolve_dependency_workspace_path(dependency)?;
+            workspaces.push(ExtraLabWorkspace {
+                role: "dependency".to_string(),
+                path,
+            });
+        }
+    }
+
+    Ok(workspaces)
+}
+
+fn resolve_dependency_workspace_path(dependency: &str) -> Result<PathBuf> {
+    let expanded = shellexpand::tilde(dependency).to_string();
+    if Path::new(&expanded).is_dir() {
+        return canonical_existing_dir(&expanded, "validation_dependencies");
+    }
+
+    let component = component::resolve_effective(Some(dependency), None, None).map_err(|err| {
+        Error::validation_invalid_argument(
+            "validation_dependencies",
+            format!(
+                "Lab offload cannot resolve validation dependency `{dependency}` to a local checkout: {}",
+                err.message
+            ),
+            Some(dependency.to_string()),
+            Some(vec![
+                "Register the dependency component locally, or pass an explicit checkout path via HOMEBOY_LAB_EXTRA_WORKSPACES_JSON.".to_string(),
+            ]),
+        )
+    })?;
+    canonical_existing_dir(&component.local_path, "validation_dependencies")
+}
+
+fn canonical_existing_dir(path: &str, field: &str) -> Result<PathBuf> {
+    let expanded = shellexpand::tilde(path).to_string();
+    let path = Path::new(&expanded);
+    if !path.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            field,
+            format!("Lab offload workspace path must be an existing directory: {expanded}"),
+            Some(expanded),
+            None,
+        ));
+    }
+    path.canonicalize().map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("canonicalize Lab workspace path".to_string()),
+        )
+    })
 }
 
 fn base_lab_plan(command: Option<&LabOffloadCommand>) -> HomeboyPlan {
@@ -1076,6 +1313,72 @@ mod tests {
             lab_offload_source_path(&args).expect("path"),
             std::path::PathBuf::from("/Users/chubes/Developer/project")
         );
+    }
+
+    #[test]
+    fn lab_workspace_mapping_metadata_records_local_to_remote_paths() {
+        let snapshot = RunnerWorkspaceSyncOutput {
+            command: "runner.workspace.sync",
+            runner_id: "lab".to_string(),
+            local_path: "/Users/chubes/Developer/app".to_string(),
+            remote_path: "/srv/homeboy/_lab_workspaces/app-abc".to_string(),
+            sync_mode: RunnerWorkspaceSyncMode::Snapshot,
+            snapshot_identity: "snapshot:abc".to_string(),
+            files: 3,
+            bytes: 12,
+            excludes: Vec::new(),
+        };
+        let git = RunnerWorkspaceSyncOutput {
+            command: "runner.workspace.sync",
+            runner_id: "lab".to_string(),
+            local_path: "/Users/chubes/Developer/dep".to_string(),
+            remote_path: "/srv/homeboy/_lab_workspaces/dep-def".to_string(),
+            sync_mode: RunnerWorkspaceSyncMode::Git,
+            snapshot_identity: "abc123".to_string(),
+            files: 0,
+            bytes: 0,
+            excludes: Vec::new(),
+        };
+
+        let entries = vec![
+            workspace_mapping_entry("primary", &snapshot),
+            workspace_mapping_entry("dependency", &git),
+        ];
+        let metadata = lab_workspace_mapping_metadata(&entries);
+
+        assert_eq!(metadata["schema"], LAB_WORKSPACE_MAPPING_SCHEMA);
+        assert_eq!(metadata["workspaces"][0]["role"], "primary");
+        assert_eq!(metadata["workspaces"][0]["sync_mode"], "snapshot");
+        assert_eq!(metadata["workspaces"][1]["role"], "dependency");
+        assert_eq!(metadata["workspaces"][1]["sync_mode"], "git");
+        assert_eq!(
+            metadata["local_to_remote"]["/Users/chubes/Developer/dep"],
+            "/srv/homeboy/_lab_workspaces/dep-def"
+        );
+    }
+
+    #[test]
+    fn lab_offload_env_contains_workspace_mapping_metadata() {
+        let mapping = serde_json::json!({
+            "schema": LAB_WORKSPACE_MAPPING_SCHEMA,
+            "local_to_remote": {
+                "/Users/chubes/Developer/app": "/srv/homeboy/_lab_workspaces/app-abc"
+            },
+            "workspaces": []
+        });
+        let metadata = serde_json::json!({
+            "schema": "homeboy/lab-offload/v1",
+            "workspace_mapping": mapping,
+        });
+
+        let env = build_lab_offload_env(&metadata);
+        let parsed: serde_json::Value = serde_json::from_str(
+            env.get(LAB_OFFLOAD_METADATA_ENV)
+                .expect("lab offload env metadata"),
+        )
+        .expect("parse lab offload metadata");
+
+        assert_eq!(parsed["workspace_mapping"], mapping);
     }
 
     #[test]

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -52,7 +52,10 @@ pub use offload_changed_since::{
     lab_offload_changed_since_ref, preflight_lab_offload_changed_since,
     prepare_git_lab_offload_changed_since,
 };
-pub use offload_metadata::{capture_lab_offload_subprocess_metadata, lab_offload_metadata};
+pub use offload_metadata::{
+    capture_lab_offload_subprocess_metadata, lab_offload_metadata,
+    lab_offload_metadata_with_workspace_mapping,
+};
 pub(crate) use resource_metrics::measured_command_output;
 pub use resource_metrics::RunnerResourceMetrics;
 pub use session::{

--- a/src/core/runner/offload_metadata.rs
+++ b/src/core/runner/offload_metadata.rs
@@ -11,6 +11,29 @@ pub fn lab_offload_metadata(
     remote_workspace: Option<&str>,
     fallback_reason: Option<&str>,
 ) -> serde_json::Value {
+    lab_offload_metadata_with_workspace_mapping(
+        plan,
+        source,
+        runner_id,
+        runner_mode,
+        status,
+        remote_workspace,
+        fallback_reason,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn lab_offload_metadata_with_workspace_mapping(
+    plan: &HomeboyPlan,
+    source: &str,
+    runner_id: Option<&str>,
+    runner_mode: Option<&str>,
+    status: &str,
+    remote_workspace: Option<&str>,
+    fallback_reason: Option<&str>,
+    workspace_mapping: Option<&serde_json::Value>,
+) -> serde_json::Value {
     let sync_mode = plan_step_input_string(plan, "lab.sync_workspace", "mode");
     serde_json::json!({
         "schema": LAB_OFFLOAD_METADATA_SCHEMA,
@@ -25,6 +48,7 @@ pub fn lab_offload_metadata(
         "capability_preflight": plan_step_status(plan, "lab.capability_preflight"),
         "extension_parity": plan_step_status(plan, "lab.extension_parity"),
         "patch_captured": plan_has_step(plan, "lab.apply_patch"),
+        "workspace_mapping": workspace_mapping,
     })
 }
 
@@ -65,7 +89,10 @@ pub fn capture_lab_offload_subprocess_metadata(metadata: serde_json::Value) {
 
 #[cfg(test)]
 mod tests {
-    use super::{lab_offload_metadata, LAB_OFFLOAD_METADATA_SCHEMA};
+    use super::{
+        lab_offload_metadata, lab_offload_metadata_with_workspace_mapping,
+        LAB_OFFLOAD_METADATA_SCHEMA,
+    };
     use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
 
     fn lab_plan() -> HomeboyPlan {
@@ -121,6 +148,7 @@ mod tests {
         assert_eq!(explicit["capability_preflight"], "success");
         assert_eq!(explicit["extension_parity"], "ready");
         assert_eq!(explicit["patch_captured"], true);
+        assert!(explicit["workspace_mapping"].is_null());
         assert!(explicit["fallback_reason"].is_null());
 
         let fallback = lab_offload_metadata(
@@ -153,5 +181,35 @@ mod tests {
         assert_eq!(skipped["status"], "skipped");
         assert!(skipped["runner_id"].is_null());
         assert_eq!(skipped["fallback_reason"], "no_default_runner");
+    }
+
+    #[test]
+    fn lab_offload_metadata_records_workspace_mapping_when_supplied() {
+        let plan = lab_plan();
+        let mapping = serde_json::json!({
+            "schema": "homeboy/workspace-map/v1",
+            "workspaces": [
+                {
+                    "role": "primary",
+                    "local_path": "/Users/chubes/Developer/app",
+                    "remote_path": "/srv/homeboy/_lab_workspaces/app-abc",
+                    "sync_mode": "snapshot",
+                    "snapshot_identity": "snapshot:abc"
+                }
+            ]
+        });
+
+        let metadata = lab_offload_metadata_with_workspace_mapping(
+            &plan,
+            "explicit",
+            Some("lab"),
+            Some("direct_ssh"),
+            "offloaded",
+            Some("/srv/homeboy/_lab_workspaces/app-abc"),
+            None,
+            Some(&mapping),
+        );
+
+        assert_eq!(metadata["workspace_mapping"], mapping);
     }
 }


### PR DESCRIPTION
## Summary
- Adds a generic Lab workspace mapping contract to `HOMEBOY_LAB_OFFLOAD_JSON` so remote hot commands can translate local checkout paths to synced runner paths.
- Syncs accepted extra workspaces and discovered `validation_dependencies` checkouts as snapshot workspaces under the runner `workspace_root` while preserving the existing primary checkout flow.
- Records focused Lab plan/env metadata tests for the new mapping contract.

## Verification
- `cargo test lab_` passed.
- `cargo test` was run; it failed in two tests that are outside this Lab change:
  - `commands::trace::tests::rig_trace_list_uses_scoped_workload_preflight` could not find local extension `nodejs`.
  - `core::deploy::safety_and_artifact::tests::test_deploy_artifact_flattens_double_nested_plugin_zip` hit the existing double-nested deploy safety rejection.

## Issues
- Fixes https://github.com/Extra-Chill/homeboy/issues/3293
- Related: https://github.com/Extra-Chill/homeboy/issues/3292

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing Lab dependency shipping.