### PR TITLE
fix(deploy): flatten nested artifacts portably

### DIFF
--- a/src/core/deploy/safety_and_artifact.rs
+++ b/src/core/deploy/safety_and_artifact.rs
@@ -357,7 +357,8 @@ fn flatten_double_nested_dir(
     // `entries` counts the non-hidden + hidden top-level entries; we require it to be
     // exactly the nested directory and nothing else.
     let detect_cmd = format!(
-        "test -d {nested} && [ \"$(cd {target} && ls -A | wc -l)\" = \"1\" ] && \
+        "test -d {nested} && \
+         [ \"$(cd {target} && find . -mindepth 1 -maxdepth 1 | wc -l | tr -d '[:space:]')\" = \"1\" ] && \
          [ \"$(cd {target} && ls -A)\" = {basename_arg} ] && echo NESTED || echo OK",
         nested = shell::quote_path(&nested_dir),
         target = shell::quote_path(normalized),
@@ -385,11 +386,13 @@ fn flatten_double_nested_dir(
     // temp staging name avoids the "cannot move a directory into itself" problem
     // when the inner dir shares the basename with its parent.
     let staging = format!("{}/.artifact-flatten-staging", normalized);
+    let target_dir = format!("{}/", normalized);
     let flatten_cmd = format!(
         "cd {target} && rm -rf {staging} && mv {nested} {staging} && \
-         find {staging} -mindepth 1 -maxdepth 1 -exec mv -t {target} {{}} + && \
+         find {staging} -mindepth 1 -maxdepth 1 -exec mv {{}} {target_dir} \\; && \
          rmdir {staging}",
         target = shell::quote_path(normalized),
+        target_dir = shell::quote_path(&target_dir),
         nested = shell::quote_path(&nested_dir),
         staging = shell::quote_path(&staging),
     );


### PR DESCRIPTION
## Summary
- Fixes the deploy artifact double-nest flattening path so it works on macOS/local shells as well as Linux remotes.
- Keeps the intended contract: classic single top-level archive directories are flattened, while unrepaired double-nested layouts are still rejected.

Closes #3338

## Verification
- `cargo fmt --check`
- `cargo test core::deploy::safety_and_artifact::tests::test_deploy_artifact_flattens_double_nested_plugin_zip -- --nocapture`
- `cargo test core::deploy::safety_and_artifact -- --nocapture`
- `homeboy test --force-hot --path /Users/chubes/Developer/homeboy@fix-3338-deploy-double-nested-artifact --extension rust -- core::deploy::safety_and_artifact -- --nocapture`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigated the deploy artifact safety contract, drafted the portability fix, and ran targeted verification; Chris remains responsible for review and merge.