### PR TITLE
Fix lab daemon exec without runner host config

### DIFF
--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -12,7 +12,9 @@ use crate::core::error::{Error, RemoteCommandFailedDetails, Result, TargetDetail
 use crate::core::http_api::{self, AnalysisJobRunner, HttpMethod, UnsupportedAnalysisJobRunner};
 use crate::core::paths;
 use crate::core::process::pid_is_running;
-use crate::core::runner::{execute_runner_process, prepare_runner_process, RunnerProcessRequest};
+use crate::core::runner::{
+    execute_runner_process, prepare_daemon_local_process, RunnerProcessRequest,
+};
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::upgrade::VERSION;
 
@@ -331,7 +333,7 @@ fn enqueue_exec_job(
                 None,
             )
         })?;
-    let plan = prepare_runner_process(RunnerProcessRequest {
+    let plan = prepare_daemon_local_process(RunnerProcessRequest {
         runner_id: request.runner_id,
         cwd: request.cwd,
         project_id: request.project_id,

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -671,6 +671,62 @@ pub(crate) fn prepare_runner_process(request: RunnerProcessRequest) -> Result<Ru
     })
 }
 
+pub(crate) fn prepare_daemon_local_process(
+    request: RunnerProcessRequest,
+) -> Result<RunnerProcessPlan> {
+    if request.command.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "command",
+            "runner exec requires a command after --",
+            None,
+            None,
+        ));
+    }
+
+    let cwd = request.cwd.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "cwd",
+            "daemon exec requires an absolute cwd",
+            Some(request.runner_id.clone()),
+            Some(vec![
+                "Pass the synced remote workspace path as cwd when submitting daemon exec."
+                    .to_string(),
+            ]),
+        )
+    })?;
+    let runner = Runner {
+        id: request.runner_id,
+        kind: RunnerKind::Local,
+        server_id: None,
+        workspace_root: Some(cwd.clone()),
+        settings: server::RunnerSettings::default(),
+        env: HashMap::new(),
+        resources: HashMap::new(),
+        policy: server::RunnerPolicy::default(),
+    };
+    validate_runner_process_cwd(&runner, &cwd)?;
+    validate_required_paths(
+        &runner,
+        &request.require_paths,
+        request.validate_require_paths_on_host,
+    )?;
+
+    let mut env = request.env;
+    normalize_runner_command_env(&mut env);
+    let source_snapshot = request.source_snapshot.unwrap_or_else(|| {
+        SourceSnapshot::collect_local(&runner.id, Path::new(&cwd), Some(&cwd), "existing_remote")
+    });
+
+    Ok(RunnerProcessPlan {
+        runner,
+        cwd,
+        command: request.command,
+        env,
+        source_snapshot,
+        require_paths: request.require_paths,
+    })
+}
+
 fn validate_required_paths(
     runner: &Runner,
     required_paths: &[String],
@@ -1423,6 +1479,7 @@ mod tests {
             Default::default(),
             false,
             None,
+            Vec::new(),
         )
         .expect_err("daemon exec failure");
 

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -55,7 +55,7 @@ pub use evidence::{
     is_retrievable_runner_artifact, reportable_artifact_evidence_path, RemoteArtifactDownload,
 };
 pub(crate) use execution::{
-    daemon_api_get, execute_runner_process, prepare_runner_process, RunnerProcessRequest,
+    daemon_api_get, execute_runner_process, prepare_daemon_local_process, RunnerProcessRequest,
 };
 pub use execution::{exec, RunnerExecMode, RunnerExecOptions, RunnerExecOutput};
 pub(crate) use git_dependency_materialization::{

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -498,6 +498,41 @@ fn routes_exec_body_to_daemon_job() {
 }
 
 #[test]
+fn daemon_exec_does_not_require_runner_config_on_daemon_host() {
+    let _home = HomeGuard::new();
+    let store = JobStore::default();
+    let response = route_with_job_store_and_body(
+        "POST",
+        "/exec",
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "cwd": std::env::current_dir().expect("cwd"),
+            "command": ["sh", "-c", "printf lab"]
+        })),
+        &store,
+    );
+
+    assert_eq!(response.status_code, 200);
+    let job_id = response.body["body"]["job"]["id"]
+        .as_str()
+        .expect("job id")
+        .to_string();
+    let job = wait_for_job(&store, &job_id);
+    assert_eq!(job.status, JobStatus::Succeeded);
+
+    let events = store.events(job.id).expect("events");
+    let result = events
+        .iter()
+        .find(|event| event.kind == JobEventKind::Result)
+        .and_then(|event| event.data.as_ref())
+        .expect("result event");
+    assert_eq!(result["runner_id"], "homeboy-lab");
+    assert_eq!(result["stdout"], "lab");
+    assert_eq!(result["source_snapshot"]["runner_id"], "homeboy-lab");
+    assert_eq!(result["source_snapshot"]["sync_mode"], "existing_remote");
+}
+
+#[test]
 fn exec_applies_request_env_to_daemon_command() {
     let _home = create_lab_local_runner();
     let store = JobStore::default();
@@ -657,7 +692,7 @@ fn exec_capture_patch_records_remote_delta_artifact() {
 }
 
 #[test]
-fn exec_rejects_requests_that_violate_runner_policy() {
+fn runner_exec_rejects_requests_that_violate_runner_policy_before_daemon_dispatch() {
     let _home = HomeGuard::new();
     crate::core::server::create(
         r#"{"id":"lab-server","host":"192.0.2.10","user":"chubes"}"#,
@@ -670,22 +705,31 @@ fn exec_rejects_requests_that_violate_runner_policy() {
     )
     .expect("create ssh runner");
 
-    let response = route_with_job_store_and_body(
-        "POST",
-        "/exec",
-        Some(serde_json::json!({
-            "runner_id": "lab-server",
-            "cwd": "/srv/homeboy/project",
-            "command": ["sh", "-c", "printf denied"],
-            "raw_exec": true
-        })),
-        daemon_job_store(),
-    );
+    let err = crate::core::runner::exec(
+        "lab-server",
+        crate::core::runner::RunnerExecOptions {
+            cwd: Some("/srv/homeboy/project".to_string()),
+            project_id: None,
+            allow_diagnostic_ssh: false,
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "printf denied".to_string(),
+            ],
+            env: Default::default(),
+            capture_patch: false,
+            raw_exec: true,
+            source_snapshot: None,
+            capability_preflight: None,
+            required_extensions: Vec::new(),
+            require_paths: Vec::new(),
+        },
+    )
+    .expect_err("policy denied");
 
-    assert_eq!(response.status_code, 400);
-    assert_eq!(response.body["error"], "runner.policy_denied");
-    assert_eq!(response.body["details"]["runner_id"], "lab-server");
-    assert_eq!(response.body["details"]["field"], "raw_exec");
+    assert_eq!(err.code.as_str(), "runner.policy_denied");
+    assert_eq!(err.details["runner_id"], "lab-server");
+    assert_eq!(err.details["field"], "raw_exec");
 }
 
 fn wait_for_job(store: &JobStore, job_id: &str) -> crate::core::api_jobs::Job {


### PR DESCRIPTION
## Summary
- Route daemon `/exec` jobs through a daemon-local process plan so Lab offload does not require controller-side runner/server config on the daemon host.
- Preserve controller runner identity and existing-remote source snapshots for daemon job results.
- Add regression coverage proving daemon `/exec` succeeds for `homeboy-lab` without local runner config, while runner-side policy denial still happens before daemon dispatch.

Fixes #3623.
Follow-up to #3625 and the reopened failure in https://github.com/Extra-Chill/homeboy/issues/3623#issuecomment-4641291751.

## Verification
- `cargo test daemon_exec_does_not_require_runner_config_on_daemon_host`
- `cargo test core::daemon::daemon_test`
- `cargo test core::runner::execution::tests`
- `cargo test commands::runner::doctor::tests`
- `cargo test commands::route::tests`
- `cargo test core::runner::lab::tests`

Known existing warning observed during adjacent suites:
- `src/commands/runs/corpus_tests.rs:15:5 unused import: serde_json::Value`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Root cause investigation, Rust implementation, targeted regression tests, verification, and PR drafting. Chris remains responsible for review and acceptance.