### PR TITLE
Add agent-task async handle lifecycle surfaces

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -37,6 +37,12 @@ pub enum AgentTaskCommand {
     Logs(StatusArgs),
     /// List artifacts and evidence refs recorded for a completed run.
     Artifacts(StatusArgs),
+    /// Mark a queued/running durable run cancelled.
+    Cancel(StatusArgs),
+    /// Resume a queued or stale-running durable run.
+    Resume(StatusArgs),
+    /// Submit a fresh durable run from an existing run's plan.
+    Retry(RetryArgs),
     /// Promote a completed generic patch artifact into a managed worktree.
     Promote(PromoteArgs),
     /// List extension-declared agent-task executor providers.
@@ -67,6 +73,20 @@ pub struct SubmitArgs {
 pub struct StatusArgs {
     /// Durable run id returned by `agent-task submit` or `agent-task run-plan --record-run-id`.
     pub run_id: String,
+}
+
+#[derive(Args, Debug)]
+pub struct RetryArgs {
+    /// Existing durable run id whose plan should be retried.
+    pub run_id: String,
+
+    /// Optional durable run id for the retry. Generated when omitted.
+    #[arg(long, value_name = "ID")]
+    pub new_run_id: Option<String>,
+
+    /// Execute the newly queued retry immediately.
+    #[arg(long)]
+    pub run: bool,
 }
 
 #[derive(Args, Debug)]
@@ -106,6 +126,9 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::Status(status_args) => status(status_args),
         AgentTaskCommand::Logs(status_args) => logs(status_args),
         AgentTaskCommand::Artifacts(status_args) => artifacts(status_args),
+        AgentTaskCommand::Cancel(status_args) => cancel(status_args),
+        AgentTaskCommand::Resume(status_args) => resume(status_args),
+        AgentTaskCommand::Retry(retry_args) => retry(retry_args),
         AgentTaskCommand::Promote(promote_args) => promote_artifact(promote_args),
         AgentTaskCommand::Providers => providers(),
     }
@@ -222,6 +245,34 @@ fn logs(args: StatusArgs) -> CmdResult<Value> {
 fn artifacts(args: StatusArgs) -> CmdResult<Value> {
     let artifacts = agent_task_lifecycle::artifacts(&args.run_id)?;
     Ok((serde_json::to_value(artifacts).unwrap_or(Value::Null), 0))
+}
+
+fn cancel(args: StatusArgs) -> CmdResult<Value> {
+    let record = agent_task_lifecycle::cancel(&args.run_id)?;
+    Ok((serde_json::to_value(record).unwrap_or(Value::Null), 0))
+}
+
+fn resume(args: StatusArgs) -> CmdResult<Value> {
+    run_resume_with_executor(args.run_id, ExtensionProviderAgentTaskExecutor::discover())
+}
+
+fn run_resume_with_executor<E>(run_id: String, executor: E) -> CmdResult<Value>
+where
+    E: AgentTaskExecutorAdapter,
+{
+    agent_task_lifecycle::mark_resuming(&run_id)?;
+    run_claimed(run_id, executor)
+}
+
+fn retry(args: RetryArgs) -> CmdResult<Value> {
+    let record = agent_task_lifecycle::retry(&args.run_id, args.new_run_id.as_deref())?;
+    if args.run {
+        return run_submitted_with_executor(
+            record.run_id,
+            ExtensionProviderAgentTaskExecutor::discover(),
+        );
+    }
+    Ok((serde_json::to_value(record).unwrap_or(Value::Null), 0))
 }
 
 fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
@@ -513,6 +564,74 @@ mod tests {
 
             assert_eq!(exit_code, 0);
             assert_eq!(value["claimed"], false);
+        });
+    }
+
+    #[test]
+    fn cancel_command_marks_submitted_run_cancelled() {
+        with_temp_home(|| {
+            agent_task_lifecycle::submit_plan(&test_plan(), Some("run-cancel-cli"))
+                .expect("submitted");
+
+            let (value, exit_code) = cancel(StatusArgs {
+                run_id: "run-cancel-cli".to_string(),
+            })
+            .expect("cancelled");
+            let record: AgentTaskRunRecord = serde_json::from_value(value).expect("record");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(record.state, AgentTaskRunState::Cancelled);
+            assert_eq!(record.tasks[0].state, AgentTaskState::Cancelled);
+        });
+    }
+
+    #[test]
+    fn retry_command_submits_new_queued_run() {
+        with_temp_home(|| {
+            agent_task_lifecycle::submit_plan(&test_plan(), Some("run-retry-source"))
+                .expect("submitted");
+
+            let (value, exit_code) = retry(RetryArgs {
+                run_id: "run-retry-source".to_string(),
+                new_run_id: Some("run-retry-cli".to_string()),
+                run: false,
+            })
+            .expect("retry queued");
+            let record: AgentTaskRunRecord = serde_json::from_value(value).expect("record");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(record.run_id, "run-retry-cli");
+            assert_eq!(record.state, AgentTaskRunState::Queued);
+            assert_eq!(record.metadata["retry_of"], json!("run-retry-source"));
+        });
+    }
+
+    #[test]
+    fn resume_command_executes_existing_run() {
+        with_temp_home(|| {
+            agent_task_lifecycle::submit_plan(&test_plan(), Some("run-resume-cli"))
+                .expect("submitted");
+            let observed_status = Arc::new(Mutex::new(None));
+
+            let (_value, exit_code) = run_resume_with_executor(
+                "run-resume-cli".to_string(),
+                InspectingExecutor {
+                    run_id: "run-resume-cli".to_string(),
+                    observed_status: Arc::clone(&observed_status),
+                },
+            )
+            .expect("resumed");
+
+            let observed = observed_status
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+                .expect("executor observed status");
+            let completed = lifecycle_status("run-resume-cli").expect("completed status");
+
+            assert_eq!(exit_code, 0);
+            assert!(observed.metadata["resume_requested_at"].is_string());
+            assert_eq!(completed.state, AgentTaskRunState::Succeeded);
         });
     }
 

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -4,7 +4,9 @@ use serde_json::{json, Value};
 use std::path::PathBuf;
 use uuid::Uuid;
 
