### PR TITLE
Reject invalid release ZIP downloads before deploy

### DIFF
--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -47,7 +47,19 @@ pub(super) fn prepare_component_deploy(
     // This is the preferred path when the component has remote_url set.
     let release_artifact: Option<PathBuf> =
         if should_try_download_release_artifact(component, config, is_git_deploy, is_file_deploy) {
-            try_download_release_artifact(component)
+            match try_download_release_artifact(component) {
+                Ok(path) => path,
+                Err(error) => {
+                    return Err(failed_component_deploy_result(
+                        component,
+                        base_path,
+                        local_version,
+                        remote_version,
+                        None,
+                        error,
+                    ));
+                }
+            }
         } else {
             None
         };
@@ -890,14 +902,26 @@ fn cleanup_empty_artifact_dirs(local_path: &Path, start_dir: Option<&Path>) {
 
 /// Try to download a release artifact from GitHub for the component's latest tag.
 ///
-/// Returns `Some(path)` if successful, `None` if anything fails (falls back to local build).
-fn try_download_release_artifact(component: &Component) -> Option<PathBuf> {
-    let remote_url = component.remote_url.as_ref()?;
-    let github = release_download::parse_github_url(remote_url)?;
-    let artifact_name = release_download::resolve_artifact_name(component)?;
+/// Returns `Ok(Some(path))` if successful and `Ok(None)` for normal download misses
+/// that should fall back to local build. Validation failures are returned as deploy
+/// errors so invalid artifacts never reach remote install.
+fn try_download_release_artifact(
+    component: &Component,
+) -> std::result::Result<Option<PathBuf>, String> {
+    let Some(remote_url) = component.remote_url.as_ref() else {
+        return Ok(None);
+    };
+    let Some(github) = release_download::parse_github_url(remote_url) else {
+        return Ok(None);
+    };
+    let Some(artifact_name) = release_download::resolve_artifact_name(component) else {
+        return Ok(None);
+    };
 
     // Get the latest tag from the local clone (already synced by the pipeline)
-    let tag = git::get_latest_tag(&component.local_path).ok().flatten()?;
+    let Some(tag) = git::get_latest_tag(&component.local_path).ok().flatten() else {
+        return Ok(None);
+    };
 
     log_status!(
         "deploy",
@@ -907,15 +931,19 @@ fn try_download_release_artifact(component: &Component) -> Option<PathBuf> {
     );
 
     match release_download::download_release_artifact(&github, &tag, &artifact_name) {
-        Ok(path) => Some(path),
+        Ok(path) => Ok(Some(path)),
         Err(e) => {
+            if e.code == crate::core::error::ErrorCode::ValidationInvalidArgument {
+                return Err(e.to_string());
+            }
+
             log_status!(
                 "deploy",
                 "Release download failed for '{}': {} — falling back to local build",
                 component.id,
                 e
             );
-            None
+            Ok(None)
         }
     }
 }

--- a/src/core/deploy/release_download.rs
+++ b/src/core/deploy/release_download.rs
@@ -34,6 +34,8 @@ const MUTABLE_DEPENDENCY_PREFIXES: &[&str] = &[
     "http://github.com/",
 ];
 
+const ZIP_MAGIC_PREFIX: &[u8] = b"PK";
+
 /// Parsed GitHub owner/repo from a remote URL.
 #[derive(Debug, Clone)]
 pub struct GitHubRepo {
@@ -192,6 +194,8 @@ pub fn download_release_artifact(
         ));
     }
 
+    validate_downloaded_artifact(&dest_path, artifact_name, &url)?;
+
     log_status!(
         "deploy",
         "Downloaded {} ({} bytes)",
@@ -200,6 +204,44 @@ pub fn download_release_artifact(
     );
 
     Ok(dest_path)
+}
+
+fn validate_downloaded_artifact(path: &Path, artifact_name: &str, url: &str) -> Result<()> {
+    if !artifact_name.ends_with(".zip") {
+        return Ok(());
+    }
+
+    let bytes = std::fs::read(path).map_err(|e| {
+        Error::internal_io(
+            format!("Failed to read downloaded artifact for validation: {}", e),
+            Some(path.display().to_string()),
+        )
+    })?;
+
+    if bytes.starts_with(ZIP_MAGIC_PREFIX) {
+        return Ok(());
+    }
+
+    let preview = String::from_utf8_lossy(&bytes[..bytes.len().min(512)]);
+    let normalized_preview = preview.trim_start().to_ascii_lowercase();
+    let hint = if normalized_preview.starts_with("<!doctype html")
+        || normalized_preview.starts_with("<html")
+        || normalized_preview.contains("class=\"html-auth\"")
+    {
+        "downloaded bytes look like an HTML authentication page; check GitHub Enterprise authentication/proxy configuration"
+    } else {
+        "downloaded bytes do not start with a ZIP file signature"
+    };
+
+    Err(Error::validation_invalid_argument(
+        "releaseArtifact",
+        format!(
+            "Downloaded release artifact '{}' from {} is not a valid ZIP archive: {}",
+            artifact_name, url, hint
+        ),
+        Some(path.display().to_string()),
+        None,
+    ))
 }
 
 /// Check if a component supports release-based deployment.
@@ -421,6 +463,43 @@ mod tests {
         // No build_artifact → false
         comp.build_artifact = None;
         assert!(!supports_release_deploy(&comp));
+    }
+
+    #[test]
+    fn validate_downloaded_artifact_rejects_html_auth_page_as_zip() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact = temp.path().join("theme.zip");
+        std::fs::write(
+            &artifact,
+            br#"<!DOCTYPE html><html lang="en" class="html-auth"><body>Sign in</body></html>"#,
+        )
+        .expect("write html artifact");
+
+        let error = validate_downloaded_artifact(
+            &artifact,
+            "theme.zip",
+            "https://github.a8c.com/Automattic/theme/releases/download/v1/theme.zip",
+        )
+        .expect_err("html auth page should be rejected");
+        let message = error.to_string();
+
+        assert!(message.contains("not a valid ZIP archive"));
+        assert!(message.contains("HTML authentication page"));
+        assert!(message.contains("GitHub Enterprise authentication/proxy"));
+    }
+
+    #[test]
+    fn validate_downloaded_artifact_accepts_zip_signature() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact = temp.path().join("theme.zip");
+        std::fs::write(&artifact, b"PK\x03\x04fixture").expect("write zip artifact");
+
+        validate_downloaded_artifact(
+            &artifact,
+            "theme.zip",
+            "https://github.com/Extra-Chill/theme/releases/download/v1/theme.zip",
+        )
+        .expect("zip signature should be accepted");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Validate downloaded release `.zip` artifacts before they enter the upload/install pipeline.
- Detect HTML/auth-page responses explicitly and fail deploy preflight with a GitHub Enterprise auth/proxy hint instead of staging invalid ZIP bytes remotely.
- Preserve local-build fallback for ordinary release download misses, while treating invalid artifact content as a hard validation failure.

Fixes #3370.

## Testing
- `cargo fmt --check`
- `cargo test core::deploy::release_download`
- `cargo check`
- `homeboy lint --path .`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the release artifact validation gap, drafting the fix and tests, and running local verification.