### PR TITLE
Resolve bench shared-state artifact paths

### DIFF
--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -416,11 +416,21 @@ fn persist_bench_result_artifact_paths(
     run_dir: &RunDir,
 ) -> Vec<BenchDiagnostic> {
     let mut diagnostics = Vec::new();
+    let shared_state = results
+        .run_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.shared_state.as_deref());
     for scenario in &mut results.scenarios {
         for (name, artifact) in &mut scenario.artifacts {
-            if let Some(diagnostic) =
-                persist_bench_artifact(observation, &scenario.id, None, name, artifact, run_dir)
-            {
+            if let Some(diagnostic) = persist_bench_artifact(
+                observation,
+                &scenario.id,
+                None,
+                name,
+                artifact,
+                run_dir,
+                shared_state,
+            ) {
                 diagnostics.push(diagnostic);
             }
         }
@@ -434,6 +444,7 @@ fn persist_bench_result_artifact_paths(
                         name,
                         artifact,
                         run_dir,
+                        shared_state,
                     ) {
                         diagnostics.push(diagnostic);
                     }
@@ -451,6 +462,7 @@ fn persist_bench_artifact(
     name: &str,
     artifact: &mut homeboy::core::extension::bench::BenchArtifact,
     run_dir: &RunDir,
+    shared_state: Option<&str>,
 ) -> Option<BenchDiagnostic> {
     let kind = artifact.kind.clone().unwrap_or_else(|| name.to_string());
     let metadata = bench_artifact_metadata(scenario_id, run_index, name, artifact);
@@ -491,7 +503,7 @@ fn persist_bench_artifact(
         ));
     }
 
-    let path = resolve_bench_artifact_path(&original_path, run_dir);
+    let path = resolve_bench_artifact_path(&original_path, run_dir, shared_state);
     let record = if path.is_file() {
         observation.0.store().record_artifact_with_metadata(
             observation.run_id(),
@@ -605,12 +617,20 @@ fn rewrite_bench_results_file(results: &BenchResults, run_dir: &RunDir) {
     let _ = fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), json);
 }
 
-fn resolve_bench_artifact_path(path: &str, run_dir: &RunDir) -> PathBuf {
+fn resolve_bench_artifact_path(
+    path: &str,
+    run_dir: &RunDir,
+    shared_state: Option<&str>,
+) -> PathBuf {
     let artifact_path = PathBuf::from(path);
     if artifact_path.exists() {
         return artifact_path;
     }
     if artifact_path.is_absolute() {
+        if let Some(shared_state_path) = resolve_shared_state_artifact(&artifact_path, shared_state)
+        {
+            return shared_state_path;
+        }
         if let Some(preserved_path) = resolve_preserved_invocation_artifact(&artifact_path, run_dir)
         {
             return preserved_path;
@@ -622,6 +642,16 @@ fn resolve_bench_artifact_path(path: &str, run_dir: &RunDir) -> PathBuf {
         return run_dir_path;
     }
     artifact_path
+}
+
+fn resolve_shared_state_artifact(path: &Path, shared_state: Option<&str>) -> Option<PathBuf> {
+    let shared_state = shared_state?;
+    let relative = path.strip_prefix("/bench-shared-state").ok()?;
+    let candidate = Path::new(shared_state).join(relative);
+    if candidate.exists() {
+        return Some(candidate);
+    }
+    None
 }
 
 fn resolve_preserved_invocation_artifact(path: &Path, run_dir: &RunDir) -> Option<PathBuf> {

--- a/tests/commands/bench/observation_artifact_test.rs
+++ b/tests/commands/bench/observation_artifact_test.rs
@@ -2,7 +2,8 @@ use std::fs;
 
 use homeboy::core::engine::run_dir::{self, RunDir};
 use homeboy::core::extension::bench::artifact::BenchArtifact;
-use homeboy::core::extension::bench::BenchRunWorkflowResult;
+use homeboy::core::extension::bench::result_types::BenchRunMetadata;
+use homeboy::core::extension::bench::{BenchRunExecution, BenchRunWorkflowResult};
 
 use super::tests::{bench_args, bench_results, XdgGuard};
 use super::{finish_success, start, BenchObservationStart};
@@ -85,6 +86,90 @@ fn bench_observation_reports_missing_and_blocked_artifacts() {
             workflow.results.as_ref().unwrap().scenarios[0].artifacts["escape"]
                 .observation_artifact_id
                 .is_none()
+        );
+    });
+}
+
+#[test]
+fn bench_observation_resolves_shared_state_mount_artifacts() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let run_dir = RunDir::create().expect("run dir");
+        fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
+
+        let shared_state = home.path().join("shared-state");
+        let host_artifact = shared_state.join("evidence/query-profile.json");
+        fs::create_dir_all(host_artifact.parent().expect("artifact parent")).expect("mkdir");
+        fs::write(&host_artifact, b"{\"ok\":true}").expect("artifact");
+
+        let mut results = bench_results("homeboy", "cold", 42.0);
+        results.run_metadata = Some(BenchRunMetadata {
+            homeboy_version: Some("test".to_string()),
+            started_at: "2026-06-08T00:00:00Z".to_string(),
+            shared_state: Some(shared_state.to_string_lossy().to_string()),
+            iterations: 10,
+            execution: BenchRunExecution {
+                runs: 1,
+                concurrency: 1,
+            },
+            warmup_iterations: None,
+            selected_scenarios: Vec::new(),
+            env_overrides: Default::default(),
+            workloads: Vec::new(),
+            runner: None,
+            diagnostics: Vec::new(),
+        });
+        results.scenarios[0].artifacts.insert(
+            "query-profile".to_string(),
+            BenchArtifact {
+                path: Some("/bench-shared-state/evidence/query-profile.json".to_string()),
+                url: None,
+                artifact_type: None,
+                kind: Some("json".to_string()),
+                label: Some("Query profile".to_string()),
+                observation_artifact_id: None,
+                ..BenchArtifact::default()
+            },
+        );
+        let mut workflow = BenchRunWorkflowResult {
+            status: "passed".to_string(),
+            component: "homeboy".to_string(),
+            exit_code: 0,
+            iterations: 10,
+            results: Some(results),
+            gate_results: Vec::new(),
+            gate_failures: Vec::new(),
+            baseline_comparison: None,
+            hints: None,
+            failure: None,
+            diagnostics: Vec::new(),
+        };
+
+        let args = bench_args();
+        let observation = start(BenchObservationStart {
+            component_id: "homeboy",
+            component_label: "homeboy",
+            source_path: home.path(),
+            args: &args,
+            selected_scenarios: &["cold".to_string()],
+            rig_id: None,
+            rig_snapshot: None,
+            run_dir: &run_dir,
+        })
+        .expect("start observation");
+
+        finish_success(Some(observation), &mut workflow, &run_dir).expect("observation summary");
+
+        let classes: Vec<_> = workflow
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.class.as_str())
+            .collect();
+        assert!(!classes.contains(&"bench_artifact_path_missing"));
+        assert!(
+            workflow.results.as_ref().unwrap().scenarios[0].artifacts["query-profile"]
+                .observation_artifact_id
+                .is_some()
         );
     });
 }


### PR DESCRIPTION
## Summary
- Maps bench artifact paths declared under the sandbox shared-state mount (`/bench-shared-state/...`) back to the host shared-state directory recorded in bench run metadata.
- Keeps existing absolute path, run-dir relative path, preserved invocation artifact, missing artifact, and parent-directory blocking behavior intact.
- Adds a regression test proving shared-state artifacts are persisted instead of reported as missing.

Closes https://github.com/Extra-Chill/homeboy/issues/3792

## Verification
- `cargo test observation_artifact_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the shared-state artifact path resolver change, added the regression test, and ran targeted verification. Chris remains responsible for review and merge.