### PR TITLE
Remove stale corpus test import

### DIFF
--- a/src/commands/runs/corpus_tests.rs
+++ b/src/commands/runs/corpus_tests.rs
@@ -12,7 +12,6 @@ use homeboy::test_support::with_isolated_home;
 
 use super::bundle::{RunsExportArgs, RunsImportArgs};
 use super::{bundle::import_runs, drift, query, RunsOutput};
-use serde_json::Value;
 
 /// Restore `XDG_DATA_HOME` for the test scope so the observation store
 /// resolves under the temporary home created by `with_isolated_home`.


### PR DESCRIPTION
## Summary
- Remove an unused `serde_json::Value` import from `runs` corpus tests.
- Keeps targeted test output warning-free so future warnings are easier to notice.

## Verification
- `cargo fmt --check`
- `cargo test runs_query_projects_select_jsonpath_over_artifact_corpus`
- `cargo test corpus_tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified and removed the stale import, then ran targeted verification; Chris remains responsible for review and merge.