### PR TITLE
Fix Cargo test filter passthrough

### DIFF
--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -102,9 +102,11 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
         &args.extension_override,
         None,
     )?;
+    let cli_passthrough_args = filter_homeboy_flags(&args.args);
 
     if !args.drift
         && args.ci_job.is_none()
+        && cli_passthrough_args.is_empty()
         && source_ctx.component.has_script(ExtensionCapability::Test)
     {
         let observation = start_test_observation(
@@ -164,7 +166,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
         Some(runner.run_dir()),
     );
     let mut passthrough_args = ci_job_passthrough_args(ci_job.as_ref());
-    passthrough_args.extend(filter_homeboy_flags(&args.args));
+    passthrough_args.extend(cli_passthrough_args);
     let workflow = extension_test::run_main_test_workflow(
         &ctx.component,
         &ctx.source_path,

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -18,11 +18,11 @@ pub use super::manifest_config::{
     DeployVerification, DepsConfig, DiscoveryConfig, EnvProviderConfig, FileContainsCondition,
     LintChangedFileRoute, LintConfig, RemotePathInferenceRule, RemotePathRootRule,
     RequirementsConfig, SinceTagConfig, TestChangedFileExclusiveEnv, TestChangedFileRouting,
-    TestChangedFileRoutingStrategy, TestConfig, TestPassthroughFilter,
-    TestPassthroughFilterStrategy, TraceConfig, VersionPatternConfig,
+    TestChangedFileRoutingStrategy, TestConfig, TraceConfig, VersionPatternConfig,
 };
 pub use super::manifest_deploy_config::DeployArchiveInstallPolicy;
 pub use super::manifest_sidecar::{StructuredSidecarContract, StructuredSidecarDeclaration};
+pub use super::manifest_test_config::{TestPassthroughFilter, TestPassthroughFilterStrategy};
 
 /// Type of action that can be executed by a extension.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -18,7 +18,8 @@ pub use super::manifest_config::{
     DeployVerification, DepsConfig, DiscoveryConfig, EnvProviderConfig, FileContainsCondition,
     LintChangedFileRoute, LintConfig, RemotePathInferenceRule, RemotePathRootRule,
     RequirementsConfig, SinceTagConfig, TestChangedFileExclusiveEnv, TestChangedFileRouting,
-    TestChangedFileRoutingStrategy, TestConfig, TraceConfig, VersionPatternConfig,
+    TestChangedFileRoutingStrategy, TestConfig, TestPassthroughFilter,
+    TestPassthroughFilterStrategy, TraceConfig, VersionPatternConfig,
 };
 pub use super::manifest_deploy_config::DeployArchiveInstallPolicy;
 pub use super::manifest_sidecar::{StructuredSidecarContract, StructuredSidecarDeclaration};

--- a/src/core/extension/manifest_config.rs
+++ b/src/core/extension/manifest_config.rs
@@ -243,6 +243,22 @@ pub struct TestConfig {
     /// extension test runner.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub changed_file_routing: Option<TestChangedFileRouting>,
+
+    /// Manifest-driven mapping for Homeboy's generic `--filter` passthrough
+    /// hint before invoking the extension test runner.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub passthrough_filter: Option<TestPassthroughFilter>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TestPassthroughFilter {
+    pub strategy: TestPassthroughFilterStrategy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TestPassthroughFilterStrategy {
+    RunnerPositional,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/extension/manifest_config.rs
+++ b/src/core/extension/manifest_config.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use super::manifest::TestDriftConfig;
+use super::manifest_test_config::TestPassthroughFilter;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RequirementsConfig {
@@ -248,17 +249,6 @@ pub struct TestConfig {
     /// hint before invoking the extension test runner.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub passthrough_filter: Option<TestPassthroughFilter>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct TestPassthroughFilter {
-    pub strategy: TestPassthroughFilterStrategy,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum TestPassthroughFilterStrategy {
-    RunnerPositional,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/extension/manifest_test_config.rs
+++ b/src/core/extension/manifest_test_config.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TestPassthroughFilter {
+    pub strategy: TestPassthroughFilterStrategy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TestPassthroughFilterStrategy {
+    RunnerPositional,
+}

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -73,8 +73,8 @@ pub use manifest::{
     ProvidesConfig, RemotePathInferenceRule, RemotePathRootRule, RequirementsConfig, RuntimeConfig,
     RuntimeRequirementsConfig, ScriptsConfig, SelectOption, SettingConfig, SinceTagConfig,
     StructuredSidecarDeclaration, TestChangedFileExclusiveEnv, TestChangedFileRouting,
-    TestChangedFileRoutingStrategy, TestConfig, TestDriftConfig, TestMappingConfig, TraceConfig,
-    VersionPatternConfig,
+    TestChangedFileRoutingStrategy, TestConfig, TestDriftConfig, TestMappingConfig,
+    TestPassthroughFilter, TestPassthroughFilterStrategy, TraceConfig, VersionPatternConfig,
 };
 pub use manifest_deploy_config::{DeployArchiveInstallPolicy, DeployRequiredHeader};
 pub use refactor_protocol::{

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -17,6 +17,7 @@ mod manifest_action_config;
 mod manifest_config;
 mod manifest_deploy_config;
 mod manifest_sidecar;
+mod manifest_test_config;
 mod refactor_protocol;
 mod registry;
 mod repair;

--- a/src/core/extension/test/mod.rs
+++ b/src/core/extension/test/mod.rs
@@ -10,7 +10,8 @@ use crate::core::component::Component;
 use crate::core::extension::test::drift::DriftOptions;
 use crate::core::extension::{
     ExtensionCapability, ExtensionExecutionContext, ExtensionRunner, TestChangedFileExclusiveEnv,
-    TestChangedFileRouting, TestChangedFileRoutingStrategy,
+    TestChangedFileRouting, TestChangedFileRoutingStrategy, TestPassthroughFilter,
+    TestPassthroughFilterStrategy,
 };
 use crate::core::git;
 use serde::Serialize;
@@ -96,24 +97,33 @@ pub fn normalize_test_passthrough_args(
     component: &Component,
     args: &[String],
 ) -> crate::core::error::Result<Vec<String>> {
-    if !uses_rust_cargo_test_routing(component)? {
+    let Some(filter) = test_passthrough_filter(component)? else {
         return Ok(args.to_vec());
-    }
+    };
 
-    Ok(normalize_rust_cargo_test_filter_args(args))
+    Ok(normalize_filter_passthrough_args(args, &filter))
 }
 
-fn uses_rust_cargo_test_routing(component: &Component) -> crate::core::error::Result<bool> {
+fn test_passthrough_filter(
+    component: &Component,
+) -> crate::core::error::Result<Option<TestPassthroughFilter>> {
     let context = resolve_test_command(component)?;
     let manifest = crate::core::extension::load_extension(&context.extension_id)?;
-
-    Ok(test_changed_file_routing(&context.extension_id)?
-        .is_some_and(|routing| routing.strategy == TestChangedFileRoutingStrategy::RustCargo)
-        || manifest.cli.as_ref().is_some_and(|cli| cli.tool == "cargo")
-        || context.extension_id == "rust")
+    Ok(manifest
+        .test
+        .and_then(|test| test.passthrough_filter.clone()))
 }
 
-fn normalize_rust_cargo_test_filter_args(args: &[String]) -> Vec<String> {
+fn normalize_filter_passthrough_args(
+    args: &[String],
+    filter: &TestPassthroughFilter,
+) -> Vec<String> {
+    match filter.strategy {
+        TestPassthroughFilterStrategy::RunnerPositional => positional_filter_args(args),
+    }
+}
+
+fn positional_filter_args(args: &[String]) -> Vec<String> {
     let mut normalized = Vec::new();
     let mut iter = args.iter();
 
@@ -614,15 +624,18 @@ mod tests {
     }
 
     #[test]
-    fn rust_cargo_passthrough_translates_equals_filter_to_positional_filter() {
+    fn positional_passthrough_translates_equals_filter_to_runner_filter() {
         let args = vec![
             "--filter=core::daemon".to_string(),
             "--".to_string(),
             "--nocapture".to_string(),
         ];
+        let filter = TestPassthroughFilter {
+            strategy: TestPassthroughFilterStrategy::RunnerPositional,
+        };
 
         assert_eq!(
-            normalize_rust_cargo_test_filter_args(&args),
+            normalize_filter_passthrough_args(&args, &filter),
             vec![
                 "core::daemon".to_string(),
                 "--".to_string(),
@@ -632,16 +645,19 @@ mod tests {
     }
 
     #[test]
-    fn rust_cargo_passthrough_translates_split_filter_to_positional_filter() {
+    fn positional_passthrough_translates_split_filter_to_runner_filter() {
         let args = vec![
             "--filter".to_string(),
             "core::daemon".to_string(),
             "--".to_string(),
             "--nocapture".to_string(),
         ];
+        let filter = TestPassthroughFilter {
+            strategy: TestPassthroughFilterStrategy::RunnerPositional,
+        };
 
         assert_eq!(
-            normalize_rust_cargo_test_filter_args(&args),
+            normalize_filter_passthrough_args(&args, &filter),
             vec![
                 "core::daemon".to_string(),
                 "--".to_string(),

--- a/src/core/extension/test/mod.rs
+++ b/src/core/extension/test/mod.rs
@@ -92,6 +92,52 @@ pub fn build_test_runner(
     Ok(runner)
 }
 
+pub fn normalize_test_passthrough_args(
+    component: &Component,
+    args: &[String],
+) -> crate::core::error::Result<Vec<String>> {
+    if !uses_rust_cargo_test_routing(component)? {
+        return Ok(args.to_vec());
+    }
+
+    Ok(normalize_rust_cargo_test_filter_args(args))
+}
+
+fn uses_rust_cargo_test_routing(component: &Component) -> crate::core::error::Result<bool> {
+    let context = resolve_test_command(component)?;
+    let manifest = crate::core::extension::load_extension(&context.extension_id)?;
+
+    Ok(test_changed_file_routing(&context.extension_id)?
+        .is_some_and(|routing| routing.strategy == TestChangedFileRoutingStrategy::RustCargo)
+        || manifest.cli.as_ref().is_some_and(|cli| cli.tool == "cargo")
+        || context.extension_id == "rust")
+}
+
+fn normalize_rust_cargo_test_filter_args(args: &[String]) -> Vec<String> {
+    let mut normalized = Vec::new();
+    let mut iter = args.iter();
+
+    while let Some(arg) = iter.next() {
+        if let Some(filter) = arg.strip_prefix("--filter=") {
+            if !filter.is_empty() {
+                normalized.push(filter.to_string());
+            }
+            continue;
+        }
+
+        if arg == "--filter" {
+            if let Some(filter) = iter.next() {
+                normalized.push(filter.clone());
+            }
+            continue;
+        }
+
+        normalized.push(arg.clone());
+    }
+
+    normalized
+}
+
 fn test_changed_file_routing(
     extension_id: &str,
 ) -> crate::core::error::Result<Option<TestChangedFileRouting>> {
@@ -565,6 +611,43 @@ mod tests {
             "HOMEBOY_TEST_RUNNER_ARGS".to_string(),
             "--\ncore::daemon".to_string()
         )));
+    }
+
+    #[test]
+    fn rust_cargo_passthrough_translates_equals_filter_to_positional_filter() {
+        let args = vec![
+            "--filter=core::daemon".to_string(),
+            "--".to_string(),
+            "--nocapture".to_string(),
+        ];
+
+        assert_eq!(
+            normalize_rust_cargo_test_filter_args(&args),
+            vec![
+                "core::daemon".to_string(),
+                "--".to_string(),
+                "--nocapture".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn rust_cargo_passthrough_translates_split_filter_to_positional_filter() {
+        let args = vec![
+            "--filter".to_string(),
+            "core::daemon".to_string(),
+            "--".to_string(),
+            "--nocapture".to_string(),
+        ];
+
+        assert_eq!(
+            normalize_rust_cargo_test_filter_args(&args),
+            vec![
+                "core::daemon".to_string(),
+                "--".to_string(),
+                "--nocapture".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -4,9 +4,10 @@ use crate::core::engine::run_dir::{self, RunDir};
 use crate::core::extension::test::analyze::{analyze, TestAnalysis, TestAnalysisInput};
 use crate::core::extension::test::baseline::{self, TestBaselineComparison, TestCounts};
 use crate::core::extension::test::{
-    build_test_runner, build_test_summary, compute_changed_test_scope, parse_coverage_file,
-    parse_failures_file, parse_test_results_file, parse_test_results_text,
-    parse_test_results_text_with_spec, CoverageOutput, TestScopeOutput, TestSummaryOutput,
+    build_test_runner, build_test_summary, compute_changed_test_scope,
+    normalize_test_passthrough_args, parse_coverage_file, parse_failures_file,
+    parse_test_results_file, parse_test_results_text, parse_test_results_text_with_spec,
+    CoverageOutput, TestScopeOutput, TestSummaryOutput,
 };
 use crate::core::extension::{self, ExtensionCapability};
 use crate::core::finding::HomeboyFinding;
@@ -228,6 +229,7 @@ pub fn run_main_test_workflow(
         .ci_env
         .iter()
         .fold(runner, |runner, (key, value)| runner.env(key, value));
+    let passthrough_args = normalize_test_passthrough_args(component, &args.passthrough_args)?;
     let output = runner
         .env_if(args.changed_since.is_some(), "SCOPE_MODE", "changed")
         .env_if(
@@ -240,7 +242,7 @@ pub fn run_main_test_workflow(
             "HOMEBOY_STRICT_VALIDATION_DEPENDENCIES",
             "1",
         )
-        .script_args(&args.passthrough_args)
+        .script_args(&passthrough_args)
         .run()?;
 
     let mut test_counts = parse_test_results_file(&results_file).or_else(|| {

--- a/src/core/extension/tests.rs
+++ b/src/core/extension/tests.rs
@@ -237,6 +237,32 @@ fn manifest_parses_changed_test_routing_contract() {
 }
 
 #[test]
+fn manifest_parses_passthrough_filter_contract() {
+    let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+        "name": "Example",
+        "version": "0.0.0",
+        "test": {
+            "extension_script": "test.sh",
+            "passthrough_filter": {
+                "strategy": "runner_positional"
+            }
+        }
+    }))
+    .unwrap();
+
+    let filter = manifest
+        .test
+        .as_ref()
+        .and_then(|test| test.passthrough_filter.as_ref())
+        .expect("test passthrough filter should parse");
+
+    assert_eq!(
+        filter.strategy,
+        TestPassthroughFilterStrategy::RunnerPositional
+    );
+}
+
+#[test]
 fn manifest_rejects_legacy_discovery_marker_alias() {
     let err = serde_json::from_value::<ExtensionManifest>(serde_json::json!({
         "name": "Example",


### PR DESCRIPTION
## Summary
- Add a generic `test.passthrough_filter` extension-manifest contract for mapping Homeboy's test filter hint to provider-supported runner argument shapes.
- Route targeted passthrough runs through the extension test workflow instead of the self-check shortcut, preserving Homeboy's consistent `homeboy test <component> -- --filter=Name` UX without hardcoding provider behavior in core.
- Add regression coverage for both `--filter=Name` and `--filter Name` forms plus manifest parsing coverage.

Closes #3543.

Paired extension PR: Extra-Chill/homeboy-extensions#1116 declares the Rust extension's filter mapping as `runner_positional`.

## Verification
- `cargo fmt`
- `cargo test positional_passthrough_translates --lib`
- `cargo test manifest_parses_passthrough_filter_contract --lib`
- `cargo test core::extension::test::tests::rust_cargo_passthrough_translates --lib` (pre-contract implementation, superseded by generic test names)
- `cargo test commands::test::tests::parses_ci_job_flag --lib`
- `cargo run --quiet --bin homeboy -- test homeboy -- --filter=rust_cargo_passthrough_translates_equals_filter_to_positional_filter` (pre-contract implementation, proved original failure shape before generic cleanup)
- Paired proof with Extra-Chill/homeboy-extensions#1116: isolated Homeboy config, installed the modified Rust extension, and ran `./target/debug/homeboy test homeboy --skip-lint -- --filter=positional_passthrough_translates_equals_filter_to_runner_filter`, which passed and ran one filtered test.

## Notes
- `cargo test --test core_agnostic_test` currently fails on existing non-baselined findings across multiple files; the final PR diff no longer adds provider-specific Rust/Cargo checks in the changed production path.
- The first local implementation hardcoded Rust/Cargo detection; the follow-up commit moves that behavior into extension metadata to preserve the core-agnostic boundary.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigated the Homeboy test runner filter path, drafted the generic passthrough filter contract, added regression tests, coordinated the paired Rust extension metadata PR, and ran verification commands. Chris remains responsible for review and merge.