### PR TITLE
fix(runner): centralize Lab workspace labels

### DIFF
--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -1,15 +1,9 @@
-use std::collections::{HashMap, HashSet};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use serde::Serialize;
-
-use crate::core::component::{self, TargetSpec};
-use crate::core::observation::{
-    LAB_OFFLOAD_METADATA_ENV, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV,
-};
+use crate::core::observation::{PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, Result};
@@ -21,12 +15,14 @@ use super::{
     rig_materialization, status, sync_workspace, LabRunnerCapabilityContract,
     LabRunnerGateDecision, LabRunnerGateMode, RunnerCapabilityPreflight, RunnerConnectReport,
     RunnerExecOptions, RunnerRequiredTool, RunnerStatusReport, RunnerTunnelMode,
-    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
 
-const LAB_EXTRA_WORKSPACES_ENV: &str = "HOMEBOY_LAB_EXTRA_WORKSPACES";
-const LAB_EXTRA_WORKSPACES_JSON_ENV: &str = "HOMEBOY_LAB_EXTRA_WORKSPACES_JSON";
-const LAB_WORKSPACE_MAPPING_SCHEMA: &str = "homeboy/workspace-map/v1";
+use super::lab_env::{build_lab_offload_env, forward_env_if_present};
+use super::lab_workspaces::{
+    lab_extra_workspaces, lab_workspace_mapping_metadata, sync_extra_lab_workspaces,
+    workspace_mapping_entry,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LabRunnerSelectionSource {
@@ -99,21 +95,6 @@ pub enum LabOffloadOutcome {
         stderr: String,
         exit_code: i32,
     },
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-struct LabWorkspaceMappingEntry {
-    role: String,
-    local_path: String,
-    remote_path: String,
-    sync_mode: String,
-    snapshot_identity: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ExtraLabWorkspace {
-    role: String,
-    path: PathBuf,
 }
 
 pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadOutcome> {
@@ -402,13 +383,7 @@ fn run_lab_offload_inner(
                 PlanValues::new()
                     .string("local_path", &synced.local_path)
                     .string("remote_path", &remote_cwd)
-                    .string(
-                        "mode",
-                        match sync_mode {
-                            RunnerWorkspaceSyncMode::Snapshot => "snapshot",
-                            RunnerWorkspaceSyncMode::Git => "git",
-                        },
-                    ),
+                    .string("mode", sync_mode.label()),
             )
             .build(),
     );
@@ -536,209 +511,6 @@ fn run_lab_offload_inner(
         stdout: exec_output.stdout,
         stderr,
         exit_code,
-    })
-}
-
-fn forward_env_if_present(env: &mut HashMap<String, String>, name: &str) {
-    if let Ok(value) = std::env::var(name) {
-        if !value.trim().is_empty() {
-            env.insert(name.to_string(), value);
-        }
-    }
-}
-
-fn build_lab_offload_env(lab_metadata: &serde_json::Value) -> HashMap<String, String> {
-    HashMap::from([(
-        LAB_OFFLOAD_METADATA_ENV.to_string(),
-        serde_json::to_string(lab_metadata).unwrap_or_default(),
-    )])
-}
-
-fn sync_extra_lab_workspaces(
-    runner_id: &str,
-    primary_local_path: &str,
-    extra_workspaces: Vec<ExtraLabWorkspace>,
-    workspace_mapping: &mut Vec<LabWorkspaceMappingEntry>,
-) -> Result<Vec<LabWorkspaceMappingEntry>> {
-    let primary = canonical_existing_dir(primary_local_path, "path")?;
-    let mut seen = HashSet::from([primary]);
-    let mut synced_entries = Vec::new();
-
-    for extra in extra_workspaces {
-        let local_path = canonical_existing_dir(&extra.path.display().to_string(), "workspace")?;
-        if !seen.insert(local_path.clone()) {
-            continue;
-        }
-        let synced = sync_workspace(
-            runner_id,
-            RunnerWorkspaceSyncOptions {
-                path: local_path.display().to_string(),
-                mode: RunnerWorkspaceSyncMode::Snapshot,
-                changed_since_base: None,
-            },
-        )?
-        .0;
-        let entry = workspace_mapping_entry(&extra.role, &synced);
-        workspace_mapping.push(entry.clone());
-        synced_entries.push(entry);
-    }
-
-    Ok(synced_entries)
-}
-
-fn workspace_mapping_entry(
-    role: impl Into<String>,
-    synced: &RunnerWorkspaceSyncOutput,
-) -> LabWorkspaceMappingEntry {
-    LabWorkspaceMappingEntry {
-        role: role.into(),
-        local_path: synced.local_path.clone(),
-        remote_path: synced.remote_path.clone(),
-        sync_mode: match synced.sync_mode {
-            RunnerWorkspaceSyncMode::Snapshot => "snapshot".to_string(),
-            RunnerWorkspaceSyncMode::Git => "git".to_string(),
-        },
-        snapshot_identity: synced.snapshot_identity.clone(),
-    }
-}
-
-fn lab_workspace_mapping_metadata(
-    workspace_mapping: &[LabWorkspaceMappingEntry],
-) -> serde_json::Value {
-    let local_to_remote = workspace_mapping
-        .iter()
-        .map(|entry| {
-            (
-                entry.local_path.clone(),
-                serde_json::Value::String(entry.remote_path.clone()),
-            )
-        })
-        .collect::<serde_json::Map<_, _>>();
-    serde_json::json!({
-        "schema": LAB_WORKSPACE_MAPPING_SCHEMA,
-        "workspaces": workspace_mapping,
-        "local_to_remote": local_to_remote,
-    })
-}
-
-fn lab_extra_workspaces(source_path: &Path) -> Result<Vec<ExtraLabWorkspace>> {
-    let mut workspaces = accepted_extra_lab_workspaces()?;
-    workspaces.extend(discovered_validation_dependency_workspaces(source_path)?);
-    Ok(workspaces)
-}
-
-fn accepted_extra_lab_workspaces() -> Result<Vec<ExtraLabWorkspace>> {
-    let mut paths = Vec::new();
-    if let Ok(raw) = std::env::var(LAB_EXTRA_WORKSPACES_JSON_ENV) {
-        if !raw.trim().is_empty() {
-            let parsed: Vec<String> = serde_json::from_str(&raw).map_err(|err| {
-                Error::validation_invalid_argument(
-                    LAB_EXTRA_WORKSPACES_JSON_ENV,
-                    format!("{LAB_EXTRA_WORKSPACES_JSON_ENV} must be a JSON array of paths: {err}"),
-                    Some(raw.clone()),
-                    None,
-                )
-            })?;
-            paths.extend(parsed);
-        }
-    }
-    if let Ok(raw) = std::env::var(LAB_EXTRA_WORKSPACES_ENV) {
-        paths.extend(
-            raw.lines()
-                .flat_map(|line| line.split(','))
-                .map(str::trim)
-                .filter(|path| !path.is_empty())
-                .map(str::to_string),
-        );
-    }
-
-    paths
-        .into_iter()
-        .map(|path| {
-            Ok(ExtraLabWorkspace {
-                role: "extra".to_string(),
-                path: canonical_existing_dir(&path, "extra_workspace")?,
-            })
-        })
-        .collect()
-}
-
-fn discovered_validation_dependency_workspaces(
-    source_path: &Path,
-) -> Result<Vec<ExtraLabWorkspace>> {
-    let source_path_string = source_path.display().to_string();
-    let Ok(target) = component::resolve_target(TargetSpec {
-        component_id: None,
-        path_override: Some(&source_path_string),
-        project: None,
-        capability: None,
-        allow_synthetic: true,
-        accept_bare_directory: true,
-    }) else {
-        return Ok(Vec::new());
-    };
-    let Some(extensions) = target.component.extensions.as_ref() else {
-        return Ok(Vec::new());
-    };
-
-    let mut workspaces = Vec::new();
-    for config in extensions.values() {
-        let Some(dependencies) = config.settings.get("validation_dependencies") else {
-            continue;
-        };
-        let Some(dependencies) = dependencies.as_array() else {
-            continue;
-        };
-        for dependency in dependencies.iter().filter_map(|value| value.as_str()) {
-            let path = resolve_dependency_workspace_path(dependency)?;
-            workspaces.push(ExtraLabWorkspace {
-                role: "dependency".to_string(),
-                path,
-            });
-        }
-    }
-
-    Ok(workspaces)
-}
-
-fn resolve_dependency_workspace_path(dependency: &str) -> Result<PathBuf> {
-    let expanded = shellexpand::tilde(dependency).to_string();
-    if Path::new(&expanded).is_dir() {
-        return canonical_existing_dir(&expanded, "validation_dependencies");
-    }
-
-    let component = component::resolve_effective(Some(dependency), None, None).map_err(|err| {
-        Error::validation_invalid_argument(
-            "validation_dependencies",
-            format!(
-                "Lab offload cannot resolve validation dependency `{dependency}` to a local checkout: {}",
-                err.message
-            ),
-            Some(dependency.to_string()),
-            Some(vec![
-                "Register the dependency component locally, or pass an explicit checkout path via HOMEBOY_LAB_EXTRA_WORKSPACES_JSON.".to_string(),
-            ]),
-        )
-    })?;
-    canonical_existing_dir(&component.local_path, "validation_dependencies")
-}
-
-fn canonical_existing_dir(path: &str, field: &str) -> Result<PathBuf> {
-    let expanded = shellexpand::tilde(path).to_string();
-    let path = Path::new(&expanded);
-    if !path.is_dir() {
-        return Err(Error::validation_invalid_argument(
-            field,
-            format!("Lab offload workspace path must be an existing directory: {expanded}"),
-            Some(expanded),
-            None,
-        ));
-    }
-    path.canonicalize().map_err(|err| {
-        Error::internal_io(
-            err.to_string(),
-            Some("canonicalize Lab workspace path".to_string()),
-        )
     })
 }
 
@@ -1195,7 +967,10 @@ fn has_docker_signal(source_path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::super::lab_workspaces::LAB_WORKSPACE_MAPPING_SCHEMA;
     use super::*;
+    use crate::core::observation::LAB_OFFLOAD_METADATA_ENV;
+    use crate::core::runner::RunnerWorkspaceSyncOutput;
 
     fn portable_lab_command(label: &'static str) -> LabOffloadCommand {
         LabOffloadCommand {

--- a/src/core/runner/lab_env.rs
+++ b/src/core/runner/lab_env.rs
@@ -1,0 +1,18 @@
+use std::collections::HashMap;
+
+use crate::core::observation::LAB_OFFLOAD_METADATA_ENV;
+
+pub(super) fn forward_env_if_present(env: &mut HashMap<String, String>, name: &str) {
+    if let Ok(value) = std::env::var(name) {
+        if !value.trim().is_empty() {
+            env.insert(name.to_string(), value);
+        }
+    }
+}
+
+pub(super) fn build_lab_offload_env(lab_metadata: &serde_json::Value) -> HashMap<String, String> {
+    HashMap::from([(
+        LAB_OFFLOAD_METADATA_ENV.to_string(),
+        serde_json::to_string(lab_metadata).unwrap_or_default(),
+    )])
+}

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -1,0 +1,215 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::core::component::{self, TargetSpec};
+use crate::core::{Error, Result};
+
+use super::{
+    sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+};
+
+const LAB_EXTRA_WORKSPACES_ENV: &str = "HOMEBOY_LAB_EXTRA_WORKSPACES";
+const LAB_EXTRA_WORKSPACES_JSON_ENV: &str = "HOMEBOY_LAB_EXTRA_WORKSPACES_JSON";
+pub(super) const LAB_WORKSPACE_MAPPING_SCHEMA: &str = "homeboy/workspace-map/v1";
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(super) struct LabWorkspaceMappingEntry {
+    role: String,
+    local_path: String,
+    remote_path: String,
+    sync_mode: String,
+    snapshot_identity: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ExtraLabWorkspace {
+    role: String,
+    path: PathBuf,
+}
+
+pub(super) fn sync_extra_lab_workspaces(
+    runner_id: &str,
+    primary_local_path: &str,
+    extra_workspaces: Vec<ExtraLabWorkspace>,
+    workspace_mapping: &mut Vec<LabWorkspaceMappingEntry>,
+) -> Result<Vec<LabWorkspaceMappingEntry>> {
+    let primary = canonical_existing_dir(primary_local_path, "path")?;
+    let mut seen = HashSet::from([primary]);
+    let mut synced_entries = Vec::new();
+
+    for extra in extra_workspaces {
+        let local_path = canonical_existing_dir(&extra.path.display().to_string(), "workspace")?;
+        if !seen.insert(local_path.clone()) {
+            continue;
+        }
+        let synced = sync_workspace(
+            runner_id,
+            RunnerWorkspaceSyncOptions {
+                path: local_path.display().to_string(),
+                mode: RunnerWorkspaceSyncMode::Snapshot,
+                changed_since_base: None,
+            },
+        )?
+        .0;
+        let entry = workspace_mapping_entry(&extra.role, &synced);
+        workspace_mapping.push(entry.clone());
+        synced_entries.push(entry);
+    }
+
+    Ok(synced_entries)
+}
+
+pub(super) fn workspace_mapping_entry(
+    role: impl Into<String>,
+    synced: &RunnerWorkspaceSyncOutput,
+) -> LabWorkspaceMappingEntry {
+    LabWorkspaceMappingEntry {
+        role: role.into(),
+        local_path: synced.local_path.clone(),
+        remote_path: synced.remote_path.clone(),
+        sync_mode: synced.sync_mode.label().to_string(),
+        snapshot_identity: synced.snapshot_identity.clone(),
+    }
+}
+
+pub(super) fn lab_workspace_mapping_metadata(
+    workspace_mapping: &[LabWorkspaceMappingEntry],
+) -> serde_json::Value {
+    let local_to_remote = workspace_mapping
+        .iter()
+        .map(|entry| {
+            (
+                entry.local_path.clone(),
+                serde_json::Value::String(entry.remote_path.clone()),
+            )
+        })
+        .collect::<serde_json::Map<_, _>>();
+    serde_json::json!({
+        "schema": LAB_WORKSPACE_MAPPING_SCHEMA,
+        "workspaces": workspace_mapping,
+        "local_to_remote": local_to_remote,
+    })
+}
+
+pub(super) fn lab_extra_workspaces(source_path: &Path) -> Result<Vec<ExtraLabWorkspace>> {
+    let mut workspaces = accepted_extra_lab_workspaces()?;
+    workspaces.extend(discovered_validation_dependency_workspaces(source_path)?);
+    Ok(workspaces)
+}
+
+fn accepted_extra_lab_workspaces() -> Result<Vec<ExtraLabWorkspace>> {
+    let mut paths = Vec::new();
+    if let Ok(raw) = std::env::var(LAB_EXTRA_WORKSPACES_JSON_ENV) {
+        if !raw.trim().is_empty() {
+            let parsed: Vec<String> = serde_json::from_str(&raw).map_err(|err| {
+                Error::validation_invalid_argument(
+                    LAB_EXTRA_WORKSPACES_JSON_ENV,
+                    format!("{LAB_EXTRA_WORKSPACES_JSON_ENV} must be a JSON array of paths: {err}"),
+                    Some(raw.clone()),
+                    None,
+                )
+            })?;
+            paths.extend(parsed);
+        }
+    }
+    if let Ok(raw) = std::env::var(LAB_EXTRA_WORKSPACES_ENV) {
+        paths.extend(
+            raw.lines()
+                .flat_map(|line| line.split(','))
+                .map(str::trim)
+                .filter(|path| !path.is_empty())
+                .map(str::to_string),
+        );
+    }
+
+    paths
+        .into_iter()
+        .map(|path| {
+            Ok(ExtraLabWorkspace {
+                role: "extra".to_string(),
+                path: canonical_existing_dir(&path, "extra_workspace")?,
+            })
+        })
+        .collect()
+}
+
+fn discovered_validation_dependency_workspaces(
+    source_path: &Path,
+) -> Result<Vec<ExtraLabWorkspace>> {
+    let source_path_string = source_path.display().to_string();
+    let Ok(target) = component::resolve_target(TargetSpec {
+        component_id: None,
+        path_override: Some(&source_path_string),
+        project: None,
+        capability: None,
+        allow_synthetic: true,
+        accept_bare_directory: true,
+    }) else {
+        return Ok(Vec::new());
+    };
+    let Some(extensions) = target.component.extensions.as_ref() else {
+        return Ok(Vec::new());
+    };
+
+    let mut workspaces = Vec::new();
+    for config in extensions.values() {
+        let Some(dependencies) = config.settings.get("validation_dependencies") else {
+            continue;
+        };
+        let Some(dependencies) = dependencies.as_array() else {
+            continue;
+        };
+        for dependency in dependencies.iter().filter_map(|value| value.as_str()) {
+            let path = resolve_dependency_workspace_path(dependency)?;
+            workspaces.push(ExtraLabWorkspace {
+                role: "dependency".to_string(),
+                path,
+            });
+        }
+    }
+
+    Ok(workspaces)
+}
+
+fn resolve_dependency_workspace_path(dependency: &str) -> Result<PathBuf> {
+    let expanded = shellexpand::tilde(dependency).to_string();
+    if Path::new(&expanded).is_dir() {
+        return canonical_existing_dir(&expanded, "validation_dependencies");
+    }
+
+    let component = component::resolve_effective(Some(dependency), None, None).map_err(|err| {
+        Error::validation_invalid_argument(
+            "validation_dependencies",
+            format!(
+                "Lab offload cannot resolve validation dependency `{dependency}` to a local checkout: {}",
+                err.message
+            ),
+            Some(dependency.to_string()),
+            Some(vec![
+                "Register the dependency component locally, or pass an explicit checkout path via HOMEBOY_LAB_EXTRA_WORKSPACES_JSON.".to_string(),
+            ]),
+        )
+    })?;
+    canonical_existing_dir(&component.local_path, "validation_dependencies")
+}
+
+fn canonical_existing_dir(path: &str, field: &str) -> Result<PathBuf> {
+    let expanded = shellexpand::tilde(path).to_string();
+    let path = Path::new(&expanded);
+    if !path.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            field,
+            format!("Lab offload workspace path must be an existing directory: {expanded}"),
+            Some(expanded),
+            None,
+        ));
+    }
+    path.canonicalize().map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("canonicalize Lab workspace path".to_string()),
+        )
+    })
+}

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -17,6 +17,8 @@ mod connection;
 mod evidence;
 mod execution;
 mod lab;
+mod lab_env;
+mod lab_workspaces;
 mod offload_changed_since;
 mod offload_metadata;
 mod resource_metrics;

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -48,6 +48,15 @@ pub enum RunnerWorkspaceSyncMode {
     Git,
 }
 
+impl RunnerWorkspaceSyncMode {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Snapshot => "snapshot",
+            Self::Git => "git",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RunnerWorkspaceSyncOptions {
     pub path: String,


### PR DESCRIPTION
## Summary
- Centralizes `RunnerWorkspaceSyncMode` label rendering so Lab metadata uses a single enum contract.
- Splits Lab env/workspace mapping helpers into focused runner modules, keeping changed-scope audit from reintroducing the existing oversized `lab.rs` findings.
- Preserves the shipped Lab dependency workspace mapping behavior from #3294.

## Verification
- `cargo test lab_`
- `cargo test runner::workspace`
- `git diff --check`
- `homeboy audit --path . --extension rust --changed-since=origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the narrow follow-up refactor and ran local verification; Chris remains responsible for review and merge.