### PR TITLE
Route private runner source materialization through controller

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -294,12 +294,19 @@ homeboy runner workspace sync <runner-id> --path <local-worktree> --mode snapsho
 homeboy runner workspace sync <runner-id> --path <local-worktree> --mode git
 ```
 
-`workspace sync` materializes a local worktree under the runner's configured `workspace_root` so runner execution can run against an explicit remote path while Git operations and canonical edits stay local.
+`workspace sync` materializes a controller-side worktree under the runner's configured `workspace_root` so runner execution can run against an explicit remote path while Git operations and canonical edits stay local.
 
 Modes:
 
-- `snapshot` copies the current local tree, including dirty edits, through a tar stream.
-- `git` requires a clean local tree, then clones or refreshes `remote.origin.url` on the runner and checks out local `HEAD` detached.
+- `snapshot` copies the current local tree, including dirty edits, through a tar stream from the controller. Use this for private or proxy-dependent sources because the runner does not need repository access.
+- `git` requires a clean local tree, then clones or refreshes `remote.origin.url` on the runner and checks out local `HEAD` detached. Use this only when the runner is allowed to fetch the remote directly.
+
+Private/proxied sources:
+
+- Private or proxy-dependent source access stays on the controller machine.
+- Materialize those sources with `homeboy runner workspace sync <runner-id> --path <local-worktree> --mode snapshot`.
+- Use the returned `remote_path` for downstream `runner exec --cwd` or job inputs.
+- Runner-side Git fetches for configured private/proxied hosts are refused with an actionable diagnostic. The default host list includes `github.a8c.com`; override with `HOMEBOY_PRIVATE_PROXIED_SOURCE_HOSTS` only when a runner is explicitly allowed to fetch those sources.
 
 Safety rules:
 

--- a/src/commands/runner/workspace/mod.rs
+++ b/src/commands/runner/workspace/mod.rs
@@ -16,7 +16,7 @@ pub enum RunnerWorkspaceOutput {
 
 #[derive(Subcommand)]
 pub(super) enum RunnerWorkspaceCommand {
-    /// Sync a local worktree snapshot into the runner workspace root
+    /// Materialize a controller-side worktree into the runner workspace root
     Sync {
         /// Runner ID
         runner_id: String,
@@ -25,7 +25,7 @@ pub(super) enum RunnerWorkspaceCommand {
         #[arg(long)]
         path: String,
 
-        /// Sync mode. snapshot includes dirty local files; git requires a clean tree and clones/checks out HEAD remotely.
+        /// Sync mode. snapshot streams source from the controller; git is only for public/runner-accessible remotes.
         #[arg(long, value_enum, default_value_t = RunnerWorkspaceSyncModeArg::Snapshot)]
         mode: RunnerWorkspaceSyncModeArg,
     },

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -92,6 +92,12 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
 
     let runner = load(runner_id)?;
     let cwd = resolve_cwd(&runner, options.cwd.as_deref())?;
+    if runner.kind != RunnerKind::Local {
+        super::source_materialization::validate_runner_exec_source_fetch(
+            &options.command,
+            &runner.id,
+        )?;
+    }
     validate_runner_policy(
         &runner,
         &cwd,

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -32,6 +32,7 @@ mod offload_metadata;
 mod resource_metrics;
 mod rig_materialization;
 mod session;
+mod source_materialization;
 mod validation_dependencies;
 mod worker;
 mod workspace;

--- a/src/core/runner/source_materialization.rs
+++ b/src/core/runner/source_materialization.rs
@@ -1,0 +1,149 @@
+use crate::core::error::{Error, Result};
+
+const PRIVATE_PROXIED_SOURCE_HOSTS_ENV: &str = "HOMEBOY_PRIVATE_PROXIED_SOURCE_HOSTS";
+const DEFAULT_PRIVATE_PROXIED_SOURCE_HOSTS: &[&str] = &["github.a8c.com"];
+
+pub(super) fn validate_runner_git_materialization(remote_url: &str, runner_id: &str) -> Result<()> {
+    if let Some(host) = private_proxied_source_host(remote_url) {
+        return Err(private_proxied_source_error(
+            "mode",
+            &host,
+            runner_id,
+            "--mode git would fetch a private/proxied source on the runner; use controller-routed workspace sync",
+        ));
+    }
+
+    Ok(())
+}
+
+pub(super) fn validate_runner_exec_source_fetch(command: &[String], runner_id: &str) -> Result<()> {
+    if !looks_like_git_fetch_command(command) {
+        return Ok(());
+    }
+
+    if let Some(host) = command
+        .iter()
+        .find_map(|arg| private_proxied_source_host(arg))
+    {
+        return Err(private_proxied_source_error(
+            "command",
+            &host,
+            runner_id,
+            "runner-side Git fetch for a private/proxied source is not allowed; use controller-routed workspace sync",
+        ));
+    }
+
+    Ok(())
+}
+
+fn private_proxied_source_error(field: &str, host: &str, runner_id: &str, problem: &str) -> Error {
+    Error::validation_invalid_argument(
+        field,
+        format!("{problem}: `{host}`"),
+        Some(runner_id.to_string()),
+        Some(vec![
+            "Keep authenticated or proxy-dependent Git operations on the controller machine."
+                .to_string(),
+            "Materialize the controller checkout with `homeboy runner workspace sync <runner-id> --path <local-worktree> --mode snapshot`.".to_string(),
+            "Use the returned `remote_path` as the runner command cwd/path.".to_string(),
+            format!(
+                "Override the private/proxied host list with `{PRIVATE_PROXIED_SOURCE_HOSTS_ENV}` only when the runner is explicitly allowed to fetch those sources."
+            ),
+        ]),
+    )
+}
+
+fn looks_like_git_fetch_command(command: &[String]) -> bool {
+    let joined = command.join(" ");
+    let lower = joined.to_ascii_lowercase();
+
+    lower.contains("git clone")
+        || lower.contains("git fetch")
+        || lower.contains("git pull")
+        || lower.contains("git ls-remote")
+}
+
+fn private_proxied_source_host(value: &str) -> Option<String> {
+    let value = value.trim();
+    private_proxied_source_hosts()
+        .into_iter()
+        .find(|host| remote_matches_host(value, host))
+}
+
+fn private_proxied_source_hosts() -> Vec<String> {
+    let raw = std::env::var(PRIVATE_PROXIED_SOURCE_HOSTS_ENV).unwrap_or_else(|_| {
+        DEFAULT_PRIVATE_PROXIED_SOURCE_HOSTS
+            .iter()
+            .copied()
+            .collect::<Vec<_>>()
+            .join(",")
+    });
+
+    raw.split(',')
+        .map(str::trim)
+        .filter(|host| !host.is_empty())
+        .map(|host| host.to_ascii_lowercase())
+        .collect()
+}
+
+fn remote_matches_host(value: &str, host: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    let host = host.trim().trim_start_matches('.');
+
+    lower == host
+        || lower.contains(&format!("@{host}:"))
+        || lower.contains(&format!("@{host}/"))
+        || lower.contains(&format!("//{host}/"))
+        || lower.contains(&format!("//{host}:"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_default_private_proxied_source_hosts() {
+        assert_eq!(
+            private_proxied_source_host("git@github.a8c.com:Automattic/example.git"),
+            Some("github.a8c.com".to_string())
+        );
+        assert_eq!(
+            private_proxied_source_host("https://github.a8c.com/Automattic/example.git"),
+            Some("github.a8c.com".to_string())
+        );
+        assert_eq!(
+            private_proxied_source_host("https://github.com/Extra-Chill/homeboy.git"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_runner_side_private_proxied_git_materialization() {
+        let err = validate_runner_git_materialization(
+            "git@github.a8c.com:Automattic/example.git",
+            "homeboy-lab",
+        )
+        .expect_err("private/proxied runner-side git materialization should fail");
+
+        assert!(err.message.contains("--mode git"));
+        assert!(err.message.contains("github.a8c.com"));
+        assert!(err.message.contains("workspace sync"));
+    }
+
+    #[test]
+    fn rejects_runner_exec_private_proxied_git_fetches() {
+        let err = validate_runner_exec_source_fetch(
+            &[
+                "sh".to_string(),
+                "-c".to_string(),
+                "git clone git@github.a8c.com:Automattic/example.git".to_string(),
+            ],
+            "homeboy-lab",
+        )
+        .expect_err("private/proxied runner-side git clone should fail");
+
+        assert!(err.message.contains("runner-side Git fetch"));
+        assert!(err.message.contains("github.a8c.com"));
+        assert!(err.message.contains("workspace sync"));
+    }
+}

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -131,6 +131,12 @@ pub fn sync_workspace(
         }
         RunnerWorkspaceSyncMode::Git => {
             let git = git_snapshot(&local_path, options.changed_since_base.as_deref())?;
+            if runner.kind != RunnerKind::Local {
+                super::source_materialization::validate_runner_git_materialization(
+                    &git.remote_url,
+                    &runner.id,
+                )?;
+            }
             let remote_path = deterministic_remote_path(workspace_root, &local_path, &git.head);
             materialize_git(
                 &runner,


### PR DESCRIPTION
## Summary
- Documents snapshot workspace sync as the controller-routed path for private/proxied sources.
- Refuses runner-side Git materialization/fetches for configured private/proxied hosts, defaulting to `github.a8c.com`, with actionable snapshot-sync remediation.
- Updates runner workspace CLI help to distinguish controller-streamed snapshots from runner-accessible Git remotes.

Closes #3586.

## Tests
- `cargo fmt --check`
- `cargo test source_materialization`
- `cargo test command_surface`

Note: tests emit an existing unrelated unused-import warning in `src/commands/runs/corpus_tests.rs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating runner workspace/source materialization surfaces, drafting the generic guard/docs changes, and running targeted verification. Chris remains responsible for review and merge.