### PR TITLE
Fix core agnostic baseline gate

### DIFF
--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -1376,6 +1376,12 @@ fn is_changed_scope_run() -> bool {
 }
 
 fn is_retired_homeboy_domain_policy_fingerprint(fingerprint: &str) -> bool {
+    if fingerprint.contains("src/core/extension/runtime/bench-helper.php")
+        && fingerprint.contains("configured ecosystem term `php`")
+    {
+        return true;
+    }
+
     [
         "`Homeboy`",
         "`homeboy.json`",


### PR DESCRIPTION
## Summary
- Retire the platform-sensitive `bench-helper.php` PHP-token fingerprints from stale baseline enforcement.
- Keep the existing baseline entries intact so environments that still emit those fingerprints remain covered.

Fixes #3484.

## Testing
- `cargo test --test core_agnostic_test core_owned_source_stays_language_and_framework_agnostic`
- `cargo test --test core_agnostic_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the failing CI test, drafted the targeted guard change, and ran local verification. Chris remains responsible for review and merge.