### PR TITLE
Fix extension structured sidecar producer metadata

### DIFF
--- a/src/core/extension/manifest_sidecar.rs
+++ b/src/core/extension/manifest_sidecar.rs
@@ -15,6 +15,7 @@ impl StructuredSidecarContract {
                 name: name.to_string(),
                 path: default_structured_sidecar_path(name),
                 schema_version: None,
+                producer: default_structured_sidecar_producer(name),
             }),
             StructuredSidecarContract::Enabled(false) => None,
             StructuredSidecarContract::Detail(detail) => {
@@ -29,6 +30,10 @@ impl StructuredSidecarContract {
                         .clone()
                         .unwrap_or_else(|| default_structured_sidecar_path(name)),
                     schema_version: detail.schema_version.clone(),
+                    producer: detail
+                        .producer
+                        .clone()
+                        .or_else(|| default_structured_sidecar_producer(name)),
                 })
             }
         }
@@ -44,6 +49,8 @@ pub struct StructuredSidecarDetail {
     pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub producer: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -59,6 +66,7 @@ fn default_structured_sidecar_path(name: &str) -> String {
         "test.coverage" => run_dir::files::COVERAGE,
         "bench.results" => run_dir::files::BENCH_RESULTS,
         "trace.results" => run_dir::files::TRACE_RESULTS,
+        "trace.artifacts" => "artifacts",
         "resource.summary" => run_dir::files::RESOURCE_SUMMARY,
         "producer.summary" => "producer-summary.json",
         "findings" => "findings.json",
@@ -68,6 +76,17 @@ fn default_structured_sidecar_path(name: &str) -> String {
     .to_string()
 }
 
+fn default_structured_sidecar_producer(name: &str) -> Option<String> {
+    match name {
+        "lint.findings" | "lint.producers" => Some("lint"),
+        "test.results" | "test.failures" | "test.coverage" => Some("test"),
+        "bench.results" => Some("bench"),
+        "trace.results" | "trace.artifacts" => Some("trace"),
+        _ => None,
+    }
+    .map(str::to_string)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct StructuredSidecarDeclaration {
@@ -75,4 +94,6 @@ pub struct StructuredSidecarDeclaration {
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub producer: Option<String>,
 }

--- a/src/core/extension/tests.rs
+++ b/src/core/extension/tests.rs
@@ -77,30 +77,40 @@ fn manifest_parses_declared_structured_sidecars() {
                 "schema_version": "1"
             },
             "producer.summary": {
-                "schema_version": "1"
+                "schema_version": "1",
+                "producer": "lint"
             },
             "lint.findings": true,
             "lint.producers": true,
             "trace.results": true,
+            "trace.artifacts": true,
             "test.coverage": false
         }
     }))
     .unwrap();
 
     let sidecars = manifest.structured_sidecars();
-    assert_eq!(sidecars.len(), 5);
+    assert_eq!(sidecars.len(), 6);
     assert_eq!(sidecars[0].name, "findings");
     assert_eq!(sidecars[0].path, "findings.json");
     assert_eq!(sidecars[0].schema_version.as_deref(), Some("1"));
+    assert_eq!(sidecars[0].producer, None);
     assert_eq!(sidecars[1].name, "lint.findings");
     assert_eq!(sidecars[1].path, "lint-findings.json");
     assert_eq!(sidecars[1].schema_version, None);
+    assert_eq!(sidecars[1].producer.as_deref(), Some("lint"));
     assert_eq!(sidecars[2].name, "lint.producers");
     assert_eq!(sidecars[2].path, "lint-producers.json");
+    assert_eq!(sidecars[2].producer.as_deref(), Some("lint"));
     assert_eq!(sidecars[3].name, "producer.summary");
     assert_eq!(sidecars[3].path, "producer-summary.json");
-    assert_eq!(sidecars[4].name, "trace.results");
-    assert_eq!(sidecars[4].path, "trace.json");
+    assert_eq!(sidecars[3].producer.as_deref(), Some("lint"));
+    assert_eq!(sidecars[4].name, "trace.artifacts");
+    assert_eq!(sidecars[4].path, "artifacts");
+    assert_eq!(sidecars[4].producer.as_deref(), Some("trace"));
+    assert_eq!(sidecars[5].name, "trace.results");
+    assert_eq!(sidecars[5].path, "trace.json");
+    assert_eq!(sidecars[5].producer.as_deref(), Some("trace"));
 }
 
 #[test]

--- a/tests/output_contracts_test.rs
+++ b/tests/output_contracts_test.rs
@@ -358,6 +358,7 @@ fn extension_show_output_contracts_use_top_level_structured_sidecars() {
                 name: "findings".to_string(),
                 path: "findings.json".to_string(),
                 schema_version: Some("1".to_string()),
+                producer: Some("lint".to_string()),
             }],
             requires: None,
         },
@@ -365,7 +366,7 @@ fn extension_show_output_contracts_use_top_level_structured_sidecars() {
 
     assert_eq!(
         output["extension"]["structured_sidecars"],
-        json!([{ "name": "findings", "path": "findings.json", "schema_version": "1" }])
+        json!([{ "name": "findings", "path": "findings.json", "schema_version": "1", "producer": "lint" }])
     );
     assert_eq!(output["extension"].get("lint"), None);
 }


### PR DESCRIPTION
## Summary
- Adds `producer` metadata to structured sidecar declarations so `extension show` identifies the capability runner expected to emit each sidecar.
- Keeps root-level `structured_sidecars` as the canonical typed manifest contract, including object-form producer overrides and validation via `deny_unknown_fields`.
- Adds a default `trace.artifacts` path so existing extension declarations report a real sidecar path instead of falling through to the logical name.

Closes #3304.

## Tests
- `cargo fmt`
- `cargo test structured_sidecar -- --nocapture`
- `cargo test extension_show_output_contracts_use_top_level_structured_sidecars -- --nocapture`
- `cargo check --release`
- `cargo run --quiet --bin homeboy -- extension show nodejs --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-nodejs-extension-show.json`
- `cargo run --quiet --bin homeboy -- extension show wordpress --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-wordpress-extension-show.json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the manifest contract, drafted the Rust schema/test changes, ran targeted verification, and prepared this PR; Chris remains responsible for review and merge.