### PR TITLE
Fail fast on noninteractive hot audit runs

### DIFF
--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -214,6 +214,36 @@ pub fn evaluate(command: HotCommand, resources: &DoctorOutput) -> Option<Resourc
     }
 }
 
+pub fn non_interactive_preflight_error(
+    warning: &ResourcePolicyWarning,
+    force_hot: bool,
+    interactive: bool,
+) -> Option<crate::core::Error> {
+    if force_hot || interactive {
+        return None;
+    }
+
+    Some(crate::core::Error::validation_invalid_argument(
+        "resource-policy",
+        format!(
+            "Refusing to start `{}` on a {} machine from a non-interactive shell. {} Use a safe Lab/offload path once this command supports it, or rerun later when `homeboy doctor resources` reports ok.",
+            warning.command,
+            severity_str(warning.recommendation),
+            primary_action(warning),
+        ),
+        None,
+        None,
+    ))
+}
+
+fn primary_action(warning: &ResourcePolicyWarning) -> &'static str {
+    if warning.message.contains("--runner <id>") {
+        "Connect a default Homeboy Lab runner or pass --runner <id> when Lab offload supports this mode."
+    } else {
+        "This command is currently local-only under resource policy."
+    }
+}
+
 fn warning_message(
     command: HotCommand,
     recommendation: ResourceRecommendation,
@@ -371,6 +401,36 @@ mod tests {
             &resources(ResourceRecommendation::Ok)
         )
         .is_none());
+    }
+
+    #[test]
+    fn non_interactive_hot_warning_fails_before_starting_command() {
+        let warning = evaluate(
+            lab_supported_hot("audit"),
+            &resources(ResourceRecommendation::Hot),
+        )
+        .expect("hot machines warn");
+
+        let error = non_interactive_preflight_error(&warning, false, false)
+            .expect("non-interactive hot runs should fail fast");
+
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        assert!(error.message.contains("Refusing to start `audit`"));
+        assert!(error.message.contains("non-interactive shell"));
+        assert!(error.message.contains("--runner <id>"));
+        assert!(!error.message.contains("Use --force-hot"));
+    }
+
+    #[test]
+    fn interactive_or_forced_hot_warning_does_not_fail_preflight() {
+        let warning = evaluate(
+            lab_supported_hot("audit"),
+            &resources(ResourceRecommendation::Hot),
+        )
+        .expect("hot machines warn");
+
+        assert!(non_interactive_preflight_error(&warning, false, true).is_none());
+        assert!(non_interactive_preflight_error(&warning, true, false).is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{ArgMatches, Command, CommandFactory, FromArgMatches};
+use std::io::IsTerminal;
 
 use homeboy::cli_surface::Cli;
 use homeboy::cli_surface::Commands;
@@ -209,6 +210,16 @@ fn main() -> std::process::ExitCode {
                     cli.force_hot,
                 ),
             );
+            if let Some(warning) = warning.as_ref() {
+                if let Some(err) = resource_policy::non_interactive_preflight_error(
+                    warning,
+                    cli.force_hot,
+                    is_interactive_shell(),
+                ) {
+                    emit_json_result(Err(err), output_file.as_deref(), 2);
+                    return std::process::ExitCode::from(exit_code_to_u8(2));
+                }
+            }
         }
     }
 
@@ -253,6 +264,10 @@ fn exit_code_to_u8(code: i32) -> u8 {
     } else {
         code as u8
     }
+}
+
+fn is_interactive_shell() -> bool {
+    std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
 }
 
 fn emit_json_result(


### PR DESCRIPTION
## Summary
- Fail fast before starting hot commands from non-interactive shells when resource policy reports warm/hot host pressure and `--force-hot` is not explicitly set.
- Keep interactive behavior unchanged while returning a structured validation error for automation instead of letting `homeboy audit --baseline` silently continue into a long local scan.
- Add resource-policy regression coverage so non-interactive hot warnings cannot silently proceed again.

Closes #3546.

## Verification
- `cargo fmt -- --check`
- `cargo test resource_policy::tests`
- `cargo test --test output_errors`
- `cargo test` currently fails in `tests/core_agnostic_test.rs::core_owned_source_stays_language_and_framework_agnostic` on pre-existing baseline debt in files not touched by this PR, including `src/commands/doctor/resources.rs`, `src/core/component/mod.rs`, `src/core/engine/edit_op_apply/imports.rs`, and others.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the small resource-policy preflight change, tests, and verification/PR notes for Chris to review.