### PR TITLE
Manage lab validation dependency lifecycle

### DIFF
--- a/src/core/hygiene.rs
+++ b/src/core/hygiene.rs
@@ -3,8 +3,10 @@ use std::process::{Command, Stdio};
 
 use serde::{Deserialize, Serialize};
 
-use crate::core::component;
+use crate::core::component::{self, Component};
 use crate::core::error::{Error, ErrorCode, Result, ValidationErrorItem};
+use crate::core::extension::{build, ExtensionCapability};
+use crate::extensions::deps_provider;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CheckoutHygieneSnapshot {
@@ -22,7 +24,8 @@ pub struct CheckoutHygieneSnapshot {
 
 impl CheckoutHygieneSnapshot {
     fn missing_required_git_metadata(&self) -> bool {
-        self.role == "validation_dependency" && (self.head.is_none() || self.dirty.is_none())
+        self.role == "validation_dependency"
+            && (self.head.is_none() || self.dirty.is_none() || self.upstream.is_none())
     }
 
     fn is_stale_or_dirty(&self) -> bool {
@@ -84,6 +87,45 @@ pub fn require_checkout_hygiene(
         .collect::<Vec<_>>();
 
     if failures.is_empty() {
+        for snapshot in snapshots
+            .iter()
+            .filter(|snapshot| snapshot.role == "validation_dependency")
+        {
+            run_validation_dependency_lifecycle(snapshot)?;
+        }
+        let lifecycle_failures = snapshots
+            .iter()
+            .filter(|snapshot| snapshot.role == "validation_dependency")
+            .map(|snapshot| {
+                checkout_hygiene_snapshot(
+                    DependencyCheckout {
+                        id: snapshot.id.clone(),
+                        role: snapshot.role.clone(),
+                        path: PathBuf::from(&snapshot.path),
+                    },
+                    snapshot.allowed,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .filter(|snapshot| !snapshot.allowed && snapshot.is_stale_or_dirty())
+            .map(|snapshot| ValidationErrorItem {
+                field: "dependency_hygiene".to_string(),
+                problem: hygiene_failure_message(&snapshot),
+                context: Some(serde_json::to_value(snapshot).unwrap_or(serde_json::Value::Null)),
+            })
+            .collect::<Vec<_>>();
+        if !lifecycle_failures.is_empty() {
+            return Err(Error::new(
+                ErrorCode::ValidationMultipleErrors,
+                "Dependency hygiene preflight failed after lifecycle preparation",
+                serde_json::json!({
+                    "errors": lifecycle_failures,
+                    "checkouts": snapshots,
+                }),
+            )
+            .with_hint("Dependency lifecycle preparation must leave validation dependencies clean and current before expensive evidence workflows."));
+        }
         return Ok(snapshots);
     }
 
@@ -272,6 +314,9 @@ fn hygiene_failure_message(snapshot: &CheckoutHygieneSnapshot) -> String {
     if snapshot.missing_required_git_metadata() {
         problems.push("missing git metadata".to_string());
     }
+    if snapshot.role == "validation_dependency" && snapshot.upstream.is_none() {
+        problems.push("missing upstream".to_string());
+    }
     if snapshot.dirty == Some(true) {
         problems.push("dirty".to_string());
     }
@@ -315,6 +360,58 @@ fn git_status(path: &Path, args: &[&str]) -> bool {
         .is_ok_and(|status| status.success())
 }
 
+fn run_validation_dependency_lifecycle(snapshot: &CheckoutHygieneSnapshot) -> Result<()> {
+    let path = Path::new(&snapshot.path);
+    let mut component =
+        component::resolve_effective(Some(&snapshot.id), Some(&snapshot.path), None)?;
+    component.local_path = snapshot.path.clone();
+
+    run_dependency_install_lifecycle(&component, path)?;
+    run_dependency_build_lifecycle(&component, path)
+}
+
+fn run_dependency_install_lifecycle(component: &Component, path: &Path) -> Result<()> {
+    let providers = match deps_provider::resolve_dependency_providers(component, path) {
+        Ok(providers) => providers,
+        Err(_) => return Ok(()),
+    };
+
+    for provider in providers {
+        provider.install(component, path)?;
+    }
+    Ok(())
+}
+
+fn run_dependency_build_lifecycle(component: &Component, path: &Path) -> Result<()> {
+    if !component.has_script(ExtensionCapability::Build)
+        && build::resolve_build_command(component).is_err()
+    {
+        return Ok(());
+    }
+
+    let (result, exit_code) = build::run_component(component)?;
+    if exit_code == 0 {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "validation_dependencies",
+        format!(
+            "Validation dependency `{}` build lifecycle failed with status {exit_code}",
+            component.id
+        ),
+        Some(path.display().to_string()),
+        Some(vec![
+            format!(
+                "Run manually: homeboy build {} --path {}",
+                component.id,
+                path.display()
+            ),
+            serde_json::to_string(&result).unwrap_or_default(),
+        ]),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -343,6 +440,18 @@ mod tests {
         fs::write(path.join("README.md"), "initial\n").unwrap();
         git(path, &["add", "."]);
         git(path, &["commit", "-m", "initial"]);
+    }
+
+    fn init_repo_with_upstream(path: &Path) -> tempfile::TempDir {
+        let remote = tempfile::tempdir().unwrap();
+        init_repo(path);
+        git(remote.path(), &["init", "--bare", "-b", "main"]);
+        git(
+            path,
+            &["remote", "add", "origin", remote.path().to_str().unwrap()],
+        );
+        git(path, &["push", "-u", "origin", "main"]);
+        remote
     }
 
     #[test]
@@ -522,5 +631,57 @@ mod tests {
 
         assert_eq!(err.code, ErrorCode::ValidationMultipleErrors);
         assert_eq!(err.details["checkouts"][0]["dirty"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn dependency_hygiene_runs_validation_dependency_lifecycle() {
+        crate::test_support::with_isolated_home(|_| {
+            let workspace_parent = tempfile::tempdir().unwrap();
+            let source = workspace_parent.path().join("source");
+            let dependency = workspace_parent.path().join("dep");
+            fs::create_dir_all(&source).unwrap();
+            fs::create_dir_all(&dependency).unwrap();
+            fs::write(
+                source.join(PORTABLE_CONFIG_FILE),
+                serde_json::json!({
+                    "id": "source",
+                    "extensions": {
+                        "example": {
+                            "settings": { "validation_dependencies": ["dep"] }
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .unwrap();
+            fs::write(
+                dependency.join(PORTABLE_CONFIG_FILE),
+                serde_json::json!({
+                    "id": "dep",
+                    "scripts": {
+                        "deps": ["sh -c 'printf install > deps-installed.txt'"],
+                        "build": ["sh -c 'printf build > build-built.txt'"]
+                    }
+                })
+                .to_string(),
+            )
+            .unwrap();
+            fs::write(
+                dependency.join(".gitignore"),
+                "deps-installed.txt\nbuild-built.txt\n",
+            )
+            .unwrap();
+            let _remote = init_repo_with_upstream(&dependency);
+
+            require_dependency_hygiene_for_source(
+                &source,
+                None,
+                DependencyHygieneOptions { allow_stale: false },
+            )
+            .expect("validation dependency lifecycle should run after hygiene passes");
+
+            assert!(dependency.join("deps-installed.txt").exists());
+            assert!(dependency.join("build-built.txt").exists());
+        });
     }
 }

--- a/src/core/runner/validation_dependencies.rs
+++ b/src/core/runner/validation_dependencies.rs
@@ -1,7 +1,9 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::core::component::{self, Component};
 use crate::core::error::{Error, Result};
+use crate::core::{git::clone_repo, paths};
 
 use super::workspace::{materialize_snapshot, parent_remote_path, sanitize_path_segment};
 use super::Runner;
@@ -42,7 +44,7 @@ fn validation_dependency_workspaces(local_path: &Path) -> Result<Vec<PathBuf>> {
 
     dependency_ids
         .into_iter()
-        .map(|dependency_id| resolve_sibling_dependency_workspace(parent, &dependency_id))
+        .map(|dependency_id| prepare_validation_dependency_workspace(parent, &dependency_id))
         .collect()
 }
 
@@ -142,6 +144,194 @@ fn resolve_sibling_dependency_workspace(parent: &Path, dependency_id: &str) -> R
     ))
 }
 
+fn prepare_validation_dependency_workspace(parent: &Path, dependency_id: &str) -> Result<PathBuf> {
+    let (mut component, path) = resolve_managed_dependency_workspace(parent, dependency_id)?;
+    component.local_path = path.display().to_string();
+
+    prepare_dependency_git_state(&component, &path)?;
+
+    path.canonicalize().map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!(
+                "canonicalize validation dependency {dependency_id}"
+            )),
+        )
+    })
+}
+
+fn resolve_managed_dependency_workspace(
+    parent: &Path,
+    dependency_id: &str,
+) -> Result<(Component, PathBuf)> {
+    if let Ok(path) = resolve_sibling_dependency_workspace(parent, dependency_id) {
+        let mut component = component::resolve_effective(
+            Some(dependency_id),
+            Some(&path.display().to_string()),
+            None,
+        )?;
+        component.local_path = path.display().to_string();
+        return Ok((component, path));
+    }
+
+    if let Ok(component) = component::resolve_effective(Some(dependency_id), None, None) {
+        let path = PathBuf::from(shellexpand::tilde(&component.local_path).as_ref());
+        if path.is_dir() {
+            return Ok((
+                component,
+                canonical_existing_dependency_dir(&path, dependency_id)?,
+            ));
+        }
+        return clone_missing_dependency(component, dependency_id);
+    }
+
+    if let Some(component) = read_standalone_dependency_config(dependency_id)? {
+        let path = PathBuf::from(shellexpand::tilde(&component.local_path).as_ref());
+        if path.is_dir() {
+            return Ok((
+                component,
+                canonical_existing_dependency_dir(&path, dependency_id)?,
+            ));
+        }
+        return clone_missing_dependency(component, dependency_id);
+    }
+
+    Err(Error::validation_invalid_argument(
+        "validation_dependencies",
+        format!(
+            "Runner workspace sync could not resolve validation dependency `{dependency_id}` as a sibling checkout or registered component"
+        ),
+        Some(parent.display().to_string()),
+        Some(vec![format!(
+            "Register `{dependency_id}` as a Homeboy component or place its checkout next to the source checkout before runner dispatch."
+        )]),
+    ))
+}
+
+fn clone_missing_dependency(
+    component: Component,
+    dependency_id: &str,
+) -> Result<(Component, PathBuf)> {
+    let path = PathBuf::from(shellexpand::tilde(&component.local_path).as_ref());
+    if path.as_os_str().is_empty() {
+        return Err(unresolvable_dependency_error(
+            dependency_id,
+            "has no local_path to clone into",
+        ));
+    }
+    if path.exists() && !path.is_dir() {
+        return Err(unresolvable_dependency_error(
+            dependency_id,
+            &format!(
+                "local_path exists but is not a directory: {}",
+                path.display()
+            ),
+        ));
+    }
+    let Some(remote_url) = component
+        .remote_url
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return Err(unresolvable_dependency_error(
+            dependency_id,
+            "is missing locally and has no remote_url for deterministic clone",
+        ));
+    };
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!(
+                    "create validation dependency parent {}",
+                    parent.display()
+                )),
+            )
+        })?;
+    }
+
+    clone_repo(remote_url, &path)?;
+    Ok((
+        component,
+        canonical_existing_dependency_dir(&path, dependency_id)?,
+    ))
+}
+
+fn canonical_existing_dependency_dir(path: &Path, dependency_id: &str) -> Result<PathBuf> {
+    if !path.is_dir() {
+        return Err(unresolvable_dependency_error(
+            dependency_id,
+            &format!("path is not a directory: {}", path.display()),
+        ));
+    }
+    path.canonicalize().map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!(
+                "canonicalize validation dependency {dependency_id}"
+            )),
+        )
+    })
+}
+
+fn read_standalone_dependency_config(dependency_id: &str) -> Result<Option<Component>> {
+    let path = paths::components()?.join(format!("{dependency_id}.json"));
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(&path)
+        .map_err(|err| Error::internal_io(err.to_string(), Some(path.display().to_string())))?;
+    let mut value: serde_json::Value = serde_json::from_str(&content).map_err(|err| {
+        Error::validation_invalid_argument(
+            "validation_dependencies",
+            format!(
+                "failed to parse registered component {}: {err}",
+                path.display()
+            ),
+            Some(dependency_id.to_string()),
+            None,
+        )
+    })?;
+    if let Some(object) = value.as_object_mut() {
+        object.insert(
+            "id".to_string(),
+            serde_json::Value::String(dependency_id.to_string()),
+        );
+    }
+    serde_json::from_value(value).map(Some).map_err(|err| {
+        Error::validation_invalid_argument(
+            "validation_dependencies",
+            format!("failed to load registered component {dependency_id}: {err}"),
+            Some(path.display().to_string()),
+            None,
+        )
+    })
+}
+
+fn prepare_dependency_git_state(component: &Component, path: &Path) -> Result<()> {
+    crate::core::hygiene::require_checkout_hygiene(
+        vec![crate::core::hygiene::DependencyCheckout {
+            id: component.id.clone(),
+            role: "validation_dependency".to_string(),
+            path: path.to_path_buf(),
+        }],
+        crate::core::hygiene::DependencyHygieneOptions { allow_stale: false },
+    )?;
+    Ok(())
+}
+
+fn unresolvable_dependency_error(dependency_id: &str, reason: &str) -> Error {
+    Error::validation_invalid_argument(
+        "validation_dependencies",
+        format!("Validation dependency `{dependency_id}` {reason}"),
+        Some(dependency_id.to_string()),
+        Some(vec![
+            "Homeboy can only repair missing validation dependencies when the component has a deterministic remote_url and local_path.".to_string(),
+            "Dirty, divergent, non-Git, missing-upstream, or unresolvable dependency states block Lab evidence runs.".to_string(),
+        ]),
+    )
+}
+
 fn is_homeboy_component_id(path: &Path, dependency_id: &str) -> bool {
     if !path.is_dir() {
         return false;
@@ -161,11 +351,42 @@ fn is_homeboy_component_id(path: &Path, dependency_id: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use std::process::Command;
 
     use super::*;
     use crate::core::runner::workspace::{
         parent_remote_path, sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
     };
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_checkout_with_upstream(path: &Path) -> tempfile::TempDir {
+        let remote = tempfile::tempdir().expect("remote");
+        git(path, &["init", "-b", "main"]);
+        git(path, &["config", "user.email", "test@example.com"]);
+        git(path, &["config", "user.name", "Homeboy Test"]);
+        git(remote.path(), &["init", "--bare", "-b", "main"]);
+        git(
+            path,
+            &["remote", "add", "origin", remote.path().to_str().unwrap()],
+        );
+        git(path, &["add", "."]);
+        git(path, &["commit", "-m", "initial"]);
+        git(path, &["push", "-u", "origin", "main"]);
+        remote
+    }
 
     #[test]
     fn sync_workspace_materializes_validation_dependency_siblings() {
@@ -198,6 +419,7 @@ mod tests {
             )
             .expect("dependency manifest");
             fs::write(dependency.join("lib/agents.php"), "<?php\n").expect("dependency file");
+            let _remote = init_checkout_with_upstream(&dependency);
 
             super::super::create(
                 &format!(
@@ -223,6 +445,152 @@ mod tests {
             assert!(Path::new(&output.remote_path).join("src/main.php").exists());
             assert!(Path::new(&remote_parent)
                 .join("agents-api/lib/agents.php")
+                .exists());
+        });
+    }
+
+    #[test]
+    fn sync_workspace_runs_validation_dependency_lifecycle_before_materializing() {
+        crate::test_support::with_isolated_home(|_| {
+            let workspace_parent = tempfile::tempdir().expect("workspace parent");
+            let source = workspace_parent.path().join("studio-web");
+            let dependency = workspace_parent.path().join("agents-api");
+            let runner_root = tempfile::tempdir().expect("runner root tempdir");
+            fs::create_dir_all(&source).expect("source dir");
+            fs::create_dir_all(&dependency).expect("dependency dir");
+            fs::write(
+                source.join("homeboy.json"),
+                serde_json::json!({
+                    "id": "studio-web",
+                    "extensions": {
+                        "wordpress": {
+                            "settings": {
+                                "validation_dependencies": ["agents-api"]
+                            }
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .expect("source manifest");
+            fs::write(
+                dependency.join("homeboy.json"),
+                serde_json::json!({
+                    "id": "agents-api",
+                    "scripts": {
+                        "deps": ["sh -c 'printf install > deps-installed.txt'"],
+                        "build": ["sh -c 'printf build > build-built.txt'"]
+                    }
+                })
+                .to_string(),
+            )
+            .expect("dependency manifest");
+            fs::write(
+                dependency.join(".gitignore"),
+                "deps-installed.txt\nbuild-built.txt\n",
+            )
+            .expect("dependency gitignore");
+            let _remote = init_checkout_with_upstream(&dependency);
+
+            super::super::create(
+                &format!(
+                    r#"{{"id":"lab-local-lifecycle","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+
+            let (output, exit_code) = sync_workspace(
+                "lab-local-lifecycle",
+                RunnerWorkspaceSyncOptions {
+                    path: source.display().to_string(),
+                    mode: RunnerWorkspaceSyncMode::Snapshot,
+                    changed_since_base: None,
+                },
+            )
+            .expect("sync workspace");
+
+            assert_eq!(exit_code, 0);
+            let remote_parent = parent_remote_path(&output.remote_path);
+            assert!(Path::new(&remote_parent)
+                .join("agents-api/deps-installed.txt")
+                .exists());
+            assert!(Path::new(&remote_parent)
+                .join("agents-api/build-built.txt")
+                .exists());
+        });
+    }
+
+    #[test]
+    fn sync_workspace_clones_missing_registered_validation_dependency() {
+        crate::test_support::with_isolated_home(|_| {
+            let workspace_parent = tempfile::tempdir().expect("workspace parent");
+            let remote_parent = tempfile::tempdir().expect("remote parent");
+            let source = workspace_parent.path().join("studio-web");
+            let seed = remote_parent.path().join("agents-api-seed");
+            let clone_target = workspace_parent.path().join("agents-api-clone");
+            let runner_root = tempfile::tempdir().expect("runner root tempdir");
+            fs::create_dir_all(&source).expect("source dir");
+            fs::create_dir_all(seed.join("lib")).expect("seed dir");
+            fs::write(
+                source.join("homeboy.json"),
+                serde_json::json!({
+                    "id": "studio-web",
+                    "extensions": {
+                        "wordpress": {
+                            "settings": {
+                                "validation_dependencies": ["agents-api"]
+                            }
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .expect("source manifest");
+            fs::write(
+                seed.join("homeboy.json"),
+                serde_json::json!({ "id": "agents-api" }).to_string(),
+            )
+            .expect("seed manifest");
+            fs::write(seed.join("lib/agents.php"), "<?php\n").expect("seed file");
+            let remote = init_checkout_with_upstream(&seed);
+            let components_dir = crate::core::paths::components().expect("components dir");
+            fs::create_dir_all(&components_dir).expect("components dir exists");
+            fs::write(
+                components_dir.join("agents-api.json"),
+                serde_json::json!({
+                    "local_path": clone_target,
+                    "remote_url": remote.path()
+                })
+                .to_string(),
+            )
+            .expect("registered dependency config");
+
+            super::super::create(
+                &format!(
+                    r#"{{"id":"lab-local-clone","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+
+            let (output, exit_code) = sync_workspace(
+                "lab-local-clone",
+                RunnerWorkspaceSyncOptions {
+                    path: source.display().to_string(),
+                    mode: RunnerWorkspaceSyncMode::Snapshot,
+                    changed_since_base: None,
+                },
+            )
+            .expect("sync workspace");
+
+            assert_eq!(exit_code, 0);
+            assert!(clone_target.join("lib/agents.php").exists());
+            let remote_parent = parent_remote_path(&output.remote_path);
+            assert!(Path::new(&remote_parent)
+                .join("agents-api-clone/lib/agents.php")
                 .exists());
         });
     }


### PR DESCRIPTION
## Summary
- Resolve declared Lab validation dependencies as managed Homeboy components, including registered component checkouts beyond sibling folders.
- Clone missing registered dependencies when a deterministic local_path and remote_url are available, then fail closed for unresolved or unsafe states.
- Run dependency-provider install and configured build lifecycle after hygiene passes, recheck cleanliness, and materialize the prepared dependency before Lab matrix execution.
- Treat validation dependencies without upstream tracking as unsafe for evidence workflows.

## Tests
- cargo fmt
- cargo test validation_dependencies --lib
- cargo test hygiene --lib
- cargo test core::runner --lib
- cargo test bench::matrix --lib
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the validation dependency lifecycle changes and targeted tests; Chris remains responsible for review and merge.