### PR TITLE
Fix small Homeboy audit cleanup findings

### DIFF
--- a/src/commands/trace/output.rs
+++ b/src/commands/trace/output.rs
@@ -843,11 +843,7 @@ fn push_trace_assertions_markdown(
         return;
     }
     for assertion in assertions {
-        let status = match assertion.status {
-            extension_trace::TraceAssertionStatus::Pass => "pass",
-            extension_trace::TraceAssertionStatus::Fail => "fail",
-            extension_trace::TraceAssertionStatus::Error => "error",
-        };
+        let status = assertion.status.as_str();
         match assertion.message.as_deref() {
             Some(message) => {
                 let _ = writeln!(out, "- `{}`: **{}** - {}", assertion.id, status, message);

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -22,6 +22,7 @@ use crate::core::agent_task_timeout_artifacts::{
     append_unique_artifacts, append_unique_evidence_refs, is_actionable_patch_artifact,
     is_empty_patch_artifact, merge_timeout_outcome, TimeoutArtifactDiscovery,
 };
+use crate::core::config::value_type_name;
 
 pub trait AgentTaskExecutorAdapter: Send + Sync + 'static {
     fn execute(
@@ -147,26 +148,18 @@ where
                     if running.is_empty() {
                         if let Some(task) = queued.pop_front() {
                             if let Some(message) =
-                                AgentTaskScheduleSupport::waiting_for_dependencies(
-                                    &task.request,
+                                AgentTaskScheduleSupport::waiting_for_task_dependencies(
+                                    &task,
                                     &completed_by_task,
                                     &output_dependencies,
                                 )
                             {
-                                backpressure.push(AgentTaskBackpressureStatus {
-                                    kind: "output_dependency".to_string(),
-                                    message: message.clone(),
-                                    task_id: Some(task.request.task_id.clone()),
-                                });
-                                events.push(event(
-                                    &task.request.task_id,
-                                    AgentTaskState::Blocked,
-                                    task.attempt,
-                                    Some(message.clone()),
-                                ));
-                                let outcome = AgentTaskScheduleSupport::blocked_outcome(
-                                    task.request.task_id,
+                                let outcome = AgentTaskScheduleSupport::block_scheduled_task(
+                                    &task,
+                                    "output_dependency",
                                     message,
+                                    &mut backpressure,
+                                    &mut events,
                                 );
                                 completed_by_task.insert(outcome.task_id.clone(), outcome.clone());
                                 outcomes.push(outcome);
@@ -184,20 +177,12 @@ where
                             let message = format!(
                                 "task requires resource_units={task_units} over max_active_units={max_active_units}"
                             );
-                            backpressure.push(AgentTaskBackpressureStatus {
-                                kind: "resource_budget".to_string(),
-                                message: message.clone(),
-                                task_id: Some(task.request.task_id.clone()),
-                            });
-                            events.push(event(
-                                &task.request.task_id,
-                                AgentTaskState::Blocked,
-                                task.attempt,
-                                Some(message.clone()),
-                            ));
-                            outcomes.push(AgentTaskScheduleSupport::blocked_outcome(
-                                task.request.task_id,
+                            outcomes.push(AgentTaskScheduleSupport::block_scheduled_task(
+                                &task,
+                                "resource_budget",
                                 message,
+                                &mut backpressure,
+                                &mut events,
                             ));
                             blocked_count += 1;
                             continue;
@@ -205,8 +190,8 @@ where
                         break;
                     }
                     let dependency_wait = queued.front().and_then(|task| {
-                        AgentTaskScheduleSupport::waiting_for_dependencies(
-                            &task.request,
+                        AgentTaskScheduleSupport::waiting_for_task_dependencies(
+                            task,
                             &completed_by_task,
                             &output_dependencies,
                         )
@@ -476,6 +461,35 @@ impl AgentTaskScheduleSupport {
                 missing.join(", ")
             )
         })
+    }
+
+    fn waiting_for_task_dependencies(
+        task: &ScheduledTask,
+        completed_by_task: &HashMap<String, AgentTaskOutcome>,
+        output_dependencies: &HashMap<String, AgentTaskOutputDependencies>,
+    ) -> Option<String> {
+        Self::waiting_for_dependencies(&task.request, completed_by_task, output_dependencies)
+    }
+
+    fn block_scheduled_task(
+        task: &ScheduledTask,
+        kind: &str,
+        message: String,
+        backpressure: &mut Vec<AgentTaskBackpressureStatus>,
+        events: &mut Vec<AgentTaskProgressEvent>,
+    ) -> AgentTaskOutcome {
+        backpressure.push(AgentTaskBackpressureStatus {
+            kind: kind.to_string(),
+            message: message.clone(),
+            task_id: Some(task.request.task_id.clone()),
+        });
+        events.push(event(
+            &task.request.task_id,
+            AgentTaskState::Blocked,
+            task.attempt,
+            Some(message.clone()),
+        ));
+        Self::blocked_outcome(task.request.task_id.clone(), message)
     }
 
     fn dependency_task_ids(
@@ -1118,13 +1132,19 @@ fn render_template_string(raw: &str, bindings: &HashMap<String, Value>) -> Strin
 }
 
 fn template_replacement(value: &Value) -> String {
-    match value {
-        Value::Null => String::new(),
-        Value::String(value) => value.clone(),
-        Value::Number(value) => value.to_string(),
-        Value::Bool(value) => value.to_string(),
-        Value::Array(_) | Value::Object(_) => value.to_string(),
+    if value.is_null() {
+        return String::new();
     }
+    if let Some(value) = value.as_str() {
+        return value.to_string();
+    }
+    if matches!(
+        value_type_name(value),
+        "number" | "bool" | "array" | "object"
+    ) {
+        return value.to_string();
+    }
+    String::new()
 }
 
 fn mark_generated_from_outputs(

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -20,6 +20,7 @@ pub(crate) use json_io::{
 pub use json_io::{serialize_with_id, to_json_string};
 pub use json_ops::collect_array_fields;
 pub(crate) use json_ops::{merge_config, remove_config};
+pub(crate) use json_pointer::value_type_name;
 pub use json_pointer::{remove_json_pointer, set_json_pointer};
 
 // ============================================================================

--- a/src/core/config/json_pointer.rs
+++ b/src/core/config/json_pointer.rs
@@ -245,7 +245,7 @@ fn unescape_token(token: &str) -> String {
     token.replace("~1", "/").replace("~0", "~")
 }
 
-fn value_type_name(value: &Value) -> &'static str {
+pub(crate) fn value_type_name(value: &Value) -> &'static str {
     match value {
         Value::Null => "null",
         Value::Bool(_) => "bool",

--- a/src/core/extension/trace/parsing.rs
+++ b/src/core/extension/trace/parsing.rs
@@ -42,6 +42,16 @@ pub enum TraceAssertionStatus {
     Error,
 }
 
+impl TraceAssertionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TraceAssertionStatus::Pass => "pass",
+            TraceAssertionStatus::Fail => "fail",
+            TraceAssertionStatus::Error => "error",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct TraceResults {

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -6,9 +6,7 @@ use std::collections::BTreeMap;
 use super::aggregate_report::TraceAggregateSpanSampleOutput;
 use super::baseline::TraceBaselineComparison;
 use super::overlay_lock::TraceOverlayLockRecord;
-use super::parsing::{
-    TraceArtifact, TraceAssertionStatus, TraceEvidenceMetadata, TraceList, TraceResults,
-};
+use super::parsing::{TraceArtifact, TraceEvidenceMetadata, TraceList, TraceResults};
 use super::run::{TraceOverlay, TraceRunWorkflowResult};
 use super::span_summary::{
     format_span_summary_metadata, format_span_summary_status, trace_span_summaries,
@@ -576,11 +574,7 @@ pub fn render_markdown(results: &TraceResults, overlays: &[TraceOverlay]) -> Str
         out.push_str("\n## Assertions\n\n");
         let (assertions, metadata) = bounded_items(&results.assertions, DEFAULT_DETAIL_ITEM_LIMIT);
         for assertion in assertions {
-            let status = match assertion.status {
-                TraceAssertionStatus::Pass => "pass",
-                TraceAssertionStatus::Fail => "fail",
-                TraceAssertionStatus::Error => "error",
-            };
+            let status = assertion.status.as_str();
             match &assertion.message {
                 Some(message) => out.push_str(&format!(
                     "- `{}`: **{}** - {}\n",


### PR DESCRIPTION
## Summary
- Centralize `TraceAssertionStatus` display strings so trace report renderers share the enum dispatch contract.
- Extract scheduler blocked-task backpressure/event handling to remove the intra-method duplicate.
- Reuse JSON value-type naming in scheduler template rendering to avoid the parallel implementation pattern.

Closes #3521.
Closes #3453.
Closes #3454.

## Tests
- `cargo test core::agent_task_scheduler::tests`
- `cargo test core::config::json_pointer`
- `cargo test commands::trace::output_tests`
- `cargo test core::extension::trace::report::tests`
- `cargo run --bin homeboy -- audit homeboy --path . --ignore-baseline --changed-since origin/main --only repeated_enum_dispatch_contract --only intra_method_duplicate --only parallel_implementation --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafting and verifying the small Rust refactors; Chris remains responsible for review and final merge.