### PR TITLE
Fix package-root expansion in rig specs

### DIFF
--- a/src/core/rig/expand.rs
+++ b/src/core/rig/expand.rs
@@ -5,6 +5,7 @@
 //!
 //! - `${components.<id>.path}` — component path from the rig spec
 //! - `${env.<NAME>}` — process environment variable (empty if unset)
+//! - `${package.root}` — installed rig package root, when source metadata exists
 //! - `~` — home directory (via `shellexpand::tilde`)
 //!
 //! Unknown `${...}` patterns are left untouched so users get a clear
@@ -96,6 +97,9 @@ fn normalize_exclusive_resource(resource: String) -> String {
 }
 
 fn resolve_token(rig: &RigSpec, token: &str) -> Option<String> {
+    if token == "package.root" {
+        return super::install::read_source_metadata(&rig.id).map(|metadata| metadata.package_path);
+    }
     if let Some(rest) = token.strip_prefix("components.") {
         // Expect "<id>.path" — future fields can add here.
         let (id, field) = rest.split_once('.')?;
@@ -103,7 +107,11 @@ fn resolve_token(rig: &RigSpec, token: &str) -> Option<String> {
             return None;
         }
         let component = rig.components.get(id)?;
-        let expanded = shellexpand::tilde(&component.path).into_owned();
+        let expanded = expand::expand_with_tilde(&component.path, |token| match token {
+            "package.root" => resolve_token(rig, token),
+            token if token.starts_with("env.") => resolve_token(rig, token),
+            _ => None,
+        });
         return Some(expanded);
     }
     if let Some(name) = token.strip_prefix("env.") {

--- a/src/core/rig/workloads.rs
+++ b/src/core/rig/workloads.rs
@@ -148,12 +148,11 @@ pub fn invocation_requirements_for_extension_workloads(
 }
 
 fn expand_workload_path(rig_spec: &RigSpec, package_root: Option<&Path>, path: &str) -> PathBuf {
-    let expanded = super::expand::expand_vars(rig_spec, path);
-    let expanded = match package_root {
-        Some(root) => expanded.replace("${package.root}", &root.to_string_lossy()),
-        None => expanded,
+    let path = match package_root {
+        Some(root) => path.replace("${package.root}", &root.to_string_lossy()),
+        None => path.to_string(),
     };
-    PathBuf::from(expanded)
+    PathBuf::from(super::expand::expand_vars(rig_spec, &path))
 }
 
 #[cfg(test)]

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -7,8 +7,10 @@ use crate::core::rig::expand::{expand_resources, expand_vars};
 use crate::core::rig::spec::{
     ComponentSpec, DiscoverSpec, RigSpec, ServiceKind, ServiceSpec, SymlinkSpec,
 };
+use crate::core::paths;
 use crate::test_support::with_isolated_home;
 use std::collections::HashMap;
+use std::fs;
 
 fn rig_with(id: &str, components: HashMap<String, ComponentSpec>) -> RigSpec {
     RigSpec {
@@ -59,6 +61,52 @@ fn test_expand_vars_component_path() {
         expand_vars(&rig, "${components.studio.path}/dist"),
         "/tmp/studio/dist"
     );
+}
+
+#[test]
+fn test_expand_vars_package_root_from_installed_source_metadata() {
+    with_isolated_home(|home| {
+        let package_root = home.path().join("rig-packages/studio-web");
+        let metadata_dir = paths::rig_sources().expect("rig sources dir");
+        fs::create_dir_all(&metadata_dir).expect("mkdir rig sources");
+        fs::write(
+            metadata_dir.join("studio-web-product-matrix.json"),
+            serde_json::json!({
+                "source": package_root,
+                "package_path": package_root,
+                "rig_path": package_root.join("rigs/studio-web-product-matrix/rig.json"),
+                "discovery_path": package_root,
+                "linked": true,
+                "source_revision": null
+            })
+            .to_string(),
+        )
+        .expect("write rig source metadata");
+
+        let mut components = HashMap::new();
+        components.insert(
+            "studio-web".to_string(),
+            ComponentSpec {
+                path: "${package.root}".to_string(),
+                checkout_root: None,
+                remote_url: None,
+                triage_remote_url: None,
+                stack: None,
+                branch: None,
+                extensions: None,
+            },
+        );
+        let rig = rig_with("studio-web-product-matrix", components);
+
+        assert_eq!(
+            expand_vars(&rig, "${package.root}/scripts/workflow-bench.mjs"),
+            package_root.join("scripts/workflow-bench.mjs").to_string_lossy()
+        );
+        assert_eq!(
+            expand_vars(&rig, "${components.studio-web.path}/bench"),
+            package_root.join("bench").to_string_lossy()
+        );
+    });
 }
 
 #[test]

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -3,11 +3,11 @@
 //! Audit convention requires a `test_expand_vars` method matching the sole
 //! public function of the module; additional cases cover edge conditions.
 
+use crate::core::paths;
 use crate::core::rig::expand::{expand_resources, expand_vars};
 use crate::core::rig::spec::{
     ComponentSpec, DiscoverSpec, RigSpec, ServiceKind, ServiceSpec, SymlinkSpec,
 };
-use crate::core::paths;
 use crate::test_support::with_isolated_home;
 use std::collections::HashMap;
 use std::fs;
@@ -100,7 +100,9 @@ fn test_expand_vars_package_root_from_installed_source_metadata() {
 
         assert_eq!(
             expand_vars(&rig, "${package.root}/scripts/workflow-bench.mjs"),
-            package_root.join("scripts/workflow-bench.mjs").to_string_lossy()
+            package_root
+                .join("scripts/workflow-bench.mjs")
+                .to_string_lossy()
         );
         assert_eq!(
             expand_vars(&rig, "${components.studio-web.path}/bench"),


### PR DESCRIPTION
## Summary
- Expand `${package.root}` through the shared rig variable expander when installed rig source metadata exists.
- Let component paths such as `${package.root}` resolve when referenced through `${components.<id>.path}`.
- Preserve explicit workload package-root overrides while still running normal rig variable expansion afterward.

## Evidence
- `cargo test test_expand_vars_package_root_from_installed_source_metadata`
- `cargo test test_extension_workloads_expand_package_root_when_available`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Root-cause tracing, code changes, regression tests, and PR drafting; Chris remains responsible for review and merge.