### PR TITLE
Recover stale submitted agent-task runs

### DIFF
--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -38,6 +38,55 @@ pub struct AgentTaskRunRecord {
     pub metadata: Value,
 }
 
+impl AgentTaskRunRecord {
+    fn record_runner_metadata(&mut self, reclaimed_stale: bool) {
+        let metadata = self.ensure_metadata_object();
+        metadata.insert("runner_pid".to_string(), json!(std::process::id()));
+        metadata.insert("runner_started_at".to_string(), json!(now_timestamp()));
+        if reclaimed_stale {
+            metadata.insert("reclaimed_stale_running".to_string(), json!(true));
+        } else {
+            metadata.remove("reclaimed_stale_running");
+        }
+        metadata.remove("stale_running");
+        metadata.remove("stale_running_reason");
+    }
+
+    fn annotate_stale_running(&mut self) {
+        if self.state != AgentTaskRunState::Running || self.owner_process_is_running() {
+            return;
+        }
+
+        let reason = if self.owner_pid().is_some() {
+            "owner_process_not_running"
+        } else {
+            "missing_runner_pid"
+        };
+        let metadata = self.ensure_metadata_object();
+        metadata.insert("stale_running".to_string(), json!(true));
+        metadata.insert("stale_running_reason".to_string(), json!(reason));
+    }
+
+    fn owner_process_is_running(&self) -> bool {
+        self.owner_pid()
+            .is_some_and(crate::core::process::pid_is_running)
+    }
+
+    fn owner_pid(&self) -> Option<u32> {
+        self.metadata
+            .get("runner_pid")
+            .and_then(Value::as_u64)
+            .and_then(|pid| u32::try_from(pid).ok())
+    }
+
+    fn ensure_metadata_object(&mut self) -> &mut serde_json::Map<String, Value> {
+        if !self.metadata.is_object() {
+            self.metadata = json!({});
+        }
+        self.metadata.as_object_mut().expect("metadata object")
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentTaskRunState {
@@ -133,13 +182,13 @@ pub fn load_plan(run_id: &str) -> Result<AgentTaskPlan> {
 
 pub fn mark_running(run_id: &str) -> Result<AgentTaskRunRecord> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
-    if record.state == AgentTaskRunState::Running && owner_process_is_running(&record) {
+    if record.state == AgentTaskRunState::Running && record.owner_process_is_running() {
         return Err(Error::validation_invalid_argument(
             "run_id",
             format!(
                 "agent-task run '{}' is already running under pid {}",
                 record.run_id,
-                owner_pid(&record).unwrap_or_default()
+                record.owner_pid().unwrap_or_default()
             ),
             Some(record.run_id),
             None,
@@ -171,7 +220,7 @@ pub fn mark_running(run_id: &str) -> Result<AgentTaskRunRecord> {
             task.state = AgentTaskState::Running;
         }
     }
-    record_runner_metadata(&mut record, reclaimed_stale);
+    record.record_runner_metadata(reclaimed_stale);
     store::write_record(&record)?;
     Ok(record)
 }
@@ -202,7 +251,7 @@ fn record_aggregate(
 
 pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
-    annotate_stale_running(&mut record);
+    record.annotate_stale_running();
     Ok(record)
 }
 
@@ -356,55 +405,6 @@ fn default_run_id() -> String {
 
 fn now_timestamp() -> String {
     Utc::now().to_rfc3339()
-}
-
-fn record_runner_metadata(record: &mut AgentTaskRunRecord, reclaimed_stale: bool) {
-    let metadata = ensure_metadata_object(record);
-    metadata.insert("runner_pid".to_string(), json!(std::process::id()));
-    metadata.insert("runner_started_at".to_string(), json!(now_timestamp()));
-    if reclaimed_stale {
-        metadata.insert("reclaimed_stale_running".to_string(), json!(true));
-    } else {
-        metadata.remove("reclaimed_stale_running");
-    }
-    metadata.remove("stale_running");
-    metadata.remove("stale_running_reason");
-}
-
-fn annotate_stale_running(record: &mut AgentTaskRunRecord) {
-    if record.state != AgentTaskRunState::Running || owner_process_is_running(record) {
-        return;
-    }
-
-    let reason = if owner_pid(record).is_some() {
-        "owner_process_not_running"
-    } else {
-        "missing_runner_pid"
-    };
-    let metadata = ensure_metadata_object(record);
-    metadata.insert("stale_running".to_string(), json!(true));
-    metadata.insert("stale_running_reason".to_string(), json!(reason));
-}
-
-fn owner_process_is_running(record: &AgentTaskRunRecord) -> bool {
-    owner_pid(record).is_some_and(crate::core::process::pid_is_running)
-}
-
-fn owner_pid(record: &AgentTaskRunRecord) -> Option<u32> {
-    record
-        .metadata
-        .get("runner_pid")
-        .and_then(Value::as_u64)
-        .and_then(|pid| u32::try_from(pid).ok())
-}
-
-fn ensure_metadata_object(
-    record: &mut AgentTaskRunRecord,
-) -> &mut serde_json::Map<String, Value> {
-    if !record.metadata.is_object() {
-        record.metadata = json!({});
-    }
-    record.metadata.as_object_mut().expect("metadata object")
 }
 
 fn sanitize_run_id(run_id: &str) -> String {
@@ -573,7 +573,10 @@ mod tests {
 
             assert_eq!(loaded.state, AgentTaskRunState::Running);
             assert_eq!(loaded.metadata["stale_running"], json!(true));
-            assert_eq!(loaded.metadata["stale_running_reason"], "missing_runner_pid");
+            assert_eq!(
+                loaded.metadata["stale_running_reason"],
+                "missing_runner_pid"
+            );
         });
     }
 
@@ -591,10 +594,7 @@ mod tests {
 
             assert_eq!(running.state, AgentTaskRunState::Running);
             assert_eq!(running.metadata["reclaimed_stale_running"], json!(true));
-            assert_eq!(
-                running.metadata["runner_pid"],
-                json!(std::process::id())
-            );
+            assert_eq!(running.metadata["runner_pid"], json!(std::process::id()));
         });
     }
 

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -7,7 +7,7 @@ use crate::core::agent_task::{AgentTaskArtifact, AgentTaskEvidenceRef, AgentTask
 use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskPlan, AgentTaskProgressEvent, AgentTaskState,
 };
-use crate::core::{paths, Result};
+use crate::core::{paths, Error, Result};
 
 #[path = "lifecycle_store.rs"]
 mod lifecycle_store;
@@ -133,6 +133,37 @@ pub fn load_plan(run_id: &str) -> Result<AgentTaskPlan> {
 
 pub fn mark_running(run_id: &str) -> Result<AgentTaskRunRecord> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    if record.state == AgentTaskRunState::Running && owner_process_is_running(&record) {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!(
+                "agent-task run '{}' is already running under pid {}",
+                record.run_id,
+                owner_pid(&record).unwrap_or_default()
+            ),
+            Some(record.run_id),
+            None,
+        ));
+    }
+    if matches!(
+        record.state,
+        AgentTaskRunState::Succeeded
+            | AgentTaskRunState::PartialFailure
+            | AgentTaskRunState::Failed
+            | AgentTaskRunState::Cancelled
+    ) {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!(
+                "agent-task run '{}' is already terminal with state {:?}",
+                record.run_id, record.state
+            ),
+            Some(record.run_id),
+            None,
+        ));
+    }
+
+    let reclaimed_stale = record.state == AgentTaskRunState::Running;
     record.state = AgentTaskRunState::Running;
     record.updated_at = Some(now_timestamp());
     for task in &mut record.tasks {
@@ -140,6 +171,7 @@ pub fn mark_running(run_id: &str) -> Result<AgentTaskRunRecord> {
             task.state = AgentTaskState::Running;
         }
     }
+    record_runner_metadata(&mut record, reclaimed_stale);
     store::write_record(&record)?;
     Ok(record)
 }
