### PR TITLE
Add browser origin evidence for previews

### DIFF
--- a/docs/architecture/browser-evidence-schemas.md
+++ b/docs/architecture/browser-evidence-schemas.md
@@ -56,7 +56,7 @@ key.
 Preview producers should emit one `BrowserOriginEvidence` row per browser probe
 that exercises a managed service. The row should capture both declared routing
 facts and browser-observed facts so hostname-sensitive failures can distinguish
-`calypso.localhost:3000`, `localhost:3000`, `127.0.0.1:3000`, and public tunnel
+`app.localhost:3000`, `localhost:3000`, `127.0.0.1:3000`, and public tunnel
 origins.
 
 Minimal example:
@@ -66,14 +66,14 @@ Minimal example:
   "origin_evidence": [
     {
       "schema_version": 1,
-      "managed_service_id": "wpcom-start",
+      "managed_service_id": "site-preview",
       "preview_artifact_id": "preview-artifact-1",
       "run_id": "trace-run-1",
-      "declared": { "host": "calypso.localhost", "port": 3000, "protocol": "http" },
-      "local_url": "http://calypso.localhost:3000/start",
-      "public_preview_url": "https://preview.example.test/start",
-      "browser_requested_url": "https://preview.example.test/start",
-      "browser_final_url": "https://preview.example.test/start?flow=site",
+      "declared": { "host": "app.localhost", "port": 3000, "protocol": "http" },
+      "local_url": "http://app.localhost:3000/",
+      "public_preview_url": "https://preview.example.test/",
+      "browser_requested_url": "https://preview.example.test/",
+      "browser_final_url": "https://preview.example.test/?view=site",
       "window_location": {
         "origin": "https://preview.example.test",
         "hostname": "preview.example.test",
@@ -83,8 +83,8 @@ Minimal example:
       },
       "redirects": [
         {
-          "from_url": "https://preview.example.test/start",
-          "to_url": "https://preview.example.test/start?flow=site",
+          "from_url": "https://preview.example.test/",
+          "to_url": "https://preview.example.test/?view=site",
           "status": 302
         }
       ],

--- a/docs/architecture/browser-evidence-schemas.md
+++ b/docs/architecture/browser-evidence-schemas.md
@@ -25,6 +25,11 @@ Current schema version: `1`.
   assigning product meaning to phase names.
 - `BrowserArtifactMetadata` describes evidence location and broad kind with
   `path`, optional `kind`, and optional `label`.
+- `BrowserOriginEvidence` describes the effective browser origin exercised for a
+  managed preview service: owning `managed_service_id`, optional
+  `preview_artifact_id` and `run_id`, declared host/port/protocol, local URL,
+  public preview URL, browser requested URL, browser final URL, redirects,
+  `window.location` origin/hostname/protocol/port, and `window.isSecureContext`.
 - `BrowserBottleneckRow` describes generic report rows with `kind`, `phase`,
   `message`, and optional `data`.
 - `TraceEvent`, `TraceAssertion`, and `TraceEnvelope` describe generic trace
@@ -37,8 +42,62 @@ and `trace.results`, core also validates known browser evidence fields when
 they are present:
 
 - `bench.results`: `browser_profiles`, `profiles`, `network`, `artifacts`,
-  `bottlenecks`, and `timings`.
-- `trace.results`: `timeline`, `assertions`, `artifacts`, and `traces`.
+  `bottlenecks`, `timings`, `origin_evidence`, and
+  `browser_origin_evidence`.
+- `trace.results`: `timeline`, `assertions`, `artifacts`, `traces`,
+  `origin_evidence`, and `browser_origin_evidence`.
+
+`origin_evidence` is the preferred field. `browser_origin_evidence` is accepted
+as an explicit alias for producers that need a more self-describing top-level
+key.
+
+## Managed Preview Origin Evidence
+
+Preview producers should emit one `BrowserOriginEvidence` row per browser probe
+that exercises a managed service. The row should capture both declared routing
+facts and browser-observed facts so hostname-sensitive failures can distinguish
+`calypso.localhost:3000`, `localhost:3000`, `127.0.0.1:3000`, and public tunnel
+origins.
+
+Minimal example:
+
+```json
+{
+  "origin_evidence": [
+    {
+      "schema_version": 1,
+      "managed_service_id": "wpcom-start",
+      "preview_artifact_id": "preview-artifact-1",
+      "run_id": "trace-run-1",
+      "declared": { "host": "calypso.localhost", "port": 3000, "protocol": "http" },
+      "local_url": "http://calypso.localhost:3000/start",
+      "public_preview_url": "https://preview.example.test/start",
+      "browser_requested_url": "https://preview.example.test/start",
+      "browser_final_url": "https://preview.example.test/start?flow=site",
+      "window_location": {
+        "origin": "https://preview.example.test",
+        "hostname": "preview.example.test",
+        "protocol": "https:",
+        "port": "",
+        "is_secure_context": true
+      },
+      "redirects": [
+        {
+          "from_url": "https://preview.example.test/start",
+          "to_url": "https://preview.example.test/start?flow=site",
+          "status": 302
+        }
+      ],
+      "network_origin": { "tunnel": "homeboy-managed" }
+    }
+  ]
+}
+```
+
+The same array can also be nested under `metadata.preview.origin_evidence` when
+the capture belongs to a preview lifecycle record instead of a bench or trace
+result sidecar. `homeboy report performance-digest` renders those rows in a
+`Browser Origin Evidence` section.
 
 Unknown fields are allowed at the sidecar envelope level so existing benchmark
 and trace producers can carry additional domain-specific payloads. Known fields

--- a/docs/architecture/preview-metadata.md
+++ b/docs/architecture/preview-metadata.md
@@ -24,12 +24,12 @@ Set `HOMEBOY_PREVIEW_JSON` to a JSON object. Recommended fields:
   "origin_evidence": [
     {
       "schema_version": 1,
-      "managed_service_id": "wpcom-start",
-      "declared": { "host": "calypso.localhost", "port": 3000, "protocol": "http" },
-      "local_url": "http://calypso.localhost:3000/start",
-      "public_preview_url": "https://preview.example.test/start",
-      "browser_requested_url": "https://preview.example.test/start",
-      "browser_final_url": "https://preview.example.test/start?flow=site",
+      "managed_service_id": "site-preview",
+      "declared": { "host": "app.localhost", "port": 3000, "protocol": "http" },
+      "local_url": "http://app.localhost:3000/",
+      "public_preview_url": "https://preview.example.test/",
+      "browser_requested_url": "https://preview.example.test/",
+      "browser_final_url": "https://preview.example.test/?view=site",
       "window_location": {
         "origin": "https://preview.example.test",
         "hostname": "preview.example.test",

--- a/docs/architecture/preview-metadata.md
+++ b/docs/architecture/preview-metadata.md
@@ -20,7 +20,25 @@ Set `HOMEBOY_PREVIEW_JSON` to a JSON object. Recommended fields:
   "status": "running",
   "process_id": "pid-123",
   "runtime_id": "runtime-abc",
-  "cleanup_status": "pending"
+  "cleanup_status": "pending",
+  "origin_evidence": [
+    {
+      "schema_version": 1,
+      "managed_service_id": "wpcom-start",
+      "declared": { "host": "calypso.localhost", "port": 3000, "protocol": "http" },
+      "local_url": "http://calypso.localhost:3000/start",
+      "public_preview_url": "https://preview.example.test/start",
+      "browser_requested_url": "https://preview.example.test/start",
+      "browser_final_url": "https://preview.example.test/start?flow=site",
+      "window_location": {
+        "origin": "https://preview.example.test",
+        "hostname": "preview.example.test",
+        "protocol": "https:",
+        "port": "",
+        "is_secure_context": true
+      }
+    }
+  ]
 }
 ```
 
@@ -43,3 +61,8 @@ same caller-supplied preview facts.
 `homeboy report performance-digest` renders scalar preview fields in a
 `Preview` section, including local URL, public URL, hold/expiry, lifecycle
 status, runtime/process ID, and cleanup status when available.
+
+When `origin_evidence` or `browser_origin_evidence` is present in preview
+metadata, `homeboy report performance-digest` also renders the effective browser
+origin details. This gives managed-service proof artifacts enough context to
+diagnose hostname-sensitive routing, redirects, and secure-context behavior.

--- a/src/commands/report/performance_digest.rs
+++ b/src/commands/report/performance_digest.rs
@@ -54,7 +54,40 @@ pub struct PerformanceDigestReport {
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub preview: BTreeMap<String, String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub preview_origin_evidence: Vec<BrowserOriginEvidenceDigest>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub gaps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BrowserOriginEvidenceDigest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub managed_service_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preview_artifact_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub declared: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_preview_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub browser_requested_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub browser_final_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub window_origin: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub window_hostname: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub window_protocol: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub window_port: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_secure_context: Option<bool>,
+    pub redirect_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -162,6 +195,10 @@ pub fn performance_digest_from_args(
     let preview = find_object_recursive(&metadata, "preview")
         .map(scalar_object)
         .unwrap_or_default();
+    let preview_origin_evidence = collect_origin_evidence(&metadata)
+        .into_iter()
+        .chain(collect_origin_evidence(&Value::Object(bench_data.clone())))
+        .collect::<Vec<_>>();
 
     let mut baseline_health =
         collect_baseline_health(&bench_data, args.min_samples, args.max_cv_pct);
@@ -188,6 +225,7 @@ pub fn performance_digest_from_args(
         host_pressure.as_ref(),
         &lab_offload,
         &preview,
+        &preview_origin_evidence,
         &gaps,
         args.run_url.as_deref().unwrap_or_default(),
     );
@@ -201,6 +239,7 @@ pub fn performance_digest_from_args(
         host_pressure,
         lab_offload,
         preview,
+        preview_origin_evidence,
         gaps,
     })
 }
@@ -577,6 +616,7 @@ mod helpers {
         host_pressure: Option<&HostPressureDigest>,
         lab_offload: &BTreeMap<String, String>,
         preview: &BTreeMap<String, String>,
+        preview_origin_evidence: &[BrowserOriginEvidenceDigest],
         gaps: &[String],
         run_url: &str,
     ) -> String {
@@ -589,6 +629,7 @@ mod helpers {
         render_host_pressure(&mut out, host_pressure);
         render_lab_offload(&mut out, lab_offload);
         render_preview(&mut out, preview);
+        render_preview_origin_evidence(&mut out, preview_origin_evidence);
         render_gaps(&mut out, gaps);
         if !run_url.is_empty() {
             let _ = writeln!(out, "### Full run\n- {}\n", run_url);
@@ -802,6 +843,114 @@ mod helpers {
             }
         }
         out.push('\n');
+    }
+
+    pub(super) fn render_preview_origin_evidence(
+        out: &mut String,
+        origin_evidence: &[BrowserOriginEvidenceDigest],
+    ) {
+        if origin_evidence.is_empty() {
+            return;
+        }
+        out.push_str("### Browser Origin Evidence\n");
+        out.push_str("| Managed service | Declared | Local URL | Public preview URL | Requested URL | Final URL | Window origin | Hostname | Secure context | Redirects |\n");
+        out.push_str("| --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: |\n");
+        for evidence in origin_evidence.iter().take(12) {
+            let _ = writeln!(
+                out,
+                "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |",
+                table_optional(evidence.managed_service_id.as_deref()),
+                table_optional(evidence.declared.as_deref()),
+                table_optional(evidence.local_url.as_deref()),
+                table_optional(evidence.public_preview_url.as_deref()),
+                table_optional(evidence.browser_requested_url.as_deref()),
+                table_optional(evidence.browser_final_url.as_deref()),
+                table_optional(evidence.window_origin.as_deref()),
+                table_optional(evidence.window_hostname.as_deref()),
+                evidence
+                    .is_secure_context
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+                evidence.redirect_count,
+            );
+        }
+        out.push('\n');
+    }
+
+    pub(super) fn collect_origin_evidence(value: &Value) -> Vec<BrowserOriginEvidenceDigest> {
+        let mut rows = Vec::new();
+        collect_origin_evidence_recursive(value, &mut rows);
+        rows
+    }
+
+    fn collect_origin_evidence_recursive(
+        value: &Value,
+        rows: &mut Vec<BrowserOriginEvidenceDigest>,
+    ) {
+        match value {
+            Value::Object(map) => {
+                for key in ["origin_evidence", "browser_origin_evidence"] {
+                    if let Some(Value::Array(items)) = map.get(key) {
+                        rows.extend(items.iter().filter_map(origin_evidence_digest));
+                    }
+                }
+                for child in map.values() {
+                    collect_origin_evidence_recursive(child, rows);
+                }
+            }
+            Value::Array(items) => {
+                for child in items {
+                    collect_origin_evidence_recursive(child, rows);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn origin_evidence_digest(value: &Value) -> Option<BrowserOriginEvidenceDigest> {
+        let object = value.as_object()?;
+        let window_location = object.get("window_location").and_then(Value::as_object);
+        Some(BrowserOriginEvidenceDigest {
+            managed_service_id: string_value(object, "managed_service_id"),
+            preview_artifact_id: string_value(object, "preview_artifact_id"),
+            run_id: string_value(object, "run_id"),
+            declared: object.get("declared").and_then(format_declared_origin),
+            local_url: string_value(object, "local_url"),
+            public_preview_url: string_value(object, "public_preview_url")
+                .or_else(|| string_value(object, "public_url")),
+            browser_requested_url: string_value(object, "browser_requested_url"),
+            browser_final_url: string_value(object, "browser_final_url"),
+            window_origin: window_location.and_then(|map| string_value(map, "origin")),
+            window_hostname: window_location.and_then(|map| string_value(map, "hostname")),
+            window_protocol: window_location.and_then(|map| string_value(map, "protocol")),
+            window_port: window_location.and_then(|map| string_value(map, "port")),
+            is_secure_context: window_location.and_then(|map| bool_value(map, "is_secure_context")),
+            redirect_count: object
+                .get("redirects")
+                .and_then(Value::as_array)
+                .map(Vec::len)
+                .unwrap_or_default(),
+        })
+    }
+
+    fn format_declared_origin(value: &Value) -> Option<String> {
+        let object = value.as_object()?;
+        let host = string_value(object, "host")?;
+        let port = object.get("port").and_then(Value::as_u64)?;
+        let protocol = string_value(object, "protocol").unwrap_or_else(|| "http".to_string());
+        Some(format!(
+            "{}://{}:{}",
+            protocol.trim_end_matches(':'),
+            host,
+            port
+        ))
+    }
+
+    fn table_optional(value: Option<&str>) -> String {
+        value
+            .filter(|value| !value.is_empty())
+            .map(|value| format!("`{}`", escape_markdown_table_cell(value)))
+            .unwrap_or_else(|| "-".to_string())
     }
 
     pub(super) fn render_gaps(out: &mut String, gaps: &[String]) {

--- a/src/core/browser_evidence.rs
+++ b/src/core/browser_evidence.rs
@@ -122,6 +122,64 @@ pub struct BrowserArtifactMetadata {
     pub label: Option<String>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BrowserOriginEvidence {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub managed_service_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preview_artifact_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declared: Option<BrowserOriginDeclaredService>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_url: Option<String>,
+    #[serde(default, alias = "public_url", skip_serializing_if = "Option::is_none")]
+    pub public_preview_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub browser_requested_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub browser_final_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_location: Option<BrowserWindowLocationEvidence>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub redirects: Vec<BrowserRedirectEvidence>,
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub network_origin: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BrowserOriginDeclaredService {
+    pub host: String,
+    pub port: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BrowserWindowLocationEvidence {
+    pub origin: String,
+    pub hostname: String,
+    pub protocol: String,
+    pub port: String,
+    #[serde(default)]
+    pub is_secure_context: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BrowserRedirectEvidence {
+    pub from_url: String,
+    pub to_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<u16>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct BrowserBottleneckRow {
@@ -206,6 +264,8 @@ pub fn validate_bench_results_payload(payload: &Value) -> Result<()> {
     validate_optional_array::<BrowserArtifactMetadata>(payload, "artifacts")?;
     validate_optional_array::<BrowserBottleneckRow>(payload, "bottlenecks")?;
     validate_optional_array::<BrowserTimingRow>(payload, "timings")?;
+    validate_optional_array::<BrowserOriginEvidence>(payload, "origin_evidence")?;
+    validate_optional_array::<BrowserOriginEvidence>(payload, "browser_origin_evidence")?;
     Ok(())
 }
 
@@ -214,6 +274,8 @@ pub fn validate_trace_results_payload(payload: &Value) -> Result<()> {
     validate_optional_array::<TraceAssertion>(payload, "assertions")?;
     validate_optional_array::<BrowserArtifactMetadata>(payload, "artifacts")?;
     validate_optional_array::<TraceEnvelope>(payload, "traces")?;
+    validate_optional_array::<BrowserOriginEvidence>(payload, "origin_evidence")?;
+    validate_optional_array::<BrowserOriginEvidence>(payload, "browser_origin_evidence")?;
     Ok(())
 }
 
@@ -289,6 +351,30 @@ mod tests {
                 "raw": { "source": "resource" }
             }],
             "artifacts": [{ "path": "browser/profile.json", "kind": "profile", "label": "profile" }],
+            "origin_evidence": [{
+                "schema_version": 1,
+                "managed_service_id": "wpcom-start",
+                "preview_artifact_id": "preview-1",
+                "run_id": "run-123",
+                "declared": { "host": "calypso.localhost", "port": 3000, "protocol": "http" },
+                "local_url": "http://calypso.localhost:3000/start",
+                "public_preview_url": "https://preview.example.test/start",
+                "browser_requested_url": "https://preview.example.test/start",
+                "browser_final_url": "https://preview.example.test/start?flow=site",
+                "window_location": {
+                    "origin": "https://preview.example.test",
+                    "hostname": "preview.example.test",
+                    "protocol": "https:",
+                    "port": "",
+                    "is_secure_context": true
+                },
+                "redirects": [{
+                    "from_url": "https://preview.example.test/start",
+                    "to_url": "https://preview.example.test/start?flow=site",
+                    "status": 302
+                }],
+                "network_origin": { "tunnel": "homeboy-managed" }
+            }],
             "bottlenecks": [{ "kind": "network", "phase": "boot", "message": "Slow script" }]
         })).unwrap();
     }
@@ -319,6 +405,16 @@ mod tests {
             }]
         }))
         .unwrap();
+    }
+
+    #[test]
+    fn validates_synthetic_browser_origin_fixture() {
+        let payload: Value = serde_json::from_str(include_str!(
+            "../../tests/fixtures/browser_origin_evidence/synthetic-origin.json"
+        ))
+        .expect("synthetic browser origin fixture should be valid JSON");
+
+        validate_trace_results_payload(&payload).unwrap();
     }
 
     #[test]

--- a/src/core/browser_evidence.rs
+++ b/src/core/browser_evidence.rs
@@ -353,14 +353,14 @@ mod tests {
             "artifacts": [{ "path": "browser/profile.json", "kind": "profile", "label": "profile" }],
             "origin_evidence": [{
                 "schema_version": 1,
-                "managed_service_id": "wpcom-start",
+                "managed_service_id": "site-preview",
                 "preview_artifact_id": "preview-1",
                 "run_id": "run-123",
-                "declared": { "host": "calypso.localhost", "port": 3000, "protocol": "http" },
-                "local_url": "http://calypso.localhost:3000/start",
-                "public_preview_url": "https://preview.example.test/start",
-                "browser_requested_url": "https://preview.example.test/start",
-                "browser_final_url": "https://preview.example.test/start?flow=site",
+                "declared": { "host": "app.localhost", "port": 3000, "protocol": "http" },
+                "local_url": "http://app.localhost:3000/",
+                "public_preview_url": "https://preview.example.test/",
+                "browser_requested_url": "https://preview.example.test/",
+                "browser_final_url": "https://preview.example.test/?view=site",
                 "window_location": {
                     "origin": "https://preview.example.test",
                     "hostname": "preview.example.test",
@@ -369,8 +369,8 @@ mod tests {
                     "is_secure_context": true
                 },
                 "redirects": [{
-                    "from_url": "https://preview.example.test/start",
-                    "to_url": "https://preview.example.test/start?flow=site",
+                    "from_url": "https://preview.example.test/",
+                    "to_url": "https://preview.example.test/?view=site",
                     "status": 302
                 }],
                 "network_origin": { "tunnel": "homeboy-managed" }

--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -808,7 +808,7 @@ mod tests {
                 policy: ServiceTunnelPolicy {
                     exposure: ServiceTunnelExposure::PrivateLoopback,
                     require_auth: true,
-                    allowed_clients: vec!["wpcom-calypso".to_string()],
+                    allowed_clients: vec!["app-runtime".to_string()],
                 },
                 description: None,
             })

--- a/tests/fixtures/browser_origin_evidence/synthetic-origin.json
+++ b/tests/fixtures/browser_origin_evidence/synthetic-origin.json
@@ -2,18 +2,18 @@
   "origin_evidence": [
     {
       "schema_version": 1,
-      "managed_service_id": "wpcom-start",
+      "managed_service_id": "site-preview",
       "preview_artifact_id": "preview-artifact-1",
       "run_id": "trace-run-1",
       "declared": {
-        "host": "calypso.localhost",
+        "host": "app.localhost",
         "port": 3000,
         "protocol": "http"
       },
-      "local_url": "http://calypso.localhost:3000/start",
-      "public_preview_url": "https://preview.example.test/start",
-      "browser_requested_url": "https://preview.example.test/start",
-      "browser_final_url": "https://preview.example.test/start?flow=site",
+      "local_url": "http://app.localhost:3000/",
+      "public_preview_url": "https://preview.example.test/",
+      "browser_requested_url": "https://preview.example.test/",
+      "browser_final_url": "https://preview.example.test/?view=site",
       "window_location": {
         "origin": "https://preview.example.test",
         "hostname": "preview.example.test",
@@ -23,8 +23,8 @@
       },
       "redirects": [
         {
-          "from_url": "https://preview.example.test/start",
-          "to_url": "https://preview.example.test/start?flow=site",
+          "from_url": "https://preview.example.test/",
+          "to_url": "https://preview.example.test/?view=site",
           "status": 302
         }
       ],

--- a/tests/fixtures/browser_origin_evidence/synthetic-origin.json
+++ b/tests/fixtures/browser_origin_evidence/synthetic-origin.json
@@ -1,0 +1,37 @@
+{
+  "origin_evidence": [
+    {
+      "schema_version": 1,
+      "managed_service_id": "wpcom-start",
+      "preview_artifact_id": "preview-artifact-1",
+      "run_id": "trace-run-1",
+      "declared": {
+        "host": "calypso.localhost",
+        "port": 3000,
+        "protocol": "http"
+      },
+      "local_url": "http://calypso.localhost:3000/start",
+      "public_preview_url": "https://preview.example.test/start",
+      "browser_requested_url": "https://preview.example.test/start",
+      "browser_final_url": "https://preview.example.test/start?flow=site",
+      "window_location": {
+        "origin": "https://preview.example.test",
+        "hostname": "preview.example.test",
+        "protocol": "https:",
+        "port": "",
+        "is_secure_context": true
+      },
+      "redirects": [
+        {
+          "from_url": "https://preview.example.test/start",
+          "to_url": "https://preview.example.test/start?flow=site",
+          "status": 302
+        }
+      ],
+      "network_origin": {
+        "tunnel": "homeboy-managed",
+        "requested_host_header": "preview.example.test"
+      }
+    }
+  ]
+}

--- a/tests/report_performance_digest_test.rs
+++ b/tests/report_performance_digest_test.rs
@@ -144,14 +144,14 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
                 "cleanup_status": "pending",
                 "origin_evidence": [{
                     "schema_version": 1,
-                    "managed_service_id": "wpcom-start",
+                    "managed_service_id": "site-preview",
                     "preview_artifact_id": "preview-artifact-1",
                     "run_id": "trace-run-1",
-                    "declared": { "host": "calypso.localhost", "port": 3000, "protocol": "http" },
-                    "local_url": "http://calypso.localhost:3000/start",
-                    "public_preview_url": "https://preview.example.test/start",
-                    "browser_requested_url": "https://preview.example.test/start",
-                    "browser_final_url": "https://preview.example.test/start?flow=site",
+                    "declared": { "host": "app.localhost", "port": 3000, "protocol": "http" },
+                    "local_url": "http://app.localhost:3000/",
+                    "public_preview_url": "https://preview.example.test/",
+                    "browser_requested_url": "https://preview.example.test/",
+                    "browser_final_url": "https://preview.example.test/?view=site",
                     "window_location": {
                         "origin": "https://preview.example.test",
                         "hostname": "preview.example.test",
@@ -160,8 +160,8 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
                         "is_secure_context": true
                     },
                     "redirects": [{
-                        "from_url": "https://preview.example.test/start",
-                        "to_url": "https://preview.example.test/start?flow=site",
+                        "from_url": "https://preview.example.test/",
+                        "to_url": "https://preview.example.test/?view=site",
                         "status": 302
                     }],
                     "network_origin": { "tunnel": "homeboy-managed" }
@@ -213,7 +213,7 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
         report.preview_origin_evidence[0]
             .managed_service_id
             .as_deref(),
-        Some("wpcom-start")
+        Some("site-preview")
     );
     assert_eq!(
         report.preview_origin_evidence[0].window_hostname.as_deref(),
@@ -252,11 +252,11 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
     assert!(report.markdown.contains("- runtime_id: `runtime-abc`"));
     assert!(report.markdown.contains("- cleanup_status: `pending`"));
     assert!(report.markdown.contains("### Browser Origin Evidence"));
-    assert!(report.markdown.contains("`wpcom-start`"));
-    assert!(report.markdown.contains("`http://calypso.localhost:3000`"));
+    assert!(report.markdown.contains("`site-preview`"));
+    assert!(report.markdown.contains("`http://app.localhost:3000`"));
     assert!(report
         .markdown
-        .contains("`https://preview.example.test/start?flow=site`"));
+        .contains("`https://preview.example.test/?view=site`"));
     assert!(report.markdown.contains("| true | 1 |"));
 
     let _ = fs::remove_dir_all(&dir);

--- a/tests/report_performance_digest_test.rs
+++ b/tests/report_performance_digest_test.rs
@@ -141,7 +141,31 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
                 "status": "running",
                 "process_id": "pid-123",
                 "runtime_id": "runtime-abc",
-                "cleanup_status": "pending"
+                "cleanup_status": "pending",
+                "origin_evidence": [{
+                    "schema_version": 1,
+                    "managed_service_id": "wpcom-start",
+                    "preview_artifact_id": "preview-artifact-1",
+                    "run_id": "trace-run-1",
+                    "declared": { "host": "calypso.localhost", "port": 3000, "protocol": "http" },
+                    "local_url": "http://calypso.localhost:3000/start",
+                    "public_preview_url": "https://preview.example.test/start",
+                    "browser_requested_url": "https://preview.example.test/start",
+                    "browser_final_url": "https://preview.example.test/start?flow=site",
+                    "window_location": {
+                        "origin": "https://preview.example.test",
+                        "hostname": "preview.example.test",
+                        "protocol": "https:",
+                        "port": "",
+                        "is_secure_context": true
+                    },
+                    "redirects": [{
+                        "from_url": "https://preview.example.test/start",
+                        "to_url": "https://preview.example.test/start?flow=site",
+                        "status": 302
+                    }],
+                    "network_origin": { "tunnel": "homeboy-managed" }
+                }]
             }
         }"#,
     );
