### PR TITLE
ci: enable differential audit gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     with:
       component: homeboy
       commands: audit,lint,test
+      differential-gating: true
       build-command: cargo build --release
       build-artifact-path: target/release/homeboy
     secrets: inherit


### PR DESCRIPTION
## Summary
- Enable Homeboy Action's differential audit/test gate for PR CI.
- Prevent existing audit debt from failing PRs when the PR introduces no new findings.

## Context
- Follow-up to #3693, where the Audit matrix job failed after reporting 614 existing warnings even though the scoped local check reported no introduced `remote_execution_preflight` findings.
- The reusable action already supports this mode via `differential-gating`; Homeboy's workflow was leaving it at the default `false`.

## Testing
- Verified the workflow diff is limited to `.github/workflows/ci.yml`.
- Confirmed `Extra-Chill/homeboy-action@v2` exposes and forwards the `differential-gating` input.
- Reproduced the #3693 scoped audit locally: `cargo run --quiet --bin homeboy -- audit --changed-since 4c01145a87d91b779edfa1244987f2f494dab37c --only remote_execution_preflight`, which reported `No introduced findings; 7 contextual finding(s) already known in touched scope` and `success: true`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the CI audit failure, inspected Homeboy Action behavior, and drafted this workflow change for Chris to review.
