### PR TITLE
Add comparison preview links

### DIFF
--- a/docs/architecture/preview-metadata.md
+++ b/docs/architecture/preview-metadata.md
@@ -43,3 +43,13 @@ same caller-supplied preview facts.
 `homeboy report performance-digest` renders scalar preview fields in a
 `Preview` section, including local URL, public URL, hold/expiry, lifecycle
 status, runtime/process ID, and cleanup status when available.
+
+Bench comparison side-by-side reports also consume structured preview artifacts
+when scenario or run artifacts use `type: "preview"`, `kind: "preview"`, the
+artifact name `preview`, or preview-specific fields such as `preview_url`,
+`public_url`, `local_url`, `status`, `expires_at`, `cleanup_status`,
+`service_lifecycle`, and `browser_origin_evidence`. The rendered
+`reports.side_by_side.rigs[].preview_links[]` table labels links by explicit
+artifact `role` when present; otherwise comparison order infers `baseline` for
+the first rig, `candidate` for the second rig, and `provider` for additional
+rigs.

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -750,6 +750,7 @@ mod tests {
                     kind: Some("json".to_string()),
                     label: Some("Transcript".to_string()),
                     observation_artifact_id: None,
+                    ..BenchArtifact::default()
                 },
             );
             results.scenarios[0].artifacts.insert(
@@ -761,6 +762,7 @@ mod tests {
                     kind: Some("admin_url".to_string()),
                     label: Some("Admin".to_string()),
                     observation_artifact_id: None,
+                    ..BenchArtifact::default()
                 },
             );
             let mut workflow = BenchRunWorkflowResult {
@@ -1022,6 +1024,7 @@ mod tests {
                     kind: Some("json".to_string()),
                     label: Some("Semantic fidelity".to_string()),
                     observation_artifact_id: None,
+                    ..BenchArtifact::default()
                 },
             );
             let mut workflow = BenchRunWorkflowResult {
@@ -1109,6 +1112,7 @@ mod tests {
                     kind: Some("json".to_string()),
                     label: Some("Semantic fidelity".to_string()),
                     observation_artifact_id: None,
+                    ..BenchArtifact::default()
                 },
             );
             let mut workflow = BenchRunWorkflowResult {
@@ -1183,6 +1187,7 @@ mod tests {
                     kind: Some("visual_comparison_dir".to_string()),
                     label: Some("Visual comparisons".to_string()),
                     observation_artifact_id: None,
+                    ..BenchArtifact::default()
                 },
             );
             let mut workflow = BenchRunWorkflowResult {

--- a/src/core/extension/bench/artifact.rs
+++ b/src/core/extension/bench/artifact.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct BenchArtifact {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -17,6 +17,24 @@ pub struct BenchArtifact {
     pub label: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observation_artifact_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preview_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup_status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_lifecycle: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub browser_origin_evidence: Option<serde_json::Value>,
 }
 
 #[cfg(test)]

--- a/src/core/extension/bench/artifact.rs
+++ b/src/core/extension/bench/artifact.rs
@@ -3,6 +3,18 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct BenchPreviewLifecycleMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup_status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_lifecycle: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub browser_origin_evidence: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct BenchArtifact {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -27,14 +39,8 @@ pub struct BenchArtifact {
     pub local_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub expires_at: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cleanup_status: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub service_lifecycle: Option<serde_json::Value>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub browser_origin_evidence: Option<serde_json::Value>,
+    #[serde(flatten)]
+    pub preview_lifecycle: BenchPreviewLifecycleMetadata,
 }
 
 #[cfg(test)]

--- a/src/core/extension/bench/artifact_validation.rs
+++ b/src/core/extension/bench/artifact_validation.rs
@@ -186,6 +186,7 @@ mod tests {
                             kind: None,
                             label: None,
                             observation_artifact_id: None,
+                            ..BenchArtifact::default()
                         },
                     )]),
                     diagnostics: Vec::new(),

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -13,7 +13,8 @@ use crate::core::rig::RigStateSnapshot;
 use crate::core::runner::reportable_artifact_evidence_path;
 
 pub use super::side_by_side::{
-    BenchSideBySideArtifact, BenchSideBySideMetric, BenchSideBySideReport, BenchSideBySideRigReport,
+    BenchSideBySideArtifact, BenchSideBySideMetric, BenchSideBySidePreviewLink,
+    BenchSideBySideReport, BenchSideBySideRigReport,
 };
 
 #[derive(Serialize)]
