### PR TITLE
fix: harden deploy version and status papercuts

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -110,6 +110,8 @@ pub struct ProjectStatusRow {
 pub enum ProjectComponentDashboardStatus {
     /// Local and remote versions match, no unreleased commits
     Current,
+    /// Local and remote versions match, but a newer origin tag exists
+    PinnedCurrent,
     /// Local version differs from remote (needs deploy)
     Outdated,
     /// Releasable code commits since the current version baseline
@@ -138,6 +140,7 @@ pub struct ProjectDashboardOutput {
 #[derive(Debug, Serialize)]
 pub struct ProjectDashboardSummary {
     pub current: usize,
+    pub pinned_current: usize,
     pub outdated: usize,
     pub needs_release: usize,
     pub docs_only: usize,
@@ -329,6 +332,7 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
     let mut rows: Vec<ProjectStatusRow> = Vec::new();
     let mut summary = ProjectDashboardSummary {
         current: 0,
+        pinned_current: 0,
         outdated: 0,
         needs_release: 0,
         docs_only: 0,
@@ -365,10 +369,14 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
                     if d.is_behind() {
                         ProjectComponentDashboardStatus::BehindUpstream
                     } else {
-                        deployed_version_dashboard_status(&local_ver, &remote_ver)
+                        deployed_version_dashboard_status(
+                            &local_ver,
+                            &remote_ver,
+                            d.latest_origin_tag.as_deref(),
+                        )
                     }
                 } else {
-                    deployed_version_dashboard_status(&local_ver, &remote_ver)
+                    deployed_version_dashboard_status(&local_ver, &remote_ver, None)
                 }
             }
             ReleaseStateStatus::Unknown => ProjectComponentDashboardStatus::Unknown,
@@ -376,6 +384,7 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
 
         match &dashboard_status {
             ProjectComponentDashboardStatus::Current => summary.current += 1,
+            ProjectComponentDashboardStatus::PinnedCurrent => summary.pinned_current += 1,
             ProjectComponentDashboardStatus::Outdated => summary.outdated += 1,
             ProjectComponentDashboardStatus::NeedsRelease => summary.needs_release += 1,
             ProjectComponentDashboardStatus::DocsOnly => summary.docs_only += 1,
@@ -398,7 +407,13 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
 
     // Apply filters
     if args.outdated {
-        rows.retain(|r| matches!(r.status, ProjectComponentDashboardStatus::Outdated));
+        rows.retain(|r| {
+            matches!(
+                r.status,
+                ProjectComponentDashboardStatus::Outdated
+                    | ProjectComponentDashboardStatus::PinnedCurrent
+            )
+        });
     }
     if args.needs_release {
         rows.retain(|r| matches!(r.status, ProjectComponentDashboardStatus::NeedsRelease));
@@ -433,12 +448,34 @@ fn run_project_dashboard(project_id: &str, args: &StatusArgs) -> CmdResult<Statu
 fn deployed_version_dashboard_status(
     local_ver: &Option<String>,
     remote_ver: &Option<String>,
+    origin_tag: Option<&str>,
 ) -> ProjectComponentDashboardStatus {
     match (local_ver, remote_ver) {
         (Some(local), Some(remote)) if local != remote => ProjectComponentDashboardStatus::Outdated,
         (Some(_), None) => ProjectComponentDashboardStatus::Outdated,
+        (Some(local), Some(remote))
+            if local == remote && origin_tag_is_newer_than_local(origin_tag, local) =>
+        {
+            ProjectComponentDashboardStatus::PinnedCurrent
+        }
         _ => ProjectComponentDashboardStatus::Current,
     }
+}
+
+fn origin_tag_is_newer_than_local(origin_tag: Option<&str>, local: &str) -> bool {
+    let Some(origin) = origin_tag else {
+        return false;
+    };
+    let origin = origin.trim_start_matches('v');
+    let local = local.trim_start_matches('v');
+    if origin == local {
+        return false;
+    }
+
+    semver::Version::parse(origin)
+        .ok()
+        .zip(semver::Version::parse(local).ok())
+        .is_some_and(|(origin, local)| origin > local)
 }
 
 /// Fetch from origin and compute upstream drift for a component.
@@ -574,6 +611,7 @@ fn log_dashboard_table(rows: &[ProjectStatusRow]) {
         let upstream = format_upstream(&row.ahead_upstream, &row.behind_upstream);
         let status_icon = match &row.status {
             ProjectComponentDashboardStatus::Current => "✅ current",
+            ProjectComponentDashboardStatus::PinnedCurrent => "📌 pinned current",
             ProjectComponentDashboardStatus::Outdated => "⚠️  outdated",
             ProjectComponentDashboardStatus::NeedsRelease => "🔶 needs release",
             ProjectComponentDashboardStatus::DocsOnly => "📝 docs only",
@@ -686,6 +724,31 @@ mod tests {
             .status()
             .expect("git init");
         (dir, repo)
+    }
+
+    #[test]
+    fn deployed_version_status_marks_current_version_with_newer_origin_tag_as_pinned_current() {
+        let status = deployed_version_dashboard_status(
+            &Some("0.139.18".to_string()),
+            &Some("0.139.18".to_string()),
+            Some("v0.139.19"),
+        );
+
+        assert!(matches!(
+            status,
+            ProjectComponentDashboardStatus::PinnedCurrent
+        ));
+    }
+
+    #[test]
+    fn deployed_version_status_keeps_exact_origin_tag_current() {
+        let status = deployed_version_dashboard_status(
+            &Some("0.139.18".to_string()),
+            &Some("0.139.18".to_string()),
+            Some("v0.139.18"),
+        );
+
+        assert!(matches!(status, ProjectComponentDashboardStatus::Current));
     }
 
     #[test]

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -38,9 +38,9 @@ pub fn run(project_id: &str, config: &DeployConfig) -> Result<DeployOrchestratio
 
 /// Deploy components across multiple projects.
 ///
-/// Handles the build-skip optimization: only the first project builds
-/// from source; subsequent projects reuse the already-built artifact.
-/// Similarly, only the first project pulls latest changes.
+/// Builds each project independently. Keeping build artifacts local to each
+/// project run avoids lifecycle coupling between deploy target cleanup and
+/// later projects in the same command.
 ///
 /// Unknown project IDs are skipped (not fatal) — fleet configs can
 /// accumulate stale references that shouldn't block the rest.
@@ -111,8 +111,6 @@ pub fn run_multi(
     let mut failed: u32 = 0;
     let skipped: u32 = unknown_projects.len() as u32;
     let mut planned: u32 = 0;
-    let mut first_project = true;
-
     // Record skipped results for unknown projects
     for pid in &unknown_projects {
         project_results.push(ProjectDeployResult {
@@ -140,12 +138,10 @@ pub fn run_multi(
             dry_run: config.dry_run,
             check: config.check,
             force: config.force,
-            // Build-skip optimization: only build on first project
-            skip_build: config.skip_build || !first_project,
+            skip_build: config.skip_build,
             keep_deps: config.keep_deps,
             expected_version: config.expected_version.clone(),
-            // Only pull on first project
-            no_pull: config.no_pull || !first_project,
+            no_pull: config.no_pull,
             head: config.head,
             tagged: config.tagged,
         };
@@ -206,8 +202,6 @@ pub fn run_multi(
                 failed += 1;
             }
         }
-
-        first_project = false;
     }
 
     let total_projects = project_results.len() as u32;

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -130,9 +130,9 @@ pub(super) fn deploy_components(
         check_unreleased_commits(&components, config)?;
     }
 
-    // Checkout latest tag for each component (unless --head or --skip-build).
+    // Checkout the deploy tag for each component (unless --head or --skip-build).
     let tag_checkouts = if !config.head && !config.skip_build {
-        checkout_latest_tags(&components)?
+        checkout_deploy_tags(&components, config.expected_version.as_deref())?
     } else {
         Vec::new()
     };
@@ -590,7 +590,10 @@ struct TagCheckout {
 ///
 /// Components without tags are skipped with a warning — they deploy
 /// from HEAD as before (the pre-tag-checkout behavior).
-fn checkout_latest_tags(components: &[Component]) -> Result<Vec<TagCheckout>> {
+fn checkout_deploy_tags(
+    components: &[Component],
+    expected_version: Option<&str>,
+) -> Result<Vec<TagCheckout>> {
     let mut checkouts = Vec::new();
 
     for component in components {
@@ -601,25 +604,27 @@ fn checkout_latest_tags(components: &[Component]) -> Result<Vec<TagCheckout>> {
 
         let path = &component.local_path;
 
-        // Get the latest tag
-        let tag = match git::get_latest_tag(path) {
-            Ok(Some(t)) => t,
-            Ok(None) => {
-                log_status!(
-                    "deploy",
-                    "Warning: '{}' has no version tags — deploying from HEAD (use --head to suppress this warning)",
-                    component.id
-                );
-                continue;
-            }
-            Err(_) => {
-                log_status!(
-                    "deploy",
-                    "Warning: could not read tags for '{}' — deploying from HEAD",
-                    component.id
-                );
-                continue;
-            }
+        let tag = match expected_version {
+            Some(version) => deploy_tag_for_version(component, version),
+            None => match git::get_latest_tag(path) {
+                Ok(Some(t)) => t,
+                Ok(None) => {
+                    log_status!(
+                        "deploy",
+                        "Warning: '{}' has no version tags — deploying from HEAD (use --head to suppress this warning)",
+                        component.id
+                    );
+                    continue;
+                }
+                Err(_) => {
+                    log_status!(
+                        "deploy",
+                        "Warning: could not read tags for '{}' — deploying from HEAD",
+                        component.id
+                    );
+                    continue;
+                }
+            },
         };
 
         // Save the current branch name. Use symbolic-ref which returns the
@@ -690,6 +695,14 @@ fn checkout_latest_tags(components: &[Component]) -> Result<Vec<TagCheckout>> {
     }
 
     Ok(checkouts)
+}
+
+fn deploy_tag_for_version(component: &Component, version: &str) -> String {
+    let version = version.trim_start_matches('v');
+    match git::MonorepoContext::detect(&component.local_path, &component.id) {
+        Some(context) => context.format_tag(version),
+        None => format!("v{}", version),
+    }
 }
 
 /// Restore original branches after deployment.
@@ -914,6 +927,25 @@ mod tests {
         assert!(run(&["commit", "--allow-empty", "-q", "-m", "init"])
             .status
             .success());
+    }
+
+    #[test]
+    fn deploy_tag_for_version_formats_regular_release_tag() {
+        let component = make_component("data-machine", "/tmp/not-a-git-repo");
+
+        assert_eq!(deploy_tag_for_version(&component, "0.139.18"), "v0.139.18");
+        assert_eq!(deploy_tag_for_version(&component, "v0.139.18"), "v0.139.18");
+    }
+
+    #[test]
+    fn deploy_tag_for_version_formats_monorepo_release_tag() {
+        let dir = TempDir::new().expect("temp dir");
+        init_clean_repo(dir.path());
+        let component_dir = dir.path().join("packages/plugin");
+        std::fs::create_dir_all(&component_dir).expect("component dir");
+        let component = make_component("plugin", &component_dir.to_string_lossy());
+
+        assert_eq!(deploy_tag_for_version(&component, "1.2.3"), "plugin-v1.2.3");
     }
 
     #[test]

--- a/src/core/deploy/path_roots.rs
+++ b/src/core/deploy/path_roots.rs
@@ -28,6 +28,8 @@ pub(super) fn resolve_effective_remote_path(
         return base_path::join_remote_path(Some(fallback_base_path), &remote_path);
     }
 
+    reject_relative_parent_traversal(component, &remote_path)?;
+
     if let Some(resolved) =
         resolve_with_project_root(project, component, fallback_base_path, &remote_path)?
     {
@@ -35,6 +37,25 @@ pub(super) fn resolve_effective_remote_path(
     }
 
     base_path::join_remote_path(Some(fallback_base_path), &remote_path)
+}
+
+fn reject_relative_parent_traversal(component: &Component, remote_path: &str) -> Result<()> {
+    if !remote_path.split('/').any(|segment| segment.trim() == "..") {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "remotePath",
+        format!(
+            "Component '{}' remote path '{}' escapes the project base_path with '..' segments",
+            component.id, remote_path
+        ),
+        Some(remote_path.to_string()),
+        Some(vec![
+            "Configure an explicit absolute remote_path when deploying outside base_path".to_string(),
+            "Configure a project path_root and use the managed path prefix when the extension supports it".to_string(),
+        ]),
+    ))
 }
 
 pub(super) fn project_with_detected_path_roots(
@@ -294,34 +315,34 @@ mod tests {
     }
 
     #[test]
-    fn parent_relative_content_paths_fall_back_to_base_path() {
+    fn parent_relative_content_paths_are_rejected() {
         with_isolated_home(|_| {
             install_extension();
 
-            let resolved = resolve_effective_remote_path(
+            let err = resolve_effective_remote_path(
                 &project_with_root(),
                 &component("../wp-content/plugins/foo"),
                 "/srv/site",
             )
-            .expect("resolve path");
+            .expect_err("parent traversal should fail");
 
-            assert_eq!(resolved, "/srv/site/../wp-content/plugins/foo");
+            assert!(err.to_string().contains("escapes the project base_path"));
         });
     }
 
     #[test]
-    fn preserves_parent_relative_paths_before_base_path_fallback() {
+    fn parent_relative_non_content_paths_are_rejected() {
         with_isolated_home(|_| {
             install_extension();
 
-            let resolved = resolve_effective_remote_path(
+            let err = resolve_effective_remote_path(
                 &project_with_root(),
                 &component("../var/log/app.log"),
                 "/srv/site",
             )
-            .expect("resolve path");
+            .expect_err("parent traversal should fail");
 
-            assert_eq!(resolved, "/srv/site/../var/log/app.log");
+            assert!(err.to_string().contains("escapes the project base_path"));
         });
     }
 


### PR DESCRIPTION
## Summary
- Rebuild multi-project deploy artifacts per project instead of reusing a cleaned artifact from the first target.
- Checkout the requested deploy version tag before building, including monorepo-prefixed tags, so `--tagged --version` provenance matches the built source.
- Keep pinned-but-current deployments visible in `status --outdated` and reject relative deploy paths that escape `base_path` with `..` segments.

## Tests
- `cargo fmt`
- `cargo test core::deploy::path_roots::tests --lib`
- `cargo test commands::status::tests --lib`
- `cargo test core::deploy::orchestration::tests --lib`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Homeboy deploy/status fixes, added focused Rust tests, and ran local verification. Chris remains responsible for review and merge.