### PR TITLE
Fix release prepare lockfile dirtiness

### DIFF
--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -511,6 +511,7 @@ fn guard_step_dirty_side_effects(
 
     let after = tracked_dirty_snapshot(&context.component.local_path)?;
     let introduced: Vec<String> = after.difference(&before).cloned().collect();
+    let introduced = release_step_unexpected_dirty_files(step, context, introduced)?;
     if introduced.is_empty() {
         return Ok(result);
     }
@@ -523,6 +524,46 @@ fn release_step_dirty_side_effects_are_guarded(step: &PlanStep) -> bool {
         step.kind.as_str(),
         "preflight.lint" | "preflight.test" | "preflight.package" | "release.prepare" | "package"
     )
+}
+
+fn release_step_unexpected_dirty_files(
+    step: &PlanStep,
+    context: &ReleaseExecutionContext,
+    files: Vec<String>,
+) -> Result<Vec<String>> {
+    if step.kind != "release.prepare" {
+        return Ok(files);
+    }
+
+    let allowed = release_prepare_allowed_dirty_files(context.component)?;
+    Ok(files
+        .into_iter()
+        .filter(|file| !allowed.iter().any(|allowed| file == allowed))
+        .collect())
+}
+
+fn release_prepare_allowed_dirty_files(
+    component: &crate::core::component::Component,
+) -> Result<Vec<String>> {
+    let changelog_path = super::changelog::resolve_changelog_path(component)?;
+    let version_targets = component
+        .version_targets
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|target| {
+            std::path::Path::new(&component.local_path)
+                .join(&target.file)
+                .to_string_lossy()
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+
+    Ok(super::planning_worktree::get_release_allowed_files(
+        &changelog_path,
+        &version_targets,
+        std::path::Path::new(&component.local_path),
+    ))
 }
 
 fn tracked_dirty_snapshot(path: &str) -> Result<BTreeSet<String>> {
@@ -581,7 +622,7 @@ fn dirty_side_effect_failure(step: &PlanStep, files: Vec<String>) -> ReleaseStep
 mod tests {
     use super::{
         execute_release_plan_step, release_step_is_plan_only, release_step_is_show_stopper,
-        ReleaseExecutionContext,
+        release_step_unexpected_dirty_files, ReleaseExecutionContext,
     };
     use crate::core::component::{Component, ComponentScriptsConfig, VersionTarget};
     use crate::core::plan::PlanStep;
@@ -891,6 +932,45 @@ mod tests {
             .hints
             .iter()
             .any(|hint| hint.message.contains("Fix the build/test/package step")));
+    }
+
+    #[test]
+    fn release_prepare_dirty_guard_allows_release_owned_lockfiles() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: root.to_string_lossy().to_string(),
+            changelog_target: Some("docs/changelog.md".to_string()),
+            version_targets: Some(vec![VersionTarget {
+                file: "Cargo.toml".to_string(),
+                pattern: None,
+            }]),
+            ..Default::default()
+        };
+        let options = ReleaseOptions::default();
+        let context = ReleaseExecutionContext {
+            component: &component,
+            extensions: &[],
+            component_id: "fixture",
+            options: &options,
+            state: ReleaseState::default(),
+            publish_failed: false,
+        };
+
+        let unexpected = release_step_unexpected_dirty_files(
+            &plan_step("release.prepare"),
+            &context,
+            vec![
+                "Cargo.lock".to_string(),
+                "Cargo.toml".to_string(),
+                "docs/changelog.md".to_string(),
+                "src/lib.rs".to_string(),
+            ],
+        )
+        .expect("guard should classify dirty files");
+
+        assert_eq!(unexpected, vec!["src/lib.rs"]);
     }
 
     #[test]

--- a/src/core/release/planning_worktree.rs
+++ b/src/core/release/planning_worktree.rs
@@ -131,7 +131,7 @@ pub(super) fn filter_homeboy_managed(files: Vec<String>) -> Vec<String> {
         .collect()
 }
 
-fn get_release_allowed_files(
+pub(super) fn get_release_allowed_files(
     changelog_path: &std::path::Path,
     version_targets: &[String],
     repo_root: &std::path::Path,
@@ -144,11 +144,39 @@ fn get_release_allowed_files(
 
     for target in version_targets {
         if let Ok(relative) = std::path::Path::new(target).strip_prefix(repo_root) {
-            allowed.push(relative.to_string_lossy().to_string());
+            let relative = relative.to_string_lossy().to_string();
+            allowed.push(relative.clone());
+            allowed.extend(derived_release_lockfiles(&relative));
         }
     }
 
+    allowed.sort();
+    allowed.dedup();
     allowed
+}
+
+fn derived_release_lockfiles(version_target: &str) -> Vec<String> {
+    let path = std::path::Path::new(version_target);
+    let parent = path
+        .parent()
+        .and_then(|parent| parent.to_str())
+        .unwrap_or("");
+    let prefix = if parent.is_empty() {
+        String::new()
+    } else {
+        format!("{parent}/")
+    };
+
+    match path.file_name().and_then(|file| file.to_str()) {
+        Some("Cargo.toml") => vec![format!("{prefix}Cargo.lock")],
+        Some("package.json") => vec![
+            format!("{prefix}package-lock.json"),
+            format!("{prefix}pnpm-lock.yaml"),
+            format!("{prefix}yarn.lock"),
+        ],
+        Some("composer.json") => vec![format!("{prefix}composer.lock")],
+        _ => Vec::new(),
+    }
 }
 
 fn get_unexpected_uncommitted_files(
@@ -394,5 +422,42 @@ mod tests {
         );
 
         assert_eq!(allowed, vec!["docs/changelog.md", "manifest.toml"]);
+    }
+
+    #[test]
+    fn release_allowed_files_include_lockfiles_derived_from_version_targets() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_root = temp_dir.path();
+        let changelog = repo_root.join("docs/changelog.md");
+        let cargo = repo_root.join("Cargo.toml");
+        let package = repo_root.join("packages/app/package.json");
+        let composer = repo_root.join("plugin/composer.json");
+
+        let allowed = get_release_allowed_files(
+            &changelog,
+            &[
+                cargo.to_string_lossy().to_string(),
+                package.to_string_lossy().to_string(),
+                composer.to_string_lossy().to_string(),
+            ],
+            repo_root,
+        );
+
+        for expected in [
+            "Cargo.lock",
+            "Cargo.toml",
+            "docs/changelog.md",
+            "packages/app/package-lock.json",
+            "packages/app/package.json",
+            "packages/app/pnpm-lock.yaml",
+            "packages/app/yarn.lock",
+            "plugin/composer.json",
+            "plugin/composer.lock",
+        ] {
+            assert!(
+                allowed.contains(&expected.to_string()),
+                "allowed release files should include {expected}, got {allowed:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Allow `release.prepare` to update lockfiles derived from configured version targets, including `Cargo.lock` for `Cargo.toml` releases.
- Keep the dirty-worktree guard strict for unrelated files so release-owned mutations are the only allowed prepare side effects.
- Add focused coverage for derived lockfile allowlisting and prepare-step dirty file classification.

## Verification
- `cargo fmt`
- `cargo test core::release::planning_worktree --lib`
- `cargo test core::release::execution_dispatch --lib`
- `cargo run --bin homeboy -- --force-hot release --dry-run`
- `git diff --check HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the release blocker, drafted the release prepare dirty-file guard change, added tests, and ran local verification for Chris to review.