### PR TITLE
Fix timeout artifact classification for empty runtime bundles

### DIFF
--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -575,10 +575,11 @@ impl AgentTaskScheduleSupport {
         timeout_kind: &str,
     ) {
         let discovery = TimeoutArtifactDiscovery::discover(request);
-        if discovery.artifacts.is_empty()
-            && discovery.evidence_refs.is_empty()
-            && discovery.outcome.is_none()
-        {
+        let has_runtime_evidence = discovery.has_runtime_evidence();
+        outcome.diagnostics.extend(discovery.diagnostics);
+        if !has_runtime_evidence {
+            append_unique_artifacts(&mut outcome.artifacts, discovery.artifacts);
+            append_unique_evidence_refs(&mut outcome.evidence_refs, discovery.evidence_refs);
             outcome.diagnostics.push(AgentTaskDiagnostic {
                 class: timeout_kind.to_string(),
                 message:
@@ -1023,6 +1024,62 @@ mod tests {
                     .and_then(Value::as_bool)
                     == Some(true)
         }));
+    }
+
+    #[test]
+    fn timeout_with_empty_runtime_bundle_preserves_preflight_without_runtime_evidence() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact_root = temp.path().join("task-1-artifacts");
+        let empty_runtime = artifact_root.join("runtime-mpxgndju-f4v9yn");
+        fs::create_dir_all(&empty_runtime).expect("empty runtime bundle");
+        let preflight_path = artifact_root.join("homeboy-codebox-task-runner.json");
+        fs::write(&preflight_path, r#"{"runner":"codebox"}"#).expect("preflight evidence");
+
+        let scheduler = AgentTaskScheduler::new(RecordingExecutor::new(
+            HashMap::new(),
+            Duration::from_millis(250),
+        ));
+        let mut plan = plan_with_tasks(1);
+        plan.tasks[0].limits.timeout_ms = Some(1);
+        plan.tasks[0].metadata = json!({ "artifact_root": artifact_root });
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+        assert_eq!(aggregate.totals.timed_out, 1);
+        let outcome = &aggregate.outcomes[0];
+        assert_eq!(outcome.status, AgentTaskOutcomeStatus::Timeout);
+        assert!(!outcome
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.kind == "runtime_bundle"));
+        assert!(outcome.artifacts.iter().any(|artifact| {
+            artifact.kind == "preflight_evidence"
+                && artifact.path.as_deref() == Some(&preflight_path.to_string_lossy())
+        }));
+        assert!(outcome.diagnostics.iter().any(|diagnostic| {
+            diagnostic.class == "empty_runtime_bundle"
+                && diagnostic.data.get("path").and_then(Value::as_str)
+                    == Some(&empty_runtime.to_string_lossy())
+                && diagnostic
+                    .data
+                    .get("missing_expected_files")
+                    .and_then(Value::as_array)
+                    .is_some_and(|files| {
+                        files
+                            .iter()
+                            .any(|file| file.as_str() == Some("agent-result.json"))
+                    })
+        }));
+        assert!(outcome.diagnostics.iter().any(|diagnostic| {
+            diagnostic.class == "scheduler_timeout"
+                && diagnostic.message
+                    == "no completed runtime artifacts were discovered before timeout finalization"
+        }));
+        assert!(!outcome
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.class == "completed_runtime_late_provider_race"));
     }
 
     #[test]

--- a/src/core/agent_task_timeout_artifacts.rs
+++ b/src/core/agent_task_timeout_artifacts.rs
@@ -5,14 +5,26 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use crate::core::agent_task::{
-    AgentTaskArtifact, AgentTaskEvidenceRef, AgentTaskOutcome, AgentTaskOutcomeStatus,
-    AgentTaskRequest, AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA,
+    AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskOutcome,
+    AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_ARTIFACT_SCHEMA,
+    AGENT_TASK_OUTCOME_SCHEMA,
 };
+
+const EXPECTED_RUNTIME_EVIDENCE_FILES: &[&str] = &[
+    "transcript.json",
+    "agent-result.json",
+    "agent_result.json",
+    "patch.diff",
+    "patch.patch",
+    "*.log",
+    "*.txt",
+];
 
 #[derive(Default)]
 pub(crate) struct TimeoutArtifactDiscovery {
     pub(crate) artifacts: Vec<AgentTaskArtifact>,
     pub(crate) evidence_refs: Vec<AgentTaskEvidenceRef>,
+    pub(crate) diagnostics: Vec<AgentTaskDiagnostic>,
     pub(crate) outcome: Option<AgentTaskOutcome>,
 }
 
