### PR TITLE
feat(agent-task): add deterministic smoke fixture

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -1,0 +1,66 @@
+# agent-task
+
+Run provider-neutral task plans through Homeboy's durable agent-task lifecycle.
+
+## Deterministic Smoke Gate
+
+Issue #3392 is covered by a no-secret fixture plan at
+`tests/fixtures/agent_task_smoke_plan.json`. It exercises the operator path
+without Codebox, Codex, chat state, or long-running external services.
+
+Run it from a disposable Homeboy worktree:
+
+```bash
+run_id="agent-task-smoke-$(date +%s)"
+target_worktree="homeboy@fix-3392-agent-task-smoke"
+
+homeboy agent-task submit \
+  --plan @tests/fixtures/agent_task_smoke_plan.json \
+  --run-id "$run_id"
+
+homeboy agent-task status "$run_id"
+homeboy agent-task logs "$run_id"
+homeboy agent-task run "$run_id"
+homeboy agent-task status "$run_id"
+homeboy agent-task artifacts "$run_id"
+homeboy agent-task promote "$run_id" \
+  --to-worktree "$target_worktree" \
+  --dry-run
+```
+
+The gate passes when:
+
+- `submit` returns a durable `run_id` immediately with `state: "queued"`.
+- Pre-run `status` and `logs` show the queued fixture cell.
+- `run` exits successfully and writes the aggregate lifecycle record.
+- Post-run `status` shows `state: "succeeded"`.
+- `artifacts` lists a patch artifact, an agent result artifact, and a transcript evidence ref.
+- `promote <run-id> --dry-run` resolves the aggregate from the durable run id and reports the selected non-empty patch plus changed files without requiring the operator to look up `aggregate_path` manually.
+
+## Fixture Backend
+
+The built-in `fixture` backend is intentionally narrow. It exists for smoke
+proofs and unit tests, not production task execution. A successful fixture cell
+writes:
+
+- `changes.patch` as a non-empty unified diff.
+- `agent-result.json` as a structured `homeboy/agent-task-outcome/v1` artifact.
+- `transcript.log` as transcript evidence.
+
+Useful fixture `executor.config` fields:
+
+- `artifact_root`: directory where fixture artifacts are written.
+- `changed_file`: diff path recorded in the generated patch.
+- `mode`: omit or set to `success`; set to `empty_patch` or `empty_runtime_bundle` for classification checks.
+
+## Failure Classifications
+
+The deterministic smoke and existing provider path expose these failure classes:
+
+| Case | Diagnostic/classification |
+| --- | --- |
+| no-op or empty patch | `agent_task.fixture_empty_patch` plus promotion rejecting `promotion refuses an empty patch artifact` |
+| provider timeout | `agent_task.provider_timeout`, `failure_classification: "timeout"` |
+| missing secrets/preflight | `agent_task.secret_env_missing`, `failure_classification: "invalid_input"` |
+| empty runtime bundle | `agent_task.fixture_empty_runtime_bundle` |
+| stale/non-terminal status | `status` annotates running records with `metadata.stale_running` and `metadata.stale_running_reason` |

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -164,8 +164,7 @@ fn artifacts(args: StatusArgs) -> CmdResult<Value> {
 }
 
 fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
-    let raw = config::read_json_spec_to_string(&args.source)?;
-    let source_path = source_spec_path(&args.source);
+    let (raw, source_path) = read_promotion_source(&args.source)?;
     let report = promote(AgentTaskPromotionOptions {
         source: raw,
         source_path,
@@ -177,6 +176,19 @@ fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
     })?;
 
     Ok((serde_json::to_value(report).unwrap_or(Value::Null), 0))
