### PR TITLE
Guard --force-hot local Lab bypass

### DIFF
--- a/docs/cli/homeboy-root-command.md
+++ b/docs/cli/homeboy-root-command.md
@@ -20,8 +20,10 @@ These are provided by clap:
 - `--help` / `-h`: print help and exit
 - `--output <PATH>`: write the structured JSON envelope to a file in addition to stdout
 - `--force-hot`: suppress resource policy warnings for intentionally hot commands
+- `--allow-local-hot`: allow `--force-hot` portable Lab commands to run locally when a default Lab runner exists
 - `--artifact-root <DIR>`: copy persisted run artifacts to a specific directory
 - `--runner <RUNNER_ID>`: route commands with portable Lab offload support to a connected Homeboy Lab runner
+- `--allow-local-fallback`: permit a selected Lab runner to fall back to local execution after offload preflight fails
 
 `--output` is a global flag, so pass it before the subcommand:
 
@@ -33,7 +35,9 @@ Resource policy warnings are stderr-only preflight notices. They currently apply
 to hot commands such as `bench`, `rig up`, `fleet exec`, and unscoped
 `audit` / `lint` / `test` runs when `homeboy doctor resources` sees a warm or
 hot machine. They do not block execution; pass `--force-hot` when the extra load
-is intentional.
+is intentional. For portable hot commands with a default Lab runner, `--force-hot`
+does not implicitly keep execution local; pass `--runner <id>` to offload or add
+`--allow-local-hot` only when local controller-machine execution is intentional.
 
 Not every hot command is offloadable. Lab offload only applies to commands with
 a portable runner contract; local-only hot commands keep running locally and

--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -160,10 +160,12 @@ job are rejected for command-native bench reproduction; use `homeboy ci run
 `homeboy bench` is resource-policy aware. If the current machine is already warm
 or hot according to `homeboy doctor resources`, Homeboy prints a stderr warning
 before running because the extra load can skew benchmark results. Use global
-`--force-hot` when running under load is intentional:
+`--force-hot` when running under load is intentional. When a default Lab runner is
+available for portable bench runs, `--force-hot` is not a local bypass by itself;
+add `--allow-local-hot` only when controller-machine execution is intentional:
 
 ```bash
