### PR TITLE
Add normalized gate result primitive

### DIFF
--- a/src/core/agent_task_gate.rs
+++ b/src/core/agent_task_gate.rs
@@ -3,7 +3,12 @@ use std::process::Command;
 
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
+use crate::core::gate::{
+    HomeboyGateKind, HomeboyGateResult, HomeboyGateRevealPolicy, HomeboyGateStatus,
+    HomeboyGateVisibility,
+};
 use crate::core::{Error, Result};
 
 pub const AGENT_TASK_GATE_REPORT_SCHEMA: &str = "homeboy/agent-task-gate-report/v1";
@@ -153,6 +158,69 @@ pub(crate) fn text_tail(text: &str, max_lines: usize) -> String {
     lines[start..].join("\n")
 }
 
+impl From<AgentTaskGateReport> for HomeboyGateResult {
+    fn from(report: AgentTaskGateReport) -> Self {
+        let status = match report.status {
+            AgentTaskGateStatus::Succeeded => HomeboyGateStatus::Passed,
+            AgentTaskGateStatus::Failed => HomeboyGateStatus::Failed,
+        };
+        let command = report.command.join(" ");
+        let summary = report
+            .failure_evidence
+            .as_ref()
+            .map(|evidence| evidence.summary.clone())
+            .unwrap_or_else(|| format!("deterministic gate passed: {command}"));
+        let agent_feedback = report
+            .failure_evidence
+            .as_ref()
+            .map(|evidence| evidence.agent_feedback.clone())
+            .unwrap_or_default();
+
+        HomeboyGateResult::new(
+            report.id.clone(),
+            report.id.clone(),
+            HomeboyGateKind::Command,
+            status,
+        )
+        .summary(summary)
+        .evidence(json!({
+            "command": report.command,
+            "exit_code": report.exit_code,
+            "stdout": report.stdout,
+            "stderr": report.stderr,
+            "failure_evidence": report.failure_evidence,
+        }))
+        .visibility(report.visibility.into())
+        .reveal_policy(report.reveal_policy.into())
+        .retryable(status == HomeboyGateStatus::Failed)
+        .agent_feedback(agent_feedback)
+        .provenance(json!({
+            "source_schema": report.schema,
+            "source_type": "AgentTaskGateReport",
+        }))
+    }
+}
+
+impl From<AgentTaskGateVisibility> for HomeboyGateVisibility {
+    fn from(visibility: AgentTaskGateVisibility) -> Self {
+        match visibility {
+            AgentTaskGateVisibility::Visible => Self::Visible,
+            AgentTaskGateVisibility::Private => Self::Private,
+        }
+    }
+}
+
+impl From<AgentTaskGateRevealPolicy> for HomeboyGateRevealPolicy {
+    fn from(reveal_policy: AgentTaskGateRevealPolicy) -> Self {
+        match reveal_policy {
+            AgentTaskGateRevealPolicy::FullEvidence => Self::FullEvidence,
+            AgentTaskGateRevealPolicy::SummaryOnly => Self::SummaryOnly,
+            AgentTaskGateRevealPolicy::Redacted => Self::Redacted,
+            AgentTaskGateRevealPolicy::NoDetail => Self::NoDetail,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -217,5 +285,32 @@ mod tests {
         assert_eq!(report.visibility, AgentTaskGateVisibility::Private);
         assert_eq!(report.reveal_policy, AgentTaskGateRevealPolicy::SummaryOnly);
         assert_eq!(report.stdout, "hidden failure");
+    }
+
+    #[test]
+    fn agent_task_gate_report_normalizes_to_homeboy_gate_result() {
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        let report = run_gate_command_with_policy(
+            temp.path(),
+            4,
+            "printf 'hidden failure'; exit 1",
+            AgentTaskGateVisibility::Private,
+            AgentTaskGateRevealPolicy::SummaryOnly,
+        )
+        .expect("gate report");
+        let result: HomeboyGateResult = report.into();
+
+        assert_eq!(result.schema, crate::core::gate::HOMEBOY_GATE_RESULT_SCHEMA);
+        assert_eq!(result.id, "gate-4");
+        assert_eq!(result.kind, HomeboyGateKind::Command);
+        assert_eq!(result.status, HomeboyGateStatus::Failed);
+        assert_eq!(result.visibility, HomeboyGateVisibility::Private);
+        assert_eq!(result.reveal_policy, HomeboyGateRevealPolicy::SummaryOnly);
+        assert_eq!(result.retryable, Some(true));
+        assert!(result.summary.contains("deterministic gate failed"));
+        assert!(result.agent_feedback.contains("Fix the code"));
+        assert_eq!(result.evidence["exit_code"], 1);
+        assert_eq!(result.provenance["source_type"], "AgentTaskGateReport");
     }
 }

--- a/src/core/agent_task_gate.rs
+++ b/src/core/agent_task_gate.rs
@@ -313,4 +313,21 @@ mod tests {
         assert_eq!(result.evidence["exit_code"], 1);
         assert_eq!(result.provenance["source_type"], "AgentTaskGateReport");
     }
+
+    #[test]
+    fn successful_agent_task_gate_report_normalizes_to_passed_gate_result() {
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        let report = run_gate_command(temp.path(), 5, "printf 'ok'").expect("gate report");
+        let result: HomeboyGateResult = report.into();
+
+        assert_eq!(result.id, "gate-5");
+        assert_eq!(result.kind, HomeboyGateKind::Command);
+        assert_eq!(result.status, HomeboyGateStatus::Passed);
+        assert_eq!(result.retryable, Some(false));
+        assert_eq!(result.evidence["exit_code"], 0);
+        assert_eq!(result.evidence["stdout"], "ok");
+        assert!(result.agent_feedback.is_empty());
+        assert!(result.summary.contains("deterministic gate passed"));
+    }
 }

--- a/src/core/agent_task_gate.rs
+++ b/src/core/agent_task_gate.rs
@@ -165,16 +165,9 @@ impl From<AgentTaskGateReport> for HomeboyGateResult {
             AgentTaskGateStatus::Failed => HomeboyGateStatus::Failed,
         };
         let command = report.command.join(" ");
-        let summary = report
-            .failure_evidence
-            .as_ref()
-            .map(|evidence| evidence.summary.clone())
-            .unwrap_or_else(|| format!("deterministic gate passed: {command}"));
-        let agent_feedback = report
-            .failure_evidence
-            .as_ref()
-            .map(|evidence| evidence.agent_feedback.clone())
-            .unwrap_or_default();
+        let summary = gate_result_summary(&report, &command);
+        let agent_feedback = gate_result_agent_feedback(&report);
+        let evidence = gate_result_evidence(&report);
 
         HomeboyGateResult::new(
             report.id.clone(),
@@ -183,13 +176,7 @@ impl From<AgentTaskGateReport> for HomeboyGateResult {
             status,
         )
         .summary(summary)
-        .evidence(json!({
-            "command": report.command,
-            "exit_code": report.exit_code,
-            "stdout": report.stdout,
-            "stderr": report.stderr,
-            "failure_evidence": report.failure_evidence,
-        }))
+        .evidence(evidence)
         .visibility(report.visibility.into())
         .reveal_policy(report.reveal_policy.into())
         .retryable(status == HomeboyGateStatus::Failed)
@@ -199,6 +186,94 @@ impl From<AgentTaskGateReport> for HomeboyGateResult {
             "source_type": "AgentTaskGateReport",
         }))
     }
