### PR TITLE
fix(bench): offload settings matrix runs to lab

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -301,7 +301,7 @@ impl Commands {
             ),
             Commands::Bench(args) => quality_json_descriptor(
                 output_file_mode,
-                args.is_run_command(),
+                args.is_lab_offload_command(),
                 args.lab_offload_writes_local_state()
                     .then_some("--baseline/--ratchet"),
                 CommandOutputContractKind::JsonEnvelope,
@@ -1046,6 +1046,15 @@ mod tests {
         assert!(parsed_command(&["homeboy", "refactor", "--from", "audit"]).supports_lab_runner());
         assert!(parsed_command(&["homeboy", "refactor", "--all"]).supports_lab_runner());
         assert!(parsed_command(&["homeboy", "bench"]).supports_lab_runner());
+        assert!(parsed_command(&[
+            "homeboy",
+            "bench",
+            "matrix",
+            "--setting-matrix",
+            "clients=10,100"
+        ])
+        .supports_lab_runner());
+        assert!(parsed_command(&["homeboy", "bench", "history", "homeboy"]).supports_lab_runner());
         assert!(parsed_command(&["homeboy", "trace"]).supports_lab_runner());
         assert!(!parsed_command(&[
             "homeboy", "refactor", "rename", "--from", "old", "--to", "new",
@@ -1071,6 +1080,20 @@ mod tests {
             (parsed_command(&["homeboy", "test"]), "test"),
             (parsed_command(&["homeboy", "audit"]), "audit"),
             (parsed_command(&["homeboy", "bench"]), "bench"),
+            (
+                parsed_command(&[
+                    "homeboy",
+                    "bench",
+                    "matrix",
+                    "--setting-matrix",
+                    "clients=10,100",
+                ]),
+                "bench",
+            ),
+            (
+                parsed_command(&["homeboy", "bench", "history", "homeboy"]),
+                "bench",
+            ),
             (parsed_command(&["homeboy", "trace"]), "trace"),
             (
                 parsed_command(&["homeboy", "refactor", "--from", "audit"]),

--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -43,7 +43,7 @@ impl Commands {
             Commands::Audit(args) if args.changed_since.is_none() && !args.conventions => {
                 lab_portable_contract("audit", None, true, LAB_NO_EXTRA_TOOLS)
             }
-            Commands::Bench(args) if args.is_run_command() => lab_portable_contract(
+            Commands::Bench(args) if args.is_lab_offload_command() => lab_portable_contract(
                 "bench",
                 args.lab_offload_writes_local_state()
                     .then_some("--baseline/--ratchet"),

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -36,16 +36,33 @@ pub struct BenchArgs {
 }
 
 impl BenchArgs {
-    pub fn is_run_command(&self) -> bool {
-        self.command.is_none()
+    pub fn is_lab_offload_command(&self) -> bool {
+        matches!(
+            self.command,
+            None | Some(BenchCommand::Matrix(_)) | Some(BenchCommand::History(_))
+        )
     }
 
     pub fn lab_offload_writes_local_state(&self) -> bool {
-        self.run.baseline_args.baseline || self.run.baseline_args.ratchet
+        self.run_args_for_lab_offload()
+            .is_some_and(|run| run.baseline_args.baseline || run.baseline_args.ratchet)
     }
 
     pub fn extension_override_ids(&self) -> &[String] {
-        &self.run.extension_override.extensions
+        self.run_args_for_lab_offload()
+            .map(|run| run.extension_override.extensions.as_slice())
+            .unwrap_or(&[])
+    }
+
+    fn run_args_for_lab_offload(&self) -> Option<&BenchRunArgs> {
+        match &self.command {
+            None => Some(&self.run),
+            Some(BenchCommand::Matrix(args)) => Some(args.run_args()),
+            Some(BenchCommand::History(_)) => None,
+            Some(BenchCommand::List(_))
+            | Some(BenchCommand::Distribution(_))
+            | Some(BenchCommand::Compare(_)) => None,
+        }
     }
 }
 

--- a/src/commands/bench/settings_matrix.rs
+++ b/src/commands/bench/settings_matrix.rs
@@ -22,6 +22,12 @@ pub(super) struct BenchMatrixArgs {
     setting_matrix: Vec<String>,
 }
 
+impl BenchMatrixArgs {
+    pub(super) fn run_args(&self) -> &BenchRunArgs {
+        &self.run
+    }
+}
+
 #[derive(Serialize)]
 pub struct BenchSettingsMatrixOutput {
     pub command: &'static str,
@@ -100,11 +106,7 @@ pub(super) fn run_settings_matrix(
     for (index, settings) in cells.into_iter().enumerate() {
         let mut child_args = run_args.clone();
         child_args.status_file = None;
-        child_args.setting_args.setting.extend(
-            settings
-                .iter()
-                .map(|(name, value)| (name.clone(), value.clone())),
-        );
+        apply_matrix_settings(&mut child_args, &settings);
         let (output, exit_code) = match child_args.rig.first() {
             Some(rig_id) => {
                 bench_runner::run_single_rig(&child_args, &passthrough_args, rig_id.clone())?
@@ -228,6 +230,57 @@ fn expand_setting_matrix_cells(
     cells
 }
 
+fn apply_matrix_settings(child_args: &mut BenchRunArgs, settings: &BTreeMap<String, String>) {
+    let mut json_roots = BTreeMap::<String, serde_json::Value>::new();
+
+    for (name, value) in settings {
+        if let Some((root, path)) = name.split_once('.') {
+            if root.is_empty() || path.is_empty() {
+                child_args
+                    .setting_args
+                    .setting
+                    .push((name.clone(), value.clone()));
+                continue;
+            }
+            let root_value = json_roots
+                .entry(root.to_string())
+                .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+            insert_json_path(root_value, path.split('.'), value.clone());
+        } else {
+            child_args
+                .setting_args
+                .setting
+                .push((name.clone(), value.clone()));
+        }
+    }
+
+    child_args.setting_args.setting_json.extend(json_roots);
+}
+
+fn insert_json_path<'a, I>(target: &mut serde_json::Value, mut path: I, value: String)
+where
+    I: Iterator<Item = &'a str>,
+{
+    let Some(segment) = path.next() else {
+        *target = serde_json::Value::String(value);
+        return;
+    };
+
+    if path.size_hint().0 == 0 {
+        if let serde_json::Value::Object(map) = target {
+            map.insert(segment.to_string(), serde_json::Value::String(value));
+        }
+        return;
+    }
+
+    if let serde_json::Value::Object(map) = target {
+        let child = map
+            .entry(segment.to_string())
+            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+        insert_json_path(child, path, value);
+    }
+}
+
 fn extract_run_id(hints: &[String]) -> Option<String> {
     hints
         .iter()
@@ -339,6 +392,52 @@ mod tests {
         assert_eq!(cells[0]["batch_size"], "1");
         assert_eq!(cells[3]["clients"], "100");
         assert_eq!(cells[3]["batch_size"], "25");
+    }
+
+    #[test]
+    fn applies_dotted_setting_axes_as_typed_json_settings() {
+        #[derive(Parser)]
+        struct MatrixCli {
+            #[command(flatten)]
+            bench: BenchMatrixArgs,
+        }
+
+        let mut args = MatrixCli::parse_from([
+            "homeboy",
+            "--setting-matrix",
+            "clients=10",
+            "--iterations",
+            "1",
+        ])
+        .bench
+        .run
+        .clone();
+        let mut settings = BTreeMap::new();
+        settings.insert(
+            "bench_env.GUTENBERG_RTC_CLIENTS".to_string(),
+            "100".to_string(),
+        );
+        settings.insert(
+            "bench_env.GUTENBERG_RTC_BATCH_SIZE".to_string(),
+            "25".to_string(),
+        );
+        settings.insert("wp_codebox_bin".to_string(), "/tmp/wp-codebox".to_string());
+
+        apply_matrix_settings(&mut args, &settings);
+
+        assert_eq!(
+            args.setting_args.setting,
+            vec![("wp_codebox_bin".to_string(), "/tmp/wp-codebox".to_string())]
+        );
+        assert_eq!(args.setting_args.setting_json.len(), 1);
+        assert_eq!(args.setting_args.setting_json[0].0, "bench_env");
+        assert_eq!(
+            args.setting_args.setting_json[0].1,
+            serde_json::json!({
+                "GUTENBERG_RTC_BATCH_SIZE": "25",
+                "GUTENBERG_RTC_CLIENTS": "100"
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Enables Lab offload contracts for `bench matrix` and `bench history`, while keeping local-only bench subcommands excluded.
- Preserves matrix subcommand extension overrides for runner extension parity checks.
- Adds dotted `--setting-matrix` axes so cells can vary typed JSON settings such as `bench_env.GUTENBERG_RTC_CLIENTS`.

Fixes #3298.

## Tests
- `cargo test test_supports_lab_runner`
- `cargo test test_lab_command_contracts_cover_hot_commands`
- `cargo test commands::bench::settings_matrix::tests`
- `cargo test cli_surface::tests`
- `cargo test --test architecture_core_agnostic_test`
- `cargo test --test command_surface_test`
- `cargo test --test output_contracts_test`
- `cargo run --bin homeboy -- bench matrix --help`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the lab-offload failure, drafting the focused code change and tests, and running verification commands. Chris remains responsible for review and merge.