### PR TITLE
Derive deploy status from applied effects

### DIFF
--- a/src/core/deploy/effect.rs
+++ b/src/core/deploy/effect.rs
@@ -1,0 +1,147 @@
+use crate::core::component::Component;
+use crate::core::project::Project;
+use crate::core::server::SshClient;
+
+use super::types::DeployEffect;
+use super::version_overrides::fetch_remote_versions_for_project;
+
+pub(super) fn remote_version_after_deploy_effect(
+    component: &Component,
+    project: &Project,
+    base_path: &str,
+    client: &SshClient,
+    effect: Option<&DeployEffect>,
+    local_version: Option<&String>,
+) -> std::result::Result<Option<String>, String> {
+    let Some(effect) = effect else {
+        return Ok(local_version.cloned());
+    };
+    let has_version_targets = component
+        .version_targets
+        .as_ref()
+        .is_some_and(|targets| !targets.is_empty());
+
+    if !has_version_targets {
+        return Ok(local_version.cloned());
+    }
+
+    let observed_versions = fetch_remote_versions_for_project(
+        std::slice::from_ref(component),
+        Some(project),
+        base_path,
+        client,
+    );
+    let observed = observed_versions.get(&component.id).cloned().ok_or_else(|| {
+        format!(
+            "Deploy command completed for '{}' at '{}', but Homeboy could not read remote_version from the applied tree. Refusing to report success from stale pre-deploy observations.",
+            component.id, effect.remote_path
+        )
+    })?;
+
+    if let Some(expected) = local_version {
+        if &observed != expected {
+            return Err(format!(
+                "Deploy command completed for '{}' at '{}', but post-deploy remote_version is '{}' instead of expected local_version '{}'. Refusing to report success from a mismatched deploy effect.",
+                component.id, effect.remote_path, observed, expected
+            ));
+        }
+    }
+
+    Ok(Some(observed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::remote_version_after_deploy_effect;
+    use crate::core::component::{Component, VersionTarget};
+    use crate::core::deploy::types::DeployEffect;
+    use crate::core::project::Project;
+    use crate::core::server::SshClient;
+    use std::collections::HashMap;
+
+    #[test]
+    fn post_effect_version_read_uses_applied_remote_tree() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let remote_dir = temp.path().join("plugin");
+        std::fs::create_dir_all(&remote_dir).expect("remote dir");
+        std::fs::write(remote_dir.join("plugin.php"), "<?php\nVersion: 1.2.3\n")
+            .expect("remote version file");
+        let component = Component {
+            id: "plugin".to_string(),
+            remote_path: "plugin".to_string(),
+            version_targets: Some(vec![VersionTarget {
+                file: "plugin.php".to_string(),
+                pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+            }]),
+            ..Component::default()
+        };
+        let effect = DeployEffect {
+            remote_path: remote_dir.to_string_lossy().to_string(),
+            artifact_path: Some("/tmp/plugin.zip".to_string()),
+            verified: false,
+        };
+        let expected_version = "1.2.3".to_string();
+
+        let version = remote_version_after_deploy_effect(
+            &component,
+            &Project::default(),
+            temp.path().to_str().expect("base path"),
+            &local_client(),
+            Some(&effect),
+            Some(&expected_version),
+        )
+        .expect("post-effect version")
+        .expect("observed version");
+
+        assert_eq!(version, "1.2.3");
+    }
+
+    #[test]
+    fn post_effect_version_read_rejects_unobserved_configured_version_target() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let remote_dir = temp.path().join("plugin");
+        std::fs::create_dir_all(&remote_dir).expect("remote dir");
+        let component = Component {
+            id: "plugin".to_string(),
+            remote_path: "plugin".to_string(),
+            version_targets: Some(vec![VersionTarget {
+                file: "plugin.php".to_string(),
+                pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+            }]),
+            ..Component::default()
+        };
+        let effect = DeployEffect {
+            remote_path: remote_dir.to_string_lossy().to_string(),
+            artifact_path: Some("/tmp/plugin.zip".to_string()),
+            verified: false,
+        };
+        let expected_version = "1.2.3".to_string();
+
+        let error = remote_version_after_deploy_effect(
+            &component,
+            &Project::default(),
+            temp.path().to_str().expect("base path"),
+            &local_client(),
+            Some(&effect),
+            Some(&expected_version),
+        )
+        .expect_err("missing post-effect remote version should fail");
+
+        assert!(
+            error.contains("could not read remote_version from the applied tree"),
+            "unexpected error: {error}"
+        );
+    }
+
+    fn local_client() -> SshClient {
+        SshClient {
+            host: "localhost".to_string(),
+            user: "test".to_string(),
+            port: 22,
+            identity_file: None,
+            auth: None,
+            is_local: true,
+            env: HashMap::new(),
+        }
+    }
+}

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -10,6 +10,7 @@ use crate::core::extension::build::resolve_artifact_path_from_root;
 use crate::core::git;
 use crate::core::project::Project;
 
