### PR TITLE
Add component-backed task worktrees

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -50,6 +50,7 @@
 - [undo](undo.md) — restore or manage write-operation snapshots
 - [upgrade](upgrade.md)
 - [version](version.md)
+- [worktree](worktree.md) — component-backed task worktree lifecycle
 - [wp](wp.md) — run WP-CLI commands via WordPress extension routing
 
 This list covers the top-level CLI commands currently surfaced by `homeboy --help` in this checkout.

--- a/docs/commands/worktree.md
+++ b/docs/commands/worktree.md
@@ -1,0 +1,15 @@
+# worktree
+
+Manage component-backed task worktrees for generic Homeboy workflows.
+
+## Commands
+
+- `homeboy worktree create <component-id> --branch <branch> [--from <ref>] [--task-url <url>] [--run-id <id>]`
+- `homeboy worktree list`
+- `homeboy worktree status <id>`
+- `homeboy worktree remove <id> [--force]`
+- `homeboy worktree cleanup [--force]`
+
+## Safety
+
+Removal refuses dirty worktrees, unpushed commits, primary checkouts, and paths outside the component checkout parent. `--force` only bypasses dirty/unpushed checks; primary checkout and containment gates always apply.

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -5,7 +5,7 @@ use crate::commands::{
     agent_task, api, audit, auth, bench, build, changelog, changes, ci, cleanup, component, config,
     daemon, db, deploy, deps, doctor, extension, file, fleet, git, http, issues, lint, logs,
     observe, project, refactor, refs, release, report, review, rig, runner, runs, self_cmd, server,
-    ssh, stack, status, test, trace, triage, tunnel, undo, upgrade, version,
+    ssh, stack, status, test, trace, triage, tunnel, undo, upgrade, version, worktree,
 };
 
 mod lab_contract;
