### PR TITLE
fix: publish prepared release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,8 @@ jobs:
       - gate-build
     if: needs.check.outputs.should-release == 'true'
     runs-on: ubuntu-latest
+    outputs:
+      audit-result: ${{ steps.audit.outcome }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -183,7 +185,10 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: Extra-Chill/homeboy-action@v2
+      - name: Run advisory audit
+        id: audit
+        uses: Extra-Chill/homeboy-action@v2
+        continue-on-error: true
         with:
           binary-path: .homeboy-bin/homeboy
           commands: audit
@@ -331,7 +336,7 @@ jobs:
       - name: Enforce release-blocking commands
         env:
           BLOCKING_COMMANDS: ${{ env.RELEASE_BLOCKING_COMMANDS }}
-          AUDIT_RESULT: ${{ needs.gate-audit.result }}
+          AUDIT_RESULT: ${{ needs.gate-audit.outputs.audit-result || needs.gate-audit.result }}
           LINT_RESULT: ${{ needs.gate-lint.result }}
           TEST_RESULT: ${{ needs.gate-test.result }}
           REFACTOR_RESULT: ${{ needs.gate-refactor.result }}
@@ -382,6 +387,7 @@ jobs:
     outputs:
       release-version: ${{ steps.recovery.outputs.release-version || steps.release.outputs.release-version }}
       release-tag: ${{ steps.recovery.outputs.release-tag || steps.release.outputs.release-tag }}
+      prepared: ${{ steps.recovery.outputs.prepared || steps.prepared.outputs.prepared }}
       released: ${{ steps.recovery.outputs.released || steps.release.outputs.released }}
     steps:
       - name: Generate GitHub App token
@@ -417,6 +423,13 @@ jobs:
           release-skip-github-release: 'true'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
+      - name: Mark prepared release for downstream publish
+        id: prepared
+        if: inputs.release_tag == '' && steps.release.outputs.release-tag != ''
+        run: |
+          echo "prepared=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::Prepared ${{ steps.release.outputs.release-tag }}; downstream jobs will publish it in this run"
+
       - name: Use existing release tag
         id: recovery
         if: inputs.release_tag != ''
@@ -426,6 +439,7 @@ jobs:
 
           echo "release-version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "release-tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "prepared=true" >> "$GITHUB_OUTPUT"
           echo "released=true" >> "$GITHUB_OUTPUT"
           echo "::notice::Skipping release preparation; downstream jobs will publish existing tag ${TAG}"
 
@@ -433,7 +447,7 @@ jobs:
   plan:
     name: Plan Build Matrix
     needs: prepare
-    if: needs.prepare.outputs.released == 'true'
+    if: needs.prepare.outputs.prepared == 'true' && needs.prepare.outputs.release-tag != ''
     runs-on: ubuntu-22.04
     outputs:
       val: ${{ steps.plan.outputs.manifest }}

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -49,10 +49,22 @@ fn release_quality_policy_defaults_to_lint_and_test_blocking() {
     let policy = job_section(release_workflow(), "release-quality-policy");
 
     assert!(policy.contains("BLOCKING_COMMANDS: ${{ env.RELEASE_BLOCKING_COMMANDS }}"));
+    assert!(policy.contains(
+        "AUDIT_RESULT: ${{ needs.gate-audit.outputs.audit-result || needs.gate-audit.result }}"
+    ));
     assert!(policy.contains("check_command audit"));
     assert!(policy.contains("check_command lint"));
     assert!(policy.contains("check_command test"));
     assert!(policy.contains("Command ${command} is tracked but not release-blocking"));
+}
+
+#[test]
+fn release_audit_is_advisory_without_losing_raw_failure_outcome() {
+    let gate_audit = job_section(release_workflow(), "gate-audit");
+
+    assert!(gate_audit.contains("audit-result: ${{ steps.audit.outcome }}"));
+    assert!(gate_audit.contains("id: audit"));
+    assert!(gate_audit.contains("continue-on-error: true"));
 }
 
 #[test]
@@ -83,6 +95,27 @@ fn release_prepare_waits_for_command_policy_not_raw_audit_or_refactor() {
     assert!(!prepare.contains("- gate-refactor"));
     assert!(prepare.contains("needs.release-quality-policy.result == 'success'"));
     assert!(prepare.contains("inputs.release_tag != ''"));
+}
+
+#[test]
+fn release_prepare_uses_prepared_output_to_unlock_publish_jobs() {
+    let prepare = job_section(release_workflow(), "prepare");
+    let plan = job_section(release_workflow(), "plan");
+
+    assert!(prepare.contains(
+        "prepared: ${{ steps.recovery.outputs.prepared || steps.prepared.outputs.prepared }}"
+    ));
+    assert!(prepare.contains("id: prepared"));
+    assert!(prepare.contains("steps.release.outputs.release-tag != ''"));
+    assert!(prepare.contains("echo \"prepared=true\" >> \"$GITHUB_OUTPUT\""));
+    assert!(prepare.contains("downstream jobs will publish it in this run"));
+    assert!(
+        prepare.contains("Skipping release preparation; downstream jobs will publish existing tag")
+    );
+
+    assert!(plan.contains("needs.prepare.outputs.prepared == 'true'"));
+    assert!(plan.contains("needs.prepare.outputs.release-tag != ''"));
+    assert!(!plan.contains("needs.prepare.outputs.released == 'true'"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add an explicit `prepared` output from the release preparation job and gate cargo-dist publish jobs on `prepared == true` plus a non-empty `release-tag`.
- Preserve `released` as the release action's own output instead of using it to mean "ready to publish downstream".
- Keep `workflow_dispatch` recovery for existing tags by setting `prepared=true` on the `release_tag` path.
- Make `Audit` advisory at the job level while exporting the raw audit step outcome so `RELEASE_BLOCKING_COMMANDS=audit` can still block releases.
- Add workflow guard tests for the prepared-tag publish gate and advisory audit behavior.

Closes #3687.

## Recovery for v0.222.14
The tag exists and the GitHub Release is missing. After this workflow fix lands, recover the existing tag with:

```bash
gh workflow run release.yml --repo Extra-Chill/homeboy --ref main -f release_tag=v0.222.14 -f dry-run=false -f release_blocking_commands=lint,test
```

Verified current state before this PR:
- `git ls-remote --tags origin v0.222.14` returns `refs/tags/v0.222.14`.
- `gh api repos/Extra-Chill/homeboy/releases/tags/v0.222.14` returns `404 Not Found`.
- Release run `27111469132` (`release: v0.222.14`) skipped `Plan Build Matrix`, binary builds, `Create GitHub Release`, Homebrew publish, and announce.

## Verification
- `cargo fmt --check`
- `cargo test --test release_workflow_test`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the release workflow regression, drafted the workflow/test changes, ran local verification, and prepared this PR. Chris remains responsible for review and merge.