+use super::effect::remote_version_after_deploy_effect;
 use super::generated_artifacts::GeneratedBuildArtifactCleanupGuard;
 use super::path_roots::{component_remote_path, resolve_effective_remote_path};
 use super::planning::{calculate_directory_size, format_bytes};
@@ -18,8 +19,8 @@ use super::release_download;
 use super::safety_and_artifact::{deploy_artifact, deploy_via_git};
 use super::types::{ComponentDeployResult, DeployConfig, DeployResult};
 use super::version_overrides::{
-    deploy_with_override, fetch_remote_versions_for_project, find_deploy_override,
-    find_deploy_verification, is_self_deploy, prefer_installed_binary, run_post_deploy_hooks,
+    deploy_with_override, find_deploy_override, find_deploy_verification, is_self_deploy,
+    prefer_installed_binary, run_post_deploy_hooks,
 };
 
 pub(super) struct PreparedComponentDeploy {
@@ -883,51 +884,6 @@ fn execute_artifact_deploy(
     }
 }
 
-fn remote_version_after_deploy_effect(
-    component: &Component,
-    project: &Project,
-    base_path: &str,
-    client: &crate::core::server::SshClient,
-    effect: Option<&super::types::DeployEffect>,
-    local_version: Option<&String>,
-) -> std::result::Result<Option<String>, String> {
-    let Some(effect) = effect else {
-        return Ok(local_version.cloned());
-    };
-    let has_version_targets = component
-        .version_targets
-        .as_ref()
-        .is_some_and(|targets| !targets.is_empty());
-
-    if !has_version_targets {
-        return Ok(local_version.cloned());
-    }
-
-    let observed_versions = fetch_remote_versions_for_project(
-        std::slice::from_ref(component),
-        Some(project),
-        base_path,
-        client,
-    );
-    let observed = observed_versions.get(&component.id).cloned().ok_or_else(|| {
-        format!(
-            "Deploy command completed for '{}' at '{}', but Homeboy could not read remote_version from the applied tree. Refusing to report success from stale pre-deploy observations.",
-            component.id, effect.remote_path
-        )
-    })?;
-
-    if let Some(expected) = local_version {
-        if &observed != expected {
-            return Err(format!(
-                "Deploy command completed for '{}' at '{}', but post-deploy remote_version is '{}' instead of expected local_version '{}'. Refusing to report success from a mismatched deploy effect.",
-                component.id, effect.remote_path, observed, expected
-            ));
-        }
-    }
-
-    Ok(Some(observed))
-}
-
 /// Remove the local build artifact created for a deploy.
 ///
 /// `homeboy build` intentionally leaves a package for humans to inspect. During
@@ -980,10 +936,6 @@ fn cleanup_empty_artifact_dirs(local_path: &Path, start_dir: Option<&Path>) {
     }
 }
 
-// =============================================================================
-// Release Artifact Download
-// =============================================================================
-
 /// Try to download a release artifact from GitHub for the component's latest tag.
 ///
 /// Returns `Ok(Some(path))` if successful and `Ok(None)` for normal download misses
@@ -1002,7 +954,6 @@ fn try_download_release_artifact(
         return Ok(None);
     };
 
-    // Get the latest tag from the local clone (already synced by the pipeline)
     let Some(tag) = git::get_latest_tag(&component.local_path).ok().flatten() else {
         return Ok(None);
     };
@@ -1032,27 +983,20 @@ fn try_download_release_artifact(
     }
 }
 
