### PR TITLE
Support build artifact inputs

### DIFF
--- a/src/commands/golden_contract_tests.rs
+++ b/src/commands/golden_contract_tests.rs
@@ -420,6 +420,7 @@ fn component_deploy_result(id: &str) -> ComponentDeployResult {
         warnings: Vec::new(),
         error: None,
         artifact_path: Some("target/dist/homeboy.tar.gz".to_string()),
+        artifact_inputs: Vec::new(),
         remote_path: Some("/srv/homeboy".to_string()),
         build_exit_code: None,
         deploy_exit_code: None,

--- a/src/core/artifact_inputs.rs
+++ b/src/core/artifact_inputs.rs
@@ -1,0 +1,299 @@
+use std::fs::{self, File};
+use std::io::{self, Read, Seek, Write};
+use std::path::{Component as PathComponent, Path};
+
+use serde::{Deserialize, Serialize};
+use zip::write::FileOptions;
+
+use crate::core::artifact_metadata::sha256_file;
+use crate::core::component::{self, ArtifactInput, Component};
+use crate::core::error::{Error, Result};
+use crate::core::extension::build::resolve_artifact_path_from_root;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedArtifactInput {
+    pub component: String,
+    pub artifact: String,
+    pub target: String,
+    pub sha256: String,
+}
+
+pub(crate) fn apply_to_component_artifact(
+    consumer: &Component,
+    consumer_artifact: &Path,
+) -> Result<Vec<ResolvedArtifactInput>> {
+    if consumer.artifact_inputs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    validate_zip_artifact(consumer_artifact)?;
+
+    let mut resolved = Vec::with_capacity(consumer.artifact_inputs.len());
+    for input in &consumer.artifact_inputs {
+        let producer_artifact = build_and_resolve_producer_artifact(input, &consumer.id)?;
+        let sha256 = sha256_file(&producer_artifact)?;
+
+        if let Some(expected) = input.sha256.as_deref() {
+            if !expected.eq_ignore_ascii_case(&sha256) {
+                return Err(Error::validation_invalid_argument(
+                    "artifact_inputs.sha256",
+                    format!(
+                        "Artifact input '{}' for component '{}' has SHA-256 {}, expected {}",
+                        input.artifact, input.component, sha256, expected
+                    ),
+                    Some(input.target.clone()),
+                    None,
+                ));
+            }
+        }
+
+        append_file_to_zip(consumer_artifact, &producer_artifact, &input.target)?;
+        resolved.push(ResolvedArtifactInput {
+            component: input.component.clone(),
+            artifact: producer_artifact.display().to_string(),
+            target: input.target.clone(),
+            sha256,
+        });
+    }
+
+    Ok(resolved)
+}
+
+pub(crate) fn resolve_metadata(component: &Component) -> Result<Vec<ResolvedArtifactInput>> {
+    component
+        .artifact_inputs
+        .iter()
+        .map(|input| {
+            let producer = component::resolve_effective(Some(&input.component), None, None)?;
+            let path = resolve_artifact_path_from_root(
+                &input.artifact,
+                Some(Path::new(&producer.local_path)),
+            )?;
+            let sha256 = sha256_file(&path)?;
+            Ok(ResolvedArtifactInput {
+                component: input.component.clone(),
+                artifact: path.display().to_string(),
+                target: input.target.clone(),
+                sha256,
+            })
+        })
+        .collect()
+}
+
+fn build_and_resolve_producer_artifact(
+    input: &ArtifactInput,
+    consumer_id: &str,
+) -> Result<std::path::PathBuf> {
+    if input.component.trim().is_empty() {
+        return Err(invalid_input(
+            "component",
+            "Artifact input component cannot be empty",
+            input,
+        ));
+    }
+    if input.artifact.trim().is_empty() {
+        return Err(invalid_input(
+            "artifact",
+            "Artifact input artifact cannot be empty",
+            input,
+        ));
+    }
+    validate_target(&input.target)?;
+    if input.component == consumer_id {
+        return Err(invalid_input(
+            "component",
+            "Artifact input cannot reference the consumer component itself",
+            input,
+        ));
+    }
+
+    let producer = component::resolve_effective(Some(&input.component), None, None)?;
+    let (exit_code, build_error) = crate::core::build::build_component(&producer);
+    if let Some(error) = build_error {
+        return Err(Error::validation_invalid_argument(
+            "artifact_inputs.component",
+            format!(
+                "Failed to build artifact input component '{}' (exit {:?}): {}",
+                input.component, exit_code, error
+            ),
+            Some(input.component.clone()),
+            None,
+        ));
+    }
+
+    resolve_artifact_path_from_root(&input.artifact, Some(Path::new(&producer.local_path)))
+}
+
+fn invalid_input(field: &str, message: &str, input: &ArtifactInput) -> Error {
+    Error::validation_invalid_argument(
+        format!("artifact_inputs.{field}"),
+        message.to_string(),
+        Some(input.target.clone()),
+        None,
+    )
+}
+
+fn validate_zip_artifact(path: &Path) -> Result<()> {
+    if path.extension().and_then(|ext| ext.to_str()) != Some("zip") {
+        return Err(Error::validation_invalid_argument(
+            "build_artifact",
+            format!(
+                "Artifact inputs currently require a ZIP consumer artifact, got {}",
+                path.display()
+            ),
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn validate_target(target: &str) -> Result<()> {
+    let path = Path::new(target);
+    if target.trim().is_empty() || path.is_absolute() {
+        return Err(Error::validation_invalid_argument(
+            "artifact_inputs.target",
+            "Artifact input target must be a relative path inside the consumer artifact",
+            Some(target.to_string()),
+            None,
+        ));
+    }
+
+    if path.components().any(|component| {
+        matches!(
+            component,
+            PathComponent::ParentDir | PathComponent::RootDir | PathComponent::Prefix(_)
+        )
+    }) {
+        return Err(Error::validation_invalid_argument(
+            "artifact_inputs.target",
+            "Artifact input target cannot escape the consumer artifact",
+            Some(target.to_string()),
+            None,
+        ));
+    }
+
+    Ok(())
+}
+
+fn append_file_to_zip(zip_path: &Path, source: &Path, target: &str) -> Result<()> {
+    let source_zip = File::open(zip_path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(zip_path.display().to_string())))?;
+    let mut archive = zip::ZipArchive::new(source_zip).map_err(zip_error(zip_path))?;
+    let temp_path = zip_path.with_extension("zip.homeboy-artifact-input.tmp");
+    let temp_file = File::create(&temp_path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(temp_path.display().to_string())))?;
+    let mut zip = zip::ZipWriter::new(temp_file);
+
+    let normalized_target = target.replace('\\', "/");
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index).map_err(zip_error(zip_path))?;
+        if entry.name() == normalized_target {
+            continue;
+        }
+        if entry.is_dir() {
+            zip.add_directory(entry.name(), FileOptions::default())
+                .map_err(zip_error(zip_path))?;
+            continue;
+        }
+
+        let mut bytes = Vec::new();
+        entry
+            .read_to_end(&mut bytes)
+            .map_err(|e| Error::internal_io(e.to_string(), Some(zip_path.display().to_string())))?;
+        zip.start_file(entry.name(), FileOptions::default())
+            .map_err(zip_error(zip_path))?;
+        zip.write_all(&bytes)
+            .map_err(|e| Error::internal_io(e.to_string(), Some(zip_path.display().to_string())))?;
+    }
+
+    append_zip_file(&mut zip, source, target)?;
+    zip.finish().map_err(zip_error(zip_path))?;
+    fs::rename(&temp_path, zip_path).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("replace artifact {}", zip_path.display())),
+        )
+    })?;
+    Ok(())
+}
+
+fn append_zip_file<W: Write + Seek>(
+    zip: &mut zip::ZipWriter<W>,
+    source: &Path,
+    target: &str,
+) -> Result<()> {
+    let mut source_file = File::open(source)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(source.display().to_string())))?;
+    zip.start_file(target.replace('\\', "/"), FileOptions::default())
+        .map_err(zip_error(source))?;
+    io::copy(&mut source_file, zip)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(source.display().to_string())))?;
+    Ok(())
+}
+
+fn zip_error(path: &Path) -> impl FnOnce(zip::result::ZipError) -> Error + '_ {
+    |e| Error::internal_io(e.to_string(), Some(path.display().to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn validate_target_rejects_escape_paths() {
+        assert!(validate_target("runtime/package.zip").is_ok());
+        assert!(validate_target("../package.zip").is_err());
+        assert!(validate_target("/tmp/package.zip").is_err());
+    }
+
+    #[test]
+    fn append_file_to_zip_places_artifact_at_target() {
+        let dir = TempDir::new().unwrap();
+        let zip_path = dir.path().join("consumer.zip");
+        let source_path = dir.path().join("producer.zip");
+        fs::write(&source_path, b"producer bytes").unwrap();
+
+        {
+            let file = File::create(&zip_path).unwrap();
+            zip::ZipWriter::new(file).finish().unwrap();
+        }
+
+        append_file_to_zip(&zip_path, &source_path, "runtime/packages/producer.zip").unwrap();
+
+        let file = File::open(&zip_path).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+        let mut embedded = archive.by_name("runtime/packages/producer.zip").unwrap();
+        let mut bytes = Vec::new();
+        std::io::copy(&mut embedded, &mut bytes).unwrap();
+        assert_eq!(bytes, b"producer bytes");
+    }
+
+    #[test]
+    fn append_file_to_zip_replaces_existing_target() {
+        let dir = TempDir::new().unwrap();
+        let zip_path = dir.path().join("consumer.zip");
+        let source_path = dir.path().join("producer.zip");
+        fs::write(&source_path, b"new bytes").unwrap();
+
+        {
+            let file = File::create(&zip_path).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            zip.start_file("runtime/packages/producer.zip", FileOptions::default())
+                .unwrap();
+            zip.write_all(b"old bytes").unwrap();
+            zip.finish().unwrap();
+        }
+
+        append_file_to_zip(&zip_path, &source_path, "runtime/packages/producer.zip").unwrap();
+
+        let file = File::open(&zip_path).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+        assert_eq!(archive.len(), 1);
+        let mut embedded = archive.by_name("runtime/packages/producer.zip").unwrap();
+        let mut bytes = Vec::new();
+        std::io::copy(&mut embedded, &mut bytes).unwrap();
+        assert_eq!(bytes, b"new bytes");
+    }
+}

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -171,6 +171,15 @@ pub struct DependencyStackEdge {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ArtifactInput {
+    pub component: String,
+    pub artifact: String,
+    pub target: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct ComponentLabConfig {
     /// Repo-owned argv prefix used when Lab offload re-enters Homeboy from this checkout.
     ///
@@ -236,6 +245,8 @@ pub struct Component {
     pub lab: Option<ComponentLabConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependency_stack: Vec<DependencyStackEdge>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_inputs: Vec<ArtifactInput>,
     /// Override the CLI path used by extension deploy install steps.
     /// For example, Studio sites need "studio wp" instead of the default "wp".
     pub cli_path: Option<String>,
@@ -322,6 +333,8 @@ struct RawComponent {
     lab: Option<ComponentLabConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     dependency_stack: Vec<DependencyStackEdge>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    artifact_inputs: Vec<ArtifactInput>,
     #[serde(skip_serializing_if = "Option::is_none")]
     cli_path: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -364,6 +377,7 @@ impl From<RawComponent> for Component {
             audit: raw.audit,
             lab: raw.lab,
             dependency_stack: raw.dependency_stack,
+            artifact_inputs: raw.artifact_inputs,
             cli_path: raw.cli_path,
             extra_drift_files: raw.extra_drift_files,
             cleanup_artifacts: raw.cleanup_artifacts,
@@ -403,6 +417,7 @@ impl From<Component> for RawComponent {
             audit: c.audit,
             lab: c.lab,
             dependency_stack: c.dependency_stack,
+            artifact_inputs: c.artifact_inputs,
             cli_path: c.cli_path,
             extra_drift_files: c.extra_drift_files,
             cleanup_artifacts: c.cleanup_artifacts,
@@ -485,6 +500,7 @@ impl Component {
             audit: None,
             lab: None,
             dependency_stack: Vec::new(),
+            artifact_inputs: Vec::new(),
             cli_path: None,
             extra_drift_files: Vec::new(),
             cleanup_artifacts: Vec::new(),

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use crate::core::artifact_inputs;
 use crate::core::build;
 use crate::core::component::Component;
 use crate::core::context::RemoteProjectContext;
@@ -212,6 +213,7 @@ fn should_try_download_release_artifact(
         && !config.head
         && !config.tagged
         && !config.skip_build
+        && component.artifact_inputs.is_empty()
         && release_download::supports_release_deploy(component)
         && !release_download::has_mutable_package_dependencies(component)
 }
@@ -727,6 +729,20 @@ fn execute_artifact_deploy(
         )
         .with_build_exit_code(prepared.build_exit_code);
     };
+    let artifact_input_metadata = match artifact_inputs::resolve_metadata(component) {
+        Ok(inputs) => inputs,
+        Err(err) => {
+            return ComponentDeployResult::failed(
+                component,
+                base_path,
+                prepared.local_version.clone(),
+                prepared.remote_version.clone(),
+                err.to_string(),
+            )
+            .with_remote_path(install_dir.to_string())
+            .with_build_exit_code(prepared.build_exit_code);
+        }
+    };
 
     // Look up verification from extensions
     let verification = find_deploy_verification(install_dir);
@@ -786,6 +802,7 @@ fn execute_artifact_deploy(
                     prepared.local_version.clone(),
                 )
                 .with_remote_path(install_dir.to_string())
+                .with_artifact_inputs(artifact_input_metadata)
                 .with_build_exit_code(prepared.build_exit_code)
                 .with_deploy_exit_code(Some(exit_code))
         }
@@ -1008,7 +1025,7 @@ mod tests {
         failed_component_deploy_result, resolve_preflight_artifact_path,
         should_try_download_release_artifact,
     };
-    use crate::core::component::Component;
+    use crate::core::component::{ArtifactInput, Component};
     use crate::core::deploy::types::DeployConfig;
     use std::process::Command;
 
@@ -1197,6 +1214,41 @@ mod tests {
         };
 
         assert!(should_try_download_release_artifact(
+            &component, &config, false, false
+        ));
+    }
+
+    #[test]
+    fn artifact_inputs_skip_release_artifact_download() {
+        let component = Component {
+            id: "example".to_string(),
+            remote_url: Some("https://github.com/example/example".to_string()),
+            build_artifact: Some("build/example.zip".to_string()),
+            artifact_inputs: vec![ArtifactInput {
+                component: "producer".to_string(),
+                artifact: "build/producer.zip".to_string(),
+                target: "runtime/packages/producer.zip".to_string(),
+                sha256: None,
+            }],
+            ..Component::default()
+        };
+        let config = DeployConfig {
+            component_ids: Vec::new(),
+            all: false,
+            outdated: false,
+            behind_upstream: false,
+            dry_run: false,
+            check: false,
+            force: false,
+            skip_build: false,
+            keep_deps: false,
+            expected_version: None,
+            no_pull: false,
+            head: false,
+            tagged: false,
+        };
+
+        assert!(!should_try_download_release_artifact(
             &component, &config, false, false
         ));
     }

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+use crate::core::artifact_inputs::ResolvedArtifactInput;
 use crate::core::component::Component;
 use crate::core::config;
 use crate::core::error::Result;
@@ -194,6 +195,8 @@ pub struct ComponentDeployResult {
     pub warnings: Vec<String>,
     pub error: Option<String>,
     pub artifact_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_inputs: Vec<ResolvedArtifactInput>,
     pub remote_path: Option<String>,
     pub build_exit_code: Option<i32>,
     pub deploy_exit_code: Option<i32>,
@@ -223,6 +226,7 @@ impl ComponentDeployResult {
             warnings: Vec::new(),
             error: None,
             artifact_path: component.build_artifact.clone(),
+            artifact_inputs: Vec::new(),
             remote_path: base_path::join_remote_path(Some(base_path), &component.remote_path).ok(),
             build_exit_code: None,
             deploy_exit_code: None,
@@ -288,6 +292,11 @@ impl ComponentDeployResult {
 
     pub(super) fn with_remote_path(mut self, path: String) -> Self {
         self.remote_path = Some(path);
+        self
+    }
+
+    pub(super) fn with_artifact_inputs(mut self, inputs: Vec<ResolvedArtifactInput>) -> Self {
+        self.artifact_inputs = inputs;
         self
     }
 

--- a/src/core/extension/build/mod.rs
+++ b/src/core/extension/build/mod.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+use crate::core::artifact_inputs::{self, ResolvedArtifactInput};
 use crate::core::component::{self, Component};
 use crate::core::config::{is_json_input, parse_bulk_ids};
 use crate::core::deploy::permissions;
@@ -152,6 +153,8 @@ pub struct BuildOutput {
     pub build_command: String,
     #[serde(flatten)]
     pub output: CapturedOutput,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_inputs: Vec<ResolvedArtifactInput>,
     pub success: bool,
 }
 
@@ -367,6 +370,7 @@ fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
                     component_id: comp.id.clone(),
                     build_command: build_cmd,
                     output: CapturedOutput::new(String::new(), stderr),
+                    artifact_inputs: Vec::new(),
                     success: false,
                 },
                 exit_code,
@@ -408,6 +412,11 @@ fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
     };
 
     let success = runner_output.success;
+    let artifact_inputs = if success {
+        apply_artifact_inputs(comp)?
+    } else {
+        Vec::new()
+    };
 
     Ok((
         BuildOutput {
@@ -415,10 +424,32 @@ fn execute_build_component(comp: &Component) -> Result<(BuildOutput, i32)> {
             component_id: comp.id.clone(),
             build_command: build_cmd,
             output: CapturedOutput::new(runner_output.stdout, runner_output.stderr),
+            artifact_inputs,
             success,
         },
         runner_output.exit_code,
     ))
+}
+
+fn apply_artifact_inputs(comp: &Component) -> Result<Vec<ResolvedArtifactInput>> {
+    if comp.artifact_inputs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let artifact_pattern = component::resolve_artifact(comp).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "build_artifact",
+            format!(
+                "Component '{}' declares artifact_inputs but has no build_artifact configured",
+                comp.id
+            ),
+            Some(comp.id.clone()),
+            None,
+        )
+    })?;
+    let artifact_path =
+        resolve_artifact_path_from_root(&artifact_pattern, Some(Path::new(&comp.local_path)))?;
+    artifact_inputs::apply_to_component_artifact(comp, &artifact_path)
 }
 
 /// Run pre-build scripts from all configured extensions.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,6 +10,7 @@ pub mod agent_task_schedule;
 pub mod agent_task_scheduler;
 pub mod agent_task_secrets;
 pub mod api_jobs;
+pub mod artifact_inputs;
 pub mod artifact_manifest;
 pub(crate) mod artifact_metadata;
 pub mod change_artifact;

--- a/src/core/project/component/overrides.rs
+++ b/src/core/project/component/overrides.rs
@@ -32,6 +32,9 @@ fn apply_overrides_layer(
     if let Some(scopes) = &overrides.scopes {
         component.scopes = Some(scopes.clone());
     }
+    if !overrides.artifact_inputs.is_empty() {
+        component.artifact_inputs = overrides.artifact_inputs.clone();
+    }
     if let Some(cli_path) = &overrides.cli_path {
         component.cli_path = Some(cli_path.clone());
     }

--- a/src/core/project/types.rs
+++ b/src/core/project/types.rs
@@ -33,6 +33,8 @@ pub struct ProjectComponentOverrides {
     pub hooks: HashMap<String, Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scopes: Option<crate::core::component::ScopeConfig>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_inputs: Vec<crate::core::component::ArtifactInput>,
     /// Override the CLI path used by extension deploy install steps.
     /// For example, Studio sites need "studio wp" instead of the default "wp".
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary
- Add `artifact_inputs` to component/project override config so consumer artifacts can embed producer artifacts at declared paths.
- Apply declared inputs after successful builds, skip release artifact reuse for input consumers, and expose resolved input metadata in build/deploy output.
- Cover ZIP target replacement/validation and release artifact download gating.

## Validation
- `cargo test artifact_inputs --lib`
- `cargo test release_artifact_download --lib`

## Notes
- A broader `cargo test --lib` run from the worker compiled and ran broadly but hit two unrelated existing trace/http-egress test failures.

## Related
- Closes Extra-Chill/homeboy#3358
- Supports Studio Web runtime package deployment for https://github.a8c.com/chubes4/studio-web/pull/345

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and implemented the artifact input config, build/deploy integration, tests, and PR summary; Chris remains responsible for review and merge.