### PR TITLE
Persist Lab trace dispatch records

### DIFF
--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -1,4 +1,10 @@
 use homeboy::cli_surface::{Cli, Commands};
+use homeboy::core::observation::RunStatus;
+use serde_json::json;
+use std::time::Duration;
+
+const DEFAULT_LAB_TRACE_DISPATCH_TIMEOUT_SECS: u64 = 9 * 60;
+const LAB_TRACE_DISPATCH_TIMEOUT_ENV: &str = "HOMEBOY_LAB_TRACE_DISPATCH_TIMEOUT_SECS";
 
 pub fn route_after_parse(
     cli: &Cli,
@@ -11,42 +17,171 @@ pub fn route_after_parse(
 
     let lab_command = lab_offload_command(&cli.command)?;
 
-    match homeboy::core::runner::execute_lab_offload(homeboy::core::runner::LabOffloadRequest {
-        command: lab_command,
-        normalized_args,
-        explicit_runner: cli.runner.as_deref(),
-        force_hot: cli.force_hot,
-        allow_local_hot: cli.allow_local_hot,
-        allow_local_fallback: cli.allow_local_fallback,
-        capture_patch: cli.command.lab_offload_mutation_flag().is_some(),
-    })? {
-        homeboy::core::runner::LabOffloadOutcome::RunLocal {
-            metadata, messages, ..
-        } => {
-            if let Some(metadata) = metadata {
-                homeboy::core::runner::capture_lab_offload_subprocess_metadata(metadata);
-            }
-            for message in messages {
-                eprintln!("{message}");
-            }
-            Ok(None)
+    let trace_runner_id = if matches!(cli.command, Commands::Trace(_)) {
+        cli.runner.clone().or_else(|| {
+            homeboy::core::runner::resolve_default_lab_runner()
+                .ok()
+                .flatten()
+        })
+    } else {
+        None
+    };
+
+    let trace_observation = match &cli.command {
+        Commands::Trace(args) => crate::commands::trace::start_lab_dispatch_observation(
+            args,
+            normalized_args,
+            trace_runner_id.as_deref(),
+        ),
+        _ => None,
+    };
+
+    let lab_result = if matches!(cli.command, Commands::Trace(_)) {
+        execute_trace_lab_offload_with_timeout(
+            lab_command,
+            normalized_args.to_vec(),
+            cli.runner.clone(),
+            cli.force_hot,
+            cli.allow_local_hot,
+            cli.allow_local_fallback,
+            cli.command.lab_offload_mutation_flag().is_some(),
+            lab_trace_dispatch_timeout(),
+        )
+    } else {
+        homeboy::core::runner::execute_lab_offload(homeboy::core::runner::LabOffloadRequest {
+            command: lab_command,
+            normalized_args,
+            explicit_runner: cli.runner.as_deref(),
+            force_hot: cli.force_hot,
+            allow_local_hot: cli.allow_local_hot,
+            allow_local_fallback: cli.allow_local_fallback,
+            capture_patch: cli.command.lab_offload_mutation_flag().is_some(),
+        })
+    };
+
+    match lab_result {
+        Err(err) => {
+            crate::commands::trace::finish_lab_dispatch_observation(
+                trace_observation,
+                RunStatus::Error,
+                json!({
+                    "lab_dispatch": {
+                        "phase": "route_lab_dispatch",
+                        "runner_id": trace_runner_id,
+                        "status": "error",
+                        "error": {
+                            "code": err.code.as_str(),
+                            "message": err.message,
+                            "details": err.details,
+                            "hints": err.hints,
+                        }
+                    }
+                }),
+            );
+            return Err(err);
         }
-        homeboy::core::runner::LabOffloadOutcome::Offloaded {
-            stdout,
-            stderr,
-            exit_code,
-            ..
-        } => {
-            if !stderr.is_empty() {
-                eprint!("{stderr}");
+        Ok(outcome) => match outcome {
+            homeboy::core::runner::LabOffloadOutcome::RunLocal {
+                metadata, messages, ..
+            } => {
+                crate::commands::trace::finish_lab_dispatch_observation(
+                    trace_observation,
+                    RunStatus::Skipped,
+                    json!({
+                        "lab_dispatch": {
+                            "phase": "route_lab_dispatch",
+                            "runner_id": trace_runner_id,
+                            "status": "run_local",
+                            "metadata": metadata,
+                            "messages": messages,
+                        }
+                    }),
+                );
+                if let Some(metadata) = metadata {
+                    homeboy::core::runner::capture_lab_offload_subprocess_metadata(metadata);
+                }
+                for message in messages {
+                    eprintln!("{message}");
+                }
+                Ok(None)
             }
-            if let Some(path) = output_file {
-                write_offloaded_stdout(path, &stdout)?;
+            homeboy::core::runner::LabOffloadOutcome::Offloaded {
+                stdout,
+                stderr,
+                exit_code,
+                ..
+            } => {
+                crate::commands::trace::finish_lab_dispatch_observation(
+                    trace_observation,
+                    if exit_code == 0 {
+                        RunStatus::Pass
+                    } else {
+                        RunStatus::Fail
+                    },
+                    json!({
+                        "lab_dispatch": {
+                            "phase": "route_lab_dispatch",
+                            "runner_id": trace_runner_id,
+                            "status": "offloaded_complete",
+                            "exit_code": exit_code,
+                        }
+                    }),
+                );
+                if !stderr.is_empty() {
+                    eprint!("{stderr}");
+                }
+                if let Some(path) = output_file {
+                    write_offloaded_stdout(path, &stdout)?;
+                }
+                print!("{stdout}");
+                Ok(Some(exit_code))
             }
-            print!("{stdout}");
-            Ok(Some(exit_code))
-        }
+        },
     }
+}
+
+fn execute_trace_lab_offload_with_timeout(
+    command: Option<homeboy::core::runner::LabOffloadCommand>,
+    normalized_args: Vec<String>,
+    explicit_runner: Option<String>,
+    force_hot: bool,
+    allow_local_hot: bool,
+    allow_local_fallback: bool,
+    capture_patch: bool,
+    timeout: Duration,
+) -> homeboy::core::Result<homeboy::core::runner::LabOffloadOutcome> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let result =
+            homeboy::core::runner::execute_lab_offload(homeboy::core::runner::LabOffloadRequest {
+                command,
+                normalized_args: &normalized_args,
+                explicit_runner: explicit_runner.as_deref(),
+                force_hot,
+                allow_local_hot,
+                allow_local_fallback,
+                capture_patch,
+            });
+        let _ = tx.send(result);
+    });
+
+    rx.recv_timeout(timeout).map_err(|_| {
+        homeboy::core::Error::internal_unexpected(format!(
+            "Lab trace dispatch did not finish before timeout after {}s",
+            timeout.as_secs()
+        ))
+        .with_hint("Inspect the controller trace run record for the last Lab dispatch phase.".to_string())
+        .with_hint("Run `homeboy runner doctor <runner-id>` and retry after the runner is healthy.".to_string())
+        .with_hint("Use `--force-hot --allow-local-hot` only for development-only investigation while fixing Lab routing.".to_string())
+    })?
+}
+
+fn lab_trace_dispatch_timeout() -> Duration {
+    std::env::var(LAB_TRACE_DISPATCH_TIMEOUT_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(DEFAULT_LAB_TRACE_DISPATCH_TIMEOUT_SECS))
 }
 
 fn is_lab_offload_subprocess() -> bool {
@@ -308,6 +443,13 @@ mod tests {
         let outcome = route_after_parse(&cli, &normalized, None).unwrap();
 
         assert_eq!(outcome, None);
+    }
+
+    #[test]
+    fn trace_lab_dispatch_timeout_reads_env_override() {
+        let _env = EnvGuard::set(LAB_TRACE_DISPATCH_TIMEOUT_ENV, "7");
+
+        assert_eq!(lab_trace_dispatch_timeout(), Duration::from_secs(7));
     }
 
     #[test]

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -1259,6 +1259,114 @@ struct ActiveTraceObservation {
     scenario_id: String,
 }
 
+pub(super) struct LabTraceDispatchObservation {
+    store: ObservationStore,
+    run_id: String,
+    component_id: String,
+    rig_id: Option<String>,
+    scenario_id: String,
+}
+
+pub(super) fn start_lab_dispatch_observation(
+    args: &TraceArgs,
+    normalized_args: &[String],
+    runner_id: Option<&str>,
+) -> Option<LabTraceDispatchObservation> {
+    let mut resolved = args.clone();
+    resolve_trace_profile_args(&mut resolved).ok()?;
+    let scenario_id = trace_scenario(&resolved).ok()?;
+    if scenario_id == "list" {
+        return None;
+    }
+    let scenario_id = scenario_id.to_string();
+    let rig_context = load_rig_context(resolved.rig.as_deref()).ok()?;
+    let component_id = resolve_component_id(
+        &resolved.comp,
+        rig_context.as_ref().map(|context| &context.rig_spec),
+    )
+    .ok()?;
+    let component_path = resolved.comp.path.clone().or_else(|| {
+        rig_context
+            .as_ref()
+            .and_then(|context| rig_component_path(&context.rig_spec, &component_id))
+    });
+    let store = ObservationStore::open_initialized().ok()?;
+    let cwd = std::env::current_dir().ok();
+    let run =
+        store
+            .start_run(
+                NewRunRecord::builder("trace")
+                    .component_id(component_id.clone())
+                    .command(normalized_args.join(" "))
+                    .optional_cwd_path(cwd.as_deref())
+                    .current_homeboy_version()
+                    .git_sha(component_path.as_deref().and_then(|path| {
+                        homeboy::core::git::short_head_revision_at(Path::new(path))
+                    }))
+                    .optional_rig_id(resolved.rig.clone())
+                    .metadata(serde_json::json!({
+                        "scenario_id": scenario_id,
+                        "component_path": component_path,
+                        "lab_dispatch": {
+                            "phase": "route_before_lab_dispatch",
+                            "runner_id": runner_id,
+                            "status": "running"
+                        }
+                    }))
+                    .build(),
+            )
+            .ok()?;
+    let observation = LabTraceDispatchObservation {
+        store,
+        run_id: run.id,
+        component_id,
+        rig_id: resolved.rig.clone(),
+        scenario_id,
+    };
+    let _ = observation.store.record_trace_run(
+        NewTraceRunRecord::builder(
+            &observation.run_id,
+            &observation.component_id,
+            &observation.scenario_id,
+            RunStatus::Running.as_str(),
+        )
+        .trace_rig_id(observation.rig_id.as_deref())
+        .metadata(serde_json::json!({
+            "lab_dispatch": {
+                "phase": "route_before_lab_dispatch",
+                "runner_id": runner_id,
+                "status": "running"
+            }
+        }))
+        .build(),
+    );
+    Some(observation)
+}
+
+pub(super) fn finish_lab_dispatch_observation(
+    observation: Option<LabTraceDispatchObservation>,
+    status: RunStatus,
+    metadata: serde_json::Value,
+) {
+    let Some(observation) = observation else {
+        return;
+    };
+    let _ = observation.store.record_trace_run(
+        NewTraceRunRecord::builder(
+            &observation.run_id,
+            &observation.component_id,
+            &observation.scenario_id,
+            status.as_str(),
+        )
+        .trace_rig_id(observation.rig_id.as_deref())
+        .metadata(metadata.clone())
+        .build(),
+    );
+    let _ = observation
+        .store
+        .finish_run(&observation.run_id, status, Some(metadata));
+}
+
 fn persist_trace_workflow_result(
     observation: &ActiveTraceObservation,
     run_dir: &RunDir,

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -26,6 +26,57 @@ fn trace_accepts_allow_local_evidence_alias() {
     assert!(cli.trace.allow_local_toolchain);
 }
 
+#[test]
+fn lab_dispatch_observation_persists_trace_run_before_remote_execution() {
+    with_isolated_home(|home| {
+        let component_dir = tempfile::TempDir::new().expect("component dir");
+        write_trace_rig(home, "studio-rig", "studio", component_dir.path());
+        let args = trace_args_for_rig("studio-rig", "studio", "studio-app-create-site");
+        let normalized = vec![
+            "homeboy".to_string(),
+            "trace".to_string(),
+            "--rig".to_string(),
+            "studio-rig".to_string(),
+            "studio".to_string(),
+            "studio-app-create-site".to_string(),
+        ];
+
+        let observation = start_lab_dispatch_observation(&args, &normalized, Some("homeboy-lab"))
+            .expect("dispatch observation");
+        let trace_run = observation
+            .store
+            .get_trace_run(&observation.run_id)
+            .expect("read trace run")
+            .expect("trace run exists before remote execution");
+        assert_eq!(trace_run.status, "running");
+        assert_eq!(trace_run.component_id, "studio");
+        assert_eq!(trace_run.scenario_id, "studio-app-create-site");
+        assert_eq!(
+            trace_run.metadata_json["lab_dispatch"]["phase"],
+            "route_before_lab_dispatch"
+        );
+
+        let run_id = observation.run_id.clone();
+        let store = ObservationStore::open_initialized().expect("store");
+        finish_lab_dispatch_observation(
+            Some(observation),
+            RunStatus::Error,
+            serde_json::json!({
+                "lab_dispatch": {
+                    "phase": "route_lab_dispatch",
+                    "status": "timeout"
+                }
+            }),
+        );
+        let trace_run = store
+            .get_trace_run(&run_id)
+            .expect("read trace run")
+            .expect("trace run remains present");
+        assert_eq!(trace_run.status, "error");
+        assert_eq!(trace_run.metadata_json["lab_dispatch"]["status"], "timeout");
+    });
+}
+
 fn trace_args_for_rig(rig_id: &str, component_id: &str, scenario_id: &str) -> TraceArgs {
     TraceArgs {
         comp: PositionalComponentArgs {

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -693,6 +693,13 @@ impl ObservationStore {
                     baseline_status,
                     metadata_json
                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                ON CONFLICT(run_id) DO UPDATE SET
+                    component_id = excluded.component_id,
+                    rig_id = excluded.rig_id,
+                    scenario_id = excluded.scenario_id,
+                    status = excluded.status,
+                    baseline_status = excluded.baseline_status,
+                    metadata_json = excluded.metadata_json
                 "#,
                 params![
                     record.run_id,


### PR DESCRIPTION
## Summary
- Create a controller-side trace run record before trace Lab dispatch starts so Lab-routed traces are visible even if dispatch/materialization hangs.
- Add a bounded Lab trace dispatch timeout with structured error metadata and remediation hints before the caller-side shell timeout can kill the process.
- Upsert trace run rows so the pre-dispatch `running` record can become `error`, `pass`, `fail`, or `skipped` as dispatch completes.

Closes #3761.

## Verification
- `cargo test commands::route --lib`
- `cargo test commands::trace::tests::lab_dispatch_observation_persists_trace_run_before_remote_execution --lib`
- `cargo test commands::trace --lib`
- `cargo test core::observation::store --lib`
- `cargo check --bins`
- `cargo test --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the Lab trace dispatch observation, timeout handling, trace run upsert behavior, regression tests, and PR text; Chris remains responsible for review and merge.