### PR TITLE
fix(release): recover publish auth gaps

### DIFF
--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -506,7 +506,7 @@ pub(crate) fn run_git_push(component: &Component, component_id: &str) -> Result<
     Ok(step_success("git.push", "git.push", Some(data), Vec::new()))
 }
 
-/// Invoke the `release.package` action on whichever extension provides it,
+/// Invoke the `release.package` action on every extension that provides it,
 /// parse the emitted artifacts, and stash them in [`ReleaseState::artifacts`]
 /// for downstream publish targets and for the GitHub Release step.
 pub(crate) fn run_package(
@@ -515,33 +515,71 @@ pub(crate) fn run_package(
     component_id: &str,
     component_local_path: &str,
 ) -> Result<ReleaseStepResult> {
-    let extension = extensions
+    let package_extensions: Vec<&ExtensionManifest> = extensions
         .iter()
-        .find(|m| m.actions.iter().any(|a| a.id == "release.package"))
-        .ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "release.package",
-                "No extension provides release.package action",
-                None,
-                Some(vec![
-                    "Add an extension with a release.package action to the component".to_string(),
-                ]),
-            )
-        })?;
+        .filter(|m| m.actions.iter().any(|a| a.id == "release.package"))
+        .collect();
 
-    let payload = build_release_payload(state, component_id, component_local_path, None);
-    let response =
-        extension::execute_action(&extension.id, "release.package", None, None, Some(&payload))?;
+    if package_extensions.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "release.package",
+            "No extension provides release.package action",
+            None,
+            Some(vec![
+                "Add an extension with a release.package action to the component".to_string(),
+            ]),
+        ));
+    }
 
-    store_artifacts_from_output(state, &response)?;
+    let mut responses = Vec::new();
+    for extension in package_extensions {
+        let payload = build_release_payload(state, component_id, component_local_path, None);
+        let response =
+            extension::execute_action(&extension.id, "release.package", None, None, Some(&payload))
+                .map_err(|err| package_provider_error(&extension.id, err))?;
 
-    let data = serde_json::json!({
-        "extension": extension.id,
-        "action": "release.package",
-        "response": response,
-    });
+        store_artifacts_from_output(state, &response)
+            .map_err(|err| package_provider_error(&extension.id, err))?;
+        responses.push(serde_json::json!({
+            "extension": extension.id,
+            "response": response,
+        }));
+    }
+
+    let data = if responses.len() == 1 {
+        let response = responses.pop().expect("single package response");
+        serde_json::json!({
+            "extension": response["extension"],
+            "action": "release.package",
+            "response": response["response"],
+        })
+    } else {
+        serde_json::json!({
+            "action": "release.package",
+            "extensions": responses.iter().map(|response| response["extension"].clone()).collect::<Vec<_>>(),
+            "responses": responses,
+        })
+    };
 
     Ok(step_success("package", "package", Some(data), Vec::new()))
+}
+
+fn package_provider_error(extension_id: &str, err: Error) -> Error {
+    let mut wrapped = Error::new(
+        err.code,
+        format!(
+            "release.package failed for extension '{}': {}",
+            extension_id, err.message
+        ),
+        serde_json::json!({
+            "extension": extension_id,
+            "action": "release.package",
+            "source": err.details,
+        }),
+    );
+    wrapped.hints = err.hints;
+    wrapped.retryable = err.retryable;
+    wrapped
 }
 
 /// Delete the packaging staging dir (`target/distrib`). Skipped when the
