### PR TITLE
fix(runner): isolate lab snapshot workspaces

### DIFF
--- a/src/core/engine/temp.rs
+++ b/src/core/engine/temp.rs
@@ -207,7 +207,7 @@ pub fn runtime_temp_dir(prefix: &str) -> Result<PathBuf> {
     Ok(path)
 }
 
-fn unique_name(prefix: &str, suffix: &str) -> String {
+pub(crate) fn unique_name(prefix: &str, suffix: &str) -> String {
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use glob_match::glob_match;
 use serde::Serialize;
@@ -11,6 +13,8 @@ use crate::core::error::{Error, Result};
 use crate::core::server::{self, Server, SshClient};
 
 use super::{load, Runner, RunnerKind};
+
+static SNAPSHOT_WORKSPACE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub(super) const DEFAULT_EXCLUDES: &[&str] = &[
     ".git",
@@ -103,7 +107,7 @@ pub fn sync_workspace(
     match options.mode {
         RunnerWorkspaceSyncMode::Snapshot => {
             let snapshot = snapshot_identity(&local_path)?;
-            let remote_path = deterministic_remote_path(workspace_root, &local_path, &snapshot);
+            let remote_path = unique_snapshot_remote_path(workspace_root, &local_path, &snapshot);
             let stats = local_snapshot_stats(&local_path, DEFAULT_EXCLUDES)?;
             materialize_snapshot(&runner, &local_path, &remote_path, DEFAULT_EXCLUDES)?;
             super::validation_dependencies::sync_validation_dependency_workspaces(
@@ -213,6 +217,23 @@ fn deterministic_remote_path(workspace_root: &str, local_path: &Path, snapshot: 
         sanitize_path_segment(name),
         digest
     )
+}
+
+fn unique_snapshot_remote_path(workspace_root: &str, local_path: &Path, snapshot: &str) -> String {
+    format!(
+        "{}-{}",
+        deterministic_remote_path(workspace_root, local_path, snapshot),
+        unique_workspace_suffix()
+    )
+}
+
+fn unique_workspace_suffix() -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let counter = SNAPSHOT_WORKSPACE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{}-{timestamp}-{counter}", std::process::id())
 }
 
 fn snapshot_identity(local_path: &Path) -> Result<String> {
@@ -413,11 +434,12 @@ fn materialize_snapshot_local(
     remote_path: &str,
     excludes: &[&str],
 ) -> Result<()> {
+    let install_command = snapshot_install_command(remote_path);
     let command = format!(
-        "rm -rf {dest} && mkdir -p {dest} && COPYFILE_DISABLE=1 tar -C {src} {exclude} -cf - . | tar -C {dest} -xf -",
+        "COPYFILE_DISABLE=1 tar -C {src} {exclude} -cf - . | sh -c {install_command}",
         src = shell::quote_arg(&local_path.display().to_string()),
-        dest = shell::quote_arg(remote_path),
         exclude = tar_exclude_args(excludes),
+        install_command = shell::quote_arg(&install_command),
     );
     run_shell_command(&command, "materialize local workspace snapshot")
 }
@@ -430,10 +452,7 @@ fn materialize_snapshot_ssh(
     client: &SshClient,
 ) -> Result<()> {
     let remote = format!("{}@{}", client.user, client.host);
-    let remote_command = format!(
-        "rm -rf {dest} && mkdir -p {dest} && tar -C {dest} -xf -",
-        dest = shell::quote_arg(remote_path),
-    );
+    let remote_command = snapshot_install_command(remote_path);
     let command = format!(
         "COPYFILE_DISABLE=1 tar -C {src} {exclude} -cf - . | ssh {ssh_args} {remote} {remote_command}",
         src = shell::quote_arg(&local_path.display().to_string()),
@@ -443,6 +462,14 @@ fn materialize_snapshot_ssh(
         remote_command = shell::quote_arg(&remote_command),
     );
     run_shell_command(&command, "materialize SSH workspace snapshot")
+}
+
+fn snapshot_install_command(remote_path: &str) -> String {
+    format!(
+        "parent={parent}; dest={dest}; tmp=\"${{dest}}.tmp.$$\"; mkdir -p \"$parent\" && trap 'rm -rf \"$tmp\"' EXIT; rm -rf \"$tmp\" && mkdir -p \"$tmp\" && tar -C \"$tmp\" -xf - && rm -rf \"$dest\" && mv \"$tmp\" \"$dest\"",
+        parent = shell::quote_arg(parent_remote_path(remote_path).as_str()),
+        dest = shell::quote_arg(remote_path),
+    )
 }
 
 fn materialize_git(
@@ -721,6 +748,44 @@ mod tests {
             assert!(!Path::new(&output.remote_path)
                 .join("target/debug/homeboy")
                 .exists());
+        });
+    }
+
+    #[test]
+    fn snapshot_sync_uses_unique_clean_workspace_for_same_snapshot() {
+        crate::test_support::with_isolated_home(|_| {
+            let source = tempfile::tempdir().expect("source tempdir");
+            let runner_root = tempfile::tempdir().expect("runner root tempdir");
+            fs::write(source.path().join("Cargo.toml"), "[package]\nname='app'\n")
+                .expect("manifest");
+
+            super::super::create(
+                &format!(
+                    r#"{{"id":"lab-local","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+
+            let options = RunnerWorkspaceSyncOptions {
+                path: source.path().display().to_string(),
+                mode: RunnerWorkspaceSyncMode::Snapshot,
+                changed_since_base: None,
+            };
+            let (first, _) = sync_workspace("lab-local", options.clone()).expect("first sync");
+            let remote_path = Path::new(&first.remote_path);
+            assert!(remote_path.join("Cargo.toml").exists());
+
+            fs::write(remote_path.join("sentinel.txt"), "kept\n").expect("sentinel");
+
+            let (second, _) = sync_workspace("lab-local", options).expect("second sync");
+            let second_remote_path = Path::new(&second.remote_path);
+
+            assert_ne!(second.remote_path, first.remote_path);
+            assert!(second_remote_path.join("Cargo.toml").exists());
+            assert!(!second_remote_path.join("sentinel.txt").exists());
+            assert!(remote_path.join("sentinel.txt").exists());
         });
     }
 

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -1,20 +1,16 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use glob_match::glob_match;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-use crate::core::engine::shell;
+use crate::core::engine::{shell, temp};
 use crate::core::error::{Error, Result};
 use crate::core::server::{self, Server, SshClient};
 
 use super::{load, Runner, RunnerKind};
-
-static SNAPSHOT_WORKSPACE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub(super) const DEFAULT_EXCLUDES: &[&str] = &[
     ".git",
@@ -107,7 +103,10 @@ pub fn sync_workspace(
     match options.mode {
         RunnerWorkspaceSyncMode::Snapshot => {
             let snapshot = snapshot_identity(&local_path)?;
-            let remote_path = unique_snapshot_remote_path(workspace_root, &local_path, &snapshot);
+            let remote_path = temp::unique_name(
+                &deterministic_remote_path(workspace_root, &local_path, &snapshot),
+                "",
+            );
             let stats = local_snapshot_stats(&local_path, DEFAULT_EXCLUDES)?;
             materialize_snapshot(&runner, &local_path, &remote_path, DEFAULT_EXCLUDES)?;
             super::validation_dependencies::sync_validation_dependency_workspaces(
@@ -217,23 +216,6 @@ fn deterministic_remote_path(workspace_root: &str, local_path: &Path, snapshot: 
         sanitize_path_segment(name),
         digest
     )
-}
-
-fn unique_snapshot_remote_path(workspace_root: &str, local_path: &Path, snapshot: &str) -> String {
-    format!(
-        "{}-{}",
-        deterministic_remote_path(workspace_root, local_path, snapshot),
-        unique_workspace_suffix()
-    )
-}
-
-fn unique_workspace_suffix() -> String {
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    let counter = SNAPSHOT_WORKSPACE_COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("{}-{timestamp}-{counter}", std::process::id())
 }
 
 fn snapshot_identity(local_path: &Path) -> Result<String> {
@@ -417,51 +399,60 @@ pub(super) fn materialize_snapshot(
     excludes: &[&str],
 ) -> Result<()> {
     match runner.kind {
-        RunnerKind::Local => materialize_snapshot_local(local_path, remote_path, excludes),
+        RunnerKind::Local => materialize_snapshot_piped(
+            local_path,
+            &format!(
+                "sh -c {}",
+                shell::quote_arg(&snapshot_install_command(remote_path))
+            ),
+            excludes,
+            "materialize local workspace snapshot",
+        ),
         RunnerKind::Ssh => {
-            let (server, client) = ssh_client_for_runner(runner)?;
+            let (_server, client) = ssh_client_for_runner(runner)?;
             if client.is_local {
-                materialize_snapshot_local(local_path, remote_path, excludes)
+                materialize_snapshot_piped(
+                    local_path,
+                    &format!(
+                        "sh -c {}",
+                        shell::quote_arg(&snapshot_install_command(remote_path))
+                    ),
+                    excludes,
+                    "materialize local workspace snapshot",
+                )
             } else {
-                materialize_snapshot_ssh(local_path, remote_path, excludes, &server, &client)
+                let remote = format!("{}@{}", client.user, client.host);
+                let remote_command = snapshot_install_command(remote_path);
+                let target = format!(
+                    "ssh {ssh_args} {remote} {remote_command}",
+                    ssh_args = ssh_args(&client),
+                    remote = shell::quote_arg(&remote),
+                    remote_command = shell::quote_arg(&remote_command),
+                );
+                materialize_snapshot_piped(
+                    local_path,
+                    &target,
+                    excludes,
+                    "materialize SSH workspace snapshot",
+                )
             }
         }
     }
 }
 
-fn materialize_snapshot_local(
+fn materialize_snapshot_piped(
     local_path: &Path,
-    remote_path: &str,
+    target_command: &str,
     excludes: &[&str],
+    action: &str,
 ) -> Result<()> {
-    let install_command = snapshot_install_command(remote_path);
     let command = format!(
-        "COPYFILE_DISABLE=1 tar -C {src} {exclude} -cf - . | sh -c {install_command}",
+        "COPYFILE_DISABLE=1 tar -C {src} {exclude} -cf - . | {target_command}",
         src = shell::quote_arg(&local_path.display().to_string()),
         exclude = tar_exclude_args(excludes),
-        install_command = shell::quote_arg(&install_command),
+        target_command = target_command,
     );
-    run_shell_command(&command, "materialize local workspace snapshot")
-}
-
-fn materialize_snapshot_ssh(
-    local_path: &Path,
-    remote_path: &str,
-    excludes: &[&str],
-    _server: &Server,
-    client: &SshClient,
-) -> Result<()> {
-    let remote = format!("{}@{}", client.user, client.host);
-    let remote_command = snapshot_install_command(remote_path);
-    let command = format!(
-        "COPYFILE_DISABLE=1 tar -C {src} {exclude} -cf - . | ssh {ssh_args} {remote} {remote_command}",
-        src = shell::quote_arg(&local_path.display().to_string()),
-        exclude = tar_exclude_args(excludes),
-        ssh_args = ssh_args(client),
-        remote = shell::quote_arg(&remote),
-        remote_command = shell::quote_arg(&remote_command),
-    );
-    run_shell_command(&command, "materialize SSH workspace snapshot")
+    run_shell_command(&command, action)
 }
 
 fn snapshot_install_command(remote_path: &str) -> String {


### PR DESCRIPTION
## Summary
- Fixes #3336 by giving snapshot Lab workspace syncs a fresh remote workspace path per sync, preventing concurrent unforced `homeboy lint/test` runs from deleting or reusing each other's snapshot checkout.
- Keeps snapshot extraction staged through a temp directory before publishing the final workspace path, so dispatch only targets a fully extracted checkout.
- Adds focused coverage that same-source snapshot syncs produce clean, distinct workspaces rather than inheriting stale remote mutations.

## Verification
- `cargo fmt`
- `cargo test workspace::tests`
- `cargo test validation_dependencies::tests::sync_workspace_materializes_validation_dependency_siblings`
- `cargo run --bin homeboy -- lint --force-hot --path /Users/chubes/Developer/homeboy@fix-3336-lab-snapshot-integrity --extension rust`
- `cargo run --bin homeboy -- test --force-hot --path /Users/chubes/Developer/homeboy@fix-3336-lab-snapshot-integrity --extension rust` failed with 2 existing unrelated failures after 3,753 passed / 18 ignored:
  - `commands::trace::tests::rig_trace_list_uses_scoped_workload_preflight` missing `nodejs` extension
  - `core::deploy::safety_and_artifact::tests::test_deploy_artifact_flattens_double_nested_plugin_zip` existing deploy artifact expectation failure

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigated the Lab snapshot sync race, drafted the code/test changes, and ran verification; Chris remains responsible for review and merge.