### PR TITLE
docs: add SUSTO Homeboy name origin to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,10 @@ homeboy docs schemas/component-schema
 Start with [docs/commands/commands-index.md](docs/commands/commands-index.md)
 for the command index.
 
+## Name
+
+Named after ["Homeboy" by SUSTO](https://www.youtube.com/watch?v=-bBvwfn2ibU), a Charleston band.
+
 ## License
 
 MIT License — Created by [Chris Huber](https://chubes.net)


### PR DESCRIPTION
## Summary
- Adds a subtle **Name** section to the README crediting ["Homeboy" by SUSTO](https://www.youtube.com/watch?v=-bBvwfn2ibU) as the inspiration for the project name.

A little lore / easter egg — kept understated, just a nod and a link.