### PR TITLE
Expose rig run artifact indexes

### DIFF
--- a/src/commands/golden_contract_tests.rs
+++ b/src/commands/golden_contract_tests.rs
@@ -338,6 +338,7 @@ fn run_summary() -> RunSummary {
         command: Some("homeboy bench --format=json".to_string()),
         cwd: Some("/work/homeboy".to_string()),
         status_note: Some("fixture".to_string()),
+        artifact_index: None,
     }
 }
 

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+mod artifact_index_tests;
 mod bench;
 mod bundle;
 #[cfg(test)]
@@ -669,86 +671,6 @@ mod tests {
             };
             assert_eq!(output.runs.len(), 1);
             assert_eq!(output.runs[0].id, bench.id);
-        });
-    }
-
-    #[test]
-    fn rig_runs_list_surfaces_compact_artifact_index() {
-        with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("store");
-            let run = store
-                .start_run(sample_run(
-                    "rig",
-                    "homeboy",
-                    "proof-rig",
-                    serde_json::json!({
-                        "pipeline": {
-                            "name": "check",
-                            "steps": [
-                                {
-                                    "kind": "command",
-                                    "label": "produce proof report",
-                                    "status": "fail",
-                                    "error": "report failed"
-                                }
-                            ],
-                            "passed": 0,
-                            "failed": 1
-                        }
-                    }),
-                ))
-                .expect("rig run");
-            store
-                .finish_run(&run.id, RunStatus::Fail, None)
-                .expect("finish rig run");
-            let report = home.path().join("proof-report.json");
-            std::fs::write(&report, "{}").expect("report artifact");
-            store
-                .record_artifact(&run.id, "proof_report", &report)
-                .expect("record report");
-
-            let (output, _) = list_runs(
-                RunsListArgs {
-                    runner: None,
-                    kind: None,
-                    component_id: None,
-                    rig: Some("proof-rig".to_string()),
-                    status: None,
-                    limit: 20,
-                },
-                "rig.runs",
-            )
-            .expect("rig runs");
-
-            let RunsOutput::List(output) = output else {
-                panic!("expected list output");
-            };
-            assert_eq!(output.command, "rig.runs");
-            assert_eq!(output.runs.len(), 1);
-            let artifact_index = output.runs[0]
-                .artifact_index
-                .as_ref()
-                .expect("artifact index");
-            assert_eq!(artifact_index.run_id, run.id);
-            assert_eq!(artifact_index.rig_id, "proof-rig");
-            assert_eq!(artifact_index.status, "fail");
-            assert!(artifact_index
-                .artifact_index_path
-                .ends_with("rig-artifact-index.json"));
-            assert_eq!(
-                artifact_index.artifacts_command,
-                format!("homeboy runs artifacts {}", run.id)
-            );
-            assert!(artifact_index
-                .key_report_refs
-                .iter()
-                .any(|artifact| artifact.kind == "proof_report"));
-            assert_eq!(artifact_index.failed_step_refs.len(), 1);
-            assert_eq!(
-                artifact_index.failed_step_refs[0].label,
-                "produce proof report"
-            );
         });
     }
 

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -371,7 +371,7 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
             limit: Some(args.limit),
         })?
         .into_iter()
-        .map(run_summary)
+        .map(|run| run_summary_with_artifact_index(&store, run))
         .collect();
 
     Ok((RunsOutput::List(RunsListOutput { command, runs }), 0))
@@ -560,6 +560,15 @@ pub(crate) fn run_summary(run: RunRecord) -> RunSummary {
         command: run.command,
         cwd: run.cwd,
         status_note,
+        artifact_index: None,
+    }
+}
+
+fn run_summary_with_artifact_index(store: &ObservationStore, run: RunRecord) -> RunSummary {
+    let artifact_index = homeboy::core::rig::artifact_index_for_run(store, &run);
+    RunSummary {
+        artifact_index,
+        ..run_summary(run)
     }
 }
 
@@ -660,6 +669,86 @@ mod tests {
             };
             assert_eq!(output.runs.len(), 1);
             assert_eq!(output.runs[0].id, bench.id);
+        });
+    }
+
+    #[test]
+    fn rig_runs_list_surfaces_compact_artifact_index() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run(
+                    "rig",
+                    "homeboy",
+                    "proof-rig",
+                    serde_json::json!({
+                        "pipeline": {
+                            "name": "check",
+                            "steps": [
+                                {
+                                    "kind": "command",
+                                    "label": "produce proof report",
+                                    "status": "fail",
+                                    "error": "report failed"
+                                }
+                            ],
+                            "passed": 0,
+                            "failed": 1
+                        }
+                    }),
+                ))
+                .expect("rig run");
+            store
+                .finish_run(&run.id, RunStatus::Fail, None)
+                .expect("finish rig run");
+            let report = home.path().join("proof-report.json");
+            std::fs::write(&report, "{}").expect("report artifact");
+            store
+                .record_artifact(&run.id, "proof_report", &report)
+                .expect("record report");
+
+            let (output, _) = list_runs(
+                RunsListArgs {
+                    runner: None,
+                    kind: None,
+                    component_id: None,
+                    rig: Some("proof-rig".to_string()),
+                    status: None,
+                    limit: 20,
+                },
+                "rig.runs",
+            )
+            .expect("rig runs");
+
+            let RunsOutput::List(output) = output else {
+                panic!("expected list output");
+            };
+            assert_eq!(output.command, "rig.runs");
+            assert_eq!(output.runs.len(), 1);
+            let artifact_index = output.runs[0]
+                .artifact_index
+                .as_ref()
+                .expect("artifact index");
+            assert_eq!(artifact_index.run_id, run.id);
+            assert_eq!(artifact_index.rig_id, "proof-rig");
+            assert_eq!(artifact_index.status, "fail");
+            assert!(artifact_index
+                .artifact_index_path
+                .ends_with("rig-artifact-index.json"));
+            assert_eq!(
+                artifact_index.artifacts_command,
+                format!("homeboy runs artifacts {}", run.id)
+            );
+            assert!(artifact_index
+                .key_report_refs
+                .iter()
+                .any(|artifact| artifact.kind == "proof_report"));
+            assert_eq!(artifact_index.failed_step_refs.len(), 1);
+            assert_eq!(
+                artifact_index.failed_step_refs[0].label,
+                "produce proof report"
+            );
         });
     }
 

