### PR TITLE
Rewrite agent-task cwd for Lab offload

### DIFF
--- a/src/core/runner/lab_args.rs
+++ b/src/core/runner/lab_args.rs
@@ -10,11 +10,12 @@ pub(super) fn lab_offload_source_path(args: &[String]) -> Result<PathBuf> {
         if arg == "--" {
             break;
         }
-        if arg == "--path" {
+        if arg == "--path" || arg == "--cwd" {
             let value = iter.next().ok_or_else(|| {
+                let field = arg.trim_start_matches("--");
                 Error::validation_invalid_argument(
-                    "path",
-                    "--path requires a value before Lab offload can sync the workspace",
+                    field,
+                    format!("{arg} requires a value before Lab offload can sync the workspace"),
                     None,
                     None,
                 )
@@ -22,6 +23,9 @@ pub(super) fn lab_offload_source_path(args: &[String]) -> Result<PathBuf> {
             return Ok(PathBuf::from(shellexpand::tilde(value).to_string()));
         }
         if let Some(value) = arg.strip_prefix("--path=") {
+            return Ok(PathBuf::from(shellexpand::tilde(value).to_string()));
+        }
+        if let Some(value) = arg.strip_prefix("--cwd=") {
             return Ok(PathBuf::from(shellexpand::tilde(value).to_string()));
         }
     }
@@ -48,7 +52,7 @@ pub(super) fn rewrite_lab_offload_args(args: &[String], remote_path: &str) -> Ve
             stripped.push(arg.clone());
             continue;
         }
-        if arg == "--path" {
+        if arg == "--path" || arg == "--cwd" {
             stripped.push(arg.clone());
             let _ = iter.next();
             stripped.push(remote_path.to_string());
@@ -56,6 +60,10 @@ pub(super) fn rewrite_lab_offload_args(args: &[String], remote_path: &str) -> Ve
         }
         if arg.starts_with("--path=") {
             stripped.push(format!("--path={remote_path}"));
+            continue;
+        }
+        if arg.starts_with("--cwd=") {
+            stripped.push(format!("--cwd={remote_path}"));
             continue;
         }
         if arg == "--runner" {
@@ -78,4 +86,54 @@ pub(super) fn rewrite_lab_offload_args(args: &[String], remote_path: &str) -> Ve
         stripped.insert(1, "--force-hot".to_string());
     }
     stripped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lab_source_path_uses_agent_task_dispatch_cwd() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "dispatch".to_string(),
+            "--cwd".to_string(),
+            "/Users/chubes/Developer/wp-site-generator".to_string(),
+            "--prompt".to_string(),
+            "cook".to_string(),
+        ];
+
+        assert_eq!(
+            lab_offload_source_path(&args).expect("source path"),
+            PathBuf::from("/Users/chubes/Developer/wp-site-generator")
+        );
+    }
+
+    #[test]
+    fn lab_args_rewrite_agent_task_dispatch_cwd() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "dispatch".to_string(),
+            "--runner".to_string(),
+            "homeboy-lab".to_string(),
+            "--cwd=/Users/chubes/Developer/wp-site-generator".to_string(),
+            "--prompt".to_string(),
+            "cook".to_string(),
+        ];
+
+        assert_eq!(
+            rewrite_lab_offload_args(&args, "/home/chubes/Developer/wp-site-generator"),
+            vec![
+                "homeboy".to_string(),
+                "--force-hot".to_string(),
+                "agent-task".to_string(),
+                "dispatch".to_string(),
+                "--cwd=/home/chubes/Developer/wp-site-generator".to_string(),
+                "--prompt".to_string(),
+                "cook".to_string(),
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- treat `--cwd` like `--path` when selecting the Lab source workspace
- rewrite `--cwd` to the remote Lab workspace path before invoking the offloaded command
- add focused coverage for `homeboy agent-task dispatch --cwd ...`

## Why
After #3721 enabled `agent-task dispatch --runner`, WPSG lab dispatch reached the runner but failed because the remote command still received the local macOS checkout path (`/Users/chubes/Developer/wp-site-generator`). Lab offload needs to sync and rewrite the agent-task workspace path just like other source-path flags.

## Testing
- `cargo test lab_source_path_uses_agent_task_dispatch_cwd`
- `cargo test lab_args_rewrite_agent_task_dispatch_cwd`
- `cargo check`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WPSG lab-dispatch path rewrite failure, drafted the small Lab args fix and tests, and prepared this PR body.