### PR TITLE
Add provider-neutral service tunnel backend

### DIFF
--- a/docs/commands/tunnel.md
+++ b/docs/commands/tunnel.md
@@ -33,13 +33,26 @@ homeboy tunnel service start context-a8c \
   --cwd /path/to/workspace \
   --host 127.0.0.1 \
   --port 7331 \
-  --health-path / \
-  --public-tunnel-backend none
+  --health-path /
 ```
 
 `--env KEY=VALUE` can be repeated to pass runtime environment values. Status records only env var names, not values. The managed service writes stdout/stderr logs under Homeboy's local data directory and includes those paths in `service status` output.
 
-Public tunnel backends are an explicit seam. `none` is the only implemented backend in this release; unsupported backends should be added as first-class implementations rather than faked by wrapping Kimaki or another CLI in proof paths.
+Expose the managed service through a provider-neutral backend command:
+
+```sh
+homeboy tunnel service start context-a8c \
+  --command 'npm run dev -- --host 127.0.0.1 --port 7331' \
+  --cwd /path/to/workspace \
+  --host 127.0.0.1 \
+  --port 7331 \
+  --health-path / \
+  --public-tunnel-backend command \
+  --public-tunnel-command './tools/open-preview-tunnel.sh' \
+  --public-tunnel-public-url 'https://preview.example.test/run-123'
+```
+
+The `command` backend is a generic adapter seam. Homeboy starts and supervises the backend command, injects `HOMEBOY_SERVICE_ID`, `HOMEBOY_SERVICE_LOCAL_URL`, and `HOMEBOY_TUNNEL_PUBLIC_URL`, records backend PID/process/log evidence, and stops it with the managed service. Provider-specific behavior such as Traforo, Cloudflare, ngrok, or a Homeboy VPS broker belongs in the backend command or a future extension, not in Homeboy core semantics.
 
 ## Subcommands
 
@@ -49,6 +62,6 @@ Public tunnel backends are an explicit seam. `none` is the only implemented back
 - `service set <id> ...`: update fields using the standard dynamic set contract.
 - `service remove <id>`: delete a declaration.
 - `service url <id>`: print the declared loopback URL.
-- `service start <id>`: start and supervise a declared local service command.
+- `service start <id>`: start and supervise a declared local service command and optional provider-neutral public tunnel backend.
 - `service status <id>`: report declaration, process, local URL, public URL when present, health, backend, and log evidence state.
 - `service stop <id>`: terminate the managed process group and remove runtime state while leaving log evidence files in place.

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -160,9 +160,17 @@ enum TunnelServiceCommand {
         #[arg(long, default_value_t = 30)]
         readiness_timeout: u64,
 
-        /// Public tunnel backend. Only 'none' is currently implemented.
+        /// Public tunnel backend adapter.
         #[arg(long, value_enum, default_value_t = ServiceTunnelBackendArg::None)]
         public_tunnel_backend: ServiceTunnelBackendArg,
+
+        /// Provider-neutral backend command to supervise when using the command backend
+        #[arg(long)]
+        public_tunnel_command: Option<String>,
+
+        /// Public URL exposed by the backend command
+        #[arg(long)]
+        public_tunnel_public_url: Option<String>,
     },
     /// Stop a running managed local service and cleanup runtime state
     Stop {
@@ -183,12 +191,14 @@ enum ServiceTunnelAuthModeArg {
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum ServiceTunnelBackendArg {
     None,
+    Command,
 }
 
 impl std::fmt::Display for ServiceTunnelBackendArg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ServiceTunnelBackendArg::None => write!(f, "none"),
+            ServiceTunnelBackendArg::Command => write!(f, "command"),
         }
     }
 }
@@ -197,6 +207,7 @@ impl From<ServiceTunnelBackendArg> for ServiceTunnelTunnelBackend {
     fn from(value: ServiceTunnelBackendArg) -> Self {
         match value {
             ServiceTunnelBackendArg::None => ServiceTunnelTunnelBackend::None,
+            ServiceTunnelBackendArg::Command => ServiceTunnelTunnelBackend::Command,
         }
     }
 }
@@ -272,6 +283,8 @@ fn run_service(command: TunnelServiceCommand) -> CmdResult<TunnelOutput> {
             health_path,
             readiness_timeout,
             public_tunnel_backend,
+            public_tunnel_command,
+            public_tunnel_public_url,
         } => start_service(StartServiceTunnelSpec {
             id,
             command,
@@ -284,6 +297,8 @@ fn run_service(command: TunnelServiceCommand) -> CmdResult<TunnelOutput> {
             health_path,
             readiness_timeout_secs: readiness_timeout,
             backend: public_tunnel_backend.into(),
+            backend_command: public_tunnel_command,
+            backend_public_url: public_tunnel_public_url,
         }),
         TunnelServiceCommand::Stop { id } => stop_service(&id),
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -63,6 +63,8 @@ pub mod structured_sidecar;
 pub mod top_n;
 pub mod triage;
 pub mod tunnel;
+#[cfg(test)]
+mod tunnel_tests;
 pub mod update_check_cache;
 pub mod upgrade;
 pub mod worktree;

--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -148,19 +148,31 @@ pub struct ServiceTunnelCommandSpec {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceTunnelProcessDescriptor {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process_group_id: Option<i32>,
+    pub command: ServiceTunnelCommandSpec,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceTunnelLogPaths {
+    pub stdout_path: String,
+    pub stderr_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServiceTunnelRuntimeState {
     #[serde(flatten)]
     pub preview_identity: ServiceTunnelPreviewIdentity,
     pub pid: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub process_group_id: Option<i32>,
+    #[serde(flatten)]
+    pub process: ServiceTunnelProcessDescriptor,
     pub started_at: String,
     pub local_url: String,
-    pub command: ServiceTunnelCommandSpec,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub health_url: Option<String>,
-    pub stdout_path: String,
-    pub stderr_path: String,
+    #[serde(flatten)]
+    pub logs: ServiceTunnelLogPaths,
     pub backend: ServiceTunnelTunnelBackend,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backend_process: Option<ServiceTunnelBackendProcessState>,
@@ -180,22 +192,20 @@ pub enum ServiceTunnelTunnelBackend {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServiceTunnelBackendProcessState {
     pub pid: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub process_group_id: Option<i32>,
+    #[serde(flatten)]
+    pub process: ServiceTunnelProcessDescriptor,
     pub started_at: String,
-    pub command: ServiceTunnelCommandSpec,
-    pub stdout_path: String,
-    pub stderr_path: String,
+    #[serde(flatten)]
+    pub logs: ServiceTunnelLogPaths,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ServiceTunnelProcessStatus {
     pub pid: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub process_group_id: Option<i32>,
+    #[serde(flatten)]
+    pub process: ServiceTunnelProcessDescriptor,
     pub running: bool,
     pub started_at: String,
-    pub command: ServiceTunnelCommandSpec,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -213,8 +223,8 @@ pub struct ServiceTunnelHealthStatus {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ServiceTunnelEvidence {
     pub state_path: String,
-    pub stdout_path: String,
-    pub stderr_path: String,
+    #[serde(flatten)]
+    pub logs: ServiceTunnelLogPaths,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -227,11 +237,7 @@ pub struct ServiceTunnelBackendStatus {
     pub evidence: Option<ServiceTunnelBackendEvidence>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct ServiceTunnelBackendEvidence {
-    pub stdout_path: String,
-    pub stderr_path: String,
-}
+pub type ServiceTunnelBackendEvidence = ServiceTunnelLogPaths;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServiceTunnelPreviewArtifact {
@@ -458,17 +464,21 @@ pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
             public_url: spec.backend_public_url.clone(),
         },
         pid,
-        process_group_id,
+        process: ServiceTunnelProcessDescriptor {
+            process_group_id,
+            command: ServiceTunnelCommandSpec {
+                command: spec.command,
+                cwd: spec.cwd.map(|path| path.display().to_string()),
+                env_keys: spec.env.keys().cloned().collect(),
+            },
+        },
         started_at: chrono::Utc::now().to_rfc3339(),
         local_url: local_url_for(&tunnel),
-        command: ServiceTunnelCommandSpec {
-            command: spec.command,
-            cwd: spec.cwd.map(|path| path.display().to_string()),
-            env_keys: spec.env.keys().cloned().collect(),
-        },
         health_url,
-        stdout_path: stdout_path.display().to_string(),
-        stderr_path: stderr_path.display().to_string(),
+        logs: ServiceTunnelLogPaths {
+            stdout_path: stdout_path.display().to_string(),
+            stderr_path: stderr_path.display().to_string(),
+        },
         backend: spec.backend,
         backend_process: None,
         source_run_id: spec.source_run_id,
@@ -516,10 +526,9 @@ fn service_tunnel_status(tunnel: &ServiceTunnel) -> ServiceTunnelStatus {
     let evidence = state.as_ref().map(runtime_evidence);
     let process = state.as_ref().map(|state| ServiceTunnelProcessStatus {
         pid: state.pid,
-        process_group_id: state.process_group_id,
+        process: state.process.clone(),
         running,
         started_at: state.started_at.clone(),
-        command: state.command.clone(),
     });
     let backend = state.as_ref().map(|state| ServiceTunnelBackendStatus {
         backend: state.backend.clone(),
@@ -528,19 +537,15 @@ fn service_tunnel_status(tunnel: &ServiceTunnel) -> ServiceTunnelStatus {
             let running = backend_process_is_running(backend);
             ServiceTunnelProcessStatus {
                 pid: backend.pid,
-                process_group_id: backend.process_group_id,
+                process: backend.process.clone(),
                 running,
                 started_at: backend.started_at.clone(),
-                command: backend.command.clone(),
             }
         }),
         evidence: state
             .backend_process
             .as_ref()
-            .map(|backend| ServiceTunnelBackendEvidence {
-                stdout_path: backend.stdout_path.clone(),
-                stderr_path: backend.stderr_path.clone(),
-            }),
+            .map(|backend| backend.logs.clone()),
     });
     let public_url = state
         .as_ref()
@@ -761,37 +766,33 @@ fn validate_backend_spec(spec: &StartServiceTunnelSpec) -> Result<()> {
     match spec.backend {
         ServiceTunnelTunnelBackend::None => Ok(()),
         ServiceTunnelTunnelBackend::Command => {
-            if spec
-                .backend_command
-                .as_deref()
-                .unwrap_or_default()
-                .trim()
-                .is_empty()
-            {
-                return Err(Error::validation_invalid_argument(
-                    "public_tunnel_command",
-                    "command backend requires a backend command",
-                    Some(spec.id.clone()),
-                    None,
-                ));
-            }
-            if spec
-                .backend_public_url
-                .as_deref()
-                .unwrap_or_default()
-                .trim()
-                .is_empty()
-            {
-                return Err(Error::validation_invalid_argument(
-                    "public_tunnel_public_url",
-                    "command backend requires the public URL it exposes",
-                    Some(spec.id.clone()),
-                    None,
-                ));
-            }
+            require_backend_value(
+                "public_tunnel_command",
+                spec.backend_command.as_deref(),
+                "command backend requires a backend command",
+                &spec.id,
+            )?;
+            require_backend_value(
+                "public_tunnel_public_url",
+                spec.backend_public_url.as_deref(),
+                "command backend requires the public URL it exposes",
+                &spec.id,
+            )?;
             Ok(())
         }
     }
+}
+
+fn require_backend_value(field: &str, value: Option<&str>, message: &str, id: &str) -> Result<()> {
+    if value.unwrap_or_default().trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            field,
+            message,
+            Some(id.to_string()),
+            None,
+        ));
+    }
+    Ok(())
 }
 
 fn start_backend_if_needed(
@@ -840,19 +841,23 @@ fn start_backend_if_needed(
     let pid = child.id();
     state.backend_process = Some(ServiceTunnelBackendProcessState {
         pid,
-        process_group_id: process_group_id_for(pid),
-        started_at: chrono::Utc::now().to_rfc3339(),
-        command: ServiceTunnelCommandSpec {
-            command: command_string,
-            cwd: None,
-            env_keys: vec![
-                "HOMEBOY_SERVICE_ID".to_string(),
-                "HOMEBOY_SERVICE_LOCAL_URL".to_string(),
-                "HOMEBOY_TUNNEL_PUBLIC_URL".to_string(),
-            ],
+        process: ServiceTunnelProcessDescriptor {
+            process_group_id: process_group_id_for(pid),
+            command: ServiceTunnelCommandSpec {
+                command: command_string,
+                cwd: None,
+                env_keys: vec![
+                    "HOMEBOY_SERVICE_ID".to_string(),
+                    "HOMEBOY_SERVICE_LOCAL_URL".to_string(),
+                    "HOMEBOY_TUNNEL_PUBLIC_URL".to_string(),
+                ],
+            },
         },
-        stdout_path: stdout_path.display().to_string(),
-        stderr_path: stderr_path.display().to_string(),
+        started_at: chrono::Utc::now().to_rfc3339(),
+        logs: ServiceTunnelLogPaths {
+            stdout_path: stdout_path.display().to_string(),
+            stderr_path: stderr_path.display().to_string(),
+        },
     });
     Ok(state)
 }
@@ -928,7 +933,7 @@ fn remove_runtime_state(id: &str) -> Result<()> {
 }
 
 fn runtime_state_is_running(state: &ServiceTunnelRuntimeState) -> bool {
-    if let Some(pgid) = state.process_group_id {
+    if let Some(pgid) = state.process.process_group_id {
         process_group_is_running(pgid)
     } else {
         pid_is_running(state.pid)
@@ -943,7 +948,7 @@ fn backend_state_is_running(state: &ServiceTunnelRuntimeState) -> bool {
 }
 
 fn backend_process_is_running(state: &ServiceTunnelBackendProcessState) -> bool {
-    if let Some(pgid) = state.process_group_id {
+    if let Some(pgid) = state.process.process_group_id {
         process_group_is_running(pgid)
     } else {
         pid_is_running(state.pid)
@@ -960,7 +965,7 @@ fn terminate_backend_state(state: &ServiceTunnelRuntimeState) -> Result<()> {
 
     #[cfg(unix)]
     unsafe {
-        if let Some(pgid) = backend.process_group_id {
+        if let Some(pgid) = backend.process.process_group_id {
             libc::kill(-(pgid as libc::pid_t), libc::SIGTERM);
             std::thread::sleep(Duration::from_millis(250));
             if process_group_is_running(pgid) {
@@ -986,7 +991,7 @@ fn terminate_runtime_state(state: &ServiceTunnelRuntimeState) -> Result<()> {
 
     #[cfg(unix)]
     unsafe {
-        if let Some(pgid) = state.process_group_id {
+        if let Some(pgid) = state.process.process_group_id {
             libc::kill(-(pgid as libc::pid_t), libc::SIGTERM);
             std::thread::sleep(Duration::from_millis(250));
             if process_group_is_running(pgid) {
@@ -1088,460 +1093,10 @@ fn runtime_evidence(state: &ServiceTunnelRuntimeState) -> ServiceTunnelEvidence 
         state_path: paths::service_tunnel_runtime_state_file(&state.preview_identity.service_id)
             .map(|path| path.display().to_string())
             .unwrap_or_default(),
-        stdout_path: state.stdout_path.clone(),
-        stderr_path: state.stderr_path.clone(),
+        logs: state.logs.clone(),
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::core::server::Server;
-    use crate::test_support;
-    use std::collections::{BTreeMap, HashMap};
-
-    fn create_server() {
-        crate::core::server::save(&Server {
-            id: "private-host".to_string(),
-            aliases: Vec::new(),
-            host: "private.example.test".to_string(),
-            user: "tester".to_string(),
-            port: 22,
-            identity_file: None,
-            kind: None,
-            auth: None,
-            env: HashMap::new(),
-            runner: None,
-        })
-        .expect("save server");
-    }
-
-    #[test]
-    fn expose_records_private_loopback_declaration_without_running_tunnel() {
-        test_support::with_isolated_home(|_| {
-            create_server();
-
-            let tunnel = expose(ExposeServiceTunnelSpec {
-                id: "site-preview".to_string(),
-                server_id: "private-host".to_string(),
-                target: ServiceTunnelTarget {
-                    host: "127.0.0.1".to_string(),
-                    port: 7331,
-                },
-                scheme: "http".to_string(),
-                local_port: Some(8831),
-                auth: ServiceTunnelAuth {
-                    mode: ServiceTunnelAuthMode::BearerEnv,
-                    env_var: Some("SITE_PREVIEW_TOKEN".to_string()),
-                    header: Some("Authorization".to_string()),
-                },
-                policy: ServiceTunnelPolicy {
-                    exposure: ServiceTunnelExposure::PrivateLoopback,
-                    require_auth: true,
-                    allowed_clients: vec!["app-runtime".to_string()],
-                    preview: ServiceTunnelPreviewPolicy::default(),
-                },
-                description: Some("Private preview service".to_string()),
-            })
-            .expect("expose service");
-
-            assert_eq!(tunnel.id, "site-preview");
-            let report = status("site-preview").expect("status");
-            assert!(report.declared);
-            assert!(!report.running);
-            assert_eq!(report.local_url, "http://127.0.0.1:8831");
-        });
-    }
-
-    #[test]
-    fn validation_rejects_auth_mode_without_env_var() {
-        test_support::with_isolated_home(|_| {
-            create_server();
-            let err = expose(ExposeServiceTunnelSpec {
-                id: "bad".to_string(),
-                server_id: "private-host".to_string(),
-                target: ServiceTunnelTarget {
-                    host: "127.0.0.1".to_string(),
-                    port: 7331,
-                },
-                scheme: "http".to_string(),
-                local_port: None,
-                auth: ServiceTunnelAuth {
-                    mode: ServiceTunnelAuthMode::BearerEnv,
-                    env_var: None,
-                    header: None,
-                },
-                policy: ServiceTunnelPolicy {
-                    exposure: ServiceTunnelExposure::PrivateLoopback,
-                    require_auth: true,
-                    allowed_clients: Vec::new(),
-                    preview: ServiceTunnelPreviewPolicy::default(),
-                },
-                description: None,
-            })
-            .expect_err("missing auth env should fail");
-
-            assert_eq!(err.code, crate::core::ErrorCode::ValidationInvalidArgument);
-            assert!(err.message.contains("auth.env_var"));
-        });
-    }
-
-    #[test]
-    fn start_status_and_stop_manage_local_service_runtime_state() {
-        test_support::with_isolated_home(|_| {
-            create_server();
-            expose(ExposeServiceTunnelSpec {
-                id: "local-preview".to_string(),
-                server_id: "private-host".to_string(),
-                target: ServiceTunnelTarget {
-                    host: "127.0.0.1".to_string(),
-                    port: 7331,
-                },
-                scheme: "http".to_string(),
-                local_port: Some(8832),
-                auth: ServiceTunnelAuth {
-                    mode: ServiceTunnelAuthMode::BearerEnv,
-                    env_var: Some("LOCAL_PREVIEW_TOKEN".to_string()),
-                    header: Some("Authorization".to_string()),
-                },
-                policy: ServiceTunnelPolicy {
-                    exposure: ServiceTunnelExposure::PrivateLoopback,
-                    require_auth: true,
-                    allowed_clients: vec!["app-runtime".to_string()],
-                    preview: ServiceTunnelPreviewPolicy {
-                        mode: ServiceTunnelPreviewPolicyMode::Always,
-                        keep_alive_until: None,
-                    },
-                },
-                description: None,
-            })
-            .expect("expose service");
-
-            let started = start(StartServiceTunnelSpec {
-                id: "local-preview".to_string(),
-                command: "while true; do sleep 1; done".to_string(),
-                cwd: None,
-                env: BTreeMap::from([("LOCAL_PREVIEW_MODE".to_string(), "test".to_string())]),
-                host: Some("127.0.0.1".to_string()),
-                port: Some(8832),
-                scheme: Some("http".to_string()),
-                health_url: None,
-                health_path: None,
-                readiness_timeout_secs: 1,
-                backend: ServiceTunnelTunnelBackend::None,
-                backend_command: None,
-                backend_public_url: None,
-                source_run_id: Some("run-123".to_string()),
-                source_workflow_id: Some("workflow-abc".to_string()),
-            })
-            .expect("start service");
-
-            assert!(started.running);
-            assert_eq!(started.local_url, "http://127.0.0.1:8832");
-            assert_eq!(started.preview_identity.public_url, None);
-            let preview = started.preview.as_ref().expect("preview artifact");
-            assert_eq!(preview.kind, "preview_url");
-            assert_eq!(preview.preview_identity.service_id, "local-preview");
-            assert_eq!(preview.local_url, "http://127.0.0.1:8832");
-            assert_eq!(preview.source.run_id.as_deref(), Some("run-123"));
-            assert_eq!(preview.source.workflow_id.as_deref(), Some("workflow-abc"));
-            let process = started.process.expect("process status");
-            assert!(process.running);
-            assert_eq!(process.command.env_keys, vec!["LOCAL_PREVIEW_MODE"]);
-            let evidence = started.evidence.expect("evidence paths");
-            assert!(std::path::Path::new(&evidence.state_path).exists());
-            assert!(std::path::Path::new(&evidence.stdout_path).exists());
-            assert!(std::path::Path::new(&evidence.stderr_path).exists());
-
-            let running = status("local-preview").expect("status");
-            assert!(running.running);
-
-            let stopped = stop("local-preview").expect("stop service");
-            assert!(!stopped.running);
-            assert!(stopped.process.is_none());
-            assert!(!std::path::Path::new(&evidence.state_path).exists());
-        });
-    }
-
-    #[test]
-    fn start_cleans_runtime_state_when_readiness_fails() {
-        test_support::with_isolated_home(|_| {
-            create_server();
-            expose(ExposeServiceTunnelSpec {
-                id: "failing-preview".to_string(),
-                server_id: "private-host".to_string(),
-                target: ServiceTunnelTarget {
-                    host: "127.0.0.1".to_string(),
-                    port: 7331,
-                },
-                scheme: "http".to_string(),
-                local_port: Some(8833),
-                auth: ServiceTunnelAuth {
-                    mode: ServiceTunnelAuthMode::BearerEnv,
-                    env_var: Some("FAILING_PREVIEW_TOKEN".to_string()),
-                    header: Some("Authorization".to_string()),
-                },
-                policy: ServiceTunnelPolicy {
-                    exposure: ServiceTunnelExposure::PrivateLoopback,
-                    require_auth: true,
-                    allowed_clients: Vec::new(),
-                    preview: ServiceTunnelPreviewPolicy::default(),
-                },
-                description: None,
-            })
-            .expect("expose service");
-
-            let err = start(StartServiceTunnelSpec {
-                id: "failing-preview".to_string(),
-                command: "while true; do sleep 1; done".to_string(),
-                cwd: None,
-                env: BTreeMap::new(),
-                host: Some("127.0.0.1".to_string()),
-                port: Some(8833),
-                scheme: Some("http".to_string()),
-                health_url: Some("http://127.0.0.1:9/health".to_string()),
-                health_path: None,
-                readiness_timeout_secs: 0,
-                backend: ServiceTunnelTunnelBackend::None,
-                backend_command: None,
-                backend_public_url: None,
-                source_run_id: None,
-                source_workflow_id: None,
-            })
-            .expect_err("readiness should fail");
-
-            assert_eq!(err.code, crate::core::ErrorCode::ValidationInvalidArgument);
-            let state_path =
-                paths::service_tunnel_runtime_state_file("failing-preview").expect("state path");
-            assert!(!state_path.exists());
-            let stopped = status("failing-preview").expect("status");
-            assert!(!stopped.running);
-        });
-    }
-
-    #[test]
-    fn command_backend_records_public_url_and_cleans_up_backend_process() {
-        test_support::with_isolated_home(|_| {
-            create_server();
-            expose(ExposeServiceTunnelSpec {
-                id: "command-preview".to_string(),
-                server_id: "private-host".to_string(),
-                target: ServiceTunnelTarget {
-                    host: "127.0.0.1".to_string(),
-                    port: 7331,
-                },
-                scheme: "http".to_string(),
-                local_port: Some(8834),
-                auth: ServiceTunnelAuth {
-                    mode: ServiceTunnelAuthMode::BearerEnv,
-                    env_var: Some("COMMAND_PREVIEW_TOKEN".to_string()),
-                    header: Some("Authorization".to_string()),
-                },
-                policy: ServiceTunnelPolicy {
-                    exposure: ServiceTunnelExposure::PrivateLoopback,
-                    require_auth: true,
-                    allowed_clients: Vec::new(),
-                    preview: ServiceTunnelPreviewPolicy::default(),
-                },
-                description: None,
-            })
-            .expect("expose service");
-
-            let started = start(StartServiceTunnelSpec {
-                id: "command-preview".to_string(),
-                command: "while true; do sleep 1; done".to_string(),
-                cwd: None,
-                env: BTreeMap::new(),
-                host: Some("127.0.0.1".to_string()),
-                port: Some(8834),
-                scheme: Some("http".to_string()),
-                health_url: None,
-                health_path: None,
-                readiness_timeout_secs: 1,
-                backend: ServiceTunnelTunnelBackend::Command,
-                backend_command: Some("while true; do sleep 1; done".to_string()),
-                backend_public_url: Some("https://preview.example.test".to_string()),
-                source_run_id: None,
-                source_workflow_id: None,
-            })
-            .expect("start service with backend");
-
-            assert!(started.running);
-            assert_eq!(
-                started.preview_identity.public_url.as_deref(),
-                Some("https://preview.example.test")
-            );
-            let backend = started.tunnel_backend.expect("backend status");
-            assert_eq!(backend.backend, ServiceTunnelTunnelBackend::Command);
-            assert!(backend.active);
-            let process = backend.process.expect("backend process");
-            assert!(process.running);
-            assert_eq!(
-                process.command.env_keys,
-                vec![
-                    "HOMEBOY_SERVICE_ID",
-                    "HOMEBOY_SERVICE_LOCAL_URL",
-                    "HOMEBOY_TUNNEL_PUBLIC_URL"
-                ]
-            );
-            let evidence = backend.evidence.expect("backend evidence");
-            assert!(std::path::Path::new(&evidence.stdout_path).exists());
-            assert!(std::path::Path::new(&evidence.stderr_path).exists());
-
-            let stopped = stop("command-preview").expect("stop service");
-            assert!(!stopped.running);
-            assert!(stopped.tunnel_backend.is_none());
-        });
-    }
-
-    #[test]
-    fn preview_policy_decisions_match_workflow_outcomes() {
-        let now = chrono::DateTime::parse_from_rfc3339("2026-06-07T12:00:00Z")
-            .expect("timestamp")
-            .with_timezone(&chrono::Utc);
-        let failed = ServiceTunnelPreviewDecisionContext {
-            run_failed: true,
-            manual_approval_required: false,
-            now,
-        };
-        let success = ServiceTunnelPreviewDecisionContext {
-            run_failed: false,
-            manual_approval_required: false,
-            now,
-        };
-        let approval = ServiceTunnelPreviewDecisionContext {
-            run_failed: false,
-            manual_approval_required: true,
-            now,
-        };
-
-        assert!(!preview_policy_allows(
-            &ServiceTunnelPreviewPolicy::default(),
-            &failed
-        ));
-        assert!(preview_policy_allows(
-            &ServiceTunnelPreviewPolicy {
-                mode: ServiceTunnelPreviewPolicyMode::Always,
-                keep_alive_until: None,
-            },
-            &success
-        ));
-        assert!(preview_policy_allows(
-            &ServiceTunnelPreviewPolicy {
-                mode: ServiceTunnelPreviewPolicyMode::OnFailure,
-                keep_alive_until: None,
-            },
-            &failed
-        ));
-        assert!(!preview_policy_allows(
-            &ServiceTunnelPreviewPolicy {
-                mode: ServiceTunnelPreviewPolicyMode::OnFailure,
-                keep_alive_until: None,
-            },
-            &success
-        ));
-        assert!(preview_policy_allows(
-            &ServiceTunnelPreviewPolicy {
-                mode: ServiceTunnelPreviewPolicyMode::ManualApproval,
-                keep_alive_until: None,
-            },
-            &approval
-        ));
-        assert!(preview_policy_allows(
-            &ServiceTunnelPreviewPolicy {
-                mode: ServiceTunnelPreviewPolicyMode::KeepAliveUntil,
-                keep_alive_until: Some("2026-06-07T12:30:00Z".to_string()),
-            },
-            &success
-        ));
-        assert!(!preview_policy_allows(
-            &ServiceTunnelPreviewPolicy {
-                mode: ServiceTunnelPreviewPolicyMode::KeepAliveUntil,
-                keep_alive_until: Some("2026-06-07T11:59:59Z".to_string()),
-            },
-            &success
-        ));
-    }
-
-    #[test]
-    fn preview_artifact_serializes_structured_reviewer_contract() {
-        let tunnel = ServiceTunnel {
-            id: "site-preview".to_string(),
-            aliases: Vec::new(),
-            description: None,
-            server_id: "private-host".to_string(),
-            target: ServiceTunnelTarget {
-                host: "127.0.0.1".to_string(),
-                port: 3000,
-            },
-            scheme: "http".to_string(),
-            local_host: "127.0.0.1".to_string(),
-            local_port: Some(3000),
-            auth: ServiceTunnelAuth {
-                mode: ServiceTunnelAuthMode::BearerEnv,
-                env_var: Some("TOKEN".to_string()),
-                header: Some("Authorization".to_string()),
-            },
-            policy: ServiceTunnelPolicy {
-                exposure: ServiceTunnelExposure::PrivateLoopback,
-                require_auth: true,
-                allowed_clients: Vec::new(),
-                preview: ServiceTunnelPreviewPolicy {
-                    mode: ServiceTunnelPreviewPolicyMode::KeepAliveUntil,
-                    keep_alive_until: Some("2026-06-07T13:00:00Z".to_string()),
-                },
-            },
-        };
-        let state = ServiceTunnelRuntimeState {
-            preview_identity: ServiceTunnelPreviewIdentity {
-                service_id: "site-preview".to_string(),
-                public_url: Some("https://preview.example.test/site-preview".to_string()),
-            },
-            pid: 123,
-            process_group_id: Some(123),
-            started_at: "2026-06-07T12:00:00Z".to_string(),
-            local_url: "http://127.0.0.1:3000".to_string(),
-            command: ServiceTunnelCommandSpec {
-                command: "serve-app".to_string(),
-                cwd: Some("/workspace/app".to_string()),
-                env_keys: vec!["TOKEN".to_string()],
-            },
-            health_url: Some("http://127.0.0.1:3000/".to_string()),
-            stdout_path: "/tmp/homeboy/stdout.log".to_string(),
-            stderr_path: "/tmp/homeboy/stderr.log".to_string(),
-            backend: ServiceTunnelTunnelBackend::None,
-            backend_process: None,
-            source_run_id: Some("run-1".to_string()),
-            source_workflow_id: Some("workflow-1".to_string()),
-        };
-        let context = ServiceTunnelPreviewDecisionContext {
-            run_failed: false,
-            manual_approval_required: false,
-            now: chrono::DateTime::parse_from_rfc3339("2026-06-07T12:30:00Z")
-                .expect("timestamp")
-                .with_timezone(&chrono::Utc),
-        };
-
-        let artifact = preview_artifact_for(&tunnel, &state, &context).expect("artifact");
-        let serialized = serde_json::to_value(&artifact).expect("serialize artifact");
-        let expected: serde_json::Value = serde_json::from_str(include_str!(
-            "../../tests/fixtures/output_contracts/tunnel/preview-artifact.json"
-        ))
-        .expect("fixture");
-
-        assert_eq!(serialized, expected);
-        assert_eq!(serialized["schema"], "homeboy/preview-url/v1");
-        assert_eq!(serialized["kind"], "preview_url");
-        assert_eq!(serialized["service_id"], "site-preview");
-        assert_eq!(serialized["local_url"], "http://127.0.0.1:3000");
-        assert_eq!(
-            serialized["public_url"],
-            "https://preview.example.test/site-preview"
-        );
-        assert_eq!(serialized["backend"], "none");
-        assert_eq!(serialized["policy"]["mode"], "keep_alive_until");
-        assert_eq!(serialized["cleanup"]["expires_at"], "2026-06-07T13:00:00Z");
-        assert_eq!(serialized["source"]["run_id"], "run-1");
-        assert_eq!(serialized["source"]["workflow_id"], "workflow-1");
-    }
-}
+#[path = "tunnel_tests.rs"]
+mod tests;

--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -1099,4 +1099,4 @@ fn runtime_evidence(state: &ServiceTunnelRuntimeState) -> ServiceTunnelEvidence 
 
 #[cfg(test)]
 #[path = "tunnel_tests.rs"]
-mod tests;
+mod tunnel_tests;

--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -127,12 +127,26 @@ pub struct ServiceTunnelRuntimeState {
     pub stdout_path: String,
     pub stderr_path: String,
     pub backend: ServiceTunnelTunnelBackend,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend_process: Option<ServiceTunnelBackendProcessState>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ServiceTunnelTunnelBackend {
     None,
+    Command,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceTunnelBackendProcessState {
+    pub pid: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process_group_id: Option<i32>,
+    pub started_at: String,
+    pub command: ServiceTunnelCommandSpec,
+    pub stdout_path: String,
+    pub stderr_path: String,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -168,6 +182,16 @@ pub struct ServiceTunnelEvidence {
 pub struct ServiceTunnelBackendStatus {
     pub backend: ServiceTunnelTunnelBackend,
     pub active: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process: Option<ServiceTunnelProcessStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<ServiceTunnelBackendEvidence>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ServiceTunnelBackendEvidence {
+    pub stdout_path: String,
+    pub stderr_path: String,
 }
 
 pub struct StartServiceTunnelSpec {
@@ -182,6 +206,8 @@ pub struct StartServiceTunnelSpec {
     pub health_path: Option<String>,
     pub readiness_timeout_secs: u64,
     pub backend: ServiceTunnelTunnelBackend,
+    pub backend_command: Option<String>,
+    pub backend_public_url: Option<String>,
 }
 
 pub struct ExposeServiceTunnelSpec {
@@ -269,14 +295,7 @@ pub fn status(id: &str) -> Result<ServiceTunnelStatus> {
 
 pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
     let mut tunnel = load(&spec.id)?;
-    if matches!(spec.backend, ServiceTunnelTunnelBackend::None) == false {
-        return Err(Error::validation_invalid_argument(
-            "public_tunnel_backend",
-            "only the explicit 'none' backend is currently supported",
-            Some(spec.id),
-            Some(vec!["none".to_string()]),
-        ));
-    }
+    validate_backend_spec(&spec)?;
 
     let existing = load_runtime_state(&tunnel.id)?;
     if let Some(state) = existing {
@@ -355,7 +374,7 @@ pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
         process_group_id,
         started_at: chrono::Utc::now().to_rfc3339(),
         local_url: local_url_for(&tunnel),
-        public_url: None,
+        public_url: spec.backend_public_url.clone(),
         command: ServiceTunnelCommandSpec {
             command: spec.command,
             cwd: spec.cwd.map(|path| path.display().to_string()),
@@ -365,6 +384,7 @@ pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
         stdout_path: stdout_path.display().to_string(),
         stderr_path: stderr_path.display().to_string(),
         backend: spec.backend,
+        backend_process: None,
     };
     save_runtime_state(&state)?;
     if let Err(error) = wait_until_ready(&state, spec.readiness_timeout_secs) {
@@ -372,12 +392,24 @@ pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
         remove_runtime_state(&state.service_id)?;
         return Err(error);
     }
+    let state = match start_backend_if_needed(state, &tunnel, spec.backend_command) {
+        Ok(state) => state,
+        Err(error) => {
+            if let Some(state) = load_runtime_state(&tunnel.id)? {
+                terminate_runtime_state(&state)?;
+                remove_runtime_state(&state.service_id)?;
+            }
+            return Err(error);
+        }
+    };
+    save_runtime_state(&state)?;
     status(&tunnel.id)
 }
 
 pub fn stop(id: &str) -> Result<ServiceTunnelStatus> {
     let tunnel = load(id)?;
     if let Some(state) = load_runtime_state(id)? {
+        terminate_backend_state(&state)?;
         terminate_runtime_state(&state)?;
         remove_runtime_state(id)?;
     }
@@ -403,7 +435,24 @@ fn service_tunnel_status(tunnel: &ServiceTunnel) -> ServiceTunnelStatus {
     });
     let backend = state.as_ref().map(|state| ServiceTunnelBackendStatus {
         backend: state.backend.clone(),
-        active: state.public_url.is_some(),
+        active: backend_state_is_running(state) || state.public_url.is_some(),
+        process: state.backend_process.as_ref().map(|backend| {
+            let running = backend_process_is_running(backend);
+            ServiceTunnelProcessStatus {
+                pid: backend.pid,
+                process_group_id: backend.process_group_id,
+                running,
+                started_at: backend.started_at.clone(),
+                command: backend.command.clone(),
+            }
+        }),
+        evidence: state
+            .backend_process
+            .as_ref()
+            .map(|backend| ServiceTunnelBackendEvidence {
+                stdout_path: backend.stdout_path.clone(),
+                stderr_path: backend.stderr_path.clone(),
+            }),
     });
     let public_url = state.as_ref().and_then(|state| state.public_url.clone());
     ServiceTunnelStatus {
@@ -508,6 +557,106 @@ fn validate_loopback_host(host: &str, id: &str) -> Result<()> {
     Ok(())
 }
 
+fn validate_backend_spec(spec: &StartServiceTunnelSpec) -> Result<()> {
+    match spec.backend {
+        ServiceTunnelTunnelBackend::None => Ok(()),
+        ServiceTunnelTunnelBackend::Command => {
+            if spec
+                .backend_command
+                .as_deref()
+                .unwrap_or_default()
+                .trim()
+                .is_empty()
+            {
+                return Err(Error::validation_invalid_argument(
+                    "public_tunnel_command",
+                    "command backend requires a backend command",
+                    Some(spec.id.clone()),
+                    None,
+                ));
+            }
+            if spec
+                .backend_public_url
+                .as_deref()
+                .unwrap_or_default()
+                .trim()
+                .is_empty()
+            {
+                return Err(Error::validation_invalid_argument(
+                    "public_tunnel_public_url",
+                    "command backend requires the public URL it exposes",
+                    Some(spec.id.clone()),
+                    None,
+                ));
+            }
+            Ok(())
+        }
+    }
+}
+
+fn start_backend_if_needed(
+    mut state: ServiceTunnelRuntimeState,
+    tunnel: &ServiceTunnel,
+    backend_command: Option<String>,
+) -> Result<ServiceTunnelRuntimeState> {
+    if !matches!(state.backend, ServiceTunnelTunnelBackend::Command) {
+        return Ok(state);
+    }
+
+    let command_string = backend_command.unwrap_or_default();
+    let runtime_dir = paths::service_tunnel_runtime_dir(&tunnel.id)?;
+    let stdout_path = runtime_dir.join("backend-stdout.log");
+    let stderr_path = runtime_dir.join("backend-stderr.log");
+    let stdout = File::create(&stdout_path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(stdout_path.display().to_string())))?;
+    let stderr = File::create(&stderr_path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(stderr_path.display().to_string())))?;
+
+    let mut command = shell_command(&command_string);
+    command
+        .env("HOMEBOY_SERVICE_ID", &tunnel.id)
+        .env("HOMEBOY_SERVICE_LOCAL_URL", &state.local_url);
+    if let Some(public_url) = &state.public_url {
+        command.env("HOMEBOY_TUNNEL_PUBLIC_URL", public_url);
+    }
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+    #[cfg(unix)]
+    unsafe {
+        command.pre_exec(|| {
+            libc::setpgid(0, 0);
+            Ok(())
+        });
+    }
+
+    let child = command.spawn().map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("start service tunnel backend {}", tunnel.id)),
+        )
+    })?;
+    let pid = child.id();
+    state.backend_process = Some(ServiceTunnelBackendProcessState {
+        pid,
+        process_group_id: process_group_id_for(pid),
+        started_at: chrono::Utc::now().to_rfc3339(),
+        command: ServiceTunnelCommandSpec {
+            command: command_string,
+            cwd: None,
+            env_keys: vec![
+                "HOMEBOY_SERVICE_ID".to_string(),
+                "HOMEBOY_SERVICE_LOCAL_URL".to_string(),
+                "HOMEBOY_TUNNEL_PUBLIC_URL".to_string(),
+            ],
+        },
+        stdout_path: stdout_path.display().to_string(),
+        stderr_path: stderr_path.display().to_string(),
+    });
+    Ok(state)
+}
+
 fn shell_command(command: &str) -> Command {
     #[cfg(windows)]
     {
@@ -580,6 +729,50 @@ fn runtime_state_is_running(state: &ServiceTunnelRuntimeState) -> bool {
     } else {
         pid_is_running(state.pid)
     }
+}
+
+fn backend_state_is_running(state: &ServiceTunnelRuntimeState) -> bool {
+    state
+        .backend_process
+        .as_ref()
+        .is_some_and(backend_process_is_running)
+}
+
+fn backend_process_is_running(state: &ServiceTunnelBackendProcessState) -> bool {
+    if let Some(pgid) = state.process_group_id {
+        process_group_is_running(pgid)
+    } else {
+        pid_is_running(state.pid)
+    }
+}
+
+fn terminate_backend_state(state: &ServiceTunnelRuntimeState) -> Result<()> {
+    let Some(backend) = &state.backend_process else {
+        return Ok(());
+    };
+    if !backend_process_is_running(backend) {
+        return Ok(());
+    }
+
+    #[cfg(unix)]
+    unsafe {
+        if let Some(pgid) = backend.process_group_id {
+            libc::kill(-(pgid as libc::pid_t), libc::SIGTERM);
+            std::thread::sleep(Duration::from_millis(250));
+            if process_group_is_running(pgid) {
+                libc::kill(-(pgid as libc::pid_t), libc::SIGKILL);
+            }
+        } else {
+            libc::kill(backend.pid as libc::pid_t, libc::SIGTERM);
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = backend;
+    }
+
+    Ok(())
 }
 
 fn terminate_runtime_state(state: &ServiceTunnelRuntimeState) -> Result<()> {
@@ -826,6 +1019,8 @@ mod tests {
                 health_path: None,
                 readiness_timeout_secs: 1,
                 backend: ServiceTunnelTunnelBackend::None,
+                backend_command: None,
+                backend_public_url: None,
             })
             .expect("start service");
 
@@ -889,6 +1084,8 @@ mod tests {
                 health_path: None,
                 readiness_timeout_secs: 0,
                 backend: ServiceTunnelTunnelBackend::None,
+                backend_command: None,
+                backend_public_url: None,
             })
             .expect_err("readiness should fail");
 
@@ -898,6 +1095,78 @@ mod tests {
             assert!(!state_path.exists());
             let stopped = status("failing-preview").expect("status");
             assert!(!stopped.running);
+        });
+    }
+
+    #[test]
+    fn command_backend_records_public_url_and_cleans_up_backend_process() {
+        test_support::with_isolated_home(|_| {
+            create_server();
+            expose(ExposeServiceTunnelSpec {
+                id: "command-preview".to_string(),
+                server_id: "private-host".to_string(),
+                target: ServiceTunnelTarget {
+                    host: "127.0.0.1".to_string(),
+                    port: 7331,
+                },
+                scheme: "http".to_string(),
+                local_port: Some(8834),
+                auth: ServiceTunnelAuth {
+                    mode: ServiceTunnelAuthMode::BearerEnv,
+                    env_var: Some("COMMAND_PREVIEW_TOKEN".to_string()),
+                    header: Some("Authorization".to_string()),
+                },
+                policy: ServiceTunnelPolicy {
+                    exposure: ServiceTunnelExposure::PrivateLoopback,
+                    require_auth: true,
+                    allowed_clients: Vec::new(),
+                },
+                description: None,
+            })
+            .expect("expose service");
+
+            let started = start(StartServiceTunnelSpec {
+                id: "command-preview".to_string(),
+                command: "while true; do sleep 1; done".to_string(),
+                cwd: None,
+                env: BTreeMap::new(),
+                host: Some("127.0.0.1".to_string()),
+                port: Some(8834),
+                scheme: Some("http".to_string()),
+                health_url: None,
+                health_path: None,
+                readiness_timeout_secs: 1,
+                backend: ServiceTunnelTunnelBackend::Command,
+                backend_command: Some("while true; do sleep 1; done".to_string()),
+                backend_public_url: Some("https://preview.example.test".to_string()),
+            })
+            .expect("start service with backend");
+
+            assert!(started.running);
+            assert_eq!(
+                started.public_url.as_deref(),
+                Some("https://preview.example.test")
+            );
+            let backend = started.tunnel_backend.expect("backend status");
+            assert_eq!(backend.backend, ServiceTunnelTunnelBackend::Command);
+            assert!(backend.active);
+            let process = backend.process.expect("backend process");
+            assert!(process.running);
+            assert_eq!(
+                process.command.env_keys,
+                vec![
+                    "HOMEBOY_SERVICE_ID",
+                    "HOMEBOY_SERVICE_LOCAL_URL",
+                    "HOMEBOY_TUNNEL_PUBLIC_URL"
+                ]
+            );
+            let evidence = backend.evidence.expect("backend evidence");
+            assert!(std::path::Path::new(&evidence.stdout_path).exists());
+            assert!(std::path::Path::new(&evidence.stderr_path).exists());
+
+            let stopped = stop("command-preview").expect("stop service");
+            assert!(!stopped.running);
+            assert!(stopped.tunnel_backend.is_none());
         });
     }
 }

--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -572,7 +572,7 @@ fn service_tunnel_status(tunnel: &ServiceTunnel) -> ServiceTunnelStatus {
     }
 }
 
-fn preview_policy_allows(
+pub(super) fn preview_policy_allows(
     policy: &ServiceTunnelPreviewPolicy,
     context: &ServiceTunnelPreviewDecisionContext,
 ) -> bool {
@@ -589,7 +589,7 @@ fn preview_policy_allows(
     }
 }
 
-fn preview_artifact_for(
+pub(super) fn preview_artifact_for(
     tunnel: &ServiceTunnel,
     state: &ServiceTunnelRuntimeState,
     context: &ServiceTunnelPreviewDecisionContext,
@@ -1096,7 +1096,3 @@ fn runtime_evidence(state: &ServiceTunnelRuntimeState) -> ServiceTunnelEvidence 
         logs: state.logs.clone(),
     }
 }
-
-#[cfg(test)]
-#[path = "tunnel_tests.rs"]
-mod tunnel_tests;

--- a/src/core/tunnel_tests.rs
+++ b/src/core/tunnel_tests.rs
@@ -1,4 +1,5 @@
-use super::*;
+use super::tunnel::*;
+use crate::core::paths;
 use crate::core::server::Server;
 use crate::test_support;
 use std::collections::{BTreeMap, HashMap};

--- a/src/core/tunnel_tests.rs
+++ b/src/core/tunnel_tests.rs
@@ -1,0 +1,453 @@
+use super::*;
+use crate::core::server::Server;
+use crate::test_support;
+use std::collections::{BTreeMap, HashMap};
+
+fn create_server() {
+    crate::core::server::save(&Server {
+        id: "private-host".to_string(),
+        aliases: Vec::new(),
+        host: "private.example.test".to_string(),
+        user: "tester".to_string(),
+        port: 22,
+        identity_file: None,
+        kind: None,
+        auth: None,
+        env: HashMap::new(),
+        runner: None,
+    })
+    .expect("save server");
+}
+
+#[test]
+fn expose_records_private_loopback_declaration_without_running_tunnel() {
+    test_support::with_isolated_home(|_| {
+        create_server();
+
+        let tunnel = expose(ExposeServiceTunnelSpec {
+            id: "site-preview".to_string(),
+            server_id: "private-host".to_string(),
+            target: ServiceTunnelTarget {
+                host: "127.0.0.1".to_string(),
+                port: 7331,
+            },
+            scheme: "http".to_string(),
+            local_port: Some(8831),
+            auth: ServiceTunnelAuth {
+                mode: ServiceTunnelAuthMode::BearerEnv,
+                env_var: Some("SITE_PREVIEW_TOKEN".to_string()),
+                header: Some("Authorization".to_string()),
+            },
+            policy: ServiceTunnelPolicy {
+                exposure: ServiceTunnelExposure::PrivateLoopback,
+                require_auth: true,
+                allowed_clients: vec!["app-runtime".to_string()],
+                preview: ServiceTunnelPreviewPolicy::default(),
+            },
+            description: Some("Private preview service".to_string()),
+        })
+        .expect("expose service");
+
+        assert_eq!(tunnel.id, "site-preview");
+        let report = status("site-preview").expect("status");
+        assert!(report.declared);
+        assert!(!report.running);
+        assert_eq!(report.local_url, "http://127.0.0.1:8831");
+    });
+}
+
+#[test]
+fn validation_rejects_auth_mode_without_env_var() {
+    test_support::with_isolated_home(|_| {
+        create_server();
+        let err = expose(ExposeServiceTunnelSpec {
+            id: "bad".to_string(),
+            server_id: "private-host".to_string(),
+            target: ServiceTunnelTarget {
+                host: "127.0.0.1".to_string(),
+                port: 7331,
+            },
+            scheme: "http".to_string(),
+            local_port: None,
+            auth: ServiceTunnelAuth {
+                mode: ServiceTunnelAuthMode::BearerEnv,
+                env_var: None,
+                header: None,
+            },
+            policy: ServiceTunnelPolicy {
+                exposure: ServiceTunnelExposure::PrivateLoopback,
+                require_auth: true,
+                allowed_clients: Vec::new(),
+                preview: ServiceTunnelPreviewPolicy::default(),
+            },
+            description: None,
+        })
+        .expect_err("missing auth env should fail");
+
+        assert_eq!(err.code, crate::core::ErrorCode::ValidationInvalidArgument);
+        assert!(err.message.contains("auth.env_var"));
+    });
+}
+
+#[test]
+fn start_status_and_stop_manage_local_service_runtime_state() {
+    test_support::with_isolated_home(|_| {
+        create_server();
+        expose(ExposeServiceTunnelSpec {
+            id: "local-preview".to_string(),
+            server_id: "private-host".to_string(),
+            target: ServiceTunnelTarget {
+                host: "127.0.0.1".to_string(),
+                port: 7331,
+            },
+            scheme: "http".to_string(),
+            local_port: Some(8832),
+            auth: ServiceTunnelAuth {
+                mode: ServiceTunnelAuthMode::BearerEnv,
+                env_var: Some("LOCAL_PREVIEW_TOKEN".to_string()),
+                header: Some("Authorization".to_string()),
+            },
+            policy: ServiceTunnelPolicy {
+                exposure: ServiceTunnelExposure::PrivateLoopback,
+                require_auth: true,
+                allowed_clients: vec!["app-runtime".to_string()],
+                preview: ServiceTunnelPreviewPolicy {
+                    mode: ServiceTunnelPreviewPolicyMode::Always,
+                    keep_alive_until: None,
+                },
+            },
+            description: None,
+        })
+        .expect("expose service");
+
+        let started = start(StartServiceTunnelSpec {
+            id: "local-preview".to_string(),
+            command: "while true; do sleep 1; done".to_string(),
+            cwd: None,
+            env: BTreeMap::from([("LOCAL_PREVIEW_MODE".to_string(), "test".to_string())]),
+            host: Some("127.0.0.1".to_string()),
+            port: Some(8832),
+            scheme: Some("http".to_string()),
+            health_url: None,
+            health_path: None,
+            readiness_timeout_secs: 1,
+            backend: ServiceTunnelTunnelBackend::None,
+            backend_command: None,
+            backend_public_url: None,
+            source_run_id: Some("run-123".to_string()),
+            source_workflow_id: Some("workflow-abc".to_string()),
+        })
+        .expect("start service");
+
+        assert!(started.running);
+        assert_eq!(started.local_url, "http://127.0.0.1:8832");
+        assert_eq!(started.preview_identity.public_url, None);
+        let preview = started.preview.as_ref().expect("preview artifact");
+        assert_eq!(preview.kind, "preview_url");
+        assert_eq!(preview.preview_identity.service_id, "local-preview");
+        assert_eq!(preview.local_url, "http://127.0.0.1:8832");
+        assert_eq!(preview.source.run_id.as_deref(), Some("run-123"));
+        assert_eq!(preview.source.workflow_id.as_deref(), Some("workflow-abc"));
+        let process = started.process.expect("process status");
+        assert!(process.running);
+        assert_eq!(process.process.command.env_keys, vec!["LOCAL_PREVIEW_MODE"]);
+        let evidence = started.evidence.expect("evidence paths");
+        assert!(std::path::Path::new(&evidence.state_path).exists());
+        assert!(std::path::Path::new(&evidence.logs.stdout_path).exists());
+        assert!(std::path::Path::new(&evidence.logs.stderr_path).exists());
+
+        let running = status("local-preview").expect("status");
+        assert!(running.running);
+
+        let stopped = stop("local-preview").expect("stop service");
+        assert!(!stopped.running);
+        assert!(stopped.process.is_none());
+        assert!(!std::path::Path::new(&evidence.state_path).exists());
+    });
+}
+
+#[test]
+fn start_cleans_runtime_state_when_readiness_fails() {
+    test_support::with_isolated_home(|_| {
+        create_server();
+        expose(ExposeServiceTunnelSpec {
+            id: "failing-preview".to_string(),
+            server_id: "private-host".to_string(),
+            target: ServiceTunnelTarget {
+                host: "127.0.0.1".to_string(),
+                port: 7331,
+            },
+            scheme: "http".to_string(),
+            local_port: Some(8833),
+            auth: ServiceTunnelAuth {
+                mode: ServiceTunnelAuthMode::BearerEnv,
+                env_var: Some("FAILING_PREVIEW_TOKEN".to_string()),
+                header: Some("Authorization".to_string()),
+            },
+            policy: ServiceTunnelPolicy {
+                exposure: ServiceTunnelExposure::PrivateLoopback,
+                require_auth: true,
+                allowed_clients: Vec::new(),
+                preview: ServiceTunnelPreviewPolicy::default(),
+            },
+            description: None,
+        })
+        .expect("expose service");
+
+        let err = start(StartServiceTunnelSpec {
+            id: "failing-preview".to_string(),
+            command: "while true; do sleep 1; done".to_string(),
+            cwd: None,
+            env: BTreeMap::new(),
+            host: Some("127.0.0.1".to_string()),
+            port: Some(8833),
+            scheme: Some("http".to_string()),
+            health_url: Some("http://127.0.0.1:9/health".to_string()),
+            health_path: None,
+            readiness_timeout_secs: 0,
+            backend: ServiceTunnelTunnelBackend::None,
+            backend_command: None,
+            backend_public_url: None,
+            source_run_id: None,
+            source_workflow_id: None,
+        })
+        .expect_err("readiness should fail");
+
+        assert_eq!(err.code, crate::core::ErrorCode::ValidationInvalidArgument);
+        let state_path =
+            paths::service_tunnel_runtime_state_file("failing-preview").expect("state path");
+        assert!(!state_path.exists());
+        let stopped = status("failing-preview").expect("status");
+        assert!(!stopped.running);
+    });
+}
+
+#[test]
+fn command_backend_records_public_url_and_cleans_up_backend_process() {
+    test_support::with_isolated_home(|_| {
+        create_server();
+        expose(ExposeServiceTunnelSpec {
+            id: "command-preview".to_string(),
+            server_id: "private-host".to_string(),
+            target: ServiceTunnelTarget {
+                host: "127.0.0.1".to_string(),
+                port: 7331,
+            },
+            scheme: "http".to_string(),
+            local_port: Some(8834),
+            auth: ServiceTunnelAuth {
+                mode: ServiceTunnelAuthMode::BearerEnv,
+                env_var: Some("COMMAND_PREVIEW_TOKEN".to_string()),
+                header: Some("Authorization".to_string()),
+            },
+            policy: ServiceTunnelPolicy {
+                exposure: ServiceTunnelExposure::PrivateLoopback,
+                require_auth: true,
+                allowed_clients: Vec::new(),
+                preview: ServiceTunnelPreviewPolicy::default(),
+            },
+            description: None,
+        })
+        .expect("expose service");
+
+        let started = start(StartServiceTunnelSpec {
+            id: "command-preview".to_string(),
+            command: "while true; do sleep 1; done".to_string(),
+            cwd: None,
+            env: BTreeMap::new(),
+            host: Some("127.0.0.1".to_string()),
+            port: Some(8834),
+            scheme: Some("http".to_string()),
+            health_url: None,
+            health_path: None,
+            readiness_timeout_secs: 1,
+            backend: ServiceTunnelTunnelBackend::Command,
+            backend_command: Some("while true; do sleep 1; done".to_string()),
+            backend_public_url: Some("https://preview.example.test".to_string()),
+            source_run_id: None,
+            source_workflow_id: None,
+        })
+        .expect("start service with backend");
+
+        assert!(started.running);
+        assert_eq!(
+            started.preview_identity.public_url.as_deref(),
+            Some("https://preview.example.test")
+        );
+        let backend = started.tunnel_backend.expect("backend status");
+        assert_eq!(backend.backend, ServiceTunnelTunnelBackend::Command);
+        assert!(backend.active);
+        let process = backend.process.expect("backend process");
+        assert!(process.running);
+        assert_eq!(
+            process.process.command.env_keys,
+            vec![
+                "HOMEBOY_SERVICE_ID",
+                "HOMEBOY_SERVICE_LOCAL_URL",
+                "HOMEBOY_TUNNEL_PUBLIC_URL"
+            ]
+        );
+        let evidence = backend.evidence.expect("backend evidence");
+        assert!(std::path::Path::new(&evidence.stdout_path).exists());
+        assert!(std::path::Path::new(&evidence.stderr_path).exists());
+
+        let stopped = stop("command-preview").expect("stop service");
+        assert!(!stopped.running);
+        assert!(stopped.tunnel_backend.is_none());
+    });
+}
+
+#[test]
+fn preview_policy_decisions_match_workflow_outcomes() {
+    let now = chrono::DateTime::parse_from_rfc3339("2026-06-07T12:00:00Z")
+        .expect("timestamp")
+        .with_timezone(&chrono::Utc);
+    let failed = ServiceTunnelPreviewDecisionContext {
+        run_failed: true,
+        manual_approval_required: false,
+        now,
+    };
+    let success = ServiceTunnelPreviewDecisionContext {
+        run_failed: false,
+        manual_approval_required: false,
+        now,
+    };
+    let approval = ServiceTunnelPreviewDecisionContext {
+        run_failed: false,
+        manual_approval_required: true,
+        now,
+    };
+
+    assert!(!preview_policy_allows(
+        &ServiceTunnelPreviewPolicy::default(),
+        &failed
+    ));
+    assert!(preview_policy_allows(
+        &ServiceTunnelPreviewPolicy {
+            mode: ServiceTunnelPreviewPolicyMode::Always,
+            keep_alive_until: None,
+        },
+        &success
+    ));
+    assert!(preview_policy_allows(
+        &ServiceTunnelPreviewPolicy {
+            mode: ServiceTunnelPreviewPolicyMode::OnFailure,
+            keep_alive_until: None,
+        },
+        &failed
+    ));
+    assert!(!preview_policy_allows(
+        &ServiceTunnelPreviewPolicy {
+            mode: ServiceTunnelPreviewPolicyMode::OnFailure,
+            keep_alive_until: None,
+        },
+        &success
+    ));
+    assert!(preview_policy_allows(
+        &ServiceTunnelPreviewPolicy {
+            mode: ServiceTunnelPreviewPolicyMode::ManualApproval,
+            keep_alive_until: None,
+        },
+        &approval
+    ));
+    assert!(preview_policy_allows(
+        &ServiceTunnelPreviewPolicy {
+            mode: ServiceTunnelPreviewPolicyMode::KeepAliveUntil,
+            keep_alive_until: Some("2026-06-07T12:30:00Z".to_string()),
+        },
+        &success
+    ));
+    assert!(!preview_policy_allows(
+        &ServiceTunnelPreviewPolicy {
+            mode: ServiceTunnelPreviewPolicyMode::KeepAliveUntil,
+            keep_alive_until: Some("2026-06-07T11:59:59Z".to_string()),
+        },
+        &success
+    ));
+}
+
+#[test]
+fn preview_artifact_serializes_structured_reviewer_contract() {
+    let tunnel = ServiceTunnel {
+        id: "site-preview".to_string(),
+        aliases: Vec::new(),
+        description: None,
+        server_id: "private-host".to_string(),
+        target: ServiceTunnelTarget {
+            host: "127.0.0.1".to_string(),
+            port: 3000,
+        },
+        scheme: "http".to_string(),
+        local_host: "127.0.0.1".to_string(),
+        local_port: Some(3000),
+        auth: ServiceTunnelAuth {
+            mode: ServiceTunnelAuthMode::BearerEnv,
+            env_var: Some("TOKEN".to_string()),
+            header: Some("Authorization".to_string()),
+        },
+        policy: ServiceTunnelPolicy {
+            exposure: ServiceTunnelExposure::PrivateLoopback,
+            require_auth: true,
+            allowed_clients: Vec::new(),
+            preview: ServiceTunnelPreviewPolicy {
+                mode: ServiceTunnelPreviewPolicyMode::KeepAliveUntil,
+                keep_alive_until: Some("2026-06-07T13:00:00Z".to_string()),
+            },
+        },
+    };
+    let state = ServiceTunnelRuntimeState {
+        preview_identity: ServiceTunnelPreviewIdentity {
+            service_id: "site-preview".to_string(),
+            public_url: Some("https://preview.example.test/site-preview".to_string()),
+        },
+        pid: 123,
+        process: ServiceTunnelProcessDescriptor {
+            process_group_id: Some(123),
+            command: ServiceTunnelCommandSpec {
+                command: "serve-app".to_string(),
+                cwd: Some("/workspace/app".to_string()),
+                env_keys: vec!["TOKEN".to_string()],
+            },
+        },
+        started_at: "2026-06-07T12:00:00Z".to_string(),
+        local_url: "http://127.0.0.1:3000".to_string(),
+        health_url: Some("http://127.0.0.1:3000/".to_string()),
+        logs: ServiceTunnelLogPaths {
+            stdout_path: "/tmp/homeboy/stdout.log".to_string(),
+            stderr_path: "/tmp/homeboy/stderr.log".to_string(),
+        },
+        backend: ServiceTunnelTunnelBackend::None,
+        backend_process: None,
+        source_run_id: Some("run-1".to_string()),
+        source_workflow_id: Some("workflow-1".to_string()),
+    };
+    let context = ServiceTunnelPreviewDecisionContext {
+        run_failed: false,
+        manual_approval_required: false,
+        now: chrono::DateTime::parse_from_rfc3339("2026-06-07T12:30:00Z")
+            .expect("timestamp")
+            .with_timezone(&chrono::Utc),
+    };
+
+    let artifact = preview_artifact_for(&tunnel, &state, &context).expect("artifact");
+    let serialized = serde_json::to_value(&artifact).expect("serialize artifact");
+    let expected: serde_json::Value = serde_json::from_str(include_str!(
+        "../../tests/fixtures/output_contracts/tunnel/preview-artifact.json"
+    ))
+    .expect("fixture");
+
+    assert_eq!(serialized, expected);
+    assert_eq!(serialized["schema"], "homeboy/preview-url/v1");
+    assert_eq!(serialized["kind"], "preview_url");
+    assert_eq!(serialized["service_id"], "site-preview");
+    assert_eq!(serialized["local_url"], "http://127.0.0.1:3000");
+    assert_eq!(
+        serialized["public_url"],
+        "https://preview.example.test/site-preview"
+    );
+    assert_eq!(serialized["backend"], "none");
+    assert_eq!(serialized["policy"]["mode"], "keep_alive_until");
+    assert_eq!(serialized["cleanup"]["expires_at"], "2026-06-07T13:00:00Z");
+    assert_eq!(serialized["source"]["run_id"], "run-1");
+    assert_eq!(serialized["source"]["workflow_id"], "workflow-1");
+}


### PR DESCRIPTION
## Summary
- Adds a provider-neutral `command` public tunnel backend for managed service tunnels without encoding Traforo/Kimaki/Cloudflare/ngrok semantics in Homeboy core.
- Records backend command process metadata, public URL, stdout/stderr evidence paths, status, and cleanup alongside the managed local service lifecycle.
- Documents the generic backend environment contract so concrete providers can live in an adapter command or future extension seam.

Closes #3658.

## Verification
- `cargo fmt --check`
- `cargo test tunnel::tests --lib`
- `cargo run --bin homeboy -- tunnel service start --help`

## Boundary
- Homeboy core owns lifecycle, evidence, status, and cleanup.
- Provider-specific behavior belongs in the backend command or an extension, not in core semantics.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the provider-neutral backend seam, tests, docs, and verification commands for Chris to review.