@@ -115,7 +116,7 @@ pub use comparison::{
 /// A compact, grep-friendly pointer to an artifact emitted by a bench
 /// scenario. `results` remains the full-fidelity source of truth; this
 /// index surfaces the paths that users need immediately after a run.
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Clone, Debug, PartialEq)]
 pub struct BenchArtifactRef {
     pub scenario_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -133,6 +134,24 @@ pub struct BenchArtifactRef {
     pub label: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub observation_artifact_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preview_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cleanup_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_lifecycle: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub browser_origin_evidence: Option<serde_json::Value>,
 }
 
 pub(crate) fn collect_artifacts(results: &BenchResults) -> Vec<BenchArtifactRef> {
@@ -171,6 +190,15 @@ fn artifact_ref(
         kind: artifact.kind.clone(),
         label: artifact.label.clone(),
         observation_artifact_id: artifact.observation_artifact_id.clone(),
+        role: artifact.role.clone(),
+        preview_url: artifact.preview_url.clone(),
+        public_url: artifact.public_url.clone(),
+        local_url: artifact.local_url.clone(),
+        status: artifact.status.clone(),
+        expires_at: artifact.expires_at.clone(),
+        cleanup_status: artifact.cleanup_status.clone(),
+        service_lifecycle: artifact.service_lifecycle.clone(),
+        browser_origin_evidence: artifact.browser_origin_evidence.clone(),
     }
 }
 

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -2,7 +2,7 @@
 
 use serde::Serialize;
 
-use super::artifact::BenchArtifact;
+use super::artifact::{BenchArtifact, BenchPreviewLifecycleMetadata};
 use super::baseline::BenchBaselineComparison;
 use super::diagnostic::BenchDiagnostic;
 use super::parsing::BenchResults;
@@ -144,14 +144,8 @@ pub struct BenchArtifactRef {
     pub local_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub expires_at: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cleanup_status: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub service_lifecycle: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub browser_origin_evidence: Option<serde_json::Value>,
+    #[serde(flatten)]
+    pub preview_lifecycle: BenchPreviewLifecycleMetadata,
 }
 
 pub(crate) fn collect_artifacts(results: &BenchResults) -> Vec<BenchArtifactRef> {
@@ -195,10 +189,7 @@ fn artifact_ref(
         public_url: artifact.public_url.clone(),
         local_url: artifact.local_url.clone(),
         status: artifact.status.clone(),
-        expires_at: artifact.expires_at.clone(),
-        cleanup_status: artifact.cleanup_status.clone(),
-        service_lifecycle: artifact.service_lifecycle.clone(),
-        browser_origin_evidence: artifact.browser_origin_evidence.clone(),
+        preview_lifecycle: artifact.preview_lifecycle.clone(),
     }
 }
 

--- a/src/core/extension/bench/side_by_side.rs
+++ b/src/core/extension/bench/side_by_side.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+use super::artifact::BenchPreviewLifecycleMetadata;
 use super::parsing::BenchResults;
 use super::report::{comparison_metrics, BenchArtifactRef, RigBenchEntry};
 
@@ -64,14 +65,8 @@ pub struct BenchSideBySidePreviewLink {
     pub local_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub expires_at: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cleanup_status: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub service_lifecycle: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub browser_origin_evidence: Option<serde_json::Value>,
+    #[serde(flatten)]
+    pub preview_lifecycle: BenchPreviewLifecycleMetadata,
 }
 
 pub(super) fn build_side_by_side_report(
@@ -186,10 +181,7 @@ fn side_by_side_preview_link(
         url,
         local_url: artifact.local_url.clone(),
         status: artifact.status.clone(),
-        expires_at: artifact.expires_at.clone(),
-        cleanup_status: artifact.cleanup_status.clone(),
-        service_lifecycle: artifact.service_lifecycle.clone(),
-        browser_origin_evidence: artifact.browser_origin_evidence.clone(),
+        preview_lifecycle: artifact.preview_lifecycle.clone(),
     })
 }
 
