### PR TITLE
Refactor proof gate scope labels

### DIFF
--- a/src/core/agent_task_pr_body.rs
+++ b/src/core/agent_task_pr_body.rs
@@ -1,7 +1,8 @@
 use crate::core::agent_task_finalization::AgentTaskPrFinalizationOptions;
 use crate::core::gate::{HomeboyGateResult, HomeboyGateStatus};
 use crate::core::proof::{
-    gate_status_label, is_ci_equivalent_gate, HomeboyProof, HomeboyProofGapKind, HomeboyProofRunner,
+    gate_scope_label, gate_status_label, is_ci_equivalent_gate, HomeboyProof, HomeboyProofGapKind,
+    HomeboyProofRunner,
 };
 
 pub(crate) fn render_pr_body(
@@ -85,13 +86,17 @@ fn gate_bullets(gates: &[HomeboyGateResult]) -> String {
     gates
         .iter()
         .map(|gate| match gate.status {
-            HomeboyGateStatus::Passed => format!("- {}: passed ({})", gate.name, proof_scope(gate)),
-            HomeboyGateStatus::Failed => format!("- {}: failed ({})", gate.name, proof_scope(gate)),
+            HomeboyGateStatus::Passed => {
+                format!("- {}: passed ({})", gate.name, gate_scope_label(gate))
+            }
+            HomeboyGateStatus::Failed => {
+                format!("- {}: failed ({})", gate.name, gate_scope_label(gate))
+            }
             HomeboyGateStatus::Skipped => {
-                format!("- {}: skipped ({})", gate.name, proof_scope(gate))
+                format!("- {}: skipped ({})", gate.name, gate_scope_label(gate))
             }
             HomeboyGateStatus::Blocked => {
-                format!("- {}: blocked ({})", gate.name, proof_scope(gate))
+                format!("- {}: blocked ({})", gate.name, gate_scope_label(gate))
             }
         })
         .collect::<Vec<_>>()
@@ -210,12 +215,4 @@ fn inline_code_list(values: &[String]) -> String {
         .map(|value| format!("`{}`", value.replace('`', "'")))
         .collect::<Vec<_>>()
         .join(", ")
-}
-
-fn proof_scope(gate: &HomeboyGateResult) -> &'static str {
-    if is_ci_equivalent_gate(gate) {
-        "CI-equivalent"
-    } else {
-        "targeted"
-    }
 }

--- a/src/core/proof.rs
+++ b/src/core/proof.rs
@@ -231,6 +231,14 @@ pub fn gate_status_label(status: HomeboyGateStatus) -> &'static str {
     }
 }
 
+pub fn gate_scope_label(gate: &HomeboyGateResult) -> &'static str {
+    if is_ci_equivalent_gate(gate) {
+        "CI-equivalent"
+    } else {
+        "targeted"
+    }
+}
+
 fn proof_schema() -> String {
     HOMEBOY_PROOF_SCHEMA.to_string()
 }
@@ -261,6 +269,8 @@ mod tests {
 
         assert_eq!(proof.scope, HomeboyProofScope::Mixed);
         assert!(proof.has_ci_equivalent_gate());
+        assert_eq!(gate_scope_label(&proof.gates[0]), "targeted");
+        assert_eq!(gate_scope_label(&proof.gates[1]), "CI-equivalent");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `gate_scope_label()` to the proof primitive for targeted vs CI-equivalent gate labels.
- Use the shared helper from the agent-task PR body renderer instead of duplicating the policy locally.
- Keep PR body output behavior unchanged while keeping proof labeling with the proof/gate policy helpers.

## Verification
- `cargo fmt --check`
- `cargo test proof_scope_distinguishes_targeted_and_ci_equivalent_gates`
- `cargo test finalization`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused proof label helper refactor, updated the PR body renderer, and ran targeted verification; Chris remains responsible for review and merge.