### PR TITLE
Fix deploy archive extraction hints and flattening

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -47,7 +47,7 @@ enum ComponentCommand {
             conflicts_with = "version_targets"
         )]
         version_targets_json: Option<String>,
-        /// Extract command to run after upload (e.g., "unzip -o {artifact} && rm {artifact}")
+        /// Extract command to run after upload (e.g., "unzip -o {{artifact}} && rm {{artifact}}")
         #[arg(long)]
         extract_command: Option<String>,
         /// Path to changelog file relative to localPath
@@ -85,7 +85,7 @@ enum ComponentCommand {
         /// Build artifact path relative to localPath
         #[arg(long)]
         build_artifact: Option<String>,
-        /// Extract command to run after upload (e.g., "unzip -o {artifact} && rm {artifact}")
+        /// Extract command to run after upload (e.g., "unzip -o {{artifact}} && rm {{artifact}}")
         #[arg(long)]
         extract_command: Option<String>,
         /// Path to changelog file relative to localPath
@@ -1105,6 +1105,8 @@ fn shared(id: Option<&str>) -> CmdResult<ComponentOutput> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli_surface::Cli;
+    use clap::CommandFactory;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
 
@@ -1173,6 +1175,34 @@ mod tests {
 
         assert_eq!(obj["local_path"], serde_json::json!("/override"));
         assert_eq!(obj["remote_path"], serde_json::json!("/keep-this"));
+    }
+
+    #[test]
+    fn component_help_uses_double_brace_extract_command_placeholder() {
+        let mut command = Cli::command();
+        let component = command
+            .find_subcommand_mut("component")
+            .expect("component command");
+        let create_help = component
+            .find_subcommand_mut("create")
+            .expect("component create command")
+            .render_long_help()
+            .to_string();
+        let set_help = component
+            .find_subcommand_mut("set")
+            .expect("component set command")
+            .render_long_help()
+            .to_string();
+        let help = format!("{create_help}\n{set_help}");
+
+        assert!(
+            help.contains("unzip -o {{artifact}} && rm {{artifact}}"),
+            "component help should document double-brace placeholders: {help}"
+        );
+        assert!(
+            !help.contains("unzip -o {artifact} && rm {artifact}"),
+            "component help should not document single-brace placeholders: {help}"
+        );
     }
 
     #[test]

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -609,7 +609,7 @@ fn resolve_preflight_artifact_path(
             build_exit_code,
             format!(
                 "Archive artifact '{}' requires an extractCommand. \
-                 Add one with: homeboy component set <id> --json '{{\"extract_command\": \"unzip -o {{artifact}} && rm {{artifact}}\"}}'",
+                 Add one with: homeboy component set <id> --json '{{\"extract_command\": \"unzip -o {{{{artifact}}}} && rm {{{{artifact}}}}\"}}'",
                 artifact_path.display()
             ),
         ));
@@ -1113,6 +1113,58 @@ mod tests {
             false,
             false,
         ));
+    }
+
+    #[test]
+    fn archive_artifact_preflight_hint_uses_double_brace_placeholder() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact = temp.path().join("build/example.zip");
+        std::fs::create_dir_all(artifact.parent().expect("artifact parent")).expect("build dir");
+        std::fs::write(&artifact, "zip bytes").expect("artifact");
+        let component = Component {
+            id: "example".to_string(),
+            local_path: temp.path().to_string_lossy().to_string(),
+            build_artifact: Some("build/example.zip".to_string()),
+            extract_command: None,
+            ..Component::default()
+        };
+        let config = DeployConfig {
+            component_ids: Vec::new(),
+            all: false,
+            outdated: false,
+            behind_upstream: false,
+            dry_run: false,
+            check: false,
+            force: false,
+            skip_build: true,
+            keep_deps: false,
+            expected_version: None,
+            no_pull: false,
+            head: false,
+            tagged: false,
+        };
+
+        let result = resolve_preflight_artifact_path(
+            &component,
+            &config,
+            "/srv/site",
+            temp.path().to_str().expect("install dir"),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect_err("archive without extract command should fail preflight");
+        let error = result.error.expect("preflight error");
+
+        assert!(
+            error.contains("unzip -o {{artifact}} && rm {{artifact}}"),
+            "hint must contain double-brace placeholder: {error}"
+        );
+        assert!(
+            !error.contains("unzip -o {artifact} && rm {artifact}"),
+            "hint must not suggest the single-brace placeholder form: {error}"
+        );
     }
 
     #[test]

--- a/src/core/deploy/safety_and_artifact.rs
+++ b/src/core/deploy/safety_and_artifact.rs
@@ -127,7 +127,7 @@ pub(super) fn deploy_artifact(
                 1,
                 format!(
                     "Archive artifact '{}' requires an extractCommand. \
-                     Add one with: homeboy component set <id> --json '{{\"extract_command\": \"unzip -o {{artifact}} && rm {{artifact}}\"}}'",
+                     Add one with: homeboy component set <id> --json '{{\"extract_command\": \"unzip -o {{{{artifact}}}} && rm {{{{artifact}}}}\"}}'",
                     local_path.display()
                 ),
             ));