--- a/src/commands/runs/artifact_index_tests.rs
+++ b/src/commands/runs/artifact_index_tests.rs
@@ -1,0 +1,114 @@
+use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
+use homeboy::test_support::with_isolated_home;
+use serde_json::Value;
+
+use super::{list_runs, RunsListArgs, RunsOutput};
+
+struct XdgGuard(Option<String>);
+
+impl XdgGuard {
+    fn unset() -> Self {
+        let prior = std::env::var("XDG_DATA_HOME").ok();
+        std::env::remove_var("XDG_DATA_HOME");
+        Self(prior)
+    }
+}
+
+impl Drop for XdgGuard {
+    fn drop(&mut self) {
+        match &self.0 {
+            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+            None => std::env::remove_var("XDG_DATA_HOME"),
+        }
+    }
+}
+
+fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
+    NewRunRecord::builder(kind)
+        .component_id(component_id)
+        .command(format!("homeboy {kind} {component_id}"))
+        .cwd_path(std::path::Path::new("/tmp/homeboy-fixture"))
+        .homeboy_version("test-version")
+        .git_sha(Some("abc123".to_string()))
+        .rig_id(rig_id)
+        .metadata(metadata)
+        .build()
+}
+
+#[test]
+fn rig_runs_list_surfaces_compact_artifact_index() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(sample_run(
+                "rig",
+                "homeboy",
+                "proof-rig",
+                serde_json::json!({
+                    "pipeline": {
+                        "name": "check",
+                        "steps": [{
+                            "kind": "command",
+                            "label": "produce proof report",
+                            "status": "fail",
+                            "error": "report failed"
+                        }],
+                        "passed": 0,
+                        "failed": 1
+                    }
+                }),
+            ))
+            .expect("rig run");
+        store
+            .finish_run(&run.id, RunStatus::Fail, None)
+            .expect("finish rig run");
+        let report = home.path().join("proof-report.json");
+        std::fs::write(&report, "{}").expect("report artifact");
+        store
+            .record_artifact(&run.id, "proof_report", &report)
+            .expect("record report");
+
+        let (output, _) = list_runs(
+            RunsListArgs {
+                runner: None,
+                kind: None,
+                component_id: None,
+                rig: Some("proof-rig".to_string()),
+                status: None,
+                limit: 20,
+            },
+            "rig.runs",
+        )
+        .expect("rig runs");
+
+        let RunsOutput::List(output) = output else {
+            panic!("expected list output");
+        };
+        assert_eq!(output.command, "rig.runs");
+        assert_eq!(output.runs.len(), 1);
+        let artifact_index = output.runs[0]
+            .artifact_index
+            .as_ref()
+            .expect("artifact index");
+        assert_eq!(artifact_index.run_id, run.id);
+        assert_eq!(artifact_index.rig_id, "proof-rig");
+        assert_eq!(artifact_index.status, "fail");
+        assert!(artifact_index
+            .artifact_index_path
+            .ends_with("rig-artifact-index.json"));
+        assert_eq!(
+            artifact_index.artifacts_command,
+            format!("homeboy runs artifacts {}", run.id)
+        );
+        assert!(artifact_index
+            .key_report_refs
+            .iter()
+            .any(|artifact| artifact.kind == "proof_report"));
+        assert_eq!(artifact_index.failed_step_refs.len(), 1);
+        assert_eq!(
+            artifact_index.failed_step_refs[0].label,
+            "produce proof report"
+        );
+    });
+}

--- a/src/commands/runs/common.rs
+++ b/src/commands/runs/common.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use homeboy::core::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
+use homeboy::core::rig::RigRunArtifactIndex;
 use homeboy::core::runner::is_reportable_artifact_evidence_path;
 use homeboy::core::Error;
 use serde::{Deserialize, Serialize};
@@ -29,6 +30,8 @@ pub struct RunSummary {
     pub cwd: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_note: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_index: Option<RigRunArtifactIndex>,
 }
 
 /// Convert a `--since <duration>` flag value into an RFC-3339 timestamp.

--- a/src/commands/runs/compare.rs
+++ b/src/commands/runs/compare.rs
@@ -395,6 +395,7 @@ mod tests {
                     command: None,
                     cwd: None,
                     status_note: None,
+                    artifact_index: None,
                 },
                 artifact_count: 3,
                 scenario_id: None,