-// =============================================================================
-// Cleanup Functions
-// =============================================================================
-
 /// Clean up build dependencies from component's local_path after successful deploy.
 /// This is a best-effort operation - failures are logged but do not fail the deploy.
 fn cleanup_build_dependencies(
     component: &Component,
     config: &DeployConfig,
 ) -> Result<Option<String>> {
-    // Skip cleanup if disabled at component level
     if !component.auto_cleanup {
         return Ok(None);
     }
 
-    // Skip cleanup if --keep-deps flag is set
     if config.keep_deps {
         return Ok(Some("skipped (--keep-deps flag)".to_string()));
     }
 
-    // Collect cleanup paths from linked extensions
     let mut cleanup_paths = Vec::new();
     if let Some(ref extensions) = component.extensions {
         for extension_id in extensions.keys() {
@@ -1134,14 +1078,11 @@ fn cleanup_build_dependencies(
 mod tests {
     use super::{
         artifact_requires_component_extract_command, cleanup_deploy_build_artifact,
-        failed_component_deploy_result, remote_version_after_deploy_effect,
-        resolve_preflight_artifact_path, should_try_download_release_artifact,
+        failed_component_deploy_result, resolve_preflight_artifact_path,
+        should_try_download_release_artifact,
     };
-    use crate::core::component::{ArtifactInput, Component, VersionTarget};
-    use crate::core::deploy::types::{DeployConfig, DeployEffect};
-    use crate::core::project::Project;
-    use crate::core::server::SshClient;
-    use std::collections::HashMap;
+    use crate::core::component::{ArtifactInput, Component};
+    use crate::core::deploy::types::DeployConfig;
     use std::process::Command;
 
     #[test]
@@ -1245,92 +1186,6 @@ mod tests {
             true,
             false,
         ));
-    }
-
-    #[test]
-    fn post_effect_version_read_uses_applied_remote_tree() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let remote_dir = temp.path().join("plugin");
-        std::fs::create_dir_all(&remote_dir).expect("remote dir");
-        std::fs::write(remote_dir.join("plugin.php"), "<?php\nVersion: 1.2.3\n")
-            .expect("remote version file");
-        let component = Component {
-            id: "plugin".to_string(),
-            remote_path: "plugin".to_string(),
-            version_targets: Some(vec![VersionTarget {
-                file: "plugin.php".to_string(),
-                pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
-            }]),
-            ..Component::default()
-        };
-        let effect = DeployEffect {
-            remote_path: remote_dir.to_string_lossy().to_string(),
-            artifact_path: Some("/tmp/plugin.zip".to_string()),
-            verified: false,
-        };
-        let expected_version = "1.2.3".to_string();
-
-        let version = remote_version_after_deploy_effect(
-            &component,
-            &Project::default(),
-            temp.path().to_str().expect("base path"),
-            &local_client(),
-            Some(&effect),
-            Some(&expected_version),
-        )
-        .expect("post-effect version")
-        .expect("observed version");
-
-        assert_eq!(version, "1.2.3");
-    }
-
-    #[test]
-    fn post_effect_version_read_rejects_unobserved_configured_version_target() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let remote_dir = temp.path().join("plugin");
-        std::fs::create_dir_all(&remote_dir).expect("remote dir");
-        let component = Component {
-            id: "plugin".to_string(),
-            remote_path: "plugin".to_string(),
-            version_targets: Some(vec![VersionTarget {
-                file: "plugin.php".to_string(),
-                pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
-            }]),
-            ..Component::default()
-        };
-        let effect = DeployEffect {
-            remote_path: remote_dir.to_string_lossy().to_string(),
-            artifact_path: Some("/tmp/plugin.zip".to_string()),
-            verified: false,
-        };
-        let expected_version = "1.2.3".to_string();
-
-        let error = remote_version_after_deploy_effect(
-            &component,
-            &Project::default(),
-            temp.path().to_str().expect("base path"),
-            &local_client(),
-            Some(&effect),
-            Some(&expected_version),
-        )
-        .expect_err("missing post-effect remote version should fail");
-
-        assert!(
-            error.contains("could not read remote_version from the applied tree"),
-            "unexpected error: {error}"
-        );
-    }
-
-    fn local_client() -> SshClient {
-        SshClient {
-            host: "localhost".to_string(),
-            user: "test".to_string(),
-            port: 22,
-            identity_file: None,
-            auth: None,
-            is_local: true,
-            env: HashMap::new(),
-        }
     }
 
     #[test]

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -18,8 +18,8 @@ use super::release_download;
 use super::safety_and_artifact::{deploy_artifact, deploy_via_git};
 use super::types::{ComponentDeployResult, DeployConfig, DeployResult};
 use super::version_overrides::{
-    deploy_with_override, find_deploy_override, find_deploy_verification, is_self_deploy,
-    prefer_installed_binary, run_post_deploy_hooks,
+    deploy_with_override, fetch_remote_versions_for_project, find_deploy_override,
+    find_deploy_verification, is_self_deploy, prefer_installed_binary, run_post_deploy_hooks,
 };
 
 pub(super) struct PreparedComponentDeploy {
@@ -805,8 +805,33 @@ fn execute_artifact_deploy(
         Ok(DeployResult {
             success: true,
             exit_code,
+            effect,
             ..
         }) => {
+            let reported_remote_version = match remote_version_after_deploy_effect(
+                component,
+                project,
+                base_path,
+                &ctx.client,
+                effect.as_ref(),
+                prepared.local_version.as_ref(),
+            ) {
+                Ok(version) => version,
+                Err(error) => {
+                    return ComponentDeployResult::failed(
+                        component,
+                        base_path,
+                        prepared.local_version.clone(),
+                        prepared.remote_version.clone(),
+                        error,
+                    )
+                    .with_remote_path(install_dir.to_string())
+                    .with_artifact_inputs(artifact_input_metadata)
+                    .with_build_exit_code(prepared.build_exit_code)
+                    .with_deploy_exit_code(Some(exit_code));
+                }
+            };
+
             if prepared.cleanup_local_artifact {
                 cleanup_deploy_build_artifact(component, artifact_path);
             }
@@ -825,10 +850,7 @@ fn execute_artifact_deploy(
 
             ComponentDeployResult::new(component, base_path)
                 .with_status("deployed")
-                .with_versions(
-                    prepared.local_version.clone(),
-                    prepared.local_version.clone(),
-                )
+                .with_versions(prepared.local_version.clone(), reported_remote_version)
                 .with_remote_path(install_dir.to_string())
                 .with_artifact_inputs(artifact_input_metadata)
                 .with_build_exit_code(prepared.build_exit_code)
@@ -838,6 +860,7 @@ fn execute_artifact_deploy(
             success: false,
             exit_code,
             error,
+            ..
         }) => ComponentDeployResult::failed(
             component,
             base_path,
@@ -858,6 +881,51 @@ fn execute_artifact_deploy(
         .with_remote_path(install_dir.to_string())
         .with_build_exit_code(prepared.build_exit_code),
     }
+}
+
+fn remote_version_after_deploy_effect(
+    component: &Component,
+    project: &Project,
+    base_path: &str,
+    client: &crate::core::server::SshClient,
+    effect: Option<&super::types::DeployEffect>,
+    local_version: Option<&String>,
+) -> std::result::Result<Option<String>, String> {
+    let Some(effect) = effect else {
+        return Ok(local_version.cloned());
+    };
+    let has_version_targets = component
+        .version_targets
+        .as_ref()
+        .is_some_and(|targets| !targets.is_empty());
+
+    if !has_version_targets {
+        return Ok(local_version.cloned());
+    }
+
+    let observed_versions = fetch_remote_versions_for_project(
+        std::slice::from_ref(component),
+        Some(project),
+        base_path,
+        client,
+    );
+    let observed = observed_versions.get(&component.id).cloned().ok_or_else(|| {
+        format!(
+            "Deploy command completed for '{}' at '{}', but Homeboy could not read remote_version from the applied tree. Refusing to report success from stale pre-deploy observations.",
+            component.id, effect.remote_path
+        )
+    })?;
+
+    if let Some(expected) = local_version {
+        if &observed != expected {
+            return Err(format!(
+                "Deploy command completed for '{}' at '{}', but post-deploy remote_version is '{}' instead of expected local_version '{}'. Refusing to report success from a mismatched deploy effect.",
+                component.id, effect.remote_path, observed, expected
+            ));
+        }
+    }
+
+    Ok(Some(observed))
 }
 
 /// Remove the local build artifact created for a deploy.
@@ -1066,11 +1134,14 @@ fn cleanup_build_dependencies(
 mod tests {
     use super::{
         artifact_requires_component_extract_command, cleanup_deploy_build_artifact,
-        failed_component_deploy_result, resolve_preflight_artifact_path,
-        should_try_download_release_artifact,
+        failed_component_deploy_result, remote_version_after_deploy_effect,
+        resolve_preflight_artifact_path, should_try_download_release_artifact,
     };
-    use crate::core::component::{ArtifactInput, Component};
-    use crate::core::deploy::types::DeployConfig;
+    use crate::core::component::{ArtifactInput, Component, VersionTarget};
+    use crate::core::deploy::types::{DeployConfig, DeployEffect};
+    use crate::core::project::Project;
+    use crate::core::server::SshClient;
+    use std::collections::HashMap;
     use std::process::Command;
 
     #[test]
@@ -1174,6 +1245,92 @@ mod tests {
             true,
             false,
         ));
+    }
+
+    #[test]
+    fn post_effect_version_read_uses_applied_remote_tree() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let remote_dir = temp.path().join("plugin");
+        std::fs::create_dir_all(&remote_dir).expect("remote dir");
+        std::fs::write(remote_dir.join("plugin.php"), "<?php\nVersion: 1.2.3\n")
+            .expect("remote version file");
+        let component = Component {
+            id: "plugin".to_string(),
+            remote_path: "plugin".to_string(),
+            version_targets: Some(vec![VersionTarget {
+                file: "plugin.php".to_string(),
+                pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+            }]),
+            ..Component::default()
+        };
+        let effect = DeployEffect {
+            remote_path: remote_dir.to_string_lossy().to_string(),
+            artifact_path: Some("/tmp/plugin.zip".to_string()),
+            verified: false,
+        };
+        let expected_version = "1.2.3".to_string();
+
+        let version = remote_version_after_deploy_effect(
+            &component,
+            &Project::default(),
+            temp.path().to_str().expect("base path"),
+            &local_client(),
+            Some(&effect),
+            Some(&expected_version),
+        )
+        .expect("post-effect version")
+        .expect("observed version");
+
+        assert_eq!(version, "1.2.3");
+    }
+
+    #[test]
+    fn post_effect_version_read_rejects_unobserved_configured_version_target() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let remote_dir = temp.path().join("plugin");
+        std::fs::create_dir_all(&remote_dir).expect("remote dir");
+        let component = Component {
+            id: "plugin".to_string(),
+            remote_path: "plugin".to_string(),
+            version_targets: Some(vec![VersionTarget {
+                file: "plugin.php".to_string(),
+                pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+            }]),
+            ..Component::default()
+        };
+        let effect = DeployEffect {
+            remote_path: remote_dir.to_string_lossy().to_string(),
+            artifact_path: Some("/tmp/plugin.zip".to_string()),
+            verified: false,
+        };
+        let expected_version = "1.2.3".to_string();
+
+        let error = remote_version_after_deploy_effect(
+            &component,
+            &Project::default(),
+            temp.path().to_str().expect("base path"),
+            &local_client(),
+            Some(&effect),
+            Some(&expected_version),
+        )
+        .expect_err("missing post-effect remote version should fail");
+
+        assert!(
+            error.contains("could not read remote_version from the applied tree"),
+            "unexpected error: {error}"
+        );
+    }
+
+    fn local_client() -> SshClient {
+        SshClient {
+            host: "localhost".to_string(),
+            user: "test".to_string(),
+            port: 22,
+            identity_file: None,
+            auth: None,
+            is_local: true,
+            env: HashMap::new(),
+        }
     }
 
     #[test]

--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -1,3 +1,4 @@
+mod effect;
 mod execution;
 mod generated_artifacts;
 mod orchestration;

--- a/src/core/deploy/safety_and_artifact.rs
+++ b/src/core/deploy/safety_and_artifact.rs
@@ -11,7 +11,7 @@ use crate::core::extension::DeployVerification;
 use crate::core::server::SshClient;
 
 use super::transfer::{upload_directory, upload_file};
-use super::types::DeployResult;
+use super::types::{DeployEffect, DeployResult};
 
 /// Framework-neutral shared directory names that typically contain sibling components.
 const DANGEROUS_PATH_SUFFIXES: &[&str] = &["/node_modules", "/vendor", "/packages", "/extensions"];
@@ -107,6 +107,7 @@ pub(super) fn deploy_artifact(
     remote_owner: Option<&str>,
 ) -> Result<DeployResult> {
     let mut uploaded_artifact_path: Option<String> = None;
+    let mut verified = false;
 
     // Step 1: Upload (directory or file)
     if local_path.is_dir() {
@@ -311,9 +312,14 @@ pub(super) fn deploy_artifact(
                 .unwrap_or_else(|| format!("Deploy verification failed for {}", remote_path));
             return Ok(DeployResult::failure(1, error_msg));
         }
+        verified = true;
     }
 
-    Ok(DeployResult::success(0))
+    Ok(DeployResult::success(0).with_effect(DeployEffect {
+        remote_path: remote_path.to_string(),
+        artifact_path: uploaded_artifact_path,
+        verified,
+    }))
 }
 
 /// Return the final path segment of `remote_path` (its basename), if any.

--- a/src/core/deploy/types.rs
+++ b/src/core/deploy/types.rs
@@ -21,6 +21,14 @@ pub struct DeployResult {
     pub success: bool,
     pub exit_code: i32,
     pub error: Option<String>,
+    pub effect: Option<DeployEffect>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DeployEffect {
+    pub remote_path: String,
+    pub artifact_path: Option<String>,
+    pub verified: bool,
 }
 
 impl DeployResult {
@@ -29,6 +37,7 @@ impl DeployResult {
             success: true,
             exit_code,
             error: None,
+            effect: None,
         }
     }
 
@@ -37,7 +46,13 @@ impl DeployResult {
             success: false,
             exit_code,
             error: Some(error),
+            effect: None,
         }
+    }
+
+    pub(super) fn with_effect(mut self, effect: DeployEffect) -> Self {
+        self.effect = Some(effect);
+        self
     }
 }
 

--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -19,7 +19,7 @@ use crate::core::server::SshClient;
 
 use super::path_roots::resolve_effective_remote_path;
 use super::transfer::scp_file;
-use super::types::DeployResult;
+use super::types::{DeployEffect, DeployResult};
 
 /// Detect if a component's artifact is a CLI binary matching the currently
 /// running process name. Used to print a post-deploy hint for self-deploy.
@@ -358,6 +358,7 @@ pub(super) fn deploy_with_override(
         })?;
 
     let staging_artifact = format!("{}/{}", override_config.staging_path, artifact_filename);
