### PR TITLE
Fix Lab cook loop discovery and smoke controls

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1120,20 +1120,18 @@ mod tests {
             parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"])
                 .supports_lab_runner()
         );
-        assert!(
-            parsed_command(&[
-                "homeboy",
-                "agent-task",
-                "loop",
-                "--to-worktree",
-                "homeboy@smoke",
-                "--verify",
-                "true",
-                "--prompt",
-                "cook"
-            ])
-            .supports_lab_runner()
-        );
+        assert!(parsed_command(&[
+            "homeboy",
+            "agent-task",
+            "loop",
+            "--to-worktree",
+            "homeboy@smoke",
+            "--verify",
+            "true",
+            "--prompt",
+            "cook"
+        ])
+        .supports_lab_runner());
         assert!(!parsed_command(&[
             "homeboy", "refactor", "rename", "--from", "old", "--to", "new",
         ])

--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -52,7 +52,12 @@ impl Commands {
                         | super::agent_task::AgentTaskCommand::Loop(_)
                 ) =>
             {
-                lab_portable_contract("agent-task dispatch/cook/loop", None, true, LAB_NO_EXTRA_TOOLS)
+                lab_portable_contract(
+                    "agent-task dispatch/cook/loop",
+                    None,
+                    true,
+                    LAB_NO_EXTRA_TOOLS,
+                )
             }
             Commands::Audit(args) if args.changed_since.is_some() => {
                 lab_local_only_contract("audit", AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON)

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -192,6 +192,10 @@ pub struct AgentTaskLoopArgs {
     #[arg(long = "max-attempts", default_value_t = 3, value_name = "N")]
     pub max_attempts: u32,
 
+    /// Stop after the first green promotion without committing, pushing, or opening/updating a PR.
+    #[arg(long = "no-finalize")]
+    pub no_finalize: bool,
+
     /// PR base branch used by finalization.
     #[arg(long, default_value = "main", value_name = "BRANCH")]
     pub base: String,
@@ -676,6 +680,19 @@ where
 
         match feedback_status {
             AgentTaskCookLoopStatus::GreenCompleted => {
+                if args.no_finalize {
+                    return Ok(loop_report(
+                        loop_id,
+                        "green_no_finalize",
+                        attempts,
+                        None,
+                        Some(
+                            "deterministic gates completed green; --no-finalize skipped commit, push, and PR finalization"
+                                .to_string(),
+                        ),
+                        0,
+                    ));
+                }
                 let finalization = finalize_loop_pr(&args, &loop_id, &promotion)?;
                 let final_status = finalization["status"]
                     .as_str()
@@ -1513,6 +1530,7 @@ mod tests {
                     private_verify: Vec::new(),
                     private_gate_reveal: AgentTaskGateRevealPolicy::SummaryOnly,
                     max_attempts: 2,
+                    no_finalize: false,
                     base: "main".to_string(),
                     head: None,
                     title: None,

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -519,27 +519,7 @@ fn show(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
         ComponentOutput {
             command: "component.show".to_string(),
             id: Some(resolved_id.clone()),
-            entity: Some({
-                let mut value = serde_json::to_value(&component).map_err(|error| {
-                    homeboy::core::Error::validation_invalid_argument(
-                        "component",
-                        "Failed to serialize component",
-                        Some(error.to_string()),
-                        None,
-                    )
-                })?;
-                if let Value::Object(ref mut map) = value {
-                    map.insert("id".to_string(), Value::String(resolved_id));
-                    // Computed: extension-declared lockfiles + component
-                    // extras + the audit baseline. Consumed by
-                    // homeboy-action to scope direct-push drift.
-                    map.insert(
-                        "drift_files".to_string(),
-                        Value::Array(drift_files.into_iter().map(Value::String).collect()),
-                    );
-                }
-                value
-            }),
+            entity: Some(component_discovery_value(&component, Some(drift_files))?),
             ..Default::default()
         },
         0,
@@ -1010,24 +990,7 @@ fn rename(id: &str, new_id: &str) -> CmdResult<ComponentOutput> {
 fn list() -> CmdResult<ComponentOutput> {
     let components: Vec<Value> = component::inventory()?
         .into_iter()
-        .map(|component| {
-            let mut value = serde_json::to_value(&component).map_err(|error| {
-                homeboy::core::Error::validation_invalid_argument(
-                    "component",
-                    "Failed to serialize component",
-                    Some(error.to_string()),
-                    None,
-                )
-            })?;
-            if let Value::Object(ref mut map) = value {
-                map.insert("id".to_string(), Value::String(component.id.clone()));
-                // Always surface remote_owner so missing config is visible (#602).
-                // Serde skips None fields, but for list output we want explicit null
-                // so users can audit which components are missing this critical config.
-                map.entry("remote_owner".to_string()).or_insert(Value::Null);
-            }
-            Ok(value)
-        })
+        .map(|component| component_discovery_value(&component, None))
         .collect::<homeboy::core::Result<Vec<Value>>>()?;
 
     Ok((
@@ -1038,6 +1001,87 @@ fn list() -> CmdResult<ComponentOutput> {
         },
         0,
     ))
+}
+
+fn component_discovery_value(
+    component: &Component,
+    drift_files: Option<Vec<String>>,
+) -> homeboy::core::Result<Value> {
+    let mut value = serde_json::to_value(component).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "component",
+            "Failed to serialize component",
+            Some(error.to_string()),
+            None,
+        )
+    })?;
+    if let Value::Object(ref mut map) = value {
+        map.insert("id".to_string(), Value::String(component.id.clone()));
+        // Always surface remote_owner so missing config is visible (#602).
+        map.entry("remote_owner".to_string()).or_insert(Value::Null);
+        summarize_large_component_metadata(map);
+        if let Some(drift_files) = drift_files {
+            // Computed: extension-declared lockfiles + component extras + the
+            // audit baseline. Consumed by homeboy-action to scope direct-push drift.
+            map.insert(
+                "drift_files".to_string(),
+                Value::Array(drift_files.into_iter().map(Value::String).collect()),
+            );
+        }
+    }
+    Ok(value)
+}
+
+fn summarize_large_component_metadata(map: &mut serde_json::Map<String, Value>) {
+    let baselines = map.remove("baselines");
+    let audit_rules = map.remove("audit_rules");
+    let mut summary = serde_json::Map::new();
+
+    if let Some(Value::Object(baselines)) = baselines {
+        summary.insert(
+            "baseline_keys".to_string(),
+            Value::Array(baselines.keys().cloned().map(Value::String).collect()),
+        );
+        if let Some(audit) = baselines.get("audit") {
+            summary.insert("audit_baseline".to_string(), audit_baseline_summary(audit));
+        }
+    }
+
+    if let Some(audit_rules) = audit_rules {
+        summary.insert("audit_rules".to_string(), value_shape_summary(&audit_rules));
+    }
+
+    if !summary.is_empty() {
+        map.insert("metadata_summary".to_string(), Value::Object(summary));
+    }
+}
+
+fn audit_baseline_summary(value: &Value) -> Value {
+    let mut summary = serde_json::Map::new();
+    if let Some(object) = value.as_object() {
+        for (key, value) in object {
+            if key == "known_fingerprints" {
+                summary.insert(
+                    "known_fingerprints_count".to_string(),
+                    Value::from(value.as_array().map_or(0, Vec::len)),
+                );
+            } else {
+                summary.insert(key.clone(), value_shape_summary(value));
+            }
+        }
+    }
+    Value::Object(summary)
+}
+
+fn value_shape_summary(value: &Value) -> Value {
+    match value {
+        Value::Array(items) => serde_json::json!({ "type": "array", "count": items.len() }),
+        Value::Object(object) => serde_json::json!({
+            "type": "object",
+            "keys": object.keys().cloned().collect::<Vec<_>>()
+        }),
+        _ => value.clone(),
+    }
 }
 
 fn projects(id: &str) -> CmdResult<ComponentOutput> {
@@ -1236,6 +1280,40 @@ mod tests {
 
         assert!(err.message.contains("unsupported legacy build_command"));
         assert!(err.message.contains("Use scripts.build instead"));
+    }
+
+    #[test]
+    fn component_discovery_value_summarizes_large_metadata() {
+        let mut component = Component::new(
+            "homeboy".to_string(),
+            "/repo/homeboy".to_string(),
+            "wp-content/plugins/homeboy".to_string(),
+            None,
+        );
+        component.baselines = Some(std::collections::HashMap::from([(
+            "audit".to_string(),
+            serde_json::json!({
+                "known_fingerprints": ["a", "b", "c"],
+                "item_count": 3
+            }),
+        )]));
+        component.audit_rules = Some(serde_json::json!({
+            "layer_rules": [{"id":"one"}],
+            "source_policies": [{"id":"two"}]
+        }));
+
+        let value = component_discovery_value(&component, None).expect("discovery value");
+
+        assert!(value.get("baselines").is_none());
+        assert!(value.get("audit_rules").is_none());
+        assert_eq!(
+            value["metadata_summary"]["audit_baseline"]["known_fingerprints_count"],
+            3
+        );
+        assert_eq!(
+            value["metadata_summary"]["baseline_keys"],
+            serde_json::json!(["audit"])
+        );
     }
 
     #[test]

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -974,6 +974,7 @@ mod tests {
             files: 3,
             bytes: 12,
             excludes: Vec::new(),
+            includes: Vec::new(),
         };
         let git = RunnerWorkspaceSyncOutput {
             command: "runner.workspace.sync",
@@ -985,6 +986,7 @@ mod tests {
             files: 0,
             bytes: 0,
             excludes: Vec::new(),
+            includes: Vec::new(),
         };
 
         let entries = vec![

--- a/src/core/runner/lab_args.rs
+++ b/src/core/runner/lab_args.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use serde_json::Value;
 
 use crate::core::config::read_json_spec_to_string;
+use crate::core::worktree;
 use crate::core::{Error, Result};
 
 pub(super) const EXPLICIT_PASSTHROUGH_SENTINEL: &str = "__homeboy_explicit_passthrough__";
@@ -145,11 +146,25 @@ pub(super) fn lab_offload_source_path(args: &[String]) -> Result<PathBuf> {
             })?;
             return Ok(PathBuf::from(shellexpand::tilde(value).to_string()));
         }
+        if arg == "--to-worktree" {
+            let value = iter.next().ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "to_worktree",
+                    "--to-worktree requires a value before Lab offload can sync the target worktree",
+                    None,
+                    None,
+                )
+            })?;
+            return worktree::resolve(value).map(|record| PathBuf::from(record.worktree_path));
+        }
         if let Some(value) = arg.strip_prefix("--path=") {
             return Ok(PathBuf::from(shellexpand::tilde(value).to_string()));
         }
         if let Some(value) = arg.strip_prefix("--cwd=") {
             return Ok(PathBuf::from(shellexpand::tilde(value).to_string()));
+        }
+        if let Some(value) = arg.strip_prefix("--to-worktree=") {
+            return worktree::resolve(value).map(|record| PathBuf::from(record.worktree_path));
         }
     }
 
@@ -231,6 +246,50 @@ mod tests {
             lab_offload_source_path(&args).expect("source path"),
             PathBuf::from("/Users/chubes/Developer/wp-site-generator")
         );
+    }
+
+    #[test]
+    fn lab_source_path_uses_agent_task_loop_to_worktree() {
+        crate::test_support::with_isolated_home(|home| {
+            let store = crate::core::paths::homeboy_data()
+                .expect("homeboy data")
+                .join("task-worktrees");
+            std::fs::create_dir_all(&store).expect("worktree store");
+            let worktree_path = home.path().join("homeboy@smoke");
+            std::fs::create_dir_all(&worktree_path).expect("worktree path");
+            std::fs::write(
+                store.join("homeboy_smoke.json"),
+                serde_json::json!({
+                    "id": "homeboy@smoke",
+                    "component_id": "homeboy",
+                    "source_checkout": home.path().join("homeboy").display().to_string(),
+                    "worktree_path": worktree_path.display().to_string(),
+                    "branch": "smoke",
+                    "base_ref": "HEAD",
+                    "cleanup_policy": "preserve_on_failure",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "state": "active"
+                })
+                .to_string(),
+            )
+            .expect("worktree record");
+            let args = vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "loop".to_string(),
+                "--to-worktree".to_string(),
+                "homeboy@smoke".to_string(),
+                "--verify".to_string(),
+                "true".to_string(),
+                "--prompt".to_string(),
+                "cook".to_string(),
+            ];
+
+            assert_eq!(
+                lab_offload_source_path(&args).expect("source path"),
+                worktree_path
+            );
+        });
     }
 
     #[test]

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -75,6 +75,7 @@ pub struct RunnerWorkspaceSyncOutput {
     pub files: usize,
     pub bytes: u64,
     pub excludes: Vec<String>,
+    pub includes: Vec<String>,
 }
 
 pub fn sync_workspace(
@@ -104,15 +105,17 @@ pub fn sync_workspace(
             excludes.push(pattern.clone());
         }
     }
