### PR TITLE
Refactor proof runner labels

### DIFF
--- a/src/core/agent_task_pr_body.rs
+++ b/src/core/agent_task_pr_body.rs
@@ -1,8 +1,8 @@
 use crate::core::agent_task_finalization::AgentTaskPrFinalizationOptions;
 use crate::core::gate::{HomeboyGateResult, HomeboyGateStatus};
 use crate::core::proof::{
-    gate_scope_label, gate_status_label, is_ci_equivalent_gate, HomeboyProof, HomeboyProofGapKind,
-    HomeboyProofRunner,
+    gate_scope_label, gate_status_label, is_ci_equivalent_gate, proof_runner_label, HomeboyProof,
+    HomeboyProofGapKind, HomeboyProofRunner,
 };
 
 pub(crate) fn render_pr_body(
@@ -56,15 +56,6 @@ fn proof_provenance(proof: &HomeboyProof) -> String {
         lines.push("- **Stable evidence:** see artifact refs below".to_string());
     }
     lines.join("\n")
-}
-
-fn proof_runner_label(runner: HomeboyProofRunner) -> &'static str {
-    match runner {
-        HomeboyProofRunner::Homeboy => "Homeboy agent-task cook loop",
-        HomeboyProofRunner::Manual => "manual",
-        HomeboyProofRunner::ExternalCi => "external CI",
-        HomeboyProofRunner::Unknown => "unknown",
-    }
 }
 
 fn bullets(values: &[String]) -> String {

--- a/src/core/proof.rs
+++ b/src/core/proof.rs
@@ -239,6 +239,15 @@ pub fn gate_scope_label(gate: &HomeboyGateResult) -> &'static str {
     }
 }
 
+pub fn proof_runner_label(runner: HomeboyProofRunner) -> &'static str {
+    match runner {
+        HomeboyProofRunner::Homeboy => "Homeboy agent-task cook loop",
+        HomeboyProofRunner::Manual => "manual",
+        HomeboyProofRunner::ExternalCi => "external CI",
+        HomeboyProofRunner::Unknown => "unknown",
+    }
+}
+
 fn proof_schema() -> String {
     HOMEBOY_PROOF_SCHEMA.to_string()
 }
@@ -271,6 +280,10 @@ mod tests {
         assert!(proof.has_ci_equivalent_gate());
         assert_eq!(gate_scope_label(&proof.gates[0]), "targeted");
         assert_eq!(gate_scope_label(&proof.gates[1]), "CI-equivalent");
+        assert_eq!(
+            proof_runner_label(proof.provenance.runner),
+            "Homeboy agent-task cook loop"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `proof_runner_label()` to the proof primitive alongside the other proof presentation helpers.
- Use the shared runner label helper from the agent-task PR body renderer.
- Keep PR body output unchanged while keeping proof runner presentation policy with `HomeboyProofRunner`.

## Verification
- `cargo fmt --check`
- `cargo test proof_scope_distinguishes_targeted_and_ci_equivalent_gates`
- `cargo test finalization`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused proof runner label helper refactor, updated the PR body renderer, and ran targeted verification; Chris remains responsible for review and merge.