### PR TITLE
Add agent-task provider auth ownership

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use homeboy::core::agent_task_gate::AgentTaskGateRevealPolicy;
 use serde_json::Value;
+use std::io::Read;
 
 use homeboy::core::agent_task::AgentTaskRequest;
 use homeboy::core::agent_task_lifecycle;
@@ -77,6 +78,8 @@ pub enum AgentTaskAuthCommand {
     SetKeychain(AgentTaskAuthSetKeychainArgs),
     /// Map a required provider env name to another process env var.
     MapEnv(AgentTaskAuthMapEnvArgs),
+    /// Map Claude Code provider secrets to Kimaki/OpenCode's active Anthropic OAuth auth file.
+    MapClaudeCodeKimaki,
     /// Remove a provider secret source mapping.
     Remove(AgentTaskAuthRemoveArgs),
 }
@@ -97,6 +100,10 @@ pub struct AgentTaskAuthSetKeychainArgs {
     /// Secret value. Omit to prompt securely.
     #[arg(value_name = "VALUE")]
     pub value: Option<String>,
+
+    /// Read the secret value from stdin.
+    #[arg(long)]
+    pub value_stdin: bool,
 
     /// Keychain scope. Defaults to agent-task.
     #[arg(long, value_name = "SCOPE")]
@@ -353,10 +360,7 @@ fn auth(args: AgentTaskAuthArgs) -> CmdResult<Value> {
             0,
         )),
         AgentTaskAuthCommand::SetKeychain(set_args) => {
-            let value = match set_args.value {
-                Some(value) => value,
-                None => prompt_password("Secret value: ")?,
-            };
+            let value = read_agent_task_secret_value(set_args.value, set_args.value_stdin)?;
             let status = agent_task_secrets::set_keychain_secret(
                 &set_args.secret_env,
                 &value,
@@ -384,6 +388,16 @@ fn auth(args: AgentTaskAuthArgs) -> CmdResult<Value> {
                 0,
             ))
         }
+        AgentTaskAuthCommand::MapClaudeCodeKimaki => {
+            let status = agent_task_secrets::map_claude_code_to_opencode_anthropic()?;
+            Ok((
+                serde_json::json!({
+                    "schema": "homeboy/agent-task-auth-configured/v1",
+                    "secret_env": status,
+                }),
+                0,
+            ))
+        }
         AgentTaskAuthCommand::Remove(remove_args) => {
             let status = agent_task_secrets::remove_secret_mapping(
                 &remove_args.secret_env,
@@ -397,6 +411,32 @@ fn auth(args: AgentTaskAuthArgs) -> CmdResult<Value> {
                 0,
             ))
         }
+    }
+}
+
+fn read_agent_task_secret_value(
+    value: Option<String>,
+    value_stdin: bool,
+) -> homeboy::core::Result<String> {
+    match (value, value_stdin) {
+        (Some(_), true) => Err(homeboy::core::Error::validation_invalid_argument(
+            "value-stdin",
+            "cannot combine VALUE with --value-stdin",
+            None,
+            None,
+        )),
+        (Some(value), false) => Ok(value),
+        (None, true) => {
+            let mut raw = String::new();
+            std::io::stdin().read_to_string(&mut raw).map_err(|error| {
+                homeboy::core::Error::internal_io(
+                    error.to_string(),
+                    Some("read agent-task secret value from stdin".to_string()),
+                )
+            })?;
+            Ok(raw.trim_end_matches(['\r', '\n']).to_string())
+        }
+        (None, false) => prompt_password("Secret value: "),
     }
 }
 

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -8,10 +8,12 @@ use homeboy::core::agent_task_provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_task_scheduler::{
     AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskScheduler,
 };
+use homeboy::core::agent_task_secrets;
 use homeboy::core::config;
 
 use super::agent_task_dispatch::{run as dispatch, DispatchArgs};
 use super::{CmdResult, GlobalArgs};
+use crate::commands::utils::tty::prompt_password;
 
 pub mod review;
 
