### PR TITLE
Require canonical trace evidence by default

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -194,9 +194,11 @@ pub struct TraceArgs {
     #[arg(long)]
     pub keep_overlay: bool,
 
+    /// Require canonical evidence. This is the default; retained for explicit command logs.
     #[arg(long, alias = "proof")]
     pub canonical: bool,
-    #[arg(long)]
+    /// Allow intentionally local/development evidence. The output is marked non-canonical.
+    #[arg(long, alias = "allow-local-evidence")]
     pub allow_local_toolchain: bool,
 
     /// Clean only stale trace overlay locks.

--- a/src/commands/trace/compare_variant_tests.rs
+++ b/src/commands/trace/compare_variant_tests.rs
@@ -74,7 +74,7 @@ fn trace_compare_variant_interleaves_run_order_and_reports_focus_spans() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )
@@ -217,7 +217,7 @@ fn trace_compare_variant_uses_component_arg_for_multi_component_named_variants()
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )
@@ -309,7 +309,7 @@ fn trace_compare_variant_reports_unknown_named_variant_for_component_arg() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         ) {

--- a/src/commands/trace/experiment_tests.rs
+++ b/src/commands/trace/experiment_tests.rs
@@ -48,7 +48,7 @@ fn trace_args_for_rig(rig_id: &str, scenario: &str) -> TraceArgs {
         stale: false,
         force: false,
         canonical: false,
-        allow_local_toolchain: false,
+        allow_local_toolchain: true,
     }
 }
 

--- a/src/commands/trace/generic_tests.rs
+++ b/src/commands/trace/generic_tests.rs
@@ -62,7 +62,7 @@ JSON
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )

--- a/src/commands/trace/guardrail_tests.rs
+++ b/src/commands/trace/guardrail_tests.rs
@@ -45,7 +45,7 @@ fn trace_args_for_rig(rig_id: &str) -> TraceArgs {
         stale: false,
         force: false,
         canonical: false,
-        allow_local_toolchain: false,
+        allow_local_toolchain: true,
     }
 }
 

--- a/src/commands/trace/matrix_tests.rs
+++ b/src/commands/trace/matrix_tests.rs
@@ -121,7 +121,7 @@ fn trace_matrix_reports_failed_cells_and_cell_artifacts() {
             stale: false,
             force: false,
             canonical: false,
-            allow_local_toolchain: false,
+            allow_local_toolchain: true,
         })
         .expect("matrix run");
 

--- a/src/commands/trace/output_tests.rs
+++ b/src/commands/trace/output_tests.rs
@@ -328,7 +328,7 @@ fn trace_compare_exits_nonzero_for_guardrail_failures() {
         stale: false,
         force: false,
         canonical: false,
-        allow_local_toolchain: false,
+        allow_local_toolchain: true,
     })
     .expect("compare should run");
 

--- a/src/commands/trace/profile_tests.rs
+++ b/src/commands/trace/profile_tests.rs
@@ -45,7 +45,7 @@ fn trace_args_for_profile(profile: &str) -> TraceArgs {
         stale: false,
         force: false,
         canonical: false,
-        allow_local_toolchain: false,
+        allow_local_toolchain: true,
     }
 }
 
@@ -186,7 +186,7 @@ fn trace_list_profiles_lists_rig_profiles() {
             stale: false,
             force: false,
             canonical: false,
-            allow_local_toolchain: false,
+            allow_local_toolchain: true,
         })
         .expect("profile list should run");
 

--- a/src/commands/trace/rig_tests.rs
+++ b/src/commands/trace/rig_tests.rs
@@ -65,7 +65,7 @@ fn trace_args_for_rig(rig_id: &str, component_id: &str, scenario_id: &str) -> Tr
         stale: false,
         force: false,
         canonical: false,
-        allow_local_toolchain: false,
+        allow_local_toolchain: true,
     }
 }
 

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -1,5 +1,7 @@
 use std::fs;
 
