### PR TITLE
Preserve typed lint settings

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -138,14 +138,14 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
     let effective_id = ctx.component_id.clone();
     let ci_job = resolve_ci_job_for_command(args.ci_job.as_deref(), &ctx.component, "lint")?;
 
-    let stringified_settings = ctx.resolved_settings().string_lossy_overrides();
+    let typed_settings = ctx.resolved_settings().typed_overrides();
 
     // --fix dispatches to the canonical refactor sources pipeline.
     // The fixer pipeline already exists; this flag connects the existing wire
     // so users don't have to re-type `homeboy refactor <component> --from lint
     // --write` to resolve the auto-fix CTA.
     if args.fix {
-        return run_fix(args, &ctx, effective_id, stringified_settings);
+        return run_fix(args, &ctx, effective_id, typed_settings);
     }
 
     let runner = ObservedWorkflowRunner::create(format!("lint {}", effective_id))?;
@@ -162,7 +162,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
             component_label: effective_id.clone(),
             component_id: ctx.component_id.clone(),
             path_override: args.comp.path.clone(),
-            settings: stringified_settings,
+            settings: typed_settings,
             summary: args.summary,
             file: args.file.clone(),
             glob: args.glob.clone(),
@@ -299,7 +299,7 @@ fn run_fix(
     args: LintArgs,
     ctx: &homeboy::core::engine::execution_context::ExecutionContext,
     component_label: String,
-    settings: Vec<(String, String)>,
+    settings: Vec<(String, serde_json::Value)>,
 ) -> CmdResult<LintCommandOutput> {
     let selected_files = if args.changed_only {
         let changes = git::get_uncommitted_changes(&ctx.component.local_path)?;
@@ -325,7 +325,7 @@ fn run_fix(
     let mut request = lint_refactor_request(
         ctx.component.clone(),
         ctx.source_path.clone(),
-        settings,
+        settings_to_legacy_strings(settings),
         lint_options,
         true,
     );
@@ -335,6 +335,19 @@ fn run_fix(
     let run = collect_refactor_sources(request)?;
 
     Ok(report::from_lint_fix(component_label, run))
+}
+
+fn settings_to_legacy_strings(settings: Vec<(String, serde_json::Value)>) -> Vec<(String, String)> {
+    settings
+        .into_iter()
+        .map(|(key, value)| {
+            let value = match value {
+                serde_json::Value::String(value) => value,
+                value => value.to_string(),
+            };
+            (key, value)
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -361,6 +361,11 @@ impl<'a> ResolvedSettings<'a> {
         Self { settings }
     }
 
+    /// Return every resolved setting with its typed JSON value preserved.
+    pub fn typed_overrides(&self) -> Vec<(String, serde_json::Value)> {
+        self.settings.to_vec()
+    }
+
     /// Return only settings that are already strings.
     pub fn string_overrides(&self) -> Vec<(String, String)> {
         self.settings

--- a/src/core/extension/lint/mod.rs
+++ b/src/core/extension/lint/mod.rs
@@ -24,7 +24,7 @@ pub fn resolve_lint_command(
 pub fn build_lint_runner(
     component: &Component,
     path_override: Option<String>,
-    settings: &[(String, String)],
+    settings: &[(String, serde_json::Value)],
     summary: bool,
     file: Option<&str>,
     glob: Option<&str>,
@@ -36,11 +36,13 @@ pub fn build_lint_runner(
     run_dir: &RunDir,
 ) -> crate::core::Result<ExtensionRunner> {
     let resolved = resolve_lint_command(component)?;
+    let (string_settings, json_settings) = split_lint_settings(settings);
 
     Ok(ExtensionRunner::for_context(resolved)
         .component(component.clone())
         .path_override(path_override)
-        .settings(settings)
+        .settings(&string_settings)
+        .settings_json(&json_settings)
         .with_run_dir(run_dir)
         .env_if(summary, "HOMEBOY_SUMMARY_MODE", "1")
         .env_opt("HOMEBOY_LINT_FILE", &file.map(str::to_string))
@@ -53,4 +55,69 @@ pub fn build_lint_runner(
             &exclude_sniffs.map(str::to_string),
         )
         .env_opt("HOMEBOY_CATEGORY", &category.map(str::to_string)))
+}
+
+fn split_lint_settings(
+    settings: &[(String, serde_json::Value)],
+) -> (Vec<(String, String)>, Vec<(String, serde_json::Value)>) {
+    settings
+        .iter()
+        .cloned()
+        .fold((Vec::new(), Vec::new()), |mut split, (key, value)| {
+            match value {
+                serde_json::Value::String(value) => split.0.push((key, value)),
+                value => split.1.push((key, value)),
+            }
+            split
+        })
+}
+
+pub(crate) fn settings_from_legacy_strings(
+    settings: &[(String, String)],
+) -> Vec<(String, serde_json::Value)> {
+    settings
+        .iter()
+        .map(|(key, value)| (key.clone(), serde_json::Value::String(value.clone())))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn split_lint_settings_preserves_typed_json_values() {
+        let settings = vec![
+            (
+                "severity".to_string(),
+                serde_json::Value::String("strict".to_string()),
+            ),
+            ("rules".to_string(), json!({ "security": true })),
+        ];
+
+        let (string_settings, json_settings) = split_lint_settings(&settings);
+
+        assert_eq!(
+            string_settings,
+            vec![("severity".to_string(), "strict".to_string())]
+        );
+        assert_eq!(
+            json_settings,
+            vec![("rules".to_string(), json!({ "security": true }))]
+        );
+    }
+
+    #[test]
+    fn legacy_lint_settings_are_explicitly_wrapped_as_strings() {
+        let settings = settings_from_legacy_strings(&[("mode".to_string(), "strict".to_string())]);
+
+        assert_eq!(
+            settings,
+            vec![(
+                "mode".to_string(),
+                serde_json::Value::String("strict".to_string()),
+            ),]
+        );
+    }
 }

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -25,7 +25,7 @@ pub struct LintRunWorkflowArgs {
     pub component_label: String,
     pub component_id: String,
     pub path_override: Option<String>,
-    pub settings: Vec<(String, String)>,
+    pub settings: Vec<(String, serde_json::Value)>,
     pub summary: bool,
     pub file: Option<String>,
     pub glob: Option<String>,

--- a/src/core/refactor/plan/sources.rs
+++ b/src/core/refactor/plan/sources.rs
@@ -648,11 +648,12 @@ fn run_lint_stage(
 
     // Helper: build the lint runner with the current stage options.
     // Used by both the diagnostic pass and the fix-only pass.
+    let typed_settings = extension::lint::settings_from_legacy_strings(settings);
     let build_lint_runner = |effective_glob: Option<&str>| {
         extension::lint::build_lint_runner(
             component,
             None,
-            settings,
+            &typed_settings,
             false,
             options.file.as_deref(),
             effective_glob,


### PR DESCRIPTION
## Summary
- Keeps resolved `homeboy lint` settings typed until the lint runner boundary instead of lossy-stringifying them in the command layer.
- Splits lint settings into string overrides and JSON overrides when constructing the extension runner, preserving typed `--setting-json` values through the workflow.
- Keeps the existing refactor lint path compatible by wrapping legacy string settings explicitly.

Refs #3268

## Tests
- `cargo fmt --check`
- `cargo test core::extension::lint -- --test-threads=1`
- `cargo test commands::lint -- --test-threads=1`
- `cargo check`
- `cargo run --bin homeboy -- audit homeboy --changed-since origin/main --only duplicate_function --json-summary`
- `cargo run --bin homeboy -- audit homeboy --changed-since origin/main --only high_item_count --json-summary`
- `cargo run --bin homeboy -- audit homeboy --changed-since origin/main --only dead_code_marker --json-summary`

Note: full changed-code audit (`cargo run --bin homeboy -- audit homeboy --changed-since origin/main --json-summary`) exceeded 15 minutes locally twice. Focused structural detectors passed with no introduced findings; `high_item_count` reported only known contextual baseline items.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the typed lint settings preservation slice, compatibility adapter, and targeted tests; Chris remains responsible for review and merge.