### PR TITLE
Add agent-task review workflow

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -27,6 +27,49 @@ identifiers in core lifecycle state. Provider-specific execution settings belong
 in `--provider-config`; durable lifecycle commands remain headless and can be
 claimed later with `agent-task run` or `agent-task run-next`.
 
+## Headless Fleet-Cooking Review
+
+The authoritative non-chat workflow is the durable `agent-task` lifecycle. Chat
+clients, Discord threads, GitHub Actions, cron, and terminal operators can all
+submit the same run id, inspect it later, and promote selected artifacts without
+depending on transport-local state.
+
+```bash
+run_id="homeboy-3357-$(date +%s)"
+
+homeboy agent-task dispatch \
+  --repo homeboy \
+  --cwd /path/to/homeboy@fix-issue \
+  --task-url https://github.com/Extra-Chill/homeboy/issues/3357 \
+  --concurrency 4 \
+  --attempts 2 \
+  --run-id "$run_id" \
+  --queue-only \
+  --prompt @task.txt
+
+# A daemon or later terminal process can claim work without chat history.
+homeboy agent-task run-next
+
+# One review envelope contains lifecycle state, logs, artifacts, aggregate
+# reconciliation, promotion candidates, and next actions.
+homeboy agent-task review "$run_id" \
+  --to-worktree homeboy@fix-issue-3357-agent-task-non-chat-flow
+```
+
+`agent-task review` returns `homeboy/agent-task-review/v1` with:
+
+- `record`: the durable run record from `status`.
+- `logs`: scheduler events from queued or completed lifecycle state.
+- `artifacts`: artifacts and evidence refs from the completed aggregate.
+- `aggregate_review`: apply/retry/issue-report/review candidate reconciliation.
+- `promotion_candidates`: generated `homeboy agent-task promote <run-id>` command
+  arrays for apply candidates, completed with `--to-worktree` when supplied.
+- `transport.chat_state_required: false`, making Homeboy the source of truth.
+
+This is the terminal/daemon-owned review surface for fleet cooking. Kimaki or any
+other chat UI should submit, poll, render, and call these commands rather than
+owning scheduling, state, artifacts, reconciliation, or promotion.
+
 ## Deterministic Smoke Gate
 
 Issue #3392 is covered by a no-secret fixture plan at
@@ -50,6 +93,8 @@ homeboy agent-task run "$run_id"
 # homeboy agent-task run-next
 homeboy agent-task status "$run_id"
 homeboy agent-task artifacts "$run_id"
+homeboy agent-task review "$run_id" \
+  --to-worktree "$target_worktree"
 homeboy agent-task promote "$run_id" \
   --to-worktree "$target_worktree" \
   --dry-run
@@ -62,6 +107,7 @@ The gate passes when:
 - `run` exits successfully and writes the aggregate lifecycle record.
 - Post-run `status` shows `state: "succeeded"`.
 - `artifacts` lists a patch artifact, an agent result artifact, and a transcript evidence ref.
+- `review` returns a `homeboy/agent-task-review/v1` envelope with `transport.chat_state_required: false`, aggregate reconciliation, and promotion candidates.
 - `promote <run-id> --dry-run` resolves the aggregate from the durable run id and reports the selected non-empty patch plus changed files without requiring the operator to look up `aggregate_path` manually.
 
 ## Dispatch Workspaces

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -1,12 +1,12 @@
 use clap::{Args, Subcommand};
 use serde_json::Value;
 
-use homeboy::core::agent_task::AgentTaskRequest;
+use homeboy::core::agent_task::{AgentTaskAggregateReport, AgentTaskRequest};
 use homeboy::core::agent_task_lifecycle;
 use homeboy::core::agent_task_promotion::{promote, AgentTaskPromotionOptions};
 use homeboy::core::agent_task_provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_task_scheduler::{
-    AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskScheduler,
+    AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskScheduler,
 };
 use homeboy::core::config;
 