@@ -124,6 +124,8 @@ pub enum Commands {
     Rig(rig::RigArgs),
     /// Manage local and SSH execution runners
     Runner(runner::RunnerArgs),
+    /// Manage component-backed task worktrees
+    Worktree(worktree::WorktreeArgs),
     /// Manage private service tunnel declarations
     Tunnel(tunnel::TunnelArgs),
     /// Inspect persisted observation runs and artifacts
@@ -347,6 +349,7 @@ impl Commands {
             | Commands::Release(_)
             | Commands::Report(_)
             | Commands::Runner(_)
+            | Commands::Worktree(_)
             | Commands::Tunnel(_)
             | Commands::Stack(_)
             | Commands::Undo(_) => CommandDescriptor {

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -3,7 +3,8 @@ use crate::cli_surface::Commands;
 use super::{map, JsonRun};
 use crate::commands::{
     agent_task, build, changelog, changes, cleanup, component, config, docs, extension, project,
-    refactor, refs, release, report, rig, runner, runs, stack, tunnel, undo, version, GlobalArgs,
+    refactor, refs, release, report, rig, runner, runs, stack, tunnel, undo, version, worktree,
+    GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
@@ -25,6 +26,7 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Refs(args) => map(refs::run(args, global)),
         Commands::Rig(args) => map(rig::run(args, global)),
         Commands::Runner(args) => map(runner::run(args, global)),
+        Commands::Worktree(args) => map(worktree::run(args, global)),
         Commands::Tunnel(args) => map(tunnel::run(args, global)),
         Commands::Runs(args) => map(runs::run(args, global)),
         Commands::Stack(args) => map(stack::run(args, global)),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -221,6 +221,7 @@ pub mod undo;
 pub mod upgrade;
 pub mod utils;
 pub mod version;
+pub mod worktree;
 
 #[cfg(test)]
 mod golden_contract_tests;

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Subcommand, ValueEnum};
+use serde::Serialize;
 
 use homeboy::core::worktree::{
     self, CleanupPolicy, WorktreeCleanupOutput, WorktreeCreateOptions, WorktreeCreateOutput,
@@ -73,7 +74,7 @@ impl From<CliCleanupPolicy> for CleanupPolicy {
     }
 }
 
-#[derive(serde::Serialize)]
+#[derive(Serialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum WorktreeOutput {
     Create(WorktreeCreateOutput),

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -1,0 +1,111 @@
+use clap::{Args, Subcommand, ValueEnum};
+
+use homeboy::core::worktree::{
+    self, CleanupPolicy, WorktreeCleanupOutput, WorktreeCreateOptions, WorktreeCreateOutput,
+    WorktreeListOutput, WorktreeRemoveOptions, WorktreeRemoveOutput, WorktreeStatusOutput,
+};
+
+use super::CmdResult;
+
+#[derive(Args)]
+pub struct WorktreeArgs {
+    #[command(subcommand)]
+    command: WorktreeCommand,
+}
+
+#[derive(Subcommand)]
+enum WorktreeCommand {
+    /// Create a task worktree from a registered component checkout
+    Create {
+        /// Component ID to use as the source checkout
+        component_id: String,
+        /// Branch to create in the task worktree
+        #[arg(long)]
+        branch: String,
+        /// Base ref for the new worktree branch
+        #[arg(long = "from")]
+        from: Option<String>,
+        /// Task or issue URL associated with this worktree
+        #[arg(long)]
+        task_url: Option<String>,
+        /// Agent-task run ID associated with this worktree
+        #[arg(long)]
+        run_id: Option<String>,
+        /// Cleanup policy for lifecycle cleanup
+        #[arg(long, value_enum)]
+        cleanup_policy: Option<CliCleanupPolicy>,
+    },
+    /// List persisted task worktrees
+    List,
+    /// Inspect one task worktree and its safety gates
+    Status {
+        /// Task worktree ID, e.g. component@branch-slug
+        id: String,
+    },
+    /// Remove one task worktree after safety checks
+    Remove {
+        /// Task worktree ID, e.g. component@branch-slug
+        id: String,
+        /// Allow dirty/unpushed worktree removal; hard gates still apply
+        #[arg(long)]
+        force: bool,
+    },
+    /// Remove cleanup-eligible task worktrees after safety checks
+    Cleanup {
+        /// Allow dirty/unpushed worktree removal; hard gates still apply
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+enum CliCleanupPolicy {
+    RemoveWhenSafe,
+    PreserveOnFailure,
+}
+
+impl From<CliCleanupPolicy> for CleanupPolicy {
+    fn from(value: CliCleanupPolicy) -> Self {
+        match value {
+            CliCleanupPolicy::RemoveWhenSafe => CleanupPolicy::RemoveWhenSafe,
+            CliCleanupPolicy::PreserveOnFailure => CleanupPolicy::PreserveOnFailure,
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum WorktreeOutput {
+    Create(WorktreeCreateOutput),
+    List(WorktreeListOutput),
+    Status(WorktreeStatusOutput),
+    Remove(WorktreeRemoveOutput),
+    Cleanup(WorktreeCleanupOutput),
+}
+
+pub fn run(args: WorktreeArgs, _global: &super::GlobalArgs) -> CmdResult<WorktreeOutput> {
+    let output = match args.command {
+        WorktreeCommand::Create {
+            component_id,
+            branch,
+            from,
+            task_url,
+            run_id,
+            cleanup_policy,
+        } => WorktreeOutput::Create(worktree::create(WorktreeCreateOptions {
+            component_id,
+            branch,
+            from,
+            task_url,
+            run_id,
+            cleanup_policy: cleanup_policy.map(Into::into),
+        })?),
+        WorktreeCommand::List => WorktreeOutput::List(worktree::list()?),
+        WorktreeCommand::Status { id } => WorktreeOutput::Status(worktree::status(&id)?),
+        WorktreeCommand::Remove { id, force } => {
+            WorktreeOutput::Remove(worktree::remove(WorktreeRemoveOptions { id, force })?)
+        }
+        WorktreeCommand::Cleanup { force } => WorktreeOutput::Cleanup(worktree::cleanup(force)?),
+    };
+    Ok((output, 0))
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -60,6 +60,7 @@ pub mod triage;
 pub mod tunnel;
 pub mod update_check_cache;
 pub mod upgrade;
+pub mod worktree;
 
 // Internal path resolution helpers.
 pub(crate) mod paths;

--- a/src/core/worktree.rs
+++ b/src/core/worktree.rs
@@ -1,0 +1,546 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::core::component::{self, TargetSpec};
+use crate::core::error::{Error, Result};
+use crate::core::{git, paths};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskWorktreeState {
+    Active,
+    Removed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CleanupPolicy {
+    RemoveWhenSafe,
+    PreserveOnFailure,
+}
+
+impl CleanupPolicy {
+    fn default_for_run(run_id: Option<&str>) -> Self {
+        if run_id.is_some() {
+            Self::PreserveOnFailure
+        } else {
+            Self::RemoveWhenSafe
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TaskWorktreeRecord {
+    pub id: String,
+    pub component_id: String,
+    pub source_checkout: String,
+    pub worktree_path: String,
+    pub branch: String,
+    pub base_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    pub cleanup_policy: CleanupPolicy,
+    pub created_at: String,
+    pub state: TaskWorktreeState,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct WorktreeSafetyReport {
+    pub dirty: bool,
+    pub unpushed_commits: u32,
+    pub primary_checkout: bool,
+    pub path_contained: bool,
+    pub safe: bool,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeCreateOutput {
+    pub record: TaskWorktreeRecord,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeListOutput {
+    pub worktrees: Vec<TaskWorktreeRecord>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeStatusOutput {
+    pub record: TaskWorktreeRecord,
+    pub safety: WorktreeSafetyReport,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeRemoveOutput {
+    pub record: TaskWorktreeRecord,
+    pub safety: WorktreeSafetyReport,
+    pub removed: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeCleanupOutput {
+    pub candidates: Vec<WorktreeRemoveOutput>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorktreeCreateOptions {
+    pub component_id: String,
+    pub branch: String,
+    pub from: Option<String>,
+    pub task_url: Option<String>,
+    pub run_id: Option<String>,
+    pub cleanup_policy: Option<CleanupPolicy>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorktreeRemoveOptions {
+    pub id: String,
+    pub force: bool,
+}
+
+pub fn create(options: WorktreeCreateOptions) -> Result<WorktreeCreateOutput> {
+    create_with_store(options, &metadata_dir()?)
+}
+
+pub fn list() -> Result<WorktreeListOutput> {
+    list_with_store(&metadata_dir()?)
+}
+
+pub fn status(id: &str) -> Result<WorktreeStatusOutput> {
+    status_with_store(id, &metadata_dir()?)
+}
+
+pub fn remove(options: WorktreeRemoveOptions) -> Result<WorktreeRemoveOutput> {
+    remove_with_store(options, &metadata_dir()?)
+}
+
+pub fn cleanup(force: bool) -> Result<WorktreeCleanupOutput> {
+    let store = metadata_dir()?;
+    let mut candidates = Vec::new();
+    for record in list_with_store(&store)?.worktrees {
+        if record.state != TaskWorktreeState::Active {
+            continue;
+        }
+        if record.cleanup_policy == CleanupPolicy::PreserveOnFailure {
+            continue;
+        }
+        candidates.push(remove_with_store(
+            WorktreeRemoveOptions {
+                id: record.id,
+                force,
+            },
+            &store,
+        )?);
+    }
+    Ok(WorktreeCleanupOutput { candidates })
+}
+
+fn create_with_store(
+    options: WorktreeCreateOptions,
+    store_dir: &Path,
+) -> Result<WorktreeCreateOutput> {
+    let target = component::resolve_target(TargetSpec {
+        component_id: Some(&options.component_id),
+        path_override: None,
+        project: None,
+        capability: None,
+        allow_synthetic: false,
+        accept_bare_directory: false,
+    })?;
+    let source_checkout = target
+        .git_root
+        .clone()
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "component",
+                "Component local_path is not inside a git checkout",
+                Some(options.component_id.clone()),
+                Some(vec!["Register a git-backed component checkout".to_string()]),
+            )
+        })?
+        .canonicalize()
+        .map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(target.source_path.display().to_string()),
+            )
+        })?;
+
+    let parent = source_checkout.parent().ok_or_else(|| {
+        Error::internal_unexpected(format!(
+            "source checkout has no parent: {}",
+            source_checkout.display()
+        ))
+    })?;
+    let id = format!("{}@{}", target.component_id, branch_slug(&options.branch));
+    let worktree_path = parent.join(&id);
+    if worktree_path.exists() {
+        return Err(Error::validation_invalid_argument(
+            "branch",
+            "Task worktree path already exists",
+            Some(worktree_path.display().to_string()),
+            Some(vec![
+                "Use a unique branch name or remove the existing task worktree".to_string(),
+            ]),
+        ));
+    }
+
+    let base_ref = options.from.unwrap_or_else(|| "HEAD".to_string());
+    git::run_git(
+        &source_checkout,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            &options.branch,
+            &worktree_path.to_string_lossy(),
+            &base_ref,
+        ],
+        "git worktree add",
+    )?;
+
+    let record = TaskWorktreeRecord {
+        id,
+        component_id: target.component_id,
+        source_checkout: source_checkout.to_string_lossy().to_string(),
+        worktree_path: worktree_path.to_string_lossy().to_string(),
+        branch: options.branch,
+        base_ref,
+        task_url: options.task_url,
+        run_id: options.run_id.clone(),
+        cleanup_policy: options
+            .cleanup_policy
+            .unwrap_or_else(|| CleanupPolicy::default_for_run(options.run_id.as_deref())),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        state: TaskWorktreeState::Active,
+    };
+    write_record(store_dir, &record)?;
+    Ok(WorktreeCreateOutput { record })
+}
+
+fn list_with_store(store_dir: &Path) -> Result<WorktreeListOutput> {
+    let mut worktrees = Vec::new();
+    if !store_dir.exists() {
+        return Ok(WorktreeListOutput { worktrees });
+    }
+    for entry in fs::read_dir(store_dir)
+        .map_err(|err| Error::internal_io(err.to_string(), Some(store_dir.display().to_string())))?
+    {
+        let entry = entry.map_err(|err| Error::internal_io(err.to_string(), None))?;
+        if entry.path().extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        worktrees.push(read_record_path(&entry.path())?);
+    }
+    worktrees.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(WorktreeListOutput { worktrees })
+}
+
+fn status_with_store(id: &str, store_dir: &Path) -> Result<WorktreeStatusOutput> {
+    let record = read_record(store_dir, id)?;
+    let safety = safety_report(&record)?;
+    Ok(WorktreeStatusOutput { record, safety })
+}
+
+fn remove_with_store(
+    options: WorktreeRemoveOptions,
+    store_dir: &Path,
+) -> Result<WorktreeRemoveOutput> {
+    let mut record = read_record(store_dir, &options.id)?;
+    let safety = safety_report(&record)?;
+    if !options.force && !safety.safe {
+        return Err(Error::validation_invalid_argument(
+            "worktree",
+            "Task worktree is not safe to remove",
+            Some(record.id.clone()),
+            Some(safety.reasons.clone()),
+        ));
+    }
+    if safety.primary_checkout || !safety.path_contained {
+        return Err(Error::validation_invalid_argument(
+            "worktree",
+            "Task worktree failed hard removal safety gates",
+            Some(record.id.clone()),
+            Some(safety.reasons.clone()),
+        ));
+    }
+
+    git::run_git(
+        Path::new(&record.source_checkout),
+        &["worktree", "remove", &record.worktree_path],
+        "git worktree remove",
+    )?;
+    record.state = TaskWorktreeState::Removed;
+    write_record(store_dir, &record)?;
+    Ok(WorktreeRemoveOutput {
+        record,
+        safety,
+        removed: true,
+    })
+}
+
+fn safety_report(record: &TaskWorktreeRecord) -> Result<WorktreeSafetyReport> {
+    let source = canonical_existing_path(&record.source_checkout)?;
+    let worktree = canonical_existing_path(&record.worktree_path)?;
+    let parent = source.parent().ok_or_else(|| {
+        Error::internal_unexpected(format!(
+            "source checkout has no parent: {}",
+            source.display()
+        ))
+    })?;
+    let primary_checkout = source == worktree;
+    let path_contained = worktree.starts_with(parent) && worktree != source;
+    let dirty = is_dirty(&worktree)?;
+    let unpushed_commits = unpushed_commit_count(&worktree, &record.base_ref)?;
+    let mut reasons = Vec::new();
+    if dirty {
+        reasons.push("dirty worktree".to_string());
+    }
+    if unpushed_commits > 0 {
+        reasons.push(format!("{unpushed_commits} unpushed commit(s)"));
+    }
+    if primary_checkout {
+        reasons.push("refuses to remove primary checkout".to_string());
+    }
+    if !path_contained {
+        reasons.push("worktree path is outside the component checkout parent".to_string());
+    }
+    let safe = reasons.is_empty();
+    Ok(WorktreeSafetyReport {
+        dirty,
+        unpushed_commits,
+        primary_checkout,
+        path_contained,
+        safe,
+        reasons,
+    })
+}
+
+fn is_dirty(path: &Path) -> Result<bool> {
+    Ok(
+        !git::run_git(path, &["status", "--porcelain=v1"], "git status")?
+            .trim()
+            .is_empty(),
+    )
+}
+
+fn unpushed_commit_count(path: &Path, base_ref: &str) -> Result<u32> {
+    let upstream = git::run_git(path, &["rev-parse", "--abbrev-ref", "@{u}"], "git upstream");
+    let range = if let Ok(upstream) = upstream {
+        let upstream = upstream.trim();
+        if upstream.is_empty() {
+            format!("{base_ref}..HEAD")
+        } else {
+            format!("{upstream}..HEAD")
+        }
+    } else {
+        format!("{base_ref}..HEAD")
+    };
+    let count = git::run_git(path, &["rev-list", "--count", &range], "git rev-list")?;
+    Ok(count.trim().parse::<u32>().unwrap_or(0))
+}
+
+fn canonical_existing_path(path: &str) -> Result<PathBuf> {
+    Path::new(path)
+        .canonicalize()
+        .map_err(|err| Error::internal_io(err.to_string(), Some(path.to_string())))
+}
+
+fn metadata_dir() -> Result<PathBuf> {
+    Ok(paths::homeboy_data()?.join("task-worktrees"))
+}
+
+fn record_path(store_dir: &Path, id: &str) -> PathBuf {
+    store_dir.join(format!("{}.json", paths::sanitize_path_segment(id)))
+}
+
+fn write_record(store_dir: &Path, record: &TaskWorktreeRecord) -> Result<()> {
+    fs::create_dir_all(store_dir).map_err(|err| {
+        Error::internal_io(err.to_string(), Some(store_dir.display().to_string()))
+    })?;
+    let json = serde_json::to_string_pretty(record)
+        .map_err(|err| Error::internal_json(err.to_string(), Some(record.id.clone())))?;
+    fs::write(record_path(store_dir, &record.id), format!("{json}\n"))
+        .map_err(|err| Error::internal_io(err.to_string(), Some(record.id.clone())))
+}
+
+fn read_record(store_dir: &Path, id: &str) -> Result<TaskWorktreeRecord> {
+    read_record_path(&record_path(store_dir, id))
+}
+
+fn read_record_path(path: &Path) -> Result<TaskWorktreeRecord> {
+    let raw = fs::read_to_string(path)
+        .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?;
+    serde_json::from_str(&raw)
+        .map_err(|err| Error::internal_json(err.to_string(), Some(path.display().to_string())))
+}
+
+fn branch_slug(branch: &str) -> String {
+    branch
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run_git(dir: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: stdout={} stderr={}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn fixture_record(source: &Path, worktree: &Path) -> TaskWorktreeRecord {
+        TaskWorktreeRecord {
+            id: "fixture@task".to_string(),
+            component_id: "fixture".to_string(),
+            source_checkout: source.to_string_lossy().to_string(),
+            worktree_path: worktree.to_string_lossy().to_string(),
+            branch: "task".to_string(),
+            base_ref: "HEAD".to_string(),
+            task_url: Some("https://example.com/task".to_string()),
+            run_id: None,
+            cleanup_policy: CleanupPolicy::RemoveWhenSafe,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            state: TaskWorktreeState::Active,
+        }
+    }
+
+    fn git_repo() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().unwrap();
+        run_git(temp.path(), &["init", "-q"]);
+        run_git(
+            temp.path(),
+            &["config", "user.email", "homeboy@example.com"],
+        );
+        run_git(temp.path(), &["config", "user.name", "Homeboy Test"]);
+        fs::write(temp.path().join("README.md"), "initial\n").unwrap();
+        run_git(temp.path(), &["add", "."]);
+        run_git(temp.path(), &["commit", "-q", "-m", "initial"]);
+        temp
+    }
+
+    #[test]
+    fn metadata_round_trips_and_lists() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source");
+        let worktree = dir.path().join("source@task");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&worktree).unwrap();
+        let store = dir.path().join("store");
+        let record = fixture_record(&source, &worktree);
+
+        write_record(&store, &record).unwrap();
+        let listed = list_with_store(&store).unwrap();
+
+        assert_eq!(listed.worktrees, vec![record]);
+    }
+
+    #[test]
+    fn safety_report_blocks_dirty_worktree() {
+        let source = git_repo();
+        let worktree = sibling_worktree_path(source.path(), "dirty");
+        run_git(
+            source.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "dirty-task",
+                &worktree.to_string_lossy(),
+            ],
+        );
+        fs::write(worktree.join("dirty.txt"), "dirty\n").unwrap();
+
+        let report = safety_report(&fixture_record(source.path(), &worktree)).unwrap();
+
+        assert!(report.dirty);
+        assert!(!report.safe);
+        assert!(report
+            .reasons
+            .iter()
+            .any(|reason| reason == "dirty worktree"));
+    }
+
+    #[test]
+    fn safety_report_blocks_primary_checkout() {
+        let source = git_repo();
+
+        let report = safety_report(&fixture_record(source.path(), source.path())).unwrap();
+
+        assert!(report.primary_checkout);
+        assert!(!report.path_contained);
+        assert!(!report.safe);
+    }
+
+    #[test]
+    fn safety_report_blocks_unpushed_commits() {
+        let remote = tempfile::tempdir().unwrap();
+        run_git(remote.path(), &["init", "--bare", "-q"]);
+        let source = tempfile::tempdir().unwrap();
+        run_git(
+            source.path(),
+            &["clone", &remote.path().to_string_lossy(), "."],
+        );
+        run_git(
+            source.path(),
+            &["config", "user.email", "homeboy@example.com"],
+        );
+        run_git(source.path(), &["config", "user.name", "Homeboy Test"]);
+        fs::write(source.path().join("README.md"), "initial\n").unwrap();
+        run_git(source.path(), &["add", "."]);
+        run_git(source.path(), &["commit", "-q", "-m", "initial"]);
+        run_git(source.path(), &["push", "-u", "origin", "HEAD:main"]);
+
+        let worktree = sibling_worktree_path(source.path(), "unpushed");
+        run_git(
+            source.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "unpushed-task",
+                &worktree.to_string_lossy(),
+                "HEAD",
+            ],
+        );
+        fs::write(worktree.join("change.txt"), "change\n").unwrap();
+        run_git(&worktree, &["add", "."]);
+        run_git(&worktree, &["commit", "-q", "-m", "change"]);
+
+        let mut record = fixture_record(source.path(), &worktree);
+        record.base_ref = "origin/main".to_string();
+        let report = safety_report(&record).unwrap();
+
+        assert_eq!(report.unpushed_commits, 1);
+        assert!(!report.safe);
+    }
+
+    fn sibling_worktree_path(source: &Path, suffix: &str) -> PathBuf {
+        let name = source
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("source");
+        source.with_file_name(format!("{name}-{suffix}-worktree"))
+    }
+}

--- a/src/core/worktree.rs
+++ b/src/core/worktree.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -6,100 +5,110 @@ use crate::core::component::{self, TargetSpec};
 use crate::core::error::{Error, Result};
 use crate::core::{git, paths};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum TaskWorktreeState {
-    Active,
-    Removed,
-}
+mod types {
+    use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum CleanupPolicy {
-    RemoveWhenSafe,
-    PreserveOnFailure,
-}
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    #[serde(rename_all = "snake_case")]
+    pub enum TaskWorktreeState {
+        Active,
+        Removed,
+    }
 
-impl CleanupPolicy {
-    fn default_for_run(run_id: Option<&str>) -> Self {
-        if run_id.is_some() {
-            Self::PreserveOnFailure
-        } else {
-            Self::RemoveWhenSafe
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    #[serde(rename_all = "snake_case")]
+    pub enum CleanupPolicy {
+        RemoveWhenSafe,
+        PreserveOnFailure,
+    }
+
+    impl CleanupPolicy {
+        pub(super) fn default_for_run(run_id: Option<&str>) -> Self {
+            if run_id.is_some() {
+                Self::PreserveOnFailure
+            } else {
+                Self::RemoveWhenSafe
+            }
         }
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    pub struct TaskWorktreeRecord {
+        pub id: String,
+        pub component_id: String,
+        pub source_checkout: String,
+        pub worktree_path: String,
+        pub branch: String,
+        pub base_ref: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub task_url: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub run_id: Option<String>,
+        pub cleanup_policy: CleanupPolicy,
+        pub created_at: String,
+        pub state: TaskWorktreeState,
+    }
+
+    #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+    pub struct WorktreeSafetyReport {
+        pub dirty: bool,
+        pub unpushed_commits: u32,
+        pub primary_checkout: bool,
+        pub path_contained: bool,
+        pub safe: bool,
+        pub reasons: Vec<String>,
+    }
+
+    #[derive(Debug, Clone, Serialize)]
+    pub struct WorktreeCreateOutput {
+        pub record: TaskWorktreeRecord,
+    }
+
+    #[derive(Debug, Clone, Serialize)]
+    pub struct WorktreeListOutput {
+        pub worktrees: Vec<TaskWorktreeRecord>,
+    }
+
+    #[derive(Debug, Clone, Serialize)]
+    pub struct WorktreeStatusOutput {
+        pub record: TaskWorktreeRecord,
+        pub safety: WorktreeSafetyReport,
+    }
+
+    #[derive(Debug, Clone, Serialize)]
+    pub struct WorktreeRemoveOutput {
+        pub record: TaskWorktreeRecord,
+        pub safety: WorktreeSafetyReport,
+        pub removed: bool,
+    }
+
+    #[derive(Debug, Clone, Serialize)]
+    pub struct WorktreeCleanupOutput {
+        pub candidates: Vec<WorktreeRemoveOutput>,
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct WorktreeCreateOptions {
+        pub component_id: String,
+        pub branch: String,
+        pub from: Option<String>,
+        pub task_url: Option<String>,
+        pub run_id: Option<String>,
+        pub cleanup_policy: Option<CleanupPolicy>,
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct WorktreeRemoveOptions {
+        pub id: String,
+        pub force: bool,
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct TaskWorktreeRecord {
-    pub id: String,
-    pub component_id: String,
-    pub source_checkout: String,
-    pub worktree_path: String,
-    pub branch: String,
-    pub base_ref: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub task_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub run_id: Option<String>,
-    pub cleanup_policy: CleanupPolicy,
-    pub created_at: String,
-    pub state: TaskWorktreeState,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct WorktreeSafetyReport {
-    pub dirty: bool,
-    pub unpushed_commits: u32,
-    pub primary_checkout: bool,
-    pub path_contained: bool,
-    pub safe: bool,
-    pub reasons: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct WorktreeCreateOutput {
-    pub record: TaskWorktreeRecord,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct WorktreeListOutput {
-    pub worktrees: Vec<TaskWorktreeRecord>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct WorktreeStatusOutput {
-    pub record: TaskWorktreeRecord,
-    pub safety: WorktreeSafetyReport,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct WorktreeRemoveOutput {
-    pub record: TaskWorktreeRecord,
-    pub safety: WorktreeSafetyReport,
-    pub removed: bool,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct WorktreeCleanupOutput {
-    pub candidates: Vec<WorktreeRemoveOutput>,
-}
-
-#[derive(Debug, Clone)]
-pub struct WorktreeCreateOptions {
-    pub component_id: String,
-    pub branch: String,
-    pub from: Option<String>,
-    pub task_url: Option<String>,
-    pub run_id: Option<String>,
-    pub cleanup_policy: Option<CleanupPolicy>,
-}
-
-#[derive(Debug, Clone)]
-pub struct WorktreeRemoveOptions {
-    pub id: String,
-    pub force: bool,
-}
+pub use types::{
+    CleanupPolicy, TaskWorktreeRecord, TaskWorktreeState, WorktreeCleanupOutput,
+    WorktreeCreateOptions, WorktreeCreateOutput, WorktreeListOutput, WorktreeRemoveOptions,
+    WorktreeRemoveOutput, WorktreeSafetyReport, WorktreeStatusOutput,
+};
 
 pub fn create(options: WorktreeCreateOptions) -> Result<WorktreeCreateOutput> {
     create_with_store(options, &metadata_dir()?)

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -39,6 +39,8 @@ fn includes_first_level_subcommands() {
     assert!(surface.contains_path(&["file", "copy"]));
     assert!(surface.contains_path(&["file", "sync"]));
     assert!(surface.contains_path(&["version", "show"]));
+    assert!(surface.contains_path(&["worktree", "create"]));
+    assert!(surface.contains_path(&["worktree", "remove"]));
     assert!(!surface.contains_path(&["version", "bump"]));
 }
 


### PR DESCRIPTION
## Summary
- Adds `homeboy worktree create/list/status/remove/cleanup` for component-backed task worktrees without DMC coupling.
- Persists task worktree metadata under Homeboy data and records component/source/path/branch/base/task/run/cleanup/state fields.
- Adds removal safety gates for dirty worktrees, unpushed commits, primary checkout protection, and path containment.

Closes #3362.

## Tests
- `cargo test core::worktree --lib`
- `cargo test worktree --lib --tests`
- `cargo test --test command_surface_test`
- `cargo run --quiet --bin homeboy -- worktree --help`
- Smoke: `homeboy worktree create`, `status`, `remove`, `list` with isolated `XDG_DATA_HOME`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the component-backed worktree primitive, tests, docs, and CLI wiring; Chris remains responsible for review and merge.