### PR TITLE
fix(test): remove reverse broker listener startup race

### DIFF
--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -170,6 +170,21 @@ where
 {
     let listener = TcpListener::bind(addr)
         .map_err(|e| Error::internal_io(e.to_string(), Some(format!("bind daemon to {}", addr))))?;
+    serve_listener_with_analysis_runner(listener, analysis_runner)
+}
+
+#[cfg(test)]
+pub(crate) fn serve_listener(listener: TcpListener) -> Result<DaemonState> {
+    serve_listener_with_analysis_runner(listener, UnsupportedAnalysisJobRunner)
+}
+
+fn serve_listener_with_analysis_runner<R>(
+    listener: TcpListener,
+    analysis_runner: R,
+) -> Result<DaemonState>
+where
+    R: AnalysisJobRunner,
+{
     let local_addr = listener.local_addr().map_err(|e| {
         Error::internal_io(e.to_string(), Some("read daemon local address".to_string()))
     })?;

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -1097,16 +1097,9 @@ mod tests {
         crate::test_support::with_isolated_home(|_| {
             let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
             let addr = listener.local_addr().expect("addr");
-            drop(listener);
             std::thread::spawn(move || {
-                let _ = crate::core::daemon::serve(addr);
+                let _ = crate::core::daemon::serve_listener(listener);
             });
-            for _ in 0..100 {
-                if std::net::TcpStream::connect(addr).is_ok() {
-                    break;
-                }
-                std::thread::sleep(Duration::from_millis(10));
-            }
             let broker_url = format!("http://{addr}");
             let worker_broker_url = broker_url.clone();
             let worker = std::thread::spawn(move || {


### PR DESCRIPTION
## Summary
- Keep the reverse broker test daemon bound on its selected ephemeral port instead of dropping and rebinding the listener.
- Add a test-only daemon entry point for serving an already-bound `TcpListener`, removing the loopback listener startup race before job claim/submit.

Fixes #3335.

## Verification
- `cargo test core::runner::execution::tests`
- `cargo test reverse_broker`
- `cargo test core::runner::worker::tests::reverse_worker_executes_claimed_job_and_finishes_it -- --exact`
- `homeboy lint --path /Users/chubes/Developer/homeboy@fix-issue-3335-reverse-broker-listener-ready`

## Notes
- `homeboy test --path /Users/chubes/Developer/homeboy@fix-issue-3335-reverse-broker-listener-ready` was also attempted. The reverse broker test passed, but the full suite failed on unrelated existing/environmental failures: two deploy artifact tests could not find `zip`, and `core::source_snapshot::tests::test_collect_local` asserted `snapshot.workspace_root.is_some()`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigated the reverse broker test race, drafted the focused listener synchronization change, and ran local verification. Chris remains responsible for review and merge.