+}
+
+fn read_promotion_source(
+    spec: &str,
+) -> homeboy::core::Result<(String, Option<std::path::PathBuf>)> {
+    if let Ok(source) = agent_task_lifecycle::aggregate_source(spec) {
+        return Ok((source.raw, Some(source.path)));
+    }
+
+    Ok((
+        config::read_json_spec_to_string(spec)?,
+        source_spec_path(spec),
+    ))
 }
 
 fn source_spec_path(spec: &str) -> Option<std::path::PathBuf> {

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -203,8 +203,8 @@ fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
 fn read_promotion_source(
     spec: &str,
 ) -> homeboy::core::Result<(String, Option<std::path::PathBuf>)> {
-    if let Ok(source) = agent_task_lifecycle::aggregate_source(spec) {
-        return Ok((source.raw, Some(source.path)));
+    if let Ok((raw, path)) = agent_task_lifecycle::aggregate_source(spec) {
+        return Ok((raw, Some(path)));
     }
 
     Ok((

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -136,12 +136,6 @@ pub struct AgentTaskRunArtifacts {
     pub evidence_refs: Vec<AgentTaskEvidenceRef>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AgentTaskRunAggregateSource {
-    pub raw: String,
-    pub path: PathBuf,
-}
-
 pub fn submit_plan(
     plan: &AgentTaskPlan,
     requested_run_id: Option<&str>,
@@ -287,7 +281,7 @@ pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
     })
 }
 
-pub fn aggregate_source(run_id: &str) -> Result<AgentTaskRunAggregateSource> {
+pub fn aggregate_source(run_id: &str) -> Result<(String, PathBuf)> {
     let record = store::read_record(&sanitize_run_id(run_id))?;
     let path = record.aggregate_path.ok_or_else(|| {
         Error::validation_invalid_argument(
@@ -303,7 +297,7 @@ pub fn aggregate_source(run_id: &str) -> Result<AgentTaskRunAggregateSource> {
     let path = PathBuf::from(path);
     let raw = std::fs::read_to_string(&path)
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
-    Ok(AgentTaskRunAggregateSource { raw, path })
+    Ok((raw, path))
 }
 
 fn aggregate_artifacts(aggregate: Option<&AgentTaskAggregate>) -> Vec<AgentTaskArtifact> {
@@ -637,10 +631,10 @@ mod tests {
             };
             record_completed_run(&plan, &aggregate, Some("run-source")).expect("recorded");
 
-            let source = aggregate_source("run-source").expect("aggregate source");
+            let (raw, path) = aggregate_source("run-source").expect("aggregate source");
 
-            assert!(source.path.ends_with("aggregate.json"));
-            assert!(source.raw.contains("task-a"));
+            assert!(path.ends_with("aggregate.json"));
+            assert!(raw.contains("task-a"));
         });
     }
 

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::path::PathBuf;
 use uuid::Uuid;
 
 use crate::core::agent_task::{AgentTaskArtifact, AgentTaskEvidenceRef, AgentTaskOutcome};
@@ -133,6 +134,12 @@ pub struct AgentTaskRunArtifacts {
     pub run_id: String,
     pub artifacts: Vec<AgentTaskArtifact>,
     pub evidence_refs: Vec<AgentTaskEvidenceRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentTaskRunAggregateSource {
+    pub raw: String,
+    pub path: PathBuf,
 }
 
 pub fn submit_plan(
@@ -278,6 +285,25 @@ pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
         artifacts: aggregate_artifacts(aggregate.as_ref()),
         evidence_refs: aggregate_evidence_refs(aggregate.as_ref()),
     })
+}
+
+pub fn aggregate_source(run_id: &str) -> Result<AgentTaskRunAggregateSource> {
+    let record = store::read_record(&sanitize_run_id(run_id))?;
+    let path = record.aggregate_path.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "run_id",
+            format!(
+                "agent-task run '{}' has no aggregate artifact yet",
+                record.run_id
+            ),
+            Some(record.run_id),
+            None,
+        )
+    })?;
+    let path = PathBuf::from(path);
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    Ok(AgentTaskRunAggregateSource { raw, path })
 }
 
 fn aggregate_artifacts(aggregate: Option<&AgentTaskAggregate>) -> Vec<AgentTaskArtifact> {
@@ -577,6 +603,44 @@ mod tests {
                 loaded.metadata["stale_running_reason"],
                 "missing_runner_pid"
             );
+        });
+    }
+
+    #[test]
+    fn aggregate_source_loads_completed_run_without_path_spelunking() {
+        with_temp_home(|| {
+            let plan = test_plan();
+            let aggregate = AgentTaskAggregate {
+                schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+                plan_id: plan.plan_id.clone(),
+                status: AgentTaskAggregateStatus::Succeeded,
+                totals: AgentTaskAggregateTotals {
+                    queued: 1,
+                    succeeded: 1,
+                    ..AgentTaskAggregateTotals::default()
+                },
+                outcomes: vec![AgentTaskOutcome {
+                    schema: crate::core::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: "task-a".to_string(),
+                    status: crate::core::agent_task::AgentTaskOutcomeStatus::Succeeded,
+                    summary: Some("ok".to_string()),
+                    failure_classification: None,
+                    artifacts: Vec::new(),
+                    evidence_refs: Vec::new(),
+                    diagnostics: Vec::new(),
+                    workflow: None,
+                    follow_up: None,
+                    metadata: Value::Null,
+                }],
+                events: Vec::new(),
+                queue: Default::default(),
+            };
+            record_completed_run(&plan, &aggregate, Some("run-source")).expect("recorded");
+
+            let source = aggregate_source("run-source").expect("aggregate source");
+
+            assert!(source.path.ends_with("aggregate.json"));
+            assert!(source.raw.contains("task-a"));
         });
     }
 

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -5,8 +6,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::core::agent_task::{
-    AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskFailureClassification, AgentTaskOutcome,
-    AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_OUTCOME_SCHEMA,
+    AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskFailureClassification,
+    AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_ARTIFACT_SCHEMA,
+    AGENT_TASK_OUTCOME_SCHEMA,
 };
 use crate::core::agent_task_scheduler::{AgentTaskExecutionContext, AgentTaskExecutorAdapter};
 use crate::core::agent_task_secrets::{resolve_secret_env, AgentTaskSecretResolutionError};
@@ -59,6 +61,10 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
         request: AgentTaskRequest,
         _context: AgentTaskExecutionContext,
     ) -> AgentTaskOutcome {
+        if request.executor.backend == "fixture" {
+            return run_fixture_provider(&request);
+        }
+
         let Some(provider) = select_provider(&self.providers, &request) else {
             return failure_outcome(
                 &request,
@@ -96,6 +102,174 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
         }
 
         run_provider_command(&request, provider)
+    }
+}
+
+fn run_fixture_provider(request: &AgentTaskRequest) -> AgentTaskOutcome {
+    let mode = request
+        .executor
+        .config
+        .get("mode")
+        .and_then(Value::as_str)
+        .unwrap_or("success");
+    let artifact_root = fixture_artifact_root(request);
+    if let Err(error) = std::fs::create_dir_all(&artifact_root) {
+        return failure_outcome(
+            request,
+            AgentTaskOutcomeStatus::ProviderError,
+            AgentTaskFailureClassification::Provider,
+            "agent_task.fixture_artifact_root_failed",
+            error.to_string(),
+            json!({ "artifact_root": artifact_root.display().to_string() }),
+        );
+    }
+
+    match mode {
+        "empty_patch" => fixture_empty_patch_outcome(request, &artifact_root),
+        "empty_runtime_bundle" => fixture_empty_runtime_bundle_outcome(request, &artifact_root),
+        _ => fixture_success_outcome(request, &artifact_root),
+    }
+}
+
+fn fixture_artifact_root(request: &AgentTaskRequest) -> PathBuf {
+    request
+        .executor
+        .config
+        .get("artifact_root")
+        .and_then(Value::as_str)
+        .map(|path| {
+            let path = PathBuf::from(path);
+            if path.is_absolute() {
+                path
+            } else {
+                std::env::current_dir()
+                    .unwrap_or_else(|_| PathBuf::from("."))
+                    .join(path)
+            }
+        })
+        .unwrap_or_else(|| {
+            std::env::temp_dir().join(format!("homeboy-agent-task-fixture-{}", request.task_id))
+        })
+}
+
+fn fixture_success_outcome(
+    request: &AgentTaskRequest,
+    artifact_root: &PathBuf,
+) -> AgentTaskOutcome {
+    let changed_file = request
+        .executor
+        .config
+        .get("changed_file")
+        .and_then(Value::as_str)
+        .unwrap_or("docs/agent-task-smoke.md");
+    let patch_path = artifact_root.join("changes.patch");
+    let transcript_path = artifact_root.join("transcript.log");
+    let result_path = artifact_root.join("agent-result.json");
+    let patch = format!(
+        "diff --git a/{changed_file} b/{changed_file}\n--- a/{changed_file}\n+++ b/{changed_file}\n@@ -1 +1 @@\n-before\n+after\n"
+    );
+    let _ = std::fs::write(&patch_path, patch);
+    let _ = std::fs::write(
+        &transcript_path,
+        "fixture provider completed successfully\n",
+    );
+
+    let mut outcome = AgentTaskOutcome {
+        schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+        task_id: request.task_id.clone(),
+        status: AgentTaskOutcomeStatus::Succeeded,
+        summary: Some("fixture provider wrote deterministic smoke artifacts".to_string()),
+        failure_classification: None,
+        artifacts: vec![
+            fixture_artifact("patch", "patch", &patch_path, Some("text/x-patch")),
+            fixture_artifact(
+                "agent-result",
+                "agent_result",
+                &result_path,
+                Some("application/json"),
+            ),
+        ],
+        evidence_refs: vec![AgentTaskEvidenceRef {
+            kind: "transcript".to_string(),
+            uri: transcript_path.display().to_string(),
+            label: Some("fixture transcript".to_string()),
+        }],
+        diagnostics: vec![AgentTaskDiagnostic {
+            class: "agent_task.fixture_success".to_string(),
+            message: "fixture provider generated patch, transcript, and result artifacts"
+                .to_string(),
+            data: json!({ "artifact_root": artifact_root.display().to_string() }),
+        }],
+        workflow: None,
+        follow_up: None,
+        metadata: json!({ "fixture_mode": "success" }),
+    };
+    let _ = std::fs::write(
+        &result_path,
+        serde_json::to_string_pretty(&outcome).unwrap_or_else(|_| "{}".to_string()),
+    );
+    outcome.artifacts[1] = fixture_artifact(
+        "agent-result",
+        "agent_result",
+        &result_path,
+        Some("application/json"),
+    );
+    outcome
+}
+
+fn fixture_empty_patch_outcome(
+    request: &AgentTaskRequest,
+    artifact_root: &PathBuf,
+) -> AgentTaskOutcome {
+    let patch_path = artifact_root.join("empty.patch");
+    let _ = std::fs::write(&patch_path, "");
+    failure_outcome(
+        request,
+        AgentTaskOutcomeStatus::NoOp,
+        AgentTaskFailureClassification::InvalidInput,
+        "agent_task.fixture_empty_patch",
+        "fixture produced an empty patch; promotion should reject it".to_string(),
+        json!({ "patch_path": patch_path.display().to_string() }),
+    )
+}
+
+fn fixture_empty_runtime_bundle_outcome(
+    request: &AgentTaskRequest,
+    artifact_root: &PathBuf,
+) -> AgentTaskOutcome {
+    let bundle_path = artifact_root.join("runtime-bundle");
+    let _ = std::fs::create_dir_all(&bundle_path);
+    let mut outcome = failure_outcome(
+        request,
+        AgentTaskOutcomeStatus::ProviderError,
+        AgentTaskFailureClassification::Provider,
+        "agent_task.fixture_empty_runtime_bundle",
+        "fixture produced an empty runtime bundle".to_string(),
+        json!({ "bundle_path": bundle_path.display().to_string() }),
+    );
+    outcome.artifacts.push(fixture_artifact(
+        "runtime-bundle",
+        "runtime_bundle",
+        &bundle_path,
+        None,
+    ));
+    outcome
+}
+
+fn fixture_artifact(id: &str, kind: &str, path: &PathBuf, mime: Option<&str>) -> AgentTaskArtifact {
+    AgentTaskArtifact {
+        schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+        id: id.to_string(),
+        kind: kind.to_string(),
+        name: path
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string()),
+        path: Some(path.display().to_string()),
+        url: None,
+        mime: mime.map(str::to_string),
+        size_bytes: std::fs::metadata(path).ok().map(|metadata| metadata.len()),
+        sha256: None,
+        metadata: json!({ "fixture": true }),
     }
 }
 
