### PR TITLE
agent-task: reject empty timeout patches

### DIFF
--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -596,7 +596,9 @@ impl AgentTaskScheduleSupport {
         append_unique_artifacts(&mut outcome.artifacts, discovery.artifacts);
         append_unique_evidence_refs(&mut outcome.evidence_refs, discovery.evidence_refs);
 
-        let actionable_patch = outcome.artifacts.iter().any(is_actionable_patch_artifact);
+        let actionable_patch = outcome.metadata.get("actionable").and_then(Value::as_bool)
+            != Some(false)
+            && outcome.artifacts.iter().any(is_actionable_patch_artifact);
         if actionable_patch {
             outcome.status = AgentTaskOutcomeStatus::Succeeded;
             outcome.failure_classification = None;
@@ -1022,6 +1024,89 @@ mod tests {
                     .get("actionable_patch")
                     .and_then(Value::as_bool)
                     == Some(true)
+        }));
+    }
+
+    #[test]
+    fn timeout_with_empty_patch_artifacts_and_actionable_false_stays_timed_out() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact_root = temp.path().join("task-1-artifacts");
+        fs::create_dir_all(&artifact_root).expect("artifact root");
+        let patch_path = artifact_root.join("patch.diff");
+        let mounted_patch_path = artifact_root.join("mount-5.patch");
+        fs::write(&patch_path, "").expect("patch diff");
+        fs::write(&mounted_patch_path, "").expect("mounted patch");
+        fs::write(artifact_root.join("transcript.log"), "runtime completed").expect("log");
+        fs::write(
+            artifact_root.join("agent-result.json"),
+            serde_json::to_string(&json!({
+                "schema": AGENT_TASK_OUTCOME_SCHEMA,
+                "task_id": "task-1",
+                "status": "succeeded",
+                "summary": "runtime produced no actionable patch",
+                "actionable": false,
+                "artifacts": [
+                    {
+                        "schema": AGENT_TASK_ARTIFACT_SCHEMA,
+                        "id": "patch",
+                        "kind": "patch",
+                        "name": "patch.diff",
+                        "path": patch_path.display().to_string(),
+                        "mime": "text/x-diff",
+                        "metadata": { "role": "patch" }
+                    },
+                    {
+                        "schema": AGENT_TASK_ARTIFACT_SCHEMA,
+                        "id": "mount-5",
+                        "kind": "patch",
+                        "name": "mount-5.patch",
+                        "path": mounted_patch_path.display().to_string(),
+                        "mime": "text/x-patch",
+                        "metadata": { "role": "patch" }
+                    }
+                ],
+                "evidence_refs": [],
+                "diagnostics": [],
+                "metadata": {}
+            }))
+            .expect("agent result json"),
+        )
+        .expect("agent result");
+
+        let scheduler = AgentTaskScheduler::new(RecordingExecutor::new(
+            HashMap::new(),
+            Duration::from_millis(250),
+        ));
+        let mut plan = plan_with_tasks(1);
+        plan.tasks[0].limits.timeout_ms = Some(1);
+        plan.tasks[0].metadata = json!({ "artifact_root": artifact_root });
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+        assert_eq!(aggregate.totals.succeeded, 0);
+        assert_eq!(aggregate.totals.timed_out, 1);
+        assert!(aggregate
+            .events
+            .iter()
+            .any(|event| event.task_id == "task-1" && event.state == AgentTaskState::TimedOut));
+        let outcome = &aggregate.outcomes[0];
+        assert_eq!(outcome.status, AgentTaskOutcomeStatus::Timeout);
+        assert_eq!(
+            outcome.failure_classification,
+            Some(AgentTaskFailureClassification::Timeout)
+        );
+        assert!(outcome.artifacts.iter().any(|artifact| {
+            artifact.kind == "patch"
+                && artifact.path.as_deref() == Some(&patch_path.to_string_lossy())
+        }));
+        assert!(outcome.diagnostics.iter().any(|diagnostic| {
+            diagnostic.class == "completed_runtime_late_provider_race"
+                && diagnostic
+                    .data
+                    .get("actionable_patch")
+                    .and_then(Value::as_bool)
+                    == Some(false)
         }));
     }
 

