### PR TITLE
Add configurable runner snapshot excludes

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -314,6 +314,7 @@ Safety rules:
 
 - The remote path is deterministic and lives under `<workspace_root>/_lab_workspaces/`.
 - Snapshot sync excludes dependency directories, build outputs, caches, `.git`, and common secret file patterns such as `.env*`, `*.pem`, and `*.key`.
+- Runner config can add project-specific generated-state patterns with `snapshot_excludes`; configured patterns are merged with the default snapshot safety excludes and affect snapshot hashing, stats, and materialization.
 - Output includes `local_path`, `remote_path`, `sync_mode`, `snapshot_identity`, and snapshot `files` / `bytes` when available.
 - The runner workspace is execution-only; this command does not push branches, commit, or make the runner authoritative for source changes.
 

--- a/docs/schemas/server-schema.md
+++ b/docs/schemas/server-schema.md
@@ -24,6 +24,7 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
     "daemon": boolean,
     "concurrency_limit": number,
     "artifact_policy": "string",
+    "snapshot_excludes": ["string"],
     "env": {},
     "resources": {}
   },
@@ -71,6 +72,7 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
     "daemon": false,
     "concurrency_limit": 4,
     "artifact_policy": "copy",
+    "snapshot_excludes": ["generated-state", "generated-state/**"],
     "env": {},
     "resources": {}
   },

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -336,6 +336,7 @@ pub fn run(
                 daemon,
                 concurrency_limit,
                 artifact_policy,
+                snapshot_excludes: Vec::new(),
             },
         })),
         RunnerCommand::Enable {
@@ -353,6 +354,7 @@ pub fn run(
                 daemon,
                 concurrency_limit,
                 artifact_policy,
+                snapshot_excludes: Vec::new(),
             },
         )),
         RunnerCommand::List => map_registry(list()),

--- a/src/core/runner/validation_dependencies.rs
+++ b/src/core/runner/validation_dependencies.rs
@@ -3,9 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::core::error::{Error, Result};
 
-use super::workspace::{
-    materialize_snapshot, parent_remote_path, sanitize_path_segment, DEFAULT_EXCLUDES,
-};
+use super::workspace::{materialize_snapshot, parent_remote_path, sanitize_path_segment};
 use super::Runner;
 
 const PORTABLE_CONFIG_FILE: &str = concat!("homeboy", ".json");
@@ -14,6 +12,7 @@ pub(super) fn sync_validation_dependency_workspaces(
     runner: &Runner,
     local_path: &Path,
     remote_path: &str,
+    excludes: &[String],
 ) -> Result<()> {
     for dependency in validation_dependency_workspaces(local_path)? {
         let remote_dependency_path = format!(
@@ -26,12 +25,7 @@ pub(super) fn sync_validation_dependency_workspaces(
                     .unwrap_or("dependency"),
             )
         );
-        materialize_snapshot(
-            runner,
-            &dependency,
-            &remote_dependency_path,
-            DEFAULT_EXCLUDES,
-        )?;
+        materialize_snapshot(runner, &dependency, &remote_dependency_path, excludes)?;
     }
     Ok(())
 }

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -33,6 +33,8 @@ pub(super) const DEFAULT_EXCLUDES: &[&str] = &[
     "target/**",
     "dist",
     "dist/**",
+    "*.tsbuildinfo",
+    "**/*.tsbuildinfo",
     ".next",
     ".next/**",
     ".turbo",
@@ -664,6 +666,16 @@ mod tests {
         ));
         assert!(is_excluded(
             root,
+            Path::new("/repo/tsconfig.tsbuildinfo"),
+            DEFAULT_EXCLUDES
+        ));
+        assert!(is_excluded(
+            root,
+            Path::new("/repo/packages/cli/tsconfig.tsbuildinfo"),
+            DEFAULT_EXCLUDES
+        ));
+        assert!(is_excluded(
+            root,
             Path::new("/repo/src/__tests__/._index.js"),
             DEFAULT_EXCLUDES
         ));
