### PR TITLE
fix: record clean trace toolchain provenance

### DIFF
--- a/src/core/extension/trace/canonicality.rs
+++ b/src/core/extension/trace/canonicality.rs
@@ -131,7 +131,8 @@ pub(crate) fn refused_trace_result(
     }
 }
 
-const LOCAL_TOOLCHAIN_ENV_KEYS: &[&str] = &["HOMEBOY_WP_CODEBOX_BIN"];
+const WP_CODEBOX_BIN_ENV_KEYS: &[&str] =
+    &["HOMEBOY_WP_CODEBOX_BIN", "HOMEBOY_SETTINGS_WP_CODEBOX_BIN"];
 
 pub(crate) fn evaluate_trace_canonicality(
     execution_context: Option<&ExtensionExecutionContext>,
@@ -182,19 +183,32 @@ pub(crate) fn evaluate_trace_canonicality(
         ));
     }
 
-    for key in LOCAL_TOOLCHAIN_ENV_KEYS {
+    for key in WP_CODEBOX_BIN_ENV_KEYS {
         let explicit = args.runner_inputs.env.iter().any(|(name, _)| name == key);
-        let inherited = std::env::var_os(key).is_some();
-        if explicit || inherited {
+        let inherited = std::env::var_os(key);
+        if explicit || inherited.is_some() {
             let source = if explicit {
                 "trace runner env"
             } else {
                 "process env"
             };
-            reasons.push(format!(
-                "arbitrary local toolchain override `{}` is set via {}",
-                key, source
-            ));
+            let value = args
+                .runner_inputs
+                .env
+                .iter()
+                .find_map(|(name, value)| (name == key).then_some(value.as_str()))
+                .or_else(|| inherited.as_deref().and_then(|value| value.to_str()));
+            match value {
+                Some(path) if !path.trim().is_empty() => checks.push(check_git_checkout(
+                    &format!("toolchain:wp-codebox ({key}, {source})"),
+                    &git_probe_path(Path::new(path)),
+                    &mut reasons,
+                )),
+                _ => reasons.push(format!(
+                    "WP Codebox toolchain path `{}` is empty via {}",
+                    key, source
+                )),
+            }
         }
     }
 
@@ -203,6 +217,16 @@ pub(crate) fn evaluate_trace_canonicality(
         reasons,
         checks,
     })
+}
+
+fn git_probe_path(path: &Path) -> std::path::PathBuf {
+    if path.is_file() {
+        path.parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| path.to_path_buf())
+    } else {
+        path.to_path_buf()
+    }
 }
 
 fn canonical_paths_equal(left: &str, right: &str) -> bool {
@@ -488,7 +512,7 @@ mod tests {
     }
 
     #[test]
-    fn canonical_trace_refuses_arbitrary_local_runner_env() {
+    fn canonical_trace_refuses_missing_wp_codebox_runner_env() {
         let temp = tempfile::tempdir().unwrap();
         init_git_repo(temp.path());
         let component = test_component(temp.path());
@@ -504,8 +528,62 @@ mod tests {
 
         assert_eq!(result.exit_code, 1);
         assert!(result.evidence.reasons.iter().any(|reason| {
-            reason.contains("arbitrary local toolchain override `HOMEBOY_WP_CODEBOX_BIN`")
+            reason.contains("toolchain:wp-codebox (HOMEBOY_WP_CODEBOX_BIN, trace runner env) checkout path is missing")
         }));
+        run_dir.cleanup();
+    }
+
+    #[test]
+    fn canonical_trace_accepts_clean_wp_codebox_runner_env() {
+        let component_dir = tempfile::tempdir().unwrap();
+        let component_remote = tempfile::tempdir().unwrap();
+        let codebox_dir = tempfile::tempdir().unwrap();
+        let codebox_remote = tempfile::tempdir().unwrap();
+        init_git_repo(component_dir.path());
+        init_bare_repo(component_remote.path());
+        git(
+            component_dir.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                component_remote.path().to_str().unwrap(),
+            ],
+        );
+        git(component_dir.path(), &["push", "-u", "origin", "main"]);
+        init_git_repo(codebox_dir.path());
+        init_bare_repo(codebox_remote.path());
+        git(
+            codebox_dir.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                codebox_remote.path().to_str().unwrap(),
+            ],
+        );
+        git(codebox_dir.path(), &["push", "-u", "origin", "main"]);
+        let bin = codebox_dir.path().join("packages/cli/dist/index.js");
+        std::fs::create_dir_all(bin.parent().unwrap()).unwrap();
+        std::fs::write(&bin, "#!/usr/bin/env node\n").unwrap();
+        git(codebox_dir.path(), &["add", "."]);
+        git(codebox_dir.path(), &["commit", "-m", "add cli bin"]);
+        git(codebox_dir.path(), &["push", "origin", "main"]);
+
+        let component = test_component(component_dir.path());
+        let run_dir = RunDir::create().unwrap();
+        let mut args = test_run_args(component_dir.path());
+        args.canonical_policy = TraceCanonicalPolicy::Canonical;
+        args.runner_inputs.env.push((
+            "HOMEBOY_WP_CODEBOX_BIN".to_string(),
+            bin.to_string_lossy().to_string(),
+        ));
+
+        let result = run_trace_workflow(&component, args, &run_dir, None).unwrap();
+
+        assert_eq!(result.exit_code, 3);
+        assert!(result.evidence.canonical);
+        assert!(result.evidence.reasons.is_empty());
         run_dir.cleanup();
     }
 

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -536,7 +536,7 @@ fn trace_provenance(
 ) -> (TraceToolchainProvenance, TraceComponentsProvenance) {
     let homeboy = homeboy_git_provenance();
     let target = git_provenance(Path::new(component_path), Some("target"));
-    let env_wp_codebox_bin = std::env::var("HOMEBOY_WP_CODEBOX_BIN").ok();
+    let env_wp_codebox_bin = wp_codebox_bin_env();
     let wp_codebox_path = execution_context
         .filter(|context| {
             context.extension_id.contains("wp-codebox")
@@ -546,26 +546,27 @@ fn trace_provenance(
                     .contains("wp-codebox")
         })
         .map(|context| context.extension_path.as_path())
-        .or_else(|| env_wp_codebox_bin.as_deref().map(Path::new));
+        .or_else(|| {
+            env_wp_codebox_bin
+                .as_ref()
+                .map(|(_, value)| Path::new(value.as_str()))
+        });
     let mut reasons = Vec::new();
     let mut wp_codebox = wp_codebox_path.map(|path| git_provenance(path, Some("wp_codebox")));
 
-    if env_wp_codebox_bin.is_some() {
-        reasons.push("HOMEBOY_WP_CODEBOX_BIN selected a local WP Codebox runner path".to_string());
+    if let Some((key, _)) = env_wp_codebox_bin.as_ref() {
         if let Some(provenance) = wp_codebox.as_mut() {
-            provenance.source = Some("env:HOMEBOY_WP_CODEBOX_BIN".to_string());
+            provenance.source = Some(format!("env:{key}"));
         }
     }
     if execution_context.is_none() {
         reasons.push("trace runner used generic local workload discovery".to_string());
     }
     for (label, provenance) in [("homeboy", &homeboy), ("target", &target)] {
-        if provenance.sha.is_none() || provenance.dirty.is_none() {
-            reasons.push(format!(
-                "{label} checkout git provenance is incomplete for {}",
-                provenance.path
-            ));
-        }
+        push_git_provenance_reasons(label, provenance, &mut reasons);
+    }
+    if let Some(provenance) = wp_codebox.as_ref() {
+        push_git_provenance_reasons("WP Codebox", provenance, &mut reasons);
     }
     if wp_codebox.is_none() {
         reasons.push("WP Codebox checkout was not resolved for this trace run".to_string());
@@ -599,6 +600,34 @@ fn trace_provenance(
     )
 }
 
+fn push_git_provenance_reasons(
+    label: &str,
+    provenance: &TraceGitProvenance,
+    reasons: &mut Vec<String>,
+) {
+    if provenance.sha.is_none() || provenance.dirty.is_none() {
+        reasons.push(format!(
+            "{label} checkout git provenance is incomplete for {}",
+            provenance.path
+        ));
+    } else if provenance.dirty == Some(true) {
+        reasons.push(format!(
+            "{label} checkout is dirty for trace toolchain provenance: {}",
+            provenance.path
+        ));
+    }
+}
+
+fn wp_codebox_bin_env() -> Option<(String, String)> {
+    ["HOMEBOY_WP_CODEBOX_BIN", "HOMEBOY_SETTINGS_WP_CODEBOX_BIN"]
+        .into_iter()
+        .find_map(|key| {
+            std::env::var(key)
+                .ok()
+                .map(|value| (key.to_string(), value))
+        })
+}
+
 fn mark_non_canonical(toolchain: &mut TraceToolchainProvenance, reason: &str) {
     toolchain.canonical = false;
     toolchain.mode = "development".to_string();
@@ -608,17 +637,27 @@ fn mark_non_canonical(toolchain: &mut TraceToolchainProvenance, reason: &str) {
 }
 
 fn git_provenance(path: &Path, source: Option<&str>) -> TraceGitProvenance {
-    let git_root = crate::core::git::get_git_root(&path.to_string_lossy())
+    let probe_path = git_probe_path(path);
+    let git_root = crate::core::git::get_git_root(&probe_path.to_string_lossy())
         .ok()
         .map(PathBuf::from)
-        .unwrap_or_else(|| path.to_path_buf());
+        .unwrap_or(probe_path);
     TraceGitProvenance {
         path: git_root.to_string_lossy().to_string(),
         sha: git_stdout(&git_root, &["rev-parse", "HEAD"]),
         branch: crate::core::git::current_branch(&git_root),
-        dirty: git_stdout(&git_root, &["status", "--porcelain=v1"])
-            .map(|status| !status.trim().is_empty()),
+        dirty: git_dirty_state(&git_root),
         source: source.map(ToString::to_string),
+    }
+}
+
+fn git_probe_path(path: &Path) -> PathBuf {
+    if path.is_file() {
+        path.parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| path.to_path_buf())
+    } else {
+        path.to_path_buf()
     }
 }
 
@@ -638,6 +677,16 @@ fn git_stdout(path: &Path, args: &[&str]) -> Option<String> {
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+}
+
+fn git_dirty_state(path: &Path) -> Option<bool> {
+    crate::core::git::run_git(
+        path,
+        &["status", "--porcelain=v1"],
+        "trace provenance git status",
+    )
+    .ok()
+    .map(|status| !status.trim().is_empty())
 }
 
 fn command_version(command: &str, args: &[&str]) -> Option<String> {
@@ -1418,6 +1467,85 @@ mod tests {
                 path: "/tmp/auth.json".to_string(),
                 interval_ms: None,
             }]
+        );
+    }
+
+    #[test]
+    fn git_dirty_state_reports_clean_checkout_as_known_clean() {
+        let temp = tempfile::tempdir().unwrap();
+        let init = Command::new("git")
+            .args(["init"])
+            .current_dir(temp.path())
+            .output()
+            .expect("git init runs");
+        assert!(init.status.success());
+
+        assert_eq!(git_dirty_state(temp.path()), Some(false));
+
+        std::fs::write(temp.path().join("untracked.txt"), "changed").unwrap();
+
+        assert_eq!(git_dirty_state(temp.path()), Some(true));
+    }
+
+    #[test]
+    fn git_provenance_resolves_file_paths_to_checkout_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let init = Command::new("git")
+            .args(["init"])
+            .current_dir(temp.path())
+            .output()
+            .expect("git init runs");
+        assert!(init.status.success());
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(temp.path())
+            .output()
+            .expect("git config user.email runs");
+        Command::new("git")
+            .args(["config", "user.name", "Homeboy Test"])
+            .current_dir(temp.path())
+            .output()
+            .expect("git config user.name runs");
+        let bin = temp.path().join("packages/cli/dist/index.js");
+        std::fs::create_dir_all(bin.parent().unwrap()).unwrap();
+        std::fs::write(&bin, "#!/usr/bin/env node\n").unwrap();
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(temp.path())
+            .output()
+            .expect("git add runs");
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(temp.path())
+            .output()
+            .expect("git commit runs");
+
+        let provenance = git_provenance(&bin, Some("wp_codebox"));
+
+        assert_eq!(
+            provenance.path,
+            temp.path().canonicalize().unwrap().to_string_lossy()
+        );
+        assert!(provenance.sha.is_some());
+        assert_eq!(provenance.dirty, Some(false));
+    }
+
+    #[test]
+    fn dirty_git_provenance_makes_toolchain_non_canonical() {
+        let mut reasons = Vec::new();
+        let provenance = TraceGitProvenance {
+            path: "/tmp/homeboy".to_string(),
+            sha: Some("abc123".to_string()),
+            branch: Some("main".to_string()),
+            dirty: Some(true),
+            source: Some("homeboy".to_string()),
+        };
+
+        push_git_provenance_reasons("homeboy", &provenance, &mut reasons);
+
+        assert_eq!(
+            reasons,
+            vec!["homeboy checkout is dirty for trace toolchain provenance: /tmp/homeboy"]
         );
     }
 


### PR DESCRIPTION
## Summary
- Preserve clean git status as known-clean trace provenance instead of treating empty `git status --porcelain` output as missing.
- Validate `HOMEBOY_WP_CODEBOX_BIN` and `HOMEBOY_SETTINGS_WP_CODEBOX_BIN` against their backing git checkouts for canonical trace evidence.
- Resolve binary file paths to checkout roots and mark dirty toolchain provenance as non-canonical in result metadata.

## Verification
- `cargo test canonical_trace_`
- `cargo test git_dirty_state_reports_clean_checkout_as_known_clean`
- `cargo test git_provenance_resolves_file_paths_to_checkout_root`
- `cargo test dirty_git_provenance_makes_toolchain_non_canonical`
- `cargo build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the trace provenance edge cases, drafted the Rust changes/tests, and ran targeted verification; Chris remains responsible for review and merge.