### PR TITLE
fix(runs): reconcile interrupted run metadata

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -377,6 +377,7 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
 
 fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
+    reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
     let run = require_run(&store, run_id)?;
     Ok((
         RunsOutput::Show(RunsShowOutput {
@@ -731,6 +732,44 @@ mod tests {
             );
             assert_eq!(output.run.artifacts.len(), 1);
             assert_eq!(output.run.artifacts[0].kind, "bench_results");
+        });
+    }
+
+    #[test]
+    fn run_show_reconciles_owned_dead_running_run_before_displaying() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            store
+                .import_run(&RunRecord {
+                    id: "dead-owned-run".to_string(),
+                    kind: "bench".to_string(),
+                    component_id: Some("homeboy".to_string()),
+                    started_at: "2026-05-02T16:46:46Z".to_string(),
+                    finished_at: None,
+                    status: "running".to_string(),
+                    command: Some("homeboy bench".to_string()),
+                    cwd: Some("/tmp/homeboy-fixture".to_string()),
+                    homeboy_version: Some("test-version".to_string()),
+                    git_sha: Some("abc123".to_string()),
+                    rig_id: Some("studio".to_string()),
+                    metadata_json: serde_json::json!({
+                        "homeboy_run_owner": { "pid": u32::MAX }
+                    }),
+                })
+                .expect("import stale fixture");
+
+            let (output, _) = show_run("dead-owned-run").expect("show");
+            let RunsOutput::Show(output) = output else {
+                panic!("expected show output");
+            };
+
+            assert_eq!(output.run.summary.status, "stale");
+            assert!(output.run.summary.finished_at.is_some());
+            assert_eq!(
+                output.run.metadata["homeboy_reconciled"]["reason"],
+                "owner_process_not_running"
+            );
         });
     }
 

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -605,6 +605,23 @@ mod tests {
             .build()
     }
 
