### PR TITLE
Add deterministic audit baseline refresh command

### DIFF
--- a/docs/commands/audit-baseline.md
+++ b/docs/commands/audit-baseline.md
@@ -1,0 +1,46 @@
+# `homeboy audit-baseline`
+
+## Synopsis
+
+```sh
+homeboy audit-baseline refresh <component-id|path> [options]
+```
+
+## Description
+
+Refresh generated audit baseline data in `homeboy.json` without rewriting unrelated component configuration. The command runs the existing scoped audit baseline workflow for files changed since a git ref, writes only `baselines.audit`, and reports added/resolved fingerprints.
+
+This is the preferred PR-branch workflow when `main` changes and the only expected churn is generated audit baseline data.
+
+## Commands
+
+- `refresh`: Recompute audit baseline entries for files changed since a git ref.
+
+## Options
+
+- `--changed-since <REF>`: Refresh baseline entries for files changed since this ref. Defaults to `origin/main`.
+- `--path <PATH>`: Override the component checkout path for this invocation.
+- `--extension <ID>`: One-shot extension override for the current invocation; repeat to layer multiple extension hints.
+
+## PR Branch Workflow
+
+```sh
+# Bring the branch up to date first.
+git fetch origin
+git rebase origin/main
+
+# Refresh only generated audit baseline data for files touched by the branch.
+homeboy audit-baseline refresh homeboy --changed-since origin/main
+```
+
+The JSON output includes:
+
+- `added_fingerprints`: fingerprints present after refresh that were absent before refresh.
+- `resolved_fingerprints`: fingerprints present before refresh that are absent after refresh.
+- `previous_source`: whether the comparison used the working-tree baseline, the git-ref baseline, or no previous baseline.
+
+If `homeboy.json` already contains merge-conflict markers, resolve non-baseline config conflicts first, then rerun `homeboy audit-baseline refresh`. Automatic merge-conflict repair for generated baseline arrays is tracked in [#3518](https://github.com/Extra-Chill/homeboy/issues/3518).
+
+## Related
+
+- [audit](audit.md) — run audits, save full baselines, and compare drift.

--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -114,6 +114,9 @@ homeboy audit my-plugin --baseline
 # Let a cleanup sprint ratchet an improved baseline forward
 homeboy audit my-plugin --ratchet
 
+# Refresh only generated baseline data after main changes
+homeboy audit-baseline refresh my-plugin --changed-since origin/main
+
 # Audit a workspace clone instead of local_path
 homeboy audit my-plugin --path /var/lib/datamachine/workspace/my-plugin
 
@@ -224,5 +227,6 @@ With `--baseline` comparison:
 ## Related
 
 - [docs](docs.md) — embedded documentation topics and codebase maps
+- [audit-baseline](audit-baseline.md) — deterministic audit baseline refresh workflow
 - [lint](lint.md) — extension-driven code style validation
 - [JSON output contract](../architecture/output-system.md)

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -3,6 +3,7 @@
 - [api](api.md)
 - [agent-task](agent-task.md)
 - [audit](audit.md) — code convention drift and structural analysis
+- [audit-baseline](audit-baseline.md) — deterministic audit baseline refresh workflow
 - [auth](auth.md)
 - [bench](bench.md) — performance benchmarks + p95 regression ratchet
 - [build](build.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ repository.
 
 - Root command + global flags: [Root command](cli/homeboy-root-command.md)
 - Full built-in command list: [Commands index](commands/commands-index.md)
-- Code audit (convention drift, structural analysis): [audit](commands/audit.md)
+- Code audit (convention drift, structural analysis): [audit](commands/audit.md), [audit-baseline](commands/audit-baseline.md)
 - Changes summary: [changes](commands/changes.md)
 - Reproducible local dev environments: [rig](commands/rig.md)
 - Rig spec JSON schema: [rig-spec](commands/rig-spec.md)

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -2,10 +2,11 @@ use clap::{Command, CommandFactory, Parser, Subcommand};
 use std::path::PathBuf;
 
 use crate::commands::{
-    agent_task, api, audit, auth, bench, build, changelog, changes, ci, cleanup, component, config,
-    daemon, db, deploy, deps, doctor, extension, file, fleet, git, http, issues, lint, logs,
-    observe, project, refactor, refs, release, report, review, rig, runner, runs, self_cmd, server,
-    ssh, stack, status, test, trace, triage, tunnel, undo, upgrade, version, worktree,
+    agent_task, api, audit, audit_baseline, auth, bench, build, changelog, changes, ci, cleanup,
+    component, config, daemon, db, deploy, deps, doctor, extension, file, fleet, git, http, issues,
+    lint, logs, observe, project, refactor, refs, release, report, review, rig, runner, runs,
+    self_cmd, server, ssh, stack, status, test, trace, triage, tunnel, undo, upgrade, version,
+    worktree,
 };
 
 mod lab_contract;
@@ -116,6 +117,9 @@ pub enum Commands {
     Review(review::ReviewArgs),
     /// Audit code conventions and detect architectural drift
     Audit(audit::AuditArgs),
+    /// Refresh and inspect generated audit baseline data
+    #[command(name = "audit-baseline")]
+    AuditBaseline(audit_baseline::AuditBaselineArgs),
     /// Structural refactoring (rename terms across codebase)
     Refactor(refactor::RefactorArgs),
     /// Read-only reference discovery for a symbol or term
@@ -317,6 +321,12 @@ impl Commands {
             Commands::Audit(_) | Commands::Observe(_) => quality_json_descriptor(
                 output_file_mode,
                 matches!(self, Commands::Audit(_)),
+                None,
+                CommandOutputContractKind::JsonEnvelope,
+            ),
+            Commands::AuditBaseline(_) => quality_json_descriptor(
+                output_file_mode,
+                false,
                 None,
                 CommandOutputContractKind::JsonEnvelope,
             ),

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -303,7 +303,7 @@ fn code_audit_result_observation_summary(
 ///
 /// Setup still speaks the legacy shell boundary (`--export` stdout), but the command
 /// converts that output into typed workflow input instead of process-global state.
-fn resolve_audit_reference_paths(source_ctx: &ExecutionContext) -> Vec<String> {
+pub(crate) fn resolve_audit_reference_paths(source_ctx: &ExecutionContext) -> Vec<String> {
     let extensions = match &source_ctx.component.extensions {
         Some(ext) => ext,
         None => return Vec::new(),

--- a/src/commands/audit_baseline.rs
+++ b/src/commands/audit_baseline.rs
@@ -1,0 +1,218 @@
+use clap::{Args, Subcommand};
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use homeboy::core::code_audit::{
+    baseline, run_main_audit_workflow, AuditCommandOutput, AuditRunWorkflowArgs,
+};
+
+use super::source_command::resolve_source_context;
+use super::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs};
+use super::{CmdResult, GlobalArgs};
+
+#[derive(Args)]
+pub struct AuditBaselineArgs {
+    #[command(subcommand)]
+    command: AuditBaselineCommand,
+}
+
+#[derive(Subcommand)]
+enum AuditBaselineCommand {
+    /// Refresh only persisted audit baseline data for changed files
+    Refresh(AuditBaselineRefreshArgs),
+}
+
+#[derive(Args)]
+pub struct AuditBaselineRefreshArgs {
+    #[command(flatten)]
+    pub comp: PositionalComponentArgs,
+
+    #[command(flatten)]
+    pub extension_override: ExtensionOverrideArgs,
+
+    /// Refresh baseline entries for files changed since this git ref
+    #[arg(long, default_value = "origin/main")]
+    pub changed_since: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuditBaselineRefreshOutput {
+    pub command: String,
+    pub component_id: String,
+    pub source_path: String,
+    pub baseline_path: String,
+    pub changed_since: String,
+    pub previous_source: String,
+    pub previous_count: usize,
+    pub current_count: usize,
+    pub added_count: usize,
+    pub resolved_count: usize,
+    pub added_fingerprints: Vec<String>,
+    pub resolved_fingerprints: Vec<String>,
+}
+
+pub fn run(args: AuditBaselineArgs, global: &GlobalArgs) -> CmdResult<AuditBaselineRefreshOutput> {
+    match args.command {
+        AuditBaselineCommand::Refresh(args) => refresh(args, global),
+    }
+}
+
+fn refresh(
+    args: AuditBaselineRefreshArgs,
+    _global: &GlobalArgs,
+) -> CmdResult<AuditBaselineRefreshOutput> {
+    let source_ctx = resolve_source_context(
+        &args.comp,
+        &SettingArgs::default(),
+        &args.extension_override,
+        None,
+    )?;
+    let reference_paths = super::audit::resolve_audit_reference_paths(&source_ctx);
+    let source_path = source_ctx.source_path.to_string_lossy().to_string();
+    let source = Path::new(&source_path);
+
+    fail_if_homeboy_json_has_conflict_markers(source)?;
+
+    let (previous_source, previous_fingerprints) =
+        previous_baseline_fingerprints(source, &source_path, &args.changed_since);
+
+    let workflow = run_main_audit_workflow(AuditRunWorkflowArgs {
+        component_id: source_ctx.component_id.clone(),
+        source_path: source_path.clone(),
+        reference_paths,
+        conventions: false,
+        only_kinds: Vec::new(),
+        exclude_kinds: Vec::new(),
+        only_labels: Vec::new(),
+        exclude_labels: Vec::new(),
+        extension_overrides: args.extension_override.extensions,
+        baseline_flags: homeboy::core::engine::baseline::BaselineFlags {
+            baseline: true,
+            ignore_baseline: false,
+            ratchet: false,
+        },
+        changed_since: Some(args.changed_since.clone()),
+        json_summary: false,
+        include_fixability: false,
+    })?;
+
+    let current = baseline::load_baseline(source).ok_or_else(|| {
+        homeboy::core::Error::internal_unexpected("Audit baseline refresh did not write a baseline")
+    })?;
+    let baseline_path = match workflow.output {
+        AuditCommandOutput::BaselineSaved { path, .. } => path,
+        _ => source.join("homeboy.json").to_string_lossy().to_string(),
+    };
+
+    let current_fingerprints = current
+        .known_fingerprints
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let added_fingerprints = sorted_difference(&current_fingerprints, &previous_fingerprints);
+    let resolved_fingerprints = sorted_difference(&previous_fingerprints, &current_fingerprints);
+
+    eprintln!(
+        "[audit-baseline] refreshed {}: +{} / -{} fingerprints",
+        baseline_path,
+        added_fingerprints.len(),
+        resolved_fingerprints.len()
+    );
+
+    let output = AuditBaselineRefreshOutput {
+        command: "audit-baseline.refresh".to_string(),
+        component_id: source_ctx.component_id,
+        source_path,
+        baseline_path,
+        changed_since: args.changed_since,
+        previous_source,
+        previous_count: previous_fingerprints.len(),
+        current_count: current_fingerprints.len(),
+        added_count: added_fingerprints.len(),
+        resolved_count: resolved_fingerprints.len(),
+        added_fingerprints,
+        resolved_fingerprints,
+    };
+
+    Ok((output, workflow.exit_code))
+}
+
+fn previous_baseline_fingerprints(
+    source: &Path,
+    source_path: &str,
+    changed_since: &str,
+) -> (String, BTreeSet<String>) {
+    if let Some(local) = baseline::load_baseline(source) {
+        return (
+            "working-tree homeboy.json".to_string(),
+            local.known_fingerprints.into_iter().collect(),
+        );
+    }
+
+    if let Some(from_ref) = baseline::load_baseline_from_ref(source_path, changed_since) {
+        return (
+            format!("{changed_since}:homeboy.json"),
+            from_ref.known_fingerprints.into_iter().collect(),
+        );
+    }
+
+    ("none".to_string(), BTreeSet::new())
+}
+
+fn sorted_difference(left: &BTreeSet<String>, right: &BTreeSet<String>) -> Vec<String> {
+    left.difference(right).cloned().collect()
+}
+
+fn fail_if_homeboy_json_has_conflict_markers(source: &Path) -> homeboy::core::Result<()> {
+    let path = source.join("homeboy.json");
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return Ok(());
+    };
+
+    if content.contains("<<<<<<<") || content.contains("=======") || content.contains(">>>>>>>") {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "homeboy.json",
+            format!(
+                "{} contains merge conflict markers. Resolve non-baseline config first, then run `homeboy audit-baseline refresh --path {} --changed-since origin/main`.",
+                path.display(),
+                source.display()
+            ),
+            None,
+            None,
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set(values: &[&str]) -> BTreeSet<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn sorted_difference_reports_added_fingerprints_deterministically() {
+        assert_eq!(
+            sorted_difference(&set(&["b", "a", "c"]), &set(&["b"])),
+            vec!["a".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn conflict_marker_preflight_rejects_unparseable_homeboy_json() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("homeboy.json"),
+            "{\n<<<<<<< HEAD\n}\n=======\n{}\n>>>>>>> main\n",
+        )
+        .expect("write fixture");
+
+        let error = fail_if_homeboy_json_has_conflict_markers(dir.path())
+            .expect_err("conflict markers should fail preflight");
+
+        assert!(error.to_string().contains("merge conflict markers"));
+    }
+}

--- a/src/commands/json_output/quality.rs
+++ b/src/commands/json_output/quality.rs
@@ -1,7 +1,9 @@
 use crate::cli_surface::Commands;
 
 use super::{map, JsonRun};
-use crate::commands::{audit, bench, lint, observe, review, test, trace, GlobalArgs};
+use crate::commands::{
+    audit, audit_baseline, bench, lint, observe, review, test, trace, GlobalArgs,
+};
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
     match command {
@@ -12,6 +14,7 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Lint(args) => map(lint::run(args, global)),
         Commands::Review(args) => map(review::run(args, global)),
         Commands::Audit(args) => map(audit::run(args, global)),
+        Commands::AuditBaseline(args) => map(audit_baseline::run(args, global)),
         _ => unreachable!("command routed to wrong JSON output family"),
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -168,6 +168,7 @@ pub fn finalize_set_spec(
 pub mod agent_task;
 pub mod api;
 pub mod audit;
+pub mod audit_baseline;
 pub mod auth;
 pub mod bench;
 pub mod build;


### PR DESCRIPTION
## Summary
- Adds `homeboy audit-baseline refresh` to run the existing scoped audit baseline save path for files changed since a git ref.
- Reports added/resolved audit baseline fingerprints so baseline-only refreshes are reviewable and CI/local friendly.
- Documents the PR-branch refresh workflow and defers automatic generated-array conflict repair to #3518.

Closes #3515.

## Testing
- `cargo fmt`
- `cargo check`
- `cargo test audit_baseline`
- `cargo test command_surface`
- `cargo run --bin homeboy -- audit-baseline --help`

## Deferred scope
- Automatic merge-conflict repair for generated `baselines.audit` arrays is tracked in #3518.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CLI helper, tests, and docs; Chris remains responsible for review and validation.