### PR TITLE
Replace dispatch DMC workspace handling

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -64,6 +64,33 @@ The gate passes when:
 - `artifacts` lists a patch artifact, an agent result artifact, and a transcript evidence ref.
 - `promote <run-id> --dry-run` resolves the aggregate from the durable run id and reports the selected non-empty patch plus changed files without requiring the operator to look up `aggregate_path` manually.
 
+## Dispatch Workspaces
+
+`agent-task dispatch` accepts generic Homeboy workspace inputs and does not
+resolve product-specific workspace handles itself.
+
+Use `--cwd <PATH>` when the caller already knows the checkout or worktree path:
+
+```bash
+homeboy agent-task dispatch \
+  --repo homeboy \
+  --cwd /path/to/homeboy@fix-issue \
+  --prompt @task.txt
+```
+
+Use `--workspace <ID_OR_PATH>` for a Homeboy-managed task worktree ID or an
+existing workspace path:
+
+```bash
+homeboy worktree create homeboy --branch fix/issue-123
+homeboy agent-task dispatch \
+  --workspace homeboy@fix-issue-123 \
+  --prompt @task.txt
+```
+
+External workspace managers should resolve their own handles to local paths and
+call dispatch with `--cwd <resolved-path>`.
+
 ## Fixture Backend
 
 The built-in `fixture` backend is intentionally narrow. It exists for smoke

--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -11,6 +11,7 @@ use homeboy::core::agent_task_scheduler::{
     AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskRetryPolicy, AgentTaskScheduler,
 };
 use homeboy::core::config;
+use homeboy::core::worktree;
 
 use super::{CmdResult, GlobalArgs};
 
@@ -28,13 +29,13 @@ pub struct DispatchArgs {
     #[arg(long = "tasks", value_name = "JSON")]
     pub tasks_json: Option<String>,
 
-    /// Existing local repo checkout or DMC worktree path to cook in.
+    /// Existing local repo checkout or worktree path to cook in.
     #[arg(long, value_name = "PATH")]
     pub cwd: Option<String>,
 
-    /// DMC worktree handle, e.g. data-machine@fix-runtime-inline-agent-bundle-import.
-    #[arg(long = "worktree", value_name = "HANDLE")]
-    pub dmc_worktree: Option<String>,
+    /// Homeboy workspace ID or existing local workspace path to cook in.
+    #[arg(long, value_name = "ID_OR_PATH")]
+    pub workspace: Option<String>,
 
     /// Repo/component slug for metadata and task grouping, e.g. data-machine.
     #[arg(long, value_name = "REPO")]
@@ -156,14 +157,20 @@ fn build_dispatch_plan(args: &DispatchArgs) -> homeboy::core::Result<AgentTaskPl
         ));
     }
 
