### PR TITLE
fix(release): link generated notes to changelog

### DIFF
--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -780,6 +780,43 @@ mod tests {
     }
 
     #[test]
+    fn github_release_notes_link_full_changelog_to_changelog_file() {
+        let notes = concat!(
+            "## What's Changed\n",
+            "* fix release notes by @chubes in https://github.com/Extra-Chill/homeboy/pull/1\n",
+            "\n",
+            "**Full Changelog**: https://github.com/Extra-Chill/homeboy/compare/v0.8.1...v0.9.0"
+        );
+
+        let rewritten = github_release::replace_full_changelog_footer(
+            notes,
+            "https://github.com/Extra-Chill/homeboy/blob/v0.9.0/CHANGELOG.md",
+        );
+
+        assert!(rewritten.contains(
+            "**Full Changelog**: https://github.com/Extra-Chill/homeboy/blob/v0.9.0/CHANGELOG.md"
+        ));
+        assert!(!rewritten.contains("/compare/v0.8.1...v0.9.0"));
+    }
+
+    #[test]
+    fn github_release_notes_append_changelog_link_when_footer_is_missing() {
+        let rewritten = github_release::replace_full_changelog_footer(
+            "## What's Changed\n* release note",
+            "https://github.com/Extra-Chill/homeboy/blob/v0.9.0/docs/CHANGELOG.md",
+        );
+
+        assert_eq!(
+            rewritten,
+            concat!(
+                "## What's Changed\n",
+                "* release note\n\n",
+                "**Full Changelog**: https://github.com/Extra-Chill/homeboy/blob/v0.9.0/docs/CHANGELOG.md"
+            )
+        );
+    }
+
+    #[test]
     fn git_push_step_fails_when_git_push_fails() {
         let temp = tempfile::tempdir().expect("tempdir");
         let init = Command::new("git")

--- a/src/core/release/executor/github_release.rs
+++ b/src/core/release/executor/github_release.rs
@@ -3,6 +3,7 @@
 use crate::core::component::Component;
 use crate::core::deploy::release_download::GitHubRepo;
 use crate::core::error::{Error, Result};
+use crate::core::release::changelog;
 use crate::core::release::types::{ReleaseState, ReleaseStepResult};
 
 use super::step_success;
@@ -168,6 +169,29 @@ pub(crate) fn run_github_release(
     }
 
     let notes_start_tag = github_generated_notes_start_tag(component, &tag)?;
+    let generated_notes = match github_generated_notes(&github, &tag, notes_start_tag.as_deref()) {
+        Ok(notes) => notes,
+        Err(err) => {
+            let fallback = fallback_gh_command(&tag);
+            log_status!(
+                "release",
+                "⚠ GitHub generated release notes failed: {}",
+                err
+            );
+            log_status!("release", "Manual fallback: {}", fallback);
+            return Ok(skipped_result(
+                &tag,
+                &github,
+                "generated-notes-failed",
+                Some(fallback),
+            ));
+        }
+    };
+    let changelog_url = github_changelog_url(component, &github, &tag);
+    let release_notes = changelog_url
+        .as_deref()
+        .map(|url| replace_full_changelog_footer(&generated_notes, url))
+        .unwrap_or(generated_notes);
 
     log_status!(
         "release",
@@ -186,7 +210,8 @@ pub(crate) fn run_github_release(
         &tag,
         "--title",
         &tag,
-        "--generate-notes",
+        "--notes",
+        &release_notes,
         "-R",
         &repo_flag,
     ];
@@ -244,10 +269,81 @@ pub(crate) fn run_github_release(
             "url": url,
             "artifact_count": artifact_paths.len(),
             "generated_notes": true,
+            "changelog_url": changelog_url,
             "notes_start_tag": notes_start_tag,
         })),
         Vec::new(),
     ))
+}
+
+fn github_generated_notes(
+    github: &GitHubRepo,
+    tag: &str,
+    previous_tag: Option<&str>,
+) -> Result<String> {
+    let endpoint = format!(
+        "repos/{}/{}/releases/generate-notes",
+        github.owner, github.repo
+    );
+    let tag_field = format!("tag_name={}", tag);
+    let mut args: Vec<&str> = vec!["api", &endpoint, "-f", &tag_field, "--jq", ".body"];
+    let previous_field;
+    if let Some(previous) = previous_tag {
+        previous_field = format!("previous_tag_name={}", previous);
+        args.extend_from_slice(&["-f", &previous_field]);
+    }
+
+    let output = std::process::Command::new("gh")
+        .args(&args)
+        .output()
+        .map_err(|e| {
+            Error::internal_io(
+                format!("Failed to invoke gh: {}", e),
+                Some("gh api releases/generate-notes".to_string()),
+            )
+        })?;
+
+    if !output.status.success() {
+        return Err(Error::internal_unexpected(format!(
+            "gh api releases/generate-notes failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn github_changelog_url(component: &Component, github: &GitHubRepo, tag: &str) -> Option<String> {
+    let changelog_path = changelog::resolve_changelog_path(component).ok()?;
+    let local_path = std::path::Path::new(&component.local_path);
+    let relative = changelog_path
+        .strip_prefix(local_path)
+        .unwrap_or(&changelog_path)
+        .to_string_lossy()
+        .replace('\\', "/");
+    Some(format!(
+        "https://github.com/{}/{}/blob/{}/{}",
+        github.owner, github.repo, tag, relative
+    ))
+}
+
+pub(super) fn replace_full_changelog_footer(notes: &str, changelog_url: &str) -> String {
+    let replacement = format!("**Full Changelog**: {}", changelog_url);
+    let mut lines: Vec<&str> = notes.lines().collect();
+
+    if let Some(index) = lines.iter().rposition(|line| {
+        line.trim_start()
+            .starts_with("**Full Changelog**: https://github.com/")
+    }) {
+        lines[index] = &replacement;
+        return lines.join("\n");
+    }
+
+    if notes.trim().is_empty() {
+        return replacement;
+    }
+
+    format!("{}\n\n{}", notes.trim_end(), replacement)
 }
 
 fn github_generated_notes_start_tag(component: &Component, tag: &str) -> Result<Option<String>> {


### PR DESCRIPTION
## Summary
- Generate GitHub release notes through the GitHub API so Homeboy can rewrite GitHub's default `Full Changelog` footer before creating the release.
- Point the footer at the resolved changelog file for the release tag instead of the GitHub compare page.
- Add regression coverage for replacing and appending the changelog footer.

## Testing
- `cargo test github_release_notes`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the release-note footer rewrite and focused regression tests; Chris remains responsible for review and merge.