### PR TITLE
fix(runner): export bash preflight runtime helper

### DIFF
--- a/docs/architecture/runner-contract.md
+++ b/docs/architecture/runner-contract.md
@@ -102,10 +102,21 @@ Trace runners also receive trace-specific variables when invoked by `homeboy tra
 
 ## Core-provided runtime helpers
 
-Core ships three shell helpers as embedded assets
+Core ships shell helpers as embedded assets
 (`src/core/extension/runtime/`) and injects their absolute paths via
 `HOMEBOY_RUNTIME_*` env vars. Extensions source them at the top of the
 runner script with a fallback to a bundled copy:
+
+### `runner-prelude.sh` (env: `HOMEBOY_RUNTIME_RUNNER_PRELUDE`)
+
+Provides `homeboy_runner_init`, `homeboy_source_runtime_helper`, and the
+shared bash-version guard for runners that want the standard context,
+step-filter, sidecar-writer, and failure-trap setup in one source call.
+
+### `bash-preflight.sh` (env: `HOMEBOY_RUNTIME_BASH_PREFLIGHT`)
+
+Provides `homeboy_require_bash_version <major>` for scripts that only need
+the bash-version guard and do not need the full runner prelude.
 
 ### `runner-steps.sh` (env: `HOMEBOY_RUNTIME_RUNNER_STEPS`)
 

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -794,17 +794,23 @@ mod tests {
     use crate::core::extension::extract_component_extension_settings;
 
     #[test]
-    fn build_exec_env_includes_runtime_runner_helper_path() {
+    fn build_exec_env_includes_runtime_runner_helper_paths() {
         crate::test_support::with_isolated_home(|_| {
             let env = build_exec_env("rust", None, None, "{}", Some("/tmp/ext"), None, None, None);
 
-            let helper = env
-                .iter()
-                .find(|(k, _)| k == runtime_helper::RUNNER_STEPS_ENV)
-                .map(|(_, v)| v.clone());
+            for (env_var, filename) in [
+                (runtime_helper::RUNNER_STEPS_ENV, "runner-steps.sh"),
+                (runtime_helper::RUNNER_PRELUDE_ENV, "runner-prelude.sh"),
+                (runtime_helper::BASH_PREFLIGHT_ENV, "bash-preflight.sh"),
+            ] {
+                let helper = env
+                    .iter()
+                    .find(|(k, _)| k == env_var)
+                    .map(|(_, v)| v.clone());
 
-            assert!(helper.is_some());
-            assert!(helper.unwrap().ends_with("runner-steps.sh"));
+                assert!(helper.is_some(), "expected env to include {env_var}");
+                assert!(helper.unwrap().ends_with(filename));
+            }
         });
     }
 

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -92,7 +92,7 @@ pub use runner_contract::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, PhaseFailure,
     PhaseFailureCategory, PhaseReport, PhaseStatus, RunnerStepFilter, VerificationPhase,
 };
-pub use runtime_helper::RUNNER_STEPS_ENV;
+pub use runtime_helper::{BASH_PREFLIGHT_ENV, RUNNER_PRELUDE_ENV, RUNNER_STEPS_ENV};
 pub use scope::ExtensionScope;
 pub use summary::{list_summaries, ActionSummary, ExtensionSummary};
 pub use update_output::{

--- a/src/core/extension/runtime/bash-preflight.sh
+++ b/src/core/extension/runtime/bash-preflight.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Shared bash-version preflight for extension scripts that do not need the full
+# runner prelude.
+
+homeboy_require_bash_version() {
+    local required_major="$1"
+
+    if [ -z "${BASH_VERSION:-}" ] || ((BASH_VERSINFO[0] < required_major)); then
+        echo "ERROR: bash ${required_major}.0+ required (found ${BASH_VERSION:-non-bash shell})" >&2
+        case "$(uname -s)" in
+            Darwin)
+                echo "macOS ships with bash 3.2. Install newer bash: brew install bash" >&2
+                echo "Then restart your terminal so Homebrew bash takes priority on PATH." >&2
+                ;;
+            Linux)
+                echo "Update bash via your package manager (apt, dnf, pacman, etc.)" >&2
+                ;;
+            MINGW*|MSYS*|CYGWIN*)
+                echo "Update Git Bash or use WSL with a modern bash version" >&2
+                ;;
+            *)
+                echo "Install bash ${required_major}.0 or later for your platform" >&2
+                ;;
+        esac
+        exit 1
+    fi
+}

--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -9,6 +9,7 @@ mod assets;
 
 pub const RUNNER_STEPS_ENV: &str = "HOMEBOY_RUNTIME_RUNNER_STEPS";
 pub const RUNNER_PRELUDE_ENV: &str = "HOMEBOY_RUNTIME_RUNNER_PRELUDE";
+pub const BASH_PREFLIGHT_ENV: &str = "HOMEBOY_RUNTIME_BASH_PREFLIGHT";
 pub const FAILURE_TRAP_ENV: &str = "HOMEBOY_RUNTIME_FAILURE_TRAP";
 pub const WRITE_TEST_RESULTS_ENV: &str = "HOMEBOY_RUNTIME_WRITE_TEST_RESULTS";
 pub const SIDECAR_WRITER_ENV: &str = "HOMEBOY_RUNTIME_SIDECAR_WRITER";
@@ -35,6 +36,12 @@ const HELPERS: &[RuntimeHelper] = &[
         filename: "runner-prelude.sh",
         content: assets::RUNNER_PRELUDE_SH,
         env_var: RUNNER_PRELUDE_ENV,
+        legacy_fallback: false,
+    },
+    RuntimeHelper {
+        filename: "bash-preflight.sh",
+        content: assets::BASH_PREFLIGHT_SH,
+        env_var: BASH_PREFLIGHT_ENV,
         legacy_fallback: false,
     },
     RuntimeHelper {

--- a/src/core/extension/runtime_helper/assets.rs
+++ b/src/core/extension/runtime_helper/assets.rs
@@ -1,5 +1,6 @@
 pub(super) const RUNNER_STEPS_SH: &str = include_str!("../runtime/runner-steps.sh");
 pub(super) const RUNNER_PRELUDE_SH: &str = include_str!("../runtime/runner-prelude.sh");
+pub(super) const BASH_PREFLIGHT_SH: &str = include_str!("../runtime/bash-preflight.sh");
 pub(super) const FAILURE_TRAP_SH: &str = include_str!("../runtime/failure-trap.sh");
 pub(super) const WRITE_TEST_RESULTS_SH: &str = include_str!("../runtime/write-test-results.sh");
 pub(super) const SIDECAR_WRITER_SH: &str = include_str!("../runtime/sidecar-writer.sh");
@@ -17,6 +18,7 @@ mod tests {
         for content in [
             RUNNER_STEPS_SH,
             RUNNER_PRELUDE_SH,
+            BASH_PREFLIGHT_SH,
             FAILURE_TRAP_SH,
             WRITE_TEST_RESULTS_SH,
             SIDECAR_WRITER_SH,

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -22,6 +22,10 @@ fn ensure_all_helpers_writes_all_files() {
             "runner prelude helper should be in pairs"
         );
         assert!(
+            pairs.iter().any(|(k, _)| k == BASH_PREFLIGHT_ENV),
+            "bash preflight helper should be in pairs"
+        );
+        assert!(
             pairs.iter().any(|(k, _)| k == WRITE_TEST_RESULTS_ENV),
             "write test results helper should be in pairs"
         );
@@ -234,7 +238,39 @@ fn ensure_all_helpers_writes_legacy_bench_fallbacks() {
                 .exists(),
             "legacy runtime dir should only carry bench fallbacks"
         );
+        assert!(
+            !home
+                .path()
+                .join(".homeboy")
+                .join("runtime")
+                .join("bash-preflight.sh")
+                .exists(),
+            "legacy runtime dir should not carry bash preflight"
+        );
     });
+}
+
+#[test]
+fn bash_preflight_helper_accepts_current_bash() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("bash-preflight.sh");
+    std::fs::write(&helper_path, assets::BASH_PREFLIGHT_SH).expect("write helper");
+
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {}; homeboy_require_bash_version 3; printf ok",
+            helper_path.display()
+        ))
+        .output()
+        .expect("run bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "ok");
 }
 
 #[test]

--- a/tests/core/extension/runtime_helper_test.rs
+++ b/tests/core/extension/runtime_helper_test.rs
@@ -24,4 +24,8 @@ fn test_ensure_all_helpers() {
         RUNTIME_HELPER_RS.contains("HOMEBOY_RUNTIME_RUNNER_PRELUDE"),
         "extension env should expose the shared runner prelude helper"
     );
+    assert!(
+        RUNTIME_HELPER_RS.contains("HOMEBOY_RUNTIME_BASH_PREFLIGHT"),
+        "extension env should expose the shared bash preflight helper"
+    );
 }


### PR DESCRIPTION
## Summary
- Adds `HOMEBOY_RUNTIME_BASH_PREFLIGHT` as a core-provided runtime helper so extensions can source the bash-version preflight from Homeboy core.
- Extends runtime helper tests and exec-env coverage to prove runner prelude and bash preflight paths are exported together.
- Documents the core-provided runner prelude and bash preflight contracts in the runner architecture notes.

Closes #3303.

## Tests
- `cargo fmt`
- `cargo test runtime_helper`
- `cargo test build_exec_env_includes_runtime_runner_helper_paths`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-issue-3303-runtime-helpers --extension rust`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the runtime helper export, tests, docs, and local verification; Chris remains responsible for review and merge.