### PR TITLE
Gate bench dependency hygiene

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -97,6 +97,10 @@ the other capabilities.
   parsing arbitrary provider YAML into runnable commands.
 - `--ignore-default-baseline`: Skip automatic single-rig expansion when
   the rig declares `bench.default_baseline_rig`.
+- `--allow-stale-dependencies`: Allow a bench run to proceed when a
+  validation dependency or extension runner checkout is dirty or behind
+  its upstream. By default, expensive bench runs fail during preflight so
+  stale dependency state cannot produce misleading evidence.
 
 Arguments after `--` are passed verbatim to the extension's bench runner
 script.

--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -64,6 +64,8 @@ homeboy trace list --profiles --rig studio
 
 JSON run, summary, and aggregate outputs include a `profile` object with the resolved profile id, rig id, component, scenario, overlays, variants, and settings used for the invocation.
 
+Trace dependency preflight rejects stale or dirty dependency checkouts before running the expensive workflow. Set `HOMEBOY_ALLOW_STALE_DEPENDENCIES=1` only when intentionally collecting non-deterministic evidence from stale local dependencies.
+
 ## Baseline/Candidate Compare
 
 `homeboy trace compare <component> <scenario>` can run the same trace scenario against two local paths or git refs, aggregate the span timings, write JSON artifacts, and render a Markdown summary. This is the first-class A/B browser proof workflow for trace rigs: pass baseline and candidate targets, choose `--runs`, and Homeboy preserves per-run artifacts while producing reviewer-ready span and browser evidence tables.

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -302,6 +302,10 @@ pub struct BenchRunArgs {
     /// auto-pairs, or to bench the candidate alone.
     #[arg(long)]
     ignore_default_baseline: bool,
+
+    /// Allow stale or dirty dependency/runner checkouts for this expensive bench run.
+    #[arg(long)]
+    allow_stale_dependencies: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]

--- a/src/commands/bench/fanout.rs
+++ b/src/commands/bench/fanout.rs
@@ -282,6 +282,7 @@ mod tests {
             profile: None,
             ci_profile: None,
             ignore_default_baseline: false,
+            allow_stale_dependencies: false,
         }
     }
 

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -490,6 +490,13 @@ fn run_component_with_rig_context(
     resolve_options.extension_overrides = args.extension_override.extensions.clone();
 
     let ctx = execution_context::resolve_with_component(&resolve_options, component_override)?;
+    homeboy::core::hygiene::require_dependency_hygiene_for_source(
+        &ctx.source_path,
+        ctx.extension_path.as_deref(),
+        homeboy::core::hygiene::DependencyHygieneOptions {
+            allow_stale: args.allow_stale_dependencies,
+        },
+    )?;
     let ci_profile_job =
         resolve_ci_profile_job(args.ci_profile.as_deref(), ctx.extension_id.as_deref())?;
 
@@ -724,6 +731,7 @@ mod tests {
             profile: None,
             ci_profile: None,
             ignore_default_baseline: false,
+            allow_stale_dependencies: false,
         }
     }
 

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -721,6 +721,7 @@ mod tests {
             profile: None,
             ci_profile: None,
             ignore_default_baseline: false,
+            allow_stale_dependencies: false,
         }
     }
 

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -295,6 +295,7 @@ pub(super) fn run_args(
             profile: None,
             ci_profile: None,
             ignore_default_baseline: false,
+            allow_stale_dependencies: false,
         },
     }
 }

