### PR TITLE
Add durable agent-task cancellation

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -64,6 +64,16 @@ The gate passes when:
 - `artifacts` lists a patch artifact, an agent result artifact, and a transcript evidence ref.
 - `promote <run-id> --dry-run` resolves the aggregate from the durable run id and reports the selected non-empty patch plus changed files without requiring the operator to look up `aggregate_path` manually.
 
+Queued runs that should not execute can be cancelled without chat/session state:
+
+```bash
+homeboy agent-task cancel "$run_id" --reason "not selected by controller"
+```
+
+`cancel` marks queued runs and stale-running records as `cancelled` in the
+durable lifecycle store. It refuses to claim live provider cancellation for an
+active runner process until a provider-owned cancellation channel is available.
+
 ## Dispatch Workspaces
 
 `agent-task dispatch` accepts generic Homeboy workspace inputs and does not

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -37,6 +37,8 @@ pub enum AgentTaskCommand {
     Logs(StatusArgs),
     /// List artifacts and evidence refs recorded for a completed run.
     Artifacts(StatusArgs),
+    /// Mark a queued or stale-running durable agent-task run as cancelled.
+    Cancel(CancelArgs),
     /// Promote a completed generic patch artifact into a managed worktree.
     Promote(PromoteArgs),
     /// List extension-declared agent-task executor providers.
@@ -67,6 +69,16 @@ pub struct SubmitArgs {
 pub struct StatusArgs {
     /// Durable run id returned by `agent-task submit` or `agent-task run-plan --record-run-id`.
     pub run_id: String,
+}
+
+#[derive(Args, Debug)]
+pub struct CancelArgs {
+    /// Durable run id returned by `agent-task submit` or `agent-task run-plan --record-run-id`.
+    pub run_id: String,
+
+    /// Operator-visible reason stored on the durable run record.
+    #[arg(long, value_name = "TEXT")]
+    pub reason: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -106,6 +118,7 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::Status(status_args) => status(status_args),
         AgentTaskCommand::Logs(status_args) => logs(status_args),
         AgentTaskCommand::Artifacts(status_args) => artifacts(status_args),
+        AgentTaskCommand::Cancel(cancel_args) => cancel(cancel_args),
         AgentTaskCommand::Promote(promote_args) => promote_artifact(promote_args),
         AgentTaskCommand::Providers => providers(),
     }
@@ -222,6 +235,11 @@ fn logs(args: StatusArgs) -> CmdResult<Value> {
 fn artifacts(args: StatusArgs) -> CmdResult<Value> {
     let artifacts = agent_task_lifecycle::artifacts(&args.run_id)?;
     Ok((serde_json::to_value(artifacts).unwrap_or(Value::Null), 0))
+}
+
+fn cancel(args: CancelArgs) -> CmdResult<Value> {
+    let record = agent_task_lifecycle::cancel_run(&args.run_id, args.reason.as_deref())?;
+    Ok((serde_json::to_value(record).unwrap_or(Value::Null), 0))
 }
 
 fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
@@ -513,6 +531,26 @@ mod tests {
 
             assert_eq!(exit_code, 0);
             assert_eq!(value["claimed"], false);
+        });
+    }
+
+    #[test]
+    fn cancel_command_marks_queued_run_cancelled() {
+        with_temp_home(|| {
+            agent_task_lifecycle::submit_plan(&test_plan(), Some("run-cli-cancel"))
+                .expect("submitted");
+
+            let (value, exit_code) = cancel(CancelArgs {
+                run_id: "run-cli-cancel".to_string(),
+                reason: Some("not selected".to_string()),
+            })
+            .expect("cancelled");
+            let record: AgentTaskRunRecord = serde_json::from_value(value).expect("record");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(record.state, AgentTaskRunState::Cancelled);
+            assert_eq!(record.tasks[0].state, AgentTaskState::Cancelled);
+            assert_eq!(record.metadata["cancel_reason"], json!("not selected"));
         });
     }
 

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -253,6 +253,69 @@ pub fn claim_next_queued_run() -> Result<Option<AgentTaskRunRecord>> {
     Ok(None)
 }
 
+pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunRecord> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    if record.state == AgentTaskRunState::Cancelled {
+        return Ok(record);
+    }
+
+    if matches!(
+        record.state,
+        AgentTaskRunState::Succeeded
+            | AgentTaskRunState::PartialFailure
+            | AgentTaskRunState::Failed
+    ) {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!(
+                "agent-task run '{}' is already terminal with state {:?}",
+                record.run_id, record.state
+            ),
+            Some(record.run_id),
+            None,
+        ));
+    }
+
+    if record.state == AgentTaskRunState::Running && record.owner_process_is_running() {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!(
+                "agent-task run '{}' is running under pid {}; provider live cancellation is not available through this durable record yet",
+                record.run_id,
+                record.owner_pid().unwrap_or_default()
+            ),
+            Some(record.run_id),
+            None,
+        ));
+    }
+
+    let cancelled_at = now_timestamp();
+    let was_stale_running = record.state == AgentTaskRunState::Running;
+    record.state = AgentTaskRunState::Cancelled;
+    record.updated_at = Some(cancelled_at.clone());
+    for task in &mut record.tasks {
+        if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
+            task.state = AgentTaskState::Cancelled;
+        }
+    }
+
+    let metadata = record.ensure_metadata_object();
+    metadata.insert("cancelled_at".to_string(), json!(cancelled_at));
+    metadata.insert("cancelled_by_pid".to_string(), json!(std::process::id()));
+    metadata.insert(
+        "cancel_reason".to_string(),
+        json!(reason.unwrap_or("cancel requested")),
+    );
+    if was_stale_running {
+        metadata.insert("cancelled_stale_running".to_string(), json!(true));
+    }
+    metadata.remove("stale_running");
+    metadata.remove("stale_running_reason");
+
+    store::write_record(&record)?;
+    Ok(record)
+}
+
 pub fn record_run_aggregate(
     run_id: &str,
     plan: &AgentTaskPlan,
@@ -727,6 +790,57 @@ mod tests {
             let error = mark_running("run-live-owner").expect_err("live run rejected");
 
             assert!(error.message.contains("already running"));
+        });
+    }
+
+    #[test]
+    fn cancel_run_marks_queued_record_cancelled() {
+        with_isolated_home(|_| {
+            let plan = test_plan();
+            submit_plan(&plan, Some("run-cancel-queued")).expect("submitted");
+
+            let cancelled =
+                cancel_run("run-cancel-queued", Some("loser cell")).expect("queued run cancelled");
+            let loaded = status("run-cancel-queued").expect("status loaded");
+
+            assert_eq!(cancelled.state, AgentTaskRunState::Cancelled);
+            assert_eq!(cancelled.tasks[0].state, AgentTaskState::Cancelled);
+            assert_eq!(cancelled.metadata["cancel_reason"], json!("loser cell"));
+            assert_eq!(loaded.state, AgentTaskRunState::Cancelled);
+        });
+    }
+
+    #[test]
+    fn cancel_run_reclaims_stale_running_record() {
+        with_isolated_home(|_| {
+            let plan = test_plan();
+            submit_plan(&plan, Some("run-cancel-stale")).expect("submitted");
+            let mut record = store::read_record("run-cancel-stale").expect("record");
+            record.state = AgentTaskRunState::Running;
+            record.tasks[0].state = AgentTaskState::Running;
+            record.metadata = json!({ "runner_pid": u32::MAX });
+            store::write_record(&record).expect("stored stale record");
+
+            let cancelled = cancel_run("run-cancel-stale", None).expect("stale run cancelled");
+
+            assert_eq!(cancelled.state, AgentTaskRunState::Cancelled);
+            assert_eq!(cancelled.tasks[0].state, AgentTaskState::Cancelled);
+            assert_eq!(cancelled.metadata["cancelled_stale_running"], json!(true));
+            assert!(cancelled.metadata.get("stale_running").is_none());
+        });
+    }
+
+    #[test]
+    fn cancel_run_rejects_live_running_record() {
+        with_isolated_home(|_| {
+            let plan = test_plan();
+            submit_plan(&plan, Some("run-cancel-live")).expect("submitted");
+            mark_running("run-cancel-live").expect("marked running");
+
+            let error = cancel_run("run-cancel-live", None).expect_err("live run rejected");
+
+            assert!(error.message.contains("running under pid"));
+            assert!(error.message.contains("provider live cancellation"));
         });
     }
 


### PR DESCRIPTION
## Summary
- Add `homeboy agent-task cancel` for durable queued-run cancellation without requiring chat/session state.
- Mark queued and stale-running records as `cancelled` while preserving lifecycle metadata and refusing to fake live provider cancellation without a provider-owned cancellation channel.
- Document the cancel path in the agent-task smoke/lifecycle guide.

Refs #3278.

## Verification
- `cargo test agent_task_lifecycle::tests::cancel_run --lib`
- `cargo test commands::agent_task::tests::cancel_command --lib`
- `cargo test agent_task --lib`
- `cargo run --quiet --bin homeboy -- agent-task --help`
- `cargo run --quiet --bin homeboy -- agent-task cancel --help`
- `XDG_DATA_HOME=$(mktemp -d) cargo run --quiet --bin homeboy -- agent-task submit --plan @tests/fixtures/agent_task_smoke_plan.json --run-id smoke-cancel-3278` followed by `agent-task cancel` and `agent-task status`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Inspecting the issue/current lifecycle code, implementing the durable cancellation slice, adding tests/docs, and running verification. Chris remains responsible for review and merge.