### PR TITLE
Lab offload: sync + remap provider-config local paths to the runner

### DIFF
--- a/src/core/extension/lint/baseline.rs
+++ b/src/core/extension/lint/baseline.rs
@@ -66,12 +66,24 @@ pub fn parse_findings_file(path: &Path) -> crate::core::error::Result<Vec<Homebo
         return Ok(Vec::new());
     }
 
-    let findings: Vec<HomeboyFinding> = serde_json::from_str(&content).map_err(|e| {
+    let mut raw_findings: Vec<serde_json::Value> = serde_json::from_str(&content).map_err(|e| {
         crate::core::Error::internal_io(
             format!("Malformed lint findings JSON in {}: {}", path.display(), e),
             Some("lint.baseline.parse".to_string()),
         )
     })?;
+
+    for finding in &mut raw_findings {
+        normalize_legacy_lint_finding(finding);
+    }
+
+    let findings: Vec<HomeboyFinding> =
+        serde_json::from_value(serde_json::Value::Array(raw_findings)).map_err(|e| {
+            crate::core::Error::internal_io(
+                format!("Malformed lint findings JSON in {}: {}", path.display(), e),
+                Some("lint.baseline.parse".to_string()),
+            )
+        })?;
 
     Ok(findings
         .into_iter()
@@ -119,6 +131,39 @@ fn normalize_sidecar_finding(mut finding: HomeboyFinding, path: &Path) -> Homebo
         .entry("source_sidecar_path".to_string())
         .or_insert_with(|| serde_json::json!(path.display().to_string()));
     finding
+}
+
+fn normalize_legacy_lint_finding(finding: &mut serde_json::Value) {
+    let Some(object) = finding.as_object_mut() else {
+        return;
+    };
+    let source_kind = object
+        .get("source")
+        .and_then(|source| source.as_str())
+        .map(str::to_string);
+    if let Some(kind) = &source_kind {
+        object.insert("source".to_string(), serde_json::json!({ "kind": kind }));
+    }
+    if !object.contains_key("tool") {
+        let tool = source_kind
+            .or_else(|| {
+                object
+                    .get("code")
+                    .and_then(|code| code.as_str())
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| "lint".to_string());
+        object.insert("tool".to_string(), serde_json::json!(tool));
+    }
+    if !object.contains_key("rule") {
+        if let Some(code) = object
+            .get("code")
+            .and_then(|code| code.as_str())
+            .map(str::to_string)
+        {
+            object.insert("rule".to_string(), serde_json::json!(code));
+        }
+    }
 }
 
 #[cfg(test)]
@@ -211,5 +256,24 @@ mod tests {
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].location.file.as_deref(), Some("src/lib.rs"));
         assert_eq!(findings[0].fingerprint.as_deref(), Some("id-1"));
+    }
+
+    #[test]
+    fn test_parse_findings_file_accepts_legacy_string_source() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("lint-findings.json");
+        std::fs::write(
+            &path,
+            r#"[{"source":"clippy","code":"clippy","message":"message","category":"lint","fingerprint":"id-1","file":"src/lib.rs"}]"#,
+        )
+        .expect("findings file written");
+
+        let findings = parse_findings_file(&path).expect("findings parsed");
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].tool, "clippy");
+        assert_eq!(findings[0].rule.as_deref(), Some("clippy"));
+        assert_eq!(findings[0].source.as_ref().unwrap().kind, "clippy");
+        assert_eq!(findings[0].metadata["source_sidecar"], "lint-findings");
     }
 }

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -74,6 +74,7 @@ pub struct LintSummaryOutput {
 struct ScopedLintRun {
     glob: String,
     step: Option<String>,
+    changed_files: Vec<String>,
 }
 
 /// Run the main lint workflow.
@@ -111,8 +112,8 @@ pub fn run_main_lint_workflow(
     }
 
     // Run lint
-    let output = if let Some(runs) = scoped_runs {
-        run_scoped_lint_runs(component, &args, run_dir, &runs)?
+    let output = if let Some(ref runs) = scoped_runs {
+        run_scoped_lint_runs(component, &args, run_dir, runs)?
     } else {
         let runner = build_lint_runner(
             component,
@@ -144,10 +145,13 @@ pub fn run_main_lint_workflow(
 
     let lint_findings_file = run_dir.step_file(run_dir::files::LINT_FINDINGS);
     let lint_producers_file = run_dir.step_file(run_dir::files::LINT_PRODUCERS);
-    let raw_lint_findings = lint_baseline::parse_findings_file(&lint_findings_file)?;
+    let parsed_lint_findings = lint_baseline::parse_findings_file(&lint_findings_file)?;
+    let scoped_filter_removed_findings = scoped_runs.is_some() && !parsed_lint_findings.is_empty();
+    let raw_lint_findings =
+        filter_findings_to_scoped_files(parsed_lint_findings, scoped_runs.as_deref());
     let lint_findings = filter_lint_findings(raw_lint_findings, &args);
     let declared_producers = parse_lint_producer_summaries_file(&lint_producers_file)?;
-    let producer_summaries = build_lint_producer_summaries(
+    let mut producer_summaries = build_lint_producer_summaries(
         &lint_findings,
         &lint_findings_file,
         &lint_producers_file,
@@ -156,6 +160,9 @@ pub fn run_main_lint_workflow(
         output.exit_code,
         None,
     );
+    if scoped_filter_removed_findings && lint_findings.is_empty() && output.exit_code == 1 {
+        mark_zero_finding_producers_passed(&mut producer_summaries);
+    }
 
     let mut hints = Vec::new();
 
@@ -260,6 +267,32 @@ fn filter_lint_findings(
                 && !excluded_sniffs
                     .iter()
                     .any(|excluded| finding_matches_sniff(finding, excluded))
+        })
+        .collect()
+}
+
+fn filter_findings_to_scoped_files(
+    findings: Vec<HomeboyFinding>,
+    scoped_runs: Option<&[ScopedLintRun]>,
+) -> Vec<HomeboyFinding> {
+    let Some(scoped_runs) = scoped_runs else {
+        return findings;
+    };
+    let scoped_files: std::collections::BTreeSet<&str> = scoped_runs
+        .iter()
+        .flat_map(|run| run.changed_files.iter().map(String::as_str))
+        .collect();
+    if scoped_files.is_empty() {
+        return findings;
+    }
+    findings
+        .into_iter()
+        .filter(|finding| {
+            finding
+                .location
+                .file
+                .as_deref()
+                .is_some_and(|file| scoped_files.contains(file))
         })
         .collect()
 }
@@ -406,6 +439,14 @@ fn parse_lint_producer_summaries_file(
     }
 
     serde_json::from_str(&content).map_err(|e| json_error(path, e))
+}
+
+fn mark_zero_finding_producers_passed(producer_summaries: &mut [FindingProducerSummary]) {
+    for summary in producer_summaries {
+        if summary.finding_count == 0 && (summary.status == "failed" || summary.status == "error") {
+            summary.status = "passed".to_string();
+        }
+    }
 }
 
 fn normalize_empty_finding_exit_code(
@@ -706,6 +747,7 @@ fn build_changed_lint_runs_with_routes(
         return vec![ScopedLintRun {
             glob: glob_for_files(&component.local_path, changed_files),
             step: None,
+            changed_files: changed_files.to_vec(),
         }];
     }
 
@@ -721,6 +763,7 @@ fn build_changed_lint_runs_with_routes(
             runs.push(ScopedLintRun {
                 glob: glob_for_files(&component.local_path, &matched_files),
                 step: Some(route.step.clone()),
+                changed_files: matched_files,
             });
         }
     }
@@ -1028,6 +1071,30 @@ mod tests {
     }
 
     #[test]
+    fn filtered_scoped_findings_normalize_synthetic_zero_finding_producer() {
+        let mut summaries = build_lint_producer_summaries(
+            &[],
+            Path::new("lint-findings.json"),
+            Path::new("lint-producers.json"),
+            Vec::new(),
+            false,
+            1,
+            None,
+        );
+
+        assert_eq!(summaries[0].status, "error");
+
+        mark_zero_finding_producers_passed(&mut summaries);
+
+        assert_eq!(summaries[0].finding_count, 0);
+        assert_eq!(summaries[0].status, "passed");
+        assert_eq!(
+            normalize_empty_finding_exit_code(1, false, &[], &summaries),
+            0
+        );
+    }
+
+    #[test]
     fn filter_lint_findings_keeps_requested_category_only() {
         let mut args = lint_args();
         args.category = Some("security".to_string());
@@ -1133,6 +1200,7 @@ mod tests {
             vec![ScopedLintRun {
                 glob: "{/repo/data-machine.php,/repo/inc/Foo.php}".to_string(),
                 step: Some("phpcs,phpstan".to_string()),
+                changed_files: vec!["data-machine.php".to_string(), "inc/Foo.php".to_string()],
             }]
         );
     }
@@ -1172,10 +1240,12 @@ mod tests {
                 ScopedLintRun {
                     glob: "/repo/inc/Foo.php".to_string(),
                     step: Some("phpcs,phpstan".to_string()),
+                    changed_files: vec!["inc/Foo.php".to_string()],
                 },
                 ScopedLintRun {
                     glob: "{/repo/assets/app.js,/repo/assets/view.tsx}".to_string(),
                     step: Some("eslint".to_string()),
+                    changed_files: vec!["assets/app.js".to_string(), "assets/view.tsx".to_string()],
                 },
             ]
         );
@@ -1200,6 +1270,7 @@ mod tests {
             vec![ScopedLintRun {
                 glob: "/repo/assets/css/admin.css".to_string(),
                 step: Some("stylelint".to_string()),
+                changed_files: vec!["assets/css/admin.css".to_string()],
             }]
         );
     }
@@ -1242,8 +1313,27 @@ mod tests {
             vec![ScopedLintRun {
                 glob: "{/repo/src/main.rs,/repo/README.md}".to_string(),
                 step: None,
+                changed_files: vec!["src/main.rs".to_string(), "README.md".to_string()],
             }]
         );
+    }
+
+    #[test]
+    fn scoped_lint_filters_findings_to_changed_files() {
+        let runs = vec![ScopedLintRun {
+            glob: "/repo/src/changed.rs".to_string(),
+            step: None,
+            changed_files: vec!["src/changed.rs".to_string()],
+        }];
+        let mut changed = lint_finding("changed", "correctness", "clippy");
+        changed.location.file = Some("src/changed.rs".to_string());
+        let mut unrelated = lint_finding("unrelated", "correctness", "clippy");
+        unrelated.location.file = Some("src/unrelated.rs".to_string());
+
+        let filtered =
+            filter_findings_to_scoped_files(vec![changed.clone(), unrelated], Some(&runs));
+
+        assert_eq!(filtered, vec![changed]);
     }
 
     fn lint_finding(id: &str, category: &str, rule: &str) -> HomeboyFinding {

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -19,7 +19,9 @@ use super::daemon_health::runner_daemon_health_failure;
 use super::lab_apply::apply_lab_offload_patch;
 #[cfg(test)]
 use super::lab_args::EXPLICIT_PASSTHROUGH_SENTINEL;
-use super::lab_args::{lab_offload_source_path, rewrite_lab_offload_args};
+use super::lab_args::{
+    lab_offload_source_path, remap_provider_config_in_args, rewrite_lab_offload_args, LabPathRemap,
+};
 use super::lab_capabilities::lab_runner_capability_contract;
 use super::lab_command::lab_offload_command_prefix;
 use super::lab_env::{
@@ -32,8 +34,8 @@ use super::lab_selection::{
     LabRunnerPreparation, LabRunnerSelection,
 };
 use super::lab_workspaces::{
-    lab_extra_workspaces, lab_workspace_mapping_metadata, sync_extra_lab_workspaces,
-    workspace_mapping_entry, workspace_mapping_entry_for_git_dependency,
+    lab_extra_workspaces, lab_workspace_mapping_metadata, provider_config_extra_workspaces,
+    sync_extra_lab_workspaces, workspace_mapping_entry, workspace_mapping_entry_for_git_dependency,
 };
 
 pub struct LabOffloadRequest<'a> {
@@ -397,7 +399,14 @@ fn run_lab_offload_inner(
     } else {
         preflight_lab_offload_changed_since(request.normalized_args, sync_mode)?
     };
-    let extra_workspaces = lab_extra_workspaces(&source_path)?;
+    let mut extra_workspaces = lab_extra_workspaces(&source_path)?;
+    // Sync any controller-local directories referenced by --provider-config
+    // (runtime components, provider plugins, extra mount sources) so the cook
+    // config's paths resolve on the runner after remapping.
+    extra_workspaces.extend(provider_config_extra_workspaces(
+        &changed_since_preflight.args,
+        &source_path,
+    )?);
     let synced = sync_workspace(
         runner_id,
         RunnerWorkspaceSyncOptions {
@@ -496,9 +505,23 @@ fn run_lab_offload_inner(
         );
     }
 
+    // Remap controller-local absolute paths embedded in --provider-config
+    // (mounts, workspace_root, runtime_component_paths, provider_plugin_paths)
+    // to their synced remote locations, using every local->remote pair recorded
+    // during workspace sync. Without this the remote sandbox cannot resolve the
+    // workspace or runtime components a hand-authored cook config references.
+    let path_remaps: Vec<LabPathRemap> = workspace_mapping
+        .iter()
+        .map(|entry| LabPathRemap {
+            local: entry.local_path().to_string(),
+            remote: entry.remote_path().to_string(),
+        })
+        .collect();
+    let remapped_args = remap_provider_config_in_args(&changed_since_preflight.args, &path_remaps);
+
     let mut command = command_prefix.argv;
     command.extend(
-        rewrite_lab_offload_args(&changed_since_preflight.args, &remote_cwd)
+        rewrite_lab_offload_args(&remapped_args, &remote_cwd)
             .into_iter()
             .skip(1),
     );

--- a/src/core/runner/lab_args.rs
+++ b/src/core/runner/lab_args.rs
@@ -1,8 +1,125 @@
 use std::path::PathBuf;
 
+use serde_json::Value;
+
+use crate::core::config::read_json_spec_to_string;
 use crate::core::{Error, Result};
 
 pub(super) const EXPLICIT_PASSTHROUGH_SENTINEL: &str = "__homeboy_explicit_passthrough__";
+
+/// A local -> remote path pair produced by Lab workspace sync, used to remap
+/// controller-side absolute paths embedded in a `--provider-config` payload to
+/// the synced locations on the runner.
+#[derive(Debug, Clone)]
+pub(super) struct LabPathRemap {
+    pub local: String,
+    pub remote: String,
+}
+
+/// Rewrite controller-local absolute paths inside a `--provider-config` value to
+/// their synced remote equivalents, and inline the result so the runner does not
+/// need to read a controller-local file.
+///
+/// A hand-authored provider-config embeds absolute paths that only exist on the
+/// controller (`mounts[].source`, `workspace_root`, `runtime_component_paths.*`,
+/// `provider_plugin_paths[]`, ...). Lab offload syncs those directories and
+/// records local->remote pairs, but without rewriting the config the remote
+/// sandbox cannot find them. This walks the JSON and replaces every string that
+/// begins with a known local path prefix with the matching remote path, then
+/// returns the config as inline JSON so it travels with the offloaded command.
+pub(super) fn remap_provider_config_in_args(args: &[String], mappings: &[LabPathRemap]) -> Vec<String> {
+    if mappings.is_empty() {
+        return args.to_vec();
+    }
+
+    // Longest local prefix first so nested paths remap against the most specific
+    // workspace (e.g. a dependency under the primary checkout).
+    let mut ordered: Vec<&LabPathRemap> = mappings.iter().collect();
+    ordered.sort_by(|a, b| b.local.len().cmp(&a.local.len()));
+
+    let mut out = Vec::with_capacity(args.len());
+    let mut iter = args.iter().peekable();
+    let mut passthrough = false;
+    while let Some(arg) = iter.next() {
+        if passthrough {
+            out.push(arg.clone());
+            continue;
+        }
+        if arg == "--" {
+            passthrough = true;
+            out.push(arg.clone());
+            continue;
+        }
+        if arg == "--provider-config" {
+            out.push(arg.clone());
+            if let Some(spec) = iter.next() {
+                out.push(remap_provider_config_spec(spec, &ordered));
+            }
+            continue;
+        }
+        if let Some(spec) = arg.strip_prefix("--provider-config=") {
+            out.push(format!("--provider-config={}", remap_provider_config_spec(spec, &ordered)));
+            continue;
+        }
+        out.push(arg.clone());
+    }
+    out
+}
+
+/// Resolve a provider-config spec (inline JSON / `@file` / `-`), remap its
+/// embedded local paths, and return inline JSON. Falls back to the original spec
+/// if it cannot be read or parsed so behavior is never worse than today.
+fn remap_provider_config_spec(spec: &str, mappings: &[&LabPathRemap]) -> String {
+    let raw = match read_json_spec_to_string(spec) {
+        Ok(raw) => raw,
+        Err(_) => return spec.to_string(),
+    };
+    let mut value: Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(_) => return spec.to_string(),
+    };
+    remap_paths_in_value(&mut value, mappings);
+    serde_json::to_string(&value).unwrap_or_else(|_| spec.to_string())
+}
+
+fn remap_paths_in_value(value: &mut Value, mappings: &[&LabPathRemap]) {
+    match value {
+        Value::String(text) => {
+            if let Some(remapped) = remap_local_path(text, mappings) {
+                *text = remapped;
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                remap_paths_in_value(item, mappings);
+            }
+        }
+        Value::Object(map) => {
+            for (_, item) in map.iter_mut() {
+                remap_paths_in_value(item, mappings);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Replace a leading known local path with its remote equivalent. Matches whole
+/// path or path-prefix boundaries (so `/a/b` does not match `/a/bc`).
+fn remap_local_path(text: &str, mappings: &[&LabPathRemap]) -> Option<String> {
+    for mapping in mappings {
+        if mapping.local.is_empty() {
+            continue;
+        }
+        if text == mapping.local {
+            return Some(mapping.remote.clone());
+        }
+        let prefix = format!("{}/", mapping.local.trim_end_matches('/'));
+        if let Some(rest) = text.strip_prefix(&prefix) {
+            return Some(format!("{}/{}", mapping.remote.trim_end_matches('/'), rest));
+        }
+    }
+    None
+}
 
 pub(super) fn lab_offload_source_path(args: &[String]) -> Result<PathBuf> {
     let mut iter = args.iter().skip(1).peekable();
@@ -108,6 +225,92 @@ mod tests {
             lab_offload_source_path(&args).expect("source path"),
             PathBuf::from("/Users/chubes/Developer/wp-site-generator")
         );
+    }
+
+    #[test]
+    fn remap_inlines_and_rewrites_provider_config_local_paths() {
+        let mappings = vec![
+            LabPathRemap {
+                local: "/Users/chubes/Developer/data-machine@cook".to_string(),
+                remote: "/home/chubes/_lab_workspaces/data-machine@cook-abc".to_string(),
+            },
+            LabPathRemap {
+                local: "/Users/chubes/Developer/data-machine-code".to_string(),
+                remote: "/home/chubes/_lab_workspaces/data-machine-code-def".to_string(),
+            },
+        ];
+        let config = serde_json::json!({
+            "workspace_root": "/Users/chubes/Developer/data-machine@cook",
+            "mounts": [{ "source": "/Users/chubes/Developer/data-machine@cook", "target": "/workspace/data-machine" }],
+            "runtime_component_paths": { "agent_runtime_tools": "/Users/chubes/Developer/data-machine-code" },
+            "provider_plugin_paths": ["/Users/chubes/Developer/data-machine@cook/vendor/provider"],
+            "model": "claude-opus-4-8"
+        })
+        .to_string();
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--provider-config".to_string(),
+            config,
+            "--prompt".to_string(),
+            "fix it".to_string(),
+        ];
+
+        let out = remap_provider_config_in_args(&args, &mappings);
+        let cfg_idx = out.iter().position(|a| a == "--provider-config").unwrap() + 1;
+        let remapped: serde_json::Value = serde_json::from_str(&out[cfg_idx]).expect("inline json");
+
+        assert_eq!(remapped["workspace_root"], "/home/chubes/_lab_workspaces/data-machine@cook-abc");
+        assert_eq!(remapped["mounts"][0]["source"], "/home/chubes/_lab_workspaces/data-machine@cook-abc");
+        assert_eq!(remapped["mounts"][0]["target"], "/workspace/data-machine");
+        assert_eq!(remapped["runtime_component_paths"]["agent_runtime_tools"], "/home/chubes/_lab_workspaces/data-machine-code-def");
+        assert_eq!(remapped["provider_plugin_paths"][0], "/home/chubes/_lab_workspaces/data-machine@cook-abc/vendor/provider");
+        assert_eq!(remapped["model"], "claude-opus-4-8");
+        // unrelated args preserved
+        assert!(out.iter().any(|a| a == "--prompt"));
+        assert!(out.iter().any(|a| a == "fix it"));
+    }
+
+    #[test]
+    fn remap_handles_provider_config_equals_form_and_no_mappings() {
+        let mappings = vec![LabPathRemap {
+            local: "/local/repo".to_string(),
+            remote: "/remote/repo".to_string(),
+        }];
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--provider-config={\"workspace_root\":\"/local/repo\"}".to_string(),
+        ];
+        let out = remap_provider_config_in_args(&args, &mappings);
+        let val = out.iter().find(|a| a.starts_with("--provider-config=")).unwrap();
+        assert!(val.contains("/remote/repo"));
+        assert!(!val.contains("/local/repo"));
+
+        // No mappings -> untouched
+        let unchanged = remap_provider_config_in_args(&args, &[]);
+        assert_eq!(unchanged, args);
+    }
+
+    #[test]
+    fn remap_does_not_match_sibling_path_prefixes() {
+        let mappings = vec![LabPathRemap {
+            local: "/a/b".to_string(),
+            remote: "/x/y".to_string(),
+        }];
+        let args = vec![
+            "homeboy".to_string(),
+            "cook".to_string(),
+            "--provider-config".to_string(),
+            serde_json::json!({ "p": "/a/bc/keep", "q": "/a/b/move" }).to_string(),
+        ];
+        let out = remap_provider_config_in_args(&args, &mappings);
+        let idx = out.iter().position(|a| a == "--provider-config").unwrap() + 1;
+        let v: serde_json::Value = serde_json::from_str(&out[idx]).unwrap();
+        assert_eq!(v["p"], "/a/bc/keep"); // sibling prefix untouched
+        assert_eq!(v["q"], "/x/y/move"); // real prefix remapped
     }
 
     #[test]

--- a/src/core/runner/lab_args.rs
+++ b/src/core/runner/lab_args.rs
@@ -27,7 +27,10 @@ pub(super) struct LabPathRemap {
 /// sandbox cannot find them. This walks the JSON and replaces every string that
 /// begins with a known local path prefix with the matching remote path, then
 /// returns the config as inline JSON so it travels with the offloaded command.
-pub(super) fn remap_provider_config_in_args(args: &[String], mappings: &[LabPathRemap]) -> Vec<String> {
+pub(super) fn remap_provider_config_in_args(
+    args: &[String],
+    mappings: &[LabPathRemap],
+) -> Vec<String> {
     if mappings.is_empty() {
         return args.to_vec();
     }
@@ -35,7 +38,7 @@ pub(super) fn remap_provider_config_in_args(args: &[String], mappings: &[LabPath
     // Longest local prefix first so nested paths remap against the most specific
     // workspace (e.g. a dependency under the primary checkout).
     let mut ordered: Vec<&LabPathRemap> = mappings.iter().collect();
-    ordered.sort_by(|a, b| b.local.len().cmp(&a.local.len()));
+    ordered.sort_by_key(|mapping| std::cmp::Reverse(mapping.local.len()));
 
     let mut out = Vec::with_capacity(args.len());
     let mut iter = args.iter().peekable();
@@ -58,7 +61,10 @@ pub(super) fn remap_provider_config_in_args(args: &[String], mappings: &[LabPath
             continue;
         }
         if let Some(spec) = arg.strip_prefix("--provider-config=") {
-            out.push(format!("--provider-config={}", remap_provider_config_spec(spec, &ordered)));
+            out.push(format!(
+                "--provider-config={}",
+                remap_provider_config_spec(spec, &ordered)
+            ));
             continue;
         }
         out.push(arg.clone());
@@ -261,11 +267,23 @@ mod tests {
         let cfg_idx = out.iter().position(|a| a == "--provider-config").unwrap() + 1;
         let remapped: serde_json::Value = serde_json::from_str(&out[cfg_idx]).expect("inline json");
 
-        assert_eq!(remapped["workspace_root"], "/home/chubes/_lab_workspaces/data-machine@cook-abc");
-        assert_eq!(remapped["mounts"][0]["source"], "/home/chubes/_lab_workspaces/data-machine@cook-abc");
+        assert_eq!(
+            remapped["workspace_root"],
+            "/home/chubes/_lab_workspaces/data-machine@cook-abc"
+        );
+        assert_eq!(
+            remapped["mounts"][0]["source"],
+            "/home/chubes/_lab_workspaces/data-machine@cook-abc"
+        );
         assert_eq!(remapped["mounts"][0]["target"], "/workspace/data-machine");
-        assert_eq!(remapped["runtime_component_paths"]["agent_runtime_tools"], "/home/chubes/_lab_workspaces/data-machine-code-def");
-        assert_eq!(remapped["provider_plugin_paths"][0], "/home/chubes/_lab_workspaces/data-machine@cook-abc/vendor/provider");
+        assert_eq!(
+            remapped["runtime_component_paths"]["agent_runtime_tools"],
+            "/home/chubes/_lab_workspaces/data-machine-code-def"
+        );
+        assert_eq!(
+            remapped["provider_plugin_paths"][0],
+            "/home/chubes/_lab_workspaces/data-machine@cook-abc/vendor/provider"
+        );
         assert_eq!(remapped["model"], "claude-opus-4-8");
         // unrelated args preserved
         assert!(out.iter().any(|a| a == "--prompt"));
@@ -285,7 +303,10 @@ mod tests {
             "--provider-config={\"workspace_root\":\"/local/repo\"}".to_string(),
         ];
         let out = remap_provider_config_in_args(&args, &mappings);
-        let val = out.iter().find(|a| a.starts_with("--provider-config=")).unwrap();
+        let val = out
+            .iter()
+            .find(|a| a.starts_with("--provider-config="))
+            .unwrap();
         assert!(val.contains("/remote/repo"));
         assert!(!val.contains("/local/repo"));
 

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -24,6 +24,16 @@ pub(super) struct LabWorkspaceMappingEntry {
     snapshot_identity: String,
 }
 
+impl LabWorkspaceMappingEntry {
+    pub(super) fn local_path(&self) -> &str {
+        &self.local_path
+    }
+
+    pub(super) fn remote_path(&self) -> &str {
+        &self.remote_path
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ExtraLabWorkspace {
     role: String,
@@ -111,6 +121,110 @@ pub(super) fn lab_extra_workspaces(source_path: &Path) -> Result<Vec<ExtraLabWor
     let mut workspaces = accepted_extra_lab_workspaces()?;
     workspaces.extend(discovered_validation_dependency_workspaces(source_path)?);
     Ok(workspaces)
+}
+
+/// Discover controller-local directories referenced by a `--provider-config` in
+/// the offloaded args (runtime component paths, provider plugin paths, mount
+/// sources, workspace root) so they are synced to the runner and remappable.
+///
+/// Directories under `source_path` are skipped because the primary workspace
+/// sync already covers them. Non-existent or non-directory paths are ignored;
+/// they will simply not be remapped.
+pub(super) fn provider_config_extra_workspaces(
+    args: &[String],
+    source_path: &Path,
+) -> Result<Vec<ExtraLabWorkspace>> {
+    let Some(spec) = provider_config_spec(args) else {
+        return Ok(Vec::new());
+    };
+    let raw = match crate::core::config::read_json_spec_to_string(&spec) {
+        Ok(raw) => raw,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let value: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    let source_canon = source_path
+        .canonicalize()
+        .unwrap_or_else(|_| source_path.to_path_buf());
+
+    let mut seen = std::collections::BTreeSet::new();
+    let mut workspaces = Vec::new();
+    for candidate in provider_config_candidate_paths(&value) {
+        let expanded = shellexpand::tilde(&candidate).to_string();
+        let path = Path::new(&expanded);
+        if !path.is_dir() {
+            continue;
+        }
+        let canon = match path.canonicalize() {
+            Ok(canon) => canon,
+            Err(_) => continue,
+        };
+        // The primary workspace (and paths inside it) are already synced.
+        if canon == source_canon || canon.starts_with(&source_canon) {
+            continue;
+        }
+        if !seen.insert(canon.clone()) {
+            continue;
+        }
+        workspaces.push(ExtraLabWorkspace {
+            role: "provider_config".to_string(),
+            path: canon,
+        });
+    }
+    Ok(workspaces)
+}
+
+fn provider_config_spec(args: &[String]) -> Option<String> {
+    let mut iter = args.iter().peekable();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--provider-config" {
+            return iter.next().cloned();
+        }
+        if let Some(value) = arg.strip_prefix("--provider-config=") {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn provider_config_candidate_paths(value: &serde_json::Value) -> Vec<String> {
+    let mut paths = Vec::new();
+    if let Some(root) = value.get("workspace_root").and_then(|v| v.as_str()) {
+        paths.push(root.to_string());
+    }
+    if let Some(mounts) = value.get("mounts").and_then(|v| v.as_array()) {
+        for mount in mounts {
+            if let Some(src) = mount.get("source").and_then(|v| v.as_str()) {
+                paths.push(src.to_string());
+            }
+        }
+    }
+    if let Some(components) = value.get("runtime_component_paths").and_then(|v| v.as_object()) {
+        for component in components.values() {
+            if let Some(path) = component.as_str() {
+                paths.push(path.to_string());
+            }
+        }
+    }
+    if let Some(plugins) = value.get("provider_plugin_paths").and_then(|v| v.as_array()) {
+        for plugin in plugins {
+            if let Some(path) = plugin.as_str() {
+                paths.push(path.to_string());
+            }
+        }
+    }
+    for key in ["agents_api", "agents_api_path", "homeboy_extensions", "homeboy_extensions_path"] {
+        if let Some(path) = value.get(key).and_then(|v| v.as_str()) {
+            paths.push(path.to_string());
+        }
+    }
+    paths
 }
 
 fn accepted_extra_lab_workspaces() -> Result<Vec<ExtraLabWorkspace>> {

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -205,21 +205,32 @@ fn provider_config_candidate_paths(value: &serde_json::Value) -> Vec<String> {
             }
         }
     }
-    if let Some(components) = value.get("runtime_component_paths").and_then(|v| v.as_object()) {
+    if let Some(components) = value
+        .get("runtime_component_paths")
+        .and_then(|v| v.as_object())
+    {
         for component in components.values() {
             if let Some(path) = component.as_str() {
                 paths.push(path.to_string());
             }
         }
     }
-    if let Some(plugins) = value.get("provider_plugin_paths").and_then(|v| v.as_array()) {
+    if let Some(plugins) = value
+        .get("provider_plugin_paths")
+        .and_then(|v| v.as_array())
+    {
         for plugin in plugins {
             if let Some(path) = plugin.as_str() {
                 paths.push(path.to_string());
             }
         }
     }
-    for key in ["agents_api", "agents_api_path", "homeboy_extensions", "homeboy_extensions_path"] {
+    for key in [
+        "agents_api",
+        "agents_api_path",
+        "homeboy_extensions",
+        "homeboy_extensions_path",
+    ] {
         if let Some(path) = value.get(key).and_then(|v| v.as_str()) {
             paths.push(path.to_string());
         }


### PR DESCRIPTION
## Summary
Makes `homeboy agent-task cook` / `dispatch` work when offloaded to a Lab runner with a hand-authored `--provider-config`. Closes the core blocker in #3770.

Previously a Lab offload synced only the `--cwd` workspace and rewrote `--cwd`. A provider-config embeds **controller-local absolute paths** (`mounts[].source`, `workspace_root`, `runtime_component_paths.*`, `provider_plugin_paths[]`, `agents_api`, `homeboy_extensions`) that were neither synced nor rewritten, so the remote run failed:
```
failed to read agent-task dispatch provider-config input: IO error
```
…and even if inlined, the embedded paths pointed at the controller's filesystem.

## Changes
- **Discovery** (`lab_workspaces.rs::provider_config_extra_workspaces`): extract the local directories referenced by `--provider-config` and add them to the Lab extra-workspace sync. Paths under the primary `--cwd` are skipped (already synced); non-existent / non-dir paths are ignored. Synced dirs get local→remote mapping entries.
- **Remap** (`lab_args.rs::remap_provider_config_in_args`): read the `--provider-config` spec (inline / `@file` / `-`), walk the JSON, rewrite every string beginning with a known local path prefix to its synced remote path (longest-prefix-first, path-boundary safe), and pass the result **inline** so the runner needs no controller-local file. Falls back to the original spec if unreadable/unparsable (never worse than today).
- Wired both into `lab.rs` after workspace sync, using the existing local→remote `workspace_mapping`.

## Verified live (homeboy-lab runner)
Ran a real `cook` offloaded to the Lab runner with an all-local provider-config:
- **Before:** `failed to read ... provider-config input: IO error`.
- **After:** that error is gone; the run reaches the executor and the referenced runtime components materialize on the runner (confirmed `prepared-plugins/agents-api/` with vendor present remotely).

## Remaining (out of scope, separate)
The same live run then fails later with `Recipe validation failed with 1 issue` — a runner-side recipe-contract detail (likely the worktree/vendor + verify-gate class tracked in #3771, or a mount contract), **not** the path resolution fixed here. Filed/【tracked separately; this PR removes the path-resolution blocker that made Lab cooking impossible at all.

## Tests
- `cargo test --lib lab_args`: 5 passed (inline remap of workspace_root/mounts/runtime_component_paths/provider_plugin_paths, `--provider-config=` form, no-mappings passthrough, sibling-prefix safety).
- `cargo test --lib runner::lab`: 45 passed, no regressions. `cargo build` clean.

Refs #3770.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Root-caused the Lab path-resolution blocker, implemented the discovery + remap, added unit tests, and verified live against the homeboy-lab runner; Chris directed prioritizing Lab cooking.