### PR TITLE
Preserve nested trace artifacts

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -1552,11 +1552,21 @@ fn persist_trace_workflow_result(
         }
     }
 
-    record_trace_artifacts(&observation.store, &observation.run_id, run_dir, results);
+    let artifact_observation =
+        record_trace_artifacts(&observation.store, &observation.run_id, run_dir, results);
+    let finish_status =
+        if run_status == RunStatus::Pass && artifact_observation.has_declared_artifact_failures() {
+            RunStatus::Fail
+        } else {
+            run_status
+        };
     let _ = observation.store.finish_run(
         &observation.run_id,
-        run_status,
-        Some(trace_run_finish_metadata(workflow)),
+        finish_status,
+        Some(trace_run_finish_metadata(
+            workflow,
+            Some(&artifact_observation),
+        )),
     );
 }
 
@@ -1583,11 +1593,16 @@ fn persist_trace_workflow_error(
         .metadata(error_metadata.clone())
         .build(),
     );
-    record_trace_artifacts(&observation.store, &observation.run_id, run_dir, None);
-    let _ =
-        observation
-            .store
-            .finish_run(&observation.run_id, RunStatus::Error, Some(error_metadata));
+    let artifact_observation =
+        record_trace_artifacts(&observation.store, &observation.run_id, run_dir, None);
+    let _ = observation.store.finish_run(
+        &observation.run_id,
+        RunStatus::Error,
+        Some(merge_trace_artifact_metadata(
+            error_metadata,
+            &artifact_observation,
+        )),
+    );
 }
 
 fn trace_run_status(workflow: &extension_trace::TraceRunWorkflowResult) -> RunStatus {
@@ -1615,8 +1630,9 @@ fn baseline_status(workflow: &extension_trace::TraceRunWorkflowResult) -> Option
 
 fn trace_run_finish_metadata(
     workflow: &extension_trace::TraceRunWorkflowResult,
+    artifact_observation: Option<&observations::TraceArtifactObservationResult>,
 ) -> serde_json::Value {
-    serde_json::json!({
+    let metadata = serde_json::json!({
         "status": &workflow.status,
         "exit_code": workflow.exit_code,
         "failure": &workflow.failure,
@@ -1624,7 +1640,32 @@ fn trace_run_finish_metadata(
         "baseline_comparison": &workflow.baseline_comparison,
         "hints": &workflow.hints,
         "results": &workflow.results,
-    })
+    });
+    if let Some(artifact_observation) = artifact_observation {
+        merge_trace_artifact_metadata(metadata, artifact_observation)
+    } else {
+        metadata
+    }
+}
+
+fn merge_trace_artifact_metadata(
+    mut metadata: serde_json::Value,
+    artifact_observation: &observations::TraceArtifactObservationResult,
+) -> serde_json::Value {
+    if !artifact_observation.has_declared_artifact_failures() {
+        return metadata;
+    }
+    if let Some(object) = metadata.as_object_mut() {
+        object.insert(
+            "artifact_validation".to_string(),
+            serde_json::json!({
+                "status": "fail",
+                "missing_declared_artifacts": artifact_observation.missing_declared_artifacts,
+                "invalid_declared_artifacts": artifact_observation.invalid_declared_artifacts,
+            }),
+        );
+    }
+    metadata
 }
 
 #[cfg(test)]

--- a/src/commands/trace/observations.rs
+++ b/src/commands/trace/observations.rs
@@ -2,14 +2,27 @@ use std::path::{Path, PathBuf};
 
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::trace as extension_trace;
-use homeboy::core::observation::ObservationStore;
+use homeboy::core::observation::{NewFindingRecord, ObservationStore};
+
+#[derive(Debug, Default)]
+pub(super) struct TraceArtifactObservationResult {
+    pub missing_declared_artifacts: usize,
+    pub invalid_declared_artifacts: usize,
+}
+
+impl TraceArtifactObservationResult {
+    pub fn has_declared_artifact_failures(&self) -> bool {
+        self.missing_declared_artifacts > 0 || self.invalid_declared_artifacts > 0
+    }
+}
 
 pub(super) fn record_trace_artifacts(
     store: &ObservationStore,
     run_id: &str,
     run_dir: &RunDir,
     results: Option<&extension_trace::TraceResults>,
-) {
+) -> TraceArtifactObservationResult {
+    let mut observation_result = TraceArtifactObservationResult::default();
     let trace_results_path =
         run_dir.step_file(homeboy::core::engine::run_dir::files::TRACE_RESULTS);
     record_artifact_if_file(store, run_id, "trace-results", &trace_results_path);
@@ -21,13 +34,248 @@ pub(super) fn record_trace_artifacts(
             } else {
                 run_dir.path().join(path)
             };
-            record_artifact_if_file(store, run_id, "trace-artifact", &resolved);
+            record_declared_artifact(
+                store,
+                run_id,
+                run_dir.path(),
+                artifact,
+                &resolved,
+                &mut observation_result,
+            );
         }
     }
+    observation_result
 }
 
 fn record_artifact_if_file(store: &ObservationStore, run_id: &str, kind: &str, path: &Path) {
     if path.is_file() {
         let _ = store.record_artifact(run_id, kind, path);
+    }
+}
+
+fn record_declared_artifact(
+    store: &ObservationStore,
+    run_id: &str,
+    run_root: &Path,
+    artifact: &extension_trace::TraceArtifact,
+    resolved: &Path,
+    result: &mut TraceArtifactObservationResult,
+) {
+    let metadata = match std::fs::metadata(resolved) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            result.missing_declared_artifacts += 1;
+            record_declared_artifact_finding(
+                store,
+                run_id,
+                "trace.artifact.missing",
+                "error",
+                format!(
+                    "trace result declared artifact '{}' at '{}', but the path does not exist",
+                    artifact.label, artifact.path
+                ),
+                artifact,
+                run_root,
+                resolved,
+            );
+            return;
+        }
+        Err(error) => {
+            result.invalid_declared_artifacts += 1;
+            record_declared_artifact_finding(
+                store,
+                run_id,
+                "trace.artifact.metadata_error",
+                "error",
+                format!(
+                    "trace result declared artifact '{}' at '{}' could not be inspected: {error}",
+                    artifact.label, artifact.path
+                ),
+                artifact,
+                run_root,
+                resolved,
+            );
+            return;
+        }
+    };
+
+    let record_result = if metadata.is_file() {
+        store.record_artifact(run_id, "trace-artifact", resolved)
+    } else if metadata.is_dir() {
+        store.record_directory_artifact(run_id, "trace-artifact", resolved)
+    } else {
+        result.invalid_declared_artifacts += 1;
+        record_declared_artifact_finding(
+            store,
+            run_id,
+            "trace.artifact.unsupported_type",
+            "error",
+            format!(
+                "trace result declared artifact '{}' at '{}' is neither a file nor a directory",
+                artifact.label, artifact.path
+            ),
+            artifact,
+            run_root,
+            resolved,
+        );
+        return;
+    };
+
+    if let Err(error) = record_result {
+        result.invalid_declared_artifacts += 1;
+        record_declared_artifact_finding(
+            store,
+            run_id,
+            "trace.artifact.record_failed",
+            "error",
+            format!(
+                "trace result declared artifact '{}' at '{}' could not be persisted: {}",
+                artifact.label, artifact.path, error.message
+            ),
+            artifact,
+            run_root,
+            resolved,
+        );
+    }
+}
+
+fn record_declared_artifact_finding(
+    store: &ObservationStore,
+    run_id: &str,
+    rule: &str,
+    severity: &str,
+    message: String,
+    artifact: &extension_trace::TraceArtifact,
+    run_root: &Path,
+    resolved: &Path,
+) {
+    let _ = store.record_finding(&NewFindingRecord {
+        run_id: run_id.to_string(),
+        tool: "trace".to_string(),
+        rule: Some(rule.to_string()),
+        file: None,
+        line: None,
+        severity: Some(severity.to_string()),
+        fingerprint: Some(format!("{rule}:{}", artifact.path)),
+        message,
+        fixable: Some(false),
+        metadata_json: serde_json::json!({
+            "declared_artifact": {
+                "label": artifact.label,
+                "path": artifact.path,
+                "resolved_path": resolved.to_string_lossy(),
+                "relative_to_run_dir": resolved.strip_prefix(run_root)
+                    .ok()
+                    .map(|path| path.to_string_lossy().to_string()),
+            }
+        }),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy::core::engine::run_dir::RunDir;
+    use homeboy::core::extension::trace::parsing::{TraceArtifact, TraceResults, TraceStatus};
+    use homeboy::core::observation::{NewRunRecord, ObservationStore};
+
+    fn sample_results(artifacts: Vec<TraceArtifact>) -> TraceResults {
+        TraceResults {
+            component_id: "homeboy".to_string(),
+            scenario_id: "browser-probe".to_string(),
+            status: TraceStatus::Pass,
+            summary: None,
+            failure: None,
+            rig: None,
+            timeline: Vec::new(),
+            span_definitions: Vec::new(),
+            span_results: Vec::new(),
+            assertions: Vec::new(),
+            temporal_assertions: Vec::new(),
+            artifacts,
+        }
+    }
+
+    #[test]
+    fn declared_nested_artifact_directory_is_recorded_recursively() {
+        crate::test_support::with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(
+                    NewRunRecord::builder("trace")
+                        .component_id("homeboy")
+                        .build(),
+                )
+                .expect("run");
+            let run_dir = RunDir::create().expect("run dir");
+            let browser_dir = run_dir
+                .path()
+                .join("artifacts/wp-codebox-artifacts/runtime-abc/files/browser");
+            std::fs::create_dir_all(&browser_dir).expect("mkdir browser artifacts");
+            std::fs::write(browser_dir.join("network.jsonl"), "{\"url\":\"/\"}\n")
+                .expect("write network");
+            std::fs::write(browser_dir.join("console.jsonl"), "{\"text\":\"ok\"}\n")
+                .expect("write console");
+            let results = sample_results(vec![TraceArtifact {
+                label: "WP Codebox browser probe".to_string(),
+                path: "artifacts/wp-codebox-artifacts/runtime-abc/files/browser".to_string(),
+            }]);
+
+            let outcome = record_trace_artifacts(&store, &run.id, &run_dir, Some(&results));
+            let artifacts = store.list_artifacts(&run.id).expect("artifacts");
+
+            assert!(!outcome.has_declared_artifact_failures());
+            assert_eq!(artifacts.len(), 1);
+            assert_eq!(artifacts[0].artifact_type, "directory");
+            let persisted = PathBuf::from(&artifacts[0].path);
+            assert_eq!(
+                std::fs::read_to_string(persisted.join("network.jsonl")).expect("network"),
+                "{\"url\":\"/\"}\n"
+            );
+            assert_eq!(
+                std::fs::read_to_string(persisted.join("console.jsonl")).expect("console"),
+                "{\"text\":\"ok\"}\n"
+            );
+            run_dir.cleanup();
+        });
+    }
+
+    #[test]
+    fn missing_declared_artifact_records_structured_failure_finding() {
+        crate::test_support::with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(
+                    NewRunRecord::builder("trace")
+                        .component_id("homeboy")
+                        .build(),
+                )
+                .expect("run");
+            let run_dir = RunDir::create().expect("run dir");
+            let results = sample_results(vec![TraceArtifact {
+                label: "network log".to_string(),
+                path: "artifacts/wp-codebox-artifacts/runtime-missing/files/browser/network.jsonl"
+                    .to_string(),
+            }]);
+
+            let outcome = record_trace_artifacts(&store, &run.id, &run_dir, Some(&results));
+            let findings = store.list_findings_for_run(&run.id).expect("findings");
+
+            assert!(outcome.has_declared_artifact_failures());
+            assert_eq!(outcome.missing_declared_artifacts, 1);
+            assert_eq!(findings.len(), 1);
+            assert_eq!(findings[0].tool, "trace");
+            assert_eq!(findings[0].rule.as_deref(), Some("trace.artifact.missing"));
+            assert_eq!(findings[0].severity.as_deref(), Some("error"));
+            assert_eq!(
+                findings[0].metadata_json["declared_artifact"]["label"],
+                "network log"
+            );
+            assert_eq!(
+                findings[0].metadata_json["declared_artifact"]["path"],
+                "artifacts/wp-codebox-artifacts/runtime-missing/files/browser/network.jsonl"
+            );
+            run_dir.cleanup();
+        });
     }
 }


### PR DESCRIPTION
## Summary
- Preserve trace-result declared artifact directories recursively, including nested WP Codebox browser-probe outputs like `wp-codebox-artifacts/runtime-*/files/browser/network.jsonl`.
- Record structured trace findings when declared artifacts are missing or cannot be persisted, and downgrade a passing observed trace run to `fail` when artifact validation fails.
- Add coverage for nested declared artifact directories and missing declared artifact diagnostics.

Fixes #3471.

## Tests
- `cargo fmt --all`
- `cargo test commands::trace::observations`
- `cargo test commands::trace`
- `cargo test core::engine::invocation`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the trace artifact preservation fix, added focused Rust tests, and ran verification; Chris remains responsible for review and merge.