### PR TITLE
refactor(bench): expand shared runtime helpers

### DIFF
--- a/src/core/extension/runtime/bench-helper.mjs
+++ b/src/core/extension/runtime/bench-helper.mjs
@@ -26,12 +26,69 @@ export function homeboyBenchScenarioId(file, extensionPattern = /\.[^.]+$/) {
         .replace(/^-+|-+$/g, '');
 }
 
+export function homeboyBenchSelectedScenarios(value = process.env.HOMEBOY_BENCH_SCENARIOS || '') {
+    return String(value)
+        .split(',')
+        .map((scenario) => scenario.trim())
+        .filter(Boolean);
+}
+
+export function homeboyBenchScenarioSelected(scenario, selected = homeboyBenchSelectedScenarios()) {
+    if (!scenario) return false;
+    if (!selected || selected.length === 0) return true;
+    return selected.includes(scenario);
+}
+
+export function homeboyBenchArtifactRef(path, { kind, label } = {}) {
+    if (!path) throw new Error('homeboyBenchArtifactRef requires a path');
+    const ref = { path };
+    if (kind) ref.kind = kind;
+    if (label) ref.label = label;
+    return ref;
+}
+
 export function homeboyBenchResultsEnvelope(componentId, iterations, scenarios) {
     return {
         component_id: componentId,
         iterations,
         scenarios,
     };
+}
+
+export function homeboyBenchScenarioInventoryEntry({
+    id,
+    file,
+    source,
+    defaultIterations,
+    tags = [],
+    metrics = {},
+    metadata,
+    artifacts,
+}) {
+    const scenario = {
+        id,
+        iterations: 0,
+        tags,
+        metrics,
+    };
+    if (defaultIterations !== undefined) scenario.default_iterations = defaultIterations;
+    if (file) scenario.file = file;
+    if (source) scenario.source = source;
+    if (metadata && Object.keys(metadata).length > 0) scenario.metadata = metadata;
+    if (artifacts && Object.keys(artifacts).length > 0) scenario.artifacts = artifacts;
+    return scenario;
+}
+
+export function homeboyBenchScenarioInventoryEnvelope(componentId, defaultIterations, scenarios) {
+    return homeboyBenchResultsEnvelope(
+        componentId,
+        0,
+        scenarios.map((scenario) => ({
+            ...scenario,
+            iterations: 0,
+            default_iterations: scenario.default_iterations ?? defaultIterations,
+        }))
+    );
 }
 
 export async function homeboyWriteBenchResults(resultsFile, componentId, iterations, scenarios) {
@@ -44,6 +101,14 @@ export async function homeboyWriteBenchResults(resultsFile, componentId, iterati
 
 export async function homeboyWriteEmptyBenchResults(resultsFile, componentId, iterations = 0) {
     await homeboyWriteBenchResults(resultsFile, componentId, iterations, []);
+}
+
+export async function homeboyWriteBenchScenarioInventory(resultsFile, componentId, defaultIterations, scenarios) {
+    await mkdir(dirname(resultsFile), { recursive: true });
+    await writeFile(
+        resultsFile,
+        JSON.stringify(homeboyBenchScenarioInventoryEnvelope(componentId, defaultIterations, scenarios), null, 2)
+    );
 }
 
 export function homeboyBenchProgress(event = {}) {

--- a/src/core/extension/runtime/bench-helper.php
+++ b/src/core/extension/runtime/bench-helper.php
@@ -31,6 +31,31 @@ function homeboy_bench_scenario_id(string $basename): string {
     return trim($name, '-');
 }
 
+function homeboy_bench_selected_scenarios(?string $selected = null): array {
+    $selected = $selected ?? (getenv('HOMEBOY_BENCH_SCENARIOS') ?: '');
+    return array_values(array_filter(array_map('trim', explode(',', $selected)), static fn($scenario) => $scenario !== ''));
+}
+
+function homeboy_bench_scenario_selected(string $scenario, ?array $selected = null): bool {
+    $selected = $selected ?? homeboy_bench_selected_scenarios();
+    return count($selected) === 0 || in_array($scenario, $selected, true);
+}
+
+function homeboy_bench_artifact_ref(string $path, ?string $kind = null, ?string $label = null): array {
+    if ($path === '') {
+        throw new InvalidArgumentException('homeboy_bench_artifact_ref requires a path');
+    }
+
+    $ref = ['path' => $path];
+    if ($kind !== null && $kind !== '') {
+        $ref['kind'] = $kind;
+    }
+    if ($label !== null && $label !== '') {
+        $ref['label'] = $label;
+    }
+    return $ref;
+}
+
 function homeboy_bench_results_envelope(string $component_id, int $iterations, array $scenarios): array {
     return [
         'component_id' => $component_id,
@@ -39,10 +64,55 @@ function homeboy_bench_results_envelope(string $component_id, int $iterations, a
     ];
 }
 
+function homeboy_bench_scenario_inventory_entry(array $scenario): array {
+    if (empty($scenario['id'])) {
+        throw new InvalidArgumentException('homeboy_bench_scenario_inventory_entry requires an id');
+    }
+
+    $entry = [
+        'id' => $scenario['id'],
+        'iterations' => 0,
+        'tags' => $scenario['tags'] ?? [],
+        'metrics' => $scenario['metrics'] ?? [],
+    ];
+
+    if (array_key_exists('default_iterations', $scenario)) {
+        $entry['default_iterations'] = (int) $scenario['default_iterations'];
+    }
+
+    foreach (['file', 'source', 'metadata', 'artifacts'] as $key) {
+        if (isset($scenario[$key]) && $scenario[$key] !== [] && $scenario[$key] !== '') {
+            $entry[$key] = $scenario[$key];
+        }
+    }
+
+    return $entry;
+}
+
+function homeboy_bench_scenario_inventory_envelope(string $component_id, int $default_iterations, array $scenarios): array {
+    return homeboy_bench_results_envelope(
+        $component_id,
+        0,
+        array_map(
+            static function (array $scenario) use ($default_iterations): array {
+                if (!array_key_exists('default_iterations', $scenario)) {
+                    $scenario['default_iterations'] = $default_iterations;
+                }
+                return homeboy_bench_scenario_inventory_entry($scenario);
+            },
+            $scenarios
+        )
+    );
+}
+
 function homeboy_write_bench_results(string $results_path, string $component_id, int $iterations, array $scenarios): void {
     $json = json_encode(homeboy_bench_results_envelope($component_id, $iterations, $scenarios), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     if ($json === false) {
         throw new RuntimeException('json_encode failed: ' . json_last_error_msg());
+    }
+    $results_dir = dirname($results_path);
+    if (!is_dir($results_dir) && !mkdir($results_dir, 0777, true) && !is_dir($results_dir)) {
+        throw new RuntimeException("failed to create $results_dir");
     }
     if (file_put_contents($results_path, $json) === false) {
         throw new RuntimeException("failed to write $results_path");
@@ -51,4 +121,18 @@ function homeboy_write_bench_results(string $results_path, string $component_id,
 
 function homeboy_write_empty_bench_results(string $results_path, string $component_id, int $iterations = 0): void {
     homeboy_write_bench_results($results_path, $component_id, $iterations, []);
+}
+
+function homeboy_write_bench_scenario_inventory(string $results_path, string $component_id, int $default_iterations, array $scenarios): void {
+    $json = json_encode(homeboy_bench_scenario_inventory_envelope($component_id, $default_iterations, $scenarios), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    if ($json === false) {
+        throw new RuntimeException('json_encode failed: ' . json_last_error_msg());
+    }
+    $results_dir = dirname($results_path);
+    if (!is_dir($results_dir) && !mkdir($results_dir, 0777, true) && !is_dir($results_dir)) {
+        throw new RuntimeException("failed to create $results_dir");
+    }
+    if (file_put_contents($results_path, $json) === false) {
+        throw new RuntimeException("failed to write $results_path");
+    }
 }

--- a/src/core/extension/runtime/bench-helper.sh
+++ b/src/core/extension/runtime/bench-helper.sh
@@ -12,6 +12,50 @@ homeboy_bench_scenario_id() {
         | tr '[:upper:]' '[:lower:]'
 }
 
+homeboy_bench_scenario_selected() {
+    local scenario="${1:-}"
+    local selected="${2:-${HOMEBOY_BENCH_SCENARIOS:-}}"
+
+    [ -n "$scenario" ] || return 1
+    [ -z "$selected" ] && return 0
+    case ",${selected}," in
+        *",${scenario},"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+homeboy_bench_artifact_ref_json() {
+    local path="${1:-}"
+    local kind="${2:-}"
+    local label="${3:-}"
+
+    if [ -z "$path" ]; then
+        echo "homeboy_bench_artifact_ref_json: path is required" >&2
+        return 2
+    fi
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "homeboy_bench_artifact_ref_json: python3 is required" >&2
+        return 2
+    fi
+
+    HOMEBOY_BENCH_ARTIFACT_PATH="$path" \
+    HOMEBOY_BENCH_ARTIFACT_KIND="$kind" \
+    HOMEBOY_BENCH_ARTIFACT_LABEL="$label" \
+    python3 - <<'PYTHON_BENCH_ARTIFACT_REF'
+import json
+import os
+
+ref = {'path': os.environ['HOMEBOY_BENCH_ARTIFACT_PATH']}
+kind = os.environ.get('HOMEBOY_BENCH_ARTIFACT_KIND') or ''
+label = os.environ.get('HOMEBOY_BENCH_ARTIFACT_LABEL') or ''
+if kind:
+    ref['kind'] = kind
+if label:
+    ref['label'] = label
+print(json.dumps(ref, separators=(',', ':')))
+PYTHON_BENCH_ARTIFACT_REF
+}
+
 homeboy_write_empty_bench_results() {
     local component_id="${1:-${HOMEBOY_COMPONENT_ID:-}}"
     local iterations="${2:-0}"

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -436,6 +436,95 @@ fn bench_shell_helper_writes_scenario_inventory() {
 }
 
 #[test]
+fn bench_shell_helper_checks_selected_scenarios_and_artifact_refs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("bench-helper.sh");
+    std::fs::write(&helper_path, assets::BENCH_HELPER_SH).expect("write helper");
+
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {}; HOMEBOY_BENCH_SCENARIOS=cold,warm; if homeboy_bench_scenario_selected cold && ! homeboy_bench_scenario_selected hot; then homeboy_bench_artifact_ref_json bench.log text 'Bench log'; fi",
+            helper_path.display()
+        ))
+        .output()
+        .expect("run bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).expect("json");
+    assert_eq!(value["path"], "bench.log");
+    assert_eq!(value["kind"], "text");
+    assert_eq!(value["label"], "Bench log");
+}
+
+#[test]
+fn bench_js_helper_writes_scenario_inventory_and_filters_selection() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("bench-helper.mjs");
+    let runner_path = dir.path().join("runner.mjs");
+    let results_path = dir.path().join("bench-results.json");
+    std::fs::write(&helper_path, assets::BENCH_HELPER_JS).expect("write helper");
+    std::fs::write(
+        &runner_path,
+        format!(
+            r#"import {{
+    homeboyBenchArtifactRef,
+    homeboyBenchScenarioInventoryEntry,
+    homeboyBenchScenarioSelected,
+    homeboyWriteBenchScenarioInventory,
+}} from './bench-helper.mjs';
+
+if (!homeboyBenchScenarioSelected('cold')) throw new Error('cold should be selected');
+if (homeboyBenchScenarioSelected('hot')) throw new Error('hot should not be selected');
+
+await homeboyWriteBenchScenarioInventory('{results}', 'demo', 9, [
+    homeboyBenchScenarioInventoryEntry({{
+        id: 'cold',
+        file: 'bench/cold.bench.js',
+        source: 'in_tree',
+        artifacts: {{ log: homeboyBenchArtifactRef('bench.log', {{ kind: 'text', label: 'Bench log' }}) }},
+    }}),
+]);
+"#,
+            results = results_path.display()
+        ),
+    )
+    .expect("write runner");
+
+    let output = std::process::Command::new("node")
+        .arg(&runner_path)
+        .env("HOMEBOY_BENCH_SCENARIOS", "cold,warm")
+        .output()
+        .expect("run node");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&results_path).expect("read results"))
+            .expect("json");
+    assert_eq!(value["component_id"], "demo");
+    assert_eq!(value["iterations"], 0);
+    assert_eq!(value["scenarios"][0]["id"], "cold");
+    assert_eq!(value["scenarios"][0]["iterations"], 0);
+    assert_eq!(value["scenarios"][0]["default_iterations"], 9);
+    assert_eq!(value["scenarios"][0]["artifacts"]["log"]["path"], "bench.log");
+}
+
+#[test]
+fn bench_php_helper_documents_inventory_selection_and_artifact_helpers() {
+    assert!(assets::BENCH_HELPER_PHP.contains("function homeboy_bench_scenario_selected"));
+    assert!(assets::BENCH_HELPER_PHP.contains("function homeboy_bench_scenario_inventory_envelope"));
+    assert!(assets::BENCH_HELPER_PHP.contains("function homeboy_bench_artifact_ref"));
+}
+
+#[test]
 fn bench_js_helper_emits_compact_progress_to_stderr() {
     let dir = tempfile::tempdir().expect("tempdir");
     let helper_path = dir.path().join("bench-helper.mjs");


### PR DESCRIPTION
## Summary
- Adds shared bench runtime helper APIs for selected-scenario checks, inventory envelopes, and artifact references across shell, JS, and PHP helpers.
- Keeps language-specific workload discovery in extensions while centralizing generic BenchResults/list-only mechanics in Homeboy core.
- Adds runtime-helper coverage for shell and JS helper behavior plus PHP helper contract coverage.

## Tests
- `cargo test bench_ --lib`
- `php -l src/core/extension/runtime/bench-helper.php`
- `cargo run --bin homeboy -- bench list --extension rust --path /Users/chubes/Developer/homeboy@fix-issue-3306-bench-helpers`
- `cargo run --bin homeboy -- bench list --extension rust --path /Users/chubes/Developer/homeboy@fix-issue-3306-bench-helpers --scenario audit-self`
- `cargo run --bin homeboy -- bench --extension rust --path /Users/chubes/Developer/homeboy@fix-issue-3306-bench-helpers --iterations 1 --scenario audit-self`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the helper API expansion, tests, verification commands, and PR text; Chris remains responsible for review and merge.

Closes #3306