### PR TITLE
fix(agent-task): reconcile terminal status

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -207,3 +207,90 @@ fn read_plan(spec: &str) -> homeboy::core::Result<AgentTaskPlan> {
         )
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy::core::agent_task::{
+        AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
+        AGENT_TASK_REQUEST_SCHEMA,
+    };
+    use homeboy::core::agent_task_lifecycle::{AgentTaskRunRecord, AgentTaskRunState};
+    use homeboy::core::agent_task_scheduler::AgentTaskState;
+    use serde_json::Value;
+    use std::sync::{Mutex, OnceLock};
+
+    #[test]
+    fn submit_run_status_reports_terminal_state() {
+        with_temp_home(|| {
+            let plan = AgentTaskPlan::new(
+                "plan-cli-terminal",
+                vec![AgentTaskRequest {
+                    schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+                    task_id: "task-cli-terminal".to_string(),
+                    group_key: None,
+                    parent_plan_id: None,
+                    executor: AgentTaskExecutor {
+                        backend: "missing-provider-test".to_string(),
+                        selector: None,
+                        required_capabilities: Vec::new(),
+                        secret_env: Vec::new(),
+                        model: None,
+                        config: Value::Null,
+                    },
+                    instructions: "exercise durable terminal status".to_string(),
+                    inputs: Value::Null,
+                    source_refs: Vec::new(),
+                    workspace: AgentTaskWorkspace::default(),
+                    policy: AgentTaskPolicy::default(),
+                    limits: AgentTaskLimits::default(),
+                    expected_artifacts: Vec::new(),
+                    metadata: Value::Null,
+                }],
+            );
+            let plan_file = tempfile::NamedTempFile::new().expect("plan file");
+            std::fs::write(
+                plan_file.path(),
+                serde_json::to_string(&plan).expect("plan json"),
+            )
+            .expect("write plan");
+            let plan_path = format!("@{}", plan_file.path().display());
+
+            submit(SubmitArgs {
+                plan: plan_path,
+                run_id: Some("run-cli-terminal".to_string()),
+            })
+            .expect("submitted");
+            let (_, run_exit_code) = run_submitted(StatusArgs {
+                run_id: "run-cli-terminal".to_string(),
+            })
+            .expect("run completed");
+            let (status_json, status_exit_code) = status(StatusArgs {
+                run_id: "run-cli-terminal".to_string(),
+            })
+            .expect("status loaded");
+            let record: AgentTaskRunRecord = serde_json::from_value(status_json).expect("record");
+
+            assert_eq!(run_exit_code, 1);
+            assert_eq!(status_exit_code, 0);
+            assert_eq!(record.state, AgentTaskRunState::Failed);
+            assert_eq!(record.tasks[0].state, AgentTaskState::Failed);
+            assert_eq!(record.totals.expect("totals").failed, 1);
+        });
+    }
+
+    fn with_temp_home(run: impl FnOnce()) {
+        let lock = test_home_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let home = tempfile::tempdir().expect("temp home");
+        std::env::set_var("HOME", home.path());
+        run();
+        drop(lock);
+    }
+
+    fn test_home_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+}

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -30,6 +30,8 @@ pub struct AgentTaskRunRecord {
     pub plan_path: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub aggregate_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub totals: Option<crate::core::agent_task_scheduler::AgentTaskAggregateTotals>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tasks: Vec<AgentTaskRunTask>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -153,6 +155,7 @@ pub fn submit_plan(
         updated_at: None,
         plan_path: plan_path.display().to_string(),
         aggregate_path: None,
+        totals: None,
         tasks: plan.tasks.iter().map(queued_task).collect(),
         artifact_refs: Vec::new(),
         metadata: json!({
@@ -240,19 +243,62 @@ fn record_aggregate(
     aggregate: &AgentTaskAggregate,
 ) -> Result<AgentTaskRunRecord> {
     let aggregate_path = store::write_aggregate(&record.run_id, aggregate)?;
-    record.state = run_state_for_aggregate(aggregate);
-    record.updated_at = Some(now_timestamp());
-    record.aggregate_path = Some(aggregate_path.display().to_string());
-    record.tasks = tasks_for_aggregate(plan, aggregate);
-    record.artifact_refs = artifact_refs_for_outcomes(&aggregate.outcomes);
+    apply_aggregate_to_record(
+        record,
+        plan,
+        aggregate,
+        aggregate_path.display().to_string(),
+    );
     store::write_record(record)?;
     Ok(record.clone())
 }
 
+fn apply_aggregate_to_record(
+    record: &mut AgentTaskRunRecord,
+    plan: &AgentTaskPlan,
+    aggregate: &AgentTaskAggregate,
+    aggregate_path: String,
+) {
+    record.state = run_state_for_aggregate(aggregate);
+    record.updated_at = Some(now_timestamp());
+    record.aggregate_path = Some(aggregate_path);
+    record.totals = Some(aggregate.totals.clone());
+    record.tasks = tasks_for_aggregate(plan, aggregate);
+    record.artifact_refs = artifact_refs_for_outcomes(&aggregate.outcomes);
+}
+
 pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    reconcile_record_from_aggregate(&mut record);
     record.annotate_stale_running();
     Ok(record)
+}
+
+fn reconcile_record_from_aggregate(record: &mut AgentTaskRunRecord) {
+    let Ok(aggregate) = store::read_aggregate(&record.run_id) else {
+        return;
+    };
+    let Ok(plan) = store::read_plan_path(&record.plan_path) else {
+        return;
+    };
+
+    let aggregate_path = store::aggregate_path(&record.run_id)
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| "aggregate.json".to_string());
+    let mut reconciled = record.clone();
+    apply_aggregate_to_record(&mut reconciled, &plan, &aggregate, aggregate_path);
+
+    if &reconciled == record {
+        return;
+    }
+
+    if let Err(error) = store::write_record(&reconciled) {
+        reconciled
+            .ensure_metadata_object()
+            .insert("finalization_error".to_string(), json!(error.message));
+    }
+
+    *record = reconciled;
 }
 
 pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
@@ -517,46 +563,43 @@ mod tests {
 
             let loaded_plan = load_plan("run-execute").expect("plan loaded");
             let running = mark_running("run-execute").expect("marked running");
-            let aggregate = AgentTaskAggregate {
-                schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
-                plan_id: loaded_plan.plan_id.clone(),
-                status: AgentTaskAggregateStatus::Succeeded,
-                totals: AgentTaskAggregateTotals {
-                    queued: 1,
-                    succeeded: 1,
-                    ..AgentTaskAggregateTotals::default()
-                },
-                outcomes: vec![AgentTaskOutcome {
-                    schema: crate::core::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
-                    task_id: "task-a".to_string(),
-                    status: crate::core::agent_task::AgentTaskOutcomeStatus::Succeeded,
-                    summary: Some("ok".to_string()),
-                    failure_classification: None,
-                    artifacts: Vec::new(),
-                    evidence_refs: Vec::new(),
-                    diagnostics: Vec::new(),
-                    workflow: None,
-                    follow_up: None,
-                    metadata: Value::Null,
-                }],
-                events: vec![AgentTaskProgressEvent {
-                    task_id: "task-a".to_string(),
-                    state: AgentTaskState::Succeeded,
-                    attempt: 1,
-                    message: Some("ok".to_string()),
-                }],
-                queue: Default::default(),
-            };
+            let aggregate = succeeded_aggregate(&loaded_plan);
 
             let completed =
                 record_run_aggregate("run-execute", &loaded_plan, &aggregate).expect("completed");
+            let durable_status = status("run-execute").expect("status");
 
             assert_eq!(loaded_plan.plan_id, "plan-a");
             assert_eq!(running.state, AgentTaskRunState::Running);
             assert_eq!(running.tasks[0].state, AgentTaskState::Running);
             assert_eq!(completed.state, AgentTaskRunState::Succeeded);
             assert_eq!(completed.tasks[0].state, AgentTaskState::Succeeded);
+            assert_eq!(completed.totals, Some(aggregate.totals.clone()));
+            assert_eq!(durable_status.state, AgentTaskRunState::Succeeded);
+            assert_eq!(durable_status.tasks[0].state, AgentTaskState::Succeeded);
+            assert_eq!(durable_status.totals, Some(aggregate.totals.clone()));
             assert!(completed.aggregate_path.is_some());
+        });
+    }
+
+    #[test]
+    fn status_recovers_terminal_state_from_durable_aggregate() {
+        with_temp_home(|| {
+            let plan = test_plan();
+            submit_plan(&plan, Some("run-stale-status")).expect("submitted");
+            mark_running("run-stale-status").expect("marked running");
+            let aggregate = succeeded_aggregate(&plan);
+            store::write_aggregate("run-stale-status", &aggregate).expect("aggregate written");
+
+            let recovered = status("run-stale-status").expect("status recovered");
+            let persisted = store::read_record("run-stale-status").expect("record persisted");
+
+            assert_eq!(recovered.state, AgentTaskRunState::Succeeded);
+            assert_eq!(recovered.tasks[0].state, AgentTaskState::Succeeded);
+            assert_eq!(recovered.totals, Some(aggregate.totals.clone()));
+            assert_eq!(persisted.state, AgentTaskRunState::Succeeded);
+            assert_eq!(persisted.tasks[0].state, AgentTaskState::Succeeded);
+            assert_eq!(persisted.totals, Some(aggregate.totals.clone()));
         });
     }
 