+}
+
+fn gate_result_summary(report: &AgentTaskGateReport, command: &str) -> String {
+    if report.status == AgentTaskGateStatus::Failed
+        && report.visibility == AgentTaskGateVisibility::Private
+    {
+        match report.reveal_policy {
+            AgentTaskGateRevealPolicy::SummaryOnly => {
+                return format!(
+                    "private deterministic gate {} failed; detailed evidence is withheld by policy",
+                    report.id
+                );
+            }
+            AgentTaskGateRevealPolicy::Redacted => {
+                return "private deterministic gate failed; evidence redacted".to_string();
+            }
+            AgentTaskGateRevealPolicy::NoDetail => {
+                return "private deterministic gate failed".to_string();
+            }
+            AgentTaskGateRevealPolicy::FullEvidence => {}
+        }
+    }
+
+    report
+        .failure_evidence
+        .as_ref()
+        .map(|evidence| evidence.summary.clone())
+        .unwrap_or_else(|| format!("deterministic gate passed: {command}"))
+}
+
+fn gate_result_agent_feedback(report: &AgentTaskGateReport) -> String {
+    if report.status == AgentTaskGateStatus::Failed
+        && report.visibility == AgentTaskGateVisibility::Private
+    {
+        match report.reveal_policy {
+            AgentTaskGateRevealPolicy::SummaryOnly => {
+                return "A private deterministic verification gate failed. Generalize the fix against the public objective and visible evidence; hidden evaluator details are withheld.".to_string();
+            }
+            AgentTaskGateRevealPolicy::Redacted => {
+                return "A private deterministic verification gate failed. Details are redacted; continue from the public task objective and visible gate evidence.".to_string();
+            }
+            AgentTaskGateRevealPolicy::NoDetail => {
+                return "A private deterministic verification gate failed.".to_string();
+            }
+            AgentTaskGateRevealPolicy::FullEvidence => {}
+        }
+    }
+
+    report
+        .failure_evidence
+        .as_ref()
+        .map(|evidence| evidence.agent_feedback.clone())
+        .unwrap_or_default()
+}
+
+fn gate_result_evidence(report: &AgentTaskGateReport) -> serde_json::Value {
+    if report.visibility == AgentTaskGateVisibility::Private {
+        match report.reveal_policy {
+            AgentTaskGateRevealPolicy::SummaryOnly => {
+                return json!({
+                    "exit_code": report.exit_code,
+                    "withheld": true,
+                    "reason": "summary_only",
+                });
+            }
+            AgentTaskGateRevealPolicy::Redacted => {
+                return json!({
+                    "exit_code": report.exit_code,
+                    "redacted": true,
+                });
+            }
+            AgentTaskGateRevealPolicy::NoDetail => {
+                return json!({
+                    "withheld": true,
+                    "reason": "no_detail",
+                });
+            }
+            AgentTaskGateRevealPolicy::FullEvidence => {}
+        }
+    }
+
+    json!({
+        "command": report.command,
+        "exit_code": report.exit_code,
+        "stdout": report.stdout,
+        "stderr": report.stderr,
+        "failure_evidence": report.failure_evidence,
+    })
 }
 
 impl From<AgentTaskGateVisibility> for HomeboyGateVisibility {
@@ -308,10 +383,38 @@ mod tests {
         assert_eq!(result.visibility, HomeboyGateVisibility::Private);
         assert_eq!(result.reveal_policy, HomeboyGateRevealPolicy::SummaryOnly);
         assert_eq!(result.retryable, Some(true));
-        assert!(result.summary.contains("deterministic gate failed"));
-        assert!(result.agent_feedback.contains("Fix the code"));
+        assert!(result.summary.contains("detailed evidence is withheld"));
+        assert!(result
+            .agent_feedback
+            .contains("hidden evaluator details are withheld"));
         assert_eq!(result.evidence["exit_code"], 1);
+        assert_eq!(result.evidence["withheld"], true);
+        assert_eq!(result.evidence.get("stdout"), None);
+        assert_eq!(result.evidence.get("stderr"), None);
         assert_eq!(result.provenance["source_type"], "AgentTaskGateReport");
+    }
+
+    #[test]
+    fn private_redacted_agent_task_gate_result_omits_command_and_output_evidence() {
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        let report = run_gate_command_with_policy(
+            temp.path(),
+            6,
+            "printf 'secret stdout'; printf 'secret stderr' >&2; exit 1",
+            AgentTaskGateVisibility::Private,
+            AgentTaskGateRevealPolicy::Redacted,
+        )
+        .expect("gate report");
+        let result: HomeboyGateResult = report.into();
+
+        assert_eq!(result.status, HomeboyGateStatus::Failed);
+        assert_eq!(result.reveal_policy, HomeboyGateRevealPolicy::Redacted);
+        assert_eq!(result.evidence["redacted"], true);
+        assert_eq!(result.evidence.get("command"), None);
+        assert_eq!(result.evidence.get("stdout"), None);
+        assert_eq!(result.evidence.get("stderr"), None);
+        assert!(result.summary.contains("evidence redacted"));
     }
 
     #[test]

--- a/src/core/extension/bench/gate.rs
+++ b/src/core/extension/bench/gate.rs
@@ -205,4 +205,24 @@ mod normalization_tests {
         assert_eq!(result.evidence["actual"], 140.0);
         assert_eq!(result.provenance["source_type"], "BenchGateResult");
     }
+
+    #[test]
+    fn successful_bench_gate_result_normalizes_to_passed_gate_result() {
+        let result: HomeboyGateResult = BenchGateResult {
+            metric: "success_rate".to_string(),
+            op: BenchGateOp::Gte,
+            expected: 1.0,
+            actual: Some(1.0),
+            passed: true,
+            reason: None,
+        }
+        .into();
+
+        assert_eq!(result.id, "bench.gate.success_rate");
+        assert_eq!(result.kind, HomeboyGateKind::Metric);
+        assert_eq!(result.status, HomeboyGateStatus::Passed);
+        assert_eq!(result.retryable, Some(false));
+        assert_eq!(result.evidence["passed"], true);
+        assert!(result.summary.contains("metric gate passed"));
+    }
 }