-use crate::core::agent_task::{AgentTaskArtifact, AgentTaskEvidenceRef, AgentTaskOutcome};
+use crate::core::agent_task::{
+    AgentTaskArtifact, AgentTaskEvidenceRef, AgentTaskExecutionHandle, AgentTaskOutcome,
+};
 use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskPlan, AgentTaskProgressEvent, AgentTaskState,
 };
@@ -39,6 +41,8 @@ pub struct AgentTaskRunRecord {
     pub tasks: Vec<AgentTaskRunTask>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifact_refs: Vec<AgentTaskArtifactRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provider_handles: Vec<AgentTaskRunProviderHandle>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
 }
@@ -126,6 +130,19 @@ pub struct AgentTaskArtifactRef {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskRunProviderHandle {
+    pub task_id: String,
+    pub backend: String,
+    pub provider_run_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_uri: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<AgentTaskState>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskRunLog {
     pub schema: String,
     pub run_id: String,
@@ -161,6 +178,7 @@ pub fn submit_plan(
         totals: None,
         tasks: plan.tasks.iter().map(queued_task).collect(),
         artifact_refs: Vec::new(),
+        provider_handles: Vec::new(),
         metadata: json!({
             "task_count": plan.tasks.len(),
             "max_concurrency": plan.options.max_concurrency,
@@ -290,6 +308,14 @@ fn apply_aggregate_to_record(
     record.totals = Some(aggregate.totals.clone());
     record.tasks = tasks_for_aggregate(plan, aggregate);
     record.artifact_refs = artifact_refs_for_outcomes(&aggregate.outcomes);
+    record.provider_handles = provider_handles_for_outcomes(&aggregate.outcomes);
+    let provider_run_ids: Vec<String> = record
+        .provider_handles
+        .iter()
+        .map(|handle| handle.provider_run_id.clone())
+        .collect();
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("provider_run_ids".to_string(), json!(provider_run_ids));
 }
 
 pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
@@ -316,6 +342,88 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
     }
     record.annotate_stale_running();
     Ok(record)
+}
+
+pub fn cancel(run_id: &str) -> Result<AgentTaskRunRecord> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    if matches!(
+        record.state,
+        AgentTaskRunState::Succeeded
+            | AgentTaskRunState::PartialFailure
+            | AgentTaskRunState::Failed
+            | AgentTaskRunState::Cancelled
+    ) {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!(
+                "agent-task run '{}' is already terminal with state {:?}",
+                record.run_id, record.state
+            ),
+            Some(record.run_id),
+            None,
+        ));
+    }
+
+    record.state = AgentTaskRunState::Cancelled;
+    record.updated_at = Some(now_timestamp());
+    for task in &mut record.tasks {
+        if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
+            task.state = AgentTaskState::Cancelled;
+        }
+    }
+    for handle in &mut record.provider_handles {
+        if !matches!(
+            handle.state,
+            Some(AgentTaskState::Succeeded | AgentTaskState::Failed | AgentTaskState::Cancelled)
+        ) {
+            handle.state = Some(AgentTaskState::Cancelled);
+        }
+    }
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("cancel_requested_at".to_string(), json!(now_timestamp()));
+    metadata.insert(
+        "cancel_note".to_string(),
+        json!("provider-specific cancellation is delegated through opaque provider handles"),
+    );
+    store::write_record(&record)?;
+    Ok(record)
+}
+
+pub fn mark_resuming(run_id: &str) -> Result<AgentTaskRunRecord> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    if matches!(
+        record.state,
+        AgentTaskRunState::Succeeded
+            | AgentTaskRunState::PartialFailure
+            | AgentTaskRunState::Failed
+            | AgentTaskRunState::Cancelled
+    ) {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!(
+                "agent-task run '{}' is already terminal with state {:?}",
+                record.run_id, record.state
+            ),
+            Some(record.run_id),
+            None,
+        ));
+    }
+
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("resume_requested_at".to_string(), json!(now_timestamp()));
+    store::write_record(&record)?;
+    mark_running(run_id)
+}
+
+pub fn retry(run_id: &str, requested_run_id: Option<&str>) -> Result<AgentTaskRunRecord> {
+    let source = store::read_record(&sanitize_run_id(run_id))?;
+    let plan = store::read_plan_path(&source.plan_path)?;
+    let mut retry = submit_plan(&plan, requested_run_id)?;
+    let metadata = retry.ensure_metadata_object();
+    metadata.insert("retry_of".to_string(), json!(source.run_id));
+    metadata.insert("retry_requested_at".to_string(), json!(now_timestamp()));
+    store::write_record(&retry)?;
+    Ok(retry)
 }
 
 pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
