### PR TITLE
agent-task: reject empty patch artifacts

### DIFF
--- a/src/core/agent_task_promotion.rs
+++ b/src/core/agent_task_promotion.rs
@@ -8,6 +8,7 @@ use crate::core::agent_task::{
     AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_OUTCOME_SCHEMA,
 };
 use crate::core::agent_task_scheduler::{AgentTaskAggregate, AGENT_TASK_AGGREGATE_SCHEMA};
+use crate::core::agent_task_timeout_artifacts::is_actionable_patch_artifact;
 use crate::core::{Error, Result};
 
 pub const AGENT_TASK_PROMOTION_REPORT_SCHEMA: &str = "homeboy/agent-task-promotion-report/v1";
@@ -226,7 +227,7 @@ fn select_patch_artifact(
         .artifacts
         .iter()
         .filter(|artifact| artifact_id.is_none_or(|expected| artifact.id == expected))
-        .filter(|artifact| is_patch_artifact(artifact))
+        .filter(|artifact| is_actionable_patch_artifact(artifact))
         .cloned()
         .collect();
 
@@ -234,7 +235,7 @@ fn select_patch_artifact(
         1 => Ok(artifacts.into_iter().next().unwrap()),
         0 => Err(Error::validation_invalid_argument(
             "artifact_id",
-            "no matching patch artifact was found",
+            "no matching non-empty patch artifact was found; inspect the agent result or transcript for diagnosis",
             None,
             None,
         )),
@@ -245,14 +246,6 @@ fn select_patch_artifact(
             None,
         )),
     }
-}
-
-fn is_patch_artifact(artifact: &AgentTaskArtifact) -> bool {
-    artifact.kind == "patch"
-        || artifact.kind == "diff"
-        || artifact.mime.as_deref() == Some("text/x-patch")
-        || artifact.mime.as_deref() == Some("text/x-diff")
-        || artifact.metadata.get("role").and_then(Value::as_str) == Some("patch")
 }
 
 fn resolve_artifact_path(
@@ -507,6 +500,41 @@ mod tests {
         let err = validate_patch("\n\t").expect_err("empty patch rejected");
 
         assert!(err.message.contains("empty patch"));
+    }
+
+    #[test]
+    fn select_patch_artifact_rejects_empty_patch_metadata() {
+        let outcome = AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: "task-1".to_string(),
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: None,
+            failure_classification: None,
+            artifacts: vec![AgentTaskArtifact {
+                schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                id: "patch".to_string(),
+                kind: "patch".to_string(),
+                name: Some("patch.diff".to_string()),
+                path: Some("patch.diff".to_string()),
+                url: None,
+                mime: Some("text/x-patch".to_string()),
+                size_bytes: Some(0),
+                sha256: Some(
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_string(),
+                ),
+                metadata: serde_json::json!({ "role": "patch" }),
+            }],
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        };
+
+        let err = select_patch_artifact(&outcome, None).expect_err("empty patch rejected");
+
+        assert!(err.message.contains("non-empty patch artifact"));
+        assert!(err.message.contains("agent result or transcript"));
     }
 
     #[test]

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -19,7 +19,7 @@ pub use crate::core::agent_task_schedule::{
 use crate::core::agent_task_timeout::timeout_with_grace;
 use crate::core::agent_task_timeout_artifacts::{
     append_unique_artifacts, append_unique_evidence_refs, is_actionable_patch_artifact,
-    merge_timeout_outcome, TimeoutArtifactDiscovery,
+    is_empty_patch_artifact, merge_timeout_outcome, TimeoutArtifactDiscovery,
 };
 
 pub trait AgentTaskExecutorAdapter: Send + Sync + 'static {
@@ -604,6 +604,15 @@ impl AgentTaskScheduleSupport {
                 "runtime completed with an actionable artifact before timeout finalization"
                     .to_string(),
             );
+        } else if outcome.status == AgentTaskOutcomeStatus::Succeeded
+            && outcome.artifacts.iter().any(is_empty_patch_artifact)
+        {
+            outcome.status = AgentTaskOutcomeStatus::NoOp;
+            outcome.failure_classification = None;
+            outcome.summary = Some(
+                "runtime completed with an empty patch artifact before timeout finalization"
+                    .to_string(),
+            );
         }
 
         outcome.diagnostics.push(AgentTaskDiagnostic {
@@ -1022,6 +1031,77 @@ mod tests {
                     .get("actionable_patch")
                     .and_then(Value::as_bool)
                     == Some(true)
+        }));
+    }
+
+    #[test]
+    fn timeout_with_empty_patch_artifact_is_not_actionable() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact_root = temp.path().join("task-1-artifacts");
+        fs::create_dir_all(&artifact_root).expect("artifact root");
+        let patch_path = artifact_root.join("patch.diff");
+        fs::write(&patch_path, "").expect("empty patch");
+        fs::write(artifact_root.join("transcript.log"), "runtime completed").expect("log");
+        fs::write(
+            artifact_root.join("agent-result.json"),
+            serde_json::to_string(&AgentTaskOutcome {
+                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: "task-1".to_string(),
+                status: AgentTaskOutcomeStatus::Succeeded,
+                summary: Some("patch ready".to_string()),
+                failure_classification: None,
+                artifacts: vec![AgentTaskArtifact {
+                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                    id: "patch".to_string(),
+                    kind: "patch".to_string(),
+                    name: Some("patch.diff".to_string()),
+                    path: Some(patch_path.display().to_string()),
+                    url: None,
+                    mime: Some("text/x-patch".to_string()),
+                    size_bytes: Some(0),
+                    sha256: Some(
+                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                            .to_string(),
+                    ),
+                    metadata: json!({ "role": "patch" }),
+                }],
+                evidence_refs: vec![AgentTaskEvidenceRef {
+                    kind: "runtime_bundle".to_string(),
+                    uri: artifact_root.display().to_string(),
+                    label: Some("runtime bundle".to_string()),
+                }],
+                diagnostics: Vec::new(),
+                workflow: None,
+                follow_up: None,
+                metadata: json!({}),
+            })
+            .expect("agent result json"),
+        )
+        .expect("agent result");
+
+        let scheduler = AgentTaskScheduler::new(RecordingExecutor::new(
+            HashMap::new(),
+            Duration::from_millis(250),
+        ));
+        let mut plan = plan_with_tasks(1);
+        plan.tasks[0].limits.timeout_ms = Some(1);
+        plan.tasks[0].metadata = json!({ "artifact_root": artifact_root });
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(aggregate.totals.succeeded, 1);
+        assert_eq!(aggregate.totals.timed_out, 0);
+        let outcome = &aggregate.outcomes[0];
+        assert_eq!(outcome.status, AgentTaskOutcomeStatus::NoOp);
+        assert!(outcome.summary.as_deref().unwrap().contains("empty patch"));
+        assert!(outcome.diagnostics.iter().any(|diagnostic| {
+            diagnostic.class == "completed_runtime_late_provider_race"
+                && diagnostic
+                    .data
+                    .get("actionable_patch")
+                    .and_then(Value::as_bool)
+                    == Some(false)
         }));
     }
 