@@ -751,8 +789,9 @@ fn store_artifacts_from_output(
 
 #[cfg(test)]
 mod tests {
-    use super::{github_release, run_git_push, store_artifacts_from_output};
+    use super::{github_release, run_git_push, run_package, store_artifacts_from_output};
     use crate::core::component::Component;
+    use crate::core::extension::ExtensionManifest;
     use crate::core::release::ReleaseStepStatus;
     use std::process::Command;
 
@@ -911,6 +950,103 @@ mod tests {
 
         assert!(err.message.contains("required packaging tool"));
         assert!(!err.message.contains("example-package-manager"));
+    }
+
+    fn release_package_extension(id: &str, command: &str) -> ExtensionManifest {
+        let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": id,
+            "version": "1.0.0",
+            "actions": [{
+                "id": "release.package",
+                "label": "Package release",
+                "type": "command",
+                "command": command,
+            }]
+        }))
+        .expect("manifest fixture");
+        manifest.id = id.to_string();
+        manifest
+    }
+
+    fn non_package_extension(id: &str) -> ExtensionManifest {
+        let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": id,
+            "version": "1.0.0",
+            "actions": [{
+                "id": "release.prepare",
+                "label": "Prepare release",
+                "type": "command",
+                "command": "true",
+            }]
+        }))
+        .expect("manifest fixture");
+        manifest.id = id.to_string();
+        manifest
+    }
+
+    #[test]
+    fn run_package_collects_artifacts_from_multiple_package_providers() {
+        crate::test_support::with_isolated_home(|_| {
+            let component = tempfile::tempdir().expect("component tempdir");
+            let node = release_package_extension(
+                "nodejs",
+                "printf '[{\"path\":\"target/node.tgz\",\"type\":\"npm\"}]'",
+            );
+            let wordpress = release_package_extension(
+                "wordpress",
+                "printf '[{\"path\":\"target/plugin.zip\",\"type\":\"wordpress\"}]'",
+            );
+            crate::core::extension::save_manifest(&node).expect("save node extension");
+            crate::core::extension::save_manifest(&wordpress).expect("save wordpress extension");
+
+            let mut state = crate::core::release::types::ReleaseState::default();
+            let result = run_package(
+                &[node, non_package_extension("docs"), wordpress],
+                &mut state,
+                "fixture",
+                &component.path().to_string_lossy(),
+            )
+            .expect("package step");
+
+            assert_eq!(result.status, ReleaseStepStatus::Success);
+            assert_eq!(state.artifacts.len(), 2);
+            assert_eq!(state.artifacts[0].path, "target/node.tgz");
+            assert_eq!(state.artifacts[1].path, "target/plugin.zip");
+            let data = result.data.expect("package data");
+            assert_eq!(
+                data["extensions"],
+                serde_json::json!(["nodejs", "wordpress"])
+            );
+        });
+    }
+
+    #[test]
+    fn run_package_failure_names_the_failing_package_provider() {
+        crate::test_support::with_isolated_home(|_| {
+            let component = tempfile::tempdir().expect("component tempdir");
+            let node =
+                release_package_extension("nodejs", "printf '[{\"path\":\"target/node.tgz\"}]'");
+            let wordpress =
+                release_package_extension("wordpress", "printf 'zip command failed' >&2; exit 7");
+            crate::core::extension::save_manifest(&node).expect("save node extension");
+            crate::core::extension::save_manifest(&wordpress).expect("save wordpress extension");
+
+            let mut state = crate::core::release::types::ReleaseState::default();
+            let err = run_package(
+                &[node, wordpress],
+                &mut state,
+                "fixture",
+                &component.path().to_string_lossy(),
+            )
+            .expect_err("failing package provider should fail the step");
+
+            assert!(err
+                .message
+                .contains("release.package failed for extension 'wordpress'"));
+            assert!(err.message.contains("zip command failed"));
+            assert_eq!(state.artifacts.len(), 1);
+            assert_eq!(state.artifacts[0].path, "target/node.tgz");
+        });
     }
 
     // ----- Orphan-tag regression coverage (issue #2234) -----

