### PR TITLE
Support GitHub Enterprise release env

### DIFF
--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -572,7 +572,7 @@ pub(super) fn build_action_env(
     project_base_path: Option<&str>,
 ) -> Vec<(String, String)> {
     let settings_json = payload.to_string();
-    build_exec_env(
+    let mut env = build_exec_env(
         extension_id,
         project_id,
         None,
@@ -581,7 +581,42 @@ pub(super) fn build_action_env(
         project_base_path,
         None,
         None, // no path override in action context
-    )
+    );
+
+    env.extend(github_release_env_from_payload(payload));
+    env
+}
+
+fn github_release_env_from_payload(payload: &serde_json::Value) -> Vec<(String, String)> {
+    let Some(host) = payload
+        .get("release")
+        .and_then(|release| release.get("github"))
+        .and_then(|github| github.get("host"))
+        .and_then(|host| host.as_str())
+        .filter(|host| !host.trim().is_empty())
+    else {
+        return Vec::new();
+    };
+
+    let repo = crate::core::deploy::release_download::GitHubRepo {
+        host: host.to_string(),
+        owner: payload
+            .get("release")
+            .and_then(|release| release.get("github"))
+            .and_then(|github| github.get("owner"))
+            .and_then(|owner| owner.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        repo: payload
+            .get("release")
+            .and_then(|release| release.get("github"))
+            .and_then(|github| github.get("repo"))
+            .and_then(|repo| repo.as_str())
+            .unwrap_or_default()
+            .to_string(),
+    };
+
+    crate::core::release::github_command_env(&repo)
 }
 
 pub(super) fn execute_extension_command(
@@ -957,6 +992,28 @@ mod tests {
             .iter()
             .any(|(k, v)| k == "HOMEBOY_STEP" && v == "lint,test"));
         assert!(env.iter().any(|(k, v)| k == "HOMEBOY_SKIP" && v == "lint"));
+    }
+
+    #[test]
+    fn build_action_env_includes_release_github_host() {
+        let payload = serde_json::json!({
+            "release": {
+                "github": {
+                    "host": "github.a8c.com",
+                    "owner": "chubes4",
+                    "repo": "studio-web"
+                }
+            }
+        });
+
+        let env = build_action_env("wordpress", None, &payload, Some("/tmp/ext"), None);
+
+        assert!(env
+            .iter()
+            .any(|(key, value)| key == "GH_HOST" && value == "github.a8c.com"));
+        assert!(env
+            .iter()
+            .any(|(key, value)| key == "HTTPS_PROXY" && value == "socks5://127.0.0.1:8080"));
     }
 
     #[test]

--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -129,8 +129,7 @@ pub(super) fn execute_release_plan_step(
             let result = executor::run_publish(
                 context.extensions,
                 &context.state,
-                context.component_id,
-                &context.component.local_path,
+                context.component,
                 target,
             )
             .unwrap_or_else(|err| {

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -24,7 +24,7 @@ use super::utils::{extract_latest_notes, parse_release_artifacts};
 
 pub(crate) mod artifacts;
 pub(crate) mod changelog;
-mod github_release;
+pub(crate) mod github_release;
 pub(crate) mod prepare;
 mod version_targets;
 
@@ -324,12 +324,19 @@ pub(crate) fn run_git_tag(
                 crate::core::deploy::release_download::parse_github_url(&remote_url)
             })
             .and_then(|github| {
-                if !github_release::gh_is_available() || !github_release::gh_is_authenticated() {
+                let github_env = github_release::github_command_env(&github);
+                if !github_release::gh_is_available(&github_env)
+                    || !github_release::gh_is_authenticated(&github.host, &github_env)
+                {
                     return None;
                 }
 
                 let repo_flag = format!("{}/{}", github.owner, github.repo);
-                Some(github_release::gh_release_exists(tag_name, &repo_flag))
+                Some(github_release::gh_release_exists(
+                    tag_name,
+                    &repo_flag,
+                    &github_env,
+                ))
             });
         let github_release_label = match github_release {
             Some(true) => "exists".to_string(),
@@ -544,8 +551,7 @@ pub(crate) fn run_package(
 pub(crate) fn run_publish(
     extensions: &[ExtensionManifest],
     state: &ReleaseState,
-    component_id: &str,
-    component_local_path: &str,
+    component: &Component,
     target: &str,
 ) -> Result<ReleaseStepResult> {
     let extension = extensions.iter().find(|m| m.id == target).ok_or_else(|| {
@@ -574,7 +580,14 @@ pub(crate) fn run_publish(
         ));
     }
 
-    let payload = build_release_payload(state, component_id, component_local_path, None);
+    let mut payload = build_release_payload(state, &component.id, &component.local_path, None);
+    if let Some(github) = release_github_repo(component) {
+        payload["release"]["github"] = serde_json::json!({
+            "host": github.host,
+            "owner": github.owner,
+            "repo": github.repo,
+        });
+    }
     let response = extension::execute_action(&extension.id, action_id, None, None, Some(&payload))?;
     let extension_data = serde_json::to_value(&response).map_err(|e| {
         Error::internal_json(e.to_string(), Some("extension action output".to_string()))
@@ -811,7 +824,9 @@ pub(crate) fn run_github_release(
             )
         })?;
 
-    if !github_release::gh_is_available() {
+    let github_env = github_release::github_command_env(&github);
+
+    if !github_release::gh_is_available(&github_env) {
         let fallback = github_release::fallback_gh_command(&tag);
         log_status!(
             "release",
@@ -826,7 +841,7 @@ pub(crate) fn run_github_release(
         ));
     }
 
-    if !github_release::gh_is_authenticated() {
+    if !github_release::gh_is_authenticated(&github.host, &github_env) {
         let fallback = github_release::fallback_gh_command(&tag);
         log_status!(
             "release",
@@ -865,7 +880,7 @@ pub(crate) fn run_github_release(
     let has_artifacts = !artifact_paths.is_empty();
 
     let repo_flag = format!("{}/{}", github.owner, github.repo);
-    if github_release::gh_release_exists(&tag, &repo_flag) {
+    if github_release::gh_release_exists(&tag, &repo_flag, &github_env) {
         // Release entry already exists (idempotent retry, or release
         // created out of band). When the release has no artifacts to
         // attach, skip — there is nothing to update. When artifacts are
@@ -902,6 +917,11 @@ pub(crate) fn run_github_release(
 
         let upload_output = std::process::Command::new("gh")
             .args(&upload_args)
+            .envs(
+                github_env
+                    .iter()
+                    .map(|(key, value)| (key.as_str(), value.as_str())),
+            )
             .output()
             .map_err(|e| {
                 Error::internal_io(
@@ -980,6 +1000,11 @@ pub(crate) fn run_github_release(
 
     let output = std::process::Command::new("gh")
         .args(&create_args)
+        .envs(
+            github_env
+                .iter()
+                .map(|(key, value)| (key.as_str(), value.as_str())),
+        )
         .output()
         .map_err(|e| {
             Error::internal_io(
@@ -1027,6 +1052,20 @@ pub(crate) fn run_github_release(
         })),
         Vec::new(),
     ))
+}
+
+fn release_github_repo(
+    component: &Component,
+) -> Option<crate::core::deploy::release_download::GitHubRepo> {
+    component
+        .remote_url
+        .clone()
+        .or_else(|| {
+            crate::core::deploy::release_download::detect_remote_url(std::path::Path::new(
+                &component.local_path,
+            ))
+        })
+        .and_then(|remote_url| crate::core::deploy::release_download::parse_github_url(&remote_url))
 }
 
 // ---------------------------------------------------------------------------
@@ -1154,7 +1193,10 @@ fn store_artifacts_from_output(
 
 #[cfg(test)]
 mod tests {
-    use super::{github_release, publish_step_result, run_git_push, store_artifacts_from_output};
+    use super::{
+        github_release, publish_step_result, release_github_repo, run_git_push,
+        store_artifacts_from_output,
+    };
     use crate::core::component::Component;
     use crate::core::release::ReleaseStepStatus;
     use std::process::Command;
@@ -1203,6 +1245,22 @@ mod tests {
         assert!(cmd.contains("gh release create v1.2.3"));
         assert!(cmd.contains("--title v1.2.3"));
         assert!(cmd.contains("--notes-file"));
+    }
+
+    #[test]
+    fn release_github_repo_detects_ghe_remote() {
+        let component = Component {
+            id: "studio-web".to_string(),
+            local_path: "/tmp/studio-web".to_string(),
+            remote_url: Some("git@github.a8c.com:chubes4/studio-web.git".to_string()),
+            ..Default::default()
+        };
+
+        let github = release_github_repo(&component).expect("github repo");
+
+        assert_eq!(github.host, "github.a8c.com");
+        assert_eq!(github.owner, "chubes4");
+        assert_eq!(github.repo, "studio-web");
     }
 
     #[test]

--- a/src/core/release/executor/github_release.rs
+++ b/src/core/release/executor/github_release.rs
@@ -1,6 +1,7 @@
 //! GitHub Release helper result builders and probes.
 
 use crate::core::deploy::release_download::GitHubRepo;
+use std::process::Command;
 
 use super::step_success;
 use crate::core::release::types::ReleaseStepResult;
@@ -68,16 +69,33 @@ pub(super) fn upload_success_result(
     )
 }
 
-pub(super) fn gh_is_available() -> bool {
-    crate::core::git::gh_probe_succeeds(&["--version"])
+pub(crate) fn github_command_env(github: &GitHubRepo) -> Vec<(String, String)> {
+    let mut env = Vec::new();
+
+    if github.host != "github.com" {
+        env.push(("GH_HOST".to_string(), github.host.clone()));
+    }
+
+    if github.host == "github.a8c.com" && !ambient_proxy_is_configured() {
+        env.push((
+            "HTTPS_PROXY".to_string(),
+            "socks5://127.0.0.1:8080".to_string(),
+        ));
+    }
+
+    env
 }
 
-pub(super) fn gh_is_authenticated() -> bool {
-    crate::core::git::gh_probe_succeeds(&["auth", "status", "--hostname", "github.com"])
+pub(super) fn gh_is_available(env: &[(String, String)]) -> bool {
+    gh_probe_succeeds_with_env(&["--version"], env)
 }
 
-pub(super) fn gh_release_exists(tag: &str, repo_flag: &str) -> bool {
-    crate::core::git::gh_probe_succeeds(&["release", "view", tag, "-R", repo_flag])
+pub(super) fn gh_is_authenticated(host: &str, env: &[(String, String)]) -> bool {
+    gh_probe_succeeds_with_env(&["auth", "status", "--hostname", host], env)
+}
+
+pub(super) fn gh_release_exists(tag: &str, repo_flag: &str, env: &[(String, String)]) -> bool {
+    gh_probe_succeeds_with_env(&["release", "view", tag, "-R", repo_flag], env)
 }
 
 pub(super) fn fallback_gh_command(tag: &str) -> String {
@@ -97,4 +115,69 @@ pub(super) fn sanitize_tag_for_filename(tag: &str) -> String {
             }
         })
         .collect()
+}
+
+fn ambient_proxy_is_configured() -> bool {
+    [
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+    ]
+    .iter()
+    .any(|key| {
+        std::env::var(key)
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false)
+    })
+}
+
+fn gh_probe_succeeds_with_env(args: &[&str], env: &[(String, String)]) -> bool {
+    Command::new("gh")
+        .args(args)
+        .envs(
+            env.iter()
+                .map(|(key, value)| (key.as_str(), value.as_str())),
+        )
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn github_command_env_sets_ghe_host() {
+        let repo = GitHubRepo {
+            host: "github.example.com".to_string(),
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+        };
+
+        assert_eq!(
+            github_command_env(&repo)
+                .into_iter()
+                .find(|(key, _)| key == "GH_HOST"),
+            Some(("GH_HOST".to_string(), "github.example.com".to_string()))
+        );
+    }
+
+    #[test]
+    fn github_command_env_keeps_github_com_default_host() {
+        let repo = GitHubRepo {
+            host: "github.com".to_string(),
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+        };
+
+        assert!(github_command_env(&repo)
+            .into_iter()
+            .all(|(key, _)| key != "GH_HOST"));
+    }
 }

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -21,6 +21,7 @@ mod utils;
 pub mod version;
 mod workflow;
 
+pub(crate) use executor::github_release::github_command_env;
 pub use pipeline::run;
 pub use planner::plan;
 pub use types::{


### PR DESCRIPTION
## Summary
- Derive GitHub release command environment from the component remote host.
- Pass `GH_HOST` and the known `github.a8c.com` proxy default through `github.release` checks/create/upload.
- Include the same GitHub host metadata in release publish payloads so extension actions receive consistent env.

Fixes #3359.

## Testing
- `cargo check`
- `cargo test core::release::executor`
- `cargo test build_action_env_includes_release_github_host`
- `cargo test release_github_repo_detects_ghe_remote`
- `cargo test github_command_env_sets_ghe_host`
- `cargo test github_command_env_keeps_github_com_default_host`

## Notes
- `cargo test core::extension::execution` still has an unrelated existing failure in `build_exec_env_includes_runtime_runner_helper_path` when the runtime helper path is unavailable in this local session.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the release proxy gap, drafting the code changes and tests, and running local verification; Chris directed the upstream fix.