+    let mut verified = false;
 
     // Step 1: Create staging directory
     let mkdir_cmd = format!(
@@ -457,6 +458,7 @@ pub(super) fn deploy_with_override(
                     .unwrap_or_else(|| format!("Deploy verification failed for {}", remote_path));
                 return Ok(DeployResult::failure(1, error_msg));
             }
+            verified = true;
         }
     }
 
@@ -467,7 +469,11 @@ pub(super) fn deploy_with_override(
         let _ = ssh_client.execute(&cleanup_cmd); // Best effort cleanup
     }
 
-    Ok(DeployResult::success(0))
+    Ok(DeployResult::success(0).with_effect(DeployEffect {
+        remote_path: remote_path.to_string(),
+        artifact_path: Some(staging_artifact),
+        verified,
+    }))
 }
 
 fn deploy_override_template_vars(


### PR DESCRIPTION
## Summary
- Adds an internal deploy-effect envelope to successful artifact/override deploy results so the reporting path knows which remote path/artifact was actually applied.
- Derives artifact deploy `remote_version` from an ordered post-effect read when `version_targets` are configured instead of copying stale pre-deploy/local assumptions.
- Refuses to report `deployed` when a successful deploy command cannot produce the configured post-effect remote version, closing the effect/report split behind false deploy statuses.

Closes #3236

## Tests
- `cargo fmt --check`
- `cargo test post_effect_version_read`
- `cargo test core::deploy`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the deploy effect/report split, drafted the internal deploy-effect contract and regression tests, and ran targeted verification for Chris to review.