@@ -184,6 +208,22 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
         report.preview.get("public_url"),
         Some(&"https://preview.example.test/run-1".to_string())
     );
+    assert_eq!(report.preview_origin_evidence.len(), 1);
+    assert_eq!(
+        report.preview_origin_evidence[0]
+            .managed_service_id
+            .as_deref(),
+        Some("wpcom-start")
+    );
+    assert_eq!(
+        report.preview_origin_evidence[0].window_hostname.as_deref(),
+        Some("preview.example.test")
+    );
+    assert_eq!(
+        report.preview_origin_evidence[0].is_secure_context,
+        Some(true)
+    );
+    assert_eq!(report.preview_origin_evidence[0].redirect_count, 1);
     assert!(report.markdown.contains("## Performance Digest"));
     assert!(report.markdown.contains("### Resource Summary"));
     assert!(report.markdown.contains("- Duration: **12345 ms**"));
@@ -211,6 +251,13 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
     assert!(report.markdown.contains("- process_id: `pid-123`"));
     assert!(report.markdown.contains("- runtime_id: `runtime-abc`"));
     assert!(report.markdown.contains("- cleanup_status: `pending`"));
+    assert!(report.markdown.contains("### Browser Origin Evidence"));
+    assert!(report.markdown.contains("`wpcom-start`"));
+    assert!(report.markdown.contains("`http://calypso.localhost:3000`"));
+    assert!(report
+        .markdown
+        .contains("`https://preview.example.test/start?flow=site`"));
+    assert!(report.markdown.contains("| true | 1 |"));
 
     let _ = fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary
- Adds a core browser origin evidence schema for managed preview services, including declared host/port, preview URLs, browser requested/final URLs, window origin fields, secure-context status, redirects, and network origin metadata.
- Validates `origin_evidence` / `browser_origin_evidence` in bench and trace sidecars and renders preview origin rows in `homeboy report performance-digest`.
- Adds a synthetic browser-origin fixture plus coverage for schema validation and performance digest rendering.

Closes #3660.

## Verification
- `cargo fmt`
- `cargo test core::browser_evidence`
- `cargo test --test report_performance_digest_test`

## Caveats
- This PR lands the schema/report integration and explicit fixture-backed capture seam. Runtime browser probes still need to emit the new `origin_evidence` rows from their producer-specific capture paths.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the schema/report/test/docs changes and ran targeted verification; Chris remains responsible for review and merge.