@@ -57,6 +59,74 @@ pub enum AgentTaskCommand {
     GateFeedback(GateFeedbackArgs),
     /// List extension-declared agent-task executor providers and optional secret readiness.
     Providers(ProvidersArgs),
+    /// Configure and inspect agent-task provider authentication secrets.
+    Auth(AgentTaskAuthArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskAuthArgs {
+    #[command(subcommand)]
+    pub command: AgentTaskAuthCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AgentTaskAuthCommand {
+    /// Show redacted readiness for provider secret environment variables.
+    Status(AgentTaskAuthStatusArgs),
+    /// Store a provider secret in the OS keychain and map it to a required env name.
+    SetKeychain(AgentTaskAuthSetKeychainArgs),
+    /// Map a required provider env name to another process env var.
+    MapEnv(AgentTaskAuthMapEnvArgs),
+    /// Remove a provider secret source mapping.
+    Remove(AgentTaskAuthRemoveArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskAuthStatusArgs {
+    /// Secret environment variable name to check without exposing its value. Repeatable.
+    #[arg(long = "secret-env", value_name = "ENV")]
+    pub secret_env: Vec<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskAuthSetKeychainArgs {
+    /// Required provider environment variable name to satisfy.
+    #[arg(value_name = "ENV")]
+    pub secret_env: String,
+
+    /// Secret value. Omit to prompt securely.
+    #[arg(value_name = "VALUE")]
+    pub value: Option<String>,
+
+    /// Keychain scope. Defaults to agent-task.
+    #[arg(long, value_name = "SCOPE")]
+    pub scope: Option<String>,
+
+    /// Keychain entry name. Defaults to ENV.
+    #[arg(long = "name", value_name = "NAME")]
+    pub keychain_name: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskAuthMapEnvArgs {
+    /// Required provider environment variable name to satisfy.
+    #[arg(value_name = "ENV")]
+    pub secret_env: String,
+
+    /// Source process environment variable. Defaults to ENV.
+    #[arg(long = "from", value_name = "ENV")]
+    pub source_env: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskAuthRemoveArgs {
+    /// Required provider environment variable name whose mapping should be removed.
+    #[arg(value_name = "ENV")]
+    pub secret_env: String,
+
+    /// Also remove the mapped keychain entry when the mapping points at keychain.
+    #[arg(long)]
+    pub keychain: bool,
 }
 
 #[derive(Args, Debug)]
@@ -269,6 +339,64 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::FinalizePr(finalize_args) => review::finalize_pull_request(finalize_args),
         AgentTaskCommand::GateFeedback(feedback_args) => review::gate_feedback(feedback_args),
         AgentTaskCommand::Providers(providers_args) => review::providers(providers_args),
+        AgentTaskCommand::Auth(auth_args) => auth(auth_args),
+    }
+}
+
+fn auth(args: AgentTaskAuthArgs) -> CmdResult<Value> {
+    match args.command {
+        AgentTaskAuthCommand::Status(status_args) => Ok((
+            serde_json::json!({
+                "schema": "homeboy/agent-task-auth-status/v1",
+                "secret_env": agent_task_secrets::secret_env_status(&status_args.secret_env),
+            }),
+            0,
+        )),
+        AgentTaskAuthCommand::SetKeychain(set_args) => {
+            let value = match set_args.value {
+                Some(value) => value,
+                None => prompt_password("Secret value: ")?,
+            };
+            let status = agent_task_secrets::set_keychain_secret(
+                &set_args.secret_env,
+                &value,
+                set_args.scope.as_deref(),
+                set_args.keychain_name.as_deref(),
+            )?;
+            Ok((
+                serde_json::json!({
+                    "schema": "homeboy/agent-task-auth-configured/v1",
+                    "secret_env": status,
+                }),
+                0,
+            ))
+        }
+        AgentTaskAuthCommand::MapEnv(map_args) => {
+            let status = agent_task_secrets::map_secret_to_env(
+                &map_args.secret_env,
+                map_args.source_env.as_deref(),
+            )?;
+            Ok((
+                serde_json::json!({
+                    "schema": "homeboy/agent-task-auth-configured/v1",
+                    "secret_env": status,
+                }),
+                0,
+            ))
+        }
+        AgentTaskAuthCommand::Remove(remove_args) => {
+            let status = agent_task_secrets::remove_secret_mapping(
+                &remove_args.secret_env,
+                remove_args.keychain,
+            )?;
+            Ok((
+                serde_json::json!({
+                    "schema": "homeboy/agent-task-auth-configured/v1",
+                    "secret_env": status,
+                }),
+                0,
+            ))
+        }
     }
 }
 

--- a/src/core/agent_task_secrets.rs
+++ b/src/core/agent_task_secrets.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::core::keychain;
 use crate::core::paths;
@@ -101,6 +102,35 @@ pub fn remove_secret_mapping(
         .into_iter()
         .next()
         .expect("single status"))
+}
+
+pub fn map_claude_code_to_opencode_anthropic() -> crate::core::Result<Vec<AgentTaskSecretEnvStatus>>
+{
+    let mut config = AgentTaskSecretConfig::load();
+    for (env_name, field_name) in [
+        ("AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN", "access"),
+        ("AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN", "refresh"),
+        ("AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT", "expires"),
+    ] {
+        config.secrets.insert(
+            env_name.to_string(),
+            AgentTaskSecretSource {
+                source: "opencode-anthropic-auth".to_string(),
+                env_var: None,
+                scope: None,
+                name: Some(field_name.to_string()),
+            },
+        );
+    }
+    config.save()?;
+    Ok(secret_env_status_with_config(
+        &[
+            "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN".to_string(),
+            "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN".to_string(),
+            "AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT".to_string(),
+        ],
+        &config,
+    ))
 }
 
 pub fn validate_secret_env(names: &[String]) -> Result<(), AgentTaskSecretResolutionError> {
@@ -246,9 +276,45 @@ impl AgentTaskSecretSource {
             )
             .ok()
             .flatten(),
+            "opencode-anthropic-auth" => {
+                opencode_anthropic_auth_value(self.name.as_deref().unwrap_or(requested_name))
+            }
             _ => None,
         }
     }
+}
+
+fn opencode_anthropic_auth_value(field_name: &str) -> Option<String> {
+    let path = opencode_auth_file_path()?;
+    let raw = fs::read_to_string(path).ok()?;
+    let data: Value = serde_json::from_str(&raw).ok()?;
+    let auth = data.get("anthropic")?;
+    if auth.get("type").and_then(Value::as_str) != Some("oauth") {
+        return None;
+    }
+
+    match field_name {
+        "access" | "refresh" => auth
+            .get(field_name)
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        "expires" => auth.get("expires").and_then(|value| {
+            value
+                .as_i64()
+                .map(|number| number.to_string())
+                .or_else(|| value.as_str().map(str::to_string))
+        }),
+        _ => None,
+    }
+}
+
+fn opencode_auth_file_path() -> Option<PathBuf> {
+    if let Ok(data_home) = env::var("XDG_DATA_HOME") {
+        return Some(PathBuf::from(data_home).join("opencode/auth.json"));
+    }
+    env::var("HOME")
+        .ok()
+        .map(|home| PathBuf::from(home).join(".local/share/opencode/auth.json"))
 }
 
 fn default_source() -> String {
@@ -375,6 +441,52 @@ mod tests {
             assert!(!status.configured);
             assert_eq!(status.source, "missing");
             std::env::remove_var(source_name);
+        });
+    }
+
+    #[test]
+    fn maps_claude_code_to_opencode_anthropic_auth_file() {
+        crate::test_support::with_isolated_home(|home| {
+            let auth_path = home.path().join(".local/share/opencode/auth.json");
+            std::fs::create_dir_all(auth_path.parent().expect("auth parent")).expect("mkdir auth");
+            std::fs::write(
+                &auth_path,
+                r#"{"anthropic":{"type":"oauth","access":"access-token","refresh":"refresh-token","expires":12345}}"#,
+            )
+            .expect("write auth");
+
+            let status = map_claude_code_to_opencode_anthropic().expect("mapping saved");
+
+            assert_eq!(status.len(), 3);
+            assert!(status.iter().all(|status| status.configured));
+            assert!(status
+                .iter()
+                .all(|status| status.source == "opencode-anthropic-auth"));
+
+            let resolved = resolve_secret_env(&[
+                "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN".to_string(),
+                "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN".to_string(),
+                "AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT".to_string(),
+            ])
+            .expect("mapped auth resolves");
+
+            assert_eq!(
+                resolved,
+                vec![
+                    (
+                        "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN".to_string(),
+                        "access-token".to_string()
+                    ),
+                    (
+                        "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN".to_string(),
+                        "refresh-token".to_string()
+                    ),
+                    (
+                        "AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT".to_string(),
+                        "12345".to_string()
+                    ),
+                ]
+            );
         });
     }
 }

--- a/src/core/agent_task_secrets.rs
+++ b/src/core/agent_task_secrets.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 use std::env;
 use std::fs;
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
 use crate::core::keychain;
 use crate::core::paths;
+use crate::core::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentTaskSecretResolutionError {
@@ -28,6 +30,77 @@ pub fn resolve_secret_env(
 
 pub fn secret_env_status(names: &[String]) -> Vec<AgentTaskSecretEnvStatus> {
     secret_env_status_with_config(names, &AgentTaskSecretConfig::load())
+}
+
+pub fn map_secret_to_env(
+    name: &str,
+    env_var: Option<&str>,
+) -> crate::core::Result<AgentTaskSecretEnvStatus> {
+    let mut config = AgentTaskSecretConfig::load();
+    config.secrets.insert(
+        name.to_string(),
+        AgentTaskSecretSource {
+            source: "env".to_string(),
+            env_var: env_var.map(str::to_string),
+            scope: None,
+            name: None,
+        },
+    );
+    config.save()?;
+    Ok(secret_env_status_with_config(&[name.to_string()], &config)
+        .into_iter()
+        .next()
+        .expect("single status"))
+}
+
+pub fn set_keychain_secret(
+    name: &str,
+    value: &str,
+    scope: Option<&str>,
+    keychain_name: Option<&str>,
+) -> crate::core::Result<AgentTaskSecretEnvStatus> {
+    let scope = scope.unwrap_or("agent-task");
+    let keychain_name = keychain_name.unwrap_or(name);
+    keychain::set(scope, keychain_name, value)?;
+
+    let mut config = AgentTaskSecretConfig::load();
+    config.secrets.insert(
+        name.to_string(),
+        AgentTaskSecretSource {
+            source: "keychain".to_string(),
+            env_var: None,
+            scope: Some(scope.to_string()),
+            name: Some(keychain_name.to_string()),
+        },
+    );
+    config.save()?;
+    Ok(secret_env_status_with_config(&[name.to_string()], &config)
+        .into_iter()
+        .next()
+        .expect("single status"))
+}
+
+pub fn remove_secret_mapping(
+    name: &str,
+    remove_keychain: bool,
+) -> crate::core::Result<AgentTaskSecretEnvStatus> {
+    let mut config = AgentTaskSecretConfig::load();
+    let source = config.secrets.remove(name);
+    config.save()?;
+
+    if remove_keychain {
+        if let Some(source) = source.filter(|source| source.source == "keychain") {
+            keychain::remove(
+                source.scope.as_deref().unwrap_or("agent-task"),
+                source.name.as_deref().unwrap_or(name),
+            )?;
+        }
+    }
+
+    Ok(secret_env_status_with_config(&[name.to_string()], &config)
+        .into_iter()
+        .next()
+        .expect("single status"))
 }
 
 pub fn validate_secret_env(names: &[String]) -> Result<(), AgentTaskSecretResolutionError> {
@@ -109,13 +182,45 @@ struct AgentTaskSecretConfig {
 
 impl AgentTaskSecretConfig {
     fn load() -> Self {
-        let Ok(path) = paths::homeboy().map(|root| root.join("agent-task-secrets.json")) else {
+        let Ok(path) = Self::path() else {
             return Self::default();
         };
         let Ok(raw) = fs::read_to_string(path) else {
             return Self::default();
         };
         serde_json::from_str(&raw).unwrap_or_default()
+    }
+
+    fn path() -> crate::core::Result<PathBuf> {
+        paths::homeboy().map(|root| root.join("agent-task-secrets.json"))
+    }
+
+    fn save(&self) -> crate::core::Result<()> {
+        let path = Self::path()?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!(
+                        "create agent-task secret config dir {}",
+                        parent.display()
+                    )),
+                )
+            })?;
+        }
+        let raw = serde_json::to_string_pretty(self).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize agent-task secret config".to_string()),
+            )
+        })?;
+        fs::write(&path, format!("{raw}\n")).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("write agent-task secret config {}", path.display())),
+            )
+        })?;
+        Ok(())
     }
 }
 
