### PR TITLE
Fix audit baseline artifact fingerprints

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -136,35 +136,39 @@
   "baselines": {
     "audit": {
       "context_id": "homeboy",
-      "created_at": "2026-06-01T03:40:08Z",
-      "item_count": 14,
+      "created_at": "2026-06-03T19:07:31Z",
+      "item_count": 18,
       "known_fingerprints": [
-        "artifact_portability::observation:0c1c8a3c-0f6c-4639-9a6b-97192be09b43::NonPortableArtifactPath",
+        "artifact_portability::artifact_portability/local_artifact_path/$.lab.remote_artifact_manifest[0].path::NonPortableArtifactPath",
+        "artifact_portability::artifact_portability/local_artifact_path/$.lab.remote_artifact_manifest[1].path::NonPortableArtifactPath",
+        "artifact_portability::artifact_portability/local_artifact_path/$.run_dir::NonPortableArtifactPath",
         "structural::src/commands/bench/tests.rs::HighItemCount",
         "structural::src/commands/runs/gh_actions.rs::HighItemCount",
         "structural::src/commands/trace.rs::GodFile",
         "structural::src/commands/trace/tests.rs::GodFile",
+        "structural::src/commands::DirectorySprawl",
         "structural::src/core/code_audit/conventions.rs::GodFile",
         "structural::src/core/code_audit/core_fingerprint.rs::GodFile",
         "structural::src/core/code_audit/mod.rs::GodFile",
         "structural::src/core/extension/grammar.rs::GodFile",
         "structural::src/core/extension/lifecycle.rs::GodFile",
         "structural::src/core/refactor/rename/mod.rs::GodFile",
+        "structural::src/core/release/executor.rs::GodFile",
         "structural::src/core/rig/pipeline.rs::HighItemCount",
         "structural::tests/core_agnostic_test.rs::GodFile",
         "structural::tests/core_agnostic_test.rs::HighItemCount"
       ],
       "metadata": {
-        "alignment_score": 0.8987341523170471,
+        "alignment_score": 0.9024389982223511,
         "known_outliers": [
-          "src/core/observation/records/run_status.rs",
           "src/core/observation/records/triage_items.rs",
+          "src/core/observation/records/run_status.rs",
           "src/core/observation/records/run_builder.rs",
-          "src/commands/report/failure_digest.rs",
           "src/commands/report/bench_coverage.rs",
+          "src/commands/report/failure_digest.rs",
           "src/core/engine/undo/rollback.rs",
-          "src/core/engine/undo/entry.rs",
-          "src/core/engine/undo/snapshot.rs"
+          "src/core/engine/undo/snapshot.rs",
+          "src/core/engine/undo/entry.rs"
         ],
         "outliers_count": 8
       }

--- a/src/core/code_audit/baseline.rs
+++ b/src/core/code_audit/baseline.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use crate::core::engine::baseline::{self as generic, BaselineConfig, Fingerprintable};
 
+use super::conventions::AuditFinding as AuditFindingKind;
 use super::findings::Finding;
 use super::CodeAuditResult;
 
@@ -48,7 +49,12 @@ struct AuditFinding<'a>(&'a Finding);
 
 impl Fingerprintable for AuditFinding<'_> {
     fn fingerprint(&self) -> String {
-        format!("{}::{}::{:?}", self.0.convention, self.0.file, self.0.kind)
+        let file = if self.0.kind == AuditFindingKind::NonPortableArtifactPath {
+            artifact_portability_baseline_file(self.0)
+        } else {
+            self.0.file.clone()
+        };
+        format!("{}::{}::{:?}", self.0.convention, file, self.0.kind)
     }
 
     fn description(&self) -> String {
@@ -58,6 +64,36 @@ impl Fingerprintable for AuditFinding<'_> {
     fn context_label(&self) -> String {
         self.0.convention.clone()
     }
+}
+
+fn artifact_portability_baseline_file(finding: &Finding) -> String {
+    let issue = if finding
+        .description
+        .contains("without a mirrored artifact record")
+    {
+        "missing_mirrored_artifact"
+    } else if finding.description.starts_with("Artifact ") {
+        "artifact_path"
+    } else if finding
+        .description
+        .contains("records local-only artifact path")
+    {
+        "local_artifact_path"
+    } else {
+        "non_portable_artifact_path"
+    };
+    let field = extract_backtick_value_after(&finding.description, "field `")
+        .unwrap_or("unknown_field")
+        .replace("::", ":");
+
+    format!("artifact_portability/{issue}/{field}")
+}
+
+fn extract_backtick_value_after<'a>(value: &'a str, marker: &str) -> Option<&'a str> {
+    let start = value.find(marker)? + marker.len();
+    let rest = &value[start..];
+    let end = rest.find('`')?;
+    Some(&rest[..end])
 }
 
 // ============================================================================
@@ -194,6 +230,22 @@ mod tests {
             description: description.to_string(),
             suggestion: String::new(),
             kind: AuditFinding::MissingMethod,
+        }
+    }
+
+    fn make_finding_with_kind(
+        convention: &str,
+        file: &str,
+        description: &str,
+        kind: AuditFinding,
+    ) -> Finding {
+        Finding {
+            convention: convention.to_string(),
+            severity: Severity::Warning,
+            file: file.to_string(),
+            description: description.to_string(),
+            suggestion: String::new(),
+            kind,
         }
     }
 