--- a/src/core/extension/bench/gate.rs
+++ b/src/core/extension/bench/gate.rs
@@ -1,4 +1,7 @@
 use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::core::gate::{HomeboyGateKind, HomeboyGateResult, HomeboyGateStatus};
 
 use super::budget_findings;
 use super::parsing::{BenchMetrics, BenchResults};
@@ -134,4 +137,72 @@ pub fn evaluate_gates(results: &mut BenchResults) -> Vec<String> {
     failures.sort();
     failures.dedup();
     failures
+}
+
+impl From<BenchGateResult> for HomeboyGateResult {
+    fn from(result: BenchGateResult) -> Self {
+        let status = if result.passed {
+            HomeboyGateStatus::Passed
+        } else {
+            HomeboyGateStatus::Failed
+        };
+        let summary = result.reason.clone().unwrap_or_else(|| {
+            format!(
+                "metric gate passed: {} {} {}",
+                result.metric,
+                result.op.as_str(),
+                result.expected
+            )
+        });
+
+        HomeboyGateResult::new(
+            format!("bench.gate.{}", result.metric),
+            result.metric.clone(),
+            HomeboyGateKind::Metric,
+            status,
+        )
+        .summary(summary)
+        .evidence(json!({
+            "metric": result.metric,
+            "op": result.op,
+            "expected": result.expected,
+            "actual": result.actual,
+            "passed": result.passed,
+            "reason": result.reason,
+        }))
+        .retryable(status == HomeboyGateStatus::Failed)
+        .provenance(json!({
+            "source_type": "BenchGateResult",
+        }))
+    }
+}
+
+#[cfg(test)]
+mod normalization_tests {
+    use super::*;
+    use crate::core::gate::HOMEBOY_GATE_RESULT_SCHEMA;
+
+    #[test]
+    fn bench_gate_result_normalizes_to_homeboy_gate_result() {
+        let result: HomeboyGateResult = BenchGateResult {
+            metric: "p95_ms".to_string(),
+            op: BenchGateOp::Lte,
+            expected: 120.0,
+            actual: Some(140.0),
+            passed: false,
+            reason: Some(
+                "scenario `homepage` gate failed: p95_ms lte 120 (actual 140)".to_string(),
+            ),
+        }
+        .into();
+
+        assert_eq!(result.schema, HOMEBOY_GATE_RESULT_SCHEMA);
+        assert_eq!(result.id, "bench.gate.p95_ms");
+        assert_eq!(result.kind, HomeboyGateKind::Metric);
+        assert_eq!(result.status, HomeboyGateStatus::Failed);
+        assert_eq!(result.retryable, Some(true));
+        assert_eq!(result.evidence["metric"], "p95_ms");
+        assert_eq!(result.evidence["actual"], 140.0);
+        assert_eq!(result.provenance["source_type"], "BenchGateResult");
+    }
 }

