### PR TITLE
fix(deploy): create missing zip artifacts

### DIFF
--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use crate::core::build;
 use crate::core::component::Component;
 use crate::core::context::RemoteProjectContext;
+use crate::core::engine::command;
 use crate::core::error::Result;
 use crate::core::extension::build::resolve_artifact_path_from_root;
 use crate::core::git;
@@ -519,6 +520,19 @@ fn resolve_preflight_artifact_path(
             }
         };
 
+        if should_create_missing_archive_artifact(component, config, artifact_pattern) {
+            if let Err(error) = create_archive_artifact_from_head(component, artifact_pattern) {
+                return Err(ComponentDeployResult::failed(
+                    component,
+                    base_path,
+                    local_version,
+                    remote_version,
+                    error,
+                )
+                .with_build_exit_code(build_exit_code));
+            }
+        }
+
         match resolve_artifact_path_from_root(
             artifact_pattern,
             Some(Path::new(&component.local_path)),
@@ -576,6 +590,89 @@ fn resolve_preflight_artifact_path(
     }
 
     Ok(artifact_path)
+}
+
+fn should_create_missing_archive_artifact(
+    component: &Component,
+    config: &DeployConfig,
+    artifact_pattern: &str,
+) -> bool {
+    !config.skip_build
+        && is_literal_zip_artifact_pattern(artifact_pattern)
+        && !resolved_literal_artifact_path(component, artifact_pattern).exists()
+}
+
+fn is_literal_zip_artifact_pattern(pattern: &str) -> bool {
+    !pattern.contains('*')
+        && !pattern.contains('?')
+        && !pattern.contains('[')
+        && !pattern.contains(']')
+        && Path::new(pattern)
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext == "zip")
+}
+
+fn resolved_literal_artifact_path(component: &Component, artifact_pattern: &str) -> PathBuf {
+    let artifact_path = PathBuf::from(artifact_pattern);
+    if artifact_path.is_absolute() {
+        artifact_path
+    } else {
+        Path::new(&component.local_path).join(artifact_path)
+    }
+}
+
+fn create_archive_artifact_from_head(
+    component: &Component,
+    artifact_pattern: &str,
+) -> std::result::Result<(), String> {
+    let artifact_path = resolved_literal_artifact_path(component, artifact_pattern);
+    let parent = artifact_path.parent().ok_or_else(|| {
+        format!(
+            "Build artifact path must include a parent directory: {}",
+            artifact_path.display()
+        )
+    })?;
+
+    if !parent.as_os_str().is_empty() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "Failed to create build artifact directory '{}': {}",
+                parent.display(),
+                error
+            )
+        })?;
+    }
+
+    let artifact_output = artifact_path.to_string_lossy().to_string();
+    let prefix = format!("{}/", component.id);
+    log_status!(
+        "deploy",
+        "Creating deploy archive artifact: {}",
+        artifact_path.display()
+    );
+
+    command::run_in(
+        &component.local_path,
+        "git",
+        &[
+            "archive",
+            "--format=zip",
+            &format!("--prefix={prefix}"),
+            &format!("--output={artifact_output}"),
+            "HEAD",
+        ],
+        "create deploy archive artifact",
+    )
+    .map(|_| ())
+    .map_err(|error| {
+        format!(
+            "Failed to create deploy archive artifact '{}'. The component build completed, but the configured build_artifact was missing. Ensure '{}' is a git checkout with a valid HEAD, or make scripts.build create the artifact explicitly. Error: {}",
+            artifact_path.display(),
+            component.id,
+            error
+        )
+    })
 }
 
 fn artifact_requires_extract_command(path: &Path) -> bool {
@@ -896,10 +993,12 @@ fn cleanup_build_dependencies(
 mod tests {
     use super::{
         artifact_requires_component_extract_command, cleanup_deploy_build_artifact,
-        failed_component_deploy_result, should_try_download_release_artifact,
+        failed_component_deploy_result, resolve_preflight_artifact_path,
+        should_try_download_release_artifact,
     };
     use crate::core::component::Component;
     use crate::core::deploy::types::DeployConfig;
+    use std::process::Command;
 
     #[test]
     fn test_execute_component_deploy_failure_helper_preserves_build_exit_code() {
@@ -1107,6 +1206,85 @@ mod tests {
 
         assert!(!artifact.exists());
         assert!(!build_dir.exists());
+    }
+
+    #[test]
+    fn preflight_creates_missing_archive_artifact_from_tracked_head() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(temp.path().join("plugin.php"), "<?php\n").expect("write plugin");
+        std::fs::create_dir_all(temp.path().join("node_modules")).expect("mkdir node_modules");
+        std::fs::write(temp.path().join("node_modules/junk.js"), "junk\n")
+            .expect("write untracked dependency");
+        git(temp.path(), &["init"]);
+        git(temp.path(), &["add", "plugin.php"]);
+        git(
+            temp.path(),
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=homeboy@example.test",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        );
+
+        let component = Component {
+            id: "demo-plugin".to_string(),
+            local_path: temp.path().to_string_lossy().to_string(),
+            build_artifact: Some("build/demo-plugin.zip".to_string()),
+            extract_command: Some("unzip -o {{artifact}} && rm {{artifact}}".to_string()),
+            ..Component::default()
+        };
+        let config = DeployConfig {
+            component_ids: Vec::new(),
+            all: false,
+            outdated: false,
+            behind_upstream: false,
+            dry_run: false,
+            check: false,
+            force: false,
+            skip_build: false,
+            keep_deps: false,
+            expected_version: None,
+            no_pull: false,
+            head: true,
+            tagged: false,
+        };
+
+        let artifact = resolve_preflight_artifact_path(
+            &component,
+            &config,
+            "/srv/site",
+            "/srv/site/wp-content/plugins/demo-plugin",
+            None,
+            None,
+            Some(0),
+            None,
+        )
+        .expect("archive artifact should resolve");
+
+        assert_eq!(artifact, temp.path().join("build/demo-plugin.zip"));
+        let file = std::fs::File::open(&artifact).expect("open zip");
+        let mut zip = zip::ZipArchive::new(file).expect("read zip");
+        assert!(zip.by_name("demo-plugin/plugin.php").is_ok());
+        assert!(zip.by_name("demo-plugin/node_modules/junk.js").is_err());
+    }
+
+    fn git(dir: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     #[test]

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -506,30 +506,30 @@ fn resolve_preflight_artifact_path(
         let artifact_pattern = match component.build_artifact.as_ref() {
             Some(pattern) => pattern,
             None => {
-                return Err(ComponentDeployResult::failed(
+                return Err(failed_preflight_artifact_result(
                     component,
                     base_path,
                     local_version,
                     remote_version,
+                    build_exit_code,
                     format!(
                         "Component '{}' has no build_artifact configured",
                         component.id
                     ),
-                )
-                .with_build_exit_code(build_exit_code));
+                ));
             }
         };
 
         if should_create_missing_archive_artifact(component, config, artifact_pattern) {
             if let Err(error) = create_archive_artifact_from_head(component, artifact_pattern) {
-                return Err(ComponentDeployResult::failed(
+                return Err(failed_preflight_artifact_result(
                     component,
                     base_path,
                     local_version,
                     remote_version,
+                    build_exit_code,
                     error,
-                )
-                .with_build_exit_code(build_exit_code));
+                ));
             }
         }
 
@@ -544,14 +544,14 @@ fn resolve_preflight_artifact_path(
                 } else {
                     format!("{}. Run build first: homeboy build {}", e, component.id)
                 };
-                return Err(ComponentDeployResult::failed(
+                return Err(failed_preflight_artifact_result(
                     component,
                     base_path,
                     local_version,
                     remote_version,
+                    build_exit_code,
                     error_msg,
-                )
-                .with_build_exit_code(build_exit_code));
+                ));
             }
         }
     };
@@ -575,21 +575,33 @@ fn resolve_preflight_artifact_path(
         component.extract_command.is_some(),
         has_deploy_override,
     ) {
-        return Err(ComponentDeployResult::failed(
+        return Err(failed_preflight_artifact_result(
             component,
             base_path,
             local_version,
             remote_version,
+            build_exit_code,
             format!(
                 "Archive artifact '{}' requires an extractCommand. \
                  Add one with: homeboy component set <id> --json '{{\"extract_command\": \"unzip -o {{artifact}} && rm {{artifact}}\"}}'",
                 artifact_path.display()
             ),
-        )
-        .with_build_exit_code(build_exit_code));
+        ));
     }
 
     Ok(artifact_path)
+}
+
+fn failed_preflight_artifact_result(
+    component: &Component,
+    base_path: &str,
+    local_version: Option<String>,
+    remote_version: Option<String>,
+    build_exit_code: Option<i32>,
+    error: String,
+) -> ComponentDeployResult {
+    ComponentDeployResult::failed(component, base_path, local_version, remote_version, error)
+        .with_build_exit_code(build_exit_code)
 }
 
 fn should_create_missing_archive_artifact(


### PR DESCRIPTION
## Summary
- Creates missing literal `.zip` deploy artifacts from the component git `HEAD` after the configured build succeeds and before deploy preflight validates the artifact path.
- Uses `git archive --format=zip` with a component-id prefix, so untracked dependency trees such as `node_modules` are not bundled.
- Adds a regression test for the Studio Web-style case where `scripts.build` succeeds but does not create `build/<component>.zip`.

Fixes #3349.

## Verification
- `cargo check`
- `cargo test core::deploy::execution::tests`

## Known failures / baseline
- `cargo test` has unrelated failures in `commands::trace::tests::failed_trace_run_persists_observation_history` (`trace-fixture` extension not found) and `core::daemon::daemon_test::test_serve_writes_state_and_routes_health_requests` (daemon connection).
- `cargo clippy --all-targets --all-features -- -D warnings` is not currently clean on `main`; it reports existing repository-wide clippy findings unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the deploy preflight change, regression test, and verification notes for Chris to review.