### PR TITLE
Refactor PR verification bullets

### DIFF
--- a/src/core/agent_task_pr_body.rs
+++ b/src/core/agent_task_pr_body.rs
@@ -127,23 +127,24 @@ fn verification_bullets(options: &AgentTaskPrFinalizationOptions) -> String {
         return "- `targeted_checks_run`: see gate results above".to_string();
     }
 
-    let mut lines = Vec::new();
-    lines.push(format!(
-        "- `targeted_checks_run`: {}",
-        inline_code_list(&verification.targeted_checks_run)
-    ));
-    lines.push(format!(
-        "- `targeted_checks_unavailable`: {}",
-        option_value(verification.targeted_checks_unavailable.as_deref())
-    ));
-    lines.push(format!(
-        "- `ci_expected`: {}",
-        inline_code_list(&verification.ci_expected)
-    ));
-    lines.push(format!(
-        "- `manual_reviewer_check`: {}",
-        option_value(verification.manual_reviewer_check.as_deref())
-    ));
+    let lines = vec![
+        format!(
+            "- `targeted_checks_run`: {}",
+            inline_code_list(&verification.targeted_checks_run)
+        ),
+        format!(
+            "- `targeted_checks_unavailable`: {}",
+            option_value(verification.targeted_checks_unavailable.as_deref())
+        ),
+        format!(
+            "- `ci_expected`: {}",
+            inline_code_list(&verification.ci_expected)
+        ),
+        format!(
+            "- `manual_reviewer_check`: {}",
+            option_value(verification.manual_reviewer_check.as_deref())
+        ),
+    ];
     lines.join("\n")
 }
 


### PR DESCRIPTION
## Summary
- Build the fixed verification capability section with a single `vec![...]` instead of repeated `push()` calls.
- Keep rendered agent-task PR body text unchanged.
- Makes the PR body renderer easier to scan and extend.

## Verification
- `cargo fmt --check`
- `cargo test finalization`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refactored fixed-shape PR verification bullet construction and ran targeted verification; Chris remains responsible for review and merge.