@@ -652,5 +695,38 @@ mod tests {
                 metadata: Value::Null,
             }],
         )
+    }
+
+    fn succeeded_aggregate(plan: &AgentTaskPlan) -> AgentTaskAggregate {
+        AgentTaskAggregate {
+            schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+            plan_id: plan.plan_id.clone(),
+            status: AgentTaskAggregateStatus::Succeeded,
+            totals: AgentTaskAggregateTotals {
+                queued: 1,
+                succeeded: 1,
+                ..AgentTaskAggregateTotals::default()
+            },
+            outcomes: vec![AgentTaskOutcome {
+                schema: crate::core::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: "task-a".to_string(),
+                status: crate::core::agent_task::AgentTaskOutcomeStatus::Succeeded,
+                summary: Some("ok".to_string()),
+                failure_classification: None,
+                artifacts: Vec::new(),
+                evidence_refs: Vec::new(),
+                diagnostics: Vec::new(),
+                workflow: None,
+                follow_up: None,
+                metadata: Value::Null,
+            }],
+            events: vec![AgentTaskProgressEvent {
+                task_id: "task-a".to_string(),
+                state: AgentTaskState::Succeeded,
+                attempt: 1,
+                message: Some("ok".to_string()),
+            }],
+            queue: Default::default(),
+        }
     }
 }