@@ -37,6 +37,8 @@ pub enum AgentTaskCommand {
     Logs(StatusArgs),
     /// List artifacts and evidence refs recorded for a completed run.
     Artifacts(StatusArgs),
+    /// Build a durable aggregate review envelope from run state, logs, artifacts, and promotion hints.
+    Review(ReviewArgs),
     /// Promote a completed generic patch artifact into a managed worktree.
     Promote(PromoteArgs),
     /// List extension-declared agent-task executor providers.
@@ -67,6 +69,16 @@ pub struct SubmitArgs {
 pub struct StatusArgs {
     /// Durable run id returned by `agent-task submit` or `agent-task run-plan --record-run-id`.
     pub run_id: String,
+}
+
+#[derive(Args, Debug)]
+pub struct ReviewArgs {
+    /// Durable run id returned by `agent-task submit`, `dispatch`, or `run-plan --record-run-id`.
+    pub run_id: String,
+
+    /// Managed DMC worktree handle to include in generated promotion commands.
+    #[arg(long, value_name = "HANDLE")]
+    pub to_worktree: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -106,6 +118,7 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::Status(status_args) => status(status_args),
         AgentTaskCommand::Logs(status_args) => logs(status_args),
         AgentTaskCommand::Artifacts(status_args) => artifacts(status_args),
+        AgentTaskCommand::Review(review_args) => review(review_args),
         AgentTaskCommand::Promote(promote_args) => promote_artifact(promote_args),
         AgentTaskCommand::Providers => providers(),
     }
@@ -222,6 +235,147 @@ fn logs(args: StatusArgs) -> CmdResult<Value> {
 fn artifacts(args: StatusArgs) -> CmdResult<Value> {
     let artifacts = agent_task_lifecycle::artifacts(&args.run_id)?;
     Ok((serde_json::to_value(artifacts).unwrap_or(Value::Null), 0))
+}
+
+fn review(args: ReviewArgs) -> CmdResult<Value> {
+    let record = agent_task_lifecycle::status(&args.run_id)?;
+    let log = agent_task_lifecycle::logs(&args.run_id)?;
+    let artifacts = agent_task_lifecycle::artifacts(&args.run_id)?;
+    let aggregate = completed_run_aggregate(&args.run_id).transpose()?;
+    let aggregate_review = aggregate
+        .as_ref()
+        .map(|aggregate| AgentTaskAggregateReport::from(aggregate.outcomes.clone()));
+    let promotion_candidates = aggregate_review
+        .as_ref()
+        .map(|review| promotion_candidates(&args.run_id, args.to_worktree.as_deref(), review))
+        .unwrap_or_default();
+    let next_actions = review_next_actions(
+        &record.state,
+        aggregate_review.as_ref(),
+        args.to_worktree.as_deref(),
+    );
+
+    Ok((
+        serde_json::json!({
+            "schema": "homeboy/agent-task-review/v1",
+            "run_id": record.run_id,
+            "state": record.state,
+            "plan_id": record.plan_id,
+            "plan_path": record.plan_path,
+            "aggregate_path": record.aggregate_path,
+            "record": record,
+            "logs": log,
+            "artifacts": artifacts,
+            "aggregate_review": aggregate_review,
+            "promotion_candidates": promotion_candidates,
+            "next_actions": next_actions,
+            "transport": {
+                "authoritative": "homeboy-agent-task-lifecycle",
+                "chat_state_required": false
+            }
+        }),
+        0,
+    ))
+}
+
+fn completed_run_aggregate(run_id: &str) -> Option<homeboy::core::Result<AgentTaskAggregate>> {
+    match agent_task_lifecycle::aggregate_source(run_id) {
+        Ok((raw, _path)) => Some(serde_json::from_str(&raw).map_err(|error| {
+            homeboy::core::Error::validation_invalid_json(
+                error,
+                Some("agent-task aggregate".to_string()),
+                Some(raw),
+            )
+        })),
+        Err(error) if error.code == homeboy::core::ErrorCode::ValidationInvalidArgument => None,
+        Err(error) => Some(Err(error)),
+    }
+}
+
+fn promotion_candidates(
+    run_id: &str,
+    to_worktree: Option<&str>,
+    review: &AgentTaskAggregateReport,
+) -> Vec<Value> {
+    review
+        .apply_candidates
+        .iter()
+        .flat_map(|candidate| {
+            candidate.artifact_ids.iter().map(move |artifact_id| {
+                let mut command = vec![
+                    "homeboy".to_string(),
+                    "agent-task".to_string(),
+                    "promote".to_string(),
+                    run_id.to_string(),
+                    "--task-id".to_string(),
+                    candidate.task_id.clone(),
+                    "--artifact-id".to_string(),
+                    artifact_id.clone(),
+                ];
+                if let Some(to_worktree) = to_worktree {
+                    command.push("--to-worktree".to_string());
+                    command.push(to_worktree.to_string());
+                }
+
+                serde_json::json!({
+                    "task_id": candidate.task_id,
+                    "artifact_id": artifact_id,
+                    "reason": candidate.reason,
+                    "command": command,
+                    "ready": to_worktree.is_some()
+                })
+            })
+        })
+        .collect()
+}
+
+fn review_next_actions(
+    state: &agent_task_lifecycle::AgentTaskRunState,
+    aggregate_review: Option<&AgentTaskAggregateReport>,
+    to_worktree: Option<&str>,
+) -> Vec<String> {
+    if matches!(state, agent_task_lifecycle::AgentTaskRunState::Queued) {
+        return vec!["run this queued durable task with `homeboy agent-task run <run-id>` or let a daemon claim it with `homeboy agent-task run-next`".to_string()];
+    }
+
+    if matches!(state, agent_task_lifecycle::AgentTaskRunState::Running) {
+        return vec!["inspect progress with `homeboy agent-task status <run-id>` and `homeboy agent-task logs <run-id>`; stale running records are annotated in status metadata".to_string()];
+    }
+
+    let Some(review) = aggregate_review else {
+        return vec!["terminal run has no aggregate artifact; inspect lifecycle status for finalization errors".to_string()];
+    };
+
+    let mut actions = Vec::new();
+    if review.summary.apply_candidates > 0 {
+        if to_worktree.is_some() {
+            actions.push("review `promotion_candidates` and run the generated `homeboy agent-task promote` command for the selected patch artifact".to_string());
+        } else {
+            actions.push("rerun review with `--to-worktree <handle>` to generate complete promotion commands for apply candidates".to_string());
+        }
+    }
+    if review.summary.retry_candidates > 0 {
+        actions.push(
+            "retry provider-error or timeout candidates after fixing executor/preflight issues"
+                .to_string(),
+        );
+    }
+    if review.summary.issue_report_candidates > 0 {
+        actions.push(
+            "open or update the tracker with `issue_report_candidates` diagnostics and evidence"
+                .to_string(),
+        );
+    }
+    if review.summary.review_candidates > 0 {
+        actions.push(
+            "inspect `review_candidates` before deciding whether to retry, report, or ignore"
+                .to_string(),
+        );
+    }
+    if actions.is_empty() {
+        actions.push("no promotion, retry, or issue-report candidates were produced; inspect task summaries for no-op completion".to_string());
+    }
+    actions
 }
 
 fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
@@ -371,8 +525,9 @@ mod tests {
     use super::*;
     use crate::test_support::with_isolated_home;
     use homeboy::core::agent_task::{
-        AgentTaskExecutor, AgentTaskLimits, AgentTaskOutcome, AgentTaskOutcomeStatus,
-        AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace, AGENT_TASK_OUTCOME_SCHEMA,
+        AgentTaskArtifact, AgentTaskEvidenceRef, AgentTaskExecutor, AgentTaskLimits,
+        AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest,
+        AgentTaskWorkspace, AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA,
         AGENT_TASK_REQUEST_SCHEMA,
     };
     use homeboy::core::agent_task_lifecycle::{
@@ -612,6 +767,77 @@ mod tests {
         assert_eq!(path.as_deref(), Some(file.path()));
     }
 
+    #[test]
+    fn review_reports_queued_run_without_chat_state() {
+        with_temp_home(|| {
+            agent_task_lifecycle::submit_plan(&test_plan(), Some("run-review-queued"))
+                .expect("submitted");
+
+            let (value, exit_code) = review(ReviewArgs {
+                run_id: "run-review-queued".to_string(),
+                to_worktree: None,
+            })
+            .expect("review loaded");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(value["schema"], "homeboy/agent-task-review/v1");
+            assert_eq!(value["run_id"], "run-review-queued");
+            assert_eq!(value["state"], "queued");
+            assert_eq!(value["transport"]["chat_state_required"], false);
+            assert!(value["aggregate_review"].is_null());
+            assert_eq!(value["logs"]["events"][0]["state"], "queued");
+            assert!(value["next_actions"][0]
+                .as_str()
+                .expect("next action")
+                .contains("run-next"));
+        });
+    }
+
+    #[test]
+    fn review_reports_completed_aggregate_and_promotion_hints() {
+        with_temp_home(|| {
+            run_loaded_plan(
+                test_plan(),
+                Some("run-review-completed"),
+                ApplyArtifactExecutor,
+            )
+            .expect("run completed");
+
+            let (value, exit_code) = review(ReviewArgs {
+                run_id: "run-review-completed".to_string(),
+                to_worktree: Some("homeboy@fix-review-flow".to_string()),
+            })
+            .expect("review loaded");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(value["state"], "succeeded");
+            assert_eq!(value["aggregate_review"]["summary"]["apply_candidates"], 1);
+            assert_eq!(value["artifacts"]["artifacts"][0]["id"], "patch-a");
+            assert_eq!(value["promotion_candidates"][0]["task_id"], "task-a");
+            assert_eq!(value["promotion_candidates"][0]["artifact_id"], "patch-a");
+            assert_eq!(value["promotion_candidates"][0]["ready"], true);
+            assert_eq!(
+                value["promotion_candidates"][0]["command"],
+                json!([
+                    "homeboy",
+                    "agent-task",
+                    "promote",
+                    "run-review-completed",
+                    "--task-id",
+                    "task-a",
+                    "--artifact-id",
+                    "patch-a",
+                    "--to-worktree",
+                    "homeboy@fix-review-flow"
+                ])
+            );
+            assert!(value["next_actions"][0]
+                .as_str()
+                .expect("next action")
+                .contains("promotion_candidates"));
+        });
+    }
+
     struct InspectingExecutor {
         run_id: String,
         observed_status: Arc<Mutex<Option<AgentTaskRunRecord>>>,
@@ -680,6 +906,46 @@ mod tests {
                 failure_classification: None,
                 artifacts: Vec::new(),
                 evidence_refs: Vec::new(),
+                diagnostics: Vec::new(),
+                outputs: Value::Null,
+                workflow: None,
+                follow_up: None,
+                metadata: Value::Null,
+            }
+        }
+    }
+
+    struct ApplyArtifactExecutor;
+
+    impl AgentTaskExecutorAdapter for ApplyArtifactExecutor {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            AgentTaskOutcome {
+                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: request.task_id,
+                status: AgentTaskOutcomeStatus::Succeeded,
+                summary: Some("produced patch".to_string()),
+                failure_classification: None,
+                artifacts: vec![AgentTaskArtifact {
+                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                    id: "patch-a".to_string(),
+                    kind: "patch".to_string(),
+                    name: Some("changes.patch".to_string()),
+                    path: Some("target/agent-task-review/changes.patch".to_string()),
+                    url: None,
+                    mime: Some("text/x-diff".to_string()),
+                    size_bytes: Some(42),
+                    sha256: Some("abc123".to_string()),
+                    metadata: Value::Null,
+                }],
+                evidence_refs: vec![AgentTaskEvidenceRef {
+                    kind: "transcript".to_string(),
+                    uri: "target/agent-task-review/transcript.log".to_string(),
+                    label: Some("transcript".to_string()),
+                }],
                 diagnostics: Vec::new(),
                 outputs: Value::Null,
                 workflow: None,


### PR DESCRIPTION
## Summary
- Add `homeboy agent-task review <run-id>` as a durable non-chat review envelope over lifecycle status, logs, artifacts, aggregate reconciliation, and promotion hints.
- Generate promotion command arrays from apply candidates so terminal/daemon operators can continue to `agent-task promote` without looking up aggregate paths or chat history.
- Document the headless fleet-cooking workflow for `dispatch --queue-only`, `run-next`, `review`, and `promote`.

## Verification
- `cargo fmt -- --check`
- `cargo test commands::agent_task`
- Isolated terminal smoke with temporary `XDG_DATA_HOME`: `agent-task submit`, `status`, `run`, and `review` against `tests/fixtures/agent_task_smoke_plan.json`.

Refs #3357

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and implemented the `agent-task review` command slice, tests, docs, and verification workflow; Chris remains responsible for review and merge.