### PR TITLE
Fix validation dependency lifecycle isolation

### DIFF
--- a/src/core/hygiene.rs
+++ b/src/core/hygiene.rs
@@ -71,6 +71,21 @@ pub fn require_checkout_hygiene(
     checkouts: Vec<DependencyCheckout>,
     options: DependencyHygieneOptions,
 ) -> Result<Vec<CheckoutHygieneSnapshot>> {
+    require_checkout_hygiene_inner(checkouts, options, true)
+}
+
+pub(crate) fn require_checkout_hygiene_without_lifecycle(
+    checkouts: Vec<DependencyCheckout>,
+    options: DependencyHygieneOptions,
+) -> Result<Vec<CheckoutHygieneSnapshot>> {
+    require_checkout_hygiene_inner(checkouts, options, false)
+}
+
+fn require_checkout_hygiene_inner(
+    checkouts: Vec<DependencyCheckout>,
+    options: DependencyHygieneOptions,
+    run_lifecycle: bool,
+) -> Result<Vec<CheckoutHygieneSnapshot>> {
     let snapshots = checkouts
         .into_iter()
         .map(|checkout| checkout_hygiene_snapshot(checkout, options.allow_stale))
@@ -87,11 +102,14 @@ pub fn require_checkout_hygiene(
         .collect::<Vec<_>>();
 
     if failures.is_empty() {
+        if !run_lifecycle {
+            return Ok(snapshots);
+        }
         for snapshot in snapshots
             .iter()
             .filter(|snapshot| snapshot.role == "validation_dependency")
         {
-            run_validation_dependency_lifecycle(snapshot)?;
+            run_validation_dependency_snapshot_lifecycle(snapshot)?;
         }
         let lifecycle_failures = snapshots
             .iter()
@@ -360,14 +378,44 @@ fn git_status(path: &Path, args: &[&str]) -> bool {
         .is_ok_and(|status| status.success())
 }
 
-fn run_validation_dependency_lifecycle(snapshot: &CheckoutHygieneSnapshot) -> Result<()> {
+fn run_validation_dependency_snapshot_lifecycle(snapshot: &CheckoutHygieneSnapshot) -> Result<()> {
     let path = Path::new(&snapshot.path);
     let mut component =
         component::resolve_effective(Some(&snapshot.id), Some(&snapshot.path), None)?;
     component.local_path = snapshot.path.clone();
 
-    run_dependency_install_lifecycle(&component, path)?;
-    run_dependency_build_lifecycle(&component, path)
+    run_validation_dependency_lifecycle_isolated(&component, path)
+}
+
+pub(crate) fn run_validation_dependency_lifecycle(
+    component: &Component,
+    path: &Path,
+) -> Result<()> {
+    run_dependency_install_lifecycle(component, path)?;
+    run_dependency_build_lifecycle(component, path)
+}
+
+fn run_validation_dependency_lifecycle_isolated(component: &Component, path: &Path) -> Result<()> {
+    let tempdir = tempfile::tempdir().map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!(
+                "create validation dependency lifecycle workspace {}",
+                component.id
+            )),
+        )
+    })?;
+    let prepared_path = tempdir.path().join("dependency");
+    let excludes = [".git", ".git/**", "node_modules", "node_modules/**"]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    crate::core::runner::copy_snapshot_to_directory(path, &prepared_path, &excludes)?;
+
+    let mut prepared = component.clone();
+    prepared.local_path = prepared_path.display().to_string();
+
+    run_validation_dependency_lifecycle(&prepared, &prepared_path)
 }
 
 fn run_dependency_install_lifecycle(component: &Component, path: &Path) -> Result<()> {
@@ -680,8 +728,11 @@ mod tests {
             )
             .expect("validation dependency lifecycle should run after hygiene passes");
 
-            assert!(dependency.join("deps-installed.txt").exists());
-            assert!(dependency.join("build-built.txt").exists());
+            assert!(!dependency.join("deps-installed.txt").exists());
+            assert!(!dependency.join("build-built.txt").exists());
+            let status =
+                git_output(&dependency, &["status", "--porcelain=v1"]).expect("dependency status");
+            assert_eq!(status, "");
         });
     }
 }

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -37,6 +37,7 @@ mod validation_dependencies;
 pub(crate) use validation_dependencies::validation_dependency_ids;
 mod worker;
 mod workspace;
