### PR TITLE
Add managed service tunnel lifecycle

### DIFF
--- a/docs/commands/tunnel.md
+++ b/docs/commands/tunnel.md
@@ -6,7 +6,7 @@
 homeboy tunnel service <COMMAND>
 ```
 
-`tunnel` manages Homeboy-native private service tunnel declarations. The first wave records explicit service, auth, and policy configuration without opening public listeners or starting unauthenticated forwarding.
+`tunnel` manages Homeboy-native private service tunnel declarations and local managed service lifecycle. Homeboy can start a long-running local command, record safe command/process/log evidence, report readiness, and stop the process group without relying on an external chat or tunnel wrapper.
 
 ## Service Tunnels
 
@@ -25,6 +25,22 @@ homeboy tunnel service expose context-a8c \
 
 The declaration requires an explicit auth mode and stores a private-loopback policy. It does not expose a public unauthenticated URL.
 
+Start a declared local service command and record lifecycle evidence:
+
+```sh
+homeboy tunnel service start context-a8c \
+  --command 'npm run dev -- --host 127.0.0.1 --port 7331' \
+  --cwd /path/to/workspace \
+  --host 127.0.0.1 \
+  --port 7331 \
+  --health-path / \
+  --public-tunnel-backend none
+```
+
+`--env KEY=VALUE` can be repeated to pass runtime environment values. Status records only env var names, not values. The managed service writes stdout/stderr logs under Homeboy's local data directory and includes those paths in `service status` output.
+
+Public tunnel backends are an explicit seam. `none` is the only implemented backend in this release; unsupported backends should be added as first-class implementations rather than faked by wrapping Kimaki or another CLI in proof paths.
+
 ## Subcommands
 
 - `service expose`: create or replace a private service tunnel declaration.
@@ -33,4 +49,6 @@ The declaration requires an explicit auth mode and stores a private-loopback pol
 - `service set <id> ...`: update fields using the standard dynamic set contract.
 - `service remove <id>`: delete a declaration.
 - `service url <id>`: print the declared loopback URL.
-- `service status <id>`: report declaration status. In this wave, status is intentionally no-op lifecycle state with `running: false`.
+- `service start <id>`: start and supervise a declared local service command.
+- `service status <id>`: report declaration, process, local URL, public URL when present, health, backend, and log evidence state.
+- `service stop <id>`: terminate the managed process group and remove runtime state while leaving log evidence files in place.

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -4,8 +4,11 @@ use serde::Serialize;
 use homeboy::core::tunnel::{
     self, ExposeServiceTunnelSpec, ServiceTunnel, ServiceTunnelAuth, ServiceTunnelAuthMode,
     ServiceTunnelExposure, ServiceTunnelPolicy, ServiceTunnelStatus, ServiceTunnelTarget,
+    ServiceTunnelTunnelBackend, StartServiceTunnelSpec,
 };
 use homeboy::core::{EntityCrudOutput, MergeOutput};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 use super::{CmdResult, DynamicSetArgs};
 
@@ -111,8 +114,58 @@ enum TunnelServiceCommand {
         /// Service tunnel ID
         id: String,
     },
-    /// Show no-op lifecycle status for a service tunnel declaration
+    /// Show declaration, process, health, backend, and evidence status
     Status {
+        /// Service tunnel ID
+        id: String,
+    },
+    /// Start and supervise a declared local service command
+    Start {
+        /// Service tunnel ID
+        id: String,
+
+        /// Long-running service command to execute through the platform shell
+        #[arg(long)]
+        command: String,
+
+        /// Working directory for the service command
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+
+        /// Environment assignment passed to the service command. Repeat for multiple values.
+        #[arg(long = "env")]
+        env: Vec<String>,
+
+        /// Local loopback host declared for this service
+        #[arg(long)]
+        host: Option<String>,
+
+        /// Local port declared for this service
+        #[arg(long)]
+        port: Option<u16>,
+
+        /// Local URL scheme
+        #[arg(long)]
+        scheme: Option<String>,
+
+        /// Full health-check URL to poll before reporting the service ready
+        #[arg(long)]
+        health_url: Option<String>,
+
+        /// Health-check path appended to the declared local URL
+        #[arg(long)]
+        health_path: Option<String>,
+
+        /// Seconds to wait for the service health check
+        #[arg(long, default_value_t = 30)]
+        readiness_timeout: u64,
+
+        /// Public tunnel backend. Only 'none' is currently implemented.
+        #[arg(long, value_enum, default_value_t = ServiceTunnelBackendArg::None)]
+        public_tunnel_backend: ServiceTunnelBackendArg,
+    },
+    /// Stop a running managed local service and cleanup runtime state
+    Stop {
         /// Service tunnel ID
         id: String,
     },
@@ -125,6 +178,27 @@ enum ServiceTunnelAuthModeArg {
     BasicEnv,
     MutualTls,
     SshOnly,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum ServiceTunnelBackendArg {
+    None,
+}
+
+impl std::fmt::Display for ServiceTunnelBackendArg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ServiceTunnelBackendArg::None => write!(f, "none"),
+        }
+    }
+}
+
+impl From<ServiceTunnelBackendArg> for ServiceTunnelTunnelBackend {
+    fn from(value: ServiceTunnelBackendArg) -> Self {
+        match value {
+            ServiceTunnelBackendArg::None => ServiceTunnelTunnelBackend::None,
+        }
+    }
 }
 
 impl From<ServiceTunnelAuthModeArg> for ServiceTunnelAuthMode {
@@ -186,6 +260,32 @@ fn run_service(command: TunnelServiceCommand) -> CmdResult<TunnelOutput> {
         TunnelServiceCommand::Remove { id } => remove_service(&id),
         TunnelServiceCommand::Url { id } => url_service(&id),
         TunnelServiceCommand::Status { id } => status_service(&id),
+        TunnelServiceCommand::Start {
+            id,
+            command,
+            cwd,
+            env,
+            host,
+            port,
+            scheme,
+            health_url,
+            health_path,
+            readiness_timeout,
+            public_tunnel_backend,
+        } => start_service(StartServiceTunnelSpec {
+            id,
+            command,
+            cwd,
+            env: parse_env_assignments(env)?,
+            host,
+            port,
+            scheme,
+            health_url,
+            health_path,
+            readiness_timeout_secs: readiness_timeout,
+            backend: public_tunnel_backend.into(),
+        }),
+        TunnelServiceCommand::Stop { id } => stop_service(&id),
     }
 }
 
@@ -309,6 +409,63 @@ fn status_service(id: &str) -> CmdResult<TunnelOutput> {
         },
         0,
     ))
+}
+
+fn start_service(spec: StartServiceTunnelSpec) -> CmdResult<TunnelOutput> {
+    let id = spec.id.clone();
+    let report = tunnel::start(spec)?;
+    Ok((
+        TunnelOutput {
+            command: "tunnel.service.start".to_string(),
+            id: Some(id),
+            extra: TunnelExtra {
+                service: Some(ServiceTunnelActionOutput::Status(report)),
+            },
+            ..Default::default()
+        },
+        0,
+    ))
+}
+
+fn stop_service(id: &str) -> CmdResult<TunnelOutput> {
+    let report = tunnel::stop(id)?;
+    Ok((
+        TunnelOutput {
+            command: "tunnel.service.stop".to_string(),
+            id: Some(id.to_string()),
+            extra: TunnelExtra {
+                service: Some(ServiceTunnelActionOutput::Status(report)),
+            },
+            ..Default::default()
+        },
+        0,
+    ))
+}
+
+fn parse_env_assignments(
+    assignments: Vec<String>,
+) -> homeboy::core::Result<BTreeMap<String, String>> {
+    let mut env = BTreeMap::new();
+    for assignment in assignments {
+        let Some((key, value)) = assignment.split_once('=') else {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "env",
+                "environment values must use KEY=VALUE syntax",
+                None,
+                Some(vec![assignment]),
+            ));
+        };
+        if key.trim().is_empty() {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "env",
+                "environment variable name is required",
+                None,
+                None,
+            ));
+        }
+        env.insert(key.to_string(), value.to_string());
+    }
+    Ok(env)
 }
 
 #[cfg(test)]

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -211,6 +211,18 @@ pub fn runner_session_file(id: &str) -> Result<PathBuf> {
     Ok(runner_sessions_dir()?.join(format!("{}.json", id)))
 }
 
+/// Managed service tunnel runtime state directory (~/.local/share/homeboy/service-tunnels/{id}/).
+pub fn service_tunnel_runtime_dir(id: &str) -> Result<PathBuf> {
+    Ok(homeboy_data()?
+        .join("service-tunnels")
+        .join(sanitize_path_segment(id)))
+}
+
+/// Managed service tunnel runtime state file.
+pub fn service_tunnel_runtime_state_file(id: &str) -> Result<PathBuf> {
+    Ok(service_tunnel_runtime_dir(id)?.join("state.json"))
+}
+
 /// Extension directory path
 pub fn extension(id: &str) -> Result<PathBuf> {
     Ok(extensions()?.join(id))

--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -1,9 +1,17 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs::{self, File};
 use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 use crate::core::config::{self, ConfigEntity};
 use crate::core::error::{Error, Result};
 use crate::core::paths;
+use crate::core::process::{pid_is_running, process_group_is_running};
 use crate::core::server;
 use crate::core::{CreateOutput, MergeOutput, RemoveResult};
 
@@ -80,8 +88,100 @@ pub struct ServiceTunnelStatus {
     pub running: bool,
     pub lifecycle: String,
     pub local_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
     pub remote_target: String,
     pub policy: ServiceTunnelPolicy,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process: Option<ServiceTunnelProcessStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub health: Option<ServiceTunnelHealthStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<ServiceTunnelEvidence>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tunnel_backend: Option<ServiceTunnelBackendStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceTunnelCommandSpec {
+    pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env_keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceTunnelRuntimeState {
+    pub service_id: String,
+    pub pid: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process_group_id: Option<i32>,
+    pub started_at: String,
+    pub local_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
+    pub command: ServiceTunnelCommandSpec,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub health_url: Option<String>,
+    pub stdout_path: String,
+    pub stderr_path: String,
+    pub backend: ServiceTunnelTunnelBackend,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceTunnelTunnelBackend {
+    None,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ServiceTunnelProcessStatus {
+    pub pid: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process_group_id: Option<i32>,
+    pub running: bool,
+    pub started_at: String,
+    pub command: ServiceTunnelCommandSpec,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ServiceTunnelHealthStatus {
+    pub checked: bool,
+    pub healthy: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_code: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ServiceTunnelEvidence {
+    pub state_path: String,
+    pub stdout_path: String,
+    pub stderr_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ServiceTunnelBackendStatus {
+    pub backend: ServiceTunnelTunnelBackend,
+    pub active: bool,
+}
+
+pub struct StartServiceTunnelSpec {
+    pub id: String,
+    pub command: String,
+    pub cwd: Option<PathBuf>,
+    pub env: BTreeMap<String, String>,
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub scheme: Option<String>,
+    pub health_url: Option<String>,
+    pub health_path: Option<String>,
+    pub readiness_timeout_secs: u64,
+    pub backend: ServiceTunnelTunnelBackend,
 }
 
 pub struct ExposeServiceTunnelSpec {
@@ -167,20 +267,158 @@ pub fn status(id: &str) -> Result<ServiceTunnelStatus> {
     Ok(service_tunnel_status(&tunnel))
 }
 
+pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
+    let mut tunnel = load(&spec.id)?;
+    if matches!(spec.backend, ServiceTunnelTunnelBackend::None) == false {
+        return Err(Error::validation_invalid_argument(
+            "public_tunnel_backend",
+            "only the explicit 'none' backend is currently supported",
+            Some(spec.id),
+            Some(vec!["none".to_string()]),
+        ));
+    }
+
+    let existing = load_runtime_state(&tunnel.id)?;
+    if let Some(state) = existing {
+        if runtime_state_is_running(&state) {
+            return Err(Error::validation_invalid_argument(
+                "service",
+                "service tunnel is already running; stop it before starting again",
+                Some(tunnel.id),
+                None,
+            ));
+        }
+    }
+
+    if let Some(host) = spec.host {
+        validate_loopback_host(&host, &tunnel.id)?;
+        tunnel.local_host = host;
+    }
+    if let Some(port) = spec.port {
+        if port == 0 {
+            return Err(Error::validation_invalid_argument(
+                "port",
+                "local port must be greater than zero",
+                Some(tunnel.id),
+                None,
+            ));
+        }
+        tunnel.local_port = Some(port);
+    }
+    if let Some(scheme) = spec.scheme {
+        tunnel.scheme = scheme;
+    }
+    validate_service_tunnel(&tunnel)?;
+    save(&tunnel)?;
+
+    let runtime_dir = paths::service_tunnel_runtime_dir(&tunnel.id)?;
+    fs::create_dir_all(&runtime_dir)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(runtime_dir.display().to_string())))?;
+    let stdout_path = runtime_dir.join("stdout.log");
+    let stderr_path = runtime_dir.join("stderr.log");
+    let stdout = File::create(&stdout_path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(stdout_path.display().to_string())))?;
+    let stderr = File::create(&stderr_path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(stderr_path.display().to_string())))?;
+
+    let mut command = shell_command(&spec.command);
+    if let Some(cwd) = &spec.cwd {
+        command.current_dir(cwd);
+    }
+    for (key, value) in &spec.env {
+        command.env(key, value);
+    }
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+    #[cfg(unix)]
+    unsafe {
+        command.pre_exec(|| {
+            libc::setpgid(0, 0);
+            Ok(())
+        });
+    }
+
+    let child = command.spawn().map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("start service tunnel {}", tunnel.id)),
+        )
+    })?;
+    let pid = child.id();
+    let process_group_id = process_group_id_for(pid);
+    let health_url = resolve_health_url(&tunnel, spec.health_url, spec.health_path);
+    let state = ServiceTunnelRuntimeState {
+        service_id: tunnel.id.clone(),
+        pid,
+        process_group_id,
+        started_at: chrono::Utc::now().to_rfc3339(),
+        local_url: local_url_for(&tunnel),
+        public_url: None,
+        command: ServiceTunnelCommandSpec {
+            command: spec.command,
+            cwd: spec.cwd.map(|path| path.display().to_string()),
+            env_keys: spec.env.keys().cloned().collect(),
+        },
+        health_url,
+        stdout_path: stdout_path.display().to_string(),
+        stderr_path: stderr_path.display().to_string(),
+        backend: spec.backend,
+    };
+    save_runtime_state(&state)?;
+    if let Err(error) = wait_until_ready(&state, spec.readiness_timeout_secs) {
+        terminate_runtime_state(&state)?;
+        remove_runtime_state(&state.service_id)?;
+        return Err(error);
+    }
+    status(&tunnel.id)
+}
+
+pub fn stop(id: &str) -> Result<ServiceTunnelStatus> {
+    let tunnel = load(id)?;
+    if let Some(state) = load_runtime_state(id)? {
+        terminate_runtime_state(&state)?;
+        remove_runtime_state(id)?;
+    }
+    Ok(service_tunnel_status(&tunnel))
+}
+
 pub fn local_url(id: &str) -> Result<String> {
     let tunnel = load(id)?;
     Ok(local_url_for(&tunnel))
 }
 
 fn service_tunnel_status(tunnel: &ServiceTunnel) -> ServiceTunnelStatus {
+    let state = load_runtime_state(&tunnel.id).ok().flatten();
+    let running = state.as_ref().is_some_and(runtime_state_is_running);
+    let health = state.as_ref().map(check_runtime_health);
+    let evidence = state.as_ref().map(runtime_evidence);
+    let process = state.as_ref().map(|state| ServiceTunnelProcessStatus {
+        pid: state.pid,
+        process_group_id: state.process_group_id,
+        running,
+        started_at: state.started_at.clone(),
+        command: state.command.clone(),
+    });
+    let backend = state.as_ref().map(|state| ServiceTunnelBackendStatus {
+        backend: state.backend.clone(),
+        active: state.public_url.is_some(),
+    });
+    let public_url = state.as_ref().and_then(|state| state.public_url.clone());
     ServiceTunnelStatus {
         service_id: tunnel.id.clone(),
         declared: true,
-        running: false,
-        lifecycle: "declared".to_string(),
+        running,
+        lifecycle: if running { "running" } else { "declared" }.to_string(),
         local_url: local_url_for(tunnel),
+        public_url,
         remote_target: format!("{}:{}", tunnel.target.host, tunnel.target.port),
         policy: tunnel.policy.clone(),
+        process,
+        health,
+        evidence,
+        tunnel_backend: backend,
     }
 }
 
@@ -215,14 +453,7 @@ fn validate_service_tunnel(tunnel: &ServiceTunnel) -> Result<()> {
             None,
         ));
     }
-    if tunnel.local_host != "127.0.0.1" && tunnel.local_host != "localhost" {
-        return Err(Error::validation_invalid_argument(
-            "local_host",
-            "service tunnels may only bind to loopback hosts",
-            Some(tunnel.id.clone()),
-            Some(vec!["127.0.0.1".to_string(), "localhost".to_string()]),
-        ));
-    }
+    validate_loopback_host(&tunnel.local_host, &tunnel.id)?;
     if !matches!(
         tunnel.policy.exposure,
         ServiceTunnelExposure::PrivateLoopback
@@ -265,12 +496,212 @@ fn validate_service_tunnel(tunnel: &ServiceTunnel) -> Result<()> {
     Ok(())
 }
 
+fn validate_loopback_host(host: &str, id: &str) -> Result<()> {
+    if host != "127.0.0.1" && host != "localhost" {
+        return Err(Error::validation_invalid_argument(
+            "local_host",
+            "service tunnels may only bind to loopback hosts",
+            Some(id.to_string()),
+            Some(vec!["127.0.0.1".to_string(), "localhost".to_string()]),
+        ));
+    }
+    Ok(())
+}
+
+fn shell_command(command: &str) -> Command {
+    #[cfg(windows)]
+    {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", command]);
+        cmd
+    }
+
+    #[cfg(not(windows))]
+    {
+        let mut cmd = Command::new("/bin/sh");
+        cmd.args(["-c", command]);
+        cmd
+    }
+}
+
+fn process_group_id_for(pid: u32) -> Option<i32> {
+    #[cfg(unix)]
+    unsafe {
+        let pgid = libc::getpgid(pid as libc::pid_t);
+        if pgid > 0 {
+            return Some(pgid);
+        }
+        None
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        None
+    }
+}
+
+fn load_runtime_state(id: &str) -> Result<Option<ServiceTunnelRuntimeState>> {
+    let path = paths::service_tunnel_runtime_state_file(id)?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let data = fs::read_to_string(&path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))?;
+    serde_json::from_str(&data)
+        .map(Some)
+        .map_err(|e| Error::internal_json(e.to_string(), Some(path.display().to_string())))
+}
+
+fn save_runtime_state(state: &ServiceTunnelRuntimeState) -> Result<()> {
+    let path = paths::service_tunnel_runtime_state_file(&state.service_id)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| Error::internal_io(e.to_string(), Some(parent.display().to_string())))?;
+    }
+    let data = serde_json::to_string_pretty(state)
+        .map_err(|e| Error::internal_json(e.to_string(), Some(state.service_id.clone())))?;
+    fs::write(&path, data)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))
+}
+
+fn remove_runtime_state(id: &str) -> Result<()> {
+    let path = paths::service_tunnel_runtime_state_file(id)?;
+    if path.exists() {
+        fs::remove_file(&path)
+            .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))?;
+    }
+    Ok(())
+}
+
+fn runtime_state_is_running(state: &ServiceTunnelRuntimeState) -> bool {
+    if let Some(pgid) = state.process_group_id {
+        process_group_is_running(pgid)
+    } else {
+        pid_is_running(state.pid)
+    }
+}
+
+fn terminate_runtime_state(state: &ServiceTunnelRuntimeState) -> Result<()> {
+    if !runtime_state_is_running(state) {
+        return Ok(());
+    }
+
+    #[cfg(unix)]
+    unsafe {
+        if let Some(pgid) = state.process_group_id {
+            libc::kill(-(pgid as libc::pid_t), libc::SIGTERM);
+            std::thread::sleep(Duration::from_millis(250));
+            if process_group_is_running(pgid) {
+                libc::kill(-(pgid as libc::pid_t), libc::SIGKILL);
+            }
+        } else {
+            libc::kill(state.pid as libc::pid_t, libc::SIGTERM);
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = state;
+    }
+
+    Ok(())
+}
+
+fn resolve_health_url(
+    tunnel: &ServiceTunnel,
+    health_url: Option<String>,
+    health_path: Option<String>,
+) -> Option<String> {
+    if let Some(url) = health_url {
+        return Some(url);
+    }
+    health_path.map(|path| {
+        let normalized = if path.starts_with('/') {
+            path
+        } else {
+            format!("/{path}")
+        };
+        format!("{}{}", local_url_for(tunnel), normalized)
+    })
+}
+
+fn wait_until_ready(state: &ServiceTunnelRuntimeState, timeout_secs: u64) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        if !runtime_state_is_running(state) {
+            return Err(Error::validation_invalid_argument(
+                "service",
+                "service process exited before becoming ready",
+                Some(state.service_id.clone()),
+                None,
+            ));
+        }
+        let health = check_runtime_health(state);
+        if health.healthy || (!health.checked && runtime_state_is_running(state)) {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(Error::validation_invalid_argument(
+                "readiness",
+                "service did not become healthy before readiness timeout",
+                Some(state.service_id.clone()),
+                health.error.map(|error| vec![error]),
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}
+
+fn check_runtime_health(state: &ServiceTunnelRuntimeState) -> ServiceTunnelHealthStatus {
+    let Some(url) = state.health_url.clone() else {
+        return ServiceTunnelHealthStatus {
+            checked: false,
+            healthy: runtime_state_is_running(state),
+            url: None,
+            status_code: None,
+            error: None,
+        };
+    };
+
+    match reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .and_then(|client| client.get(&url).send())
+    {
+        Ok(response) => ServiceTunnelHealthStatus {
+            checked: true,
+            healthy: response.status().is_success(),
+            url: Some(url),
+            status_code: Some(response.status().as_u16()),
+            error: None,
+        },
+        Err(error) => ServiceTunnelHealthStatus {
+            checked: true,
+            healthy: false,
+            url: Some(url),
+            status_code: None,
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+fn runtime_evidence(state: &ServiceTunnelRuntimeState) -> ServiceTunnelEvidence {
+    ServiceTunnelEvidence {
+        state_path: paths::service_tunnel_runtime_state_file(&state.service_id)
+            .map(|path| path.display().to_string())
+            .unwrap_or_default(),
+        stdout_path: state.stdout_path.clone(),
+        stderr_path: state.stderr_path.clone(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::core::server::Server;
     use crate::test_support;
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     fn create_server() {
         crate::core::server::save(&Server {
@@ -353,6 +784,120 @@ mod tests {
 
             assert_eq!(err.code, crate::core::ErrorCode::ValidationInvalidArgument);
             assert!(err.message.contains("auth.env_var"));
+        });
+    }
+
+    #[test]
+    fn start_status_and_stop_manage_local_service_runtime_state() {
+        test_support::with_isolated_home(|_| {
+            create_server();
+            expose(ExposeServiceTunnelSpec {
+                id: "local-preview".to_string(),
+                server_id: "private-host".to_string(),
+                target: ServiceTunnelTarget {
+                    host: "127.0.0.1".to_string(),
+                    port: 7331,
+                },
+                scheme: "http".to_string(),
+                local_port: Some(8832),
+                auth: ServiceTunnelAuth {
+                    mode: ServiceTunnelAuthMode::BearerEnv,
+                    env_var: Some("LOCAL_PREVIEW_TOKEN".to_string()),
+                    header: Some("Authorization".to_string()),
+                },
+                policy: ServiceTunnelPolicy {
+                    exposure: ServiceTunnelExposure::PrivateLoopback,
+                    require_auth: true,
+                    allowed_clients: vec!["wpcom-calypso".to_string()],
+                },
+                description: None,
+            })
+            .expect("expose service");
+
+            let started = start(StartServiceTunnelSpec {
+                id: "local-preview".to_string(),
+                command: "while true; do sleep 1; done".to_string(),
+                cwd: None,
+                env: BTreeMap::from([("LOCAL_PREVIEW_MODE".to_string(), "test".to_string())]),
+                host: Some("127.0.0.1".to_string()),
+                port: Some(8832),
+                scheme: Some("http".to_string()),
+                health_url: None,
+                health_path: None,
+                readiness_timeout_secs: 1,
+                backend: ServiceTunnelTunnelBackend::None,
+            })
+            .expect("start service");
+
+            assert!(started.running);
+            assert_eq!(started.local_url, "http://127.0.0.1:8832");
+            assert_eq!(started.public_url, None);
+            let process = started.process.expect("process status");
+            assert!(process.running);
+            assert_eq!(process.command.env_keys, vec!["LOCAL_PREVIEW_MODE"]);
+            let evidence = started.evidence.expect("evidence paths");
+            assert!(std::path::Path::new(&evidence.state_path).exists());
+            assert!(std::path::Path::new(&evidence.stdout_path).exists());
+            assert!(std::path::Path::new(&evidence.stderr_path).exists());
+
+            let running = status("local-preview").expect("status");
+            assert!(running.running);
+
+            let stopped = stop("local-preview").expect("stop service");
+            assert!(!stopped.running);
+            assert!(stopped.process.is_none());
+            assert!(!std::path::Path::new(&evidence.state_path).exists());
+        });
+    }
+
+    #[test]
+    fn start_cleans_runtime_state_when_readiness_fails() {
+        test_support::with_isolated_home(|_| {
+            create_server();
+            expose(ExposeServiceTunnelSpec {
+                id: "failing-preview".to_string(),
+                server_id: "private-host".to_string(),
+                target: ServiceTunnelTarget {
+                    host: "127.0.0.1".to_string(),
+                    port: 7331,
+                },
+                scheme: "http".to_string(),
+                local_port: Some(8833),
+                auth: ServiceTunnelAuth {
+                    mode: ServiceTunnelAuthMode::BearerEnv,
+                    env_var: Some("FAILING_PREVIEW_TOKEN".to_string()),
+                    header: Some("Authorization".to_string()),
+                },
+                policy: ServiceTunnelPolicy {
+                    exposure: ServiceTunnelExposure::PrivateLoopback,
+                    require_auth: true,
+                    allowed_clients: Vec::new(),
+                },
+                description: None,
+            })
+            .expect("expose service");
+
+            let err = start(StartServiceTunnelSpec {
+                id: "failing-preview".to_string(),
+                command: "while true; do sleep 1; done".to_string(),
+                cwd: None,
+                env: BTreeMap::new(),
+                host: Some("127.0.0.1".to_string()),
+                port: Some(8833),
+                scheme: Some("http".to_string()),
+                health_url: Some("http://127.0.0.1:9/health".to_string()),
+                health_path: None,
+                readiness_timeout_secs: 0,
+                backend: ServiceTunnelTunnelBackend::None,
+            })
+            .expect_err("readiness should fail");
+
+            assert_eq!(err.code, crate::core::ErrorCode::ValidationInvalidArgument);
+            let state_path =
+                paths::service_tunnel_runtime_state_file("failing-preview").expect("state path");
+            assert!(!state_path.exists());
+            let stopped = status("failing-preview").expect("status");
+            assert!(!stopped.running);
         });
     }
 }


### PR DESCRIPTION
## Summary
- Adds `homeboy tunnel service start|stop` to manage a declared local service command with cwd/env metadata, loopback host/port, readiness checks, process status, and stdout/stderr evidence paths.
- Extends `service status` to report running state, local URL, optional public URL, process/session metadata, health, backend state, and lifecycle evidence.
- Documents the Homeboy-native lifecycle path and keeps public tunnel support as an explicit `none` backend seam until a real backend is implemented.

Closes #3356.

## Verification
- `cargo fmt --check`
- `cargo test tunnel::tests --lib`
- `cargo run --bin homeboy -- tunnel service --help`

## Caveats
- Public tunnel backend support is intentionally not faked. `none` is the only implemented backend in this PR; future tunnel backends should plug into the new explicit lifecycle state rather than wrapping chat tooling.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the managed service lifecycle implementation, tests, docs, and verification commands for Chris to review.