@@ -464,6 +572,61 @@ fn artifact_refs_for_outcomes(outcomes: &[AgentTaskOutcome]) -> Vec<AgentTaskArt
         .collect()
 }
 
+fn provider_handles_for_outcomes(outcomes: &[AgentTaskOutcome]) -> Vec<AgentTaskRunProviderHandle> {
+    outcomes
+        .iter()
+        .flat_map(|outcome| provider_handles_for_outcome(outcome))
+        .collect()
+}
+
+fn provider_handles_for_outcome(outcome: &AgentTaskOutcome) -> Vec<AgentTaskRunProviderHandle> {
+    let mut handles = Vec::new();
+    if let Some(handle) = outcome
+        .metadata
+        .get("provider_handle")
+        .and_then(provider_handle_from_value)
+    {
+        handles.push(run_provider_handle(outcome, handle));
+    }
+    if let Some(values) = outcome
+        .metadata
+        .get("provider_handles")
+        .and_then(Value::as_array)
+    {
+        handles.extend(
+            values
+                .iter()
+                .filter_map(provider_handle_from_value)
+                .map(|handle| run_provider_handle(outcome, handle)),
+        );
+    }
+    handles
+}
+
+fn provider_handle_from_value(value: &Value) -> Option<AgentTaskExecutionHandle> {
+    serde_json::from_value(value.clone()).ok()
+}
+
+fn run_provider_handle(
+    outcome: &AgentTaskOutcome,
+    handle: AgentTaskExecutionHandle,
+) -> AgentTaskRunProviderHandle {
+    AgentTaskRunProviderHandle {
+        task_id: handle.task_id,
+        backend: handle.backend,
+        provider_run_id: handle.run_id,
+        stream_uri: handle.stream_uri,
+        state: Some(match outcome.status {
+            crate::core::agent_task::AgentTaskOutcomeStatus::Succeeded
+            | crate::core::agent_task::AgentTaskOutcomeStatus::NoOp => AgentTaskState::Succeeded,
+            crate::core::agent_task::AgentTaskOutcomeStatus::Timeout => AgentTaskState::TimedOut,
+            crate::core::agent_task::AgentTaskOutcomeStatus::Cancelled => AgentTaskState::Cancelled,
+            _ => AgentTaskState::Failed,
+        }),
+        metadata: handle.metadata,
+    }
+}
+
 fn run_state_for_aggregate(aggregate: &AgentTaskAggregate) -> AgentTaskRunState {
     match aggregate.status {
         crate::core::agent_task_scheduler::AgentTaskAggregateStatus::Succeeded => {
@@ -502,8 +665,8 @@ fn sanitize_run_id(run_id: &str) -> String {
 mod tests {
     use super::*;
     use crate::core::agent_task::{
-        AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
-        AGENT_TASK_REQUEST_SCHEMA,
+        AgentTaskExecutionHandle, AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy,
+        AgentTaskRequest, AgentTaskWorkspace, AGENT_TASK_REQUEST_SCHEMA,
     };
     use crate::core::agent_task_scheduler::{
         AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
@@ -616,6 +779,80 @@ mod tests {
             assert_eq!(durable_status.tasks[0].state, AgentTaskState::Succeeded);
             assert_eq!(durable_status.totals, Some(aggregate.totals.clone()));
             assert!(completed.aggregate_path.is_some());
+        });
+    }
+
+    #[test]
+    fn completed_run_persists_opaque_provider_handles_from_outcome_metadata() {
+        with_isolated_home(|_| {
+            let plan = test_plan();
+            let mut aggregate = succeeded_aggregate(&plan);
+            aggregate.outcomes[0].metadata = json!({
+                "provider_handle": AgentTaskExecutionHandle {
+                    task_id: "task-a".to_string(),
+                    backend: "codebox".to_string(),
+                    run_id: "provider-run-123".to_string(),
+                    stream_uri: Some("provider://runs/provider-run-123/events".to_string()),
+                    metadata: json!({ "opaque": { "provider_owned": true } }),
+                }
+            });
+
+            let record = record_completed_run(&plan, &aggregate, Some("run-provider-handle"))
+                .expect("recorded");
+
+            assert_eq!(record.provider_handles.len(), 1);
+            assert_eq!(record.provider_handles[0].task_id, "task-a");
+            assert_eq!(record.provider_handles[0].backend, "codebox");
+            assert_eq!(
+                record.provider_handles[0].provider_run_id,
+                "provider-run-123"
+            );
+            assert_eq!(
+                record.provider_handles[0].stream_uri.as_deref(),
+                Some("provider://runs/provider-run-123/events")
+            );
+            assert_eq!(
+                record.provider_handles[0].state,
+                Some(AgentTaskState::Succeeded)
+            );
+            assert_eq!(
+                record.provider_handles[0].metadata["opaque"]["provider_owned"],
+                json!(true)
+            );
+            assert_eq!(
+                record.metadata["provider_run_ids"],
+                json!(["provider-run-123"])
+            );
+        });
+    }
+
+    #[test]
+    fn cancel_marks_queued_run_and_tasks_cancelled() {
+        with_isolated_home(|_| {
+            let plan = test_plan();
+            submit_plan(&plan, Some("run-cancel")).expect("submitted");
+
+            let record = cancel("run-cancel").expect("cancelled");
+
+            assert_eq!(record.state, AgentTaskRunState::Cancelled);
+            assert_eq!(record.tasks[0].state, AgentTaskState::Cancelled);
+            assert!(record.metadata["cancel_requested_at"].is_string());
+        });
+    }
+
+    #[test]
+    fn retry_submits_new_run_from_existing_plan() {
+        with_isolated_home(|_| {
+            let plan = test_plan();
+            submit_plan(&plan, Some("run-original")).expect("submitted");
+
+            let record = retry("run-original", Some("run-retry")).expect("retry submitted");
+            let loaded_plan = load_plan("run-retry").expect("retry plan loaded");
+
+            assert_eq!(record.run_id, "run-retry");
+            assert_eq!(record.state, AgentTaskRunState::Queued);
+            assert_eq!(record.metadata["retry_of"], json!("run-original"));
+            assert_eq!(loaded_plan.plan_id, "plan-a");
         });
     }
 


### PR DESCRIPTION
## Summary
- Persist provider-native execution handles from normalized agent-task outcome metadata as generic durable run refs.
- Add `agent-task cancel`, `agent-task resume`, and `agent-task retry` lifecycle surfaces over submitted runs.
- Keep provider-owned handle metadata opaque in Homeboy core while surfacing generic run ids, stream URIs, and lifecycle state.

## Scope
- This lands the next smallest complete slice for #3286: durable provider refs plus generic cancel/resume/retry command surfaces.
- Provider-specific polling/cancellation adapter hooks remain a follow-up slice; this PR avoids encoding Codebox-specific fields in Homeboy core.

## Verification
- `cargo test agent_task_lifecycle`
- `cargo test agent_task::tests`
- `cargo test agent_task_provider`
- `cargo test agent_task_scheduler`
- `cargo test command_surface`
- `cargo run --bin homeboy -- agent-task --help`
- `cargo run --bin homeboy -- agent-task retry --help`
- `cargo run --bin homeboy -- agent-task cancel --help`
- `cargo run --bin homeboy -- agent-task resume --help`

Refs #3286

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the focused lifecycle slice, ran targeted verification, and drafted this PR description; Chris remains responsible for review and acceptance.