### PR TITLE
Fix core runner sidecar contracts

### DIFF
--- a/docs/architecture/structured-sidecars.md
+++ b/docs/architecture/structured-sidecars.md
@@ -1,0 +1,24 @@
+# Structured Sidecars
+
+Homeboy core owns the structured sidecar registry used by extension runners.
+
+Extension manifests declare support with `structured_sidecars`. Boolean declarations use the core default path, producer, and schema version. Detailed declarations may override the path or producer for extension-specific packaging needs.
+
+Canonical sidecar keys:
+
+- `lint.findings` writes normalized lint finding arrays to `lint-findings.json`.
+- `test.results` writes normalized test result objects to `test-results.json`.
+- `test.failures` writes parsed test failure arrays to `test-failures.json`.
+- `bench.results` writes benchmark result objects to `bench-results.json`.
+- `trace.results` writes trace result objects to `trace.json`.
+- `trace.artifacts` writes trace artifact metadata arrays under `artifacts`.
+- `annotations` writes inline-review annotation arrays under `annotations`.
+
+Core validation is intentionally shape-focused: it rejects unknown sidecar keys, wrong top-level JSON containers, non-object array items, and missing minimum required fields. Extension-specific parsers can still enforce richer producer semantics after the generic contract passes.
+
+Runtime helper distribution is also core-owned. Normal Homeboy extension execution injects `HOMEBOY_RUNTIME_*` helper paths, and direct invocations can resolve a helper with:
+
+```bash
+homeboy runtime helper path runner-prelude.sh
+homeboy runtime helper path HOMEBOY_RUNTIME_COMMAND_CAPTURE
+```

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -38,6 +38,7 @@
 - [review](review.md) — scoped audit + lint + test umbrella for PR-style changes
 - [rig](rig.md) — reproducible local dev environments ([spec](rig-spec.md))
 - [runner](runner.md) — local and SSH execution runner registry
+- [runtime](runtime.md) — core-owned runner runtime helper lookup
 - [runs](runs.md) — persisted observation runs and artifacts
 - [server](server.md)
 - [self](self.md) — active binary and install-signal inspection

--- a/docs/commands/runtime.md
+++ b/docs/commands/runtime.md
@@ -1,0 +1,14 @@
+# `homeboy runtime`
+
+Inspect Homeboy core-owned runtime assets used by extension runners.
+
+## Helper Paths
+
+Resolve the materialized path for a core runtime helper:
+
+```bash
+homeboy runtime helper path runner-prelude.sh
+homeboy runtime helper path HOMEBOY_RUNTIME_COMMAND_CAPTURE
+```
+
+The command accepts either the helper filename or the injected `HOMEBOY_RUNTIME_*` environment variable name. Normal extension execution receives these paths automatically in the runner environment.

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -5,8 +5,8 @@ use crate::commands::{
     agent_task, api, audit, audit_baseline, auth, bench, build, changelog, changes, ci, cleanup,
     component, config, daemon, db, deploy, deps, doctor, extension, file, fleet, git, http, issues,
     lint, logs, observe, project, refactor, refs, release, report, review, rig, runner, runs,
-    self_cmd, server, ssh, stack, status, test, trace, triage, tunnel, undo, upgrade, version,
-    worktree,
+    runtime, self_cmd, server, ssh, stack, status, test, trace, triage, tunnel, undo, upgrade,
+    version, worktree,
 };
 
 mod lab_contract;
