### PR TITLE
Allow agent-task loop Lab offload

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1120,6 +1120,20 @@ mod tests {
             parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"])
                 .supports_lab_runner()
         );
+        assert!(
+            parsed_command(&[
+                "homeboy",
+                "agent-task",
+                "loop",
+                "--to-worktree",
+                "homeboy@smoke",
+                "--verify",
+                "true",
+                "--prompt",
+                "cook"
+            ])
+            .supports_lab_runner()
+        );
         assert!(!parsed_command(&[
             "homeboy", "refactor", "rename", "--from", "old", "--to", "new",
         ])
@@ -1188,11 +1202,25 @@ mod tests {
             ),
             (
                 parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"]),
-                "agent-task dispatch/cook",
+                "agent-task dispatch/cook/loop",
             ),
             (
                 parsed_command(&["homeboy", "agent-task", "cook", "--prompt", "cook"]),
-                "agent-task dispatch/cook",
+                "agent-task dispatch/cook/loop",
+            ),
+            (
+                parsed_command(&[
+                    "homeboy",
+                    "agent-task",
+                    "loop",
+                    "--to-worktree",
+                    "homeboy@smoke",
+                    "--verify",
+                    "true",
+                    "--prompt",
+                    "cook",
+                ]),
+                "agent-task dispatch/cook/loop",
             ),
         ];
 

--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -49,9 +49,10 @@ impl Commands {
                     args.command,
                     super::agent_task::AgentTaskCommand::Cook(_)
                         | super::agent_task::AgentTaskCommand::Dispatch(_)
+                        | super::agent_task::AgentTaskCommand::Loop(_)
                 ) =>
             {
-                lab_portable_contract("agent-task dispatch/cook", None, true, LAB_NO_EXTRA_TOOLS)
+                lab_portable_contract("agent-task dispatch/cook/loop", None, true, LAB_NO_EXTRA_TOOLS)
             }
             Commands::Audit(args) if args.changed_since.is_some() => {
                 lab_local_only_contract("audit", AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON)

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -85,7 +85,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             "runner",
             message,
             Some(runner_id.to_string()),
-            Some(vec!["Current Lab offload support: agent-task dispatch/cook, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+            Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
         )
     };
     let mut plan = base_lab_plan(request.command.as_ref());
@@ -93,7 +93,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if let Some(runner_id) = request.explicit_runner {
             return Err(unsupported_runner_error(
                 runner_id,
-                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop, lint, test, audit, bench, trace, and refactor source runs".to_string(),
             ));
         }
         return Ok(LabOffloadOutcome::RunLocal {
@@ -106,7 +106,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.portable {
         if let Some(runner_id) = request.explicit_runner {
             let message = contract.unsupported_reason.map_or_else(
-                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
             );
             return Err(unsupported_runner_error(runner_id, message));

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -338,14 +338,14 @@ pub(super) fn resolve_lab_runner_selection_from_default(
     if let Some(runner_id) = explicit_runner {
         if !command.portable {
             let message = command.unsupported_reason.map_or_else(
-                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this hot command. {reason}"),
             );
             return Err(Error::validation_invalid_argument(
                 "runner",
                 message,
                 Some(runner_id.to_string()),
-                Some(vec!["Current Lab offload support: agent-task dispatch/cook, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
             ));
         }
 


### PR DESCRIPTION
## Summary
- Treat `agent-task loop` as part of the Lab-portable agent-task command family when `--runner` is supplied.
- Update user-facing Lab offload support labels from `agent-task dispatch/cook` to `agent-task dispatch/cook/loop`.
- Add CLI surface coverage so `agent-task loop --runner` remains accepted.

## Testing
- `cargo test cli_surface::tests::test_`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Lab offload command-surface mismatch, drafted the contract/test update; Chris reviews and owns the change.