### PR TITLE
fix(agent-task): resolve declared secret env before dispatch

### DIFF
--- a/docs/architecture/agent-task-executor-adapter.md
+++ b/docs/architecture/agent-task-executor-adapter.md
@@ -85,6 +85,43 @@ Retry policy stays executor-agnostic. `max_attempts` bounds per-task attempts,
 `retryable_failure_classifications` lets callers retry only normalized failure
 classes such as `Provider` or `ExecutionFailed`.
 
+## Secret environment
+
+Agent-task requests may declare required provider environment names in
+`executor.secret_env`. Homeboy core resolves those names before provider
+dispatch, validates that each name has a value, and injects the resolved values
+into the provider process environment. Secret values are not included in
+outcomes, diagnostics, aggregate JSON, or artifacts.
+
+Resolution order is:
+
+- The current process environment using the declared name.
+- `~/.config/homeboy/agent-task-secrets.json` entries.
+
+The optional local config file uses provider-agnostic sources:
+
+```json
+{
+  "secrets": {
+    "PROVIDER_TOKEN": {
+      "source": "env",
+      "env_var": "CI_PROVIDER_TOKEN"
+    },
+    "LOCAL_PROVIDER_TOKEN": {
+      "source": "keychain",
+      "scope": "agent-task",
+      "name": "LOCAL_PROVIDER_TOKEN"
+    }
+  }
+}
+```
+
+Use `source: "env"` in CI when a runner exposes a differently named variable.
+Use `source: "keychain"` for local operator machines that store secrets through
+Homeboy's OS keychain integration. Missing declared names produce a structured
+`agent_task.secret_env_missing` preflight outcome before the provider process is
+spawned.
+
 ## Provider payloads
 
 Provider payloads are intentionally opaque `serde_json::Value` objects until

--- a/src/commands/bench/fanout.rs
+++ b/src/commands/bench/fanout.rs
@@ -172,6 +172,7 @@ fn matrix_template_request(
             backend: executor_backend.to_string(),
             selector: None,
             required_capabilities: vec!["bench".to_string(), "matrix".to_string()],
+            secret_env: Vec::new(),
             model: None,
             config: serde_json::json!({}),
         },

--- a/src/core/agent_task.rs
+++ b/src/core/agent_task.rs
@@ -283,6 +283,8 @@ pub struct AgentTaskExecutor {
     pub selector: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub required_capabilities: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secret_env: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
@@ -650,6 +652,7 @@ mod tests {
                 backend: "browser_sandbox".to_string(),
                 selector: Some("lab-a".to_string()),
                 required_capabilities: vec!["structured_output".to_string()],
+                secret_env: Vec::new(),
                 model: Some("quality-model".to_string()),
                 config: json!({ "account": "team-a" }),
             },
@@ -856,6 +859,7 @@ mod tests {
                 backend: "cli_agent".to_string(),
                 selector: None,
                 required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
                 model: None,
                 config: json!({ "api_key": "secret-value" }),
             },
@@ -1133,6 +1137,7 @@ mod tests {
                 backend: "fake".to_string(),
                 selector: None,
                 required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
                 model: None,
                 config: json!({}),
             },
@@ -1267,6 +1272,7 @@ mod tests {
                 backend: "fake".to_string(),
                 selector: None,
                 required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
                 model: None,
                 config: json!({}),
             },

--- a/src/core/agent_task/matrix.rs
+++ b/src/core/agent_task/matrix.rs
@@ -484,6 +484,7 @@ mod tests {
                 backend: "runner".to_string(),
                 selector: Some("homeboy-lab".to_string()),
                 required_capabilities: vec!["bench".to_string()],
+                secret_env: Vec::new(),
                 model: None,
                 config: json!({}),
             },

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -504,6 +504,7 @@ mod tests {
                     backend: "test".to_string(),
                     selector: Some("fixture".to_string()),
                     required_capabilities: Vec::new(),
+                    secret_env: Vec::new(),
                     model: None,
                     config: Value::Null,
                 },

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -9,6 +9,7 @@ use crate::core::agent_task::{
     AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_OUTCOME_SCHEMA,
 };
 use crate::core::agent_task_scheduler::{AgentTaskExecutionContext, AgentTaskExecutorAdapter};
+use crate::core::agent_task_secrets::{resolve_secret_env, AgentTaskSecretResolutionError};
 use crate::core::extension::load_all_extensions;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -164,7 +165,19 @@ fn run_provider_command(
             )
         }
     };
-    let env = provider_command_env(request, provider);
+    let env = match provider_command_env(request, provider) {
+        Ok(env) => env,
+        Err(error) => {
+            return failure_outcome(
+                request,
+                AgentTaskOutcomeStatus::ProviderError,
+                AgentTaskFailureClassification::InvalidInput,
+                "agent_task.secret_env_missing",
+                error.message,
+                json!({ "provider": provider.id, "missing_secret_env": error.missing_secret_env }),
+            )
+        }
+    };
 
     let mut child = match Command::new(&program)
         .args(&args)