--- a/src/core/agent_task_timeout_artifacts.rs
+++ b/src/core/agent_task_timeout_artifacts.rs
@@ -134,10 +134,16 @@ impl TimeoutArtifactDiscovery {
 pub(crate) fn merge_timeout_outcome(base: &mut AgentTaskOutcome, discovered: AgentTaskOutcome) {
     append_unique_artifacts(&mut base.artifacts, discovered.artifacts);
     append_unique_evidence_refs(&mut base.evidence_refs, discovered.evidence_refs);
-    if matches!(
-        discovered.status,
-        AgentTaskOutcomeStatus::Succeeded | AgentTaskOutcomeStatus::NoOp
-    ) {
+    if discovered
+        .metadata
+        .get("actionable")
+        .and_then(Value::as_bool)
+        != Some(false)
+        && matches!(
+            discovered.status,
+            AgentTaskOutcomeStatus::Succeeded | AgentTaskOutcomeStatus::NoOp
+        )
+    {
         base.status = discovered.status;
         base.failure_classification = discovered.failure_classification;
         base.summary = discovered.summary.or_else(|| base.summary.clone());
@@ -179,11 +185,30 @@ pub(crate) fn append_unique_evidence_refs(
 }
 
 pub(crate) fn is_actionable_patch_artifact(artifact: &AgentTaskArtifact) -> bool {
+    artifact_has_patch_shape(artifact)
+        && artifact_has_content(artifact)
+        && artifact.metadata.get("actionable").and_then(Value::as_bool) != Some(false)
+}
+
+fn artifact_has_patch_shape(artifact: &AgentTaskArtifact) -> bool {
     artifact.kind == "patch"
         || artifact.kind == "diff"
         || artifact.mime.as_deref() == Some("text/x-patch")
         || artifact.mime.as_deref() == Some("text/x-diff")
         || artifact.metadata.get("role").and_then(Value::as_str) == Some("patch")
+}
+
+fn artifact_has_content(artifact: &AgentTaskArtifact) -> bool {
+    if artifact.size_bytes == Some(0) {
+        return false;
+    }
+
+    artifact
+        .path
+        .as_deref()
+        .and_then(|path| fs::metadata(path).ok())
+        .map(|metadata| metadata.len() > 0)
+        .unwrap_or(true)
 }
 
 fn artifact_discovery_paths(request: &AgentTaskRequest) -> Vec<PathBuf> {
@@ -225,6 +250,7 @@ fn read_discovered_outcome(path: &Path, request: &AgentTaskRequest) -> Option<Ag
         return None;
     }
     let raw = fs::read_to_string(path).ok()?;
+    let value: Value = serde_json::from_str(&raw).ok()?;
     let mut outcome: AgentTaskOutcome = serde_json::from_str(&raw).ok()?;
     if outcome.task_id != request.task_id {
         return None;
@@ -232,7 +258,22 @@ fn read_discovered_outcome(path: &Path, request: &AgentTaskRequest) -> Option<Ag
     if outcome.schema != AGENT_TASK_OUTCOME_SCHEMA {
         outcome.schema = AGENT_TASK_OUTCOME_SCHEMA.to_string();
     }
+    if outcome.metadata.get("actionable").is_none() {
+        if let Some(actionable) = value.get("actionable").and_then(Value::as_bool) {
+            outcome.metadata = merge_outcome_metadata_actionable(outcome.metadata, actionable);
+        }
+    }
     Some(outcome)
+}
+
+fn merge_outcome_metadata_actionable(metadata: Value, actionable: bool) -> Value {
+    match metadata {
+        Value::Object(mut object) => {
+            object.insert("actionable".to_string(), Value::Bool(actionable));
+            Value::Object(object)
+        }
+        _ => serde_json::json!({ "actionable": actionable }),
+    }
 }
 
 fn artifact_kind_from_path(path: &Path) -> Option<String> {


### PR DESCRIPTION
## Summary
- Prevent timeout artifact reconciliation from treating zero-byte patch-shaped files as actionable patches.
- Preserve top-level `actionable:false` from discovered `agent-result.json` and keep timeout outcomes failed when the runtime explicitly reports no actionable patch.
- Add regression coverage for empty `patch.diff` and `mount-5.patch` artifacts with `actionable:false`.

Closes #3383.
Parent tracker: #3378.

## Verification
- `cargo fmt`
- `cargo test agent_task_scheduler::tests::timeout_with`
- `cargo test --lib commands::trace::tests::failed_trace_run_persists_observation_history`
- `cargo test --lib core::code_audit::report::report_test::test_compute_fixability_with_analysis`

## Test notes
- `cargo test --lib` is not clean in this checkout: under parallel execution it failed `commands::trace::tests::failed_trace_run_persists_observation_history` with `ExtensionNotFound("trace-fixture")`; the test passed when rerun alone.
- `cargo test --lib -- --test-threads=1` later failed `core::code_audit::report::report_test::test_compute_fixability_with_analysis`; that test also passed when rerun alone.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the timeout artifact classification fix, regression test, and PR description; Chris remains responsible for review and merge.