### PR TITLE
Refactor agent task promotion workspace seam

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -111,9 +111,13 @@ pub struct ReviewArgs {
     /// Durable run id returned by `agent-task submit`, `dispatch`, or `run-plan --record-run-id`.
     pub run_id: String,
 
-    /// Managed DMC worktree handle to include in generated promotion commands.
+    /// Target workspace handle to include in generated promotion commands.
     #[arg(long, value_name = "HANDLE")]
     pub to_worktree: Option<String>,
+
+    /// External workspace provider command to include in generated promotion commands.
+    #[arg(long, value_name = "COMMAND")]
+    pub provider_command: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -122,9 +126,13 @@ pub struct PromoteArgs {
     #[arg(value_name = "SOURCE")]
     pub source: String,
 
-    /// Managed DMC worktree handle to apply into, e.g. repo@branch-slug.
+    /// Target workspace handle to apply into.
     #[arg(long, value_name = "HANDLE")]
     pub to_worktree: String,
+
+    /// External workspace provider command. When omitted, HOMEBOY_AGENT_TASK_PROMOTION_COMMAND is used.
+    #[arg(long, value_name = "COMMAND")]
+    pub provider_command: Option<String>,
 
     /// Outcome task id to select when SOURCE is an aggregate.
     #[arg(long, value_name = "TASK_ID")]
@@ -789,6 +797,7 @@ mod tests {
             let (value, exit_code) = review::review(ReviewArgs {
                 run_id: "run-review-queued".to_string(),
                 to_worktree: None,
+                provider_command: None,
             })
             .expect("review loaded");
 
@@ -819,6 +828,7 @@ mod tests {
             let (value, exit_code) = review::review(ReviewArgs {
                 run_id: "run-review-completed".to_string(),
                 to_worktree: Some("homeboy@fix-review-flow".to_string()),
+                provider_command: None,
             })
             .expect("review loaded");
 
@@ -835,7 +845,7 @@ mod tests {
                     "homeboy",
                     "agent-task",
                     "promote",
-                    "run-review-completed",
+                    value["aggregate_path"].as_str().expect("aggregate path"),
                     "--task-id",
                     "task-a",
                     "--artifact-id",

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -61,7 +61,15 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
         .map(|aggregate| AgentTaskAggregateReport::from(aggregate.outcomes.clone()));
     let promotion_candidates = aggregate_review
         .as_ref()
-        .map(|review| promotion_candidates(&args.run_id, args.to_worktree.as_deref(), review))
+        .map(|review| {
+            let promotion_source = record.aggregate_path.as_deref().unwrap_or(&args.run_id);
+            promotion_candidates(
+                promotion_source,
+                args.to_worktree.as_deref(),
+                args.provider_command.as_deref(),
+                review,
+            )
+        })
         .unwrap_or_default();
     let next_actions = review_next_actions(
         &record.state,
@@ -102,6 +110,7 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
         artifact_id: args.artifact_id,
         dry_run: args.dry_run,
         verify: args.verify,
+        provider_command: args.provider_command,
     })?;
     let exit_code = if report.status == AgentTaskPromotionStatus::GateFailed {
         1
@@ -211,8 +220,9 @@ fn completed_run_aggregate(run_id: &str) -> Option<homeboy::core::Result<AgentTa
 }
 
 fn promotion_candidates(
-    run_id: &str,
+    source: &str,
     to_worktree: Option<&str>,
+    provider_command: Option<&str>,
     review: &AgentTaskAggregateReport,
 ) -> Vec<Value> {
     review
@@ -224,7 +234,7 @@ fn promotion_candidates(
                     "homeboy".to_string(),
                     "agent-task".to_string(),
                     "promote".to_string(),
-                    run_id.to_string(),
+                    source.to_string(),
                     "--task-id".to_string(),
                     candidate.task_id.clone(),
                     "--artifact-id".to_string(),
@@ -233,6 +243,10 @@ fn promotion_candidates(
                 if let Some(to_worktree) = to_worktree {
                     command.push("--to-worktree".to_string());
                     command.push(to_worktree.to_string());
+                }
+                if let Some(provider_command) = provider_command {
+                    command.push("--provider-command".to_string());
+                    command.push(provider_command.to_string());
                 }
 
                 serde_json::json!({

--- a/src/core/agent_task_cook_loop.rs
+++ b/src/core/agent_task_cook_loop.rs
@@ -392,7 +392,7 @@ mod tests {
                 sha256: Some("abc123".to_string()),
             },
             changed_files: vec!["src/core/agent_task_gate.rs".to_string()],
-            dmc_commands: Vec::new(),
+            command_evidence: Vec::new(),
             deterministic_gates,
             provenance: json!({ "worktree_path": "/tmp/homeboy@fix-3676" }),
         }

--- a/src/core/agent_task_promotion.rs
+++ b/src/core/agent_task_promotion.rs
@@ -39,7 +39,8 @@ pub struct AgentTaskPromotionReport {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub changed_files: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub dmc_commands: Vec<AgentTaskPromotionCommandReport>,
+    #[serde(rename = "dmc_commands")]
+    pub command_evidence: Vec<AgentTaskPromotionCommandReport>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub deterministic_gates: Vec<AgentTaskGateReport>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
@@ -82,12 +83,12 @@ pub struct AgentTaskPromotionCommandReport {
 }
 
 pub fn promote(options: AgentTaskPromotionOptions) -> Result<AgentTaskPromotionReport> {
-    promote_with_runner(options, &mut DmcPromotionRunner)
+    promote_with_adapter(options, &mut DmcPromotionWorkspaceAdapter)
 }
 
-fn promote_with_runner(
+fn promote_with_adapter(
     options: AgentTaskPromotionOptions,
-    runner: &mut impl AgentTaskPromotionRunner,
+    workspace: &mut impl AgentTaskPromotionWorkspaceAdapter,
 ) -> Result<AgentTaskPromotionReport> {
     validate_worktree_handle(&options.to_worktree)?;
     let source_value: Value = serde_json::from_str(&options.source).map_err(|error| {
@@ -122,28 +123,13 @@ fn promote_with_runner(
     validate_artifact_content(&artifact, &patch)?;
     let changed_files = validate_patch(&patch)?;
 
-    let mut dmc_commands = Vec::new();
+    let mut command_evidence = Vec::new();
     let mut applied_worktree_path = None;
     if !options.dry_run {
-        let worktree_path = match runner.worktree_path(&options.to_worktree)? {
-            Some(path) => path,
-            None => {
-                dmc_commands.append(&mut runner.ensure_worktree(&options.to_worktree)?);
-                runner.worktree_path(&options.to_worktree)?.ok_or_else(|| {
-                    Error::validation_invalid_argument(
-                        "to_worktree",
-                        format!(
-                            "managed worktree {} was not found after creation",
-                            options.to_worktree
-                        ),
-                        None,
-                        None,
-                    )
-                })?
-            }
-        };
-        dmc_commands.push(runner.apply_patch(&options.to_worktree, &patch_path)?);
-        applied_worktree_path = Some(worktree_path);
+        let target = workspace.ensure_workspace(&options.to_worktree)?;
+        command_evidence.extend(target.command_evidence);
+        command_evidence.push(workspace.apply_patch(&options.to_worktree, &patch_path)?);
+        applied_worktree_path = Some(target.path);
     }
 
     let mut deterministic_gates = Vec::new();
@@ -157,7 +143,7 @@ fn promote_with_runner(
             )
         })?;
         for (index, command) in options.verify.iter().enumerate() {
-            deterministic_gates.push(runner.verify(worktree_path, index + 1, command)?);
+            deterministic_gates.push(workspace.verify(worktree_path, index + 1, command)?);
         }
     }
     let has_gate_failure = deterministic_gates
@@ -189,7 +175,7 @@ fn promote_with_runner(
             sha256: artifact.sha256,
         },
         changed_files,
-        dmc_commands,
+        command_evidence,
         deterministic_gates,
         provenance: json!({
             "source_schema": outcome.schema,
@@ -198,9 +184,14 @@ fn promote_with_runner(
     })
 }
 
-trait AgentTaskPromotionRunner {
-    fn worktree_path(&mut self, handle: &str) -> Result<Option<PathBuf>>;
-    fn ensure_worktree(&mut self, handle: &str) -> Result<Vec<AgentTaskPromotionCommandReport>>;
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AgentTaskPromotionWorkspace {
+    path: PathBuf,
+    command_evidence: Vec<AgentTaskPromotionCommandReport>,
+}
+
+trait AgentTaskPromotionWorkspaceAdapter {
+    fn ensure_workspace(&mut self, handle: &str) -> Result<AgentTaskPromotionWorkspace>;
     fn apply_patch(
         &mut self,
         handle: &str,
@@ -209,15 +200,30 @@ trait AgentTaskPromotionRunner {
     fn verify(&mut self, cwd: &Path, index: usize, command: &str) -> Result<AgentTaskGateReport>;
 }
 
-struct DmcPromotionRunner;
+struct DmcPromotionWorkspaceAdapter;
 
-impl AgentTaskPromotionRunner for DmcPromotionRunner {
-    fn worktree_path(&mut self, handle: &str) -> Result<Option<PathBuf>> {
-        dmc_worktree_path(handle)
-    }
+impl AgentTaskPromotionWorkspaceAdapter for DmcPromotionWorkspaceAdapter {
+    fn ensure_workspace(&mut self, handle: &str) -> Result<AgentTaskPromotionWorkspace> {
+        let mut command_evidence = Vec::new();
+        let path = match self.worktree_path(handle)? {
+            Some(path) => path,
+            None => {
+                command_evidence.push(self.add_worktree(handle)?);
+                self.worktree_path(handle)?.ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "to_worktree",
+                        format!("managed worktree {} was not found after creation", handle),
+                        None,
+                        None,
+                    )
+                })?
+            }
+        };
 
-    fn ensure_worktree(&mut self, handle: &str) -> Result<Vec<AgentTaskPromotionCommandReport>> {
-        ensure_worktree(handle)
+        Ok(AgentTaskPromotionWorkspace {
+            path,
+            command_evidence,
+        })
     }
 
     fn apply_patch(
@@ -225,11 +231,21 @@ impl AgentTaskPromotionRunner for DmcPromotionRunner {
         handle: &str,
         patch_path: &Path,
     ) -> Result<AgentTaskPromotionCommandReport> {
-        apply_patch_with_dmc(handle, patch_path)
+        run_command(dmc_patch_apply_command(handle, patch_path), None)
     }
 
     fn verify(&mut self, cwd: &Path, index: usize, command: &str) -> Result<AgentTaskGateReport> {
         run_gate_command(cwd, index, command)
+    }
+}
+
+impl DmcPromotionWorkspaceAdapter {
+    fn worktree_path(&mut self, handle: &str) -> Result<Option<PathBuf>> {
+        dmc_worktree_path(handle)
+    }
+
+    fn add_worktree(&mut self, handle: &str) -> Result<AgentTaskPromotionCommandReport> {
+        run_command(dmc_worktree_add_command(handle)?, None)
     }
 }
 
@@ -466,13 +482,9 @@ fn split_worktree_handle(handle: &str) -> Result<(&str, &str)> {
     })
 }
 
-fn ensure_worktree(handle: &str) -> Result<Vec<AgentTaskPromotionCommandReport>> {
-    if dmc_worktree_path(handle)?.is_some() {
-        return Ok(Vec::new());
-    }
-
+fn dmc_worktree_add_command(handle: &str) -> Result<Vec<String>> {
     let (repo, branch) = split_worktree_handle(handle)?;
-    let command = vec![
+    Ok(vec![
         "studio".to_string(),
         "wp".to_string(),
         "datamachine-code".to_string(),
@@ -481,45 +493,39 @@ fn ensure_worktree(handle: &str) -> Result<Vec<AgentTaskPromotionCommandReport>>
         "add".to_string(),
         repo.to_string(),
         branch.to_string(),
-    ];
-    Ok(vec![run_command(command, None)?])
+    ])
 }
 
-fn apply_patch_with_dmc(
-    handle: &str,
-    patch_path: &Path,
-) -> Result<AgentTaskPromotionCommandReport> {
-    run_command(
-        vec![
-            "studio".to_string(),
-            "wp".to_string(),
-            "datamachine-code".to_string(),
-            "workspace".to_string(),
-            "patch".to_string(),
-            "apply".to_string(),
-            handle.to_string(),
-            format!("--patch=@{}", patch_path.display()),
-            "--format=json".to_string(),
-        ],
-        None,
-    )
+fn dmc_patch_apply_command(handle: &str, patch_path: &Path) -> Vec<String> {
+    vec![
+        "studio".to_string(),
+        "wp".to_string(),
+        "datamachine-code".to_string(),
+        "workspace".to_string(),
+        "patch".to_string(),
+        "apply".to_string(),
+        handle.to_string(),
+        format!("--patch=@{}", patch_path.display()),
+        "--format=json".to_string(),
+    ]
+}
+
+fn dmc_worktree_list_command(repo: &str) -> Vec<String> {
+    vec![
+        "studio".to_string(),
+        "wp".to_string(),
+        "datamachine-code".to_string(),
+        "workspace".to_string(),
+        "worktree".to_string(),
+        "list".to_string(),
+        repo.to_string(),
+        "--format=json".to_string(),
+    ]
 }
 
 fn dmc_worktree_path(handle: &str) -> Result<Option<PathBuf>> {
     let (repo, _) = split_worktree_handle(handle)?;
-    let report = run_command(
-        vec![
-            "studio".to_string(),
-            "wp".to_string(),
-            "datamachine-code".to_string(),
-            "workspace".to_string(),
-            "worktree".to_string(),
-            "list".to_string(),
-            repo.to_string(),
-            "--format=json".to_string(),
-        ],
-        None,
-    )?;
+    let report = run_command(dmc_worktree_list_command(repo), None)?;
     let rows: Value = serde_json::from_str(&report.stdout).map_err(|error| {
         Error::validation_invalid_json(
             error,
@@ -591,37 +597,44 @@ mod tests {
     const VALID_PATCH: &str = "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
 
     #[derive(Debug, Default)]
-    struct FakePromotionRunner {
-        worktree_path: Option<PathBuf>,
+    struct FakePromotionWorkspaceAdapter {
+        workspace_path: Option<PathBuf>,
         ensure_creates_worktree: bool,
         ensure_calls: Vec<String>,
         apply_calls: Vec<(String, PathBuf)>,
         verify_calls: Vec<(PathBuf, String)>,
     }
 
-    impl AgentTaskPromotionRunner for FakePromotionRunner {
-        fn worktree_path(&mut self, _handle: &str) -> Result<Option<PathBuf>> {
-            Ok(self.worktree_path.clone())
-        }
-
-        fn ensure_worktree(
-            &mut self,
-            handle: &str,
-        ) -> Result<Vec<AgentTaskPromotionCommandReport>> {
+    impl AgentTaskPromotionWorkspaceAdapter for FakePromotionWorkspaceAdapter {
+        fn ensure_workspace(&mut self, handle: &str) -> Result<AgentTaskPromotionWorkspace> {
             self.ensure_calls.push(handle.to_string());
-            if self.ensure_creates_worktree {
-                self.worktree_path = Some(PathBuf::from("/tmp/homeboy-controlled-worktree"));
-            }
-            Ok(vec![command_report(vec![
-                "studio",
-                "wp",
-                "datamachine-code",
-                "workspace",
-                "worktree",
-                "add",
-                "repo",
-                "controlled-worktree",
-            ])])
+            let already_exists = self.workspace_path.is_some();
+            let path = self
+                .workspace_path
+                .clone()
+                .or_else(|| {
+                    self.ensure_creates_worktree
+                        .then(|| PathBuf::from("/tmp/homeboy-controlled-workspace"))
+                })
+                .ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "to_worktree",
+                        "fake workspace adapter could not resolve the requested workspace",
+                        None,
+                        None,
+                    )
+                })?;
+
+            self.workspace_path = Some(path.clone());
+            let command_evidence = if already_exists {
+                Vec::new()
+            } else {
+                vec![command_report(vec!["fake-workspace", "ensure", handle])]
+            };
+            Ok(AgentTaskPromotionWorkspace {
+                path,
+                command_evidence,
+            })
         }
 
         fn apply_patch(
@@ -632,12 +645,8 @@ mod tests {
             self.apply_calls
                 .push((handle.to_string(), patch_path.to_path_buf()));
             Ok(command_report(vec![
-                "studio",
-                "wp",
-                "datamachine-code",
-                "workspace",
-                "patch",
-                "apply",
+                "fake-workspace",
+                "apply-patch",
                 handle,
             ]))
         }
@@ -847,21 +856,21 @@ mod tests {
         assert_eq!(report.source.task_id, "task-1");
         assert_eq!(report.patch_artifact.id, "patch");
         assert_eq!(report.changed_files, vec!["src/lib.rs"]);
-        assert!(report.dmc_commands.is_empty());
+        assert!(report.command_evidence.is_empty());
         assert!(report.deterministic_gates.is_empty());
     }
 
     #[test]
-    fn promote_applies_patch_into_existing_controlled_worktree() {
+    fn promote_applies_patch_with_fake_workspace_adapter() {
         let temp = tempfile::tempdir().expect("tempdir");
         let worktree_path = temp.path().join("controlled-worktree");
         let (source_path, source) = write_patch_source(&temp);
-        let mut runner = FakePromotionRunner {
-            worktree_path: Some(worktree_path.clone()),
+        let mut adapter = FakePromotionWorkspaceAdapter {
+            workspace_path: Some(worktree_path.clone()),
             ..Default::default()
         };
 
-        let report = promote_with_runner(
+        let report = promote_with_adapter(
             AgentTaskPromotionOptions {
                 source,
                 source_path: Some(source_path),
@@ -871,24 +880,25 @@ mod tests {
                 dry_run: false,
                 verify: vec!["cargo test --lib agent_task_promotion".to_string()],
             },
-            &mut runner,
+            &mut adapter,
         )
         .expect("applied promotion report");
 
         assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
         assert_eq!(report.changed_files, vec!["src/lib.rs"]);
-        assert!(runner.ensure_calls.is_empty());
-        assert_eq!(runner.apply_calls.len(), 1);
-        assert_eq!(runner.apply_calls[0].0, "repo@controlled-worktree");
-        assert!(runner.apply_calls[0].1.ends_with("changes.patch"));
+        assert_eq!(adapter.ensure_calls, vec!["repo@controlled-worktree"]);
+        assert_eq!(adapter.apply_calls.len(), 1);
+        assert_eq!(adapter.apply_calls[0].0, "repo@controlled-worktree");
+        assert!(adapter.apply_calls[0].1.ends_with("changes.patch"));
         assert_eq!(
-            runner.verify_calls,
+            adapter.verify_calls,
             vec![(
                 worktree_path,
                 "cargo test --lib agent_task_promotion".to_string()
             )]
         );
-        assert_eq!(report.dmc_commands.len(), 1);
+        assert_eq!(report.command_evidence.len(), 1);
+        assert_eq!(report.command_evidence[0].command[0], "fake-workspace");
         assert_eq!(report.deterministic_gates.len(), 1);
         assert_eq!(report.deterministic_gates[0].id, "gate-1");
     }
@@ -897,12 +907,12 @@ mod tests {
     fn promote_creates_missing_worktree_before_apply() {
         let temp = tempfile::tempdir().expect("tempdir");
         let (source_path, source) = write_patch_source(&temp);
-        let mut runner = FakePromotionRunner {
+        let mut adapter = FakePromotionWorkspaceAdapter {
             ensure_creates_worktree: true,
             ..Default::default()
         };
 
-        let report = promote_with_runner(
+        let report = promote_with_adapter(
             AgentTaskPromotionOptions {
                 source,
                 source_path: Some(source_path),
@@ -912,12 +922,91 @@ mod tests {
                 dry_run: false,
                 verify: Vec::new(),
             },
-            &mut runner,
+            &mut adapter,
         )
         .expect("applied promotion report");
 
-        assert_eq!(runner.ensure_calls, vec!["repo@controlled-worktree"]);
-        assert_eq!(runner.apply_calls.len(), 1);
-        assert_eq!(report.dmc_commands.len(), 2);
+        assert_eq!(adapter.ensure_calls, vec!["repo@controlled-worktree"]);
+        assert_eq!(adapter.apply_calls.len(), 1);
+        assert_eq!(report.command_evidence.len(), 2);
+        assert_eq!(report.command_evidence[0].command[0], "fake-workspace");
+    }
+
+    #[test]
+    fn promotion_report_serializes_command_evidence_with_legacy_key() {
+        let report = AgentTaskPromotionReport {
+            schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
+            status: AgentTaskPromotionStatus::Applied,
+            source: AgentTaskPromotionSource {
+                kind: "outcome".to_string(),
+                task_id: "task-1".to_string(),
+                path: None,
+            },
+            to_worktree: "repo@controlled-worktree".to_string(),
+            patch_artifact: AgentTaskPromotionArtifactRef {
+                id: "patch".to_string(),
+                kind: "patch".to_string(),
+                path: "changes.patch".to_string(),
+                sha256: None,
+            },
+            changed_files: vec!["src/lib.rs".to_string()],
+            command_evidence: vec![command_report(vec!["fake-workspace", "apply-patch"])],
+            deterministic_gates: Vec::new(),
+            provenance: Value::Null,
+        };
+
+        let value = serde_json::to_value(report).expect("serialize report");
+
+        assert!(value.get("command_evidence").is_none());
+        assert_eq!(
+            value["dmc_commands"][0]["command"][0].as_str(),
+            Some("fake-workspace")
+        );
+    }
+
+    #[test]
+    fn dmc_adapter_preserves_current_command_shapes() {
+        let patch_path = PathBuf::from("/tmp/changes.patch");
+
+        assert_eq!(
+            dmc_worktree_add_command("homeboy@fix-3690").expect("add command"),
+            vec![
+                "studio",
+                "wp",
+                "datamachine-code",
+                "workspace",
+                "worktree",
+                "add",
+                "homeboy",
+                "fix-3690"
+            ]
+        );
+        assert_eq!(
+            dmc_patch_apply_command("homeboy@fix-3690", &patch_path),
+            vec![
+                "studio",
+                "wp",
+                "datamachine-code",
+                "workspace",
+                "patch",
+                "apply",
+                "homeboy@fix-3690",
+                "--patch=@/tmp/changes.patch",
+                "--format=json"
+            ]
+        );
+        assert_eq!(
+            dmc_worktree_list_command("homeboy"),
+            vec![
+                "studio",
+                "wp",
+                "datamachine-code",
+                "workspace",
+                "worktree",
+                "list",
+                "homeboy",
+                "--format=json"
+            ]
+        );
     }
 }

--- a/src/core/agent_task_promotion.rs
+++ b/src/core/agent_task_promotion.rs
@@ -1,5 +1,6 @@
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -14,6 +15,7 @@ use crate::core::agent_task_timeout_artifacts::is_actionable_patch_artifact;
 use crate::core::{Error, Result};
 
 pub const AGENT_TASK_PROMOTION_REPORT_SCHEMA: &str = "homeboy/agent-task-promotion-report/v1";
+const PROMOTION_PROVIDER_COMMAND_ENV: &str = "HOMEBOY_AGENT_TASK_PROMOTION_COMMAND";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskPromotionOptions {
@@ -26,6 +28,8 @@ pub struct AgentTaskPromotionOptions {
     pub dry_run: bool,
     #[serde(default)]
     pub verify: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_command: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -39,7 +43,6 @@ pub struct AgentTaskPromotionReport {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub changed_files: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[serde(rename = "dmc_commands")]
     pub command_evidence: Vec<AgentTaskPromotionCommandReport>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub deterministic_gates: Vec<AgentTaskGateReport>,
@@ -83,14 +86,15 @@ pub struct AgentTaskPromotionCommandReport {
 }
 
 pub fn promote(options: AgentTaskPromotionOptions) -> Result<AgentTaskPromotionReport> {
-    promote_with_adapter(options, &mut DmcPromotionWorkspaceAdapter)
+    let mut provider = ExternalPromotionWorkspaceProvider::from_options(&options);
+    promote_with_provider(options, &mut provider)
 }
 
-fn promote_with_adapter(
+fn promote_with_provider(
     options: AgentTaskPromotionOptions,
-    workspace: &mut impl AgentTaskPromotionWorkspaceAdapter,
+    provider: &mut impl AgentTaskPromotionWorkspaceProvider,
 ) -> Result<AgentTaskPromotionReport> {
-    validate_worktree_handle(&options.to_worktree)?;
+    validate_workspace_handle(&options.to_worktree)?;
     let source_value: Value = serde_json::from_str(&options.source).map_err(|error| {
         Error::validation_invalid_json(
             error,
@@ -126,9 +130,13 @@ fn promote_with_adapter(
     let mut command_evidence = Vec::new();
     let mut applied_worktree_path = None;
     if !options.dry_run {
-        let target = workspace.ensure_workspace(&options.to_worktree)?;
+        let target = provider.apply_patch(AgentTaskPromotionApplyRequest {
+            schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+            to_workspace: options.to_worktree.clone(),
+            patch_path: patch_path.display().to_string(),
+            changed_files: changed_files.clone(),
+        })?;
         command_evidence.extend(target.command_evidence);
-        command_evidence.push(workspace.apply_patch(&options.to_worktree, &patch_path)?);
         applied_worktree_path = Some(target.path);
     }
 
@@ -143,7 +151,7 @@ fn promote_with_adapter(
             )
         })?;
         for (index, command) in options.verify.iter().enumerate() {
-            deterministic_gates.push(workspace.verify(worktree_path, index + 1, command)?);
+            deterministic_gates.push(provider.verify(worktree_path, index + 1, command)?);
         }
     }
     let has_gate_failure = deterministic_gates
@@ -184,68 +192,77 @@ fn promote_with_adapter(
     })
 }
 
+const AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA: &str =
+    "homeboy/agent-task-promotion-apply-request/v1";
+const AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA: &str =
+    "homeboy/agent-task-promotion-apply-response/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct AgentTaskPromotionApplyRequest {
+    schema: String,
+    to_workspace: String,
+    patch_path: String,
+    changed_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct AgentTaskPromotionApplyResponse {
+    #[serde(default)]
+    schema: String,
+    workspace_path: String,
+    #[serde(default)]
+    command_evidence: Vec<AgentTaskPromotionCommandReport>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AgentTaskPromotionWorkspace {
     path: PathBuf,
     command_evidence: Vec<AgentTaskPromotionCommandReport>,
 }
 
-trait AgentTaskPromotionWorkspaceAdapter {
-    fn ensure_workspace(&mut self, handle: &str) -> Result<AgentTaskPromotionWorkspace>;
+trait AgentTaskPromotionWorkspaceProvider {
     fn apply_patch(
         &mut self,
-        handle: &str,
-        patch_path: &Path,
-    ) -> Result<AgentTaskPromotionCommandReport>;
+        request: AgentTaskPromotionApplyRequest,
+    ) -> Result<AgentTaskPromotionWorkspace>;
     fn verify(&mut self, cwd: &Path, index: usize, command: &str) -> Result<AgentTaskGateReport>;
 }
 
-struct DmcPromotionWorkspaceAdapter;
+struct ExternalPromotionWorkspaceProvider {
+    command: Option<String>,
+}
 
-impl AgentTaskPromotionWorkspaceAdapter for DmcPromotionWorkspaceAdapter {
-    fn ensure_workspace(&mut self, handle: &str) -> Result<AgentTaskPromotionWorkspace> {
-        let mut command_evidence = Vec::new();
-        let path = match self.worktree_path(handle)? {
-            Some(path) => path,
-            None => {
-                command_evidence.push(self.add_worktree(handle)?);
-                self.worktree_path(handle)?.ok_or_else(|| {
-                    Error::validation_invalid_argument(
-                        "to_worktree",
-                        format!("managed worktree {} was not found after creation", handle),
-                        None,
-                        None,
-                    )
-                })?
-            }
-        };
-
-        Ok(AgentTaskPromotionWorkspace {
-            path,
-            command_evidence,
-        })
+impl ExternalPromotionWorkspaceProvider {
+    fn from_options(options: &AgentTaskPromotionOptions) -> Self {
+        Self {
+            command: options
+                .provider_command
+                .clone()
+                .or_else(|| std::env::var(PROMOTION_PROVIDER_COMMAND_ENV).ok()),
+        }
     }
+}
 
+impl AgentTaskPromotionWorkspaceProvider for ExternalPromotionWorkspaceProvider {
     fn apply_patch(
         &mut self,
-        handle: &str,
-        patch_path: &Path,
-    ) -> Result<AgentTaskPromotionCommandReport> {
-        run_command(dmc_patch_apply_command(handle, patch_path), None)
+        request: AgentTaskPromotionApplyRequest,
+    ) -> Result<AgentTaskPromotionWorkspace> {
+        let command = self.command.as_deref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "promotion_provider",
+                format!(
+                    "agent-task promotion requires a workspace provider command; pass --provider-command or set {PROMOTION_PROVIDER_COMMAND_ENV}"
+                ),
+                None,
+                None,
+            )
+        })?;
+        run_provider_command(command, &request)
     }
 
     fn verify(&mut self, cwd: &Path, index: usize, command: &str) -> Result<AgentTaskGateReport> {
         run_gate_command(cwd, index, command)
-    }
-}
-
-impl DmcPromotionWorkspaceAdapter {
-    fn worktree_path(&mut self, handle: &str) -> Result<Option<PathBuf>> {
-        dmc_worktree_path(handle)
-    }
-
-    fn add_worktree(&mut self, handle: &str) -> Result<AgentTaskPromotionCommandReport> {
-        run_command(dmc_worktree_add_command(handle)?, None)
     }
 }
 
@@ -458,12 +475,11 @@ fn validate_patch_path(path: &str) -> Result<()> {
     Ok(())
 }
 
-fn validate_worktree_handle(handle: &str) -> Result<()> {
-    let (repo, branch) = split_worktree_handle(handle)?;
-    if repo.is_empty() || branch.is_empty() {
+fn validate_workspace_handle(handle: &str) -> Result<()> {
+    if handle.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
             "to_worktree",
-            "worktree handle must use <repo>@<branch-slug>",
+            "target workspace handle must not be empty",
             None,
             None,
         ));
@@ -471,102 +487,55 @@ fn validate_worktree_handle(handle: &str) -> Result<()> {
     Ok(())
 }
 
-fn split_worktree_handle(handle: &str) -> Result<(&str, &str)> {
-    handle.split_once('@').ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "to_worktree",
-            "worktree handle must use <repo>@<branch-slug>",
-            None,
-            None,
-        )
-    })
-}
-
-fn dmc_worktree_add_command(handle: &str) -> Result<Vec<String>> {
-    let (repo, branch) = split_worktree_handle(handle)?;
-    Ok(vec![
-        "studio".to_string(),
-        "wp".to_string(),
-        "datamachine-code".to_string(),
-        "workspace".to_string(),
-        "worktree".to_string(),
-        "add".to_string(),
-        repo.to_string(),
-        branch.to_string(),
-    ])
-}
-
-fn dmc_patch_apply_command(handle: &str, patch_path: &Path) -> Vec<String> {
-    vec![
-        "studio".to_string(),
-        "wp".to_string(),
-        "datamachine-code".to_string(),
-        "workspace".to_string(),
-        "patch".to_string(),
-        "apply".to_string(),
-        handle.to_string(),
-        format!("--patch=@{}", patch_path.display()),
-        "--format=json".to_string(),
-    ]
-}
-
-fn dmc_worktree_list_command(repo: &str) -> Vec<String> {
-    vec![
-        "studio".to_string(),
-        "wp".to_string(),
-        "datamachine-code".to_string(),
-        "workspace".to_string(),
-        "worktree".to_string(),
-        "list".to_string(),
-        repo.to_string(),
-        "--format=json".to_string(),
-    ]
-}
-
-fn dmc_worktree_path(handle: &str) -> Result<Option<PathBuf>> {
-    let (repo, _) = split_worktree_handle(handle)?;
-    let report = run_command(dmc_worktree_list_command(repo), None)?;
-    let rows: Value = serde_json::from_str(&report.stdout).map_err(|error| {
+fn run_provider_command(
+    command: &str,
+    request: &AgentTaskPromotionApplyRequest,
+) -> Result<AgentTaskPromotionWorkspace> {
+    let request_json = serde_json::to_vec(request).map_err(|error| {
         Error::validation_invalid_json(
             error,
-            Some("datamachine-code worktree list output".to_string()),
-            Some(report.stdout.clone()),
-        )
-    })?;
-    let rows = rows.as_array().ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "datamachine-code worktree list output",
-            "expected a JSON array of worktree rows",
+            Some("agent-task promotion provider request".to_string()),
             None,
-            Some(vec![report.stdout.clone()]),
         )
     })?;
-
-    Ok(rows
-        .iter()
-        .find(|row| row.get("handle").and_then(Value::as_str) == Some(handle))
-        .and_then(|row| row.get("path").and_then(Value::as_str))
-        .map(PathBuf::from))
-}
-
-fn run_command(
-    command: Vec<String>,
-    cwd: Option<&Path>,
-) -> Result<AgentTaskPromotionCommandReport> {
-    let mut process = Command::new(&command[0]);
-    process.args(&command[1..]);
-    if let Some(cwd) = cwd {
-        process.current_dir(cwd);
-    }
-    let output = process.output().map_err(|error| {
+    let mut process = Command::new("sh")
+        .arg("-lc")
+        .arg(command)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("start agent-task promotion provider command".to_string()),
+            )
+        })?;
+    process
+        .stdin
+        .as_mut()
+        .ok_or_else(|| {
+            Error::internal_io(
+                "provider command stdin was not available".to_string(),
+                Some("write agent-task promotion provider request".to_string()),
+            )
+        })?
+        .write_all(&request_json)
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("write agent-task promotion provider request".to_string()),
+            )
+        })?;
+    let output = process.wait_with_output().map_err(|error| {
         Error::internal_io(
             error.to_string(),
-            Some(format!("run {}", command.join(" "))),
+            Some("run agent-task promotion provider command".to_string()),
         )
     })?;
     let exit_code = output.status.code().unwrap_or(1);
     let report = AgentTaskPromotionCommandReport {
-        command,
+        command: vec!["sh".to_string(), "-lc".to_string(), command.to_string()],
         exit_code,
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),
         stderr: String::from_utf8_lossy(&output.stderr).to_string(),
@@ -575,7 +544,7 @@ fn run_command(
         return Err(Error::validation_invalid_argument(
             "command",
             format!(
-                "promotion command failed with exit code {}: {}",
+                "promotion provider command failed with exit code {}: {}",
                 exit_code,
                 report.command.join(" ")
             ),
@@ -583,7 +552,43 @@ fn run_command(
             Some(vec![report.stderr.clone()]),
         ));
     }
-    Ok(report)
+    let response: AgentTaskPromotionApplyResponse =
+        serde_json::from_str(&report.stdout).map_err(|error| {
+            Error::validation_invalid_json(
+                error,
+                Some("agent-task promotion provider response".to_string()),
+                Some(report.stdout.clone()),
+            )
+        })?;
+    if !response.schema.is_empty() && response.schema != AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA
+    {
+        return Err(Error::validation_invalid_argument(
+            "promotion_provider.response.schema",
+            format!(
+                "expected {}, got {}",
+                AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA, response.schema
+            ),
+            None,
+            None,
+        ));
+    }
+    if response.workspace_path.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "promotion_provider.response.workspace_path",
+            "promotion provider response must include a workspace_path",
+            None,
+            None,
+        ));
+    }
+
+    let mut command_evidence = response.command_evidence;
+    if command_evidence.is_empty() {
+        command_evidence.push(report);
+    }
+    Ok(AgentTaskPromotionWorkspace {
+        path: PathBuf::from(response.workspace_path),
+        command_evidence,
+    })
 }
 
 #[cfg(test)]
@@ -597,58 +602,34 @@ mod tests {
     const VALID_PATCH: &str = "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
 
     #[derive(Debug, Default)]
-    struct FakePromotionWorkspaceAdapter {
+    struct FakePromotionWorkspaceProvider {
         workspace_path: Option<PathBuf>,
-        ensure_creates_worktree: bool,
-        ensure_calls: Vec<String>,
-        apply_calls: Vec<(String, PathBuf)>,
+        apply_calls: Vec<AgentTaskPromotionApplyRequest>,
         verify_calls: Vec<(PathBuf, String)>,
     }
 
-    impl AgentTaskPromotionWorkspaceAdapter for FakePromotionWorkspaceAdapter {
-        fn ensure_workspace(&mut self, handle: &str) -> Result<AgentTaskPromotionWorkspace> {
-            self.ensure_calls.push(handle.to_string());
-            let already_exists = self.workspace_path.is_some();
-            let path = self
-                .workspace_path
-                .clone()
-                .or_else(|| {
-                    self.ensure_creates_worktree
-                        .then(|| PathBuf::from("/tmp/homeboy-controlled-workspace"))
-                })
-                .ok_or_else(|| {
-                    Error::validation_invalid_argument(
-                        "to_worktree",
-                        "fake workspace adapter could not resolve the requested workspace",
-                        None,
-                        None,
-                    )
-                })?;
-
-            self.workspace_path = Some(path.clone());
-            let command_evidence = if already_exists {
-                Vec::new()
-            } else {
-                vec![command_report(vec!["fake-workspace", "ensure", handle])]
-            };
-            Ok(AgentTaskPromotionWorkspace {
-                path,
-                command_evidence,
-            })
-        }
-
+    impl AgentTaskPromotionWorkspaceProvider for FakePromotionWorkspaceProvider {
         fn apply_patch(
             &mut self,
-            handle: &str,
-            patch_path: &Path,
-        ) -> Result<AgentTaskPromotionCommandReport> {
-            self.apply_calls
-                .push((handle.to_string(), patch_path.to_path_buf()));
-            Ok(command_report(vec![
-                "fake-workspace",
-                "apply-patch",
-                handle,
-            ]))
+            request: AgentTaskPromotionApplyRequest,
+        ) -> Result<AgentTaskPromotionWorkspace> {
+            self.apply_calls.push(request.clone());
+            let path = self.workspace_path.clone().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "to_worktree",
+                    "fake workspace provider could not resolve the requested workspace",
+                    None,
+                    None,
+                )
+            })?;
+            Ok(AgentTaskPromotionWorkspace {
+                path,
+                command_evidence: vec![command_report(vec![
+                    "fake-workspace-provider",
+                    "apply-patch",
+                    request.to_workspace.as_str(),
+                ])],
+            })
         }
 
         fn verify(
@@ -837,7 +818,7 @@ mod tests {
     }
 
     #[test]
-    fn promote_dry_run_reports_selected_patch_without_dmc_mutation() {
+    fn promote_dry_run_reports_selected_patch_without_provider_mutation() {
         let temp = tempfile::tempdir().expect("tempdir");
         let (source_path, source) = write_patch_source(&temp);
 
@@ -849,6 +830,7 @@ mod tests {
             artifact_id: None,
             dry_run: true,
             verify: Vec::new(),
+            provider_command: None,
         })
         .expect("dry-run promotion report");
 
@@ -861,16 +843,16 @@ mod tests {
     }
 
     #[test]
-    fn promote_applies_patch_with_fake_workspace_adapter() {
+    fn promote_applies_patch_with_fake_workspace_provider() {
         let temp = tempfile::tempdir().expect("tempdir");
         let worktree_path = temp.path().join("controlled-worktree");
         let (source_path, source) = write_patch_source(&temp);
-        let mut adapter = FakePromotionWorkspaceAdapter {
+        let mut provider = FakePromotionWorkspaceProvider {
             workspace_path: Some(worktree_path.clone()),
             ..Default::default()
         };
 
-        let report = promote_with_adapter(
+        let report = promote_with_provider(
             AgentTaskPromotionOptions {
                 source,
                 source_path: Some(source_path),
@@ -879,61 +861,61 @@ mod tests {
                 artifact_id: None,
                 dry_run: false,
                 verify: vec!["cargo test --lib agent_task_promotion".to_string()],
+                provider_command: None,
             },
-            &mut adapter,
+            &mut provider,
         )
         .expect("applied promotion report");
 
         assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
         assert_eq!(report.changed_files, vec!["src/lib.rs"]);
-        assert_eq!(adapter.ensure_calls, vec!["repo@controlled-worktree"]);
-        assert_eq!(adapter.apply_calls.len(), 1);
-        assert_eq!(adapter.apply_calls[0].0, "repo@controlled-worktree");
-        assert!(adapter.apply_calls[0].1.ends_with("changes.patch"));
+        assert_eq!(provider.apply_calls.len(), 1);
         assert_eq!(
-            adapter.verify_calls,
+            provider.apply_calls[0].to_workspace,
+            "repo@controlled-worktree"
+        );
+        assert!(provider.apply_calls[0]
+            .patch_path
+            .ends_with("changes.patch"));
+        assert_eq!(provider.apply_calls[0].changed_files, vec!["src/lib.rs"]);
+        assert_eq!(
+            provider.verify_calls,
             vec![(
                 worktree_path,
                 "cargo test --lib agent_task_promotion".to_string()
             )]
         );
         assert_eq!(report.command_evidence.len(), 1);
-        assert_eq!(report.command_evidence[0].command[0], "fake-workspace");
+        assert_eq!(
+            report.command_evidence[0].command[0],
+            "fake-workspace-provider"
+        );
         assert_eq!(report.deterministic_gates.len(), 1);
         assert_eq!(report.deterministic_gates[0].id, "gate-1");
     }
 
     #[test]
-    fn promote_creates_missing_worktree_before_apply() {
+    fn promote_requires_provider_for_apply() {
         let temp = tempfile::tempdir().expect("tempdir");
         let (source_path, source) = write_patch_source(&temp);
-        let mut adapter = FakePromotionWorkspaceAdapter {
-            ensure_creates_worktree: true,
-            ..Default::default()
-        };
 
-        let report = promote_with_adapter(
-            AgentTaskPromotionOptions {
-                source,
-                source_path: Some(source_path),
-                to_worktree: "repo@controlled-worktree".to_string(),
-                task_id: None,
-                artifact_id: None,
-                dry_run: false,
-                verify: Vec::new(),
-            },
-            &mut adapter,
-        )
-        .expect("applied promotion report");
+        let err = promote(AgentTaskPromotionOptions {
+            source,
+            source_path: Some(source_path),
+            to_worktree: "repo@controlled-worktree".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            verify: Vec::new(),
+            provider_command: None,
+        })
+        .expect_err("missing provider rejected");
 
-        assert_eq!(adapter.ensure_calls, vec!["repo@controlled-worktree"]);
-        assert_eq!(adapter.apply_calls.len(), 1);
-        assert_eq!(report.command_evidence.len(), 2);
-        assert_eq!(report.command_evidence[0].command[0], "fake-workspace");
+        assert!(err.message.contains("workspace provider command"));
     }
 
     #[test]
-    fn promotion_report_serializes_command_evidence_with_legacy_key() {
+    fn promotion_report_serializes_generic_command_evidence() {
         let report = AgentTaskPromotionReport {
             schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
             status: AgentTaskPromotionStatus::Applied,
@@ -950,63 +932,53 @@ mod tests {
                 sha256: None,
             },
             changed_files: vec!["src/lib.rs".to_string()],
-            command_evidence: vec![command_report(vec!["fake-workspace", "apply-patch"])],
+            command_evidence: vec![command_report(vec![
+                "fake-workspace-provider",
+                "apply-patch",
+            ])],
             deterministic_gates: Vec::new(),
             provenance: Value::Null,
         };
 
         let value = serde_json::to_value(report).expect("serialize report");
 
-        assert!(value.get("command_evidence").is_none());
         assert_eq!(
-            value["dmc_commands"][0]["command"][0].as_str(),
-            Some("fake-workspace")
+            value["command_evidence"][0]["command"][0].as_str(),
+            Some("fake-workspace-provider")
         );
     }
 
     #[test]
-    fn dmc_adapter_preserves_current_command_shapes() {
-        let patch_path = PathBuf::from("/tmp/changes.patch");
+    fn provider_command_response_supplies_workspace_and_evidence() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let response_path = temp.path().join("response.json");
+        std::fs::write(
+            &response_path,
+            serde_json::json!({
+                "schema": AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
+                "workspace_path": temp.path().join("workspace").display().to_string(),
+                "command_evidence": [{
+                    "command": ["provider", "apply"],
+                    "exit_code": 0
+                }]
+            })
+            .to_string(),
+        )
+        .expect("write response");
 
+        let request = AgentTaskPromotionApplyRequest {
+            schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+            to_workspace: "target-workspace".to_string(),
+            patch_path: temp.path().join("changes.patch").display().to_string(),
+            changed_files: vec!["src/lib.rs".to_string()],
+        };
+        let workspace = run_provider_command(&format!("cat {}", response_path.display()), &request)
+            .expect("provider response");
+
+        assert!(workspace.path.ends_with("workspace"));
         assert_eq!(
-            dmc_worktree_add_command("homeboy@fix-3690").expect("add command"),
-            vec![
-                "studio",
-                "wp",
-                "datamachine-code",
-                "workspace",
-                "worktree",
-                "add",
-                "homeboy",
-                "fix-3690"
-            ]
-        );
-        assert_eq!(
-            dmc_patch_apply_command("homeboy@fix-3690", &patch_path),
-            vec![
-                "studio",
-                "wp",
-                "datamachine-code",
-                "workspace",
-                "patch",
-                "apply",
-                "homeboy@fix-3690",
-                "--patch=@/tmp/changes.patch",
-                "--format=json"
-            ]
-        );
-        assert_eq!(
-            dmc_worktree_list_command("homeboy"),
-            vec![
-                "studio",
-                "wp",
-                "datamachine-code",
-                "workspace",
-                "worktree",
-                "list",
-                "homeboy",
-                "--format=json"
-            ]
+            workspace.command_evidence[0].command,
+            vec!["provider", "apply"]
         );
     }
 }


### PR DESCRIPTION
## Summary
- Removes Homeboy's built-in workspace promotion backend so agent-task promotion no longer knows about any concrete workspace implementation.
- Keeps Homeboy responsible for generic promotion lifecycle only: validate/select patch artifacts, build a generic apply request, invoke a configured workspace provider command, record generic command evidence, and run deterministic gates in the returned workspace path.
- Updates review-generated promotion commands and CLI help to use generic workspace/provider concepts.

Closes #3690.

## Provider contract
- Apply requires `--provider-command <COMMAND>` or `HOMEBOY_AGENT_TASK_PROMOTION_COMMAND`.
- Homeboy sends JSON on stdin with schema `homeboy/agent-task-promotion-apply-request/v1` and fields `to_workspace`, `patch_path`, and `changed_files`.
- The provider returns JSON on stdout with schema `homeboy/agent-task-promotion-apply-response/v1`, `workspace_path`, and optional `command_evidence`.

## Concrete provider
- DMC-backed behavior is implemented outside Homeboy in companion PR: Extra-Chill/homeboy-extensions#1186.
- Homeboy core intentionally contains no DMC command strings, adapter names, or DMC-specific tests.

## Tests
- `cargo fmt`
- `grep -R "datamachine-code\|Data Machine Code\|DMC\|datamachine_code\|dmc_commands" .` (no matches)
- `cargo test agent_task_promotion`
- `cargo test review_reports`
- `cargo test --test command_surface_test`
- `cargo test --test output_contracts_test`
- `cargo test --test architecture_core_agnostic_test`

## Caveats
- `cargo test --test core_agnostic_test` still fails on pre-existing ecosystem-term baseline findings in unrelated files (`src/commands/doctor/resources.rs`, `src/core/defaults/builtins.rs`, etc.); this PR does not touch those files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the stricter generic promotion-provider seam, removed Homeboy-owned concrete backend coupling, added provider/fake tests, ran targeted verification, and drafted this PR description for Chris to review.