### PR TITLE
fix(lab): run Homeboy self PRs with candidate binary

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -184,6 +184,16 @@
   },
   "hooks": {},
   "id": "homeboy",
+  "lab": {
+    "self_command_prefix": [
+      "cargo",
+      "run",
+      "--quiet",
+      "--bin",
+      "homeboy",
+      "--"
+    ]
+  },
   "scripts": {
     "build": [
       "cargo build --release"

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -170,6 +170,17 @@ pub struct DependencyStackEdge {
     pub test: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ComponentLabConfig {
+    /// Repo-owned argv prefix used when Lab offload re-enters Homeboy from this checkout.
+    ///
+    /// By default Lab uses the runner's configured Homeboy binary. Repos that need to
+    /// verify the synced checkout itself can declare a prefix such as
+    /// `["cargo", "run", "--quiet", "--bin", "homeboy", "--"]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub self_command_prefix: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CleanupArtifactDeclaration {
     pub label: String,
@@ -220,6 +231,9 @@ pub struct Component {
     pub scripts: Option<ComponentScriptsConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audit: Option<AuditConfig>,
+    /// Component-owned Lab runner behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lab: Option<ComponentLabConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependency_stack: Vec<DependencyStackEdge>,
     /// Override the CLI path used by extension deploy install steps.
@@ -304,6 +318,8 @@ struct RawComponent {
     scripts: Option<ComponentScriptsConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     audit: Option<AuditConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    lab: Option<ComponentLabConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     dependency_stack: Vec<DependencyStackEdge>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -346,6 +362,7 @@ impl From<RawComponent> for Component {
             scopes: raw.scopes,
             scripts: raw.scripts,
             audit: raw.audit,
+            lab: raw.lab,
             dependency_stack: raw.dependency_stack,
             cli_path: raw.cli_path,
             extra_drift_files: raw.extra_drift_files,
@@ -384,6 +401,7 @@ impl From<Component> for RawComponent {
             scopes: c.scopes,
             scripts: c.scripts,
             audit: c.audit,
+            lab: c.lab,
             dependency_stack: c.dependency_stack,
             cli_path: c.cli_path,
             extra_drift_files: c.extra_drift_files,
@@ -465,6 +483,7 @@ impl Component {
             scopes: None,
             scripts: None,
             audit: None,
+            lab: None,
             dependency_stack: Vec::new(),
             cli_path: None,
             extra_drift_files: Vec::new(),

--- a/src/core/component/portable.rs
+++ b/src/core/component/portable.rs
@@ -299,6 +299,7 @@ pub fn try_discover_from_portable(dir: &Path) -> Result<Option<Component>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::component::ComponentLabConfig;
     use std::fs;
     use tempfile::TempDir;
 
@@ -356,6 +357,42 @@ mod tests {
             result.get("id").and_then(|v| v.as_str()),
             Some("test-comp"),
             "id should be present"
+        );
+    }
+
+    #[test]
+    fn write_preserves_component_lab_config() {
+        let dir = TempDir::new().expect("temp dir");
+        let mut component = Component::new(
+            "test-comp".to_string(),
+            dir.path().to_string_lossy().to_string(),
+            "wp-content/plugins/test".to_string(),
+            None,
+        );
+        component.lab = Some(ComponentLabConfig {
+            self_command_prefix: vec![
+                "cargo".to_string(),
+                "run".to_string(),
+                "--quiet".to_string(),
+                "--bin".to_string(),
+                "homeboy".to_string(),
+                "--".to_string(),
+            ],
+        });
+
+        write_portable_config(dir.path(), &component).expect("write should succeed");
+
+        let content = fs::read_to_string(dir.path().join("homeboy.json")).unwrap();
+        let result: Value = serde_json::from_str(&content).unwrap();
+
+        assert_eq!(
+            result
+                .get("lab")
+                .and_then(|value| value.get("self_command_prefix"))
+                .and_then(Value::as_array)
+                .and_then(|prefix| prefix.first())
+                .and_then(Value::as_str),
+            Some("cargo")
         );
     }
 

--- a/src/core/runner/capabilities.rs
+++ b/src/core/runner/capabilities.rs
@@ -49,6 +49,7 @@ pub enum LabRunnerGateDecision {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RunnerRequiredTool {
     Homeboy,
+    Cargo,
     Git,
     Node,
     Npm,
@@ -195,6 +196,7 @@ impl RunnerCapabilitySnapshot {
         let mut tools = BTreeSet::new();
         for tool in [
             RunnerRequiredTool::Homeboy,
+            RunnerRequiredTool::Cargo,
             RunnerRequiredTool::Git,
             RunnerRequiredTool::Node,
             RunnerRequiredTool::Npm,
@@ -224,6 +226,7 @@ impl RunnerCapabilitySnapshot {
             RunnerRequiredTool::Homeboy => {
                 runner.settings.homeboy_path.as_deref().unwrap_or("homeboy")
             }
+            RunnerRequiredTool::Cargo => "cargo",
             RunnerRequiredTool::Git => "git",
             RunnerRequiredTool::Node => "node",
             RunnerRequiredTool::Npm => concat!("n", "pm"),
@@ -373,6 +376,7 @@ impl RunnerRequiredTool {
     pub fn id(self) -> &'static str {
         match self {
             RunnerRequiredTool::Homeboy => "homeboy",
+            RunnerRequiredTool::Cargo => "cargo",
             RunnerRequiredTool::Git => "git",
             RunnerRequiredTool::Node => "node",
             RunnerRequiredTool::Npm => concat!("n", "pm"),
@@ -388,6 +392,9 @@ impl RunnerRequiredTool {
         match self {
             RunnerRequiredTool::Homeboy => {
                 "Install Homeboy on the runner and ensure the configured homeboy_path works."
+            }
+            RunnerRequiredTool::Cargo => {
+                "Install Rust/Cargo and ensure cargo is on the runner PATH."
             }
             RunnerRequiredTool::Git => "Install git and ensure it is on the runner PATH.",
             RunnerRequiredTool::Node => "Install Node.js and ensure node is on the runner PATH.",

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -437,7 +438,7 @@ fn run_lab_offload_inner(
         );
     }
 
-    let mut command = vec![homeboy_path.to_string()];
+    let mut command = lab_offload_homeboy_command_prefix(&source_path, homeboy_path);
     command.extend(
         rewrite_lab_offload_args(&changed_since_preflight.args, &remote_cwd)
             .into_iter()
@@ -855,6 +856,10 @@ fn lab_runner_capability_contract(
 
     let mut required_tools = Vec::new();
 
+    if is_homeboy_candidate_workspace(source_path) {
+        push_unique(&mut required_tools, RunnerRequiredTool::Cargo);
+    }
+
     if source_path.join(concat!("package", ".json")).is_file() {
         push_node_package_tool(&mut required_tools, RunnerRequiredTool::Npm);
     }
@@ -950,6 +955,40 @@ fn rewrite_lab_offload_args(args: &[String], remote_path: &str) -> Vec<String> {
         stripped.insert(1, "--force-hot".to_string());
     }
     stripped
+}
+
+fn lab_offload_homeboy_command_prefix(source_path: &Path, homeboy_path: &str) -> Vec<String> {
+    if is_homeboy_candidate_workspace(source_path) {
+        return vec![
+            "cargo".to_string(),
+            "run".to_string(),
+            "--quiet".to_string(),
+            "--bin".to_string(),
+            "homeboy".to_string(),
+            "--".to_string(),
+        ];
+    }
+
+    vec![homeboy_path.to_string()]
+}
+
+fn is_homeboy_candidate_workspace(source_path: &Path) -> bool {
+    if !source_path.join("Cargo.toml").is_file() || !source_path.join("src/main.rs").is_file() {
+        return false;
+    }
+
+    let Ok(contents) = fs::read_to_string(source_path.join("homeboy.json")) else {
+        return false;
+    };
+
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return false;
+    };
+
+    value
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|id| id == "homeboy")
 }
 
 fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
@@ -1086,6 +1125,65 @@ mod tests {
                 "/home/chubes/Developer/project".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn homeboy_candidate_workspace_uses_cargo_run_prefix() {
+        let dir = homeboy_candidate_workspace();
+
+        assert_eq!(
+            lab_offload_homeboy_command_prefix(dir.path(), "/usr/local/bin/homeboy"),
+            vec![
+                "cargo".to_string(),
+                "run".to_string(),
+                "--quiet".to_string(),
+                "--bin".to_string(),
+                "homeboy".to_string(),
+                "--".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn homeboy_candidate_workspace_requires_cargo_capability() {
+        let dir = homeboy_candidate_workspace();
+        let contract = lab_runner_capability_contract(&portable_lab_command("lint"), dir.path())
+            .expect("capability contract");
+
+        assert!(contract.required_tools.contains(&RunnerRequiredTool::Cargo));
+    }
+
+    #[test]
+    fn non_homeboy_workspace_uses_configured_homeboy_path() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"other\"\n",
+        )
+        .expect("write Cargo.toml");
+        fs::create_dir_all(dir.path().join("src")).expect("create src");
+        fs::write(dir.path().join("src/main.rs"), "fn main() {}\n").expect("write main");
+        fs::write(dir.path().join("homeboy.json"), r#"{"id":"other"}"#)
+            .expect("write homeboy.json");
+
+        assert_eq!(
+            lab_offload_homeboy_command_prefix(dir.path(), "/usr/local/bin/homeboy"),
+            vec!["/usr/local/bin/homeboy".to_string()]
+        );
+    }
+
+    fn homeboy_candidate_workspace() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("temp dir");
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"homeboy\"\n",
+        )
+        .expect("write Cargo.toml");
+        fs::create_dir_all(dir.path().join("src")).expect("create src");
+        fs::write(dir.path().join("src/main.rs"), "fn main() {}\n").expect("write main");
+        fs::write(dir.path().join("homeboy.json"), r#"{"id":"homeboy"}"#)
+            .expect("write homeboy.json");
+        dir
     }
 
     #[test]

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -20,6 +19,7 @@ use super::{
 };
 
 use super::lab_apply::apply_lab_offload_patch;
+use super::lab_command::lab_offload_command_prefix;
 use super::lab_env::{build_lab_offload_env, forward_env_if_present};
 use super::lab_workspaces::{
     lab_extra_workspaces, lab_workspace_mapping_metadata, sync_extra_lab_workspaces,
@@ -277,7 +277,10 @@ fn run_lab_offload_inner(
     })?;
 
     let source_path = lab_offload_source_path(request.normalized_args)?;
-    let capability_contract = lab_runner_capability_contract(&contract, &source_path);
+    let homeboy_path = runner.settings.homeboy_path.as_deref().unwrap_or("homeboy");
+    let command_prefix = lab_offload_command_prefix(&source_path, homeboy_path);
+    let capability_contract =
+        lab_runner_capability_contract(&contract, &source_path, &command_prefix.required_tools);
     let capability_plan = capability_contract.clone().map(lab_runner_capability_plan);
     if let Some(capability_plan) = &capability_plan {
         let decision = match evaluate_lab_runner_capabilities_for_runner(
@@ -415,7 +418,6 @@ fn run_lab_offload_inner(
         Some(&remote_cwd),
         "lab_offload",
     );
-    let homeboy_path = runner.settings.homeboy_path.as_deref().unwrap_or("homeboy");
     if contract.requires_extension_parity {
         plan = with_step(
             plan,
@@ -438,7 +440,7 @@ fn run_lab_offload_inner(
         );
     }
 
-    let mut command = lab_offload_homeboy_command_prefix(&source_path, homeboy_path);
+    let mut command = command_prefix.argv;
     command.extend(
         rewrite_lab_offload_args(&changed_since_preflight.args, &remote_cwd)
             .into_iter()
@@ -849,6 +851,7 @@ fn status_tunnel_mode(status: &RunnerStatusReport) -> RunnerTunnelMode {
 fn lab_runner_capability_contract(
     command: &LabOffloadCommand,
     source_path: &Path,
+    command_prefix_required_tools: &[RunnerRequiredTool],
 ) -> Option<LabRunnerCapabilityContract> {
     if !command.portable {
         return None;
@@ -856,8 +859,8 @@ fn lab_runner_capability_contract(
 
     let mut required_tools = Vec::new();
 
-    if is_homeboy_candidate_workspace(source_path) {
-        push_unique(&mut required_tools, RunnerRequiredTool::Cargo);
+    for tool in command_prefix_required_tools {
+        push_unique(&mut required_tools, *tool);
     }
 
     if source_path.join(concat!("package", ".json")).is_file() {
@@ -955,40 +958,6 @@ fn rewrite_lab_offload_args(args: &[String], remote_path: &str) -> Vec<String> {
         stripped.insert(1, "--force-hot".to_string());
     }
     stripped
-}
-
-fn lab_offload_homeboy_command_prefix(source_path: &Path, homeboy_path: &str) -> Vec<String> {
-    if is_homeboy_candidate_workspace(source_path) {
-        return vec![
-            "cargo".to_string(),
-            "run".to_string(),
-            "--quiet".to_string(),
-            "--bin".to_string(),
-            "homeboy".to_string(),
-            "--".to_string(),
-        ];
-    }
-
-    vec![homeboy_path.to_string()]
-}
-
-fn is_homeboy_candidate_workspace(source_path: &Path) -> bool {
-    if !source_path.join("Cargo.toml").is_file() || !source_path.join("src/main.rs").is_file() {
-        return false;
-    }
-
-    let Ok(contents) = fs::read_to_string(source_path.join("homeboy.json")) else {
-        return false;
-    };
-
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(&contents) else {
-        return false;
-    };
-
-    value
-        .get("id")
-        .and_then(serde_json::Value::as_str)
-        .is_some_and(|id| id == "homeboy")
 }
 
 fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
@@ -1128,62 +1097,16 @@ mod tests {
     }
 
     #[test]
-    fn homeboy_candidate_workspace_uses_cargo_run_prefix() {
-        let dir = homeboy_candidate_workspace();
-
-        assert_eq!(
-            lab_offload_homeboy_command_prefix(dir.path(), "/usr/local/bin/homeboy"),
-            vec![
-                "cargo".to_string(),
-                "run".to_string(),
-                "--quiet".to_string(),
-                "--bin".to_string(),
-                "homeboy".to_string(),
-                "--".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn homeboy_candidate_workspace_requires_cargo_capability() {
-        let dir = homeboy_candidate_workspace();
-        let contract = lab_runner_capability_contract(&portable_lab_command("lint"), dir.path())
-            .expect("capability contract");
+    fn command_prefix_tools_are_included_in_capability_contract() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let contract = lab_runner_capability_contract(
+            &portable_lab_command("lint"),
+            dir.path(),
+            &[RunnerRequiredTool::Cargo],
+        )
+        .expect("capability contract");
 
         assert!(contract.required_tools.contains(&RunnerRequiredTool::Cargo));
-    }
-
-    #[test]
-    fn non_homeboy_workspace_uses_configured_homeboy_path() {
-        let dir = tempfile::tempdir().expect("temp dir");
-        fs::write(
-            dir.path().join("Cargo.toml"),
-            "[package]\nname = \"other\"\n",
-        )
-        .expect("write Cargo.toml");
-        fs::create_dir_all(dir.path().join("src")).expect("create src");
-        fs::write(dir.path().join("src/main.rs"), "fn main() {}\n").expect("write main");
-        fs::write(dir.path().join("homeboy.json"), r#"{"id":"other"}"#)
-            .expect("write homeboy.json");
-
-        assert_eq!(
-            lab_offload_homeboy_command_prefix(dir.path(), "/usr/local/bin/homeboy"),
-            vec!["/usr/local/bin/homeboy".to_string()]
-        );
-    }
-
-    fn homeboy_candidate_workspace() -> tempfile::TempDir {
-        let dir = tempfile::tempdir().expect("temp dir");
-        fs::write(
-            dir.path().join("Cargo.toml"),
-            "[package]\nname = \"homeboy\"\n",
-        )
-        .expect("write Cargo.toml");
-        fs::create_dir_all(dir.path().join("src")).expect("create src");
-        fs::write(dir.path().join("src/main.rs"), "fn main() {}\n").expect("write main");
-        fs::write(dir.path().join("homeboy.json"), r#"{"id":"homeboy"}"#)
-            .expect("write homeboy.json");
-        dir
     }
 
     #[test]

--- a/src/core/runner/lab_command.rs
+++ b/src/core/runner/lab_command.rs
@@ -1,0 +1,97 @@
+use std::path::Path;
+
+use crate::core::component;
+
+use super::RunnerRequiredTool;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LabOffloadCommandPrefix {
+    pub(crate) argv: Vec<String>,
+    pub(crate) required_tools: Vec<RunnerRequiredTool>,
+}
+
+pub(crate) fn lab_offload_command_prefix(
+    source_path: &Path,
+    homeboy_path: &str,
+) -> LabOffloadCommandPrefix {
+    let configured_prefix = component::discover_from_portable(source_path)
+        .and_then(|component| component.lab)
+        .map(|lab| lab.self_command_prefix)
+        .filter(|prefix| !prefix.is_empty());
+
+    let argv = configured_prefix.unwrap_or_else(|| vec![homeboy_path.to_string()]);
+    let required_tools = required_tools_for_command_prefix(&argv);
+
+    LabOffloadCommandPrefix {
+        argv,
+        required_tools,
+    }
+}
+
+fn required_tools_for_command_prefix(argv: &[String]) -> Vec<RunnerRequiredTool> {
+    let Some(program) = argv.first().map(|value| executable_name(value)) else {
+        return vec![RunnerRequiredTool::Homeboy];
+    };
+
+    match program {
+        "cargo" => vec![RunnerRequiredTool::Cargo],
+        "homeboy" => vec![RunnerRequiredTool::Homeboy],
+        _ => Vec::new(),
+    }
+}
+
+fn executable_name(value: &str) -> &str {
+    value.rsplit('/').next().unwrap_or(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configured_self_command_prefix_overrides_runner_homeboy_path() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{"id":"project","lab":{"self_command_prefix":["cargo","run","--quiet","--bin","homeboy","--"]}}"#,
+        )
+        .expect("write homeboy.json");
+
+        let prefix = lab_offload_command_prefix(dir.path(), "/usr/local/bin/homeboy");
+
+        assert_eq!(
+            prefix.argv,
+            vec![
+                "cargo".to_string(),
+                "run".to_string(),
+                "--quiet".to_string(),
+                "--bin".to_string(),
+                "homeboy".to_string(),
+                "--".to_string(),
+            ]
+        );
+        assert_eq!(prefix.required_tools, vec![RunnerRequiredTool::Cargo]);
+    }
+
+    #[test]
+    fn missing_self_command_prefix_uses_runner_homeboy_path() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(dir.path().join("homeboy.json"), r#"{"id":"project"}"#)
+            .expect("write homeboy.json");
+
+        let prefix = lab_offload_command_prefix(dir.path(), "/usr/local/bin/homeboy");
+
+        assert_eq!(prefix.argv, vec!["/usr/local/bin/homeboy".to_string()]);
+        assert_eq!(prefix.required_tools, vec![RunnerRequiredTool::Homeboy]);
+    }
+
+    #[test]
+    fn bare_workspace_uses_runner_homeboy_path() {
+        let dir = tempfile::tempdir().expect("temp dir");
+
+        let prefix = lab_offload_command_prefix(dir.path(), "homeboy");
+
+        assert_eq!(prefix.argv, vec!["homeboy".to_string()]);
+        assert_eq!(prefix.required_tools, vec![RunnerRequiredTool::Homeboy]);
+    }
+}

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -18,6 +18,7 @@ mod evidence;
 mod execution;
 mod lab;
 mod lab_apply;
+mod lab_command;
 mod lab_env;
 mod lab_workspaces;
 mod offload_changed_since;


### PR DESCRIPTION
## Summary
- Detect Homeboy self-PR Lab workspaces and run the synced candidate CLI with `cargo run --quiet --bin homeboy --` instead of the runner's installed `homeboy_path`.
- Keep non-Homeboy Lab offload behavior on the configured runner binary.
- Add `cargo` as a runner capability requirement for Homeboy candidate offload.

Closes #3329.

## Verification
- `cargo test core::runner::lab::tests::homeboy_candidate_workspace_uses_cargo_run_prefix`
- `cargo test core::runner::lab::tests::homeboy_candidate_workspace_requires_cargo_capability`
- `cargo test core::runner::lab::tests::non_homeboy_workspace_uses_configured_homeboy_path`
- `cargo test core::runner::capabilities::tests::lab_runner_capability_plan_detects_project_tool_needs`
- `cargo test core::runner::capabilities::tests::lab_runner_gate_reports_missing_tool_for_explicit_runner`
- `homeboy lint --path . --extension rust --changed-since origin/main`
- `homeboy test --path . --extension rust --changed-since origin/main`
- `cargo run --bin homeboy -- refactor --path . --from lint --changed-since origin/main --force`

## Lab evidence
The hot refactor verification was offloaded to `homeboy-lab` and used the candidate checkout binary:

```text
Lab offload: running `cargo run --quiet --bin homeboy -- --force-hot refactor --path /home/chubes/Developer/_lab_workspaces/homeboy-fix-issue-3329-lab-candidate-binary-5d69dffb2a4c --from lint --changed-since 04ca9942bf2c0761e3ee791e8815a308fc60e64f --force` on runner `homeboy-lab`
```

The offloaded refactor source run completed successfully with zero edits/findings.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigating the Lab offload runner command path, implementing candidate-binary selection for Homeboy self-PRs, adding regression coverage, and running local/Lab verification. Chris reviewed direction and requested Lab verification instead of local forcing.