### PR TITLE
Fix output format footgun

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -21,8 +21,8 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 #[command(version = VERSION)]
 #[command(about = "Headless automation for agentic software engineering workflows")]
 pub struct Cli {
-    /// Write structured JSON output to a file (in addition to stdout).
-    /// The file contains command-specific JSON — no log text.
+    /// Write structured JSON output to a file path (in addition to stdout).
+    /// Bare format names like `json` are rejected; use `./output.json`.
     #[arg(long, global = true, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,13 @@ fn main() -> std::process::ExitCode {
         .flatten()
         .map(|path| path.to_string_lossy().to_string());
 
+    if let Some(path) = output_file.as_deref() {
+        if let Some(err) = validate_output_file_path(path) {
+            emit_json_result(Err(err), None, 2);
+            return std::process::ExitCode::from(exit_code_to_u8(2));
+        }
+    }
+
     let artifact_root_override = matches
         .try_get_one::<std::path::PathBuf>("artifact_root")
         .ok()
@@ -298,6 +305,31 @@ fn emit_json_result(
         output::write_json_to_file(&result, path, exit_code);
     }
     output::print_json_result(result, exit_code).ok();
+}
+
+fn validate_output_file_path(path: &str) -> Option<homeboy::core::Error> {
+    let value = path.trim();
+    let looks_like_format = matches!(
+        value.to_ascii_lowercase().as_str(),
+        "json" | "yaml" | "yml" | "table" | "csv" | "text" | "markdown" | "md"
+    );
+
+    if !looks_like_format {
+        return None;
+    }
+
+    Some(homeboy::core::Error::validation_invalid_argument(
+        "output",
+        format!(
+            "`--output {value}` looks like an output format, but --output writes to a file path"
+        ),
+        None,
+        Some(vec![
+            "Use an explicit file path, for example: --output ./homeboy-output.json".to_string(),
+            "Use command-specific --format flags where available, for example: --format=json"
+                .to_string(),
+        ]),
+    ))
 }
 
 fn lab_offload_command(

--- a/tests/output_errors.rs
+++ b/tests/output_errors.rs
@@ -59,6 +59,80 @@ fn unsupported_runner_validation_error_writes_json_output_file() {
     assert!(file_json.get("data").is_none());
 }
 
+#[test]
+fn output_json_is_rejected_as_format_footgun() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let output = Command::new(homeboy_bin())
+        .args(["--runner", "lab", "--output", "json", "status"])
+        .current_dir(dir.path())
+        .env("HOME", dir.path())
+        .output()
+        .expect("run homeboy");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        !dir.path().join("json").exists(),
+        "bare --output json should not create a literal json file"
+    );
+
+    let stdout_json: Value = serde_json::from_slice(&output.stdout).expect("stdout json");
+    assert_eq!(stdout_json["success"], false);
+    assert_eq!(stdout_json["error"]["code"], "validation.invalid_argument");
+    assert!(stdout_json["error"]["message"]
+        .as_str()
+        .expect("message")
+        .contains("looks like an output format"));
+}
+
+#[test]
+fn output_equals_json_is_rejected_as_format_footgun() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let output = Command::new(homeboy_bin())
+        .args(["--runner", "lab", "--output=json", "status"])
+        .current_dir(dir.path())
+        .env("HOME", dir.path())
+        .output()
+        .expect("run homeboy");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        !dir.path().join("json").exists(),
+        "bare --output=json should not create a literal json file"
+    );
+
+    let stdout_json: Value = serde_json::from_slice(&output.stdout).expect("stdout json");
+    assert_eq!(stdout_json["error"]["code"], "validation.invalid_argument");
+}
+
+#[test]
+fn explicit_json_path_is_allowed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let output = Command::new(homeboy_bin())
+        .args(["--runner", "lab", "--output", "./json", "status"])
+        .current_dir(dir.path())
+        .env("HOME", dir.path())
+        .output()
+        .expect("run homeboy");
+
+    assert_eq!(output.status.code(), Some(2));
+
+    let output_path = dir.path().join("json");
+    assert!(
+        output_path.exists(),
+        "explicit relative path should still be accepted; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let file_json: Value =
+        serde_json::from_str(&std::fs::read_to_string(output_path).expect("read output file"))
+            .expect("output file json");
+    assert_eq!(file_json["error"]["code"], "validation.invalid_argument");
+}
+
 fn homeboy_bin() -> PathBuf {
     PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
 }


### PR DESCRIPTION
## Summary
- Reject bare format-looking `--output` values such as `json` before Homeboy writes a literal file.
- Keep explicit file paths like `./json` valid and clarify the global `--output` help text.
- Add regression coverage for `--output json`, `--output=json`, and explicit relative paths.

Closes #3345.

## Tests
- `cargo test --test output_errors`
- `cargo test cli_surface::tests::test_output_artifact_policy`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the CLI output parsing path, drafted the guard/tests, and ran targeted verification; Chris reviewed and requested the PR.