### PR TITLE
fix: include tempfile in runtime dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,14 +49,12 @@ semver = "1.0"
 libc = "0.2"
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde_json_path = "0.7"
+tempfile = "3.14"
 
 # CLI dependencies
 clap = { version = "4.5", features = ["derive", "string"] }
 toml = "1.0.3"
 sha2 = "0.10.9"
-
-[dev-dependencies]
-tempfile = "3.14"
 
 [profile.dist]
 inherits = "release"


### PR DESCRIPTION
## Summary
- Promotes `tempfile` from dev-dependencies to runtime dependencies so the validation dependency lifecycle code merged in #3729 builds from main.

## Verification
- `cargo build --release`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Identified the missing runtime dependency from the failed main build, made the minimal manifest fix, and verified the release build.