### PR TITLE
Fix Lab write refactor patch write-back

### DIFF
--- a/src/core/runner/apply.rs
+++ b/src/core/runner/apply.rs
@@ -48,7 +48,15 @@ pub fn apply_workspace_patch(
     options: RunnerWorkspaceApplyOptions,
 ) -> Result<(RunnerWorkspaceApplyOutput, i32)> {
     let input = read_apply_input(&options.input)?;
-    let artifact = input.artifact;
+    let output = apply_change_artifact(input.artifact, options.force)?;
+
+    Ok((output, 0))
+}
+
+pub fn apply_change_artifact(
+    artifact: ChangeArtifact,
+    force: bool,
+) -> Result<RunnerWorkspaceApplyOutput> {
     let local_path = local_source_path(&artifact.source_snapshot)?;
     let current = SourceSnapshot::collect_local(
         &artifact.source_snapshot.runner_id,
@@ -57,7 +65,7 @@ pub fn apply_workspace_patch(
         &artifact.source_snapshot.sync_mode,
     );
 
-    if current.snapshot_hash != artifact.source_snapshot.snapshot_hash && !options.force {
+    if current.snapshot_hash != artifact.source_snapshot.snapshot_hash && !force {
         return Err(Error::validation_invalid_argument(
             "source_snapshot",
             "local source worktree has drifted since the Lab snapshot; rerun the Lab job from a fresh snapshot or pass --force to apply explicitly",
@@ -92,20 +100,17 @@ pub fn apply_workspace_patch(
 
     let artifact_summary = artifact.summary();
 
-    Ok((
-        RunnerWorkspaceApplyOutput {
-            command: "runner.workspace.apply",
-            local_path: local_path.display().to_string(),
-            result: ChangeApplyResult::applied(
-                options.force,
-                artifact.source_snapshot.snapshot_hash,
-                current.snapshot_hash,
-                modified_files,
-                Some(artifact_summary),
-            ),
-        },
-        0,
-    ))
+    Ok(RunnerWorkspaceApplyOutput {
+        command: "runner.workspace.apply",
+        local_path: local_path.display().to_string(),
+        result: ChangeApplyResult::applied(
+            force,
+            artifact.source_snapshot.snapshot_hash,
+            current.snapshot_hash,
+            modified_files,
+            Some(artifact_summary),
+        ),
+    })
 }
 
 fn read_apply_input(path: &str) -> Result<LabPatchApplyInput> {

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -3,18 +3,20 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
+use crate::core::change_artifact::{ChangeArtifact, ChangePatch, CHANGE_ARTIFACT_SCHEMA};
 use crate::core::observation::{PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, Result};
 
 use super::{
-    evaluate_lab_runner_capabilities_for_runner, exec, lab_offload_changed_since_ref,
-    lab_offload_metadata, lab_offload_metadata_with_workspace_mapping, lab_runner_capability_plan,
-    load, preflight_lab_offload_changed_since, prepare_git_lab_offload_changed_since,
+    apply_change_artifact, download_remote_artifact, evaluate_lab_runner_capabilities_for_runner,
+    exec, is_retrievable_runner_artifact, lab_offload_changed_since_ref, lab_offload_metadata,
+    lab_offload_metadata_with_workspace_mapping, lab_runner_capability_plan, load,
+    preflight_lab_offload_changed_since, prepare_git_lab_offload_changed_since,
     rig_materialization, status, sync_workspace, LabRunnerCapabilityContract,
     LabRunnerGateDecision, LabRunnerGateMode, RunnerCapabilityPreflight, RunnerConnectReport,
-    RunnerExecOptions, RunnerRequiredTool, RunnerStatusReport, RunnerTunnelMode,
+    RunnerExecOptions, RunnerExecOutput, RunnerRequiredTool, RunnerStatusReport, RunnerTunnelMode,
     RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
 
@@ -495,8 +497,20 @@ fn run_lab_offload_inner(
     if exec_output.mirror_run_id.is_some() {
         plan = add_success_step(plan, "lab.mirror_evidence");
     }
-    if request.capture_patch {
-        plan = add_success_step(plan, "lab.apply_patch");
+    if request.capture_patch && exit_code == 0 {
+        let apply_output = apply_lab_offload_patch(&exec_output)?;
+        if let Some(apply_output) = apply_output {
+            plan = with_step(
+                plan,
+                PlanStep::builder(
+                    "lab.apply_patch",
+                    "lab.apply_patch",
+                    PlanStepStatus::Success,
+                )
+                .inputs(PlanValues::new().json("apply", &apply_output))
+                .build(),
+            );
+        }
     }
 
     let mut stderr = String::new();
@@ -511,6 +525,70 @@ fn run_lab_offload_inner(
         stdout: exec_output.stdout,
         stderr,
         exit_code,
+    })
+}
+
+fn apply_lab_offload_patch(
+    exec_output: &RunnerExecOutput,
+) -> Result<Option<super::RunnerWorkspaceApplyOutput>> {
+    let Some(patch) = exec_output.patch.as_ref() else {
+        return Ok(None);
+    };
+    let modified_files = patch
+        .get("modified_files")
+        .and_then(|value| value.as_array())
+        .map(|files| {
+            files
+                .iter()
+                .filter_map(|file| file.as_str())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let Some(patch_path) = patch
+        .get("patch_artifact_path")
+        .and_then(|value| value.as_str())
+    else {
+        if modified_files.is_empty() {
+            return Ok(None);
+        }
+        return Err(Error::internal_unexpected(
+            "Lab offload captured modified files but did not return a patch artifact path",
+        ));
+    };
+    let source_snapshot = exec_output.source_snapshot.clone().ok_or_else(|| {
+        Error::internal_unexpected("Lab offload patch apply requires the source snapshot")
+    })?;
+    let patch_content = read_lab_patch_artifact(patch_path)?;
+    if patch_content.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let artifact = ChangeArtifact {
+        schema: CHANGE_ARTIFACT_SCHEMA.to_string(),
+        source_snapshot,
+        patch: Some(ChangePatch {
+            format: "unified_diff".to_string(),
+            content: patch_content,
+        }),
+        delta: None,
+        provenance: None,
+        digest: None,
+    };
+
+    apply_change_artifact(artifact, false).map(Some)
+}
+
+fn read_lab_patch_artifact(path: &str) -> Result<String> {
+    let local_path = if is_retrievable_runner_artifact(path) {
+        download_remote_artifact(path, None)?.output_path
+    } else {
+        PathBuf::from(path)
+    };
+    std::fs::read_to_string(&local_path).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("read Lab patch artifact {}", local_path.display())),
+        )
     })
 }
 
@@ -1157,6 +1235,61 @@ mod tests {
     }
 
     #[test]
+    fn apply_lab_offload_patch_writes_runner_patch_to_local_source() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        git(repo.path(), &["init"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(repo.path().join("file.txt"), "before\n").expect("seed file");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "base"]);
+        let snapshot = SourceSnapshot::collect_local(
+            "lab",
+            repo.path(),
+            Some("/srv/homeboy/_lab_workspaces/repo-abc"),
+            "lab_offload",
+        );
+        let artifact_dir = tempfile::tempdir().expect("artifact tempdir");
+        let patch_path = artifact_dir.path().join("patch.diff");
+        std::fs::write(
+            &patch_path,
+            "diff --git a/file.txt b/file.txt\nindex 5626abf..f719efd 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-before\n+after\n",
+        )
+        .expect("patch file");
+        let exec_output = RunnerExecOutput {
+            command: "runner.exec",
+            runner_id: "lab".to_string(),
+            mode: super::super::RunnerExecMode::Daemon,
+            argv: vec!["homeboy".to_string(), "refactor".to_string()],
+            remote_cwd: "/srv/homeboy/_lab_workspaces/repo-abc".to_string(),
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            source_snapshot: Some(snapshot),
+            job: None,
+            job_id: None,
+            job_events: None,
+            mirror_run_id: None,
+            patch: Some(serde_json::json!({
+                "modified_files": ["file.txt"],
+                "patch_artifact_path": patch_path.display().to_string(),
+            })),
+            metrics: None,
+            capture: None,
+        };
+
+        let output = apply_lab_offload_patch(&exec_output)
+            .expect("apply patch")
+            .expect("patch applied");
+
+        assert_eq!(output.result.modified_files, vec!["file.txt".to_string()]);
+        assert_eq!(
+            std::fs::read_to_string(repo.path().join("file.txt")).expect("file"),
+            "after\n"
+        );
+    }
+
+    #[test]
     fn lab_runner_selection_keeps_explicit_runner_precedence() {
         let command = portable_lab_command("test");
         let selection = resolve_lab_runner_selection_from_default(
@@ -1421,5 +1554,19 @@ mod tests {
         assert_eq!(plan.steps[0].id, "lab.select_runner");
         assert_eq!(plan.steps[0].status, PlanStepStatus::Skipped);
         assert_eq!(metadata.expect("metadata")["status"], "skipped");
+    }
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -3,23 +3,22 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use crate::core::change_artifact::{ChangeArtifact, ChangePatch, CHANGE_ARTIFACT_SCHEMA};
 use crate::core::observation::{PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, Result};
 
 use super::{
-    apply_change_artifact, download_remote_artifact, evaluate_lab_runner_capabilities_for_runner,
-    exec, is_retrievable_runner_artifact, lab_offload_changed_since_ref, lab_offload_metadata,
-    lab_offload_metadata_with_workspace_mapping, lab_runner_capability_plan, load,
-    preflight_lab_offload_changed_since, prepare_git_lab_offload_changed_since,
+    evaluate_lab_runner_capabilities_for_runner, exec, lab_offload_changed_since_ref,
+    lab_offload_metadata, lab_offload_metadata_with_workspace_mapping, lab_runner_capability_plan,
+    load, preflight_lab_offload_changed_since, prepare_git_lab_offload_changed_since,
     rig_materialization, status, sync_workspace, LabRunnerCapabilityContract,
     LabRunnerGateDecision, LabRunnerGateMode, RunnerCapabilityPreflight, RunnerConnectReport,
-    RunnerExecOptions, RunnerExecOutput, RunnerRequiredTool, RunnerStatusReport, RunnerTunnelMode,
+    RunnerExecOptions, RunnerRequiredTool, RunnerStatusReport, RunnerTunnelMode,
     RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
 
+use super::lab_apply::apply_lab_offload_patch;
 use super::lab_env::{build_lab_offload_env, forward_env_if_present};
 use super::lab_workspaces::{
     lab_extra_workspaces, lab_workspace_mapping_metadata, sync_extra_lab_workspaces,
@@ -525,70 +524,6 @@ fn run_lab_offload_inner(
         stdout: exec_output.stdout,
         stderr,
         exit_code,
-    })
-}
-
-fn apply_lab_offload_patch(
-    exec_output: &RunnerExecOutput,
-) -> Result<Option<super::RunnerWorkspaceApplyOutput>> {
-    let Some(patch) = exec_output.patch.as_ref() else {
-        return Ok(None);
-    };
-    let modified_files = patch
-        .get("modified_files")
-        .and_then(|value| value.as_array())
-        .map(|files| {
-            files
-                .iter()
-                .filter_map(|file| file.as_str())
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-    let Some(patch_path) = patch
-        .get("patch_artifact_path")
-        .and_then(|value| value.as_str())
-    else {
-        if modified_files.is_empty() {
-            return Ok(None);
-        }
-        return Err(Error::internal_unexpected(
-            "Lab offload captured modified files but did not return a patch artifact path",
-        ));
-    };
-    let source_snapshot = exec_output.source_snapshot.clone().ok_or_else(|| {
-        Error::internal_unexpected("Lab offload patch apply requires the source snapshot")
-    })?;
-    let patch_content = read_lab_patch_artifact(patch_path)?;
-    if patch_content.trim().is_empty() {
-        return Ok(None);
-    }
-
-    let artifact = ChangeArtifact {
-        schema: CHANGE_ARTIFACT_SCHEMA.to_string(),
-        source_snapshot,
-        patch: Some(ChangePatch {
-            format: "unified_diff".to_string(),
-            content: patch_content,
-        }),
-        delta: None,
-        provenance: None,
-        digest: None,
-    };
-
-    apply_change_artifact(artifact, false).map(Some)
-}
-
-fn read_lab_patch_artifact(path: &str) -> Result<String> {
-    let local_path = if is_retrievable_runner_artifact(path) {
-        download_remote_artifact(path, None)?.output_path
-    } else {
-        PathBuf::from(path)
-    };
-    std::fs::read_to_string(&local_path).map_err(|err| {
-        Error::internal_io(
-            err.to_string(),
-            Some(format!("read Lab patch artifact {}", local_path.display())),
-        )
     })
 }
 
@@ -1235,61 +1170,6 @@ mod tests {
     }
 
     #[test]
-    fn apply_lab_offload_patch_writes_runner_patch_to_local_source() {
-        let repo = tempfile::tempdir().expect("repo tempdir");
-        git(repo.path(), &["init"]);
-        git(repo.path(), &["config", "user.email", "test@example.com"]);
-        git(repo.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(repo.path().join("file.txt"), "before\n").expect("seed file");
-        git(repo.path(), &["add", "."]);
-        git(repo.path(), &["commit", "-m", "base"]);
-        let snapshot = SourceSnapshot::collect_local(
-            "lab",
-            repo.path(),
-            Some("/srv/homeboy/_lab_workspaces/repo-abc"),
-            "lab_offload",
-        );
-        let artifact_dir = tempfile::tempdir().expect("artifact tempdir");
-        let patch_path = artifact_dir.path().join("patch.diff");
-        std::fs::write(
-            &patch_path,
-            "diff --git a/file.txt b/file.txt\nindex 5626abf..f719efd 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-before\n+after\n",
-        )
-        .expect("patch file");
-        let exec_output = RunnerExecOutput {
-            command: "runner.exec",
-            runner_id: "lab".to_string(),
-            mode: super::super::RunnerExecMode::Daemon,
-            argv: vec!["homeboy".to_string(), "refactor".to_string()],
-            remote_cwd: "/srv/homeboy/_lab_workspaces/repo-abc".to_string(),
-            exit_code: 0,
-            stdout: String::new(),
-            stderr: String::new(),
-            source_snapshot: Some(snapshot),
-            job: None,
-            job_id: None,
-            job_events: None,
-            mirror_run_id: None,
-            patch: Some(serde_json::json!({
-                "modified_files": ["file.txt"],
-                "patch_artifact_path": patch_path.display().to_string(),
-            })),
-            metrics: None,
-            capture: None,
-        };
-
-        let output = apply_lab_offload_patch(&exec_output)
-            .expect("apply patch")
-            .expect("patch applied");
-
-        assert_eq!(output.result.modified_files, vec!["file.txt".to_string()]);
-        assert_eq!(
-            std::fs::read_to_string(repo.path().join("file.txt")).expect("file"),
-            "after\n"
-        );
-    }
-
-    #[test]
     fn lab_runner_selection_keeps_explicit_runner_precedence() {
         let command = portable_lab_command("test");
         let selection = resolve_lab_runner_selection_from_default(
@@ -1554,19 +1434,5 @@ mod tests {
         assert_eq!(plan.steps[0].id, "lab.select_runner");
         assert_eq!(plan.steps[0].status, PlanStepStatus::Skipped);
         assert_eq!(metadata.expect("metadata")["status"], "skipped");
-    }
-
-    fn git(path: &Path, args: &[&str]) {
-        let output = std::process::Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
-        assert!(
-            output.status.success(),
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
     }
 }

--- a/src/core/runner/lab_apply.rs
+++ b/src/core/runner/lab_apply.rs
@@ -1,0 +1,151 @@
+use std::path::PathBuf;
+
+use crate::core::change_artifact::{ChangeArtifact, ChangePatch, CHANGE_ARTIFACT_SCHEMA};
+use crate::core::{Error, Result};
+
+use super::{
+    apply_change_artifact, download_remote_artifact, is_retrievable_runner_artifact,
+    RunnerExecOutput, RunnerWorkspaceApplyOutput,
+};
+
+pub(super) fn apply_lab_offload_patch(
+    exec_output: &RunnerExecOutput,
+) -> Result<Option<RunnerWorkspaceApplyOutput>> {
+    let Some(patch) = exec_output.patch.as_ref() else {
+        return Ok(None);
+    };
+    let modified_files = patch
+        .get("modified_files")
+        .and_then(|value| value.as_array())
+        .map(|files| {
+            files
+                .iter()
+                .filter_map(|file| file.as_str())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let Some(patch_path) = patch
+        .get("patch_artifact_path")
+        .and_then(|value| value.as_str())
+    else {
+        if modified_files.is_empty() {
+            return Ok(None);
+        }
+        return Err(Error::internal_unexpected(
+            "Lab offload captured modified files but did not return a patch artifact path",
+        ));
+    };
+    let source_snapshot = exec_output.source_snapshot.clone().ok_or_else(|| {
+        Error::internal_unexpected("Lab offload patch apply requires the source snapshot")
+    })?;
+    let patch_content = read_lab_patch_artifact(patch_path)?;
+    if patch_content.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let artifact = ChangeArtifact {
+        schema: CHANGE_ARTIFACT_SCHEMA.to_string(),
+        source_snapshot,
+        patch: Some(ChangePatch {
+            format: "unified_diff".to_string(),
+            content: patch_content,
+        }),
+        delta: None,
+        provenance: None,
+        digest: None,
+    };
+
+    apply_change_artifact(artifact, false).map(Some)
+}
+
+fn read_lab_patch_artifact(path: &str) -> Result<String> {
+    let local_path = if is_retrievable_runner_artifact(path) {
+        download_remote_artifact(path, None)?.output_path
+    } else {
+        PathBuf::from(path)
+    };
+    std::fs::read_to_string(&local_path).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("read Lab patch artifact {}", local_path.display())),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use crate::core::source_snapshot::SourceSnapshot;
+
+    use super::*;
+
+    #[test]
+    fn apply_lab_offload_patch_writes_runner_patch_to_local_source() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        git(repo.path(), &["init"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(repo.path().join("file.txt"), "before\n").expect("seed file");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "base"]);
+        let snapshot = SourceSnapshot::collect_local(
+            "lab",
+            repo.path(),
+            Some("/srv/homeboy/_lab_workspaces/repo-abc"),
+            "lab_offload",
+        );
+        let artifact_dir = tempfile::tempdir().expect("artifact tempdir");
+        let patch_path = artifact_dir.path().join("patch.diff");
+        std::fs::write(
+            &patch_path,
+            "diff --git a/file.txt b/file.txt\nindex 5626abf..f719efd 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-before\n+after\n",
+        )
+        .expect("patch file");
+        let exec_output = RunnerExecOutput {
+            command: "runner.exec",
+            runner_id: "lab".to_string(),
+            mode: super::super::RunnerExecMode::Daemon,
+            argv: vec!["homeboy".to_string(), "refactor".to_string()],
+            remote_cwd: "/srv/homeboy/_lab_workspaces/repo-abc".to_string(),
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            source_snapshot: Some(snapshot),
+            job: None,
+            job_id: None,
+            job_events: None,
+            mirror_run_id: None,
+            patch: Some(serde_json::json!({
+                "modified_files": ["file.txt"],
+                "patch_artifact_path": patch_path.display().to_string(),
+            })),
+            metrics: None,
+            capture: None,
+        };
+
+        let output = apply_lab_offload_patch(&exec_output)
+            .expect("apply patch")
+            .expect("patch applied");
+
+        assert_eq!(output.result.modified_files, vec!["file.txt".to_string()]);
+        assert_eq!(
+            std::fs::read_to_string(repo.path().join("file.txt")).expect("file"),
+            "after\n"
+        );
+    }
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -29,8 +29,8 @@ mod worker;
 mod workspace;
 
 pub use apply::{
-    apply_workspace_patch, RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput,
-    RunnerWorkspaceApplyStatus,
+    apply_change_artifact, apply_workspace_patch, RunnerWorkspaceApplyOptions,
+    RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus,
 };
 pub use capabilities::{
     evaluate_lab_runner_capabilities_for_runner, lab_runner_capability_plan,

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -17,6 +17,7 @@ mod connection;
 mod evidence;
 mod execution;
 mod lab;
+mod lab_apply;
 mod lab_env;
 mod lab_workspaces;
 mod offload_changed_since;

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -495,7 +495,7 @@ fn materialize_git_command(
         .unwrap_or_default();
 
     format!(
-        "mkdir -p {parent} && if [ -d {dest}/.git ]; then git -C {dest} fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf {dest} && git clone {url} {dest} && git -C {dest} fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_changed_since} && git -C {dest} checkout --detach {head} && git -C {dest} clean -ffdqx",
+        "mkdir -p {parent} && if [ -d {dest}/.git ]; then git -C {dest} reset --hard && git -C {dest} clean -ffdqx && git -C {dest} fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf {dest} && git clone {url} {dest} && git -C {dest} fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_changed_since} && git -C {dest} checkout --detach {head} && git -C {dest} reset --hard {head} && git -C {dest} clean -ffdqx",
         parent = shell::quote_arg(parent_remote_path(remote_path).as_str()),
         dest = dest,
         url = shell::quote_arg(remote_url),
@@ -737,6 +737,8 @@ mod tests {
         assert!(command.contains("rev-parse --verify -q 'def456^{commit}'"));
         assert!(command.contains("fetch origin def456"));
         assert!(command.contains("checkout --detach abc123"));
+        assert!(command.contains("reset --hard"));
+        assert!(command.contains("reset --hard abc123"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Applies successful Lab offload patch artifacts back to the controller worktree for mutating commands such as `refactor --write`.
- Resets reused git-backed Lab runner workspaces before and after checkout so stale dirty state from a previous offloaded write does not poison retries.
- Keeps `runner.workspace.apply` compatibility while exposing an in-memory change-artifact apply helper for controller-side write-back.

Fixes #3296.

## Testing
- `cargo test apply_lab_offload_patch_writes_runner_patch_to_local_source`
- `cargo test git_materialization_fetches_changed_since_base_before_checkout`
- `cargo test test_apply_workspace_patch`
- `cargo test rig_trace_list_uses_scoped_workload_preflight`

## Known unrelated failure
- `cargo test test_deploy_artifact_flattens_double_nested_plugin_zip` still fails on `origin/main` after rebase with the existing deploy double-nested-layout assertion.
- Full `cargo test` before rebase had 3,726 passing tests and failed on that deploy test plus `rig_trace_list_uses_scoped_workload_preflight`; the trace test passes after rebasing onto latest `origin/main`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runner write-back/reset patch, added targeted tests, and ran verification; Chris remains responsible for review and merge.