### PR TITLE
Route test audit detectors through descriptors

### DIFF
--- a/src/core/code_audit/descriptor_runtime.rs
+++ b/src/core/code_audit/descriptor_runtime.rs
@@ -1,12 +1,17 @@
 use super::detectors::{
     aggregate_construction, facade_passthrough, repeated_literal_shape, shared_scaffolding,
+    test_topology, test_wiring,
 };
 use super::{
     fingerprint, shadow_modules, time_audit_detector, AuditExecutionPlan, AuditTiming,
-    DetectorDescriptor, DetectorRuntime, Finding, FingerprintDetectorRunner,
+    DetectorDescriptor, DetectorRuntime, Finding, FingerprintDetectorRunner, RootDetectorRunner,
 };
+use crate::core::component::AuditConfig;
+use std::path::Path;
 
 pub(super) struct DetectorRunContext<'a> {
+    pub(super) root: &'a Path,
+    pub(super) audit_config: &'a AuditConfig,
     pub(super) all_fingerprints: &'a [&'a fingerprint::FileFingerprint],
 }
 
@@ -28,6 +33,16 @@ fn run_fingerprint_descriptor(
         FingerprintDetectorRunner::AggregateConstruction => {
             aggregate_construction::run(context.all_fingerprints)
         }
+    }
+}
+
+fn run_root_descriptor(
+    runner: RootDetectorRunner,
+    context: &DetectorRunContext<'_>,
+) -> Vec<Finding> {
+    match runner {
+        RootDetectorRunner::TestTopology => test_topology::run(context.root),
+        RootDetectorRunner::TestWiring => test_wiring::run(context.root, context.audit_config),
     }
 }
 
@@ -62,17 +77,23 @@ pub(super) fn run_descriptor_detectors(
             continue;
         }
 
-        let DetectorRuntime::Fingerprint(runner) = descriptor.runtime else {
-            continue;
+        let findings = match descriptor.runtime {
+            DetectorRuntime::Fingerprint(runner) => time_audit_detector(
+                timing,
+                descriptor.timing_id,
+                plan.detector_enabled(descriptor.id),
+                || run_fingerprint_descriptor(runner, context),
+                Vec::new,
+            ),
+            DetectorRuntime::Root(runner) => time_audit_detector(
+                timing,
+                descriptor.timing_id,
+                plan.detector_enabled(descriptor.id),
+                || run_root_descriptor(runner, context),
+                Vec::new,
+            ),
+            DetectorRuntime::Manual => continue,
         };
-
-        let findings = time_audit_detector(
-            timing,
-            descriptor.timing_id,
-            plan.detector_enabled(descriptor.id),
-            || run_fingerprint_descriptor(runner, context),
-            Vec::new,
-        );
         extend_descriptor_findings(all_findings, descriptor, findings);
     }
 }

