### PR TITLE
Add agent task gate feedback loop

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -117,6 +117,26 @@ set promotion `status: "gate_failed"`, exit nonzero, and include
 `failure_evidence.agent_feedback` plus stdout/stderr tails so the next cook-loop
 agent task can receive exact failure context instead of a generic shell error.
 
+`agent-task gate-feedback` converts a promotion report and the original
+`AgentTaskRequest` into a provider-neutral cook-loop decision:
+
+```bash
+homeboy agent-task gate-feedback \
+  --promotion @promotion.json \
+  --source-task @source-task.json \
+  --source-run-id "$run_id" \
+  --attempt 1 \
+  --max-attempts 3 \
+  --current-diff @current.diff
+```
+
+The command returns `homeboy/agent-task-cook-loop-report/v1`. Red gates with
+remaining budget produce `status: "retry_requested"` and a complete
+`follow_up_request` containing the failed command, exit status, log tails,
+changed files, patch artifact ref, current diff context, and source run/task
+refs. Red gates with exhausted budget return `status: "retries_exhausted"`.
+Green promotion returns `status: "green_completed"` and no follow-up task.
+
 Queued runs that should not execute can be cancelled without chat/session state:
 
 ```bash

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -50,6 +50,8 @@ pub enum AgentTaskCommand {
     Promote(PromoteArgs),
     /// Finalize a green cook run into a review-ready pull request.
     FinalizePr(FinalizePrArgs),
+    /// Convert deterministic gate results into a cook-loop retry or stop decision.
+    GateFeedback(GateFeedbackArgs),
     /// List extension-declared agent-task executor providers.
     Providers,
 }
@@ -191,6 +193,33 @@ pub struct FinalizePrArgs {
     pub ai_used_for: String,
 }
 
+#[derive(Args, Debug)]
+pub struct GateFeedbackArgs {
+    /// AgentTaskPromotionReport JSON file, @file, or - for stdin.
+    #[arg(long, value_name = "PATH")]
+    pub promotion: String,
+
+    /// Original AgentTaskRequest JSON file, @file, or - for stdin.
+    #[arg(long = "source-task", value_name = "PATH")]
+    pub source_task: String,
+
+    /// Current deterministic gate attempt number.
+    #[arg(long, default_value_t = 1, value_name = "N")]
+    pub attempt: u32,
+
+    /// Maximum deterministic gate attempts allowed for this cook loop.
+    #[arg(long = "max-attempts", default_value_t = 3, value_name = "N")]
+    pub max_attempts: u32,
+
+    /// Durable source run id to include in evidence refs.
+    #[arg(long = "source-run-id", value_name = "ID")]
+    pub source_run_id: Option<String>,
+
+    /// Current candidate diff/context as a string, @file, or - for stdin.
+    #[arg(long = "current-diff", value_name = "SPEC")]
+    pub current_diff: Option<String>,
+}
+
 pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
     match args.command {
         AgentTaskCommand::Dispatch(dispatch_args) => dispatch(dispatch_args, global),
@@ -207,6 +236,7 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::Review(review_args) => review::review(review_args),
         AgentTaskCommand::Promote(promote_args) => review::promote_artifact(promote_args),
         AgentTaskCommand::FinalizePr(finalize_args) => review::finalize_pull_request(finalize_args),
+        AgentTaskCommand::GateFeedback(feedback_args) => review::gate_feedback(feedback_args),
         AgentTaskCommand::Providers => review::providers(),
     }
 }

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -1,20 +1,21 @@
 use clap::Args;
 use serde_json::Value;
 
-use homeboy::core::agent_task::AgentTaskAggregateReport;
+use homeboy::core::agent_task::{AgentTaskAggregateReport, AgentTaskRequest};
+use homeboy::core::agent_task_cook_loop::{evaluate_cook_loop, AgentTaskCookLoopOptions};
 use homeboy::core::agent_task_finalization::{
     finalize_pr, AgentTaskGateResult, AgentTaskPrEvidence, AgentTaskPrFinalizationOptions,
 };
 use homeboy::core::agent_task_lifecycle;
 use homeboy::core::agent_task_promotion::{
-    promote, AgentTaskPromotionOptions, AgentTaskPromotionStatus,
+    promote, AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionStatus,
 };
 use homeboy::core::agent_task_provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_task_scheduler::AgentTaskAggregate;
 use homeboy::core::config;
 
 use super::super::CmdResult;
-use super::{FinalizePrArgs, PromoteArgs, ReviewArgs};
+use super::{FinalizePrArgs, GateFeedbackArgs, PromoteArgs, ReviewArgs};
 
 #[derive(Args, Debug)]
 pub struct FinalizePrEvidenceArgs {
@@ -139,6 +140,44 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
         serde_json::to_value(report).unwrap_or(Value::Null),
         exit_code,
     ))
+}
+
+pub(crate) fn gate_feedback(args: GateFeedbackArgs) -> CmdResult<Value> {
+    let promotion_raw = config::read_json_spec_to_string(&args.promotion)?;
+    let source_task_raw = config::read_json_spec_to_string(&args.source_task)?;
+    let promotion_report: AgentTaskPromotionReport =
+        serde_json::from_str(&promotion_raw).map_err(|error| {
+            homeboy::core::Error::validation_invalid_json(
+                error,
+                Some("agent-task promotion report".to_string()),
+                Some(promotion_raw.clone()),
+            )
+        })?;
+    let source_request: AgentTaskRequest =
+        serde_json::from_str(&source_task_raw).map_err(|error| {
+            homeboy::core::Error::validation_invalid_json(
+                error,
+                Some("agent-task source request".to_string()),
+                Some(source_task_raw.clone()),
+            )
+        })?;
+    let current_diff = args
+        .current_diff
+        .as_deref()
+        .map(config::read_json_spec_to_string)
+        .transpose()?
+        .unwrap_or_default();
+    let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
+        source_request,
+        promotion_report,
+        attempt: args.attempt,
+        max_attempts: args.max_attempts.max(1),
+        source_run_id: args.source_run_id,
+        current_diff,
+        metadata: Value::Null,
+    });
+
+    Ok((serde_json::to_value(report).unwrap_or(Value::Null), 0))
 }
 
 pub(crate) fn providers() -> CmdResult<Value> {

--- a/src/core/agent_task_cook_loop.rs
+++ b/src/core/agent_task_cook_loop.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use crate::core::agent_task::{
     AgentTaskRequest, AgentTaskSourceRef, AgentTaskWorkspaceMode, AGENT_TASK_REQUEST_SCHEMA,
 };
-use crate::core::agent_task_gate::{AgentTaskGateReport, AgentTaskGateStatus};
+use crate::core::agent_task_gate::{text_tail, AgentTaskGateReport, AgentTaskGateStatus};
 use crate::core::agent_task_promotion::{AgentTaskPromotionReport, AgentTaskPromotionStatus};
 
 pub const AGENT_TASK_COOK_LOOP_REPORT_SCHEMA: &str = "homeboy/agent-task-cook-loop-report/v1";
@@ -249,12 +249,6 @@ fn worktree_root_hint(report: &AgentTaskPromotionReport) -> Option<String> {
         .get("worktree_path")
         .and_then(Value::as_str)
         .map(str::to_string)
-}
-
-fn text_tail(text: &str, max_lines: usize) -> String {
-    let lines: Vec<&str> = text.lines().collect();
-    let start = lines.len().saturating_sub(max_lines);
-    lines[start..].join("\n")
 }
 
 fn cook_loop_report_schema() -> String {

--- a/src/core/agent_task_cook_loop.rs
+++ b/src/core/agent_task_cook_loop.rs
@@ -1,0 +1,448 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::core::agent_task::{
+    AgentTaskRequest, AgentTaskSourceRef, AgentTaskWorkspaceMode, AGENT_TASK_REQUEST_SCHEMA,
+};
+use crate::core::agent_task_gate::{AgentTaskGateReport, AgentTaskGateStatus};
+use crate::core::agent_task_promotion::{AgentTaskPromotionReport, AgentTaskPromotionStatus};
+
+pub const AGENT_TASK_COOK_LOOP_REPORT_SCHEMA: &str = "homeboy/agent-task-cook-loop-report/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskCookLoopOptions {
+    pub source_request: AgentTaskRequest,
+    pub promotion_report: AgentTaskPromotionReport,
+    pub attempt: u32,
+    pub max_attempts: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub current_diff: String,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskCookLoopReport {
+    #[serde(default = "cook_loop_report_schema")]
+    pub schema: String,
+    pub status: AgentTaskCookLoopStatus,
+    pub attempt: u32,
+    pub max_attempts: u32,
+    pub retry_budget_remaining: u32,
+    pub source_task_id: String,
+    pub source_run_id: Option<String>,
+    pub promotion_status: AgentTaskPromotionStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed_gates: Vec<AgentTaskCookLoopGateFailure>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub follow_up_request: Option<AgentTaskRequest>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskCookLoopStatus {
+    GreenCompleted,
+    RetryRequested,
+    RetriesExhausted,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskCookLoopGateFailure {
+    pub gate_id: String,
+    pub command: String,
+    pub exit_code: i32,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stdout_tail: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stderr_tail: String,
+    pub summary: String,
+    pub agent_feedback: String,
+}
+
+pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoopReport {
+    let failed_gates: Vec<AgentTaskCookLoopGateFailure> = options
+        .promotion_report
+        .deterministic_gates
+        .iter()
+        .filter(|gate| gate.status == AgentTaskGateStatus::Failed)
+        .map(gate_failure)
+        .collect();
+    let retry_budget_remaining = options.max_attempts.saturating_sub(options.attempt);
+    let should_retry = options.promotion_report.status == AgentTaskPromotionStatus::GateFailed
+        && !failed_gates.is_empty()
+        && retry_budget_remaining > 0;
+    let follow_up_request = should_retry.then(|| build_follow_up_request(&options, &failed_gates));
+    let status = if follow_up_request.is_some() {
+        AgentTaskCookLoopStatus::RetryRequested
+    } else if failed_gates.is_empty() {
+        AgentTaskCookLoopStatus::GreenCompleted
+    } else {
+        AgentTaskCookLoopStatus::RetriesExhausted
+    };
+
+    AgentTaskCookLoopReport {
+        schema: AGENT_TASK_COOK_LOOP_REPORT_SCHEMA.to_string(),
+        status,
+        attempt: options.attempt,
+        max_attempts: options.max_attempts,
+        retry_budget_remaining,
+        source_task_id: options.source_request.task_id.clone(),
+        source_run_id: options.source_run_id.clone(),
+        promotion_status: options.promotion_report.status,
+        failed_gates,
+        follow_up_request,
+        metadata: options.metadata,
+    }
+}
+
+fn build_follow_up_request(
+    options: &AgentTaskCookLoopOptions,
+    failed_gates: &[AgentTaskCookLoopGateFailure],
+) -> AgentTaskRequest {
+    let mut request = options.source_request.clone();
+    let next_attempt = options.attempt.saturating_add(1);
+    request.schema = AGENT_TASK_REQUEST_SCHEMA.to_string();
+    request.task_id = format!("{}-gate-fix-{}", request.task_id, next_attempt);
+    request.parent_plan_id = request
+        .parent_plan_id
+        .clone()
+        .or_else(|| options.source_run_id.clone());
+    request.instructions = follow_up_instructions(options, failed_gates);
+    request.inputs = json!({
+        "cook_loop": {
+            "source_run_id": options.source_run_id,
+            "source_task_id": options.source_request.task_id,
+            "source_patch_task_id": options.promotion_report.source.task_id,
+            "promotion_status": options.promotion_report.status,
+            "attempt": options.attempt,
+            "next_attempt": next_attempt,
+            "max_attempts": options.max_attempts,
+            "retry_budget_remaining_after_dispatch": options.max_attempts.saturating_sub(next_attempt),
+            "to_worktree": options.promotion_report.to_worktree,
+            "changed_files": options.promotion_report.changed_files,
+            "patch_artifact": options.promotion_report.patch_artifact,
+            "failed_gates": failed_gates,
+            "current_diff": options.current_diff,
+        }
+    });
+    request.source_refs.push(AgentTaskSourceRef {
+        kind: "agent-task-run".to_string(),
+        uri: options
+            .source_run_id
+            .as_ref()
+            .map(|run_id| format!("homeboy://agent-task/run/{run_id}"))
+            .unwrap_or_else(|| {
+                format!(
+                    "homeboy://agent-task/task/{}",
+                    options.source_request.task_id
+                )
+            }),
+        revision: None,
+    });
+    request.source_refs.push(AgentTaskSourceRef {
+        kind: "agent-task-promotion".to_string(),
+        uri: format!(
+            "homeboy://agent-task/promotion/{}/{}",
+            options.promotion_report.source.task_id, options.promotion_report.patch_artifact.id
+        ),
+        revision: None,
+    });
+    request.workspace.mode = AgentTaskWorkspaceMode::Existing;
+    request.workspace.root = request
+        .workspace
+        .root
+        .clone()
+        .or_else(|| worktree_root_hint(&options.promotion_report));
+    request.metadata = json!({
+        "cook_loop": {
+            "kind": "deterministic-gate-feedback",
+            "attempt": next_attempt,
+            "previous_attempt": options.attempt,
+            "max_attempts": options.max_attempts,
+            "source_task_id": options.source_request.task_id,
+            "source_run_id": options.source_run_id,
+            "failed_gate_count": failed_gates.len(),
+        }
+    });
+    request
+}
+
+fn gate_failure(gate: &AgentTaskGateReport) -> AgentTaskCookLoopGateFailure {
+    let command = gate
+        .failure_evidence
+        .as_ref()
+        .map(|evidence| evidence.command.clone())
+        .unwrap_or_else(|| gate.command.join(" "));
+    let stdout_tail = gate
+        .failure_evidence
+        .as_ref()
+        .map(|evidence| evidence.stdout_tail.clone())
+        .unwrap_or_else(|| text_tail(&gate.stdout, 20));
+    let stderr_tail = gate
+        .failure_evidence
+        .as_ref()
+        .map(|evidence| evidence.stderr_tail.clone())
+        .unwrap_or_else(|| text_tail(&gate.stderr, 20));
+    let summary = gate
+        .failure_evidence
+        .as_ref()
+        .map(|evidence| evidence.summary.clone())
+        .unwrap_or_else(|| {
+            format!(
+                "deterministic gate failed with exit code {}: {command}",
+                gate.exit_code
+            )
+        });
+    let agent_feedback = gate
+        .failure_evidence
+        .as_ref()
+        .map(|evidence| evidence.agent_feedback.clone())
+        .unwrap_or_else(|| {
+            format!(
+                "Use the deterministic gate evidence to update the candidate patch so `{command}` passes."
+            )
+        });
+
+    AgentTaskCookLoopGateFailure {
+        gate_id: gate.id.clone(),
+        command,
+        exit_code: gate.exit_code,
+        stdout_tail,
+        stderr_tail,
+        summary,
+        agent_feedback,
+    }
+}
+
+fn follow_up_instructions(
+    options: &AgentTaskCookLoopOptions,
+    failed_gates: &[AgentTaskCookLoopGateFailure],
+) -> String {
+    let gate_list = failed_gates
+        .iter()
+        .map(|failure| {
+            format!(
+                "- `{}` exited {}: {}",
+                failure.command, failure.exit_code, failure.summary
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let changed_files = if options.promotion_report.changed_files.is_empty() {
+        "none reported".to_string()
+    } else {
+        options.promotion_report.changed_files.join(", ")
+    };
+
+    format!(
+        "Continue the Homeboy cook loop from the current candidate worktree state.\n\nDeterministic gates failed after Homeboy applied the previous candidate patch. Produce a focused follow-up patch that makes the failed gates pass while preserving the candidate intent.\n\nFailed gates:\n{gate_list}\n\nChanged files in the candidate patch: {changed_files}\n\nUse the structured `inputs.cook_loop` evidence as the primary context. Return an updated patch artifact and concise summary of the fix."
+    )
+}
+
+fn worktree_root_hint(report: &AgentTaskPromotionReport) -> Option<String> {
+    report
+        .provenance
+        .get("worktree_path")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn text_tail(text: &str, max_lines: usize) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    let start = lines.len().saturating_sub(max_lines);
+    lines[start..].join("\n")
+}
+
+fn cook_loop_report_schema() -> String {
+    AGENT_TASK_COOK_LOOP_REPORT_SCHEMA.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::agent_task::{
+        AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskWorkspace,
+        AGENT_TASK_REQUEST_SCHEMA,
+    };
+    use crate::core::agent_task_gate::{
+        AgentTaskGateFailureEvidence, AGENT_TASK_GATE_REPORT_SCHEMA,
+    };
+    use crate::core::agent_task_promotion::{
+        AgentTaskPromotionArtifactRef, AgentTaskPromotionSource, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
+    };
+
+    #[test]
+    fn red_gate_creates_follow_up_request_with_failure_evidence_and_diff() {
+        let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(
+                AgentTaskPromotionStatus::GateFailed,
+                vec![failed_gate()],
+            ),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: Some("run-3676".to_string()),
+            current_diff: "diff --git a/src/lib.rs b/src/lib.rs".to_string(),
+            metadata: Value::Null,
+        });
+
+        assert_eq!(report.status, AgentTaskCookLoopStatus::RetryRequested);
+        assert_eq!(report.retry_budget_remaining, 2);
+        assert_eq!(report.failed_gates.len(), 1);
+        let request = report.follow_up_request.expect("follow-up request");
+        assert_eq!(request.task_id, "cook-homeboy-gate-fix-2");
+        assert!(request.instructions.contains("Deterministic gates failed"));
+        assert!(request.instructions.contains("cargo test agent_task_gate"));
+        assert_eq!(
+            request.inputs["cook_loop"]["failed_gates"][0]["exit_code"],
+            101
+        );
+        assert_eq!(
+            request.inputs["cook_loop"]["current_diff"],
+            "diff --git a/src/lib.rs b/src/lib.rs"
+        );
+        assert_eq!(
+            request.source_refs[0].uri,
+            "homeboy://agent-task/run/run-3676"
+        );
+        assert_eq!(request.workspace.mode, AgentTaskWorkspaceMode::Existing);
+    }
+
+    #[test]
+    fn exhausted_retry_budget_stops_without_follow_up_request() {
+        let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(
+                AgentTaskPromotionStatus::GateFailed,
+                vec![failed_gate()],
+            ),
+            attempt: 2,
+            max_attempts: 2,
+            source_run_id: Some("run-3676".to_string()),
+            current_diff: String::new(),
+            metadata: Value::Null,
+        });
+
+        assert_eq!(report.status, AgentTaskCookLoopStatus::RetriesExhausted);
+        assert_eq!(report.retry_budget_remaining, 0);
+        assert!(report.follow_up_request.is_none());
+        assert_eq!(report.failed_gates[0].stderr_tail, "boom");
+    }
+
+    #[test]
+    fn green_completion_does_not_create_follow_up_request() {
+        let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(
+                AgentTaskPromotionStatus::Applied,
+                vec![green_gate()],
+            ),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: None,
+            current_diff: String::new(),
+            metadata: Value::Null,
+        });
+
+        assert_eq!(report.status, AgentTaskCookLoopStatus::GreenCompleted);
+        assert!(report.failed_gates.is_empty());
+        assert!(report.follow_up_request.is_none());
+    }
+
+    fn source_request() -> AgentTaskRequest {
+        AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: "cook-homeboy".to_string(),
+            group_key: Some("cook".to_string()),
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "test".to_string(),
+                selector: Some("fixture".to_string()),
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                model: None,
+                config: Value::Null,
+            },
+            instructions: "Cook the issue".to_string(),
+            inputs: Value::Null,
+            source_refs: Vec::new(),
+            workspace: AgentTaskWorkspace::default(),
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: vec!["patch".to_string()],
+            metadata: Value::Null,
+        }
+    }
+
+    fn promotion_report(
+        status: AgentTaskPromotionStatus,
+        deterministic_gates: Vec<AgentTaskGateReport>,
+    ) -> AgentTaskPromotionReport {
+        AgentTaskPromotionReport {
+            schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
+            status,
+            source: AgentTaskPromotionSource {
+                kind: "aggregate".to_string(),
+                task_id: "cook-homeboy".to_string(),
+                path: Some("aggregate.json".to_string()),
+            },
+            to_worktree: "homeboy@fix-3676".to_string(),
+            patch_artifact: AgentTaskPromotionArtifactRef {
+                id: "patch".to_string(),
+                kind: "patch".to_string(),
+                path: "changes.patch".to_string(),
+                sha256: Some("abc123".to_string()),
+            },
+            changed_files: vec!["src/core/agent_task_gate.rs".to_string()],
+            dmc_commands: Vec::new(),
+            deterministic_gates,
+            provenance: json!({ "worktree_path": "/tmp/homeboy@fix-3676" }),
+        }
+    }
+
+    fn failed_gate() -> AgentTaskGateReport {
+        AgentTaskGateReport {
+            schema: AGENT_TASK_GATE_REPORT_SCHEMA.to_string(),
+            id: "gate-1".to_string(),
+            status: AgentTaskGateStatus::Failed,
+            command: vec![
+                "sh".to_string(),
+                "-lc".to_string(),
+                "cargo test agent_task_gate".to_string(),
+            ],
+            exit_code: 101,
+            stdout: "running tests".to_string(),
+            stderr: "boom".to_string(),
+            failure_evidence: Some(AgentTaskGateFailureEvidence {
+                summary: "agent_task_gate failed".to_string(),
+                command: "cargo test agent_task_gate".to_string(),
+                exit_code: 101,
+                stdout_tail: "running tests".to_string(),
+                stderr_tail: "boom".to_string(),
+                agent_feedback: "Update the patch so cargo test agent_task_gate passes."
+                    .to_string(),
+            }),
+        }
+    }
+
+    fn green_gate() -> AgentTaskGateReport {
+        AgentTaskGateReport {
+            schema: AGENT_TASK_GATE_REPORT_SCHEMA.to_string(),
+            id: "gate-1".to_string(),
+            status: AgentTaskGateStatus::Succeeded,
+            command: vec![
+                "sh".to_string(),
+                "-lc".to_string(),
+                "cargo test".to_string(),
+            ],
+            exit_code: 0,
+            stdout: "ok".to_string(),
+            stderr: String::new(),
+            failure_evidence: None,
+        }
+    }
+}

--- a/src/core/agent_task_gate.rs
+++ b/src/core/agent_task_gate.rs
@@ -106,7 +106,7 @@ fn gate_failure_evidence(
     }
 }
 
-fn text_tail(text: &str, max_lines: usize) -> String {
+pub(crate) fn text_tail(text: &str, max_lines: usize) -> String {
     let lines: Vec<&str> = text.lines().collect();
     let start = lines.len().saturating_sub(max_lines);
     lines[start..].join("\n")

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 pub mod config;
 pub mod agent_task;
 pub mod agent_task_aggregate;
+pub mod agent_task_cook_loop;
 pub mod agent_task_fanout;
 pub mod agent_task_finalization;
 pub mod agent_task_gate;


### PR DESCRIPTION
## Summary
- Adds a provider-neutral `homeboy/agent-task-cook-loop-report/v1` evaluator that turns deterministic gate failures into structured follow-up `AgentTaskRequest` payloads.
- Adds `homeboy agent-task gate-feedback` for converting promotion reports plus original task requests into `retry_requested`, `retries_exhausted`, or `green_completed` decisions.
- Documents the red-gate feedback path for the headless agent-task cook loop.

Closes #3676.

## Tests
- `cargo fmt`
- `cargo test agent_task_cook_loop`
- `cargo test agent_task_gate`
- `cargo test agent_task_promotion`
- `cargo test agent_task_finalization`
- `cargo test command_surface`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the cook-loop evaluator, CLI wiring, focused tests, and docs; Chris reviews and owns the change.