@@ -198,10 +190,10 @@ fn is_preview_artifact(artifact: &BenchArtifactRef) -> bool {
         || artifact.public_url.is_some()
         || artifact.local_url.is_some()
         || artifact.status.is_some()
-        || artifact.expires_at.is_some()
-        || artifact.cleanup_status.is_some()
-        || artifact.service_lifecycle.is_some()
-        || artifact.browser_origin_evidence.is_some()
+        || artifact.preview_lifecycle.expires_at.is_some()
+        || artifact.preview_lifecycle.cleanup_status.is_some()
+        || artifact.preview_lifecycle.service_lifecycle.is_some()
+        || artifact.preview_lifecycle.browser_origin_evidence.is_some()
         || artifact.kind.as_deref() == Some("preview")
         || artifact.artifact_type.as_deref() == Some("preview")
         || artifact.name == "preview"

--- a/src/core/extension/bench/side_by_side.rs
+++ b/src/core/extension/bench/side_by_side.rs
@@ -23,6 +23,8 @@ pub struct BenchSideBySideRigReport {
     pub key_metrics: Vec<BenchSideBySideMetric>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub artifacts: Vec<BenchSideBySideArtifact>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub preview_links: Vec<BenchSideBySidePreviewLink>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_reason: Option<String>,
 }
@@ -50,6 +52,28 @@ pub struct BenchSideBySideArtifact {
     pub label: Option<String>,
 }
 
+#[derive(Serialize, Debug, PartialEq)]
+pub struct BenchSideBySidePreviewLink {
+    pub role: String,
+    pub scenario_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_index: Option<usize>,
+    pub name: String,
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cleanup_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_lifecycle: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub browser_origin_evidence: Option<serde_json::Value>,
+}
+
 pub(super) fn build_side_by_side_report(
     component: &str,
     iterations: u64,
@@ -59,11 +83,15 @@ pub(super) fn build_side_by_side_report(
         report: "side_by_side",
         component: component.to_string(),
         iterations,
-        rigs: entries.iter().map(side_by_side_rig_report).collect(),
+        rigs: entries
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| side_by_side_rig_report(index, entry))
+            .collect(),
     }
 }
 
-fn side_by_side_rig_report(entry: &RigBenchEntry) -> BenchSideBySideRigReport {
+fn side_by_side_rig_report(index: usize, entry: &RigBenchEntry) -> BenchSideBySideRigReport {
     let key_metrics = entry
         .results
         .as_ref()
@@ -78,6 +106,11 @@ fn side_by_side_rig_report(entry: &RigBenchEntry) -> BenchSideBySideRigReport {
         elapsed_ms: entry.results.as_ref().and_then(total_elapsed_ms),
         key_metrics,
         artifacts: entry.artifacts.iter().map(side_by_side_artifact).collect(),
+        preview_links: entry
+            .artifacts
+            .iter()
+            .filter_map(|artifact| side_by_side_preview_link(index, artifact))
+            .collect(),
         failure_reason: failure_reason(entry),
     }
 }
@@ -124,6 +157,61 @@ fn side_by_side_artifact(artifact: &BenchArtifactRef) -> BenchSideBySideArtifact
             .or_else(|| artifact.path.as_deref().and_then(url_from_artifact_path)),
         kind: artifact.kind.clone(),
         label: artifact.label.clone(),
+    }
+}
+
+fn side_by_side_preview_link(
+    rig_index: usize,
+    artifact: &BenchArtifactRef,
+) -> Option<BenchSideBySidePreviewLink> {
+    let url = artifact
+        .preview_url
+        .clone()
+        .or_else(|| artifact.public_url.clone())
+        .or_else(|| artifact.url.clone())
+        .or_else(|| artifact.path.as_deref().and_then(url_from_artifact_path))?;
+
+    if !is_preview_artifact(artifact) {
+        return None;
+    }
+
+    Some(BenchSideBySidePreviewLink {
+        role: artifact
+            .role
+            .clone()
+            .unwrap_or_else(|| inferred_role(rig_index).to_string()),
+        scenario_id: artifact.scenario_id.clone(),
+        run_index: artifact.run_index,
+        name: artifact.name.clone(),
+        url,
+        local_url: artifact.local_url.clone(),
+        status: artifact.status.clone(),
+        expires_at: artifact.expires_at.clone(),
+        cleanup_status: artifact.cleanup_status.clone(),
+        service_lifecycle: artifact.service_lifecycle.clone(),
+        browser_origin_evidence: artifact.browser_origin_evidence.clone(),
+    })
+}
+
+fn is_preview_artifact(artifact: &BenchArtifactRef) -> bool {
+    artifact.preview_url.is_some()
+        || artifact.public_url.is_some()
+        || artifact.local_url.is_some()
+        || artifact.status.is_some()
+        || artifact.expires_at.is_some()
+        || artifact.cleanup_status.is_some()
+        || artifact.service_lifecycle.is_some()
+        || artifact.browser_origin_evidence.is_some()
+        || artifact.kind.as_deref() == Some("preview")
+        || artifact.artifact_type.as_deref() == Some("preview")
+        || artifact.name == "preview"
+}
+
+fn inferred_role(rig_index: usize) -> &'static str {
+    match rig_index {
+        0 => "baseline",
+        1 => "candidate",
+        _ => "provider",
     }
 }
 

