### PR TITLE
docs: add lab command index entry

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -26,6 +26,7 @@
 - [git](git.md)
 - [http](http.md) — generic proxied authenticated HTTP requests
 - [issues](issues.md) — reconcile findings against issue trackers
+- [lab](lab.md) — remote Lab runner status and benchmark routing helpers
 - [lint](lint.md)
 - [list](list.md)
 - [logs](logs.md)

--- a/docs/commands/lab.md
+++ b/docs/commands/lab.md
@@ -1,0 +1,32 @@
+# Lab Command
+
+Inspect and use configured Lab runners for remote benchmark execution.
+
+## Synopsis
+
+```bash
+homeboy lab status
+homeboy lab bench <component> [options] [-- <runner-args>]
+```
+
+## Description
+
+The `lab` command surfaces Lab runner availability and provides a discoverable
+benchmark entry point for remote execution. For normal benchmark runs, prefer
+`homeboy bench <component>`: Homeboy automatically selects a Lab runner when the
+component declares `lab.preferred_runner` or when exactly one Lab runner is
+configured.
+
+`homeboy lab bench` delegates to the same benchmark path while making the Lab
+intent explicit at the command surface.
+
+## Commands
+
+- `status`: Show configured Lab runners and benchmark routing guidance.
+- `bench`: Run a benchmark through the standard benchmark pipeline with Lab
+  routing intent.
+
+## Related
+
+- [Bench command](bench.md)
+- [Runner command](runner.md)


### PR DESCRIPTION
## Summary
- Add the new `lab` command to `docs/commands/commands-index.md`.
- Add a small `docs/commands/lab.md` page so the command index link resolves.

## Testing
- `cargo test --test command_surface_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the command-surface CI failure and preparing the minimal docs/index fix; Chris remains responsible for review and merge.