### PR TITLE
Introduce product identity primitive

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -167,6 +167,9 @@
           "src/commands/review/mod.rs",
           "src/commands/test.rs"
         ],
+        "exclude_path_contains": [
+          "src/core/product_identity.rs"
+        ],
         "kind": "core_boundary_leak",
         "suggestion": "Move ecosystem-specific behavior into extension metadata/rules, or add an explicit audit allowlist for intentional examples.",
         "terms": [

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -9,7 +9,7 @@ mod builtins;
 
 pub(crate) use builtins::deploy_generated_build_dir;
 
-/// Root configuration structure for homeboy.json
+/// Root configuration structure for the product config file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HomeboyConfig {
     #[serde(default)]
@@ -23,9 +23,8 @@ pub struct HomeboyConfig {
 
     /// Directory where persisted run artifacts are copied.
     ///
-    /// Defaults to the machine-local Homeboy data directory under
-    /// `artifacts/`. Override with `homeboy --artifact-root <path>`,
-    /// `HOMEBOY_ARTIFACT_ROOT`, or `homeboy config set /artifact_root`.
+    /// Defaults to the machine-local product data directory under
+    /// `artifacts/`. Override with CLI, environment, or config.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifact_root: Option<String>,
 
@@ -64,7 +63,7 @@ pub struct TriageConfig {
     pub priority_labels: Option<Vec<String>>,
 }
 
-/// All configurable defaults that can be overridden via homeboy.json
+/// All configurable defaults that can be overridden via the product config file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Defaults {
     #[serde(default = "builtins::default_install_methods")]
@@ -156,12 +155,12 @@ pub struct PermissionModes {
 // =============================================================================
 
 /// Load defaults, merging file config with built-in defaults.
-/// If homeboy.json is missing or invalid, silently returns built-in defaults.
+/// If the product config file is missing or invalid, silently returns built-in defaults.
 pub fn load_defaults() -> Defaults {
     load_config().defaults
 }
 
-/// Load the full homeboy.json config, falling back to defaults on any error.
+/// Load the full product config, falling back to defaults on any error.
 /// Warns to stderr if the file exists but fails to parse, so the user knows
 /// their config is being ignored rather than silently resetting to defaults.
 pub fn load_config() -> HomeboyConfig {
@@ -172,7 +171,8 @@ pub fn load_config() -> HomeboyConfig {
             if config_exists() {
                 log_status!(
                     "config",
-                    "Warning: failed to load homeboy.json ({}), using defaults",
+                    "Warning: failed to load {} ({}), using defaults",
+                    crate::core::product_identity::PRODUCT_IDENTITY.config_filename,
                     err.message
                 );
             }
@@ -181,13 +181,16 @@ pub fn load_config() -> HomeboyConfig {
     }
 }
 
-/// Attempt to load config from homeboy.json file.
+/// Attempt to load config from the product config file.
 fn load_config_from_file() -> crate::core::Result<HomeboyConfig> {
     let path = paths::homeboy_json()?;
 
     if !path.exists() {
         return Err(crate::core::Error::internal_io(
-            "homeboy.json not found",
+            format!(
+                "{} not found",
+                crate::core::product_identity::PRODUCT_IDENTITY.config_filename
+            ),
             Some(path.display().to_string()),
         ));
     }
@@ -197,7 +200,10 @@ fn load_config_from_file() -> crate::core::Result<HomeboyConfig> {
     let config: HomeboyConfig = serde_json::from_str(&content).map_err(|e| {
         crate::core::Error::validation_invalid_json(
             e,
-            Some("parse homeboy.json".to_string()),
+            Some(format!(
+                "parse {}",
+                crate::core::product_identity::PRODUCT_IDENTITY.config_filename
+            )),
             Some(content.chars().take(200).collect::<String>()),
         )
     })?;
@@ -205,7 +211,7 @@ fn load_config_from_file() -> crate::core::Result<HomeboyConfig> {
     Ok(config)
 }
 
-/// Save config to homeboy.json file (creates if missing).
+/// Save config to the product config file (creates if missing).
 pub fn save_config(config: &HomeboyConfig) -> crate::core::Result<()> {
     let path = paths::homeboy_json()?;
 
@@ -226,12 +232,12 @@ pub fn save_config(config: &HomeboyConfig) -> crate::core::Result<()> {
     Ok(())
 }
 
-/// Check if homeboy.json file exists
+/// Check if the product config file exists.
 pub fn config_exists() -> bool {
     paths::homeboy_json().map(|p| p.exists()).unwrap_or(false)
 }
 
-/// Delete homeboy.json file (reset to defaults)
+/// Delete the product config file (reset to defaults).
 pub fn reset_config() -> crate::core::Result<bool> {
     let path = paths::homeboy_json()?;
 
@@ -248,7 +254,7 @@ pub fn reset_config() -> crate::core::Result<bool> {
     }
 }
 
-/// Get the path to homeboy.json (for display purposes)
+/// Get the product config path (for display purposes).
 pub fn config_path() -> crate::core::Result<String> {
     Ok(paths::homeboy_json()?.display().to_string())
 }

--- a/src/core/defaults/builtins.rs
+++ b/src/core/defaults/builtins.rs
@@ -160,7 +160,9 @@ pub(super) fn default_scp_flags() -> Vec<String> {
 }
 
 pub(super) fn default_artifact_prefix() -> String {
-    ".homeboy-".to_string()
+    crate::core::product_identity::PRODUCT_IDENTITY
+        .artifact_prefix
+        .to_string()
 }
 
 pub(crate) fn deploy_generated_build_dir() -> String {

--- a/src/core/engine/run_dir.rs
+++ b/src/core/engine/run_dir.rs
@@ -3,7 +3,7 @@
 //! Each pipeline run gets a directory where steps write their outputs
 //! and read predecessor outputs. This replaces the ad-hoc pattern of
 //! creating random temp files and passing their paths via individual
-//! `HOMEBOY_*_FILE` environment variables.
+//! product-prefixed environment variables.
 //!
 //! ## Layout
 //!
@@ -19,10 +19,10 @@
 //!
 //! ## Backward compatibility
 //!
-//! During migration, homeboy sets both `HOMEBOY_RUN_DIR` and the legacy
-//! per-file env vars (e.g. `HOMEBOY_LINT_FINDINGS_FILE`). The legacy vars
+//! During migration, the CLI sets both the run-dir env var and the legacy
+//! per-file env vars. The legacy vars
 //! point into the run dir, so extension scripts that use the old vars
-//! continue working. New scripts can use `HOMEBOY_RUN_DIR` directly.
+//! continue working. New scripts can use the run-dir env var directly.
 
 use crate::core::error::{Error, Result};
 use std::path::{Path, PathBuf};
@@ -43,7 +43,9 @@ pub mod files {
 }
 
 /// Environment variable name for the run directory.
-pub const RUN_DIR_ENV: &str = "HOMEBOY_RUN_DIR";
+pub fn run_dir_env() -> String {
+    crate::core::product_identity::PRODUCT_IDENTITY.env_var("RUN_DIR")
+}
 
 /// A run directory for a single pipeline execution.
 ///
@@ -62,7 +64,9 @@ impl RunDir {
     /// drops or explicitly cleans it up — homeboy's temp pruner handles
     /// orphans from killed processes.
     pub fn create() -> Result<Self> {
-        let path = super::temp::runtime_temp_dir("homeboy-run")?;
+        let path = super::temp::runtime_temp_dir(
+            crate::core::product_identity::PRODUCT_IDENTITY.run_dir_prefix,
+        )?;
         // Create annotations subdirectory
         let annotations = path.join(files::ANNOTATIONS_DIR);
         std::fs::create_dir_all(&annotations).map_err(|e| {
@@ -71,7 +75,7 @@ impl RunDir {
         Ok(Self { path })
     }
 
-    /// Wrap an existing directory as a run dir (e.g. from `HOMEBOY_RUN_DIR` env var).
+    /// Wrap an existing directory as a run dir.
     pub fn from_existing(path: PathBuf) -> Result<Self> {
         if !path.is_dir() {
             return Err(Error::internal_io(
@@ -99,65 +103,63 @@ impl RunDir {
 
     /// Generate backward-compatible env var pairs for extension scripts.
     ///
-    /// Returns `(key, value)` pairs that map the legacy `HOMEBOY_*_FILE`
+    /// Returns `(key, value)` pairs that map the legacy product-prefixed
+    /// file environment variables
     /// env vars to files within this run directory. Extension scripts that
     /// still use the old vars will read/write the correct locations.
     pub fn legacy_env_vars(&self) -> Vec<(String, String)> {
         vec![
+            (run_dir_env(), self.path.to_string_lossy().to_string()),
             (
-                "HOMEBOY_RUN_DIR".to_string(),
-                self.path.to_string_lossy().to_string(),
-            ),
-            (
-                "HOMEBOY_LINT_FINDINGS_FILE".to_string(),
+                crate::core::product_identity::PRODUCT_IDENTITY.env_var("LINT_FINDINGS_FILE"),
                 self.step_file(files::LINT_FINDINGS)
                     .to_string_lossy()
                     .to_string(),
             ),
             (
-                "HOMEBOY_LINT_PRODUCERS_FILE".to_string(),
+                crate::core::product_identity::PRODUCT_IDENTITY.env_var("LINT_PRODUCERS_FILE"),
                 self.step_file(files::LINT_PRODUCERS)
                     .to_string_lossy()
                     .to_string(),
             ),
             (
-                "HOMEBOY_TEST_RESULTS_FILE".to_string(),
+                crate::core::product_identity::PRODUCT_IDENTITY.env_var("TEST_RESULTS_FILE"),
                 self.step_file(files::TEST_RESULTS)
                     .to_string_lossy()
                     .to_string(),
             ),
             (
-                "HOMEBOY_TEST_FAILURES_FILE".to_string(),
+                crate::core::product_identity::PRODUCT_IDENTITY.env_var("TEST_FAILURES_FILE"),
                 self.step_file(files::TEST_FAILURES)
                     .to_string_lossy()
                     .to_string(),
             ),
             (
-                "HOMEBOY_COVERAGE_FILE".to_string(),
+                crate::core::product_identity::PRODUCT_IDENTITY.env_var("COVERAGE_FILE"),
                 self.step_file(files::COVERAGE)
                     .to_string_lossy()
                     .to_string(),
             ),
             (
-                "HOMEBOY_FIX_RESULTS_FILE".to_string(),
+                crate::core::product_identity::PRODUCT_IDENTITY.env_var("FIX_RESULTS_FILE"),
                 self.step_file(files::FIX_RESULTS)
                     .to_string_lossy()
                     .to_string(),
             ),
             (
-                "HOMEBOY_BENCH_RESULTS_FILE".to_string(),
+                crate::core::product_identity::PRODUCT_IDENTITY.env_var("BENCH_RESULTS_FILE"),
                 self.step_file(files::BENCH_RESULTS)
                     .to_string_lossy()
                     .to_string(),
             ),
             (
-                "HOMEBOY_TRACE_RESULTS_FILE".to_string(),
+                crate::core::product_identity::PRODUCT_IDENTITY.env_var("TRACE_RESULTS_FILE"),
                 self.step_file(files::TRACE_RESULTS)
                     .to_string_lossy()
                     .to_string(),
             ),
             (
-                "HOMEBOY_ANNOTATIONS_DIR".to_string(),
+                crate::core::product_identity::PRODUCT_IDENTITY.env_var("ANNOTATIONS_DIR"),
                 self.annotations_dir().to_string_lossy().to_string(),
             ),
         ]

--- a/src/core/engine/temp.rs
+++ b/src/core/engine/temp.rs
@@ -6,10 +6,8 @@ use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-const HOMEBOY_RUNTIME_TMPDIR_ENV: &str = "HOMEBOY_RUNTIME_TMPDIR";
-
 fn runtime_root() -> Result<PathBuf> {
-    if let Ok(override_dir) = env::var(HOMEBOY_RUNTIME_TMPDIR_ENV) {
+    if let Ok(override_dir) = env::var(runtime_tmpdir_env()) {
         let trimmed = override_dir.trim();
         if !trimmed.is_empty() {
             return Ok(PathBuf::from(trimmed));
@@ -17,6 +15,10 @@ fn runtime_root() -> Result<PathBuf> {
     }
 
     Ok(paths::homeboy()?.join("runtime").join("tmp"))
+}
+
+fn runtime_tmpdir_env() -> String {
+    crate::core::product_identity::PRODUCT_IDENTITY.env_var("RUNTIME_TMPDIR")
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -225,13 +227,13 @@ mod tests {
     fn runtime_temp_dir_honors_override() {
         let _guard = home_env_guard();
         let dir = tempfile::tempdir().expect("tempdir");
-        env::set_var(HOMEBOY_RUNTIME_TMPDIR_ENV, dir.path());
+        env::set_var(runtime_tmpdir_env(), dir.path());
 
         let path = runtime_temp_dir("homeboy-test-dir").expect("temp dir path");
         assert!(path.starts_with(dir.path()));
         assert!(path.is_dir());
 
-        env::remove_var(HOMEBOY_RUNTIME_TMPDIR_ENV);
+        env::remove_var(runtime_tmpdir_env());
     }
 
     #[test]
@@ -249,7 +251,7 @@ mod tests {
     fn cleanup_runtime_tmp_plans_and_removes_old_entries() {
         let _guard = home_env_guard();
         let dir = tempfile::tempdir().expect("tempdir");
-        env::set_var(HOMEBOY_RUNTIME_TMPDIR_ENV, dir.path());
+        env::set_var(runtime_tmpdir_env(), dir.path());
         let prefix = "homeboy-cleanup-test";
         let stale = runtime_temp_dir(prefix).expect("temp dir");
         fs::write(stale.join("trace.json"), b"trace").expect("write trace");
@@ -264,6 +266,6 @@ mod tests {
         assert_eq!(applied.removed_count, 1);
         assert!(!stale.exists());
 
-        env::remove_var(HOMEBOY_RUNTIME_TMPDIR_ENV);
+        env::remove_var(runtime_tmpdir_env());
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -43,6 +43,7 @@ pub mod observation;
 pub mod output;
 pub mod plan;
 pub mod process;
+pub mod product_identity;
 pub mod project;
 pub mod quality;
 pub mod redaction;

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -23,7 +23,7 @@ pub fn set_artifact_root_override(path: Option<PathBuf>) {
     *guard = path;
 }
 
-/// Base homeboy config directory (universal ~/.config/homeboy/ on all platforms)
+/// Base product config directory (universal ~/.config/homeboy/ on all platforms)
 pub fn homeboy() -> Result<PathBuf> {
     #[cfg(windows)]
     {
@@ -32,7 +32,8 @@ pub fn homeboy() -> Result<PathBuf> {
                 "APPDATA environment variable not set on Windows".to_string(),
             )
         })?;
-        Ok(PathBuf::from(appdata).join("homeboy"))
+        Ok(PathBuf::from(appdata)
+            .join(crate::core::product_identity::PRODUCT_IDENTITY.config_dirname))
     }
 
     #[cfg(not(windows))]
@@ -42,13 +43,15 @@ pub fn homeboy() -> Result<PathBuf> {
                 "HOME environment variable not set on Unix-like system".to_string(),
             )
         })?;
-        Ok(PathBuf::from(home).join(".config").join("homeboy"))
+        Ok(PathBuf::from(home)
+            .join(".config")
+            .join(crate::core::product_identity::PRODUCT_IDENTITY.config_dirname))
     }
 }
 
-/// Global homeboy.json config file path
+/// Global product config file path
 pub fn homeboy_json() -> Result<PathBuf> {
-    Ok(homeboy()?.join("homeboy.json"))
+    Ok(crate::core::product_identity::PRODUCT_IDENTITY.config_file(homeboy()?))
 }
 
 /// Base Homeboy data directory for local observed state.
@@ -65,14 +68,15 @@ pub fn homeboy_data() -> Result<PathBuf> {
                     "LOCALAPPDATA or APPDATA environment variable not set on Windows".to_string(),
                 )
             })?;
-        Ok(PathBuf::from(base).join("homeboy"))
+        Ok(PathBuf::from(base).join(crate::core::product_identity::PRODUCT_IDENTITY.data_dirname))
     }
 
     #[cfg(not(windows))]
     {
         if let Ok(xdg_data_home) = env::var("XDG_DATA_HOME") {
             if !xdg_data_home.trim().is_empty() {
-                return Ok(PathBuf::from(xdg_data_home).join("homeboy"));
+                return Ok(PathBuf::from(xdg_data_home)
+                    .join(crate::core::product_identity::PRODUCT_IDENTITY.data_dirname));
             }
         }
 
@@ -84,7 +88,7 @@ pub fn homeboy_data() -> Result<PathBuf> {
         Ok(PathBuf::from(home)
             .join(".local")
             .join("share")
-            .join("homeboy"))
+            .join(crate::core::product_identity::PRODUCT_IDENTITY.data_dirname))
     }
 }
 

--- a/src/core/product_identity.rs
+++ b/src/core/product_identity.rs
@@ -1,0 +1,36 @@
+use std::path::PathBuf;
+
+/// Homeboy-owned product literals that core code needs for config, paths, and
+/// backward-compatible environment contracts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProductIdentity {
+    pub name: &'static str,
+    pub binary_name: &'static str,
+    pub config_filename: &'static str,
+    pub config_dirname: &'static str,
+    pub data_dirname: &'static str,
+    pub env_prefix: &'static str,
+    pub artifact_prefix: &'static str,
+    pub run_dir_prefix: &'static str,
+}
+
+pub const PRODUCT_IDENTITY: ProductIdentity = ProductIdentity {
+    name: "Homeboy",
+    binary_name: "homeboy",
+    config_filename: "homeboy.json",
+    config_dirname: "homeboy",
+    data_dirname: "homeboy",
+    env_prefix: "HOMEBOY_",
+    artifact_prefix: ".homeboy-",
+    run_dir_prefix: "homeboy-run",
+};
+
+impl ProductIdentity {
+    pub fn env_var(self, suffix: &str) -> String {
+        format!("{}{}", self.env_prefix, suffix)
+    }
+
+    pub fn config_file(self, base: PathBuf) -> PathBuf {
+        base.join(self.config_filename)
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces `core::product_identity::ProductIdentity` as the typed owner for Homeboy product labels, config filenames, env prefixes, artifact prefixes, and run directory prefixes.
- Migrates high-value config/path/runtime call sites to request product literals from `PRODUCT_IDENTITY` instead of embedding them directly.
- Excludes the owning identity module from the core-agnostic source policy so scattered new product literals still remain guarded elsewhere.

Closes #3495.

## Verification
- `cargo fmt` passed.
- `cargo test core_owned_source_stays_language_and_framework_agnostic --test core_agnostic_test -- --nocapture` currently fails because the line-numbered audit baseline needs ratcheting after the centralized identity call-site edits.
- `SCOPE_MODE=changed cargo test core_owned_source_stays_language_and_framework_agnostic --test core_agnostic_test -- --nocapture` currently fails with the same new fingerprint shape; the attempted `cargo run --bin homeboy -- audit homeboy --path . --baseline --only core_boundary_leak --force-hot` timed out locally after 900s.

## Follow-up
- Ratchet `baselines.audit` for the line-numbered source-policy fingerprints once the audit baseline command completes in CI or a cooler local runner.
- Continue migrating producer labels, artifact namespaces, and remaining default filenames through the new primitive in smaller follow-ups.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the product identity primitive, migrated selected call sites, ran local verification, and prepared this PR for Chris to review/test.