### PR TITLE
Fix release CI env propagation for test gates

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1080,8 +1080,10 @@ mod tests {
         .supports_lab_runner());
         assert!(parsed_command(&["homeboy", "bench", "history", "homeboy"]).supports_lab_runner());
         assert!(parsed_command(&["homeboy", "trace"]).supports_lab_runner());
-        assert!(parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"])
-            .supports_lab_runner());
+        assert!(
+            parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"])
+                .supports_lab_runner()
+        );
         assert!(!parsed_command(&[
             "homeboy", "refactor", "rename", "--from", "old", "--to", "new",
         ])

--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -44,7 +44,12 @@ const FLEET_EXEC_LAB_UNSUPPORTED_REASON: &str = "`fleet exec` stays local becaus
 impl Commands {
     pub fn lab_contract(&self) -> Option<LabCommandContract> {
         let contract = match self {
-            Commands::AgentTask(args) if matches!(args.command, super::agent_task::AgentTaskCommand::Dispatch(_)) => {
+            Commands::AgentTask(args)
+                if matches!(
+                    args.command,
+                    super::agent_task::AgentTaskCommand::Dispatch(_)
+                ) =>
+            {
                 lab_portable_contract("agent-task dispatch", None, true, LAB_NO_EXTRA_TOOLS)
             }
             Commands::Audit(args) if args.changed_since.is_some() => {

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -186,7 +186,7 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
             },
             changed_since: args.changed_since.clone(),
             json_summary: args.json_summary,
-            ci_env: ci_profile::ci_job_env(ci_job.as_ref()),
+            ci_env: test_runner_ci_env(ci_job.as_ref()),
             passthrough_args: passthrough_args.clone(),
         },
         runner.run_dir(),
@@ -206,6 +206,18 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
 
 fn ci_job_passthrough_args(job: Option<&CiResolvedJob>) -> Vec<String> {
     job.map(|job| job.spec.args.clone()).unwrap_or_default()
+}
+
+fn test_runner_ci_env(job: Option<&CiResolvedJob>) -> Vec<(String, String)> {
+    let mut env = ci_profile::ci_job_env(job);
+
+    for key in ["GITHUB_ACTIONS", "RELEASE_BLOCKING_COMMANDS"] {
+        if let Ok(value) = std::env::var(key) {
+            env.push((key.to_string(), value));
+        }
+    }
+
+    env
 }
 
 struct TestObservation(ActiveObservation);

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -21,7 +21,9 @@ use super::lab_args::EXPLICIT_PASSTHROUGH_SENTINEL;
 use super::lab_args::{lab_offload_source_path, rewrite_lab_offload_args};
 use super::lab_capabilities::lab_runner_capability_contract;
 use super::lab_command::lab_offload_command_prefix;
-use super::lab_env::{build_lab_offload_env, forward_env_if_present, settings_env_diagnostics};
+use super::lab_env::{
+    build_lab_offload_env, forward_env_if_present, forward_release_ci_env, settings_env_diagnostics,
+};
 use super::lab_plan::{base_lab_plan, disabled_select_runner_plan, with_step};
 pub use super::lab_selection::LabRunnerSelectionSource;
 use super::lab_selection::{
@@ -526,6 +528,7 @@ fn run_lab_offload_inner(
     let mut env = build_lab_offload_env(&lab_metadata);
     forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
     forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
+    forward_release_ci_env(&mut env);
     lab_metadata["settings_env"] = settings_env_diagnostics(&changed_since_preflight.args, &env);
     lab_metadata["rig_sync"] = serde_json::json!({
         "step": "lab.sync_rigs",
@@ -535,6 +538,7 @@ fn run_lab_offload_inner(
     env = build_lab_offload_env(&lab_metadata);
     forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
     forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
+    forward_release_ci_env(&mut env);
     let exec_result = exec(
         runner_id,
         RunnerExecOptions {

--- a/src/core/runner/lab_env.rs
+++ b/src/core/runner/lab_env.rs
@@ -12,6 +12,12 @@ pub(super) fn forward_env_if_present(env: &mut HashMap<String, String>, name: &s
     }
 }
 
+pub(super) fn forward_release_ci_env(env: &mut HashMap<String, String>) {
+    for name in ["GITHUB_ACTIONS", "RELEASE_BLOCKING_COMMANDS"] {
+        forward_env_if_present(env, name);
+    }
+}
+
 pub(super) fn build_lab_offload_env(lab_metadata: &serde_json::Value) -> HashMap<String, String> {
     HashMap::from([(
         LAB_OFFLOAD_METADATA_ENV.to_string(),
@@ -161,6 +167,28 @@ fn redacted_value_preview(value: &str, redacted: bool) -> String {
 mod tests {
     use super::*;
 
+    struct EnvVarGuard {
+        name: &'static str,
+        prior: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(name: &'static str, value: &str) -> Self {
+            let prior = std::env::var(name).ok();
+            std::env::set_var(name, value);
+            Self { name, prior }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
+
     #[test]
     fn parsed_setting_args_reads_split_and_equals_forms() {
         let args = vec![
@@ -239,6 +267,21 @@ mod tests {
         assert_eq!(
             diagnostics["forwarded_environment"][0]["value_preview"],
             "<redacted>"
+        );
+    }
+
+    #[test]
+    fn forward_release_ci_env_preserves_release_gate_context() {
+        let _github_actions = EnvVarGuard::set("GITHUB_ACTIONS", "true");
+        let _blocking = EnvVarGuard::set("RELEASE_BLOCKING_COMMANDS", "lint,test");
+        let mut env = HashMap::new();
+
+        forward_release_ci_env(&mut env);
+
+        assert_eq!(env.get("GITHUB_ACTIONS").map(String::as_str), Some("true"));
+        assert_eq!(
+            env.get("RELEASE_BLOCKING_COMMANDS").map(String::as_str),
+            Some("lint,test")
         );
     }
 }


### PR DESCRIPTION
## Summary
- Fixes `cargo fmt --check` drift that blocked the Homeboy Release workflow on `main`.
- Preserves release CI gate context for `homeboy test` subprocesses and Lab-offloaded test runs so release-blocking policy reaches Rust tests consistently.
- Adds focused coverage for forwarding `GITHUB_ACTIONS` and `RELEASE_BLOCKING_COMMANDS` through Lab offload env construction.

## Verification
- `cargo fmt --check`
- `cargo test --quiet core::runner::lab_env::tests::forward_release_ci_env_preserves_release_gate_context`
- `cargo run --quiet --bin homeboy -- lint homeboy --path /Users/chubes/Developer/homeboy@fix-main-release-formatting-20260608`
- `GITHUB_ACTIONS=true RELEASE_BLOCKING_COMMANDS=lint,test cargo run --quiet --bin homeboy -- test homeboy --path /Users/chubes/Developer/homeboy@fix-main-release-formatting-20260608`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the failed Release workflow, implemented the formatting and release CI env propagation fix, and ran local verification. Chris reviewed and requested the PR path.