### PR TITLE
Refactor PR body gate status labels

### DIFF
--- a/src/core/agent_task_pr_body.rs
+++ b/src/core/agent_task_pr_body.rs
@@ -1,5 +1,5 @@
 use crate::core::agent_task_finalization::AgentTaskPrFinalizationOptions;
-use crate::core::gate::{HomeboyGateResult, HomeboyGateStatus};
+use crate::core::gate::HomeboyGateResult;
 use crate::core::proof::{
     gate_scope_label, gate_status_label, is_ci_equivalent_gate, proof_runner_label, HomeboyProof,
     HomeboyProofGapKind, HomeboyProofRunner,
@@ -76,19 +76,13 @@ fn gate_bullets(gates: &[HomeboyGateResult]) -> String {
 
     gates
         .iter()
-        .map(|gate| match gate.status {
-            HomeboyGateStatus::Passed => {
-                format!("- {}: passed ({})", gate.name, gate_scope_label(gate))
-            }
-            HomeboyGateStatus::Failed => {
-                format!("- {}: failed ({})", gate.name, gate_scope_label(gate))
-            }
-            HomeboyGateStatus::Skipped => {
-                format!("- {}: skipped ({})", gate.name, gate_scope_label(gate))
-            }
-            HomeboyGateStatus::Blocked => {
-                format!("- {}: blocked ({})", gate.name, gate_scope_label(gate))
-            }
+        .map(|gate| {
+            format!(
+                "- {}: {} ({})",
+                gate.name,
+                gate_status_label(gate.status),
+                gate_scope_label(gate)
+            )
         })
         .collect::<Vec<_>>()
         .join("\n")


### PR DESCRIPTION
## Summary
- Use the shared `gate_status_label()` helper when rendering agent-task PR body gate bullets.
- Remove a local status match that duplicated proof/gate presentation policy.
- Keep PR body output unchanged while reducing future status-label drift.

## Verification
- `cargo fmt --check`
- `cargo test finalization`

## Note
- `cargo test finalization` still reports the pre-existing `serde_json::Value` corpus-test warning on this branch because #3889 fixes that independently and this PR does not stack on it.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified the duplicated PR body status-label match, refactored it to the shared helper, and ran targeted verification; Chris remains responsible for review and merge.