### PR TITLE
Fail closed for bench validation dependencies

### DIFF
--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -490,9 +490,10 @@ fn run_component_with_rig_context(
     resolve_options.extension_overrides = args.extension_override.extensions.clone();
 
     let ctx = execution_context::resolve_with_component(&resolve_options, component_override)?;
-    homeboy::core::hygiene::require_dependency_hygiene_for_source(
+    homeboy::core::hygiene::require_dependency_hygiene_for_source_with_settings(
         &ctx.source_path,
         ctx.extension_path.as_deref(),
+        &ctx.settings,
         homeboy::core::hygiene::DependencyHygieneOptions {
             allow_stale: args.allow_stale_dependencies,
         },

--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -439,8 +439,31 @@ fn read_durable_store(path: &Path) -> Result<DurableJobStore> {
 
     let content = fs::read_to_string(path)
         .map_err(|e| Error::internal_io(e.to_string(), Some(format!("read {}", path.display()))))?;
-    serde_json::from_str(&content)
-        .map_err(|e| Error::config_invalid_json(path.display().to_string(), e))
+    match serde_json::from_str(&content) {
+        Ok(store) => Ok(store),
+        Err(err) => {
+            let quarantine_path = path.with_file_name(format!(
+                "{}.corrupt-{}",
+                path.file_name()
+                    .and_then(|value| value.to_str())
+                    .unwrap_or("jobs.json"),
+                timestamp_ms()
+            ));
+            fs::rename(path, &quarantine_path).map_err(|rename_err| {
+                Error::config_invalid_json(path.display().to_string(), err).with_hint(format!(
+                    "Homeboy could not quarantine the corrupt durable job store to {}: {}",
+                    quarantine_path.display(),
+                    rename_err
+                ))
+            })?;
+            eprintln!(
+                "Homeboy quarantined corrupt daemon job store {} to {} and started with an empty queue",
+                path.display(),
+                quarantine_path.display()
+            );
+            Ok(DurableJobStore::default())
+        }
+    }
 }
 
 fn write_durable_store(path: &Path, durable: &DurableJobStore) -> Result<()> {
@@ -945,6 +968,25 @@ mod tests {
         assert!(events
             .iter()
             .any(|event| event.kind == JobEventKind::Result));
+    }
+
+    #[test]
+    fn open_quarantines_corrupt_durable_store() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        fs::write(&path, b"{").expect("corrupt store");
+
+        let store = JobStore::open(&path).expect("corrupt store is quarantined");
+        assert!(store.list().is_empty());
+        assert!(path.exists());
+
+        let quarantined = fs::read_dir(temp.path())
+            .expect("read temp dir")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().to_string())
+            .filter(|name| name.starts_with("jobs.json.corrupt-"))
+            .collect::<Vec<_>>();
+        assert_eq!(quarantined.len(), 1);
     }
 
     #[test]

--- a/src/core/hygiene.rs
+++ b/src/core/hygiene.rs
@@ -21,8 +21,14 @@ pub struct CheckoutHygieneSnapshot {
 }
 
 impl CheckoutHygieneSnapshot {
+    fn missing_required_git_metadata(&self) -> bool {
+        self.role == "validation_dependency" && (self.head.is_none() || self.dirty.is_none())
+    }
+
     fn is_stale_or_dirty(&self) -> bool {
-        self.dirty == Some(true) || self.behind.unwrap_or(0) > 0
+        self.missing_required_git_metadata()
+            || self.dirty == Some(true)
+            || self.behind.unwrap_or(0) > 0
     }
 }
 
@@ -36,7 +42,17 @@ pub fn require_dependency_hygiene_for_source(
     extension_path: Option<&Path>,
     options: DependencyHygieneOptions,
 ) -> Result<Vec<CheckoutHygieneSnapshot>> {
+    require_dependency_hygiene_for_source_with_settings(source_path, extension_path, &[], options)
+}
+
+pub fn require_dependency_hygiene_for_source_with_settings(
+    source_path: &Path,
+    extension_path: Option<&Path>,
+    settings: &[(String, serde_json::Value)],
+    options: DependencyHygieneOptions,
+) -> Result<Vec<CheckoutHygieneSnapshot>> {
     let mut checkouts = dependency_checkouts_for_source(source_path)?;
+    checkouts.extend(dependency_checkouts_for_settings(source_path, settings)?);
     if let Some(extension_path) = extension_path {
         checkouts.push(DependencyCheckout {
             id: "extension".to_string(),
@@ -104,6 +120,42 @@ fn dependency_checkouts_for_source(source_path: &Path) -> Result<Vec<DependencyC
                 path,
             })
         })
+        .collect()
+}
+
+fn dependency_checkouts_for_settings(
+    source_path: &Path,
+    settings: &[(String, serde_json::Value)],
+) -> Result<Vec<DependencyCheckout>> {
+    let ids = settings
+        .iter()
+        .filter(|(key, _)| key == "validation_dependencies")
+        .flat_map(|(_, value)| validation_dependency_ids_from_value(value))
+        .collect::<Vec<_>>();
+
+    ids.into_iter()
+        .map(|id| {
+            let path = resolve_validation_dependency_path(source_path, &id)?;
+            Ok(DependencyCheckout {
+                id,
+                role: "validation_dependency".to_string(),
+                path,
+            })
+        })
+        .collect()
+}
+
+fn validation_dependency_ids_from_value(value: &serde_json::Value) -> Vec<String> {
+    let Some(dependencies) = value.as_array() else {
+        return Vec::new();
+    };
+
+    dependencies
+        .iter()
+        .filter_map(|item| item.as_str())
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .map(str::to_string)
         .collect()
 }
 
@@ -201,6 +253,9 @@ fn checkout_hygiene_snapshot(
 
 fn hygiene_failure_message(snapshot: &CheckoutHygieneSnapshot) -> String {
     let mut problems = Vec::new();
+    if snapshot.missing_required_git_metadata() {
+        problems.push("missing git metadata".to_string());
+    }
     if snapshot.dirty == Some(true) {
         problems.push("dirty".to_string());
     }
@@ -327,6 +382,28 @@ mod tests {
     }
 
     #[test]
+    fn dependency_hygiene_fails_when_git_metadata_is_missing() {
+        let dependency = tempfile::tempdir().unwrap();
+        fs::write(dependency.path().join("README.md"), "snapshot\n").unwrap();
+
+        let err = require_checkout_hygiene(
+            vec![DependencyCheckout {
+                id: "snapshot-dep".to_string(),
+                role: "validation_dependency".to_string(),
+                path: dependency.path().to_path_buf(),
+            }],
+            DependencyHygieneOptions { allow_stale: false },
+        )
+        .expect_err("dependency without git metadata should fail");
+
+        assert_eq!(err.code, ErrorCode::ValidationMultipleErrors);
+        assert!(err.details["errors"][0]["problem"]
+            .as_str()
+            .unwrap()
+            .contains("missing git metadata"));
+    }
+
+    #[test]
     fn dependency_hygiene_fails_when_declared_dependency_is_missing() {
         let source = tempfile::tempdir().unwrap();
         fs::write(
@@ -352,5 +429,28 @@ mod tests {
 
         assert_eq!(err.details["field"], "validation_dependencies");
         assert!(err.message.contains("missing-dep"));
+    }
+
+    #[test]
+    fn dependency_hygiene_reads_validation_dependencies_from_runtime_settings() {
+        let source = tempfile::tempdir().unwrap();
+        let dependency = tempfile::tempdir().unwrap();
+        init_repo(dependency.path());
+        fs::write(dependency.path().join("dirty.txt"), "dirty\n").unwrap();
+
+        let settings = vec![(
+            "validation_dependencies".to_string(),
+            serde_json::json!([dependency.path().to_str().unwrap()]),
+        )];
+        let err = require_dependency_hygiene_for_source_with_settings(
+            source.path(),
+            None,
+            &settings,
+            DependencyHygieneOptions { allow_stale: false },
+        )
+        .expect_err("dirty dependency from settings should fail");
+
+        assert_eq!(err.code, ErrorCode::ValidationMultipleErrors);
+        assert_eq!(err.details["checkouts"][0]["dirty"].as_bool(), Some(true));
     }
 }


### PR DESCRIPTION
## Summary
- include runtime `validation_dependencies` settings in bench dependency hygiene preflight
- fail declared validation dependencies that lack Git metadata instead of treating snapshots as clean
- quarantine corrupt daemon `jobs.json` files and start with an empty queue instead of blocking daemon startup

## Tests
- `cargo test dependency_hygiene`
- `cargo test open_quarantines_corrupt_durable_store`
- Lab guard proof: `homeboy bench --runner homeboy-lab ... --setting-json validation_dependencies=[...]` now fails before Workflow Bench when dependency snapshots lack Git metadata

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identifying the Homeboy hygiene gap, drafting the Rust patch and tests, and running local/Lab verification; Chris remains responsible for review and merge.
