### PR TITLE
agent-task: claim queued durable runs

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -21,6 +21,8 @@ homeboy agent-task submit \
 homeboy agent-task status "$run_id"
 homeboy agent-task logs "$run_id"
 homeboy agent-task run "$run_id"
+# Or let a generic worker claim the oldest queued durable run:
+# homeboy agent-task run-next
 homeboy agent-task status "$run_id"
 homeboy agent-task artifacts "$run_id"
 homeboy agent-task promote "$run_id" \

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -23,6 +23,8 @@ pub enum AgentTaskCommand {
     RunPlan(RunPlanArgs),
     /// Execute a previously submitted durable agent-task run.
     Run(StatusArgs),
+    /// Claim and execute the oldest queued durable agent-task run.
+    RunNext,
     /// Persist an agent-task plan and return a durable run id without executing it.
     Submit(SubmitArgs),
     /// Read durable agent-task run status.
@@ -94,6 +96,7 @@ pub fn run(args: AgentTaskArgs, _global: &GlobalArgs) -> CmdResult<Value> {
     match args.command {
         AgentTaskCommand::RunPlan(run_args) => run_plan(run_args),
         AgentTaskCommand::Run(status_args) => run_submitted(status_args),
+        AgentTaskCommand::RunNext => run_next(),
         AgentTaskCommand::Submit(submit_args) => submit(submit_args),
         AgentTaskCommand::Status(status_args) => status(status_args),
         AgentTaskCommand::Logs(status_args) => logs(status_args),
@@ -145,11 +148,40 @@ where
 }
 
 fn run_submitted(args: StatusArgs) -> CmdResult<Value> {
-    let plan = agent_task_lifecycle::load_plan(&args.run_id)?;
-    agent_task_lifecycle::mark_running(&args.run_id)?;
-    let scheduler = AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::discover());
+    run_submitted_with_executor(args.run_id, ExtensionProviderAgentTaskExecutor::discover())
+}
+
+fn run_submitted_with_executor<E>(run_id: String, executor: E) -> CmdResult<Value>
+where
+    E: AgentTaskExecutorAdapter,
+{
+    agent_task_lifecycle::mark_running(&run_id)?;
+    run_claimed(run_id, executor)
+}
+
+fn run_next() -> CmdResult<Value> {
+    run_next_with_executor(ExtensionProviderAgentTaskExecutor::discover())
+}
+
+fn run_next_with_executor<E>(executor: E) -> CmdResult<Value>
+where
+    E: AgentTaskExecutorAdapter,
+{
+    let Some(record) = agent_task_lifecycle::claim_next_queued_run()? else {
+        return Ok((serde_json::json!({ "claimed": false }), 0));
+    };
+
+    run_claimed(record.run_id, executor)
+}
+
+fn run_claimed<E>(run_id: String, executor: E) -> CmdResult<Value>
+where
+    E: AgentTaskExecutorAdapter,
+{
+    let plan = agent_task_lifecycle::load_plan(&run_id)?;
+    let scheduler = AgentTaskScheduler::new(executor);
     let aggregate = scheduler.run(plan.clone());
-    agent_task_lifecycle::record_run_aggregate(&args.run_id, &plan, &aggregate)?;
+    agent_task_lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;
     let exit_code = if aggregate.totals.failed == 0
         && aggregate.totals.cancelled == 0
         && aggregate.totals.timed_out == 0
@@ -345,6 +377,50 @@ mod tests {
             assert_eq!(completed.state, AgentTaskRunState::Succeeded);
             assert_eq!(completed.tasks[0].state, AgentTaskState::Succeeded);
             assert!(completed.aggregate_path.is_some());
+        });
+    }
+
+    #[test]
+    fn run_next_claims_oldest_queued_run_and_leaves_later_runs_queued() {
+        with_temp_home(|| {
+            agent_task_lifecycle::submit_plan(&test_plan(), Some("run-next-a"))
+                .expect("first submitted");
+            agent_task_lifecycle::submit_plan(&test_plan(), Some("run-next-b"))
+                .expect("second submitted");
+            let observed_status = Arc::new(Mutex::new(None));
+
+            let (_value, exit_code) = run_next_with_executor(InspectingExecutor {
+                run_id: "run-next-a".to_string(),
+                observed_status: Arc::clone(&observed_status),
+            })
+            .expect("claimed run completed");
+
+            let observed = observed_status
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+                .expect("executor observed claimed status");
+            let first = lifecycle_status("run-next-a").expect("first status");
+            let second = lifecycle_status("run-next-b").expect("second status");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(observed.state, AgentTaskRunState::Running);
+            assert_eq!(first.state, AgentTaskRunState::Succeeded);
+            assert_eq!(second.state, AgentTaskRunState::Queued);
+        });
+    }
+
+    #[test]
+    fn run_next_returns_unclaimed_when_no_queued_runs_exist() {
+        with_temp_home(|| {
+            let (value, exit_code) = run_next_with_executor(InspectingExecutor {
+                run_id: "unused".to_string(),
+                observed_status: Arc::new(Mutex::new(None)),
+            })
+            .expect("run-next checked queue");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(value["claimed"], false);
         });
     }
 

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -8,7 +8,7 @@ use crate::core::agent_task::{AgentTaskArtifact, AgentTaskEvidenceRef, AgentTask
 use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskPlan, AgentTaskProgressEvent, AgentTaskState,
 };
