### PR TITLE
fix(rig): diagnose stale linked rig sources

### DIFF
--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -92,6 +92,9 @@ pub(crate) fn files_match(left: &Path, right: &Path) -> bool {
 fn read_config(id: &str) -> Result<(RigSpec, Option<String>)> {
     let path = paths::rig_config(id)?;
     if !path.exists() {
+        if let Some(error) = stale_source_error(id, &path) {
+            return Err(error);
+        }
         let suggestions = list_ids().unwrap_or_default();
         return Err(Error::rig_not_found(id, suggestions));
     }
@@ -108,6 +111,47 @@ fn read_config(id: &str) -> Result<(RigSpec, Option<String>)> {
     let declared_id = (!spec.id.is_empty() && spec.id != id).then(|| spec.id.clone());
     spec.id = id.to_string();
     Ok((spec, declared_id))
+}
+
+fn stale_source_error(id: &str, config_path: &Path) -> Option<Error> {
+    let metadata = read_source_metadata(id)?;
+    let package_present = Path::new(&metadata.package_path).exists();
+    let rig_present = Path::new(&metadata.rig_path).is_file();
+    let config_entry_present = fs::symlink_metadata(config_path).is_ok();
+    if package_present && rig_present && !config_entry_present {
+        return None;
+    }
+
+    let problem = if metadata.linked && !package_present {
+        format!(
+            "Rig '{}' is installed from linked rig source '{}' but that source path is missing",
+            id, metadata.package_path
+        )
+    } else if !rig_present {
+        format!(
+            "Rig '{}' has installed source metadata but the recorded rig spec is missing: {}",
+            id, metadata.rig_path
+        )
+    } else {
+        format!(
+            "Rig '{}' has installed source metadata but its config path is missing: {}",
+            id,
+            config_path.display()
+        )
+    };
+
+    Some(
+        Error::validation_invalid_argument("rig_id", problem, Some(id.to_string()), None)
+            .with_hint("Run `homeboy rig sources list` to inspect installed rig sources")
+            .with_hint(format!(
+                "Restore the source path or remove the stale source: homeboy rig sources remove {}",
+                metadata.package_path
+            ))
+            .with_hint(format!(
+                "After removing it, reinstall the rig source: homeboy rig install {} --id {}",
+                metadata.source, id
+            )),
+    )
 }
 
 /// Load a rig spec by ID from `~/.config/homeboy/rigs/{id}.json`.
@@ -144,5 +188,11 @@ pub fn list_ids() -> Result<Vec<String>> {
     json_config::sorted_json_config_entries(&dir, "list rigs", "read rig entry", |e, context| {
         Error::internal_unexpected(format!("Failed to {}: {}", context, e))
     })
-    .map(|entries| entries.into_iter().map(|entry| entry.id).collect())
+    .map(|entries| {
+        entries
+            .into_iter()
+            .filter(|entry| entry.path.exists())
+            .map(|entry| entry.id)
+            .collect()
+    })
 }

--- a/src/core/rig/source.rs
+++ b/src/core/rig/source.rs
@@ -553,13 +553,16 @@ fn new_source_group(
     linked: bool,
     source_revision: Option<String>,
 ) -> RigSourceGroup {
+    let package_present = Path::new(package_path).exists();
     RigSourceGroup {
         source: source.to_string(),
         package_id: package_id_from_path(package_path),
         package_path: package_path.to_string(),
+        package_present,
         discovery_path,
         linked,
         source_revision,
+        stale_reason: stale_source_reason(linked, package_present),
         rigs: Vec::new(),
         stacks: Vec::new(),
     }
@@ -594,12 +597,15 @@ fn source_rig(
     config_present: bool,
     config_owned: bool,
 ) -> RigSourceRig {
+    let rig_present = Path::new(&entry.metadata.rig_path).is_file();
     RigSourceRig {
         id: entry.id,
         rig_path: entry.metadata.rig_path,
+        rig_present,
         config_path: source_config_path(config_path),
         config_present,
         config_owned,
+        stale_reason: stale_config_reason(rig_present, config_present),
     }
 }
 
@@ -609,12 +615,36 @@ fn source_stack(
     config_present: bool,
     config_owned: bool,
 ) -> RigSourceStack {
+    let stack_present = Path::new(&entry.metadata.stack_path).is_file();
     RigSourceStack {
         id: entry.id,
         stack_path: entry.metadata.stack_path,
+        stack_present,
         config_path: source_config_path(config_path),
         config_present,
         config_owned,
+        stale_reason: stale_config_reason(stack_present, config_present),
+    }
+}
+
+fn stale_source_reason(linked: bool, package_present: bool) -> Option<String> {
+    (linked && !package_present).then(|| {
+        "linked local rig source path is missing; restore it or run `homeboy rig sources remove <source>` and reinstall".to_string()
+    })
+}
+
+fn stale_config_reason(spec_present: bool, config_present: bool) -> Option<String> {
+    if !spec_present {
+        Some(
+            "recorded source spec path is missing; refresh/remove the rig source and reinstall"
+                .to_string(),
+        )
+    } else if !config_present {
+        Some(
+            "installed rig config is missing or points at a missing linked source path".to_string(),
+        )
+    } else {
+        None
     }
 }
 

--- a/src/core/rig/source/types.rs
+++ b/src/core/rig/source/types.rs
@@ -10,11 +10,14 @@ pub struct RigSourceListResult {
 pub struct RigSourceGroup {
     pub source: String,
     pub package_path: String,
+    pub package_present: bool,
     pub discovery_path: String,
     pub package_id: String,
     pub linked: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stale_reason: Option<String>,
     pub rigs: Vec<RigSourceRig>,
     pub stacks: Vec<RigSourceStack>,
 }
@@ -23,18 +26,24 @@ pub struct RigSourceGroup {
 pub struct RigSourceRig {
     pub id: String,
     pub rig_path: String,
+    pub rig_present: bool,
     pub config_path: String,
     pub config_present: bool,
     pub config_owned: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stale_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RigSourceStack {
     pub id: String,
     pub stack_path: String,
+    pub stack_present: bool,
     pub config_path: String,
     pub config_present: bool,
     pub config_owned: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stale_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -1,7 +1,8 @@
 //! Rig source lifecycle tests. Covers `src/core/rig/source.rs`.
 
 use crate::core::rig::{
-    install, list_sources, remove_source, update_all_sources, update_source, update_source_for_rig,
+    install, list_ids, list_sources, load, remove_source, update_all_sources, update_source,
+    update_source_for_rig,
 };
 use crate::test_support::HomeGuard;
 use std::fs;
@@ -206,6 +207,60 @@ fn sources_list_reports_corrupt_metadata_and_missing_configs() {
     assert_eq!(result.sources[0].rigs[0].id, "missing");
     assert!(!result.sources[0].rigs[0].config_present);
     assert!(!result.sources[0].rigs[0].config_owned);
+}
+
+#[test]
+fn sources_list_reports_missing_linked_source_paths() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+
+    install(package.path().to_str().unwrap(), None, false).expect("install linked");
+    fs::remove_dir_all(package.path()).expect("remove linked source");
+
+    let result = list_sources().expect("sources");
+
+    assert_eq!(result.sources.len(), 1);
+    let source = &result.sources[0];
+    assert!(source.linked);
+    assert!(!source.package_present);
+    assert!(source
+        .stale_reason
+        .as_deref()
+        .unwrap_or_default()
+        .contains("linked local rig source path is missing"));
+    assert_eq!(source.rigs.len(), 1);
+    assert!(!source.rigs[0].rig_present);
+    assert!(!source.rigs[0].config_present);
+    assert!(source.rigs[0]
+        .stale_reason
+        .as_deref()
+        .unwrap_or_default()
+        .contains("recorded source spec path is missing"));
+}
+
+#[test]
+fn missing_linked_source_gets_rig_source_diagnostic_not_not_found_hint() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+
+    install(package.path().to_str().unwrap(), None, false).expect("install linked");
+    fs::remove_dir_all(package.path()).expect("remove linked source");
+
+    let err = load("alpha").expect_err("stale source error");
+
+    assert!(err.message.contains("linked rig source"));
+    assert!(err.message.contains("source path is missing"));
+    assert!(err
+        .hints
+        .iter()
+        .any(|hint| hint.message.contains("homeboy rig sources list")));
+    assert!(err
+        .hints
+        .iter()
+        .any(|hint| hint.message.contains("homeboy rig sources remove")));
+    assert!(!list_ids().expect("list ids").contains(&"alpha".to_string()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Detect stale installed rig source metadata when a linked local rig source path or recorded rig spec disappears.
- Surface rig-source-specific diagnostics and refresh/remove guidance instead of generic rig-not-found suggestions.
- Add stale-state fields to `rig sources list` output so source list/show/load hints agree.

## Tests
- `cargo test source_test -- --nocapture`
- `cargo test bench_default_baseline_dispatch_test -- --nocapture`
- `cargo test bench_rig_path_override_test -- --nocapture`
- `cargo test bench_rig_concurrency_dispatch_test -- --nocapture`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented and tested the stale linked rig source diagnostics; Chris remains responsible for review and merge.

Fixes #3319