### PR TITLE
feat(trace): summarize named spans in reports

### DIFF
--- a/src/commands/report/failure_digest/trace.rs
+++ b/src/commands/report/failure_digest/trace.rs
@@ -65,6 +65,127 @@ fn render_trace_summary(
         }
         out.push('\n');
     }
+
+    render_trace_spans(out, data, results);
+}
+
+fn render_trace_spans(out: &mut String, data: &Map<String, Value>, results: &Map<String, Value>) {
+    let spans = collect_trace_spans(data, results);
+    if spans.is_empty() {
+        return;
+    }
+
+    out.push_str("**Spans**\n");
+    out.push_str("| Span | From | To | Duration | Status | Metadata |\n");
+    out.push_str("|---|---|---|---:|---|---|\n");
+    for span in spans {
+        let duration = span
+            .duration_ms
+            .map(|ms| format!("{ms}ms"))
+            .unwrap_or_else(|| "-".to_string());
+        let _ = writeln!(
+            out,
+            "| `{}` | `{}` | `{}` | {} | {} | {} |",
+            span.id, span.from, span.to, duration, span.status, span.metadata
+        );
+    }
+    out.push('\n');
+}
+
+#[derive(Debug, PartialEq)]
+struct TraceSpanRow {
+    id: String,
+    from: String,
+    to: String,
+    duration_ms: Option<u64>,
+    status: String,
+    metadata: String,
+}
+
+fn collect_trace_spans(
+    data: &Map<String, Value>,
+    results: &Map<String, Value>,
+) -> Vec<TraceSpanRow> {
+    let summaries = super::array_value(data, "span_summaries");
+    if !summaries.is_empty() {
+        return summaries
+            .iter()
+            .filter_map(|value| trace_span_row(value.as_object()?))
+            .collect();
+    }
+
+    let summaries = super::array_value(results, "span_summaries");
+    if !summaries.is_empty() {
+        return summaries
+            .iter()
+            .filter_map(|value| trace_span_row(value.as_object()?))
+            .collect();
+    }
+
+    super::array_value(results, "span_results")
+        .iter()
+        .filter_map(|value| trace_span_row(value.as_object()?))
+        .collect()
+}
+
+fn trace_span_row(span: &Map<String, Value>) -> Option<TraceSpanRow> {
+    let id = string_value(span, "id")?;
+    let from = string_value(span, "from")?;
+    let to = string_value(span, "to")?;
+    let duration_ms = span.get("duration_ms").and_then(Value::as_u64);
+    let mut status_parts = vec![string_value(span, "status").unwrap_or_else(|| "unknown".into())];
+    let missing = span
+        .get("missing")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if !missing.is_empty() {
+        status_parts.push(format!("missing `{}`", missing.join("`, `")));
+    }
+    if let Some(message) = string_value(span, "message") {
+        status_parts.push(message);
+    }
+    Some(TraceSpanRow {
+        id,
+        from,
+        to,
+        duration_ms,
+        status: status_parts.join(": "),
+        metadata: span
+            .get("metadata")
+            .and_then(Value::as_object)
+            .map(trace_span_metadata_label)
+            .filter(|label| !label.is_empty())
+            .unwrap_or_else(|| "-".to_string()),
+    })
+}
+
+fn trace_span_metadata_label(metadata: &Map<String, Value>) -> String {
+    let mut parts = Vec::new();
+    if let Some(category) = string_value(metadata, "category") {
+        parts.push(format!("category={category}"));
+    }
+    if let Some(blocks) = string_value(metadata, "blocks") {
+        parts.push(format!("blocks={blocks}"));
+    }
+    for key in [
+        "critical",
+        "blocking",
+        "cacheable",
+        "prewarmable",
+        "deferrable",
+    ] {
+        if metadata.get(key).and_then(Value::as_bool) == Some(true) {
+            parts.push(key.to_string());
+        }
+    }
+    parts.join(", ")
 }
 
 fn render_trace_artifacts(

--- a/src/commands/report/failure_digest/trace.rs
+++ b/src/commands/report/failure_digest/trace.rs
@@ -106,23 +106,20 @@ fn collect_trace_spans(
     data: &Map<String, Value>,
     results: &Map<String, Value>,
 ) -> Vec<TraceSpanRow> {
-    let summaries = super::array_value(data, "span_summaries");
-    if !summaries.is_empty() {
-        return summaries
-            .iter()
-            .filter_map(|value| trace_span_row(value.as_object()?))
-            .collect();
+    for summaries in [
+        super::array_value(data, "span_summaries"),
+        super::array_value(results, "span_summaries"),
+    ] {
+        if !summaries.is_empty() {
+            return trace_span_rows(summaries);
+        }
     }
 
-    let summaries = super::array_value(results, "span_summaries");
-    if !summaries.is_empty() {
-        return summaries
-            .iter()
-            .filter_map(|value| trace_span_row(value.as_object()?))
-            .collect();
-    }
+    trace_span_rows(super::array_value(results, "span_results"))
+}
 
-    super::array_value(results, "span_results")
+fn trace_span_rows(spans: Vec<&Value>) -> Vec<TraceSpanRow> {
+    spans
         .iter()
         .filter_map(|value| trace_span_row(value.as_object()?))
         .collect()

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -352,6 +352,7 @@ fn run_outputs(mut args: TraceArgs) -> CmdResult<(TraceCommandOutput, Option<Tra
 
     let summary_only = args.json_summary;
     let profile = resolved_profile_output_for_args(&args);
+    let span_metadata = trace_span_metadata_for_args(&args)?;
     let execution = execute_trace_run(args)?;
 
     let (mut stdout_output, mut artifact_output, exit_code) =
@@ -360,8 +361,10 @@ fn run_outputs(mut args: TraceArgs) -> CmdResult<(TraceCommandOutput, Option<Tra
             execution.rig_state,
             summary_only,
         );
+    extension_trace::attach_span_summary_metadata(&mut stdout_output, &span_metadata);
     attach_profile_output(&mut stdout_output, profile.clone());
     if let Some(output) = artifact_output.as_mut() {
+        extension_trace::attach_span_summary_metadata(output, &span_metadata);
         attach_profile_output(output, profile);
     }
     Ok(((stdout_output, artifact_output), exit_code))

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -17,6 +17,7 @@ pub mod parsing;
 pub mod probes;
 pub mod report;
 pub mod run;
+mod span_summary;
 pub mod spans;
 
 use crate::core::component::Component;
@@ -35,19 +36,19 @@ pub use parsing::{
 pub use parsing::{TraceAssertionStatus, TraceResults, TraceSpanDefinition, TraceSpanResult};
 pub use probes::{ActiveTraceProbes, TraceProbeConfig};
 pub use report::{
-    attach_span_summary_metadata, from_list_workflow, from_main_workflow,
-    from_main_workflow_outputs, TraceAggregateOutput, TraceAggregateRunOutput,
-    TraceAggregateSpanOutput, TraceClassificationSummaryOutput, TraceCommandOutput,
-    TraceCompareClassificationSummaryOutput, TraceCompareOutput, TraceCompareSpanOutput,
-    TraceGuardrailOutput, TraceListOutput, TraceOverlayLocksOutput, TraceProfileListItem,
-    TraceResolvedProfileOutput, TraceRunOrderEntryOutput, TraceSpanMetadata,
-    TraceSpanSummaryOutput, TraceVariantMatrixOutput, TraceVariantMatrixRunOutput,
+    from_list_workflow, from_main_workflow, from_main_workflow_outputs, TraceAggregateOutput,
+    TraceAggregateRunOutput, TraceAggregateSpanOutput, TraceClassificationSummaryOutput,
+    TraceCommandOutput, TraceCompareClassificationSummaryOutput, TraceCompareOutput,
+    TraceCompareSpanOutput, TraceGuardrailOutput, TraceListOutput, TraceOverlayLocksOutput,
+    TraceProfileListItem, TraceResolvedProfileOutput, TraceRunOrderEntryOutput, TraceSpanMetadata,
+    TraceVariantMatrixOutput, TraceVariantMatrixRunOutput,
 };
 pub use report::{push_overlay_markdown, render_markdown};
 pub use run::{
     run_trace_list_workflow, run_trace_workflow, trace_is_unclaimed, TraceListWorkflowArgs,
 };
 pub use run::{TraceRunWorkflowArgs, TraceRunWorkflowResult, TraceRunnerInputs};
+pub use span_summary::{attach_span_summary_metadata, TraceSpanSummaryOutput};
 
 pub fn resolve_trace_command(
     component: &Component,

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -35,12 +35,13 @@ pub use parsing::{
 pub use parsing::{TraceAssertionStatus, TraceResults, TraceSpanDefinition, TraceSpanResult};
 pub use probes::{ActiveTraceProbes, TraceProbeConfig};
 pub use report::{
-    from_list_workflow, from_main_workflow, from_main_workflow_outputs, TraceAggregateOutput,
-    TraceAggregateRunOutput, TraceAggregateSpanOutput, TraceClassificationSummaryOutput,
-    TraceCommandOutput, TraceCompareClassificationSummaryOutput, TraceCompareOutput,
-    TraceCompareSpanOutput, TraceGuardrailOutput, TraceListOutput, TraceOverlayLocksOutput,
-    TraceProfileListItem, TraceResolvedProfileOutput, TraceRunOrderEntryOutput, TraceSpanMetadata,
-    TraceVariantMatrixOutput, TraceVariantMatrixRunOutput,
+    attach_span_summary_metadata, from_list_workflow, from_main_workflow,
+    from_main_workflow_outputs, TraceAggregateOutput, TraceAggregateRunOutput,
+    TraceAggregateSpanOutput, TraceClassificationSummaryOutput, TraceCommandOutput,
+    TraceCompareClassificationSummaryOutput, TraceCompareOutput, TraceCompareSpanOutput,
+    TraceGuardrailOutput, TraceListOutput, TraceOverlayLocksOutput, TraceProfileListItem,
+    TraceResolvedProfileOutput, TraceRunOrderEntryOutput, TraceSpanMetadata,
+    TraceSpanSummaryOutput, TraceVariantMatrixOutput, TraceVariantMatrixRunOutput,
 };
 pub use report::{push_overlay_markdown, render_markdown};
 pub use run::{

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -5,10 +5,12 @@ use std::collections::BTreeMap;
 
 use super::baseline::TraceBaselineComparison;
 use super::overlay_lock::TraceOverlayLockRecord;
-use super::parsing::{
-    TraceArtifact, TraceAssertionStatus, TraceList, TraceResults, TraceSpanStatus,
-};
+use super::parsing::{TraceArtifact, TraceAssertionStatus, TraceList, TraceResults};
 use super::run::{TraceOverlay, TraceRunWorkflowResult};
+use super::span_summary::{
+    format_span_summary_metadata, format_span_summary_status, trace_span_summaries,
+    TraceSpanSummaryOutput,
+};
 use crate::core::engine::detail_output::{bounded_items, DEFAULT_DETAIL_ITEM_LIMIT};
 use crate::core::rig::RigStateSnapshot;
 use crate::core::runner::is_reportable_artifact_evidence_path;
@@ -49,26 +51,6 @@ pub struct TraceRunOutput {
     pub hints: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub profile: Option<TraceResolvedProfileOutput>,
-}
-
-#[derive(Serialize, Clone, Debug, PartialEq)]
-pub struct TraceSpanSummaryOutput {
-    pub id: String,
-    pub from: String,
-    pub to: String,
-    pub status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration_ms: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub from_t_ms: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub to_t_ms: Option<u64>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub missing: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<TraceSpanMetadata>,
 }
 
 #[derive(Serialize)]
@@ -468,46 +450,6 @@ fn from_run_workflow_result(
     }))
 }
 
-pub fn trace_span_summaries(
-    results: &TraceResults,
-    metadata_by_span: &BTreeMap<String, TraceSpanMetadata>,
-) -> Vec<TraceSpanSummaryOutput> {
-    results
-        .span_results
-        .iter()
-        .map(|span| TraceSpanSummaryOutput {
-            id: span.id.clone(),
-            from: span.from.clone(),
-            to: span.to.clone(),
-            status: match span.status {
-                TraceSpanStatus::Ok => "ok".to_string(),
-                TraceSpanStatus::Skipped => "skipped".to_string(),
-            },
-            duration_ms: span.duration_ms,
-            from_t_ms: span.from_t_ms,
-            to_t_ms: span.to_t_ms,
-            missing: span.missing.clone(),
-            message: span.message.clone(),
-            metadata: metadata_by_span.get(&span.id).cloned(),
-        })
-        .collect()
-}
-
-pub fn attach_span_summary_metadata(
-    output: &mut TraceCommandOutput,
-    metadata_by_span: &BTreeMap<String, TraceSpanMetadata>,
-) {
-    if metadata_by_span.is_empty() {
-        return;
-    }
-    let TraceCommandOutput::Run(run) = output else {
-        return;
-    };
-    if let Some(results) = run.results.as_ref() {
-        run.span_summaries = trace_span_summaries(results, metadata_by_span);
-    }
-}
-
 pub fn render_markdown(results: &TraceResults, overlays: &[TraceOverlay]) -> String {
     let mut out = String::new();
     out.push_str(&format!("# Trace: `{}`\n\n", results.scenario_id));
@@ -586,50 +528,6 @@ pub fn render_markdown(results: &TraceResults, overlays: &[TraceOverlay]) -> Str
     }
 
     out
-}
-
-fn format_span_summary_status(span: &TraceSpanSummaryOutput) -> String {
-    let mut parts = vec![span.status.clone()];
-    if !span.missing.is_empty() {
-        parts.push(format!("missing `{}`", span.missing.join("`, `")));
-    }
-    if let Some(message) = span.message.as_deref() {
-        parts.push(message.to_string());
-    }
-    parts.join(": ")
-}
-
-fn format_span_summary_metadata(metadata: Option<&TraceSpanMetadata>) -> String {
-    let Some(metadata) = metadata else {
-        return "-".to_string();
-    };
-    let mut parts = Vec::new();
-    if let Some(category) = metadata.category.as_deref() {
-        parts.push(format!("category={category}"));
-    }
-    if let Some(blocks) = metadata.blocks.as_deref() {
-        parts.push(format!("blocks={blocks}"));
-    }
-    if metadata.critical {
-        parts.push("critical".to_string());
-    }
-    if metadata.blocking {
-        parts.push("blocking".to_string());
-    }
-    if metadata.cacheable {
-        parts.push("cacheable".to_string());
-    }
-    if metadata.prewarmable {
-        parts.push("prewarmable".to_string());
-    }
-    if metadata.deferrable {
-        parts.push("deferrable".to_string());
-    }
-    if parts.is_empty() {
-        "-".to_string()
-    } else {
-        parts.join(", ")
-    }
 }
 
 fn reportable_trace_artifacts(artifacts: &[TraceArtifact]) -> Vec<TraceArtifact> {

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -35,6 +35,8 @@ pub struct TraceRunOutput {
     pub artifacts: Vec<TraceArtifact>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub results: Option<TraceResults>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub span_summaries: Vec<TraceSpanSummaryOutput>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rig_state: Option<RigStateSnapshot>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -47,6 +49,26 @@ pub struct TraceRunOutput {
     pub hints: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub profile: Option<TraceResolvedProfileOutput>,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct TraceSpanSummaryOutput {
+    pub id: String,
+    pub from: String,
+    pub to: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_t_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_t_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<TraceSpanMetadata>,
 }
 
 #[derive(Serialize)]
@@ -424,6 +446,11 @@ fn from_run_workflow_result(
         .as_ref()
         .map(|r| reportable_trace_artifacts(&r.artifacts))
         .unwrap_or_default();
+    let span_summaries = result
+        .results
+        .as_ref()
+        .map(|results| trace_span_summaries(results, &BTreeMap::new()))
+        .unwrap_or_default();
     TraceCommandOutput::Run(Box::new(TraceRunOutput {
         passed: result.exit_code == 0 && result.status == "pass",
         status: result.status,
@@ -431,6 +458,7 @@ fn from_run_workflow_result(
         exit_code: result.exit_code,
         artifacts,
         results: result.results,
+        span_summaries,
         rig_state,
         failure: result.failure,
         overlays: result.overlays,
@@ -438,6 +466,46 @@ fn from_run_workflow_result(
         hints: result.hints,
         profile: None,
     }))
+}
+
+pub fn trace_span_summaries(
+    results: &TraceResults,
+    metadata_by_span: &BTreeMap<String, TraceSpanMetadata>,
+) -> Vec<TraceSpanSummaryOutput> {
+    results
+        .span_results
+        .iter()
+        .map(|span| TraceSpanSummaryOutput {
+            id: span.id.clone(),
+            from: span.from.clone(),
+            to: span.to.clone(),
+            status: match span.status {
+                TraceSpanStatus::Ok => "ok".to_string(),
+                TraceSpanStatus::Skipped => "skipped".to_string(),
+            },
+            duration_ms: span.duration_ms,
+            from_t_ms: span.from_t_ms,
+            to_t_ms: span.to_t_ms,
+            missing: span.missing.clone(),
+            message: span.message.clone(),
+            metadata: metadata_by_span.get(&span.id).cloned(),
+        })
+        .collect()
+}
+
+pub fn attach_span_summary_metadata(
+    output: &mut TraceCommandOutput,
+    metadata_by_span: &BTreeMap<String, TraceSpanMetadata>,
+) {
+    if metadata_by_span.is_empty() {
+        return;
+    }
+    let TraceCommandOutput::Run(run) = output else {
+        return;
+    };
+    if let Some(results) = run.results.as_ref() {
+        run.span_summaries = trace_span_summaries(results, metadata_by_span);
+    }
 }
 
 pub fn render_markdown(results: &TraceResults, overlays: &[TraceOverlay]) -> String {
@@ -456,24 +524,20 @@ pub fn render_markdown(results: &TraceResults, overlays: &[TraceOverlay]) -> Str
 
     if !results.span_results.is_empty() {
         out.push_str("\n## Spans\n\n");
-        out.push_str("| Span | From | To | Duration | Status |\n");
-        out.push_str("|---|---|---|---:|---|\n");
-        let (spans, metadata) = bounded_items(&results.span_results, DEFAULT_DETAIL_ITEM_LIMIT);
+        out.push_str("| Span | From | To | Duration | Status | Metadata |\n");
+        out.push_str("|---|---|---|---:|---|---|\n");
+        let summaries = trace_span_summaries(results, &BTreeMap::new());
+        let (spans, metadata) = bounded_items(&summaries, DEFAULT_DETAIL_ITEM_LIMIT);
         for span in spans {
             let duration = span
                 .duration_ms
                 .map(|ms| format!("{}ms", ms))
                 .unwrap_or_else(|| "-".to_string());
-            let status = match span.status {
-                TraceSpanStatus::Ok => "ok".to_string(),
-                TraceSpanStatus::Skipped => span
-                    .message
-                    .clone()
-                    .unwrap_or_else(|| "skipped".to_string()),
-            };
+            let status = format_span_summary_status(&span);
+            let metadata = format_span_summary_metadata(span.metadata.as_ref());
             out.push_str(&format!(
-                "| `{}` | `{}` | `{}` | {} | {} |\n",
-                span.id, span.from, span.to, duration, status
+                "| `{}` | `{}` | `{}` | {} | {} | {} |\n",
+                span.id, span.from, span.to, duration, status, metadata
             ));
         }
         push_omitted_detail_line(&mut out, "span(s)", &metadata);
@@ -522,6 +586,50 @@ pub fn render_markdown(results: &TraceResults, overlays: &[TraceOverlay]) -> Str
     }
 
     out
+}
+
+fn format_span_summary_status(span: &TraceSpanSummaryOutput) -> String {
+    let mut parts = vec![span.status.clone()];
+    if !span.missing.is_empty() {
+        parts.push(format!("missing `{}`", span.missing.join("`, `")));
+    }
+    if let Some(message) = span.message.as_deref() {
+        parts.push(message.to_string());
+    }
+    parts.join(": ")
+}
+
+fn format_span_summary_metadata(metadata: Option<&TraceSpanMetadata>) -> String {
+    let Some(metadata) = metadata else {
+        return "-".to_string();
+    };
+    let mut parts = Vec::new();
+    if let Some(category) = metadata.category.as_deref() {
+        parts.push(format!("category={category}"));
+    }
+    if let Some(blocks) = metadata.blocks.as_deref() {
+        parts.push(format!("blocks={blocks}"));
+    }
+    if metadata.critical {
+        parts.push("critical".to_string());
+    }
+    if metadata.blocking {
+        parts.push("blocking".to_string());
+    }
+    if metadata.cacheable {
+        parts.push("cacheable".to_string());
+    }
+    if metadata.prewarmable {
+        parts.push("prewarmable".to_string());
+    }
+    if metadata.deferrable {
+        parts.push("deferrable".to_string());
+    }
+    if parts.is_empty() {
+        "-".to_string()
+    } else {
+        parts.join(", ")
+    }
 }
 
 fn reportable_trace_artifacts(artifacts: &[TraceArtifact]) -> Vec<TraceArtifact> {

--- a/src/core/extension/trace/span_summary.rs
+++ b/src/core/extension/trace/span_summary.rs
@@ -1,0 +1,110 @@
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+use super::parsing::{TraceResults, TraceSpanStatus};
+use super::report::TraceCommandOutput;
+use super::TraceSpanMetadata;
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct TraceSpanSummaryOutput {
+    pub id: String,
+    pub from: String,
+    pub to: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_t_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_t_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<TraceSpanMetadata>,
+}
+
+pub fn trace_span_summaries(
+    results: &TraceResults,
+    metadata_by_span: &BTreeMap<String, TraceSpanMetadata>,
+) -> Vec<TraceSpanSummaryOutput> {
+    results
+        .span_results
+        .iter()
+        .map(|span| TraceSpanSummaryOutput {
+            id: span.id.clone(),
+            from: span.from.clone(),
+            to: span.to.clone(),
+            status: match span.status {
+                TraceSpanStatus::Ok => "ok".to_string(),
+                TraceSpanStatus::Skipped => "skipped".to_string(),
+            },
+            duration_ms: span.duration_ms,
+            from_t_ms: span.from_t_ms,
+            to_t_ms: span.to_t_ms,
+            missing: span.missing.clone(),
+            message: span.message.clone(),
+            metadata: metadata_by_span.get(&span.id).cloned(),
+        })
+        .collect()
+}
+
+pub fn attach_span_summary_metadata(
+    output: &mut TraceCommandOutput,
+    metadata_by_span: &BTreeMap<String, TraceSpanMetadata>,
+) {
+    if metadata_by_span.is_empty() {
+        return;
+    }
+    let TraceCommandOutput::Run(run) = output else {
+        return;
+    };
+    if let Some(results) = run.results.as_ref() {
+        run.span_summaries = trace_span_summaries(results, metadata_by_span);
+    }
+}
+
+pub fn format_span_summary_status(span: &TraceSpanSummaryOutput) -> String {
+    let mut parts = vec![span.status.clone()];
+    if !span.missing.is_empty() {
+        parts.push(format!("missing `{}`", span.missing.join("`, `")));
+    }
+    if let Some(message) = span.message.as_deref() {
+        parts.push(message.to_string());
+    }
+    parts.join(": ")
+}
+
+pub fn format_span_summary_metadata(metadata: Option<&TraceSpanMetadata>) -> String {
+    let Some(metadata) = metadata else {
+        return "-".to_string();
+    };
+    let mut parts = Vec::new();
+    if let Some(category) = metadata.category.as_deref() {
+        parts.push(format!("category={category}"));
+    }
+    if let Some(blocks) = metadata.blocks.as_deref() {
+        parts.push(format!("blocks={blocks}"));
+    }
+    if metadata.critical {
+        parts.push("critical".to_string());
+    }
+    if metadata.blocking {
+        parts.push("blocking".to_string());
+    }
+    if metadata.cacheable {
+        parts.push("cacheable".to_string());
+    }
+    if metadata.prewarmable {
+        parts.push("prewarmable".to_string());
+    }
+    if metadata.deferrable {
+        parts.push("deferrable".to_string());
+    }
+    if parts.is_empty() {
+        "-".to_string()
+    } else {
+        parts.join(", ")
+    }
+}

--- a/tests/report_failure_digest_test.rs
+++ b/tests/report_failure_digest_test.rs
@@ -67,6 +67,56 @@ fn trace_json(status: &str, summary: &str) -> String {
     )
 }
 
+fn trace_json_with_span_summaries() -> &'static str {
+    r#"{
+        "success": false,
+        "data": {
+            "passed": false,
+            "status": "fail",
+            "component": "studio",
+            "exit_code": 1,
+            "span_summaries": [
+                {
+                    "id": "phase.boot_to_ready",
+                    "from": "runner.boot",
+                    "to": "runner.ready",
+                    "status": "ok",
+                    "duration_ms": 125,
+                    "from_t_ms": 10,
+                    "to_t_ms": 135,
+                    "metadata": {
+                        "category": "startup",
+                        "critical": true,
+                        "blocking": true,
+                        "cacheable": true
+                    }
+                },
+                {
+                    "id": "phase.ready_to_open",
+                    "from": "runner.ready",
+                    "to": "app.opened",
+                    "status": "skipped",
+                    "missing": ["app.opened"],
+                    "message": "span endpoint missing from timeline",
+                    "metadata": {
+                        "category": "ui",
+                        "prewarmable": true
+                    }
+                }
+            ],
+            "results": {
+                "component_id": "studio",
+                "scenario_id": "close-window-running-site",
+                "status": "fail",
+                "summary": "Window reopened after close.",
+                "timeline": [],
+                "assertions": [],
+                "artifacts": []
+            }
+        }
+    }"#
+}
+
 fn bench_json() -> &'static str {
     r#"{
         "success": true,
@@ -366,6 +416,21 @@ fn renders_trace_fail_status_without_inlining_artifact_content() {
     assert!(markdown.contains("- Window reopened after close."));
     assert!(markdown.contains("- main log: artifacts/main.log"));
     assert!(!markdown.contains("raw log body that should never appear"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn renders_trace_span_summaries_with_metadata_and_missing_endpoints() {
+    let dir = tmp_dir("trace-span-summaries");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    write_file(&dir, "trace.json", trace_json_with_span_summaries());
+
+    let markdown = render(&dir, r#"{"trace":"fail"}"#, false, false);
+
+    assert!(markdown.contains("**Spans**"));
+    assert!(markdown.contains("| `phase.boot_to_ready` | `runner.boot` | `runner.ready` | 125ms | ok | category=startup, critical, blocking, cacheable |"));
+    assert!(markdown.contains("| `phase.ready_to_open` | `runner.ready` | `app.opened` | - | skipped: missing `app.opened`: span endpoint missing from timeline | category=ui, prewarmable |"));
 
     let _ = fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary
- Add trace `span_summaries` to run output from existing span results, including endpoints, duration, missing endpoint diagnostics, and optional rig span metadata.
- Render span summaries in trace markdown and failure digests so phase preset spans no longer need README-maintained tables.
- Keep the report shape generic and target-app agnostic.

Closes #3300.

## Tests
- `cargo test --test report_failure_digest_test`
- `cargo test trace_span`
- `cargo test summarize_spans`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the trace summary/reporting implementation and targeted tests; Chris remains responsible for review and validation.