### PR TITLE
observation: centralize lint and audit workflow persistence

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -7,12 +7,15 @@ use homeboy::core::code_audit::{
 use homeboy::core::engine::execution_context::ExecutionContext;
 use homeboy::core::git::short_head_revision_at;
 use homeboy::core::observation::{
-    finding_records_from_audit, ActiveObservation, NewRunRecord, RunStatus,
+    finding_records_from_audit, NewFindingRecord, NewRunRecord, RunStatus,
 };
 
 use super::source_command::resolve_source_context;
 use super::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs,
+};
+use super::utils::observed_workflow::{
+    finish_adapted_observed_workflow, WorkflowObservationAdapter,
 };
 use super::{CmdResult, GlobalArgs};
 
@@ -82,7 +85,7 @@ pub fn run(args: AuditArgs, _global: &GlobalArgs) -> CmdResult<AuditCommandOutpu
     let resolved_id = source_ctx.component_id.clone();
     let resolved_path = source_ctx.source_path.to_string_lossy().to_string();
 
-    let observation = start_audit_observation(&resolved_id, &resolved_path, &args);
+    let observation = AuditObservationAdapter::new(&resolved_id, &resolved_path, &args);
     let workflow = run_main_audit_workflow(AuditRunWorkflowArgs {
         component_id: resolved_id.clone(),
         source_path: resolved_path.clone(),
@@ -103,81 +106,74 @@ pub fn run(args: AuditArgs, _global: &GlobalArgs) -> CmdResult<AuditCommandOutpu
         include_fixability: args.fixability,
     });
 
-    let workflow = match workflow {
-        Ok(workflow) => {
-            finish_audit_observation(observation, &workflow);
-            workflow
-        }
-        Err(error) => {
-            finish_audit_observation_error(observation, &error);
-            return Err(error);
-        }
-    };
+    let workflow = finish_adapted_observed_workflow(observation, workflow)?;
 
     Ok(report::from_main_workflow(workflow))
 }
 
-struct AuditObservation(ActiveObservation);
+struct AuditObservationAdapter {
+    component_id: String,
+    source_path: String,
+    command: String,
+    initial_metadata: serde_json::Value,
+}
 