@@ -285,8 +298,8 @@ fn provider_command_parts(command: &str) -> Option<(String, Vec<String>)> {
 fn provider_command_env(
     request: &AgentTaskRequest,
     provider: &AgentTaskExecutorProvider,
-) -> Vec<(String, String)> {
-    vec![
+) -> Result<Vec<(String, String)>, AgentTaskSecretResolutionError> {
+    let mut env = vec![
         (
             "HOMEBOY_AGENT_TASK_PROVIDER_ID".to_string(),
             provider.id.clone(),
@@ -303,7 +316,9 @@ fn provider_command_env(
             "HOMEBOY_EXTENSION_PATH".to_string(),
             provider.extension_path.clone().unwrap_or_default(),
         ),
-    ]
+    ];
+    env.extend(resolve_secret_env(&request.executor.secret_env)?);
+    Ok(env)
 }
 
 fn failure_outcome(
@@ -379,6 +394,7 @@ mod tests {
                 backend: "test".to_string(),
                 selector: None,
                 required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
                 model: None,
                 config: Value::Null,
             },
@@ -455,6 +471,64 @@ mod tests {
         assert_eq!(
             aggregate.outcomes[0].summary.as_deref(),
             Some("test.provider")
+        );
+    }
+
+    #[test]
+    fn provider_command_receives_declared_secret_env() {
+        let secret_name = format!("HOMEBOY_TEST_AGENT_TASK_SECRET_{}", std::process::id());
+        std::env::set_var(&secret_name, "hydrated-secret");
+        let command = format!(
+            "node {}",
+            script(&format!(
+                "let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:process.env.{secret_name}==='hydrated-secret'?'succeeded':'failed',summary:'checked'}}));"
+            ))
+        );
+        let (mut request, provider) = request("task-secret-env", command);
+        request.executor.secret_env = vec![secret_name.clone()];
+        let scheduler =
+            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+                provider,
+            ]));
+
+        let aggregate = scheduler.run(AgentTaskPlan::new("plan-secret-env", vec![request]));
+
+        assert_eq!(aggregate.totals.succeeded, 1);
+        std::env::remove_var(secret_name);
+    }
+
+    #[test]
+    fn missing_declared_secret_env_fails_before_provider_spawn() {
+        let secret_name = format!(
+            "HOMEBOY_TEST_MISSING_AGENT_TASK_SECRET_{}",
+            std::process::id()
+        );
+        std::env::remove_var(&secret_name);
+        let command = format!(
+            "node {}",
+            script("throw new Error('provider should not run');")
+        );
+        let (mut request, provider) = request("task-missing-secret-env", command);
+        request.executor.secret_env = vec![secret_name.clone()];
+        let scheduler =
+            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+                provider,
+            ]));
+
+        let aggregate = scheduler.run(AgentTaskPlan::new("plan-missing-secret-env", vec![request]));
+
+        assert_eq!(aggregate.totals.failed, 1);
+        assert_eq!(
+            aggregate.outcomes[0].failure_classification,
+            Some(AgentTaskFailureClassification::InvalidInput)
+        );
+        assert_eq!(
+            aggregate.outcomes[0].diagnostics[0].class,
+            "agent_task.secret_env_missing"
+        );
+        assert_eq!(
+            aggregate.outcomes[0].diagnostics[0].data["missing_secret_env"],
+            json!([secret_name])
         );
     }
 }

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -1171,6 +1171,7 @@ mod tests {
                 backend: "test".to_string(),
                 selector: None,
                 required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
                 model: None,
                 config: Value::Null,
             },