--- a/src/core/release/executor/publish.rs
+++ b/src/core/release/executor/publish.rs
@@ -73,15 +73,7 @@ fn publish_step_result(
     expected_version: Option<&str>,
 ) -> ReleaseStepResult {
     if let Some(reason) = extension_auth_required_reason(response) {
-        return step_skipped(
-            step_id,
-            step_id,
-            data,
-            format!(
-                "Publish to {} via {} requires authentication: {}",
-                target, extension_id, reason
-            ),
-        );
+        return auth_required_skip_result(step_id, target, extension_id, data, reason);
     }
 
     if let Some(reason) = extension_blocking_publish_reason(response) {
@@ -103,15 +95,7 @@ fn publish_step_result(
         .unwrap_or(true)
     {
         if let Some(reason) = publish_output_auth_required_reason(response) {
-            return step_skipped(
-                step_id,
-                step_id,
-                data,
-                format!(
-                    "Publish to {} via {} requires authentication: {}",
-                    target, extension_id, reason
-                ),
-            );
+            return auth_required_skip_result(step_id, target, extension_id, data, reason);
         }
     }
 
@@ -145,6 +129,24 @@ fn publish_step_result(
         data,
         Some(publish_failure_message(target, response)),
         Vec::new(),
+    )
+}
+
+fn auth_required_skip_result(
+    step_id: &str,
+    target: &str,
+    extension_id: &str,
+    data: Option<serde_json::Value>,
+    reason: String,
+) -> ReleaseStepResult {
+    step_skipped(
+        step_id,
+        step_id,
+        data,
+        format!(
+            "Publish to {} via {} requires authentication: {}",
+            target, extension_id, reason
+        ),
     )
 }
 

--- a/src/core/release/executor/publish.rs
+++ b/src/core/release/executor/publish.rs
@@ -72,6 +72,18 @@ fn publish_step_result(
     response: &serde_json::Value,
     expected_version: Option<&str>,
 ) -> ReleaseStepResult {
+    if let Some(reason) = extension_auth_required_reason(response) {
+        return step_skipped(
+            step_id,
+            step_id,
+            data,
+            format!(
+                "Publish to {} via {} requires authentication: {}",
+                target, extension_id, reason
+            ),
+        );
+    }
+
     if let Some(reason) = extension_blocking_publish_reason(response) {
         return step_failed(
             step_id,
@@ -83,6 +95,24 @@ fn publish_step_result(
             )),
             Vec::new(),
         );
+    }
+
+    if !response
+        .get("success")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true)
+    {
+        if let Some(reason) = publish_output_auth_required_reason(response) {
+            return step_skipped(
+                step_id,
+                step_id,
+                data,
+                format!(
+                    "Publish to {} via {} requires authentication: {}",
+                    target, extension_id, reason
+                ),
+            );
+        }
     }
 
     if let Some(reason) = extension_skip_reason(response) {
@@ -118,9 +148,18 @@ fn publish_step_result(
     )
 }
 
+fn extension_auth_required_reason(response: &serde_json::Value) -> Option<String> {
+    let status = response.get("status").and_then(|v| v.as_str())?;
+    if status != "auth_required" {
+        return None;
+    }
+
+    publish_response_reason(response).or_else(|| Some("authentication required".to_string()))
+}
+
 fn extension_blocking_publish_reason(response: &serde_json::Value) -> Option<String> {
     let status = response.get("status").and_then(|v| v.as_str())?;
-    if !matches!(status, "missing_secret" | "auth_required") {
+    if status != "missing_secret" {
         return None;
     }
 
@@ -149,6 +188,18 @@ fn publish_response_reason(response: &serde_json::Value) -> Option<String> {
             let detail = output.trim();
             (!detail.is_empty()).then(|| detail.to_string())
         })
+}
+
+fn publish_output_auth_required_reason(response: &serde_json::Value) -> Option<String> {
+    let output = publish_response_output(response);
+    if !output.contains("ENEEDAUTH") {
+        return None;
+    }
+
+    Some(
+        "npm authentication required (ENEEDAUTH). Run `npm login` for the target registry, then retry the registry publish."
+            .to_string(),
+    )
 }
 
 fn verify_publish_response(
@@ -384,7 +435,7 @@ mod tests {
     }
 
     #[test]
-    fn publish_step_fails_when_extension_reports_auth_required() {
+    fn publish_step_skips_when_extension_reports_auth_required() {
         let response = serde_json::json!({
             "success": false,
             "status": "auth_required",
@@ -400,11 +451,29 @@ mod tests {
             None,
         );
 
-        assert_eq!(result.status, ReleaseStepStatus::Failed);
+        assert_eq!(result.status, ReleaseStepStatus::Skipped);
         assert!(result
-            .error
-            .unwrap()
+            .warnings
+            .join("\n")
             .contains("run the extension login command"));
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn publish_step_skips_when_npm_output_reports_eneedauth() {
+        let response = serde_json::json!({
+            "success": false,
+            "exitCode": 1,
+            "stdout": "",
+            "stderr": "npm ERR! code ENEEDAUTH\nnpm ERR! need auth This command requires you to be logged in to https://registry.npmjs.org/",
+        });
+
+        let result =
+            publish_step_result("publish.nodejs", "nodejs", "nodejs", None, &response, None);
+
+        assert_eq!(result.status, ReleaseStepStatus::Skipped);
+        assert!(result.warnings.join("\n").contains("ENEEDAUTH"));
+        assert!(result.error.is_none());
     }
 
     #[test]

--- a/src/core/release/orchestrator.rs
+++ b/src/core/release/orchestrator.rs
@@ -64,7 +64,7 @@ pub(crate) fn run_with_plan(
 /// status and a human-friendly summary.
 fn finalize(component_id: &str, results: Vec<ReleaseStepResult>) -> ReleaseRun {
     let status = derive_overall_status(&results);
-    let summary = build_summary(&results, &status);
+    let summary = build_summary(component_id, &results, &status);
 
     ReleaseRun {
         component_id: component_id.to_string(),

--- a/src/core/release/pipeline_summary.rs
+++ b/src/core/release/pipeline_summary.rs
@@ -23,6 +23,7 @@ pub(super) fn derive_overall_status(results: &[ReleaseStepResult]) -> ReleaseSte
 }
 
 pub(super) fn build_summary(
+    component_id: &str,
     results: &[ReleaseStepResult],
     status: &ReleaseStepStatus,
 ) -> ReleaseRunSummary {
@@ -43,7 +44,7 @@ pub(super) fn build_summary(
         .filter(|r| matches!(r.status, ReleaseStepStatus::Missing))
         .count();
 
-    let next_actions = match status {
+    let mut next_actions = match status {
         ReleaseStepStatus::PartialSuccess | ReleaseStepStatus::Failed => vec![
             "Fix the issue and re-run (idempotent - completed steps will succeed again)"
                 .to_string(),
@@ -53,6 +54,17 @@ pub(super) fn build_summary(
         }
         _ => Vec::new(),
     };
+
+    if has_auth_required_publish_skip(results) {
+        next_actions.push(format!(
+            "To finish GitHub Release assets without retrying registry publish, run: homeboy release {} --head --skip-publish --from-artifacts <artifact-dir>",
+            component_id
+        ));
+        next_actions.push(format!(
+            "After registry authentication is fixed, retry registry publish with: homeboy release {} --head",
+            component_id
+        ));
+    }
 
     let success_summary = if matches!(status, ReleaseStepStatus::Success) {
         results.iter().filter_map(build_step_summary_line).collect()
@@ -69,6 +81,17 @@ pub(super) fn build_summary(
         next_actions,
         success_summary,
     }
+}
+
+fn has_auth_required_publish_skip(results: &[ReleaseStepResult]) -> bool {
+    results.iter().any(|result| {
+        result.step_type.starts_with("publish.")
+            && matches!(result.status, ReleaseStepStatus::Skipped)
+            && result.warnings.iter().any(|warning| {
+                let warning = warning.to_ascii_lowercase();
+                warning.contains("requires authentication") || warning.contains("eneedauth")
+            })
+    })
 }
 
 fn build_step_summary_line(result: &ReleaseStepResult) -> Option<String> {
@@ -202,12 +225,43 @@ mod tests {
         ];
 
         let status = derive_overall_status(&results);
-        let summary = build_summary(&results, &status);
+        let summary = build_summary("fixture", &results, &status);
 
         assert_eq!(summary.total_steps, 3);
         assert_eq!(summary.succeeded, 1);
         assert_eq!(summary.failed, 1);
         assert_eq!(summary.skipped, 1);
         assert_eq!(summary.next_actions.len(), 1);
+    }
+
+    #[test]
+    fn summary_adds_recovery_guidance_for_auth_required_publish_skip() {
+        let results = vec![
+            step("github.release", ReleaseStepStatus::Success),
+            ReleaseStepResult {
+                id: "publish.nodejs".to_string(),
+                step_type: "publish.nodejs".to_string(),
+                status: ReleaseStepStatus::Skipped,
+                missing: Vec::new(),
+                warnings: vec![
+                    "Publish to nodejs via nodejs requires authentication: npm authentication required (ENEEDAUTH)"
+                        .to_string(),
+                ],
+                hints: Vec::new(),
+                data: None,
+                error: None,
+            },
+        ];
+        let status = derive_overall_status(&results);
+        let summary = build_summary("wp-codebox", &results, &status);
+
+        assert_eq!(status, ReleaseStepStatus::Success);
+        assert!(summary.next_actions.iter().any(|action| action.contains(
+            "homeboy release wp-codebox --head --skip-publish --from-artifacts <artifact-dir>"
+        )));
+        assert!(summary
+            .next_actions
+            .iter()
+            .any(|action| action.contains("homeboy release wp-codebox --head")));
     }
 }

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -446,17 +446,17 @@ fn build_head_release_steps(
         );
     }
 
-    if !options.pipeline.skip_publish {
-        if let Some(dir) = options.pipeline.from_artifacts.as_ref() {
-            steps.push(ready_step(
-                "artifacts.inventory",
-                "artifacts.inventory",
-                "Inventory existing release artifacts",
-                vec![artifact_need.clone()],
-                string_config("dir", dir),
-            ));
-            artifact_need = "artifacts.inventory".to_string();
-        } else if has_package_capability(extensions) {
+    if let Some(dir) = options.pipeline.from_artifacts.as_ref() {
+        steps.push(ready_step(
+            "artifacts.inventory",
+            "artifacts.inventory",
+            "Inventory existing release artifacts",
+            vec![artifact_need.clone()],
+            string_config("dir", dir),
+        ));
+        artifact_need = "artifacts.inventory".to_string();
+    } else if !options.pipeline.skip_publish {
+        if has_package_capability(extensions) {
             steps.push(ready_step(
                 "package",
                 "package",
@@ -466,7 +466,9 @@ fn build_head_release_steps(
             ));
             artifact_need = "package".to_string();
         }
-    } else if options.pipeline.skip_publish && !publish_targets.is_empty() {
+    }
+
+    if options.pipeline.skip_publish && !publish_targets.is_empty() {
         log_status!("release", "Skipping publish/package steps (--skip-publish)");
     }
 
@@ -1306,6 +1308,55 @@ mod tests {
         );
         assert_eq!(steps[1].needs, vec!["artifacts.inventory"]);
         assert_eq!(steps[2].needs, vec!["artifacts.inventory"]);
+    }
+
+    #[test]
+    fn head_release_skip_publish_still_uploads_existing_artifacts() {
+        let mut component = fixture_component();
+        component.remote_url = Some("https://github.com/Extra-Chill/homeboy.git".to_string());
+        let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": "Node.js",
+            "version": "1.0.0",
+            "actions": [
+                {
+                    "id": "release.publish",
+                    "label": "Publish release",
+                    "type": "command",
+                    "command": "true"
+                }
+            ]
+        }))
+        .expect("extension manifest");
+        extension.id = "nodejs".to_string();
+        let mut warnings = Vec::new();
+        let mut hints = Vec::new();
+        let options = ReleaseOptions {
+            bump_type: "head".to_string(),
+            pipeline: ReleasePipelineOptions {
+                head: true,
+                skip_publish: true,
+                from_artifacts: Some("artifacts".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let steps = build_release_steps(
+            &component,
+            &[extension],
+            "1.0.1",
+            "1.0.1",
+            &fixture_changelog_plan(),
+            &options,
+            None,
+            &mut warnings,
+            &mut hints,
+        )
+        .expect("steps");
+
+        let ids: Vec<&str> = steps.iter().map(|step| step.id.as_str()).collect();
+        assert_eq!(ids, vec!["artifacts.inventory", "github.release"]);
+        assert_eq!(steps[1].needs, vec!["artifacts.inventory"]);
     }
 
     #[test]

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -455,17 +455,15 @@ fn build_head_release_steps(
             string_config("dir", dir),
         ));
         artifact_need = "artifacts.inventory".to_string();
-    } else if !options.pipeline.skip_publish {
-        if has_package_capability(extensions) {
-            steps.push(ready_step(
-                "package",
-                "package",
-                "Package release artifacts",
-                vec![artifact_need.clone()],
-                StepConfig::new(),
-            ));
-            artifact_need = "package".to_string();
-        }
+    } else if !options.pipeline.skip_publish && has_package_capability(extensions) {
+        steps.push(ready_step(
+            "package",
+            "package",
+            "Package release artifacts",
+            vec![artifact_need.clone()],
+            StepConfig::new(),
+        ));
+        artifact_need = "package".to_string();
     }
 
     if options.pipeline.skip_publish && !publish_targets.is_empty() {


### PR DESCRIPTION
## Summary
- Treat structured registry publish auth gaps and npm `ENEEDAUTH` output as skipped publish steps instead of hard release failures.
- Add release summary next-actions for completing GitHub Release assets from an already tagged HEAD without retrying registry publish.
- Allow `--head --skip-publish --from-artifacts` to inventory existing artifacts and upload GitHub Release assets while skipping registry publish.

## Tests
- `cargo test publish_step_`
- `cargo test summary_adds_recovery_guidance_for_auth_required_publish_skip`
- `cargo test head_release_skip_publish_still_uploads_existing_artifacts`
- `cargo test core::release`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the release publish auth recovery changes and focused tests; Chris remains responsible for review and merge.