### PR TITLE
fix: preserve artifact get output bytes

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -461,6 +461,10 @@ impl Commands {
     pub fn output_file_mode(&self, has_output_file: bool) -> CommandOutputFileMode {
         self.descriptor(has_output_file).output_file_mode
     }
+
+    pub fn consumes_output_file_as_command_arg(&self) -> bool {
+        matches!(self, Commands::Runs(args) if args.is_artifact_get())
+    }
 }
 
 fn raw_ops_descriptor(
@@ -1075,6 +1079,23 @@ mod tests {
                 output_file: CommandOutputFileMode::TraceJsonSummaryArtifact,
             }
         );
+    }
+
+    #[test]
+    fn artifact_get_output_flag_is_command_payload_destination() {
+        assert!(parsed_command(&[
+            "homeboy",
+            "runs",
+            "artifact",
+            "get",
+            "run-1",
+            "artifact-1",
+            "-o",
+            "artifact.bin",
+        ])
+        .consumes_output_file_as_command_arg());
+
+        assert!(!parsed_command(&["homeboy", "status"]).consumes_output_file_as_command_arg());
     }
 
     #[test]

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -343,6 +343,15 @@ impl RunsArgs {
     pub fn is_bundle_export(&self) -> bool {
         matches!(self.command, RunsCommand::Export(_))
     }
+
+    pub fn is_artifact_get(&self) -> bool {
+        matches!(
+            self.command,
+            RunsCommand::Artifact(RunsArtifactArgs {
+                command: RunsArtifactCommand::Get(_),
+            })
+        )
+    }
 }
 
 pub fn run_markdown(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,11 @@ fn main() -> std::process::ExitCode {
         output_file = None;
     }
 
+    if cli.command.consumes_output_file_as_command_arg() {
+        // This command owns `--output/-o`; it is not the global JSON envelope.
+        output_file = None;
+    }
+
     if let Some(hot_command) = resource_policy::hot_command(&cli.command) {
         if let Ok((resources, _)) = homeboy::commands::doctor::resources::run(
             homeboy::commands::doctor::resources::ResourcesArgs {},


### PR DESCRIPTION
## Summary
- Treat `runs artifact get --output/-o` as the artifact payload destination, not the global JSON envelope output file.
- Suppress the global JSON writer for `runs artifact get` so the copied artifact bytes are not overwritten after a successful command response.
- Add command-surface coverage for the special output-file ownership case.

Closes #3791.

## Tests
- `cargo test cli_surface::tests::artifact_get_output_flag_is_command_payload_destination --lib`
- `cargo test commands::runs::tests::artifact_get_copies_registered_file_without_raw_path_lookup --lib`
- `cargo test cli_surface::tests::test_response_plan --lib`
- `cargo test commands::runs --lib`
- `cargo test cli_surface --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the Clap/global-output collision, implemented the focused suppression, added regression coverage, and prepared the PR for Chris to review.