### PR TITLE
Deploy: clean generated build artifacts

### DIFF
--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -10,6 +10,7 @@ use crate::core::extension::build::resolve_artifact_path_from_root;
 use crate::core::git;
 use crate::core::project::Project;
 
+use super::generated_artifacts::GeneratedBuildArtifactCleanupGuard;
 use super::path_roots::{component_remote_path, resolve_effective_remote_path};
 use super::planning::{calculate_directory_size, format_bytes};
 use super::policy::{owner_hint_for_path, protected_path_suffixes, validate_deploy_target};
@@ -63,6 +64,15 @@ pub(super) fn prepare_component_deploy(
         } else {
             None
         };
+
+    let cleanup_generated_artifacts = !is_git_deploy
+        && !is_file_deploy
+        && !config.skip_build
+        && release_artifact.is_none()
+        && !is_self_deploy(component);
+    let local_path = Path::new(&component.local_path);
+    let mut generated_cleanup_guard =
+        GeneratedBuildArtifactCleanupGuard::new(local_path, cleanup_generated_artifacts);
 
     // Build (git-deploy, file-deploy, skip-build, and release-download skip this step)
     let (build_exit_code, build_error) =
@@ -160,6 +170,8 @@ pub(super) fn prepare_component_deploy(
             Err(result) => return Err(result),
         }
     };