-fn start_audit_observation(
-    component_id: &str,
-    source_path: &str,
-    args: &AuditArgs,
-) -> Option<AuditObservation> {
-    let path = Path::new(source_path);
-    let metadata = audit_observation_initial_metadata(source_path, args);
-    ActiveObservation::start_best_effort(
+impl AuditObservationAdapter {
+    fn new(component_id: &str, source_path: &str, args: &AuditArgs) -> Self {
+        Self {
+            component_id: component_id.to_string(),
+            source_path: source_path.to_string(),
+            command: audit_observation_command(component_id, args),
+            initial_metadata: audit_observation_initial_metadata(source_path, args),
+        }
+    }
+}
+
+impl WorkflowObservationAdapter<code_audit::AuditRunWorkflowResult> for AuditObservationAdapter {
+    fn start_record(&self) -> NewRunRecord {
+        let path = Path::new(&self.source_path);
         NewRunRecord::builder("audit")
-            .component_id(component_id)
-            .command(audit_observation_command(component_id, args))
+            .component_id(self.component_id.clone())
+            .command(self.command.clone())
             .cwd_path(path)
             .current_homeboy_version()
             .git_sha(short_head_revision_at(path))
-            .metadata(metadata)
-            .build(),
-    )
-    .map(AuditObservation)
-}
+            .metadata(self.initial_metadata.clone())
+            .build()
+    }
 
-fn finish_audit_observation(
-    observation: Option<AuditObservation>,
-    workflow: &code_audit::AuditRunWorkflowResult,
-) {
-    let Some(observation) = observation else {
-        return;
-    };
+    fn success_status(&self, workflow: &code_audit::AuditRunWorkflowResult) -> RunStatus {
+        if workflow.exit_code == 0 {
+            RunStatus::Pass
+        } else {
+            RunStatus::Fail
+        }
+    }
 
-    let metadata = serde_json::json!({
-        "observation_status": if workflow.exit_code == 0 { "pass" } else { "fail" },
-        "exit_code": workflow.exit_code,
-        "summary": audit_observation_summary(&workflow.output),
-        "timing": audit_observation_timing(&workflow.timing),
-    });
-    let records = finding_records_from_audit(observation.0.run_id(), &workflow.findings);
-    observation.0.record_findings(&records);
-    let status = if workflow.exit_code == 0 {
-        RunStatus::Pass
-    } else {
-        RunStatus::Fail
-    };
-    observation.0.finish_with_merged_metadata(status, metadata);
-}
+    fn success_metadata(&self, workflow: &code_audit::AuditRunWorkflowResult) -> serde_json::Value {
+        serde_json::json!({
+            "observation_status": if workflow.exit_code == 0 { "pass" } else { "fail" },
+            "exit_code": workflow.exit_code,
+            "summary": audit_observation_summary(&workflow.output),
+            "timing": audit_observation_timing(&workflow.timing),
+        })
+    }
 
-fn finish_audit_observation_error(
-    observation: Option<AuditObservation>,
-    error: &homeboy::core::Error,
-) {
-    let Some(observation) = observation else {
-        return;
-    };
+    fn success_findings(
+        &self,
+        run_id: &str,
+        workflow: &code_audit::AuditRunWorkflowResult,
+    ) -> Vec<NewFindingRecord> {
+        finding_records_from_audit(run_id, &workflow.findings)
+    }
 
-    observation
-        .0
-        .finish_error_with_merged_metadata(serde_json::json!({
+    fn error_metadata(&self, error: &homeboy::core::Error) -> Option<serde_json::Value> {
+        Some(serde_json::json!({
             "observation_status": "error",
             "error": error.to_string(),
             "timing": audit_observation_timing(&code_audit::AuditTiming::default()),
-        }));
+        }))
+    }
 }
 
 fn audit_observation_timing(timing: &code_audit::AuditTiming) -> serde_json::Value {
@@ -400,7 +396,7 @@ mod tests {
         with_isolated_audit_home, with_isolated_home, write_source_extension,
     };
     use clap::Parser;
-    use homeboy::core::observation::ObservationStore;
+    use homeboy::core::observation::{ObservationStore, RunListFilter};
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -458,6 +454,59 @@ mod tests {
             changed_since: Some("origin/main".to_string()),
             json_summary: true,
             fixability: false,
+        }
+    }
+
+    fn latest_audit_run(store: &ObservationStore) -> homeboy::core::observation::RunRecord {
+        store
+            .latest_run(RunListFilter {
+                kind: Some("audit".to_string()),
+                component_id: Some("homeboy".to_string()),
+                ..RunListFilter::default()
+            })
+            .expect("latest run")
+            .expect("audit run")
+    }
+
+    fn sample_audit_workflow(home: &std::path::Path) -> code_audit::AuditRunWorkflowResult {
+        let finding = code_audit::Finding {
+            convention: "command modules".to_string(),
+            severity: code_audit::Severity::Warning,
+            file: "src/commands/foo.rs".to_string(),
+            description: "Missing run function".to_string(),
+            suggestion: "Add run()".to_string(),
+            kind: code_audit::AuditFinding::MissingMethod,
+        };
+        code_audit::AuditRunWorkflowResult {
+            output: AuditCommandOutput::Full {
+                passed: false,
+                result: code_audit::CodeAuditResult {
+                    component_id: "homeboy".to_string(),
+                    source_path: home.to_string_lossy().to_string(),
+                    summary: code_audit::AuditSummary {
+                        files_scanned: 1,
+                        conventions_detected: 1,
+                        outliers_found: 1,
+                        alignment_score: Some(0.5),
+                        files_skipped: 0,
+                        warnings: vec![],
+                    },
+                    conventions: vec![],
+                    directory_conventions: vec![],
+                    findings: vec![finding.clone()],
+                    duplicate_groups: vec![],
+                },
+                fixability: None,
+            },
+            exit_code: 1,
+            findings: vec![finding],
+            timing: code_audit::AuditTiming {
+                spans: vec![code_audit::AuditTimingSpan {
+                    id: "detector.structural".to_string(),
+                    status: "ok".to_string(),
+                    duration_ms: Some(1.0),
+                }],
+            },
         }
     }
 
@@ -686,26 +735,21 @@ mod tests {
             let _xdg = XdgGuard::unset();
             let args = sample_args();
 
-            let observation =
-                start_audit_observation("homeboy", &home.path().to_string_lossy(), &args)
-                    .expect("observation should start");
-            let run_id = observation.0.run_id().to_string();
-
-            finish_audit_observation_error(
-                Some(observation),
-                &homeboy::core::Error::validation_invalid_argument(
-                    "fixture",
-                    "simulated audit error",
-                    None,
-                    None,
+            let result = finish_adapted_observed_workflow(
+                AuditObservationAdapter::new("homeboy", &home.path().to_string_lossy(), &args),
+                Err::<code_audit::AuditRunWorkflowResult, _>(
+                    homeboy::core::Error::validation_invalid_argument(
+                        "fixture",
+                        "simulated audit error",
+                        None,
+                        None,
+                    ),
                 ),
             );
+            assert!(result.is_err());
 
             let store = ObservationStore::open_initialized().expect("store");
-            let run = store
-                .get_run(&run_id)
-                .expect("read run")
-                .expect("run exists");
+            let run = latest_audit_run(&store);
 
             assert_eq!(run.kind, "audit");
             assert_eq!(run.status, "error");
@@ -720,56 +764,19 @@ mod tests {
         with_isolated_home(|home| {
             let _xdg = XdgGuard::unset();
             let args = sample_args();
-            let observation =
-                start_audit_observation("homeboy", &home.path().to_string_lossy(), &args)
-                    .expect("observation should start");
-            let run_id = observation.0.run_id().to_string();
-            let finding = code_audit::Finding {
-                convention: "command modules".to_string(),
-                severity: code_audit::Severity::Warning,
-                file: "src/commands/foo.rs".to_string(),
-                description: "Missing run function".to_string(),
-                suggestion: "Add run()".to_string(),
-                kind: code_audit::AuditFinding::MissingMethod,
-            };
-            let workflow = code_audit::AuditRunWorkflowResult {
-                output: AuditCommandOutput::Full {
-                    passed: false,
-                    result: code_audit::CodeAuditResult {
-                        component_id: "homeboy".to_string(),
-                        source_path: home.path().to_string_lossy().to_string(),
-                        summary: code_audit::AuditSummary {
-                            files_scanned: 1,
-                            conventions_detected: 1,
-                            outliers_found: 1,
-                            alignment_score: Some(0.5),
-                            files_skipped: 0,
-                            warnings: vec![],
-                        },
-                        conventions: vec![],
-                        directory_conventions: vec![],
-                        findings: vec![finding.clone()],
-                        duplicate_groups: vec![],
-                    },
-                    fixability: None,
-                },
-                exit_code: 1,
-                findings: vec![finding],
-                timing: code_audit::AuditTiming {
-                    spans: vec![code_audit::AuditTimingSpan {
-                        id: "detector.structural".to_string(),
-                        status: "ok".to_string(),
-                        duration_ms: Some(1.0),
-                    }],
-                },
-            };
+            let workflow = sample_audit_workflow(home.path());
 
-            finish_audit_observation(Some(observation), &workflow);
+            finish_adapted_observed_workflow(
+                AuditObservationAdapter::new("homeboy", &home.path().to_string_lossy(), &args),
+                Ok(workflow),
+            )
+            .expect("finish workflow");
 
             let store = ObservationStore::open_initialized().expect("store");
+            let run = latest_audit_run(&store);
             let findings = store
                 .list_findings(homeboy::core::observation::FindingListFilter {
-                    run_id: Some(run_id.clone()),
+                    run_id: Some(run.id.clone()),
                     tool: Some("audit".to_string()),
                     ..homeboy::core::observation::FindingListFilter::default()
                 })
@@ -786,10 +793,6 @@ mod tests {
                 "audit-findings"
             );
 
-            let run = store
-                .get_run(&run_id)
-                .expect("read run")
-                .expect("run exists");
             assert_eq!(
                 run.metadata_json["timing"]["spans"][0]["id"],
                 "detector.structural"
@@ -805,10 +808,16 @@ mod tests {
             fs::write(&bad_data_home, "file blocks observation dir").expect("write marker");
             let _xdg = XdgGuard::set(&bad_data_home);
 
-            let observation =
-                start_audit_observation("homeboy", &home.path().to_string_lossy(), &sample_args());
+            let result = finish_adapted_observed_workflow(
+                AuditObservationAdapter::new(
+                    "homeboy",
+                    &home.path().to_string_lossy(),
+                    &sample_args(),
+                ),
+                Ok(sample_audit_workflow(home.path())),
+            );
 
-            assert!(observation.is_none());
+            assert!(result.is_ok());
         });
     }
 

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -8,7 +8,7 @@ use homeboy::core::extension::lint::{
 use homeboy::core::extension::ExtensionCapability;
 use homeboy::core::git;
 use homeboy::core::observation::{
-    finding_records_from_lint, ActiveObservation, NewRunRecord, RunStatus,
+    finding_records_from_lint, NewFindingRecord, NewRunRecord, RunStatus,
 };
 use homeboy::core::refactor::plan::{
     collect_refactor_sources, lint_refactor_request, LintSourceOptions,
@@ -18,7 +18,9 @@ use super::source_command::{resolve_ci_job_for_command, resolve_source_context};
 use super::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs,
 };
-use super::utils::observed_workflow::{finish_observed_workflow, ObservedWorkflowRunner};
+use super::utils::observed_workflow::{
+    finish_adapted_observed_workflow, ObservedWorkflowRunner, WorkflowObservationAdapter,
+};
 use super::{CmdResult, GlobalArgs};
 
 #[derive(Args)]
@@ -109,12 +111,12 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
         && args.ci_job.is_none()
         && source_ctx.component.has_script(ExtensionCapability::Lint)
     {
-        let observation = LintObservation::start(
+        let observation = LintObservationAdapter::new(
             source_ctx.component_id.clone(),
             &source_ctx.source_path,
             lint_command_label(&source_ctx.component_id, &args),
         );
-        let workflow = finish_lint_workflow(
+        let workflow = finish_adapted_observed_workflow(
             observation,
             run_self_check_lint_workflow(
                 &source_ctx.component,
@@ -147,7 +149,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
     }
 
     let runner = ObservedWorkflowRunner::create(format!("lint {}", effective_id))?;
-    let observation = LintObservation::start(
+    let observation = LintObservationAdapter::new(
         ctx.component_id.clone(),
         &ctx.source_path,
         lint_command_label(&effective_id, &args),
@@ -180,12 +182,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
         },
         runner.run_dir(),
     );
-    let workflow = runner.finish(
-        observation,
-        workflow,
-        |observation, workflow| observation.finish_workflow(workflow),
-        |observation, _error| observation.finish_error(),
-    )?;
+    let workflow = runner.finish_adapted(observation, workflow)?;
 
     Ok(report::from_main_workflow_with_ci_context(
         workflow,
@@ -193,57 +190,67 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
     ))
 }
 
-fn finish_lint_workflow(
-    observation: Option<LintObservation>,
-    workflow: homeboy::core::Result<homeboy::core::extension::lint::LintRunWorkflowResult>,
-) -> homeboy::core::Result<homeboy::core::extension::lint::LintRunWorkflowResult> {
-    finish_observed_workflow(
-        observation,
-        workflow,
-        |observation, workflow| observation.finish_workflow(workflow),
-        |observation, _error| observation.finish_error(),
-    )
+struct LintObservationAdapter {
+    component_id: String,
+    source_path: std::path::PathBuf,
+    command: String,
 }
 
-struct LintObservation(ActiveObservation);
+impl LintObservationAdapter {
+    fn new(component_id: String, source_path: &std::path::Path, command: String) -> Self {
+        Self {
+            component_id,
+            source_path: source_path.to_path_buf(),
+            command,
+        }
+    }
+}
 
-impl LintObservation {
-    fn start(component_id: String, source_path: &std::path::Path, command: String) -> Option<Self> {
-        ActiveObservation::start_best_effort(
-            NewRunRecord::builder("lint")
-                .component_id(component_id)
-                .command(command)
-                .cwd_path(source_path)
-                .current_homeboy_version()
-                .metadata(serde_json::json!({ "source": "homeboy lint" }))
-                .build(),
-        )
-        .map(Self)
+impl WorkflowObservationAdapter<homeboy::core::extension::lint::LintRunWorkflowResult>
+    for LintObservationAdapter
+{
+    fn start_record(&self) -> NewRunRecord {
+        NewRunRecord::builder("lint")
+            .component_id(self.component_id.clone())
+            .command(self.command.clone())
+            .cwd_path(&self.source_path)
+            .current_homeboy_version()
+            .metadata(serde_json::json!({ "source": "homeboy lint" }))
+            .build()
     }
 
-    fn finish_workflow(self, workflow: &homeboy::core::extension::lint::LintRunWorkflowResult) {
-        if let Some(findings) = &workflow.findings {
-            let records = finding_records_from_lint(self.0.run_id(), findings);
-            self.0.record_findings(&records);
-        }
-
-        let status = if workflow.status == "passed" {
+    fn success_status(
+        &self,
+        workflow: &homeboy::core::extension::lint::LintRunWorkflowResult,
+    ) -> RunStatus {
+        if workflow.status == "passed" {
             RunStatus::Pass
         } else {
             RunStatus::Fail
-        };
-        self.0.finish(
-            status,
-            Some(serde_json::json!({
-                "exit_code": workflow.exit_code,
-                "finding_count": workflow.findings.as_ref().map(Vec::len).unwrap_or(0),
-                "producer_summaries": workflow.producer_summaries,
-            })),
-        );
+        }
     }
 
-    fn finish_error(self) {
-        self.0.finish_error(None);
+    fn success_metadata(
+        &self,
+        workflow: &homeboy::core::extension::lint::LintRunWorkflowResult,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "exit_code": workflow.exit_code,
+            "finding_count": workflow.findings.as_ref().map(Vec::len).unwrap_or(0),
+            "producer_summaries": workflow.producer_summaries,
+        })
+    }
+
+    fn success_findings(
+        &self,
+        run_id: &str,
+        workflow: &homeboy::core::extension::lint::LintRunWorkflowResult,
+    ) -> Vec<NewFindingRecord> {
+        workflow
+            .findings
+            .as_ref()
+            .map(|findings| finding_records_from_lint(run_id, findings))
+            .unwrap_or_default()
     }
 }
 

--- a/src/commands/utils/observed_workflow.rs
+++ b/src/commands/utils/observed_workflow.rs
@@ -1,5 +1,186 @@
 use homeboy::core::engine::resource::ResourceSummaryRun;
 use homeboy::core::engine::run_dir::RunDir;
+use homeboy::core::observation::{
+    merge_metadata, ActiveObservation, NewFindingRecord, NewRunRecord, RunStatus,
+};
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ObservationPersistenceWarning {
+    pub(crate) operation: String,
+    pub(crate) message: String,
+}
+
+impl ObservationPersistenceWarning {
+    fn new(operation: impl Into<String>, error: impl std::fmt::Display) -> Self {
+        Self {
+            operation: operation.into(),
+            message: error.to_string(),
+        }
+    }
+
+    fn as_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "operation": self.operation,
+            "message": self.message,
+        })
+    }
+}
+
+pub(crate) trait WorkflowObservationAdapter<T> {
+    fn start_record(&self) -> NewRunRecord;
+
+    fn success_status(&self, workflow: &T) -> RunStatus;
+
+    fn success_metadata(&self, workflow: &T) -> serde_json::Value;
+
+    fn success_findings(&self, _run_id: &str, _workflow: &T) -> Vec<NewFindingRecord> {
+        Vec::new()
+    }
+
+    fn error_metadata(&self, _error: &homeboy::core::Error) -> Option<serde_json::Value> {
+        None
+    }
+}
+
+pub(crate) fn finish_adapted_observed_workflow<T, A>(
+    adapter: A,
+    workflow: homeboy::core::Result<T>,
+) -> homeboy::core::Result<T>
+where
+    A: WorkflowObservationAdapter<T>,
+{
+    let mut observation = BestEffortObservedRun::start(adapter.start_record());
+    match workflow {
+        Ok(workflow) => {
+            if let Some(run_id) = observation.run_id().map(str::to_string) {
+                let findings = adapter.success_findings(&run_id, &workflow);
+                observation.record_findings(&findings);
+            }
+            observation.finish_with_merged_metadata(
+                adapter.success_status(&workflow),
+                adapter.success_metadata(&workflow),
+            );
+            Ok(workflow)
+        }
+        Err(error) => {
+            observation.finish_error_with_merged_metadata(adapter.error_metadata(&error));
+            Err(error)
+        }
+    }
+}
+
+struct BestEffortObservedRun {
+    observation: Option<ActiveObservation>,
+    warnings: Vec<ObservationPersistenceWarning>,
+}
+
+impl BestEffortObservedRun {
+    fn start(record: NewRunRecord) -> Self {
+        match ActiveObservation::start(record) {
+            Ok(observation) => Self {
+                observation: Some(observation),
+                warnings: Vec::new(),
+            },
+            Err(error) => {
+                warn_observation_persistence(&ObservationPersistenceWarning::new("start", error));
+                Self {
+                    observation: None,
+                    warnings: vec![ObservationPersistenceWarning::new(
+                        "start",
+                        "observation start failed; run was not persisted",
+                    )],
+                }
+            }
+        }
+    }
+
+    fn run_id(&self) -> Option<&str> {
+        self.observation.as_ref().map(ActiveObservation::run_id)
+    }
+
+    fn record_findings(&mut self, records: &[NewFindingRecord]) {
+        if records.is_empty() {
+            return;
+        }
+        let Some(observation) = &self.observation else {
+            return;
+        };
+        if let Err(error) = observation.store().record_findings(records) {
+            self.warn("record_findings", error);
+        }
+    }
+
+    #[allow(dead_code)]
+    fn record_artifact_if_file(&mut self, kind: &str, path: &Path) {
+        if !path.is_file() {
+            return;
+        }
+        let Some(observation) = &self.observation else {
+            return;
+        };
+        if let Err(error) = observation
+            .store()
+            .record_artifact(observation.run_id(), kind, path)
+        {
+            self.warn("record_artifact", error);
+        }
+    }
+
+    fn finish_with_merged_metadata(&mut self, status: RunStatus, metadata: serde_json::Value) {
+        let Some(observation) = &self.observation else {
+            return;
+        };
+        let metadata =
+            self.metadata_with_warnings(observation.initial_metadata().clone(), metadata);
+        if let Err(error) =
+            observation
+                .store()
+                .finish_run(observation.run_id(), status, Some(metadata))
+        {
+            self.warn("finish_run", error);
+        }
+    }
+
+    fn finish_error_with_merged_metadata(&mut self, metadata: Option<serde_json::Value>) {
+        self.finish_with_merged_metadata(
+            RunStatus::Error,
+            metadata.unwrap_or_else(|| serde_json::json!({ "observation_status": "error" })),
+        );
+    }
+
+    fn metadata_with_warnings(
+        &self,
+        initial: serde_json::Value,
+        finish: serde_json::Value,
+    ) -> serde_json::Value {
+        let mut metadata = merge_metadata(initial, finish);
+        if !self.warnings.is_empty() {
+            metadata["observation_warnings"] = serde_json::Value::Array(
+                self.warnings
+                    .iter()
+                    .map(ObservationPersistenceWarning::as_json)
+                    .collect(),
+            );
+        }
+        metadata
+    }
+
+    fn warn(&mut self, operation: &'static str, error: homeboy::core::Error) {
+        let warning = ObservationPersistenceWarning::new(operation, error);
+        warn_observation_persistence(&warning);
+        self.warnings.push(warning);
+    }
+}
+
+fn warn_observation_persistence(warning: &ObservationPersistenceWarning) {
+    homeboy::log_status!(
+        "observe",
+        "warning: observation {} persistence failed: {}",
+        warning.operation,
+        warning.message
+    );
+}
 
 pub(crate) fn finish_observed_workflow<O, T, F, E>(
     observation: Option<O>,
@@ -65,13 +246,110 @@ impl ObservedWorkflowRunner {
             }
         }
     }
+
+    pub(crate) fn finish_adapted<T, A>(
+        self,
+        adapter: A,
+        workflow: homeboy::core::Result<T>,
+    ) -> homeboy::core::Result<T>
+    where
+        A: WorkflowObservationAdapter<T>,
+    {
+        match self.resource_run.write_to_run_dir(&self.run_dir) {
+            Ok(_) => finish_adapted_observed_workflow(adapter, workflow),
+            Err(error) => {
+                let mut observation = BestEffortObservedRun::start(adapter.start_record());
+                observation.finish_error_with_merged_metadata(Some(serde_json::json!({
+                    "observation_status": "error",
+                    "error": error.to_string(),
+                })));
+                Err(error)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::ObservedWorkflowRunner;
+    use super::{
+        finish_adapted_observed_workflow, ObservedWorkflowRunner, WorkflowObservationAdapter,
+    };
+    use crate::test_support::with_isolated_home;
+    use homeboy::core::observation::{
+        NewFindingRecord, NewRunRecord, ObservationStore, RunListFilter, RunStatus,
+    };
     use std::cell::RefCell;
+    use std::path::Path;
     use std::rc::Rc;
+
+    struct FixtureAdapter {
+        bad_finding: bool,
+    }
+
+    impl WorkflowObservationAdapter<i32> for FixtureAdapter {
+        fn start_record(&self) -> NewRunRecord {
+            NewRunRecord::builder("fixture")
+                .component_id("homeboy")
+                .command("homeboy fixture")
+                .cwd_path(Path::new("/tmp/homeboy"))
+                .current_homeboy_version()
+                .metadata(serde_json::json!({ "phase": "initial" }))
+                .build()
+        }
+
+        fn success_status(&self, workflow: &i32) -> RunStatus {
+            if *workflow == 0 {
+                RunStatus::Pass
+            } else {
+                RunStatus::Fail
+            }
+        }
+
+        fn success_metadata(&self, workflow: &i32) -> serde_json::Value {
+            serde_json::json!({
+                "exit_code": workflow,
+                "observation_status": if *workflow == 0 { "pass" } else { "fail" },
+            })
+        }
+
+        fn success_findings(&self, run_id: &str, _workflow: &i32) -> Vec<NewFindingRecord> {
+            vec![NewFindingRecord {
+                run_id: if self.bad_finding {
+                    "missing-run".to_string()
+                } else {
+                    run_id.to_string()
+                },
+                tool: "fixture".to_string(),
+                rule: Some("rule".to_string()),
+                file: Some("src/lib.rs".to_string()),
+                line: Some(1),
+                severity: Some("warning".to_string()),
+                fingerprint: Some("fingerprint".to_string()),
+                message: "fixture finding".to_string(),
+                fixable: Some(false),
+                metadata_json: serde_json::json!({}),
+            }]
+        }
+
+        fn error_metadata(&self, error: &homeboy::core::Error) -> Option<serde_json::Value> {
+            Some(serde_json::json!({
+                "observation_status": "error",
+                "error": error.to_string(),
+            }))
+        }
+    }
+
+    fn latest_fixture_run() -> homeboy::core::observation::RunRecord {
+        ObservationStore::open_initialized()
+            .expect("store")
+            .latest_run(RunListFilter {
+                kind: Some("fixture".to_string()),
+                component_id: Some("homeboy".to_string()),
+                ..RunListFilter::default()
+            })
+            .expect("latest run")
+            .expect("fixture run")
+    }
 
     #[test]
     fn observed_workflow_runner_finishes_success_after_resource_summary() {
@@ -114,5 +392,80 @@ mod tests {
         assert!(resource_summary_path.is_file());
         assert_eq!(events.borrow().len(), 1);
         assert!(events.borrow()[0].contains("simulated workflow error"));
+    }
+
+    #[test]
+    fn adapted_observed_workflow_finishes_success_and_records_findings() {
+        with_isolated_home(|_| {
+            let result = finish_adapted_observed_workflow(
+                FixtureAdapter { bad_finding: false },
+                Ok::<_, homeboy::core::Error>(0),
+            );
+
+            assert_eq!(result.expect("workflow"), 0);
+            let run = latest_fixture_run();
+            assert_eq!(run.status, "pass");
+            assert_eq!(run.metadata_json["phase"], "initial");
+            assert_eq!(run.metadata_json["observation_status"], "pass");
+
+            let findings = ObservationStore::open_initialized()
+                .expect("store")
+                .list_findings(homeboy::core::observation::FindingListFilter {
+                    run_id: Some(run.id),
+                    tool: Some("fixture".to_string()),
+                    ..homeboy::core::observation::FindingListFilter::default()
+                })
+                .expect("findings");
+            assert_eq!(findings.len(), 1);
+        });
+    }
+
+    #[test]
+    fn adapted_observed_workflow_finishes_errors() {
+        with_isolated_home(|_| {
+            let error = homeboy::core::Error::validation_invalid_argument(
+                "fixture",
+                "simulated workflow error",
+                None,
+                None,
+            );
+
+            let result = finish_adapted_observed_workflow(
+                FixtureAdapter { bad_finding: false },
+                Err::<i32, _>(error),
+            );
+
+            assert!(result.is_err());
+            let run = latest_fixture_run();
+            assert_eq!(run.status, "error");
+            assert_eq!(run.metadata_json["phase"], "initial");
+            assert_eq!(run.metadata_json["observation_status"], "error");
+            assert!(run.metadata_json["error"]
+                .as_str()
+                .expect("error metadata")
+                .contains("simulated workflow error"));
+        });
+    }
+
+    #[test]
+    fn adapted_observed_workflow_surfaces_persistence_warnings_in_metadata() {
+        with_isolated_home(|_| {
+            finish_adapted_observed_workflow(
+                FixtureAdapter { bad_finding: true },
+                Ok::<_, homeboy::core::Error>(1),
+            )
+            .expect("workflow still succeeds");
+
+            let run = latest_fixture_run();
+            assert_eq!(run.status, "fail");
+            assert_eq!(
+                run.metadata_json["observation_warnings"][0]["operation"],
+                "record_findings"
+            );
+            assert!(run.metadata_json["observation_warnings"][0]["message"]
+                .as_str()
+                .expect("warning message")
+                .contains("referenced run record not found"));
+        });
     }
 }

--- a/src/commands/utils/observed_workflow.rs
+++ b/src/commands/utils/observed_workflow.rs
@@ -3,7 +3,6 @@ use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::observation::{
     merge_metadata, ActiveObservation, NewFindingRecord, NewRunRecord, RunStatus,
 };
-use std::path::Path;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ObservationPersistenceWarning {
@@ -108,22 +107,6 @@ impl BestEffortObservedRun {
         };
         if let Err(error) = observation.store().record_findings(records) {
             self.warn("record_findings", error);
-        }
-    }
-
-    #[allow(dead_code)]
-    fn record_artifact_if_file(&mut self, kind: &str, path: &Path) {
-        if !path.is_file() {
-            return;
-        }
-        let Some(observation) = &self.observation else {
-            return;
-        };
-        if let Err(error) = observation
-            .store()
-            .record_artifact(observation.run_id(), kind, path)
-        {
-            self.warn("record_artifact", error);
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a typed observed workflow adapter path for command workflows to centralize start, success/error finish, status mapping, metadata merge, finding recording, and persistence warnings.
- Migrates lint and audit observation handling off bespoke wrappers and onto the shared adapter surface.
- Records observation persistence warnings in run metadata before finish and logs persistence failures instead of silently dropping them.

Refs #3265

## Tests
- `cargo fmt --all --check`
- `cargo test commands::utils::observed_workflow`
- `cargo test commands::audit::tests::audit_observation`
- `cargo test commands::lint::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the observed workflow adapter slice, migrated lint/audit observation handling, and added targeted tests; Chris remains responsible for review and merge.