### PR TITLE
Allow audit baselines through lab offload

### DIFF
--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -60,18 +60,15 @@ fn lab_offload_command(
     } else {
         Vec::new()
     };
-    let mutation_flag = contract.mutation_flag;
     Ok(Some(homeboy::core::runner::LabOffloadCommand {
         hot_label: contract.hot_label,
-        portable: mutation_flag.is_none()
-            && matches!(
-                contract.portability,
-                homeboy::cli_surface::LabCommandPortability::Portable
-            ),
-        unsupported_reason: match (mutation_flag, contract.portability) {
-            (Some(flag), _) => Some(flag),
-            (None, homeboy::cli_surface::LabCommandPortability::Portable) => None,
-            (None, homeboy::cli_surface::LabCommandPortability::LocalOnly(reason)) => Some(reason),
+        portable: matches!(
+            contract.portability,
+            homeboy::cli_surface::LabCommandPortability::Portable
+        ),
+        unsupported_reason: match contract.portability {
+            homeboy::cli_surface::LabCommandPortability::Portable => None,
+            homeboy::cli_surface::LabCommandPortability::LocalOnly(reason) => Some(reason),
         },
         workspace_mode_policy: match contract.workspace_mode_policy {
             homeboy::cli_surface::LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot => {
@@ -186,14 +183,26 @@ mod tests {
     }
 
     #[test]
-    fn lab_command_with_local_mutation_flag_stays_local() {
+    fn lab_command_with_mutation_flag_stays_portable_for_patch_capture() {
         let cli = Cli::parse_from(["homeboy", "audit", "--baseline"]);
 
         let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
         assert_eq!(command.hot_label, "audit");
-        assert!(!command.portable);
-        assert_eq!(command.unsupported_reason, Some("--baseline/--ratchet"));
+        assert!(command.portable);
+        assert_eq!(command.unsupported_reason, None);
+        assert!(command.requires_extension_parity);
+    }
+
+    #[test]
+    fn lab_command_with_ratchet_stays_portable_for_patch_capture() {
+        let cli = Cli::parse_from(["homeboy", "audit", "--ratchet"]);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+        assert_eq!(command.hot_label, "audit");
+        assert!(command.portable);
+        assert_eq!(command.unsupported_reason, None);
         assert!(command.requires_extension_parity);
     }
 

--- a/src/core/runner/lab_apply.rs
+++ b/src/core/runner/lab_apply.rs
@@ -138,6 +138,69 @@ mod tests {
         );
     }
 
+    #[test]
+    fn apply_lab_offload_patch_writes_returned_homeboy_json_baseline() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        git(repo.path(), &["init"]);
+        git(repo.path(), &["config", "user.email", "test@example.com"]);
+        git(repo.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(repo.path().join("homeboy.json"), "{\"id\":\"demo\"}\n")
+            .expect("seed manifest");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "base"]);
+        let snapshot = SourceSnapshot::collect_local(
+            "lab",
+            repo.path(),
+            Some("/srv/homeboy/_lab_workspaces/repo-abc"),
+            "lab_offload",
+        );
+        let artifact_dir = tempfile::tempdir().expect("artifact tempdir");
+        let patch_path = artifact_dir.path().join("patch.diff");
+        std::fs::write(
+            &patch_path,
+            "diff --git a/homeboy.json b/homeboy.json\nindex 9911a67..6856254 100644\n--- a/homeboy.json\n+++ b/homeboy.json\n@@ -1 +1 @@\n-{\"id\":\"demo\"}\n+{\"id\":\"demo\",\"baselines\":{\"audit\":{\"known_fingerprints\":[\"abc\"]}}}\n",
+        )
+        .expect("patch file");
+        let exec_output = RunnerExecOutput {
+            command: "runner.exec",
+            runner_id: "lab".to_string(),
+            mode: super::super::RunnerExecMode::Daemon,
+            argv: vec![
+                "homeboy".to_string(),
+                "audit".to_string(),
+                "--baseline".to_string(),
+            ],
+            remote_cwd: "/srv/homeboy/_lab_workspaces/repo-abc".to_string(),
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            source_snapshot: Some(snapshot),
+            job: None,
+            job_id: None,
+            job_events: None,
+            mirror_run_id: None,
+            patch: Some(serde_json::json!({
+                "modified_files": ["homeboy.json"],
+                "patch_artifact_path": patch_path.display().to_string(),
+            })),
+            metrics: None,
+            capture: None,
+        };
+
+        let output = apply_lab_offload_patch(&exec_output)
+            .expect("apply patch")
+            .expect("patch applied");
+
+        assert_eq!(
+            output.result.modified_files,
+            vec!["homeboy.json".to_string()]
+        );
+        assert_eq!(
+            std::fs::read_to_string(repo.path().join("homeboy.json")).expect("manifest"),
+            "{\"id\":\"demo\",\"baselines\":{\"audit\":{\"known_fingerprints\":[\"abc\"]}}}\n"
+        );
+    }
+
     fn git(path: &Path, args: &[&str]) {
         let output = std::process::Command::new("git")
             .args(args)


### PR DESCRIPTION
## Summary
- Keeps portable Lab commands portable even when they request mutation return, so `homeboy audit --baseline --runner homeboy-lab` and `homeboy audit --ratchet --runner homeboy-lab` can use the existing patch-capture/apply path instead of being rejected as local-only.
- Adds route coverage for audit baseline/ratchet Lab portability.
- Adds patch-apply coverage proving returned `homeboy.json` baseline mutations are applied locally.

Closes #3544.

## Verification
- `cargo fmt`
- `cargo test apply_lab_offload_patch_writes_returned_homeboy_json_baseline`
- `cargo test lab_command_with_mutation_flag_stays_portable_for_patch_capture`
- `cargo test lab_command_with_ratchet_stays_portable_for_patch_capture`
- `cargo test lab_offload`
- `cargo test lab_command`
- `cargo test test_lab_offload_mutation_flag`
- `cargo run --quiet --bin homeboy -- audit --baseline --runner __missing_lab_runner_for_3544__` now reaches runner resolution instead of the previous local-only `--baseline/--ratchet` rejection.

## Caveat
- `cargo clippy --all-targets -- -D warnings` was run and fails on existing repository-wide Clippy baseline drift in unrelated files, including `src/core/agent_task_provider.rs`, `src/core/code_audit/*`, `src/core/deploy/execution.rs`, and other pre-existing warnings. No Clippy failure was introduced by the touched files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the route fix, focused tests, verification commands, and PR description; Chris remains responsible for review and merge.