### PR TITLE
refactor: normalize gate result plumbing

### DIFF
--- a/src/core/agent_task_finalization.rs
+++ b/src/core/agent_task_finalization.rs
@@ -317,9 +317,8 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     options: AgentTaskPrFinalizationOptions,
     backend: &mut B,
 ) -> Result<AgentTaskPrFinalizationReport> {
-    let normalized_gate_results = normalized_finalization_gates(&options);
-    validate_green_gates(&normalized_gate_results)?;
-    let proof = build_finalization_proof(&options, normalized_gate_results.clone());
+    validate_green_gates(&options.normalized_gate_results)?;
+    let proof = build_finalization_proof(&options, options.normalized_gate_results.clone());
     let head = options
         .head
         .clone()
@@ -403,21 +402,6 @@ fn validate_green_gates(gates: &[HomeboyGateResult]) -> Result<()> {
     Ok(())
 }
 
-fn normalized_finalization_gates(
-    options: &AgentTaskPrFinalizationOptions,
-) -> Vec<HomeboyGateResult> {
-    if !options.normalized_gate_results.is_empty() {
-        return options.normalized_gate_results.clone();
-    }
-
-    options
-        .gate_results
-        .iter()
-        .cloned()
-        .map(HomeboyGateResult::from)
-        .collect()
-}
-
 fn is_green_status(status: &str) -> bool {
     matches!(
         status.trim().to_ascii_lowercase().as_str(),
@@ -489,7 +473,7 @@ fn report(
     changed_files: Vec<String>,
     proof: Option<HomeboyProof>,
 ) -> AgentTaskPrFinalizationReport {
-    let normalized_gate_results = normalized_finalization_gates(options);
+    let normalized_gate_results = options.normalized_gate_results.clone();
     let proof =
         proof.unwrap_or_else(|| build_finalization_proof(options, normalized_gate_results.clone()));
     AgentTaskPrFinalizationReport {
@@ -836,6 +820,8 @@ mod tests {
         };
         let mut options = options();
         options.gate_results[0].status = "failed".to_string();
+        options.normalized_gate_results[0] =
+            HomeboyGateResult::from(options.gate_results[0].clone());
 
         let error = finalize_pr_with_backend(options, &mut backend).expect_err("blocked");
 
@@ -844,6 +830,17 @@ mod tests {
     }
 
     fn options() -> AgentTaskPrFinalizationOptions {
+        let gate_results = vec![AgentTaskGateResult {
+            name: "focused project check".to_string(),
+            status: "passed".to_string(),
+            detail: Some("targeted".to_string()),
+        }];
+        let normalized_gate_results = gate_results
+            .iter()
+            .cloned()
+            .map(HomeboyGateResult::from)
+            .collect();
+
         AgentTaskPrFinalizationOptions {
             path: "/repo".to_string(),
             run_id: "cook-3678".to_string(),
@@ -851,12 +848,8 @@ mod tests {
             head: None,
             title: "Cook issue #3678".to_string(),
             commit_message: "finalize cook loop PR plumbing".to_string(),
-            gate_results: vec![AgentTaskGateResult {
-                name: "focused project check".to_string(),
-                status: "passed".to_string(),
-                detail: Some("targeted".to_string()),
-            }],
-            normalized_gate_results: Vec::new(),
+            gate_results,
+            normalized_gate_results,
             changed_files: Vec::new(),
             evidence: AgentTaskPrEvidence {
                 source_refs: vec!["https://github.com/Extra-Chill/homeboy/issues/3678".to_string()],

--- a/src/core/agent_task_gate.rs
+++ b/src/core/agent_task_gate.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 use std::process::Command;
 
-use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -14,6 +13,9 @@ use crate::core::{Error, Result};
 
 pub const AGENT_TASK_GATE_REPORT_SCHEMA: &str = "homeboy/agent-task-gate-report/v1";
 const TASK_AFFECTING_ENV_VARS: &[&str] = &["STUDIO_RUNTIME"];
+
+pub type AgentTaskGateVisibility = HomeboyGateVisibility;
+pub type AgentTaskGateRevealPolicy = HomeboyGateRevealPolicy;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskGateReport {
@@ -57,24 +59,6 @@ impl AgentTaskGateEnvironment {
     fn is_empty(&self) -> bool {
         self.inherited.is_empty() && self.sanitized.is_empty()
     }
-}
-
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
-#[serde(rename_all = "snake_case")]
-pub enum AgentTaskGateVisibility {
-    #[default]
-    Visible,
-    Private,
-}
-
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
-#[serde(rename_all = "snake_case")]
-pub enum AgentTaskGateRevealPolicy {
-    #[default]
-    FullEvidence,
-    SummaryOnly,
-    Redacted,
-    NoDetail,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -123,8 +107,8 @@ impl AgentTaskGateReport {
                 AgentTaskGateStatus::Failed => HomeboyGateStatus::Failed,
             },
         )
-        .visibility(visibility.into())
-        .reveal_policy(reveal_policy.into())
+        .visibility(visibility)
+        .reveal_policy(reveal_policy)
         .retryable(status == AgentTaskGateStatus::Failed);
         let step = PlanStep::builder(
             id.clone(),
@@ -288,8 +272,8 @@ impl From<AgentTaskGateReport> for HomeboyGateResult {
         )
         .summary(summary)
         .evidence(evidence)
-        .visibility(report.visibility.into())
-        .reveal_policy(report.reveal_policy.into())
+        .visibility(report.visibility)
+        .reveal_policy(report.reveal_policy)
         .retryable(status == HomeboyGateStatus::Failed)
         .agent_feedback(agent_feedback)
         .provenance(json!({
@@ -386,26 +370,6 @@ fn gate_result_evidence(report: &AgentTaskGateReport) -> serde_json::Value {
         "failure_evidence": report.failure_evidence,
         "environment": report.environment,
     })
-}
-
-impl From<AgentTaskGateVisibility> for HomeboyGateVisibility {
-    fn from(visibility: AgentTaskGateVisibility) -> Self {
-        match visibility {
-            AgentTaskGateVisibility::Visible => Self::Visible,
-            AgentTaskGateVisibility::Private => Self::Private,
-        }
-    }
-}
-
-impl From<AgentTaskGateRevealPolicy> for HomeboyGateRevealPolicy {
-    fn from(reveal_policy: AgentTaskGateRevealPolicy) -> Self {
-        match reveal_policy {
-            AgentTaskGateRevealPolicy::FullEvidence => Self::FullEvidence,
-            AgentTaskGateRevealPolicy::SummaryOnly => Self::SummaryOnly,
-            AgentTaskGateRevealPolicy::Redacted => Self::Redacted,
-            AgentTaskGateRevealPolicy::NoDetail => Self::NoDetail,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/core/extension/bench/gate.rs
+++ b/src/core/extension/bench/gate.rs
@@ -203,92 +203,9 @@ fn normalized_gate_result_for_scenario(
     }))
 }
 
-impl From<BenchGateResult> for HomeboyGateResult {
-    fn from(result: BenchGateResult) -> Self {
-        let status = if result.passed {
-            HomeboyGateStatus::Passed
-        } else {
-            HomeboyGateStatus::Failed
-        };
-        let summary = result.reason.clone().unwrap_or_else(|| {
-            format!(
-                "metric gate passed: {} {} {}",
-                result.metric,
-                result.op.as_str(),
-                result.expected
-            )
-        });
-
-        HomeboyGateResult::new(
-            format!("bench.gate.{}", result.metric),
-            result.metric.clone(),
-            HomeboyGateKind::Metric,
-            status,
-        )
-        .summary(summary)
-        .evidence(json!({
-            "metric": result.metric,
-            "op": result.op,
-            "expected": result.expected,
-            "actual": result.actual,
-            "passed": result.passed,
-            "reason": result.reason,
-        }))
-        .retryable(status == HomeboyGateStatus::Failed)
-        .provenance(json!({
-            "source_type": "BenchGateResult",
-        }))
-    }
-}
-
 #[cfg(test)]
 mod normalization_tests {
     use super::*;
-    use crate::core::gate::HOMEBOY_GATE_RESULT_SCHEMA;
-
-    #[test]
-    fn bench_gate_result_normalizes_to_homeboy_gate_result() {
-        let result: HomeboyGateResult = BenchGateResult {
-            metric: "p95_ms".to_string(),
-            op: BenchGateOp::Lte,
-            expected: 120.0,
-            actual: Some(140.0),
-            passed: false,
-            reason: Some(
-                "scenario `homepage` gate failed: p95_ms lte 120 (actual 140)".to_string(),
-            ),
-        }
-        .into();
-
-        assert_eq!(result.schema, HOMEBOY_GATE_RESULT_SCHEMA);
-        assert_eq!(result.id, "bench.gate.p95_ms");
-        assert_eq!(result.kind, HomeboyGateKind::Metric);
-        assert_eq!(result.status, HomeboyGateStatus::Failed);
-        assert_eq!(result.retryable, Some(true));
-        assert_eq!(result.evidence["metric"], "p95_ms");
-        assert_eq!(result.evidence["actual"], 140.0);
-        assert_eq!(result.provenance["source_type"], "BenchGateResult");
-    }
-
-    #[test]
-    fn successful_bench_gate_result_normalizes_to_passed_gate_result() {
-        let result: HomeboyGateResult = BenchGateResult {
-            metric: "success_rate".to_string(),
-            op: BenchGateOp::Gte,
-            expected: 1.0,
-            actual: Some(1.0),
-            passed: true,
-            reason: None,
-        }
-        .into();
-
-        assert_eq!(result.id, "bench.gate.success_rate");
-        assert_eq!(result.kind, HomeboyGateKind::Metric);
-        assert_eq!(result.status, HomeboyGateStatus::Passed);
-        assert_eq!(result.retryable, Some(false));
-        assert_eq!(result.evidence["passed"], true);
-        assert!(result.summary.contains("metric gate passed"));
-    }
 
     #[test]
     fn normalized_gate_results_are_scenario_scoped_and_agent_actionable() {

--- a/src/core/gate.rs
+++ b/src/core/gate.rs
@@ -1,3 +1,4 @@
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -52,7 +53,7 @@ pub enum HomeboyGateStatus {
     Blocked,
 }
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum HomeboyGateVisibility {
     #[default]
@@ -60,7 +61,7 @@ pub enum HomeboyGateVisibility {
     Private,
 }
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum HomeboyGateRevealPolicy {
     #[default]


### PR DESCRIPTION
## Summary
- Use the generic Homeboy gate visibility/reveal enums as the agent-task gate source of truth while preserving existing agent-task type names as aliases.
- Remove the scenario-less bench `BenchGateResult -> HomeboyGateResult` conversion so bench gates stay scenario-scoped.
- Make PR finalization consume normalized gate results directly instead of falling back from legacy gate strings internally.

## Testing
- `cargo fmt --check`
- `cargo test agent_task_gate`
- `cargo test finalization`
- `cargo test normalized_gate_results`
- `cargo test output_contracts`
- `cargo test command_surface`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Audited gate/proof seams, drafted the cleanup refactor and targeted tests; Chris remains responsible for review and acceptance.