+pub(crate) use workspace::copy_snapshot_to_directory;
 
 pub use apply::{
     apply_change_artifact, apply_workspace_patch, RunnerWorkspaceApplyOptions,

--- a/src/core/runner/validation_dependencies.rs
+++ b/src/core/runner/validation_dependencies.rs
@@ -16,23 +16,33 @@ pub(super) fn sync_validation_dependency_workspaces(
     remote_path: &str,
     excludes: &[String],
 ) -> Result<()> {
-    for dependency in validation_dependency_workspaces(local_path)? {
+    for dependency in validation_dependency_workspaces(local_path, excludes)? {
         let remote_dependency_path = format!(
             "{}/{}",
             parent_remote_path(remote_path),
-            sanitize_path_segment(
-                dependency
-                    .file_name()
-                    .and_then(|value| value.to_str())
-                    .unwrap_or("dependency"),
-            )
+            sanitize_path_segment(&dependency.remote_name)
         );
-        materialize_snapshot(runner, &dependency, &remote_dependency_path, excludes)?;
+        materialize_snapshot(
+            runner,
+            &dependency.prepared_path,
+            &remote_dependency_path,
+            excludes,
+        )?;
     }
     Ok(())
 }
 
-fn validation_dependency_workspaces(local_path: &Path) -> Result<Vec<PathBuf>> {
+#[derive(Debug)]
+struct PreparedValidationDependencyWorkspace {
+    remote_name: String,
+    prepared_path: PathBuf,
+    _tempdir: tempfile::TempDir,
+}
+
+fn validation_dependency_workspaces(
+    local_path: &Path,
+    excludes: &[String],
+) -> Result<Vec<PreparedValidationDependencyWorkspace>> {
     let dependency_ids = validation_dependency_ids(local_path)?;
     if dependency_ids.is_empty() {
         return Ok(Vec::new());
@@ -44,7 +54,9 @@ fn validation_dependency_workspaces(local_path: &Path) -> Result<Vec<PathBuf>> {
 
     dependency_ids
         .into_iter()
-        .map(|dependency_id| prepare_validation_dependency_workspace(parent, &dependency_id))
+        .map(|dependency_id| {
+            prepare_validation_dependency_workspace(parent, &dependency_id, excludes)
+        })
         .collect()
 }
 
@@ -144,19 +156,44 @@ fn resolve_sibling_dependency_workspace(parent: &Path, dependency_id: &str) -> R
     ))
 }
 
-fn prepare_validation_dependency_workspace(parent: &Path, dependency_id: &str) -> Result<PathBuf> {
+fn prepare_validation_dependency_workspace(
+    parent: &Path,
+    dependency_id: &str,
+    excludes: &[String],
+) -> Result<PreparedValidationDependencyWorkspace> {
     let (mut component, path) = resolve_managed_dependency_workspace(parent, dependency_id)?;
     component.local_path = path.display().to_string();
 
     prepare_dependency_git_state(&component, &path)?;
 
-    path.canonicalize().map_err(|err| {
+    let tempdir = tempfile::tempdir().map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!(
+                "create validation dependency workspace {}",
+                component.id
+            )),
+        )
+    })?;
+    let prepared_path = tempdir.path().join(sanitize_path_segment(&component.id));
+    crate::core::runner::copy_snapshot_to_directory(&path, &prepared_path, excludes)?;
+
+    component.local_path = prepared_path.display().to_string();
+    run_dependency_lifecycle(&component, &prepared_path)?;
+
+    let prepared_path = prepared_path.canonicalize().map_err(|err| {
         Error::internal_io(
             err.to_string(),
             Some(format!(
                 "canonicalize validation dependency {dependency_id}"
             )),
         )
+    })?;
+
+    Ok(PreparedValidationDependencyWorkspace {
+        remote_name: component.id,
+        prepared_path,
+        _tempdir: tempdir,
     })
 }
 
@@ -165,11 +202,8 @@ fn resolve_managed_dependency_workspace(
     dependency_id: &str,
 ) -> Result<(Component, PathBuf)> {
     if let Ok(path) = resolve_sibling_dependency_workspace(parent, dependency_id) {
-        let mut component = component::resolve_effective(
-            Some(dependency_id),
-            Some(&path.display().to_string()),
-            None,
-        )?;
+        let mut component =
+            component::resolve_effective(None, Some(&path.display().to_string()), None)?;
         component.local_path = path.display().to_string();
         return Ok((component, path));
     }
@@ -309,7 +343,7 @@ fn read_standalone_dependency_config(dependency_id: &str) -> Result<Option<Compo
 }
 
 fn prepare_dependency_git_state(component: &Component, path: &Path) -> Result<()> {
-    crate::core::hygiene::require_checkout_hygiene(
+    crate::core::hygiene::require_checkout_hygiene_without_lifecycle(
         vec![crate::core::hygiene::DependencyCheckout {
             id: component.id.clone(),
             role: "validation_dependency".to_string(),
@@ -318,6 +352,10 @@ fn prepare_dependency_git_state(component: &Component, path: &Path) -> Result<()
         crate::core::hygiene::DependencyHygieneOptions { allow_stale: false },
     )?;
     Ok(())
+}
+
+fn run_dependency_lifecycle(component: &Component, path: &Path) -> Result<()> {
+    crate::core::hygiene::run_validation_dependency_lifecycle(component, path)
 }
 
 fn unresolvable_dependency_error(dependency_id: &str, reason: &str) -> Error {
@@ -519,6 +557,146 @@ mod tests {
             assert!(Path::new(&remote_parent)
                 .join("agents-api/build-built.txt")
                 .exists());
+            assert!(!dependency.join("deps-installed.txt").exists());
+            assert!(!dependency.join("build-built.txt").exists());
+        });
+    }
+
+    #[test]
+    fn sync_workspace_uses_manifest_id_for_absolute_validation_dependency() {
+        crate::test_support::with_isolated_home(|_| {
+            let workspace_parent = tempfile::tempdir().expect("workspace parent");
+            let source = workspace_parent.path().join("studio-web");
+            let dependency = workspace_parent.path().join("agents-api");
+            let runner_root = tempfile::tempdir().expect("runner root tempdir");
+            fs::create_dir_all(&source).expect("source dir");
+            fs::create_dir_all(&dependency).expect("dependency dir");
+            fs::write(
+                source.join("homeboy.json"),
+                serde_json::json!({
+                    "id": "studio-web",
+                    "extensions": {
+                        "wordpress": {
+                            "settings": {
+                                "validation_dependencies": [dependency.display().to_string()]
+                            }
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .expect("source manifest");
+            fs::write(
+                dependency.join("homeboy.json"),
+                serde_json::json!({
+                    "id": "agents-api",
+                    "scripts": {
+                        "build": ["sh -c 'printf \"$HOMEBOY_COMPONENT_ID\" > component-id.txt'"]
+                    }
+                })
+                .to_string(),
+            )
+            .expect("dependency manifest");
+            fs::write(dependency.join(".gitignore"), "component-id.txt\n")
+                .expect("dependency gitignore");
+            let _remote = init_checkout_with_upstream(&dependency);
+
+            super::super::create(
+                &format!(
+                    r#"{{"id":"lab-local-absolute-dependency","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+
+            let (output, exit_code) = sync_workspace(
+                "lab-local-absolute-dependency",
+                RunnerWorkspaceSyncOptions {
+                    path: source.display().to_string(),
+                    mode: RunnerWorkspaceSyncMode::Snapshot,
+                    changed_since_base: None,
+                },
+            )
+            .expect("sync workspace");
+
+            assert_eq!(exit_code, 0);
+            let remote_parent = parent_remote_path(&output.remote_path);
+            let remote_dependency = Path::new(&remote_parent).join("agents-api");
+            assert!(remote_dependency.join("component-id.txt").exists());
+            assert_eq!(
+                fs::read_to_string(remote_dependency.join("component-id.txt")).unwrap(),
+                "agents-api"
+            );
+            assert!(!Path::new(&remote_parent).join("Users").exists());
+        });
+    }
+
+    #[test]
+    fn sync_workspace_failed_validation_dependency_build_keeps_source_clean() {
+        crate::test_support::with_isolated_home(|_| {
+            let workspace_parent = tempfile::tempdir().expect("workspace parent");
+            let source = workspace_parent.path().join("studio-web");
+            let dependency = workspace_parent.path().join("agents-api");
+            let runner_root = tempfile::tempdir().expect("runner root tempdir");
+            fs::create_dir_all(&source).expect("source dir");
+            fs::create_dir_all(&dependency).expect("dependency dir");
+            fs::write(
+                source.join("homeboy.json"),
+                serde_json::json!({
+                    "id": "studio-web",
+                    "extensions": {
+                        "wordpress": {
+                            "settings": {
+                                "validation_dependencies": ["agents-api"]
+                            }
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .expect("source manifest");
+            fs::write(
+                dependency.join("homeboy.json"),
+                serde_json::json!({
+                    "id": "agents-api",
+                    "scripts": {
+                        "build": ["sh -c 'mkdir .homeboy-build && printf dirty > .homeboy-build/state && exit 7'"]
+                    }
+                })
+                .to_string(),
+            )
+            .expect("dependency manifest");
+            let _remote = init_checkout_with_upstream(&dependency);
+
+            super::super::create(
+                &format!(
+                    r#"{{"id":"lab-local-failed-dependency","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+
+            let err = sync_workspace(
+                "lab-local-failed-dependency",
+                RunnerWorkspaceSyncOptions {
+                    path: source.display().to_string(),
+                    mode: RunnerWorkspaceSyncMode::Snapshot,
+                    changed_since_base: None,
+                },
+            )
+            .expect_err("failed dependency build should fail sync");
+
+            assert!(err.message.contains("build lifecycle failed"));
+            assert!(!dependency.join(".homeboy-build").exists());
+            let output = Command::new("git")
+                .args(["status", "--porcelain=v1"])
+                .current_dir(&dependency)
+                .output()
+                .expect("git status");
+            assert!(output.status.success());
+            assert_eq!(String::from_utf8_lossy(&output.stdout), "");
         });
     }
 
@@ -590,7 +768,7 @@ mod tests {
             assert!(clone_target.join("lib/agents.php").exists());
             let remote_parent = parent_remote_path(&output.remote_path);
             assert!(Path::new(&remote_parent)
-                .join("agents-api-clone/lib/agents.php")
+                .join("agents-api/lib/agents.php")
                 .exists());
         });
     }
@@ -616,7 +794,7 @@ mod tests {
         )
         .expect("source manifest");
 
-        let err = validation_dependency_workspaces(&source).expect_err("missing dependency");
+        let err = validation_dependency_workspaces(&source, &[]).expect_err("missing dependency");
 
         assert_eq!(err.details["field"], "validation_dependencies");
         assert!(err.message.contains("agents-api"));

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -453,6 +453,24 @@ pub(super) fn materialize_snapshot(
     }
 }
 
+pub(crate) fn copy_snapshot_to_directory(
+    local_path: &Path,
+    destination: &Path,
+    excludes: &[String],
+) -> Result<()> {
+    materialize_snapshot_piped(
+        local_path,
+        &format!(
+            "sh -c {}",
+            shell::quote_arg(&snapshot_install_command(
+                &destination.display().to_string()
+            ))
+        ),
+        excludes,
+        "prepare local workspace snapshot",
+    )
+}
+
 fn materialize_snapshot_piped(
     local_path: &Path,
     target_command: &str,

--- a/src/extensions/npm_deps_provider.rs
+++ b/src/extensions/npm_deps_provider.rs
@@ -98,9 +98,50 @@ impl NpmDependencyProvider {
     pub(crate) fn install(
         &self,
         _component: &Component,
-        _path: &Path,
+        path: &Path,
     ) -> Result<Option<DependencyCommandResult>> {
-        Ok(None)
+        let args = if path.join("package-lock.json").is_file() {
+            vec!["ci".to_string()]
+        } else {
+            vec!["install".to_string()]
+        };
+        let output = Command::new("npm")
+            .args(&args)
+            .current_dir(path)
+            .output()
+            .map_err(|e| {
+                Error::internal_io(e.to_string(), Some("run dependency provider".to_string()))
+            })?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let status = output.status.code();
+        if !output.status.success() {
+            return Err(Error::validation_invalid_argument(
+                "dependency_provider",
+                format!(
+                    "Dependency provider install failed with status {}: {}",
+                    output.status,
+                    first_non_empty_line(&stderr)
+                        .or_else(|| first_non_empty_line(&stdout))
+                        .unwrap_or("no output")
+                ),
+                None,
+                Some(vec![format!(
+                    "Run manually in {}: npm {}",
+                    path.display(),
+                    args.join(" ")
+                )]),
+            ));
+        }
+
+        Ok(Some(DependencyCommandResult {
+            command: std::iter::once("npm".to_string()).chain(args).collect(),
+            skipped: false,
+            status,
+            stdout,
+            stderr,
+        }))
     }
 }
 
@@ -261,4 +302,43 @@ fn read_optional_json_file(path: &Path) -> Result<Option<Value>> {
 
 fn first_non_empty_line(output: &str) -> Option<&str> {
     output.lines().find(|line| !line.trim().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn npm_install_installs_full_dependency_tree_for_build_lifecycle() {
+        let _guard = crate::test_support::home_env_guard();
+        let old_path = std::env::var("PATH").unwrap_or_default();
+        let bin = tempfile::tempdir().expect("bin tempdir");
+        let project = tempfile::tempdir().expect("project tempdir");
+        let npm = bin.path().join("npm");
+        std::fs::write(&npm, "#!/bin/sh\nprintf '%s\n' \"$@\" > npm-args.txt\n").expect("fake npm");
+        let mode = std::fs::metadata(&npm)
+            .expect("fake npm metadata")
+            .permissions();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut mode = mode;
+            mode.set_mode(0o755);
+            std::fs::set_permissions(&npm, mode).expect("chmod fake npm");
+        }
+        std::env::set_var("PATH", format!("{}:{old_path}", bin.path().display()));
+        std::fs::write(project.path().join("package.json"), "{}").expect("package json");
+
+        let result = NpmDependencyProvider
+            .install(&Component::default(), project.path())
+            .expect("npm install");
+
+        std::env::set_var("PATH", old_path);
+        let result = result.expect("install result");
+        assert_eq!(result.command, vec!["npm", "install"]);
+        assert_eq!(
+            std::fs::read_to_string(project.path().join("npm-args.txt")).unwrap(),
+            "install\n"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes #3727.
- Build validation dependencies from owned temporary snapshots before syncing them to Lab/offloaded runner workspaces.
- Preserve fail-closed source checkout hygiene while preventing lifecycle/build artifacts from dirtying long-lived dependency checkouts.
- Resolve absolute validation dependency paths through the dependency's manifest/component identity so path strings do not become package or remote output names.
- Install npm validation dependencies with `npm ci` when a lockfile exists, otherwise `npm install`, so build-time dev tools such as `tsx` are available in the isolated build workspace without syncing `node_modules` into runner packages.

## Tests
- `rustfmt --check src/core/runner/workspace.rs src/core/runner/mod.rs src/core/runner/validation_dependencies.rs src/core/hygiene.rs src/extensions/npm_deps_provider.rs`
- `cargo test validation_dependencies --lib`
- `cargo test npm_install_installs_full_dependency_tree_for_build_lifecycle --lib`
- `cargo test dependency_hygiene --lib`
- `cargo test sync_workspace --lib`
- `cargo test --lib`
- `git diff --check`

## Notes
- Repository-wide `cargo fmt --check` still reports pre-existing formatting diffs in unrelated `src/cli_surface*.rs` files, so this PR only formats the touched files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation and regression tests; Chris remains responsible for review and merge.