@@ -385,16 +385,14 @@ fn flatten_double_nested_dir(
     // up into remote_path, then remove the now-empty staging directory. Using a
     // temp staging name avoids the "cannot move a directory into itself" problem
     // when the inner dir shares the basename with its parent.
-    let staging = format!("{}/.artifact-flatten-staging", normalized);
-    let target_dir = format!("{}/", normalized);
+    let staging = ".artifact-flatten-staging";
     let flatten_cmd = format!(
         "cd {target} && rm -rf {staging} && mv {nested} {staging} && \
-         find {staging} -mindepth 1 -maxdepth 1 -exec mv {{}} {target_dir} \\; && \
+         find {staging} -mindepth 1 -maxdepth 1 -exec mv {{}} . \\; && \
          rmdir {staging}",
         target = shell::quote_path(normalized),
-        target_dir = shell::quote_path(&target_dir),
-        nested = shell::quote_path(&nested_dir),
-        staging = shell::quote_path(&staging),
+        nested = shell::quote_path(basename),
+        staging = shell::quote_path(staging),
     );
     let flatten_output = ssh_client.execute(&flatten_cmd);
     if !flatten_output.success {
@@ -777,11 +775,10 @@ mod tests {
         assert!(target.join("plugin.php").is_file());
     }
 
-    /// The "requires an extractCommand" hint must use single-brace `{artifact}`
-    /// placeholders so a copy-paste of the JSON works (render_extract_command +
-    /// render_map both resolve `{artifact}` correctly).
+    /// The "requires an extractCommand" hint must use the canonical double-brace
+    /// `{{artifact}}` template syntax so copy-pasted JSON matches configured components.
     #[test]
-    fn test_archive_without_extract_command_hint_uses_single_brace_placeholder() {
+    fn test_archive_without_extract_command_hint_uses_double_brace_placeholder() {
         let temp = tempfile::tempdir().expect("temp dir");
         let archive = temp.path().join("plugin.zip");
         fs::write(&archive, "zip bytes").expect("archive");
@@ -800,12 +797,43 @@ mod tests {
         assert!(!result.success);
         let error = result.error.expect("hint error");
         assert!(
-            error.contains("{artifact}"),
-            "hint must contain single-brace placeholder: {error}"
+            error.contains("unzip -o {{artifact}} && rm {{artifact}}"),
+            "hint must contain double-brace placeholder: {error}"
         );
         assert!(
-            !error.contains("{{artifact}}"),
-            "hint must NOT contain double-brace placeholder: {error}"
+            !error.contains("unzip -o {artifact} && rm {artifact}"),
+            "hint must not suggest the single-brace placeholder form: {error}"
         );
+    }
+
+    /// Relative remote paths already run flatten from inside `remote_path`; the
+    /// inner directory must therefore be addressed by basename only, not by
+    /// prefixing `remote_path` a second time.
+    #[test]
+    #[cfg(unix)]
+    fn test_flatten_double_nested_dir_handles_relative_remote_path() {
+        let current_dir = std::env::current_dir().expect("current dir");
+        let temp = tempfile::Builder::new()
+            .prefix("homeboy-relative-flatten-")
+            .tempdir_in(&current_dir)
+            .expect("temp dir in cwd");
+        let plugin = "data-machine";
+        let target = temp.path().join("wp-content/plugins").join(plugin);
+        let nested = target.join(plugin);
+        fs::create_dir_all(&nested).expect("nested dir");
+        fs::write(nested.join("data-machine.php"), "<?php").expect("plugin main");
+
+        let relative_target = target
+            .strip_prefix(&current_dir)
+            .expect("target under cwd")
+            .to_str()
+            .expect("relative target");
+
+        let result = flatten_double_nested_dir(&local_client(), relative_target).expect("ok");
+
+        assert!(result.is_none(), "flatten should not fail");
+        assert!(target.join("data-machine.php").is_file());
+        assert!(!target.join(plugin).exists());
+        assert!(!target.join(".artifact-flatten-staging").exists());
     }
 }


### PR DESCRIPTION
## Summary
- Fix `extract_command` examples and deploy error hints to output the canonical `{{artifact}}` placeholder syntax instead of accidentally rendering single braces from Rust `format!` strings.
- Fix double-nested archive flattening so relative `remote_path` targets do not double-prefix paths after `cd {target}`.
- Add regression tests for deploy artifact hints, preflight hints, component help text, and relative-path flattening.

## Follow-ups
- Bug 2 from #3444 (bad extraction debris in the local checkout) was not addressed here because it appears to need a broader staging/extraction boundary audit beyond the blocking hint/flatten fixes.
- Bug 4 from #3444 (auto-pull version drift surprise) was not addressed here because it is deploy policy/UX behavior rather than the blocking archive extraction path.

## Tests
- `cargo test -q core::deploy::safety_and_artifact::tests::`
- `cargo test -q core::deploy::execution::tests::archive_artifact_preflight_hint_uses_double_brace_placeholder`
- `cargo test -q commands::component::tests::component_help_uses_double_brace_extract_command_placeholder`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the targeted deploy bug fixes and regression tests; Chris remains responsible for review and merge.