### PR TITLE
Fix release audit fixture isolation

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -388,7 +388,9 @@ fn normalize_shell_export_value(value: &str) -> String {
 mod tests {
     use super::*;
     use crate::commands::utils::args::{BaselineArgs, ExtensionOverrideArgs, SettingArgs};
-    use crate::test_support::with_isolated_home;
+    use crate::test_support::{
+        with_isolated_audit_home, with_isolated_home, write_source_extension,
+    };
     use clap::Parser;
     use homeboy::core::observation::ObservationStore;
     use std::fs;
@@ -789,60 +791,65 @@ mod tests {
     /// Fixes are now owned by `homeboy refactor --from audit --write`.
     #[test]
     fn audit_detects_outliers_in_convention_group() {
-        let _audit_guard = crate::test_support::AuditGuard::new();
-        let root = tmp_dir("audit-read-only");
-        fs::create_dir_all(root.join("commands")).unwrap();
+        with_isolated_audit_home(|home| {
+            write_source_extension(home.path(), "source-fixture", "rs");
+            let root = tmp_dir("audit-read-only");
+            fs::create_dir_all(root.join("commands")).unwrap();
 
-        fs::write(
-            root.join("commands/good_one.rs"),
-            "pub fn run() {}\npub fn execute() {}\n",
-        )
-        .unwrap();
-        fs::write(
-            root.join("commands/good_two.rs"),
-            "pub fn run() {}\npub fn execute() {}\n",
-        )
-        .unwrap();
-        fs::write(
-            root.join("commands/good_three.rs"),
-            "pub fn run() {}\npub fn execute() {}\n",
-        )
-        .unwrap();
-        fs::write(root.join("commands/bad.rs"), "pub fn run() {}\n").unwrap();
+            fs::write(
+                root.join("commands/good_one.rs"),
+                "pub fn run() {}\npub fn execute() {}\n",
+            )
+            .unwrap();
+            fs::write(
+                root.join("commands/good_two.rs"),
+                "pub fn run() {}\npub fn execute() {}\n",
+            )
+            .unwrap();
+            fs::write(
+                root.join("commands/good_three.rs"),
+                "pub fn run() {}\npub fn execute() {}\n",
+            )
+            .unwrap();
+            fs::write(root.join("commands/bad.rs"), "pub fn run() {}\n").unwrap();
 
-        let args = AuditArgs {
-            comp: PositionalComponentArgs {
-                component: Some(root.to_string_lossy().to_string()),
-                path: None,
-            },
-            extension_override: ExtensionOverrideArgs::default(),
-            conventions: false,
-            only: vec![],
-            exclude: vec![],
-            baseline_args: BaselineArgs {
-                baseline: false,
-                ignore_baseline: true,
-                ratchet: false,
-            },
-            changed_since: None,
-            json_summary: false,
-            fixability: false,
-        };
+            let args = AuditArgs {
+                comp: PositionalComponentArgs {
+                    component: Some(root.to_string_lossy().to_string()),
+                    path: None,
+                },
+                extension_override: ExtensionOverrideArgs {
+                    extensions: vec!["source-fixture".to_string()],
+                },
+                conventions: false,
+                only: vec![],
+                exclude: vec![],
+                baseline_args: BaselineArgs {
+                    baseline: false,
+                    ignore_baseline: true,
+                    ratchet: false,
+                },
+                changed_since: None,
+                json_summary: false,
+                fixability: false,
+            };
 
-        let (output, code) = run(args, &crate::commands::GlobalArgs {}).expect("audit should run");
+            let (output, code) =
+                run(args, &crate::commands::GlobalArgs {}).expect("audit should run");
 
-        // Audit should detect the outlier and return findings
-        // Summary or other modes are also valid.
-        if let AuditCommandOutput::Full { result, .. } = output {
-            assert!(
-                !result.findings.is_empty(),
-                "expected findings for the outlier file"
-            );
-        }
+            // Audit should detect the outlier and return findings
+            // Summary or other modes are also valid.
+            if let AuditCommandOutput::Full { result, .. } = output {
+                assert!(
+                    !result.findings.is_empty(),
+                    "expected findings for the outlier file"
+                );
+            }
 
-        // Non-zero exit expected when outliers are found
-        assert!(code >= 0, "audit should complete without error");
+            // Non-zero exit expected when outliers are found
+            assert!(code >= 0, "audit should complete without error");
 
-        let _ = fs::remove_dir_all(root);
+            let _ = fs::remove_dir_all(root);
+        });
     }
 }

--- a/src/core/code_audit/detectors/artifact_portability.rs
+++ b/src/core/code_audit/detectors/artifact_portability.rs
@@ -135,10 +135,10 @@ fn metadata_path_findings(
     let cleanup_promised = metadata_promises_cleanup(&run.metadata_json);
     let mut scan = MetadataPathScan::default();
     for field in metadata_string_fields(&run.metadata_json) {
-        scan.fields_scanned += 1;
         if is_runner_artifact_ref(field.value)
             && !artifact_paths.iter().any(|path| path == field.value)
         {
+            scan.fields_scanned += 1;
             scan.findings.push(portability_finding(
                 run,
                 &field.path,
@@ -155,6 +155,7 @@ fn metadata_path_findings(
         if !field_expects_portable_artifact_ref(&field.path) {
             continue;
         }
+        scan.fields_scanned += 1;
         if !looks_like_local_absolute_path(field.value, artifact_root, config) {
             continue;
         }
@@ -579,7 +580,7 @@ mod tests {
 
             assert_eq!(report.run_window, DEFAULT_OBSERVATION_RUN_WINDOW);
             assert_eq!(report.runs_scanned, 60);
-            assert_eq!(report.metadata_fields_scanned, 120);
+            assert_eq!(report.metadata_fields_scanned, 60);
             assert_eq!(report.findings.len(), 60);
             assert!(report
                 .findings
@@ -627,7 +628,7 @@ mod tests {
 
             assert_eq!(report.run_window, 2);
             assert_eq!(report.runs_scanned, 2);
-            assert_eq!(report.metadata_fields_scanned, 4);
+            assert_eq!(report.metadata_fields_scanned, 2);
             assert_eq!(report.findings.len(), 2);
             assert!(!report
                 .findings

--- a/src/core/code_audit/detectors/artifact_portability.rs
+++ b/src/core/code_audit/detectors/artifact_portability.rs
@@ -135,10 +135,10 @@ fn metadata_path_findings(
     let cleanup_promised = metadata_promises_cleanup(&run.metadata_json);
     let mut scan = MetadataPathScan::default();
     for field in metadata_string_fields(&run.metadata_json) {
-        scan.fields_scanned += 1;
         if is_runner_artifact_ref(field.value)
             && !artifact_paths.iter().any(|path| path == field.value)
         {
+            scan.fields_scanned += 1;
             scan.findings.push(portability_finding(
                 run,
                 &field.path,
@@ -155,6 +155,7 @@ fn metadata_path_findings(
         if !field_expects_portable_artifact_ref(&field.path) {
             continue;
         }
+        scan.fields_scanned += 1;
         if !looks_like_local_absolute_path(field.value, artifact_root, config) {
             continue;
         }
@@ -579,7 +580,7 @@ mod tests {
 
             assert_eq!(report.run_window, DEFAULT_OBSERVATION_RUN_WINDOW);
             assert_eq!(report.runs_scanned, 60);
-            assert!(report.metadata_fields_scanned >= 120);
+            assert_eq!(report.metadata_fields_scanned, 60);
             assert_eq!(report.findings.len(), 60);
             assert!(report
                 .findings
@@ -627,7 +628,7 @@ mod tests {
 
             assert_eq!(report.run_window, 2);
             assert_eq!(report.runs_scanned, 2);
-            assert!(report.metadata_fields_scanned >= 4);
+            assert_eq!(report.metadata_fields_scanned, 2);
             assert_eq!(report.findings.len(), 2);
             assert!(!report
                 .findings

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -172,19 +172,16 @@ pub(crate) fn write_source_extension(home: &std::path::Path, id: &str, file_exte
     .expect("fingerprint script");
 
     if matches!(file_extension, "rs" | "fixture") {
-        std::fs::write(
-            extension_dir.join("grammar.toml"),
-            minimal_source_grammar(file_extension),
-        )
-        .expect("source grammar");
+        std::fs::write(extension_dir.join("grammar.toml"), minimal_source_grammar())
+            .expect("source grammar");
     }
 }
 
-fn minimal_source_grammar(file_extension: &str) -> String {
+fn minimal_source_grammar() -> &'static str {
     r#"
 [language]
 id = "source"
-extensions = ["__FILE_EXTENSION__"]
+extensions = ["rs", "fixture"]
 
 [comments]
 line = ["//"]
@@ -255,7 +252,6 @@ context = "any"
 regex = '#\[cfg\(test\)\]'
 context = "any"
 "#
-    .replace("__FILE_EXTENSION__", file_extension)
 }
 
 pub(crate) fn home_env_guard() -> MutexGuard<'static, ()> {

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -22,6 +22,11 @@ pub(crate) struct AuditGuard {
     _home_guard: MutexGuard<'static, ()>,
 }
 
+pub(crate) struct AuditHomeGuard {
+    home: HomeGuard,
+    _guard: MutexGuard<'static, ()>,
+}
+
 impl AuditGuard {
     pub(crate) fn new() -> Self {
         let home_guard = home_lock().lock().unwrap_or_else(|e| e.into_inner());
@@ -29,6 +34,17 @@ impl AuditGuard {
         Self {
             _guard: guard,
             _home_guard: home_guard,
+        }
+    }
+}
+
+impl AuditHomeGuard {
+    pub(crate) fn new() -> Self {
+        let home = HomeGuard::new();
+        let guard = audit_lock().lock().unwrap_or_else(|e| e.into_inner());
+        Self {
+            _guard: guard,
+            home,
         }
     }
 }
@@ -124,6 +140,122 @@ impl Drop for HomeGuard {
 pub(crate) fn with_isolated_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {
     let home = HomeGuard::new();
     body(&home.dir)
+}
+
+pub(crate) fn with_isolated_audit_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {
+    let guard = AuditHomeGuard::new();
+    body(&guard.home.dir)
+}
+
+pub(crate) fn write_source_extension(home: &std::path::Path, id: &str, file_extension: &str) {
+    let extension_dir = home.join(".config/homeboy/extensions").join(id);
+    std::fs::create_dir_all(&extension_dir).expect("extension dir");
+    std::fs::write(
+        extension_dir.join(format!("{id}.json")),
+        serde_json::json!({
+            "name": id,
+            "version": "0.0.0",
+            "provides": {
+                "file_extensions": [file_extension]
+            },
+            "scripts": {
+                "fingerprint": "fingerprint.sh"
+            }
+        })
+        .to_string(),
+    )
+    .expect("source extension manifest");
+    std::fs::write(
+        extension_dir.join("fingerprint.sh"),
+        "#!/usr/bin/env sh\nexit 1\n",
+    )
+    .expect("fingerprint script");
+
+    if matches!(file_extension, "rs" | "fixture") {
+        std::fs::write(
+            extension_dir.join("grammar.toml"),
+            minimal_source_grammar(file_extension),
+        )
+        .expect("source grammar");
+    }
+}
+
+fn minimal_source_grammar(file_extension: &str) -> String {
+    r#"
+[language]
+id = "source"
+extensions = ["__FILE_EXTENSION__"]
+
+[comments]
+line = ["//"]
+block = [["/*", "*/"]]
+doc = ["///", "//!"]
+
+[strings]
+quotes = ['"']
+escape = "\\"
+
+[blocks]
+open = "{"
+close = "}"
+
+[fingerprint]
+keywords = ["fn", "let", "if", "for", "return", "true", "false", "pub", "struct", "impl", "trait", "Self", "Result", "String", "bool", "i32", "usize"]
+skip_calls = ["if", "for", "return", "println", "write", "assert"]
+contract_method_names = []
+contract_type_hints = []
+registration_concepts = ["macro_invocation"]
+registration_skip_names = ["println", "assert", "write"]
+registration_skip_prefixes = ["test"]
+
+[fingerprint.namespace_derivation]
+prefix = "crate::"
+strip_leading_segments = 1
+separator = "::"
+include_file_stem_when_root = true
+
+[patterns.function]
+regex = '^\s*(pub(?:\(crate\))?\s+)?(?:async\s+)?(?:unsafe\s+)?(?:const\s+)?fn\s+(\w+)\s*\(([^)]*)\)'
+context = "any"
+
+[patterns.function.captures]
+visibility = 1
+name = 2
+params = 3
+
+[patterns.struct]
+regex = '^\s*(pub(?:\(crate\))?\s+)?(struct|enum|trait)\s+(\w+)'
+context = "top_level"
+
+[patterns.struct.captures]
+visibility = 1
+kind = 2
+name = 3
+
+[patterns.import]
+regex = '^use\s+([\w:]+(?:::\{[^}]+\})?)\s*;'
+context = "top_level"
+
+[patterns.import.captures]
+path = 1
+
+[patterns.impl_block]
+regex = '^\s*impl(?:<[^>]*>)?\s+(?:(\w+)\s+for\s+)?(\w+)'
+context = "any"
+
+[patterns.impl_block.captures]
+trait_name = 1
+type_name = 2
+
+[patterns.test_attribute]
+regex = '#\[test\]'
+context = "any"
+
+[patterns.cfg_test]
+regex = '#\[cfg\(test\)\]'
+context = "any"
+"#
+    .replace("__FILE_EXTENSION__", file_extension)
 }
 
 pub(crate) fn home_env_guard() -> MutexGuard<'static, ()> {

--- a/tests/architecture_core_agnostic_test.rs
+++ b/tests/architecture_core_agnostic_test.rs
@@ -134,10 +134,6 @@ const DETECTOR_AGNOSTIC_BASELINE: &[DetectorAgnosticBaseline] = &[
         token: "Rust",
     },
     DetectorAgnosticBaseline {
-        path: "src/core/code_audit/detectors/artifact_portability.rs",
-        token: "runner-artifact://",
-    },
-    DetectorAgnosticBaseline {
         path: "src/core/code_audit/detectors/command_status_contracts.rs",
         token: "Homeboy",
     },
@@ -294,7 +290,7 @@ const DETECTOR_AGNOSTIC_BASELINE: &[DetectorAgnosticBaseline] = &[
         token: "php",
     },
 ];
-const DETECTOR_AGNOSTIC_BASELINE_OCCURRENCES: usize = 80;
+const DETECTOR_AGNOSTIC_BASELINE_OCCURRENCES: usize = 77;
 
 fn source_file(relative_path: &str) -> String {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path);

--- a/tests/core/code_audit/report_test.rs
+++ b/tests/core/code_audit/report_test.rs
@@ -323,59 +323,61 @@ fn test_compute_fixability_counts_fixes_from_real_audit() {
 fn test_compute_fixability_with_analysis() {
     use std::fs;
 
-    let _audit_guard = crate::test_support::AuditGuard::new();
-    let dir = tempfile::tempdir().expect("temp dir");
-    let root = dir.path();
+    crate::test_support::with_isolated_audit_home(|home| {
+        crate::test_support::write_source_extension(home.path(), "source-fixture", "fixture");
+        let dir = tempfile::tempdir().expect("temp dir");
+        let root = dir.path();
 
-    fs::create_dir_all(root.join("commands")).unwrap();
-    fs::write(
-        root.join("commands/good_one.rs"),
-        "pub fn run() {}\npub fn helper() {}\n",
-    )
-    .unwrap();
-    fs::write(
-        root.join("commands/good_two.rs"),
-        "pub fn run() {}\npub fn helper() {}\n",
-    )
-    .unwrap();
-    fs::write(root.join("commands/bad.rs"), "pub fn run() {}\n").unwrap();
+        fs::create_dir_all(root.join("commands")).unwrap();
+        fs::write(
+            root.join("commands/good_one.fixture"),
+            "pub fn run() {}\npub fn helper() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("commands/good_two.fixture"),
+            "pub fn run() {}\npub fn helper() {}\n",
+        )
+        .unwrap();
+        fs::write(root.join("commands/bad.fixture"), "pub fn run() {}\n").unwrap();
 
-    let audit = crate::core::code_audit::audit_path_with_id_with_plan_and_analysis(
-        "fixability-context-test",
-        &root.to_string_lossy(),
-        &crate::core::code_audit::AuditExecutionPlan::full(),
-        &[],
-        &[],
-    )
-    .expect("audit should run with analysis");
+        let audit = crate::core::code_audit::audit_path_with_id_with_plan_and_analysis(
+            "fixability-context-test",
+            &root.to_string_lossy(),
+            &crate::core::code_audit::AuditExecutionPlan::full(),
+            &[],
+            &["source-fixture".to_string()],
+        )
+        .expect("audit should run with analysis");
 
-    assert!(
-        !audit.analysis.fingerprints.is_empty(),
-        "audit analysis should retain fingerprints for fixability planning"
-    );
-    assert!(
-        audit
-            .analysis
-            .fingerprints
-            .iter()
-            .any(|fp| fp.relative_path == "commands/good_one.rs"
-                && fp.content.contains("pub fn helper")),
-        "audit analysis should retain source content for downstream fix planning"
-    );
-
-    let from_context = compute_fixability_with_analysis(&audit.result, &audit.analysis);
-    let from_wrapper = compute_fixability(&audit.result);
-
-    assert_eq!(from_context.is_some(), from_wrapper.is_some());
-    if let (Some(context), Some(wrapper)) = (from_context, from_wrapper) {
-        assert_eq!(context.fixable_count, wrapper.fixable_count);
-        assert_eq!(context.automated_count, wrapper.automated_count);
-        assert_eq!(context.manual_only_count, wrapper.manual_only_count);
-        assert_eq!(
-            serde_json::to_value(&context.by_kind).unwrap(),
-            serde_json::to_value(&wrapper.by_kind).unwrap()
+        assert!(
+            !audit.analysis.fingerprints.is_empty(),
+            "audit analysis should retain fingerprints for fixability planning"
         );
-    }
+        assert!(
+            audit
+                .analysis
+                .fingerprints
+                .iter()
+                .any(|fp| fp.relative_path == "commands/good_one.fixture"
+                    && fp.content.contains("pub fn helper")),
+            "audit analysis should retain source content for downstream fix planning"
+        );
+
+        let from_context = compute_fixability_with_analysis(&audit.result, &audit.analysis);
+        let from_wrapper = compute_fixability(&audit.result);
+
+        assert_eq!(from_context.is_some(), from_wrapper.is_some());
+        if let (Some(context), Some(wrapper)) = (from_context, from_wrapper) {
+            assert_eq!(context.fixable_count, wrapper.fixable_count);
+            assert_eq!(context.automated_count, wrapper.automated_count);
+            assert_eq!(context.manual_only_count, wrapper.manual_only_count);
+            assert_eq!(
+                serde_json::to_value(&context.by_kind).unwrap(),
+                serde_json::to_value(&wrapper.by_kind).unwrap()
+            );
+        }
+    });
 }
 
 #[test]

--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -566,14 +566,6 @@ const BASELINE: &[ViolationKey] = &[
         term: "homeboy.json",
     },
     ViolationKey {
-        path: "src/core/code_audit/detectors/artifact_portability.rs",
-        term: "HOMEBOY_",
-    },
-    ViolationKey {
-        path: "src/core/code_audit/detectors/artifact_portability.rs",
-        term: "runner-artifact://",
-    },
-    ViolationKey {
         path: "src/core/code_audit/detectors/command_status_contracts.rs",
         term: "Homeboy",
     },
@@ -1159,7 +1151,7 @@ const BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const BASELINE_OCCURRENCES: usize = 664;
+const BASELINE_OCCURRENCES: usize = 659;
 
 // Known core-owned test/fixture literal debt tracked by #3034. Keep this list
 // explicit so stale rows and occurrence-count changes force cleanup or review.

--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -1050,15 +1050,11 @@ const BASELINE: &[ViolationKey] = &[
         term: "Homeboy",
     },
     ViolationKey {
-        path: "src/core/runner/lab.rs",
-        term: ".homeboy",
-    },
-    ViolationKey {
-        path: "src/core/runner/lab.rs",
+        path: "src/core/runner/lab_args.rs",
         term: "Lab",
     },
     ViolationKey {
-        path: "src/core/runner/lab.rs",
+        path: "src/core/runner/lab_args.rs",
         term: "offload",
     },
     ViolationKey {
@@ -1068,6 +1064,18 @@ const BASELINE: &[ViolationKey] = &[
     ViolationKey {
         path: "src/core/runner/lab_command.rs",
         term: "cargo",
+    },
+    ViolationKey {
+        path: "src/core/runner/lab_selection.rs",
+        term: ".homeboy",
+    },
+    ViolationKey {
+        path: "src/core/runner/lab_selection.rs",
+        term: "Lab",
+    },
+    ViolationKey {
+        path: "src/core/runner/lab_selection.rs",
+        term: "offload",
     },
     ViolationKey {
         path: "src/core/runner/offload_changed_since.rs",
@@ -1151,7 +1159,7 @@ const BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const BASELINE_OCCURRENCES: usize = 659;
+const BASELINE_OCCURRENCES: usize = 631;
 
 // Known core-owned test/fixture literal debt tracked by #3034. Keep this list
 // explicit so stale rows and occurrence-count changes force cleanup or review.


### PR DESCRIPTION
## Summary
- Isolates audit/fixability tests from ambient user Homeboy extension state by creating a test-local source extension and grammar fixture.
- Keeps core-owned integration fixtures language-neutral by using `.fixture` files where the core-agnostic test-content gate scans string literals.
- Fixes artifact portability diagnostic scan counts to count candidate artifact-reference metadata fields instead of every normalized metadata string, and prunes now-stale agnostic baseline rows.

## Verification
- `cargo test audit_detects_outliers_in_convention_group -- --nocapture`
- `cargo test test_compute_fixability_with_analysis -- --nocapture`
- `cargo test core_owned_test_content_stays_language_and_framework_agnostic --test core_agnostic_test`
- `cargo test artifact_portability --lib -- --nocapture`
- `cargo test core_owned_source_stays_language_and_framework_agnostic --test core_agnostic_test`
- `cargo test detector_implementations_stay_domain_agnostic --test architecture_core_agnostic_test`
- `cargo run --bin homeboy -- test homeboy --path /Users/chubes/Developer/homeboy@fix-release-audit-fixability-gate` via lab offload: `3910 total`, `3887 passed`, `0 failed`, `23 skipped/ignored`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the release test failures, implemented the test isolation and artifact-portability counter fixes, resolved rebase conflicts, and ran verification. Chris remains responsible for review and merge.