### PR TITLE
Fix release repair gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,15 +144,16 @@ jobs:
           path: target/release/homeboy
           retention-days: 1
 
-  # ── Step 3: Quality gate (parallel read-only checks + repair PR) ──
+  # ── Step 3: Quality gate (parallel read-only checks + repair) ──
   # Unlike PR CI (scoped to changed files), release quality gate runs
   # unscoped against the entire codebase.
   # Read-only gates run in parallel after the shared build, then release
   # preparation waits for the repaired quality state from gate-refactor instead
   # of failing immediately on the first read-only drift signal. Read-only gates
-  # use autofix: false. The dedicated auto-refactor job opens a generated repair
-  # PR for fixable baseline/autofix drift so the release is blocked with a
-  # concrete repair path instead of becoming a manual investigation.
+  # use autofix: false. The dedicated auto-refactor job runs Homeboy Action's
+  # non-PR repair path: drift-only baseline/Cargo.lock changes are committed
+  # directly back to the release branch, while source autofixes fall through to
+  # the generated PR path.
   gate-audit:
     name: Audit
     needs:
@@ -295,9 +296,9 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      # On push/manual release runs, generated repair PRs are safer than
-      # direct-to-main fix commits because the current release run cannot
-      # continue against a branch it just repaired out-of-band.
+      # In Homeboy Action, autofix-open-pr gates the non-PR repair transaction.
+      # Baseline/Cargo.lock-only drift is pushed directly to the base branch;
+      # source changes still use the generated autofix PR fallback.
       - name: Run autofix via homeboy-action
         uses: Extra-Chill/homeboy-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,13 +144,15 @@ jobs:
           path: target/release/homeboy
           retention-days: 1
 
-  # ── Step 3: Quality gate (parallel read-only checks + direct autofix) ──
+  # ── Step 3: Quality gate (parallel read-only checks + repair PR) ──
   # Unlike PR CI (scoped to changed files), release quality gate runs
   # unscoped against the entire codebase.
   # Read-only gates run in parallel after the shared build, then release
-  # preparation waits for audit, lint, and test to finish. Read-only gates use
-  # autofix: false. The dedicated auto-refactor job keeps direct-to-main
-  # baseline/autofix commits but disables automated PR creation.
+  # preparation waits for the repaired quality state from gate-refactor instead
+  # of failing immediately on the first read-only drift signal. Read-only gates
+  # use autofix: false. The dedicated auto-refactor job opens a generated repair
+  # PR for fixable baseline/autofix drift so the release is blocked with a
+  # concrete repair path instead of becoming a manual investigation.
   gate-audit:
     name: Audit
     needs:
@@ -293,8 +295,9 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      # Keep direct-to-main autofix/baseline updates, but do not open
-      # generated autofix PRs until that path reliably produces green branches.
+      # On push/manual release runs, generated repair PRs are safer than
+      # direct-to-main fix commits because the current release run cannot
+      # continue against a branch it just repaired out-of-band.
       - name: Run autofix via homeboy-action
         uses: Extra-Chill/homeboy-action@v2
         with:
@@ -303,7 +306,7 @@ jobs:
           expected-commands: audit,lint,test
           autofix: 'true'
           autofix-mode: always
-          autofix-open-pr: 'false'
+          autofix-open-pr: 'true'
           app-token: ${{ steps.app-token.outputs.token }}
 
   # ── Step 4: Version bump + changelog + tag ──
@@ -312,9 +315,8 @@ jobs:
     needs:
       - check
       - gate-build
