### PR TITLE
Fix deploy debris checks and pull drift warnings

### DIFF
--- a/src/core/deploy/generated_artifacts.rs
+++ b/src/core/deploy/generated_artifacts.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use crate::core::component::Component;
 use crate::core::defaults::deploy_generated_build_dir;
 use crate::core::error::Result;
 use crate::core::git;
@@ -10,21 +11,66 @@ pub(super) fn is_generated_build_path(rel_path: &str) -> bool {
 }
 
 pub(super) fn unexpected_uncommitted_files_excluding_generated_build(
-    local_path: &str,
+    component: &Component,
 ) -> Result<Vec<String>> {
+    let local_path = &component.local_path;
     let uncommitted = git::get_uncommitted_changes(local_path)?;
     if !uncommitted.has_changes {
         return Ok(Vec::new());
     }
 
-    Ok(uncommitted
+    let mut unexpected: Vec<String> = uncommitted
         .staged
         .iter()
         .chain(uncommitted.unstaged.iter())
-        .chain(uncommitted.untracked.iter())
         .filter(|path| !is_generated_build_path(path))
         .cloned()
-        .collect())
+        .collect();
+
+    unexpected.extend(
+        uncommitted
+            .untracked
+            .iter()
+            .filter(|path| !is_generated_build_path(path))
+            .filter(|path| !is_deploy_target_debris_path(component, path))
+            .cloned(),
+    );
+
+    Ok(unexpected)
+}
+
+fn is_deploy_target_debris_path(component: &Component, rel_path: &str) -> bool {
+    if !component_uses_archive_deploy(component) {
+        return false;
+    }
+
+    let remote_path = component
+        .remote_path
+        .trim()
+        .trim_start_matches("./")
+        .trim_matches('/');
+    if remote_path.is_empty() || remote_path.starts_with('/') {
+        return false;
+    }
+
+    let rel_path = rel_path.trim().trim_start_matches("./").trim_matches('/');
+    if rel_path.is_empty() {
+        return false;
+    }
+
+    rel_path == remote_path
+        || rel_path.starts_with(&format!("{remote_path}/"))
+        || remote_path.starts_with(&format!("{rel_path}/"))
+}
+
+fn component_uses_archive_deploy(component: &Component) -> bool {
+    component.extract_command.is_some()
+        || component
+            .build_artifact
+            .as_deref()
+            .and_then(|artifact| Path::new(artifact).extension())
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| matches!(extension, "zip" | "tar" | "gz" | "tgz"))
 }
 
 pub(super) fn cleanup_generated_build_artifacts(local_path: &Path) {
@@ -78,9 +124,10 @@ impl Drop for GeneratedBuildArtifactCleanupGuard<'_> {
 #[cfg(test)]
 mod tests {
     use super::{
-        cleanup_generated_build_artifacts, is_generated_build_path,
+        cleanup_generated_build_artifacts, is_deploy_target_debris_path, is_generated_build_path,
         unexpected_uncommitted_files_excluding_generated_build,
     };
+    use crate::core::component::Component;
     use crate::core::defaults::deploy_generated_build_dir;
 
     fn run_git(dir: &std::path::Path, args: &[&str]) {
@@ -130,11 +177,30 @@ mod tests {
         std::fs::write(dir.join(&build_dir).join("plugin.zip"), "artifact").expect("artifact");
         std::fs::write(dir.join("src.rs"), "source\n").expect("source");
 
+        let component = Component {
+            local_path: dir.to_string_lossy().to_string(),
+            ..Component::default()
+        };
         let unexpected =
-            unexpected_uncommitted_files_excluding_generated_build(&dir.to_string_lossy())
-                .expect("status");
+            unexpected_uncommitted_files_excluding_generated_build(&component).expect("status");
 
         assert_eq!(unexpected, vec!["src.rs"]);
+    }
+
+    #[test]
+    fn deploy_target_debris_matches_relative_remote_path_and_collapsed_untracked_dir() {
+        let component = Component {
+            remote_path: "wp-content/plugins/data-machine".to_string(),
+            build_artifact: Some("dist/data-machine.zip".to_string()),
+            ..Component::default()
+        };
+
+        assert!(is_deploy_target_debris_path(
+            &component,
+            "wp-content/plugins/data-machine/data-machine"
+        ));
+        assert!(is_deploy_target_debris_path(&component, "wp-content/"));
+        assert!(!is_deploy_target_debris_path(&component, "src/lib.rs"));
     }
 
     #[test]

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -447,7 +447,7 @@ fn check_uncommitted_changes(components: &[Component]) -> Result<()> {
             non_git.push(component);
             continue;
         }
-        match unexpected_uncommitted_files_excluding_generated_build(&component.local_path) {
+        match unexpected_uncommitted_files_excluding_generated_build(component) {
             Ok(unexpected) if unexpected.is_empty() => {}
             Ok(_) | Err(_) => dirty.push(component.id.as_str()),
         }
@@ -513,6 +513,8 @@ fn sync_components(components: &[Component]) -> Result<()> {
 
         let path = &component.local_path;
 
+        let version_before_pull = version::get_component_version(component);
+
         // Check if behind remote
         match git::fetch_and_get_behind_count(path) {
             Ok(Some(behind)) => {
@@ -530,6 +532,13 @@ fn sync_components(components: &[Component]) -> Result<()> {
                         pull_result.stderr.lines().next().unwrap_or("unknown error")
                     )));
                 }
+                if let Some(message) = auto_pull_version_drift_message(
+                    component,
+                    version_before_pull.as_deref(),
+                    version::get_component_version(component).as_deref(),
+                ) {
+                    log_status!("deploy", "{}", message);
+                }
                 log_status!("deploy", "'{}' is now up to date", component.id);
             }
             Ok(None) => {
@@ -546,6 +555,23 @@ fn sync_components(components: &[Component]) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn auto_pull_version_drift_message(
+    component: &Component,
+    before: Option<&str>,
+    after: Option<&str>,
+) -> Option<String> {
+    if before == after {
+        return None;
+    }
+
+    Some(format!(
+        "Warning: auto-pull changed '{}' deploy version from {} to {}",
+        component.id,
+        before.unwrap_or("unknown"),
+        after.unwrap_or("unknown")
+    ))
 }
 
 /// Record of a tag checkout for later branch restoration.
@@ -872,6 +898,24 @@ mod tests {
             .success());
     }
 
+    fn init_clean_repo(path: &Path) {
+        let run = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .output()
+                .expect("git command")
+        };
+        assert!(run(&["init", "-q"]).status.success());
+        assert!(run(&["config", "user.email", "test@example.com"])
+            .status
+            .success());
+        assert!(run(&["config", "user.name", "Test"]).status.success());
+        assert!(run(&["commit", "--allow-empty", "-q", "-m", "init"])
+            .status
+            .success());
+    }
+
     #[test]
     fn check_uncommitted_changes_reports_non_git_local_path() {
         // A directory exists but is not a git repo — the error must say so clearly
@@ -1015,27 +1059,35 @@ mod tests {
         let dir = TempDir::new().expect("temp dir");
         let path = dir.path();
 
-        let run = |args: &[&str]| {
-            std::process::Command::new("git")
-                .args(args)
-                .current_dir(path)
-                .output()
-                .expect("git command")
-        };
-        assert!(run(&["init", "-q"]).status.success());
-        assert!(run(&["config", "user.email", "test@example.com"])
-            .status
-            .success());
-        assert!(run(&["config", "user.name", "Test"]).status.success());
-        assert!(run(&["commit", "--allow-empty", "-q", "-m", "init"])
-            .status
-            .success());
+        init_clean_repo(path);
         std::fs::create_dir_all(path.join(".homeboy-build")).expect("build dir");
         std::fs::write(path.join(".homeboy-build/plugin.zip"), "artifact").expect("artifact");
 
         let component = make_component("test", &path.to_string_lossy());
         check_uncommitted_changes(&[component])
             .expect("generated Homeboy deploy artifacts should not block deploy");
+    }
+
+    #[test]
+    fn check_uncommitted_changes_ignores_untracked_deploy_target_debris() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path();
+
+        init_clean_repo(path);
+        std::fs::create_dir_all(path.join("wp-content/plugins/data-machine/data-machine"))
+            .expect("deploy debris dir");
+        std::fs::write(
+            path.join("wp-content/plugins/data-machine/data-machine/plugin.php"),
+            "<?php",
+        )
+        .expect("deploy debris file");
+
+        let mut component = make_component("data-machine", &path.to_string_lossy());
+        component.remote_path = "wp-content/plugins/data-machine".to_string();
+        component.build_artifact = Some("dist/data-machine.zip".to_string());
+
+        check_uncommitted_changes(&[component])
+            .expect("untracked deploy-target debris should not block deploy");
     }
 
     #[test]
@@ -1067,6 +1119,29 @@ mod tests {
             .expect_err("source changes should still block deploy");
 
         assert!(err.message.contains("uncommitted changes"));
+    }
+
+    #[test]
+    fn auto_pull_version_drift_message_reports_changed_version() {
+        let component = make_component("data-machine", "/tmp/data-machine");
+
+        let message =
+            auto_pull_version_drift_message(&component, Some("0.139.12"), Some("0.139.13"))
+                .expect("version drift message");
+
+        assert!(message.contains("data-machine"));
+        assert!(message.contains("0.139.12"));
+        assert!(message.contains("0.139.13"));
+    }
+
+    #[test]
+    fn auto_pull_version_drift_message_skips_unchanged_version() {
+        let component = make_component("data-machine", "/tmp/data-machine");
+
+        assert!(
+            auto_pull_version_drift_message(&component, Some("0.139.12"), Some("0.139.12"))
+                .is_none()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Keep untracked archive-deploy target debris from blocking deploy preflight as ordinary source changes when it matches the component's relative `remote_path`.
- Preserve normal dirty-check behavior for source changes, staged changes, modified files, and non-archive components.
- Log a loud warning when deploy auto-pull changes a component's detected deploy version.

## Issues
- Fixes #3448
- Fixes #3449
- Follow-up to #3444 and #3446

## Tests
- `cargo test -q core::deploy::generated_artifacts::tests::`
- `cargo test -q core::deploy::orchestration::tests::`
- `cargo test -q core::deploy::`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the deploy dirty-check and auto-pull drift warning fixes plus regression tests; Chris remains responsible for review and merge.