@@ -128,6 +128,8 @@ pub enum Commands {
     Rig(rig::RigArgs),
     /// Manage local and SSH execution runners
     Runner(runner::RunnerArgs),
+    /// Inspect core-owned runtime helper assets
+    Runtime(runtime::RuntimeArgs),
     /// Manage component-backed task worktrees
     Worktree(worktree::WorktreeArgs),
     /// Manage private service tunnel declarations
@@ -359,6 +361,7 @@ impl Commands {
             | Commands::Release(_)
             | Commands::Report(_)
             | Commands::Runner(_)
+            | Commands::Runtime(_)
             | Commands::Worktree(_)
             | Commands::Tunnel(_)
             | Commands::Stack(_)

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -3,8 +3,8 @@ use crate::cli_surface::Commands;
 use super::{map, JsonRun};
 use crate::commands::{
     agent_task, build, changelog, changes, cleanup, component, config, docs, extension, project,
-    refactor, refs, release, report, rig, runner, runs, stack, tunnel, undo, version, worktree,
-    GlobalArgs,
+    refactor, refs, release, report, rig, runner, runs, runtime, stack, tunnel, undo, version,
+    worktree, GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
@@ -26,6 +26,7 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Refs(args) => map(refs::run(args, global)),
         Commands::Rig(args) => map(rig::run(args, global)),
         Commands::Runner(args) => map(runner::run(args, global)),
+        Commands::Runtime(args) => map(runtime::run(args, global)),
         Commands::Worktree(args) => map(worktree::run(args, global)),
         Commands::Tunnel(args) => map(tunnel::run(args, global)),
         Commands::Runs(args) => map(runs::run(args, global)),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -209,6 +209,7 @@ pub mod rig;
 pub mod route;
 pub mod runner;
 pub mod runs;
+pub mod runtime;
 pub mod self_cmd;
 pub mod server;
 pub mod source_command;

--- a/src/commands/runtime.rs
+++ b/src/commands/runtime.rs
@@ -1,0 +1,79 @@
+use clap::{Args, Subcommand};
+use serde::Serialize;
+
+use super::CmdResult;
+
+#[derive(Args)]
+pub struct RuntimeArgs {
+    #[command(subcommand)]
+    command: RuntimeCommand,
+}
+
+#[derive(Subcommand)]
+enum RuntimeCommand {
+    /// Resolve core-owned runner runtime helper paths.
+    Helper {
+        #[command(subcommand)]
+        command: RuntimeHelperCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum RuntimeHelperCommand {
+    /// Print the materialized path for a runtime helper.
+    Path {
+        /// Helper filename or HOMEBOY_RUNTIME_* env var name.
+        helper: String,
+    },
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum RuntimeOutput {
+    HelperPath(RuntimeHelperPathOutput),
+}
+
+#[derive(Serialize)]
+pub struct RuntimeHelperPathOutput {
+    command: String,
+    helper: String,
+    path: String,
+}
+
+pub fn run(args: RuntimeArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<RuntimeOutput> {
+    match args.command {
+        RuntimeCommand::Helper { command } => match command {
+            RuntimeHelperCommand::Path { helper } => helper_path(&helper),
+        },
+    }
+}
+
+fn helper_path(helper: &str) -> CmdResult<RuntimeOutput> {
+    let path = homeboy::core::extension::helper_path(helper)?;
+
+    Ok((
+        RuntimeOutput::HelperPath(RuntimeHelperPathOutput {
+            command: "runtime.helper.path".to_string(),
+            helper: helper.to_string(),
+            path: path.to_string_lossy().to_string(),
+        }),
+        0,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn helper_path_resolves_core_helper() {
+        crate::test_support::with_isolated_home(|_| {
+            let (output, exit_code) = helper_path("command-capture.sh").unwrap();
+
+            assert_eq!(exit_code, 0);
+            let RuntimeOutput::HelperPath(output) = output;
+            assert!(output.path.ends_with("command-capture.sh"));
+            assert!(std::path::Path::new(&output.path).is_file());
+        });
+    }
+}

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -806,6 +806,7 @@ mod tests {
             for (env_var, filename) in [
                 (runtime_helper::RUNNER_STEPS_ENV, "runner-steps.sh"),
                 (runtime_helper::RUNNER_PRELUDE_ENV, "runner-prelude.sh"),
+                (runtime_helper::COMMAND_CAPTURE_ENV, "command-capture.sh"),
                 (runtime_helper::BASH_PREFLIGHT_ENV, "bash-preflight.sh"),
             ] {
                 let helper = env

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -625,10 +625,15 @@ impl ExtensionManifest {
         self.structured_sidecars
             .get(name)
             .and_then(|contract| match contract {
-                StructuredSidecarContract::Detail(detail) if detail.enabled => {
-                    detail.schema_version.as_deref()
+                StructuredSidecarContract::Enabled(true) => {
+                    crate::core::structured_sidecar::default_schema_version(name)
                 }
-                _ => None,
+                StructuredSidecarContract::Enabled(false) => None,
+                StructuredSidecarContract::Detail(detail) if detail.enabled => detail
+                    .schema_version
+                    .as_deref()
+                    .or_else(|| crate::core::structured_sidecar::default_schema_version(name)),
+                StructuredSidecarContract::Detail(_) => None,
             })
     }
 

--- a/src/core/extension/manifest_sidecar.rs
+++ b/src/core/extension/manifest_sidecar.rs
@@ -1,4 +1,4 @@
-use crate::core::engine::run_dir;
+use crate::core::{engine::run_dir, structured_sidecar};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -14,7 +14,8 @@ impl StructuredSidecarContract {
             StructuredSidecarContract::Enabled(true) => Some(StructuredSidecarDeclaration {
                 name: name.to_string(),
                 path: default_structured_sidecar_path(name),
-                schema_version: None,
+                schema_version: structured_sidecar::default_schema_version(name)
+                    .map(str::to_string),
                 producer: default_structured_sidecar_producer(name),
             }),
             StructuredSidecarContract::Enabled(false) => None,
@@ -58,6 +59,10 @@ fn default_true() -> bool {
 }
 
 fn default_structured_sidecar_path(name: &str) -> String {
+    if let Some(path) = structured_sidecar::default_path(name) {
+        return path.to_string();
+    }
+
     match name {
         "lint.findings" => run_dir::files::LINT_FINDINGS,
         "lint.producers" => run_dir::files::LINT_PRODUCERS,
@@ -77,6 +82,10 @@ fn default_structured_sidecar_path(name: &str) -> String {
 }
 
 fn default_structured_sidecar_producer(name: &str) -> Option<String> {
+    if let Some(producer) = structured_sidecar::default_producer(name) {
+        return Some(producer.to_string());
+    }
+
     match name {
         "lint.findings" | "lint.producers" => Some("lint"),
         "test.results" | "test.failures" | "test.coverage" => Some("test"),

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -93,7 +93,9 @@ pub use runner_contract::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, PhaseFailure,
     PhaseFailureCategory, PhaseReport, PhaseStatus, RunnerStepFilter, VerificationPhase,
 };
-pub use runtime_helper::{BASH_PREFLIGHT_ENV, RUNNER_PRELUDE_ENV, RUNNER_STEPS_ENV};
+pub use runtime_helper::{
+    helper_path, BASH_PREFLIGHT_ENV, COMMAND_CAPTURE_ENV, RUNNER_PRELUDE_ENV, RUNNER_STEPS_ENV,
+};
 pub use scope::ExtensionScope;
 pub use summary::{list_summaries, ActionSummary, ExtensionSummary};
 pub use update_output::{

--- a/src/core/extension/runtime/command-capture.sh
+++ b/src/core/extension/runtime/command-capture.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+homeboy_run_step_capture() {
+    local output_var="$1"
+    local exit_var="$2"
+    local step_name="$3"
+    shift 3
+
+    if [ "${1:-}" = "--" ]; then
+        shift
+    fi
+
+    if [ "$#" -eq 0 ]; then
+        printf -v "$output_var" '%s' ''
+        printf -v "$exit_var" '%s' '127'
+        FAILED_STEP="${step_name}"
+        FAILURE_OUTPUT="No command provided"
+        return 127
+    fi
+
+    local output_file
+    output_file="$(mktemp "${TMPDIR:-/tmp}/homeboy-command.XXXXXX")"
+
+    set +e
+    "$@" 2>&1 | tee "$output_file"
+    local command_exit=${PIPESTATUS[0]}
+    set -e
+
+    printf -v "$output_var" '%s' "$output_file"
+    printf -v "$exit_var" '%s' "$command_exit"
+
+    if [ "$command_exit" -ne 0 ]; then
+        FAILED_STEP="${step_name}"
+        local tail_lines="${HOMEBOY_FAILURE_TAIL_LINES:-20}"
+        if [ "$tail_lines" -gt 0 ] 2>/dev/null; then
+            FAILURE_OUTPUT="$(tail -"$tail_lines" "$output_file")"
+        else
+            FAILURE_OUTPUT=""
+        fi
+    fi
+
+    return "$command_exit"
+}
+
+homeboy_cleanup_step_capture() {
+    local output_file="$1"
+    [ -z "$output_file" ] || rm -f "$output_file"
+}
+
+homeboy_run_step() {
+    local output_file=""
+    local command_exit="0"
+
+    homeboy_run_step_capture output_file command_exit "$@" || command_exit=$?
+    homeboy_cleanup_step_capture "$output_file"
+    return "$command_exit"
+}

--- a/src/core/extension/runtime_helper.rs
+++ b/src/core/extension/runtime_helper.rs
@@ -9,6 +9,7 @@ mod assets;
 
 pub const RUNNER_STEPS_ENV: &str = "HOMEBOY_RUNTIME_RUNNER_STEPS";
 pub const RUNNER_PRELUDE_ENV: &str = "HOMEBOY_RUNTIME_RUNNER_PRELUDE";
+pub const COMMAND_CAPTURE_ENV: &str = "HOMEBOY_RUNTIME_COMMAND_CAPTURE";
 pub const BASH_PREFLIGHT_ENV: &str = "HOMEBOY_RUNTIME_BASH_PREFLIGHT";
 pub const FAILURE_TRAP_ENV: &str = "HOMEBOY_RUNTIME_FAILURE_TRAP";
 pub const WRITE_TEST_RESULTS_ENV: &str = "HOMEBOY_RUNTIME_WRITE_TEST_RESULTS";
@@ -36,6 +37,12 @@ const HELPERS: &[RuntimeHelper] = &[
         filename: "runner-prelude.sh",
         content: assets::RUNNER_PRELUDE_SH,
         env_var: RUNNER_PRELUDE_ENV,
+        legacy_fallback: false,
+    },
+    RuntimeHelper {
+        filename: "command-capture.sh",
+        content: assets::COMMAND_CAPTURE_SH,
+        env_var: COMMAND_CAPTURE_ENV,
         legacy_fallback: false,
     },
     RuntimeHelper {
@@ -154,6 +161,47 @@ pub fn ensure_all_helpers() -> Result<Vec<(String, String)>> {
     }
 
     Ok(env_pairs)
+}
+
+pub fn helper_path(name: &str) -> Result<PathBuf> {
+    let normalized = name.trim();
+    let helper = HELPERS
+        .iter()
+        .find(|helper| helper.filename == normalized || helper.env_var == normalized)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "helper",
+                format!("unknown runtime helper `{normalized}`"),
+                None,
+                Some(vec![format!(
+                    "Known helpers: {}",
+                    HELPERS
+                        .iter()
+                        .map(|helper| helper.filename)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )]),
+            )
+        })?;
+
+    let pairs = ensure_all_helpers()?;
+    let path = pairs
+        .into_iter()
+        .find_map(|(key, path)| (key == helper.env_var).then(|| PathBuf::from(path)))
+        .ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "runtime helper `{normalized}` was not materialized"
+            ))
+        })?;
+
+    if !path.is_file() {
+        return Err(Error::internal_unexpected(format!(
+            "runtime helper `{normalized}` path does not exist: {}",
+            path.display()
+        )));
+    }
+
+    Ok(path)
 }
 
 #[cfg(test)]

--- a/src/core/extension/runtime_helper/assets.rs
+++ b/src/core/extension/runtime_helper/assets.rs
@@ -1,5 +1,6 @@
 pub(super) const RUNNER_STEPS_SH: &str = include_str!("../runtime/runner-steps.sh");
 pub(super) const RUNNER_PRELUDE_SH: &str = include_str!("../runtime/runner-prelude.sh");
+pub(super) const COMMAND_CAPTURE_SH: &str = include_str!("../runtime/command-capture.sh");
 pub(super) const BASH_PREFLIGHT_SH: &str = include_str!("../runtime/bash-preflight.sh");
 pub(super) const FAILURE_TRAP_SH: &str = include_str!("../runtime/failure-trap.sh");
 pub(super) const WRITE_TEST_RESULTS_SH: &str = include_str!("../runtime/write-test-results.sh");
@@ -18,6 +19,7 @@ mod tests {
         for content in [
             RUNNER_STEPS_SH,
             RUNNER_PRELUDE_SH,
+            COMMAND_CAPTURE_SH,
             BASH_PREFLIGHT_SH,
             FAILURE_TRAP_SH,
             WRITE_TEST_RESULTS_SH,

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -68,16 +68,25 @@ fn runner_prelude_initializes_context_steps_trap_and_sidecar() {
     let dir = tempfile::tempdir().expect("tempdir");
     let runtime_dir = dir.path().join("runtime");
     std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
-    std::fs::write(runtime_dir.join("runner-prelude.sh"), assets::RUNNER_PRELUDE_SH)
-        .expect("write prelude");
-    std::fs::write(runtime_dir.join("resolve-context.sh"), assets::RESOLVE_CONTEXT_SH)
-        .expect("write resolve context");
+    std::fs::write(
+        runtime_dir.join("runner-prelude.sh"),
+        assets::RUNNER_PRELUDE_SH,
+    )
+    .expect("write prelude");
+    std::fs::write(
+        runtime_dir.join("resolve-context.sh"),
+        assets::RESOLVE_CONTEXT_SH,
+    )
+    .expect("write resolve context");
     std::fs::write(runtime_dir.join("runner-steps.sh"), assets::RUNNER_STEPS_SH)
         .expect("write runner steps");
     std::fs::write(runtime_dir.join("failure-trap.sh"), assets::FAILURE_TRAP_SH)
         .expect("write failure trap");
-    std::fs::write(runtime_dir.join("sidecar-writer.sh"), assets::SIDECAR_WRITER_SH)
-        .expect("write sidecar writer");
+    std::fs::write(
+        runtime_dir.join("sidecar-writer.sh"),
+        assets::SIDECAR_WRITER_SH,
+    )
+    .expect("write sidecar writer");
 
     let output = std::process::Command::new("bash")
         .arg("-c")
@@ -450,7 +459,10 @@ fn bench_shell_helper_writes_scenarios_from_payload_files() {
     assert_eq!(value["scenarios"][0]["memory"]["peak_bytes"], 4096);
     assert_eq!(value["scenarios"][0]["source"], "custom");
     assert_eq!(value["scenarios"][0]["metadata"]["fixture"], true);
-    assert_eq!(value["scenarios"][0]["artifacts"]["stdout"]["path"], "bench.log");
+    assert_eq!(
+        value["scenarios"][0]["artifacts"]["stdout"]["path"],
+        "bench.log"
+    );
 }
 
 #[test]
@@ -565,7 +577,10 @@ await homeboyWriteBenchScenarioInventory('{results}', 'demo', 9, [
     assert_eq!(value["scenarios"][0]["id"], "cold");
     assert_eq!(value["scenarios"][0]["iterations"], 0);
     assert_eq!(value["scenarios"][0]["default_iterations"], 9);
-    assert_eq!(value["scenarios"][0]["artifacts"]["log"]["path"], "bench.log");
+    assert_eq!(
+        value["scenarios"][0]["artifacts"]["log"]["path"],
+        "bench.log"
+    );
 }
 
 #[test]

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -22,6 +22,10 @@ fn ensure_all_helpers_writes_all_files() {
             "runner prelude helper should be in pairs"
         );
         assert!(
+            pairs.iter().any(|(k, _)| k == COMMAND_CAPTURE_ENV),
+            "command capture helper should be in pairs"
+        );
+        assert!(
             pairs.iter().any(|(k, _)| k == BASH_PREFLIGHT_ENV),
             "bash preflight helper should be in pairs"
         );
@@ -45,6 +49,17 @@ fn ensure_all_helpers_writes_all_files() {
             pairs.iter().any(|(k, _)| k == BENCH_HELPER_PHP_ENV),
             "bench PHP helper should be in pairs"
         );
+    });
+}
+
+#[test]
+fn helper_path_resolves_by_filename_and_env_var() {
+    with_isolated_home(|_| {
+        let by_filename = helper_path("command-capture.sh").expect("helper path by filename");
+        let by_env = helper_path(COMMAND_CAPTURE_ENV).expect("helper path by env var");
+
+        assert_eq!(by_filename, by_env);
+        assert!(by_filename.is_file());
     });
 }
 

--- a/src/core/extension/tests.rs
+++ b/src/core/extension/tests.rs
@@ -97,7 +97,7 @@ fn manifest_parses_declared_structured_sidecars() {
     assert_eq!(sidecars[0].producer, None);
     assert_eq!(sidecars[1].name, "lint.findings");
     assert_eq!(sidecars[1].path, "lint-findings.json");
-    assert_eq!(sidecars[1].schema_version, None);
+    assert_eq!(sidecars[1].schema_version.as_deref(), Some("v1"));
     assert_eq!(sidecars[1].producer.as_deref(), Some("lint"));
     assert_eq!(sidecars[2].name, "lint.producers");
     assert_eq!(sidecars[2].path, "lint-producers.json");
@@ -139,7 +139,7 @@ fn structured_sidecar_schema_versions_come_from_top_level_contract() {
     );
     assert_eq!(
         manifest.structured_sidecar_schema_version("lint.findings"),
-        None
+        Some("v1")
     );
     assert_eq!(
         manifest.structured_sidecar_schema_version("test.failures"),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -57,6 +57,7 @@ pub mod self_status;
 pub mod server;
 pub mod source_snapshot;
 pub mod stack;
+pub mod structured_sidecar;
 pub mod top_n;
 pub mod triage;
 pub mod tunnel;

--- a/src/core/structured_sidecar.rs
+++ b/src/core/structured_sidecar.rs
@@ -1,0 +1,245 @@
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::core::engine::run_dir;
+use crate::core::{Error, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StructuredSidecarShape {
+    Array,
+    Object,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct StructuredSidecarSchema {
+    pub key: &'static str,
+    pub schema_version: &'static str,
+    pub path: &'static str,
+    pub producer: Option<&'static str>,
+    pub shape: StructuredSidecarShape,
+    pub required_fields: &'static [&'static str],
+}
+
+pub const REGISTRY: &[StructuredSidecarSchema] = &[
+    StructuredSidecarSchema {
+        key: "lint.findings",
+        schema_version: "v1",
+        path: run_dir::files::LINT_FINDINGS,
+        producer: Some("lint"),
+        shape: StructuredSidecarShape::Array,
+        required_fields: &["message"],
+    },
+    StructuredSidecarSchema {
+        key: "test.results",
+        schema_version: "v1",
+        path: run_dir::files::TEST_RESULTS,
+        producer: Some("test"),
+        shape: StructuredSidecarShape::Object,
+        required_fields: &[],
+    },
+    StructuredSidecarSchema {
+        key: "test.failures",
+        schema_version: "v1",
+        path: run_dir::files::TEST_FAILURES,
+        producer: Some("test"),
+        shape: StructuredSidecarShape::Array,
+        required_fields: &["message"],
+    },
+    StructuredSidecarSchema {
+        key: "bench.results",
+        schema_version: "v1",
+        path: run_dir::files::BENCH_RESULTS,
+        producer: Some("bench"),
+        shape: StructuredSidecarShape::Object,
+        required_fields: &[],
+    },
+    StructuredSidecarSchema {
+        key: "trace.results",
+        schema_version: "v1",
+        path: run_dir::files::TRACE_RESULTS,
+        producer: Some("trace"),
+        shape: StructuredSidecarShape::Object,
+        required_fields: &[],
+    },
+    StructuredSidecarSchema {
+        key: "trace.artifacts",
+        schema_version: "v1",
+        path: "artifacts",
+        producer: Some("trace"),
+        shape: StructuredSidecarShape::Array,
+        required_fields: &[],
+    },
+    StructuredSidecarSchema {
+        key: "annotations",
+        schema_version: "v1",
+        path: run_dir::files::ANNOTATIONS_DIR,
+        producer: None,
+        shape: StructuredSidecarShape::Array,
+        required_fields: &[],
+    },
+];
+
+pub fn registry() -> &'static [StructuredSidecarSchema] {
+    REGISTRY
+}
+
+pub fn schema(key: &str) -> Option<&'static StructuredSidecarSchema> {
+    REGISTRY.iter().find(|entry| entry.key == key)
+}
+
+pub fn default_path(key: &str) -> Option<&'static str> {
+    schema(key).map(|entry| entry.path)
+}
+
+pub fn default_producer(key: &str) -> Option<&'static str> {
+    schema(key).and_then(|entry| entry.producer)
+}
+
+pub fn default_schema_version(key: &str) -> Option<&'static str> {
+    schema(key).map(|entry| entry.schema_version)
+}
+
+pub fn validate_payload(key: &str, payload: &Value) -> Result<()> {
+    let schema = schema(key).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "structured_sidecar",
+            format!("unknown structured sidecar key `{key}`"),
+            None,
+            Some(vec![format!(
+                "Known keys: {}",
+                REGISTRY
+                    .iter()
+                    .map(|entry| entry.key)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )]),
+        )
+    })?;
+
+    match schema.shape {
+        StructuredSidecarShape::Array => validate_array_payload(schema, payload),
+        StructuredSidecarShape::Object => validate_object_payload(schema, payload),
+    }
+}
+
+fn validate_array_payload(schema: &StructuredSidecarSchema, payload: &Value) -> Result<()> {
+    let Some(items) = payload.as_array() else {
+        return Err(shape_error(schema, "JSON array"));
+    };
+
+    for (index, item) in items.iter().enumerate() {
+        let Some(object) = item.as_object() else {
+            return Err(Error::validation_invalid_argument(
+                "structured_sidecar",
+                format!(
+                    "structured sidecar `{}` item {index} must be a JSON object",
+                    schema.key
+                ),
+                None,
+                None,
+            ));
+        };
+
+        for field in schema.required_fields {
+            if !object.contains_key(*field) {
+                return Err(Error::validation_invalid_argument(
+                    "structured_sidecar",
+                    format!(
+                        "structured sidecar `{}` item {index} is missing required field `{field}`",
+                        schema.key
+                    ),
+                    None,
+                    None,
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_object_payload(schema: &StructuredSidecarSchema, payload: &Value) -> Result<()> {
+    let Some(object) = payload.as_object() else {
+        return Err(shape_error(schema, "JSON object"));
+    };
+
+    for field in schema.required_fields {
+        if !object.contains_key(*field) {
+            return Err(Error::validation_invalid_argument(
+                "structured_sidecar",
+                format!(
+                    "structured sidecar `{}` is missing required field `{field}`",
+                    schema.key
+                ),
+                None,
+                None,
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn shape_error(schema: &StructuredSidecarSchema, expected: &str) -> Error {
+    Error::validation_invalid_argument(
+        "structured_sidecar",
+        format!(
+            "structured sidecar `{}` must be a {expected} for schema {}",
+            schema.key, schema.schema_version
+        ),
+        None,
+        None,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn registry_contains_current_core_sidecars() {
+        let keys: Vec<&str> = registry().iter().map(|entry| entry.key).collect();
+
+        for key in [
+            "lint.findings",
+            "test.results",
+            "test.failures",
+            "bench.results",
+            "trace.results",
+        ] {
+            assert!(keys.contains(&key), "missing registry key {key}");
+            assert_eq!(default_schema_version(key), Some("v1"));
+        }
+    }
+
+    #[test]
+    fn validates_known_valid_payloads() {
+        validate_payload("lint.findings", &json!([{ "message": "lint failed" }])).unwrap();
+        validate_payload("test.results", &json!({ "total": 2, "failed": 0 })).unwrap();
+        validate_payload("test.failures", &json!([{ "message": "test failed" }])).unwrap();
+        validate_payload("bench.results", &json!({ "results": [] })).unwrap();
+        validate_payload("trace.results", &json!({ "runs": [] })).unwrap();
+    }
+
+    #[test]
+    fn rejects_invalid_payload_shapes() {
+        let err = validate_payload("lint.findings", &json!({ "message": "wrong" }))
+            .expect_err("lint findings must be an array");
+
+        assert!(err.to_string().contains("JSON array"));
+    }
+
+    #[test]
+    fn rejects_missing_required_array_fields() {
+        let err = validate_payload("test.failures", &json!([{ "test_id": "demo" }]))
+            .expect_err("test failure message is required");
+
+        assert!(err.to_string().contains("message"));
+    }
+}
+
+#[cfg(test)]
+#[path = "../../tests/core/extension/structured_sidecar_test.rs"]
+mod structured_sidecar_test;

--- a/tests/core/extension/runtime_helper_test.rs
+++ b/tests/core/extension/runtime_helper_test.rs
@@ -28,4 +28,8 @@ fn test_ensure_all_helpers() {
         RUNTIME_HELPER_RS.contains("HOMEBOY_RUNTIME_BASH_PREFLIGHT"),
         "extension env should expose the shared bash preflight helper"
     );
+    assert!(
+        RUNTIME_HELPER_RS.contains("HOMEBOY_RUNTIME_COMMAND_CAPTURE"),
+        "extension env should expose the shared command capture helper"
+    );
 }

--- a/tests/core/extension/structured_sidecar_test.rs
+++ b/tests/core/extension/structured_sidecar_test.rs
@@ -1,0 +1,27 @@
+use serde_json::json;
+
+#[test]
+fn core_structured_sidecar_registry_validates_current_contracts() {
+    for (key, payload) in [
+        ("lint.findings", json!([{ "message": "lint failed" }])),
+        ("test.results", json!({ "total": 1, "passed": 1 })),
+        ("test.failures", json!([{ "message": "test failed" }])),
+        ("bench.results", json!({ "results": [] })),
+        ("trace.results", json!({ "traces": [] })),
+    ] {
+        homeboy::core::structured_sidecar::validate_payload(key, &payload)
+            .unwrap_or_else(|err| panic!("{key} should validate: {err}"));
+    }
+}
+
+#[test]
+fn core_structured_sidecar_registry_rejects_malformed_output() {
+    let err = homeboy::core::structured_sidecar::validate_payload(
+        "lint.findings",
+        &json!({ "message": "not an array" }),
+    )
+    .expect_err("lint findings must be an array");
+
+    assert!(err.to_string().contains("lint.findings"));
+    assert!(err.to_string().contains("JSON array"));
+}


### PR DESCRIPTION
## Summary
- Add a core-owned structured sidecar registry with schema versions, default paths/producers, and shape-focused payload validation for the current runner sidecar contracts.
- Add core distribution/lookup for the copied `command-capture.sh` runtime helper and expose `homeboy runtime helper path <helper>` for direct invocation diagnostics.
- Document the core sidecar/runtime helper contracts and update command-surface docs.

Closes #3592.
Closes #3595.

## Verification
- `cargo check`
- `cargo test structured_sidecar --lib`
- `cargo test runtime_helper --lib`
- `cargo test helper_path_resolves_core_helper --lib`
- `cargo test --test command_surface_test`
- `cargo test --lib`
- `cargo run --bin homeboy -- runtime helper path command-capture.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the core registry/helper primitives, tests, docs, and PR preparation; Chris remains responsible for review and acceptance.