--- a/src/core/rig/artifact_index.rs
+++ b/src/core/rig/artifact_index.rs
@@ -1,0 +1,218 @@
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use super::pipeline::PipelineOutcome;
+use super::spec::RigSpec;
+use crate::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RigRunArtifactIndex {
+    pub run_id: String,
+    pub rig_id: String,
+    pub status: String,
+    pub artifact_root: String,
+    pub artifact_index_path: String,
+    pub artifact_index_command: String,
+    pub evidence_command: String,
+    pub artifacts_command: String,
+    pub export_command: String,
+    pub retrieval_commands: Vec<String>,
+    pub key_report_refs: Vec<RigRunArtifactRef>,
+    pub failed_step_refs: Vec<RigRunFailedStepRef>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RigRunArtifactRef {
+    pub id: String,
+    pub kind: String,
+    #[serde(rename = "type")]
+    pub artifact_type: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub get_command: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RigRunFailedStepRef {
+    pub pipeline: String,
+    pub kind: String,
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+pub fn for_completed_rig_run(
+    store: &ObservationStore,
+    rig: &RigSpec,
+    run_id: &str,
+    status: &str,
+    pipeline: Option<&PipelineOutcome>,
+) -> Option<RigRunArtifactIndex> {
+    let artifact_root = crate::core::artifact_root().ok()?;
+    let run_artifact_root = artifact_root.join(run_id);
+    let artifact_index_path = run_artifact_root.join("rig-artifact-index.json");
+    let artifacts = store.list_artifacts(run_id).unwrap_or_default();
+    let mut index = build(
+        &rig.id,
+        run_id,
+        status,
+        &artifact_root,
+        &artifact_index_path,
+        &artifacts,
+        pipeline.map(failed_step_refs).unwrap_or_default(),
+    );
+
+    write_index_file(&artifact_index_path, &index);
+    if let Ok(artifact) = store.record_artifact(run_id, "rig_artifact_index", &artifact_index_path)
+    {
+        index.key_report_refs.insert(0, artifact_ref(&artifact));
+    }
+    Some(index)
+}
+
+pub fn for_run(store: &ObservationStore, run: &RunRecord) -> Option<RigRunArtifactIndex> {
+    let rig_id = run.rig_id.as_ref()?;
+    if run.kind != "rig" {
+        return None;
+    }
+    let artifact_root = crate::core::artifact_root().ok()?;
+    let artifact_index_path = artifact_root.join(&run.id).join("rig-artifact-index.json");
+    let artifacts = store.list_artifacts(&run.id).unwrap_or_default();
+    Some(build(
+        rig_id,
+        &run.id,
+        &run.status,
+        &artifact_root,
+        &artifact_index_path,
+        &artifacts,
+        failed_step_refs_from_metadata(&run.metadata_json),
+    ))
+}
+
+fn build(
+    rig_id: &str,
+    run_id: &str,
+    status: &str,
+    artifact_root: &Path,
+    artifact_index_path: &Path,
+    artifacts: &[ArtifactRecord],
+    failed_step_refs: Vec<RigRunFailedStepRef>,
+) -> RigRunArtifactIndex {
+    let artifacts_command = format!("homeboy runs artifacts {run_id}");
+    let evidence_command = format!("homeboy runs evidence {run_id}");
+    let export_command = format!(
+        "homeboy runs export --run {run_id} --output ~/.local/share/homeboy/exports/{run_id}"
+    );
+    let key_report_refs = artifacts
+        .iter()
+        .filter(|artifact| artifact_is_key_report_ref(artifact))
+        .map(artifact_ref)
+        .collect::<Vec<_>>();
+    RigRunArtifactIndex {
+        run_id: run_id.to_string(),
+        rig_id: rig_id.to_string(),
+        status: status.to_string(),
+        artifact_root: artifact_root.display().to_string(),
+        artifact_index_path: artifact_index_path.display().to_string(),
+        artifact_index_command: artifacts_command.clone(),
+        evidence_command: evidence_command.clone(),
+        artifacts_command: artifacts_command.clone(),
+        export_command: export_command.clone(),
+        retrieval_commands: vec![artifacts_command, evidence_command, export_command],
+        key_report_refs,
+        failed_step_refs,
+    }
+}
+
+fn write_index_file(path: &Path, index: &RigRunArtifactIndex) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(bytes) = serde_json::to_vec_pretty(index) {
+        let _ = std::fs::write(path, bytes);
+    }
+}
+
+fn artifact_is_key_report_ref(artifact: &ArtifactRecord) -> bool {
+    [artifact.kind.as_str(), artifact.path.as_str()]
+        .iter()
+        .any(|value| {
+            let value = value.to_ascii_lowercase();
+            value.contains("report")
+                || value.contains("summary")
+                || value.contains("result")
+                || value.contains("evidence")
+                || value.contains("index")
+        })
+}
+
+fn artifact_ref(artifact: &ArtifactRecord) -> RigRunArtifactRef {
+    RigRunArtifactRef {
+        id: artifact.id.clone(),
+        kind: artifact.kind.clone(),
+        artifact_type: artifact.artifact_type.clone(),
+        path: artifact.path.clone(),
+        url: artifact
+            .url
+            .clone()
+            .or_else(|| (artifact.artifact_type == "url").then(|| artifact.path.clone())),
+        get_command: (artifact.artifact_type == "file").then(|| {
+            format!(
+                "homeboy runs artifact get {} {}",
+                artifact.run_id, artifact.id
+            )
+        }),
+    }
+}
+
+fn failed_step_refs(pipeline: &PipelineOutcome) -> Vec<RigRunFailedStepRef> {
+    pipeline
+        .steps
+        .iter()
+        .filter(|step| step.status == "fail")
+        .map(|step| RigRunFailedStepRef {
+            pipeline: pipeline.name.clone(),
+            kind: step.kind.clone(),
+            label: step.label.clone(),
+            error: step.error.clone(),
+        })
+        .collect()
+}
+
+fn failed_step_refs_from_metadata(metadata: &serde_json::Value) -> Vec<RigRunFailedStepRef> {
+    let Some(pipeline) = metadata.get("pipeline") else {
+        return Vec::new();
+    };
+    let pipeline_name = pipeline
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("pipeline")
+        .to_string();
+    pipeline
+        .get("steps")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|step| step.get("status").and_then(serde_json::Value::as_str) == Some("fail"))
+        .map(|step| RigRunFailedStepRef {
+            pipeline: pipeline_name.clone(),
+            kind: step
+                .get("kind")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("step")
+                .to_string(),
+            label: step
+                .get("label")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unnamed step")
+                .to_string(),
+            error: step
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+        })
+        .collect()
+}

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -18,6 +18,7 @@
 //! lifecycle automation, extension-registered service kinds, spec sharing.
 
 pub mod app;
+pub mod artifact_index;
 pub mod check;
 pub mod expand;
 pub mod install;
@@ -34,6 +35,9 @@ pub mod toolchain;
 pub mod workloads;
 
 pub use app::{AppLauncherAction, AppLauncherOptions, AppLauncherReport};
+pub use artifact_index::{
+    for_run as artifact_index_for_run, RigRunArtifactIndex, RigRunArtifactRef, RigRunFailedStepRef,
+};
 pub use install::{
     discover_rigs, discover_stacks, install, read_source_metadata, read_stack_source_metadata,
     DiscoveredRig, DiscoveredStack, InstalledStack, RigInstallResult, RigSourceMetadata,
@@ -42,10 +46,9 @@ pub use install::{
 pub use lease::{acquire_active_run_lease, active_run_leases, ActiveRigRunLease, RigRunLease};
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use runner::{
-    artifact_index_for_run, head_sha_and_branch, run_bench_prepare, run_check, run_check_groups,
-    run_down, run_repair, run_status, run_up, snapshot_state, BenchPrepareReport, CheckReport,
-    DownReport, RepairReport, RepairResourceReport, RigRunArtifactIndex, RigRunArtifactRef,
-    RigRunFailedStepRef, RigStatusReport, SymlinkStatusReport, SymlinkStatusState, UpReport,
+    head_sha_and_branch, run_bench_prepare, run_check, run_check_groups, run_down, run_repair,
+    run_status, run_up, snapshot_state, BenchPrepareReport, CheckReport, DownReport, RepairReport,
+    RepairResourceReport, RigStatusReport, SymlinkStatusReport, SymlinkStatusState, UpReport,
 };
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use source::{

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -42,9 +42,10 @@ pub use install::{
 pub use lease::{acquire_active_run_lease, active_run_leases, ActiveRigRunLease, RigRunLease};
 pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
 pub use runner::{
-    head_sha_and_branch, run_bench_prepare, run_check, run_check_groups, run_down, run_repair,
-    run_status, run_up, snapshot_state, BenchPrepareReport, CheckReport, DownReport, RepairReport,
-    RepairResourceReport, RigStatusReport, SymlinkStatusReport, SymlinkStatusState, UpReport,
+    artifact_index_for_run, head_sha_and_branch, run_bench_prepare, run_check, run_check_groups,
+    run_down, run_repair, run_status, run_up, snapshot_state, BenchPrepareReport, CheckReport,
+    DownReport, RepairReport, RepairResourceReport, RigRunArtifactIndex, RigRunArtifactRef,
+    RigRunFailedStepRef, RigStatusReport, SymlinkStatusReport, SymlinkStatusState, UpReport,
 };
 pub use service::{DiscoveredProcess, ServiceStatus};
 pub use source::{

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -6,7 +6,6 @@
 //! Every step emits a `PipelineStepOutcome`. The runner aggregates them into
 //! a `PipelineOutcome` with overall success/failure.
 
-use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -25,10 +24,6 @@ use super::state::{now_rfc3339, RigState, SharedPathState};
 use super::toolchain;
 use crate::core::component::Component;
 use crate::core::error::{Error, Result};
-
-thread_local! {
-    static COMMAND_ENV: RefCell<Vec<(String, String)>> = const { RefCell::new(Vec::new()) };
-}
 
 /// Result of one pipeline step.
 #[derive(Debug, Clone, Serialize)]
@@ -62,26 +57,6 @@ pub fn run_pipeline(rig: &RigSpec, name: &str, fail_fast: bool) -> Result<Pipeli
     let steps = rig.pipeline.get(name).cloned().unwrap_or_default();
     let ordered_indices = order_pipeline_steps(rig, name, &steps)?;
     run_ordered_steps(rig, name, &steps, ordered_indices, fail_fast)
-}
-
-pub fn with_command_env<T>(vars: Vec<(String, String)>, f: impl FnOnce() -> T) -> T {
-    COMMAND_ENV.with(|env| {
-        let prior = env.replace(vars);
-        let _guard = CommandEnvGuard { prior };
-        f()
-    })
-}
-
-struct CommandEnvGuard {
-    prior: Vec<(String, String)>,
-}
-
-impl Drop for CommandEnvGuard {
-    fn drop(&mut self) {
-        COMMAND_ENV.with(|env| {
-            env.replace(std::mem::take(&mut self.prior));
-        });
-    }
 }
 
 pub fn run_pipeline_check_groups(
@@ -588,12 +563,6 @@ fn run_command_step(
             command.env("PATH", path);
         }
     }
-
-    COMMAND_ENV.with(|vars| {
-        for (key, value) in vars.borrow().iter() {
-            command.env(key, value);
-        }
-    });
 
     for (k, v) in env {
         command.env(k, expand_vars(rig, v));

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -6,6 +6,7 @@
 //! Every step emits a `PipelineStepOutcome`. The runner aggregates them into
 //! a `PipelineOutcome` with overall success/failure.
 
+use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -24,6 +25,10 @@ use super::state::{now_rfc3339, RigState, SharedPathState};
 use super::toolchain;
 use crate::core::component::Component;
 use crate::core::error::{Error, Result};
+
+thread_local! {
+    static COMMAND_ENV: RefCell<Vec<(String, String)>> = const { RefCell::new(Vec::new()) };
+}
 
 /// Result of one pipeline step.
 #[derive(Debug, Clone, Serialize)]
@@ -57,6 +62,26 @@ pub fn run_pipeline(rig: &RigSpec, name: &str, fail_fast: bool) -> Result<Pipeli
     let steps = rig.pipeline.get(name).cloned().unwrap_or_default();
     let ordered_indices = order_pipeline_steps(rig, name, &steps)?;
     run_ordered_steps(rig, name, &steps, ordered_indices, fail_fast)
+}
+
+pub fn with_command_env<T>(vars: Vec<(String, String)>, f: impl FnOnce() -> T) -> T {
+    COMMAND_ENV.with(|env| {
+        let prior = env.replace(vars);
+        let _guard = CommandEnvGuard { prior };
+        f()
+    })
+}
+
+struct CommandEnvGuard {
+    prior: Vec<(String, String)>,
+}
+
+impl Drop for CommandEnvGuard {
+    fn drop(&mut self) {
+        COMMAND_ENV.with(|env| {
+            env.replace(std::mem::take(&mut self.prior));
+        });
+    }
 }
 
 pub fn run_pipeline_check_groups(
@@ -563,6 +588,12 @@ fn run_command_step(
             command.env("PATH", path);
         }
     }
+
+    COMMAND_ENV.with(|vars| {
+        for (key, value) in vars.borrow().iter() {
+            command.env(key, value);
+        }
+    });
 
     for (k, v) in env {
         command.env(k, expand_vars(rig, v));

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -7,7 +7,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::expand::{expand_resources, expand_vars};
 use super::lease::acquire_active_run_lease;
@@ -21,22 +21,70 @@ use super::state::{
 };
 use crate::core::engine::command::run_in_optional;
 use crate::core::error::{Error, Result};
-use crate::core::observation::{NewRunRecord, ObservationStore, RunStatus};
+use crate::core::observation::{
+    ArtifactRecord, NewRunRecord, ObservationStore, RunRecord, RunStatus,
+};
 
 /// Report from `rig up`.
 #[derive(Debug, Clone, Serialize)]
 pub struct UpReport {
     pub rig_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
     pub pipeline: PipelineOutcome,
     pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_index: Option<RigRunArtifactIndex>,
 }
 
 /// Report from `rig check`.
 #[derive(Debug, Clone, Serialize)]
 pub struct CheckReport {
     pub rig_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
     pub pipeline: PipelineOutcome,
     pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_index: Option<RigRunArtifactIndex>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RigRunArtifactIndex {
+    pub run_id: String,
+    pub rig_id: String,
+    pub status: String,
+    pub artifact_root: String,
+    pub artifact_index_path: String,
+    pub artifact_index_command: String,
+    pub evidence_command: String,
+    pub artifacts_command: String,
+    pub export_command: String,
+    pub retrieval_commands: Vec<String>,
+    pub key_report_refs: Vec<RigRunArtifactRef>,
+    pub failed_step_refs: Vec<RigRunFailedStepRef>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RigRunArtifactRef {
+    pub id: String,
+    pub kind: String,
+    #[serde(rename = "type")]
+    pub artifact_type: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub get_command: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RigRunFailedStepRef {
+    pub pipeline: String,
+    pub kind: String,
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 /// Report from a bench preparation pipeline.
@@ -129,8 +177,11 @@ pub enum SymlinkStatusState {
 pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
     let _lease = acquire_active_run_lease(rig, "up")?;
     let observer = RigRunObserver::start(rig, "up");
+    let command_env = observer
+        .as_ref()
+        .and_then(|observer| rig_run_command_env(rig, &observer.run_id));
 
-    let result = (|| {
+    let mut result = super::pipeline::with_command_env(command_env.unwrap_or_default(), || {
         let outcome = run_pipeline(rig, "up", true)?;
 
         if outcome.is_success() {
@@ -149,17 +200,23 @@ pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
 
         Ok(UpReport {
             rig_id: rig.id.clone(),
+            run_id: None,
             success: outcome.is_success(),
             pipeline: outcome,
+            artifact_index: None,
         })
-    })();
+    });
 
-    RigRunObserver::finish(
+    let artifact_index = RigRunObserver::finish(
         observer.as_ref(),
         rig,
         result.as_ref().ok().map(|report| &report.pipeline),
         &result,
     );
+    if let Ok(report) = result.as_mut() {
+        report.run_id = observer.as_ref().map(|observer| observer.run_id.clone());
+        report.artifact_index = artifact_index;
+    }
     result
 }
 
@@ -167,8 +224,11 @@ pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
 /// failing check so the user can fix them all in one pass.
 pub fn run_check(rig: &RigSpec) -> Result<CheckReport> {
     let observer = RigRunObserver::start(rig, "check");
+    let command_env = observer
+        .as_ref()
+        .and_then(|observer| rig_run_command_env(rig, &observer.run_id));
 
-    let result = (|| {
+    let mut result = super::pipeline::with_command_env(command_env.unwrap_or_default(), || {
         let outcome = run_pipeline(rig, "check", false)?;
 
         let mut state = RigState::load(&rig.id)?;
@@ -179,17 +239,23 @@ pub fn run_check(rig: &RigSpec) -> Result<CheckReport> {
 
         Ok(CheckReport {
             rig_id: rig.id.clone(),
+            run_id: None,
             success: outcome.is_success(),
             pipeline: outcome,
+            artifact_index: None,
         })
-    })();
+    });
 
-    RigRunObserver::finish(
+    let artifact_index = RigRunObserver::finish(
         observer.as_ref(),
         rig,
         result.as_ref().ok().map(|report| &report.pipeline),
         &result,
     );
+    if let Ok(report) = result.as_mut() {
+        report.run_id = observer.as_ref().map(|observer| observer.run_id.clone());
+        report.artifact_index = artifact_index;
+    }
     result
 }
 
@@ -202,8 +268,10 @@ pub fn run_check_groups(rig: &RigSpec, groups: &[String]) -> Result<CheckReport>
 
     Ok(CheckReport {
         rig_id: rig.id.clone(),
+        run_id: None,
         success: outcome.is_success(),
         pipeline: outcome,
+        artifact_index: None,
     })
 }
 
@@ -575,9 +643,9 @@ impl RigRunObserver {
         rig: &RigSpec,
         pipeline: Option<&PipelineOutcome>,
         result: &Result<T>,
-    ) {
+    ) -> Option<RigRunArtifactIndex> {
         let Some(observer) = observer else {
-            return;
+            return None;
         };
         let status = match result {
             Ok(_) if pipeline.is_some_and(PipelineOutcome::is_success) => RunStatus::Pass,
@@ -591,7 +659,211 @@ impl RigRunObserver {
         let _ = observer
             .store
             .finish_run(&observer.run_id, status, Some(metadata));
+        rig_run_artifact_index(
+            &observer.store,
+            rig,
+            &observer.run_id,
+            status.as_str(),
+            pipeline,
+        )
     }
+}
+
+fn rig_run_artifact_index(
+    store: &ObservationStore,
+    rig: &RigSpec,
+    run_id: &str,
+    status: &str,
+    pipeline: Option<&PipelineOutcome>,
+) -> Option<RigRunArtifactIndex> {
+    let artifact_root = crate::core::artifact_root().ok()?;
+    let run_artifact_root = artifact_root.join(run_id);
+    let artifact_index_path = run_artifact_root.join("rig-artifact-index.json");
+    let artifacts = store.list_artifacts(run_id).unwrap_or_default();
+    let mut index = build_rig_run_artifact_index(
+        &rig.id,
+        run_id,
+        status,
+        &artifact_root,
+        &artifact_index_path,
+        &artifacts,
+        pipeline.map(failed_step_refs).unwrap_or_default(),
+    );
+
+    write_rig_artifact_index_file(&artifact_index_path, &index);
+    if let Ok(artifact) = store.record_artifact(run_id, "rig_artifact_index", &artifact_index_path)
+    {
+        index
+            .key_report_refs
+            .insert(0, rig_run_artifact_ref(&artifact));
+    }
+    Some(index)
+}
+
+fn rig_run_command_env(rig: &RigSpec, run_id: &str) -> Option<Vec<(String, String)>> {
+    let artifact_root = crate::core::artifact_root().ok()?;
+    let run_artifact_root = artifact_root.join(run_id);
+    let artifact_index_path = run_artifact_root.join("rig-artifact-index.json");
+    Some(vec![
+        ("HOMEBOY_RIG_ID".to_string(), rig.id.clone()),
+        ("HOMEBOY_RUN_ID".to_string(), run_id.to_string()),
+        ("HOMEBOY_RIG_RUN_ID".to_string(), run_id.to_string()),
+        (
+            "HOMEBOY_RIG_ARTIFACT_ROOT".to_string(),
+            run_artifact_root.display().to_string(),
+        ),
+        (
+            "HOMEBOY_RIG_ARTIFACT_INDEX".to_string(),
+            artifact_index_path.display().to_string(),
+        ),
+    ])
+}
+
+pub fn artifact_index_for_run(
+    store: &ObservationStore,
+    run: &RunRecord,
+) -> Option<RigRunArtifactIndex> {
+    let rig_id = run.rig_id.as_ref()?;
+    if run.kind != "rig" {
+        return None;
+    }
+    let artifact_root = crate::core::artifact_root().ok()?;
+    let artifact_index_path = artifact_root.join(&run.id).join("rig-artifact-index.json");
+    let artifacts = store.list_artifacts(&run.id).unwrap_or_default();
+    Some(build_rig_run_artifact_index(
+        rig_id,
+        &run.id,
+        &run.status,
+        &artifact_root,
+        &artifact_index_path,
+        &artifacts,
+        failed_step_refs_from_metadata(&run.metadata_json),
+    ))
+}
+
+fn build_rig_run_artifact_index(
+    rig_id: &str,
+    run_id: &str,
+    status: &str,
+    artifact_root: &Path,
+    artifact_index_path: &Path,
+    artifacts: &[ArtifactRecord],
+    failed_step_refs: Vec<RigRunFailedStepRef>,
+) -> RigRunArtifactIndex {
+    let artifacts_command = format!("homeboy runs artifacts {run_id}");
+    let evidence_command = format!("homeboy runs evidence {run_id}");
+    let export_command = format!(
+        "homeboy runs export --run {run_id} --output ~/.local/share/homeboy/exports/{run_id}"
+    );
+    let key_report_refs = artifacts
+        .iter()
+        .filter(|artifact| artifact_is_key_report_ref(artifact))
+        .map(rig_run_artifact_ref)
+        .collect::<Vec<_>>();
+    RigRunArtifactIndex {
+        run_id: run_id.to_string(),
+        rig_id: rig_id.to_string(),
+        status: status.to_string(),
+        artifact_root: artifact_root.display().to_string(),
+        artifact_index_path: artifact_index_path.display().to_string(),
+        artifact_index_command: artifacts_command.clone(),
+        evidence_command: evidence_command.clone(),
+        artifacts_command: artifacts_command.clone(),
+        export_command: export_command.clone(),
+        retrieval_commands: vec![artifacts_command, evidence_command, export_command],
+        key_report_refs,
+        failed_step_refs,
+    }
+}
+
+fn write_rig_artifact_index_file(path: &Path, index: &RigRunArtifactIndex) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(bytes) = serde_json::to_vec_pretty(index) {
+        let _ = std::fs::write(path, bytes);
+    }
+}
+
+fn artifact_is_key_report_ref(artifact: &ArtifactRecord) -> bool {
+    [artifact.kind.as_str(), artifact.path.as_str()]
+        .iter()
+        .any(|value| {
+            let value = value.to_ascii_lowercase();
+            value.contains("report")
+                || value.contains("summary")
+                || value.contains("result")
+                || value.contains("evidence")
+                || value.contains("index")
+        })
+}
+
+fn rig_run_artifact_ref(artifact: &ArtifactRecord) -> RigRunArtifactRef {
+    RigRunArtifactRef {
+        id: artifact.id.clone(),
+        kind: artifact.kind.clone(),
+        artifact_type: artifact.artifact_type.clone(),
+        path: artifact.path.clone(),
+        url: artifact
+            .url
+            .clone()
+            .or_else(|| (artifact.artifact_type == "url").then(|| artifact.path.clone())),
+        get_command: (artifact.artifact_type == "file").then(|| {
+            format!(
+                "homeboy runs artifact get {} {}",
+                artifact.run_id, artifact.id
+            )
+        }),
+    }
+}
+
+fn failed_step_refs(pipeline: &PipelineOutcome) -> Vec<RigRunFailedStepRef> {
+    pipeline
+        .steps
+        .iter()
+        .filter(|step| step.status == "fail")
+        .map(|step| RigRunFailedStepRef {
+            pipeline: pipeline.name.clone(),
+            kind: step.kind.clone(),
+            label: step.label.clone(),
+            error: step.error.clone(),
+        })
+        .collect()
+}
+
+fn failed_step_refs_from_metadata(metadata: &serde_json::Value) -> Vec<RigRunFailedStepRef> {
+    let Some(pipeline) = metadata.get("pipeline") else {
+        return Vec::new();
+    };
+    let pipeline_name = pipeline
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("pipeline")
+        .to_string();
+    pipeline
+        .get("steps")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|step| step.get("status").and_then(serde_json::Value::as_str) == Some("fail"))
+        .map(|step| RigRunFailedStepRef {
+            pipeline: pipeline_name.clone(),
+            kind: step
+                .get("kind")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("step")
+                .to_string(),
+            label: step
+                .get("label")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unnamed step")
+                .to_string(),
+            error: step
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+        })
+        .collect()
 }
 
 fn rig_observation_metadata(

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -7,7 +7,9 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
+
+use super::artifact_index::{self, RigRunArtifactIndex};
 
 use super::expand::{expand_resources, expand_vars};
 use super::lease::acquire_active_run_lease;
@@ -21,9 +23,7 @@ use super::state::{
 };
 use crate::core::engine::command::run_in_optional;
 use crate::core::error::{Error, Result};
-use crate::core::observation::{
-    ArtifactRecord, NewRunRecord, ObservationStore, RunRecord, RunStatus,
-};
+use crate::core::observation::{NewRunRecord, ObservationStore, RunStatus};
 
 /// Report from `rig up`.
 #[derive(Debug, Clone, Serialize)]
@@ -47,44 +47,6 @@ pub struct CheckReport {
     pub success: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub artifact_index: Option<RigRunArtifactIndex>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RigRunArtifactIndex {
-    pub run_id: String,
-    pub rig_id: String,
-    pub status: String,
-    pub artifact_root: String,
-    pub artifact_index_path: String,
-    pub artifact_index_command: String,
-    pub evidence_command: String,
-    pub artifacts_command: String,
-    pub export_command: String,
-    pub retrieval_commands: Vec<String>,
-    pub key_report_refs: Vec<RigRunArtifactRef>,
-    pub failed_step_refs: Vec<RigRunFailedStepRef>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RigRunArtifactRef {
-    pub id: String,
-    pub kind: String,
-    #[serde(rename = "type")]
-    pub artifact_type: String,
-    pub path: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub get_command: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RigRunFailedStepRef {
-    pub pipeline: String,
-    pub kind: String,
-    pub label: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
 }
 
 /// Report from a bench preparation pipeline.
@@ -177,11 +139,8 @@ pub enum SymlinkStatusState {
 pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
     let _lease = acquire_active_run_lease(rig, "up")?;
     let observer = RigRunObserver::start(rig, "up");
-    let command_env = observer
-        .as_ref()
-        .and_then(|observer| rig_run_command_env(rig, &observer.run_id));
 
-    let mut result = super::pipeline::with_command_env(command_env.unwrap_or_default(), || {
+    let mut result = (|| {
         let outcome = run_pipeline(rig, "up", true)?;
 
         if outcome.is_success() {
@@ -205,7 +164,7 @@ pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
             pipeline: outcome,
             artifact_index: None,
         })
-    });
+    })();
 
     let artifact_index = RigRunObserver::finish(
         observer.as_ref(),
@@ -224,11 +183,8 @@ pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
 /// failing check so the user can fix them all in one pass.
 pub fn run_check(rig: &RigSpec) -> Result<CheckReport> {
     let observer = RigRunObserver::start(rig, "check");
-    let command_env = observer
-        .as_ref()
-        .and_then(|observer| rig_run_command_env(rig, &observer.run_id));
 
-    let mut result = super::pipeline::with_command_env(command_env.unwrap_or_default(), || {
+    let mut result = (|| {
         let outcome = run_pipeline(rig, "check", false)?;
 
         let mut state = RigState::load(&rig.id)?;
@@ -244,7 +200,7 @@ pub fn run_check(rig: &RigSpec) -> Result<CheckReport> {
             pipeline: outcome,
             artifact_index: None,
         })
-    });
+    })();
 
     let artifact_index = RigRunObserver::finish(
         observer.as_ref(),
@@ -659,7 +615,7 @@ impl RigRunObserver {
         let _ = observer
             .store
             .finish_run(&observer.run_id, status, Some(metadata));
-        rig_run_artifact_index(
+        artifact_index::for_completed_rig_run(
             &observer.store,
             rig,
             &observer.run_id,
@@ -667,203 +623,6 @@ impl RigRunObserver {
             pipeline,
         )
     }
-}
-
-fn rig_run_artifact_index(
-    store: &ObservationStore,
-    rig: &RigSpec,
-    run_id: &str,
-    status: &str,
-    pipeline: Option<&PipelineOutcome>,
-) -> Option<RigRunArtifactIndex> {
-    let artifact_root = crate::core::artifact_root().ok()?;
-    let run_artifact_root = artifact_root.join(run_id);
-    let artifact_index_path = run_artifact_root.join("rig-artifact-index.json");
-    let artifacts = store.list_artifacts(run_id).unwrap_or_default();
-    let mut index = build_rig_run_artifact_index(
-        &rig.id,
-        run_id,
-        status,
-        &artifact_root,
-        &artifact_index_path,
-        &artifacts,
-        pipeline.map(failed_step_refs).unwrap_or_default(),
-    );
-
-    write_rig_artifact_index_file(&artifact_index_path, &index);
-    if let Ok(artifact) = store.record_artifact(run_id, "rig_artifact_index", &artifact_index_path)
-    {
-        index
-            .key_report_refs
-            .insert(0, rig_run_artifact_ref(&artifact));
-    }
-    Some(index)
-}
-
-fn rig_run_command_env(rig: &RigSpec, run_id: &str) -> Option<Vec<(String, String)>> {
-    let artifact_root = crate::core::artifact_root().ok()?;
-    let run_artifact_root = artifact_root.join(run_id);
-    let artifact_index_path = run_artifact_root.join("rig-artifact-index.json");
-    Some(vec![
-        ("HOMEBOY_RIG_ID".to_string(), rig.id.clone()),
-        ("HOMEBOY_RUN_ID".to_string(), run_id.to_string()),
-        ("HOMEBOY_RIG_RUN_ID".to_string(), run_id.to_string()),
-        (
-            "HOMEBOY_RIG_ARTIFACT_ROOT".to_string(),
-            run_artifact_root.display().to_string(),
-        ),
-        (
-            "HOMEBOY_RIG_ARTIFACT_INDEX".to_string(),
-            artifact_index_path.display().to_string(),
-        ),
-    ])
-}
-
-pub fn artifact_index_for_run(
-    store: &ObservationStore,
-    run: &RunRecord,
-) -> Option<RigRunArtifactIndex> {
-    let rig_id = run.rig_id.as_ref()?;
-    if run.kind != "rig" {
-        return None;
-    }
-    let artifact_root = crate::core::artifact_root().ok()?;
-    let artifact_index_path = artifact_root.join(&run.id).join("rig-artifact-index.json");
-    let artifacts = store.list_artifacts(&run.id).unwrap_or_default();
-    Some(build_rig_run_artifact_index(
-        rig_id,
-        &run.id,
-        &run.status,
-        &artifact_root,
-        &artifact_index_path,
-        &artifacts,
-        failed_step_refs_from_metadata(&run.metadata_json),
-    ))
-}
-
-fn build_rig_run_artifact_index(
-    rig_id: &str,
-    run_id: &str,
-    status: &str,
-    artifact_root: &Path,
-    artifact_index_path: &Path,
-    artifacts: &[ArtifactRecord],
-    failed_step_refs: Vec<RigRunFailedStepRef>,
-) -> RigRunArtifactIndex {
-    let artifacts_command = format!("homeboy runs artifacts {run_id}");
-    let evidence_command = format!("homeboy runs evidence {run_id}");
-    let export_command = format!(
-        "homeboy runs export --run {run_id} --output ~/.local/share/homeboy/exports/{run_id}"
-    );
-    let key_report_refs = artifacts
-        .iter()
-        .filter(|artifact| artifact_is_key_report_ref(artifact))
-        .map(rig_run_artifact_ref)
-        .collect::<Vec<_>>();
-    RigRunArtifactIndex {
-        run_id: run_id.to_string(),
-        rig_id: rig_id.to_string(),
-        status: status.to_string(),
-        artifact_root: artifact_root.display().to_string(),
-        artifact_index_path: artifact_index_path.display().to_string(),
-        artifact_index_command: artifacts_command.clone(),
-        evidence_command: evidence_command.clone(),
-        artifacts_command: artifacts_command.clone(),
-        export_command: export_command.clone(),
-        retrieval_commands: vec![artifacts_command, evidence_command, export_command],
-        key_report_refs,
-        failed_step_refs,
-    }
-}
-
-fn write_rig_artifact_index_file(path: &Path, index: &RigRunArtifactIndex) {
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    if let Ok(bytes) = serde_json::to_vec_pretty(index) {
-        let _ = std::fs::write(path, bytes);
-    }
-}
-
-fn artifact_is_key_report_ref(artifact: &ArtifactRecord) -> bool {
-    [artifact.kind.as_str(), artifact.path.as_str()]
-        .iter()
-        .any(|value| {
-            let value = value.to_ascii_lowercase();
-            value.contains("report")
-                || value.contains("summary")
-                || value.contains("result")
-                || value.contains("evidence")
-                || value.contains("index")
-        })
-}
-
-fn rig_run_artifact_ref(artifact: &ArtifactRecord) -> RigRunArtifactRef {
-    RigRunArtifactRef {
-        id: artifact.id.clone(),
-        kind: artifact.kind.clone(),
-        artifact_type: artifact.artifact_type.clone(),
-        path: artifact.path.clone(),
-        url: artifact
-            .url
-            .clone()
-            .or_else(|| (artifact.artifact_type == "url").then(|| artifact.path.clone())),
-        get_command: (artifact.artifact_type == "file").then(|| {
-            format!(
-                "homeboy runs artifact get {} {}",
-                artifact.run_id, artifact.id
-            )
-        }),
-    }
-}
-
-fn failed_step_refs(pipeline: &PipelineOutcome) -> Vec<RigRunFailedStepRef> {
-    pipeline
-        .steps
-        .iter()
-        .filter(|step| step.status == "fail")
-        .map(|step| RigRunFailedStepRef {
-            pipeline: pipeline.name.clone(),
-            kind: step.kind.clone(),
-            label: step.label.clone(),
-            error: step.error.clone(),
-        })
-        .collect()
-}
-
-fn failed_step_refs_from_metadata(metadata: &serde_json::Value) -> Vec<RigRunFailedStepRef> {
-    let Some(pipeline) = metadata.get("pipeline") else {
-        return Vec::new();
-    };
-    let pipeline_name = pipeline
-        .get("name")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("pipeline")
-        .to_string();
-    pipeline
-        .get("steps")
-        .and_then(serde_json::Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter(|step| step.get("status").and_then(serde_json::Value::as_str) == Some("fail"))
-        .map(|step| RigRunFailedStepRef {
-            pipeline: pipeline_name.clone(),
-            kind: step
-                .get("kind")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("step")
-                .to_string(),
-            label: step
-                .get("label")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("unnamed step")
-                .to_string(),
-            error: step
-                .get("error")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_string),
-        })
-        .collect()
 }
 
 fn rig_observation_metadata(

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -109,7 +109,7 @@ fn test_run_check_persists_failing_observation() {
             vec![PipelineStep::Command {
                 step_id: None,
                 depends_on: Vec::new(),
-                cmd: "test -n \"$HOMEBOY_RUN_ID\" && test -n \"$HOMEBOY_RIG_ARTIFACT_INDEX\" && exit 1 || exit 2".to_string(),
+                cmd: "false".to_string(),
                 cwd: None,
                 env: HashMap::new(),
                 label: Some("intentional check failure".to_string()),

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -109,7 +109,7 @@ fn test_run_check_persists_failing_observation() {
             vec![PipelineStep::Command {
                 step_id: None,
                 depends_on: Vec::new(),
-                cmd: "false".to_string(),
+                cmd: "test -n \"$HOMEBOY_RUN_ID\" && test -n \"$HOMEBOY_RIG_ARTIFACT_INDEX\" && exit 1 || exit 2".to_string(),
                 cwd: None,
                 env: HashMap::new(),
                 label: Some("intentional check failure".to_string()),
@@ -118,10 +118,47 @@ fn test_run_check_persists_failing_observation() {
 
         let report = run_check(&rig).expect("check returns failed report");
         assert!(!report.success);
+        let run_id = report.run_id.as_deref().expect("run id exposed");
+        let artifact_index = report
+            .artifact_index
+            .as_ref()
+            .expect("artifact index exposed");
+        assert_eq!(artifact_index.run_id, run_id);
+        assert_eq!(artifact_index.rig_id, rig.id);
+        assert_eq!(artifact_index.status, "fail");
+        assert!(artifact_index
+            .artifact_index_path
+            .ends_with("rig-artifact-index.json"));
+        assert!(std::path::Path::new(&artifact_index.artifact_index_path).is_file());
+        assert_eq!(
+            artifact_index.artifacts_command,
+            format!("homeboy runs artifacts {run_id}")
+        );
+        assert!(artifact_index
+            .retrieval_commands
+            .contains(&format!("homeboy runs evidence {run_id}")));
+        assert_eq!(artifact_index.failed_step_refs.len(), 1);
+        assert_eq!(artifact_index.failed_step_refs[0].pipeline, "check");
+        assert_eq!(artifact_index.failed_step_refs[0].kind, "command");
+        assert_eq!(
+            artifact_index.failed_step_refs[0].label,
+            "intentional check failure"
+        );
+        assert!(artifact_index
+            .key_report_refs
+            .iter()
+            .any(|artifact| artifact.kind == "rig_artifact_index"));
 
         let runs = list_rig_runs(&rig.id);
         assert_eq!(runs.len(), 1);
         let run = &runs[0];
+        let persisted_index = crate::core::rig::artifact_index_for_run(
+            &ObservationStore::open_initialized().expect("store"),
+            run,
+        )
+        .expect("persisted run artifact index");
+        assert_eq!(persisted_index.run_id, run_id);
+        assert_eq!(persisted_index.failed_step_refs.len(), 1);
         assert_eq!(run.status, "fail");
         assert_eq!(run.metadata_json["pipeline"]["failed"], 1);
         assert_eq!(

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -79,8 +79,10 @@ fn unix_symlink(target: &std::path::Path, link: &std::path::Path) {
 fn test_up_report_serializes_success_flag() {
     let report = UpReport {
         rig_id: "test".to_string(),
+        run_id: None,
         pipeline: empty_pipeline("up"),
         success: true,
+        artifact_index: None,
     };
     let json = serde_json::to_string(&report).expect("serialize");
     assert!(json.contains("\"rig_id\":\"test\""));
@@ -91,8 +93,10 @@ fn test_up_report_serializes_success_flag() {
 fn test_check_report_serializes_success_flag() {
     let report = CheckReport {
         rig_id: "test".to_string(),
+        run_id: None,
         pipeline: empty_pipeline("check"),
         success: false,
+        artifact_index: None,
     };
     let json = serde_json::to_string(&report).expect("serialize");
     assert!(json.contains("\"success\":false"));


### PR DESCRIPTION
## Summary
- Add a generic rig run artifact index to `rig up` and `rig check` outputs with run id, rig id, status, artifact root/index path, retrieval commands, key report refs, and failed step refs.
- Surface the same compact index from `rig runs` by enriching local rig run summaries from the existing observation store and artifact records.
- Keep the artifact-index implementation in a generic rig module so Homeboy core does not learn package-specific proof-rig semantics.

Closes #3560.

## Verification
- `cargo fmt && cargo check`
- `cargo test test_run_check_persists_failing_observation`
- `cargo test commands::runs::tests::rig_runs_list_surfaces_compact_artifact_index`
- `cargo test runs_rig_and_bench_output_variants_have_unambiguous_contracts`
- Earlier `cargo test` reached the full library suite successfully (`3931 passed; 0 failed; 18 ignored`) but then failed in `tests/core_agnostic_test.rs` on existing baseline core-boundary findings in unrelated files such as `src/core/defaults/builtins.rs`, `src/core/component/mod.rs`, and `src/commands/doctor/resources.rs`. This PR does not modify those reported files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the generic rig artifact index plumbing, adding focused Rust coverage, and running verification. Chris remains responsible for review and merge.