--- a/src/core/lifecycle_store.rs
+++ b/src/core/lifecycle_store.rs
@@ -24,7 +24,11 @@ pub(super) fn write_aggregate(run_id: &str, aggregate: &AgentTaskAggregate) -> R
 }
 
 pub(super) fn read_aggregate(run_id: &str) -> Result<AgentTaskAggregate> {
-    read_json(&run_dir(run_id)?.join("aggregate.json"))
+    read_json(&aggregate_path(run_id)?)
+}
+
+pub(super) fn aggregate_path(run_id: &str) -> Result<PathBuf> {
+    Ok(run_dir(run_id)?.join("aggregate.json"))
 }
 
 pub(super) fn write_record(record: &AgentTaskRunRecord) -> Result<()> {


### PR DESCRIPTION
## Summary
- Reconcile durable agent-task status records from `aggregate.json` when a terminal aggregate exists but `status.json` is stale.
- Persist aggregate totals on completed status records so `agent-task status` reflects the completed run output.
- Add lifecycle and command-level regression coverage for submit -> run -> status terminal state.

## Verification
- `cargo test agent_task_lifecycle::tests::submitted_run_can_be_loaded_marked_running_and_completed`
- `cargo test agent_task_lifecycle::tests::status_recovers_terminal_state_from_durable_aggregate`
- `cargo test commands::agent_task::tests::submit_run_status_reports_terminal_state`
- `cargo test agent_task_lifecycle::tests`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigating the stale durable agent-task status path, drafting the status reconciliation fix, adding regression coverage, and running targeted verification. Chris remains responsible for review and merge.

Closes #3391