@@ -550,5 +724,58 @@ mod tests {
             aggregate.outcomes[0].diagnostics[0].data["missing_secret_env"],
             json!([secret_name])
         );
+    }
+
+    #[test]
+    fn fixture_backend_produces_deterministic_smoke_artifacts() {
+        let artifact_root = tempfile::tempdir().expect("artifact root");
+        let (mut request, _provider) = request("task-fixture", "unused".to_string());
+        request.executor.backend = "fixture".to_string();
+        request.executor.config = json!({
+            "artifact_root": artifact_root.path().display().to_string(),
+            "changed_file": "docs/smoke.md"
+        });
+        let scheduler = AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::default());
+
+        let aggregate = scheduler.run(AgentTaskPlan::new("plan-fixture", vec![request]));
+
+        assert_eq!(aggregate.totals.succeeded, 1);
+        let outcome = &aggregate.outcomes[0];
+        assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
+        assert!(outcome.artifacts.iter().any(
+            |artifact| artifact.kind == "patch" && artifact.size_bytes.unwrap_or_default() > 0
+        ));
+        assert!(outcome
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.kind == "agent_result"));
+        assert!(outcome
+            .evidence_refs
+            .iter()
+            .any(|evidence| evidence.kind == "transcript"));
+    }
+
+    #[test]
+    fn fixture_backend_classifies_empty_runtime_bundle() {
+        let artifact_root = tempfile::tempdir().expect("artifact root");
+        let (mut request, _provider) = request("task-empty-runtime", "unused".to_string());
+        request.executor.backend = "fixture".to_string();
+        request.executor.config = json!({
+            "artifact_root": artifact_root.path().display().to_string(),
+            "mode": "empty_runtime_bundle"
+        });
+        let scheduler = AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::default());
+
+        let aggregate = scheduler.run(AgentTaskPlan::new("plan-empty-runtime", vec![request]));
+
+        assert_eq!(aggregate.totals.failed, 1);
+        assert_eq!(
+            aggregate.outcomes[0].diagnostics[0].class,
+            "agent_task.fixture_empty_runtime_bundle"
+        );
+        assert!(aggregate.outcomes[0]
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.kind == "runtime_bundle"));
     }
 }

