### PR TITLE
Block stale lab dependency bypasses

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -97,10 +97,6 @@ the other capabilities.
   parsing arbitrary provider YAML into runnable commands.
 - `--ignore-default-baseline`: Skip automatic single-rig expansion when
   the rig declares `bench.default_baseline_rig`.
-- `--allow-stale-dependencies`: Allow a bench run to proceed when a
-  validation dependency or extension runner checkout is dirty or behind
-  its upstream. By default, expensive bench runs fail during preflight so
-  stale dependency state cannot produce misleading evidence.
 
 Arguments after `--` are passed verbatim to the extension's bench runner
 script.

--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -64,7 +64,7 @@ homeboy trace list --profiles --rig studio
 
 JSON run, summary, and aggregate outputs include a `profile` object with the resolved profile id, rig id, component, scenario, overlays, variants, and settings used for the invocation.
 
-Trace dependency preflight rejects stale or dirty dependency checkouts before running the expensive workflow. Set `HOMEBOY_ALLOW_STALE_DEPENDENCIES=1` only when intentionally collecting non-deterministic evidence from stale local dependencies.
+Trace dependency preflight rejects stale or dirty dependency checkouts before running the expensive workflow so stale local dependencies cannot produce misleading evidence.
 
 ## Baseline/Candidate Compare
 

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -302,10 +302,6 @@ pub struct BenchRunArgs {
     /// auto-pairs, or to bench the candidate alone.
     #[arg(long)]
     ignore_default_baseline: bool,
-
-    /// Allow stale or dirty dependency/runner checkouts for this expensive bench run.
-    #[arg(long)]
-    allow_stale_dependencies: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]

--- a/src/commands/bench/fanout.rs
+++ b/src/commands/bench/fanout.rs
@@ -282,7 +282,6 @@ mod tests {
             profile: None,
             ci_profile: None,
             ignore_default_baseline: false,
-            allow_stale_dependencies: false,
         }
     }
 

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -494,9 +494,7 @@ fn run_component_with_rig_context(
         &ctx.source_path,
         ctx.extension_path.as_deref(),
         &ctx.settings,
-        homeboy::core::hygiene::DependencyHygieneOptions {
-            allow_stale: args.allow_stale_dependencies,
-        },
+        homeboy::core::hygiene::DependencyHygieneOptions { allow_stale: false },
     )?;
     let ci_profile_job =
         resolve_ci_profile_job(args.ci_profile.as_deref(), ctx.extension_id.as_deref())?;
@@ -732,7 +730,6 @@ mod tests {
             profile: None,
             ci_profile: None,
             ignore_default_baseline: false,
-            allow_stale_dependencies: false,
         }
     }
 

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -721,7 +721,6 @@ mod tests {
             profile: None,
             ci_profile: None,
             ignore_default_baseline: false,
-            allow_stale_dependencies: false,
         }
     }
 

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::test_support::with_isolated_home;
+use clap::error::ErrorKind;
 use clap::Parser;
 use homeboy::core::extension::bench::aggregate_comparison;
 use std::fs;
@@ -295,7 +296,6 @@ pub(super) fn run_args(
             profile: None,
             ci_profile: None,
             ignore_default_baseline: false,
-            allow_stale_dependencies: false,
         },
     }
 }
@@ -545,6 +545,16 @@ fn parses_rig_concurrency_flag() {
     .expect("bench --rig-concurrency should parse");
 
     assert_eq!(cli.bench.run.rig_concurrency, 2);
+}
+
+#[test]
+fn rejects_allow_stale_dependencies_flag() {
+    let err = match TestCli::try_parse_from(["bench", "homeboy", "--allow-stale-dependencies"]) {
+        Ok(_) => panic!("stale dependency bypass should not parse"),
+        Err(err) => err,
+    };
+
+    assert_eq!(err.kind(), ErrorKind::UnknownArgument);
 }
 
 #[test]

