### PR TITLE
fix(release): derive github token for wordpress publish

### DIFF
--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -24,7 +24,7 @@ use super::runner_contract::RunnerStepFilter;
 use super::runtime_helper;
 use super::scope::ExtensionScope;
 
-pub(crate) use action::execute_action;
+pub(crate) use action::{execute_action, wordpress_release_publish_token_remediation};
 pub use readiness::{extension_ready_status, is_extension_compatible, ExtensionReadyStatus};
 
 /// Result of executing a extension.

--- a/src/core/extension/execution/action.rs
+++ b/src/core/extension/execution/action.rs
@@ -120,17 +120,27 @@ pub(crate) fn execute_action(
                 crate::core::engine::text::json_path_str(&payload, &["release", "local_path"])
                     .unwrap_or(extension_path);
 
+            let mut env = build_action_env(
+                extension_id,
+                project_id,
+                &payload,
+                Some(extension_path),
+                project_base_path.as_deref(),
+            );
+            if let Some(response) = preflight_wordpress_release_publish_token(
+                extension_id,
+                action_id,
+                &payload,
+                &mut env,
+            ) {
+                return Ok(response);
+            }
+
             let execution = execute_extension_command(
                 command_template,
                 &vars,
                 Some(working_dir),
-                &build_action_env(
-                    extension_id,
-                    project_id,
-                    &payload,
-                    Some(extension_path),
-                    project_base_path.as_deref(),
-                ),
+                &env,
                 ExtensionExecutionMode::Captured,
             )?;
             Ok(serde_json::json!({
@@ -142,6 +152,42 @@ pub(crate) fn execute_action(
             }))
         }
     }