@@ -229,5 +334,47 @@ mod tests {
             vec![(configured_name, "configured-secret-value".to_string())]
         );
         std::env::remove_var(source_name);
+    }
+
+    #[test]
+    fn maps_declared_secret_to_env_source_file() {
+        crate::test_support::with_isolated_home(|_| {
+            let configured_name = unique_env("MAPPED_SECRET");
+            let source_name = unique_env("MAPPED_SOURCE");
+            std::env::remove_var(&configured_name);
+            std::env::set_var(&source_name, "mapped-secret-value");
+
+            let status = map_secret_to_env(&configured_name, Some(&source_name))
+                .expect("secret mapping saved");
+
+            assert_eq!(status.name, configured_name);
+            assert!(status.configured);
+            assert_eq!(status.source, "env");
+
+            let resolved = resolve_secret_env(std::slice::from_ref(&status.name))
+                .expect("mapped secret resolves");
+            assert_eq!(
+                resolved,
+                vec![(status.name, "mapped-secret-value".to_string())]
+            );
+            std::env::remove_var(source_name);
+        });
+    }
+
+    #[test]
+    fn removes_declared_secret_mapping() {
+        crate::test_support::with_isolated_home(|_| {
+            let configured_name = unique_env("REMOVED_SECRET");
+            let source_name = unique_env("REMOVED_SOURCE");
+            std::env::set_var(&source_name, "removed-secret-value");
+            map_secret_to_env(&configured_name, Some(&source_name)).expect("secret mapping saved");
+
+            let status = remove_secret_mapping(&configured_name, false).expect("mapping removed");
+
+            assert_eq!(status.name, configured_name);
+            assert!(!status.configured);
+            assert_eq!(status.source, "missing");
+            std::env::remove_var(source_name);
+        });
     }
 }

