### PR TITLE
chore: format lab workspace code

### DIFF
--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -185,7 +185,10 @@ pub(super) fn provider_config_extra_workspaces(
             continue;
         }
         if !seen.insert(canon.clone()) {
-            if let Some(existing) = workspaces.iter_mut().find(|workspace| workspace.path == canon) {
+            if let Some(existing) = workspaces
+                .iter_mut()
+                .find(|workspace| workspace.path == canon)
+            {
                 for include in snapshot_includes {
                     if !existing.snapshot_includes.contains(&include) {
                         existing.snapshot_includes.push(include);


### PR DESCRIPTION
## Summary
- Format `lab_workspaces.rs` so `cargo fmt --check` passes on `main`.
- Unblocks differential CI baseline runs that checkout `main` before comparing candidate branches.

## Testing
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identifying the CI baseline formatting blocker and preparing the minimal rustfmt-only PR; Chris remains responsible for review and merge.