+
+    generated_cleanup_guard.disarm();
 
     let cleanup_local_artifact = artifact_path.as_ref().is_some_and(|_| {
         release_artifact.is_none() && !config.skip_build && !is_self_deploy(component)
@@ -728,6 +740,10 @@ fn execute_artifact_deploy(
     let component = &prepared.component;
     let config = &prepared.config;
     let install_dir = prepared.install_dir.as_str();
+    let _generated_cleanup_guard = GeneratedBuildArtifactCleanupGuard::new(
+        Path::new(&component.local_path),
+        prepared.cleanup_local_artifact,
+    );
     let Some(artifact_path) = prepared.artifact_path.as_ref() else {
         return ComponentDeployResult::failed(
             component,

--- a/src/core/deploy/generated_artifacts.rs
+++ b/src/core/deploy/generated_artifacts.rs
@@ -1,0 +1,148 @@
+use std::path::Path;
+
+use crate::core::error::Result;
+use crate::core::git;
+
+const HOMEBOY_BUILD_DIR: &str = ".homeboy-build";
+
+pub(super) fn is_homeboy_generated_build_path(rel_path: &str) -> bool {
+    rel_path == HOMEBOY_BUILD_DIR || rel_path.starts_with(&format!("{HOMEBOY_BUILD_DIR}/"))
+}
+
+pub(super) fn unexpected_uncommitted_files_excluding_homeboy_build(
+    local_path: &str,
+) -> Result<Vec<String>> {
+    let uncommitted = git::get_uncommitted_changes(local_path)?;
+    if !uncommitted.has_changes {
+        return Ok(Vec::new());
+    }
+
+    Ok(uncommitted
+        .staged
+        .iter()
+        .chain(uncommitted.unstaged.iter())
+        .chain(uncommitted.untracked.iter())
+        .filter(|path| !is_homeboy_generated_build_path(path))
+        .cloned()
+        .collect())
+}
+
+pub(super) fn cleanup_homeboy_generated_build_artifacts(local_path: &Path) {
+    let build_dir = local_path.join(HOMEBOY_BUILD_DIR);
+    if !build_dir.exists() {
+        return;
+    }
+
+    if let Err(error) = std::fs::remove_dir_all(&build_dir) {
+        log_status!(
+            "cleanup",
+            "Warning: failed to remove generated deploy artifact directory {}: {}",
+            build_dir.display(),
+            error
+        );
+    } else {
+        log_status!(
+            "cleanup",
+            "Removed generated deploy artifact directory {}",
+            build_dir.display()
+        );
+    }
+}
+
+pub(super) struct GeneratedBuildArtifactCleanupGuard<'a> {
+    local_path: &'a Path,
+    enabled: bool,
+}
+
+impl<'a> GeneratedBuildArtifactCleanupGuard<'a> {
+    pub(super) fn new(local_path: &'a Path, enabled: bool) -> Self {
+        Self {
+            local_path,
+            enabled,
+        }
+    }
+
+    pub(super) fn disarm(&mut self) {
+        self.enabled = false;
+    }
+}
+
+impl Drop for GeneratedBuildArtifactCleanupGuard<'_> {
+    fn drop(&mut self) {
+        if self.enabled {
+            cleanup_homeboy_generated_build_artifacts(self.local_path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        cleanup_homeboy_generated_build_artifacts, is_homeboy_generated_build_path,
+        unexpected_uncommitted_files_excluding_homeboy_build,
+    };
+
+    fn run_git(dir: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: stdout={} stderr={}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_repo() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path();
+        run_git(dir, &["init", "-q"]);
+        run_git(dir, &["config", "user.email", "homeboy@example.com"]);
+        run_git(dir, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(dir.join("README.md"), "fixture\n").expect("readme");
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "-q", "-m", "chore: initial"]);
+        temp
+    }
+
+    #[test]
+    fn root_homeboy_build_paths_are_generated() {
+        assert!(is_homeboy_generated_build_path(".homeboy-build"));
+        assert!(is_homeboy_generated_build_path(".homeboy-build/plugin.zip"));
+        assert!(!is_homeboy_generated_build_path(
+            "src/.homeboy-build/plugin.zip"
+        ));
+        assert!(!is_homeboy_generated_build_path("src/lib.rs"));
+    }
+
+    #[test]
+    fn uncommitted_filter_ignores_only_generated_build_artifacts() {
+        let temp = git_repo();
+        let dir = temp.path();
+        std::fs::create_dir_all(dir.join(".homeboy-build")).expect("build dir");
+        std::fs::write(dir.join(".homeboy-build/plugin.zip"), "artifact").expect("artifact");
+        std::fs::write(dir.join("src.rs"), "source\n").expect("source");
+
+        let unexpected =
+            unexpected_uncommitted_files_excluding_homeboy_build(&dir.to_string_lossy())
+                .expect("status");
+
+        assert_eq!(unexpected, vec!["src.rs"]);
+    }
+
+    #[test]
+    fn cleanup_removes_generated_build_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let build_dir = temp.path().join(".homeboy-build");
+        std::fs::create_dir_all(&build_dir).expect("build dir");
+        std::fs::write(build_dir.join("plugin.zip"), "artifact").expect("artifact");
+
+        cleanup_homeboy_generated_build_artifacts(temp.path());
+
+        assert!(!build_dir.exists());
+    }
+}

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -1,4 +1,5 @@
 mod execution;
+mod generated_artifacts;
 mod orchestration;
 mod path_roots;
 pub(crate) mod permissions;

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::path::Path;
 
 use crate::core::component::Component;
 use crate::core::context::RemoteProjectContext;
@@ -11,6 +10,7 @@ use crate::core::release::version;
 use super::execution::{
     execute_preflighted_component_deploy, prepare_component_deploy, PreparedComponentDeploy,
 };
+use super::generated_artifacts::unexpected_uncommitted_files_excluding_homeboy_build;
 use super::path_roots::{project_with_detected_path_roots, resolve_effective_remote_path};
 use super::planning::{
     calculate_component_status, calculate_release_state, load_project_components, plan_components,
@@ -443,13 +443,13 @@ fn check_uncommitted_changes(components: &[Component]) -> Result<()> {
         if component.is_file_component() {
             continue;
         }
-        let path = Path::new(&component.local_path);
         if !git::is_git_repo(&component.local_path) {
             non_git.push(component);
             continue;
         }
-        if !git::is_workdir_clean(path) {
-            dirty.push(component.id.as_str());
+        match unexpected_uncommitted_files_excluding_homeboy_build(&component.local_path) {
+            Ok(unexpected) if unexpected.is_empty() => {}
+            Ok(_) | Err(_) => dirty.push(component.id.as_str()),
         }
     }
 
@@ -799,8 +799,10 @@ fn verify_expected_version(components: &[Component], expected: &str) -> Result<(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::component::ComponentScriptsConfig;
     use crate::core::project::ProjectComponentAttachment;
     use std::collections::HashMap;
+    use std::path::Path;
     use tempfile::TempDir;
 
     fn make_component(id: &str, local_path: &str) -> Component {
@@ -815,6 +817,18 @@ mod tests {
             Some(artifact.to_string()),
         );
         component.extract_command = Some("unzip -o {artifact}".to_string());
+        component
+    }
+
+    fn failing_build_artifact_component(id: &str, local_path: &str, artifact: &str) -> Component {
+        let mut component = artifact_component(id, local_path, artifact);
+        component.scripts = Some(ComponentScriptsConfig {
+            build: vec![
+                "mkdir -p .homeboy-build && printf artifact > .homeboy-build/plugin.zip && exit 42"
+                    .to_string(),
+            ],
+            ..ComponentScriptsConfig::default()
+        });
         component
     }
 
@@ -997,6 +1011,65 @@ mod tests {
     }
 
     #[test]
+    fn check_uncommitted_changes_ignores_homeboy_build_artifacts() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path();
+
+        let run = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .output()
+                .expect("git command")
+        };
+        assert!(run(&["init", "-q"]).status.success());
+        assert!(run(&["config", "user.email", "test@example.com"])
+            .status
+            .success());
+        assert!(run(&["config", "user.name", "Test"]).status.success());
+        assert!(run(&["commit", "--allow-empty", "-q", "-m", "init"])
+            .status
+            .success());
+        std::fs::create_dir_all(path.join(".homeboy-build")).expect("build dir");
+        std::fs::write(path.join(".homeboy-build/plugin.zip"), "artifact").expect("artifact");
+
+        let component = make_component("test", &path.to_string_lossy());
+        check_uncommitted_changes(&[component])
+            .expect("generated Homeboy deploy artifacts should not block deploy");
+    }
+
+    #[test]
+    fn check_uncommitted_changes_still_rejects_source_changes() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path();
+
+        let run = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .output()
+                .expect("git command")
+        };
+        assert!(run(&["init", "-q"]).status.success());
+        assert!(run(&["config", "user.email", "test@example.com"])
+            .status
+            .success());
+        assert!(run(&["config", "user.name", "Test"]).status.success());
+        assert!(run(&["commit", "--allow-empty", "-q", "-m", "init"])
+            .status
+            .success());
+        std::fs::create_dir_all(path.join(".homeboy-build")).expect("build dir");
+        std::fs::write(path.join(".homeboy-build/plugin.zip"), "artifact").expect("artifact");
+        std::fs::write(path.join("src.rs"), "source\n").expect("source");
+
+        let component = make_component("test", &path.to_string_lossy());
+        let err = check_uncommitted_changes(&[component])
+            .expect_err("source changes should still block deploy");
+
+        assert!(err.message.contains("uncommitted changes"));
+    }
+
+    #[test]
     fn tagged_deploy_allows_head_ahead_of_latest_tag() {
         let dir = TempDir::new().expect("temp dir");
         init_repo_with_tag_gap(dir.path());
@@ -1097,6 +1170,42 @@ mod tests {
                 .contains("missing.zip"),
             "unexpected error: {:?}",
             failures[0].error
+        );
+    }
+
+    #[test]
+    fn deploy_preflight_cleans_homeboy_build_dir_after_failed_build() {
+        let dir = TempDir::new().expect("temp dir");
+        let component = failing_build_artifact_component(
+            "failing",
+            &dir.path().to_string_lossy(),
+            ".homeboy-build/plugin.zip",
+        );
+        let project = Project {
+            id: "site".to_string(),
+            ..Project::default()
+        };
+        let mut config = base_deploy_config();
+        config.force = true;
+        config.head = true;
+
+        let failures = match prepare_component_deployments(
+            &[component],
+            &config,
+            &project,
+            "/srv/site",
+            &HashMap::new(),
+            &HashMap::new(),
+        ) {
+            Ok(_) => panic!("failed build should abort preflight"),
+            Err(failures) => failures,
+        };
+
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].build_exit_code, Some(42));
+        assert!(
+            !dir.path().join(".homeboy-build").exists(),
+            "deploy-context failed builds must clean Homeboy-generated build artifacts"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Clean Homeboy-generated `.homeboy-build/` artifacts with a deploy-scoped cleanup guard when deploy-context builds or preflights fail.
- Keep the deploy dirty-worktree guard intact for real source changes while ignoring only root-level `.homeboy-build/` generated artifacts.
- Add targeted coverage for failed-build cleanup and dirty-guard behavior.

Fixes #3380.

## Verification
- `cargo fmt`
- `cargo test core::deploy::generated_artifacts`
- `cargo test core::deploy::orchestration`
- `cargo test core::deploy::execution`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the deploy cleanup implementation and targeted tests; Chris remains responsible for review and validation.