+use clap::Parser;
+
 use crate::test_support::with_isolated_home;
 
 use super::test_fixture::{
@@ -9,6 +11,21 @@ use super::test_fixture::{
     write_trace_rig_with_span_metadata, write_trace_rig_with_variant,
 };
 use super::*;
+
+#[derive(Parser)]
+struct TestCli {
+    #[command(flatten)]
+    trace: TraceArgs,
+}
+
+#[test]
+fn trace_accepts_allow_local_evidence_alias() {
+    let cli = TestCli::try_parse_from(["trace", "component", "scenario", "--allow-local-evidence"])
+        .expect("trace args parse");
+
+    assert!(cli.trace.allow_local_toolchain);
+}
+
 fn trace_args_for_rig(rig_id: &str, component_id: &str, scenario_id: &str) -> TraceArgs {
     TraceArgs {
         comp: PositionalComponentArgs {
@@ -49,7 +66,7 @@ fn trace_args_for_rig(rig_id: &str, component_id: &str, scenario_id: &str) -> Tr
         stale: false,
         force: false,
         canonical: false,
-        allow_local_toolchain: false,
+        allow_local_toolchain: true,
     }
 }
 
@@ -101,7 +118,7 @@ fn rig_trace_run_uses_rig_owned_workload_extension_without_component_link() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )
@@ -197,7 +214,7 @@ fn trace_run_persists_observation_history() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )
@@ -367,7 +384,7 @@ fn trace_repeat_aggregates_span_timings_and_preserves_artifacts() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )
@@ -468,7 +485,7 @@ fn trace_repeat_loads_span_metadata_and_reports_unknown_ids() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )
@@ -651,7 +668,7 @@ fn trace_repeat_reports_overlay_touched_files_at_top_level() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )
@@ -734,7 +751,7 @@ fn trace_run_resolves_named_variants_and_reports_unknown_names() {
             stale: false,
             force: false,
             canonical: false,
-            allow_local_toolchain: false,
+            allow_local_toolchain: true,
         };
 
         let (output, exit_code) =
@@ -851,7 +868,7 @@ fn trace_compare_variant_writes_experiment_bundle() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )
@@ -933,7 +950,7 @@ fn trace_compare_variant_resolves_named_variants() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )
@@ -1030,7 +1047,7 @@ fn trace_compare_variant_reports_unknown_named_variants() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         ) {
@@ -1105,7 +1122,7 @@ fn trace_run_expands_phase_chain_into_adjacent_and_total_spans() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )
@@ -1181,7 +1198,7 @@ fn trace_run_expands_named_workload_phase_preset() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )
@@ -1257,7 +1274,7 @@ fn trace_aggregate_spans_uses_workload_default_phase_preset() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )
@@ -1329,7 +1346,7 @@ fn trace_repeat_counts_failed_runs_as_span_failures() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )
@@ -1405,7 +1422,7 @@ fn failed_trace_run_persists_observation_history() {
                 stale: false,
                 force: false,
                 canonical: false,
-                allow_local_toolchain: false,
+                allow_local_toolchain: true,
             },
             &GlobalArgs {},
         )