-    let workspace_root = resolve_dispatch_workspace(args)?;
+    let workspace_target = resolve_dispatch_workspace(args)?;
+    let workspace_root = workspace_target.as_ref().map(|target| target.root.clone());
     let repo = args
         .repo
         .clone()
         .or_else(|| {
-            args.dmc_worktree
+            workspace_target
                 .as_ref()
-                .and_then(|handle| handle.split('@').next().map(str::to_string))
+                .and_then(|target| target.component_id.clone())
+        })
+        .or_else(|| {
+            workspace_target
+                .as_ref()
+                .and_then(|target| target.slug.clone())
         })
         .or_else(|| {
             workspace_root
@@ -181,7 +188,7 @@ fn build_dispatch_plan(args: &DispatchArgs) -> homeboy::core::Result<AgentTaskPl
 
     let client_context = dispatch_client_context(args)?;
     let provider_config =
-        dispatch_provider_config(args, &repo, workspace_root.as_ref(), &client_context)?;
+        dispatch_provider_config(args, &repo, workspace_target.as_ref(), &client_context)?;
     let mut tasks = Vec::new();
     for (index, prompt_spec) in prompt_specs.iter().enumerate() {
         let instructions = read_text_spec(prompt_spec, "prompt")?;
@@ -217,19 +224,24 @@ fn build_dispatch_plan(args: &DispatchArgs) -> homeboy::core::Result<AgentTaskPl
                     .as_ref()
                     .map(|path| path.display().to_string()),
                 slug: repo.clone(),
-                kind: args
-                    .dmc_worktree
+                kind: workspace_target
                     .as_ref()
-                    .map(|_| "dmc-worktree".to_string()),
-                component_id: None,
-                branch: None,
-                base_ref: None,
+                    .and_then(|target| target.kind.clone()),
+                component_id: workspace_target
+                    .as_ref()
+                    .and_then(|target| target.component_id.clone()),
+                branch: workspace_target
+                    .as_ref()
+                    .and_then(|target| target.branch.clone()),
+                base_ref: workspace_target
+                    .as_ref()
+                    .and_then(|target| target.base_ref.clone()),
                 task_url: args.task_url.clone(),
                 cleanup: Some("preserve".to_string()),
-                materialization: serde_json::json!({
-                    "dmc_worktree": args.dmc_worktree,
-                    "repo": repo,
-                }),
+                materialization: dispatch_workspace_materialization(
+                    workspace_target.as_ref(),
+                    &repo,
+                ),
             },
             policy: AgentTaskPolicy {
                 read: "workspace".to_string(),
@@ -244,8 +256,8 @@ fn build_dispatch_plan(args: &DispatchArgs) -> homeboy::core::Result<AgentTaskPl
             ],
             metadata: serde_json::json!({
                 "repo": repo,
-                "dmc_worktree": args.dmc_worktree,
                 "client_context": client_context,
+                "workspace": workspace_target.as_ref().map(|target| target.metadata.clone()),
                 "task_url": args.task_url,
                 "prompt_source": prompt_spec,
                 "dispatch": "agent-task dispatch",
@@ -266,7 +278,7 @@ fn build_dispatch_plan(args: &DispatchArgs) -> homeboy::core::Result<AgentTaskPl
     plan.metadata = serde_json::json!({
         "kind": "repo-cooking-dispatch",
         "repo": repo,
-        "dmc_worktree": args.dmc_worktree,
+        "workspace": workspace_target.as_ref().map(|target| target.metadata.clone()),
         "workspace_root": workspace_root.map(|path| path.display().to_string()),
         "client_context": client_context,
         "task_url": args.task_url,
@@ -277,7 +289,7 @@ fn build_dispatch_plan(args: &DispatchArgs) -> homeboy::core::Result<AgentTaskPl
 
 fn resolve_dispatch_workspace(
     args: &DispatchArgs,
-) -> homeboy::core::Result<Option<std::path::PathBuf>> {
+) -> homeboy::core::Result<Option<DispatchWorkspaceTarget>> {
     if let Some(cwd) = &args.cwd {
         let path = std::path::PathBuf::from(cwd);
         if !path.is_dir() {
@@ -291,35 +303,116 @@ fn resolve_dispatch_workspace(
                 None,
             ));
         }
-        return Ok(Some(path));
+        return Ok(Some(DispatchWorkspaceTarget::path(path, "cwd")));
     }
 
-    let Some(handle) = &args.dmc_worktree else {
+    let Some(workspace) = &args.workspace else {
         return Ok(None);
     };
 
-    let root = std::env::var("HOMEBOY_DMC_WORKSPACE_ROOT")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| {
-            std::env::var("HOME")
-                .map(|home| std::path::PathBuf::from(home).join("Developer"))
-                .unwrap_or_else(|_| std::path::PathBuf::from("/Users/chubes/Developer"))
-        });
-    let path = root.join(handle);
-    if !path.is_dir() {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "worktree",
+    let path = std::path::PathBuf::from(workspace);
+    if path.is_dir() {
+        return Ok(Some(DispatchWorkspaceTarget::path(path, "workspace-path")));
+    }
+
+    let record = worktree::resolve(workspace).map_err(|_| {
+        homeboy::core::Error::validation_invalid_argument(
+            "workspace",
             format!(
-                "DMC worktree handle '{}' did not resolve to an existing directory at {}; pass --cwd explicitly if it lives elsewhere",
-                handle,
-                path.display()
+                "agent-task dispatch workspace '{}' is neither an existing directory nor a Homeboy worktree record",
+                workspace
             ),
-            Some(handle.clone()),
+            Some(workspace.clone()),
+            Some(vec![
+                "Pass --cwd <path> for an explicit checkout".to_string(),
+                "Pass --workspace <path> for an existing workspace path".to_string(),
+                "Create or list Homeboy task worktrees with `homeboy worktree create` and `homeboy worktree list`".to_string(),
+            ]),
+        )
+    })?;
+    let root = std::path::PathBuf::from(&record.worktree_path);
+    if !root.is_dir() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "workspace",
+            format!(
+                "Homeboy worktree '{}' points at a missing directory {}; recreate or remove the stale record",
+                record.id,
+                root.display()
+            ),
+            Some(workspace.clone()),
             None,
         ));
     }
 
-    Ok(Some(path))
+    Ok(Some(DispatchWorkspaceTarget::record(record)))
+}
+
+#[derive(Debug, Clone)]
+struct DispatchWorkspaceTarget {
+    root: std::path::PathBuf,
+    slug: Option<String>,
+    kind: Option<String>,
+    component_id: Option<String>,
+    branch: Option<String>,
+    base_ref: Option<String>,
+    metadata: Value,
+}
+
+impl DispatchWorkspaceTarget {
+    fn path(root: std::path::PathBuf, kind: &str) -> Self {
+        let slug = root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(str::to_string);
+        Self {
+            root: root.clone(),
+            slug,
+            kind: Some(kind.to_string()),
+            component_id: None,
+            branch: None,
+            base_ref: None,
+            metadata: serde_json::json!({
+                "kind": kind,
+                "root": root.display().to_string(),
+            }),
+        }
+    }
+
+    fn record(record: worktree::TaskWorktreeRecord) -> Self {
+        let root = std::path::PathBuf::from(&record.worktree_path);
+        Self {
+            root,
+            slug: Some(record.component_id.clone()),
+            kind: Some("homeboy-worktree".to_string()),
+            component_id: Some(record.component_id.clone()),
+            branch: Some(record.branch.clone()),
+            base_ref: Some(record.base_ref.clone()),
+            metadata: serde_json::json!({
+                "kind": "homeboy-worktree",
+                "id": record.id,
+                "component_id": record.component_id,
+                "branch": record.branch,
+                "base_ref": record.base_ref,
+                "root": record.worktree_path,
+                "source_checkout": record.source_checkout,
+                "task_url": record.task_url,
+            }),
+        }
+    }
+}
+
+fn dispatch_workspace_materialization(
+    workspace: Option<&DispatchWorkspaceTarget>,
+    repo: &Option<String>,
+) -> Value {
+    let Some(workspace) = workspace else {
+        return serde_json::json!({ "repo": repo });
+    };
+
+    serde_json::json!({
+        "repo": repo,
+        "workspace": workspace.metadata,
+    })
 }
 
 fn dispatch_client_context(args: &DispatchArgs) -> homeboy::core::Result<Value> {
@@ -351,7 +444,7 @@ fn dispatch_client_context(args: &DispatchArgs) -> homeboy::core::Result<Value> 
 fn dispatch_provider_config(
     args: &DispatchArgs,
     repo: &Option<String>,
-    workspace_root: Option<&std::path::PathBuf>,
+    workspace: Option<&DispatchWorkspaceTarget>,
     client_context: &Value,
 ) -> homeboy::core::Result<Value> {
     let mut config = if let Some(spec) = &args.provider_config {
@@ -381,10 +474,10 @@ fn dispatch_provider_config(
         .or_insert_with(|| serde_json::json!("repo-cooking"));
     map.entry("repo".to_string())
         .or_insert_with(|| serde_json::json!(repo));
-    map.entry("dmc_worktree".to_string())
-        .or_insert_with(|| serde_json::json!(args.dmc_worktree));
+    map.entry("workspace".to_string())
+        .or_insert_with(|| serde_json::json!(workspace.map(|target| target.metadata.clone())));
     map.entry("workspace_root".to_string()).or_insert_with(|| {
-        serde_json::json!(workspace_root.map(|path| path.display().to_string()))
+        serde_json::json!(workspace.map(|target| target.root.display().to_string()))
     });
     map.entry("client_context".to_string())
         .or_insert_with(|| client_context.clone());
@@ -625,30 +718,95 @@ mod tests {
     }
 
     #[test]
-    fn resolves_dmc_worktree_handle_under_configured_root() {
-        let root = tempfile::tempdir().expect("dmc root");
-        let worktree = root.path().join("data-machine@fix-runtime");
-        std::fs::create_dir(&worktree).expect("worktree dir");
-        std::env::set_var("HOMEBOY_DMC_WORKSPACE_ROOT", root.path());
+    fn resolves_workspace_path_without_specialized_coupling() {
+        let worktree = tempfile::tempdir().expect("workspace");
 
         let plan = build_dispatch_plan(&dispatch_args(DispatchArgOverrides {
-            prompt: Some("Cook DMC worktree.".to_string()),
-            dmc_worktree: Some("data-machine@fix-runtime".to_string()),
+            prompt: Some("Cook generic workspace.".to_string()),
+            workspace: Some(worktree.path().display().to_string()),
             ..DispatchArgOverrides::default()
         }))
-        .expect("dispatch dmc plan");
+        .expect("dispatch workspace plan");
 
-        assert_eq!(plan.group_key.as_deref(), Some("data-machine"));
         assert_eq!(
             plan.tasks[0].workspace.root.as_deref(),
-            Some(worktree.to_str().expect("worktree utf8"))
+            Some(worktree.path().to_str().expect("worktree utf8"))
         );
         assert_eq!(
             plan.tasks[0].workspace.kind.as_deref(),
-            Some("dmc-worktree")
+            Some("workspace-path")
         );
+        assert_eq!(
+            plan.tasks[0].metadata["workspace"]["kind"],
+            "workspace-path"
+        );
+    }
 
-        std::env::remove_var("HOMEBOY_DMC_WORKSPACE_ROOT");
+    #[test]
+    fn resolves_homeboy_worktree_record_as_generic_workspace() {
+        with_isolated_home(|_| {
+            let root = tempfile::tempdir().expect("workspace root");
+            let source = root.path().join("homeboy");
+            let worktree_path = root.path().join("homeboy@fix-runtime");
+            std::fs::create_dir(&source).expect("source dir");
+            std::fs::create_dir(&worktree_path).expect("worktree dir");
+            let record = worktree::TaskWorktreeRecord {
+                id: "homeboy@fix-runtime".to_string(),
+                component_id: "homeboy".to_string(),
+                source_checkout: source.display().to_string(),
+                worktree_path: worktree_path.display().to_string(),
+                branch: "fix/runtime".to_string(),
+                base_ref: "origin/main".to_string(),
+                task_url: Some("https://github.com/Extra-Chill/homeboy/issues/3653".to_string()),
+                run_id: None,
+                cleanup_policy: worktree::CleanupPolicy::PreserveOnFailure,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                state: worktree::TaskWorktreeState::Active,
+            };
+            let store = homeboy::core::paths::observation_db()
+                .expect("observation db")
+                .parent()
+                .expect("data root")
+                .join("task-worktrees");
+            std::fs::create_dir_all(&store).expect("store dir");
+            std::fs::write(
+                store.join(format!(
+                    "{}.json",
+                    homeboy::core::paths::sanitize_path_segment("homeboy@fix-runtime")
+                )),
+                serde_json::to_string_pretty(&record).expect("record json"),
+            )
+            .expect("write record");
+
+            let plan = build_dispatch_plan(&dispatch_args(DispatchArgOverrides {
+                prompt: Some("Cook Homeboy workspace.".to_string()),
+                workspace: Some("homeboy@fix-runtime".to_string()),
+                ..DispatchArgOverrides::default()
+            }))
+            .expect("dispatch workspace plan");
+
+            assert_eq!(plan.group_key.as_deref(), Some("homeboy"));
+            assert_eq!(
+                plan.tasks[0].workspace.root.as_deref(),
+                Some(worktree_path.to_str().expect("worktree utf8"))
+            );
+            assert_eq!(
+                plan.tasks[0].workspace.kind.as_deref(),
+                Some("homeboy-worktree")
+            );
+            assert_eq!(
+                plan.tasks[0].workspace.component_id.as_deref(),
+                Some("homeboy")
+            );
+            assert_eq!(
+                plan.tasks[0].workspace.branch.as_deref(),
+                Some("fix/runtime")
+            );
+            assert_eq!(
+                plan.tasks[0].executor.config["workspace"]["id"],
+                "homeboy@fix-runtime"
+            );
+        });
     }
 
     struct NoopExecutor;
@@ -681,7 +839,7 @@ mod tests {
         prompt: Option<String>,
         tasks_json: Option<String>,
         cwd: Option<String>,
-        dmc_worktree: Option<String>,
+        workspace: Option<String>,
         repo: Option<String>,
         client_context: Option<String>,
         concurrency: usize,
@@ -696,7 +854,7 @@ mod tests {
             tasks: Vec::new(),
             tasks_json: overrides.tasks_json,
             cwd: overrides.cwd,
-            dmc_worktree: overrides.dmc_worktree,
+            workspace: overrides.workspace,
             repo: overrides.repo,
             task_url: None,
             backend: "fixture".to_string(),

--- a/src/core/worktree.rs
+++ b/src/core/worktree.rs
@@ -122,6 +122,10 @@ pub fn status(id: &str) -> Result<WorktreeStatusOutput> {
     status_with_store(id, &metadata_dir()?)
 }
 
+pub fn resolve(id: &str) -> Result<TaskWorktreeRecord> {
+    read_record(&metadata_dir()?, id)
+}
+
 pub fn remove(options: WorktreeRemoveOptions) -> Result<WorktreeRemoveOutput> {
     remove_with_store(options, &metadata_dir()?)
 }


### PR DESCRIPTION
## Summary
- Replaces `agent-task dispatch --worktree` DMC handle resolution with generic `--workspace <ID_OR_PATH>` resolution.
- Keeps explicit `--cwd <PATH>` dispatch working while resolving Homeboy-managed worktree records generically.
- Removes dispatch metadata/config fields named `dmc_worktree` and documents the generic workspace contract.

## Verification
- `cargo fmt --check`
- `cargo test commands::agent_task_dispatch`
- `cargo test core::worktree`
- `cargo run --quiet --bin homeboy -- agent-task dispatch --help`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the dispatch workspace boundary cleanup, updated tests/docs, and ran targeted verification; Chris remains responsible for review and merge.