### PR TITLE
Pass component id to release extension actions

### DIFF
--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -582,15 +582,20 @@ pub(super) fn build_action_env(
     project_base_path: Option<&str>,
 ) -> Vec<(String, String)> {
     let settings_json = payload.to_string();
+    let component_id =
+        crate::core::engine::text::json_path_str(payload, &["release", "component_id"]);
+    let component_path =
+        crate::core::engine::text::json_path_str(payload, &["release", "local_path"]);
+
     build_exec_env(
         extension_id,
         project_id,
-        None,
+        component_id,
         &settings_json,
         extension_path,
         project_base_path,
         None,
-        None, // no path override in action context
+        component_path,
     )
 }
 

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -1133,10 +1133,6 @@ mod tests {
             .expect("package step");
 
             assert_eq!(result.status, ReleaseStepStatus::Success);
-            assert_ne!(
-                component.path().file_name().unwrap().to_string_lossy(),
-                "intelligence-horse-theme"
-            );
             assert_eq!(state.artifacts.len(), 1);
             assert_eq!(
                 state.artifacts[0].path,

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -1113,6 +1113,39 @@ mod tests {
     }
 
     #[test]
+    fn run_package_passes_component_id_from_release_payload_to_action_env() {
+        crate::test_support::with_isolated_home(|_| {
+            let component = tempfile::tempdir_in(std::env::temp_dir())
+                .expect("component tempdir with mismatched basename");
+            let package = release_package_extension(
+                "wordpress",
+                "printf '[{\"path\":\"build/%s.zip\",\"type\":\"wordpress\"}]' \"$HOMEBOY_COMPONENT_ID\"",
+            );
+            crate::core::extension::save_manifest(&package).expect("save package extension");
+
+            let mut state = crate::core::release::types::ReleaseState::default();
+            let result = run_package(
+                &[package],
+                &mut state,
+                "intelligence-horse-theme",
+                &component.path().to_string_lossy(),
+            )
+            .expect("package step");
+
+            assert_eq!(result.status, ReleaseStepStatus::Success);
+            assert_ne!(
+                component.path().file_name().unwrap().to_string_lossy(),
+                "intelligence-horse-theme"
+            );
+            assert_eq!(state.artifacts.len(), 1);
+            assert_eq!(
+                state.artifacts[0].path,
+                "build/intelligence-horse-theme.zip"
+            );
+        });
+    }
+
+    #[test]
     fn run_package_failure_names_the_failing_package_provider() {
         crate::test_support::with_isolated_home(|_| {
             let component = tempfile::tempdir().expect("component tempdir");

--- a/src/core/release/executor/publish.rs
+++ b/src/core/release/executor/publish.rs
@@ -368,7 +368,9 @@ fn publish_failure_message(target: &str, response: &serde_json::Value) -> String
 
 #[cfg(test)]
 mod tests {
-    use super::publish_step_result;
+    use super::{publish_step_result, run_publish};
+    use crate::core::extension::ExtensionManifest;
+    use crate::core::release::types::ReleaseState;
     use crate::core::release::ReleaseStepStatus;
     use std::io::{Read, Write};
     use std::net::TcpListener;
@@ -406,6 +408,58 @@ mod tests {
             registry_url,
             handle,
         }
+    }
+
+    fn release_publish_extension(id: &str, command: &str) -> ExtensionManifest {
+        let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "name": id,
+            "version": "1.0.0",
+            "actions": [{
+                "id": "release.publish",
+                "label": "Publish release",
+                "type": "command",
+                "command": command,
+            }]
+        }))
+        .expect("manifest fixture");
+        manifest.id = id.to_string();
+        manifest
+    }
+
+    #[test]
+    fn run_publish_passes_component_id_from_release_payload_to_action_env() {
+        crate::test_support::with_isolated_home(|_| {
+            let component = tempfile::tempdir_in(std::env::temp_dir())
+                .expect("component tempdir with mismatched basename");
+            let publish = release_publish_extension(
+                "registry",
+                "printf '{\"component_id\":\"%s\",\"component_path\":\"%s\"}' \"$HOMEBOY_COMPONENT_ID\" \"$HOMEBOY_COMPONENT_PATH\"",
+            );
+            crate::core::extension::save_manifest(&publish).expect("save publish extension");
+
+            let result = run_publish(
+                &[publish],
+                &ReleaseState::default(),
+                "intelligence-horse-theme",
+                &component.path().to_string_lossy(),
+                "registry",
+            )
+            .expect("publish step");
+
+            assert_eq!(result.status, ReleaseStepStatus::Success);
+            assert_ne!(
+                component.path().file_name().unwrap().to_string_lossy(),
+                "intelligence-horse-theme"
+            );
+            let data = result.data.expect("publish data");
+            let stdout = data["response"]["stdout"].as_str().expect("stdout");
+            let env: serde_json::Value = serde_json::from_str(stdout).expect("env stdout json");
+            assert_eq!(env["component_id"], "intelligence-horse-theme");
+            assert_eq!(
+                env["component_path"].as_str().expect("component path"),
+                component.path().to_string_lossy()
+            );
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Pass release payload component context into command-action environments so release extensions receive `HOMEBOY_COMPONENT_ID` and `HOMEBOY_COMPONENT_PATH`.
- Add regression coverage for `release.package` and `release.publish` when the registered component id differs from the local checkout basename.

Closes #3371.

## Verification
- `cargo test run_package_passes_component_id_from_release_payload_to_action_env --lib`
- `cargo test run_publish_passes_component_id_from_release_payload_to_action_env --lib`
- `cargo test core::release::executor --lib`

## Caveat
- `cargo clippy --lib --tests -- -D warnings` is not currently green on this checkout due to existing unrelated repository-wide warnings outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the minimal env propagation change and regression tests; Chris remains responsible for review and validation.