### PR TITLE
test(rig): cover packaged stack preservation

### DIFF
--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -131,7 +131,7 @@ homeboy rig install ./packages/studio
 homeboy rig install https://github.com/chubes4/homeboy-rigs.git//packages --all
 ```
 
-Installs rigs from a local directory or git-backed package. Package discovery accepts either a single `rig.json` or a package layout with `rigs/<id>/rig.json`. If the selected package also contains `stacks/*.json`, those stack specs are installed alongside the rig.
+Installs rigs from a local directory or git-backed package. Package discovery accepts either a single `rig.json` or a package layout with `rigs/<id>/rig.json`. If the selected package also contains `stacks/*.json`, those stack specs are installed alongside the rig. Existing stack specs with different content are treated as user-owned config and are left in place instead of being overwritten.
 
 Git sources may include a Terraform-style `repo.git//subpath` selector. Homeboy clones the package root, records source metadata, and discovers rigs from the selected subpath. Local package sources are linked in place and are updated outside Homeboy.
 

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -266,16 +266,18 @@ fn install_rejects_existing_stack_with_different_content() {
     let package = tempfile::tempdir().expect("package");
     write_rig(package.path(), "studio", &minimal_rig("studio"));
     write_stack(package.path(), "studio-combined", "studio");
+    let manual_stack = minimal_stack("studio-combined", "other");
 
     fs::create_dir_all(crate::core::paths::stacks().expect("stacks dir")).expect("stacks dir");
-    fs::write(
-        crate::core::paths::stack_config("studio-combined").expect("stack path"),
-        minimal_stack("studio-combined", "other"),
-    )
-    .expect("conflicting stack");
+    let stack_config = crate::core::paths::stack_config("studio-combined").expect("stack path");
+    fs::write(&stack_config, &manual_stack).expect("conflicting stack");
 
     let err = install(package.path().to_str().unwrap(), None, false).expect_err("stack collision");
     assert!(err.message.contains("different content"));
+    assert_eq!(
+        fs::read_to_string(stack_config).expect("manual stack preserved"),
+        manual_stack
+    );
 }
 
 #[test]

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -134,6 +134,28 @@ fn remove_source_preserves_replaced_config_but_drops_metadata() {
 }
 
 #[test]
+fn remove_source_preserves_replaced_stack_config_but_drops_metadata() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    write_stack(package.path(), "alpha-combined", "alpha");
+
+    install(package.path().to_str().unwrap(), None, false).expect("install");
+    let config = crate::core::paths::stack_config("alpha-combined").expect("stack config");
+    fs::remove_file(&config).expect("remove symlink");
+    fs::write(&config, minimal_stack("alpha-combined", "manual")).expect("replacement stack");
+
+    let result = remove_source(&package.path().to_string_lossy()).expect("remove source");
+
+    assert!(result.removed_stacks.is_empty());
+    assert_eq!(result.skipped_stacks.len(), 1);
+    assert!(config.exists());
+    assert!(!crate::core::paths::stack_source_metadata("alpha-combined")
+        .unwrap()
+        .exists());
+}
+
+#[test]
 fn remove_source_treats_copied_config_as_owned_when_contents_match() {
     let _home = HomeGuard::new();
     let package = tempfile::tempdir().expect("package");


### PR DESCRIPTION
## Summary
- Adds regression coverage that packaged stack install refuses to overwrite divergent user stack config.
- Adds source lifecycle coverage that removing a rig package preserves user-replaced stack config while dropping package metadata.
- Clarifies `homeboy rig install` docs for stack spec non-overwrite behavior.

Closes #3301.

## Tests
- `cargo fmt --check`
- `cargo test core::rig:: -- --nocapture`
- `cargo test core::stack:: -- --nocapture`

## Caveat
- `cargo test` was run and failed in unrelated existing tests: `commands::trace::tests::rig_trace_list_uses_scoped_workload_preflight` and `core::deploy::safety_and_artifact::tests::test_deploy_artifact_flattens_double_nested_plugin_zip`. The changed-area suites above pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Inspected the existing packaged stack lifecycle, added targeted preservation tests/docs, ran verification, and prepared this PR. Chris remains responsible for review and merge.