--- a/src/core/extension/trace/preflight.rs
+++ b/src/core/extension/trace/preflight.rs
@@ -9,11 +9,32 @@ use super::parsing::TraceDependencyProvenance;
 
 pub(super) fn preflight_trace_dependencies(
     dependencies: &[TraceDependencySpec],
+    allow_stale_dependencies: bool,
 ) -> Result<Vec<TraceDependencyProvenance>> {
-    dependencies
+    let provenance = dependencies
         .iter()
         .map(preflight_trace_dependency)
-        .collect()
+        .collect::<Result<Vec<_>>>()?;
+
+    let checkouts = dependencies
+        .iter()
+        .filter_map(|dependency| {
+            let path = dependency.path.as_deref().filter(|path| !path.is_empty())?;
+            Some(crate::core::hygiene::DependencyCheckout {
+                id: dependency.id.clone(),
+                role: "trace_dependency".to_string(),
+                path: Path::new(path).to_path_buf(),
+            })
+        })
+        .collect::<Vec<_>>();
+    crate::core::hygiene::require_checkout_hygiene(
+        checkouts,
+        crate::core::hygiene::DependencyHygieneOptions {
+            allow_stale: allow_stale_dependencies,
+        },
+    )?;
+
+    Ok(provenance)
 }
 
 fn preflight_trace_dependency(
@@ -188,19 +209,22 @@ mod tests {
         std::fs::create_dir_all(plugin_root.join("vendor")).unwrap();
         std::fs::write(plugin_root.join("package/entrypoint.txt"), "entry").unwrap();
 
-        let provenance = preflight_trace_dependencies(&[TraceDependencySpec {
-            id: "sample".to_string(),
-            kind: "package".to_string(),
-            source: "release-package-or-build-artifact".to_string(),
-            path: Some(plugin_root.to_string_lossy().to_string()),
-            plugin_file: Some("package/entrypoint.txt".to_string()),
-            requires_built_assets: true,
-            required_paths: vec!["vendor".to_string()],
-            source_url: Some("https://example.com/sample.zip".to_string()),
-            version: Some("10.0.0".to_string()),
-            r#ref: Some("v10.0.0".to_string()),
-            package_marker: Some("packaged-zip".to_string()),
-        }])
+        let provenance = preflight_trace_dependencies(
+            &[TraceDependencySpec {
+                id: "sample".to_string(),
+                kind: "package".to_string(),
+                source: "release-package-or-build-artifact".to_string(),
+                path: Some(plugin_root.to_string_lossy().to_string()),
+                plugin_file: Some("package/entrypoint.txt".to_string()),
+                requires_built_assets: true,
+                required_paths: vec!["vendor".to_string()],
+                source_url: Some("https://example.com/sample.zip".to_string()),
+                version: Some("10.0.0".to_string()),
+                r#ref: Some("v10.0.0".to_string()),
+                package_marker: Some("packaged-zip".to_string()),
+            }],
+            false,
+        )
         .expect("packaged plugin dependency should pass preflight");
 
         assert_eq!(provenance.len(), 1);
@@ -222,19 +246,22 @@ mod tests {
         std::fs::create_dir_all(plugin_root.join("package")).unwrap();
         std::fs::write(plugin_root.join("package/entrypoint.txt"), "entry").unwrap();
 
-        let err = preflight_trace_dependencies(&[TraceDependencySpec {
-            id: "sample".to_string(),
-            kind: "package".to_string(),
-            source: "release-package-or-build-artifact".to_string(),
-            path: Some(plugin_root.to_string_lossy().to_string()),
-            plugin_file: Some("package/entrypoint.txt".to_string()),
-            requires_built_assets: true,
-            required_paths: vec!["vendor".to_string()],
-            source_url: None,
-            version: None,
-            r#ref: None,
-            package_marker: None,
-        }])
+        let err = preflight_trace_dependencies(
+            &[TraceDependencySpec {
+                id: "sample".to_string(),
+                kind: "package".to_string(),
+                source: "release-package-or-build-artifact".to_string(),
+                path: Some(plugin_root.to_string_lossy().to_string()),
+                plugin_file: Some("package/entrypoint.txt".to_string()),
+                requires_built_assets: true,
+                required_paths: vec!["vendor".to_string()],
+                source_url: None,
+                version: None,
+                r#ref: None,
+                package_marker: None,
+            }],
+            false,
+        )
         .expect_err("raw plugin checkout should fail dependency preflight");
 
         assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -167,6 +167,10 @@ pub fn run_trace_workflow(
     )
 }
 
+fn allow_stale_dependencies_from_env() -> bool {
+    std::env::var_os("HOMEBOY_ALLOW_STALE_DEPENDENCIES").is_some()
+}
+
 fn run_trace_workflow_with_component_script(
     component: &Component,
     mut args: TraceRunWorkflowArgs,
@@ -177,7 +181,10 @@ fn run_trace_workflow_with_component_script(
         .path_override
         .clone()
         .unwrap_or_else(|| component.local_path.clone());
-    let dependency_provenance = preflight_trace_dependencies(&args.runner_inputs.dependencies)?;
+    let dependency_provenance = preflight_trace_dependencies(
+        &args.runner_inputs.dependencies,
+        allow_stale_dependencies_from_env(),
+    )?;
     preflight_trace_runner_capabilities(None, &args.runner_inputs.runner_capabilities)?;
     let canonicality = evaluate_trace_canonicality(None, component, &args)?;
     if args.canonical_policy.refuses_non_canonical() && !canonicality.is_canonical() {
@@ -316,7 +323,10 @@ fn run_trace_workflow_with_context(
         .path_override
         .clone()
         .unwrap_or_else(|| component.local_path.clone());
-    let dependency_provenance = preflight_trace_dependencies(&args.runner_inputs.dependencies)?;
+    let dependency_provenance = preflight_trace_dependencies(
+        &args.runner_inputs.dependencies,
+        allow_stale_dependencies_from_env(),
+    )?;
     preflight_trace_runner_capabilities(
         execution_context,
         &args.runner_inputs.runner_capabilities,

--- a/src/core/hygiene.rs
+++ b/src/core/hygiene.rs
@@ -277,7 +277,13 @@ mod tests {
         git(local.path(), &["push", "-u", "origin", "main"]);
         git(
             writer.path(),
-            &["clone", "--branch", "main", remote.path().to_str().unwrap(), "."],
+            &[
+                "clone",
+                "--branch",
+                "main",
+                remote.path().to_str().unwrap(),
+                ".",
+            ],
         );
         git(writer.path(), &["config", "user.email", "test@example.com"]);
         git(writer.path(), &["config", "user.name", "Homeboy Test"]);

--- a/src/core/hygiene.rs
+++ b/src/core/hygiene.rs
@@ -330,7 +330,7 @@ mod tests {
         fs::write(writer.path().join("remote.txt"), "remote\n").unwrap();
         git(writer.path(), &["add", "."]);
         git(writer.path(), &["commit", "-m", "remote update"]);
-        git(writer.path(), &["push", "origin", "main"]);
+        git(writer.path(), &["push", "origin", "HEAD:main"]);
 
         let err = require_checkout_hygiene(
             vec![DependencyCheckout {
@@ -374,7 +374,7 @@ mod tests {
             serde_json::json!({
                 "id": "source",
                 "extensions": {
-                    "wordpress": {
+                    "example": {
                         "settings": { "validation_dependencies": ["missing-dep"] }
                     }
                 }

--- a/src/core/hygiene.rs
+++ b/src/core/hygiene.rs
@@ -1,0 +1,396 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::component;
+use crate::core::error::{Error, ErrorCode, Result, ValidationErrorItem};
+
+const PORTABLE_CONFIG_FILE: &str = concat!("homeboy", ".json");
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CheckoutHygieneSnapshot {
+    pub id: String,
+    pub role: String,
+    pub path: String,
+    pub head: Option<String>,
+    pub branch: Option<String>,
+    pub upstream: Option<String>,
+    pub ahead: Option<u32>,
+    pub behind: Option<u32>,
+    pub dirty: Option<bool>,
+    pub allowed: bool,
+}
+
+impl CheckoutHygieneSnapshot {
+    pub fn is_stale_or_dirty(&self) -> bool {
+        self.dirty == Some(true) || self.behind.unwrap_or(0) > 0
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DependencyHygieneOptions {
+    pub allow_stale: bool,
+}
+
+pub fn require_dependency_hygiene_for_source(
+    source_path: &Path,
+    extension_path: Option<&Path>,
+    options: DependencyHygieneOptions,
+) -> Result<Vec<CheckoutHygieneSnapshot>> {
+    let mut checkouts = dependency_checkouts_for_source(source_path)?;
+    if let Some(extension_path) = extension_path {
+        checkouts.push(DependencyCheckout {
+            id: "extension".to_string(),
+            role: "extension".to_string(),
+            path: extension_path.to_path_buf(),
+        });
+    }
+
+    require_checkout_hygiene(checkouts, options)
+}
+
+pub fn require_checkout_hygiene(
+    checkouts: Vec<DependencyCheckout>,
+    options: DependencyHygieneOptions,
+) -> Result<Vec<CheckoutHygieneSnapshot>> {
+    let snapshots = checkouts
+        .into_iter()
+        .map(|checkout| checkout_hygiene_snapshot(checkout, options.allow_stale))
+        .collect::<Result<Vec<_>>>()?;
+
+    let failures = snapshots
+        .iter()
+        .filter(|snapshot| !snapshot.allowed && snapshot.is_stale_or_dirty())
+        .map(|snapshot| ValidationErrorItem {
+            field: "dependency_hygiene".to_string(),
+            problem: hygiene_failure_message(snapshot),
+            context: Some(serde_json::to_value(snapshot).unwrap_or(serde_json::Value::Null)),
+        })
+        .collect::<Vec<_>>();
+
+    if failures.is_empty() {
+        return Ok(snapshots);
+    }
+
+    Err(Error::new(
+        ErrorCode::ValidationMultipleErrors,
+        "Dependency hygiene preflight failed",
+        serde_json::json!({
+            "errors": failures,
+            "checkouts": snapshots,
+        }),
+    )
+    .with_hint("Update the stale dependency checkout or rerun with --allow-stale-dependencies to accept non-deterministic evidence."))
+}
+
+#[derive(Debug, Clone)]
+pub struct DependencyCheckout {
+    pub id: String,
+    pub role: String,
+    pub path: PathBuf,
+}
+
+fn dependency_checkouts_for_source(source_path: &Path) -> Result<Vec<DependencyCheckout>> {
+    let ids = validation_dependency_ids(source_path)?;
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    ids.into_iter()
+        .map(|id| {
+            let path = resolve_validation_dependency_path(source_path, &id)?;
+            Ok(DependencyCheckout {
+                id,
+                role: "validation_dependency".to_string(),
+                path,
+            })
+        })
+        .collect()
+}
+
+fn validation_dependency_ids(source_path: &Path) -> Result<Vec<String>> {
+    let manifest_path = source_path.join(PORTABLE_CONFIG_FILE);
+    let Ok(content) = fs::read_to_string(&manifest_path) else {
+        return Ok(Vec::new());
+    };
+    let manifest: serde_json::Value = serde_json::from_str(&content).map_err(|err| {
+        Error::validation_invalid_argument(
+            PORTABLE_CONFIG_FILE,
+            format!("failed to parse {}: {err}", manifest_path.display()),
+            None,
+            None,
+        )
+    })?;
+
+    let mut ids = BTreeSet::new();
+    if let Some(extensions) = manifest
+        .get("extensions")
+        .and_then(|value| value.as_object())
+    {
+        for extension in extensions.values() {
+            collect_validation_dependency_ids(extension, &mut ids);
+            if let Some(settings) = extension.get("settings") {
+                collect_validation_dependency_ids(settings, &mut ids);
+            }
+        }
+    }
+    Ok(ids.into_iter().collect())
+}
+
+fn collect_validation_dependency_ids(value: &serde_json::Value, ids: &mut BTreeSet<String>) {
+    let Some(dependencies) = value
+        .get("validation_dependencies")
+        .and_then(|value| value.as_array())
+    else {
+        return;
+    };
+
+    ids.extend(
+        dependencies
+            .iter()
+            .filter_map(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+    );
+}
+
+fn resolve_validation_dependency_path(source_path: &Path, dependency: &str) -> Result<PathBuf> {
+    let expanded = shellexpand::tilde(dependency).to_string();
+    let explicit = Path::new(&expanded);
+    if explicit.is_dir() {
+        return canonical_existing_dir(explicit, dependency);
+    }
+
+    if let Some(parent) = source_path.parent() {
+        let sibling = parent.join(dependency);
+        if sibling.is_dir() {
+            return canonical_existing_dir(&sibling, dependency);
+        }
+    }
+
+    let component = component::resolve_effective(Some(dependency), None, None).map_err(|err| {
+        Error::validation_invalid_argument(
+            "validation_dependencies",
+            format!(
+                "Cannot resolve validation dependency `{dependency}` to a local checkout: {}",
+                err.message
+            ),
+            Some(dependency.to_string()),
+            Some(vec![format!(
+                "Clone/register `{dependency}` locally before running expensive evidence workflows."
+            )]),
+        )
+    })?;
+    canonical_existing_dir(Path::new(&component.local_path), dependency)
+}
+
+fn canonical_existing_dir(path: &Path, dependency: &str) -> Result<PathBuf> {
+    if !path.is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "validation_dependencies",
+            format!(
+                "Validation dependency `{dependency}` path is not a directory: {}",
+                path.display()
+            ),
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    path.canonicalize().map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("canonicalize validation dependency {dependency}")),
+        )
+    })
+}
+
+fn checkout_hygiene_snapshot(
+    checkout: DependencyCheckout,
+    allowed: bool,
+) -> Result<CheckoutHygieneSnapshot> {
+    let path = checkout.path;
+    let head = git_output(&path, &["rev-parse", "HEAD"]);
+    let branch = git_output(&path, &["rev-parse", "--abbrev-ref", "HEAD"]);
+    let upstream = git_output(&path, &["rev-parse", "--abbrev-ref", "@{upstream}"]);
+    if upstream.is_some() {
+        let _ = git_output(&path, &["fetch", "--quiet"]);
+    }
+    let (behind, ahead) = git_output(
+        &path,
+        &["rev-list", "--left-right", "--count", "@{upstream}...HEAD"],
+    )
+    .and_then(|value| parse_ahead_behind(&value))
+    .unwrap_or((None, None));
+    let dirty = git_output(&path, &["status", "--porcelain=v1"]).map(|value| !value.is_empty());
+
+    Ok(CheckoutHygieneSnapshot {
+        id: checkout.id,
+        role: checkout.role,
+        path: path.to_string_lossy().to_string(),
+        head,
+        branch,
+        upstream,
+        ahead,
+        behind,
+        dirty,
+        allowed,
+    })
+}
+
+fn hygiene_failure_message(snapshot: &CheckoutHygieneSnapshot) -> String {
+    let mut problems = Vec::new();
+    if snapshot.dirty == Some(true) {
+        problems.push("dirty".to_string());
+    }
+    if snapshot.behind.unwrap_or(0) > 0 {
+        problems.push(format!(
+            "behind upstream by {} commit(s)",
+            snapshot.behind.unwrap_or(0)
+        ));
+    }
+    format!(
+        "{} `{}` checkout is {}: {}",
+        snapshot.role,
+        snapshot.id,
+        problems.join(" and "),
+        snapshot.path
+    )
+}
+
+fn git_output(path: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn parse_ahead_behind(value: &str) -> Option<(Option<u32>, Option<u32>)> {
+    let mut parts = value.split_whitespace();
+    let behind = parts.next()?.parse::<u32>().ok()?;
+    let ahead = parts.next()?.parse::<u32>().ok()?;
+    Some((Some(behind), Some(ahead)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo(path: &Path) {
+        git(path, &["init", "-b", "main"]);
+        git(path, &["config", "user.email", "test@example.com"]);
+        git(path, &["config", "user.name", "Homeboy Test"]);
+        fs::write(path.join("README.md"), "initial\n").unwrap();
+        git(path, &["add", "."]);
+        git(path, &["commit", "-m", "initial"]);
+    }
+
+    #[test]
+    fn dependency_hygiene_fails_when_checkout_is_behind_upstream() {
+        let local = tempfile::tempdir().unwrap();
+        let remote = tempfile::tempdir().unwrap();
+        let writer = tempfile::tempdir().unwrap();
+        init_repo(local.path());
+        git(remote.path(), &["init", "--bare"]);
+        git(
+            local.path(),
+            &["remote", "add", "origin", remote.path().to_str().unwrap()],
+        );
+        git(local.path(), &["push", "-u", "origin", "main"]);
+        git(
+            writer.path(),
+            &["clone", remote.path().to_str().unwrap(), "."],
+        );
+        git(writer.path(), &["config", "user.email", "test@example.com"]);
+        git(writer.path(), &["config", "user.name", "Homeboy Test"]);
+        fs::write(writer.path().join("remote.txt"), "remote\n").unwrap();
+        git(writer.path(), &["add", "."]);
+        git(writer.path(), &["commit", "-m", "remote update"]);
+        git(writer.path(), &["push", "origin", "main"]);
+
+        let err = require_checkout_hygiene(
+            vec![DependencyCheckout {
+                id: "dep".to_string(),
+                role: "validation_dependency".to_string(),
+                path: local.path().to_path_buf(),
+            }],
+            DependencyHygieneOptions { allow_stale: false },
+        )
+        .expect_err("behind checkout should fail");
+
+        assert_eq!(err.code, ErrorCode::ValidationMultipleErrors);
+        assert_eq!(err.details["checkouts"][0]["behind"].as_u64(), Some(1));
+    }
+
+    #[test]
+    fn dependency_hygiene_allows_stale_with_explicit_opt_in() {
+        let local = tempfile::tempdir().unwrap();
+        init_repo(local.path());
+        fs::write(local.path().join("dirty.txt"), "dirty\n").unwrap();
+
+        let snapshots = require_checkout_hygiene(
+            vec![DependencyCheckout {
+                id: "dep".to_string(),
+                role: "validation_dependency".to_string(),
+                path: local.path().to_path_buf(),
+            }],
+            DependencyHygieneOptions { allow_stale: true },
+        )
+        .expect("explicit opt-in should allow dirty checkout");
+
+        assert!(snapshots[0].allowed);
+        assert_eq!(snapshots[0].dirty, Some(true));
+    }
+
+    #[test]
+    fn dependency_hygiene_fails_when_declared_dependency_is_missing() {
+        let source = tempfile::tempdir().unwrap();
+        fs::write(
+            source.path().join(PORTABLE_CONFIG_FILE),
+            serde_json::json!({
+                "id": "source",
+                "extensions": {
+                    "wordpress": {
+                        "settings": { "validation_dependencies": ["missing-dep"] }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let err = require_dependency_hygiene_for_source(
+            source.path(),
+            None,
+            DependencyHygieneOptions { allow_stale: false },
+        )
+        .expect_err("missing dependency should fail");
+
+        assert_eq!(err.details["field"], "validation_dependencies");
+        assert!(err.message.contains("missing-dep"));
+    }
+}

--- a/src/core/hygiene.rs
+++ b/src/core/hygiene.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -7,8 +5,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::core::component;
 use crate::core::error::{Error, ErrorCode, Result, ValidationErrorItem};
-
-const PORTABLE_CONFIG_FILE: &str = concat!("homeboy", ".json");
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CheckoutHygieneSnapshot {
@@ -25,7 +21,7 @@ pub struct CheckoutHygieneSnapshot {
 }
 
 impl CheckoutHygieneSnapshot {
-    pub fn is_stale_or_dirty(&self) -> bool {
+    fn is_stale_or_dirty(&self) -> bool {
         self.dirty == Some(true) || self.behind.unwrap_or(0) > 0
     }
 }
@@ -112,50 +108,7 @@ fn dependency_checkouts_for_source(source_path: &Path) -> Result<Vec<DependencyC
 }
 
 fn validation_dependency_ids(source_path: &Path) -> Result<Vec<String>> {
-    let manifest_path = source_path.join(PORTABLE_CONFIG_FILE);
-    let Ok(content) = fs::read_to_string(&manifest_path) else {
-        return Ok(Vec::new());
-    };
-    let manifest: serde_json::Value = serde_json::from_str(&content).map_err(|err| {
-        Error::validation_invalid_argument(
-            PORTABLE_CONFIG_FILE,
-            format!("failed to parse {}: {err}", manifest_path.display()),
-            None,
-            None,
-        )
-    })?;
-
-    let mut ids = BTreeSet::new();
-    if let Some(extensions) = manifest
-        .get("extensions")
-        .and_then(|value| value.as_object())
-    {
-        for extension in extensions.values() {
-            collect_validation_dependency_ids(extension, &mut ids);
-            if let Some(settings) = extension.get("settings") {
-                collect_validation_dependency_ids(settings, &mut ids);
-            }
-        }
-    }
-    Ok(ids.into_iter().collect())
-}
-
-fn collect_validation_dependency_ids(value: &serde_json::Value, ids: &mut BTreeSet<String>) {
-    let Some(dependencies) = value
-        .get("validation_dependencies")
-        .and_then(|value| value.as_array())
-    else {
-        return;
-    };
-
-    ids.extend(
-        dependencies
-            .iter()
-            .filter_map(|value| value.as_str())
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string),
-    );
+    crate::core::runner::validation_dependency_ids(source_path)
 }
 
 fn resolve_validation_dependency_path(source_path: &Path, dependency: &str) -> Result<PathBuf> {
@@ -223,7 +176,12 @@ fn checkout_hygiene_snapshot(
         &path,
         &["rev-list", "--left-right", "--count", "@{upstream}...HEAD"],
     )
-    .and_then(|value| parse_ahead_behind(&value))
+    .and_then(|value| {
+        let mut parts = value.split_whitespace();
+        let behind = parts.next()?.parse::<u32>().ok()?;
+        let ahead = parts.next()?.parse::<u32>().ok()?;
+        Some((Some(behind), Some(ahead)))
+    })
     .unwrap_or((None, None));
     let dirty = git_output(&path, &["status", "--porcelain=v1"]).map(|value| !value.is_empty());
 
@@ -275,16 +233,12 @@ fn git_output(path: &Path, args: &[&str]) -> Option<String> {
     Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-fn parse_ahead_behind(value: &str) -> Option<(Option<u32>, Option<u32>)> {
-    let mut parts = value.split_whitespace();
-    let behind = parts.next()?.parse::<u32>().ok()?;
-    let ahead = parts.next()?.parse::<u32>().ok()?;
-    Some((Some(behind), Some(ahead)))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+
+    const PORTABLE_CONFIG_FILE: &str = concat!("homeboy", ".json");
 
     fn git(path: &Path, args: &[&str]) {
         let output = Command::new("git")

--- a/src/core/hygiene.rs
+++ b/src/core/hygiene.rs
@@ -269,7 +269,7 @@ mod tests {
         let remote = tempfile::tempdir().unwrap();
         let writer = tempfile::tempdir().unwrap();
         init_repo(local.path());
-        git(remote.path(), &["init", "--bare"]);
+        git(remote.path(), &["init", "--bare", "-b", "main"]);
         git(
             local.path(),
             &["remote", "add", "origin", remote.path().to_str().unwrap()],
@@ -277,7 +277,7 @@ mod tests {
         git(local.path(), &["push", "-u", "origin", "main"]);
         git(
             writer.path(),
-            &["clone", remote.path().to_str().unwrap(), "."],
+            &["clone", "--branch", "main", remote.path().to_str().unwrap(), "."],
         );
         git(writer.path(), &["config", "user.email", "test@example.com"]);
         git(writer.path(), &["config", "user.name", "Homeboy Test"]);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -43,6 +43,7 @@ pub mod git;
 pub mod http_api;
 pub(crate) mod http_probe;
 pub mod http_request;
+pub mod hygiene;
 pub(crate) mod io;
 pub mod issues;
 pub mod keychain;

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -34,6 +34,7 @@ mod rig_materialization;
 mod session;
 mod source_materialization;
 mod validation_dependencies;
+pub(crate) use validation_dependencies::validation_dependency_ids;
 mod worker;
 mod workspace;
 

--- a/src/core/runner/validation_dependencies.rs
+++ b/src/core/runner/validation_dependencies.rs
@@ -46,7 +46,7 @@ fn validation_dependency_workspaces(local_path: &Path) -> Result<Vec<PathBuf>> {
         .collect()
 }
 
-fn validation_dependency_ids(local_path: &Path) -> Result<Vec<String>> {
+pub(crate) fn validation_dependency_ids(local_path: &Path) -> Result<Vec<String>> {
     let manifest_path = local_path.join(PORTABLE_CONFIG_FILE);
     let Ok(content) = fs::read_to_string(&manifest_path) else {
         return Ok(Vec::new());

--- a/tests/core/rig/bench_default_baseline_dispatch_test.rs
+++ b/tests/core/rig/bench_default_baseline_dispatch_test.rs
@@ -68,6 +68,7 @@ fn make_args(
             profile: None,
             ci_profile: None,
             ignore_default_baseline,
+            allow_stale_dependencies: false,
         },
     }
 }


### PR DESCRIPTION
## Summary
- Add deterministic dependency checkout hygiene preflight for expensive bench runs.
- Fail early when validation dependency or extension runner checkouts are dirty or behind upstream, with structured checkout details in the validation error.
- Add bench opt-out via `--allow-stale-dependencies`; trace dependency preflight uses the same gate with `HOMEBOY_ALLOW_STALE_DEPENDENCIES=1` as an explicit opt-in.

Closes #3694

## Tests
- `cargo fmt`
- `cargo test hygiene --lib`
- `cargo test bench:: --lib`
- `cargo test trace:: --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation and tests drafted by coding agent, reviewed/verified by Chris