--- a/src/core/code_audit/execution_plan.rs
+++ b/src/core/code_audit/execution_plan.rs
@@ -24,6 +24,7 @@ impl DetectorAccess {
 pub(crate) enum DetectorRuntime {
     Manual,
     Fingerprint(FingerprintDetectorRunner),
+    Root(RootDetectorRunner),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -33,6 +34,12 @@ pub(crate) enum FingerprintDetectorRunner {
     LiteralShapes,
     SharedScaffolding,
     AggregateConstruction,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RootDetectorRunner {
+    TestTopology,
+    TestWiring,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -148,7 +155,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
             AuditFinding::VacuousTest,
         ],
         access: DetectorAccess::RootOnly,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Root(RootDetectorRunner::TestTopology),
         timing_id: "detector.test_topology",
         log_label: "Test topology",
         log_summary: "inline/scattered test placement",
@@ -157,7 +164,7 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         id: "test_wiring",
         findings: &[AuditFinding::UnwiredNestedRustTest],
         access: DetectorAccess::RootOnly,
-        runtime: DetectorRuntime::Manual,
+        runtime: DetectorRuntime::Root(RootDetectorRunner::TestWiring),
         timing_id: "detector.test_wiring",
         log_label: "Nested test wiring",
         log_summary: "nested tests not wired into the test runner",
@@ -462,14 +469,6 @@ impl AuditExecutionPlan {
         self.detector_enabled("layer_ownership")
     }
 
-    pub(crate) fn run_test_topology(&self) -> bool {
-        self.detector_enabled("test_topology")
-    }
-
-    pub(crate) fn run_test_wiring(&self) -> bool {
-        self.detector_enabled("test_wiring")
-    }
-
     pub(crate) fn run_docs(&self) -> bool {
         self.detector_enabled("docs")
     }
@@ -594,4 +593,26 @@ fn family_enabled(
     let fully_excluded = emitted.iter().all(|kind| exclude.contains(kind));
 
     requested && !fully_excluded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detector_cluster_uses_root_descriptor_runtime() {
+        let runtimes: Vec<_> = AuditExecutionPlan::descriptors()
+            .iter()
+            .filter(|descriptor| ["test_topology", "test_wiring"].contains(&descriptor.id))
+            .map(|descriptor| descriptor.runtime)
+            .collect();
+
+        assert_eq!(
+            runtimes,
+            vec![
+                DetectorRuntime::Root(RootDetectorRunner::TestTopology),
+                DetectorRuntime::Root(RootDetectorRunner::TestWiring),
+            ]
+        );
+    }
 }

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -55,8 +55,8 @@ use self::detectors::{
     artifact_portability, command_status_contracts, config_key_usage, core_boundary_leak,
     dead_guard, deprecation_age, enum_dispatch_contracts, field_patterns, global_env_guard,
     mutating_resource_access, parallel_runner_setup, public_registry_exposure, redirect_validation,
-    requested_detectors, runner_offload_preflight, source_policy, test_coverage, test_topology,
-    test_wiring, unbounded_output_capture, wrapper_inference,
+    requested_detectors, runner_offload_preflight, source_policy, test_coverage,
+    unbounded_output_capture, wrapper_inference,
 };
 use descriptor_runtime::{run_descriptor_detectors, DetectorRunContext};
 
@@ -68,6 +68,7 @@ pub use conventions::{AuditFinding, Convention, Deviation, Language, Outlier};
 pub use duplication::DuplicateGroup;
 pub(crate) use execution_plan::{
     AuditExecutionPlan, DetectorDescriptor, DetectorRuntime, FingerprintDetectorRunner,
+    RootDetectorRunner,
 };
 pub use findings::{homeboy_finding_from_audit, Finding, FindingConfidence, Severity};
 pub use fingerprint::FileFingerprint;
@@ -587,6 +588,8 @@ fn audit_internal(
     let convention_methods =
         build_convention_method_set(&discovered_conventions, &all_fingerprints);
     let detector_context = DetectorRunContext {
+        root,
+        audit_config: &audit_config,
         all_fingerprints: &all_fingerprints,
     };
 
@@ -770,39 +773,13 @@ fn audit_internal(
         all_findings.extend(layer_findings);
     }
 
-    // Phase 4i: Test topology checks (extension-driven classification + central policy)
-    let topology_findings = time_audit_detector(
+    run_descriptor_detectors(
+        plan,
         &mut timing,
-        "detector.test_topology",
-        plan.run_test_topology(),
-        || test_topology::run(root),
-        Vec::new,
+        &mut all_findings,
+        &detector_context,
+        &["test_topology", "test_wiring"],
     );
-    if !topology_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Test topology: {} finding(s) (inline/scattered test placement)",
-            topology_findings.len()
-        );
-        all_findings.extend(topology_findings);
-    }
-
-    // Phase 4i2: Configured test harness wiring checks.
-    let test_wiring_findings = time_audit_detector(
-        &mut timing,
-        "detector.test_wiring",
-        plan.run_test_wiring(),
-        || test_wiring::run(root, &audit_config),
-        Vec::new,
-    );
-    if !test_wiring_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Test wiring: {} finding(s) (tests not wired into the configured harness)",
-            test_wiring_findings.len()
-        );
-        all_findings.extend(test_wiring_findings);
-    }
 
     // Phase 4j: Documentation drift detection (broken/stale references in markdown)
     let doc_findings = time_audit_detector(
@@ -1370,6 +1347,11 @@ fn audit_root_only(
 ) -> CodeAuditResult {
     let audit_config = audit_config_for(component_id, root, extension_overrides);
     let mut findings = Vec::new();
+    let detector_context = DetectorRunContext {
+        root,
+        audit_config: &audit_config,
+        all_fingerprints: &[],
+    };
 
     let structural_findings = time_audit_detector(
         timing,
@@ -1403,37 +1385,13 @@ fn audit_root_only(
         findings.extend(layer_findings);
     }
 
-    let topology_findings = time_audit_detector(
+    run_descriptor_detectors(
+        plan,
         timing,
-        "detector.test_topology",
-        plan.run_test_topology(),
-        || test_topology::run(root),
-        Vec::new,
+        &mut findings,
+        &detector_context,
+        &["test_topology", "test_wiring"],
     );
-    if !topology_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Test topology: {} finding(s) (inline/scattered test placement)",
-            topology_findings.len()
-        );
-        findings.extend(topology_findings);
-    }
-
-    let test_wiring_findings = time_audit_detector(
-        timing,
-        "detector.test_wiring",
-        plan.run_test_wiring(),
-        || test_wiring::run(root, &audit_config),
-        Vec::new,
-    );
-    if !test_wiring_findings.is_empty() {
-        log_status!(
-            "audit",
-            "Test wiring: {} finding(s) (tests not wired into the configured harness)",
-            test_wiring_findings.len()
-        );
-        findings.extend(test_wiring_findings);
-    }
 
     let doc_findings = time_audit_detector(
         timing,
@@ -1900,7 +1858,7 @@ mod tests {
             "coverage detector also emits vacuous_test for mapped tests"
         );
         assert!(
-            plan.run_test_topology(),
+            plan.detector_enabled("test_topology"),
             "test topology/test quality detector emits standalone vacuous_test findings"
         );
     }

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -581,8 +581,8 @@ fn migrated_fingerprint_detector_descriptors_keep_filtering() {
 fn execution_plan_for_unwired_nested_rust_test_runs_wiring_detector() {
     let plan = AuditExecutionPlan::from_filters(&[AuditFinding::UnwiredNestedRustTest], &[]);
 
-    assert!(plan.run_test_wiring());
-    assert!(!plan.run_test_topology());
+    assert!(plan.detector_enabled("test_wiring"));
+    assert!(!plan.detector_enabled("test_topology"));
     assert_eq!(
         detector_step_status(&plan, "conventions"),
         &PlanStepStatus::Disabled


### PR DESCRIPTION
## Summary
- Adds a root-only detector runtime path to the audit descriptor executor.
- Migrates the test topology and test wiring detector families from bespoke manual calls into descriptor-routed execution.
- Keeps filtering/timing/log labels sourced from detector descriptors and adds a guard test for the migrated cluster.

## Tests
- `cargo check`
- `cargo test test_detector_cluster_uses_root_descriptor_runtime`
- `cargo test execution_plan_for_unwired_nested_rust_test_runs_wiring_detector`

## Manual runtime families left
- Convention/discovery orchestration, duplication, dead code, test coverage, docs, compiler warnings, artifact portability, and config-dependent fingerprint families remain manual because they have multi-step setup, non-`Vec<Finding>` report shapes, reference fingerprinting, extension lookups, or custom side effects that should be migrated in smaller follow-up slices.

Closes #3497.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and implemented the focused descriptor-runtime migration, updated tests, and ran local verification; Chris remains responsible for review and merge.