### PR TITLE
Migrate agent task gates to normalized results

### DIFF
--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -13,6 +13,7 @@ use homeboy::core::agent_task_promotion::{
 use homeboy::core::agent_task_provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_task_scheduler::AgentTaskAggregate;
 use homeboy::core::config;
+use homeboy::core::gate::HomeboyGateResult;
 
 use super::super::CmdResult;
 use super::{FinalizePrArgs, GateFeedbackArgs, PromoteArgs, ReviewArgs};
@@ -128,6 +129,11 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
 
 pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
     let gate_results = parse_gate_results(&args.gate_results)?;
+    let normalized_gate_results = gate_results
+        .iter()
+        .cloned()
+        .map(HomeboyGateResult::from)
+        .collect();
     let report = finalize_pr(AgentTaskPrFinalizationOptions {
         path: args.path,
         run_id: args.run_id,
@@ -136,6 +142,7 @@ pub(crate) fn finalize_pull_request(args: FinalizePrArgs) -> CmdResult<Value> {
         title: args.title,
         commit_message: args.commit_message,
         gate_results,
+        normalized_gate_results,
         changed_files: args.changed_files,
         evidence: args.evidence.into(),
         ai_used_for: args.ai_used_for,

--- a/src/core/agent_task_cook_loop.rs
+++ b/src/core/agent_task_cook_loop.rs
@@ -9,6 +9,7 @@ use crate::core::agent_task_gate::{
     AgentTaskGateVisibility,
 };
 use crate::core::agent_task_promotion::{AgentTaskPromotionReport, AgentTaskPromotionStatus};
+use crate::core::gate::{HomeboyGateResult, HomeboyGateStatus};
 
 pub const AGENT_TASK_COOK_LOOP_REPORT_SCHEMA: &str = "homeboy/agent-task-cook-loop-report/v1";
 
@@ -39,6 +40,8 @@ pub struct AgentTaskCookLoopReport {
     pub promotion_status: AgentTaskPromotionStatus,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub failed_gates: Vec<AgentTaskCookLoopGateFailure>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed_gate_results: Vec<HomeboyGateResult>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub follow_up_request: Option<AgentTaskRequest>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
@@ -79,6 +82,10 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
         .filter(|gate| gate.status == AgentTaskGateStatus::Failed)
         .map(gate_failure)
         .collect();
+    let failed_gate_results: Vec<HomeboyGateResult> =
+        normalized_promotion_gate_results(&options.promotion_report)
+            .filter(|gate| gate.status == HomeboyGateStatus::Failed)
+            .collect();
     let retry_budget_remaining = options.max_attempts.saturating_sub(options.attempt);
     let should_retry = options.promotion_report.status == AgentTaskPromotionStatus::GateFailed
         && !failed_gates.is_empty()
@@ -102,8 +109,45 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
         source_run_id: options.source_run_id.clone(),
         promotion_status: options.promotion_report.status,
         failed_gates,
+        failed_gate_results,
         follow_up_request,
         metadata: options.metadata,
+    }
+}
+
+fn normalized_promotion_gate_results(
+    report: &AgentTaskPromotionReport,
+) -> impl Iterator<Item = HomeboyGateResult> + '_ {
+    if report.gate_results.is_empty() {
+        EitherGateResults::Legacy(
+            report
+                .deterministic_gates
+                .iter()
+                .cloned()
+                .map(HomeboyGateResult::from),
+        )
+    } else {
+        EitherGateResults::Normalized(report.gate_results.iter().cloned())
+    }
+}
+
+enum EitherGateResults<L, R> {
+    Legacy(L),
+    Normalized(R),
+}
+
+impl<T, L, R> Iterator for EitherGateResults<L, R>
+where
+    L: Iterator<Item = T>,
+    R: Iterator<Item = T>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Legacy(iter) => iter.next(),
+            Self::Normalized(iter) => iter.next(),
+        }
     }
 }
 
@@ -545,6 +589,7 @@ mod tests {
             changed_files: vec!["src/core/agent_task_gate.rs".to_string()],
             command_evidence: Vec::new(),
             deterministic_gates,
+            gate_results: Vec::new(),
             provenance: json!({ "worktree_path": "/tmp/homeboy@fix-3676" }),
         }
     }

