### PR TITLE
audit: reduce analysis fingerprint cloning

### DIFF
--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -476,9 +476,6 @@ fn audit_internal(
         .iter()
         .flat_map(|(_, _, fps)| fps.iter())
         .collect();
-    let analysis = AuditAnalysisContext {
-        fingerprints: all_fingerprints.iter().map(|fp| (*fp).clone()).collect(),
-    };
 
     // Build convention method set ONCE — used by duplication, near-duplicate, and parallel detectors.
     // Convention-expected methods are excluded from duplication/parallel findings because identical
@@ -1171,6 +1168,15 @@ fn audit_internal(
             total_dir_outliers
         );
     }
+
+    drop(all_fingerprints);
+    let analysis = AuditAnalysisContext {
+        fingerprints: discovery
+            .groups
+            .into_iter()
+            .flat_map(|(_, _, fingerprints)| fingerprints)
+            .collect(),
+    };
 
     Ok(AuditWithAnalysis {
         result: CodeAuditResult {

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -353,6 +353,15 @@ fn test_compute_fixability_with_analysis() {
         !audit.analysis.fingerprints.is_empty(),
         "audit analysis should retain fingerprints for fixability planning"
     );
+    assert!(
+        audit
+            .analysis
+            .fingerprints
+            .iter()
+            .any(|fp| fp.relative_path == "commands/good_one.rs"
+                && fp.content.contains("pub fn helper")),
+        "audit analysis should retain source content for downstream fix planning"
+    );
 
     let from_context = compute_fixability_with_analysis(&audit.result, &audit.analysis);
     let from_wrapper = compute_fixability(&audit.result);


### PR DESCRIPTION
## Summary
- Move existing discovery fingerprints into `AuditAnalysisContext` after audit detectors finish instead of cloning every fingerprint and its source content mid-run.
- Keep detector inputs unchanged, preserving audit signal behavior while reducing one full source-content copy retained for fixability/report analysis.
- Add coverage that analysis-backed fixability still receives fingerprint source content.

Closes #3402.

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo test test_compute_fixability_with_analysis`
- `cargo test fingerprint_content_matches_fingerprint_file`
- `cargo test from_snapshot_index_matches_per_file_get_calls`
- `cargo run --bin homeboy -- audit homeboy --path . --ignore-baseline --json-summary` (completed; exit code 1 expected because existing audit findings are present)

## Follow-up
- This is the safe first step. A larger ownership refactor could still reduce the remaining duplication between `CodebaseSnapshot` source strings and `FileFingerprint::content`, but that should be designed around detector readability and signal quality rather than lifetime churn.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the audit fingerprint/analysis ownership path, implementing the move-based memory reduction, and running focused verification. Chris remains responsible for review and merge.