### PR TITLE
fix lint refactor dirty-file reporting

### DIFF
--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -24,8 +24,9 @@ use cache::{
 };
 use extension_source::{read_optional_json, try_extension_refactor_source_stage};
 use lint_scope::{
-    capture_release_owned_files, constrain_lint_fix_changes, lint_finding_scope_files,
-    lint_scope_glob, reject_unsafe_lint_autofix_changes, restore_release_owned_files,
+    capture_dirty_file_snapshot, capture_release_owned_files, constrain_lint_fix_changes,
+    lint_finding_scope_files, lint_scope_glob, reject_unsafe_lint_autofix_changes,
+    restore_release_owned_files,
 };
 use planning::{
     analyze_stage_overlaps, collect_collected_edits, collect_stage_changed_files,
@@ -736,6 +737,7 @@ fn run_lint_stage(
     };
     let (stage_changed_files, fix_results, stage_warnings) = if write && !lint_findings.is_empty() {
         let before_dirty = git::get_dirty_files(&root_str).unwrap_or_default();
+        let before_dirty_snapshot = capture_dirty_file_snapshot(root, &before_dirty);
 
         // Save undo snapshot before applying lint fixes.
         let mut snap = UndoSnapshot::new(root, "lint fix");
@@ -765,6 +767,7 @@ fn run_lint_stage(
             root,
             fix_scope_files,
             &before_dirty,
+            &before_dirty_snapshot,
             after_dirty,
             &release_owned,
         )?;

--- a/src/core/refactor/plan/sources/lint_scope.rs
+++ b/src/core/refactor/plan/sources/lint_scope.rs
@@ -1,7 +1,7 @@
 use crate::core::component::Component;
 use crate::core::git;
 use crate::core::Error;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
@@ -15,6 +15,22 @@ pub(super) struct ReleaseOwnedFileSnapshot {
 pub(super) struct LintFixScopeOutcome {
     pub(super) changed_files: Vec<String>,
     pub(super) warnings: Vec<String>,
+}
+
+pub(super) type DirtyFileSnapshot = BTreeMap<String, Vec<u8>>;
+
+pub(super) fn capture_dirty_file_snapshot(
+    root: &Path,
+    dirty_files: &[String],
+) -> DirtyFileSnapshot {
+    dirty_files
+        .iter()
+        .filter_map(|file| {
+            fs::read(root.join(file))
+                .ok()
+                .map(|bytes| (file.clone(), bytes))
+        })
+        .collect()
 }
 
 pub(super) fn capture_release_owned_files(
@@ -85,24 +101,37 @@ pub(super) fn constrain_lint_fix_changes(
     root: &Path,
     selected_files: Option<&[String]>,
     before_dirty: &[String],
+    before_dirty_snapshot: &DirtyFileSnapshot,
     after_dirty: Vec<String>,
     release_owned: &[ReleaseOwnedFileSnapshot],
 ) -> crate::core::Result<LintFixScopeOutcome> {
     let before_set: HashSet<&str> = before_dirty.iter().map(|file| file.as_str()).collect();
+    let after_set: HashSet<String> = after_dirty.iter().cloned().collect();
     let release_owned_set: HashSet<&str> = release_owned
         .iter()
         .map(|snapshot| snapshot.relative.as_str())
         .collect();
-    let newly_changed: Vec<String> = after_dirty
-        .into_iter()
-        .filter(|file| {
-            !before_set.contains(file.as_str()) && !release_owned_set.contains(file.as_str())
-        })
-        .collect();
+    let mut changed = BTreeSet::new();
+    for file in after_dirty {
+        if release_owned_set.contains(file.as_str()) {
+            continue;
+        }
+
+        if !before_set.contains(file.as_str()) {
+            changed.insert(file);
+            continue;
+        }
+
+        if let Some(before_bytes) = before_dirty_snapshot.get(&file) {
+            if fs::read(root.join(&file)).is_ok_and(|after_bytes| after_bytes != *before_bytes) {
+                changed.insert(file);
+            }
+        }
+    }
 
     let Some(selected_files) = selected_files else {
         return Ok(LintFixScopeOutcome {
-            changed_files: newly_changed,
+            changed_files: changed.into_iter().collect(),
             warnings: Vec::new(),
         });
     };
@@ -111,9 +140,12 @@ pub(super) fn constrain_lint_fix_changes(
     let mut allowed = Vec::new();
     let mut out_of_scope = Vec::new();
 
-    for file in newly_changed {
+    let mut dirty_out_of_scope = Vec::new();
+    for file in changed {
         if selected_set.contains(file.as_str()) {
             allowed.push(file);
+        } else if before_set.contains(file.as_str()) || !after_set.contains(&file) {
+            dirty_out_of_scope.push(file);
         } else {
             out_of_scope.push(file);
         }
@@ -126,6 +158,13 @@ pub(super) fn constrain_lint_fix_changes(
             "Discarded {} lint autofix change(s) outside selected scope: {}",
             out_of_scope.len(),
             out_of_scope.join(", ")
+        ));
+    }
+    if !dirty_out_of_scope.is_empty() {
+        warnings.push(format!(
+            "Left {} pre-existing dirty lint autofix change(s) outside selected scope untouched: {}",
+            dirty_out_of_scope.len(),
+            dirty_out_of_scope.join(", ")
         ));
     }
 
@@ -439,9 +478,16 @@ mod tests {
 
         let after_dirty = git::get_dirty_files(&root.to_string_lossy()).unwrap();
         let selected_files = vec!["src/scoped.rs".to_string()];
-        let outcome =
-            constrain_lint_fix_changes(&root, Some(&selected_files), &[], after_dirty, &[])
-                .unwrap();
+        let before_dirty_snapshot = DirtyFileSnapshot::new();
+        let outcome = constrain_lint_fix_changes(
+            &root,
+            Some(&selected_files),
+            &[],
+            &before_dirty_snapshot,
+            after_dirty,
+            &[],
+        )
+        .unwrap();
 
         assert_eq!(outcome.changed_files, vec!["src/scoped.rs"]);
         assert_eq!(
@@ -457,6 +503,41 @@ mod tests {
             .warnings
             .iter()
             .any(|warning| warning.contains("outside selected scope")));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lint_fix_scope_counts_selected_file_that_was_dirty_before_fix() {
+        let root = tmp_dir("lint-fix-dirty-selected");
+        fs::create_dir_all(root.join("src")).unwrap();
+        run_git(&root, &["init", "-q"]);
+        run_git(&root, &["config", "user.email", "test@example.com"]);
+        run_git(&root, &["config", "user.name", "test"]);
+
+        fs::write(root.join("src/scoped.php"), "<?php\nfunction bad(){\n}\n").unwrap();
+        run_git(&root, &["add", "."]);
+        run_git(&root, &["commit", "-q", "-m", "init"]);
+
+        fs::write(root.join("src/scoped.php"), "<?php\nfunction bad( ){\n}\n").unwrap();
+        let before_dirty = git::get_dirty_files(&root.to_string_lossy()).unwrap();
+        let before_dirty_snapshot = capture_dirty_file_snapshot(&root, &before_dirty);
+
+        fs::write(root.join("src/scoped.php"), "<?php\nfunction bad() {\n}\n").unwrap();
+        let after_dirty = git::get_dirty_files(&root.to_string_lossy()).unwrap();
+        let selected_files = vec!["src/scoped.php".to_string()];
+        let outcome = constrain_lint_fix_changes(
+            &root,
+            Some(&selected_files),
+            &before_dirty,
+            &before_dirty_snapshot,
+            after_dirty,
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(outcome.changed_files, vec!["src/scoped.php"]);
+        assert!(outcome.warnings.is_empty());
 
         let _ = fs::remove_dir_all(root);
     }


### PR DESCRIPTION
## Summary
- Fixes `homeboy refactor --from lint --write --force` reporting no lint autofix changes when PHPCBF modifies a file that was already dirty before the fix pass.
- Snapshots pre-existing dirty files before invoking the lint fixer and counts selected files whose bytes changed during the fix pass.
- Keeps pre-existing dirty out-of-scope files untouched instead of discarding user work.

Fixes #3418.
Related: #1145.

## Verification
- `cargo fmt --check`
- `cargo test lint_fix_scope --lib`
- `cargo test core::refactor::plan::sources --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the refactor/lint plumbing, implemented the dirty-file accounting fix, and added focused regression coverage. Chris remains responsible for review and merge.