+}
+
+pub(crate) fn wordpress_release_publish_token_remediation() -> &'static str {
+    "GH_TOKEN is required to push the WordPress release-latest mirror. Set GH_TOKEN with `export GH_TOKEN=\"$(gh auth token)\"`, or run `gh auth login` and rerun the release."
+}
+
+fn preflight_wordpress_release_publish_token(
+    extension_id: &str,
+    action_id: &str,
+    payload: &serde_json::Value,
+    env: &mut Vec<(String, String)>,
+) -> Option<serde_json::Value> {
+    if extension_id != "wordpress" || action_id != "release.publish" {
+        return None;
+    }
+
+    let Some(token) = crate::core::git::github_token_from_env_or_gh() else {
+        return Some(serde_json::json!({
+            "success": false,
+            "status": "missing_secret",
+            "reason": wordpress_release_publish_token_remediation(),
+            "payload": payload,
+        }));
+    };
+
+    upsert_env(env, "GH_TOKEN", token);
+    None
+}
+
+fn upsert_env(env: &mut Vec<(String, String)>, key: &str, value: String) {
+    if let Some((_, existing)) = env.iter_mut().find(|(env_key, _)| env_key == key) {
+        *existing = value;
+        return;
+    }
+
+    env.push((key.to_string(), value));
 }
 
 fn interpolate_action_payload(
@@ -220,5 +266,34 @@ fn interpolate_payload_value(
             Ok(serde_json::Value::Object(result))
         }
         _ => Ok(value.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::upsert_env;
+
+    #[test]
+    fn upsert_env_adds_missing_key() {
+        let mut env = vec![("A".to_string(), "one".to_string())];
+
+        upsert_env(&mut env, "GH_TOKEN", "token".to_string());
+
+        assert_eq!(
+            env,
+            vec![
+                ("A".to_string(), "one".to_string()),
+                ("GH_TOKEN".to_string(), "token".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn upsert_env_replaces_existing_key() {
+        let mut env = vec![("GH_TOKEN".to_string(), "old".to_string())];
+
+        upsert_env(&mut env, "GH_TOKEN", "new".to_string());
+
+        assert_eq!(env, vec![("GH_TOKEN".to_string(), "new".to_string())]);
     }
 }

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -45,7 +45,7 @@ pub(crate) use compiler_warning_contract::{
     extensions_for_compiler_warning_contract, run_compiler_warning_contract_script,
     CompilerWarningContract,
 };
-pub(crate) use execution::execute_action;
+pub(crate) use execution::{execute_action, wordpress_release_publish_token_remediation};
 pub use execution::{
     extension_ready_status, is_extension_compatible, run_action, run_extension, run_setup,
     ExtensionExecutionMode, ExtensionReadyStatus, ExtensionRunResult, ExtensionSetupResult,

--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -630,6 +630,44 @@ pub fn gh_probe_succeeds(args: &[&str]) -> bool {
         .unwrap_or(false)
 }
 
+/// Resolve a GitHub token for scripts that require `GH_TOKEN` explicitly.
+///
+/// Prefer the caller's environment, then fall back to the authenticated GitHub
+/// CLI token so extension scripts do not fail late after Homeboy has already
+/// verified that `gh` is usable.
+pub fn github_token_from_env_or_gh() -> Option<String> {
+    select_github_token(
+        std::env::var("GH_TOKEN").ok(),
+        std::env::var("GITHUB_TOKEN").ok(),
+        gh_auth_token,
+    )
+}
+
+fn select_github_token(
+    gh_token: Option<String>,
+    github_token: Option<String>,
+    gh_auth_token: impl FnOnce() -> Option<String>,
+) -> Option<String> {
+    gh_token
+        .and_then(non_empty_token)
+        .or_else(|| github_token.and_then(non_empty_token))
+        .or_else(gh_auth_token)
+}
+
+fn non_empty_token(token: String) -> Option<String> {
+    let token = token.trim().to_string();
+    (!token.is_empty()).then_some(token)
+}
+
+fn gh_auth_token() -> Option<String> {
+    let output = Command::new("gh").args(["auth", "token"]).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    non_empty_token(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
 /// Error out if `gh` is missing or unauthenticated. Unlike `run_github_release`
 /// (which soft-fails because the tag is already pushed), primitive operations
 /// have no already-committed side effect to preserve — fail loudly.
@@ -764,6 +802,35 @@ fn parse_pr_list_json(raw: &str) -> Result<Vec<GithubFindItem>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn github_token_prefers_gh_token_env() {
+        let token = select_github_token(
+            Some(" env-gh-token \n".to_string()),
+            Some("github-token".to_string()),
+            || Some("cli-token".to_string()),
+        );
+
+        assert_eq!(token.as_deref(), Some("env-gh-token"));
+    }
+
+    #[test]
+    fn github_token_falls_back_to_github_token_env() {
+        let token = select_github_token(
+            Some("  ".to_string()),
+            Some("github-token".to_string()),
+            || Some("cli-token".to_string()),
+        );
+
+        assert_eq!(token.as_deref(), Some("github-token"));
+    }
+
+    #[test]
+    fn github_token_falls_back_to_gh_auth_token() {
+        let token = select_github_token(None, None, || Some("cli-token".to_string()));
+
+        assert_eq!(token.as_deref(), Some("cli-token"));
+    }
 
     #[test]
     fn parse_issue_number_from_issue_url() {

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -27,11 +27,12 @@ pub use commits::{
     CommitCategory, CommitCounts, CommitInfo, MonorepoContext, SemverBump,
 };
 pub use github::{
-    gh_probe_succeeds, issue_close, issue_comment, issue_create, issue_edit, issue_find, pr_create,
-    pr_edit, pr_files, pr_find, pr_merge, pr_view, GithubFindItem, GithubFindOutput,
-    GithubIssueOutput, GithubPrOutput, GithubPrView, IssueCloseOptions, IssueCloseReason,
-    IssueCommentOptions, IssueCreateOptions, IssueEditOptions, IssueFindOptions, IssueState,
-    PrCreateOptions, PrEditOptions, PrFindOptions, PrMergeOptions, PrState,
+    gh_probe_succeeds, github_token_from_env_or_gh, issue_close, issue_comment, issue_create,
+    issue_edit, issue_find, pr_create, pr_edit, pr_files, pr_find, pr_merge, pr_view,
+    GithubFindItem, GithubFindOutput, GithubIssueOutput, GithubPrOutput, GithubPrView,
+    IssueCloseOptions, IssueCloseReason, IssueCommentOptions, IssueCreateOptions, IssueEditOptions,
+    IssueFindOptions, IssueState, PrCreateOptions, PrEditOptions, PrFindOptions, PrMergeOptions,
+    PrState,
 };
 pub use github_pr_comments::{pr_comment, PrCommentMode, PrCommentOptions};
 pub use operation_output::GitOutput;

--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -31,6 +31,9 @@ pub(super) fn execute_release_plan_step(
         "preflight.working_tree" => Ok(Some(run_working_tree_preflight(step, context))),
         "preflight.remote_sync" => Ok(Some(run_remote_sync_preflight(step, context))),
         "preflight.bump_policy" => Ok(Some(run_bump_policy_preflight(step))),
+        "preflight.wordpress_publish_token" => {
+            Ok(Some(run_wordpress_publish_token_preflight(step)))
+        }
         "preflight.lint" => Ok(Some(run_lint_preflight(step, context))),
         "preflight.test" => Ok(Some(run_test_preflight(step, context))),
         "preflight.changelog_bootstrap" => {
@@ -167,12 +170,46 @@ fn release_step_is_plan_only(step: &PlanStep) -> bool {
         && step.kind != "preflight.working_tree"
         && step.kind != "preflight.remote_sync"
         && step.kind != "preflight.bump_policy"
+        && step.kind != "preflight.wordpress_publish_token"
         && step.kind != "preflight.lint"
         && step.kind != "preflight.test"
         && step.kind != "preflight.changelog_bootstrap"
         && step.kind != "preflight.package")
         || step.kind == "changelog.policy"
         || step.kind == "changelog.generate"
+}
+
+fn run_wordpress_publish_token_preflight(step: &PlanStep) -> ReleaseStepResult {
+    if crate::core::git::github_token_from_env_or_gh().is_some() {
+        return ReleaseStepResult {
+            id: step.id.clone(),
+            step_type: step.kind.clone(),
+            status: ReleaseStepStatus::Success,
+            missing: Vec::new(),
+            warnings: Vec::new(),
+            hints: Vec::new(),
+            data: Some(serde_json::json!({
+                "token_source": "env-or-gh-auth-token",
+            })),
+            error: None,
+        };
+    }
+
+    ReleaseStepResult {
+        id: step.id.clone(),
+        step_type: step.kind.clone(),
+        status: ReleaseStepStatus::Failed,
+        missing: Vec::new(),
+        warnings: Vec::new(),
+        hints: vec![crate::core::error::Hint {
+            message: "Run `gh auth login`, or export `GH_TOKEN=\"$(gh auth token)\"`, then rerun the release.".to_string(),
+        }],
+        data: Some(serde_json::json!({
+            "required_env": "GH_TOKEN",
+            "fallback": "gh auth token",
+        })),
+        error: Some(crate::core::extension::wordpress_release_publish_token_remediation().to_string()),
+    }
 }
 
 fn run_default_branch_preflight(

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -17,7 +17,7 @@ pub(super) fn build_initial_preflight_plan(
     component_id: &str,
     options: &ReleaseOptions,
 ) -> ReleasePlan {
-    let steps = build_preflight_steps(options, None)
+    let steps = build_preflight_steps(options, None, &[])
         .into_iter()
         .filter(|step| initial_executable_preflight_ids().contains(&step.id.as_str()))
         .collect();

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -61,6 +61,7 @@ fn string_config(key: &str, value: impl Into<String>) -> StepConfig {
 pub(super) fn build_preflight_steps(
     options: &ReleaseOptions,
     semver_recommendation: Option<&ReleaseSemverRecommendation>,
+    extensions: &[ExtensionManifest],
 ) -> Vec<PlanStep> {
     let default_branch_step = if options.pipeline.head {
         disabled_step(
@@ -108,6 +109,16 @@ pub(super) fn build_preflight_steps(
         build_bump_policy_step(options, semver_recommendation),
     ];
 
+    if has_wordpress_release_publish_target(extensions) {
+        steps.push(ready_step(
+            "preflight.wordpress_publish_token",
+            "preflight.wordpress_publish_token",
+            "Validate WordPress release publish token",
+            vec!["preflight.bump_policy".to_string()],
+            StepConfig::new(),
+        ));
+    }
+
     if let Some(identity) = options.git_identity.as_ref() {
         steps.insert(
             1,
@@ -144,6 +155,16 @@ pub(super) fn build_preflight_steps(
     }
 
     steps
+}
+
+fn has_wordpress_release_publish_target(extensions: &[ExtensionManifest]) -> bool {
+    extensions.iter().any(|extension| {
+        extension.id == "wordpress"
+            && extension
+                .actions
+                .iter()
+                .any(|action| action.id == "release.publish")
+    })
 }
 
 fn build_quality_steps(options: &ReleaseOptions) -> Vec<PlanStep> {
@@ -696,7 +717,7 @@ mod tests {
             ..Default::default()
         };
 
-        let steps = build_preflight_steps(&options, None);
+        let steps = build_preflight_steps(&options, None, &[]);
         let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
 
         assert_eq!(
@@ -726,7 +747,7 @@ mod tests {
             ..Default::default()
         };
 
-        let steps = build_preflight_steps(&options, None);
+        let steps = build_preflight_steps(&options, None, &[]);
         let identity = steps
             .iter()
             .find(|step| step.id == "preflight.git_identity")
@@ -744,6 +765,37 @@ mod tests {
     }
 
     #[test]
+    fn release_plan_adds_wordpress_publish_token_preflight_for_wordpress_publish() {
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            ..Default::default()
+        };
+        let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "WordPress",
+            "version": "1.0.0",
+            "actions": [
+                {
+                    "id": "release.publish",
+                    "label": "Publish release",
+                    "type": "command",
+                    "command": "true"
+                }
+            ]
+        }))
+        .expect("extension manifest");
+        extension.id = "wordpress".to_string();
+
+        let steps = build_preflight_steps(&options, None, &[extension]);
+        let token = steps
+            .iter()
+            .find(|step| step.id == "preflight.wordpress_publish_token")
+            .expect("wordpress publish token preflight");
+
+        assert_eq!(token.status, PlanStepStatus::Ready);
+        assert_eq!(token.needs, vec!["preflight.bump_policy"]);
+    }
+
+    #[test]
     fn release_plan_marks_quality_preflights_disabled_when_checks_are_skipped() {
         let options = ReleaseOptions {
             bump_type: "patch".to_string(),
@@ -751,7 +803,7 @@ mod tests {
             ..Default::default()
         };
 
-        let steps = build_preflight_steps(&options, None);
+        let steps = build_preflight_steps(&options, None, &[]);
         for step_id in ["preflight.audit", "preflight.lint", "preflight.test"] {
             let quality = steps
                 .iter()
@@ -781,7 +833,7 @@ mod tests {
             ..Default::default()
         };
 
-        let steps = build_preflight_steps(&options, None);
+        let steps = build_preflight_steps(&options, None, &[]);
         let default_branch = steps
             .iter()
             .find(|step| step.id == "preflight.default_branch")
@@ -818,7 +870,7 @@ mod tests {
             ..Default::default()
         };
 
-        let steps = build_preflight_steps(&options, None);
+        let steps = build_preflight_steps(&options, None, &[]);
         let audit = steps
             .iter()
             .find(|step| step.id == "preflight.audit")
@@ -856,7 +908,7 @@ mod tests {
         };
         let recommendation = semver_recommendation("minor", "patch", true);
 
-        let steps = build_preflight_steps(&options, Some(&recommendation));
+        let steps = build_preflight_steps(&options, Some(&recommendation), &[]);
         let bump_policy = steps
             .iter()
             .find(|step| step.id == "preflight.bump_policy")
@@ -906,7 +958,7 @@ mod tests {
         };
         let recommendation = semver_recommendation("minor", "patch", true);
 
-        let steps = build_preflight_steps(&options, Some(&recommendation));
+        let steps = build_preflight_steps(&options, Some(&recommendation), &[]);
         let bump_policy = steps
             .iter()
             .find(|step| step.id == "preflight.bump_policy")
@@ -937,7 +989,7 @@ mod tests {
         };
         let recommendation = semver_recommendation("minor", "patch", true);
 
-        let steps = build_preflight_steps(&options, Some(&recommendation));
+        let steps = build_preflight_steps(&options, Some(&recommendation), &[]);
         let bump_policy = steps
             .iter()
             .find(|step| step.id == "preflight.bump_policy")

--- a/src/core/release/planner.rs
+++ b/src/core/release/planner.rs
@@ -137,7 +137,7 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     let mut hints = Vec::new();
     let changelog_plan = build_changelog_plan(&component, options, pending_entries)?;
 
-    let mut steps = build_preflight_steps(options, semver_recommendation.as_ref());
+    let mut steps = build_preflight_steps(options, semver_recommendation.as_ref(), &extensions);
     steps.extend(build_release_steps(
         &component,
         &extensions,


### PR DESCRIPTION
## Summary
- Derive `GH_TOKEN` from `GH_TOKEN`, `GITHUB_TOKEN`, or `gh auth token` before running the WordPress `release.publish` action.
- Add a WordPress publish token preflight so unauthenticated release runs fail before version/tag/publish mutation with remediation.
- Cover token selection, publish env injection, and the new WordPress publish preflight plan step.

Closes #3351

## Tests
- `cargo test --no-run`
- `cargo test github_token_`
- `cargo test upsert_env_`
- `cargo test release_plan_adds_wordpress_publish_token_preflight_for_wordpress_publish`
- `cargo run --quiet --bin homeboy -- test --path . --extension rust -- github_token_`
- `cargo run --quiet --bin homeboy -- test --path . --extension rust -- upsert_env_`
- `cargo run --quiet --bin homeboy -- test --path . --extension rust -- release_plan_adds_wordpress_publish_token_preflight_for_wordpress_publish`
- `git diff --check`

## Caveats
- A full `homeboy test --path . --extension rust` run was attempted before narrowing verification. It reached 3,768 passing tests and then hit an unrelated SQLite observation-store `disk I/O error` in `commands::runs::tests::artifact_get_copies_registered_file_without_raw_path_lookup`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigating the release publish path, drafting the token/preflight fix, adding tests, and running verification. Chris remains responsible for review and merge.