### PR TITLE
Fix main quality gate regressions

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -245,6 +245,7 @@ fn read_plan(spec: &str) -> homeboy::core::Result<AgentTaskPlan> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::with_isolated_home;
     use homeboy::core::agent_task::{
         AgentTaskExecutor, AgentTaskLimits, AgentTaskOutcome, AgentTaskOutcomeStatus,
         AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace, AGENT_TASK_OUTCOME_SCHEMA,
@@ -255,7 +256,7 @@ mod tests {
     };
     use homeboy::core::agent_task_scheduler::{AgentTaskExecutionContext, AgentTaskState};
     use serde_json::Value;
-    use std::sync::{Arc, Mutex, OnceLock};
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn submit_run_status_reports_terminal_state() {
@@ -382,18 +383,7 @@ mod tests {
     }
 
     fn with_temp_home(run: impl FnOnce()) {
-        let lock = test_home_lock()
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let home = tempfile::tempdir().expect("temp home");
-        std::env::set_var("HOME", home.path());
-        run();
-        drop(lock);
-    }
-
-    fn test_home_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
+        with_isolated_home(|_| run());
     }
 
     fn test_plan() -> AgentTaskPlan {

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -485,7 +485,7 @@ mod tests {
         AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
         AGENT_TASK_AGGREGATE_SCHEMA,
     };
-    use std::sync::{Mutex, OnceLock};
+    use crate::test_support::with_isolated_home;
 
     #[test]
     fn submit_plan_persists_queued_status() {
@@ -705,18 +705,7 @@ mod tests {
     }
 
     fn with_temp_home(run: impl FnOnce()) {
-        let lock = test_home_lock()
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let home = tempfile::tempdir().expect("temp home");
-        std::env::set_var("HOME", home.path());
-        run();
-        drop(lock);
-    }
-
-    fn test_home_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
+        with_isolated_home(|_| run());
     }
 
     fn test_plan() -> AgentTaskPlan {

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -15,9 +15,11 @@ mod lifecycle_store;
 
 use lifecycle_store as store;
 
-pub const AGENT_TASK_RUN_SCHEMA: &str = "homeboy/agent-task-run/v1";
-pub const AGENT_TASK_RUN_LOG_SCHEMA: &str = "homeboy/agent-task-run-log/v1";
-pub const AGENT_TASK_RUN_ARTIFACTS_SCHEMA: &str = "homeboy/agent-task-run-artifacts/v1";
+mod schemas {
+    pub(super) const RUN: &str = "homeboy/agent-task-run/v1";
+    pub(super) const RUN_LOG: &str = "homeboy/agent-task-run-log/v1";
+    pub(super) const RUN_ARTIFACTS: &str = "homeboy/agent-task-run-artifacts/v1";
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskRunRecord {
@@ -148,7 +150,7 @@ pub fn submit_plan(
     let plan_path = store::write_plan(&run_id, plan)?;
 
     let record = AgentTaskRunRecord {
-        schema: AGENT_TASK_RUN_SCHEMA.to_string(),
+        schema: schemas::RUN.to_string(),
         run_id,
         plan_id: plan.plan_id.clone(),
         state: AgentTaskRunState::Queued,
@@ -301,7 +303,7 @@ pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
         .map(|aggregate| aggregate.events)
         .unwrap_or_else(|_| queued_events(&record.tasks));
     Ok(AgentTaskRunLog {
-        schema: AGENT_TASK_RUN_LOG_SCHEMA.to_string(),
+        schema: schemas::RUN_LOG.to_string(),
         run_id,
         events,
     })
@@ -312,7 +314,7 @@ pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
     store::read_record(&run_id)?;
     let aggregate = store::read_aggregate(&run_id).ok();
     Ok(AgentTaskRunArtifacts {
-        schema: AGENT_TASK_RUN_ARTIFACTS_SCHEMA.to_string(),
+        schema: schemas::RUN_ARTIFACTS.to_string(),
         run_id,
         artifacts: aggregate_artifacts(aggregate.as_ref()),
         evidence_refs: aggregate_evidence_refs(aggregate.as_ref()),
@@ -489,7 +491,7 @@ mod tests {
 
     #[test]
     fn submit_plan_persists_queued_status() {
-        with_temp_home(|| {
+        with_isolated_home(|_| {
             let plan = test_plan();
 
             let record = submit_plan(&plan, Some("run/a")).expect("submitted");
@@ -507,7 +509,7 @@ mod tests {
 
     #[test]
     fn record_completed_run_exposes_logs_and_artifacts() {
-        with_temp_home(|| {
+        with_isolated_home(|_| {
             let plan = test_plan();
             let aggregate = AgentTaskAggregate {
                 schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
@@ -569,7 +571,7 @@ mod tests {
 
     #[test]
     fn submitted_run_can_be_loaded_marked_running_and_completed() {
-        with_temp_home(|| {
+        with_isolated_home(|_| {
             let plan = test_plan();
             submit_plan(&plan, Some("run-execute")).expect("submitted");
 
@@ -596,7 +598,7 @@ mod tests {
 
     #[test]
     fn status_recovers_terminal_state_from_durable_aggregate() {
-        with_temp_home(|| {
+        with_isolated_home(|_| {
             let plan = test_plan();
             submit_plan(&plan, Some("run-stale-status")).expect("submitted");
             mark_running("run-stale-status").expect("marked running");
@@ -617,7 +619,7 @@ mod tests {
 
     #[test]
     fn status_marks_running_run_without_owner_as_stale() {
-        with_temp_home(|| {
+        with_isolated_home(|_| {
             let plan = test_plan();
             submit_plan(&plan, Some("run-stale-missing-owner")).expect("submitted");
             let mut record = store::read_record("run-stale-missing-owner").expect("record");
@@ -637,7 +639,7 @@ mod tests {
 
     #[test]
     fn aggregate_source_loads_completed_run_without_path_spelunking() {
-        with_temp_home(|| {
+        with_isolated_home(|_| {
             let plan = test_plan();
             let aggregate = AgentTaskAggregate {
                 schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
@@ -675,7 +677,7 @@ mod tests {
 
     #[test]
     fn mark_running_reclaims_stale_running_record() {
-        with_temp_home(|| {
+        with_isolated_home(|_| {
             let plan = test_plan();
             submit_plan(&plan, Some("run-stale-dead-owner")).expect("submitted");
             let mut record = store::read_record("run-stale-dead-owner").expect("record");
@@ -693,7 +695,7 @@ mod tests {
 
     #[test]
     fn mark_running_rejects_live_running_record() {
-        with_temp_home(|| {
+        with_isolated_home(|_| {
             let plan = test_plan();
             submit_plan(&plan, Some("run-live-owner")).expect("submitted");
             mark_running("run-live-owner").expect("marked running");
@@ -702,10 +704,6 @@ mod tests {
 
             assert!(error.message.contains("already running"));
         });
-    }
-
-    fn with_temp_home(run: impl FnOnce()) {
-        with_isolated_home(|_| run());
     }
 
     fn test_plan() -> AgentTaskPlan {

--- a/src/core/deploy/generated_artifacts.rs
+++ b/src/core/deploy/generated_artifacts.rs
@@ -81,6 +81,7 @@ mod tests {
         cleanup_generated_build_artifacts, is_generated_build_path,
         unexpected_uncommitted_files_excluding_generated_build,
     };
+    use crate::core::defaults::deploy_generated_build_dir;
 
     fn run_git(dir: &std::path::Path, args: &[&str]) {
         let output = std::process::Command::new("git")
@@ -102,7 +103,7 @@ mod tests {
         let dir = temp.path();
         run_git(dir, &["init", "-q"]);
         run_git(dir, &["config", "user.email", "homeboy@example.com"]);
-        run_git(dir, &["config", "user.name", "Homeboy Test"]);
+        run_git(dir, &["config", "user.name", "Fixture Test"]);
         std::fs::write(dir.join("README.md"), "fixture\n").expect("readme");
         run_git(dir, &["add", "."]);
         run_git(dir, &["commit", "-q", "-m", "chore: initial"]);
@@ -111,9 +112,12 @@ mod tests {
 
     #[test]
     fn root_homeboy_build_paths_are_generated() {
-        assert!(is_generated_build_path(".homeboy-build"));
-        assert!(is_generated_build_path(".homeboy-build/plugin.zip"));
-        assert!(!is_generated_build_path("src/.homeboy-build/plugin.zip"));
+        let build_dir = deploy_generated_build_dir();
+        assert!(is_generated_build_path(&build_dir));
+        assert!(is_generated_build_path(&format!("{build_dir}/plugin.zip")));
+        assert!(!is_generated_build_path(&format!(
+            "src/{build_dir}/plugin.zip"
+        )));
         assert!(!is_generated_build_path("src/lib.rs"));
     }
 
@@ -121,8 +125,9 @@ mod tests {
     fn uncommitted_filter_ignores_only_generated_build_artifacts() {
         let temp = git_repo();
         let dir = temp.path();
-        std::fs::create_dir_all(dir.join(".homeboy-build")).expect("build dir");
-        std::fs::write(dir.join(".homeboy-build/plugin.zip"), "artifact").expect("artifact");
+        let build_dir = deploy_generated_build_dir();
+        std::fs::create_dir_all(dir.join(&build_dir)).expect("build dir");
+        std::fs::write(dir.join(&build_dir).join("plugin.zip"), "artifact").expect("artifact");
         std::fs::write(dir.join("src.rs"), "source\n").expect("source");
 
         let unexpected =
@@ -135,7 +140,7 @@ mod tests {
     #[test]
     fn cleanup_removes_generated_build_dir() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let build_dir = temp.path().join(".homeboy-build");
+        let build_dir = temp.path().join(deploy_generated_build_dir());
         std::fs::create_dir_all(&build_dir).expect("build dir");
         std::fs::write(build_dir.join("plugin.zip"), "artifact").expect("artifact");
 

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -56,7 +56,7 @@ pub use pr_policy::{
 };
 pub use primitives::{
     clone_repo, clone_repo_at_ref, current_branch, get_component_path_prefix, get_git_root,
-    is_workdir_clean, is_workdir_clean_or_not_git, pull_repo, run_git, short_head_revision,
+    is_workdir_clean_or_not_git, pull_repo, run_git, short_head_revision,
     update_to_remote_default_branch,
 };
 pub(crate) use primitives::{is_git_repo, list_tracked_markdown_files};

--- a/src/core/git/primitives.rs
+++ b/src/core/git/primitives.rs
@@ -60,7 +60,7 @@ pub fn pull_repo(repo_dir: &Path) -> Result<()> {
 /// Uses direct Command execution to properly handle empty output (clean repo).
 /// `run_in_optional` returns None for empty stdout, which would incorrectly
 /// indicate a dirty repo when used with `.unwrap_or(false)`.
-pub fn is_workdir_clean(path: &Path) -> bool {
+fn is_workdir_clean(path: &Path) -> bool {
     let output = Command::new("git")
         .args(["status", "--porcelain"])
         .current_dir(path)


### PR DESCRIPTION
## Summary
- Fix main quality gate regressions by keeping deploy generated-artifact helpers domain-neutral while preserving the `.homeboy-build` path behavior.
- Remove a stale public git helper export and make `is_workdir_clean` private to clear dead surface area.
- Route agent-task command/lifecycle tests through the shared isolated home guard so parallel test runs do not race on `HOME` / `XDG_DATA_HOME`.

## Verification
- `cargo test --lib`
- `cargo build --release`
- `./target/release/homeboy test homeboy`
- `XDG_DATA_HOME="/tmp/homeboy-clean-data-audit-$$" ./target/release/homeboy audit homeboy --force-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the release/test/audit failures, drafted the code changes, and ran local verification. Chris remains responsible for review and merge.