--- a/tests/fixtures/agent_task_smoke_plan.json
+++ b/tests/fixtures/agent_task_smoke_plan.json
@@ -1,0 +1,40 @@
+{
+  "schema": "homeboy/agent-task-plan/v1",
+  "plan_id": "agent-task-smoke-fixture",
+  "tasks": [
+    {
+      "schema": "homeboy/agent-task-request/v1",
+      "task_id": "docs-smoke-cell-1",
+      "executor": {
+        "backend": "fixture",
+        "config": {
+          "artifact_root": "target/agent-task-smoke/docs-smoke-cell-1",
+          "changed_file": "docs/agent-task-smoke.md"
+        }
+      },
+      "instructions": "Generate a deterministic docs-only patch for the agent-task smoke gate.",
+      "workspace": {
+        "mode": "existing"
+      },
+      "policy": {
+        "read": "allow",
+        "write": "patch_only",
+        "apply": "dry_run_only"
+      },
+      "expected_artifacts": [
+        "target/agent-task-smoke/docs-smoke-cell-1"
+      ],
+      "metadata": {
+        "smoke": "submit-run-artifacts-promote",
+        "issue": "https://github.com/Extra-Chill/homeboy/issues/3392"
+      }
+    }
+  ],
+  "options": {
+    "max_concurrency": 1,
+    "max_queue_depth": 1
+  },
+  "metadata": {
+    "purpose": "deterministic agent-task submit/run/artifacts/promote smoke fixture"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a built-in `fixture` agent-task backend for deterministic no-secret smoke runs that produce patch, agent-result, transcript, and diagnostics artifacts.
- Lets `agent-task promote <run-id> --dry-run` resolve the completed durable aggregate directly, removing manual `aggregate_path` lookup from the smoke gate.
- Adds a committed smoke fixture plan plus operator docs for the `submit -> status/logs -> run -> artifacts -> promote --dry-run` acceptance path and failure classifications.

## Verification
- `cargo test agent_task_provider`
- `cargo test agent_task_lifecycle`
- `cargo test agent_task_promotion`
- `cargo test command_surface`
- Full fixture smoke chain:
  `./target/debug/homeboy agent-task submit --plan @tests/fixtures/agent_task_smoke_plan.json --run-id <run_id> && ./target/debug/homeboy agent-task status <run_id> && ./target/debug/homeboy agent-task logs <run_id> && ./target/debug/homeboy agent-task run <run_id> && ./target/debug/homeboy agent-task status <run_id> && ./target/debug/homeboy agent-task artifacts <run_id> && ./target/debug/homeboy agent-task promote <run_id> --to-worktree homeboy@fix-3392-agent-task-smoke --dry-run`

Closes #3392.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the deterministic agent-task fixture backend, durable run-id promotion lookup, docs, fixture plan, and targeted verification.