-homeboy --force-hot bench my-component
+homeboy --force-hot --allow-local-hot bench my-component
 ```
 
 ## Observation History

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -48,14 +48,15 @@ After this, `<runner-id>` is both the server ID and the runner ID.
 Commands that are both resource-policy hot and portable for Lab offload (`audit`, full `lint`, `test`, `bench run`, and `trace`) auto-select a default runner when `--runner` is omitted. Selection is conservative:
 
 - `--runner <id>` always wins.
-- `--force-hot` keeps the command local.
+- `--force-hot` only suppresses the resource-policy warning. If a default Lab runner is available for a portable hot command, Homeboy refuses to use `--force-hot` as an implicit local bypass.
+- `--force-hot --allow-local-hot` keeps a portable hot command local even when a default Lab runner is available. Use it only when controller-machine execution is intentional.
 - `lab.preferred_runner` is used when it names an SSH runner, even if that runner is not connected yet.
 - Without `lab.preferred_runner`, Homeboy auto-selects only when exactly one SSH runner is configured or exactly one SSH runner is already connected.
 - Local runners are never auto-selected.
 - If the auto-selected runner is disconnected, Homeboy attempts a short bounded `runner connect` before execution. Connection failure prints the reason and falls back to local execution.
 - Explicit `--runner <id>` also attempts to connect a disconnected runner, but connection failure remains a command error instead of falling back silently.
 
-Observation metadata records the routing decision under `metadata.lab_offload` when an observed run is created. The stable contract is `schema: "homeboy/lab-offload/v1"` and keeps the existing top-level compatibility fields: `source` is `automatic` or `explicit`; `status` is `offloaded`, `skipped`, or `fallback`; successful offloads include `runner_id` plus `remote_workspace`; local fallback records the runner and `fallback_reason`; skipped local execution records why no automatic offload was used, such as `force_hot` or `no_default_runner`. The same object also carries `plan_id` and plan-derived phase fields including `sync_mode`, `capability_preflight`, `extension_parity`, and `patch_captured`.
+Observation metadata records the routing decision under `metadata.lab_offload` when an observed run is created. The stable contract is `schema: "homeboy/lab-offload/v1"` and keeps the existing top-level compatibility fields: `source` is `automatic` or `explicit`; `status` is `offloaded`, `skipped`, or `fallback`; successful offloads include `runner_id` plus `remote_workspace`; local fallback records the runner and `fallback_reason`; skipped local execution records why no automatic offload was used, such as `force_hot`, `force_hot_local_override`, or `no_default_runner`. The same object also carries `plan_id` and plan-derived phase fields including `sync_mode`, `capability_preflight`, `extension_parity`, and `patch_captured`.
 
 Lab offload support is intentionally command-specific:
 

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -31,6 +31,10 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub force_hot: bool,
 
+    /// Allow --force-hot portable Lab commands to stay local even when a default Lab runner exists.
+    #[arg(long, global = true)]
+    pub allow_local_hot: bool,
+
     /// Directory where persisted run artifacts are copied.
     /// Overrides HOMEBOY_ARTIFACT_ROOT and global config /artifact_root.
     #[arg(long, global = true, value_name = "DIR")]
@@ -1101,6 +1105,11 @@ mod tests {
         ]);
         assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
         assert!(cli.allow_local_fallback);
+
+        let cli = parsed_cli(&["homeboy", "--force-hot", "--allow-local-hot", "bench"]);
+        assert!(cli.force_hot);
+        assert!(cli.allow_local_hot);
+        assert!(cli.command.supports_lab_runner());
     }
 
     #[test]

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -16,6 +16,7 @@ pub fn route_after_parse(
         normalized_args,
         explicit_runner: cli.runner.as_deref(),
         force_hot: cli.force_hot,
+        allow_local_hot: cli.allow_local_hot,
         allow_local_fallback: cli.allow_local_fallback,
         capture_patch: cli.command.lab_offload_mutation_flag().is_some(),
     })? {

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -38,6 +38,7 @@ pub struct LabOffloadRequest<'a> {
     pub normalized_args: &'a [String],
     pub explicit_runner: Option<&'a str>,
     pub force_hot: bool,
+    pub allow_local_hot: bool,
     pub allow_local_fallback: bool,
     pub capture_patch: bool,
 }
@@ -112,10 +113,16 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         });
     }
 
-    let selection =
-        resolve_lab_runner_selection(&contract, request.explicit_runner, request.force_hot)?;
+    let selection = resolve_lab_runner_selection(
+        &contract,
+        request.explicit_runner,
+        request.force_hot,
+        request.allow_local_hot,
+    )?;
     let Some(selection) = selection else {
-        let reason = if request.force_hot {
+        let reason = if request.force_hot && request.allow_local_hot {
+            "force_hot_local_override"
+        } else if request.force_hot {
             "force_hot"
         } else {
             "no_default_runner"
@@ -928,6 +935,24 @@ mod tests {
             &command,
             Some("lab-explicit"),
             false,
+            false,
+            Some("lab-default".to_string()),
+        )
+        .expect("selection")
+        .expect("explicit runner selected");
+
+        assert_eq!(selection.runner_id, "lab-explicit");
+        assert_eq!(selection.source, LabRunnerSelectionSource::Explicit);
+    }
+
+    #[test]
+    fn lab_runner_selection_force_hot_keeps_explicit_runner_precedence() {
+        let command = portable_lab_command("test");
+        let selection = resolve_lab_runner_selection_from_default(
+            &command,
+            Some("lab-explicit"),
+            true,
+            false,
             Some("lab-default".to_string()),
         )
         .expect("selection")
@@ -944,6 +969,7 @@ mod tests {
             &command,
             None,
             false,
+            false,
             Some("lab-default".to_string()),
         )
         .expect("selection")
@@ -958,21 +984,57 @@ mod tests {
         let command = portable_lab_command("test");
 
         assert!(
-            resolve_lab_runner_selection_from_default(&command, None, false, None)
+            resolve_lab_runner_selection_from_default(&command, None, false, false, None)
                 .expect("selection")
                 .is_none()
         );
     }
 
     #[test]
-    fn lab_runner_selection_force_hot_is_local_escape_hatch() {
+    fn lab_runner_selection_force_hot_refuses_local_when_default_runner_exists() {
+        let command = portable_lab_command("test");
+
+        let err = resolve_lab_runner_selection_from_default(
+            &command,
+            None,
+            true,
+            false,
+            Some("lab-default".to_string()),
+        )
+        .expect_err("force-hot should require explicit local override");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err
+            .message
+            .contains("--force-hot would run portable hot command"));
+        assert!(err.message.contains("lab-default"));
+        let tried = err.details["tried"].as_array().expect("tried");
+        assert!(tried.iter().any(|hint| hint
+            .as_str()
+            .is_some_and(|hint| hint.contains("--allow-local-hot"))));
+    }
+
+    #[test]
+    fn lab_runner_selection_force_hot_runs_locally_without_default_runner() {
+        let command = portable_lab_command("test");
+
+        assert!(
+            resolve_lab_runner_selection_from_default(&command, None, true, false, None)
+                .expect("selection")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn lab_runner_selection_allow_local_hot_overrides_default_runner_gate() {
         let command = portable_lab_command("test");
 
         assert!(resolve_lab_runner_selection_from_default(
             &command,
             None,
             true,
-            Some("lab-default".to_string())
+            true,
+            Some("lab-default".to_string()),
         )
         .expect("selection")
         .is_none());
@@ -983,6 +1045,7 @@ mod tests {
         let err = resolve_lab_runner_selection_from_default(
             &local_only_lab_command("current single-workspace Lab snapshot cannot safely mirror"),
             Some("lab-explicit"),
+            false,
             false,
             Some("lab-default".to_string()),
         )
@@ -1118,6 +1181,7 @@ mod tests {
             normalized_args: &["homeboy".to_string(), "test".to_string()],
             explicit_runner: None,
             force_hot: true,
+            allow_local_hot: true,
             allow_local_fallback: false,
             capture_patch: false,
         })

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -311,20 +311,28 @@ pub(super) fn resolve_lab_runner_selection(
     command: &LabOffloadCommand,
     explicit_runner: Option<&str>,
     force_hot: bool,
+    allow_local_hot: bool,
 ) -> Result<Option<LabRunnerSelection>> {
-    let default_runner = if explicit_runner.is_none() && !force_hot && command.portable {
+    let default_runner = if explicit_runner.is_none() && command.portable {
         super::resolve_default_lab_runner()?
     } else {
         None
     };
 
-    resolve_lab_runner_selection_from_default(command, explicit_runner, force_hot, default_runner)
+    resolve_lab_runner_selection_from_default(
+        command,
+        explicit_runner,
+        force_hot,
+        allow_local_hot,
+        default_runner,
+    )
 }
 
 pub(super) fn resolve_lab_runner_selection_from_default(
     command: &LabOffloadCommand,
     explicit_runner: Option<&str>,
     force_hot: bool,
+    allow_local_hot: bool,
     default_runner: Option<String>,
 ) -> Result<Option<LabRunnerSelection>> {
     if let Some(runner_id) = explicit_runner {
@@ -346,6 +354,22 @@ pub(super) fn resolve_lab_runner_selection_from_default(
             source: LabRunnerSelectionSource::Explicit,
             mode: runner_status_tunnel_mode(runner_id),
         }));
+    }
+
+    if force_hot && command.portable && default_runner.is_some() && !allow_local_hot {
+        let runner_id = default_runner.expect("checked above");
+        return Err(Error::validation_invalid_argument(
+            "force_hot",
+            format!(
+                "--force-hot would run portable hot command `{}` locally, but default Lab runner `{runner_id}` is available",
+                command.hot_label
+            ),
+            Some(runner_id),
+            Some(vec![
+                "Omit --force-hot or pass --runner to offload the command to Lab.".to_string(),
+                "Pass --force-hot --allow-local-hot only when you intentionally want this portable hot command to run on the controller machine.".to_string(),
+            ]),
+        ));
     }
 
     if force_hot || !command.portable {


### PR DESCRIPTION
## Summary
- Add explicit global `--allow-local-hot` override for portable hot Lab commands.
- Refuse `--force-hot` local execution when a default Lab runner is available unless `--allow-local-hot` is also provided.
- Preserve local execution when no default runner exists and preserve explicit `--runner` precedence.
- Update Lab runner, root CLI, and bench docs to clarify the safer routing behavior.

Fixes #3692

## Tests
- `cargo test lab_runner_selection --lib`
- `cargo test test_supports_lab_runner --lib`
- `cargo test parses_force_hot_after_bench_without_losing_settings --lib`
- `cargo test plan_records_skipped_auto_offload --lib`
- `cargo test commands::route::tests --lib`
- `git diff --check`

Note: targeted Rust tests pass. They emit an existing unrelated unused-import warning from `src/commands/runs/corpus_tests.rs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation and tests drafted by coding agent, reviewed/verified by Chris