### PR TITLE
audit: optimize parallel implementation scoring

### DIFF
--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -698,6 +698,18 @@ struct MethodCallSequence {
     shape: BodyShape,
 }
 
+/// Per-method call sequence after detector-level signal filtering.
+#[derive(Debug)]
+struct ScoredCallSequence {
+    file: String,
+    method: String,
+    /// Ordered signal calls used for LCS scoring.
+    signal_calls: Vec<String>,
+    /// Unique signal calls used for Jaccard scoring and cheap prefilters.
+    signal_set: HashSet<String>,
+    shape: BodyShape,
+}
+
 /// Generic looping markers — substrings that indicate the body iterates over
 /// something. Covers control-flow keywords (`for`, `while`, `loop`,
 /// `foreach`) shared by most languages and common iterator-pipeline calls
@@ -867,6 +879,31 @@ fn signal_calls(
         .collect()
 }
 
+fn scored_call_sequences(
+    sequences: Vec<MethodCallSequence>,
+    extra_plumbing: &HashSet<&str>,
+    common_calls: &HashSet<String>,
+) -> Vec<ScoredCallSequence> {
+    sequences
+        .into_iter()
+        .filter_map(|sequence| {
+            let signal_calls = signal_calls(&sequence.calls, extra_plumbing, common_calls);
+            if signal_calls.len() < MIN_CALL_COUNT {
+                return None;
+            }
+
+            let signal_set = signal_calls.iter().cloned().collect();
+            Some(ScoredCallSequence {
+                file: sequence.file,
+                method: sequence.method,
+                signal_calls,
+                signal_set,
+                shape: sequence.shape,
+            })
+        })
+        .collect()
+}
+
 /// Check if a name is a language keyword (not a function call).
 fn is_keyword(name: &str) -> bool {
     matches!(
@@ -981,12 +1018,8 @@ fn extract_call_sequences(
 }
 
 /// Compute Jaccard similarity between two sets.
-fn jaccard_similarity(a: &[String], b: &[String]) -> f64 {
-    let set_a: std::collections::HashSet<&str> = a.iter().map(|s| s.as_str()).collect();
-    let set_b: std::collections::HashSet<&str> = b.iter().map(|s| s.as_str()).collect();
-
-    let intersection = set_a.intersection(&set_b).count();
-    let union = set_a.union(&set_b).count();
+fn jaccard_similarity(a: &HashSet<String>, b: &HashSet<String>, intersection: usize) -> f64 {
+    let union = a.len() + b.len() - intersection;
 
     if union == 0 {
         0.0
@@ -995,23 +1028,33 @@ fn jaccard_similarity(a: &[String], b: &[String]) -> f64 {
     }
 }
 
+fn shared_signal_call_count(a: &HashSet<String>, b: &HashSet<String>) -> usize {
+    if a.len() <= b.len() {
+        a.iter().filter(|call| b.contains(*call)).count()
+    } else {
+        b.iter().filter(|call| a.contains(*call)).count()
+    }
+}
+
 /// Compute longest common subsequence length between two sequences.
 fn lcs_length(a: &[String], b: &[String]) -> usize {
-    let m = a.len();
-    let n = b.len();
-    let mut dp = vec![vec![0usize; n + 1]; m + 1];
+    let (longer, shorter) = if a.len() >= b.len() { (a, b) } else { (b, a) };
+    let mut previous = vec![0usize; shorter.len() + 1];
+    let mut current = vec![0usize; shorter.len() + 1];
 
-    for i in 1..=m {
-        for j in 1..=n {
-            if a[i - 1] == b[j - 1] {
-                dp[i][j] = dp[i - 1][j - 1] + 1;
+    for longer_call in longer {
+        for j in 1..=shorter.len() {
+            if longer_call == &shorter[j - 1] {
+                current[j] = previous[j - 1] + 1;
             } else {
-                dp[i][j] = dp[i - 1][j].max(dp[i][j - 1]);
+                current[j] = previous[j].max(current[j - 1]);
             }
         }
+        std::mem::swap(&mut previous, &mut current);
+        current.fill(0);
     }
 
-    dp[m][n]
+    previous[shorter.len()]
 }
 
 /// Compute LCS ratio: 2 * LCS / (len(a) + len(b)).
@@ -1064,6 +1107,7 @@ pub(crate) fn detect_parallel_implementations(
 
     let sequences = extract_call_sequences(fingerprints, &extra_trivial);
     let common_calls = corpus_common_calls(&sequences);
+    let sequences = scored_call_sequences(sequences, &extra_plumbing, &common_calls);
 
     // Build sets of already-flagged pairs (exact + near duplicates) to avoid double-flagging
     let exact_groups = build_groups(fingerprints);
@@ -1074,9 +1118,6 @@ pub(crate) fn detect_parallel_implementations(
         .collect();
 
     let mut findings = Vec::new();
-    let mut reported_pairs: std::collections::HashSet<(String, String)> =
-        std::collections::HashSet::new();
-
     for i in 0..sequences.len() {
         for j in (i + 1)..sequences.len() {
             let a = &sequences[i];
@@ -1103,35 +1144,19 @@ pub(crate) fn detect_parallel_implementations(
                 continue;
             }
 
-            // Skip already-reported pairs (both directions)
-            let pair_key = if a.file < b.file || (a.file == b.file && a.method < b.method) {
-                (
-                    format!("{}::{}", a.file, a.method),
-                    format!("{}::{}", b.file, b.method),
-                )
-            } else {
-                (
-                    format!("{}::{}", b.file, b.method),
-                    format!("{}::{}", a.file, a.method),
-                )
-            };
-            if reported_pairs.contains(&pair_key) {
-                continue;
-            }
-
-            let a_signal = signal_calls(&a.calls, &extra_plumbing, &common_calls);
-            let b_signal = signal_calls(&b.calls, &extra_plumbing, &common_calls);
-
-            if a_signal.len() < MIN_CALL_COUNT || b_signal.len() < MIN_CALL_COUNT {
-                continue;
-            }
-
             // Body-shape gate (issue #2334): a parallel-implementation finding
             // must reflect a shared workflow, not just a shared call set. Two
             // bodies with incompatible shapes (e.g. a single-file copy helper
             // vs a recursive directory walk) are not the same workflow even
             // when they share `fs::copy` and `create_dir_all`.
             if !a.shape.compatible_with(b.shape) {
+                continue;
+            }
+
+            let shared_count = shared_signal_call_count(&a.signal_set, &b.signal_set);
+            // This is a conservative prefilter: the old path discarded these
+            // pairs after Jaccard/LCS, so skipping LCS here preserves findings.
+            if shared_count < MIN_SHARED_CALLS {
                 continue;
             }
 
@@ -1148,72 +1173,68 @@ pub(crate) fn detect_parallel_implementations(
                 MIN_JACCARD_SIMILARITY
             };
 
-            let jaccard = jaccard_similarity(&a_signal, &b_signal);
-            let lcs = lcs_ratio(&a_signal, &b_signal);
-
-            if jaccard >= jaccard_floor && lcs >= MIN_LCS_RATIO {
-                // Find the shared calls for the description
-                let set_a: std::collections::HashSet<&str> =
-                    a_signal.iter().map(|s| s.as_str()).collect();
-                let set_b: std::collections::HashSet<&str> =
-                    b_signal.iter().map(|s| s.as_str()).collect();
-                let mut shared: Vec<&&str> = set_a.intersection(&set_b).collect();
-
-                // Require a minimum absolute number of shared calls.
-                // Jaccard/LCS alone can trigger on tiny overlaps (2 shared out of 4 total).
-                if shared.len() < MIN_SHARED_CALLS {
-                    continue;
-                }
-
-                reported_pairs.insert(pair_key);
-                shared.sort();
-                let shared_preview: String = shared
-                    .iter()
-                    .take(5)
-                    .map(|s| format!("`{}`", s))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let extra = if shared.len() > 5 {
-                    format!(" (+{} more)", shared.len() - 5)
-                } else {
-                    String::new()
-                };
-
-                let suggestion = format!(
-                    "`{}` and `{}` follow the same call pattern (Jaccard: {:.0}%, sequence: {:.0}%). \
-                     Consider extracting the shared workflow into a parameterized function.",
-                    a.method,
-                    b.method,
-                    jaccard * 100.0,
-                    lcs * 100.0
-                );
-
-                // Emit finding for file A
-                findings.push(Finding {
-                    convention: "parallel-implementation".to_string(),
-                    severity: Severity::Info,
-                    file: a.file.clone(),
-                    description: format!(
-                        "Parallel implementation: `{}` has similar call pattern to `{}` in {} — shared calls: {}{}",
-                        a.method, b.method, b.file, shared_preview, extra
-                    ),
-                    suggestion: suggestion.clone(),
-                    kind: AuditFinding::ParallelImplementation,
-                });
-
-                // Emit finding for file B
-                findings.push(Finding {
-                    convention: "parallel-implementation".to_string(),
-                    severity: Severity::Info,
-                    file: b.file.clone(),
-                    description: format!(
-                        "Parallel implementation: `{}` has similar call pattern to `{}` in {} — shared calls: {}{}",
-                        b.method, a.method, a.file, shared_preview, extra
-                    ),
-                    suggestion,
-                    kind: AuditFinding::ParallelImplementation,
-                });
+            let jaccard = jaccard_similarity(&a.signal_set, &b.signal_set, shared_count);
+            if jaccard < jaccard_floor {
+                continue;
             }
+
+            let lcs = lcs_ratio(&a.signal_calls, &b.signal_calls);
+            if lcs < MIN_LCS_RATIO {
+                continue;
+            }
+
+            let mut shared: Vec<&str> = a
+                .signal_set
+                .intersection(&b.signal_set)
+                .map(|call| call.as_str())
+                .collect();
+            shared.sort_unstable();
+            let shared_preview: String = shared
+                .iter()
+                .take(5)
+                .map(|s| format!("`{}`", s))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let extra = if shared.len() > 5 {
+                format!(" (+{} more)", shared.len() - 5)
+            } else {
+                String::new()
+            };
+
+            let suggestion = format!(
+                "`{}` and `{}` follow the same call pattern (Jaccard: {:.0}%, sequence: {:.0}%). \
+                 Consider extracting the shared workflow into a parameterized function.",
+                a.method,
+                b.method,
+                jaccard * 100.0,
+                lcs * 100.0
+            );
+
+            // Emit finding for file A
+            findings.push(Finding {
+                convention: "parallel-implementation".to_string(),
+                severity: Severity::Info,
+                file: a.file.clone(),
+                description: format!(
+                    "Parallel implementation: `{}` has similar call pattern to `{}` in {} — shared calls: {}{}",
+                    a.method, b.method, b.file, shared_preview, extra
+                ),
+                suggestion: suggestion.clone(),
+                kind: AuditFinding::ParallelImplementation,
+            });
+
+            // Emit finding for file B
+            findings.push(Finding {
+                convention: "parallel-implementation".to_string(),
+                severity: Severity::Info,
+                file: b.file.clone(),
+                description: format!(
+                    "Parallel implementation: `{}` has similar call pattern to `{}` in {} — shared calls: {}{}",
+                    b.method, a.method, a.file, shared_preview, extra
+                ),
+                suggestion,
+                kind: AuditFinding::ParallelImplementation,
+            });
         }
     }
 

--- a/src/core/code_audit/duplication/tests/parallel.rs
+++ b/src/core/code_audit/duplication/tests/parallel.rs
@@ -272,15 +272,40 @@ fn no_parallel_for_generic_names() {
 
 #[test]
 fn jaccard_identical_sets() {
-    let a = vec!["foo".to_string(), "bar".to_string()];
-    assert!((jaccard_similarity(&a, &a) - 1.0).abs() < f64::EPSILON);
+    let a = std::collections::HashSet::from(["foo".to_string(), "bar".to_string()]);
+    assert!((jaccard_similarity(&a, &a, a.len()) - 1.0).abs() < f64::EPSILON);
 }
 
 #[test]
 fn jaccard_disjoint_sets() {
-    let a = vec!["foo".to_string()];
-    let b = vec!["bar".to_string()];
-    assert!((jaccard_similarity(&a, &b)).abs() < f64::EPSILON);
+    let a = std::collections::HashSet::from(["foo".to_string()]);
+    let b = std::collections::HashSet::from(["bar".to_string()]);
+    assert!((jaccard_similarity(&a, &b, 0)).abs() < f64::EPSILON);
+}
+
+#[test]
+fn shared_signal_call_count_counts_unique_overlap() {
+    let a = std::collections::HashSet::from([
+        "shared_one".to_string(),
+        "shared_two".to_string(),
+        "shared_three".to_string(),
+        "unique_a".to_string(),
+    ]);
+    let b = std::collections::HashSet::from([
+        "shared_one".to_string(),
+        "shared_two".to_string(),
+        "shared_three".to_string(),
+        "unique_b".to_string(),
+    ]);
+    let c = std::collections::HashSet::from([
+        "shared_one".to_string(),
+        "shared_two".to_string(),
+        "unique_c".to_string(),
+        "another_c".to_string(),
+    ]);
+
+    assert_eq!(shared_signal_call_count(&a, &b), MIN_SHARED_CALLS);
+    assert_eq!(shared_signal_call_count(&a, &c), MIN_SHARED_CALLS - 1);
 }
 
 #[test]

--- a/src/core/code_audit/duplication/tests/parallel.rs
+++ b/src/core/code_audit/duplication/tests/parallel.rs
@@ -271,16 +271,53 @@ fn no_parallel_for_generic_names() {
 }
 
 #[test]
-fn jaccard_identical_sets() {
-    let a = std::collections::HashSet::from(["foo".to_string(), "bar".to_string()]);
-    assert!((jaccard_similarity(&a, &a, a.len()) - 1.0).abs() < f64::EPSILON);
-}
+fn jaccard_floor_preserves_parallel_detection_behavior() {
+    let weak_overlap_a = make_fingerprint_with_content(
+            "src/weak_a.rs",
+            &["deploy_weak_overlap"],
+            "fn deploy_weak_overlap() {\n    for host in hosts {\n        validate_component();\n        build_artifact();\n        upload_to_host();\n        deploy_only_one();\n        deploy_only_two();\n        deploy_only_three();\n        deploy_only_four();\n    }\n}",
+        );
+    let weak_overlap_b = make_fingerprint_with_content(
+            "src/weak_b.rs",
+            &["upgrade_weak_overlap"],
+            "fn upgrade_weak_overlap() {\n    for host in hosts {\n        validate_component();\n        build_artifact();\n        upload_to_host();\n        upgrade_only_one();\n        upgrade_only_two();\n        upgrade_only_three();\n        upgrade_only_four();\n    }\n}",
+        );
 
-#[test]
-fn jaccard_disjoint_sets() {
-    let a = std::collections::HashSet::from(["foo".to_string()]);
-    let b = std::collections::HashSet::from(["bar".to_string()]);
-    assert!((jaccard_similarity(&a, &b, 0)).abs() < f64::EPSILON);
+    let weak_findings = detect_parallel_implementations(
+        &[&weak_overlap_a, &weak_overlap_b],
+        &std::collections::HashSet::new(),
+        &DuplicationDetectorConfig::default(),
+    );
+    assert!(
+        weak_findings.is_empty(),
+        "Pairs with enough shared calls but weak Jaccard overlap must stay suppressed, got: {:?}",
+        weak_findings
+            .iter()
+            .map(|f| &f.description)
+            .collect::<Vec<_>>()
+    );
+
+    let strong_overlap_a = make_fingerprint_with_content(
+            "src/strong_a.rs",
+            &["deploy_strong_overlap"],
+            "fn deploy_strong_overlap() {\n    for host in hosts {\n        validate_component();\n        build_artifact();\n        upload_to_host();\n        run_post_hooks();\n        deploy_only();\n    }\n}",
+        );
+    let strong_overlap_b = make_fingerprint_with_content(
+            "src/strong_b.rs",
+            &["upgrade_strong_overlap"],
+            "fn upgrade_strong_overlap() {\n    for host in hosts {\n        validate_component();\n        build_artifact();\n        upload_to_host();\n        run_post_hooks();\n        upgrade_only();\n    }\n}",
+        );
+
+    let strong_findings = detect_parallel_implementations(
+        &[&strong_overlap_a, &strong_overlap_b],
+        &std::collections::HashSet::new(),
+        &DuplicationDetectorConfig::default(),
+    );
+    assert_eq!(
+        strong_findings.len(),
+        2,
+        "Pairs above the Jaccard floor must still produce parallel implementation findings"
+    );
 }
 
 #[test]
@@ -337,17 +374,53 @@ fn shared_call_floor_preserves_parallel_detection_behavior() {
 }
 
 #[test]
-fn lcs_identical_sequences() {
-    let a = vec!["a".to_string(), "b".to_string(), "c".to_string()];
-    assert_eq!(lcs_length(&a, &a), 3);
-    assert!((lcs_ratio(&a, &a) - 1.0).abs() < f64::EPSILON);
-}
+fn sequence_order_gate_preserves_parallel_detection_behavior() {
+    let reversed_a = make_fingerprint_with_content(
+            "src/reversed_a.rs",
+            &["deploy_reversed_order"],
+            "fn deploy_reversed_order() {\n    for host in hosts {\n        validate_component();\n        build_artifact();\n        upload_to_host();\n        run_post_hooks();\n    }\n}",
+        );
+    let reversed_b = make_fingerprint_with_content(
+            "src/reversed_b.rs",
+            &["upgrade_reversed_order"],
+            "fn upgrade_reversed_order() {\n    for host in hosts {\n        run_post_hooks();\n        upload_to_host();\n        build_artifact();\n        validate_component();\n    }\n}",
+        );
 
-#[test]
-fn lcs_partial_overlap() {
-    let a = vec!["a".to_string(), "b".to_string(), "c".to_string()];
-    let b = vec!["a".to_string(), "x".to_string(), "c".to_string()];
-    assert_eq!(lcs_length(&a, &b), 2); // a, c
+    let reversed_findings = detect_parallel_implementations(
+        &[&reversed_a, &reversed_b],
+        &std::collections::HashSet::new(),
+        &DuplicationDetectorConfig::default(),
+    );
+    assert!(
+        reversed_findings.is_empty(),
+        "Pairs with the same calls in incompatible order must stay suppressed, got: {:?}",
+        reversed_findings
+            .iter()
+            .map(|f| &f.description)
+            .collect::<Vec<_>>()
+    );
+
+    let ordered_a = make_fingerprint_with_content(
+            "src/ordered_a.rs",
+            &["deploy_ordered"],
+            "fn deploy_ordered() {\n    for host in hosts {\n        validate_component();\n        build_artifact();\n        upload_to_host();\n        run_post_hooks();\n    }\n}",
+        );
+    let ordered_b = make_fingerprint_with_content(
+            "src/ordered_b.rs",
+            &["upgrade_ordered"],
+            "fn upgrade_ordered() {\n    for host in hosts {\n        validate_component();\n        build_artifact();\n        upload_to_host();\n        run_post_hooks();\n    }\n}",
+        );
+
+    let ordered_findings = detect_parallel_implementations(
+        &[&ordered_a, &ordered_b],
+        &std::collections::HashSet::new(),
+        &DuplicationDetectorConfig::default(),
+    );
+    assert_eq!(
+        ordered_findings.len(),
+        2,
+        "Pairs with strong call-set and sequence overlap must still produce parallel implementation findings"
+    );
 }
 
 #[test]

--- a/src/core/code_audit/duplication/tests/parallel.rs
+++ b/src/core/code_audit/duplication/tests/parallel.rs
@@ -284,28 +284,56 @@ fn jaccard_disjoint_sets() {
 }
 
 #[test]
-fn shared_signal_call_count_counts_unique_overlap() {
-    let a = std::collections::HashSet::from([
-        "shared_one".to_string(),
-        "shared_two".to_string(),
-        "shared_three".to_string(),
-        "unique_a".to_string(),
-    ]);
-    let b = std::collections::HashSet::from([
-        "shared_one".to_string(),
-        "shared_two".to_string(),
-        "shared_three".to_string(),
-        "unique_b".to_string(),
-    ]);
-    let c = std::collections::HashSet::from([
-        "shared_one".to_string(),
-        "shared_two".to_string(),
-        "unique_c".to_string(),
-        "another_c".to_string(),
-    ]);
+fn shared_call_floor_preserves_parallel_detection_behavior() {
+    let below_floor_a = make_fingerprint_with_content(
+            "src/below_a.rs",
+            &["deploy_below_floor"],
+            "fn deploy_below_floor() {\n    for host in hosts {\n        validate_component();\n        build_artifact();\n        prepare_deploy_only();\n        notify_deploy_only();\n    }\n}",
+        );
+    let below_floor_b = make_fingerprint_with_content(
+            "src/below_b.rs",
+            &["upgrade_below_floor"],
+            "fn upgrade_below_floor() {\n    for host in hosts {\n        validate_component();\n        build_artifact();\n        prepare_upgrade_only();\n        notify_upgrade_only();\n    }\n}",
+        );
 
-    assert_eq!(shared_signal_call_count(&a, &b), MIN_SHARED_CALLS);
-    assert_eq!(shared_signal_call_count(&a, &c), MIN_SHARED_CALLS - 1);
+    let below_floor_findings = detect_parallel_implementations(
+        &[&below_floor_a, &below_floor_b],
+        &std::collections::HashSet::new(),
+        &DuplicationDetectorConfig::default(),
+    );
+    assert!(
+        below_floor_findings.is_empty(),
+        "Pairs below the shared-call floor must stay suppressed, got: {:?}",
+        below_floor_findings
+            .iter()
+            .map(|f| &f.description)
+            .collect::<Vec<_>>()
+    );
+
+    let at_floor_a = make_fingerprint_with_content(
+            "src/at_floor_a.rs",
+            &["deploy_at_floor"],
+            "fn deploy_at_floor() {\n    for host in hosts {\n        validate_component();\n        build_artifact();\n        upload_to_host();\n        notify_deploy_only();\n    }\n}",
+        );
+    let at_floor_b = make_fingerprint_with_content(
+            "src/at_floor_b.rs",
+            &["upgrade_at_floor"],
+            "fn upgrade_at_floor() {\n    for host in hosts {\n        validate_component();\n        build_artifact();\n        upload_to_host();\n        notify_upgrade_only();\n    }\n}",
+        );
+
+    let at_floor_findings = detect_parallel_implementations(
+        &[&at_floor_a, &at_floor_b],
+        &std::collections::HashSet::new(),
+        &DuplicationDetectorConfig::default(),
+    );
+    assert_eq!(
+        at_floor_findings.len(),
+        2,
+        "Pairs at the shared-call floor must still produce parallel implementation findings"
+    );
+    assert!(at_floor_findings
+        .iter()
+        .all(|finding| finding.kind == AuditFinding::ParallelImplementation));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Precompute filtered signal call sequences and unique signal sets once per method before pair scoring.
- Preserve the existing all-pairs ordering and finding semantics while skipping LCS for pairs that fail the already-required shared-call floor.
- Replace the per-pair full LCS matrix with a rolling-row implementation to reduce allocation pressure.

Fixes #3403.

## Verification
- `cargo fmt --check`
- `cargo test core::code_audit::duplication::tests::parallel --lib`
- `cargo test core::code_audit::duplication --lib`
- `cargo run --bin homeboy -- audit --force-hot --only parallel-implementation homeboy`

Full `cargo run --bin homeboy -- audit homeboy` smoke was attempted, but the lab runner health check failed, the local machine was hot, and the command hit the 20-minute tool timeout before completion.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the parallel-implementation scoring path, drafting the signal-preserving optimization, updating focused tests, and running verification.