-      - gate-lint
-      - gate-test
-      - gate-audit
+      - gate-refactor
+    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.gate-build.result == 'success' && (inputs.release_tag != '' || needs.gate-refactor.result == 'success') }}
     runs-on: ubuntu-latest
     outputs:
       release-version: ${{ steps.recovery.outputs.release-version || steps.release.outputs.release-version }}

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -1,0 +1,60 @@
+fn release_workflow() -> &'static str {
+    include_str!("../.github/workflows/release.yml")
+}
+
+fn job_section<'a>(workflow: &'a str, job: &str) -> &'a str {
+    let marker = format!("  {job}:\n");
+    let start = workflow
+        .find(&marker)
+        .unwrap_or_else(|| panic!("missing {job} job"));
+    let rest = &workflow[start + marker.len()..];
+    let end = rest
+        .lines()
+        .scan(0usize, |offset, line| {
+            let current = *offset;
+            *offset += line.len() + 1;
+            Some((current, line))
+        })
+        .skip(1)
+        .find_map(|(offset, line)| {
+            let is_next_job = line.starts_with("  ")
+                && !line.starts_with("    ")
+                && line.trim_end().ends_with(':');
+
+            is_next_job.then_some(offset.saturating_sub(1))
+        })
+        .unwrap_or(rest.len());
+
+    &rest[..end]
+}
+
+#[test]
+fn release_refactor_gate_opens_repair_prs() {
+    let gate_refactor = job_section(release_workflow(), "gate-refactor");
+
+    assert!(gate_refactor.contains("commands: audit,lint,test"));
+    assert!(gate_refactor.contains("autofix: 'true'"));
+    assert!(gate_refactor.contains("autofix-mode: always"));
+    assert!(gate_refactor.contains("autofix-open-pr: 'true'"));
+}
+
+#[test]
+fn release_prepare_waits_for_repaired_quality_state() {
+    let gate_refactor = job_section(release_workflow(), "gate-refactor");
+    let prepare = job_section(release_workflow(), "prepare");
+
+    for gate in ["gate-audit", "gate-lint", "gate-test"] {
+        assert!(
+            gate_refactor.contains(&format!("- {gate}")),
+            "gate-refactor should inspect the read-only {gate} result before repair"
+        );
+        assert!(
+            !prepare.contains(&format!("- {gate}")),
+            "prepare should wait on gate-refactor, not fail directly on {gate}"
+        );
+    }
+
+    assert!(prepare.contains("- gate-refactor"));
+    assert!(prepare.contains("needs.gate-refactor.result == 'success'"));
+    assert!(prepare.contains("inputs.release_tag != ''"));
+}

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -29,12 +29,13 @@ fn job_section<'a>(workflow: &'a str, job: &str) -> &'a str {
 }
 
 #[test]
-fn release_refactor_gate_opens_repair_prs() {
+fn release_refactor_gate_enables_non_pr_repair_path() {
     let gate_refactor = job_section(release_workflow(), "gate-refactor");
 
     assert!(gate_refactor.contains("commands: audit,lint,test"));
     assert!(gate_refactor.contains("autofix: 'true'"));
     assert!(gate_refactor.contains("autofix-mode: always"));
+    assert!(gate_refactor.contains("Baseline/Cargo.lock-only drift is pushed directly"));
     assert!(gate_refactor.contains("autofix-open-pr: 'true'"));
 }
 


### PR DESCRIPTION
## Summary
- Route release preparation through the repaired `gate-refactor` quality state instead of directly blocking on first-pass read-only audit/lint/test drift.
- Enable Homeboy Action's non-PR repair transaction before `prepare`: drift-only baseline/Cargo.lock updates are pushed directly back to the release branch, while source autofixes still fall through to the generated autofix PR fallback.
- Add a workflow-shape test that locks the repaired-state dependency and non-PR repair path behavior.

Closes #3538.

## Tests
- `cargo fmt --check`
- `cargo test --test release_workflow_test`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "workflow yaml ok"'`
- `cargo test` *(fails on existing `tests/core_agnostic_test.rs::core_owned_source_stays_language_and_framework_agnostic` baseline drift in `src/commands/doctor/resources.rs`, `src/core/component/mod.rs`, and other already-detected core-agnostic findings)*

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the workflow dependency change, corrected the non-PR repair-path framing after reviewing Homeboy Action behavior, added the workflow-shape regression test, and ran local verification. Chris remains responsible for review and merge.