@@ -691,6 +703,7 @@ mod tests {
                 .expect("extension scripts build dir");
             fs::create_dir_all(source.path().join(".git")).expect("git dir");
             fs::create_dir_all(source.path().join("target/debug")).expect("target dir");
+            fs::create_dir_all(source.path().join("packages/cli")).expect("package dir");
             fs::write(source.path().join("src/main.rs"), "fn main() {}\n").expect("source file");
             fs::write(source.path().join("build/bundle.js"), "artifact").expect("build file");
             fs::write(source.path().join("vendor/autoload.php"), "<?php\n").expect("vendor file");
@@ -704,6 +717,11 @@ mod tests {
             fs::write(source.path().join("src/._main.rs"), "appledouble").expect("sidecar file");
             fs::write(source.path().join(".env.local"), "SECRET=1\n").expect("secret file");
             fs::write(source.path().join("target/debug/homeboy"), "binary").expect("build file");
+            fs::write(
+                source.path().join("packages/cli/tsconfig.tsbuildinfo"),
+                "stale incremental metadata",
+            )
+            .expect("typescript incremental metadata");
 
             super::super::create(
                 &format!(
@@ -744,6 +762,9 @@ mod tests {
             assert!(!Path::new(&output.remote_path).join(".env.local").exists());
             assert!(!Path::new(&output.remote_path)
                 .join("target/debug/homeboy")
+                .exists());
+            assert!(!Path::new(&output.remote_path)
+                .join("packages/cli/tsconfig.tsbuildinfo")
                 .exists());
         });
     }

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -33,8 +33,6 @@ pub(super) const DEFAULT_EXCLUDES: &[&str] = &[
     "target/**",
     "dist",
     "dist/**",
-    "*.tsbuildinfo",
-    "**/*.tsbuildinfo",
     ".next",
     ".next/**",
     ".turbo",
@@ -97,24 +95,22 @@ pub fn sync_workspace(
     })?;
     validate_absolute_path("workspace_root", workspace_root)?;
 
-    let excludes = DEFAULT_EXCLUDES
-        .iter()
-        .map(|value| value.to_string())
-        .collect::<Vec<_>>();
+    let excludes = snapshot_excludes(&runner);
 
     match options.mode {
         RunnerWorkspaceSyncMode::Snapshot => {
-            let snapshot = snapshot_identity(&local_path)?;
+            let snapshot = snapshot_identity(&local_path, &excludes)?;
             let remote_path = temp::unique_name(
                 &deterministic_remote_path(workspace_root, &local_path, &snapshot),
                 "",
             );
-            let stats = local_snapshot_stats(&local_path, DEFAULT_EXCLUDES)?;
-            materialize_snapshot(&runner, &local_path, &remote_path, DEFAULT_EXCLUDES)?;
+            let stats = local_snapshot_stats(&local_path, &excludes)?;
+            materialize_snapshot(&runner, &local_path, &remote_path, &excludes)?;
             super::validation_dependencies::sync_validation_dependency_workspaces(
                 &runner,
                 &local_path,
                 &remote_path,
+                &excludes,
             )?;
             Ok((
                 RunnerWorkspaceSyncOutput {
@@ -151,6 +147,7 @@ pub fn sync_workspace(
                 &runner,
                 &local_path,
                 &remote_path,
+                &excludes,
             )?;
             Ok((
                 RunnerWorkspaceSyncOutput {
@@ -226,7 +223,7 @@ fn deterministic_remote_path(workspace_root: &str, local_path: &Path, snapshot: 
     )
 }
 
-fn snapshot_identity(local_path: &Path) -> Result<String> {
+fn snapshot_identity(local_path: &Path, excludes: &[String]) -> Result<String> {
     let head =
         git_output(local_path, &["rev-parse", "HEAD"]).unwrap_or_else(|_| "nogit".to_string());
     let status = git_output(local_path, &["status", "--porcelain=v1"])
@@ -240,8 +237,23 @@ fn snapshot_identity(local_path: &Path) -> Result<String> {
     hasher.update(status.as_bytes());
     hasher.update(diff.as_bytes());
     hasher.update(staged.as_bytes());
-    hash_snapshot_tree(local_path, local_path, DEFAULT_EXCLUDES, &mut hasher)?;
+    hash_snapshot_tree(local_path, local_path, excludes, &mut hasher)?;
     Ok(format!("snapshot:{}", hex_prefix(&hasher.finalize(), 16)))
+}
+
+fn snapshot_excludes(runner: &Runner) -> Vec<String> {
+    let mut excludes = DEFAULT_EXCLUDES
+        .iter()
+        .map(|value| value.to_string())
+        .collect::<Vec<_>>();
+
+    for pattern in &runner.settings.snapshot_excludes {
+        if !excludes.contains(pattern) {
+            excludes.push(pattern.clone());
+        }
+    }
+
+    excludes
 }
 
 fn git_snapshot(local_path: &Path, changed_since_base: Option<&str>) -> Result<GitSnapshot> {
@@ -303,7 +315,7 @@ pub(super) fn git_output(local_path: &Path, args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-fn local_snapshot_stats(path: &Path, excludes: &[&str]) -> Result<SnapshotStats> {
+fn local_snapshot_stats(path: &Path, excludes: &[String]) -> Result<SnapshotStats> {
     let mut stats = SnapshotStats { files: 0, bytes: 0 };
     collect_stats(path, path, excludes, &mut stats)?;
     Ok(stats)
@@ -312,7 +324,7 @@ fn local_snapshot_stats(path: &Path, excludes: &[&str]) -> Result<SnapshotStats>
 fn hash_snapshot_tree(
     root: &Path,
     path: &Path,
-    excludes: &[&str],
+    excludes: &[String],
     hasher: &mut Sha256,
 ) -> Result<()> {
     let mut entries = fs::read_dir(path)
@@ -359,7 +371,7 @@ fn hash_snapshot_tree(
 fn collect_stats(
     root: &Path,
     path: &Path,
-    excludes: &[&str],
+    excludes: &[String],
     stats: &mut SnapshotStats,
 ) -> Result<()> {
     for entry in fs::read_dir(path).map_err(|err| {
@@ -388,7 +400,7 @@ fn collect_stats(
     Ok(())
 }
 
-fn is_excluded(root: &Path, path: &Path, excludes: &[&str]) -> bool {
+fn is_excluded(root: &Path, path: &Path, excludes: &[String]) -> bool {
     let rel = path.strip_prefix(root).unwrap_or(path).to_string_lossy();
     let rel = rel.trim_start_matches('/');
     let name = path
@@ -396,7 +408,7 @@ fn is_excluded(root: &Path, path: &Path, excludes: &[&str]) -> bool {
         .and_then(|value| value.to_str())
         .unwrap_or("");
     excludes.iter().any(|pattern| {
-        *pattern == rel || *pattern == name || glob_match(pattern, rel) || glob_match(pattern, name)
+        pattern == rel || pattern == name || glob_match(pattern, rel) || glob_match(pattern, name)
     })
 }
 
@@ -404,7 +416,7 @@ pub(super) fn materialize_snapshot(
     runner: &Runner,
     local_path: &Path,
     remote_path: &str,
-    excludes: &[&str],
+    excludes: &[String],
 ) -> Result<()> {
     match runner.kind {
         RunnerKind::Local => materialize_snapshot_piped(
@@ -451,7 +463,7 @@ pub(super) fn materialize_snapshot(
 fn materialize_snapshot_piped(
     local_path: &Path,
     target_command: &str,
-    excludes: &[&str],
+    excludes: &[String],
     action: &str,
 ) -> Result<()> {
     let command = format!(
@@ -559,7 +571,7 @@ fn run_shell_command(command: &str, action: &str) -> Result<()> {
     )))
 }
 
-fn tar_exclude_args(excludes: &[&str]) -> String {
+fn tar_exclude_args(excludes: &[String]) -> String {
     excludes
         .iter()
         .map(|pattern| format!("--exclude {}", shell::quote_arg(pattern)))
@@ -648,47 +660,81 @@ mod tests {
     #[test]
     fn default_excludes_filter_generated_outputs_and_secrets() {
         let root = Path::new("/repo");
+        let excludes = DEFAULT_EXCLUDES
+            .iter()
+            .map(|value| value.to_string())
+            .collect::<Vec<_>>();
 
         assert!(is_excluded(
             root,
             Path::new("/repo/node_modules/pkg/index.js"),
-            DEFAULT_EXCLUDES
+            &excludes
         ));
-        assert!(is_excluded(
-            root,
-            Path::new("/repo/.env.local"),
-            DEFAULT_EXCLUDES
-        ));
+        assert!(is_excluded(root, Path::new("/repo/.env.local"), &excludes));
         assert!(is_excluded(
             root,
             Path::new("/repo/target/debug/homeboy"),
-            DEFAULT_EXCLUDES
-        ));
-        assert!(is_excluded(
-            root,
-            Path::new("/repo/tsconfig.tsbuildinfo"),
-            DEFAULT_EXCLUDES
-        ));
-        assert!(is_excluded(
-            root,
-            Path::new("/repo/packages/cli/tsconfig.tsbuildinfo"),
-            DEFAULT_EXCLUDES
+            &excludes
         ));
         assert!(is_excluded(
             root,
             Path::new("/repo/src/__tests__/._index.js"),
-            DEFAULT_EXCLUDES
+            &excludes
         ));
         assert!(!is_excluded(
             root,
             Path::new("/repo/src/main.rs"),
-            DEFAULT_EXCLUDES
+            &excludes
         ));
         assert!(!is_excluded(
             root,
             Path::new("/repo/vendor/autoload.php"),
-            DEFAULT_EXCLUDES
+            &excludes
         ));
+    }
+
+    #[test]
+    fn runner_snapshot_excludes_extend_default_snapshot_policy() {
+        crate::test_support::with_isolated_home(|_| {
+            let source = tempfile::tempdir().expect("source tempdir");
+            let runner_root = tempfile::tempdir().expect("runner root tempdir");
+            fs::create_dir_all(source.path().join("src")).expect("src dir");
+            fs::create_dir_all(source.path().join("generated-state")).expect("state dir");
+            fs::write(source.path().join("src/source.txt"), "source\n").expect("source file");
+            fs::write(source.path().join("generated-state/cache.bin"), "cache\n")
+                .expect("excluded state file");
+            fs::write(source.path().join("local.state"), "state\n").expect("excluded marker");
+
+            super::super::create(
+                &format!(
+                    r#"{{"id":"lab-local","kind":"local","workspace_root":"{}","snapshot_excludes":["generated-state","generated-state/**","*.state"]}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+
+            let (output, exit_code) = sync_workspace(
+                "lab-local",
+                RunnerWorkspaceSyncOptions {
+                    path: source.path().display().to_string(),
+                    mode: RunnerWorkspaceSyncMode::Snapshot,
+                    changed_since_base: None,
+                },
+            )
+            .expect("sync workspace");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(output.files, 1);
+            assert!(output.excludes.contains(&"generated-state/**".to_string()));
+            assert!(Path::new(&output.remote_path)
+                .join("src/source.txt")
+                .exists());
+            assert!(!Path::new(&output.remote_path)
+                .join("generated-state/cache.bin")
+                .exists());
+            assert!(!Path::new(&output.remote_path).join("local.state").exists());
+        });
     }
 
     #[test]
@@ -703,7 +749,6 @@ mod tests {
                 .expect("extension scripts build dir");
             fs::create_dir_all(source.path().join(".git")).expect("git dir");
             fs::create_dir_all(source.path().join("target/debug")).expect("target dir");
-            fs::create_dir_all(source.path().join("packages/cli")).expect("package dir");
             fs::write(source.path().join("src/main.rs"), "fn main() {}\n").expect("source file");
             fs::write(source.path().join("build/bundle.js"), "artifact").expect("build file");
             fs::write(source.path().join("vendor/autoload.php"), "<?php\n").expect("vendor file");
@@ -717,11 +762,6 @@ mod tests {
             fs::write(source.path().join("src/._main.rs"), "appledouble").expect("sidecar file");
             fs::write(source.path().join(".env.local"), "SECRET=1\n").expect("secret file");
             fs::write(source.path().join("target/debug/homeboy"), "binary").expect("build file");
-            fs::write(
-                source.path().join("packages/cli/tsconfig.tsbuildinfo"),
-                "stale incremental metadata",
-            )
-            .expect("typescript incremental metadata");
 
             super::super::create(
                 &format!(
@@ -762,9 +802,6 @@ mod tests {
             assert!(!Path::new(&output.remote_path).join(".env.local").exists());
             assert!(!Path::new(&output.remote_path)
                 .join("target/debug/homeboy")
-                .exists());
-            assert!(!Path::new(&output.remote_path)
-                .join("packages/cli/tsconfig.tsbuildinfo")
                 .exists());
         });
     }

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -66,6 +66,8 @@ pub struct RunnerSettings {
     pub concurrency_limit: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifact_policy: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub snapshot_excludes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -115,6 +115,10 @@ const TERMS: &[Term] = &[
         kind: MatchKind::Literal,
     },
     Term {
+        name: "tsbuildinfo",
+        kind: MatchKind::Token,
+    },
+    Term {
         name: "go vet",
         kind: MatchKind::Literal,
     },


### PR DESCRIPTION
## Summary
- Adds generic runner policy `snapshot_excludes` config that extends Homeboy's default runner snapshot safety excludes.
- Applies the merged exclude policy consistently to snapshot hashing, file stats, primary workspace materialization, and validation dependency workspace materialization.
- Adds focused coverage proving configured generated-state patterns are reported, counted out, and omitted from runner snapshot materialization.

## Evidence
- Fixes https://github.com/Extra-Chill/homeboy/issues/3643.
- Issue evidence: runner snapshot sync intentionally excludes generated `dist` directories, but project-specific incremental build metadata can remain. That lets a build command report success without emitting missing generated files, causing later commands such as `packages/cli/dist/index.js` execution to fail until a forced rebuild is used.
- This keeps Homeboy core generic: core owns the default safe snapshot transport policy plus a configurable exclude extension point; repo/tool-specific generated-state metadata belongs in runner/project policy, not in Homeboy core defaults.

## Verification
- `cargo fmt --check`
- `cargo test core::runner::workspace::tests`
- `cargo test --test core_agnostic_test core_owned_test_content_stays_language_and_framework_agnostic`
- `cargo test --test architecture_core_agnostic_test`

## Notes
- I also added `tsbuildinfo` to the core-agnostic test vocabulary so future attempts to hardcode that TypeScript-specific generated-state marker in core-owned test content are caught by the guard.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Root-caused the runner snapshot stale generated-state problem, corrected the first TypeScript-specific draft into a generic runner snapshot exclude policy contract, drafted the code/tests/docs, and ran targeted verification. Chris remains responsible for review and merge.