### PR TITLE
Report iterator PR guardrails

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -830,26 +830,14 @@ fn finalize_loop_pr(
                 .model
                 .clone()
                 .or_else(|| ai_model_from_tool(&args.ai_tool)),
-            source_relationship: AgentTaskPrSourceRelationship {
-                related_finding_id: args.dispatch.task_url.clone(),
-                source_packet_id: None,
-                change_kind: Some("runtime-fix".to_string()),
-                supersedes: Vec::new(),
-                depends_on: Vec::new(),
-            },
+            source_relationship: AgentTaskPrSourceRelationship::default(),
             verification: AgentTaskPrVerification {
                 targeted_checks_run: args.verify.clone(),
                 targeted_checks_unavailable: None,
                 ci_expected: vec!["Homeboy CI after push".to_string()],
                 manual_reviewer_check: None,
             },
-            runtime_guardrails: AgentTaskPrRuntimeGuardrails {
-                why_not_broader_than_packet: Some(
-                    "Generated runtime fixes must stay bounded to the source task/finding evidence and preserve nearby predicates or contracts unless the prompt explicitly requests broader behavior.".to_string(),
-                ),
-                evidence_discriminators: Vec::new(),
-                nearby_contracts_preserved: Vec::new(),
-            },
+            runtime_guardrails: AgentTaskPrRuntimeGuardrails::default(),
         },
         ai_used_for: args.ai_used_for.clone(),
         protected_branches: args.protected_branches.clone(),

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -3,7 +3,8 @@ use homeboy::core::agent_task_cook_loop::{
     evaluate_cook_loop, AgentTaskCookLoopOptions, AgentTaskCookLoopStatus,
 };
 use homeboy::core::agent_task_finalization::{
-    finalize_pr, AgentTaskPrEvidence, AgentTaskPrFinalizationOptions,
+    finalize_pr, AgentTaskPrEvidence, AgentTaskPrFinalizationOptions, AgentTaskPrRuntimeGuardrails,
+    AgentTaskPrSourceRelationship, AgentTaskPrVerification,
 };
 use homeboy::core::agent_task_gate::AgentTaskGateRevealPolicy;
 use homeboy::core::agent_task_promotion::{
@@ -824,11 +825,43 @@ fn finalize_loop_pr(
                 promotion.deterministic_gates.len()
             ),
             ai_tool: args.ai_tool.clone(),
+            ai_model: args
+                .dispatch
+                .model
+                .clone()
+                .or_else(|| ai_model_from_tool(&args.ai_tool)),
+            source_relationship: AgentTaskPrSourceRelationship {
+                related_finding_id: args.dispatch.task_url.clone(),
+                source_packet_id: None,
+                change_kind: Some("runtime-fix".to_string()),
+                supersedes: Vec::new(),
+                depends_on: Vec::new(),
+            },
+            verification: AgentTaskPrVerification {
+                targeted_checks_run: args.verify.clone(),
+                targeted_checks_unavailable: None,
+                ci_expected: vec!["Homeboy CI after push".to_string()],
+                manual_reviewer_check: None,
+            },
+            runtime_guardrails: AgentTaskPrRuntimeGuardrails {
+                why_not_broader_than_packet: Some(
+                    "Generated runtime fixes must stay bounded to the source task/finding evidence and preserve nearby predicates or contracts unless the prompt explicitly requests broader behavior.".to_string(),
+                ),
+                evidence_discriminators: Vec::new(),
+                nearby_contracts_preserved: Vec::new(),
+            },
         },
         ai_used_for: args.ai_used_for.clone(),
         protected_branches: args.protected_branches.clone(),
     })?;
     Ok(serde_json::to_value(report).unwrap_or(Value::Null))
