### PR TITLE
Fix Lab offload rig refresh for trace commands

### DIFF
--- a/src/core/runner/rig_materialization.rs
+++ b/src/core/runner/rig_materialization.rs
@@ -229,10 +229,6 @@ fn normalize_path_for_prefix(path: &Path) -> PathBuf {
 
 fn lab_offload_rig_ids(args: &[String]) -> Vec<String> {
     let mut rig_ids = Vec::new();
-    let is_bench = args.iter().any(|arg| arg == "bench");
-    if !is_bench {
-        return rig_ids;
-    }
 
     let mut iter = args.iter().peekable();
     let mut passthrough = false;
@@ -292,14 +288,14 @@ mod tests {
     }
 
     #[test]
-    fn ignores_non_bench_and_passthrough_rig_args_for_lab_materialization() {
-        let non_bench = vec![
+    fn extracts_trace_rig_ids_and_ignores_passthrough_args_for_lab_materialization() {
+        let trace = vec![
             "homeboy".to_string(),
-            "test".to_string(),
+            "trace".to_string(),
             "--rig".to_string(),
             "candidate".to_string(),
         ];
-        assert!(lab_offload_rig_ids(&non_bench).is_empty());
+        assert_eq!(lab_offload_rig_ids(&trace), vec!["candidate".to_string()]);
 
         let passthrough = vec![
             "homeboy".to_string(),


### PR DESCRIPTION
## Summary
- Fixes Lab offload rig materialization so any offloaded command carrying `--rig` refreshes the runner-side rig package, not only `homeboy bench`.
- Adds focused coverage for `homeboy trace --rig ...` while preserving passthrough `--` behavior.

## Evidence
- Issue #3641 reports stale offloaded trace runs continuing to use an older `_lab_workspaces/...` linked rig snapshot after local rig changes, `homeboy runner workspace sync`, and `homeboy rig install`.
- Root cause: Lab offload rig materialization only extracted `--rig` IDs when the command argv contained `bench`, so `homeboy trace --rig ...` skipped runner-side linked rig snapshot refresh and could keep using whatever rig metadata was already installed on the runner.
- Fix: remove the bench-only guard from generic Lab offload rig ID extraction so trace and future linked-rig/offload commands refresh their rig package snapshots before remote execution.

Fixes #3641.

## Verification
- `cargo test core::runner::rig_materialization`
- `cargo fmt --check`
- `cargo test core::runner::lab`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Root-cause analysis, implementation, focused test update, verification, and PR drafting. Chris remains responsible for review and merge.