### PR TITLE
Refactor PR body AI model fallback

### DIFF
--- a/src/core/agent_task_pr_body.rs
+++ b/src/core/agent_task_pr_body.rs
@@ -7,6 +7,7 @@ use crate::core::proof::{
 
 const NONE_RECORDED: &str = "none recorded";
 const NONE_RECORDED_BULLET: &str = "- none recorded";
+const AI_MODEL_NOT_RECORDED: &str = "not recorded by provider metadata";
 
 pub(crate) fn render_pr_body(
     options: &AgentTaskPrFinalizationOptions,
@@ -36,7 +37,7 @@ pub(crate) fn render_pr_body(
             .evidence
             .ai_model
             .as_deref()
-            .unwrap_or("not recorded by provider metadata"),
+            .unwrap_or(AI_MODEL_NOT_RECORDED),
         options.ai_used_for
     )
 }


### PR DESCRIPTION
## Summary
- Add a named `AI_MODEL_NOT_RECORDED` fallback for agent-task PR body rendering.
- Keep rendered PR body text unchanged.
- Makes absence-label wording easier to hold and update alongside the other PR body fallback constants.

## Verification
- `cargo fmt --check`
- `cargo test finalization`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Centralized the AI model fallback text and ran targeted finalization tests; Chris remains responsible for review and merge.