+}
+
+fn ai_model_from_tool(ai_tool: &str) -> Option<String> {
+    let start = ai_tool.find('(')?;
+    let end = ai_tool[start + 1..].find(')')? + start + 1;
+    let model = ai_tool[start + 1..end].trim();
+    (!model.is_empty()).then(|| model.to_string())
 }
 
 fn default_loop_title(args: &AgentTaskLoopArgs) -> String {

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -5,6 +5,7 @@ use homeboy::core::agent_task::{AgentTaskAggregateReport, AgentTaskRequest};
 use homeboy::core::agent_task_cook_loop::{evaluate_cook_loop, AgentTaskCookLoopOptions};
 use homeboy::core::agent_task_finalization::{
     finalize_pr, AgentTaskGateResult, AgentTaskPrEvidence, AgentTaskPrFinalizationOptions,
+    AgentTaskPrRuntimeGuardrails, AgentTaskPrSourceRelationship, AgentTaskPrVerification,
 };
 use homeboy::core::agent_task_lifecycle;
 use homeboy::core::agent_task_promotion::{
@@ -39,6 +40,58 @@ pub struct FinalizePrEvidenceArgs {
     /// AI tool disclosure line for the PR body.
     #[arg(long, default_value = "OpenCode (GPT-5.5)", value_name = "TEXT")]
     pub ai_tool: String,
+
+    /// Actual model identifier for AI disclosure. Use "not recorded" only when provider metadata is missing.
+    #[arg(long, value_name = "MODEL")]
+    pub ai_model: Option<String>,
+
+    /// Source finding id shared by sibling generated PRs.
+    #[arg(long, value_name = "ID")]
+    pub related_finding_id: Option<String>,
+
+    /// Source validation packet id shared by sibling generated PRs.
+    #[arg(long, value_name = "ID")]
+    pub source_packet_id: Option<String>,
+
+    /// Generated change kind, e.g. evidence-only, runtime-fix, or test-only.
+    #[arg(long, value_name = "KIND")]
+    pub change_kind: Option<String>,
+
+    /// Generated PR or artifact this PR supersedes. Repeatable.
+    #[arg(long, value_name = "REF")]
+    pub supersedes: Vec<String>,
+
+    /// Generated PR or artifact this PR depends on. Repeatable.
+    #[arg(long, value_name = "REF")]
+    pub depends_on: Vec<String>,
+
+    /// Targeted verification command that ran before finalization. Repeatable.
+    #[arg(long = "targeted-check-run", value_name = "COMMAND")]
+    pub targeted_checks_run: Vec<String>,
+
+    /// Exact backend limitation when targeted checks could not be run.
+    #[arg(long, value_name = "TEXT")]
+    pub targeted_checks_unavailable: Option<String>,
+
+    /// CI check expected to run after push. Repeatable.
+    #[arg(long = "ci-expected", value_name = "CHECK")]
+    pub ci_expected: Vec<String>,
+
+    /// Manual reviewer verification requested when targeted checks/CI do not cover behavior.
+    #[arg(long, value_name = "TEXT")]
+    pub manual_reviewer_check: Option<String>,
+
+    /// Runtime-fix evidence bound for generated predicates/semantics.
+    #[arg(long, value_name = "TEXT")]
+    pub why_not_broader_than_packet: Option<String>,
+
+    /// Evidence-specific discriminator preserved by the runtime fix. Repeatable.
+    #[arg(long = "evidence-discriminator", value_name = "TEXT")]
+    pub evidence_discriminators: Vec<String>,
+
+    /// Nearby predicate/contract preserved by the runtime fix. Repeatable.
+    #[arg(long = "nearby-contract-preserved", value_name = "TEXT")]
+    pub nearby_contracts_preserved: Vec<String>,
 }
 
 impl From<FinalizePrEvidenceArgs> for AgentTaskPrEvidence {
@@ -48,6 +101,25 @@ impl From<FinalizePrEvidenceArgs> for AgentTaskPrEvidence {
             artifact_refs: args.artifact_refs,
             attempt_summary: args.attempt_summary,
             ai_tool: args.ai_tool,
+            ai_model: args.ai_model,
+            source_relationship: AgentTaskPrSourceRelationship {
+                related_finding_id: args.related_finding_id,
+                source_packet_id: args.source_packet_id,
+                change_kind: args.change_kind,
+                supersedes: args.supersedes,
+                depends_on: args.depends_on,
+            },
+            verification: AgentTaskPrVerification {
+                targeted_checks_run: args.targeted_checks_run,
+                targeted_checks_unavailable: args.targeted_checks_unavailable,
+                ci_expected: args.ci_expected,
+                manual_reviewer_check: args.manual_reviewer_check,
+            },
+            runtime_guardrails: AgentTaskPrRuntimeGuardrails {
+                why_not_broader_than_packet: args.why_not_broader_than_packet,
+                evidence_discriminators: args.evidence_discriminators,
+                nearby_contracts_preserved: args.nearby_contracts_preserved,
+            },
         }
     }
 }

--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -315,12 +315,12 @@ fn preflight_dispatch_provider_secrets(plan: &AgentTaskPlan) -> homeboy::core::R
 }
 
 fn dispatch_instructions(instructions: String, task_url: Option<&str>) -> String {
-    if task_url.is_none() || instructions.contains("Iterator runtime-fix guardrails") {
+    if task_url.is_none() || instructions.contains("Generated change guardrails") {
         return instructions;
     }
 
     format!(
-        "{instructions}\n\nIterator runtime-fix guardrails:\n- Before adding a new runtime predicate or transform, search for nearby existing predicates and transform families that already cover the finding shape.\n- Keep generated runtime changes bounded to the source finding evidence; preserve evidence-specific discriminators such as class, href, role, text, or DOM shape unless the task explicitly asks for broader behavior.\n- If existing behavior plus evidence/test coverage already resolves the finding, prefer evidence-only or test-only output over a broader runtime change.\n- In the PR evidence, report source relationship, change kind, verification capability, and why any runtime change is not broader than the packet evidence."
+        "{instructions}\n\nGenerated change guardrails:\n- First look for nearby existing predicates, contracts, or implementation families that already cover the requested behavior.\n- Keep generated changes bounded to the source evidence and task scope; preserve evidence-specific discriminators unless the task explicitly asks for broader behavior.\n- If existing behavior plus evidence/test coverage already resolves the task, prefer evidence-only or test-only output over a broader runtime change.\n- In PR evidence, report source relationship, change kind, verification capability, and why any runtime change is not broader than the source evidence."
     )
 }
 
@@ -727,7 +727,7 @@ mod tests {
     }
 
     #[test]
-    fn tracker_backed_dispatch_adds_runtime_fix_guardrails() {
+    fn tracker_backed_dispatch_adds_generated_change_guardrails() {
         let plan = build_dispatch_plan(&dispatch_args(DispatchArgOverrides {
             prompt: Some("Fix the finding.".to_string()),
             repo: Some("homeboy".to_string()),
@@ -738,10 +738,10 @@ mod tests {
 
         assert!(plan.tasks[0]
             .instructions
-            .contains("Iterator runtime-fix guardrails"));
+            .contains("Generated change guardrails"));
         assert!(plan.tasks[0]
             .instructions
-            .contains("bounded to the source finding evidence"));
+            .contains("bounded to the source evidence"));
     }
 
     #[test]

--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -193,7 +193,10 @@ fn build_dispatch_plan(args: &DispatchArgs) -> homeboy::core::Result<AgentTaskPl
         dispatch_provider_config(args, &repo, workspace_target.as_ref(), &client_context)?;
     let mut tasks = Vec::new();
     for (index, prompt_spec) in prompt_specs.iter().enumerate() {
-        let instructions = read_text_spec(prompt_spec, "prompt")?;
+        let instructions = dispatch_instructions(
+            read_text_spec(prompt_spec, "prompt")?,
+            args.task_url.as_deref(),
+        );
         let task_id = dispatch_task_id(repo.as_deref(), index);
         let mut source_refs = Vec::new();
         if let Some(task_url) = &args.task_url {
@@ -309,6 +312,16 @@ fn preflight_dispatch_provider_secrets(plan: &AgentTaskPlan) -> homeboy::core::R
             ]),
         )
     })
+}
+
+fn dispatch_instructions(instructions: String, task_url: Option<&str>) -> String {
+    if task_url.is_none() || instructions.contains("Iterator runtime-fix guardrails") {
+        return instructions;
+    }
+
+    format!(
+        "{instructions}\n\nIterator runtime-fix guardrails:\n- Before adding a new runtime predicate or transform, search for nearby existing predicates and transform families that already cover the finding shape.\n- Keep generated runtime changes bounded to the source finding evidence; preserve evidence-specific discriminators such as class, href, role, text, or DOM shape unless the task explicitly asks for broader behavior.\n- If existing behavior plus evidence/test coverage already resolves the finding, prefer evidence-only or test-only output over a broader runtime change.\n- In the PR evidence, report source relationship, change kind, verification capability, and why any runtime change is not broader than the packet evidence."
+    )
 }
 
 fn resolve_dispatch_workspace(
@@ -714,6 +727,24 @@ mod tests {
     }
 
     #[test]
+    fn tracker_backed_dispatch_adds_runtime_fix_guardrails() {
+        let plan = build_dispatch_plan(&dispatch_args(DispatchArgOverrides {
+            prompt: Some("Fix the finding.".to_string()),
+            repo: Some("homeboy".to_string()),
+            task_url: Some("https://github.com/Extra-Chill/homeboy/issues/3810".to_string()),
+            ..DispatchArgOverrides::default()
+        }))
+        .expect("dispatch plan");
+
+        assert!(plan.tasks[0]
+            .instructions
+            .contains("Iterator runtime-fix guardrails"));
+        assert!(plan.tasks[0]
+            .instructions
+            .contains("bounded to the source finding evidence"));
+    }
+
+    #[test]
     fn queue_only_returns_durable_run_without_executing() {
         with_isolated_home(|_| {
             let workspace = tempfile::tempdir().expect("workspace");
@@ -890,6 +921,7 @@ mod tests {
         cwd: Option<String>,
         workspace: Option<String>,
         repo: Option<String>,
+        task_url: Option<String>,
         secret_env: Vec<String>,
         client_context: Option<String>,
         concurrency: usize,
@@ -906,7 +938,7 @@ mod tests {
             cwd: overrides.cwd,
             workspace: overrides.workspace,
             repo: overrides.repo,
-            task_url: None,
+            task_url: overrides.task_url,
             backend: "fixture".to_string(),
             selector: None,
             model: None,

--- a/src/core/agent_task_finalization.rs
+++ b/src/core/agent_task_finalization.rs
@@ -46,6 +46,83 @@ pub struct AgentTaskPrEvidence {
     pub artifact_refs: Vec<String>,
     pub attempt_summary: String,
     pub ai_tool: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ai_model: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "AgentTaskPrSourceRelationship::is_empty"
+    )]
+    pub source_relationship: AgentTaskPrSourceRelationship,
+    #[serde(default, skip_serializing_if = "AgentTaskPrVerification::is_empty")]
+    pub verification: AgentTaskPrVerification,
+    #[serde(
+        default,
+        skip_serializing_if = "AgentTaskPrRuntimeGuardrails::is_empty"
+    )]
+    pub runtime_guardrails: AgentTaskPrRuntimeGuardrails,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPrSourceRelationship {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub related_finding_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_packet_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub change_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub supersedes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
+}
+
+impl AgentTaskPrSourceRelationship {
+    pub fn is_empty(&self) -> bool {
+        self.related_finding_id.is_none()
+            && self.source_packet_id.is_none()
+            && self.change_kind.is_none()
+            && self.supersedes.is_empty()
+            && self.depends_on.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPrVerification {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub targeted_checks_run: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub targeted_checks_unavailable: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ci_expected: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manual_reviewer_check: Option<String>,
+}
+
+impl AgentTaskPrVerification {
+    pub fn is_empty(&self) -> bool {
+        self.targeted_checks_run.is_empty()
+            && self.targeted_checks_unavailable.is_none()
+            && self.ci_expected.is_empty()
+            && self.manual_reviewer_check.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPrRuntimeGuardrails {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub why_not_broader_than_packet: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence_discriminators: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub nearby_contracts_preserved: Vec<String>,
+}
+
+impl AgentTaskPrRuntimeGuardrails {
+    pub fn is_empty(&self) -> bool {
+        self.why_not_broader_than_packet.is_none()
+            && self.evidence_discriminators.is_empty()
+            && self.nearby_contracts_preserved.is_empty()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -526,6 +603,48 @@ mod tests {
     }
 
     #[test]
+    fn pr_body_reports_iterator_evidence_metadata() {
+        let mut backend = MockBackend {
+            changed_files: vec!["src/lib.rs".to_string()],
+            ..Default::default()
+        };
+        let mut options = options();
+        options.evidence.source_relationship = AgentTaskPrSourceRelationship {
+            related_finding_id: Some("finding-123".to_string()),
+            source_packet_id: Some("packet-456".to_string()),
+            change_kind: Some("runtime-fix".to_string()),
+            supersedes: vec!["https://github.com/org/repo/pull/1".to_string()],
+            depends_on: vec!["https://github.com/org/repo/pull/2".to_string()],
+        };
+        options.evidence.verification = AgentTaskPrVerification {
+            targeted_checks_run: vec!["cargo test pr_body".to_string()],
+            targeted_checks_unavailable: None,
+            ci_expected: vec!["Homeboy CI".to_string()],
+            manual_reviewer_check: None,
+        };
+        options.evidence.runtime_guardrails = AgentTaskPrRuntimeGuardrails {
+            why_not_broader_than_packet: Some("Preserves class and href gates.".to_string()),
+            evidence_discriminators: vec!["class=brand".to_string(), "href=#top".to_string()],
+            nearby_contracts_preserved: vec!["is_branded_inline_anchor".to_string()],
+        };
+
+        finalize_pr_with_backend(options, &mut backend).expect("finalized");
+
+        assert!(backend.last_body.contains("## Source relationship"));
+        assert!(backend.last_body.contains("finding-123"));
+        assert!(backend.last_body.contains("## Verification capability"));
+        assert!(backend
+            .last_body
+            .contains("`targeted_checks_run`: `cargo test pr_body`"));
+        assert!(backend.last_body.contains("## Runtime guardrails"));
+        assert!(backend
+            .last_body
+            .contains("Preserves class and href gates."));
+        assert!(backend.last_body.contains("## Sibling PR relationship"));
+        assert!(backend.last_body.contains("- **Model:** GPT-5.5"));
+    }
+
+    #[test]
     fn updates_existing_pr_for_same_branch() {
         let mut backend = MockBackend {
             changed_files: vec!["src/lib.rs".to_string()],
@@ -622,6 +741,10 @@ mod tests {
                 artifact_refs: vec!["artifact://aggregate.json".to_string()],
                 attempt_summary: "attempt 1 passed deterministic gates".to_string(),
                 ai_tool: "OpenCode (GPT-5.5)".to_string(),
+                ai_model: Some("GPT-5.5".to_string()),
+                source_relationship: AgentTaskPrSourceRelationship::default(),
+                verification: AgentTaskPrVerification::default(),
+                runtime_guardrails: AgentTaskPrRuntimeGuardrails::default(),
             },
             ai_used_for: "Drafted implementation and tests; Chris reviews and owns the change."
                 .to_string(),

--- a/src/core/agent_task_pr_body.rs
+++ b/src/core/agent_task_pr_body.rs
@@ -7,17 +7,26 @@ pub(crate) fn render_pr_body(
     changed_files: &[String],
 ) -> String {
     format!(
-        "## Summary\n- Finalized Homeboy agent-task cook run `{}` into review-ready branch `{}`.\n\n## Source refs\n{}\n\n## Attempt summary\n{}\n\n## Gate results\n{}\n\n## Changed files\n{}\n\n## Artifact refs\n{}\n\n## Final status\n- **Status:** review-ready\n- **Base:** `{}`\n- **Head:** `{}`\n- **Merge/deploy:** not performed\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** {}\n- **Used for:** {}\n",
+        "## Summary\n- Finalized Homeboy agent-task cook run `{}` into review-ready branch `{}`.\n\n## Source refs\n{}\n\n{}{}## Attempt summary\n{}\n\n## Gate results\n{}\n\n## Verification capability\n{}\n\n## Changed files\n{}\n\n## Artifact refs\n{}\n\n{}## Final status\n- **Status:** review-ready\n- **Base:** `{}`\n- **Head:** `{}`\n- **Merge/deploy:** not performed\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** {}\n- **Model:** {}\n- **Used for:** {}\n",
         options.run_id,
         head,
         bullets(&options.evidence.source_refs),
+        source_relationship_section(options),
+        runtime_guardrails_section(options),
         options.evidence.attempt_summary,
         gate_bullets(&normalized_gate_results(options)),
+        verification_bullets(options),
         bullets(changed_files),
         bullets(&options.evidence.artifact_refs),
+        supersession_note(options),
         options.base,
         head,
         options.evidence.ai_tool,
+        options
+            .evidence
+            .ai_model
+            .as_deref()
+            .unwrap_or("not recorded by provider metadata"),
         options.ai_used_for
     )
 }
@@ -44,6 +53,96 @@ fn gate_bullets(gates: &[HomeboyGateResult]) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn source_relationship_section(options: &AgentTaskPrFinalizationOptions) -> String {
+    let relationship = &options.evidence.source_relationship;
+    if relationship.is_empty() {
+        return String::new();
+    }
+
+    format!(
+        "## Source relationship\n- **Related finding ID:** {}\n- **Source packet ID:** {}\n- **Change kind:** {}\n- **Supersedes:** {}\n- **Depends on:** {}\n\n",
+        option_value(relationship.related_finding_id.as_deref()),
+        option_value(relationship.source_packet_id.as_deref()),
+        option_value(relationship.change_kind.as_deref()),
+        inline_list(&relationship.supersedes),
+        inline_list(&relationship.depends_on),
+    )
+}
+
+fn runtime_guardrails_section(options: &AgentTaskPrFinalizationOptions) -> String {
+    let guardrails = &options.evidence.runtime_guardrails;
+    if guardrails.is_empty() {
+        return String::new();
+    }
+
+    format!(
+        "## Runtime guardrails\n- **Why this is not broader than the packet evidence:** {}\n- **Evidence discriminators preserved:** {}\n- **Nearby contracts preserved:** {}\n\n",
+        option_value(guardrails.why_not_broader_than_packet.as_deref()),
+        inline_list(&guardrails.evidence_discriminators),
+        inline_list(&guardrails.nearby_contracts_preserved),
+    )
+}
+
+fn verification_bullets(options: &AgentTaskPrFinalizationOptions) -> String {
+    let verification = &options.evidence.verification;
+    if verification.is_empty() {
+        return "- `targeted_checks_run`: see gate results above".to_string();
+    }
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "- `targeted_checks_run`: {}",
+        inline_code_list(&verification.targeted_checks_run)
+    ));
+    lines.push(format!(
+        "- `targeted_checks_unavailable`: {}",
+        option_value(verification.targeted_checks_unavailable.as_deref())
+    ));
+    lines.push(format!(
+        "- `ci_expected`: {}",
+        inline_code_list(&verification.ci_expected)
+    ));
+    lines.push(format!(
+        "- `manual_reviewer_check`: {}",
+        option_value(verification.manual_reviewer_check.as_deref())
+    ));
+    lines.join("\n")
+}
+
+fn supersession_note(options: &AgentTaskPrFinalizationOptions) -> String {
+    let relationship = &options.evidence.source_relationship;
+    if relationship.supersedes.is_empty() && relationship.depends_on.is_empty() {
+        return String::new();
+    }
+
+    "## Sibling PR relationship\n- Review sibling generated PRs for the same finding before merging; superseded runtime fixes should be narrowed or closed after safer evidence/test-only coverage lands.\n\n".to_string()
+}
+
+fn option_value(value: Option<&str>) -> String {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("none recorded")
+        .to_string()
+}
+
+fn inline_list(values: &[String]) -> String {
+    if values.is_empty() {
+        return "none recorded".to_string();
+    }
+    values.join(", ")
+}
+
+fn inline_code_list(values: &[String]) -> String {
+    if values.is_empty() {
+        return "none recorded".to_string();
+    }
+    values
+        .iter()
+        .map(|value| format!("`{}`", value.replace('`', "'")))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn normalized_gate_results(options: &AgentTaskPrFinalizationOptions) -> Vec<HomeboyGateResult> {

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -378,7 +378,7 @@ mod provider_config_candidate_paths_tests {
             },
             "provider_plugin_paths": ["/local/ai-provider-for-claude-code"],
             "runtime_overlays": [
-                { "kind": "bundled-library", "library": "php-ai-client", "source": "/local/php-ai-client@custom-provider-auth", "target": "/wordpress/wp-includes/php-ai-client" }
+                { "kind": "bundled-library", "library": "portable-ai-client", "source": "/local/portable-ai-client@custom-provider-auth", "target": "/runtime/includes/portable-ai-client" }
             ],
             "agents_api": "/local/agents-api",
             "model": "claude-opus-4-8"
@@ -391,7 +391,7 @@ mod provider_config_candidate_paths_tests {
             "/local/data-machine",
             "/local/data-machine-code",
             "/local/ai-provider-for-claude-code",
-            "/local/php-ai-client@custom-provider-auth",
+            "/local/portable-ai-client@custom-provider-auth",
             "/local/agents-api",
         ] {
             assert!(


### PR DESCRIPTION
## Summary
- Add structured iterator PR evidence for source relationship, generated change kind, sibling PR supersession/dependency hints, verification capability, CI expectations, and runtime guardrails.
- Render complete AI assistance metadata in finalized agent-task PR bodies, including the model when available and an explicit missing-model placeholder otherwise.
- Append bounded runtime-fix guardrails to tracker-backed agent-task dispatch prompts so generated predicates preserve evidence-specific discriminators and nearby contracts.

## Issues
Fixes https://github.com/Extra-Chill/homeboy/issues/3804
Fixes https://github.com/Extra-Chill/homeboy/issues/3810
Fixes https://github.com/Extra-Chill/homeboy/issues/3814
Fixes https://github.com/Extra-Chill/homeboy/issues/3817

## Verification
- `cargo fmt --check`
- `cargo test agent_task_finalization`
- `cargo test agent_task_dispatch`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation, tests, PR body, and targeted verification commands; Chris reviews and owns the change.