### PR TITLE
Guard Homeboy core against concrete extension IDs

### DIFF
--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -856,7 +856,7 @@ mod tests {
                     "studio": {{
                         "path": "{}",
                         "extensions": {{
-                            "nodejs": {{
+                            "fixture-bench": {{
                                 "package_manager": "pnpm",
                                 "workspace": "apps/studio"
                             }}
@@ -874,17 +874,17 @@ mod tests {
 
         assert_eq!(component.id, "studio");
         assert_eq!(component.local_path, temp.path().to_string_lossy());
-        let nodejs = component
+        let fixture_bench = component
             .extensions
             .as_ref()
-            .and_then(|extensions| extensions.get("nodejs"))
-            .expect("nodejs config preserved");
+            .and_then(|extensions| extensions.get("fixture-bench"))
+            .expect("fixture-bench config preserved");
         assert_eq!(
-            nodejs.settings.get("package_manager"),
+            fixture_bench.settings.get("package_manager"),
             Some(&serde_json::json!("pnpm"))
         );
         assert_eq!(
-            nodejs.settings.get("workspace"),
+            fixture_bench.settings.get("workspace"),
             Some(&serde_json::json!("apps/studio"))
         );
     }
@@ -907,7 +907,7 @@ mod tests {
     #[test]
     fn rig_component_extension_config_resolves_bench_context() {
         with_isolated_home(|home| {
-            write_bench_extension(home, "nodejs");
+            write_bench_extension(home, "fixture-bench");
             let temp = tempfile::TempDir::new().expect("component dir");
             let rig_spec: RigSpec = serde_json::from_str(&format!(
                 r#"{{
@@ -916,7 +916,7 @@ mod tests {
                         "studio": {{
                             "path": "{}",
                             "extensions": {{
-                                "nodejs": {{ "package_manager": "pnpm" }}
+                                "fixture-bench": {{ "package_manager": "pnpm" }}
                             }}
                         }}
                     }},
@@ -940,7 +940,7 @@ mod tests {
             .expect("rig-owned extension config resolves bench context");
 
             assert_eq!(ctx.component_id, "studio");
-            assert_eq!(ctx.extension_id.as_deref(), Some("nodejs"));
+            assert_eq!(ctx.extension_id.as_deref(), Some("fixture-bench"));
             assert!(ctx
                 .settings
                 .iter()

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -20,12 +20,12 @@ fn write_bench_extension(home: &TempDir) {
         .join(".config")
         .join("homeboy")
         .join("extensions")
-        .join("nodejs");
+        .join("fixture-bench");
     fs::create_dir_all(&extension_dir).expect("mkdir extension");
     fs::write(
-        extension_dir.join("nodejs.json"),
+        extension_dir.join("fixture-bench.json"),
         r#"{
-                "name": "Node.js",
+                "name": "Fixture Bench",
                 "version": "0.0.0",
                 "bench": { "extension_script": "bench-runner.sh" }
             }"#,
@@ -106,12 +106,12 @@ fn write_failing_bench_extension(home: &TempDir) {
         .join(".config")
         .join("homeboy")
         .join("extensions")
-        .join("nodejs");
+        .join("fixture-bench");
     fs::create_dir_all(&extension_dir).expect("mkdir extension");
     fs::write(
-        extension_dir.join("nodejs.json"),
+        extension_dir.join("fixture-bench.json"),
         r#"{
-                "name": "Node.js",
+                "name": "Fixture Bench",
                 "version": "0.0.0",
                 "bench": { "extension_script": "bench-runner.sh" }
             }"#,
@@ -170,7 +170,7 @@ fn write_registered_component(home: &TempDir, component_id: &str, path: &std::pa
         serde_json::json!({
             "id": component_id,
             "local_path": path,
-            "extensions": { "nodejs": {} }
+            "extensions": { "fixture-bench": {} }
         })
         .to_string(),
     )
@@ -197,11 +197,11 @@ fn write_rig_with_profiles(
                     "components": {{
                         "{component_id}": {{
                             "path": "{}",
-                            "extensions": {{ "nodejs": {{}} }}
+                            "extensions": {{ "fixture-bench": {{}} }}
                         }}
                     }},
                     "bench": {{ "default_component": "{component_id}" }},
-                    "bench_workloads": {{ "nodejs": [
+                    "bench_workloads": {{ "fixture-bench": [
                         {{ "path": "${{components.{component_id}.path}}/rig-extra.bench.js" }},
                         {{ "path": "${{components.{component_id}.path}}/rig-slow.bench.mjs" }}
                     ] }},

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -171,7 +171,7 @@ mod tests {
             "--path",
             "/tmp/repo",
             "--extension",
-            "nodejs",
+            "fixture-ci",
         ])
         .expect("parse cli");
 
@@ -183,7 +183,7 @@ mod tests {
         };
 
         assert_eq!(args.comp.path.as_deref(), Some("/tmp/repo"));
-        assert_eq!(args.extension_override.extensions, vec!["nodejs"]);
+        assert_eq!(args.extension_override.extensions, vec!["fixture-ci"]);
     }
 
     #[test]
@@ -195,7 +195,7 @@ mod tests {
             "--path",
             "/tmp/repo",
             "--extension",
-            "nodejs",
+            "fixture-ci",
             "--job",
             "lint",
         ])
@@ -209,7 +209,7 @@ mod tests {
         };
 
         assert_eq!(args.comp.path.as_deref(), Some("/tmp/repo"));
-        assert_eq!(args.extension_override.extensions, vec!["nodejs"]);
+        assert_eq!(args.extension_override.extensions, vec!["fixture-ci"]);
         assert_eq!(args.job.as_deref(), Some("lint"));
     }
 

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -1220,12 +1220,12 @@ mod tests {
             .expect("runtime requirements");
         let mut runtimes = BTreeMap::new();
 
-        apply_extension_runtime_requirements("nodejs", &runtime, &mut runtimes);
+        apply_extension_runtime_requirements("fixture-runtime", &runtime, &mut runtimes);
 
         assert_eq!(runtimes["node"].version, "24");
-        assert_eq!(runtimes["node"].source, "extension:nodejs");
+        assert_eq!(runtimes["node"].source, "extension:fixture-runtime");
         assert_eq!(runtimes["php"].version, "8.3");
-        assert_eq!(runtimes["php"].source, "extension:nodejs");
+        assert_eq!(runtimes["php"].source, "extension:fixture-runtime");
     }
 
     #[test]
@@ -1350,7 +1350,7 @@ mod tests {
             ),
         ]);
 
-        apply_extension_runtime_requirements("nodejs", &runtime, &mut runtimes);
+        apply_extension_runtime_requirements("fixture-runtime", &runtime, &mut runtimes);
 
         assert_eq!(runtimes["node"].version, "22");
         assert_eq!(runtimes["node"].source, "component");

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -357,13 +357,13 @@ mod tests {
             "--path",
             "/tmp/repo",
             "--extension",
-            "nodejs",
+            "fixture-lint",
             "--changed-since",
             "origin/main",
         ])
         .expect("lint should parse --extension override");
 
-        assert_eq!(cli.lint.extension_override.extensions, vec!["nodejs"]);
+        assert_eq!(cli.lint.extension_override.extensions, vec!["fixture-lint"]);
         assert_eq!(cli.lint.changed_since.as_deref(), Some("origin/main"));
     }
 

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -878,13 +878,16 @@ mod tests {
             "test",
             "my-comp",
             "--extension",
-            "nodejs",
+            "fixture-review",
             "--changed-since",
             "origin/main",
         ])
         .expect("review should parse --extension override");
 
-        assert_eq!(cli.review.extension_override.extensions, vec!["nodejs"]);
+        assert_eq!(
+            cli.review.extension_override.extensions,
+            vec!["fixture-review"]
+        );
         assert_eq!(cli.review.changed_since.as_deref(), Some("origin/main"));
     }
 

--- a/src/commands/runner/doctor.rs
+++ b/src/commands/runner/doctor.rs
@@ -1351,10 +1351,10 @@ mod tests {
             normalized_extension_ids(&[
                 " rust ".to_string(),
                 "".to_string(),
-                "nodejs".to_string(),
+                "fixture-a".to_string(),
                 "rust".to_string(),
             ]),
-            vec!["nodejs".to_string(), "rust".to_string()]
+            vec!["fixture-a".to_string(), "rust".to_string()]
         );
     }
 

--- a/src/commands/source_command.rs
+++ b/src/commands/source_command.rs
@@ -55,8 +55,8 @@ mod tests {
     #[test]
     fn component_extension_ids_are_sorted() {
         let mut extensions = HashMap::new();
-        extensions.insert("wordpress".to_string(), ScopedExtensionConfig::default());
-        extensions.insert("nodejs".to_string(), ScopedExtensionConfig::default());
+        extensions.insert("fixture-b".to_string(), ScopedExtensionConfig::default());
+        extensions.insert("fixture-a".to_string(), ScopedExtensionConfig::default());
         let mut component = Component::new(
             "demo".to_string(),
             "/tmp/demo".to_string(),
@@ -67,7 +67,7 @@ mod tests {
 
         assert_eq!(
             component_extension_ids(&component),
-            vec!["nodejs", "wordpress"]
+            vec!["fixture-a", "fixture-b"]
         );
     }
 }

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -594,13 +594,13 @@ mod tests {
             "--path",
             "/tmp/repo",
             "--extension",
-            "nodejs",
+            "fixture-test",
             "--changed-since",
             "origin/main",
         ])
         .expect("test should parse --extension override");
 
-        assert_eq!(cli.test.extension_override.extensions, vec!["nodejs"]);
+        assert_eq!(cli.test.extension_override.extensions, vec!["fixture-test"]);
         assert_eq!(cli.test.changed_since.as_deref(), Some("origin/main"));
     }
 
@@ -647,7 +647,7 @@ mod tests {
 
         let args = vec![
             "--extension".to_string(),
-            "nodejs".to_string(),
+            "fixture-test".to_string(),
             "--filter=SomeTest".to_string(),
         ];
         let result = filter_homeboy_flags(&args);

--- a/src/commands/trace/compare_variant_tests.rs
+++ b/src/commands/trace/compare_variant_tests.rs
@@ -325,7 +325,7 @@ fn write_multi_component_variant_rig(
                     "studio": {{ "path": "{}" }},
                     "wordpress": {{ "path": "{}" }}
                 }},
-                "trace_workloads": {{ "nodejs": [
+                "trace_workloads": {{ "fixture-trace": [
                     {{ "path": "${{components.studio.path}}/studio-app-create-site.trace.mjs" }}
                 ] }},
                 "trace_variants": {{

--- a/src/commands/trace/experiment_tests.rs
+++ b/src/commands/trace/experiment_tests.rs
@@ -51,12 +51,12 @@ fn write_trace_experiment_extension(home: &tempfile::TempDir, fail: bool) {
         .join(".config")
         .join("homeboy")
         .join("extensions")
-        .join("nodejs");
+        .join("fixture-trace");
     fs::create_dir_all(&extension_dir).expect("mkdir extension");
     fs::write(
-        extension_dir.join("nodejs.json"),
+        extension_dir.join("fixture-trace.json"),
         r#"{
-                "name": "Node.js",
+                "name": "Fixture Trace",
                 "version": "0.0.0",
                 "trace": { "extension_script": "trace-runner.sh" }
             }"#,
@@ -111,7 +111,7 @@ fn write_trace_experiment_rig(home: &tempfile::TempDir, component_path: &std::pa
                 "components": {{
                     "studio": {{ "path": "{}" }}
                 }},
-                "trace_workloads": {{ "nodejs": [
+                "trace_workloads": {{ "fixture-trace": [
                     {{ "path": "${{components.studio.path}}/product-workflow.trace.mjs" }}
                 ] }},
                 "trace_experiments": {{

--- a/src/commands/trace/test_fixture.rs
+++ b/src/commands/trace/test_fixture.rs
@@ -7,12 +7,12 @@ pub(super) fn write_trace_extension(home: &tempfile::TempDir) {
         .join(".config")
         .join("homeboy")
         .join("extensions")
-        .join("nodejs");
+        .join("fixture-trace");
     fs::create_dir_all(&extension_dir).expect("mkdir extension");
     fs::write(
-        extension_dir.join("nodejs.json"),
+        extension_dir.join("fixture-trace.json"),
         r#"{
-                "name": "Node.js",
+                "name": "Fixture Trace",
                 "version": "0.0.0",
                 "trace": { "extension_script": "trace-runner.sh" }
             }"#,
@@ -128,7 +128,7 @@ pub(super) fn write_trace_rig(
                     "components": {{
                         "{component_id}": {{ "path": "{}" }}
                     }},
-                    "trace_workloads": {{ "nodejs": [
+                    "trace_workloads": {{ "fixture-trace": [
                         {{ "path": "${{components.{component_id}.path}}/studio-app-create-site.trace.mjs" }},
                         {{ "path": "${{components.{component_id}.path}}/studio-list-sites.trace.mjs" }}
                     ] }}
@@ -154,7 +154,7 @@ pub(super) fn write_trace_rig_with_phase_preset(
                     "components": {{
                         "{component_id}": {{ "path": "{}" }}
                     }},
-                    "trace_workloads": {{ "nodejs": [
+                    "trace_workloads": {{ "fixture-trace": [
                         {{
                             "path": "${{components.{component_id}.path}}/studio-app-create-site.trace.mjs",
                             "check_groups": [],
@@ -186,7 +186,7 @@ pub(super) fn write_trace_rig_with_span_metadata(
                     "components": {{
                         "{component_id}": {{ "path": "{}" }}
                     }},
-                    "trace_workloads": {{ "nodejs": [
+                    "trace_workloads": {{ "fixture-trace": [
                         {{
                             "path": "${{components.{component_id}.path}}/studio-app-create-site.trace.mjs",
                             "check_groups": [],
@@ -266,7 +266,7 @@ pub(super) fn write_trace_rig_with_variant(
                     "components": {{
                         "{component_id}": {{ "path": "{}" }}
                     }},
-                    "trace_workloads": {{ "nodejs": [
+                    "trace_workloads": {{ "fixture-trace": [
                         {{ "path": "${{components.{component_id}.path}}/studio-app-create-site.trace.mjs" }}
                     ] }},
                     "trace_variants": {{

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -67,7 +67,7 @@ fn write_trace_rig_with_profile(
                     "components": {{
                         "{component_id}": {{ "path": "{}" }}
                     }},
-                    "trace_workloads": {{ "nodejs": [
+                    "trace_workloads": {{ "fixture-trace": [
                         {{ "path": "${{components.{component_id}.path}}/close-window-running-site.trace.mjs" }}
                     ] }},
                     "trace_profiles": {{
@@ -130,7 +130,7 @@ fn rig_component_for_trace_synthesizes_trace_workload_extensions() {
                     "studio": { "path": "/tmp/studio" }
                 },
                 "trace_workloads": {
-                    "nodejs": [{ "path": "/tmp/create-site.trace.mjs" }]
+                    "fixture-trace": [{ "path": "/tmp/create-site.trace.mjs" }]
                 }
             }"#,
     )
@@ -142,7 +142,7 @@ fn rig_component_for_trace_synthesizes_trace_workload_extensions() {
         .extensions
         .as_ref()
         .expect("extensions")
-        .contains_key("nodejs"));
+        .contains_key("fixture-trace"));
 }
 
 #[test]
@@ -356,7 +356,7 @@ fn rig_trace_list_uses_scoped_workload_preflight() {
                                 }}
                             ]
                         }},
-                        "trace_workloads": {{ "nodejs": [
+                        "trace_workloads": {{ "fixture-trace": [
                             {{
                                 "path": "${{components.studio.path}}/studio-app-create-site.trace.mjs",
                                 "check_groups": ["desktop-app"]

--- a/src/core/ci_profile.rs
+++ b/src/core/ci_profile.rs
@@ -505,9 +505,9 @@ mod tests {
     #[test]
     fn list_from_manifest_returns_declared_profiles_and_jobs() {
         let tmp = TempDir::new().expect("temp dir");
-        let inventory = list_from_manifest(tmp.path(), "nodejs", &manifest_with_ci());
+        let inventory = list_from_manifest(tmp.path(), "fixture-ci", &manifest_with_ci());
 
-        assert_eq!(inventory.extension_id, "nodejs");
+        assert_eq!(inventory.extension_id, "fixture-ci");
         assert_eq!(inventory.profiles[0].id, "pr");
         assert_eq!(inventory.jobs[0].id, "lint");
         assert_eq!(
@@ -520,12 +520,12 @@ mod tests {
     fn test_list_for_extension() {
         crate::test_support::with_isolated_home(|home| {
             let mut extension = manifest_with_ci();
-            extension.id = "nodejs".to_string();
+            extension.id = "fixture-ci".to_string();
             crate::core::extension::save_manifest(&extension).expect("save extension");
 
-            let inventory = list_for_extension(home.path(), "nodejs").expect("list inventory");
+            let inventory = list_for_extension(home.path(), "fixture-ci").expect("list inventory");
 
-            assert_eq!(inventory.extension_id, "nodejs");
+            assert_eq!(inventory.extension_id, "fixture-ci");
             assert_eq!(inventory.profiles[0].id, "pr");
         });
     }
@@ -549,11 +549,11 @@ mod tests {
     #[test]
     fn select_extension_id_requires_one_extension() {
         assert_eq!(
-            select_extension_id(&["nodejs".to_string()]).unwrap(),
-            "nodejs"
+            select_extension_id(&["fixture-ci".to_string()]).unwrap(),
+            "fixture-ci"
         );
         assert!(select_extension_id(&[]).is_err());
-        assert!(select_extension_id(&["nodejs".to_string(), "rust".to_string()]).is_err());
+        assert!(select_extension_id(&["fixture-a".to_string(), "fixture-b".to_string()]).is_err());
     }
 
     #[test]

--- a/src/core/component/resolution.rs
+++ b/src/core/component/resolution.rs
@@ -722,7 +722,7 @@ mod tests {
         std::fs::create_dir_all(&repo).expect("create repo dir");
         std::fs::write(
             repo.join("homeboy.json"),
-            r#"{"id":"portable-id","extensions":{"nodejs":{}}}"#,
+            r#"{"id":"portable-id","extensions":{"fixture-extension":{}}}"#,
         )
         .expect("write portable config");
 
@@ -735,7 +735,7 @@ mod tests {
             .extensions
             .as_ref()
             .expect("extensions")
-            .contains_key("nodejs"));
+            .contains_key("fixture-extension"));
     }
 
     #[test]
@@ -743,8 +743,11 @@ mod tests {
         let dir = tempfile::tempdir().expect("temp dir");
         let repo = dir.path().join("portable-repo");
         std::fs::create_dir_all(&repo).expect("create repo dir");
-        std::fs::write(repo.join("homeboy.json"), r#"{"extensions":{"nodejs":{}}}"#)
-            .expect("write portable config");
+        std::fs::write(
+            repo.join("homeboy.json"),
+            r#"{"extensions":{"fixture-extension":{}}}"#,
+        )
+        .expect("write portable config");
 
         let error = resolve_effective(None, repo.to_str(), None)
             .expect_err("path-only portable config without id should fail");

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -626,7 +626,7 @@ mod tests {
         with_isolated_home(|home| {
             write_extension(
                 home,
-                "nodejs",
+                "fixture-a",
                 r#""lint": { "extension_script": "lint.sh" }"#,
             );
             let dir = TempDir::new().expect("component dir");
@@ -643,12 +643,12 @@ mod tests {
                 ExtensionCapability::Lint,
                 Vec::new(),
             );
-            options.extension_overrides = vec!["nodejs".to_string()];
+            options.extension_overrides = vec!["fixture-a".to_string()];
 
             let ctx = resolve_with_component(&options, Some(component.clone()))
                 .expect("one-shot extension should resolve");
 
-            assert_eq!(ctx.extension_id.as_deref(), Some("nodejs"));
+            assert_eq!(ctx.extension_id.as_deref(), Some("fixture-a"));
             assert!(
                 component.extensions.is_none(),
                 "source component is unchanged"
@@ -657,7 +657,7 @@ mod tests {
                 .component
                 .extensions
                 .as_ref()
-                .is_some_and(|extensions| extensions.contains_key("nodejs")));
+                .is_some_and(|extensions| extensions.contains_key("fixture-a")));
         });
     }
 
@@ -666,18 +666,18 @@ mod tests {
         with_isolated_home(|home| {
             write_extension(
                 home,
-                "wordpress",
+                "fixture-a",
                 r#""lint": { "extension_script": "lint.sh" }"#,
             );
             write_extension(
                 home,
-                "nodejs",
+                "fixture-b",
                 r#""lint": { "extension_script": "lint.sh" }"#,
             );
             let dir = TempDir::new().expect("component dir");
             let mut configured = HashMap::new();
             configured.insert(
-                "wordpress".to_string(),
+                "fixture-a".to_string(),
                 ScopedExtensionConfig {
                     settings: HashMap::from([(
                         "package_manager".to_string(),
@@ -687,7 +687,7 @@ mod tests {
                 },
             );
             configured.insert(
-                "nodejs".to_string(),
+                "fixture-b".to_string(),
                 ScopedExtensionConfig {
                     settings: HashMap::from([(
                         "package_manager".to_string(),
@@ -709,19 +709,19 @@ mod tests {
                 ExtensionCapability::Lint,
                 Vec::new(),
             );
-            options.extension_overrides = vec!["nodejs".to_string()];
+            options.extension_overrides = vec!["fixture-b".to_string()];
 
             let ctx = resolve_with_component(&options, Some(component.clone()))
-                .expect("override should select nodejs only");
+                .expect("override should select fixture-b only");
             let runtime_extensions = ctx
                 .component
                 .extensions
                 .as_ref()
                 .expect("runtime extensions");
 
-            assert_eq!(ctx.extension_id.as_deref(), Some("nodejs"));
-            assert!(runtime_extensions.contains_key("nodejs"));
-            assert!(!runtime_extensions.contains_key("wordpress"));
+            assert_eq!(ctx.extension_id.as_deref(), Some("fixture-b"));
+            assert!(runtime_extensions.contains_key("fixture-b"));
+            assert!(!runtime_extensions.contains_key("fixture-a"));
             assert!(ctx
                 .settings
                 .iter()
@@ -729,7 +729,7 @@ mod tests {
             assert!(component
                 .extensions
                 .as_ref()
-                .is_some_and(|extensions| extensions.contains_key("wordpress")));
+                .is_some_and(|extensions| extensions.contains_key("fixture-a")));
         });
     }
 

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -817,7 +817,7 @@ mod tests {
     #[test]
     fn build_exec_env_includes_toolchain_path() {
         let env = build_exec_env(
-            "nodejs",
+            "fixture-extension",
             None,
             None,
             "{}",

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -1238,15 +1238,22 @@ exec '{}' "$@"
             let home = home.path();
             let source = home.join("source-repo");
             fs::create_dir_all(&source).expect("source repo");
-            let _remote = match prepare_git_extension_monorepo(&source, &["nodejs", "rust"]) {
+            let _remote = match prepare_git_extension_monorepo(&source, &["fixture-a", "fixture-b"])
+            {
                 Some(remote) => remote,
                 None => return,
             };
 
-            install(&source.join("nodejs").to_string_lossy(), Some("nodejs"))
-                .expect("install linked nodejs extension");
-            install(&source.join("rust").to_string_lossy(), Some("rust"))
-                .expect("install linked rust extension");
+            install(
+                &source.join("fixture-a").to_string_lossy(),
+                Some("fixture-a"),
+            )
+            .expect("install linked fixture-a extension");
+            install(
+                &source.join("fixture-b").to_string_lossy(),
+                Some("fixture-b"),
+            )
+            .expect("install linked fixture-b extension");
 
             let bin_dir = home.join("bin");
             let pull_count_file = home.join("pull-count");
@@ -1263,7 +1270,7 @@ exec '{}' "$@"
                 .iter()
                 .map(|entry| entry.extension_id.as_str())
                 .collect::<Vec<_>>();
-            assert_eq!(updated_ids, vec!["nodejs", "rust"]);
+            assert_eq!(updated_ids, vec!["fixture-a", "fixture-b"]);
             assert!(result.skipped.is_empty());
             assert_eq!(
                 fs::read_to_string(&pull_count_file)
@@ -1273,20 +1280,20 @@ exec '{}' "$@"
                 "linked extensions sharing one git root should run one git pull"
             );
             assert_eq!(
-                fs::read_to_string(source.join("nodejs/setup-count.txt"))
+                fs::read_to_string(source.join("fixture-a/setup-count.txt"))
                     .unwrap_or_default()
                     .matches("setup")
                     .count(),
                 1,
-                "nodejs setup should still run after the shared root update"
+                "fixture-a setup should still run after the shared root update"
             );
             assert_eq!(
-                fs::read_to_string(source.join("rust/setup-count.txt"))
+                fs::read_to_string(source.join("fixture-b/setup-count.txt"))
                     .unwrap_or_default()
                     .matches("setup")
                     .count(),
                 1,
-                "rust setup should still run after the shared root update"
+                "fixture-b setup should still run after the shared root update"
             );
         });
     }

--- a/src/core/release/context.rs
+++ b/src/core/release/context.rs
@@ -43,7 +43,7 @@ mod tests {
                 "id": "fixture",
                 "components": {
                     "fixture": {
-                        "type": "nodejs",
+                        "type": "fixture-type",
                         "path": "."
                     }
                 }

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -762,7 +762,7 @@ mod tests {
                     { "label": "health", "http": "http://127.0.0.1:3000/health" }
                 ],
                 "trace_workloads": {
-                    "nodejs": [
+                    "fixture-trace": [
                         {
                             "path": "trace/create-site.trace.mjs",
                             "trace_guardrails": [
@@ -788,7 +788,9 @@ mod tests {
             spec.trace_guardrails[0].check.http.as_deref(),
             Some("http://127.0.0.1:3000/health")
         );
-        let workload = spec.trace_workloads["nodejs"].first().expect("workload");
+        let workload = spec.trace_workloads["fixture-trace"]
+            .first()
+            .expect("workload");
         assert_eq!(
             workload.trace_guardrails()[0].check.command.as_deref(),
             Some("npm run smoke:list-sites")

--- a/src/core/runner/capabilities.rs
+++ b/src/core/runner/capabilities.rs
@@ -596,12 +596,12 @@ mod tests {
         let preflight = RunnerCapabilityPreflight {
             command: "test".to_string(),
             required_tools: vec![RunnerRequiredTool::Git, RunnerRequiredTool::Pnpm],
-            required_components: vec!["nodejs".to_string(), "wordpress".to_string()],
+            required_components: vec!["fixture-a".to_string(), "fixture-b".to_string()],
             required_env: vec!["HOMEBOY_TOKEN".to_string()],
         };
         let capabilities = RunnerCapabilitySnapshot {
             tools: [RunnerRequiredTool::Git].into_iter().collect(),
-            components: ["nodejs".to_string()].into_iter().collect(),
+            components: ["fixture-a".to_string()].into_iter().collect(),
         };
 
         let err =
@@ -610,7 +610,7 @@ mod tests {
 
         assert_eq!(err.code.as_str(), "validation.invalid_argument");
         assert!(err.message.contains(concat!("tools: p", "n", "pm")));
-        assert!(err.message.contains("components: wordpress"));
+        assert!(err.message.contains("components: fixture-b"));
         assert!(err.message.contains("environment: HOMEBOY_TOKEN"));
         let tried = err
             .details
@@ -627,14 +627,14 @@ mod tests {
         let preflight = RunnerCapabilityPreflight {
             command: "lint".to_string(),
             required_tools: vec![RunnerRequiredTool::Git, RunnerRequiredTool::Node],
-            required_components: vec!["nodejs".to_string()],
+            required_components: vec!["fixture-a".to_string()],
             required_env: vec!["HOMEBOY_TOKEN".to_string()],
         };
         let capabilities = RunnerCapabilitySnapshot {
             tools: [RunnerRequiredTool::Git, RunnerRequiredTool::Node]
                 .into_iter()
                 .collect(),
-            components: ["nodejs".to_string()].into_iter().collect(),
+            components: ["fixture-a".to_string()].into_iter().collect(),
         };
         let mut env = HashMap::new();
         env.insert("HOMEBOY_TOKEN".to_string(), "present".to_string());
@@ -648,22 +648,22 @@ mod tests {
         let mut runner = ssh_runner();
         runner.resources.insert(
             "components".to_string(),
-            serde_json::json!(["nodejs", { "id": "wordpress" }]),
+            serde_json::json!(["fixture-a", { "id": "fixture-b" }]),
         );
         assert_eq!(
             configured_runner_components(&runner),
-            ["nodejs".to_string(), "wordpress".to_string()]
+            ["fixture-a".to_string(), "fixture-b".to_string()]
                 .into_iter()
                 .collect()
         );
 
         runner.resources.insert(
             "components".to_string(),
-            serde_json::json!({ "rust": true, "php": true }),
+            serde_json::json!({ "fixture-c": true, "fixture-d": true }),
         );
         assert_eq!(
             configured_runner_components(&runner),
-            ["php".to_string(), "rust".to_string()]
+            ["fixture-c".to_string(), "fixture-d".to_string()]
                 .into_iter()
                 .collect()
         );

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -952,7 +952,7 @@ mod tests {
             "lint".to_string(),
             "--extension".to_string(),
             "rust".to_string(),
-            "--extension=nodejs".to_string(),
+            "--extension=fixture-build".to_string(),
         ];
 
         assert_eq!(
@@ -960,7 +960,7 @@ mod tests {
             vec![
                 "wordpress".to_string(),
                 "rust".to_string(),
-                "nodejs".to_string(),
+                "fixture-build".to_string(),
             ]
         );
     }

--- a/tests/core/rig/bench_default_baseline_spec_test.rs
+++ b/tests/core/rig/bench_default_baseline_spec_test.rs
@@ -79,35 +79,38 @@ fn test_rig_spec_deserializes_bench_workloads_by_extension() {
         r#"{
             "id": "studio",
             "bench_workloads": {
-                "wordpress": [
+                "extension-b": [
                     { "path": "/private/benches/cold-boot.php" },
                     { "path": "~/benches/wc-loaded.php" }
                 ],
-                "nodejs": [{ "path": "/private/benches/electron-startup.bench.ts" }]
+                "extension-a": [{ "path": "/private/benches/electron-startup.bench.ts" }]
             }
         }"#,
     )
     .expect("parse RigSpec");
 
-    let wordpress: Vec<&str> = spec
+    let extension_b: Vec<&str> = spec
         .bench_workloads
-        .get("wordpress")
-        .expect("wordpress workloads")
+        .get("extension-b")
+        .expect("extension-b workloads")
         .iter()
         .map(|workload| workload.path())
         .collect();
     assert_eq!(
-        wordpress,
+        extension_b,
         vec!["/private/benches/cold-boot.php", "~/benches/wc-loaded.php"]
     );
-    let nodejs: Vec<&str> = spec
+    let extension_a: Vec<&str> = spec
         .bench_workloads
-        .get("nodejs")
-        .expect("nodejs workloads")
+        .get("extension-a")
+        .expect("extension-a workloads")
         .iter()
         .map(|workload| workload.path())
         .collect();
-    assert_eq!(nodejs, vec!["/private/benches/electron-startup.bench.ts"]);
+    assert_eq!(
+        extension_a,
+        vec!["/private/benches/electron-startup.bench.ts"]
+    );
 }
 
 #[test]
@@ -116,38 +119,38 @@ fn test_rig_spec_deserializes_trace_workloads_by_extension() {
         r#"{
             "id": "studio",
             "trace_workloads": {
-                "nodejs": [
+                "extension-a": [
                     { "path": "${package.root}/bench/studio-app-create-site.trace.mjs" },
                     { "path": "~/traces/window-close.trace.mjs" }
                 ],
-                "wordpress": [{ "path": "/private/traces/wp-admin-load.trace.php" }]
+                "extension-b": [{ "path": "/private/traces/wp-admin-load.trace.php" }]
             }
         }"#,
     )
     .expect("parse RigSpec");
 
-    let nodejs: Vec<&str> = spec
+    let extension_a: Vec<&str> = spec
         .trace_workloads
-        .get("nodejs")
-        .expect("nodejs workloads")
+        .get("extension-a")
+        .expect("extension-a workloads")
         .iter()
         .map(|workload| workload.path())
         .collect();
     assert_eq!(
-        nodejs,
+        extension_a,
         vec![
             "${package.root}/bench/studio-app-create-site.trace.mjs",
             "~/traces/window-close.trace.mjs",
         ]
     );
-    let wordpress: Vec<&str> = spec
+    let extension_b: Vec<&str> = spec
         .trace_workloads
-        .get("wordpress")
-        .expect("wordpress workloads")
+        .get("extension-b")
+        .expect("extension-b workloads")
         .iter()
         .map(|workload| workload.path())
         .collect();
-    assert_eq!(wordpress, vec!["/private/traces/wp-admin-load.trace.php"]);
+    assert_eq!(extension_b, vec!["/private/traces/wp-admin-load.trace.php"]);
 }
 
 #[test]
@@ -156,7 +159,7 @@ fn test_trace_phase_preset() {
         r#"{
             "id": "studio",
             "trace_workloads": {
-                "nodejs": [
+                "extension-a": [
                     {
                         "path": "${package.root}/bench/studio.trace.mjs",
                         "trace_phase_presets": {
@@ -171,9 +174,9 @@ fn test_trace_phase_preset() {
 
     let workload = spec
         .trace_workloads
-        .get("nodejs")
+        .get("extension-a")
         .and_then(|workloads| workloads.first())
-        .expect("nodejs trace workload");
+        .expect("extension-a trace workload");
 
     assert_eq!(workload.trace_phase_preset("missing"), None);
     assert_eq!(
@@ -191,7 +194,7 @@ fn test_trace_default_phase_preset() {
         r#"{
             "id": "studio",
             "trace_workloads": {
-                "nodejs": [
+                "extension-a": [
                     {
                         "path": "${package.root}/bench/studio.trace.mjs",
                         "trace_default_phase_preset": "startup"
@@ -204,9 +207,9 @@ fn test_trace_default_phase_preset() {
 
     let workload = spec
         .trace_workloads
-        .get("nodejs")
+        .get("extension-a")
         .and_then(|workloads| workloads.first())
-        .expect("nodejs trace workload");
+        .expect("extension-a trace workload");
 
     assert_eq!(workload.trace_default_phase_preset(), Some("startup"));
     let workload_without_default: WorkloadSpec =
@@ -258,7 +261,7 @@ fn test_rig_component_deserializes_extension_config() {
                 "studio": {
                     "path": "~/Developer/studio",
                     "extensions": {
-                        "nodejs": {
+                        "extension-a": {
                             "package_manager": "pnpm",
                             "workspace": "apps/studio"
                         }
@@ -272,15 +275,15 @@ fn test_rig_component_deserializes_extension_config() {
 
     let component = spec.components.get("studio").expect("studio component");
     let extensions = component.extensions.as_ref().expect("extensions present");
-    let nodejs = extensions.get("nodejs").expect("nodejs extension config");
+    let extension_a = extensions.get("extension-a").expect("extension-a config");
 
     assert_eq!(component.path, "~/Developer/studio");
     assert_eq!(
-        nodejs.settings.get("package_manager"),
+        extension_a.settings.get("package_manager"),
         Some(&serde_json::json!("pnpm"))
     );
     assert_eq!(
-        nodejs.settings.get("workspace"),
+        extension_a.settings.get("workspace"),
         Some(&serde_json::json!("apps/studio"))
     );
 }
@@ -293,7 +296,7 @@ fn test_rig_component_extension_config_round_trips() {
             "studio": {
                 "path": "/tmp/studio",
                 "extensions": {
-                    "nodejs": { "package_manager": "pnpm" }
+                    "extension-a": { "package_manager": "pnpm" }
                 }
             }
         }
@@ -307,7 +310,7 @@ fn test_rig_component_extension_config_round_trips() {
         .get("studio")
         .and_then(|component| component.extensions.as_ref())
         .expect("extensions preserved");
-    assert!(extensions.contains_key("nodejs"));
+    assert!(extensions.contains_key("extension-a"));
     assert!(re_serialized.contains("extensions"));
 }
 

--- a/tests/core/rig/bench_prepare_pipeline_test.rs
+++ b/tests/core/rig/bench_prepare_pipeline_test.rs
@@ -11,11 +11,11 @@ fn write_logging_bench_extension(home: &TempDir, log_path: &std::path::Path) {
         .join(".config")
         .join("homeboy")
         .join("extensions")
-        .join("nodejs");
+        .join("fixture-bench");
     fs::create_dir_all(&extension_dir).expect("mkdir extension");
     fs::write(
-        extension_dir.join("nodejs.json"),
-        r#"{"name":"Node.js","version":"0.0.0","bench":{"extension_script":"bench-runner.sh"}}"#,
+        extension_dir.join("fixture-bench.json"),
+        r#"{"name":"Fixture Bench","version":"0.0.0","bench":{"extension_script":"bench-runner.sh"}}"#,
     )
     .expect("write extension manifest");
 
@@ -77,7 +77,7 @@ fn write_pipeline_rig(
         "components": {
             "studio": {
                 "path": component_path,
-                "extensions": { "nodejs": {} }
+                "extensions": { "fixture-bench": {} }
             }
         },
         "bench": { "default_component": "studio" },

--- a/tests/core/rig/bench_rig_concurrency_dispatch_test.rs
+++ b/tests/core/rig/bench_rig_concurrency_dispatch_test.rs
@@ -11,11 +11,11 @@ fn write_ordering_bench_extension(home: &TempDir) {
         .join(".config")
         .join("homeboy")
         .join("extensions")
-        .join("nodejs");
+        .join("fixture-bench");
     fs::create_dir_all(&extension_dir).expect("mkdir extension");
     fs::write(
-        extension_dir.join("nodejs.json"),
-        r#"{"name":"Node.js","version":"0.0.0","bench":{"extension_script":"bench-runner.sh"}}"#,
+        extension_dir.join("fixture-bench.json"),
+        r#"{"name":"Fixture Bench","version":"0.0.0","bench":{"extension_script":"bench-runner.sh"}}"#,
     )
     .expect("write extension manifest");
 

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -557,7 +557,7 @@ mod extension_lifecycle {
 
         let mut extensions = HashMap::new();
         extensions.insert(
-            "nodejs".to_string(),
+            "fixture-build".to_string(),
             ScopedExtensionConfig {
                 version: None,
                 settings: component_settings,
@@ -601,13 +601,13 @@ mod extension_lifecycle {
         }
     }
 
-    fn write_nodejs_build_extension(home: &std::path::Path) {
-        let extension_dir = home.join(".config/homeboy/extensions/nodejs");
+    fn write_fixture_build_extension(home: &std::path::Path) {
+        let extension_dir = home.join(".config/homeboy/extensions/fixture-build");
         fs::create_dir_all(&extension_dir).expect("extension dir");
         fs::write(
-            extension_dir.join("nodejs.json"),
+            extension_dir.join("fixture-build.json"),
             r#"{
-                "name": "Node.js",
+                "name": "Fixture Build",
                 "version": "1.0.0",
                 "build": {
                     "extension_script": "build.sh",
@@ -627,7 +627,7 @@ mod extension_lifecycle {
     #[test]
     fn test_extension_build_uses_rig_component_path_and_extension_config() {
         test_support::with_isolated_home(|home| {
-            write_nodejs_build_extension(home.path());
+            write_fixture_build_extension(home.path());
             let component_dir = tempfile::tempdir().expect("component dir");
             let component_path = component_dir.path().to_string_lossy().to_string();
             let rig = rig_with_step(

--- a/tests/core/rig/workloads_test.rs
+++ b/tests/core/rig/workloads_test.rs
@@ -16,17 +16,17 @@ fn test_bench_workloads_for_extension_filters_and_expands_paths() {
                 "playground": { "path": "/tmp/playground" }
             },
             "bench_workloads": {
-                "wordpress": [
+                "extension-b": [
                     { "path": "${env.HOMEBOY_TEST_BENCH_ROOT}/cold-boot.php" },
                     { "path": "${components.playground.path}/fixtures/wc-loaded.php" }
                 ],
-                "nodejs": [{ "path": "/tmp/node-only.bench.ts" }]
+                "extension-a": [{ "path": "/tmp/node-only.bench.ts" }]
             }
         }"#,
     )
     .expect("parse rig spec");
 
-    let workloads = workloads_for_extension(&rig_spec, RigWorkloadKind::Bench, None, "wordpress");
+    let workloads = workloads_for_extension(&rig_spec, RigWorkloadKind::Bench, None, "extension-b");
 
     assert_eq!(
         workloads,
@@ -35,7 +35,9 @@ fn test_bench_workloads_for_extension_filters_and_expands_paths() {
             PathBuf::from("/tmp/playground/fixtures/wc-loaded.php"),
         ]
     );
-    assert!(workloads_for_extension(&rig_spec, RigWorkloadKind::Bench, None, "rust").is_empty());
+    assert!(
+        workloads_for_extension(&rig_spec, RigWorkloadKind::Bench, None, "extension-c").is_empty()
+    );
 }
 
 #[test]
@@ -44,7 +46,7 @@ fn test_workload_string_shorthand_is_rejected() {
         r#"{
             "id": "studio",
             "bench_workloads": {
-                "nodejs": ["/tmp/legacy.bench.mjs"]
+                "extension-a": ["/tmp/legacy.bench.mjs"]
             }
         }"#,
     )
@@ -63,7 +65,7 @@ fn test_invocation_requirements_for_extension_workloads() {
         r#"{
             "id": "playground-bench",
             "bench_workloads": {
-                "nodejs": [
+                "extension-a": [
                     {
                         "path": "/tmp/playground-server.bench.mjs",
                         "port_range_size": 8,
@@ -83,7 +85,7 @@ fn test_invocation_requirements_for_extension_workloads() {
     let requirements = crate::core::rig::invocation_requirements_for_extension_workloads(
         &rig_spec,
         crate::core::rig::RigWorkloadKind::Bench,
-        "nodejs",
+        "extension-a",
     );
 
     assert_eq!(requirements.port_range_size, Some(8));
@@ -103,17 +105,17 @@ fn test_trace_workloads_for_extension_filters_and_expands_paths() {
                 "studio": { "path": "/tmp/studio" }
             },
             "trace_workloads": {
-                "nodejs": [
+                "extension-a": [
                     { "path": "${env.HOMEBOY_TEST_TRACE_ROOT}/create-site.trace.mjs" },
                     { "path": "${components.studio.path}/bench/admin-load.trace.mjs" }
                 ],
-                "wordpress": [{ "path": "/tmp/wp.trace.php" }]
+                "extension-b": [{ "path": "/tmp/wp.trace.php" }]
             }
         }"#,
     )
     .expect("parse rig spec");
 
-    let workloads = workloads_for_extension(&rig_spec, RigWorkloadKind::Trace, None, "nodejs");
+    let workloads = workloads_for_extension(&rig_spec, RigWorkloadKind::Trace, None, "extension-a");
 
     assert_eq!(
         workloads,
@@ -122,7 +124,9 @@ fn test_trace_workloads_for_extension_filters_and_expands_paths() {
             PathBuf::from("/tmp/studio/bench/admin-load.trace.mjs"),
         ]
     );
-    assert!(workloads_for_extension(&rig_spec, RigWorkloadKind::Trace, None, "rust").is_empty());
+    assert!(
+        workloads_for_extension(&rig_spec, RigWorkloadKind::Trace, None, "extension-c").is_empty()
+    );
 }
 
 #[test]
@@ -131,10 +135,10 @@ fn test_extension_workloads_expand_package_root_when_available() {
         r#"{
             "id": "studio-agent-sdk",
             "bench_workloads": {
-                "nodejs": [{ "path": "${package.root}/bench/studio-agent-runtime.bench.mjs" }]
+                "extension-a": [{ "path": "${package.root}/bench/studio-agent-runtime.bench.mjs" }]
             },
             "trace_workloads": {
-                "nodejs": [{ "path": "${package.root}/bench/studio-app-create-site.trace.mjs" }]
+                "extension-a": [{ "path": "${package.root}/bench/studio-app-create-site.trace.mjs" }]
             }
         }"#,
     )
@@ -142,13 +146,23 @@ fn test_extension_workloads_expand_package_root_when_available() {
     let package = PathBuf::from("/tmp/homeboy-rigs/Automattic/studio");
 
     assert_eq!(
-        workloads_for_extension(&rig_spec, RigWorkloadKind::Bench, Some(&package), "nodejs"),
+        workloads_for_extension(
+            &rig_spec,
+            RigWorkloadKind::Bench,
+            Some(&package),
+            "extension-a"
+        ),
         vec![PathBuf::from(
             "/tmp/homeboy-rigs/Automattic/studio/bench/studio-agent-runtime.bench.mjs"
         )]
     );
     assert_eq!(
-        workloads_for_extension(&rig_spec, RigWorkloadKind::Trace, Some(&package), "nodejs"),
+        workloads_for_extension(
+            &rig_spec,
+            RigWorkloadKind::Trace,
+            Some(&package),
+            "extension-a"
+        ),
         vec![PathBuf::from(
             "/tmp/homeboy-rigs/Automattic/studio/bench/studio-app-create-site.trace.mjs"
         )]
@@ -161,21 +175,21 @@ fn test_extension_workloads_leave_package_root_unexpanded_without_metadata() {
         r#"{
             "id": "manual",
             "bench_workloads": {
-                "nodejs": [{ "path": "${package.root}/bench/manual.bench.mjs" }]
+                "extension-a": [{ "path": "${package.root}/bench/manual.bench.mjs" }]
             },
             "trace_workloads": {
-                "nodejs": [{ "path": "${package.root}/bench/manual.trace.mjs" }]
+                "extension-a": [{ "path": "${package.root}/bench/manual.trace.mjs" }]
             }
         }"#,
     )
     .expect("parse rig spec");
 
     assert_eq!(
-        workloads_for_extension(&rig_spec, RigWorkloadKind::Bench, None, "nodejs"),
+        workloads_for_extension(&rig_spec, RigWorkloadKind::Bench, None, "extension-a"),
         vec![PathBuf::from("${package.root}/bench/manual.bench.mjs")]
     );
     assert_eq!(
-        workloads_for_extension(&rig_spec, RigWorkloadKind::Trace, None, "nodejs"),
+        workloads_for_extension(&rig_spec, RigWorkloadKind::Trace, None, "extension-a"),
         vec![PathBuf::from("${package.root}/bench/manual.trace.mjs")]
     );
 }
@@ -189,10 +203,10 @@ fn test_check_groups_for_extension_workloads() {
                 "studio": { "path": "/tmp/studio" }
             },
             "trace_workloads": {
-                "nodejs": [
+                "extension-a": [
                     {
                         "path": "${components.studio.path}/bench/create-site.trace.mjs",
-                        "check_groups": ["desktop-app", "nodejs-trace"]
+                        "check_groups": ["desktop-app", "extension-a-trace"]
                     },
                     {
                         "path": "/tmp/other.trace.mjs",
@@ -205,16 +219,16 @@ fn test_check_groups_for_extension_workloads() {
     .expect("parse rig spec");
 
     assert_eq!(
-        workloads_for_extension(&rig_spec, RigWorkloadKind::Trace, None, "nodejs"),
+        workloads_for_extension(&rig_spec, RigWorkloadKind::Trace, None, "extension-a"),
         vec![
             PathBuf::from("/tmp/studio/bench/create-site.trace.mjs"),
             PathBuf::from("/tmp/other.trace.mjs"),
         ]
     );
     assert_eq!(
-        check_groups_for_extension_workloads(&rig_spec, RigWorkloadKind::Trace, "nodejs")
+        check_groups_for_extension_workloads(&rig_spec, RigWorkloadKind::Trace, "extension-a")
             .expect("scoped groups"),
-        vec!["desktop-app".to_string(), "nodejs-trace".to_string()]
+        vec!["desktop-app".to_string(), "extension-a-trace".to_string()]
     );
 }
 
@@ -224,14 +238,14 @@ fn test_workloads_without_check_groups_keep_full_check_contract() {
         r#"{
             "id": "studio",
             "trace_workloads": {
-                "nodejs": [{ "path": "/tmp/create-site.trace.mjs" }]
+                "extension-a": [{ "path": "/tmp/create-site.trace.mjs" }]
             }
         }"#,
     )
     .expect("parse rig spec");
 
     assert_eq!(
-        check_groups_for_extension_workloads(&rig_spec, RigWorkloadKind::Trace, "nodejs"),
+        check_groups_for_extension_workloads(&rig_spec, RigWorkloadKind::Trace, "extension-a"),
         None
     );
 }
@@ -242,12 +256,12 @@ fn test_extension_ids_for_workloads_are_sorted_by_kind() {
         r#"{
             "id": "studio",
             "bench_workloads": {
-                "wordpress": [{ "path": "/tmp/wp.bench.php" }],
-                "nodejs": [{ "path": "/tmp/node.bench.mjs" }]
+                "extension-b": [{ "path": "/tmp/wp.bench.php" }],
+                "extension-a": [{ "path": "/tmp/node.bench.mjs" }]
             },
             "trace_workloads": {
-                "rust": [{ "path": "/tmp/rust.trace.rs" }],
-                "nodejs": [{ "path": "/tmp/node.trace.mjs" }]
+                "extension-c": [{ "path": "/tmp/rust.trace.rs" }],
+                "extension-a": [{ "path": "/tmp/node.trace.mjs" }]
             }
         }"#,
     )
@@ -255,10 +269,10 @@ fn test_extension_ids_for_workloads_are_sorted_by_kind() {
 
     assert_eq!(
         extension_ids_for_workloads(&rig_spec, RigWorkloadKind::Bench),
-        vec!["nodejs".to_string(), "wordpress".to_string()]
+        vec!["extension-a".to_string(), "extension-b".to_string()]
     );
     assert_eq!(
         extension_ids_for_workloads(&rig_spec, RigWorkloadKind::Trace),
-        vec!["nodejs".to_string(), "rust".to_string()]
+        vec!["extension-a".to_string(), "extension-c".to_string()]
     );
 }

--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -33,6 +33,17 @@ const CORE_OWNED_SOURCE_ROOTS: &[&str] = &[
 
 const CORE_OWNED_TEST_CONTENT_ROOTS: &[&str] = &["tests/core", "tests/fixtures"];
 
+const CORE_EXTENSION_BOUNDARY_ROOTS: &[&str] =
+    &["src/core", "src/commands", "tests/core", "tests/fixtures"];
+
+// Concrete extension IDs belong in extension-owned fixtures/config, not in
+// Homeboy core or core-owned tests. Keep this list to IDs provided by external
+// extensions so the guard stays independent of any one regression site.
+const CONCRETE_EXTENSION_IDS: &[Term] = &[Term {
+    name: "nodejs",
+    kind: MatchKind::Token,
+}];
+
 const TERMS: &[Term] = &[
     Term {
         name: "wordpress",
@@ -1238,10 +1249,6 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
         term: "wordpress",
     },
     ViolationKey {
-        path: "tests/core/rig/workloads_test.rs",
-        term: "nodejs",
-    },
-    ViolationKey {
         path: "tests/fixtures/failure_digest/lint.json",
         term: "phpcs",
     },
@@ -1343,6 +1350,30 @@ fn core_owned_test_content_stays_language_and_framework_agnostic() {
     assert!(
         !term_distribution.is_empty(),
         "test-content baseline should stay explicit until the #3034 cleanup removes existing core-owned fixture leaks"
+    );
+}
+
+#[test]
+fn core_content_stays_free_of_concrete_extension_ids() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut found = BTreeMap::<(String, String), Vec<usize>>::new();
+
+    for source_root in CORE_EXTENSION_BOUNDARY_ROOTS {
+        let path = root.join(source_root);
+        if path.exists() {
+            scan_concrete_extension_ids(root, &path, &mut found);
+        }
+    }
+
+    let unexpected = found
+        .iter()
+        .map(|((path, term), lines)| format!("{path}: `{term}` on lines {lines:?}"))
+        .collect::<Vec<_>>();
+
+    assert!(
+        unexpected.is_empty(),
+        "Homeboy core and core-owned tests must not reference concrete extension IDs. Use neutral fixture IDs in core tests and move real extension dependencies into extension-owned tests/config. Concrete extension references found:\n{}",
+        unexpected.join("\n")
     );
 }
 
@@ -1494,6 +1525,44 @@ fn scan_test_content_line(
                 .entry((relative.to_string(), term.name.to_string()))
                 .or_default()
                 .push(line_number);
+        }
+    }
+}
+
+fn scan_concrete_extension_ids(
+    root: &Path,
+    path: &Path,
+    found: &mut BTreeMap<(String, String), Vec<usize>>,
+) {
+    if path.is_dir() {
+        for entry in fs::read_dir(path).expect("boundary path should be readable") {
+            let entry = entry.expect("boundary entry should be readable");
+            scan_concrete_extension_ids(root, &entry.path(), found);
+        }
+        return;
+    }
+
+    if !is_scannable_test_content_file(path) {
+        return;
+    }
+
+    let content = fs::read_to_string(path).expect("boundary file should be readable");
+    let relative = relative_path(root, path);
+    let rust_string_literals_only = path.extension().is_some_and(|ext| ext == "rs");
+
+    for (index, line) in content.lines().enumerate() {
+        let segments = if rust_string_literals_only {
+            rust_string_literal_segments(line)
+        } else {
+            vec![line.to_string()]
+        };
+        for term in CONCRETE_EXTENSION_IDS {
+            if segments.iter().any(|segment| term.matches(segment)) {
+                found
+                    .entry((relative.clone(), term.name.to_string()))
+                    .or_default()
+                    .push(index + 1);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a core-agnostic guard that scans core-owned source, command code, core tests, and fixtures for concrete extension IDs such as `nodejs`.
- Replace core/core-test `nodejs` fixture identities with neutral fixture extension IDs so real extension dependencies stay outside Homeboy core.
- Remove the old `tests/core/rig/workloads_test.rs` `nodejs` baseline row now that the fixture is generic.

Closes #3340.

## Verification
- `cargo test --test core_agnostic_test core_content_stays_free_of_concrete_extension_ids -- --nocapture`
- `cargo test --lib rig_trace_list_uses_scoped_workload_preflight -- --nocapture`
- `cargo test --lib rig_component_for_trace_synthesizes_trace_workload_extensions -- --nocapture`
- `cargo test --lib rig_component_extension_config_resolves_bench_context -- --nocapture`
- `cargo test --lib parses_one_shot_extension_override -- --nocapture`
- `cargo test --lib workloads_for_extension -- --nocapture`
- `cargo test --lib extension_config -- --nocapture`
- `cargo test --lib bench_prepare_runs_before_check_and_workload -- --nocapture`
- `cargo test --lib cross_rig_default_runs_rigs_sequentially -- --nocapture`
- `cargo test --lib cross_rig_concurrency_runs_rigs_in_parallel -- --nocapture`

Known pre-existing failure:
- `cargo test --test core_agnostic_test -- --nocapture` still fails in the existing source/test-content guards on unrelated non-baselined Lab/homeboy/wordpress debt that was present before this change. The new `core_content_stays_free_of_concrete_extension_ids` guard passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the guardrail test change, neutral fixture ID updates, targeted verification, and PR description. Chris remains responsible for review and merge.