### PR TITLE
audit: run structural detector from snapshot

### DIFF
--- a/src/core/code_audit/discovery.rs
+++ b/src/core/code_audit/discovery.rs
@@ -5,8 +5,11 @@ use std::path::Path;
 
 use super::conventions::Language;
 use super::fingerprint::{fingerprint_content, normalize_convention_tags, FileFingerprint};
-use super::walker::{is_test_path, walk_source_files_snapshot};
+use super::walker::{
+    extension_provided_file_extensions, is_extension_provided_source_file, is_test_path,
+};
 use crate::core::component::AuditConfig;
+use crate::core::engine::codebase_scan::CodebaseSnapshot;
 
 type DiscoveryGroupKey = (String, Language, bool, Vec<String>);
 
@@ -25,11 +28,14 @@ pub struct DiscoveryResult {
 /// Returns groups of (group_name, glob_pattern, files) for directories that
 /// contain 2+ files of the same language, plus counts of walked vs fingerprinted files.
 ///
-/// Walks `root` once via [`walk_source_files_snapshot`] and reads each file
-/// exactly once. Fingerprinting goes through [`fingerprint_content`] so the
-/// snapshot's already-loaded content is reused — no second `read_to_string`.
-/// Slice 2 of #1492.
-pub(crate) fn auto_discover_groups(root: &Path, audit_config: &AuditConfig) -> DiscoveryResult {
+/// Consumes a caller-provided source snapshot. Fingerprinting goes through
+/// [`fingerprint_content`] so the snapshot's already-loaded content is reused —
+/// no second `read_to_string`.
+pub(crate) fn auto_discover_groups_from_snapshot(
+    root: &Path,
+    audit_config: &AuditConfig,
+    snapshot: &CodebaseSnapshot,
+) -> DiscoveryResult {
     // Walk directories, group files by (parent dir, language, is_test, opaque convention tags).
     // Test files are separated from production files so conventions from
     // production code don't get applied to test files and vice versa.
@@ -38,9 +44,12 @@ pub(crate) fn auto_discover_groups(root: &Path, audit_config: &AuditConfig) -> D
     let mut dir_files: HashMap<DiscoveryGroupKey, Vec<FileFingerprint>> = HashMap::new();
     let mut files_walked: usize = 0;
     let mut files_fingerprinted: usize = 0;
+    let source_extensions = extension_provided_file_extensions();
 
-    let snapshot = walk_source_files_snapshot(root);
     for (path, content) in snapshot.iter() {
+        if !is_extension_provided_source_file(path, &source_extensions) {
+            continue;
+        }
         files_walked += 1;
         if let Some(mut fp) = fingerprint_content(path, root, content) {
             files_fingerprinted += 1;

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -380,7 +380,10 @@ fn audit_internal(
     }
 
     // Phase 1: Auto-discover file groups (always full codebase for convention detection)
-    let discovery = discovery::auto_discover_groups(root, &audit_config);
+    let source_snapshot =
+        walker::walk_shared_audit_files_snapshot(root, structural::source_extensions());
+    let discovery =
+        discovery::auto_discover_groups_from_snapshot(root, &audit_config, &source_snapshot);
     let files_skipped = discovery
         .files_walked
         .saturating_sub(discovery.files_fingerprinted);
@@ -457,8 +460,7 @@ fn audit_internal(
 
     // Phase 4b: Structural complexity analysis (god files, high item counts)
     let structural_findings = if plan.run_structural() {
-        let snapshot = structural::build_snapshot(root);
-        structural::analyze_snapshot(root, &snapshot)
+        structural::analyze_snapshot(root, &source_snapshot)
     } else {
         Vec::new()
     };

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -457,7 +457,8 @@ fn audit_internal(
 
     // Phase 4b: Structural complexity analysis (god files, high item counts)
     let structural_findings = if plan.run_structural() {
-        structural::analyze_structure(root)
+        let snapshot = structural::build_snapshot(root);
+        structural::analyze_snapshot(root, &snapshot)
     } else {
         Vec::new()
     };

--- a/src/core/code_audit/structural.rs
+++ b/src/core/code_audit/structural.rs
@@ -23,6 +23,10 @@ const SOURCE_EXTENSIONS: &[&str] = &[
     "cpp", "h",
 ];
 
+pub(crate) fn source_extensions() -> &'static [&'static str] {
+    SOURCE_EXTENSIONS
+}
+
 pub(crate) fn build_snapshot(root: &Path) -> CodebaseSnapshot {
     let config = ScanConfig {
         extensions: ExtensionFilter::Only(
@@ -48,14 +52,17 @@ pub(crate) fn analyze_snapshot(root: &Path, snapshot: &CodebaseSnapshot) -> Vec<
     let mut dir_source_counts: HashMap<String, usize> = HashMap::new();
 
     for (path, content) in snapshot.iter() {
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if !SOURCE_EXTENSIONS.contains(&ext) {
+            continue;
+        }
+
         let parent_rel = path
             .parent()
             .and_then(|p| p.strip_prefix(root).ok())
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_default();
         *dir_source_counts.entry(parent_rel).or_insert(0) += 1;
-
-        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
         let relative = path
             .strip_prefix(root)
@@ -429,11 +436,17 @@ export default function main() {}
             content.push_str(&format!("fn item_{}() {{}}\n", i));
         }
         std::fs::write(dir.join("many.rs"), &content).unwrap();
+        std::fs::write(dir.join("readme.md"), "# Not source\n").unwrap();
 
         let snapshot = build_snapshot(&dir);
+        let broad_snapshot = CodebaseSnapshot::build(&dir, &ScanConfig::default());
         assert_eq!(snapshot.len(), 1);
         assert_eq!(
             serde_json::to_value(analyze_snapshot(&dir, &snapshot)).unwrap(),
+            serde_json::to_value(analyze_structure(&dir)).unwrap()
+        );
+        assert_eq!(
+            serde_json::to_value(analyze_snapshot(&dir, &broad_snapshot)).unwrap(),
             serde_json::to_value(analyze_structure(&dir)).unwrap()
         );
 

--- a/src/core/code_audit/structural.rs
+++ b/src/core/code_audit/structural.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
+use crate::core::engine::codebase_scan::{CodebaseSnapshot, ExtensionFilter, ScanConfig};
 
 use super::conventions::AuditFinding;
 use super::findings::{Finding, Severity};
@@ -23,33 +23,37 @@ const SOURCE_EXTENSIONS: &[&str] = &[
     "cpp", "h",
 ];
 
-/// Run structural analysis on all source files under a root directory.
-///
-/// Returns findings for files that exceed structural thresholds.
-pub(crate) fn analyze_structure(root: &Path) -> Vec<Finding> {
+pub(crate) fn build_snapshot(root: &Path) -> CodebaseSnapshot {
     let config = ScanConfig {
         extensions: ExtensionFilter::Only(
             SOURCE_EXTENSIONS.iter().map(|e| e.to_string()).collect(),
         ),
         ..Default::default()
     };
-    let files = codebase_scan::walk_files(root, &config);
 
+    CodebaseSnapshot::build(root, &config)
+}
+
+/// Run structural analysis on all source files under a root directory.
+///
+/// Returns findings for files that exceed structural thresholds.
+pub(crate) fn analyze_structure(root: &Path) -> Vec<Finding> {
+    let snapshot = build_snapshot(root);
+    analyze_snapshot(root, &snapshot)
+}
+
+/// Run structural analysis from an already-loaded codebase snapshot.
+pub(crate) fn analyze_snapshot(root: &Path, snapshot: &CodebaseSnapshot) -> Vec<Finding> {
     let mut findings = Vec::new();
     let mut dir_source_counts: HashMap<String, usize> = HashMap::new();
 
-    for path in files {
+    for (path, content) in snapshot.iter() {
         let parent_rel = path
             .parent()
             .and_then(|p| p.strip_prefix(root).ok())
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_default();
         *dir_source_counts.entry(parent_rel).or_insert(0) += 1;
-
-        let content = match std::fs::read_to_string(&path) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
 
         let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
@@ -410,6 +414,28 @@ export default function main() {}
         assert_eq!(god_findings[0].file, "big.rs");
         assert!(god_findings[0].description.contains("1600 lines"));
         assert_eq!(god_findings[0].severity, Severity::Warning);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn snapshot_analysis_matches_root_analysis() {
+        let dir = std::env::temp_dir().join("homeboy_structural_snapshot_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::create_dir_all(&dir);
+
+        let mut content = String::new();
+        for i in 0..35 {
+            content.push_str(&format!("fn item_{}() {{}}\n", i));
+        }
+        std::fs::write(dir.join("many.rs"), &content).unwrap();
+
+        let snapshot = build_snapshot(&dir);
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(
+            serde_json::to_value(analyze_snapshot(&dir, &snapshot)).unwrap(),
+            serde_json::to_value(analyze_structure(&dir)).unwrap()
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/core/code_audit/walker.rs
+++ b/src/core/code_audit/walker.rs
@@ -51,6 +51,38 @@ fn source_scan_config() -> ScanConfig {
     }
 }
 
+fn extension_matches(path: &Path, extensions: &[String]) -> bool {
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    extensions.iter().any(|candidate| candidate == ext)
+}
+
+pub(crate) fn is_extension_provided_source_file(path: &Path, extensions: &[String]) -> bool {
+    extension_matches(path, extensions) && !is_index_file(path)
+}
+
+/// Build the shared audit source snapshot for full audit runs.
+///
+/// The snapshot includes extension-provided convention files plus detector-owned
+/// source extensions so downstream detectors can filter one shared walk/read
+/// without reducing their existing coverage.
+pub(crate) fn walk_shared_audit_files_snapshot(
+    root: &Path,
+    additional_extensions: &[&str],
+) -> CodebaseSnapshot {
+    let mut extensions = extension_provided_file_extensions();
+    extensions.extend(additional_extensions.iter().map(|ext| (*ext).to_string()));
+    extensions.sort();
+    extensions.dedup();
+
+    CodebaseSnapshot::build(
+        root,
+        &ScanConfig {
+            extensions: ExtensionFilter::Only(extensions),
+            ..Default::default()
+        },
+    )
+}
+
 /// Walk source files under a root, skipping common non-source directories
 /// and extension index files.
 ///


### PR DESCRIPTION
## Summary
- Migrates the structural audit detector to analyze an already-loaded `CodebaseSnapshot` instead of walking and rereading files inside the detector.
- Keeps the detector-specific source extension coverage intact so structural findings stay unchanged.
- Adds a regression test that compares snapshot-backed structural findings against the root wrapper output.

Refs #3401.

## Tests
- `cargo test structural`
- `cargo run --bin homeboy -- audit --path . --only god_file --ignore-baseline --json-summary`

## Follow-ups
- `field_patterns` still does its own whole-tree walk/read.
- `enum_dispatch_contracts` still does its own Rust-only whole-tree walk/read.
- Other root-level detectors called out in #3401 should be migrated only when the shared state preserves their current coverage and finding payloads.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting audit detector scan paths, implementing the structural snapshot-backed slice, and drafting this PR description.