+    fn dead_owned_run(id: &str) -> RunRecord {
+        RunRecord {
+            id: id.to_string(),
+            kind: "bench".to_string(),
+            component_id: Some("homeboy".to_string()),
+            started_at: "2026-05-02T16:46:46Z".to_string(),
+            finished_at: None,
+            status: "running".to_string(),
+            command: Some("homeboy bench".to_string()),
+            cwd: Some("/tmp/homeboy-fixture".to_string()),
+            homeboy_version: Some("test-version".to_string()),
+            git_sha: Some("abc123".to_string()),
+            rig_id: Some("studio".to_string()),
+            metadata_json: serde_json::json!({ "homeboy_run_owner": { "pid": u32::MAX } }),
+        }
+    }
+
     #[test]
     fn run_list_filters_kind_component_rig_and_status() {
         with_isolated_home(|_home| {
@@ -650,22 +667,7 @@ mod tests {
             let _xdg = XdgGuard::unset();
             let store = ObservationStore::open_initialized().expect("store");
             store
-                .import_run(&RunRecord {
-                    id: "dead-owned-run".to_string(),
-                    kind: "bench".to_string(),
-                    component_id: Some("homeboy".to_string()),
-                    started_at: "2026-05-02T16:46:46Z".to_string(),
-                    finished_at: None,
-                    status: "running".to_string(),
-                    command: Some("homeboy bench".to_string()),
-                    cwd: Some("/tmp/homeboy-fixture".to_string()),
-                    homeboy_version: Some("test-version".to_string()),
-                    git_sha: Some("abc123".to_string()),
-                    rig_id: Some("studio".to_string()),
-                    metadata_json: serde_json::json!({
-                        "homeboy_run_owner": { "pid": u32::MAX }
-                    }),
-                })
+                .import_run(&dead_owned_run("dead-owned-run"))
                 .expect("import stale fixture");
 
             let (output, _) = list_runs(
@@ -741,31 +743,13 @@ mod tests {
             let _xdg = XdgGuard::unset();
             let store = ObservationStore::open_initialized().expect("store");
             store
-                .import_run(&RunRecord {
-                    id: "dead-owned-run".to_string(),
-                    kind: "bench".to_string(),
-                    component_id: Some("homeboy".to_string()),
-                    started_at: "2026-05-02T16:46:46Z".to_string(),
-                    finished_at: None,
-                    status: "running".to_string(),
-                    command: Some("homeboy bench".to_string()),
-                    cwd: Some("/tmp/homeboy-fixture".to_string()),
-                    homeboy_version: Some("test-version".to_string()),
-                    git_sha: Some("abc123".to_string()),
-                    rig_id: Some("studio".to_string()),
-                    metadata_json: serde_json::json!({
-                        "homeboy_run_owner": { "pid": u32::MAX }
-                    }),
-                })
+                .import_run(&dead_owned_run("dead-owned-run"))
                 .expect("import stale fixture");
-
             let (output, _) = show_run("dead-owned-run").expect("show");
             let RunsOutput::Show(output) = output else {
                 panic!("expected show output");
             };
-
             assert_eq!(output.run.summary.status, "stale");
-            assert!(output.run.summary.finished_at.is_some());
             assert_eq!(
                 output.run.metadata["homeboy_reconciled"]["reason"],
                 "owner_process_not_running"

--- a/src/commands/runs/reconcile.rs
+++ b/src/commands/runs/reconcile.rs
@@ -1,7 +1,9 @@
 use clap::Args;
 use serde::Serialize;
 use serde_json::Value;
+use std::path::{Path, PathBuf};
 
+use homeboy::core::engine::run_dir;
 use homeboy::core::observation::{
     run_owner_pid, ObservationStore, RunListFilter, RunRecord, RunStatus,
 };
@@ -96,11 +98,20 @@ where
         }
 
         let reason = "owner_process_not_running".to_string();
-        let artifact_count = store.list_artifacts(&run.id)?.len();
+        let artifact_count = if dry_run {
+            store.list_artifacts(&run.id)?.len()
+        } else {
+            reconcile_available_run_dir_artifacts(store, &run)?
+        };
         let finished = if dry_run {
             None
         } else {
-            let metadata = with_reconcile_metadata(&run, owner_pid, &reason);
+            let metadata = with_reconcile_metadata(
+                &run,
+                owner_pid,
+                &reason,
+                &reconcile_run_dir_metadata(&run),
+            );
             Some(store.finish_run(&run.id, RunStatus::Stale, Some(metadata))?)
         };
 
@@ -124,14 +135,26 @@ pub fn running_status_note(run: &RunRecord) -> Option<String> {
     homeboy::core::observation::running_status_note(run)
 }
 
-fn with_reconcile_metadata(run: &RunRecord, owner_pid: u32, reason: &str) -> Value {
+fn with_reconcile_metadata(
+    run: &RunRecord,
+    owner_pid: u32,
+    reason: &str,
+    run_dir_metadata: &Value,
+) -> Value {
     let mut metadata = run.metadata_json.clone();
-    let marker = serde_json::json!({
+    let mut marker = serde_json::json!({
         "status": RunStatus::Stale.as_str(),
         "reason": reason,
         "owner_pid": owner_pid,
         "reconciled_at": chrono::Utc::now().to_rfc3339(),
     });
+    if let (Some(marker), Some(run_dir_metadata)) =
+        (marker.as_object_mut(), run_dir_metadata.as_object())
+    {
+        for (key, value) in run_dir_metadata {
+            marker.insert(key.clone(), value.clone());
+        }
+    }
 
     if let Some(object) = metadata.as_object_mut() {
         object.insert("homeboy_reconciled".to_string(), marker);
@@ -142,6 +165,79 @@ fn with_reconcile_metadata(run: &RunRecord, owner_pid: u32, reason: &str) -> Val
         "homeboy_reconciled": marker,
         "homeboy_original_metadata": metadata,
     })
+}
+
+fn reconcile_available_run_dir_artifacts(
+    store: &ObservationStore,
+    run: &RunRecord,
+) -> homeboy::core::Result<usize> {
+    if let Some(path) = run_dir_path(run) {
+        let resource_summary = path.join(run_dir::files::RESOURCE_SUMMARY);
+        if resource_summary.is_file() {
+            let already_recorded = store
+                .list_artifacts(&run.id)?
+                .iter()
+                .any(|artifact| artifact.kind == "resource_summary");
+            if !already_recorded {
+                let _ = store.record_artifact(&run.id, "resource_summary", &resource_summary);
+            }
+        }
+    }
+
+    Ok(store.list_artifacts(&run.id)?.len())
+}
+
+fn reconcile_run_dir_metadata(run: &RunRecord) -> Value {
+    let Some(path) = run_dir_path(run) else {
+        return Value::Null;
+    };
+    let extension_children = read_extension_children(&path);
+    if extension_children.is_empty() {
+        return Value::Null;
+    }
+    serde_json::json!({
+        "run_dir": path.to_string_lossy().to_string(),
+        "extension_children": extension_children,
+    })
+}
+
+fn run_dir_path(run: &RunRecord) -> Option<PathBuf> {
+    run.metadata_json
+        .get("run_dir")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .filter(|path| path.is_dir())
+}
+
+fn read_extension_children(run_dir_path: &Path) -> Vec<Value> {
+    let dir = run_dir_path.join(run_dir::files::EXTENSION_CHILDREN_DIR);
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut children = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if let Ok(value) = serde_json::from_str::<Value>(&content) {
+            children.push(value);
+        }
+    }
+    children.sort_by(|a, b| {
+        a.get("started_at")
+            .and_then(Value::as_str)
+            .cmp(&b.get("started_at").and_then(Value::as_str))
+            .then(
+                a.get("root_pid")
+                    .and_then(Value::as_u64)
+                    .cmp(&b.get("root_pid").and_then(Value::as_u64)),
+            )
+    });
+    children
 }
 
 #[cfg(test)]
@@ -218,6 +314,58 @@ mod tests {
             assert_eq!(
                 updated.metadata_json["homeboy_reconciled"]["status"],
                 "stale"
+            );
+            assert_eq!(store.list_artifacts(&run.id).expect("artifacts").len(), 1);
+        });
+    }
+
+    #[test]
+    fn reconcile_preserves_run_dir_child_metadata_when_parent_was_killed() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run_dir = home.path().join("homeboy-run-fixture");
+            let children_dir = run_dir.join(run_dir::files::EXTENSION_CHILDREN_DIR);
+            std::fs::create_dir_all(&children_dir).expect("children dir");
+            std::fs::write(run_dir.join(run_dir::files::RESOURCE_SUMMARY), b"{}").expect("summary");
+            std::fs::write(
+                children_dir.join("123.json"),
+                serde_json::to_vec_pretty(&serde_json::json!({
+                    "root_pid": 123,
+                    "command_label": "bench-runner.sh",
+                    "started_at": "2026-06-02T02:48:48.860570691+00:00",
+                    "finished_at": "2026-06-02T02:48:48.966939782+00:00",
+                    "duration_ms": 106,
+                    "sampled_peak_rss_bytes": 2052096,
+                    "sampled_peak_cpu_percent": 0,
+                    "warnings": []
+                }))
+                .expect("serialize child"),
+            )
+            .expect("child summary");
+
+            let run = store
+                .start_run(sample_run(
+                    "bench",
+                    "homeboy",
+                    "studio",
+                    serde_json::json!({ "run_dir": run_dir }),
+                ))
+                .expect("run");
+
+            let reconciled =
+                reconcile_orphaned_running_runs(&store, 1000, false, |_| false).expect("reconcile");
+            let updated = store
+                .get_run(&run.id)
+                .expect("get run")
+                .expect("run exists");
+
+            assert_eq!(reconciled.len(), 1);
+            assert_eq!(reconciled[0].artifact_count, 1);
+            assert_eq!(updated.status, "stale");
+            assert_eq!(
+                updated.metadata_json["homeboy_reconciled"]["extension_children"][0]["root_pid"],
+                123
             );
             assert_eq!(store.list_artifacts(&run.id).expect("artifacts").len(), 1);
         });


### PR DESCRIPTION
## Summary
- Reconcile dead-owned `running` records before `runs show`, matching the existing `runs list` behavior.
- Extend `runs reconcile` to recover available `resource-summary.json` artifacts from recorded `run_dir` metadata and preserve `extension-children/*.json` child metadata in the reconciliation marker.
- Keep `--dry-run` read-only while still reporting stale candidates.

Closes #3320.

## Tests
- `cargo test commands::runs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the run reconciliation code changes and focused regression tests; Chris remains responsible for review and verification.