### PR TITLE
Fix dotted bench setting overrides

### DIFF
--- a/src/commands/bench/parse_tests.rs
+++ b/src/commands/bench/parse_tests.rs
@@ -72,3 +72,23 @@ fn scenario_and_profile_conflict() {
 
     assert!(err.to_string().contains("cannot be used with"));
 }
+
+#[test]
+fn parses_dotted_setting_override_for_nested_bench_env() {
+    let cli = TestCli::try_parse_from([
+        "bench",
+        "--rig",
+        "woocommerce-performance",
+        "--setting",
+        "bench_env.WC_REST_BATCH_IMPORT_ITEMS=100",
+    ])
+    .expect("bench dotted --setting should parse");
+
+    assert_eq!(
+        cli.bench.run.setting_args.setting,
+        vec![(
+            "bench_env.WC_REST_BATCH_IMPORT_ITEMS".to_string(),
+            "100".to_string()
+        )]
+    );
+}

--- a/src/commands/utils/args.rs
+++ b/src/commands/utils/args.rs
@@ -570,7 +570,13 @@ pub struct DryRunArgs {
 /// strictly more expressive and was specified later in the merge order).
 #[derive(Args, Debug, Clone, Default)]
 pub struct SettingArgs {
-    #[arg(long, value_parser = crate::commands::parse_key_val)]
+    /// String setting override. Repeatable.
+    ///
+    /// Format: `--setting key=value`. Use dotted keys such as
+    /// `--setting bench_env.FOO=bar` to merge string fields into object
+    /// settings. Use `--setting-json bench_env='{"FOO":"bar"}'` when an
+    /// entire object, array, or typed scalar is needed.
+    #[arg(long, value_name = "KEY=VALUE", value_parser = crate::commands::parse_key_val)]
     pub setting: Vec<(String, String)>,
 
     /// Typed-JSON setting override. Repeatable.

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -272,11 +272,10 @@ pub fn resolve_with_component(
         )
     } else {
         // No extension context — only CLI overrides, wrapped as JSON strings.
-        let settings = options
-            .settings_overrides
-            .iter()
-            .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
-            .collect();
+        let mut settings = Vec::new();
+        for (key, value) in &options.settings_overrides {
+            merge_string_setting_override(&mut settings, key, value);
+        }
         (None, None, settings)
     };
 
@@ -289,6 +288,62 @@ pub fn resolve_with_component(
         extension_path,
         settings,
     })
+}
+
+fn merge_string_setting_override(
+    settings: &mut Vec<(String, serde_json::Value)>,
+    key: &str,
+    value: &str,
+) {
+    let Some((root, child_path)) = key.split_once('.') else {
+        settings.retain(|(k, _)| k != key);
+        settings.push((
+            key.to_string(),
+            serde_json::Value::String(value.to_string()),
+        ));
+        return;
+    };
+
+    if root.is_empty() || child_path.is_empty() || child_path.split('.').any(str::is_empty) {
+        settings.retain(|(k, _)| k != key);
+        settings.push((
+            key.to_string(),
+            serde_json::Value::String(value.to_string()),
+        ));
+        return;
+    }
+
+    let mut root_value = settings
+        .iter()
+        .find(|(k, _)| k == root)
+        .map(|(_, v)| v.clone())
+        .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+    if !root_value.is_object() {
+        root_value = serde_json::Value::Object(serde_json::Map::new());
+    }
+
+    let mut current = root_value.as_object_mut().expect("root setting is object");
+    let mut parts = child_path.split('.').peekable();
+    while let Some(part) = parts.next() {
+        if parts.peek().is_none() {
+            current.insert(
+                part.to_string(),
+                serde_json::Value::String(value.to_string()),
+            );
+            break;
+        }
+
+        let child = current
+            .entry(part.to_string())
+            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+        if !child.is_object() {
+            *child = serde_json::Value::Object(serde_json::Map::new());
+        }
+        current = child.as_object_mut().expect("nested setting is object");
+    }
+
+    settings.retain(|(k, _)| k != root);
+    settings.push((root.to_string(), root_value));
 }
 
 impl ExecutionContext {
@@ -949,5 +1004,27 @@ mod tests {
             .settings
             .iter()
             .any(|(k, v)| k == "mode" && v == "strict"));
+    }
+
+    #[test]
+    fn dotted_settings_merge_into_object_settings() {
+        let mut settings = vec![(
+            "bench_env".to_string(),
+            serde_json::json!({ "EXISTING": "yes" }),
+        )];
+
+        merge_string_setting_override(&mut settings, "bench_env.WC_REST_BATCH_IMPORT_ITEMS", "100");
+
+        assert_eq!(settings.len(), 1);
+        assert_eq!(
+            settings[0],
+            (
+                "bench_env".to_string(),
+                serde_json::json!({
+                    "EXISTING": "yes",
+                    "WC_REST_BATCH_IMPORT_ITEMS": "100"
+                })
+            )
+        );
     }
 }

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -313,7 +313,7 @@ pub(crate) fn build_settings_json_from_manifest(
 
         // String overrides from `--setting key=value` (always strings).
         for (key, value) in settings_overrides {
-            obj.insert(key.clone(), serde_json::Value::String(value.clone()));
+            merge_string_setting_override(obj, key, value);
         }
 
         // Typed-JSON overrides from `--setting-json key=<json>` (preserves
@@ -326,6 +326,55 @@ pub(crate) fn build_settings_json_from_manifest(
     }
 
     crate::core::config::to_json_string(&settings)
+}
+
+fn merge_string_setting_override(
+    settings: &mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    value: &str,
+) {
+    let Some((root, child_path)) = key.split_once('.') else {
+        settings.insert(
+            key.to_string(),
+            serde_json::Value::String(value.to_string()),
+        );
+        return;
+    };
+
+    if root.is_empty() || child_path.is_empty() || child_path.split('.').any(str::is_empty) {
+        settings.insert(
+            key.to_string(),
+            serde_json::Value::String(value.to_string()),
+        );
+        return;
+    }
+
+    let root_value = settings
+        .entry(root.to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    if !root_value.is_object() {
+        *root_value = serde_json::Value::Object(serde_json::Map::new());
+    }
+
+    let mut current = root_value.as_object_mut().expect("root setting is object");
+    let mut parts = child_path.split('.').peekable();
+    while let Some(part) = parts.next() {
+        if parts.peek().is_none() {
+            current.insert(
+                part.to_string(),
+                serde_json::Value::String(value.to_string()),
+            );
+            return;
+        }
+
+        let child = current
+            .entry(part.to_string())
+            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+        if !child.is_object() {
+            *child = serde_json::Value::Object(serde_json::Map::new());
+        }
+        current = child.as_object_mut().expect("nested setting is object");
+    }
 }
 
 pub(crate) fn validate_capability_script_exists(


### PR DESCRIPTION
## Summary
- Adds useful `homeboy bench --help` documentation for `--setting`, including the dotted `bench_env.FOO=bar` form.
- Merges dotted string settings into nested JSON object settings so bench env overrides reach the runner without requiring full `--setting-json` replacement.
- Covers CLI parsing and nested settings merge behavior with regression tests.

Fixes #3811

## Testing
- `cargo fmt`
- `cargo test commands::bench::parse_tests::parses_dotted_setting_override_for_nested_bench_env`
- `cargo test core::engine::execution_context::tests::dotted_settings_merge_into_object_settings`
- `cargo run --quiet --bin homeboy -- bench --help`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and targeted tests; Chris remains responsible for review and merge.