### PR TITLE
fix: tighten rig runner diagnostics

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1003,6 +1003,21 @@ mod tests {
     }
 
     #[test]
+    fn rig_check_supports_lab_runner_but_rig_up_stays_local_only() {
+        let rig_check = parsed_command(&["homeboy", "rig", "check", "studio"]);
+        let rig_check_descriptor = rig_check.descriptor(false);
+        assert!(rig_check_descriptor.supports_lab_runner);
+        assert!(rig_check_descriptor.lab_runner_unsupported_reason.is_none());
+
+        let rig_up = parsed_command(&["homeboy", "rig", "up", "studio"]);
+        let rig_up_descriptor = rig_up.descriptor(false);
+        assert!(!rig_up_descriptor.supports_lab_runner);
+        assert!(rig_up_descriptor
+            .lab_runner_unsupported_reason
+            .is_some_and(|reason| reason.contains("rig up")));
+    }
+
+    #[test]
     fn public_variant_contracts_have_discriminators_or_fixtures() {
         let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let fixtures = root.join("tests/fixtures/golden_json_contracts");

--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -89,6 +89,9 @@ impl Commands {
                 false,
                 LAB_NO_EXTRA_TOOLS,
             ),
+            Commands::Rig(args) if args.is_check_command() => {
+                lab_portable_workload_contract("rig check", None, false, LAB_NO_EXTRA_TOOLS)
+            }
             Commands::Rig(args) if args.is_hot_resource_command() => {
                 lab_local_only_contract("rig up", RIG_UP_LAB_UNSUPPORTED_REASON)
             }

--- a/src/commands/bench/fanout.rs
+++ b/src/commands/bench/fanout.rs
@@ -2,7 +2,8 @@ use serde::Serialize;
 
 use homeboy::core::agent_task::{
     expand_agent_task_matrix, AgentTaskExecutor, AgentTaskMatrixAggregate, AgentTaskMatrixAxis,
-    AgentTaskRequest, AgentTaskWorkspace, AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
+    AgentTaskOutcomeStatus, AgentTaskRequest, AgentTaskWorkspace, AGENT_TASK_OUTCOME_SCHEMA,
+    AGENT_TASK_REQUEST_SCHEMA,
 };
 use homeboy::core::agent_task_scheduler::{
     AgentTaskExecutionContext, AgentTaskPlan, AgentTaskScheduleOptions, AgentTaskScheduler,
@@ -86,6 +87,24 @@ pub(super) fn run_matrix_fanout(
     let scheduler_aggregate = scheduler.run(schedule);
     let matrix_aggregate =
         AgentTaskMatrixAggregate::from_outcomes(&matrix_plan, &scheduler_aggregate.outcomes);
+    let no_op_cells = scheduler_aggregate
+        .outcomes
+        .iter()
+        .filter(|outcome| matches!(outcome.status, AgentTaskOutcomeStatus::NoOp))
+        .count();
+    if no_op_cells > 0 {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "matrix",
+            format!(
+                "bench matrix executor produced {no_op_cells} no-op cell(s); no benchmark workload ran"
+            ),
+            Some(run_args.matrix.join(",")),
+            Some(vec![
+                "Use a bench matrix executor that returns completed workload outcomes with artifacts/metrics.".to_string(),
+                "Run explicit bench commands for each cell until matrix fan-out has a real workload executor.".to_string(),
+            ]),
+        ));
+    }
     let report = BenchMatrixFanoutReport {
         format: run_args.report.first().copied(),
         passed: matrix_aggregate.passed,
@@ -327,25 +346,13 @@ mod tests {
         args.matrix_max_queue_depth = Some(3);
         args.expected_artifact = vec!["bench-results".to_string()];
 
-        let output = run_matrix_fanout(&args).expect("matrix fan-out runs");
+        let err = match run_matrix_fanout(&args) {
+            Ok(_) => panic!("no-op matrix cells must fail"),
+            Err(err) => err,
+        };
 
-        assert_eq!(output.command, "bench.matrix");
-        assert_eq!(output.executor_backend, "local");
-        assert_eq!(output.scheduler.queue.max_concurrency, 2);
-        assert_eq!(output.scheduler.queue.max_queue_depth, Some(3));
-        assert_eq!(output.scheduler.totals.succeeded, 3);
-        assert_eq!(output.scheduler.totals.blocked, 1);
-        assert_eq!(output.scheduler.totals.failed, 0);
-        assert_eq!(output.matrix.cells.len(), 4);
-        assert!(!output.matrix.passed);
-        assert_eq!(output.report.cells, 4);
-        assert_eq!(output.report.succeeded, 3);
-        assert_eq!(output.report.blocked, 1);
-        assert_eq!(output.report.failed, 0);
-        assert!(output
-            .matrix
-            .cells
-            .iter()
-            .any(|cell| cell.axes["model"] == "kimi" && cell.axes["prompt"] == "site-b"));
+        assert_eq!(err.details["field"], "matrix");
+        assert!(err.message.contains("no-op cell"));
+        assert!(err.message.contains("no benchmark workload ran"));
     }
 }

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -24,7 +24,14 @@ pub struct RigArgs {
 
 impl RigArgs {
     pub fn is_hot_resource_command(&self) -> bool {
-        matches!(self.command, RigCommand::Up { .. })
+        matches!(
+            self.command,
+            RigCommand::Up { .. } | RigCommand::Check { .. }
+        )
+    }
+
+    pub fn is_check_command(&self) -> bool {
+        matches!(self.command, RigCommand::Check { .. })
     }
 }
 

--- a/src/commands/runner/doctor.rs
+++ b/src/commands/runner/doctor.rs
@@ -105,6 +105,8 @@ mod types {
         pub docker: bool,
         pub playwright: bool,
         pub browser_ready: bool,
+        pub xvfb_ready: bool,
+        pub headed_browser_ready: bool,
         pub workspace_writable: bool,
         pub artifact_store_available: bool,
     }
@@ -332,7 +334,15 @@ mod local {
 
         let playwright = probes::tool_available(&tools, "playwright");
         let browser_ready = probes::local_browser_ready();
+        let display_ready = probes::local_display_ready();
+        let xvfb_ready = probes::local_xvfb_ready();
+        let headed_browser_ready = probes::headed_browser_ready(display_ready, xvfb_ready);
         checks.push(checks::playwright_check(playwright, browser_ready));
+        checks.push(checks::headed_browser_check(
+            headed_browser_ready,
+            display_ready,
+            xvfb_ready,
+        ));
 
         let workspace_writable = probes::local_path_writable(&workspace_root);
         checks.push(checks::path_writable_check(
@@ -365,6 +375,8 @@ mod local {
             false,
             playwright,
             browser_ready,
+            xvfb_ready,
+            headed_browser_ready,
             workspace_writable,
             artifact_store_available,
         );
@@ -529,7 +541,15 @@ mod remote {
 
         let playwright = probes::tool_available(&tools, "playwright");
         let browser_ready = probes::remote_browser_ready(client);
+        let display_ready = probes::remote_display_ready(client);
+        let xvfb_ready = probes::remote_xvfb_ready(client);
+        let headed_browser_ready = probes::headed_browser_ready(display_ready, xvfb_ready);
         checks.push(checks::playwright_check(playwright, browser_ready));
+        checks.push(checks::headed_browser_check(
+            headed_browser_ready,
+            display_ready,
+            xvfb_ready,
+        ));
 
         let workspace_writable = probes::remote_path_writable(client, &workspace_root);
         checks.push(checks::path_writable_check(
@@ -568,6 +588,8 @@ mod remote {
             true,
             playwright,
             browser_ready,
+            xvfb_ready,
+            headed_browser_ready,
             workspace_writable,
             artifact_store_available,
         );
@@ -716,6 +738,8 @@ mod probes {
         ssh_execution: bool,
         playwright: bool,
         browser_ready: bool,
+        xvfb_ready: bool,
+        headed_browser_ready: bool,
         workspace_writable: bool,
         artifact_store_available: bool,
     ) -> RunnerCapabilities {
@@ -732,6 +756,8 @@ mod probes {
             docker: tool_available(tools, "docker"),
             playwright,
             browser_ready,
+            xvfb_ready,
+            headed_browser_ready,
             workspace_writable,
             artifact_store_available,
         }
@@ -902,6 +928,27 @@ mod probes {
     pub fn remote_browser_ready(client: &SshClient) -> bool {
         let command = "for d in \"${PLAYWRIGHT_BROWSERS_PATH:-}\" \"$HOME/Library/Caches/ms-playwright\" \"$HOME/.cache/ms-playwright\"; do [ -n \"$d\" ] && [ -d \"$d\" ] && find \"$d\" -mindepth 1 -maxdepth 1 2>/dev/null | grep -q . && exit 0; done; exit 1";
         client.execute(command).success
+    }
+
+    pub fn headed_browser_ready(display_ready: bool, xvfb_ready: bool) -> bool {
+        display_ready || xvfb_ready
+    }
+
+    pub fn local_display_ready() -> bool {
+        env::var("DISPLAY").is_ok_and(|value| !value.trim().is_empty())
+    }
+
+    pub fn remote_display_ready(client: &SshClient) -> bool {
+        client.execute("[ -n \"${DISPLAY:-}\" ]").success
+    }
+
+    pub fn local_xvfb_ready() -> bool {
+        local_tool_probe("xvfb-run", &[]).available || local_tool_probe("Xvfb", &[]).available
+    }
+
+    pub fn remote_xvfb_ready(client: &SshClient) -> bool {
+        remote_tool_probe(client, "xvfb-run", &[]).available
+            || remote_tool_probe(client, "Xvfb", &[]).available
     }
 
     #[cfg(unix)]
@@ -1188,6 +1235,30 @@ mod checks {
                     "Install Playwright and browser binaries for browser-backed traces".to_string(),
                 ),
             ),
+        }
+    }
+
+    pub fn headed_browser_check(
+        headed_browser_ready: bool,
+        display_ready: bool,
+        xvfb_ready: bool,
+    ) -> RunnerCheck {
+        let mut details = BTreeMap::new();
+        details.insert("display_ready".to_string(), display_ready.to_string());
+        details.insert("xvfb_ready".to_string(), xvfb_ready.to_string());
+        if headed_browser_ready {
+            ok_with_details(
+                "browser.headed_ready",
+                "Display or Xvfb support is available for headed browser workloads".to_string(),
+                details,
+            )
+        } else {
+            warning_with_details(
+                "browser.headed_ready",
+                "No DISPLAY or Xvfb support was detected for headed browser workloads".to_string(),
+                Some("Install xvfb/xvfb-run on Linux runners or run Electron/Chromium workloads in headless/Ozone mode".to_string()),
+                details,
+            )
         }
     }
 

--- a/src/commands/runner/doctor/tests.rs
+++ b/src/commands/runner/doctor/tests.rs
@@ -152,6 +152,33 @@ fn required_tool_check_errors_with_actionable_remediation() {
 }
 
 #[test]
+fn headed_browser_check_warns_without_display_or_xvfb() {
+    let check = checks::headed_browser_check(false, false, false);
+
+    assert_eq!(check.id, "browser.headed_ready");
+    assert_eq!(check.status, RunnerDoctorStatus::Warning);
+    assert_eq!(
+        check.details.get("display_ready").map(String::as_str),
+        Some("false")
+    );
+    assert_eq!(
+        check.details.get("xvfb_ready").map(String::as_str),
+        Some("false")
+    );
+    assert!(check
+        .remediation
+        .as_deref()
+        .is_some_and(|value| value.contains("headless/Ozone")));
+}
+
+#[test]
+fn headed_browser_ready_accepts_display_or_xvfb() {
+    assert!(probes::headed_browser_ready(true, false));
+    assert!(probes::headed_browser_ready(false, true));
+    assert!(!probes::headed_browser_ready(false, false));
+}
+
+#[test]
 fn local_doctor_honors_required_tool_errors() {
     let (report, exit_code) = run_with_options(
         "local",

--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -87,7 +87,7 @@ pub struct StackSourceMetadata {
 
 pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallResult> {
     let prepared = prepare_source(source)?;
-    let discovered = discover_rigs(&prepared.discovery_path)?;
+    let discovered = discover_rigs_for_install(&prepared.discovery_path, id, all)?;
     let selected = select_rigs(discovered, id, all, source)?;
     let discovered_stacks = discover_stacks(&prepared.discovery_path)?;
 
@@ -375,6 +375,27 @@ fn prepare_local_source(source: &str) -> Result<PreparedSource> {
 }
 
 pub fn discover_rigs(package_path: &Path) -> Result<Vec<DiscoveredRig>> {
+    discover_rigs_matching(package_path, None)
+}
+
+fn discover_rigs_for_install(
+    package_path: &Path,
+    id: Option<&str>,
+    all: bool,
+) -> Result<Vec<DiscoveredRig>> {
+    if all {
+        return discover_rigs(package_path);
+    }
+    let Some(id) = id else {
+        return discover_rigs(package_path);
+    };
+    discover_rigs_matching(package_path, Some(&extension::slugify_id(id)?))
+}
+
+fn discover_rigs_matching(
+    package_path: &Path,
+    only_id: Option<&str>,
+) -> Result<Vec<DiscoveredRig>> {
     let mut rigs = Vec::new();
 
     let single = package_path.join("rig.json");
@@ -396,6 +417,16 @@ pub fn discover_rigs(package_path: &Path) -> Result<Vec<DiscoveredRig>> {
             }
             let rig_path = path.join("rig.json");
             if rig_path.is_file() {
+                if let Some(only_id) = only_id {
+                    let candidate = path
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .map(extension::slugify_id)
+                        .transpose()?;
+                    if candidate.as_deref() != Some(only_id) {
+                        continue;
+                    }
+                }
                 rigs.push(discovered_from_path(&rig_path, path.file_name())?);
             }
         }
@@ -405,6 +436,9 @@ pub fn discover_rigs(package_path: &Path) -> Result<Vec<DiscoveredRig>> {
     rigs.dedup_by(|a, b| a.id == b.id);
 
     if rigs.is_empty() {
+        if only_id.is_some() {
+            return Ok(rigs);
+        }
         return Err(Error::validation_invalid_argument(
             "source",
             format!(

--- a/src/core/runner/rig_materialization.rs
+++ b/src/core/runner/rig_materialization.rs
@@ -5,9 +5,10 @@ use crate::core::rig;
 use crate::core::{Error, Result};
 
 use super::{
-    exec, load, materialize_git_dependency, sync_workspace, RunnerExecOptions,
-    RunnerGitDependencyMaterializationOptions, RunnerGitDependencyMaterializationOutput,
-    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+    exec, load, materialize_git_dependency, sync_workspace,
+    workspace::{parent_remote_path, sanitize_path_segment},
+    RunnerExecOptions, RunnerGitDependencyMaterializationOptions,
+    RunnerGitDependencyMaterializationOutput, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15,6 +16,7 @@ pub(super) struct RigComponentDependency {
     pub rig_id: String,
     pub component_id: String,
     pub local_checkout_root: String,
+    pub declared_checkout_root: String,
     pub remote_checkout_root: String,
     pub required_subpath: Option<String>,
     pub remote_url: Option<String>,
@@ -158,10 +160,12 @@ pub(super) fn lab_offload_rig_component_dependencies(
                 rig_id: rig_id.clone(),
                 component_id: component_id.clone(),
                 remote_checkout_root: remote_checkout_root_for_local(
+                    checkout_root,
                     &local_checkout_root,
                     primary_workspace,
                 ),
                 local_checkout_root,
+                declared_checkout_root: checkout_root.to_string(),
                 required_subpath,
                 remote_url: component.remote_url.clone(),
             });
@@ -175,6 +179,7 @@ fn expanded_local_path(spec: &rig::RigSpec, value: &str) -> String {
 }
 
 fn remote_checkout_root_for_local(
+    declared_checkout_root: &str,
     local_checkout_root: &str,
     primary_workspace: Option<(&str, &str)>,
 ) -> String {
@@ -186,7 +191,22 @@ fn remote_checkout_root_for_local(
     {
         return primary_remote_path.to_string();
     }
-    local_checkout_root.to_string()
+    if is_portable_runner_path(declared_checkout_root) {
+        return declared_checkout_root.to_string();
+    }
+    let name = Path::new(local_checkout_root)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("dependency");
+    format!(
+        "{}/{}",
+        parent_remote_path(primary_remote_path),
+        sanitize_path_segment(name)
+    )
+}
+
+fn is_portable_runner_path(path: &str) -> bool {
+    path == "~" || path.starts_with("~/")
 }
 
 fn should_materialize_dependency(
@@ -348,6 +368,10 @@ mod tests {
                 checkout.display().to_string()
             );
             assert_eq!(
+                dependencies[0].declared_checkout_root,
+                checkout.display().to_string()
+            );
+            assert_eq!(
                 dependencies[0].remote_checkout_root,
                 checkout.display().to_string()
             );
@@ -428,12 +452,45 @@ mod tests {
     }
 
     #[test]
+    fn maps_non_primary_rig_dependency_to_runner_workspace_parent() {
+        let remote = remote_checkout_root_for_local(
+            "/Users/chubes/Developer/studio@fix-many-sites-memory",
+            "/Users/chubes/Developer/studio@fix-many-sites-memory",
+            Some((
+                "/Users/chubes/Developer/homeboy-rigs/Automattic/studio",
+                "/home/chubes/Developer/_lab_workspaces/studio-rigs-snapshot",
+            )),
+        );
+
+        assert_eq!(
+            remote,
+            "/home/chubes/Developer/_lab_workspaces/studio-fix-many-sites-memory"
+        );
+        assert!(!remote.contains("/Users/"));
+    }
+
+    #[test]
+    fn preserves_portable_declared_rig_dependency_path_for_runner() {
+        let remote = remote_checkout_root_for_local(
+            "~/Developer/studio@fix-many-sites-memory",
+            "/Users/chubes/Developer/studio@fix-many-sites-memory",
+            Some((
+                "/Users/chubes/Developer/homeboy-rigs/Automattic/studio",
+                "/home/chubes/Developer/_lab_workspaces/studio-rigs-snapshot",
+            )),
+        );
+
+        assert_eq!(remote, "~/Developer/studio@fix-many-sites-memory");
+    }
+
+    #[test]
     fn primary_workspace_dependency_is_not_materialized_again() {
         let primary_remote_path = "/home/chubes/Developer/_lab_workspaces/studio-web-snapshot";
         let dependencies = vec![RigComponentDependency {
             rig_id: "studio-web-product-matrix".to_string(),
             component_id: "studio-web".to_string(),
             local_checkout_root: "/Users/chubes/Developer/studio-web".to_string(),
+            declared_checkout_root: "/Users/chubes/Developer/studio-web".to_string(),
             remote_checkout_root: primary_remote_path.to_string(),
             required_subpath: None,
             remote_url: Some("https://github.a8c.com/chubes4/studio-web.git".to_string()),

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -162,6 +162,41 @@ fn install_multi_rig_package_can_select_id() {
 }
 
 #[test]
+fn install_id_skips_invalid_unrelated_rigs_in_package() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+    let broken = package.path().join("rigs").join("broken");
+    fs::create_dir_all(&broken).expect("broken rig dir");
+    fs::write(
+        broken.join("rig.json"),
+        r#"{"id":"broken","bench_workloads":{"node":["legacy"]}}"#,
+    )
+    .expect("broken rig json");
+
+    let result = install(package.path().to_str().unwrap(), Some("alpha"), false).expect("install");
+
+    assert_eq!(result.installed.len(), 1);
+    assert_eq!(result.installed[0].id, "alpha");
+    assert!(crate::core::paths::rig_config("alpha").unwrap().exists());
+    assert!(!crate::core::paths::rig_config("broken").unwrap().exists());
+}
+
+#[test]
+fn install_id_missing_reports_requested_rig_not_found() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    write_rig(package.path(), "alpha", &minimal_rig("alpha"));
+
+    let err = install(package.path().to_str().unwrap(), Some("missing"), false)
+        .expect_err("missing rig should error");
+
+    assert_eq!(err.details["field"], "id");
+    assert!(err.message.contains("missing"));
+    assert!(err.message.contains("not found"));
+}
+
+#[test]
 fn install_multi_rig_package_can_install_all() {
     let _home = HomeGuard::new();
     let package = tempfile::tempdir().expect("package");


### PR DESCRIPTION
## Summary
- Fix rig dependency materialization so runner-side dependencies use portable declared paths or a runner workspace sibling instead of controller-local `/Users/...` paths.
- Add headed browser/Xvfb readiness to `runner doctor`, fail no-op `bench --matrix` proofs, and make `rig check --runner` Lab-portable while keeping `rig up` local-only.
- Make `rig install --id` parse only the requested rig in multi-rig packages so unrelated invalid specs do not block targeted installs.

Closes #3741
Closes #3744
Closes #3745
Closes #3746
Closes #3747

## Verification
- `cargo test core::runner::rig_materialization::tests --lib`
- `cargo test core::rig::install::install_test --lib`
- `cargo test commands::runner::doctor::tests --lib`
- `cargo test commands::bench::fanout::tests --lib`
- `cargo test rig_check_supports_lab_runner_but_rig_up_stays_local_only --lib`
- `cargo check --bins`
- `cargo test --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the implementation across rig install, runner doctor, bench matrix, rig Lab routing, and runner materialization paths; Chris remains responsible for review and merge.