### PR TITLE
Add reverse runner worker loop mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +398,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +456,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -774,6 +796,7 @@ dependencies = [
  "chrono",
  "clap",
  "core-foundation-sys",
+ "ctrlc",
  "glob",
  "glob-match",
  "heck",
@@ -1291,6 +1314,18 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ security-framework-sys = "2.17"
 reqwest = { version = "0.12", features = ["json", "blocking", "rustls-tls", "socks"] }
 arboard = "3"
 chrono = "0.4"
+ctrlc = "3.4"
 semver = "1.0"
 libc = "0.2"
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -184,6 +184,7 @@ broker exposure.
 ```sh
 homeboy runner work <runner-id> --broker-url <url>
 homeboy runner work <runner-id> --broker-url <url> --project <project-id> --lease-ms 30000
+homeboy runner work <runner-id> --broker-url <url> --loop
 ```
 
 Claims one brokered reverse-runner job for the runner, executes it on the runner
@@ -195,6 +196,41 @@ broker and does not require inbound SSH or a public listening port on the lab.
 The command exits `0` when no job is available, with `claimed: false` in the JSON
 payload. When a job is claimed, the process exit code matches the executed
 command's exit code.
+
+Use `--loop` for a long-running reverse runner service. Loop mode emits one
+structured JSON status line per lifecycle event to stderr so systemd/journald can
+index startup, idle backoff, job completion, transient broker failures, and
+shutdown without mixing those events into the final stdout JSON payload. Empty
+queues use exponential backoff controlled by `--idle-backoff-ms` and
+`--max-idle-backoff-ms`, so workers do not hot-spin when no work is available.
+Transient broker failures sleep for `--broker-failure-backoff-ms` and exit
+non-zero after `--broker-retry-limit` consecutive failures. `SIGINT` and
+`SIGTERM` request graceful shutdown after the current claim attempt or job.
+
+Minimal Homeboy Lab systemd unit:
+
+```ini
+[Unit]
+Description=Homeboy reverse runner worker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=chubes
+WorkingDirectory=/home/chubes
+ExecStart=/usr/local/bin/homeboy runner work homeboy-lab --broker-url https://controller.example.com --loop --idle-backoff-ms 1000 --max-idle-backoff-ms 30000 --broker-retry-limit 12
+Restart=on-failure
+RestartSec=10
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target
+```
+
+The unit intentionally leaves authentication out until the broker auth contract
+lands; configure the broker URL and any future auth material using the production
+mechanism for issue #2990 rather than embedding secrets in the unit file.
 
 ### `status`
 

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -289,6 +289,26 @@ enum RunnerCommand {
         /// Claim lease duration in milliseconds
         #[arg(long, default_value_t = 30_000)]
         lease_ms: u64,
+
+        /// Keep claiming jobs until SIGINT/SIGTERM instead of exiting after one claim
+        #[arg(long)]
+        r#loop: bool,
+
+        /// Initial sleep after an empty claim in loop mode
+        #[arg(long, default_value_t = 1_000)]
+        idle_backoff_ms: u64,
+
+        /// Maximum sleep after repeated empty claims in loop mode
+        #[arg(long, default_value_t = 30_000)]
+        max_idle_backoff_ms: u64,
+
+        /// Sleep after transient broker failures in loop mode
+        #[arg(long, default_value_t = 5_000)]
+        broker_failure_backoff_ms: u64,
+
+        /// Consecutive broker failures allowed before the worker exits non-zero
+        #[arg(long, default_value_t = 5)]
+        broker_retry_limit: u32,
     },
     /// Materialize local workspaces on a configured runner
     Workspace {
@@ -446,11 +466,21 @@ pub fn run(
             broker_url,
             project,
             lease_ms,
+            r#loop,
+            idle_backoff_ms,
+            max_idle_backoff_ms,
+            broker_failure_backoff_ms,
+            broker_retry_limit,
         } => map_worker(runner::run_reverse_worker(ReverseRunnerWorkerOptions {
             runner_id,
             broker_url,
             project_id: project,
             lease_ms,
+            loop_mode: r#loop,
+            idle_backoff_ms,
+            max_idle_backoff_ms,
+            broker_failure_backoff_ms,
+            broker_retry_limit,
         })),
         RunnerCommand::Workspace { command } => workspace::run(command)
             .map(|(output, exit_code)| (RunnerCommandOutput::Workspace(output), exit_code)),

--- a/src/core/runner/worker.rs
+++ b/src/core/runner/worker.rs
@@ -1,3 +1,7 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::time::Duration;
 
 use reqwest::blocking::Client;
@@ -16,6 +20,11 @@ pub struct ReverseRunnerWorkerOptions {
     pub broker_url: String,
     pub project_id: Option<String>,
     pub lease_ms: u64,
+    pub loop_mode: bool,
+    pub idle_backoff_ms: u64,
+    pub max_idle_backoff_ms: u64,
+    pub broker_failure_backoff_ms: u64,
+    pub broker_retry_limit: u32,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -24,14 +33,52 @@ pub struct ReverseRunnerWorkerOutput {
     pub runner_id: String,
     pub broker_url: String,
     pub claimed: bool,
+    #[serde(skip_serializing_if = "is_false")]
+    pub loop_mode: bool,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub iterations: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub jobs_claimed: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub broker_failures: u32,
+    #[serde(skip_serializing_if = "is_false")]
+    pub stopped: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_claim: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_result: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub job: Option<Job>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exit_code: Option<i32>,
 }
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+fn is_zero<T>(value: &T) -> bool
+where
+    T: PartialEq + From<u8>,
+{
+    *value == T::from(0)
+}
+
 pub fn run_reverse_worker(
     options: ReverseRunnerWorkerOptions,
+) -> Result<(ReverseRunnerWorkerOutput, i32)> {
+    let stop = Arc::new(AtomicBool::new(false));
+    if options.loop_mode {
+        install_shutdown_handler(stop.clone())?;
+    }
+    run_reverse_worker_with_stop(options, stop)
+}
+
+fn run_reverse_worker_with_stop(
+    options: ReverseRunnerWorkerOptions,
+    stop: Arc<AtomicBool>,
 ) -> Result<(ReverseRunnerWorkerOutput, i32)> {
     if options.runner_id.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -41,6 +88,147 @@ pub fn run_reverse_worker(
             None,
         ));
     }
+    if options.loop_mode {
+        run_loop(options, stop, std::thread::sleep)
+    } else {
+        run_once_output(options, 1, 0, 0, false)
+    }
+}
+
+fn run_loop(
+    options: ReverseRunnerWorkerOptions,
+    stop: Arc<AtomicBool>,
+    mut sleep: impl FnMut(Duration),
+) -> Result<(ReverseRunnerWorkerOutput, i32)> {
+    let mut iterations = 0;
+    let mut jobs_claimed = 0;
+    let mut broker_failures = 0;
+    let mut idle_backoff = Duration::from_millis(options.idle_backoff_ms.max(1));
+    let max_idle_backoff = Duration::from_millis(options.max_idle_backoff_ms.max(1));
+    let broker_failure_backoff = Duration::from_millis(options.broker_failure_backoff_ms.max(1));
+    let mut last_job = None;
+    let mut last_exit_code = None;
+    let mut last_claim = None;
+    let mut last_result = None;
+    let mut last_error = None;
+
+    log_worker_event(
+        &options,
+        "started",
+        json!({
+            "loop": true,
+            "idle_backoff_ms": idle_backoff.as_millis(),
+            "max_idle_backoff_ms": max_idle_backoff.as_millis(),
+            "broker_failure_backoff_ms": broker_failure_backoff.as_millis(),
+            "broker_retry_limit": options.broker_retry_limit,
+        }),
+    );
+
+    while !stop.load(Ordering::SeqCst) {
+        iterations += 1;
+        match run_once_output(
+            options.clone(),
+            iterations,
+            jobs_claimed,
+            broker_failures,
+            false,
+        ) {
+            Ok((output, exit_code)) => {
+                broker_failures = 0;
+                if output.claimed {
+                    jobs_claimed += 1;
+                    idle_backoff = Duration::from_millis(options.idle_backoff_ms.max(1));
+                    last_claim = output.job.as_ref().map(|job| job.id.to_string());
+                    last_result = Some(exit_code);
+                    if exit_code == 0 {
+                        last_error = None;
+                    } else {
+                        last_error = Some(format!("job exited with code {exit_code}"));
+                    }
+                    last_job = output.job;
+                    last_exit_code = Some(exit_code);
+                    log_worker_event(
+                        &options,
+                        "job_finished",
+                        json!({
+                            "iteration": iterations,
+                            "job_id": last_claim.as_ref(),
+                            "exit_code": exit_code,
+                            "jobs_claimed": jobs_claimed,
+                        }),
+                    );
+                } else {
+                    log_worker_event(
+                        &options,
+                        "idle",
+                        json!({
+                            "iteration": iterations,
+                            "sleep_ms": idle_backoff.as_millis(),
+                        }),
+                    );
+                    sleep(idle_backoff);
+                    idle_backoff = std::cmp::min(idle_backoff.saturating_mul(2), max_idle_backoff);
+                }
+            }
+            Err(err) => {
+                broker_failures = broker_failures.saturating_add(1);
+                last_error = Some(err.to_string());
+                log_worker_event(
+                    &options,
+                    "broker_failure",
+                    json!({
+                        "iteration": iterations,
+                        "broker_failures": broker_failures,
+                        "retry_limit": options.broker_retry_limit,
+                        "sleep_ms": broker_failure_backoff.as_millis(),
+                        "error": err.to_string(),
+                    }),
+                );
+                if broker_failures > options.broker_retry_limit {
+                    return Err(err);
+                }
+                sleep(broker_failure_backoff);
+            }
+        }
+    }
+
+    log_worker_event(
+        &options,
+        "stopped",
+        json!({
+            "iterations": iterations,
+            "jobs_claimed": jobs_claimed,
+            "broker_failures": broker_failures,
+        }),
+    );
+    Ok((
+        ReverseRunnerWorkerOutput {
+            command: "runner.work",
+            runner_id: options.runner_id,
+            broker_url: options.broker_url,
+            claimed: jobs_claimed > 0,
+            loop_mode: true,
+            iterations,
+            jobs_claimed,
+            broker_failures,
+            stopped: true,
+            last_claim,
+            last_result,
+            last_error,
+            job: last_job,
+            exit_code: last_exit_code,
+        },
+        0,
+    ))
+}
+
+fn run_once_output(
+    options: ReverseRunnerWorkerOptions,
+    iterations: u64,
+    jobs_claimed: u64,
+    broker_failures: u32,
+    stopped: bool,
+) -> Result<(ReverseRunnerWorkerOutput, i32)> {
     if options.broker_url.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
             "broker_url",
@@ -56,12 +244,21 @@ pub fn run_reverse_worker(
         .map_err(|err| Error::internal_unexpected(format!("build broker HTTP client: {err}")))?;
     let claim = claim_job(&client, &options)?;
     let Some(claim) = claim else {
+        let loop_mode = options.loop_mode;
         return Ok((
             ReverseRunnerWorkerOutput {
                 command: "runner.work",
                 runner_id: options.runner_id,
                 broker_url: options.broker_url,
                 claimed: false,
+                loop_mode,
+                iterations: if loop_mode { iterations } else { 0 },
+                jobs_claimed: if loop_mode { jobs_claimed } else { 0 },
+                broker_failures: if loop_mode { broker_failures } else { 0 },
+                stopped,
+                last_claim: None,
+                last_result: None,
+                last_error: None,
                 job: None,
                 exit_code: None,
             },
@@ -70,7 +267,7 @@ pub fn run_reverse_worker(
     };
 
     append_progress(&client, &options.broker_url, &options.runner_id, &claim.job)?;
-    let (exec_output, exit_code) = exec(
+    let exec_result = exec(
         &options.runner_id,
         RunnerExecOptions {
             cwd: claim.request.cwd.clone(),
@@ -85,7 +282,40 @@ pub fn run_reverse_worker(
             required_extensions: Vec::new(),
             require_paths: claim.request.require_paths.clone(),
         },
-    )?;
+    );
+    let (exec_output, exit_code) = match exec_result {
+        Ok(result) => result,
+        Err(err) => {
+            let job = finish_job(
+                &client,
+                &options.broker_url,
+                &options.runner_id,
+                &claim.job,
+                RemoteRunnerJobResult {
+                    exit_code: 1,
+                    stdout: None,
+                    stderr: Some(err.to_string()),
+                    data: Some(json!({
+                        "error": err.to_string(),
+                    })),
+                    artifacts: Vec::new(),
+                },
+            )?;
+            let exit_code = 1;
+            return Ok((
+                claimed_output(
+                    options,
+                    iterations,
+                    jobs_claimed,
+                    broker_failures,
+                    stopped,
+                    job,
+                    exit_code,
+                ),
+                exit_code,
+            ));
+        }
+    };
     let job = finish_job(
         &client,
         &options.broker_url,
@@ -105,16 +335,76 @@ pub fn run_reverse_worker(
     )?;
 
     Ok((
-        ReverseRunnerWorkerOutput {
-            command: "runner.work",
-            runner_id: options.runner_id,
-            broker_url: options.broker_url,
-            claimed: true,
-            job: Some(job),
-            exit_code: Some(exit_code),
-        },
+        claimed_output(
+            options,
+            iterations,
+            jobs_claimed,
+            broker_failures,
+            stopped,
+            job,
+            exit_code,
+        ),
         exit_code,
     ))
+}
+
+fn claimed_output(
+    options: ReverseRunnerWorkerOptions,
+    iterations: u64,
+    jobs_claimed: u64,
+    broker_failures: u32,
+    stopped: bool,
+    job: Job,
+    exit_code: i32,
+) -> ReverseRunnerWorkerOutput {
+    let loop_mode = options.loop_mode;
+    ReverseRunnerWorkerOutput {
+        command: "runner.work",
+        runner_id: options.runner_id,
+        broker_url: options.broker_url,
+        claimed: true,
+        loop_mode,
+        iterations: if loop_mode { iterations } else { 0 },
+        jobs_claimed: if loop_mode { jobs_claimed + 1 } else { 0 },
+        broker_failures: if loop_mode { broker_failures } else { 0 },
+        stopped,
+        last_claim: if loop_mode {
+            Some(job.id.to_string())
+        } else {
+            None
+        },
+        last_result: if loop_mode { Some(exit_code) } else { None },
+        last_error: if loop_mode && exit_code != 0 {
+            Some(format!("job exited with code {exit_code}"))
+        } else {
+            None
+        },
+        job: Some(job),
+        exit_code: Some(exit_code),
+    }
+}
+
+fn install_shutdown_handler(stop: Arc<AtomicBool>) -> Result<()> {
+    ctrlc::set_handler(move || {
+        stop.store(true, Ordering::SeqCst);
+    })
+    .map_err(|err| {
+        Error::internal_unexpected(format!("install runner worker signal handler: {err}"))
+    })
+}
+
+fn log_worker_event(options: &ReverseRunnerWorkerOptions, event: &str, data: serde_json::Value) {
+    eprintln!(
+        "{}",
+        json!({
+            "command": "runner.work",
+            "event": event,
+            "runner_id": options.runner_id,
+            "broker_url": options.broker_url,
+            "project_id": options.project_id,
+            "data": data,
+        })
+    );
 }
 
 fn claim_job(
@@ -194,6 +484,20 @@ mod tests {
     use crate::test_support;
     use serde_json::Value;
 
+    fn worker_options(broker_url: String) -> ReverseRunnerWorkerOptions {
+        ReverseRunnerWorkerOptions {
+            runner_id: "lab".to_string(),
+            broker_url,
+            project_id: None,
+            lease_ms: 30_000,
+            loop_mode: false,
+            idle_backoff_ms: 1,
+            max_idle_backoff_ms: 10,
+            broker_failure_backoff_ms: 1,
+            broker_retry_limit: 1,
+        }
+    }
+
     #[test]
     fn reverse_worker_executes_claimed_job_and_finishes_it() {
         test_support::with_isolated_home(|_| {
@@ -237,16 +541,18 @@ mod tests {
                 .expect("submit job");
             let (broker_url, handle) = spawn_mock_broker(store.clone(), 3);
 
-            let (output, exit_code) = run_reverse_worker(ReverseRunnerWorkerOptions {
-                runner_id: "lab".to_string(),
-                broker_url: broker_url.clone(),
-                project_id: None,
-                lease_ms: 30_000,
-            })
-            .expect("run worker");
+            let (output, exit_code) =
+                run_reverse_worker(worker_options(broker_url.clone())).expect("run worker");
 
             assert_eq!(exit_code, 0);
             assert!(output.claimed);
+            let serialized = serde_json::to_value(&output).expect("serialize output");
+            assert_eq!(serialized["command"], serde_json::json!("runner.work"));
+            assert_eq!(serialized["claimed"], serde_json::json!(true));
+            assert!(serialized.get("loop_mode").is_none());
+            assert!(serialized.get("iterations").is_none());
+            assert!(serialized.get("jobs_claimed").is_none());
+            assert!(serialized.get("last_claim").is_none());
             let job = output.job.expect("job");
             assert_eq!(job.status, JobStatus::Succeeded);
             handle.join().expect("mock broker joins");
@@ -270,6 +576,155 @@ mod tests {
                 assert!(result["metrics"]["sample_count"].as_u64().is_some());
             }
         });
+    }
+
+    #[test]
+    fn reverse_worker_loop_backs_off_when_no_job_is_available() {
+        test_support::with_isolated_home(|_| {
+            crate::core::runner::create(
+                r#"{"id":"lab","kind":"local","workspace_root":"/tmp"}"#,
+                false,
+            )
+            .expect("create runner");
+            let store = JobStore::default();
+            let (broker_url, handle) = spawn_mock_broker(store, 1);
+            let stop = Arc::new(AtomicBool::new(false));
+            let stop_after_sleep = stop.clone();
+            let mut sleeps = Vec::new();
+            let (output, exit_code) = run_loop(worker_options(broker_url), stop, |duration| {
+                sleeps.push(duration);
+                stop_after_sleep.store(true, Ordering::SeqCst);
+            })
+            .expect("run loop");
+
+            assert_eq!(exit_code, 0);
+            assert!(!output.claimed);
+            assert!(output.stopped);
+            assert_eq!(output.iterations, 1);
+            assert_eq!(output.last_claim, None);
+            assert_eq!(output.last_result, None);
+            assert_eq!(output.last_error, None);
+            assert_eq!(sleeps, vec![Duration::from_millis(1)]);
+            handle.join().expect("mock broker joins");
+        });
+    }
+
+    #[test]
+    fn reverse_worker_reports_execution_failure_to_broker() {
+        test_support::with_isolated_home(|_| {
+            crate::core::runner::create(
+                r#"{"id":"lab","kind":"local","workspace_root":"/tmp"}"#,
+                false,
+            )
+            .expect("create runner");
+            let store = JobStore::default();
+            store
+                .submit_remote_runner_job(RemoteRunnerJobRequest {
+                    runner_id: "lab".to_string(),
+                    project_id: None,
+                    operation: "runner.exec".to_string(),
+                    command: vec!["not-allowed".to_string()],
+                    cwd: Some("/tmp".to_string()),
+                    env: Default::default(),
+                    capture_patch: false,
+                    source_snapshot: None,
+                    metadata: None,
+                })
+                .expect("submit job");
+            let (broker_url, handle) = spawn_mock_broker(store.clone(), 3);
+
+            let (output, exit_code) =
+                run_reverse_worker(worker_options(broker_url)).expect("run worker");
+
+            assert_eq!(exit_code, 1);
+            assert!(output.claimed);
+            let job = output.job.expect("job");
+            assert_eq!(job.status, JobStatus::Failed);
+            handle.join().expect("mock broker joins");
+            let events = store.events(job.id).expect("events");
+            assert!(events.iter().any(|event| event.kind == JobEventKind::Error));
+        });
+    }
+
+    #[test]
+    fn reverse_worker_loop_reports_failed_job_status() {
+        test_support::with_isolated_home(|_| {
+            crate::core::runner::create(
+                r#"{"id":"lab","kind":"local","workspace_root":"/tmp"}"#,
+                false,
+            )
+            .expect("create runner");
+            let store = JobStore::default();
+            store
+                .submit_remote_runner_job(RemoteRunnerJobRequest {
+                    runner_id: "lab".to_string(),
+                    project_id: None,
+                    operation: "runner.exec".to_string(),
+                    command: vec!["not-allowed".to_string()],
+                    cwd: Some("/tmp".to_string()),
+                    env: Default::default(),
+                    capture_patch: false,
+                    source_snapshot: None,
+                    metadata: None,
+                })
+                .expect("submit job");
+            let (broker_url, handle) = spawn_mock_broker(store.clone(), 4);
+            let stop = Arc::new(AtomicBool::new(false));
+            let stop_after_sleep = stop.clone();
+            let mut options = worker_options(broker_url);
+            options.loop_mode = true;
+
+            let (output, exit_code) = run_loop(options, stop, |_| {
+                stop_after_sleep.store(true, Ordering::SeqCst);
+            })
+            .expect("run loop");
+
+            assert_eq!(exit_code, 0);
+            assert!(output.claimed);
+            assert_eq!(output.jobs_claimed, 1);
+            assert_eq!(output.last_result, Some(1));
+            assert_eq!(output.last_error.as_deref(), Some("job exited with code 1"));
+            assert!(output.last_claim.is_some());
+            let job = output.job.expect("job");
+            assert_eq!(job.status, JobStatus::Failed);
+            handle.join().expect("mock broker joins");
+        });
+    }
+
+    #[test]
+    fn reverse_worker_loop_stops_without_claiming_when_stop_is_already_set() {
+        let stop = Arc::new(AtomicBool::new(true));
+        let (output, exit_code) = run_loop(
+            worker_options("http://127.0.0.1:1".to_string()),
+            stop,
+            |_| panic!("worker should not sleep when already stopped"),
+        )
+        .expect("run loop");
+
+        assert_eq!(exit_code, 0);
+        assert!(output.stopped);
+        assert_eq!(output.iterations, 0);
+        assert_eq!(output.jobs_claimed, 0);
+        assert_eq!(output.last_claim, None);
+        assert_eq!(output.last_result, None);
+        assert_eq!(output.last_error, None);
+    }
+
+    #[test]
+    fn reverse_worker_loop_bounds_transient_broker_failures() {
+        let (broker_url, handle) = spawn_failing_broker(2);
+        let mut options = worker_options(broker_url);
+        options.broker_retry_limit = 1;
+        let stop = Arc::new(AtomicBool::new(false));
+        let mut sleeps = 0;
+        let err = run_loop(options, stop, |_| {
+            sleeps += 1;
+        })
+        .expect_err("broker failures should exceed retry budget");
+
+        assert!(err.to_string().contains("broker request failed"));
+        assert_eq!(sleeps, 1);
+        handle.join().expect("mock broker joins");
     }
 
     fn spawn_mock_broker(
@@ -403,5 +858,24 @@ mod tests {
         stream
             .write_all(response.as_bytes())
             .expect("write response");
+    }
+
+    fn spawn_failing_broker(expected_requests: usize) -> (String, std::thread::JoinHandle<()>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let addr = listener.local_addr().expect("addr");
+        let handle = std::thread::spawn(move || {
+            for _ in 0..expected_requests {
+                let (mut stream, _) = listener.accept().expect("accept request");
+                let _ = read_request(&mut stream);
+                write_response(
+                    &mut stream,
+                    serde_json::json!({
+                        "success": false,
+                        "error": { "message": "broker unavailable" }
+                    }),
+                );
+            }
+        });
+        (format!("http://{addr}"), handle)
     }
 }

--- a/src/core/runner/worker.rs
+++ b/src/core/runner/worker.rs
@@ -299,6 +299,7 @@ fn run_once_output(
                         "error": err.to_string(),
                     })),
                     artifacts: Vec::new(),
+                    metrics: None,
                 },
             )?;
             let exit_code = 1;
@@ -628,6 +629,7 @@ mod tests {
                     env: Default::default(),
                     capture_patch: false,
                     source_snapshot: None,
+                    require_paths: Vec::new(),
                     metadata: None,
                 })
                 .expect("submit job");
@@ -665,6 +667,7 @@ mod tests {
                     env: Default::default(),
                     capture_patch: false,
                     source_snapshot: None,
+                    require_paths: Vec::new(),
                     metadata: None,
                 })
                 .expect("submit job");


### PR DESCRIPTION
## Summary
- Add `homeboy runner work --loop` for long-running reverse-runner workers with idle backoff, bounded broker failure retries, and SIGINT/SIGTERM shutdown handling.
- Emit structured JSON lifecycle logs to stderr and include loop status fields for broker URL, runner ID, last claim, last result, and last error in the final output.
- Report execution setup failures back to the broker as failed job results, and document a minimal systemd service unit.

Closes #2991.

## Tests
- `cargo test reverse_worker --lib`
- `cargo test runner --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and tested the reverse runner loop implementation, tests, and docs; Chris remains responsible for review and merge.