--- a/src/core/extension/trace/preflight.rs
+++ b/src/core/extension/trace/preflight.rs
@@ -9,7 +9,6 @@ use super::parsing::TraceDependencyProvenance;
 
 pub(super) fn preflight_trace_dependencies(
     dependencies: &[TraceDependencySpec],
-    allow_stale_dependencies: bool,
 ) -> Result<Vec<TraceDependencyProvenance>> {
     let provenance = dependencies
         .iter()
@@ -29,9 +28,7 @@ pub(super) fn preflight_trace_dependencies(
         .collect::<Vec<_>>();
     crate::core::hygiene::require_checkout_hygiene(
         checkouts,
-        crate::core::hygiene::DependencyHygieneOptions {
-            allow_stale: allow_stale_dependencies,
-        },
+        crate::core::hygiene::DependencyHygieneOptions { allow_stale: false },
     )?;
 
     Ok(provenance)
@@ -209,22 +206,19 @@ mod tests {
         std::fs::create_dir_all(plugin_root.join("vendor")).unwrap();
         std::fs::write(plugin_root.join("package/entrypoint.txt"), "entry").unwrap();
 
-        let provenance = preflight_trace_dependencies(
-            &[TraceDependencySpec {
-                id: "sample".to_string(),
-                kind: "package".to_string(),
-                source: "release-package-or-build-artifact".to_string(),
-                path: Some(plugin_root.to_string_lossy().to_string()),
-                plugin_file: Some("package/entrypoint.txt".to_string()),
-                requires_built_assets: true,
-                required_paths: vec!["vendor".to_string()],
-                source_url: Some("https://example.com/sample.zip".to_string()),
-                version: Some("10.0.0".to_string()),
-                r#ref: Some("v10.0.0".to_string()),
-                package_marker: Some("packaged-zip".to_string()),
-            }],
-            false,
-        )
+        let provenance = preflight_trace_dependencies(&[TraceDependencySpec {
+            id: "sample".to_string(),
+            kind: "package".to_string(),
+            source: "release-package-or-build-artifact".to_string(),
+            path: Some(plugin_root.to_string_lossy().to_string()),
+            plugin_file: Some("package/entrypoint.txt".to_string()),
+            requires_built_assets: true,
+            required_paths: vec!["vendor".to_string()],
+            source_url: Some("https://example.com/sample.zip".to_string()),
+            version: Some("10.0.0".to_string()),
+            r#ref: Some("v10.0.0".to_string()),
+            package_marker: Some("packaged-zip".to_string()),
+        }])
         .expect("packaged plugin dependency should pass preflight");
 
         assert_eq!(provenance.len(), 1);
@@ -246,22 +240,19 @@ mod tests {
         std::fs::create_dir_all(plugin_root.join("package")).unwrap();
         std::fs::write(plugin_root.join("package/entrypoint.txt"), "entry").unwrap();
 
-        let err = preflight_trace_dependencies(
-            &[TraceDependencySpec {
-                id: "sample".to_string(),
-                kind: "package".to_string(),
-                source: "release-package-or-build-artifact".to_string(),
-                path: Some(plugin_root.to_string_lossy().to_string()),
-                plugin_file: Some("package/entrypoint.txt".to_string()),
-                requires_built_assets: true,
-                required_paths: vec!["vendor".to_string()],
-                source_url: None,
-                version: None,
-                r#ref: None,
-                package_marker: None,
-            }],
-            false,
-        )
+        let err = preflight_trace_dependencies(&[TraceDependencySpec {
+            id: "sample".to_string(),
+            kind: "package".to_string(),
+            source: "release-package-or-build-artifact".to_string(),
+            path: Some(plugin_root.to_string_lossy().to_string()),
+            plugin_file: Some("package/entrypoint.txt".to_string()),
+            requires_built_assets: true,
+            required_paths: vec!["vendor".to_string()],
+            source_url: None,
+            version: None,
+            r#ref: None,
+            package_marker: None,
+        }])
         .expect_err("raw plugin checkout should fail dependency preflight");
 
         assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -167,10 +167,6 @@ pub fn run_trace_workflow(
     )
 }
 
-fn allow_stale_dependencies_from_env() -> bool {
-    std::env::var_os("HOMEBOY_ALLOW_STALE_DEPENDENCIES").is_some()
-}
-
 fn run_trace_workflow_with_component_script(
     component: &Component,
     mut args: TraceRunWorkflowArgs,
@@ -181,10 +177,7 @@ fn run_trace_workflow_with_component_script(
         .path_override
         .clone()
         .unwrap_or_else(|| component.local_path.clone());
-    let dependency_provenance = preflight_trace_dependencies(
-        &args.runner_inputs.dependencies,
-        allow_stale_dependencies_from_env(),
-    )?;
+    let dependency_provenance = preflight_trace_dependencies(&args.runner_inputs.dependencies)?;
     preflight_trace_runner_capabilities(None, &args.runner_inputs.runner_capabilities)?;
     let canonicality = evaluate_trace_canonicality(None, component, &args)?;
     if args.canonical_policy.refuses_non_canonical() && !canonicality.is_canonical() {
@@ -323,10 +316,7 @@ fn run_trace_workflow_with_context(
         .path_override
         .clone()
         .unwrap_or_else(|| component.local_path.clone());
-    let dependency_provenance = preflight_trace_dependencies(
-        &args.runner_inputs.dependencies,
-        allow_stale_dependencies_from_env(),
-    )?;
+    let dependency_provenance = preflight_trace_dependencies(&args.runner_inputs.dependencies)?;
     preflight_trace_runner_capabilities(
         execution_context,
         &args.runner_inputs.runner_capabilities,

--- a/src/core/hygiene.rs
+++ b/src/core/hygiene.rs
@@ -95,7 +95,7 @@ pub fn require_checkout_hygiene(
             "checkouts": snapshots,
         }),
     )
-    .with_hint("Update the stale dependency checkout or rerun with --allow-stale-dependencies to accept non-deterministic evidence."))
+    .with_hint("Update the stale dependency checkout. Homeboy automatically fast-forwards clean validation dependencies, but dirty, non-Git, missing-upstream, or divergent checkouts must be fixed before running expensive evidence workflows."))
 }
 
 #[derive(Debug, Clone)]
@@ -218,23 +218,25 @@ fn checkout_hygiene_snapshot(
     allowed: bool,
 ) -> Result<CheckoutHygieneSnapshot> {
     let path = checkout.path;
-    let head = git_output(&path, &["rev-parse", "HEAD"]);
+    let mut head = git_output(&path, &["rev-parse", "HEAD"]);
     let branch = git_output(&path, &["rev-parse", "--abbrev-ref", "HEAD"]);
     let upstream = git_output(&path, &["rev-parse", "--abbrev-ref", "@{upstream}"]);
     if upstream.is_some() {
         let _ = git_output(&path, &["fetch", "--quiet"]);
     }
-    let (behind, ahead) = git_output(
-        &path,
-        &["rev-list", "--left-right", "--count", "@{upstream}...HEAD"],
-    )
-    .and_then(|value| {
-        let mut parts = value.split_whitespace();
-        let behind = parts.next()?.parse::<u32>().ok()?;
-        let ahead = parts.next()?.parse::<u32>().ok()?;
-        Some((Some(behind), Some(ahead)))
-    })
-    .unwrap_or((None, None));
+    let dirty = git_output(&path, &["status", "--porcelain=v1"]).map(|value| !value.is_empty());
+    let (mut behind, mut ahead) = git_ahead_behind(&path);
+    if checkout.role == "validation_dependency"
+        && !allowed
+        && upstream.is_some()
+        && dirty == Some(false)
+        && ahead.unwrap_or(0) == 0
+        && behind.unwrap_or(0) > 0
+        && git_status(&path, &["merge", "--ff-only", "@{upstream}"])
+    {
+        head = git_output(&path, &["rev-parse", "HEAD"]);
+        (behind, ahead) = git_ahead_behind(&path);
+    }
     let dirty = git_output(&path, &["status", "--porcelain=v1"]).map(|value| !value.is_empty());
 
     Ok(CheckoutHygieneSnapshot {
@@ -249,6 +251,20 @@ fn checkout_hygiene_snapshot(
         dirty,
         allowed,
     })
+}
+
+fn git_ahead_behind(path: &Path) -> (Option<u32>, Option<u32>) {
+    git_output(
+        &path,
+        &["rev-list", "--left-right", "--count", "@{upstream}...HEAD"],
+    )
+    .and_then(|value| {
+        let mut parts = value.split_whitespace();
+        let behind = parts.next()?.parse::<u32>().ok()?;
+        let ahead = parts.next()?.parse::<u32>().ok()?;
+        Some((Some(behind), Some(ahead)))
+    })
+    .unwrap_or((None, None))
 }
 
 fn hygiene_failure_message(snapshot: &CheckoutHygieneSnapshot) -> String {
@@ -288,6 +304,17 @@ fn git_output(path: &Path, args: &[&str]) -> Option<String> {
     Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+fn git_status(path: &Path, args: &[&str]) -> bool {
+    Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -319,7 +346,50 @@ mod tests {
     }
 
     #[test]
-    fn dependency_hygiene_fails_when_checkout_is_behind_upstream() {
+    fn dependency_hygiene_fast_forwards_validation_dependency_behind_upstream() {
+        let local = tempfile::tempdir().unwrap();
+        let remote = tempfile::tempdir().unwrap();
+        let writer = tempfile::tempdir().unwrap();
+        init_repo(local.path());
+        git(remote.path(), &["init", "--bare", "-b", "main"]);
+        git(
+            local.path(),
+            &["remote", "add", "origin", remote.path().to_str().unwrap()],
+        );
+        git(local.path(), &["push", "-u", "origin", "main"]);
+        git(
+            writer.path(),
+            &[
+                "clone",
+                "--branch",
+                "main",
+                remote.path().to_str().unwrap(),
+                ".",
+            ],
+        );
+        git(writer.path(), &["config", "user.email", "test@example.com"]);
+        git(writer.path(), &["config", "user.name", "Homeboy Test"]);
+        fs::write(writer.path().join("remote.txt"), "remote\n").unwrap();
+        git(writer.path(), &["add", "."]);
+        git(writer.path(), &["commit", "-m", "remote update"]);
+        git(writer.path(), &["push", "origin", "HEAD:main"]);
+
+        let snapshots = require_checkout_hygiene(
+            vec![DependencyCheckout {
+                id: "dep".to_string(),
+                role: "validation_dependency".to_string(),
+                path: local.path().to_path_buf(),
+            }],
+            DependencyHygieneOptions { allow_stale: false },
+        )
+        .expect("clean validation dependency should fast-forward");
+
+        assert_eq!(snapshots[0].behind, Some(0));
+        assert!(local.path().join("remote.txt").exists());
+    }
+
+    #[test]
+    fn dependency_hygiene_fails_when_trace_dependency_is_behind_upstream() {
         let local = tempfile::tempdir().unwrap();
         let remote = tempfile::tempdir().unwrap();
         let writer = tempfile::tempdir().unwrap();
@@ -350,12 +420,12 @@ mod tests {
         let err = require_checkout_hygiene(
             vec![DependencyCheckout {
                 id: "dep".to_string(),
-                role: "validation_dependency".to_string(),
+                role: "trace_dependency".to_string(),
                 path: local.path().to_path_buf(),
             }],
             DependencyHygieneOptions { allow_stale: false },
         )
-        .expect_err("behind checkout should fail");
+        .expect_err("behind trace dependency should fail");
 
         assert_eq!(err.code, ErrorCode::ValidationMultipleErrors);
         assert_eq!(err.details["checkouts"][0]["behind"].as_u64(), Some(1));

--- a/tests/core/rig/bench_default_baseline_dispatch_test.rs
+++ b/tests/core/rig/bench_default_baseline_dispatch_test.rs
@@ -68,7 +68,6 @@ fn make_args(
             profile: None,
             ci_profile: None,
             ignore_default_baseline,
-            allow_stale_dependencies: false,
         },
     }
 }


### PR DESCRIPTION
## Summary
- remove the bench --allow-stale-dependencies escape hatch
- remove the trace HOMEBOY_ALLOW_STALE_DEPENDENCIES bypass
- auto fast-forward clean validation dependency checkouts before hygiene fails, while continuing to block dirty, non-Git, missing-upstream, or divergent dependency state

## Tests
- cargo fmt
- cargo test core::hygiene
- cargo test core::extension::trace::preflight
- cargo test commands::bench

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the stale dependency enforcement changes, regression tests, and documentation updates; Chris directed the behavior and retains review responsibility.