### PR TITLE
Plan local-only lab routing for scoped hot commands

### DIFF
--- a/docs/cli/homeboy-root-command.md
+++ b/docs/cli/homeboy-root-command.md
@@ -32,11 +32,12 @@ homeboy --output /tmp/homeboy-results/review.json review my-component --changed-
 ```
 
 Resource policy warnings are stderr-only preflight notices. They currently apply
-to hot commands such as `bench`, `rig up`, `fleet exec`, and unscoped
-`audit` / `lint` / `test` runs when `homeboy doctor resources` sees a warm or
-hot machine. They do not block execution; pass `--force-hot` when the extra load
-is intentional. For portable hot commands with a default Lab runner, `--force-hot`
-does not implicitly keep execution local; pass `--runner <id>` to offload or add
+to hot commands such as `bench`, `rig up`, `fleet exec`, full-workspace
+`audit` / `lint` / `test` runs, and changed-scope `audit` / `lint` / `test`
+runs when `homeboy doctor resources` sees a warm or hot machine. They do not
+block execution; pass `--force-hot` when the extra load is intentional. For
+portable hot commands with a default Lab runner, `--force-hot` does not
+implicitly keep execution local; pass `--runner <id>` to offload or add
 `--allow-local-hot` only when local controller-machine execution is intentional.
 
 Not every hot command is offloadable. Lab offload only applies to commands with

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -63,9 +63,12 @@ Lab offload support is intentionally command-specific:
 | Command | Auto offload | Explicit `--runner` | Decision |
 |---|---:|---:|---|
 | `audit` full workspace | Yes | Yes | Safe single-workspace replay after snapshot sync. |
+| `audit --changed-since` | No | No | Runs locally for now because changed-since audit depends on git base refs that Lab sync may not have fetched. The Lab plan records the skipped local-only decision. |
 | `bench run` / default bench run | Yes | Yes | Safe single-workspace replay; local baseline/ratchet writes are treated as mutation flags. |
 | `lint` full workspace | Yes | Yes | Safe single-workspace replay; `--fix` is treated as a mutation flag. |
+| `lint --changed-since` / `lint --changed-only` | No | No | Runs locally for now because changed-file scopes are not represented in the Lab portability contract yet. The Lab plan records the skipped local-only decision. |
 | `test` full workspace | Yes | Yes | Safe single-workspace replay with runner extension parity preflight. |
+| `test --changed-since` | No | No | Runs locally for now because changed-since test selection depends on git base refs that Lab sync may not have fetched. The Lab plan records the skipped local-only decision. |
 | `trace` | Yes | Yes | Safe single-workspace replay with Playwright/browser capability gate. |
 | `rig up` | No | No | Stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace snapshot cannot safely mirror. |
 | `fleet exec` | No | No | Stays local because fleet execution depends on local fleet/project/server config before opening SSH sessions to each project; runner-side config parity is not guaranteed. |

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1091,6 +1091,14 @@ mod tests {
         );
         assert!(!parsed_command(&["homeboy", "status"]).supports_lab_runner());
         assert!(!parsed_command(&["homeboy", "bench", "list"]).supports_lab_runner());
+        assert!(
+            !parsed_command(&["homeboy", "lint", "--changed-since", "origin/main"])
+                .supports_lab_runner()
+        );
+        assert!(
+            !parsed_command(&["homeboy", "test", "--changed-since", "origin/main"])
+                .supports_lab_runner()
+        );
 
         let cli = parsed_cli(&["homeboy", "lint", "--runner", "lab-a"]);
         assert_eq!(cli.runner.as_deref(), Some("lab-a"));
@@ -1224,6 +1232,18 @@ mod tests {
                 .lab_runner_unsupported_reason()
                 .expect("fleet exec reason")
                 .contains("config parity")
+        );
+        assert!(
+            parsed_command(&["homeboy", "lint", "--changed-since", "origin/main"])
+                .lab_runner_unsupported_reason()
+                .expect("changed-scope lint reason")
+                .contains("Changed-scope lint runs stay local")
+        );
+        assert!(
+            parsed_command(&["homeboy", "test", "--changed-since", "origin/main"])
+                .lab_runner_unsupported_reason()
+                .expect("changed-since test reason")
+                .contains("test --changed-since")
         );
         assert!(parsed_command(&["homeboy", "status"])
             .lab_runner_unsupported_reason()

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1182,12 +1182,35 @@ mod tests {
             LabCommandPortability::LocalOnly(reason) if reason.contains("config parity")
         ));
 
+        for args in [
+            ["homeboy", "audit", "--changed-since", "origin/main"].as_slice(),
+            ["homeboy", "lint", "--changed-since", "origin/main"].as_slice(),
+            ["homeboy", "lint", "--changed-only"].as_slice(),
+            ["homeboy", "test", "--changed-since", "origin/main"].as_slice(),
+        ] {
+            let contract = parsed_command(args)
+                .lab_contract()
+                .expect("scoped hot command should have a Lab plan contract");
+            assert!(matches!(
+                contract.portability,
+                LabCommandPortability::LocalOnly(_)
+            ));
+        }
+
         assert!(parsed_command(&["homeboy", "status"])
             .lab_contract()
             .is_none());
         assert!(parsed_command(&["homeboy", "bench", "list"])
             .lab_contract()
             .is_none());
+        assert!(parsed_command(&["homeboy", "audit", "--conventions"])
+            .lab_contract()
+            .is_none());
+        assert!(
+            parsed_command(&["homeboy", "lint", "--file", "src/main.rs"])
+                .lab_contract()
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -35,21 +35,26 @@ pub enum LabCommandRequiredTool {
 
 pub const LAB_TRACE_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[LabCommandRequiredTool::Playwright];
 const LAB_NO_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[];
+const AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON: &str = "`audit --changed-since` is not Lab-portable yet because changed-since audit depends on git base refs that the current Lab workspace sync may not have fetched.";
+const LINT_CHANGED_SCOPE_LAB_UNSUPPORTED_REASON: &str = "Changed-scope lint runs stay local because changed-file scopes are not represented in the current Lab portability contract yet.";
+const TEST_CHANGED_SINCE_LAB_UNSUPPORTED_REASON: &str = "`test --changed-since` is not Lab-portable yet because changed-since test selection depends on git base refs that the current Lab workspace sync may not have fetched.";
 const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.";
 const FLEET_EXEC_LAB_UNSUPPORTED_REASON: &str = "`fleet exec` stays local because it depends on local fleet, project, and server configuration before opening SSH sessions to each project; runner-side config parity is not guaranteed.";
 
 impl Commands {
     pub fn lab_contract(&self) -> Option<LabCommandContract> {
         let contract = match self {
-            Commands::Audit(args) if args.changed_since.is_none() && !args.conventions => {
-                lab_portable_contract(
-                    "audit",
-                    (args.baseline_args.baseline || args.baseline_args.ratchet)
-                        .then_some("--baseline/--ratchet"),
-                    true,
-                    LAB_NO_EXTRA_TOOLS,
-                )
+            Commands::Audit(args) if args.changed_since.is_some() => {
+                lab_local_only_contract("audit", AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON)
             }
+            Commands::Audit(args) if args.conventions => return None,
+            Commands::Audit(args) => lab_portable_contract(
+                "audit",
+                (args.baseline_args.baseline || args.baseline_args.ratchet)
+                    .then_some("--baseline/--ratchet"),
+                true,
+                LAB_NO_EXTRA_TOOLS,
+            ),
             Commands::Bench(args) if args.is_lab_offload_command() => lab_portable_contract(
                 "bench",
                 args.lab_offload_writes_local_state()
@@ -66,6 +71,9 @@ impl Commands {
                 true,
                 LAB_NO_EXTRA_TOOLS,
             ),
+            Commands::Lint(args) if args.changed_since.is_some() || args.changed_only => {
+                lab_local_only_contract("lint", LINT_CHANGED_SCOPE_LAB_UNSUPPORTED_REASON)
+            }
             Commands::Refactor(args) if args.is_hot_resource_command() => lab_portable_contract(
                 "refactor",
                 args.lab_offload_writes_local_state()
@@ -82,6 +90,9 @@ impl Commands {
                 true,
                 LAB_NO_EXTRA_TOOLS,
             ),
+            Commands::Test(_) => {
+                lab_local_only_contract("test", TEST_CHANGED_SINCE_LAB_UNSUPPORTED_REASON)
+            }
             Commands::Trace(args) => lab_portable_workload_contract(
                 "trace",
                 args.keep_overlay.then_some("--keep-overlay"),

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -178,6 +178,17 @@ mod tests {
                 _guard: guard,
             }
         }
+
+        fn remove(name: &'static str) -> Self {
+            let guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+            let previous = std::env::var(name).ok();
+            std::env::remove_var(name);
+            Self {
+                name,
+                previous,
+                _guard: guard,
+            }
+        }
     }
 
     fn env_lock() -> &'static Mutex<()> {
@@ -201,6 +212,70 @@ mod tests {
         let outcome = route_after_parse(&cli, &["homeboy".into(), "status".into()], None).unwrap();
 
         assert_eq!(outcome, None);
+    }
+
+    #[test]
+    fn hot_local_only_command_records_lab_plan_metadata() {
+        let _env = EnvGuard::remove(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV);
+        let cli = Cli::parse_from(["homeboy", "lint", "--changed-since", "origin/main"]);
+
+        let outcome = route_after_parse(
+            &cli,
+            &[
+                "homeboy".into(),
+                "lint".into(),
+                "--changed-since".into(),
+                "origin/main".into(),
+            ],
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(outcome, None);
+        let raw = std::env::var(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV)
+            .expect("Lab routing metadata captured");
+        let metadata: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(metadata["status"], "skipped");
+        assert_eq!(metadata["source"], "automatic");
+        assert!(metadata["plan_id"]
+            .as_str()
+            .unwrap()
+            .contains("lab_offload"));
+        assert!(metadata["fallback_reason"]
+            .as_str()
+            .unwrap()
+            .contains("Changed-scope lint runs stay local"));
+    }
+
+    #[test]
+    fn explicit_runner_for_local_only_hot_command_errors_from_lab_plan_path() {
+        let _env = EnvGuard::remove(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV);
+        let cli = Cli::parse_from([
+            "homeboy",
+            "--runner",
+            "homeboy-lab",
+            "test",
+            "--changed-since",
+            "origin/main",
+        ]);
+
+        let err = route_after_parse(
+            &cli,
+            &[
+                "homeboy".into(),
+                "--runner".into(),
+                "homeboy-lab".into(),
+                "test".into(),
+                "--changed-since".into(),
+                "origin/main".into(),
+            ],
+            None,
+        )
+        .expect_err("local-only hot command rejects explicit runner");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("--runner is unavailable"));
+        assert!(err.message.contains("test --changed-since"));
     }
 
     #[test]

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -315,9 +315,11 @@ fn primary_reason(resources: &DoctorOutput) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli_surface::Cli;
     use crate::commands::doctor::resources::{
         LoadSummary, MemorySummary, ProcessSummary, RigLeaseSummary,
     };
+    use clap::Parser;
     fn resources(recommendation: ResourceRecommendation) -> DoctorOutput {
         DoctorOutput {
             command: "doctor.resources",
@@ -392,6 +394,21 @@ mod tests {
         assert!(warning.message.contains("`rig up` stays local"));
         assert!(warning.message.contains("--force-hot"));
         assert!(!warning.message.contains("--runner <id>"));
+    }
+
+    #[test]
+    fn changed_scope_commands_are_hot_but_file_scoped_lint_is_not() {
+        let changed_lint = Cli::parse_from(["homeboy", "lint", "--changed-since", "origin/main"]);
+        let hot = hot_command(&changed_lint.command).expect("changed-scope lint is hot");
+        assert_eq!(hot.label, "lint");
+        assert!(!hot.lab_offload_supported);
+        assert!(hot
+            .lab_offload_unsupported_reason
+            .expect("unsupported reason")
+            .contains("Changed-scope lint runs stay local"));
+
+        let file_lint = Cli::parse_from(["homeboy", "lint", "--file", "src/main.rs"]);
+        assert!(hot_command(&file_lint.command).is_none());
     }
 
     #[test]

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -106,9 +106,21 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             );
             return Err(unsupported_runner_error(runner_id, message));
         }
+        let reason = contract
+            .unsupported_reason
+            .unwrap_or("command is local-only");
+        plan = disabled_select_runner_plan(plan, reason);
         return Ok(LabOffloadOutcome::RunLocal {
-            plan: disabled_select_runner_plan(plan, "command is local-only"),
-            metadata: None,
+            metadata: Some(lab_offload_metadata(
+                &plan,
+                "automatic",
+                None,
+                None,
+                "skipped",
+                None,
+                Some(reason),
+            )),
+            plan,
             messages: Vec::new(),
         });
     }


### PR DESCRIPTION
## Summary
- Route changed-scope hot commands through the Lab plan path even when they are not currently portable.
- Record skipped Lab metadata for local-only Lab contracts so observations explain why offload did not happen.
- Keep lightweight inventory/single-file forms outside Lab/resource-policy classification.
- Add route and CLI-surface tests for local-only Lab plan decisions and explicit `--runner` errors.

## Tests
- `cargo test commands::route::tests --lib`
- `cargo test test_supports_lab_runner --lib`
- `cargo test plan_records_skipped_auto_offload --lib`
- `cargo test resource_policy --lib`
- `git diff --check`

Note: targeted Rust tests pass. They emit an existing unrelated unused-import warning from `src/commands/runs/corpus_tests.rs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation and tests drafted by coding agent, reviewed/verified by Chris
