### PR TITLE
Scope trace lab runner tool inference

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1147,11 +1147,13 @@ mod tests {
             .expect("trace contract");
         assert_eq!(trace.extra_required_tools, LAB_TRACE_EXTRA_TOOLS);
         assert!(!trace.requires_extension_parity);
+        assert!(!trace.infer_source_path_tools);
 
         let lint = parsed_command(&["homeboy", "lint"])
             .lab_contract()
             .expect("lint contract");
         assert!(lint.requires_extension_parity);
+        assert!(lint.infer_source_path_tools);
 
         let rig = parsed_command(&["homeboy", "rig", "up", "studio"])
             .lab_contract()

--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -9,6 +9,7 @@ pub struct LabCommandContract {
     pub mutation_flag: Option<&'static str>,
     pub requires_extension_parity: bool,
     pub extra_required_tools: &'static [LabCommandRequiredTool],
+    pub infer_source_path_tools: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -81,7 +82,7 @@ impl Commands {
                 true,
                 LAB_NO_EXTRA_TOOLS,
             ),
-            Commands::Trace(args) => lab_portable_contract(
+            Commands::Trace(args) => lab_portable_workload_contract(
                 "trace",
                 args.keep_overlay.then_some("--keep-overlay"),
                 false,
@@ -122,6 +123,24 @@ fn lab_portable_contract(
         mutation_flag,
         requires_extension_parity,
         extra_required_tools,
+        infer_source_path_tools: true,
+    }
+}
+
+fn lab_portable_workload_contract(
+    hot_label: &'static str,
+    mutation_flag: Option<&'static str>,
+    requires_extension_parity: bool,
+    extra_required_tools: &'static [LabCommandRequiredTool],
+) -> LabCommandContract {
+    LabCommandContract {
+        infer_source_path_tools: false,
+        ..lab_portable_contract(
+            hot_label,
+            mutation_flag,
+            requires_extension_parity,
+            extra_required_tools,
+        )
     }
 }
 
@@ -134,5 +153,6 @@ fn lab_local_only_contract(hot_label: &'static str, reason: &'static str) -> Lab
         mutation_flag: None,
         requires_extension_parity: false,
         extra_required_tools: LAB_NO_EXTRA_TOOLS,
+        infer_source_path_tools: false,
     }
 }

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -93,6 +93,7 @@ fn lab_offload_command(
                 homeboy::cli_surface::LabCommandRequiredTool::Playwright
             )
         }),
+        infer_source_path_tools: contract.infer_source_path_tools,
     }))
 }
 

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -51,6 +51,7 @@ pub struct LabOffloadCommand {
     pub requires_extension_parity: bool,
     pub required_extensions: Vec<String>,
     pub requires_playwright: bool,
+    pub infer_source_path_tools: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -741,6 +742,7 @@ mod tests {
             requires_extension_parity: true,
             required_extensions: Vec::new(),
             requires_playwright: false,
+            infer_source_path_tools: true,
         }
     }
 
@@ -753,6 +755,7 @@ mod tests {
             requires_extension_parity: false,
             required_extensions: Vec::new(),
             requires_playwright: false,
+            infer_source_path_tools: false,
         }
     }
 
@@ -792,6 +795,53 @@ mod tests {
         .expect("capability contract");
 
         assert!(contract.required_tools.contains(&RunnerRequiredTool::Cargo));
+    }
+
+    #[test]
+    fn full_workspace_lab_contract_infers_source_path_tools() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(dir.path().join("package.json"), "{}").expect("package signal");
+        std::fs::write(dir.path().join("docker-compose.yml"), "services: {}")
+            .expect("docker signal");
+
+        let contract = lab_runner_capability_contract(
+            &portable_lab_command("test"),
+            dir.path(),
+            &[RunnerRequiredTool::Homeboy],
+        )
+        .expect("capability contract");
+
+        assert!(contract
+            .required_tools
+            .contains(&RunnerRequiredTool::Homeboy));
+        assert!(contract.required_tools.contains(&RunnerRequiredTool::Node));
+        assert!(contract.required_tools.contains(&RunnerRequiredTool::Npm));
+        assert!(contract
+            .required_tools
+            .contains(&RunnerRequiredTool::Docker));
+    }
+
+    #[test]
+    fn workload_scoped_lab_contract_ignores_source_path_docker_signal() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(dir.path().join("package.json"), "{}").expect("package signal");
+        std::fs::write(dir.path().join("docker-compose.yml"), "services: {}")
+            .expect("docker signal");
+        let mut command = portable_lab_command("trace");
+        command.infer_source_path_tools = false;
+
+        let contract =
+            lab_runner_capability_contract(&command, dir.path(), &[RunnerRequiredTool::Homeboy])
+                .expect("capability contract");
+
+        assert!(contract
+            .required_tools
+            .contains(&RunnerRequiredTool::Homeboy));
+        assert!(!contract.required_tools.contains(&RunnerRequiredTool::Node));
+        assert!(!contract.required_tools.contains(&RunnerRequiredTool::Npm));
+        assert!(!contract
+            .required_tools
+            .contains(&RunnerRequiredTool::Docker));
     }
 
     #[test]

--- a/src/core/runner/lab_capabilities.rs
+++ b/src/core/runner/lab_capabilities.rs
@@ -17,21 +17,23 @@ pub(super) fn lab_runner_capability_contract(
         push_unique(&mut required_tools, *tool);
     }
 
-    if source_path.join(concat!("package", ".json")).is_file() {
-        push_node_package_tool(&mut required_tools, RunnerRequiredTool::Npm);
-    }
+    if command.infer_source_path_tools {
+        if source_path.join(concat!("package", ".json")).is_file() {
+            push_node_package_tool(&mut required_tools, RunnerRequiredTool::Npm);
+        }
 
-    if source_path.join("pnpm-lock.yaml").is_file() {
-        push_node_package_tool(&mut required_tools, RunnerRequiredTool::Pnpm);
-    }
+        if source_path.join("pnpm-lock.yaml").is_file() {
+            push_node_package_tool(&mut required_tools, RunnerRequiredTool::Pnpm);
+        }
 
-    if source_path.join(concat!("com", "poser", ".json")).is_file() {
-        push_unique(&mut required_tools, RunnerRequiredTool::Php);
-        push_unique(&mut required_tools, RunnerRequiredTool::Composer);
-    }
+        if source_path.join(concat!("com", "poser", ".json")).is_file() {
+            push_unique(&mut required_tools, RunnerRequiredTool::Php);
+            push_unique(&mut required_tools, RunnerRequiredTool::Composer);
+        }
 
-    if has_docker_signal(source_path) {
-        push_unique(&mut required_tools, RunnerRequiredTool::Docker);
+        if has_docker_signal(source_path) {
+            push_unique(&mut required_tools, RunnerRequiredTool::Docker);
+        }
     }
 
     Some(LabRunnerCapabilityContract {


### PR DESCRIPTION
## Summary
- Stops `trace` Lab offload from inferring package/Docker runner tools from broad component checkout files.
- Keeps source-path tool inference for full-workspace Lab commands such as lint/test.
- Adds targeted coverage proving workload-scoped Lab contracts ignore Docker/package checkout signals.

Closes #3621.

## Tests
- `cargo test lab_contract --lib`
- `cargo test test_lab_command_contracts_cover_hot_commands --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the scoped Lab runner capability fix and targeted tests; Chris remains responsible for review and merge.