### PR TITLE
Lab offload: sync runtime_overlays sources to the runner

### DIFF
--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -225,6 +225,16 @@ fn provider_config_candidate_paths(value: &serde_json::Value) -> Vec<String> {
             }
         }
     }
+    // Runtime overlay sources (e.g. a bundled-library php-ai-client build that
+    // supplies provider-request-auth APIs) are controller-local directories the
+    // sandbox mounts; sync them so the overlay resolves on the runner.
+    if let Some(overlays) = value.get("runtime_overlays").and_then(|v| v.as_array()) {
+        for overlay in overlays {
+            if let Some(src) = overlay.get("source").and_then(|v| v.as_str()) {
+                paths.push(src.to_string());
+            }
+        }
+    }
     for key in [
         "agents_api",
         "agents_api_path",
@@ -351,4 +361,51 @@ fn canonical_existing_dir(path: &str, field: &str) -> Result<PathBuf> {
             Some("canonicalize runner workspace path".to_string()),
         )
     })
+}
+
+#[cfg(test)]
+mod provider_config_candidate_paths_tests {
+    use super::provider_config_candidate_paths;
+
+    #[test]
+    fn extracts_all_local_path_sources_including_runtime_overlays() {
+        let value = serde_json::json!({
+            "workspace_root": "/local/data-machine@cook",
+            "mounts": [{ "source": "/local/data-machine@cook", "target": "/workspace/data-machine" }],
+            "runtime_component_paths": {
+                "agent_runtime": "/local/data-machine",
+                "agent_runtime_tools": "/local/data-machine-code"
+            },
+            "provider_plugin_paths": ["/local/ai-provider-for-claude-code"],
+            "runtime_overlays": [
+                { "kind": "bundled-library", "library": "php-ai-client", "source": "/local/php-ai-client@custom-provider-auth", "target": "/wordpress/wp-includes/php-ai-client" }
+            ],
+            "agents_api": "/local/agents-api",
+            "model": "claude-opus-4-8"
+        });
+
+        let paths = provider_config_candidate_paths(&value);
+
+        for expected in [
+            "/local/data-machine@cook",
+            "/local/data-machine",
+            "/local/data-machine-code",
+            "/local/ai-provider-for-claude-code",
+            "/local/php-ai-client@custom-provider-auth",
+            "/local/agents-api",
+        ] {
+            assert!(
+                paths.iter().any(|p| p == expected),
+                "missing candidate path: {expected}"
+            );
+        }
+        // Non-path scalars are not collected.
+        assert!(!paths.iter().any(|p| p == "claude-opus-4-8"));
+    }
+
+    #[test]
+    fn empty_config_yields_no_candidates() {
+        let value = serde_json::json!({ "model": "x" });
+        assert!(provider_config_candidate_paths(&value).is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
#3774 synced and remapped provider-config local paths (mounts, workspace_root, runtime_component_paths, provider_plugin_paths) but **not `runtime_overlays[].source`**. A bundled-library overlay (e.g. a php-ai-client build supplying the provider-request-auth APIs a coding-agent provider needs) is a controller-local directory; without syncing it the overlay does not resolve on the runner.

Extend `provider_config_candidate_paths` to also collect `runtime_overlays[].source` so those directories sync to the runner and get local→remote mapping entries (the existing #3774 remap then rewrites the overlay source inline).

## Context — Lab cooking now works end to end
This is part of the final set that made Lab cooking complete. With #3774 (path remap), Automattic/wp-codebox#840 + #841 (plugin entry-file resolution), and this overlay-source sync, a real Lab cook **succeeds** on the homeboy-lab runner: the provider registers and the agent writes its file on the runner.

## Testing
- `provider_config_candidate_paths` tests cover all source kinds incl. `runtime_overlays` and the empty-config case.
- `cargo test --lib runner::lab` (47 passed), fmt + clippy clean, build clean.

Refs #3770.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Identified runtime_overlays sources were not synced for Lab, implemented the discovery + tests, verified live on the runner; Chris directed prioritizing Lab cooking.