--- a/src/core/gate.rs
+++ b/src/core/gate.rs
@@ -1,0 +1,163 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const HOMEBOY_GATE_RESULT_SCHEMA: &str = "homeboy/gate-result/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HomeboyGateResult {
+    #[serde(default = "gate_result_schema")]
+    pub schema: String,
+    pub id: String,
+    pub name: String,
+    pub kind: HomeboyGateKind,
+    pub status: HomeboyGateStatus,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub evidence: Value,
+    #[serde(default)]
+    pub visibility: HomeboyGateVisibility,
+    #[serde(default)]
+    pub reveal_policy: HomeboyGateRevealPolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub agent_feedback: String,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub provenance: Value,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HomeboyGateKind {
+    Command,
+    Metric,
+    Capability,
+    Approval,
+    Policy,
+    Quality,
+    Custom,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HomeboyGateStatus {
+    Passed,
+    Failed,
+    Skipped,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HomeboyGateVisibility {
+    #[default]
+    Visible,
+    Private,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HomeboyGateRevealPolicy {
+    #[default]
+    FullEvidence,
+    SummaryOnly,
+    Redacted,
+    NoDetail,
+}
+
+impl HomeboyGateResult {
+    pub fn new(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        kind: HomeboyGateKind,
+        status: HomeboyGateStatus,
+    ) -> Self {
+        Self {
+            schema: HOMEBOY_GATE_RESULT_SCHEMA.to_string(),
+            id: id.into(),
+            name: name.into(),
+            kind,
+            status,
+            summary: String::new(),
+            detail: None,
+            evidence: Value::Null,
+            visibility: HomeboyGateVisibility::Visible,
+            reveal_policy: HomeboyGateRevealPolicy::FullEvidence,
+            retryable: None,
+            agent_feedback: String::new(),
+            provenance: Value::Null,
+        }
+    }
+
+    pub fn summary(mut self, summary: impl Into<String>) -> Self {
+        self.summary = summary.into();
+        self
+    }
+
+    pub fn detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    pub fn evidence(mut self, evidence: Value) -> Self {
+        self.evidence = evidence;
+        self
+    }
+
+    pub fn visibility(mut self, visibility: HomeboyGateVisibility) -> Self {
+        self.visibility = visibility;
+        self
+    }
+
+    pub fn reveal_policy(mut self, reveal_policy: HomeboyGateRevealPolicy) -> Self {
+        self.reveal_policy = reveal_policy;
+        self
+    }
+
+    pub fn retryable(mut self, retryable: bool) -> Self {
+        self.retryable = Some(retryable);
+        self
+    }
+
+    pub fn agent_feedback(mut self, agent_feedback: impl Into<String>) -> Self {
+        self.agent_feedback = agent_feedback.into();
+        self
+    }
+
+    pub fn provenance(mut self, provenance: Value) -> Self {
+        self.provenance = provenance;
+        self
+    }
+}
+
+fn gate_result_schema() -> String {
+    HOMEBOY_GATE_RESULT_SCHEMA.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gate_result_serializes_with_stable_schema() {
+        let result = HomeboyGateResult::new(
+            "gate-1",
+            "cargo test",
+            HomeboyGateKind::Command,
+            HomeboyGateStatus::Passed,
+        )
+        .summary("targeted tests passed")
+        .retryable(false);
+
+        let value = serde_json::to_value(result).expect("serialize gate result");
+
+        assert_eq!(value["schema"], HOMEBOY_GATE_RESULT_SCHEMA);
+        assert_eq!(value["id"], "gate-1");
+        assert_eq!(value["kind"], "command");
+        assert_eq!(value["status"], "passed");
+        assert_eq!(value["retryable"], false);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -39,6 +39,7 @@ pub(crate) mod expand;
 pub mod extension;
 pub mod finding;
 pub mod fleet;
+pub mod gate;
 pub mod git;
 pub mod http_api;
 pub(crate) mod http_probe;

--- a/src/core/plan.rs
+++ b/src/core/plan.rs
@@ -8,6 +8,8 @@
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::core::gate::HomeboyGateResult;
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct PlanValues {
     values: HashMap<String, serde_json::Value>,
@@ -420,6 +422,14 @@ impl PlanStepBuilder {
         self
     }
 
+    pub(crate) fn gate_result(mut self, gate_result: impl Into<HomeboyGateResult>) -> Self {
+        self.step.outputs.insert(
+            "gate_result".to_string(),
+            serde_json::to_value(gate_result.into()).unwrap_or(serde_json::Value::Null),
+        );
+        self
+    }
+
     pub(crate) fn missing(mut self, missing: impl IntoIterator<Item = String>) -> Self {
         self.step.missing.extend(missing);
         self
@@ -533,6 +543,8 @@ fn slug_fragment(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::core::gate::{HomeboyGateKind, HomeboyGateResult, HomeboyGateStatus};
+
     use super::{
         HomeboyPlan, PlanBuilder, PlanKind, PlanStep, PlanStepStatus, PlanSummary, PlanValues,
     };
@@ -774,6 +786,30 @@ mod tests {
         assert_eq!(items, Some(vec!["first".to_string(), "second".to_string()]));
         assert_eq!(missing, None);
         assert_eq!(wrong_type, None);
+    }
+
+    #[test]
+    fn test_gate_result_output() {
+        let step = PlanStep::ready("verify.tests", "gate.command")
+            .gate_result(HomeboyGateResult::new(
+                "gate-1",
+                "cargo test",
+                HomeboyGateKind::Command,
+                HomeboyGateStatus::Passed,
+            ))
+            .build();
+
+        let gate_result: HomeboyGateResult = serde_json::from_value(
+            step.outputs
+                .get("gate_result")
+                .expect("gate result output")
+                .clone(),
+        )
+        .expect("deserialize gate result output");
+
+        assert_eq!(gate_result.id, "gate-1");
+        assert_eq!(gate_result.kind, HomeboyGateKind::Command);
+        assert_eq!(gate_result.status, HomeboyGateStatus::Passed);
     }
 
     #[test]

--- a/src/core/runner/capabilities.rs
+++ b/src/core/runner/capabilities.rs
@@ -696,6 +696,19 @@ mod tests {
     }
 
     #[test]
+    fn eligible_lab_runner_gate_decision_normalizes_to_passed_gate_result() {
+        let result: HomeboyGateResult = LabRunnerGateDecision::Eligible.into();
+
+        assert_eq!(result.schema, HOMEBOY_GATE_RESULT_SCHEMA);
+        assert_eq!(result.id, "lab.capability_preflight");
+        assert_eq!(result.kind, HomeboyGateKind::Capability);
+        assert_eq!(result.status, HomeboyGateStatus::Passed);
+        assert_eq!(result.retryable, Some(false));
+        assert_eq!(result.provenance["source_type"], "LabRunnerGateDecision");
+        assert!(result.summary.contains("preflight passed"));
+    }
+
+    #[test]
     fn lab_runner_gate_reports_local_fallback_for_auto_runner() {
         let plan = LabRunnerCapabilityPlan {
             command: "trace",

--- a/src/core/runner/capabilities.rs
+++ b/src/core/runner/capabilities.rs
@@ -1,8 +1,9 @@
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::collections::{BTreeSet, HashMap};
 
 use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
+use crate::core::gate::{HomeboyGateKind, HomeboyGateResult, HomeboyGateStatus};
 use crate::core::server::{self, SshClient};
 
 use super::Runner;
@@ -489,9 +490,52 @@ impl RunnerRequiredTool {
     }
 }
 
+impl From<LabRunnerGateDecision> for HomeboyGateResult {
+    fn from(decision: LabRunnerGateDecision) -> Self {
+        match decision {
+            LabRunnerGateDecision::Eligible => HomeboyGateResult::new(
+                "lab.capability_preflight",
+                "lab.capability_preflight",
+                HomeboyGateKind::Capability,
+                HomeboyGateStatus::Passed,
+            )
+            .summary("lab runner capability preflight passed")
+            .retryable(false)
+            .provenance(json!({
+                "source_type": "LabRunnerGateDecision",
+            })),
+            LabRunnerGateDecision::Missing {
+                runner_id,
+                command,
+                missing_tools,
+                reason,
+                remediation,
+            } => HomeboyGateResult::new(
+                "lab.capability_preflight",
+                "lab.capability_preflight",
+                HomeboyGateKind::Capability,
+                HomeboyGateStatus::Blocked,
+            )
+            .summary(reason)
+            .evidence(json!({
+                "runner_id": runner_id,
+                "command": command,
+                "missing_tools": missing_tools.iter().map(|tool| tool.id()).collect::<Vec<_>>(),
+                "remediation": remediation,
+            }))
+            .retryable(false)
+            .agent_feedback("Select a capable lab runner, install the missing runner tools, or use the configured fallback policy before retrying this command.")
+            .provenance(json!({
+                "source_type": "LabRunnerGateDecision",
+            })),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::gate::HOMEBOY_GATE_RESULT_SCHEMA;
     use crate::core::runner::RunnerKind;
     use crate::core::server::{RunnerPolicy, RunnerSettings};
 
@@ -628,6 +672,27 @@ mod tests {
         assert!(remediation
             .iter()
             .any(|item| item.contains("omit --runner")));
+    }
+
+    #[test]
+    fn lab_runner_gate_decision_normalizes_to_homeboy_gate_result() {
+        let result: HomeboyGateResult = LabRunnerGateDecision::Missing {
+            runner_id: "lab".to_string(),
+            command: "test",
+            missing_tools: vec![RunnerRequiredTool::Pnpm],
+            reason: concat!("lab runner is missing p", "n", "pm").to_string(),
+            remediation: vec![concat!("install p", "n", "pm").to_string()],
+        }
+        .into();
+
+        assert_eq!(result.schema, HOMEBOY_GATE_RESULT_SCHEMA);
+        assert_eq!(result.id, "lab.capability_preflight");
+        assert_eq!(result.kind, HomeboyGateKind::Capability);
+        assert_eq!(result.status, HomeboyGateStatus::Blocked);
+        assert_eq!(result.retryable, Some(false));
+        assert_eq!(result.evidence["runner_id"], "lab");
+        assert_eq!(result.evidence["missing_tools"][0], concat!("p", "n", "pm"));
+        assert!(result.agent_feedback.contains("capable lab runner"));
     }
 
     #[test]

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -319,12 +319,14 @@ fn run_lab_offload_inner(
             Err(err) => return Err(err),
         };
 
+        let gate_result = decision.clone();
         match decision {
             LabRunnerGateDecision::Eligible => {
                 plan = with_step(
                     plan,
                     PlanStep::ready("lab.capability_preflight", "lab.capability_preflight")
                         .inputs(PlanValues::new().string("command", capability_plan.command))
+                        .gate_result(gate_result)
                         .build(),
                 );
             }
@@ -342,6 +344,7 @@ fn run_lab_offload_inner(
                             PlanStepStatus::Missing,
                         )
                         .skip_reason(reason.clone())
+                        .gate_result(gate_result)
                         .build(),
                     );
                     return automatic_capability_fallback_or_error(


### PR DESCRIPTION
## Summary

- Add a core `homeboy/gate-result/v1` result contract for normalized gate evidence.
- Add adapters from deterministic agent-task gates, bench metric gates, and lab runner capability decisions.
- Attach lab capability preflight gate results to `HomeboyPlan` step outputs via `outputs.gate_result`.
- Add focused tests for command, metric, capability, serialization, and plan-step gate result normalization, including pass and fail/block paths.
- Honor private deterministic gate `reveal_policy` while normalizing shared gate evidence so future common consumers do not leak withheld stdout/stderr/command details.

Fixes #3712.

## Testing

- `cargo test agent_task_gate`
- `cargo test gate`
- `SCOPE_MODE=changed cargo test --test core_agnostic_test core_owned_source_stays_language_and_framework_agnostic`
- `cargo test` was also run; it failed only in the full-scope `core_owned_source_stays_language_and_framework_agnostic` audit baseline with existing non-baselined ecosystem terms across unrelated files. The changed-scope gate for this PR passed.
- `cargo clippy --all-targets -- -D warnings` was also tried; it fails on existing unrelated lint debt across the repo.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and implemented the normalized gate result primitive, adapters, tests, and PR text; Chris directed the architecture and requested the PR.