--- a/src/core/refactor/transform.rs
+++ b/src/core/refactor/transform.rs
@@ -46,11 +46,11 @@ pub struct TransformRule {
     /// Backslash escapes are collapsed before the template is handed to the
     /// regex engine: `\\` → one literal backslash, `\n` → newline, `\t` → tab,
     /// `\r` → CR, `\0` → nul, `\"` → `"`, `\'` → `'`. Unknown escapes pass
-    /// through verbatim. This means that to emit a PHP fully-qualified name
-    /// like `\WP_Foo` on disk, write `\\WP_Foo` in JSON (which decodes to
-    /// `\WP_Foo` in memory — the literal `\` you want). See #1277.
+    /// through verbatim. This means that to emit a fully-qualified name like
+    /// `\Example_Name` on disk, write `\\Example_Name` in JSON (which decodes
+    /// to `\Example_Name` in memory — the literal `\` you want). See #1277.
     pub replace: String,
-    /// Glob pattern for files to apply to (e.g., `tests/**/*.php`).
+    /// Glob pattern for files to apply to (e.g., `tests/**/*.txt`).
     #[serde(default = "default_files_glob")]
     pub files: String,
     /// Match context: "line" (default) or "file" (whole-file regex, for multi-line).

--- a/src/core/rig/service.rs
+++ b/src/core/rig/service.rs
@@ -65,7 +65,7 @@ pub fn log_path(rig_id: &str, service_id: &str) -> Result<std::path::PathBuf> {
 /// process matches — both callers treat that as "nothing to do."
 ///
 /// Implementation: shells out to `ps -axo pid=,lstart=,args=` and filters
-/// in Rust. We pick the newest match (largest start-time) so a stale +
+/// the output locally. We pick the newest match (largest start-time) so a stale +
 /// fresh pair surfaces the fresh one to consumers (the rig wants to know
 /// "is the live daemon stale?").
 pub fn discover_newest(pattern: &str) -> Result<Option<DiscoveredProcess>> {

--- a/tests/commands/bench/observation_artifact_test.rs
+++ b/tests/commands/bench/observation_artifact_test.rs
@@ -25,6 +25,7 @@ fn bench_observation_reports_missing_and_blocked_artifacts() {
                 kind: Some("json".to_string()),
                 label: Some("Missing".to_string()),
                 observation_artifact_id: None,
+                ..BenchArtifact::default()
             },
         );
         results.scenarios[0].artifacts.insert(
@@ -36,6 +37,7 @@ fn bench_observation_reports_missing_and_blocked_artifacts() {
                 kind: Some("json".to_string()),
                 label: Some("Escape".to_string()),
                 observation_artifact_id: None,
+                ..BenchArtifact::default()
             },
         );
         let mut workflow = BenchRunWorkflowResult {

--- a/tests/core/extension/bench/artifact_test.rs
+++ b/tests/core/extension/bench/artifact_test.rs
@@ -1,4 +1,4 @@
-use super::BenchArtifact;
+use super::{BenchArtifact, BenchPreviewLifecycleMetadata};
 
 #[test]
 fn bench_artifact_serializes_optional_fields_when_present() {
@@ -68,12 +68,14 @@ fn bench_artifact_serializes_preview_metadata_when_present() {
         public_url: Some("https://preview.example.test/".to_string()),
         local_url: Some("http://127.0.0.1:8080".to_string()),
         status: Some("running".to_string()),
-        expires_at: Some("2026-06-08T12:00:00Z".to_string()),
-        cleanup_status: Some("pending".to_string()),
-        service_lifecycle: Some(serde_json::json!({ "service_id": "site-preview" })),
-        browser_origin_evidence: Some(serde_json::json!({
-            "browser_effective_origin": "https://preview.example.test/"
-        })),
+        preview_lifecycle: BenchPreviewLifecycleMetadata {
+            expires_at: Some("2026-06-08T12:00:00Z".to_string()),
+            cleanup_status: Some("pending".to_string()),
+            service_lifecycle: Some(serde_json::json!({ "service_id": "site-preview" })),
+            browser_origin_evidence: Some(serde_json::json!({
+                "browser_effective_origin": "https://preview.example.test/"
+            })),
+        },
         ..BenchArtifact::default()
     };
 

--- a/tests/core/extension/bench/artifact_test.rs
+++ b/tests/core/extension/bench/artifact_test.rs
@@ -9,6 +9,7 @@ fn bench_artifact_serializes_optional_fields_when_present() {
         kind: Some("json".to_string()),
         label: Some("Run 1 transcript".to_string()),
         observation_artifact_id: None,
+        ..BenchArtifact::default()
     };
 
     let raw = serde_json::to_string(&artifact).unwrap();
@@ -28,6 +29,7 @@ fn bench_artifact_omits_absent_optional_fields() {
         kind: None,
         label: None,
         observation_artifact_id: None,
+        ..BenchArtifact::default()
     };
 
     let raw = serde_json::to_string(&artifact).unwrap();
@@ -44,6 +46,7 @@ fn bench_artifact_serializes_url_fields_when_present() {
         kind: Some("admin_url".to_string()),
         label: Some("Admin".to_string()),
         observation_artifact_id: None,
+        ..BenchArtifact::default()
     };
 
     let raw = serde_json::to_string(&artifact).unwrap();
@@ -51,6 +54,40 @@ fn bench_artifact_serializes_url_fields_when_present() {
     assert_eq!(
         raw,
         r#"{"url":"https://example.test/wp-admin/","type":"url","kind":"admin_url","label":"Admin"}"#
+    );
+}
+
+#[test]
+fn bench_artifact_serializes_preview_metadata_when_present() {
+    let artifact = BenchArtifact {
+        path: Some("artifacts/preview.json".to_string()),
+        artifact_type: Some("preview".to_string()),
+        kind: Some("preview".to_string()),
+        role: Some("baseline".to_string()),
+        preview_url: Some("https://preview.example.test/".to_string()),
+        public_url: Some("https://preview.example.test/".to_string()),
+        local_url: Some("http://127.0.0.1:8080".to_string()),
+        status: Some("running".to_string()),
+        expires_at: Some("2026-06-08T12:00:00Z".to_string()),
+        cleanup_status: Some("pending".to_string()),
+        service_lifecycle: Some(serde_json::json!({ "service_id": "site-preview" })),
+        browser_origin_evidence: Some(serde_json::json!({
+            "browser_effective_origin": "https://preview.example.test/"
+        })),
+        ..BenchArtifact::default()
+    };
+
+    let value = serde_json::to_value(&artifact).unwrap();
+
+    assert_eq!(value["role"], "baseline");
+    assert_eq!(value["preview_url"], "https://preview.example.test/");
+    assert_eq!(value["status"], "running");
+    assert_eq!(value["expires_at"], "2026-06-08T12:00:00Z");
+    assert_eq!(value["cleanup_status"], "pending");
+    assert_eq!(value["service_lifecycle"]["service_id"], "site-preview");
+    assert_eq!(
+        value["browser_origin_evidence"]["browser_effective_origin"],
+        "https://preview.example.test/"
     );
 }
 

--- a/tests/core/extension/bench/report_comparison_test.rs
+++ b/tests/core/extension/bench/report_comparison_test.rs
@@ -5,7 +5,7 @@ use super::{
     aggregate_comparison, aggregate_comparison_with_axes, BenchComparisonDiff, BenchPhaseGroups,
     RigBenchEntry,
 };
-use crate::core::extension::bench::artifact::BenchArtifact;
+use crate::core::extension::bench::artifact::{BenchArtifact, BenchPreviewLifecycleMetadata};
 use crate::core::extension::bench::diagnostic::{BenchDiagnostic, BenchDiagnosticSource};
 use crate::core::extension::bench::distribution::BenchRunDistribution;
 use crate::core::extension::bench::parsing::{
@@ -170,17 +170,19 @@ mod fixtures {
             public_url: Some(preview_url.to_string()),
             local_url: Some("http://127.0.0.1:8080".to_string()),
             status: Some(status.to_string()),
-            expires_at: expires_at.map(str::to_string),
-            cleanup_status: Some("pending".to_string()),
-            service_lifecycle: Some(serde_json::json!({
-                "service_id": "site-preview",
-                "lifecycle": status,
-                "running": status == "running"
-            })),
-            browser_origin_evidence: Some(serde_json::json!({
-                "browser_effective_origin": preview_url,
-                "window_is_secure_context": true
-            })),
+            preview_lifecycle: BenchPreviewLifecycleMetadata {
+                expires_at: expires_at.map(str::to_string),
+                cleanup_status: Some("pending".to_string()),
+                service_lifecycle: Some(serde_json::json!({
+                    "service_id": "site-preview",
+                    "lifecycle": status,
+                    "running": status == "running"
+                })),
+                browser_origin_evidence: Some(serde_json::json!({
+                    "browser_effective_origin": preview_url,
+                    "window_is_secure_context": true
+                })),
+            },
         }
     }
 
@@ -280,11 +282,15 @@ fn comparison_side_by_side_renders_baseline_and_candidate_preview_links() {
         "https://baseline-preview.example.test/"
     );
     assert_eq!(
-        report.rigs[0].preview_links[0].expires_at.as_deref(),
+        report.rigs[0].preview_links[0]
+            .preview_lifecycle
+            .expires_at
+            .as_deref(),
         Some("2026-06-08T12:00:00Z")
     );
     assert_eq!(
         report.rigs[0].preview_links[0]
+            .preview_lifecycle
             .service_lifecycle
             .as_ref()
             .unwrap()["service_id"],
@@ -292,6 +298,7 @@ fn comparison_side_by_side_renders_baseline_and_candidate_preview_links() {
     );
     assert_eq!(
         report.rigs[0].preview_links[0]
+            .preview_lifecycle
             .browser_origin_evidence
             .as_ref()
             .unwrap()["window_is_secure_context"],

--- a/tests/core/extension/bench/report_comparison_test.rs
+++ b/tests/core/extension/bench/report_comparison_test.rs
@@ -131,6 +131,7 @@ mod fixtures {
             kind: kind.map(str::to_string),
             label: label.map(str::to_string),
             observation_artifact_id: None,
+            ..BenchArtifact::default()
         }
     }
 
@@ -147,6 +148,39 @@ mod fixtures {
             kind: kind.map(str::to_string),
             label: label.map(str::to_string),
             observation_artifact_id: None,
+            ..BenchArtifact::default()
+        }
+    }
+
+    pub(super) fn preview_artifact(
+        role: Option<&str>,
+        preview_url: &str,
+        status: &str,
+        expires_at: Option<&str>,
+    ) -> BenchArtifact {
+        BenchArtifact {
+            path: Some("artifacts/preview.json".to_string()),
+            url: None,
+            artifact_type: Some("preview".to_string()),
+            kind: Some("preview".to_string()),
+            label: Some("Public preview".to_string()),
+            observation_artifact_id: Some("obs-preview".to_string()),
+            role: role.map(str::to_string),
+            preview_url: Some(preview_url.to_string()),
+            public_url: Some(preview_url.to_string()),
+            local_url: Some("http://127.0.0.1:8080".to_string()),
+            status: Some(status.to_string()),
+            expires_at: expires_at.map(str::to_string),
+            cleanup_status: Some("pending".to_string()),
+            service_lifecycle: Some(serde_json::json!({
+                "service_id": "site-preview",
+                "lifecycle": status,
+                "running": status == "running"
+            })),
+            browser_origin_evidence: Some(serde_json::json!({
+                "browser_effective_origin": preview_url,
+                "window_is_secure_context": true
+            })),
         }
     }
 
@@ -200,6 +234,83 @@ mod fixtures {
 }
 
 use fixtures::*;
+
+#[test]
+fn comparison_side_by_side_renders_baseline_and_candidate_preview_links() {
+    let mut baseline_scenario = scenario("site-build", &[("elapsed_ms", 12_000.0)]);
+    baseline_scenario.artifacts.insert(
+        "preview".to_string(),
+        preview_artifact(
+            None,
+            "https://baseline-preview.example.test/",
+            "running",
+            Some("2026-06-08T12:00:00Z"),
+        ),
+    );
+
+    let mut candidate_scenario = scenario("site-build", &[("elapsed_ms", 8_000.0)]);
+    candidate_scenario.artifacts.insert(
+        "preview".to_string(),
+        preview_artifact(
+            Some("candidate"),
+            "https://candidate-preview.example.test/",
+            "expired",
+            Some("2026-06-07T12:00:00Z"),
+        ),
+    );
+
+    let entries = vec![
+        entry("baseline-rig", true, Some(results(vec![baseline_scenario]))),
+        entry(
+            "candidate-rig",
+            true,
+            Some(results(vec![candidate_scenario])),
+        ),
+    ];
+
+    let (out, exit) = aggregate_comparison("studio".into(), 10, entries);
+    let value = serde_json::to_value(&out).expect("serialize comparison");
+    let report = &out.reports.side_by_side;
+
+    assert_eq!(exit, 0);
+    assert_eq!(report.rigs[0].preview_links.len(), 1);
+    assert_eq!(report.rigs[0].preview_links[0].role, "baseline");
+    assert_eq!(
+        report.rigs[0].preview_links[0].url,
+        "https://baseline-preview.example.test/"
+    );
+    assert_eq!(
+        report.rigs[0].preview_links[0].expires_at.as_deref(),
+        Some("2026-06-08T12:00:00Z")
+    );
+    assert_eq!(
+        report.rigs[0].preview_links[0]
+            .service_lifecycle
+            .as_ref()
+            .unwrap()["service_id"],
+        "site-preview"
+    );
+    assert_eq!(
+        report.rigs[0].preview_links[0]
+            .browser_origin_evidence
+            .as_ref()
+            .unwrap()["window_is_secure_context"],
+        true
+    );
+    assert_eq!(report.rigs[1].preview_links[0].role, "candidate");
+    assert_eq!(
+        report.rigs[1].preview_links[0].status.as_deref(),
+        Some("expired")
+    );
+    assert_eq!(
+        value["reports"]["side_by_side"]["rigs"][0]["preview_links"][0]["role"],
+        "baseline"
+    );
+    assert_eq!(
+        value["reports"]["side_by_side"]["rigs"][1]["preview_links"][0]["url"],
+        "https://candidate-preview.example.test/"
+    );
+}
 
 #[test]
 fn test_from_main_workflow() {
@@ -503,6 +614,7 @@ fn test_collect_url_artifacts() {
             kind: Some("frontend_url".to_string()),
             label: Some("Frontend".to_string()),
             observation_artifact_id: None,
+            ..BenchArtifact::default()
         },
     );
 

--- a/tests/core/extension/bench/runs_flag_test.rs
+++ b/tests/core/extension/bench/runs_flag_test.rs
@@ -159,6 +159,7 @@ mod cases {
                 kind: Some("json".to_string()),
                 label: Some("Run 1 transcript".to_string()),
                 observation_artifact_id: None,
+                ..BenchArtifact::default()
             },
         );
         let mut second = scenario("agent", &[("success_rate", 1.0)]);
@@ -171,6 +172,7 @@ mod cases {
                 kind: Some("json".to_string()),
                 label: Some("Run 2 transcript".to_string()),
                 observation_artifact_id: None,
+                ..BenchArtifact::default()
             },
         );
 


### PR DESCRIPTION
## Summary
- Adds structured preview metadata fields to bench artifacts and artifact refs so comparison reports can consume preview artifacts without knowing how tunnels are created.
- Adds `reports.side_by_side.rigs[].preview_links[]` with baseline/candidate/provider role labeling, preview URL, lifecycle/expiry/cleanup metadata, managed service lifecycle evidence, and browser-origin evidence when present.
- Covers preview artifact serialization and baseline/candidate side-by-side comparison rendering, and documents the preview artifact contract.

Closes #3661.

## Verification
- `cargo fmt`
- `cargo test core::extension::bench::artifact`
- `cargo test core::extension::bench::report::comparison`
- `cargo check`

## Notes
- Report rendering remains tolerant of fixtures without backend/origin evidence; those fields are omitted unless supplied by the artifact.
- `cargo test` emitted an existing unrelated warning for an unused `serde_json::Value` import in `src/commands/runs/corpus_tests.rs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the report model/rendering changes, tests, docs, and local verification commands for Chris to review.