-use crate::core::{paths, Error, Result};
+use crate::core::{paths, Error, ErrorCode, Result};
 
 #[path = "lifecycle_store.rs"]
 mod lifecycle_store;
@@ -229,6 +229,28 @@ pub fn mark_running(run_id: &str) -> Result<AgentTaskRunRecord> {
     record.record_runner_metadata(reclaimed_stale);
     store::write_record(&record)?;
     Ok(record)
+}
+
+pub fn claim_next_queued_run() -> Result<Option<AgentTaskRunRecord>> {
+    let mut queued: Vec<AgentTaskRunRecord> = store::read_records()?
+        .into_iter()
+        .filter(|record| record.state == AgentTaskRunState::Queued)
+        .collect();
+    queued.sort_by(|left, right| {
+        left.submitted_at
+            .cmp(&right.submitted_at)
+            .then_with(|| left.run_id.cmp(&right.run_id))
+    });
+
+    for record in queued {
+        match mark_running(&record.run_id) {
+            Ok(claimed) => return Ok(Some(claimed)),
+            Err(error) if error.code == ErrorCode::ValidationInvalidArgument => continue,
+            Err(error) => return Err(error),
+        }
+    }
+
+    Ok(None)
 }
 
 pub fn record_run_aggregate(

--- a/src/core/lifecycle_store.rs
+++ b/src/core/lifecycle_store.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::ErrorKind;
 use std::path::PathBuf;
 
 use serde::Serialize;
@@ -37,6 +38,34 @@ pub(super) fn write_record(record: &AgentTaskRunRecord) -> Result<()> {
 
 pub(super) fn read_record(run_id: &str) -> Result<AgentTaskRunRecord> {
     read_json(&record_path(run_id)?)
+}
+
+pub(super) fn read_records() -> Result<Vec<AgentTaskRunRecord>> {
+    let root = paths::homeboy_data()?.join("agent-task-runs");
+    let entries = match fs::read_dir(&root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some(root.display().to_string()),
+            ));
+        }
+    };
+
+    let mut records = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            Error::internal_io(error.to_string(), Some(root.display().to_string()))
+        })?;
+        let path = entry.path().join("status.json");
+        if !path.exists() {
+            continue;
+        }
+        records.push(read_json(&path)?);
+    }
+
+    Ok(records)
 }
 
 fn read_json<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Result<T> {


### PR DESCRIPTION
## Summary
- Adds `homeboy agent-task run-next` so a generic worker can claim the oldest queued durable agent-task run and execute it from the stored lifecycle plan.
- Reuses the existing scheduler/finalization path so status, logs, artifacts, evidence refs, and terminal state continue to land in the same durable run files.
- Adds focused coverage for queued-run claiming and empty-queue behavior, plus docs for the worker-style smoke path.

Closes #3285.
Advances #3278/#3357 by turning submitted durable lifecycle records into executable queue items instead of requiring a caller to keep the original plan path or run synchronously.

## Tests
- `cargo test commands::agent_task::tests::run_next --lib`
- `cargo test core::agent_task_provider::tests::provider_can_return_timeout_payload_during_wrapper_grace --lib`
- `cargo test agent_task --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the small durable-run claim/dispatch path, focused tests, docs, and local verification. Chris remains responsible for review and merge.