--- a/src/core/extension/trace/canonicality.rs
+++ b/src/core/extension/trace/canonicality.rs
@@ -20,13 +20,11 @@ pub enum TraceCanonicalPolicy {
 }
 
 impl TraceCanonicalPolicy {
-    pub fn from_flags(canonical: bool, allow_local_toolchain: bool) -> Self {
+    pub fn from_flags(_canonical: bool, allow_local_toolchain: bool) -> Self {
         if allow_local_toolchain {
             Self::AllowLocalToolchain
-        } else if canonical {
-            Self::Canonical
         } else {
-            Self::Development
+            Self::Canonical
         }
     }
 
@@ -126,7 +124,7 @@ pub(crate) fn refused_trace_result(
         overlays: Vec::new(),
         baseline_comparison: None,
         hints: Some(vec![
-            "Use --allow-local-toolchain for development-only trace runs; evidence will be marked non-canonical.".to_string(),
+            "Use --allow-local-evidence for development-only trace runs; evidence will be marked non-canonical.".to_string(),
         ]),
         toolchain: None,
         components: None,
@@ -377,6 +375,22 @@ mod tests {
     use crate::core::extension::trace::run::{run_trace_workflow, TraceRunnerInputs};
 
     #[test]
+    fn trace_canonical_policy_defaults_to_canonical() {
+        assert_eq!(
+            TraceCanonicalPolicy::from_flags(false, false),
+            TraceCanonicalPolicy::Canonical
+        );
+        assert_eq!(
+            TraceCanonicalPolicy::from_flags(true, false),
+            TraceCanonicalPolicy::Canonical
+        );
+        assert_eq!(
+            TraceCanonicalPolicy::from_flags(false, true),
+            TraceCanonicalPolicy::AllowLocalToolchain
+        );
+    }
+
+    #[test]
     fn canonical_trace_refuses_dirty_checkout_before_workload_execution() {
         let temp = tempfile::tempdir().unwrap();
         init_git_repo(temp.path());
@@ -513,6 +527,9 @@ mod tests {
         assert_eq!(result.exit_code, 3);
         assert!(!result.evidence.canonical);
         assert_eq!(result.evidence.mode, "allow-local-toolchain");
+        assert!(result.hints.as_ref().is_some_and(|hints| hints
+            .iter()
+            .any(|hint| hint.contains("Non-canonical local evidence mode"))));
         assert!(result.results.is_none());
         run_dir.cleanup();
     }

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -186,6 +186,7 @@ fn run_trace_workflow_with_component_script(
             canonicality.metadata(TraceCanonicalPolicy::Canonical),
         ));
     }
+    let evidence = canonicality.metadata(args.canonical_policy);
     let (mut toolchain, components) = trace_provenance(None, &component_path);
     mark_non_canonical(
         &mut toolchain,
@@ -228,7 +229,7 @@ fn run_trace_workflow_with_component_script(
         if parsed.rig.is_none() {
             parsed.rig = rig_state;
         }
-        parsed.evidence = Some(canonicality.metadata(args.canonical_policy));
+        parsed.evidence = Some(evidence.clone());
         Some(parsed)
     } else {
         None
@@ -281,7 +282,7 @@ fn run_trace_workflow_with_component_script(
         status,
         component: args.component_label,
         exit_code,
-        evidence: canonicality.metadata(args.canonical_policy),
+        evidence: evidence.clone(),
         results,
         failure,
         overlays: applied_overlays
@@ -296,10 +297,14 @@ fn run_trace_workflow_with_component_script(
             })
             .collect(),
         baseline_comparison: None,
-        hints: Some(vec![
+        hints: Some({
+            let mut hints = non_canonical_evidence_hints(&evidence);
+            hints.push(
             "Component scripts use the extension runner env contract without extension resolution."
                 .to_string(),
-        ]),
+            );
+            hints
+        }),
         toolchain: Some(toolchain),
         components: Some(components),
     })
@@ -328,6 +333,7 @@ fn run_trace_workflow_with_context(
             canonicality.metadata(TraceCanonicalPolicy::Canonical),
         ));
     }
+    let evidence = canonicality.metadata(args.canonical_policy);
     let (toolchain, components) = trace_provenance(execution_context, &component_path);
     let _overlay_locks = if args.overlays.is_empty() {
         None
@@ -379,7 +385,7 @@ fn run_trace_workflow_with_context(
         if parsed.rig.is_none() {
             parsed.rig = rig_state;
         }
-        parsed.evidence = Some(canonicality.metadata(args.canonical_policy));
+        parsed.evidence = Some(evidence.clone());
         Some(parsed)
     } else {
         None
@@ -424,7 +430,7 @@ fn run_trace_workflow_with_context(
     let baseline_root = resolve_trace_baseline_root(&component_path, rig_id)?;
     let mut baseline_comparison = None;
     let mut baseline_exit_override = None;
-    let mut hints = Vec::new();
+    let mut hints = non_canonical_evidence_hints(&evidence);
     let has_baseline_items = results
         .as_ref()
         .is_some_and(|parsed| !parsed.span_results.is_empty() || !parsed.assertions.is_empty());
@@ -493,7 +499,7 @@ fn run_trace_workflow_with_context(
         status,
         component: args.component_label,
         exit_code,
-        evidence: canonicality.metadata(args.canonical_policy),
+        evidence,
         results,
         failure,
         overlays: applied_overlays
@@ -512,6 +518,16 @@ fn run_trace_workflow_with_context(
         toolchain: Some(toolchain),
         components: Some(components),
     })
+}
+
+fn non_canonical_evidence_hints(evidence: &TraceEvidenceMetadata) -> Vec<String> {
+    if evidence.canonical {
+        return Vec::new();
+    }
+    vec![format!(
+        "Non-canonical local evidence mode `{}` is active; do not use this run as reviewer-facing proof until the reported canonicality reasons are fixed.",
+        evidence.mode
+    )]
 }
 
 fn trace_provenance(


### PR DESCRIPTION
## Summary
- Make trace runs canonical by default so dirty, behind, ahead, or otherwise non-canonical component checkouts fail before producing reviewer-facing evidence.
- Add `--allow-local-evidence` as the explicit development-only escape hatch while preserving `--allow-local-toolchain`.
- Mark local evidence runs with an output hint and update trace fixtures to opt into local evidence where canonicality is not under test.

Closes #3751.

## Verification
- `cargo test commands::trace --lib`
- `cargo test core::extension::trace --lib`
- `cargo check --bins`
- `cargo test --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the trace canonicality default, CLI alias, test updates, and PR text; Chris remains responsible for review and merge.