### PR TITLE
Allow agent-task dispatch to use Lab runners

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1080,6 +1080,8 @@ mod tests {
         .supports_lab_runner());
         assert!(parsed_command(&["homeboy", "bench", "history", "homeboy"]).supports_lab_runner());
         assert!(parsed_command(&["homeboy", "trace"]).supports_lab_runner());
+        assert!(parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"])
+            .supports_lab_runner());
         assert!(!parsed_command(&[
             "homeboy", "refactor", "rename", "--from", "old", "--to", "new",
         ])
@@ -1145,6 +1147,10 @@ mod tests {
             (
                 parsed_command(&["homeboy", "refactor", "--from", "audit"]),
                 "refactor",
+            ),
+            (
+                parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"]),
+                "agent-task dispatch",
             ),
         ];
 

--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -44,6 +44,9 @@ const FLEET_EXEC_LAB_UNSUPPORTED_REASON: &str = "`fleet exec` stays local becaus
 impl Commands {
     pub fn lab_contract(&self) -> Option<LabCommandContract> {
         let contract = match self {
+            Commands::AgentTask(args) if matches!(args.command, super::agent_task::AgentTaskCommand::Dispatch(_)) => {
+                lab_portable_contract("agent-task dispatch", None, true, LAB_NO_EXTRA_TOOLS)
+            }
             Commands::Audit(args) if args.changed_since.is_some() => {
                 lab_local_only_contract("audit", AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON)
             }

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -80,7 +80,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             "runner",
             message,
             Some(runner_id.to_string()),
-            Some(vec!["Current Lab offload support: audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+            Some(vec!["Current Lab offload support: agent-task dispatch, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
         )
     };
     let mut plan = base_lab_plan(request.command.as_ref());
@@ -88,7 +88,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if let Some(runner_id) = request.explicit_runner {
             return Err(unsupported_runner_error(
                 runner_id,
-                "--runner is only supported for commands with portable Lab offload support: lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch, lint, test, audit, bench, trace, and refactor source runs".to_string(),
             ));
         }
         return Ok(LabOffloadOutcome::RunLocal {
@@ -101,7 +101,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.portable {
         if let Some(runner_id) = request.explicit_runner {
             let message = contract.unsupported_reason.map_or_else(
-                || "--runner is only supported for commands with portable Lab offload support: lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
             );
             return Err(unsupported_runner_error(runner_id, message));

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -338,14 +338,14 @@ pub(super) fn resolve_lab_runner_selection_from_default(
     if let Some(runner_id) = explicit_runner {
         if !command.portable {
             let message = command.unsupported_reason.map_or_else(
-                || "--runner is only supported for hot Lab-offload commands: lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this hot command. {reason}"),
             );
             return Err(Error::validation_invalid_argument(
                 "runner",
                 message,
                 Some(runner_id.to_string()),
-                Some(vec!["Current Lab offload support: audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+                Some(vec!["Current Lab offload support: agent-task dispatch, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
             ));
         }
 


### PR DESCRIPTION
## Summary
- mark `homeboy agent-task dispatch` as a portable Lab-supported command
- require extension parity for lab-dispatched agent tasks so provider selection stays runner-safe
- update runner validation messages to include agent-task dispatch
- add command-surface coverage for `supports_lab_runner()` and the Lab contract label

## Why
The `agent-task dispatch` help exposes `--runner`, but the global Lab validation rejected it as unsupported. That blocked WPSG iterator workers from being dispatched to `homeboy-lab` and forced either local execution or no execution.

## Testing
- `cargo test test_supports_lab_runner`
- `cargo test test_lab_command_contracts_cover_hot_commands`
- `cargo check`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the lab-dispatch validation blocker, drafted the small command-surface fix and tests, and prepared this PR body.