@@ -23,6 +35,10 @@ impl TimeoutArtifactDiscovery {
             discovery.scan_path(&path, request);
         }
         discovery
+    }
+
+    pub(crate) fn has_runtime_evidence(&self) -> bool {
+        self.runtime_evidence_count() > 0
     }
 
     fn scan_path(&mut self, path: &Path, request: &AgentTaskRequest) {
@@ -39,14 +55,32 @@ impl TimeoutArtifactDiscovery {
             return;
         }
 
-        self.record_directory(path);
+        let runtime_evidence_count_before = self.runtime_evidence_count();
         self.scan_directory_files(path, request, 0, &mut 0);
+        self.record_directory_if_useful(
+            path,
+            self.runtime_evidence_count() > runtime_evidence_count_before,
+        );
     }
 
-    fn record_directory(&mut self, path: &Path) {
+    fn runtime_evidence_count(&self) -> usize {
+        self.artifacts
+            .iter()
+            .filter(|artifact| artifact.kind != "preflight_evidence")
+            .count()
+            + self.evidence_refs.len()
+            + usize::from(self.outcome.is_some())
+    }
+
+    fn record_directory_if_useful(&mut self, path: &Path, has_runtime_evidence: bool) {
         let Some(id) = artifact_id_from_path(path) else {
             return;
         };
+        if !has_runtime_evidence {
+            self.record_empty_runtime_bundle(path);
+            return;
+        }
+
         self.artifacts.push(AgentTaskArtifact {
             schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
             id,
@@ -60,6 +94,20 @@ impl TimeoutArtifactDiscovery {
             size_bytes: None,
             sha256: None,
             metadata: serde_json::json!({ "discovered_from": "timeout_artifact_scan" }),
+        });
+    }
+
+    fn record_empty_runtime_bundle(&mut self, path: &Path) {
+        if !is_runtime_bundle_dir(path) {
+            return;
+        }
+        self.diagnostics.push(AgentTaskDiagnostic {
+            class: "empty_runtime_bundle".to_string(),
+            message: "timeout artifact scan found an empty runtime bundle directory".to_string(),
+            data: serde_json::json!({
+                "path": path.display().to_string(),
+                "missing_expected_files": EXPECTED_RUNTIME_EVIDENCE_FILES,
+            }),
         });
     }
 
@@ -125,7 +173,12 @@ impl TimeoutArtifactDiscovery {
             if child_metadata.is_file() {
                 self.record_file(&child, request);
             } else if child_metadata.is_dir() {
+                let runtime_evidence_count_before = self.runtime_evidence_count();
                 self.scan_directory_files(&child, request, depth + 1, visited);
+                self.record_directory_if_useful(
+                    &child,
+                    self.runtime_evidence_count() > runtime_evidence_count_before,
+                );
             }
         }
     }
@@ -255,6 +308,9 @@ fn artifact_kind_from_path(path: &Path) -> Option<String> {
     if file_name.contains("agent-result") || file_name.contains("agent_result") {
         return Some("agent_result".to_string());
     }
+    if file_name == "homeboy-codebox-task-runner.json" {
+        return Some("preflight_evidence".to_string());
+    }
 
     None
 }
@@ -273,6 +329,12 @@ fn artifact_id_from_path(path: &Path) -> Option<String> {
             })
             .collect(),
     )
+}
+
+fn is_runtime_bundle_dir(path: &Path) -> bool {
+    path.file_name()
+        .map(|name| name.to_string_lossy().to_ascii_lowercase())
+        .is_some_and(|name| name.starts_with("runtime-") || name.contains("runtime_bundle"))
 }
 
 fn mime_from_path(path: &Path) -> Option<String> {


### PR DESCRIPTION
## Summary
- Classify empty timeout-discovered runtime bundle directories with `empty_runtime_bundle` diagnostics instead of preserving them as runtime evidence.
- Preserve `homeboy-codebox-task-runner.json` as `preflight_evidence` so preflight artifacts remain visible without triggering completed-runtime classification.
- Add regression coverage for an artifact root containing preflight evidence plus an empty nested `runtime-*` directory.

Fixes #3389.

## Verification
- `cargo test -q timeout_with_`
- `cargo test -q core::agent_task_scheduler::tests::`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafting the timeout artifact classification fix, regression test, and PR description; Chris remains responsible for review and merge.