--- a/src/core/agent_task_secrets.rs
+++ b/src/core/agent_task_secrets.rs
@@ -1,0 +1,170 @@
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::keychain;
+use crate::core::paths;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentTaskSecretResolutionError {
+    pub missing_secret_env: Vec<String>,
+    pub message: String,
+}
+
+pub fn resolve_secret_env(
+    names: &[String],
+) -> Result<Vec<(String, String)>, AgentTaskSecretResolutionError> {
+    resolve_secret_env_with_config(names, &AgentTaskSecretConfig::load())
+}
+
+fn resolve_secret_env_with_config(
+    names: &[String],
+    config: &AgentTaskSecretConfig,
+) -> Result<Vec<(String, String)>, AgentTaskSecretResolutionError> {
+    if names.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut resolved = Vec::new();
+    let mut missing = Vec::new();
+
+    for name in names {
+        if let Ok(value) = env::var(name) {
+            resolved.push((name.clone(), value));
+            continue;
+        }
+
+        match config
+            .secrets
+            .get(name)
+            .and_then(|source| source.resolve(name))
+        {
+            Some(value) => resolved.push((name.clone(), value)),
+            None => missing.push(name.clone()),
+        }
+    }
+
+    if missing.is_empty() {
+        Ok(resolved)
+    } else {
+        Err(AgentTaskSecretResolutionError {
+            message: format!(
+                "missing required agent-task secret env: {}",
+                missing.join(", ")
+            ),
+            missing_secret_env: missing,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct AgentTaskSecretConfig {
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    secrets: HashMap<String, AgentTaskSecretSource>,
+}
+
+impl AgentTaskSecretConfig {
+    fn load() -> Self {
+        let Ok(path) = paths::homeboy().map(|root| root.join("agent-task-secrets.json")) else {
+            return Self::default();
+        };
+        let Ok(raw) = fs::read_to_string(path) else {
+            return Self::default();
+        };
+        serde_json::from_str(&raw).unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct AgentTaskSecretSource {
+    #[serde(default = "default_source")]
+    source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    env_var: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    scope: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+}
+
+impl AgentTaskSecretSource {
+    fn resolve(&self, requested_name: &str) -> Option<String> {
+        match self.source.as_str() {
+            "env" => env::var(self.env_var.as_deref().unwrap_or(requested_name)).ok(),
+            "keychain" => keychain::get(
+                self.scope.as_deref().unwrap_or("agent-task"),
+                self.name.as_deref().unwrap_or(requested_name),
+            )
+            .ok()
+            .flatten(),
+            _ => None,
+        }
+    }
+}
+
+fn default_source() -> String {
+    "env".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_env(name: &str) -> String {
+        format!("HOMEBOY_TEST_{}_{}", name, std::process::id())
+    }
+
+    #[test]
+    fn resolves_declared_secret_from_process_env() {
+        let name = unique_env("DIRECT_SECRET");
+        std::env::set_var(&name, "secret-value");
+
+        let resolved = resolve_secret_env(std::slice::from_ref(&name)).expect("secret resolves");
+
+        assert_eq!(resolved, vec![(name.clone(), "secret-value".to_string())]);
+        std::env::remove_var(name);
+    }
+
+    #[test]
+    fn reports_missing_declared_secret_names_without_values() {
+        let name = unique_env("MISSING_SECRET");
+        std::env::remove_var(&name);
+
+        let error = resolve_secret_env(std::slice::from_ref(&name)).expect_err("secret missing");
+
+        assert_eq!(error.missing_secret_env, vec![name.clone()]);
+        assert!(error.message.contains(&name));
+        assert!(!error.message.contains("secret-value"));
+    }
+
+    #[test]
+    fn resolves_declared_secret_from_configured_env_source() {
+        let configured_name = unique_env("CONFIGURED_SECRET");
+        let source_name = unique_env("CONFIGURED_SOURCE");
+        std::env::remove_var(&configured_name);
+        std::env::set_var(&source_name, "configured-secret-value");
+        let mut secrets = HashMap::new();
+        secrets.insert(
+            configured_name.clone(),
+            AgentTaskSecretSource {
+                source: "env".to_string(),
+                env_var: Some(source_name.clone()),
+                scope: None,
+                name: None,
+            },
+        );
+        let config = AgentTaskSecretConfig { secrets };
+
+        let resolved =
+            resolve_secret_env_with_config(std::slice::from_ref(&configured_name), &config)
+                .expect("secret resolves");
+
+        assert_eq!(
+            resolved,
+            vec![(configured_name, "configured-secret-value".to_string())]
+        );
+        std::env::remove_var(source_name);
+    }
+}

--- a/src/core/extension/bench/report/comparison.rs
+++ b/src/core/extension/bench/report/comparison.rs
@@ -423,6 +423,7 @@ fn build_agent_task_matrix_summary(
                 backend: "homeboy.bench".to_string(),
                 selector: None,
                 required_capabilities: vec!["bench".to_string()],
+                secret_env: Vec::new(),
                 model: None,
                 config: Value::Null,
             },

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,6 +8,7 @@ pub mod agent_task_promotion;
 pub mod agent_task_provider;
 pub mod agent_task_schedule;
 pub mod agent_task_scheduler;
+pub mod agent_task_secrets;
 pub mod api_jobs;
 pub mod artifact_manifest;
 pub(crate) mod artifact_metadata;


### PR DESCRIPTION
## Summary
- Adds `executor.secret_env` to generic agent-task requests so plans can declare provider environment names without provider-specific Homeboy code.
- Resolves declared names before extension provider dispatch from process env or `~/.config/homeboy/agent-task-secrets.json` using generic `env` and `keychain` sources.
- Returns structured `agent_task.secret_env_missing` preflight outcomes before spawning providers, while keeping secret values out of diagnostics/artifacts.

## Verification
- `cargo test agent_task_secrets --lib` passed: 3 passed.
- `cargo test agent_task_provider --lib` passed: 5 passed.
- `cargo check --release` passed.
- `homeboy lint` passed with no findings.
- `homeboy test` did not complete because the current local harness has unrelated environment failures: missing `zip` for deploy archive tests, daemon connection failure, resource run-dir artifact write failure, and source snapshot workspace-root detection failure.

## Blockers
- Full `homeboy test` is blocked locally by the unrelated harness/environment failures listed above. The targeted agent-task coverage and release compile are green.

Closes #3313.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and implemented the generic agent-task secret env resolver, tests, docs, and PR text; Chris remains responsible for review and merge decisions.