### PR TITLE
core: own browser evidence schemas

### DIFF
--- a/docs/architecture/browser-evidence-schemas.md
+++ b/docs/architecture/browser-evidence-schemas.md
@@ -1,0 +1,51 @@
+# Browser Evidence Schemas
+
+Homeboy core owns the product-neutral browser, profile, and trace evidence
+schema vocabulary. Extensions can normalize product-specific data into these
+shapes, but route semantics, application labels, and attribution rules stay in
+the extension that owns that product surface.
+
+## Version
+
+Current schema version: `1`.
+
+## Core Shapes
+
+- `BrowserPerformanceProfileEnvelope` describes one captured browser profile:
+  `schema_version`, `page_url`, generic summary data, timing arrays, network
+  rows, console/page error arrays, paint/layout/task arrays, `phase_marks`, and
+  computed `phases`.
+- `BrowserNetworkRequestRow` describes one network request with URL, method,
+  resource type, HTTP status, failure flag, start time, duration, and optional
+  failure text.
+- `BrowserTimingRow` describes a correlation row derived from browser resources
+  or network requests. URL normalization is caller-owned so product semantics do
+  not move into core.
+- `BrowserPhaseMark` and `BrowserPhaseWindow` describe timeline phases without
+  assigning product meaning to phase names.
+- `BrowserArtifactMetadata` describes evidence location and broad kind with
+  `path`, optional `kind`, and optional `label`.
+- `BrowserBottleneckRow` describes generic report rows with `kind`, `phase`,
+  `message`, and optional `data`.
+- `TraceEvent`, `TraceAssertion`, and `TraceEnvelope` describe generic trace
+  timelines, assertions, artifacts, status, summary, and optional failure data.
+
+## Sidecar Validation
+
+Structured sidecar validation stays shape-focused first. For `bench.results`
+and `trace.results`, core also validates known browser evidence fields when
+they are present:
+
+- `bench.results`: `browser_profiles`, `profiles`, `network`, `artifacts`,
+  `bottlenecks`, and `timings`.
+- `trace.results`: `timeline`, `assertions`, `artifacts`, and `traces`.
+
+Unknown fields are allowed at the sidecar envelope level so existing benchmark
+and trace producers can carry additional domain-specific payloads. Known fields
+must match the core product-neutral schemas.
+
+## Boundary
+
+Core owns transportable evidence contracts. Extensions own normalization and
+meaning. For example, WordPress REST route grouping, Site Editor attribution,
+Studio workflow labels, and WooCommerce scenario semantics remain outside core.

--- a/docs/architecture/structured-sidecars.md
+++ b/docs/architecture/structured-sidecars.md
@@ -16,6 +16,8 @@ Canonical sidecar keys:
 
 Core validation is intentionally shape-focused: it rejects unknown sidecar keys, wrong top-level JSON containers, non-object array items, and missing minimum required fields. Extension-specific parsers can still enforce richer producer semantics after the generic contract passes.
 
