### PR TITLE
Harden parallel test observation isolation

### DIFF
--- a/src/core/engine/resource.rs
+++ b/src/core/engine/resource.rs
@@ -289,6 +289,7 @@ fn homeboy_rss_bytes(warnings: &mut Vec<String>) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::with_isolated_home;
 
     #[derive(Debug)]
     struct FakeProbe {
@@ -369,107 +370,113 @@ mod tests {
 
     #[test]
     fn writes_summary_to_run_dir_artifact() {
-        let run_dir = RunDir::create().expect("run dir");
-        let summary = RunResourceSummary::from_snapshots(
-            Some("lint".to_string()),
-            7,
-            Utc::now().to_rfc3339(),
-            Utc::now().to_rfc3339(),
-            1,
-            "test".to_string(),
-            ResourceSnapshot {
-                load_average: None,
-                homeboy_rss_bytes: None,
-                warnings: vec!["load_average_unsupported".to_string()],
-            },
-            ResourceSnapshot {
-                load_average: None,
-                homeboy_rss_bytes: None,
-                warnings: vec!["homeboy_rss_unsupported".to_string()],
-            },
-            vec![ExtensionChildResourceSummary {
-                child: ChildProcessIdentity {
-                    root_pid: 99,
-                    command_label: "runner".to_string(),
+        with_isolated_home(|_| {
+            let run_dir = RunDir::create().expect("run dir");
+            let summary = RunResourceSummary::from_snapshots(
+                Some("lint".to_string()),
+                7,
+                Utc::now().to_rfc3339(),
+                Utc::now().to_rfc3339(),
+                1,
+                "test".to_string(),
+                ResourceSnapshot {
+                    load_average: None,
+                    homeboy_rss_bytes: None,
+                    warnings: vec!["load_average_unsupported".to_string()],
                 },
-                started_at: Utc::now().to_rfc3339(),
-                finished_at: Utc::now().to_rfc3339(),
-                duration_ms: 10,
-                sampled_peak_rss_bytes: Some(2048),
-                sampled_peak_cpu_percent: Some(12.5),
-                warnings: Vec::new(),
-            }],
-        );
+                ResourceSnapshot {
+                    load_average: None,
+                    homeboy_rss_bytes: None,
+                    warnings: vec!["homeboy_rss_unsupported".to_string()],
+                },
+                vec![ExtensionChildResourceSummary {
+                    child: ChildProcessIdentity {
+                        root_pid: 99,
+                        command_label: "runner".to_string(),
+                    },
+                    started_at: Utc::now().to_rfc3339(),
+                    finished_at: Utc::now().to_rfc3339(),
+                    duration_ms: 10,
+                    sampled_peak_rss_bytes: Some(2048),
+                    sampled_peak_cpu_percent: Some(12.5),
+                    warnings: Vec::new(),
+                }],
+            );
 
-        write_summary(&run_dir, &summary).expect("write summary");
-        let output = run_dir
-            .read_step_output(run_dir::files::RESOURCE_SUMMARY)
-            .expect("resource summary json");
+            write_summary(&run_dir, &summary).expect("write summary");
+            let output = run_dir
+                .read_step_output(run_dir::files::RESOURCE_SUMMARY)
+                .expect("resource summary json");
 
-        assert_eq!(output["label"], "lint");
-        assert_eq!(output["pid"], 7);
-        assert_eq!(output["warnings"].as_array().unwrap().len(), 2);
-        assert_eq!(output["extension_children"][0]["root_pid"], 99);
+            assert_eq!(output["label"], "lint");
+            assert_eq!(output["pid"], 7);
+            assert_eq!(output["warnings"].as_array().unwrap().len(), 2);
+            assert_eq!(output["extension_children"][0]["root_pid"], 99);
 
-        run_dir.cleanup();
+            run_dir.cleanup();
+        });
     }
 
     #[test]
     fn test_write_to_run_dir() {
-        let run_dir = RunDir::create().expect("run dir");
-        let resource_run = ResourceSummaryRun::start(Some("lint homeboy".to_string()));
+        with_isolated_home(|_| {
+            let run_dir = RunDir::create().expect("run dir");
+            let resource_run = ResourceSummaryRun::start(Some("lint homeboy".to_string()));
 
-        let summary = resource_run
-            .write_to_run_dir(&run_dir)
-            .expect("write resource summary");
-        let output = run_dir
-            .read_step_output(run_dir::files::RESOURCE_SUMMARY)
-            .expect("resource summary json");
+            let summary = resource_run
+                .write_to_run_dir(&run_dir)
+                .expect("write resource summary");
+            let output = run_dir
+                .read_step_output(run_dir::files::RESOURCE_SUMMARY)
+                .expect("resource summary json");
 
-        assert_eq!(summary.label.as_deref(), Some("lint homeboy"));
-        assert_eq!(output["label"], "lint homeboy");
-        assert_eq!(output["pid"], std::process::id());
-        assert!(output["duration_ms"].as_u64().is_some());
-        assert_eq!(output["platform"], std::env::consts::OS);
+            assert_eq!(summary.label.as_deref(), Some("lint homeboy"));
+            assert_eq!(output["label"], "lint homeboy");
+            assert_eq!(output["pid"], std::process::id());
+            assert!(output["duration_ms"].as_u64().is_some());
+            assert_eq!(output["platform"], std::env::consts::OS);
 
-        run_dir.cleanup();
+            run_dir.cleanup();
+        });
     }
 
     #[test]
     fn test_record_extension_child_resource() {
-        let run_dir = RunDir::create().expect("run dir");
-        let child = ExtensionChildResourceSummary {
-            child: ChildProcessIdentity {
-                root_pid: 123,
-                command_label: "extension-runner".to_string(),
-            },
-            started_at: "2026-04-30T00:00:00+00:00".to_string(),
-            finished_at: "2026-04-30T00:00:00.100+00:00".to_string(),
-            duration_ms: 100,
-            sampled_peak_rss_bytes: Some(4096),
-            sampled_peak_cpu_percent: Some(1.5),
-            warnings: vec!["probe_warning".to_string()],
-        };
+        with_isolated_home(|_| {
+            let run_dir = RunDir::create().expect("run dir");
+            let child = ExtensionChildResourceSummary {
+                child: ChildProcessIdentity {
+                    root_pid: 123,
+                    command_label: "extension-runner".to_string(),
+                },
+                started_at: "2026-04-30T00:00:00+00:00".to_string(),
+                finished_at: "2026-04-30T00:00:00.100+00:00".to_string(),
+                duration_ms: 100,
+                sampled_peak_rss_bytes: Some(4096),
+                sampled_peak_cpu_percent: Some(1.5),
+                warnings: vec!["probe_warning".to_string()],
+            };
 
-        record_extension_child_resource(run_dir.path(), &child).expect("record child resource");
-        let resource_run = ResourceSummaryRun::start(Some("test fixture".to_string()));
-        let summary = resource_run
-            .write_to_run_dir(&run_dir)
-            .expect("write resource summary");
+            record_extension_child_resource(run_dir.path(), &child).expect("record child resource");
+            let resource_run = ResourceSummaryRun::start(Some("test fixture".to_string()));
+            let summary = resource_run
+                .write_to_run_dir(&run_dir)
+                .expect("write resource summary");
 
-        assert_eq!(summary.extension_children, vec![child]);
-        let output = run_dir
-            .read_step_output(run_dir::files::RESOURCE_SUMMARY)
-            .expect("resource summary json");
-        assert_eq!(
-            output["extension_children"][0]["command_label"],
-            "extension-runner"
-        );
-        assert_eq!(
-            output["extension_children"][0]["sampled_peak_rss_bytes"],
-            4096
-        );
+            assert_eq!(summary.extension_children, vec![child]);
+            let output = run_dir
+                .read_step_output(run_dir::files::RESOURCE_SUMMARY)
+                .expect("resource summary json");
+            assert_eq!(
+                output["extension_children"][0]["command_label"],
+                "extension-runner"
+            );
+            assert_eq!(
+                output["extension_children"][0]["sampled_peak_rss_bytes"],
+                4096
+            );
 
-        run_dir.cleanup();
+            run_dir.cleanup();
+        });
     }
 }

--- a/src/core/engine/run_dir.rs
+++ b/src/core/engine/run_dir.rs
@@ -222,9 +222,11 @@ mod tests {
 
     #[test]
     fn test_path() {
-        let run_dir = RunDir::create().expect("should create run dir");
-        assert!(run_dir.path().is_dir());
-        run_dir.cleanup();
+        crate::test_support::with_isolated_home(|_| {
+            let run_dir = RunDir::create().expect("should create run dir");
+            assert!(run_dir.path().is_dir());
+            run_dir.cleanup();
+        });
     }
 
     #[test]

--- a/src/core/observation/store/schema.rs
+++ b/src/core/observation/store/schema.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use rusqlite::Connection;
 
@@ -110,10 +111,7 @@ const MIGRATIONS: &[Migration] = &[
     },
     Migration {
         version: 4,
-        sql: r#"
-        ALTER TABLE artifacts
-            ADD COLUMN artifact_type TEXT NOT NULL DEFAULT 'file';
-    "#,
+        sql: "",
     },
     Migration {
         version: 5,
@@ -192,11 +190,14 @@ pub(crate) fn apply_migrations(connection: &Connection) -> Result<()> {
         let tx = connection
             .unchecked_transaction()
             .map_err(sqlite_error("begin observation migration"))?;
-        tx.execute_batch(migration.sql)
-            .map_err(sqlite_error(format!(
-                "apply migration {}",
+        if migration_applied(&tx, migration.version)? {
+            tx.commit().map_err(sqlite_error(format!(
+                "commit migration {}",
                 migration.version
             )))?;
+            continue;
+        }
+        apply_migration_sql(&tx, migration)?;
         tx.execute(
             "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES (?1, ?2)",
             rusqlite::params![migration.version, chrono::Utc::now().to_rfc3339()],
@@ -229,10 +230,37 @@ pub(crate) fn status_for_open_connection(
 }
 
 pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
-    Connection::open(path).map_err(sqlite_error(format!(
+    let connection = Connection::open(path).map_err(sqlite_error(format!(
         "open observation store {}",
         path.display()
-    )))
+    )))?;
+    connection
+        .busy_timeout(Duration::from_secs(5))
+        .map_err(sqlite_error("configure observation store busy timeout"))?;
+    Ok(connection)
+}
+
+fn apply_migration_sql(connection: &Connection, migration: &Migration) -> Result<()> {
+    if migration.version == 4 {
+        if !column_exists(connection, "artifacts", "artifact_type")? {
+            connection
+                .execute_batch(
+                    r#"
+                    ALTER TABLE artifacts
+                        ADD COLUMN artifact_type TEXT NOT NULL DEFAULT 'file';
+                    "#,
+                )
+                .map_err(sqlite_error("apply migration 4"))?;
+        }
+        return Ok(());
+    }
+
+    connection
+        .execute_batch(migration.sql)
+        .map_err(sqlite_error(format!(
+            "apply migration {}",
+            migration.version
+        )))
 }
 
 fn migration_applied(connection: &Connection, version: i64) -> Result<bool> {
@@ -291,4 +319,20 @@ fn table_exists(connection: &Connection, table: &str) -> Result<bool> {
         )
         .map_err(sqlite_error(format!("check table {}", table)))?;
     Ok(count > 0)
+}
+
+fn column_exists(connection: &Connection, table: &str, column: &str) -> Result<bool> {
+    let mut statement = connection
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .map_err(sqlite_error(format!("inspect table {table}")))?;
+    let rows = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(sqlite_error(format!("list columns for {table}")))?;
+
+    for row in rows {
+        if row.map_err(sqlite_error(format!("read column for {table}")))? == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }

--- a/src/core/observation/store/schema.rs
+++ b/src/core/observation/store/schema.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use rusqlite::Connection;
@@ -149,6 +150,8 @@ const MIGRATIONS: &[Migration] = &[
     },
 ];
 
+static MIGRATION_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
 pub(crate) fn database_path() -> Result<PathBuf> {
     paths::observation_db()
 }
@@ -171,6 +174,13 @@ pub(crate) fn status() -> Result<ObservationDbStatus> {
 }
 
 pub(crate) fn apply_migrations(connection: &Connection) -> Result<()> {
+    let _guard = MIGRATION_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .map_err(|_| {
+            crate::core::Error::internal_unexpected("observation migration lock poisoned")
+        })?;
+
     connection
         .execute_batch(
             r#"

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -9,6 +9,7 @@ pub(crate) struct HomeGuard {
     prior_runtime_tmpdir: Option<String>,
     prior_invocation_runtime: Option<String>,
     dir: TempDir,
+    _runtime_dir: TempDir,
     /// Held alongside `dir` so the short invocation runtime tempdir is
     /// dropped only after the test completes. Distinct from `dir` so the
     /// invocation root can live on a short path (e.g. `/tmp/hb-XXXX`)
@@ -62,7 +63,8 @@ impl HomeGuard {
         std::env::set_var("HOME", dir.path());
         std::env::set_var("XDG_DATA_HOME", dir.path().join(".local").join("share"));
         std::env::remove_var("HOMEBOY_ARTIFACT_ROOT");
-        std::env::remove_var("HOMEBOY_RUNTIME_TMPDIR");
+        let runtime_dir = TempDir::new().expect("runtime tempdir");
+        std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", runtime_dir.path());
         crate::core::set_artifact_root_override(None);
         // Pin invocation runtime to a SHORT tempdir, isolated from `$TMPDIR`
         // and from the home tempdir (which itself can already live on a long
@@ -81,6 +83,7 @@ impl HomeGuard {
             prior_runtime_tmpdir,
             prior_invocation_runtime,
             dir,
+            _runtime_dir: runtime_dir,
             _inv_dir: Some(inv_dir),
             _guard: guard,
         }

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -12,6 +12,7 @@ use crate::core::observation::{
     RunRecord, RunStatus,
 };
 use crate::test_support::with_isolated_home;
+use std::sync::{Arc, Barrier};
 
 struct XdgGuard {
     prior: Option<String>,
@@ -125,6 +126,54 @@ fn initialization_is_idempotent() {
         assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
         assert_eq!(status.migration_count, 5);
         assert_eq!(status.table_count, 7);
+    });
+}
+
+#[test]
+fn initialization_recovers_when_artifact_type_migration_was_interrupted() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+
+        ObservationStore::open_initialized().expect("initial migration");
+        let path = store::database_path().expect("db path");
+        let connection = rusqlite::Connection::open(&path).expect("open raw db");
+        connection
+            .execute("DELETE FROM schema_migrations WHERE version = 4", [])
+            .expect("remove migration marker");
+        drop(connection);
+
+        let reopened = ObservationStore::open_initialized().expect("resume migration");
+        let status = reopened.status().expect("status");
+
+        assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
+        assert_eq!(status.migration_count, 5);
+    });
+}
+
+#[test]
+fn initialization_is_safe_under_concurrent_setup() {
+    with_isolated_home(|_home| {
+        let _xdg = XdgGuard::unset();
+        let workers = 4;
+        let barrier = Arc::new(Barrier::new(workers));
+        let handles = (0..workers)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    ObservationStore::open_initialized()
+                        .expect("concurrent init")
+                        .status()
+                        .expect("status")
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            let status = handle.join().expect("worker joined");
+            assert_eq!(status.schema_version, CURRENT_SCHEMA_VERSION);
+            assert_eq!(status.migration_count, 5);
+        }
     });
 }
 


### PR DESCRIPTION
## Summary
- Isolate Homeboy runtime temp dirs in the shared `with_isolated_home` test helper so run-dir artifacts do not collide with shared runtime state.
- Make observation-store migrations safer under interrupted or concurrent initialization by adding a SQLite busy timeout and idempotent handling for the `artifacts.artifact_type` migration.
- Add regression coverage for interrupted migration recovery, concurrent observation-store initialization, and run-dir resource artifact isolation.

Closes #3545.

## Verification
- `cargo fmt`
- `cargo test initialization_ -- --nocapture`
- `cargo test core::engine::resource::tests -- --nocapture`
- `cargo test export_ -- --nocapture`
- `cargo test` passed unit coverage, then failed in existing integration baseline drift: `tests/core_agnostic_test.rs::core_owned_source_stays_language_and_framework_agnostic` reports pre-existing core-boundary baseline findings in unrelated files.
- `./target/debug/homeboy test homeboy --path .` failed on the same existing `core_owned_source_stays_language_and_framework_agnostic` baseline drift after 3938 passed / 1 failed / 18 skipped.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the isolation and migration hardening patch, added regression tests, and ran local verification. Chris remains responsible for review and merge.