### PR TITLE
Add managed service preview artifacts

### DIFF
--- a/docs/commands/tunnel.md
+++ b/docs/commands/tunnel.md
@@ -20,10 +20,11 @@ homeboy tunnel service expose context-a8c \
   --auth-mode bearer-env \
   --auth-env CONTEXTA8C_TOKEN \
   --auth-header Authorization \
-  --allow-client wp-runtime
+  --allow-client wp-runtime \
+  --preview-policy always
 ```
 
-The declaration requires an explicit auth mode and stores a private-loopback policy. It does not expose a public unauthenticated URL.
+The declaration requires an explicit auth mode and stores a private-loopback policy. It does not expose a public unauthenticated URL. `--preview-policy` defaults to `none`; workloads can opt into `always`, `on-failure`, `manual-approval`, or `keep-alive-until` when reviewer-facing preview artifacts are useful.
 
 Start a declared local service command and record lifecycle evidence:
 
@@ -34,12 +35,16 @@ homeboy tunnel service start context-a8c \
   --host 127.0.0.1 \
   --port 7331 \
   --health-path / \
-  --public-tunnel-backend none
+  --public-tunnel-backend none \
+  --source-run-id run-123 \
+  --source-workflow-id workflow-abc
 ```
 
 `--env KEY=VALUE` can be repeated to pass runtime environment values. Status records only env var names, not values. The managed service writes stdout/stderr logs under Homeboy's local data directory and includes those paths in `service status` output.
 
 Public tunnel backends are an explicit seam. `none` is the only implemented backend in this release; unsupported backends should be added as first-class implementations rather than faked by wrapping Kimaki or another CLI in proof paths.
+
+When a service's preview policy is relevant, `service status` and `service start` include a structured `preview` artifact with schema `homeboy/preview-url/v1`. The artifact records the service ID, local URL, optional public URL, backend, policy, cleanup/expiry metadata, and owning run/workflow IDs when the start command supplied them.
 
 ## Subcommands
 

--- a/docs/commands/tunnel.md
+++ b/docs/commands/tunnel.md
@@ -13,14 +13,14 @@ homeboy tunnel service <COMMAND>
 Declare a private service reachable from a configured SSH server:
 
 ```sh
-homeboy tunnel service expose context-a8c \
-  --server wp-cloud-runtime \
+homeboy tunnel service expose site-preview \
+  --server private-runtime \
   --remote-host 127.0.0.1 \
   --remote-port 7331 \
   --auth-mode bearer-env \
-  --auth-env CONTEXTA8C_TOKEN \
+  --auth-env SITE_PREVIEW_TOKEN \
   --auth-header Authorization \
-  --allow-client wp-runtime \
+  --allow-client app-runtime \
   --preview-policy always
 ```
 
