### PR TITLE
Add manual dispatch for PR quality workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}

--- a/README.md
+++ b/README.md
@@ -159,7 +159,9 @@ extensions, runs commands, posts PR comments, and can apply safe autofixes.
 
 ```yaml
 name: Homeboy
-on: [pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   quality:
@@ -171,6 +173,10 @@ jobs:
           extension: rust
           commands: audit,lint,test,review
 ```
+
+If a pull request needs a fresh quality run without pushing another commit,
+rerun the workflow from the GitHub Actions UI or with
+`gh workflow run <workflow-file> --ref <branch>`.
 
 ## Core Workflows
 


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` to the Homeboy CI workflow so maintainers and agents can manually run PR quality checks for a branch/ref.
- Update the README CI example with the manual rerun pattern.

Fixes #3514.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parsed"'`
- `gh workflow view ci.yml --repo Extra-Chill/homeboy`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the workflow/docs change and ran local/GitHub CLI verification; Chris remains responsible for review and merge.