### PR TITLE
Add bench phase memory attribution

### DIFF
--- a/src/core/engine/resource.rs
+++ b/src/core/engine/resource.rs
@@ -48,6 +48,8 @@ pub struct ChildProcessIdentity {
 pub struct ExtensionChildResourceSummary {
     #[serde(flatten)]
     pub child: ChildProcessIdentity,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
     pub started_at: String,
     pub finished_at: String,
     pub duration_ms: u128,
@@ -67,6 +69,8 @@ pub struct ExtensionChildResourceSample {
     pub elapsed_ms: u128,
     pub timestamp: String,
     pub root_pid: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
     pub rss_bytes: u64,
     pub cpu_percent: f64,
     pub child_count: usize,
@@ -220,7 +224,7 @@ pub fn record_extension_child_resource(
     })
 }
 
-fn read_extension_child_resources(run_dir: &RunDir) -> Vec<ExtensionChildResourceSummary> {
+pub fn read_extension_child_resources(run_dir: &RunDir) -> Vec<ExtensionChildResourceSummary> {
     let dir = run_dir.step_file(run_dir::files::EXTENSION_CHILDREN_DIR);
     let mut summaries = Vec::new();
 
@@ -420,6 +424,7 @@ mod tests {
                         root_pid: 99,
                         command_label: "runner".to_string(),
                     },
+                    phase: None,
                     started_at: Utc::now().to_rfc3339(),
                     finished_at: Utc::now().to_rfc3339(),
                     duration_ms: 10,
@@ -478,6 +483,7 @@ mod tests {
                     root_pid: 123,
                     command_label: "extension-runner".to_string(),
                 },
+                phase: Some("install".to_string()),
                 started_at: "2026-04-30T00:00:00+00:00".to_string(),
                 finished_at: "2026-04-30T00:00:00.100+00:00".to_string(),
                 duration_ms: 100,
@@ -496,6 +502,10 @@ mod tests {
                 .expect("write resource summary");
 
             assert_eq!(summary.extension_children, vec![child]);
+            assert_eq!(
+                summary.extension_children[0].phase.as_deref(),
+                Some("install")
+            );
             let output = run_dir
                 .read_step_output(run_dir::files::RESOURCE_SUMMARY)
                 .expect("resource summary json");

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use crate::core::component::Component;
 use crate::core::engine::baseline::BaselineFlags;
 use crate::core::engine::invocation::InvocationRequirements;
-use crate::core::engine::resource::ExtensionChildResourceSummary;
+use crate::core::engine::resource::{self, ExtensionChildResourceSummary};
 use crate::core::engine::run_dir::{self, RunDir};
 use crate::core::error::{Error, Result};
 use crate::core::extension::bench::aggregate_runs;
@@ -1422,6 +1422,32 @@ fn attach_memory_timeline_artifacts(
     results
         .metadata
         .insert("memory_timeline".to_string(), memory_metadata);
+
+    let phase_resources = phase_child_resources(run_dir);
+    let phase_memory = if phase_resources.is_empty() {
+        None
+    } else {
+        Some(preserve_phase_memory_timeline_artifacts(
+            &phase_resources,
+            run_dir,
+            suffix,
+        )?)
+    };
+    let phase_metrics = phase_memory
+        .as_ref()
+        .map(|phase_memory| phase_memory.metrics.clone())
+        .unwrap_or_default();
+    if let Some(phase_memory) = phase_memory.as_ref() {
+        results.metadata.insert(
+            "phase_memory".to_string(),
+            serde_json::json!({
+                "phases": phase_memory.phases,
+                "timeline_json": phase_memory.json_filename,
+                "timeline_csv": phase_memory.csv_filename,
+                "sample_count": phase_memory.sample_count,
+            }),
+        );
+    }
     results
         .metric_groups
         .entry("memory".to_string())
@@ -1432,6 +1458,11 @@ fn attach_memory_timeline_artifacts(
             ("sample_count".to_string(), sample_count as f64),
             ("peak_at_ms".to_string(), peak_at_ms as f64),
         ]);
+    results
+        .metric_groups
+        .entry("memory".to_string())
+        .or_default()
+        .extend(phase_metrics.clone());
 
     for scenario in &mut results.scenarios {
         scenario
@@ -1446,6 +1477,7 @@ fn attach_memory_timeline_artifacts(
             .metrics
             .values
             .insert("memory_sample_count".to_string(), sample_count as f64);
+        scenario.metrics.values.extend(phase_metrics.clone());
         scenario.artifacts.insert(
             "memory_timeline_json".to_string(),
             BenchArtifact {
@@ -1466,9 +1498,137 @@ fn attach_memory_timeline_artifacts(
                 ..BenchArtifact::default()
             },
         );
+        if let Some(phase_memory) = phase_memory.as_ref() {
+            scenario.artifacts.insert(
+                "phase_memory_timeline_json".to_string(),
+                BenchArtifact {
+                    path: Some(phase_memory.json_filename.clone()),
+                    artifact_type: Some("file".to_string()),
+                    kind: Some("bench_memory_timeline".to_string()),
+                    label: Some("Bench phase memory timeline (JSON)".to_string()),
+                    ..BenchArtifact::default()
+                },
+            );
+            scenario.artifacts.insert(
+                "phase_memory_timeline_csv".to_string(),
+                BenchArtifact {
+                    path: Some(phase_memory.csv_filename.clone()),
+                    artifact_type: Some("file".to_string()),
+                    kind: Some("bench_memory_timeline".to_string()),
+                    label: Some("Bench phase memory timeline (CSV)".to_string()),
+                    ..BenchArtifact::default()
+                },
+            );
+        }
     }
 
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct PhaseMemoryArtifacts {
+    json_filename: String,
+    csv_filename: String,
+    phases: BTreeMap<String, serde_json::Value>,
+    metrics: BTreeMap<String, f64>,
+    sample_count: usize,
+}
+
+fn phase_child_resources(run_dir: &RunDir) -> Vec<ExtensionChildResourceSummary> {
+    resource::read_extension_child_resources(run_dir)
+        .into_iter()
+        .filter(|summary| {
+            summary
+                .phase
+                .as_deref()
+                .is_some_and(|phase| !phase.is_empty())
+        })
+        .collect()
+}
+
+fn preserve_phase_memory_timeline_artifacts(
+    phase_resources: &[ExtensionChildResourceSummary],
+    run_dir: &RunDir,
+    suffix: Option<&str>,
+) -> Result<PhaseMemoryArtifacts> {
+    let artifact_stem = match suffix {
+        Some(suffix) => format!("bench-memory-timeline-phases-{suffix}"),
+        None => "bench-memory-timeline-phases".to_string(),
+    };
+    let json_filename = format!("{artifact_stem}.json");
+    let csv_filename = format!("{artifact_stem}.csv");
+    let json_path = run_dir.step_file(&json_filename);
+    let csv_path = run_dir.step_file(&csv_filename);
+
+    let mut phases = BTreeMap::new();
+    let mut metrics = BTreeMap::new();
+    let mut sample_count = 0;
+    for resource in phase_resources {
+        let Some(phase) = resource.phase.as_deref().filter(|phase| !phase.is_empty()) else {
+            continue;
+        };
+        let peak_rss_bytes = resource.sampled_peak_rss_bytes.unwrap_or(0);
+        let peak_rss_mb = bytes_to_mb(peak_rss_bytes);
+        sample_count += resource.samples.len();
+        phases.insert(
+            phase.to_string(),
+            serde_json::json!({
+                "peak_rss_bytes": peak_rss_bytes,
+                "peak_rss_mb": peak_rss_mb,
+                "peak_at_ms": resource.sampled_peak_at_ms.unwrap_or(0),
+                "peak_child_count": resource.sampled_peak_child_count.unwrap_or(0),
+                "sample_count": resource.samples.len(),
+                "root_pid": resource.child.root_pid,
+                "command_label": resource.child.command_label,
+            }),
+        );
+        metrics.insert(
+            format!("peak_{}_rss_mb", metric_phase_slug(phase)),
+            peak_rss_mb,
+        );
+    }
+
+    let json = serde_json::to_vec_pretty(&serde_json::json!({
+        "schema": "homeboy/bench-memory-timeline/v1",
+        "phases": phases.clone(),
+        "sample_count": sample_count,
+        "resources": phase_resources,
+    }))
+    .map_err(|e| {
+        Error::internal_json(
+            e.to_string(),
+            Some("serialize bench phase memory timeline".to_string()),
+        )
+    })?;
+    fs::write(&json_path, json).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to write bench phase memory timeline {}: {}",
+                json_path.display(),
+                e
+            ),
+            Some("bench.memory_timeline".to_string()),
+        )
+    })?;
+
+    fs::write(&csv_path, phase_memory_timeline_csv(phase_resources)).map_err(|e| {
+        Error::internal_io(
+            format!(
+                "Failed to write bench phase memory timeline CSV {}: {}",
+                csv_path.display(),
+                e
+            ),
+            Some("bench.memory_timeline".to_string()),
+        )
+    })?;
+
+    Ok(PhaseMemoryArtifacts {
+        json_filename,
+        csv_filename,
+        phases,
+        metrics,
+        sample_count,
+    })
 }
 
 type MemoryTimelineArtifacts = (String, String, u64, f64, usize, usize, u128);
@@ -1559,13 +1719,14 @@ fn bytes_to_mb(bytes: u64) -> f64 {
 
 fn memory_timeline_csv(child_resource: &ExtensionChildResourceSummary) -> String {
     let mut csv = String::from(
-        "timestamp,elapsed_ms,root_pid,rss_bytes,rss_mb,cpu_percent,child_count,process_count\n",
+        "timestamp,elapsed_ms,phase,root_pid,rss_bytes,rss_mb,cpu_percent,child_count,process_count\n",
     );
     for sample in &child_resource.samples {
         csv.push_str(&format!(
-            "{},{},{},{},{:.6},{:.3},{},{}\n",
+            "{},{},{},{},{},{:.6},{:.3},{},{}\n",
             sample.timestamp,
             sample.elapsed_ms,
+            csv_field(sample.phase.as_deref().unwrap_or("")),
             sample.root_pid,
             sample.rss_bytes,
             bytes_to_mb(sample.rss_bytes),
@@ -1575,6 +1736,62 @@ fn memory_timeline_csv(child_resource: &ExtensionChildResourceSummary) -> String
         ));
     }
     csv
+}
+
+fn phase_memory_timeline_csv(phase_resources: &[ExtensionChildResourceSummary]) -> String {
+    let mut csv = String::from(
+        "timestamp,elapsed_ms,phase,root_pid,rss_bytes,rss_mb,cpu_percent,child_count,process_count\n",
+    );
+    for resource in phase_resources {
+        for sample in &resource.samples {
+            let phase = sample
+                .phase
+                .as_deref()
+                .or(resource.phase.as_deref())
+                .unwrap_or("");
+            csv.push_str(&format!(
+                "{},{},{},{},{},{:.6},{:.3},{},{}\n",
+                sample.timestamp,
+                sample.elapsed_ms,
+                csv_field(phase),
+                sample.root_pid,
+                sample.rss_bytes,
+                bytes_to_mb(sample.rss_bytes),
+                sample.cpu_percent,
+                sample.child_count,
+                sample.processes.len(),
+            ));
+        }
+    }
+    csv
+}
+
+fn metric_phase_slug(phase: &str) -> String {
+    let slug = phase
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('_')
+        .to_string();
+    if slug.is_empty() {
+        "phase".to_string()
+    } else {
+        slug
+    }
+}
+
+fn csv_field(value: &str) -> String {
+    if value.contains(&[',', '"', '\n', '\r'][..]) {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
+    }
 }
 
 #[cfg(test)]
@@ -1730,6 +1947,7 @@ mod tests {
                 root_pid: 42,
                 command_label: "bench fixture".to_string(),
             },
+            phase: None,
             started_at: "2026-06-08T00:00:00Z".to_string(),
             finished_at: "2026-06-08T00:00:01Z".to_string(),
             duration_ms: 1000,
@@ -1741,6 +1959,7 @@ mod tests {
                 elapsed_ms: 100,
                 timestamp: "2026-06-08T00:00:00.100Z".to_string(),
                 root_pid: 42,
+                phase: None,
                 rss_bytes: 2 * 1024 * 1024,
                 cpu_percent: 3.5,
                 child_count: 1,
@@ -1754,17 +1973,45 @@ mod tests {
             }],
             warnings: Vec::new(),
         };
+        let mut phase_child = child.clone();
+        phase_child.child.root_pid = 43;
+        phase_child.child.command_label = "npm install".to_string();
+        phase_child.phase = Some("install".to_string());
+        phase_child.sampled_peak_rss_bytes = Some(3 * 1024 * 1024);
+        phase_child.samples[0].root_pid = 43;
+        phase_child.samples[0].phase = Some("install".to_string());
+        phase_child.samples[0].rss_bytes = 3 * 1024 * 1024;
+        resource::record_extension_child_resource(run_dir.path(), &phase_child)
+            .expect("record phase resource");
 
         attach_memory_timeline_artifacts(&mut results, Some(&child), &run_dir, None)
             .expect("attach memory timeline");
 
         assert_eq!(results.metric_groups["memory"]["peak_rss_mb"], 2.0);
+        assert_eq!(results.metric_groups["memory"]["peak_install_rss_mb"], 3.0);
         assert_eq!(results.scenarios[0].metrics.values["peak_rss_mb"], 2.0);
+        assert_eq!(
+            results.scenarios[0].metrics.values["peak_install_rss_mb"],
+            3.0
+        );
+        assert_eq!(
+            results.metadata["phase_memory"]["phases"]["install"]["peak_rss_mb"].as_f64(),
+            Some(3.0)
+        );
         assert!(results.scenarios[0]
             .artifacts
             .contains_key("memory_timeline_json"));
+        assert!(results.scenarios[0]
+            .artifacts
+            .contains_key("phase_memory_timeline_json"));
         assert!(run_dir.step_file("bench-memory-timeline.json").is_file());
         assert!(run_dir.step_file("bench-memory-timeline.csv").is_file());
+        assert!(run_dir
+            .step_file("bench-memory-timeline-phases.json")
+            .is_file());
+        assert!(run_dir
+            .step_file("bench-memory-timeline-phases.csv")
+            .is_file());
 
         run_dir.cleanup();
     }

--- a/src/core/extension/runtime/bench-helper.mjs
+++ b/src/core/extension/runtime/bench-helper.mjs
@@ -1,4 +1,5 @@
 import { appendFile, mkdir, writeFile } from 'node:fs/promises';
+import { execFileSync, spawn } from 'node:child_process';
 import { basename, dirname } from 'node:path';
 
 const homeboyBenchProgressStart = Date.now();
@@ -147,6 +148,183 @@ export async function homeboyBenchResponsivenessPing(event = {}) {
     };
     await mkdir(dirname(file), { recursive: true });
     await appendFile(file, `${JSON.stringify(ping)}\n`);
+}
+
+export async function homeboyRunBenchPhase(phase, command, args = [], options = {}) {
+    if (!phase || typeof phase !== 'string') throw new Error('homeboyRunBenchPhase requires a phase label');
+    if (!command || typeof command !== 'string') throw new Error('homeboyRunBenchPhase requires a command');
+
+    const started = Date.now();
+    const startedAt = new Date().toISOString();
+    const child = spawn(command, args, {
+        cwd: options.cwd || process.cwd(),
+        env: { ...process.env, ...(options.env || {}) },
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let settled = false;
+    let stdout = '';
+    let stderr = '';
+    const samples = [];
+    const warnings = [];
+    const sampleIntervalMs = Number.isFinite(options.sampleIntervalMs)
+        ? options.sampleIntervalMs
+        : homeboyBenchIntEnv('HOMEBOY_BENCH_PHASE_MEMORY_SAMPLE_INTERVAL_MS', 1000);
+
+    const sampleMemory = () => {
+        const sample = homeboyBenchProcessTreeSample(child.pid, phase, started);
+        if (sample) samples.push(sample);
+    };
+    sampleMemory();
+    const memoryTimer = setInterval(sampleMemory, sampleIntervalMs);
+    const timeoutMs = options.timeoutMs;
+    const timer = timeoutMs
+        ? setTimeout(() => {
+            if (settled) return;
+            settled = true;
+            child.kill('SIGKILL');
+        }, timeoutMs)
+        : undefined;
+
+    child.stdout.on('data', (chunk) => {
+        stdout += String(chunk);
+        if (options.stdout === 'inherit') process.stdout.write(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+        stderr += String(chunk);
+        if (options.stderr === 'inherit') process.stderr.write(chunk);
+    });
+
+    const result = await new Promise((resolve, reject) => {
+        child.on('error', reject);
+        child.on('close', (code, signal) => {
+            if (timer) clearTimeout(timer);
+            clearInterval(memoryTimer);
+            sampleMemory();
+            const durationMs = Date.now() - started;
+            resolve({ code, signal, stdout, stderr, elapsedMs: durationMs });
+        });
+    });
+
+    await homeboyWriteBenchPhaseResource({
+        phase,
+        commandLabel: [command, ...args].join(' '),
+        rootPid: child.pid,
+        startedAt,
+        finishedAt: new Date().toISOString(),
+        durationMs: result.elapsedMs,
+        samples,
+        warnings,
+    });
+
+    return {
+        ...result,
+        phase,
+        phaseEvents: [
+            { phase, status: 'started', t_ms: 0, started_at: startedAt },
+            {
+                phase,
+                status: result.code === 0 ? 'completed' : 'failed',
+                t_ms: result.elapsedMs,
+                ended_at: new Date().toISOString(),
+                duration_ms: result.elapsedMs,
+                message: result.code === 0 ? undefined : `${command} exited with ${result.code ?? result.signal}`,
+            },
+        ],
+    };
+}
+
+async function homeboyWriteBenchPhaseResource({
+    phase,
+    commandLabel,
+    rootPid,
+    startedAt,
+    finishedAt,
+    durationMs,
+    samples,
+    warnings,
+}) {
+    const runDir = process.env.HOMEBOY_RUN_DIR;
+    if (!runDir || !rootPid) return;
+    const dir = `${runDir}/extension-children`;
+    await mkdir(dir, { recursive: true });
+    const peak = samples.reduce((current, sample) => {
+        if (!current || sample.rss_bytes > current.rss_bytes) return sample;
+        return current;
+    }, null);
+    const summary = {
+        root_pid: rootPid,
+        command_label: commandLabel,
+        phase,
+        started_at: startedAt,
+        finished_at: finishedAt,
+        duration_ms: durationMs,
+        sampled_peak_rss_bytes: peak?.rss_bytes,
+        sampled_peak_cpu_percent: samples.reduce((value, sample) => Math.max(value, sample.cpu_percent || 0), 0),
+        sampled_peak_at_ms: peak?.elapsed_ms,
+        sampled_peak_child_count: peak?.child_count,
+        samples,
+        warnings,
+    };
+    const safePhase = phase.replace(/[^a-z0-9]+/gi, '-').replace(/^-+|-+$/g, '') || 'phase';
+    await writeFile(`${dir}/${rootPid}-${Date.now()}-${safePhase}.json`, JSON.stringify(summary, null, 2));
+}
+
+function homeboyBenchProcessTreeSample(rootPid, phase, started) {
+    if (!rootPid || process.platform === 'win32') return null;
+    let rows = [];
+    try {
+        rows = execFileSync('ps', ['-axo', 'pid=,ppid=,rss=,pcpu=,comm='], { encoding: 'utf8' })
+            .trim()
+            .split('\n')
+            .map((line) => {
+                const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\d+)\s+([0-9.]+)\s+(.+)$/);
+                if (!match) return null;
+                return {
+                    pid: Number.parseInt(match[1], 10),
+                    parent_pid: Number.parseInt(match[2], 10),
+                    rss_bytes: Number.parseInt(match[3], 10) * 1024,
+                    cpu_percent: Number.parseFloat(match[4]),
+                    command: match[5],
+                };
+            })
+            .filter(Boolean);
+    } catch {
+        return null;
+    }
+    const children = new Map();
+    for (const row of rows) {
+        const list = children.get(row.parent_pid) || [];
+        list.push(row.pid);
+        children.set(row.parent_pid, list);
+    }
+    const seen = new Set([rootPid]);
+    const queue = [rootPid];
+    while (queue.length) {
+        const pid = queue.shift();
+        for (const childPid of children.get(pid) || []) {
+            if (!seen.has(childPid)) {
+                seen.add(childPid);
+                queue.push(childPid);
+            }
+        }
+    }
+    const processes = rows.filter((row) => seen.has(row.pid)).sort((a, b) => a.pid - b.pid);
+    if (!processes.length) return null;
+    return {
+        elapsed_ms: Date.now() - started,
+        timestamp: new Date().toISOString(),
+        root_pid: rootPid,
+        phase,
+        rss_bytes: processes.reduce((sum, row) => sum + row.rss_bytes, 0),
+        cpu_percent: processes.reduce((sum, row) => sum + row.cpu_percent, 0),
+        child_count: Math.max(0, processes.length - 1),
+        processes,
+    };
+}
+
+function homeboyBenchIntEnv(name, defaultValue) {
+    const value = Number.parseInt(process.env[name] || '', 10);
+    return Number.isFinite(value) && value > 0 ? value : defaultValue;
 }
 
 function homeboyBenchProgressEnabled() {

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -584,6 +584,53 @@ await homeboyWriteBenchScenarioInventory('{results}', 'demo', 9, [
 }
 
 #[test]
+fn bench_js_helper_records_phase_resource_summary() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("bench-helper.mjs");
+    let runner_path = dir.path().join("runner.mjs");
+    let run_dir = dir.path().join("run");
+    std::fs::create_dir_all(&run_dir).expect("run dir");
+    std::fs::write(&helper_path, assets::BENCH_HELPER_JS).expect("write helper");
+    std::fs::write(
+        &runner_path,
+        r#"import { homeboyRunBenchPhase } from './bench-helper.mjs';
+
+const result = await homeboyRunBenchPhase('install', process.execPath, ['-e', 'setTimeout(() => {}, 25)'], {
+    sampleIntervalMs: 10,
+});
+if (result.code !== 0) throw new Error(`phase command failed: ${result.code}`);
+"#,
+    )
+    .expect("write runner");
+
+    let output = std::process::Command::new("node")
+        .arg(&runner_path)
+        .env("HOMEBOY_RUN_DIR", &run_dir)
+        .output()
+        .expect("run node");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let children_dir = run_dir.join("extension-children");
+    let child_file = std::fs::read_dir(&children_dir)
+        .expect("children dir")
+        .flatten()
+        .find(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json"))
+        .expect("phase resource file")
+        .path();
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(child_file).expect("read child resource"))
+            .expect("json");
+    assert_eq!(value["phase"], "install");
+    assert_eq!(value["command_label"].as_str().is_some(), true);
+    assert!(value["samples"].as_array().is_some_and(|samples| !samples.is_empty()));
+    assert_eq!(value["samples"][0]["phase"], "install");
+}
+
+#[test]
 fn bench_php_helper_documents_inventory_selection_and_artifact_helpers() {
     assert!(assets::BENCH_HELPER_PHP.contains("function homeboy_bench_scenario_selected"));
     assert!(assets::BENCH_HELPER_PHP.contains("function homeboy_bench_scenario_inventory_envelope"));

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -1270,6 +1270,7 @@ mod tests {
                         root_pid: 4242,
                         command_label: "wp-codebox recipe-run recipes/stripe-ece.yml".to_string(),
                     },
+                    phase: None,
                     started_at: "2026-06-06T00:00:00Z".to_string(),
                     finished_at: "2026-06-06T00:00:01Z".to_string(),
                     duration_ms: 1000,

--- a/src/core/server/client.rs
+++ b/src/core/server/client.rs
@@ -906,6 +906,7 @@ impl ChildResourceMonitor {
 
         ExtensionChildResourceSummary {
             child: self.child,
+            phase: None,
             started_at: self.started_at,
             finished_at: Utc::now().to_rfc3339(),
             duration_ms: self.started_instant.elapsed().as_millis(),
@@ -995,6 +996,7 @@ fn probe_child_resources(
         elapsed_ms: 0,
         timestamp: Utc::now().to_rfc3339(),
         root_pid,
+        phase: None,
         rss_bytes,
         cpu_percent,
         child_count: selected.len().saturating_sub(1),


### PR DESCRIPTION
## Summary
- Adds optional phase labels to extension child resource summaries/samples so nested bench commands can attribute process-tree memory to named phases.
- Adds `homeboyRunBenchPhase()` to the JS bench helper and persists phase-labeled child resource evidence into `extension-children/`.
- Emits `phase_memory` metadata, `peak_<phase>_rss_mb` metrics, and standard `bench-memory-timeline-phases.{json,csv}` artifacts when phase resources are present.

Fixes #3862.

## Testing
- `cargo test attach_memory_timeline_adds_metrics_and_artifacts`
- `cargo test bench_js_helper_records_phase_resource_summary`
- `cargo test test_record_extension_child_resource`
- `node --check src/core/extension/runtime/bench-helper.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, and PR description; Chris remains responsible for review and merge.