@@ -482,6 +534,52 @@ mod tests {
             AuditFinding(&f1).fingerprint(),
             AuditFinding(&f2).fingerprint(),
             "fingerprint should not change when line count changes"
+        );
+    }
+
+    #[test]
+    fn artifact_portability_fingerprint_ignores_observation_run_and_path() {
+        let f1 = make_finding_with_kind(
+            "artifact_portability",
+            "observation:run-a",
+            "Run metadata field $.run_dir records local-only artifact path /tmp/homeboy-run-a; command `homeboy test`; field `$.run_dir`",
+            AuditFinding::NonPortableArtifactPath,
+        );
+        let f2 = make_finding_with_kind(
+            "artifact_portability",
+            "observation:run-b",
+            "Run metadata field $.run_dir records local-only artifact path /Users/chris/.config/homeboy/runtime/tmp/homeboy-run-b; command `homeboy lint`; field `$.run_dir`",
+            AuditFinding::NonPortableArtifactPath,
+        );
+
+        assert_eq!(
+            AuditFinding(&f1).fingerprint(),
+            AuditFinding(&f2).fingerprint()
+        );
+        assert_eq!(
+            AuditFinding(&f1).fingerprint(),
+            "artifact_portability::artifact_portability/local_artifact_path/$.run_dir::NonPortableArtifactPath"
+        );
+    }
+
+    #[test]
+    fn artifact_portability_fingerprint_distinguishes_violation_shape() {
+        let local_path = make_finding_with_kind(
+            "artifact_portability",
+            "observation:run-a",
+            "Run metadata field $.patch_artifact_path records local-only artifact path /tmp/homeboy-run-a/patch.diff; command `homeboy test`; field `$.patch_artifact_path`",
+            AuditFinding::NonPortableArtifactPath,
+        );
+        let missing_mirror = make_finding_with_kind(
+            "artifact_portability",
+            "observation:run-b",
+            "Run metadata field $.patch_artifact_path records remote artifact ref runner-artifact://lab/run/patch without a mirrored artifact record; command `homeboy test`; field `$.patch_artifact_path`",
+            AuditFinding::NonPortableArtifactPath,
+        );
+
+        assert_ne!(
+            AuditFinding(&local_path).fingerprint(),
+            AuditFinding(&missing_mirror).fingerprint()
         );
     }
 

--- a/src/core/engine/baseline.rs
+++ b/src/core/engine/baseline.rs
@@ -132,6 +132,7 @@ pub fn save<M: Serialize + for<'de> Deserialize<'de>>(
 ) -> Result<PathBuf> {
     let mut known_fingerprints: Vec<String> = items.iter().map(|item| item.fingerprint()).collect();
     known_fingerprints.sort();
+    known_fingerprints.dedup();
     let metadata_value = serde_json::to_value(&metadata).map_err(|error| {
         Error::internal_io(
             format!("Failed to serialize baseline metadata: {}", error),
@@ -158,7 +159,7 @@ pub fn save<M: Serialize + for<'de> Deserialize<'de>>(
     let baseline = Baseline {
         created_at: utc_now_iso8601(),
         context_id: context_id.to_string(),
-        item_count: items.len(),
+        item_count: known_fingerprints.len(),
         known_fingerprints,
         metadata,
     };
@@ -323,12 +324,13 @@ pub fn compare<T: Fingerprintable, M: Serialize>(
         .map(|item| item.fingerprint())
         .collect();
     let current_set: HashSet<&String> = current_fingerprints.iter().collect();
+    let mut seen_new = HashSet::new();
 
     let new_items = current_items
         .iter()
         .filter(|item| {
             let fingerprint = item.fingerprint();
-            !baseline_set.contains(&fingerprint)
+            !baseline_set.contains(&fingerprint) && seen_new.insert(fingerprint)
         })
         .map(|item| NewItem {
             fingerprint: item.fingerprint(),
@@ -344,7 +346,7 @@ pub fn compare<T: Fingerprintable, M: Serialize>(
         .cloned()
         .collect::<Vec<_>>();
 
-    let delta = current_items.len() as i64 - baseline.item_count as i64;
+    let delta = current_set.len() as i64 - baseline.item_count as i64;
 
     Comparison {
         drift_increased: !new_items.is_empty(),


### PR DESCRIPTION
## Summary
- Stabilize audit baseline fingerprints for artifact-portability findings so observation run IDs and local artifact paths do not leak into `homeboy.json`.
- Deduplicate generic baseline fingerprints before saving/comparing so repeated findings share one baseline identity.
- Refresh the Homeboy audit baseline with stable artifact-portability field fingerprints.

## Verification
- `cargo test core::code_audit::baseline --lib`
- `cargo run --bin homeboy -- --force-hot audit --path . --json-summary`
- `cargo check --lib`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the audit baseline drift, drafted the fingerprinting/baseline changes, refreshed the baseline, and ran local verification. Chris remains responsible for review and merge.