### PR TITLE
Fix selected lab runner fallback safety

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -40,6 +40,10 @@ pub struct Cli {
     #[arg(long, global = true, value_name = "RUNNER_ID")]
     pub runner: Option<String>,
 
+    /// Permit a selected Lab runner to fall back to local execution after offload preflight fails.
+    #[arg(long, global = true)]
+    pub allow_local_fallback: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -1087,6 +1091,16 @@ mod tests {
         let cli = parsed_cli(&["homeboy", "lint", "--runner", "lab-a"]);
         assert_eq!(cli.runner.as_deref(), Some("lab-a"));
         assert!(cli.command.supports_lab_runner());
+
+        let cli = parsed_cli(&[
+            "homeboy",
+            "trace",
+            "--runner",
+            "homeboy-lab",
+            "--allow-local-fallback",
+        ]);
+        assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+        assert!(cli.allow_local_fallback);
     }
 
     #[test]

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -12,6 +12,7 @@ pub fn route_after_parse(
         normalized_args,
         explicit_runner: cli.runner.as_deref(),
         force_hot: cli.force_hot,
+        allow_local_fallback: cli.allow_local_fallback,
         capture_patch: cli.command.lab_offload_mutation_flag().is_some(),
     })? {
         homeboy::core::runner::LabOffloadOutcome::RunLocal {

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -38,6 +38,7 @@ pub struct LabOffloadRequest<'a> {
     pub normalized_args: &'a [String],
     pub explicit_runner: Option<&'a str>,
     pub force_hot: bool,
+    pub allow_local_fallback: bool,
     pub capture_patch: bool,
 }
 
@@ -182,6 +183,17 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
                 .skip_reason(reason.clone())
                 .build(),
             );