+    let includes = runner.policy.snapshot_includes.clone();
+    let excludes = effective_snapshot_excludes(excludes, &includes);
 
     match options.mode {
         RunnerWorkspaceSyncMode::Snapshot => {
-            let snapshot = snapshot_identity(&local_path, &excludes)?;
+            let snapshot = snapshot_identity(&local_path, &excludes, &includes)?;
             let remote_path = temp::unique_name(
                 &deterministic_remote_path(workspace_root, &local_path, &snapshot),
                 "",
             );
-            let stats = local_snapshot_stats(&local_path, &excludes)?;
+            let stats = local_snapshot_stats(&local_path, &excludes, &includes)?;
             materialize_snapshot(&runner, &local_path, &remote_path, &excludes)?;
             super::validation_dependencies::sync_validation_dependency_workspaces(
                 &runner,
@@ -131,6 +134,7 @@ pub fn sync_workspace(
                     files: stats.files,
                     bytes: stats.bytes,
                     excludes,
+                    includes,
                 },
                 0,
             ))
@@ -168,6 +172,7 @@ pub fn sync_workspace(
                     files: 0,
                     bytes: 0,
                     excludes,
+                    includes,
                 },
                 0,
             ))
@@ -231,7 +236,11 @@ fn deterministic_remote_path(workspace_root: &str, local_path: &Path, snapshot: 
     )
 }
 