--- a/src/core/keychain.rs
+++ b/src/core/keychain.rs
@@ -50,6 +50,12 @@ pub fn get(project_id: &str, variable_name: &str) -> Result<Option<String>> {
 
 /// Removes a project API variable from the OS keychain.
 pub fn remove(project_id: &str, variable_name: &str) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        return macos::remove(project_id, variable_name);
+    }
+
+    #[cfg(not(target_os = "macos"))]
     match entry(project_id, variable_name)?.delete_credential() {
         Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
         Err(e) => Err(keyring_error(e)),
@@ -103,11 +109,15 @@ mod macos {
     use security_framework_sys::keychain::{
         SecKeychainAddGenericPassword, SecKeychainFindGenericPassword,
     };
-    use security_framework_sys::keychain_item::SecKeychainItemModifyAttributesAndData;
+    use security_framework_sys::keychain_item::{
+        SecKeychainItemDelete, SecKeychainItemModifyAttributesAndData,
+    };
     use std::ffi::CString;
     use std::os::raw::{c_char, c_void};
     use std::os::unix::ffi::OsStrExt;
     use std::ptr;
+
+    const ERR_SEC_NO_ACCESS_FOR_ITEM: OSStatus = -25320;
 
     enum OpaqueSecTrustedApplicationRef {}
     type SecTrustedApplicationRef = *mut OpaqueSecTrustedApplicationRef;
@@ -162,6 +172,29 @@ mod macos {
         set_current_exe_access(item)?;
         unsafe { CFRelease(item as CFTypeRef) };
         Ok(())
+    }
+
+    pub fn remove(project_id: &str, variable_name: &str) -> Result<()> {
+        let account = account_key(project_id, variable_name);
+        let item = match find_item(&account) {
+            Ok(item) => item,
+            Err(error)
+                if error
+                    .details
+                    .get("status")
+                    .and_then(|status| status.as_i64())
+                    == Some(-25300) =>
+            {
+                return Ok(())
+            }
+            Err(error) => return Err(error),
+        };
+        let result = cvt(
+            unsafe { SecKeychainItemDelete(item) },
+            "delete keychain item",
+        );
+        unsafe { CFRelease(item as CFTypeRef) };
+        result
     }
 
     fn find_item(account: &str) -> Result<SecKeychainItemRef> {
@@ -249,6 +282,9 @@ mod macos {
 
         let set_status = unsafe { SecKeychainItemSetAccess(item, access) };
         unsafe { CFRelease(access as CFTypeRef) };
+        if set_status == ERR_SEC_NO_ACCESS_FOR_ITEM {
+            return Ok(());
+        }
         cvt(set_status, "set keychain item access")
     }
 

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use crate::core::agent_task_secrets;
 use crate::core::observation::{PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
 use crate::core::plan::{HomeboyPlan, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::source_snapshot::SourceSnapshot;
@@ -529,6 +530,8 @@ fn run_lab_offload_inner(
     forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
     forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
     forward_release_ci_env(&mut env);
+    let agent_task_secret_env = hydrate_agent_task_secret_env(&command, &mut env)?;
+    lab_metadata["agent_task_secret_env"] = agent_task_secret_env;
     lab_metadata["settings_env"] = settings_env_diagnostics(&changed_since_preflight.args, &env);
     lab_metadata["rig_sync"] = serde_json::json!({
         "step": "lab.sync_rigs",
@@ -539,6 +542,7 @@ fn run_lab_offload_inner(
     forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
     forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
     forward_release_ci_env(&mut env);
+    hydrate_agent_task_secret_env(&command, &mut env)?;
     let exec_result = exec(
         runner_id,
         RunnerExecOptions {
@@ -658,6 +662,60 @@ fn run_lab_offload_inner(
         stderr,
         exit_code,
     })
+}
+
+fn hydrate_agent_task_secret_env(
+    args: &[String],
+    env: &mut std::collections::HashMap<String, String>,
+) -> Result<serde_json::Value> {
+    let names = declared_agent_task_secret_env(args);
+    if names.is_empty() {
+        return Ok(serde_json::json!({
+            "schema": "homeboy/lab-agent-task-secret-env/v1",
+            "secret_env": [],
+        }));
+    }
+
+    let resolved = agent_task_secrets::resolve_secret_env(&names).map_err(|error| {
+        Error::validation_invalid_argument(
+            "secret-env",
+            error.message,
+            None,
+            Some(vec![
+                "Configure provider secrets with `homeboy agent-task auth status` and `homeboy agent-task auth map-claude-code-kimaki`.".to_string(),
+            ]),
+        )
+    })?;
+    for (name, value) in resolved {
+        env.insert(name, value);
+    }
+
+    Ok(serde_json::json!({
+        "schema": "homeboy/lab-agent-task-secret-env/v1",
+        "secret_env": agent_task_secrets::secret_env_status(&names),
+    }))
+}
+
+fn declared_agent_task_secret_env(args: &[String]) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--secret-env" {
+            if let Some(name) = args.get(index + 1) {
+                names.push(name.clone());
+            }
+            index += 2;
+            continue;
+        }
+        if let Some(name) = arg.strip_prefix("--secret-env=") {
+            names.push(name.to_string());
+        }
+        index += 1;
+    }
+    names.sort();
+    names.dedup();
+    names
 }
 
 fn automatic_capability_fallback(
@@ -945,6 +1003,28 @@ mod tests {
         .expect("parse lab offload metadata");
 
         assert_eq!(parsed["workspace_mapping"], mapping);
+    }
+
+    #[test]
+    fn declared_agent_task_secret_env_parses_repeated_and_equals_args() {
+        let names = declared_agent_task_secret_env(&[
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "dispatch".to_string(),
+            "--secret-env".to_string(),
+            "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN".to_string(),
+            "--secret-env=AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN".to_string(),
+            "--secret-env".to_string(),
+            "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN".to_string(),
+        ]);
+
+        assert_eq!(
+            names,
+            vec![
+                "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN".to_string(),
+                "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN".to_string(),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `homeboy agent-task auth` for redacted provider secret readiness, keychain-backed secret storage, stdin-safe secret input, env-source mapping, Kimaki/OpenCode Claude Code token mapping, and mapping removal.
- Persists agent-task secret source mappings in Homeboy config so provider preflight can resolve required env names without relying only on ambient globals.
- Maps Claude Code provider env names to Kimaki/OpenCode's active Anthropic OAuth auth file so token rotation remains dynamic instead of freezing copied credentials.
- Hydrates declared `--secret-env` values into Lab offload command environments with redacted metadata, so runner-side provider preflight can use controller-owned provider auth.
- Adds macOS keychain cleanup hardening for bad Homeboy-created keychain entries.

## Verification
- `cargo fmt`
- `cargo test core::agent_task_secrets --lib`
- `cargo test commands::agent_task::tests --lib`
- `cargo test agent_task_dispatch --lib`
- `cargo test core::agent_task_provider::tests --lib`
- `cargo test declared_agent_task_secret_env_parses_repeated_and_equals_args --lib`
- `cargo test lab_args_rewrite_agent_task_dispatch_cwd --lib`
- `cargo test core::keychain::tests::account_key_uses_project_and_variable --lib`
- `cargo run --quiet --bin homeboy -- agent-task auth --help`
- `cargo run --quiet --bin homeboy -- agent-task auth map-claude-code-kimaki`
- `cargo run --quiet --bin homeboy -- agent-task auth status --secret-env AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN --secret-env AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN --secret-env AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT`

## Follow-up evidence
- Re-ran SSI #322 pilot via Lab after this branch hydrated secrets into runner env.
- The run advanced past `agent_task.secret_env_missing` and reached WP Codebox recipe validation.
- New blocker filed in Homeboy Extensions: https://github.com/Extra-Chill/homeboy-extensions/issues/1206

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the provider auth lifecycle CLI, Kimaki/OpenCode Claude token mapping, Lab offload secret hydration, keychain cleanup hardening, and targeted tests; Chris remains responsible for review and merge.