### PR TITLE
Add output-driven agent-task DAG phases

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -53,7 +53,89 @@ Useful fixture `executor.config` fields:
 
 - `artifact_root`: directory where fixture artifacts are written.
 - `changed_file`: diff path recorded in the generated patch.
+- `metadata`: optional JSON object copied into the fixture outcome metadata.
 - `mode`: omit or set to `success`; set to `empty_patch` or `empty_runtime_bundle` for classification checks.
+
+## Output-Driven DAG Phases
+
+`agent-task run-plan` supports backend-neutral output dependencies with a
+plan-level `output_dependencies` map keyed by downstream task id. A task with
+bindings waits until every declared upstream task has a terminal outcome, selects
+values from prior `homeboy/agent-task-outcome/v1` payloads with JSON Pointer,
+renders `{{outputs.<name>}}` placeholders into the downstream request, then
+dispatches the generated task.
+
+Example:
+
+```json
+{
+  "schema": "homeboy/agent-task-plan/v1",
+  "plan_id": "site-generator-static-fanout",
+  "tasks": [
+    {
+      "schema": "homeboy/agent-task-request/v1",
+      "task_id": "idea",
+      "executor": { "backend": "codebox" },
+      "instructions": "Create the GitHub issue for this site idea."
+    },
+    {
+      "schema": "homeboy/agent-task-request/v1",
+      "task_id": "design",
+      "executor": {
+        "backend": "codebox",
+        "config": {
+          "github_issue": "{{outputs.issue_number}}"
+        }
+      },
+      "instructions": "Build the design for GitHub issue #{{outputs.issue_number}}."
+    }
+  ],
+  "output_dependencies": {
+    "design": {
+      "bindings": {
+        "issue_number": {
+          "task_id": "idea",
+          "path": "/metadata/github/issue_number",
+          "required": true
+        }
+      }
+    }
+  }
+}
+```
+
+Supported rendering targets:
+
+- `instructions`
+- `inputs`
+- `executor.config`
+- `workspace.materialization`
+- `metadata`
+- `expected_artifacts`
+
+If a field is exactly `{{outputs.<name>}}`, Homeboy preserves the selected JSON
+value type. Inline placeholders render as strings. If a required binding is
+missing, the downstream task is not sent to the provider; the aggregate records a
+`skipped` scheduler event, increments `totals.skipped`, and writes a no-op
+outcome with diagnostic class `output_dependency_missing`.
+
+Use `depends_on` for ordering-only edges that do not bind values:
+
+```json
+{
+  "output_dependencies": {
+    "static-build": {
+      "depends_on": ["design"],
+      "bindings": {
+        "issue_number": {
+          "task_id": "idea",
+          "path": "/metadata/github/issue_number"
+        }
+      }
+    }
+  }
+}
+```
 
 ## Failure Classifications
 

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -174,6 +174,12 @@ fn fixture_success_outcome(
         "fixture provider completed successfully\n",
     );
 
+    let metadata = request
+        .executor
+        .config
+        .get("metadata")
+        .cloned()
+        .unwrap_or_else(|| json!({ "fixture_mode": "success" }));
     let mut outcome = AgentTaskOutcome {
         schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
         task_id: request.task_id.clone(),
@@ -202,7 +208,7 @@ fn fixture_success_outcome(
         }],
         workflow: None,
         follow_up: None,