+`bench.results` and `trace.results` additionally validate known product-neutral browser/profile/trace evidence fields against the core browser evidence schemas. See [Browser Evidence Schemas](browser-evidence-schemas.md).
+
 Runtime helper distribution is also core-owned. Normal Homeboy extension execution injects `HOMEBOY_RUNTIME_*` helper paths, and direct invocations can resolve a helper with:
 
 ```bash

--- a/src/core/browser_evidence.rs
+++ b/src/core/browser_evidence.rs
@@ -1,0 +1,323 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::core::{Error, Result};
+
+pub const BROWSER_EVIDENCE_SCHEMA_VERSION: u64 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BrowserPerformanceProfileEnvelope {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u64,
+    #[serde(default, alias = "url")]
+    pub page_url: String,
+    #[serde(default)]
+    pub summary: Map<String, Value>,
+    #[serde(default)]
+    pub navigation: Vec<Value>,
+    #[serde(default)]
+    pub resources: Vec<Value>,
+    #[serde(default)]
+    pub network: Vec<BrowserNetworkRequestRow>,
+    #[serde(default)]
+    pub console_messages: Vec<Value>,
+    #[serde(default)]
+    pub page_errors: Vec<Value>,
+    #[serde(default)]
+    pub paints: Vec<Value>,
+    #[serde(default)]
+    pub largest_contentful_paint: Vec<Value>,
+    #[serde(default)]
+    pub layout_shifts: Vec<Value>,
+    #[serde(default)]
+    pub long_tasks: Vec<Value>,
+    #[serde(default)]
+    pub phase_marks: Vec<BrowserPhaseMark>,
+    #[serde(default)]
+    pub phases: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BrowserNetworkRequestRow {
+    #[serde(default, alias = "name")]
+    pub url: String,
+    #[serde(default)]
+    pub method: String,
+    #[serde(
+        default,
+        alias = "resourceType",
+        alias = "initiator_type",
+        alias = "initiatorType"
+    )]
+    pub resource_type: String,
+    #[serde(
+        default,
+        alias = "statusCode",
+        alias = "status_code",
+        alias = "http_status"
+    )]
+    pub status: Option<u64>,
+    #[serde(default)]
+    pub failed: bool,
+    #[serde(default, alias = "startTime", alias = "start_ms", alias = "startMs")]
+    pub start_time_ms: Option<f64>,
+    #[serde(default, alias = "durationMs", alias = "duration")]
+    pub duration_ms: Option<f64>,
+    #[serde(default, alias = "failureText")]
+    pub failure_text: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BrowserTimingRow {
+    pub url: String,
+    #[serde(default, alias = "normalizedUrl")]
+    pub normalized_url: String,
+    #[serde(default)]
+    pub method: Option<String>,
+    #[serde(default)]
+    pub status: Option<u64>,
+    #[serde(default)]
+    pub failed: Option<bool>,
+    #[serde(default, alias = "startTime")]
+    pub start_time: Option<f64>,
+    #[serde(default, alias = "ttfbMs")]
+    pub ttfb_ms: Option<f64>,
+    #[serde(default, alias = "durationMs")]
+    pub duration_ms: Option<f64>,
+    #[serde(default, alias = "initiatorType")]
+    pub initiator_type: Option<String>,
+    #[serde(default)]
+    pub phase: Option<String>,
+    #[serde(default)]
+    pub raw: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BrowserPhaseMark {
+    pub name: String,
+    #[serde(alias = "startTime", alias = "start_ms", alias = "startMs")]
+    pub start_time_ms: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BrowserPhaseWindow {
+    pub start_time_ms: f64,
+    #[serde(default)]
+    pub end_time_ms: Option<f64>,
+    pub duration_ms: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BrowserArtifactMetadata {
+    pub path: String,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BrowserBottleneckRow {
+    pub kind: String,
+    pub phase: String,
+    pub message: String,
+    #[serde(default)]
+    pub data: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct TraceEvent {
+    pub t_ms: f64,
+    pub source: String,
+    pub event: String,
+    #[serde(default)]
+    pub data: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceAssertionStatus {
+    Pass,
+    Fail,
+    Skip,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct TraceAssertion {
+    pub id: String,
+    pub status: TraceAssertionStatus,
+    pub message: String,
+    #[serde(default)]
+    pub data: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceEnvelopeStatus {
+    Pass,
+    Fail,
+    Error,
+    Skip,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct TraceEnvelope {
+    pub component_id: String,
+    pub scenario_id: String,
+    pub status: TraceEnvelopeStatus,
+    pub summary: String,
+    #[serde(default)]
+    pub timeline: Vec<TraceEvent>,
+    #[serde(default)]
+    pub assertions: Vec<TraceAssertion>,
+    #[serde(default)]
+    pub artifacts: Vec<BrowserArtifactMetadata>,
+    #[serde(default)]
+    pub failure: Option<Value>,
+}
+
+pub fn validate_bench_results_payload(payload: &Value) -> Result<()> {
+    validate_optional_array::<BrowserPerformanceProfileEnvelope>(payload, "browser_profiles")?;
+    validate_optional_array::<BrowserPerformanceProfileEnvelope>(payload, "profiles")?;
+    validate_optional_array::<BrowserNetworkRequestRow>(payload, "network")?;
+    validate_optional_array::<BrowserArtifactMetadata>(payload, "artifacts")?;
+    validate_optional_array::<BrowserBottleneckRow>(payload, "bottlenecks")?;
+    validate_optional_array::<BrowserTimingRow>(payload, "timings")?;
+    Ok(())
+}
+
+pub fn validate_trace_results_payload(payload: &Value) -> Result<()> {
+    validate_optional_array::<TraceEvent>(payload, "timeline")?;
+    validate_optional_array::<TraceAssertion>(payload, "assertions")?;
+    validate_optional_array::<BrowserArtifactMetadata>(payload, "artifacts")?;
+    validate_optional_array::<TraceEnvelope>(payload, "traces")?;
+    Ok(())
+}
+
+fn validate_optional_array<T>(payload: &Value, field: &str) -> Result<()>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let Some(value) = payload.get(field) else {
+        return Ok(());
+    };
+    let Some(items) = value.as_array() else {
+        return Err(Error::validation_invalid_argument(
+            "browser_evidence",
+            format!("browser evidence field `{field}` must be a JSON array"),
+            None,
+            None,
+        ));
+    };
+
+    for (index, item) in items.iter().enumerate() {
+        serde_json::from_value::<T>(item.clone()).map_err(|err| {
+            Error::validation_invalid_argument(
+                "browser_evidence",
+                format!("browser evidence field `{field}` item {index} does not match the core schema: {err}"),
+                None,
+                None,
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+fn default_schema_version() -> u64 {
+    BROWSER_EVIDENCE_SCHEMA_VERSION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn validates_representative_bench_payload_shapes() {
+        validate_bench_results_payload(&json!({
+            "browser_profiles": [{
+                "schema_version": 1,
+                "page_url": "https://example.test/",
+                "summary": { "ready_ms": 425.5 },
+                "network": [{
+                    "url": "https://example.test/app.js",
+                    "method": "GET",
+                    "resource_type": "script",
+                    "status": 200,
+                    "failed": false,
+                    "start_time_ms": 12.25,
+                    "duration_ms": 40.5
+                }],
+                "phase_marks": [{ "name": "boot", "start_time_ms": 0 }],
+                "phases": { "boot": { "start_time_ms": 0, "end_time_ms": 42, "duration_ms": 42 } }
+            }],
+            "timings": [{
+                "url": "https://example.test/app.js",
+                "normalizedUrl": "/app.js",
+                "method": "GET",
+                "status": 200,
+                "failed": false,
+                "startTime": 12.25,
+                "ttfbMs": 18.5,
+                "durationMs": 40.5,
+                "initiatorType": "script",
+                "phase": "boot",
+                "raw": { "source": "resource" }
+            }],
+            "artifacts": [{ "path": "browser/profile.json", "kind": "profile", "label": "profile" }],
+            "bottlenecks": [{ "kind": "network", "phase": "boot", "message": "Slow script" }]
+        })).unwrap();
+    }
+
+    #[test]
+    fn validates_representative_trace_payload_shapes() {
+        validate_trace_results_payload(&json!({
+            "timeline": [{
+                "t_ms": 1.5,
+                "source": "scenario",
+                "event": "loaded",
+                "data": { "selector": "main" }
+            }],
+            "assertions": [{
+                "id": "ready",
+                "status": "pass",
+                "message": "Page became ready"
+            }],
+            "artifacts": [{ "path": "trace.zip", "kind": "trace", "label": "trace" }],
+            "traces": [{
+                "component_id": "component",
+                "scenario_id": "scenario",
+                "status": "pass",
+                "summary": "Trace completed",
+                "timeline": [{ "t_ms": 1.5, "source": "scenario", "event": "loaded", "data": {} }],
+                "assertions": [{ "id": "ready", "status": "pass", "message": "Page became ready" }],
+                "artifacts": [{ "path": "trace.zip" }]
+            }]
+        }))
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_invalid_known_browser_evidence_fields() {
+        let err = validate_trace_results_payload(&json!({
+            "assertions": [{ "id": "ready", "status": "maybe", "message": "invalid" }]
+        }))
+        .expect_err("invalid assertion status should fail");
+
+        assert!(err.to_string().contains("assertions"));
+        assert!(err.to_string().contains("core schema"));
+    }
+}

--- a/src/core/browser_evidence.rs
+++ b/src/core/browser_evidence.rs
@@ -161,6 +161,18 @@ pub struct TraceAssertion {
     pub data: Option<Value>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct TraceTimeline {
+    #[serde(default)]
+    pub timeline: Vec<TraceEvent>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct TraceAssertions {
+    #[serde(default)]
+    pub assertions: Vec<TraceAssertion>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TraceEnvelopeStatus {
@@ -172,16 +184,15 @@ pub enum TraceEnvelopeStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
 pub struct TraceEnvelope {
     pub component_id: String,
     pub scenario_id: String,
     pub status: TraceEnvelopeStatus,
     pub summary: String,
-    #[serde(default)]
-    pub timeline: Vec<TraceEvent>,
-    #[serde(default)]
-    pub assertions: Vec<TraceAssertion>,
+    #[serde(flatten)]
+    pub timeline: TraceTimeline,
+    #[serde(flatten)]
+    pub assertions: TraceAssertions,
     #[serde(default)]
     pub artifacts: Vec<BrowserArtifactMetadata>,
     #[serde(default)]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,6 +15,7 @@ pub mod api_jobs;
 pub mod artifact_inputs;
 pub mod artifact_manifest;
 pub(crate) mod artifact_metadata;
+pub mod browser_evidence;
 pub mod change_artifact;
 pub mod ci_profile;
 pub mod cleanup;

--- a/src/core/structured_sidecar.rs
+++ b/src/core/structured_sidecar.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::core::engine::run_dir;
+use crate::core::{browser_evidence, engine::run_dir};
 use crate::core::{Error, Result};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -120,6 +120,12 @@ pub fn validate_payload(key: &str, payload: &Value) -> Result<()> {
     match schema.shape {
         StructuredSidecarShape::Array => validate_array_payload(schema, payload),
         StructuredSidecarShape::Object => validate_object_payload(schema, payload),
+    }?;
+
+    match key {
+        "bench.results" => browser_evidence::validate_bench_results_payload(payload),
+        "trace.results" => browser_evidence::validate_trace_results_payload(payload),
+        _ => Ok(()),
     }
 }
 
@@ -221,6 +227,12 @@ mod tests {
         validate_payload("test.failures", &json!([{ "message": "test failed" }])).unwrap();
         validate_payload("bench.results", &json!({ "results": [] })).unwrap();
         validate_payload("trace.results", &json!({ "runs": [] })).unwrap();
+        validate_payload("bench.results", &json!({ "browser_profiles": [] })).unwrap();
+        validate_payload(
+            "trace.results",
+            &json!({ "timeline": [], "assertions": [] }),
+        )
+        .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a core `browser_evidence` schema module for product-neutral browser/profile/trace payload contracts.
- Validates known `bench.results` and `trace.results` browser evidence fields while leaving envelope-level product semantics to extensions.
- Documents the schema boundary so WordPress, Studio, WooCommerce, and other product-specific attribution stays out of core.

Closes https://github.com/Extra-Chill/homeboy/issues/3594

## Tests
- `cargo fmt`
- `cargo test browser_evidence --lib`
- `cargo test structured_sidecar --lib`
- `cargo test --test report_browser_evidence_compare_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the focused core schema/docs follow-up and ran targeted verification; Chris remains responsible for review and merge.