-fn snapshot_identity(local_path: &Path, excludes: &[String]) -> Result<String> {
+fn snapshot_identity(
+    local_path: &Path,
+    excludes: &[String],
+    includes: &[String],
+) -> Result<String> {
     let head =
         git_output(local_path, &["rev-parse", "HEAD"]).unwrap_or_else(|_| "nogit".to_string());
     let status = git_output(local_path, &["status", "--porcelain=v1"])
@@ -245,7 +254,7 @@ fn snapshot_identity(local_path: &Path, excludes: &[String]) -> Result<String> {
     hasher.update(status.as_bytes());
     hasher.update(diff.as_bytes());
     hasher.update(staged.as_bytes());
-    hash_snapshot_tree(local_path, local_path, excludes, &mut hasher)?;
+    hash_snapshot_tree(local_path, local_path, excludes, includes, &mut hasher)?;
     Ok(format!("snapshot:{}", hex_prefix(&hasher.finalize(), 16)))
 }
 
@@ -308,9 +317,13 @@ pub(super) fn git_output(local_path: &Path, args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-fn local_snapshot_stats(path: &Path, excludes: &[String]) -> Result<SnapshotStats> {
+fn local_snapshot_stats(
+    path: &Path,
+    excludes: &[String],
+    includes: &[String],
+) -> Result<SnapshotStats> {
     let mut stats = SnapshotStats { files: 0, bytes: 0 };
-    collect_stats(path, path, excludes, &mut stats)?;
+    collect_stats(path, path, excludes, includes, &mut stats)?;
     Ok(stats)
 }
 
@@ -318,6 +331,7 @@ fn hash_snapshot_tree(
     root: &Path,
     path: &Path,
     excludes: &[String],
+    includes: &[String],
     hasher: &mut Sha256,
 ) -> Result<()> {
     let mut entries = fs::read_dir(path)
@@ -335,7 +349,7 @@ fn hash_snapshot_tree(
 
     for entry in entries {
         let entry_path = entry.path();
-        if is_excluded(root, &entry_path, excludes) {
+        if is_excluded(root, &entry_path, excludes, includes) {
             continue;
         }
         let metadata = entry.metadata().map_err(|err| {
@@ -348,7 +362,7 @@ fn hash_snapshot_tree(
         hasher.update(rel.as_bytes());
         if metadata.is_dir() {
             hasher.update(b"/dir");
-            hash_snapshot_tree(root, &entry_path, excludes, hasher)?;
+            hash_snapshot_tree(root, &entry_path, excludes, includes, hasher)?;
         } else if metadata.is_file() {
             hasher.update(b"/file");
             hasher.update(metadata.len().to_le_bytes());
@@ -365,6 +379,7 @@ fn collect_stats(
     root: &Path,
     path: &Path,
     excludes: &[String],
+    includes: &[String],
     stats: &mut SnapshotStats,
 ) -> Result<()> {
     for entry in fs::read_dir(path).map_err(|err| {
@@ -377,14 +392,14 @@ fn collect_stats(
             )
         })?;
         let entry_path = entry.path();
-        if is_excluded(root, &entry_path, excludes) {
+        if is_excluded(root, &entry_path, excludes, includes) {
             continue;
         }
         let metadata = entry.metadata().map_err(|err| {
             Error::internal_io(err.to_string(), Some("read sync file metadata".to_string()))
         })?;
         if metadata.is_dir() {
-            collect_stats(root, &entry_path, excludes, stats)?;
+            collect_stats(root, &entry_path, excludes, includes, stats)?;
         } else if metadata.is_file() {
             stats.files += 1;
             stats.bytes = stats.bytes.saturating_add(metadata.len());
@@ -393,13 +408,18 @@ fn collect_stats(
     Ok(())
 }
 
-fn is_excluded(root: &Path, path: &Path, excludes: &[String]) -> bool {
+fn is_excluded(root: &Path, path: &Path, excludes: &[String], includes: &[String]) -> bool {
     let rel = path.strip_prefix(root).unwrap_or(path).to_string_lossy();
     let rel = rel.trim_start_matches('/');
     let name = path
         .file_name()
         .and_then(|value| value.to_str())
         .unwrap_or("");
+    if includes.iter().any(|pattern| {
+        pattern == rel || pattern == name || glob_match(pattern, rel) || glob_match(pattern, name)
+    }) {
+        return false;
+    }
     excludes.iter().any(|pattern| {
         pattern == rel || pattern == name || glob_match(pattern, rel) || glob_match(pattern, name)
     })
@@ -484,6 +504,34 @@ fn materialize_snapshot_piped(
         target_command = target_command,
     );
     run_shell_command(&command, action)
+}
+
+fn effective_snapshot_excludes(excludes: Vec<String>, includes: &[String]) -> Vec<String> {
+    if includes.is_empty() {
+        return excludes;
+    }
+
+    excludes
+        .into_iter()
+        .filter(|exclude| !includes_override_exclude(includes, exclude))
+        .collect()
+}
+
+fn includes_override_exclude(includes: &[String], exclude: &str) -> bool {
+    let excluded_name = exclude
+        .trim_start_matches("./")
+        .trim_end_matches("/**")
+        .trim_end_matches('/');
+    if excluded_name.is_empty() || excluded_name.contains('*') || excluded_name.contains('/') {
+        return false;
+    }
+
+    includes.iter().any(|include| {
+        include
+            .trim_start_matches("./")
+            .split('/')
+            .any(|segment| segment == excluded_name)
+    })
 }
 
 fn snapshot_install_command(remote_path: &str) -> String {
@@ -679,29 +727,81 @@ mod tests {
         assert!(is_excluded(
             root,
             Path::new("/repo/node_modules/pkg/index.js"),
-            &excludes
+            &excludes,
+            &[]
         ));
-        assert!(is_excluded(root, Path::new("/repo/.env.local"), &excludes));
+        assert!(is_excluded(
+            root,
+            Path::new("/repo/.env.local"),
+            &excludes,
+            &[]
+        ));
         assert!(is_excluded(
             root,
             Path::new("/repo/target/debug/homeboy"),
-            &excludes
+            &excludes,
+            &[]
         ));
         assert!(is_excluded(
             root,
             Path::new("/repo/src/__tests__/._index.js"),
-            &excludes
+            &excludes,
+            &[]
         ));
         assert!(!is_excluded(
             root,
             Path::new("/repo/src/main.rs"),
-            &excludes
+            &excludes,
+            &[]
         ));
         assert!(!is_excluded(
             root,
             Path::new("/repo/vendor/autoload.php"),
-            &excludes
+            &excludes,
+            &[]
         ));
+    }
+
+    #[test]
+    fn runner_snapshot_includes_override_generated_output_excludes() {
+        crate::test_support::with_isolated_home(|_| {
+            let source = tempfile::tempdir().expect("source tempdir");
+            let runner_root = tempfile::tempdir().expect("runner root tempdir");
+            fs::create_dir_all(source.path().join("packages/cli/dist")).expect("dist dir");
+            fs::write(
+                source.path().join("packages/cli/dist/homeboy.js"),
+                "built\n",
+            )
+            .expect("built output");
+
+            super::super::create(
+                &format!(
+                    r#"{{"id":"lab-local-includes","kind":"local","workspace_root":"{}","policy":{{"snapshot_includes":["packages/cli/dist","packages/cli/dist/**"]}}}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+
+            let (output, exit_code) = sync_workspace(
+                "lab-local-includes",
+                RunnerWorkspaceSyncOptions {
+                    path: source.path().display().to_string(),
+                    mode: RunnerWorkspaceSyncMode::Snapshot,
+                    changed_since_base: None,
+                },
+            )
+            .expect("sync workspace");
+
+            assert_eq!(exit_code, 0);
+            assert!(output
+                .includes
+                .contains(&"packages/cli/dist/**".to_string()));
+            assert!(!output.excludes.contains(&"dist".to_string()));
+            assert!(Path::new(&output.remote_path)
+                .join("packages/cli/dist/homeboy.js")
+                .exists());
+        });
     }
 
     #[test]

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -86,6 +86,8 @@ pub struct RunnerPolicy {
     pub artifact_policy: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub snapshot_excludes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub snapshot_includes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -112,6 +114,7 @@ impl RunnerPolicy {
             && self.workspace_roots.is_empty()
             && self.artifact_policy.is_none()
             && self.snapshot_excludes.is_empty()
+            && self.snapshot_includes.is_empty()
     }
 }
 


### PR DESCRIPTION
## Summary
- Allows `agent-task loop` smoke runs to stop after green verification with `--no-finalize`, avoiding commit/push/PR side effects.
- Infers Lab offload source paths from `--to-worktree` so loop offload syncs the managed target checkout.
- Adds explicit runner `policy.snapshot_includes` support and compact component discovery metadata to avoid missing built artifacts and noisy baseline payloads.

Fixes #3820.
Fixes #3821.
Fixes #3822.
Fixes #3823.
Fixes #3824.

## Testing
- `cargo test runner::workspace::tests::runner_snapshot_includes_override_generated_output_excludes`
- `cargo test runner::lab_args::tests::lab_source_path_uses_agent_task_loop_to_worktree`
- `cargo test agent_task::tests::loop_returns_durable_id_when_promotion_provider_is_missing`
- `cargo test component::tests::component_show_rejects_legacy_build_command`
- `cargo test component::tests::component_discovery_value_summarizes_large_metadata`
- `cargo test cli_surface::tests::test_supports_lab_runner`
- `cargo test cli_surface::tests::test_lab_command_contracts_cover_hot_commands`
- `cargo run --bin homeboy -- agent-task loop --help`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted implementation and targeted regression tests; Chris reviews and owns the change.