-        metadata: json!({ "fixture_mode": "success" }),
+        metadata,
     };
     let _ = std::fs::write(
         &result_path,

--- a/src/core/agent_task_schedule.rs
+++ b/src/core/agent_task_schedule.rs
@@ -17,6 +17,8 @@ pub struct AgentTaskPlan {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub group_key: Option<String>,
     pub tasks: Vec<AgentTaskRequest>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub output_dependencies: HashMap<String, AgentTaskOutputDependencies>,
     #[serde(default)]
     pub options: AgentTaskScheduleOptions,
     #[serde(default, skip_serializing_if = "Value::is_null")]
@@ -30,10 +32,30 @@ impl AgentTaskPlan {
             plan_id: plan_id.into(),
             group_key: None,
             tasks,
+            output_dependencies: HashMap::new(),
             options: AgentTaskScheduleOptions::default(),
             metadata: Value::Null,
         }
     }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskOutputDependencies {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub bindings: HashMap<String, AgentTaskOutputBinding>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskOutputBinding {
+    pub task_id: String,
+    /// JSON Pointer into the prior `homeboy/agent-task-outcome/v1` object.
+    pub path: String,
+    #[serde(default = "default_required_output")]
+    pub required: bool,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub default: Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -133,6 +155,7 @@ pub struct AgentTaskAggregateTotals {
     pub queued: usize,
     pub running: usize,
     pub blocked: usize,
+    pub skipped: usize,
     pub succeeded: usize,
     pub failed: usize,
     pub cancelled: usize,
@@ -154,6 +177,7 @@ pub struct AgentTaskProgressEvent {
 pub enum AgentTaskState {
     Queued,
     Blocked,
+    Skipped,
     Running,
     Succeeded,
     Failed,
@@ -241,4 +265,8 @@ fn default_max_concurrency() -> usize {
 
 fn default_task_resource_units() -> u32 {
     1
+}
+
+fn default_required_output() -> bool {
+    true
 }

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -3,7 +3,7 @@ use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use crate::core::agent_task::{
     AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskFailureClassification, AgentTaskOutcome,
@@ -12,9 +12,10 @@ use crate::core::agent_task::{
 pub use crate::core::agent_task_schedule::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     AgentTaskBackpressureStatus, AgentTaskCancellationToken, AgentTaskExecutionContext,
-    AgentTaskPlan, AgentTaskProgressEvent, AgentTaskQueueStatus, AgentTaskResourceBudget,
-    AgentTaskResourceBudgetStatus, AgentTaskRetryPolicy, AgentTaskScheduleOptions, AgentTaskState,
-    AGENT_TASK_AGGREGATE_SCHEMA, AGENT_TASK_PLAN_SCHEMA,
+    AgentTaskOutputBinding, AgentTaskOutputDependencies, AgentTaskPlan, AgentTaskProgressEvent,
+    AgentTaskQueueStatus, AgentTaskResourceBudget, AgentTaskResourceBudgetStatus,
+    AgentTaskRetryPolicy, AgentTaskScheduleOptions, AgentTaskState, AGENT_TASK_AGGREGATE_SCHEMA,
+    AGENT_TASK_PLAN_SCHEMA,
 };
 use crate::core::agent_task_timeout::timeout_with_grace;
 use crate::core::agent_task_timeout_artifacts::{
@@ -59,6 +60,7 @@ where
         let total_tasks = plan.tasks.len();
         let max_queue_depth = plan.options.max_queue_depth.or(plan.options.max_tasks);
         let retry_budget_total = plan.options.retry.max_retries_total;
+        let output_dependencies = plan.output_dependencies.clone();
         let mut retry_budget_used = 0;
         let mut backpressure = Vec::new();
         let mut blocked_count = 0;
@@ -80,6 +82,7 @@ where
             .collect();
         let mut running: Vec<RunningTask> = Vec::new();
         let mut outcomes = Vec::new();
+        let mut completed_by_task: HashMap<String, AgentTaskOutcome> = HashMap::new();
         let mut events = Vec::new();
         let mut cancellation_notified = false;
         let max_attempts = plan.options.retry.max_attempts.max(1);
@@ -135,12 +138,42 @@ where
                 let Some(next_index) = AgentTaskScheduleSupport::next_dispatchable_index(
                     &queued,
                     &running,
+                    &completed_by_task,
+                    &output_dependencies,
                     &plan.options.per_executor_concurrency,
                     &plan.options.per_model_concurrency,
                     &plan.options.resource_budget,
                 ) else {
                     if running.is_empty() {
                         if let Some(task) = queued.pop_front() {
+                            if let Some(message) =
+                                AgentTaskScheduleSupport::waiting_for_dependencies(
+                                    &task.request,
+                                    &completed_by_task,
+                                    &output_dependencies,
+                                )
+                            {
+                                backpressure.push(AgentTaskBackpressureStatus {
+                                    kind: "output_dependency".to_string(),
+                                    message: message.clone(),
+                                    task_id: Some(task.request.task_id.clone()),
+                                });
+                                events.push(event(
+                                    &task.request.task_id,
+                                    AgentTaskState::Blocked,
+                                    task.attempt,
+                                    Some(message.clone()),
+                                ));
+                                let outcome = AgentTaskScheduleSupport::blocked_outcome(
+                                    task.request.task_id,
+                                    message,
+                                );
+                                completed_by_task.insert(outcome.task_id.clone(), outcome.clone());
+                                outcomes.push(outcome);
+                                blocked_count += 1;
+                                continue;
+                            }
+
                             let task_units =
                                 task_resource_units(&task.request, &plan.options.resource_budget);
                             let max_active_units = plan
@@ -171,22 +204,50 @@ where
                         }
                         break;
                     }
-                    backpressure.push(AgentTaskBackpressureStatus {
-                        kind: AgentTaskScheduleSupport::backpressure_kind(
-                            &queued,
-                            &running,
-                            &plan.options.per_executor_concurrency,
-                            &plan.options.per_model_concurrency,
-                            &plan.options.resource_budget,
+                    let dependency_wait = queued.front().and_then(|task| {
+                        AgentTaskScheduleSupport::waiting_for_dependencies(
+                            &task.request,
+                            &completed_by_task,
+                            &output_dependencies,
                         )
-                        .to_string(),
-                        message: "queued tasks are waiting for scheduler capacity".to_string(),
+                    });
+                    backpressure.push(AgentTaskBackpressureStatus {
+                        kind: if dependency_wait.is_some() {
+                            "output_dependency".to_string()
+                        } else {
+                            AgentTaskScheduleSupport::backpressure_kind(
+                                &queued,
+                                &running,
+                                &plan.options.per_executor_concurrency,
+                                &plan.options.per_model_concurrency,
+                                &plan.options.resource_budget,
+                            )
+                            .to_string()
+                        },
+                        message: dependency_wait.unwrap_or_else(|| {
+                            "queued tasks are waiting for scheduler capacity".to_string()
+                        }),
                         task_id: queued.front().map(|task| task.request.task_id.clone()),
                     });
                     break;
                 };
                 let scheduled = queued.remove(next_index).expect("queued task");
-                let request = scheduled.request;
+                let mut request = scheduled.request;
+                if let Err(outcome) = AgentTaskScheduleSupport::render_output_dependencies(
+                    &mut request,
+                    &completed_by_task,
+                    &output_dependencies,
+                ) {
+                    events.push(event(
+                        &outcome.task_id,
+                        AgentTaskState::Skipped,
+                        scheduled.attempt,
+                        outcome.summary.clone(),
+                    ));
+                    completed_by_task.insert(outcome.task_id.clone(), outcome.clone());
+                    outcomes.push(outcome);
+                    continue;
+                }
                 let task_id = request.task_id.clone();
                 let executor_key = executor_key(&request);
                 let executor = Arc::clone(&self.executor);
@@ -282,6 +343,7 @@ where
                         });
                         continue;
                     }
+                    completed_by_task.insert(outcome.task_id.clone(), outcome.clone());
                     outcomes.push(outcome);
                 }
                 Err(mpsc::RecvTimeoutError::Timeout) => {}
@@ -342,11 +404,18 @@ impl AgentTaskScheduleSupport {
     fn next_dispatchable_index(
         queued: &VecDeque<ScheduledTask>,
         running: &[RunningTask],
+        completed_by_task: &HashMap<String, AgentTaskOutcome>,
+        output_dependencies: &HashMap<String, AgentTaskOutputDependencies>,
         per_executor_concurrency: &HashMap<String, usize>,
         per_model_concurrency: &HashMap<String, usize>,
         resource_budget: &AgentTaskResourceBudget,
     ) -> Option<usize> {
         queued.iter().position(|task| {
+            if !Self::dependencies_satisfied(&task.request, completed_by_task, output_dependencies)
+            {
+                return false;
+            }
+
             let executor_key = executor_key(&task.request);
             let limit = per_executor_concurrency
                 .get(&executor_key)
@@ -379,6 +448,145 @@ impl AgentTaskScheduleSupport {
 
             resource_capacity_available(&task.request, running, resource_budget)
         })
+    }
+
+    fn dependencies_satisfied(
+        request: &AgentTaskRequest,
+        completed_by_task: &HashMap<String, AgentTaskOutcome>,
+        output_dependencies: &HashMap<String, AgentTaskOutputDependencies>,
+    ) -> bool {
+        Self::dependency_task_ids(request, output_dependencies)
+            .iter()
+            .all(|task_id| completed_by_task.contains_key(task_id))
+    }
+
+    fn waiting_for_dependencies(
+        request: &AgentTaskRequest,
+        completed_by_task: &HashMap<String, AgentTaskOutcome>,
+        output_dependencies: &HashMap<String, AgentTaskOutputDependencies>,
+    ) -> Option<String> {
+        let missing: Vec<String> = Self::dependency_task_ids(request, output_dependencies)
+            .into_iter()
+            .filter(|task_id| !completed_by_task.contains_key(task_id))
+            .collect();
+
+        (!missing.is_empty()).then(|| {
+            format!(
+                "task blocked waiting for output dependencies: {}",
+                missing.join(", ")
+            )
+        })
+    }
+
+    fn dependency_task_ids(
+        request: &AgentTaskRequest,
+        output_dependencies: &HashMap<String, AgentTaskOutputDependencies>,
+    ) -> Vec<String> {
+        let Some(dependencies) = output_dependencies.get(&request.task_id) else {
+            return Vec::new();
+        };
+        let mut task_ids = dependencies.depends_on.clone();
+        for binding in dependencies.bindings.values() {
+            if !task_ids.contains(&binding.task_id) {
+                task_ids.push(binding.task_id.clone());
+            }
+        }
+        task_ids
+    }
+
+    fn render_output_dependencies(
+        request: &mut AgentTaskRequest,
+        completed_by_task: &HashMap<String, AgentTaskOutcome>,
+        output_dependencies: &HashMap<String, AgentTaskOutputDependencies>,
+    ) -> Result<(), AgentTaskOutcome> {
+        let Some(dependencies) = output_dependencies.get(&request.task_id) else {
+            return Ok(());
+        };
+        let bindings = match Self::resolve_output_bindings(request, dependencies, completed_by_task)
+        {
+            Ok(bindings) => bindings,
+            Err(message) => return Err(Self::skipped_output_dependency_outcome(request, message)),
+        };
+
+        request.instructions = render_template_string(&request.instructions, &bindings);
+        render_value_templates(&mut request.inputs, &bindings);
+        render_value_templates(&mut request.executor.config, &bindings);
+        render_value_templates(&mut request.workspace.materialization, &bindings);
+        render_value_templates(&mut request.metadata, &bindings);
+        for artifact in &mut request.expected_artifacts {
+            *artifact = render_template_string(artifact, &bindings);
+        }
+        mark_generated_from_outputs(request, dependencies, &bindings);
+        Ok(())
+    }
+
+    fn resolve_output_bindings(
+        request: &AgentTaskRequest,
+        dependencies: &AgentTaskOutputDependencies,
+        completed_by_task: &HashMap<String, AgentTaskOutcome>,
+    ) -> Result<HashMap<String, Value>, String> {
+        let mut bindings = HashMap::new();
+        for (name, binding) in &dependencies.bindings {
+            let value = Self::select_bound_output(request, name, binding, completed_by_task)?;
+            bindings.insert(name.clone(), value);
+        }
+        Ok(bindings)
+    }
+
+    fn select_bound_output(
+        request: &AgentTaskRequest,
+        name: &str,
+        binding: &AgentTaskOutputBinding,
+        completed_by_task: &HashMap<String, AgentTaskOutcome>,
+    ) -> Result<Value, String> {
+        let Some(outcome) = completed_by_task.get(&binding.task_id) else {
+            return Err(format!(
+                "task '{}' skipped because output binding '{}' waited for missing task '{}'",
+                request.task_id, name, binding.task_id
+            ));
+        };
+
+        let outcome_value = serde_json::to_value(outcome).unwrap_or(Value::Null);
+        if let Some(value) = outcome_value.pointer(&binding.path) {
+            return Ok(value.clone());
+        }
+        if !binding.default.is_null() {
+            return Ok(binding.default.clone());
+        }
+        if binding.required {
+            return Err(format!(
+                "task '{}' skipped because required output binding '{}' was missing at '{}' from task '{}'",
+                request.task_id, name, binding.path, binding.task_id
+            ));
+        }
+        Ok(Value::String(String::new()))
+    }
+
+    fn skipped_output_dependency_outcome(
+        request: &AgentTaskRequest,
+        summary: String,
+    ) -> AgentTaskOutcome {
+        AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: request.task_id.clone(),
+            status: AgentTaskOutcomeStatus::NoOp,
+            summary: Some(summary.clone()),
+            failure_classification: None,
+            artifacts: Vec::new(),
+            evidence_refs: vec![AgentTaskEvidenceRef {
+                kind: "scheduler".to_string(),
+                uri: "homeboy://agent-task/output-dependency-skipped".to_string(),
+                label: Some("scheduler output dependency skip".to_string()),
+            }],
+            diagnostics: vec![AgentTaskDiagnostic {
+                class: "output_dependency_missing".to_string(),
+                message: summary,
+                data: Value::Null,
+            }],
+            workflow: None,
+            follow_up: None,
+            metadata: serde_json::json!({ "skipped": true, "skip_reason": "output_dependency_missing" }),
+        }
     }
 
     fn backpressure_kind(
@@ -784,6 +992,15 @@ impl AgentTaskScheduleSupport {
         };
 
         for outcome in outcomes {
+            if outcome
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.class == "output_dependency_missing")
+            {
+                totals.skipped += 1;
+                continue;
+            }
+
             match outcome.status {
                 AgentTaskOutcomeStatus::Succeeded | AgentTaskOutcomeStatus::NoOp => {
                     totals.succeeded += 1
@@ -856,6 +1073,90 @@ fn resource_capacity_available(
     };
     active_resource_units(running).saturating_add(task_resource_units(request, budget))
         <= max_active_units
+}
+
+fn render_value_templates(value: &mut Value, bindings: &HashMap<String, Value>) {
+    match value {
+        Value::String(raw) => {
+            if let Some(rendered) = render_template_value(raw, bindings) {
+                *value = rendered;
+            } else {
+                *raw = render_template_string(raw, bindings);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                render_value_templates(item, bindings);
+            }
+        }
+        Value::Object(object) => {
+            for value in object.values_mut() {
+                render_value_templates(value, bindings);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn render_template_value(raw: &str, bindings: &HashMap<String, Value>) -> Option<Value> {
+    let trimmed = raw.trim();
+    let inner = trimmed.strip_prefix("{{")?.strip_suffix("}}")?.trim();
+    let name = inner.strip_prefix("outputs.")?.trim();
+    bindings.get(name).cloned()
+}
+
+fn render_template_string(raw: &str, bindings: &HashMap<String, Value>) -> String {
+    let mut rendered = raw.to_string();
+    for (name, value) in bindings {
+        let replacement = template_replacement(value);
+        let compact = format!("{{{{outputs.{name}}}}}");
+        let spaced = format!("{{{{ outputs.{name} }}}}");
+        rendered = rendered.replace(&compact, &replacement);
+        rendered = rendered.replace(&spaced, &replacement);
+    }
+    rendered
+}
+
+fn template_replacement(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::String(value) => value.clone(),
+        Value::Number(value) => value.to_string(),
+        Value::Bool(value) => value.to_string(),
+        Value::Array(_) | Value::Object(_) => value.to_string(),
+    }
+}
+
+fn mark_generated_from_outputs(
+    request: &mut AgentTaskRequest,
+    dependencies: &AgentTaskOutputDependencies,
+    bindings: &HashMap<String, Value>,
+) {
+    if !request.metadata.is_object() {
+        request.metadata = Value::Object(Map::new());
+    }
+    let metadata = request.metadata.as_object_mut().expect("metadata object");
+    metadata.insert("generated_from_outputs".to_string(), Value::Bool(true));
+    metadata.insert(
+        "depends_on".to_string(),
+        Value::Array(
+            dependencies
+                .depends_on
+                .iter()
+                .cloned()
+                .map(Value::String)
+                .collect(),
+        ),
+    );
+    metadata.insert(
+        "resolved_output_bindings".to_string(),
+        Value::Object(
+            bindings
+                .iter()
+                .map(|(name, value)| (name.clone(), value.clone()))
+                .collect(),
+        ),
+    );
 }
 
 fn event(
@@ -1323,6 +1624,133 @@ mod tests {
     }
 
     #[test]
+    fn templates_prior_output_into_downstream_task_request() {
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
+            observed: Arc::clone(&observed),
+            include_issue_number: true,
+        });
+        let mut plan =
+            AgentTaskPlan::new("plan-output-dag", vec![request("idea"), request("design")]);
+        plan.options.max_concurrency = 2;
+        plan.tasks[1].instructions = "Build design for issue #{{outputs.issue_number}}".to_string();
+        plan.tasks[1].executor.config = json!({
+            "github_issue": "{{outputs.issue_number}}",
+            "instructions": "Use issue {{ outputs.issue_number }}"
+        });
+        plan.output_dependencies.insert(
+            "design".to_string(),
+            AgentTaskOutputDependencies {
+                depends_on: Vec::new(),
+                bindings: HashMap::from([(
+                    "issue_number".to_string(),
+                    AgentTaskOutputBinding {
+                        task_id: "idea".to_string(),
+                        path: "/metadata/github/issue_number".to_string(),
+                        required: true,
+                        default: Value::Null,
+                    },
+                )]),
+            },
+        );
+
+        let aggregate = scheduler.run(plan);
+        let observed = observed.lock().expect("observed requests");
+        let design = observed
+            .iter()
+            .find(|request| request.task_id == "design")
+            .expect("design request dispatched");
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(aggregate.totals.succeeded, 2);
+        assert_eq!(design.instructions, "Build design for issue #3447");
+        assert_eq!(design.executor.config["github_issue"], json!(3447));
+        assert_eq!(design.executor.config["instructions"], "Use issue 3447");
+        assert_eq!(design.metadata["generated_from_outputs"], json!(true));
+        assert_eq!(
+            design.metadata["resolved_output_bindings"]["issue_number"],
+            json!(3447)
+        );
+        let idea_succeeded_index = aggregate
+            .events
+            .iter()
+            .position(|event| event.task_id == "idea" && event.state == AgentTaskState::Succeeded)
+            .expect("idea succeeded event");
+        let design_running_index = aggregate
+            .events
+            .iter()
+            .position(|event| event.task_id == "design" && event.state == AgentTaskState::Running)
+            .expect("design running event");
+        assert!(idea_succeeded_index < design_running_index);
+    }
+
+    #[test]
+    fn skips_downstream_task_when_required_output_is_missing() {
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
+            observed: Arc::clone(&observed),
+            include_issue_number: false,
+        });
+        let mut plan =
+            AgentTaskPlan::new("plan-output-skip", vec![request("idea"), request("design")]);
+        plan.options.max_concurrency = 2;
+        plan.tasks[1].instructions = "Build design for issue #{{outputs.issue_number}}".to_string();
+        plan.output_dependencies.insert(
+            "design".to_string(),
+            AgentTaskOutputDependencies {
+                depends_on: Vec::new(),
+                bindings: HashMap::from([(
+                    "issue_number".to_string(),
+                    AgentTaskOutputBinding {
+                        task_id: "idea".to_string(),
+                        path: "/metadata/github/issue_number".to_string(),
+                        required: true,
+                        default: Value::Null,
+                    },
+                )]),
+            },
+        );
+
+        let aggregate = scheduler.run(plan);
+        let observed = observed.lock().expect("observed requests");
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(aggregate.totals.succeeded, 1);
+        assert_eq!(aggregate.totals.skipped, 1);
+        assert!(observed.iter().all(|request| request.task_id != "design"));
+        assert!(aggregate
+            .events
+            .iter()
+            .any(|event| { event.task_id == "design" && event.state == AgentTaskState::Skipped }));
+        let skipped = aggregate
+            .outcomes
+            .iter()
+            .find(|outcome| outcome.task_id == "design")
+            .expect("skipped outcome");
+        assert_eq!(skipped.status, AgentTaskOutcomeStatus::NoOp);
+        assert!(skipped.diagnostics.iter().any(|diagnostic| {
+            diagnostic.class == "output_dependency_missing"
+                && diagnostic.message.contains("required output binding")
+        }));
+    }
+
+    #[test]
+    fn static_batch_plans_remain_compatible_without_output_dependencies() {
+        let scheduler = AgentTaskScheduler::new(RecordingExecutor::new(
+            HashMap::new(),
+            Duration::from_millis(0),
+        ));
+        let plan_json = serde_json::to_string(&plan_with_tasks(2)).expect("plan json");
+        let plan: AgentTaskPlan = serde_json::from_str(&plan_json).expect("static plan decodes");
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(aggregate.totals.succeeded, 2);
+        assert_eq!(aggregate.totals.skipped, 0);
+    }
+
+    #[test]
     fn cancellation_stops_queued_tasks_and_notifies_running_executor() {
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(100));
         let cancel_calls = Arc::clone(&executor.cancel_calls);
@@ -1376,6 +1804,43 @@ mod tests {
         running: Arc<AtomicUsize>,
         max_seen: Arc<AtomicUsize>,
         cancel_calls: Arc<Mutex<Vec<String>>>,
+    }
+
+    struct OutputTemplateExecutor {
+        observed: Arc<Mutex<Vec<AgentTaskRequest>>>,
+        include_issue_number: bool,
+    }
+
+    impl AgentTaskExecutorAdapter for OutputTemplateExecutor {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            self.observed
+                .lock()
+                .expect("observed requests")
+                .push(request.clone());
+            let metadata = if request.task_id == "idea" && self.include_issue_number {
+                json!({ "github": { "issue_number": 3447 } })
+            } else {
+                json!({})
+            };
+
+            AgentTaskOutcome {
+                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: request.task_id,
+                status: AgentTaskOutcomeStatus::Succeeded,
+                summary: Some("ok".to_string()),
+                failure_classification: None,
+                artifacts: Vec::new(),
+                evidence_refs: Vec::new(),
+                diagnostics: Vec::new(),
+                workflow: None,
+                follow_up: None,
+                metadata,
+            }
+        }
     }
 
     impl RecordingExecutor {

--- a/tests/fixtures/agent_task_output_dag_plan.json
+++ b/tests/fixtures/agent_task_output_dag_plan.json
@@ -1,0 +1,57 @@
+{
+  "schema": "homeboy/agent-task-plan/v1",
+  "plan_id": "agent-task-output-dag-fixture",
+  "tasks": [
+    {
+      "schema": "homeboy/agent-task-request/v1",
+      "task_id": "idea",
+      "executor": {
+        "backend": "fixture",
+        "config": {
+          "artifact_root": "target/agent-task-output-dag/idea",
+          "changed_file": "docs/agent-task-output-dag-idea.md",
+          "metadata": {
+            "fixture_mode": "success",
+            "github": {
+              "issue_number": 3447
+            }
+          }
+        }
+      },
+      "instructions": "Produce the upstream idea outcome with GitHub issue metadata."
+    },
+    {
+      "schema": "homeboy/agent-task-request/v1",
+      "task_id": "design",
+      "executor": {
+        "backend": "fixture",
+        "config": {
+          "artifact_root": "target/agent-task-output-dag/design",
+          "changed_file": "docs/issue-{{outputs.issue_number}}-design.md",
+          "github_issue": "{{outputs.issue_number}}"
+        }
+      },
+      "instructions": "Produce the design artifact for GitHub issue #{{outputs.issue_number}}.",
+      "metadata": {
+        "issue": "{{outputs.issue_number}}"
+      }
+    }
+  ],
+  "output_dependencies": {
+    "design": {
+      "bindings": {
+        "issue_number": {
+          "task_id": "idea",
+          "path": "/metadata/github/issue_number",
+          "required": true
+        }
+      }
+    }
+  },
+  "options": {
+    "max_concurrency": 2
+  },
+  "metadata": {
+    "purpose": "documents output-driven DAG phase plan shape for Extra-Chill/homeboy#3447"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds plan-level `output_dependencies` for output-driven DAG phases in `homeboy agent-task run-plan`.
- Renders selected prior outcome values into downstream task instructions/config/metadata and preserves native JSON values for exact placeholders.
- Records skipped downstream tasks clearly when required outputs are missing, and documents the JSON shape with a runnable fixture plan.

Fixes #3447.

## Tests
- `cargo test agent_task`
- `cargo run --quiet --bin homeboy -- agent-task run-plan --plan @tests/fixtures/agent_task_output_dag_plan.json`
- `cargo test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted and iterated on the Rust implementation, focused tests, fixture, and docs; Chris remains responsible for review and validation.