### PR TITLE
Fail missing agent task output dependencies

### DIFF
--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -583,9 +583,9 @@ impl AgentTaskScheduleSupport {
         AgentTaskOutcome {
             schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
             task_id: request.task_id.clone(),
-            status: AgentTaskOutcomeStatus::NoOp,
+            status: AgentTaskOutcomeStatus::Failed,
             summary: Some(summary.clone()),
-            failure_classification: None,
+            failure_classification: Some(AgentTaskFailureClassification::InvalidInput),
             artifacts: Vec::new(),
             evidence_refs: vec![AgentTaskEvidenceRef {
                 kind: "scheduler".to_string(),
@@ -1739,9 +1739,10 @@ mod tests {
         let aggregate = scheduler.run(plan);
         let observed = observed.lock().expect("observed requests");
 
-        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::PartialFailure);
         assert_eq!(aggregate.totals.succeeded, 1);
         assert_eq!(aggregate.totals.skipped, 1);
+        assert_eq!(aggregate.totals.failed, 0);
         assert!(observed.iter().all(|request| request.task_id != "design"));
         assert!(aggregate
             .events
@@ -1752,7 +1753,11 @@ mod tests {
             .iter()
             .find(|outcome| outcome.task_id == "design")
             .expect("skipped outcome");
-        assert_eq!(skipped.status, AgentTaskOutcomeStatus::NoOp);
+        assert_eq!(skipped.status, AgentTaskOutcomeStatus::Failed);
+        assert_eq!(
+            skipped.failure_classification,
+            Some(AgentTaskFailureClassification::InvalidInput)
+        );
         assert!(skipped.diagnostics.iter().any(|diagnostic| {
             diagnostic.class == "output_dependency_missing"
                 && diagnostic.message.contains("required output binding")


### PR DESCRIPTION
## Summary
- Treat required output dependency misses as failed scheduler outcomes instead of success-equivalent no-ops.
- Keep undispatched dependency misses counted as skipped while making aggregate status non-green.
- Update scheduler coverage to assert partial failure and `InvalidInput` classification.

## Verification
- `cargo test agent_task_scheduler`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the scheduler aggregate/output-dependency behavior, drafted the focused Rust change and test expectation, and ran local verification. Chris remains responsible for review and acceptance.