--- a/src/core/agent_task_finalization.rs
+++ b/src/core/agent_task_finalization.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 use crate::core::agent_task_pr_body::render_pr_body;
 use crate::core::error::{Error, Result};
+use crate::core::gate::{HomeboyGateKind, HomeboyGateResult, HomeboyGateStatus};
 use crate::core::git::{
     commit_at, get_uncommitted_changes, pr_create, pr_edit, pr_find, push_at, CommitOptions,
     PrCreateOptions, PrEditOptions, PrFindOptions, PrState, PushOptions,
@@ -17,7 +19,7 @@ pub struct AgentTaskGateResult {
     pub detail: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct AgentTaskPrFinalizationReport {
     pub schema: String,
     pub run_id: String,
@@ -32,6 +34,8 @@ pub struct AgentTaskPrFinalizationReport {
     pub pr_url: Option<String>,
     pub changed_files: Vec<String>,
     pub gate_results: Vec<AgentTaskGateResult>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub normalized_gate_results: Vec<HomeboyGateResult>,
     #[serde(flatten)]
     pub evidence: AgentTaskPrEvidence,
 }
@@ -53,6 +57,7 @@ pub struct AgentTaskPrFinalizationOptions {
     pub title: String,
     pub commit_message: String,
     pub gate_results: Vec<AgentTaskGateResult>,
+    pub normalized_gate_results: Vec<HomeboyGateResult>,
     pub changed_files: Vec<String>,
     pub evidence: AgentTaskPrEvidence,
     pub ai_used_for: String,
@@ -230,7 +235,8 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     options: AgentTaskPrFinalizationOptions,
     backend: &mut B,
 ) -> Result<AgentTaskPrFinalizationReport> {
-    validate_green_gates(&options.gate_results)?;
+    let normalized_gate_results = normalized_finalization_gates(&options);
+    validate_green_gates(&normalized_gate_results)?;
     let head = options
         .head
         .clone()
@@ -284,7 +290,7 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     ))
 }
 
-fn validate_green_gates(gates: &[AgentTaskGateResult]) -> Result<()> {
+fn validate_green_gates(gates: &[HomeboyGateResult]) -> Result<()> {
     if gates.is_empty() {
         return Err(Error::validation_invalid_argument(
             "gate_results",
@@ -295,8 +301,8 @@ fn validate_green_gates(gates: &[AgentTaskGateResult]) -> Result<()> {
     }
     let red: Vec<String> = gates
         .iter()
-        .filter(|gate| !is_green_status(&gate.status))
-        .map(|gate| format!("{}={}", gate.name, gate.status))
+        .filter(|gate| gate.status != HomeboyGateStatus::Passed)
+        .map(|gate| format!("{}={:?}", gate.name, gate.status))
         .collect();
     if !red.is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -312,11 +318,65 @@ fn validate_green_gates(gates: &[AgentTaskGateResult]) -> Result<()> {
     Ok(())
 }
 
+fn normalized_finalization_gates(
+    options: &AgentTaskPrFinalizationOptions,
+) -> Vec<HomeboyGateResult> {
+    if !options.normalized_gate_results.is_empty() {
+        return options.normalized_gate_results.clone();
+    }
+
+    options
+        .gate_results
+        .iter()
+        .cloned()
+        .map(HomeboyGateResult::from)
+        .collect()
+}
+
 fn is_green_status(status: &str) -> bool {
     matches!(
         status.trim().to_ascii_lowercase().as_str(),
         "green" | "passed" | "pass" | "succeeded" | "success" | "ok"
     )
+}
+
+impl From<AgentTaskGateResult> for HomeboyGateResult {
+    fn from(gate: AgentTaskGateResult) -> Self {
+        gate_result_from_legacy(gate)
+    }
+}
+
+pub(crate) fn gate_result_from_legacy(gate: AgentTaskGateResult) -> HomeboyGateResult {
+    let status = if is_green_status(&gate.status) {
+        HomeboyGateStatus::Passed
+    } else {
+        HomeboyGateStatus::Failed
+    };
+    let summary = match gate
+        .detail
+        .as_deref()
+        .filter(|detail| !detail.trim().is_empty())
+    {
+        Some(detail) => format!("{}: {} ({detail})", gate.name, gate.status),
+        None => format!("{}: {}", gate.name, gate.status),
+    };
+
+    HomeboyGateResult::new(
+        format!("finalization.gate.{}", gate.name),
+        gate.name.clone(),
+        HomeboyGateKind::Command,
+        status,
+    )
+    .summary(summary)
+    .evidence(json!({
+        "name": gate.name,
+        "status": gate.status,
+        "detail": gate.detail,
+    }))
+    .retryable(status == HomeboyGateStatus::Failed)
+    .provenance(json!({
+        "source_type": "AgentTaskGateResult",
+    }))
 }
 
 fn refuse_protected_head(head: &str, protected_branches: &[String]) -> Result<()> {
@@ -343,6 +403,7 @@ fn report(
     pr_url: Option<String>,
     changed_files: Vec<String>,
 ) -> AgentTaskPrFinalizationReport {
+    let normalized_gate_results = normalized_finalization_gates(options);
     AgentTaskPrFinalizationReport {
         schema: AGENT_TASK_PR_FINALIZATION_SCHEMA.to_string(),
         run_id: options.run_id.clone(),
@@ -355,6 +416,7 @@ fn report(
         pr_url,
         changed_files,
         gate_results: options.gate_results.clone(),
+        normalized_gate_results,
         evidence: options.evidence.clone(),
     }
 }
@@ -553,6 +615,7 @@ mod tests {
                 status: "passed".to_string(),
                 detail: Some("targeted".to_string()),
             }],
+            normalized_gate_results: Vec::new(),
             changed_files: Vec::new(),
             evidence: AgentTaskPrEvidence {
                 source_refs: vec!["https://github.com/Extra-Chill/homeboy/issues/3678".to_string()],

--- a/src/core/agent_task_pr_body.rs
+++ b/src/core/agent_task_pr_body.rs
@@ -1,4 +1,5 @@
-use crate::core::agent_task_finalization::{AgentTaskGateResult, AgentTaskPrFinalizationOptions};
+use crate::core::agent_task_finalization::AgentTaskPrFinalizationOptions;
+use crate::core::gate::{HomeboyGateResult, HomeboyGateStatus};
 
 pub(crate) fn render_pr_body(
     options: &AgentTaskPrFinalizationOptions,
@@ -11,7 +12,7 @@ pub(crate) fn render_pr_body(
         head,
         bullets(&options.evidence.source_refs),
         options.evidence.attempt_summary,
-        gate_bullets(&options.gate_results),
+        gate_bullets(&normalized_gate_results(options)),
         bullets(changed_files),
         bullets(&options.evidence.artifact_refs),
         options.base,
@@ -32,15 +33,28 @@ fn bullets(values: &[String]) -> String {
         .join("\n")
 }
 
-fn gate_bullets(gates: &[AgentTaskGateResult]) -> String {
+fn gate_bullets(gates: &[HomeboyGateResult]) -> String {
     gates
         .iter()
-        .map(|gate| match &gate.detail {
-            Some(detail) if !detail.trim().is_empty() => {
-                format!("- {}: {} ({})", gate.name, gate.status, detail)
-            }
-            _ => format!("- {}: {}", gate.name, gate.status),
+        .map(|gate| match gate.status {
+            HomeboyGateStatus::Passed => format!("- {}: passed", gate.name),
+            HomeboyGateStatus::Failed => format!("- {}: failed", gate.name),
+            HomeboyGateStatus::Skipped => format!("- {}: skipped", gate.name),
+            HomeboyGateStatus::Blocked => format!("- {}: blocked", gate.name),
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn normalized_gate_results(options: &AgentTaskPrFinalizationOptions) -> Vec<HomeboyGateResult> {
+    if !options.normalized_gate_results.is_empty() {
+        return options.normalized_gate_results.clone();
+    }
+
+    options
+        .gate_results
+        .iter()
+        .cloned()
+        .map(crate::core::agent_task_finalization::gate_result_from_legacy)
+        .collect()
 }

--- a/src/core/agent_task_promotion.rs
+++ b/src/core/agent_task_promotion.rs
@@ -15,6 +15,7 @@ use crate::core::agent_task_gate::{
 };
 use crate::core::agent_task_scheduler::{AgentTaskAggregate, AGENT_TASK_AGGREGATE_SCHEMA};
 use crate::core::agent_task_timeout_artifacts::is_actionable_patch_artifact;
+use crate::core::gate::HomeboyGateResult;
 use crate::core::{Error, Result};
 
 pub const AGENT_TASK_PROMOTION_REPORT_SCHEMA: &str = "homeboy/agent-task-promotion-report/v1";
@@ -53,6 +54,8 @@ pub struct AgentTaskPromotionReport {
     pub command_evidence: Vec<AgentTaskPromotionCommandReport>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub deterministic_gates: Vec<AgentTaskGateReport>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub gate_results: Vec<HomeboyGateResult>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub provenance: Value,
 }
@@ -180,6 +183,11 @@ fn promote_with_provider(
     let has_gate_failure = deterministic_gates
         .iter()
         .any(|gate| gate.status == AgentTaskGateStatus::Failed);
+    let gate_results = deterministic_gates
+        .iter()
+        .cloned()
+        .map(HomeboyGateResult::from)
+        .collect();
 
     Ok(AgentTaskPromotionReport {
         schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
@@ -208,6 +216,7 @@ fn promote_with_provider(
         changed_files,
         command_evidence,
         deterministic_gates,
+        gate_results,
         provenance: json!({
             "source_schema": outcome.schema,
             "artifact_metadata": artifact.metadata,
@@ -1017,6 +1026,7 @@ mod tests {
                 "apply-patch",
             ])],
             deterministic_gates: Vec::new(),
+            gate_results: Vec::new(),
             provenance: Value::Null,
         };
 

--- a/src/core/gate.rs
+++ b/src/core/gate.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::core::plan::HomeboyPlan;
+
 pub const HOMEBOY_GATE_RESULT_SCHEMA: &str = "homeboy/gate-result/v1";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -133,6 +135,14 @@ impl HomeboyGateResult {
     }
 }
 
+pub fn collect_plan_gate_results(plan: &HomeboyPlan) -> Vec<HomeboyGateResult> {
+    plan.steps
+        .iter()
+        .filter_map(|step| step.outputs.get("gate_result"))
+        .filter_map(|value| serde_json::from_value(value.clone()).ok())
+        .collect()
+}
+
 fn gate_result_schema() -> String {
     HOMEBOY_GATE_RESULT_SCHEMA.to_string()
 }
@@ -159,5 +169,31 @@ mod tests {
         assert_eq!(value["kind"], "command");
         assert_eq!(value["status"], "passed");
         assert_eq!(value["retryable"], false);
+    }
+
+    #[test]
+    fn collect_plan_gate_results_reads_step_outputs() {
+        let plan = crate::core::plan::HomeboyPlan::builder_for_component(
+            crate::core::plan::PlanKind::Quality,
+            "fixture",
+        )
+        .steps(vec![crate::core::plan::PlanStep::ready(
+            "verify",
+            "gate.command",
+        )
+        .gate_result(HomeboyGateResult::new(
+            "gate-1",
+            "cargo test",
+            HomeboyGateKind::Command,
+            HomeboyGateStatus::Passed,
+        ))
+        .build()])
+        .build();
+
+        let results = collect_plan_gate_results(&plan);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "gate-1");
+        assert_eq!(results[0].status, HomeboyGateStatus::Passed);
     }
 }


### PR DESCRIPTION
## Summary
- Adds normalized `HomeboyGateResult` outputs alongside legacy agent-task gate reports.
- Validates and renders PR finalization gates through normalized gate results with legacy fallback.
- Carries normalized failed gate results through promotion and cook-loop reports.

Fixes #3712

## Testing
- `cargo test gate`
- `cargo test agent_task_finalization`
- `cargo test agent_task_cook_loop`
- `cargo test agent_task_promotion`
- `SCOPE_MODE=changed cargo test --test core_agnostic_test core_owned_source_stays_language_and_framework_agnostic`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the normalized gate migration code, updated focused fixtures, and ran targeted verification. Chris remains responsible for review and testing.
