### PR TITLE
ci: parallelize release quality gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,11 +144,12 @@ jobs:
           path: target/release/homeboy
           retention-days: 1
 
-  # ── Step 3: Quality gate (read-only checks + auto-refactor) ──
-   # Unlike PR CI (scoped to changed files), release quality gate runs
+  # ── Step 3: Quality gate (parallel read-only checks + auto-refactor) ──
+  # Unlike PR CI (scoped to changed files), release quality gate runs
   # unscoped against the entire codebase.
-  # Serial pipeline: audit → lint → test → release.
-   # All quality gates are read-only (autofix: false). The dedicated
+  # Read-only gates run in parallel after the shared build, then release
+  # preparation waits for audit, lint, and test to finish.
+  # All quality gates are read-only (autofix: false). The dedicated
   # auto-refactor job at the end owns all code changes.
   gate-audit:
     name: Audit
@@ -190,7 +191,6 @@ jobs:
     needs:
       - check
       - gate-build
-      - gate-audit
     if: needs.check.outputs.should-release == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -226,7 +226,6 @@ jobs:
     needs:
       - check
       - gate-build
-      - gate-lint
     if: needs.check.outputs.should-release == 'true'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Run release `gate-audit`, `gate-lint`, and `gate-test` in parallel after the shared build.
- Keep release preparation waiting on all read-only gates, while leaving the autofix/refactor job separate.
- Update adjacent workflow comments to document the parallel read-only gate shape.

## Verification
- Parsed `.github/workflows/release.yml` with Ruby YAML.
- Extracted job dependencies and confirmed `gate-audit`, `gate-lint`, and `gate-test` each need only `check,gate-build`; `prepare` still needs all three gates plus `check,gate-build`.
- Checked `actionlint` availability; not installed locally and no repo-declared actionlint/yamllint script was found.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the workflow dependency/comment update and performed local verification; Chris remains responsible for review and merge.