### PR TITLE
Refresh release lockfile fixture baseline

### DIFF
--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -256,6 +256,10 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
         term: "wordpress",
     },
     ViolationKey {
+        path: "src/core/release/planning_worktree.rs",
+        term: "npm",
+    },
+    ViolationKey {
         path: "src/core/rig/spec.rs",
         term: "wordpress",
     },
@@ -321,7 +325,7 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const TEST_CONTENT_BASELINE_OCCURRENCES: usize = 102;
+const TEST_CONTENT_BASELINE_OCCURRENCES: usize = 103;
 
 #[test]
 fn core_owned_source_stays_language_and_framework_agnostic() {


### PR DESCRIPTION
## Summary
- Refreshes the core-owned test-content baseline for the release lockfile fixture added by the release prepare fix.
- Keeps the release `Test` gate aligned with the intentional package-manager lockfile coverage.

## Verification
- `RELEASE_BLOCKING_COMMANDS=lint,test GITHUB_ACTIONS=true cargo test --test core_agnostic_test -- --nocapture`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the release gate failure, reproduced the failing test mode, and drafted the targeted baseline update for Chris to review.