### PR TITLE
Tighten agent-task runner cook lifecycle

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1152,7 +1152,11 @@ mod tests {
             ),
             (
                 parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"]),
-                "agent-task dispatch",
+                "agent-task dispatch/cook",
+            ),
+            (
+                parsed_command(&["homeboy", "agent-task", "cook", "--prompt", "cook"]),
+                "agent-task dispatch/cook",
             ),
         ];
 

--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -47,10 +47,11 @@ impl Commands {
             Commands::AgentTask(args)
                 if matches!(
                     args.command,
-                    super::agent_task::AgentTaskCommand::Dispatch(_)
+                    super::agent_task::AgentTaskCommand::Cook(_)
+                        | super::agent_task::AgentTaskCommand::Dispatch(_)
                 ) =>
             {
-                lab_portable_contract("agent-task dispatch", None, true, LAB_NO_EXTRA_TOOLS)
+                lab_portable_contract("agent-task dispatch/cook", None, true, LAB_NO_EXTRA_TOOLS)
             }
             Commands::Audit(args) if args.changed_since.is_some() => {
                 lab_local_only_contract("audit", AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON)

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -23,6 +23,8 @@ pub struct AgentTaskArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum AgentTaskCommand {
+    /// Sync a workspace if --runner is supplied, dispatch a repo-cooking task, and return the durable run id.
+    Cook(DispatchArgs),
     /// Build and dispatch common repo-cooking agent tasks without hand-authored provider JSON.
     Dispatch(DispatchArgs),
     /// Run an agent-task plan through extension-declared executor providers.
@@ -53,8 +55,15 @@ pub enum AgentTaskCommand {
     FinalizePr(FinalizePrArgs),
     /// Convert deterministic gate results into a cook-loop retry or stop decision.
     GateFeedback(GateFeedbackArgs),
-    /// List extension-declared agent-task executor providers.
-    Providers,
+    /// List extension-declared agent-task executor providers and optional secret readiness.
+    Providers(ProvidersArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct ProvidersArgs {
+    /// Secret environment variable name to check without exposing its value. Repeatable.
+    #[arg(long = "secret-env", value_name = "ENV")]
+    pub secret_env: Vec<String>,
 }
 
 #[derive(Args, Debug)]
@@ -243,6 +252,7 @@ pub struct GateFeedbackArgs {
 
 pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
     match args.command {
+        AgentTaskCommand::Cook(dispatch_args) => dispatch(dispatch_args, global),
         AgentTaskCommand::Dispatch(dispatch_args) => dispatch(dispatch_args, global),
         AgentTaskCommand::RunPlan(run_args) => run_plan(run_args),
         AgentTaskCommand::Run(status_args) => run_submitted(status_args),
@@ -258,7 +268,7 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::Promote(promote_args) => review::promote_artifact(promote_args),
         AgentTaskCommand::FinalizePr(finalize_args) => review::finalize_pull_request(finalize_args),
         AgentTaskCommand::GateFeedback(feedback_args) => review::gate_feedback(feedback_args),
-        AgentTaskCommand::Providers => review::providers(),
+        AgentTaskCommand::Providers(providers_args) => review::providers(providers_args),
     }
 }
 

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -16,7 +16,7 @@ use homeboy::core::config;
 use homeboy::core::gate::HomeboyGateResult;
 
 use super::super::CmdResult;
-use super::{FinalizePrArgs, GateFeedbackArgs, PromoteArgs, ReviewArgs};
+use super::{FinalizePrArgs, GateFeedbackArgs, PromoteArgs, ProvidersArgs, ReviewArgs};
 
 #[derive(Args, Debug)]
 pub struct FinalizePrEvidenceArgs {
@@ -198,10 +198,14 @@ pub(crate) fn gate_feedback(args: GateFeedbackArgs) -> CmdResult<Value> {
     Ok((serde_json::to_value(report).unwrap_or(Value::Null), 0))
 }
 
-pub(crate) fn providers() -> CmdResult<Value> {
+pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
     let executor = ExtensionProviderAgentTaskExecutor::discover();
     Ok((
-        serde_json::to_value(executor.providers()).unwrap_or(Value::Null),
+        serde_json::json!({
+            "schema": "homeboy/agent-task-providers/v1",
+            "providers": executor.providers(),
+            "secret_env": homeboy::core::agent_task_secrets::secret_env_status(&args.secret_env),
+        }),
         0,
     ))
 }

--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -10,6 +10,7 @@ use homeboy::core::agent_task_provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_task_scheduler::{
     AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskRetryPolicy, AgentTaskScheduler,
 };
+use homeboy::core::agent_task_secrets::validate_secret_env;
 use homeboy::core::config;
 use homeboy::core::worktree;
 
@@ -95,6 +96,7 @@ where
     E: AgentTaskExecutorAdapter,
 {
     let plan = build_dispatch_plan(&args)?;
+    preflight_dispatch_provider_secrets(&plan)?;
     let submitted = agent_task_lifecycle::submit_plan(&plan, args.run_id.as_deref())?;
     let run_id = submitted.run_id.clone();
 
@@ -285,6 +287,28 @@ fn build_dispatch_plan(args: &DispatchArgs) -> homeboy::core::Result<AgentTaskPl
     });
 
     Ok(plan)
+}
+
+fn preflight_dispatch_provider_secrets(plan: &AgentTaskPlan) -> homeboy::core::Result<()> {
+    let mut names = Vec::new();
+    for task in &plan.tasks {
+        for name in &task.executor.secret_env {
+            if !names.contains(name) {
+                names.push(name.clone());
+            }
+        }
+    }
+
+    validate_secret_env(&names).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "secret_env",
+            error.message,
+            None,
+            Some(vec![
+                "Configure provider credentials with Homeboy's agent-task secret config or run `homeboy agent-task providers --secret-env <ENV>` to inspect redacted readiness.".to_string(),
+            ]),
+        )
+    })
 }
 
 fn resolve_dispatch_workspace(
@@ -718,6 +742,31 @@ mod tests {
     }
 
     #[test]
+    fn dispatch_preflights_missing_secret_env_before_submitting() {
+        with_isolated_home(|_| {
+            let missing = format!(
+                "HOMEBOY_TEST_DISPATCH_MISSING_SECRET_{}",
+                std::process::id()
+            );
+            std::env::remove_var(&missing);
+
+            let err = dispatch_with_executor(
+                dispatch_args(DispatchArgOverrides {
+                    prompt: Some("Cook with missing provider auth.".to_string()),
+                    secret_env: vec![missing.clone()],
+                    run_id: Some("dispatch-missing-secret".to_string()),
+                    ..DispatchArgOverrides::default()
+                }),
+                NoopExecutor,
+            )
+            .expect_err("missing secret should fail before submit");
+
+            assert!(err.to_string().contains(&missing));
+            assert!(agent_task_lifecycle::status("dispatch-missing-secret").is_err());
+        });
+    }
+
+    #[test]
     fn resolves_workspace_path_without_specialized_coupling() {
         let worktree = tempfile::tempdir().expect("workspace");
 
@@ -841,6 +890,7 @@ mod tests {
         cwd: Option<String>,
         workspace: Option<String>,
         repo: Option<String>,
+        secret_env: Vec<String>,
         client_context: Option<String>,
         concurrency: usize,
         attempts: u32,
@@ -860,7 +910,7 @@ mod tests {
             backend: "fixture".to_string(),
             selector: None,
             model: None,
-            secret_env: Vec::new(),
+            secret_env: overrides.secret_env,
             provider_config: None,
             client_context: overrides.client_context,
             concurrency: if overrides.concurrency == 0 {

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -1010,7 +1010,7 @@ impl AgentTaskScheduleSupport {
 
     fn totals(total_tasks: usize, outcomes: &[AgentTaskOutcome]) -> AgentTaskAggregateTotals {
         let mut totals = AgentTaskAggregateTotals {
-            queued: total_tasks,
+            queued: total_tasks.saturating_sub(outcomes.len()),
             ..AgentTaskAggregateTotals::default()
         };
 
@@ -1227,6 +1227,7 @@ mod tests {
         let aggregate = scheduler.run(plan);
 
         assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(aggregate.totals.queued, 0);
         assert_eq!(aggregate.totals.succeeded, 4);
         assert!(max_seen.load(Ordering::SeqCst) <= 2);
         assert!(aggregate
@@ -1247,6 +1248,7 @@ mod tests {
         let aggregate = scheduler.run(plan);
 
         assert_eq!(aggregate.status, AgentTaskAggregateStatus::PartialFailure);
+        assert_eq!(aggregate.totals.queued, 0);
         assert_eq!(aggregate.totals.succeeded, 2);
         assert_eq!(aggregate.totals.failed, 1);
         let failed = aggregate
@@ -1255,6 +1257,21 @@ mod tests {
             .find(|outcome| outcome.task_id == "task-2")
             .expect("failed task outcome");
         assert_eq!(failed.evidence_refs[0].kind, "log");
+    }
+
+    #[test]
+    fn failed_single_task_is_not_also_counted_as_queued() {
+        let mut statuses = HashMap::new();
+        statuses.insert("task-1".to_string(), AgentTaskOutcomeStatus::Failed);
+        let scheduler =
+            AgentTaskScheduler::new(RecordingExecutor::new(statuses, Duration::from_millis(0)));
+
+        let aggregate = scheduler.run(plan_with_tasks(1));
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+        assert_eq!(aggregate.totals.failed, 1);
+        assert_eq!(aggregate.totals.queued, 0);
+        assert_eq!(aggregate.queue.queued, 0);
     }
 
     #[test]

--- a/src/core/agent_task_secrets.rs
+++ b/src/core/agent_task_secrets.rs
@@ -13,10 +13,52 @@ pub struct AgentTaskSecretResolutionError {
     pub message: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskSecretEnvStatus {
+    pub name: String,
+    pub configured: bool,
+    pub source: String,
+}
+
 pub fn resolve_secret_env(
     names: &[String],
 ) -> Result<Vec<(String, String)>, AgentTaskSecretResolutionError> {
     resolve_secret_env_with_config(names, &AgentTaskSecretConfig::load())
+}
+
+pub fn secret_env_status(names: &[String]) -> Vec<AgentTaskSecretEnvStatus> {
+    secret_env_status_with_config(names, &AgentTaskSecretConfig::load())
+}
+
+pub fn validate_secret_env(names: &[String]) -> Result<(), AgentTaskSecretResolutionError> {
+    resolve_secret_env(names).map(|_| ())
+}
+
+fn secret_env_status_with_config(
+    names: &[String],
+    config: &AgentTaskSecretConfig,
+) -> Vec<AgentTaskSecretEnvStatus> {
+    names
+        .iter()
+        .map(|name| {
+            if env::var(name).is_ok() {
+                return AgentTaskSecretEnvStatus {
+                    name: name.clone(),
+                    configured: true,
+                    source: "env".to_string(),
+                };
+            }
+
+            let source = config.secrets.get(name);
+            AgentTaskSecretEnvStatus {
+                name: name.clone(),
+                configured: source.is_some_and(|source| source.resolve(name).is_some()),
+                source: source
+                    .map(|source| source.source.clone())
+                    .unwrap_or_else(|| "missing".to_string()),
+            }
+        })
+        .collect()
 }
 
 fn resolve_secret_env_with_config(
@@ -137,6 +179,27 @@ mod tests {
         assert_eq!(error.missing_secret_env, vec![name.clone()]);
         assert!(error.message.contains(&name));
         assert!(!error.message.contains("secret-value"));
+    }
+
+    #[test]
+    fn reports_redacted_secret_readiness() {
+        let present = unique_env("READY_SECRET");
+        let missing = unique_env("NOT_READY_SECRET");
+        std::env::set_var(&present, "secret-value");
+        std::env::remove_var(&missing);
+        let names = vec![present.clone(), missing.clone()];
+
+        let status = secret_env_status_with_config(&names, &AgentTaskSecretConfig::default());
+
+        assert_eq!(status[0].name, present);
+        assert!(status[0].configured);
+        assert_eq!(status[0].source, "env");
+        assert_eq!(status[1].name, missing);
+        assert!(!status[1].configured);
+        assert_eq!(status[1].source, "missing");
+        let serialized = serde_json::to_string(&status).expect("status json");
+        assert!(!serialized.contains("secret-value"));
+        std::env::remove_var(present);
     }
 
     #[test]

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -82,7 +82,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             "runner",
             message,
             Some(runner_id.to_string()),
-            Some(vec!["Current Lab offload support: agent-task dispatch, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+            Some(vec!["Current Lab offload support: agent-task dispatch/cook, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
         )
     };
     let mut plan = base_lab_plan(request.command.as_ref());
@@ -90,7 +90,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if let Some(runner_id) = request.explicit_runner {
             return Err(unsupported_runner_error(
                 runner_id,
-                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook, lint, test, audit, bench, trace, and refactor source runs".to_string(),
             ));
         }
         return Ok(LabOffloadOutcome::RunLocal {
@@ -103,7 +103,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.portable {
         if let Some(runner_id) = request.explicit_runner {
             let message = contract.unsupported_reason.map_or_else(
-                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
             );
             return Err(unsupported_runner_error(runner_id, message));

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -338,14 +338,14 @@ pub(super) fn resolve_lab_runner_selection_from_default(
     if let Some(runner_id) = explicit_runner {
         if !command.portable {
             let message = command.unsupported_reason.map_or_else(
-                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this hot command. {reason}"),
             );
             return Err(Error::validation_invalid_argument(
                 "runner",
                 message,
                 Some(runner_id.to_string()),
-                Some(vec!["Current Lab offload support: agent-task dispatch, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+                Some(vec!["Current Lab offload support: agent-task dispatch/cook, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
             ));
         }
 


### PR DESCRIPTION
## Summary
- Adds `homeboy agent-task cook` as a discoverable alias for the existing dispatch flow, including the Lab runner sync/handoff contract already used by `agent-task dispatch --runner`.
- Preflights declared provider `--secret-env` names before dispatch submits a durable run, and expands `agent-task providers` with redacted secret readiness checks.
- Fixes aggregate totals so terminal outcomes are no longer also counted as queued after failures.

Fixes #3733.
Fixes #3734.
Fixes #3735.
Fixes #3736.

## Verification
- `cargo fmt`
- `cargo test failed_single_task_is_not_also_counted_as_queued --lib`
- `cargo test reports_redacted_secret_readiness --lib`
- `cargo test dispatch_preflights_missing_secret_env_before_submitting --lib`
- `cargo test cli_surface::tests::test_lab_command_contracts_cover_hot_commands --lib`
- `cargo test agent_task_dispatch --lib`
- `cargo test commands::agent_task::tests --lib`
- `cargo test core::agent_task_provider::tests --lib`
- `cargo test core::agent_task_secrets::tests --lib`
- `cargo test core::agent_task_scheduler::tests --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the agent-task lifecycle ergonomics, provider secret readiness preflight, aggregate totals fix, and targeted tests; Chris remains responsible for review and merge.