@@ -169,7 +201,9 @@ fn record_aggregate(
 }
 
 pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
-    store::read_record(&sanitize_run_id(run_id))
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    annotate_stale_running(&mut record);
+    Ok(record)
 }
 
 pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
@@ -324,6 +358,55 @@ fn now_timestamp() -> String {
     Utc::now().to_rfc3339()
 }
 
+fn record_runner_metadata(record: &mut AgentTaskRunRecord, reclaimed_stale: bool) {
+    let metadata = ensure_metadata_object(record);
+    metadata.insert("runner_pid".to_string(), json!(std::process::id()));
+    metadata.insert("runner_started_at".to_string(), json!(now_timestamp()));
+    if reclaimed_stale {
+        metadata.insert("reclaimed_stale_running".to_string(), json!(true));
+    } else {
+        metadata.remove("reclaimed_stale_running");
+    }
+    metadata.remove("stale_running");
+    metadata.remove("stale_running_reason");
+}
+
+fn annotate_stale_running(record: &mut AgentTaskRunRecord) {
+    if record.state != AgentTaskRunState::Running || owner_process_is_running(record) {
+        return;
+    }
+
+    let reason = if owner_pid(record).is_some() {
+        "owner_process_not_running"
+    } else {
+        "missing_runner_pid"
+    };
+    let metadata = ensure_metadata_object(record);
+    metadata.insert("stale_running".to_string(), json!(true));
+    metadata.insert("stale_running_reason".to_string(), json!(reason));
+}
+
+fn owner_process_is_running(record: &AgentTaskRunRecord) -> bool {
+    owner_pid(record).is_some_and(crate::core::process::pid_is_running)
+}
+
+fn owner_pid(record: &AgentTaskRunRecord) -> Option<u32> {
+    record
+        .metadata
+        .get("runner_pid")
+        .and_then(Value::as_u64)
+        .and_then(|pid| u32::try_from(pid).ok())
+}
+
+fn ensure_metadata_object(
+    record: &mut AgentTaskRunRecord,
+) -> &mut serde_json::Map<String, Value> {
+    if !record.metadata.is_object() {
+        record.metadata = json!({});
+    }
+    record.metadata.as_object_mut().expect("metadata object")
+}
+
 fn sanitize_run_id(run_id: &str) -> String {
     let sanitized = paths::sanitize_path_segment(run_id);
     if sanitized.is_empty() {
@@ -474,6 +557,57 @@ mod tests {
             assert_eq!(completed.state, AgentTaskRunState::Succeeded);
             assert_eq!(completed.tasks[0].state, AgentTaskState::Succeeded);
             assert!(completed.aggregate_path.is_some());
+        });
+    }
+
+    #[test]
+    fn status_marks_running_run_without_owner_as_stale() {
+        with_temp_home(|| {
+            let plan = test_plan();
+            submit_plan(&plan, Some("run-stale-missing-owner")).expect("submitted");
+            let mut record = store::read_record("run-stale-missing-owner").expect("record");
+            record.state = AgentTaskRunState::Running;
+            store::write_record(&record).expect("stored running record");
+
+            let loaded = status("run-stale-missing-owner").expect("status loaded");
+
+            assert_eq!(loaded.state, AgentTaskRunState::Running);
+            assert_eq!(loaded.metadata["stale_running"], json!(true));
+            assert_eq!(loaded.metadata["stale_running_reason"], "missing_runner_pid");
+        });
+    }
+
+    #[test]
+    fn mark_running_reclaims_stale_running_record() {
+        with_temp_home(|| {
+            let plan = test_plan();
+            submit_plan(&plan, Some("run-stale-dead-owner")).expect("submitted");
+            let mut record = store::read_record("run-stale-dead-owner").expect("record");
+            record.state = AgentTaskRunState::Running;
+            record.metadata = json!({ "runner_pid": u32::MAX });
+            store::write_record(&record).expect("stored stale record");
+
+            let running = mark_running("run-stale-dead-owner").expect("reclaimed");
+
+            assert_eq!(running.state, AgentTaskRunState::Running);
+            assert_eq!(running.metadata["reclaimed_stale_running"], json!(true));
+            assert_eq!(
+                running.metadata["runner_pid"],
+                json!(std::process::id())
+            );
+        });
+    }
+
+    #[test]
+    fn mark_running_rejects_live_running_record() {
+        with_temp_home(|| {
+            let plan = test_plan();
+            submit_plan(&plan, Some("run-live-owner")).expect("submitted");
+            mark_running("run-live-owner").expect("marked running");
+
+            let error = mark_running("run-live-owner").expect_err("live run rejected");
+
+            assert!(error.message.contains("already running"));
         });
     }
 


### PR DESCRIPTION
## Summary
- Record runner PID/start metadata when a submitted `agent-task run` starts.
- Annotate stale `running` records when the owner process is gone or missing.
- Allow stale runs to be reclaimed while rejecting live-running and terminal records.

Fixes #3364.

## Verification
- `cargo test agent_task_lifecycle`
- Submitted-run lifecycle smoke through `target/debug/homeboy agent-task submit` and `target/debug/homeboy agent-task run`
- Reclaimed real stale run `wp-coding-agents-179-codebox-guidance-sandbox-20260602` and recorded terminal outcome

## Notes
This does not make async fleet cooking fully production-ready. It fixes stale lifecycle recovery; timeout artifact preservation/cancellation remains tracked in #3311.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the stale submitted-run lifecycle failure, drafted the patch/tests, ran local verification, and prepared this PR description. Chris remains responsible for review and merge decisions.