@@ -29,9 +29,9 @@ The declaration requires an explicit auth mode and stores a private-loopback pol
 Start a declared local service command and record lifecycle evidence:
 
 ```sh
-homeboy tunnel service start context-a8c \
-  --command 'npm run dev -- --host 127.0.0.1 --port 7331' \
-  --cwd /path/to/workspace \
+homeboy tunnel service start site-preview \
+  --command 'serve-app --host 127.0.0.1 --port 7331' \
+  --cwd /workspace/app \
   --host 127.0.0.1 \
   --port 7331 \
   --health-path / \

--- a/src/commands/report/performance_digest.rs
+++ b/src/commands/report/performance_digest.rs
@@ -849,14 +849,30 @@ mod helpers {
     }
 
     pub(super) fn scalar_object(map: &Map<String, Value>) -> BTreeMap<String, String> {
-        map.iter()
-            .filter_map(|(key, value)| match value {
+        let mut flattened = BTreeMap::new();
+        flatten_scalar_object("", map, &mut flattened);
+        flattened
+    }
+
+    fn flatten_scalar_object(
+        prefix: &str,
+        map: &Map<String, Value>,
+        out: &mut BTreeMap<String, String>,
+    ) {
+        for (key, value) in map {
+            let path = if prefix.is_empty() {
+                key.clone()
+            } else {
+                format!("{prefix}.{key}")
+            };
+            match value {
                 Value::String(_) | Value::Number(_) | Value::Bool(_) => {
-                    Some((key.clone(), scalar_display(value)))
+                    out.insert(path, scalar_display(value));
                 }
-                _ => None,
-            })
-            .collect()
+                Value::Object(child) => flatten_scalar_object(&path, child, out),
+                _ => {}
+            }
+        }
     }
 
     pub(super) fn dedupe_diagnostics(

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -548,16 +548,16 @@ mod tests {
         test_support::with_isolated_home(|_| {
             create_server();
             let (output, exit_code) = run_service(TunnelServiceCommand::Expose {
-                id: "context-a8c".to_string(),
+                id: "site-preview".to_string(),
                 server: "private-host".to_string(),
                 remote_host: "127.0.0.1".to_string(),
                 remote_port: 7331,
                 scheme: "http".to_string(),
                 local_port: Some(8831),
                 auth_mode: ServiceTunnelAuthModeArg::BearerEnv,
-                auth_env: Some("CONTEXTA8C_TOKEN".to_string()),
+                auth_env: Some("SITE_PREVIEW_TOKEN".to_string()),
                 auth_header: Some("Authorization".to_string()),
-                allowed_clients: vec!["wp-runtime".to_string()],
+                allowed_clients: vec!["app-runtime".to_string()],
                 description: None,
                 preview_policy: ServiceTunnelPreviewPolicyArg::None,
                 preview_keep_alive_until: None,
@@ -566,7 +566,7 @@ mod tests {
 
             assert_eq!(exit_code, 0);
             assert_eq!(output.command, "tunnel.service.expose");
-            assert_eq!(output.entity.expect("entity").id, "context-a8c");
+            assert_eq!(output.entity.expect("entity").id, "site-preview");
         });
     }
 }

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -3,7 +3,8 @@ use serde::Serialize;
 
 use homeboy::core::tunnel::{
     self, ExposeServiceTunnelSpec, ServiceTunnel, ServiceTunnelAuth, ServiceTunnelAuthMode,
-    ServiceTunnelExposure, ServiceTunnelPolicy, ServiceTunnelStatus, ServiceTunnelTarget,
+    ServiceTunnelExposure, ServiceTunnelPolicy, ServiceTunnelPreviewPolicy,
+    ServiceTunnelPreviewPolicyMode, ServiceTunnelStatus, ServiceTunnelTarget,
     ServiceTunnelTunnelBackend, StartServiceTunnelSpec,
 };
 use homeboy::core::{EntityCrudOutput, MergeOutput};
@@ -91,6 +92,14 @@ enum TunnelServiceCommand {
         /// Human-readable description
         #[arg(long)]
         description: Option<String>,
+
+        /// Workflow preview URL policy for this managed service
+        #[arg(long, value_enum, default_value_t = ServiceTunnelPreviewPolicyArg::None)]
+        preview_policy: ServiceTunnelPreviewPolicyArg,
+
+        /// RFC3339 expiry for --preview-policy keep-alive-until
+        #[arg(long)]
+        preview_keep_alive_until: Option<String>,
     },
     /// List private service tunnel declarations
     List,
@@ -163,6 +172,14 @@ enum TunnelServiceCommand {
         /// Public tunnel backend. Only 'none' is currently implemented.
         #[arg(long, value_enum, default_value_t = ServiceTunnelBackendArg::None)]
         public_tunnel_backend: ServiceTunnelBackendArg,
+
+        /// Owning workflow run ID to attach to preview artifacts
+        #[arg(long)]
+        source_run_id: Option<String>,
+
+        /// Owning workflow ID to attach to preview artifacts
+        #[arg(long)]
+        source_workflow_id: Option<String>,
     },
     /// Stop a running managed local service and cleanup runtime state
     Stop {
@@ -183,6 +200,31 @@ enum ServiceTunnelAuthModeArg {
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum ServiceTunnelBackendArg {
     None,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum ServiceTunnelPreviewPolicyArg {
+    None,
+    Always,
+    OnFailure,
+    ManualApproval,
+    KeepAliveUntil,
+}
+
+impl From<ServiceTunnelPreviewPolicyArg> for ServiceTunnelPreviewPolicyMode {
+    fn from(value: ServiceTunnelPreviewPolicyArg) -> Self {
+        match value {
+            ServiceTunnelPreviewPolicyArg::None => ServiceTunnelPreviewPolicyMode::None,
+            ServiceTunnelPreviewPolicyArg::Always => ServiceTunnelPreviewPolicyMode::Always,
+            ServiceTunnelPreviewPolicyArg::OnFailure => ServiceTunnelPreviewPolicyMode::OnFailure,
+            ServiceTunnelPreviewPolicyArg::ManualApproval => {
+                ServiceTunnelPreviewPolicyMode::ManualApproval
+            }
+            ServiceTunnelPreviewPolicyArg::KeepAliveUntil => {
+                ServiceTunnelPreviewPolicyMode::KeepAliveUntil
+            }
+        }
+    }
 }
 
 impl std::fmt::Display for ServiceTunnelBackendArg {
@@ -233,6 +275,8 @@ fn run_service(command: TunnelServiceCommand) -> CmdResult<TunnelOutput> {
             auth_header,
             allowed_clients,
             description,
+            preview_policy,
+            preview_keep_alive_until,
         } => expose_service(ExposeServiceTunnelSpec {
             id,
             server_id: server,
@@ -251,6 +295,10 @@ fn run_service(command: TunnelServiceCommand) -> CmdResult<TunnelOutput> {
                 exposure: ServiceTunnelExposure::PrivateLoopback,
                 require_auth: true,
                 allowed_clients,
+                preview: ServiceTunnelPreviewPolicy {
+                    mode: preview_policy.into(),
+                    keep_alive_until: preview_keep_alive_until,
+                },
             },
             description,
         }),
@@ -272,6 +320,8 @@ fn run_service(command: TunnelServiceCommand) -> CmdResult<TunnelOutput> {
             health_path,
             readiness_timeout,
             public_tunnel_backend,
+            source_run_id,
+            source_workflow_id,
         } => start_service(StartServiceTunnelSpec {
             id,
             command,
@@ -284,6 +334,8 @@ fn run_service(command: TunnelServiceCommand) -> CmdResult<TunnelOutput> {
             health_path,
             readiness_timeout_secs: readiness_timeout,
             backend: public_tunnel_backend.into(),
+            source_run_id,
+            source_workflow_id,
         }),
         TunnelServiceCommand::Stop { id } => stop_service(&id),
     }
@@ -507,6 +559,8 @@ mod tests {
                 auth_header: Some("Authorization".to_string()),
                 allowed_clients: vec!["wp-runtime".to_string()],
                 description: None,
+                preview_policy: ServiceTunnelPreviewPolicyArg::None,
+                preview_keep_alive_until: None,
             })
             .expect("command succeeds");
 

--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -118,13 +118,12 @@ impl Default for ServiceTunnelPreviewPolicyMode {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ServiceTunnelStatus {
-    pub service_id: String,
+    #[serde(flatten)]
+    pub preview_identity: ServiceTunnelPreviewIdentity,
     pub declared: bool,
     pub running: bool,
     pub lifecycle: String,
     pub local_url: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub public_url: Option<String>,
     pub remote_target: String,
     pub policy: ServiceTunnelPolicy,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -150,14 +149,13 @@ pub struct ServiceTunnelCommandSpec {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServiceTunnelRuntimeState {
-    pub service_id: String,
+    #[serde(flatten)]
+    pub preview_identity: ServiceTunnelPreviewIdentity,
     pub pid: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub process_group_id: Option<i32>,
     pub started_at: String,
     pub local_url: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub public_url: Option<String>,
     pub command: ServiceTunnelCommandSpec,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub health_url: Option<String>,
@@ -215,14 +213,20 @@ pub struct ServiceTunnelBackendStatus {
 pub struct ServiceTunnelPreviewArtifact {
     pub schema: String,
     pub kind: String,
-    pub service_id: String,
+    #[serde(flatten)]
+    pub preview_identity: ServiceTunnelPreviewIdentity,
     pub local_url: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub public_url: Option<String>,
     pub backend: ServiceTunnelTunnelBackend,
     pub policy: ServiceTunnelPreviewPolicy,
     pub cleanup: ServiceTunnelPreviewCleanupMetadata,
     pub source: ServiceTunnelPreviewSource,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceTunnelPreviewIdentity {
+    pub service_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -430,12 +434,14 @@ pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
     let process_group_id = process_group_id_for(pid);
     let health_url = resolve_health_url(&tunnel, spec.health_url, spec.health_path);
     let state = ServiceTunnelRuntimeState {
-        service_id: tunnel.id.clone(),
+        preview_identity: ServiceTunnelPreviewIdentity {
+            service_id: tunnel.id.clone(),
+            public_url: None,
+        },
         pid,
         process_group_id,
         started_at: chrono::Utc::now().to_rfc3339(),
         local_url: local_url_for(&tunnel),
-        public_url: None,
         command: ServiceTunnelCommandSpec {
             command: spec.command,
             cwd: spec.cwd.map(|path| path.display().to_string()),
@@ -451,7 +457,7 @@ pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
     save_runtime_state(&state)?;
     if let Err(error) = wait_until_ready(&state, spec.readiness_timeout_secs) {
         terminate_runtime_state(&state)?;
-        remove_runtime_state(&state.service_id)?;
+        remove_runtime_state(&state.preview_identity.service_id)?;
         return Err(error);
     }
     status(&tunnel.id)
@@ -485,19 +491,23 @@ fn service_tunnel_status(tunnel: &ServiceTunnel) -> ServiceTunnelStatus {
     });
     let backend = state.as_ref().map(|state| ServiceTunnelBackendStatus {
         backend: state.backend.clone(),
-        active: state.public_url.is_some(),
+        active: state.preview_identity.public_url.is_some(),
     });
-    let public_url = state.as_ref().and_then(|state| state.public_url.clone());
+    let public_url = state
+        .as_ref()
+        .and_then(|state| state.preview_identity.public_url.clone());
     let preview = state
         .as_ref()
         .and_then(|state| preview_artifact_for_status(tunnel, state));
     ServiceTunnelStatus {
-        service_id: tunnel.id.clone(),
+        preview_identity: ServiceTunnelPreviewIdentity {
+            service_id: tunnel.id.clone(),
+            public_url,
+        },
         declared: true,
         running,
         lifecycle: if running { "running" } else { "declared" }.to_string(),
         local_url: local_url_for(tunnel),
-        public_url,
         remote_target: format!("{}:{}", tunnel.target.host, tunnel.target.port),
         policy: tunnel.policy.clone(),
         process,
@@ -508,7 +518,7 @@ fn service_tunnel_status(tunnel: &ServiceTunnel) -> ServiceTunnelStatus {
     }
 }
 
-pub fn preview_policy_allows(
+fn preview_policy_allows(
     policy: &ServiceTunnelPreviewPolicy,
     context: &ServiceTunnelPreviewDecisionContext,
 ) -> bool {
@@ -525,7 +535,7 @@ pub fn preview_policy_allows(
     }
 }
 
-pub fn preview_artifact_for(
+fn preview_artifact_for(
     tunnel: &ServiceTunnel,
     state: &ServiceTunnelRuntimeState,
     context: &ServiceTunnelPreviewDecisionContext,
@@ -537,9 +547,11 @@ pub fn preview_artifact_for(
     Some(ServiceTunnelPreviewArtifact {
         schema: "homeboy/preview-url/v1".to_string(),
         kind: "preview_url".to_string(),
-        service_id: tunnel.id.clone(),
+        preview_identity: ServiceTunnelPreviewIdentity {
+            service_id: tunnel.id.clone(),
+            public_url: state.preview_identity.public_url.clone(),
+        },
         local_url: state.local_url.clone(),
-        public_url: state.public_url.clone(),
         backend: state.backend.clone(),
         policy: tunnel.policy.preview.clone(),
         cleanup: preview_cleanup_metadata(&tunnel.policy.preview),
@@ -742,13 +754,17 @@ fn load_runtime_state(id: &str) -> Result<Option<ServiceTunnelRuntimeState>> {
 }
 
 fn save_runtime_state(state: &ServiceTunnelRuntimeState) -> Result<()> {
-    let path = paths::service_tunnel_runtime_state_file(&state.service_id)?;
+    let path = paths::service_tunnel_runtime_state_file(&state.preview_identity.service_id)?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .map_err(|e| Error::internal_io(e.to_string(), Some(parent.display().to_string())))?;
     }
-    let data = serde_json::to_string_pretty(state)
-        .map_err(|e| Error::internal_json(e.to_string(), Some(state.service_id.clone())))?;
+    let data = serde_json::to_string_pretty(state).map_err(|e| {
+        Error::internal_json(
+            e.to_string(),
+            Some(state.preview_identity.service_id.clone()),
+        )
+    })?;
     fs::write(&path, data)
         .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))
 }
@@ -821,7 +837,7 @@ fn wait_until_ready(state: &ServiceTunnelRuntimeState, timeout_secs: u64) -> Res
             return Err(Error::validation_invalid_argument(
                 "service",
                 "service process exited before becoming ready",
-                Some(state.service_id.clone()),
+                Some(state.preview_identity.service_id.clone()),
                 None,
             ));
         }
@@ -833,7 +849,7 @@ fn wait_until_ready(state: &ServiceTunnelRuntimeState, timeout_secs: u64) -> Res
             return Err(Error::validation_invalid_argument(
                 "readiness",
                 "service did not become healthy before readiness timeout",
-                Some(state.service_id.clone()),
+                Some(state.preview_identity.service_id.clone()),
                 health.error.map(|error| vec![error]),
             ));
         }
@@ -876,7 +892,7 @@ fn check_runtime_health(state: &ServiceTunnelRuntimeState) -> ServiceTunnelHealt
 
 fn runtime_evidence(state: &ServiceTunnelRuntimeState) -> ServiceTunnelEvidence {
     ServiceTunnelEvidence {
-        state_path: paths::service_tunnel_runtime_state_file(&state.service_id)
+        state_path: paths::service_tunnel_runtime_state_file(&state.preview_identity.service_id)
             .map(|path| path.display().to_string())
             .unwrap_or_default(),
         stdout_path: state.stdout_path.clone(),
@@ -913,7 +929,7 @@ mod tests {
             create_server();
 
             let tunnel = expose(ExposeServiceTunnelSpec {
-                id: "context-a8c".to_string(),
+                id: "site-preview".to_string(),
                 server_id: "private-host".to_string(),
                 target: ServiceTunnelTarget {
                     host: "127.0.0.1".to_string(),
@@ -923,21 +939,21 @@ mod tests {
                 local_port: Some(8831),
                 auth: ServiceTunnelAuth {
                     mode: ServiceTunnelAuthMode::BearerEnv,
-                    env_var: Some("CONTEXTA8C_TOKEN".to_string()),
+                    env_var: Some("SITE_PREVIEW_TOKEN".to_string()),
                     header: Some("Authorization".to_string()),
                 },
                 policy: ServiceTunnelPolicy {
                     exposure: ServiceTunnelExposure::PrivateLoopback,
                     require_auth: true,
-                    allowed_clients: vec!["wp-runtime".to_string()],
+                    allowed_clients: vec!["app-runtime".to_string()],
                     preview: ServiceTunnelPreviewPolicy::default(),
                 },
-                description: Some("Private MCP service".to_string()),
+                description: Some("Private preview service".to_string()),
             })
             .expect("expose service");
 
-            assert_eq!(tunnel.id, "context-a8c");
-            let report = status("context-a8c").expect("status");
+            assert_eq!(tunnel.id, "site-preview");
+            let report = status("site-preview").expect("status");
             assert!(report.declared);
             assert!(!report.running);
             assert_eq!(report.local_url, "http://127.0.0.1:8831");
@@ -998,7 +1014,7 @@ mod tests {
                 policy: ServiceTunnelPolicy {
                     exposure: ServiceTunnelExposure::PrivateLoopback,
                     require_auth: true,
-                    allowed_clients: vec!["wpcom-calypso".to_string()],
+                    allowed_clients: vec!["app-runtime".to_string()],
                     preview: ServiceTunnelPreviewPolicy {
                         mode: ServiceTunnelPreviewPolicyMode::Always,
                         keep_alive_until: None,
@@ -1027,10 +1043,10 @@ mod tests {
 
             assert!(started.running);
             assert_eq!(started.local_url, "http://127.0.0.1:8832");
-            assert_eq!(started.public_url, None);
+            assert_eq!(started.preview_identity.public_url, None);
             let preview = started.preview.as_ref().expect("preview artifact");
             assert_eq!(preview.kind, "preview_url");
-            assert_eq!(preview.service_id, "local-preview");
+            assert_eq!(preview.preview_identity.service_id, "local-preview");
             assert_eq!(preview.local_url, "http://127.0.0.1:8832");
             assert_eq!(preview.source.run_id.as_deref(), Some("run-123"));
             assert_eq!(preview.source.workflow_id.as_deref(), Some("workflow-abc"));
@@ -1178,7 +1194,7 @@ mod tests {
     #[test]
     fn preview_artifact_serializes_structured_reviewer_contract() {
         let tunnel = ServiceTunnel {
-            id: "wpcom-calypso".to_string(),
+            id: "site-preview".to_string(),
             aliases: Vec::new(),
             description: None,
             server_id: "private-host".to_string(),
@@ -1205,18 +1221,20 @@ mod tests {
             },
         };
         let state = ServiceTunnelRuntimeState {
-            service_id: "wpcom-calypso".to_string(),
+            preview_identity: ServiceTunnelPreviewIdentity {
+                service_id: "site-preview".to_string(),
+                public_url: Some("https://preview.example.test/site-preview".to_string()),
+            },
             pid: 123,
             process_group_id: Some(123),
             started_at: "2026-06-07T12:00:00Z".to_string(),
             local_url: "http://127.0.0.1:3000".to_string(),
-            public_url: Some("https://preview.example.test/wpcom-calypso".to_string()),
             command: ServiceTunnelCommandSpec {
-                command: "npm run dev".to_string(),
-                cwd: Some("/workspace/wpcom".to_string()),
+                command: "serve-app".to_string(),
+                cwd: Some("/workspace/app".to_string()),
                 env_keys: vec!["TOKEN".to_string()],
             },
-            health_url: Some("http://127.0.0.1:3000/start".to_string()),
+            health_url: Some("http://127.0.0.1:3000/".to_string()),
             stdout_path: "/tmp/homeboy/stdout.log".to_string(),
             stderr_path: "/tmp/homeboy/stderr.log".to_string(),
             backend: ServiceTunnelTunnelBackend::None,
@@ -1241,11 +1259,11 @@ mod tests {
         assert_eq!(serialized, expected);
         assert_eq!(serialized["schema"], "homeboy/preview-url/v1");
         assert_eq!(serialized["kind"], "preview_url");
-        assert_eq!(serialized["service_id"], "wpcom-calypso");
+        assert_eq!(serialized["service_id"], "site-preview");
         assert_eq!(serialized["local_url"], "http://127.0.0.1:3000");
         assert_eq!(
             serialized["public_url"],
-            "https://preview.example.test/wpcom-calypso"
+            "https://preview.example.test/site-preview"
         );
         assert_eq!(serialized["backend"], "none");
         assert_eq!(serialized["policy"]["mode"], "keep_alive_until");

--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -79,6 +79,41 @@ pub struct ServiceTunnelPolicy {
     pub require_auth: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub allowed_clients: Vec<String>,
+    #[serde(default)]
+    pub preview: ServiceTunnelPreviewPolicy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceTunnelPreviewPolicy {
+    #[serde(default)]
+    pub mode: ServiceTunnelPreviewPolicyMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keep_alive_until: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceTunnelPreviewPolicyMode {
+    None,
+    Always,
+    OnFailure,
+    ManualApproval,
+    KeepAliveUntil,
+}
+
+impl Default for ServiceTunnelPreviewPolicy {
+    fn default() -> Self {
+        Self {
+            mode: ServiceTunnelPreviewPolicyMode::None,
+            keep_alive_until: None,
+        }
+    }
+}
+
+impl Default for ServiceTunnelPreviewPolicyMode {
+    fn default() -> Self {
+        Self::None
+    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -100,6 +135,8 @@ pub struct ServiceTunnelStatus {
     pub evidence: Option<ServiceTunnelEvidence>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tunnel_backend: Option<ServiceTunnelBackendStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preview: Option<ServiceTunnelPreviewArtifact>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -127,6 +164,10 @@ pub struct ServiceTunnelRuntimeState {
     pub stdout_path: String,
     pub stderr_path: String,
     pub backend: ServiceTunnelTunnelBackend,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_workflow_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -170,6 +211,43 @@ pub struct ServiceTunnelBackendStatus {
     pub active: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceTunnelPreviewArtifact {
+    pub schema: String,
+    pub kind: String,
+    pub service_id: String,
+    pub local_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
+    pub backend: ServiceTunnelTunnelBackend,
+    pub policy: ServiceTunnelPreviewPolicy,
+    pub cleanup: ServiceTunnelPreviewCleanupMetadata,
+    pub source: ServiceTunnelPreviewSource,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceTunnelPreviewCleanupMetadata {
+    pub cleanup_policy: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    pub stop_on_cleanup: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceTunnelPreviewSource {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceTunnelPreviewDecisionContext {
+    pub run_failed: bool,
+    pub manual_approval_required: bool,
+    pub now: chrono::DateTime<chrono::Utc>,
+}
+
 pub struct StartServiceTunnelSpec {
     pub id: String,
     pub command: String,
@@ -182,6 +260,8 @@ pub struct StartServiceTunnelSpec {
     pub health_path: Option<String>,
     pub readiness_timeout_secs: u64,
     pub backend: ServiceTunnelTunnelBackend,
+    pub source_run_id: Option<String>,
+    pub source_workflow_id: Option<String>,
 }
 
 pub struct ExposeServiceTunnelSpec {
@@ -365,6 +445,8 @@ pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
         stdout_path: stdout_path.display().to_string(),
         stderr_path: stderr_path.display().to_string(),
         backend: spec.backend,
+        source_run_id: spec.source_run_id,
+        source_workflow_id: spec.source_workflow_id,
     };
     save_runtime_state(&state)?;
     if let Err(error) = wait_until_ready(&state, spec.readiness_timeout_secs) {
@@ -406,6 +488,9 @@ fn service_tunnel_status(tunnel: &ServiceTunnel) -> ServiceTunnelStatus {
         active: state.public_url.is_some(),
     });
     let public_url = state.as_ref().and_then(|state| state.public_url.clone());
+    let preview = state
+        .as_ref()
+        .and_then(|state| preview_artifact_for_status(tunnel, state));
     ServiceTunnelStatus {
         service_id: tunnel.id.clone(),
         declared: true,
@@ -419,7 +504,89 @@ fn service_tunnel_status(tunnel: &ServiceTunnel) -> ServiceTunnelStatus {
         health,
         evidence,
         tunnel_backend: backend,
+        preview,
     }
+}
+
+pub fn preview_policy_allows(
+    policy: &ServiceTunnelPreviewPolicy,
+    context: &ServiceTunnelPreviewDecisionContext,
+) -> bool {
+    match policy.mode {
+        ServiceTunnelPreviewPolicyMode::None => false,
+        ServiceTunnelPreviewPolicyMode::Always => true,
+        ServiceTunnelPreviewPolicyMode::OnFailure => context.run_failed,
+        ServiceTunnelPreviewPolicyMode::ManualApproval => context.manual_approval_required,
+        ServiceTunnelPreviewPolicyMode::KeepAliveUntil => policy
+            .keep_alive_until
+            .as_deref()
+            .and_then(parse_rfc3339_utc)
+            .is_some_and(|expires_at| context.now <= expires_at),
+    }
+}
+
+pub fn preview_artifact_for(
+    tunnel: &ServiceTunnel,
+    state: &ServiceTunnelRuntimeState,
+    context: &ServiceTunnelPreviewDecisionContext,
+) -> Option<ServiceTunnelPreviewArtifact> {
+    if !preview_policy_allows(&tunnel.policy.preview, context) {
+        return None;
+    }
+
+    Some(ServiceTunnelPreviewArtifact {
+        schema: "homeboy/preview-url/v1".to_string(),
+        kind: "preview_url".to_string(),
+        service_id: tunnel.id.clone(),
+        local_url: state.local_url.clone(),
+        public_url: state.public_url.clone(),
+        backend: state.backend.clone(),
+        policy: tunnel.policy.preview.clone(),
+        cleanup: preview_cleanup_metadata(&tunnel.policy.preview),
+        source: ServiceTunnelPreviewSource {
+            run_id: state.source_run_id.clone(),
+            workflow_id: state.source_workflow_id.clone(),
+        },
+    })
+}
+
+fn preview_artifact_for_status(
+    tunnel: &ServiceTunnel,
+    state: &ServiceTunnelRuntimeState,
+) -> Option<ServiceTunnelPreviewArtifact> {
+    preview_artifact_for(
+        tunnel,
+        state,
+        &ServiceTunnelPreviewDecisionContext {
+            run_failed: false,
+            manual_approval_required: false,
+            now: chrono::Utc::now(),
+        },
+    )
+}
+
+fn preview_cleanup_metadata(
+    policy: &ServiceTunnelPreviewPolicy,
+) -> ServiceTunnelPreviewCleanupMetadata {
+    let cleanup_policy = match policy.mode {
+        ServiceTunnelPreviewPolicyMode::None => "stop_immediately",
+        ServiceTunnelPreviewPolicyMode::Always => "keep_while_running",
+        ServiceTunnelPreviewPolicyMode::OnFailure => "keep_on_failure",
+        ServiceTunnelPreviewPolicyMode::ManualApproval => "keep_for_manual_approval",
+        ServiceTunnelPreviewPolicyMode::KeepAliveUntil => "keep_alive_until",
+    };
+
+    ServiceTunnelPreviewCleanupMetadata {
+        cleanup_policy: cleanup_policy.to_string(),
+        expires_at: policy.keep_alive_until.clone(),
+        stop_on_cleanup: true,
+    }
+}
+
+fn parse_rfc3339_utc(value: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|datetime| datetime.with_timezone(&chrono::Utc))
 }
 
 fn local_url_for(tunnel: &ServiceTunnel) -> String {
@@ -492,6 +659,27 @@ fn validate_service_tunnel(tunnel: &ServiceTunnel) -> Result<()> {
             Some(tunnel.id.clone()),
             None,
         ));
+    }
+    if matches!(
+        tunnel.policy.preview.mode,
+        ServiceTunnelPreviewPolicyMode::KeepAliveUntil
+    ) {
+        let Some(expires_at) = tunnel.policy.preview.keep_alive_until.as_deref() else {
+            return Err(Error::validation_invalid_argument(
+                "policy.preview.keep_alive_until",
+                "keep_alive_until preview policy requires an RFC3339 expiry",
+                Some(tunnel.id.clone()),
+                None,
+            ));
+        };
+        if parse_rfc3339_utc(expires_at).is_none() {
+            return Err(Error::validation_invalid_argument(
+                "policy.preview.keep_alive_until",
+                "preview expiry must be a valid RFC3339 timestamp",
+                Some(tunnel.id.clone()),
+                None,
+            ));
+        }
     }
     Ok(())
 }
@@ -742,6 +930,7 @@ mod tests {
                     exposure: ServiceTunnelExposure::PrivateLoopback,
                     require_auth: true,
                     allowed_clients: vec!["wp-runtime".to_string()],
+                    preview: ServiceTunnelPreviewPolicy::default(),
                 },
                 description: Some("Private MCP service".to_string()),
             })
@@ -777,6 +966,7 @@ mod tests {
                     exposure: ServiceTunnelExposure::PrivateLoopback,
                     require_auth: true,
                     allowed_clients: Vec::new(),
+                    preview: ServiceTunnelPreviewPolicy::default(),
                 },
                 description: None,
             })
@@ -809,6 +999,10 @@ mod tests {
                     exposure: ServiceTunnelExposure::PrivateLoopback,
                     require_auth: true,
                     allowed_clients: vec!["wpcom-calypso".to_string()],
+                    preview: ServiceTunnelPreviewPolicy {
+                        mode: ServiceTunnelPreviewPolicyMode::Always,
+                        keep_alive_until: None,
+                    },
                 },
                 description: None,
             })
@@ -826,12 +1020,20 @@ mod tests {
                 health_path: None,
                 readiness_timeout_secs: 1,
                 backend: ServiceTunnelTunnelBackend::None,
+                source_run_id: Some("run-123".to_string()),
+                source_workflow_id: Some("workflow-abc".to_string()),
             })
             .expect("start service");
 
             assert!(started.running);
             assert_eq!(started.local_url, "http://127.0.0.1:8832");
             assert_eq!(started.public_url, None);
+            let preview = started.preview.as_ref().expect("preview artifact");
+            assert_eq!(preview.kind, "preview_url");
+            assert_eq!(preview.service_id, "local-preview");
+            assert_eq!(preview.local_url, "http://127.0.0.1:8832");
+            assert_eq!(preview.source.run_id.as_deref(), Some("run-123"));
+            assert_eq!(preview.source.workflow_id.as_deref(), Some("workflow-abc"));
             let process = started.process.expect("process status");
             assert!(process.running);
             assert_eq!(process.command.env_keys, vec!["LOCAL_PREVIEW_MODE"]);
@@ -872,6 +1074,7 @@ mod tests {
                     exposure: ServiceTunnelExposure::PrivateLoopback,
                     require_auth: true,
                     allowed_clients: Vec::new(),
+                    preview: ServiceTunnelPreviewPolicy::default(),
                 },
                 description: None,
             })
@@ -889,6 +1092,8 @@ mod tests {
                 health_path: None,
                 readiness_timeout_secs: 0,
                 backend: ServiceTunnelTunnelBackend::None,
+                source_run_id: None,
+                source_workflow_id: None,
             })
             .expect_err("readiness should fail");
 
@@ -899,5 +1104,153 @@ mod tests {
             let stopped = status("failing-preview").expect("status");
             assert!(!stopped.running);
         });
+    }
+
+    #[test]
+    fn preview_policy_decisions_match_workflow_outcomes() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-06-07T12:00:00Z")
+            .expect("timestamp")
+            .with_timezone(&chrono::Utc);
+        let failed = ServiceTunnelPreviewDecisionContext {
+            run_failed: true,
+            manual_approval_required: false,
+            now,
+        };
+        let success = ServiceTunnelPreviewDecisionContext {
+            run_failed: false,
+            manual_approval_required: false,
+            now,
+        };
+        let approval = ServiceTunnelPreviewDecisionContext {
+            run_failed: false,
+            manual_approval_required: true,
+            now,
+        };
+
+        assert!(!preview_policy_allows(
+            &ServiceTunnelPreviewPolicy::default(),
+            &failed
+        ));
+        assert!(preview_policy_allows(
+            &ServiceTunnelPreviewPolicy {
+                mode: ServiceTunnelPreviewPolicyMode::Always,
+                keep_alive_until: None,
+            },
+            &success
+        ));
+        assert!(preview_policy_allows(
+            &ServiceTunnelPreviewPolicy {
+                mode: ServiceTunnelPreviewPolicyMode::OnFailure,
+                keep_alive_until: None,
+            },
+            &failed
+        ));
+        assert!(!preview_policy_allows(
+            &ServiceTunnelPreviewPolicy {
+                mode: ServiceTunnelPreviewPolicyMode::OnFailure,
+                keep_alive_until: None,
+            },
+            &success
+        ));
+        assert!(preview_policy_allows(
+            &ServiceTunnelPreviewPolicy {
+                mode: ServiceTunnelPreviewPolicyMode::ManualApproval,
+                keep_alive_until: None,
+            },
+            &approval
+        ));
+        assert!(preview_policy_allows(
+            &ServiceTunnelPreviewPolicy {
+                mode: ServiceTunnelPreviewPolicyMode::KeepAliveUntil,
+                keep_alive_until: Some("2026-06-07T12:30:00Z".to_string()),
+            },
+            &success
+        ));
+        assert!(!preview_policy_allows(
+            &ServiceTunnelPreviewPolicy {
+                mode: ServiceTunnelPreviewPolicyMode::KeepAliveUntil,
+                keep_alive_until: Some("2026-06-07T11:59:59Z".to_string()),
+            },
+            &success
+        ));
+    }
+
+    #[test]
+    fn preview_artifact_serializes_structured_reviewer_contract() {
+        let tunnel = ServiceTunnel {
+            id: "wpcom-calypso".to_string(),
+            aliases: Vec::new(),
+            description: None,
+            server_id: "private-host".to_string(),
+            target: ServiceTunnelTarget {
+                host: "127.0.0.1".to_string(),
+                port: 3000,
+            },
+            scheme: "http".to_string(),
+            local_host: "127.0.0.1".to_string(),
+            local_port: Some(3000),
+            auth: ServiceTunnelAuth {
+                mode: ServiceTunnelAuthMode::BearerEnv,
+                env_var: Some("TOKEN".to_string()),
+                header: Some("Authorization".to_string()),
+            },
+            policy: ServiceTunnelPolicy {
+                exposure: ServiceTunnelExposure::PrivateLoopback,
+                require_auth: true,
+                allowed_clients: Vec::new(),
+                preview: ServiceTunnelPreviewPolicy {
+                    mode: ServiceTunnelPreviewPolicyMode::KeepAliveUntil,
+                    keep_alive_until: Some("2026-06-07T13:00:00Z".to_string()),
+                },
+            },
+        };
+        let state = ServiceTunnelRuntimeState {
+            service_id: "wpcom-calypso".to_string(),
+            pid: 123,
+            process_group_id: Some(123),
+            started_at: "2026-06-07T12:00:00Z".to_string(),
+            local_url: "http://127.0.0.1:3000".to_string(),
+            public_url: Some("https://preview.example.test/wpcom-calypso".to_string()),
+            command: ServiceTunnelCommandSpec {
+                command: "npm run dev".to_string(),
+                cwd: Some("/workspace/wpcom".to_string()),
+                env_keys: vec!["TOKEN".to_string()],
+            },
+            health_url: Some("http://127.0.0.1:3000/start".to_string()),
+            stdout_path: "/tmp/homeboy/stdout.log".to_string(),
+            stderr_path: "/tmp/homeboy/stderr.log".to_string(),
+            backend: ServiceTunnelTunnelBackend::None,
+            source_run_id: Some("run-1".to_string()),
+            source_workflow_id: Some("workflow-1".to_string()),
+        };
+        let context = ServiceTunnelPreviewDecisionContext {
+            run_failed: false,
+            manual_approval_required: false,
+            now: chrono::DateTime::parse_from_rfc3339("2026-06-07T12:30:00Z")
+                .expect("timestamp")
+                .with_timezone(&chrono::Utc),
+        };
+
+        let artifact = preview_artifact_for(&tunnel, &state, &context).expect("artifact");
+        let serialized = serde_json::to_value(&artifact).expect("serialize artifact");
+        let expected: serde_json::Value = serde_json::from_str(include_str!(
+            "../../tests/fixtures/output_contracts/tunnel/preview-artifact.json"
+        ))
+        .expect("fixture");
+
+        assert_eq!(serialized, expected);
+        assert_eq!(serialized["schema"], "homeboy/preview-url/v1");
+        assert_eq!(serialized["kind"], "preview_url");
+        assert_eq!(serialized["service_id"], "wpcom-calypso");
+        assert_eq!(serialized["local_url"], "http://127.0.0.1:3000");
+        assert_eq!(
+            serialized["public_url"],
+            "https://preview.example.test/wpcom-calypso"
+        );
+        assert_eq!(serialized["backend"], "none");
+        assert_eq!(serialized["policy"]["mode"], "keep_alive_until");
+        assert_eq!(serialized["cleanup"]["expires_at"], "2026-06-07T13:00:00Z");
+        assert_eq!(serialized["source"]["run_id"], "run-1");
+        assert_eq!(serialized["source"]["workflow_id"], "workflow-1");
     }
 }

--- a/tests/fixtures/output_contracts/tunnel/preview-artifact.json
+++ b/tests/fixtures/output_contracts/tunnel/preview-artifact.json
@@ -1,0 +1,21 @@
+{
+  "schema": "homeboy/preview-url/v1",
+  "kind": "preview_url",
+  "service_id": "wpcom-calypso",
+  "local_url": "http://127.0.0.1:3000",
+  "public_url": "https://preview.example.test/wpcom-calypso",
+  "backend": "none",
+  "policy": {
+    "mode": "keep_alive_until",
+    "keep_alive_until": "2026-06-07T13:00:00Z"
+  },
+  "cleanup": {
+    "cleanup_policy": "keep_alive_until",
+    "expires_at": "2026-06-07T13:00:00Z",
+    "stop_on_cleanup": true
+  },
+  "source": {
+    "run_id": "run-1",
+    "workflow_id": "workflow-1"
+  }
+}

--- a/tests/fixtures/output_contracts/tunnel/preview-artifact.json
+++ b/tests/fixtures/output_contracts/tunnel/preview-artifact.json
@@ -1,9 +1,9 @@
 {
   "schema": "homeboy/preview-url/v1",
   "kind": "preview_url",
-  "service_id": "wpcom-calypso",
+  "service_id": "site-preview",
   "local_url": "http://127.0.0.1:3000",
-  "public_url": "https://preview.example.test/wpcom-calypso",
+  "public_url": "https://preview.example.test/site-preview",
   "backend": "none",
   "policy": {
     "mode": "keep_alive_until",

--- a/tests/report_performance_digest_test.rs
+++ b/tests/report_performance_digest_test.rs
@@ -216,6 +216,54 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
 }
 
 #[test]
+fn renders_managed_service_preview_url_artifact_metadata() {
+    let dir = tmp_dir("managed-preview");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    write_fixture_file(&dir, "resource-summary.json", r#"{}"#);
+    write_fixture_file(&dir, "bench.json", r#"{}"#);
+    write_fixture_file(
+        &dir,
+        "metadata.json",
+        &format!(
+            r#"{{"preview":{}}}"#,
+            include_str!("fixtures/output_contracts/tunnel/preview-artifact.json")
+        ),
+    );
+
+    let report = performance_digest_from_args(&args(&dir)).expect("digest should render");
+
+    assert_eq!(
+        report.preview.get("schema"),
+        Some(&"homeboy/preview-url/v1".to_string())
+    );
+    assert_eq!(
+        report.preview.get("policy.mode"),
+        Some(&"keep_alive_until".to_string())
+    );
+    assert_eq!(
+        report.preview.get("cleanup.expires_at"),
+        Some(&"2026-06-07T13:00:00Z".to_string())
+    );
+    assert_eq!(
+        report.preview.get("source.run_id"),
+        Some(&"run-1".to_string())
+    );
+    assert!(report.markdown.contains("### Preview"));
+    assert!(report
+        .markdown
+        .contains("- public_url: `https://preview.example.test/wpcom-calypso`"));
+    assert!(report
+        .markdown
+        .contains("- policy.mode: `keep_alive_until`"));
+    assert!(report
+        .markdown
+        .contains("- cleanup.expires_at: `2026-06-07T13:00:00Z`"));
+    assert!(report.markdown.contains("- source.run_id: `run-1`"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn reads_persisted_uuid_prefixed_artifacts() {
     let dir = tmp_dir("persisted");
     fs::create_dir_all(&dir).expect("temp dir should exist");

--- a/tests/report_performance_digest_test.rs
+++ b/tests/report_performance_digest_test.rs
@@ -251,7 +251,7 @@ fn renders_managed_service_preview_url_artifact_metadata() {
     assert!(report.markdown.contains("### Preview"));
     assert!(report
         .markdown
-        .contains("- public_url: `https://preview.example.test/wpcom-calypso`"));
+        .contains("- public_url: `https://preview.example.test/site-preview`"));
     assert!(report
         .markdown
         .contains("- policy.mode: `keep_alive_until`"));


### PR DESCRIPTION
## Summary
- Adds managed-service preview policy declarations and status artifacts for `none`, `always`, `on_failure`, `manual_approval`, and `keep_alive_until` workflow cases.
- Includes structured `homeboy/preview-url/v1` artifacts with service URL, backend, cleanup/expiry, and run/workflow ownership metadata while leaving public tunnel backend behavior on the existing explicit seam.
- Teaches the performance digest preview surface to render nested preview artifact metadata without coupling report rendering to tunnel internals.

Closes #3659.

## Verification
- `cargo fmt --check`
- `cargo test tunnel::tests --lib`
- `cargo test commands::tunnel::tests --lib`
- `cargo test --test report_performance_digest_test`
- `cargo run --bin homeboy -- tunnel service expose --help`
- `cargo run --bin homeboy -- tunnel service start --help`

## Caveats
- #3658 is still open, so this PR does not implement a live public tunnel backend. `public_url` remains optional and the only implemented backend remains `none`.
- Targeted lib tests still emit an existing unrelated warning from `src/commands/runs/corpus_tests.rs` for an unused `serde_json::Value` import.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the managed-service preview policy/artifact plumbing, fixture-backed tests, report rendering compatibility, docs, and verification commands for Chris to review.