--- a/src/core/agent_task_timeout_artifacts.rs
+++ b/src/core/agent_task_timeout_artifacts.rs
@@ -9,6 +9,8 @@ use crate::core::agent_task::{
     AgentTaskRequest, AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA,
 };
 
+const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
 #[derive(Default)]
 pub(crate) struct TimeoutArtifactDiscovery {
     pub(crate) artifacts: Vec<AgentTaskArtifact>,
@@ -179,6 +181,17 @@ pub(crate) fn append_unique_evidence_refs(
 }
 
 pub(crate) fn is_actionable_patch_artifact(artifact: &AgentTaskArtifact) -> bool {
+    is_patch_artifact(artifact) && !is_empty_patch_artifact(artifact)
+}
+
+pub(crate) fn is_empty_patch_artifact(artifact: &AgentTaskArtifact) -> bool {
+    is_patch_artifact(artifact)
+        && (artifact.size_bytes == Some(0)
+            || artifact.sha256.as_deref() == Some(EMPTY_SHA256)
+            || artifact.sha256.as_deref() == Some(""))
+}
+
+fn is_patch_artifact(artifact: &AgentTaskArtifact) -> bool {
     artifact.kind == "patch"
         || artifact.kind == "diff"
         || artifact.mime.as_deref() == Some("text/x-patch")


### PR DESCRIPTION
## Summary
- Treat patch/diff artifacts with size `0`, empty SHA-256, or empty SHA metadata as non-actionable.
- Classify completed timeout artifacts with only empty patches as `no_op` instead of actionable success.
- Reject promotion when no non-empty patch artifact is available, with guidance to inspect the agent result or transcript.

Closes #3390.

## Verification
- `cargo test timeout_with_empty_patch_artifact_is_not_actionable`
- `cargo test select_patch_artifact_rejects_empty_patch_metadata`
- `cargo test provider_can_return_timeout_payload_during_wrapper_grace`
- `cargo test agent_task`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the zero-byte patch artifact classification/promotion fix and drafting regression coverage; Chris remains responsible for review and validation.