### PR TITLE
extension: install monorepo shared scripts

### DIFF
--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -269,6 +269,8 @@ pub(crate) fn resolve_cloned_extension(
         let content = local_files::local().read(&manifest_in_subdir)?;
         let _manifest: ExtensionManifest = from_str(&content)?;
 
+        install_monorepo_shared_scripts(temp_dir, extension_dir)?;
+
         // Move just the subdirectory to the final extension location.
         rename_dir(&subdir, extension_dir)?;
         return Ok(extension_id.to_string());
@@ -303,6 +305,28 @@ pub(crate) fn resolve_cloned_extension(
         "Install a specific extension with: homeboy extension install <url> --id <extension>\nAvailable: {}",
         list
     )))
+}
+
+fn install_monorepo_shared_scripts(repo_dir: &Path, extension_dir: &Path) -> Result<()> {
+    let shared_scripts = repo_dir.join("scripts");
+    if !shared_scripts.is_dir() {
+        return Ok(());
+    }
+
+    let Some(extensions_dir) = extension_dir.parent() else {
+        return Ok(());
+    };
+
+    let target = extensions_dir.join("scripts");
+    if target.exists() {
+        std::fs::remove_dir_all(&target).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some("replace shared extension scripts".to_string()),
+            )
+        })?;
+    }
+    copy_dir_recursive(&shared_scripts, &target)
 }
 
 /// Scan a cloned repo for subdirectories that contain a matching manifest file.
@@ -1124,6 +1148,38 @@ exec '{}' "$@"
                 result.source_revision,
                 "monorepo installs keep the stored source revision after .git is discarded"
             );
+        });
+    }
+
+    #[test]
+    fn cloned_monorepo_install_materializes_shared_scripts() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let source = home.join("source-repo");
+            fs::create_dir_all(&source).expect("source repo");
+            write_extension_fixture(&source, "rust");
+            let shared_helper = source.join("scripts/lib/test-result-adapters.sh");
+            fs::create_dir_all(shared_helper.parent().expect("helper parent"))
+                .expect("shared scripts dir");
+            fs::write(
+                &shared_helper,
+                "homeboy_parse_test_results_with_adapters() { :; }\n",
+            )
+            .expect("shared helper");
+            let remote = match prepare_git_repo(&source) {
+                Some(remote) => remote,
+                None => return,
+            };
+            let remote_url = remote.path().join("extension.git");
+
+            install(&remote_url.to_string_lossy(), Some("rust")).expect("install cloned extension");
+
+            assert!(home
+                .join(".config/homeboy/extensions/rust/rust.json")
+                .exists());
+            assert!(home
+                .join(".config/homeboy/extensions/scripts/lib/test-result-adapters.sh")
+                .exists());
         });
     }
 


### PR DESCRIPTION
## Summary
- Copies repo-level `scripts/` helpers into the installed extensions root when installing a subdirectory extension from a monorepo.
- Preserves the existing selected-extension install behavior while making paths like `~/.config/homeboy/extensions/scripts/lib/test-result-adapters.sh` available to installed parser scripts.
- Adds regression coverage for monorepo installs materializing shared test-result adapter helpers.

## Fixes
- Fixes #3405.

## Evidence
Release runs showed the Rust extension parser failing because the installed layout lacked the shared adapter helper:

```text
/home/runner/.config/homeboy/extensions/rust/scripts/parse-test-results.sh: line 23: /home/runner/.config/homeboy/extensions/scripts/lib/test-result-adapters.sh: No such file or directory
```

Relevant failed runs:
- https://github.com/Extra-Chill/homeboy/actions/runs/26884112333
- https://github.com/Extra-Chill/homeboy/actions/runs/26887017819

## Tests
- `cargo test cloned_monorepo_install_materializes_shared_scripts`
- `cargo test monorepo_install`
- `cargo test core_owned_source_stays_language_and_framework_agnostic`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the installed extension layout gap, drafted the minimal Homeboy core fix, and ran targeted verification; Chris remains responsible for review and merge.