### PR TITLE
Fix lab offload fallback for stale runner daemon

### DIFF
--- a/src/core/runner/daemon_health.rs
+++ b/src/core/runner/daemon_health.rs
@@ -1,0 +1,48 @@
+use crate::core::error::{Error, ErrorCode};
+
+pub(super) fn runner_daemon_health_failure(err: &Error) -> Option<String> {
+    if !matches!(
+        err.code,
+        ErrorCode::InternalUnexpected | ErrorCode::InternalJsonError
+    ) {
+        return None;
+    }
+
+    let message = err.message.as_str();
+    let daemon_transport_failure = message.contains("query runner daemon")
+        || message.contains("submit runner daemon exec job")
+        || message.contains("parse daemon exec response")
+        || message.contains("daemon exec request failed");
+    if daemon_transport_failure {
+        Some(format!("runner daemon health check failed: {message}"))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_stale_daemon_transport_failures() {
+        let err = Error::internal_unexpected(
+            "query runner daemon: error sending request for url (http://127.0.0.1:63534/jobs/id)",
+        );
+
+        assert_eq!(
+            runner_daemon_health_failure(&err),
+            Some(
+                "runner daemon health check failed: query runner daemon: error sending request for url (http://127.0.0.1:63534/jobs/id)"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn does_not_classify_unrelated_internal_errors_as_daemon_health() {
+        let err = Error::internal_unexpected("workspace sync failed unexpectedly");
+
+        assert_eq!(runner_daemon_health_failure(&err), None);
+    }
+}

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use crate::core::error::ErrorCode;
 use crate::core::observation::{PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::source_snapshot::SourceSnapshot;
@@ -19,6 +18,7 @@ use super::{
     RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
 
+use super::daemon_health::runner_daemon_health_failure;
 use super::lab_apply::apply_lab_offload_patch;
 use super::lab_env::{build_lab_offload_env, forward_env_if_present};
 use super::lab_workspaces::{
@@ -611,26 +611,6 @@ fn automatic_capability_fallback(
         )),
         plan,
         messages: vec![format!("Lab offload: {reason}; running locally.")],
-    }
-}
-
-fn runner_daemon_health_failure(err: &Error) -> Option<String> {
-    if !matches!(
-        err.code,
-        ErrorCode::InternalUnexpected | ErrorCode::InternalJsonError
-    ) {
-        return None;
-    }
-
-    let message = err.message.as_str();
-    let daemon_transport_failure = message.contains("query runner daemon")
-        || message.contains("submit runner daemon exec job")
-        || message.contains("parse daemon exec response")
-        || message.contains("daemon exec request failed");
-    if daemon_transport_failure {
-        Some(format!("runner daemon health check failed: {message}"))
-    } else {
-        None
     }
 }
 
@@ -1479,28 +1459,6 @@ mod tests {
         .expect_err("explicit runner should error");
 
         assert!(err.message.contains("could not connect runner"));
-    }
-
-    #[test]
-    fn lab_offload_classifies_stale_daemon_transport_failures() {
-        let err = Error::internal_unexpected(
-            "query runner daemon: error sending request for url (http://127.0.0.1:63534/jobs/id)",
-        );
-
-        assert_eq!(
-            runner_daemon_health_failure(&err),
-            Some(
-                "runner daemon health check failed: query runner daemon: error sending request for url (http://127.0.0.1:63534/jobs/id)"
-                    .to_string()
-            )
-        );
-    }
-
-    #[test]
-    fn lab_offload_does_not_classify_unrelated_internal_errors_as_daemon_health() {
-        let err = Error::internal_unexpected("workspace sync failed unexpectedly");
-
-        assert_eq!(runner_daemon_health_failure(&err), None);
     }
 
     #[test]

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
+use crate::core::error::ErrorCode;
 use crate::core::observation::{PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::source_snapshot::SourceSnapshot;
@@ -470,10 +471,10 @@ fn run_lab_offload_inner(
     let mut env = build_lab_offload_env(&lab_metadata);
     forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
     forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
-    let (exec_output, exit_code) = exec(
+    let exec_result = exec(
         runner_id,
         RunnerExecOptions {
-            cwd: Some(remote_cwd),
+            cwd: Some(remote_cwd.clone()),
             project_id: None,
             allow_diagnostic_ssh: false,
             command,
@@ -484,7 +485,51 @@ fn run_lab_offload_inner(
             capability_preflight,
             required_extensions: contract.required_extensions,
         },
-    )?;
+    );
+    let (exec_output, exit_code) = match exec_result {
+        Ok(output) => output,
+        Err(err) => {
+            if let Some(reason) = runner_daemon_health_failure(&err) {
+                plan = with_step(
+                    plan,
+                    PlanStep::builder("lab.exec", "lab.exec", PlanStepStatus::Failed)
+                        .skip_reason(reason.clone())
+                        .build(),
+                );
+                return match selection.source {
+                    LabRunnerSelectionSource::Default => Ok(LabOffloadOutcome::RunLocal {
+                        metadata: Some(lab_offload_metadata_with_workspace_mapping(
+                            &plan,
+                            selection.source.metadata_value(),
+                            Some(runner_id),
+                            Some(status_tunnel_mode(&runner_status).metadata_value()),
+                            "fallback",
+                            Some(&remote_cwd),
+                            Some(&reason),
+                            Some(&workspace_mapping_metadata),
+                        )),
+                        plan,
+                        messages: vec![format!("Lab offload: {reason}; running locally.")],
+                    }),
+                    LabRunnerSelectionSource::Explicit => Err(Error::validation_invalid_argument(
+                        "runner",
+                        format!(
+                            "Lab offload runner `{runner_id}` is connected but its daemon did not respond: {}",
+                            err.message
+                        ),
+                        Some(runner_id.to_string()),
+                        Some(vec![
+                            format!("Reconnect runner `{runner_id}` before retrying Lab offload."),
+                            "Use --force-hot to run the command locally instead of offloading."
+                                .to_string(),
+                        ]),
+                    )),
+                };
+            }
+
+            return Err(err);
+        }
+    };
 
     let add_success_step = |plan, id| {
         with_step(
@@ -566,6 +611,26 @@ fn automatic_capability_fallback(
         )),
         plan,
         messages: vec![format!("Lab offload: {reason}; running locally.")],
+    }
+}
+
+fn runner_daemon_health_failure(err: &Error) -> Option<String> {
+    if !matches!(
+        err.code,
+        ErrorCode::InternalUnexpected | ErrorCode::InternalJsonError
+    ) {
+        return None;
+    }
+
+    let message = err.message.as_str();
+    let daemon_transport_failure = message.contains("query runner daemon")
+        || message.contains("submit runner daemon exec job")
+        || message.contains("parse daemon exec response")
+        || message.contains("daemon exec request failed");
+    if daemon_transport_failure {
+        Some(format!("runner daemon health check failed: {message}"))
+    } else {
+        None
     }
 }
 
@@ -1414,6 +1479,28 @@ mod tests {
         .expect_err("explicit runner should error");
 
         assert!(err.message.contains("could not connect runner"));
+    }
+
+    #[test]
+    fn lab_offload_classifies_stale_daemon_transport_failures() {
+        let err = Error::internal_unexpected(
+            "query runner daemon: error sending request for url (http://127.0.0.1:63534/jobs/id)",
+        );
+
+        assert_eq!(
+            runner_daemon_health_failure(&err),
+            Some(
+                "runner daemon health check failed: query runner daemon: error sending request for url (http://127.0.0.1:63534/jobs/id)"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn lab_offload_does_not_classify_unrelated_internal_errors_as_daemon_health() {
+        let err = Error::internal_unexpected("workspace sync failed unexpectedly");
+
+        assert_eq!(runner_daemon_health_failure(&err), None);
     }
 
     #[test]

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -14,6 +14,7 @@ mod broker_http;
 mod capabilities;
 mod command_path;
 mod connection;
+mod daemon_health;
 mod evidence;
 mod execution;
 mod lab;


### PR DESCRIPTION
## Summary
- Treat direct SSH runner daemon transport/query failures during Lab offload execution as runner health failures instead of opaque `internal.unexpected` crashes.
- Fall back locally for auto-selected runners when the connected daemon is stale/dead, while explicit `--runner` requests now receive a clear runner validation error with recovery guidance.
- Add focused coverage for classifying stale daemon transport failures without swallowing unrelated internal errors.

Fixes #3326.

## Verification
- `cargo fmt --check`
- `cargo test lab_offload_`
- `homeboy lint --force-hot --path /Users/chubes/Developer/homeboy@fix-issue-3326-lab-offload-stale-daemon --extension rust`
- `homeboy test --force-hot --path /Users/chubes/Developer/homeboy@fix-issue-3326-lab-offload-stale-daemon --extension rust` (2 unrelated existing failures: `commands::trace::tests::rig_trace_list_uses_scoped_workload_preflight` missing local `nodejs` extension fixture, and `core::deploy::safety_and_artifact::tests::test_deploy_artifact_flattens_double_nested_plugin_zip` double-nested artifact assertion)

## Lab offload notes
- Initial unforced `homeboy lint/test` verification attempted Lab offload and failed in remote snapshot/materialization before local checks: lint saw no remote `Cargo.toml`; test hit `rm ... Directory not empty` during snapshot materialization. The focused fix was verified locally with `--force-hot` and targeted Lab/offload tests.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigated the Lab offload runner path, drafted the focused code/test changes, and ran verification; Chris remains responsible for review and merge.