### PR TITLE
Refactor CI-required proof gate handling

### DIFF
--- a/src/core/agent_task_finalization.rs
+++ b/src/core/agent_task_finalization.rs
@@ -512,10 +512,9 @@ fn build_finalization_proof(
         format!("agent-task-finalization:{}", options.run_id),
         provenance,
     )
-    .gates(gates)
+    .gates_requiring_ci_equivalent(gates)
     .artifacts(artifacts)
     .environment(environment)
-    .with_ci_equivalent_gap_if_missing()
 }
 
 fn proof_environment_from_gates(

--- a/src/core/proof.rs
+++ b/src/core/proof.rs
@@ -117,6 +117,13 @@ impl HomeboyProof {
         self
     }
 
+    pub fn gates_requiring_ci_equivalent(
+        self,
+        gates: impl IntoIterator<Item = HomeboyGateResult>,
+    ) -> Self {
+        self.gates(gates).with_ci_equivalent_gap_if_missing()
+    }
+
     pub fn artifacts(
         mut self,
         artifacts: impl IntoIterator<Item = HomeboyProofArtifactRef>,
@@ -259,13 +266,12 @@ mod tests {
     #[test]
     fn proof_records_ci_equivalent_gap_when_missing() {
         let proof = HomeboyProof::new("proof-1", HomeboyProofProvenance::homeboy_run("run-1"))
-            .gates([HomeboyGateResult::new(
+            .gates_requiring_ci_equivalent([HomeboyGateResult::new(
                 "gate-1",
                 "focused check",
                 HomeboyGateKind::Command,
                 HomeboyGateStatus::Passed,
-            )])
-            .with_ci_equivalent_gap_if_missing();
+            )]);
 
         assert_eq!(proof.scope, HomeboyProofScope::Targeted);
         assert_eq!(proof.gaps.len(), 1);

--- a/src/core/runner/offload_metadata.rs
+++ b/src/core/runner/offload_metadata.rs
@@ -113,8 +113,7 @@ fn lab_offload_proof(
                 notes,
             },
         )
-        .gates(gate_results.iter().cloned())
-        .with_ci_equivalent_gap_if_missing(),
+        .gates_requiring_ci_equivalent(gate_results.iter().cloned()),
     )
 }
 


### PR DESCRIPTION
## Summary
- Add a `HomeboyProof::gates_requiring_ci_equivalent()` helper for proof paths that require explicit CI-equivalent coverage.
- Use the helper in agent-task PR finalization proof and Lab offload metadata proof.
- Keep proof scope/gap behavior unchanged while moving the policy into the proof primitive.

## Verification
- `cargo fmt --check`
- `cargo test proof_`
- `cargo test lab_offload_metadata`
- `cargo test finalization`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused proof helper refactor, updated production callers, and ran targeted verification; Chris remains responsible for review and merge.