+            if !request.allow_local_fallback {
+                return Err(selected_runner_fallback_error(
+                    &selection,
+                    "Lab offload selected a runner but could not prepare it for remote execution",
+                    &reason,
+                    vec![format!(
+                        "Reconnect runner `{}` before retrying Lab offload.",
+                        selection.runner_id
+                    )],
+                ));
+            }
             return Ok(LabOffloadOutcome::RunLocal {
                 metadata: Some(lab_offload_metadata(
                     &plan,
@@ -324,12 +336,14 @@ fn run_lab_offload_inner(
                         .skip_reason(reason.clone())
                         .build(),
                     );
-                    return Ok(automatic_capability_fallback(
+                    return automatic_capability_fallback_or_error(
                         plan,
-                        runner_id,
+                        &selection,
                         &runner_status,
                         reason,
-                    ));
+                        remediation,
+                        request.allow_local_fallback,
+                    );
                 }
                 LabRunnerSelectionSource::Explicit => {
                     return Err(Error::validation_invalid_argument(
@@ -513,20 +527,35 @@ fn run_lab_offload_inner(
                         .build(),
                 );
                 return match selection.source {
-                    LabRunnerSelectionSource::Default => Ok(LabOffloadOutcome::RunLocal {
-                        metadata: Some(lab_offload_metadata_with_workspace_mapping(
-                            &plan,
-                            selection.source.metadata_value(),
-                            Some(runner_id),
-                            Some(status_tunnel_mode(&runner_status).metadata_value()),
-                            "fallback",
-                            Some(&remote_cwd),
-                            Some(&reason),
-                            Some(&workspace_mapping_metadata),
-                        )),
-                        plan,
-                        messages: vec![format!("Lab offload: {reason}; running locally.")],
-                    }),
+                    LabRunnerSelectionSource::Default => {
+                        if !request.allow_local_fallback {
+                            Err(selected_runner_fallback_error(
+                                &selection,
+                                "Lab offload selected a runner but its daemon did not respond",
+                                &reason,
+                                vec![format!(
+                                    "Reconnect runner `{runner_id}` before retrying Lab offload."
+                                )],
+                            ))
+                        } else {
+                            Ok(LabOffloadOutcome::RunLocal {
+                                metadata: Some(lab_offload_metadata_with_workspace_mapping(
+                                    &plan,
+                                    selection.source.metadata_value(),
+                                    Some(runner_id),
+                                    Some(status_tunnel_mode(&runner_status).metadata_value()),
+                                    "fallback",
+                                    Some(&remote_cwd),
+                                    Some(&reason),
+                                    Some(&workspace_mapping_metadata),
+                                )),
+                                plan,
+                                messages: vec![format!(
+                                    "Lab offload: {reason}; running locally."
+                                )],
+                            })
+                        }
+                    }
                     LabRunnerSelectionSource::Explicit => Err(Error::validation_invalid_argument(
                         "runner",
                         format!(
@@ -611,6 +640,51 @@ fn automatic_capability_fallback(
         plan,
         messages: vec![format!("Lab offload: {reason}; running locally.")],
     }
+}
+
+fn automatic_capability_fallback_or_error(
+    plan: HomeboyPlan,
+    selection: &LabRunnerSelection,
+    runner_status: &RunnerStatusReport,
+    reason: String,
+    remediation: Vec<String>,
+    allow_local_fallback: bool,
+) -> Result<LabOffloadOutcome> {
+    if !allow_local_fallback {
+        return Err(selected_runner_fallback_error(
+            selection,
+            "Lab offload selected a runner that is missing required capability parity",
+            &reason,
+            remediation,
+        ));
+    }
+
+    Ok(automatic_capability_fallback(
+        plan,
+        &selection.runner_id,
+        runner_status,
+        reason,
+    ))
+}
+
+fn selected_runner_fallback_error(
+    selection: &LabRunnerSelection,
+    message: &str,
+    reason: &str,
+    mut remediation: Vec<String>,
+) -> Error {
+    remediation.push(
+        "Pass --allow-local-fallback only when local execution is intentional and safe for this controller."
+            .to_string(),
+    );
+    remediation.push("Use --force-hot to bypass Lab offload selection entirely.".to_string());
+
+    Error::validation_invalid_argument(
+        "runner",
+        format!("{message}: {reason}"),
+        Some(selection.runner_id.clone()),
+        Some(remediation),
+    )
 }
 
 fn mutation_return_unavailable_outcome(
@@ -912,12 +986,77 @@ mod tests {
     }
 
     #[test]
+    fn default_runner_missing_capabilities_fails_without_local_fallback_opt_in() {
+        let plan = base_lab_plan(Some(&portable_lab_command("trace")));
+        let selection = LabRunnerSelection {
+            runner_id: "homeboy-lab".to_string(),
+            source: LabRunnerSelectionSource::Default,
+            mode: RunnerTunnelMode::Reverse,
+        };
+        let status = reverse_status("homeboy-lab");
+
+        let result = automatic_capability_fallback_or_error(
+            plan,
+            &selection,
+            &status,
+            "Runner 'homeboy-lab' is missing required capability parity for `trace`: tools: playwright."
+                .to_string(),
+            vec!["Install Playwright and browser binaries on the runner.".to_string()],
+            false,
+        );
+
+        let Err(err) = result else {
+            panic!("expected selected default runner to fail fast");
+        };
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("missing required capability parity"));
+        assert!(err.message.contains("playwright"));
+        assert_eq!(err.details["id"], "homeboy-lab");
+        let tried = err.details["tried"].as_array().expect("tried");
+        assert!(tried.iter().any(|hint| hint
+            .as_str()
+            .is_some_and(|hint| hint.contains("--allow-local-fallback"))));
+    }
+
+    #[test]
+    fn default_runner_missing_capabilities_can_fallback_with_explicit_opt_in() {
+        let plan = base_lab_plan(Some(&portable_lab_command("trace")));
+        let selection = LabRunnerSelection {
+            runner_id: "homeboy-lab".to_string(),
+            source: LabRunnerSelectionSource::Default,
+            mode: RunnerTunnelMode::Reverse,
+        };
+        let status = reverse_status("homeboy-lab");
+
+        let outcome = automatic_capability_fallback_or_error(
+            plan,
+            &selection,
+            &status,
+            "Runner 'homeboy-lab' is missing required capability parity for `trace`: tools: playwright."
+                .to_string(),
+            Vec::new(),
+            true,
+        )
+        .expect("explicit fallback opt-in should allow local run");
+
+        let LabOffloadOutcome::RunLocal {
+            messages, metadata, ..
+        } = outcome
+        else {
+            panic!("expected local fallback");
+        };
+        assert!(messages[0].contains("running locally"));
+        assert_eq!(metadata.expect("metadata")["status"], "fallback");
+    }
+
+    #[test]
     fn plan_records_skipped_auto_offload() {
         let outcome = execute_lab_offload(LabOffloadRequest {
             command: Some(portable_lab_command("test")),
             normalized_args: &["homeboy".to_string(), "test".to_string()],
             explicit_runner: None,
             force_hot: true,
+            allow_local_fallback: false,
             capture_patch: false,
         })
         .expect("outcome");


### PR DESCRIPTION
## Summary
- Fixes #3619.
- Adds a global `--allow-local-fallback` opt-in for selected Lab runner fallback.
- Fails fast when a default-selected/offload runner is missing required capability parity or its daemon is not usable, instead of silently running heavy work on the controller.
- Preserves local execution when no Lab runner is selected, no default runner exists, or `--force-hot` intentionally bypasses offload.

## Evidence
- Before: issue #3619 reports browser-backed `homeboy trace` auto-selected `homeboy-lab`, found missing `playwright+browsers`, then fell back to local execution while the controller was hot.
- `cargo fmt --check`
- `cargo test core::runner::lab::tests --lib` passed: 13 passed.
- `cargo test commands::route::tests --lib` passed: 6 passed.
- `cargo test cli_surface::tests::test_supports_lab_runner --lib` passed: 1 passed.

## Notes
- Test runs emit an existing unrelated warning from `src/commands/runs/corpus_tests.rs`: unused import `serde_json::Value`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the Lab fallback policy change, added targeted tests, ran narrow verification, and drafted this PR body for Chris to review.