### PR TITLE
Support Lab offload for agent-task run-plan

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1123,6 +1123,10 @@ mod tests {
             parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"])
                 .supports_lab_runner()
         );
+        assert!(
+            parsed_command(&["homeboy", "agent-task", "run-plan", "--plan", "@plan.json"])
+                .supports_lab_runner()
+        );
         assert!(parsed_command(&[
             "homeboy",
             "agent-task",
@@ -1203,11 +1207,11 @@ mod tests {
             ),
             (
                 parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"]),
-                "agent-task dispatch/cook/loop",
+                "agent-task dispatch/cook/loop/run-plan",
             ),
             (
                 parsed_command(&["homeboy", "agent-task", "cook", "--prompt", "cook"]),
-                "agent-task dispatch/cook/loop",
+                "agent-task dispatch/cook/loop/run-plan",
             ),
             (
                 parsed_command(&[
@@ -1221,7 +1225,11 @@ mod tests {
                     "--prompt",
                     "cook",
                 ]),
-                "agent-task dispatch/cook/loop",
+                "agent-task dispatch/cook/loop/run-plan",
+            ),
+            (
+                parsed_command(&["homeboy", "agent-task", "run-plan", "--plan", "@plan.json"]),
+                "agent-task dispatch/cook/loop/run-plan",
             ),
         ];
 

--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -50,10 +50,11 @@ impl Commands {
                     super::agent_task::AgentTaskCommand::Cook(_)
                         | super::agent_task::AgentTaskCommand::Dispatch(_)
                         | super::agent_task::AgentTaskCommand::Loop(_)
+                        | super::agent_task::AgentTaskCommand::RunPlan(_)
                 ) =>
             {
                 lab_portable_contract(
-                    "agent-task dispatch/cook/loop",
+                    "agent-task dispatch/cook/loop/run-plan",
                     None,
                     true,
                     LAB_NO_EXTRA_TOOLS,

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -1,10 +1,11 @@
 use std::path::Path;
 
-use crate::core::agent_task_secrets;
+use crate::core::agent_task_lifecycle;
+use crate::core::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
 use crate::core::observation::{PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
 use crate::core::plan::{HomeboyPlan, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::source_snapshot::SourceSnapshot;
-use crate::core::{Error, Result};
+use crate::core::{agent_task_secrets, config, Error, Result};
 
 use super::{
     evaluate_lab_runner_capabilities_for_runner, exec, lab_offload_changed_since_ref,
@@ -20,7 +21,8 @@ use super::lab_apply::apply_lab_offload_patch;
 #[cfg(test)]
 use super::lab_args::EXPLICIT_PASSTHROUGH_SENTINEL;
 use super::lab_args::{
-    lab_offload_source_path, remap_provider_config_in_args, rewrite_lab_offload_args, LabPathRemap,
+    lab_offload_source_path, remap_agent_task_plan_in_args, remap_provider_config_in_args,
+    rewrite_lab_offload_args, LabPathRemap,
 };
 use super::lab_capabilities::lab_runner_capability_contract;
 use super::lab_command::lab_offload_command_prefix;
@@ -86,7 +88,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             "runner",
             message,
             Some(runner_id.to_string()),
-            Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+            Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
         )
     };
     let mut plan = base_lab_plan(request.command.as_ref());
@@ -94,7 +96,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if let Some(runner_id) = request.explicit_runner {
             return Err(unsupported_runner_error(
                 runner_id,
-                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, lint, test, audit, bench, trace, and refactor source runs".to_string(),
             ));
         }
         return Ok(LabOffloadOutcome::RunLocal {
@@ -107,7 +109,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.portable {
         if let Some(runner_id) = request.explicit_runner {
             let message = contract.unsupported_reason.map_or_else(
-                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
             );
             return Err(unsupported_runner_error(runner_id, message));
@@ -525,6 +527,7 @@ fn run_lab_offload_inner(
         &synced.excludes,
     )?;
     let remapped_args = remap_provider_config_in_args(&changed_since_preflight.args, &path_remaps);
+    let remapped_args = remap_agent_task_plan_in_args(&remapped_args, &path_remaps);
 
     let mut command = command_prefix.argv;
     command.extend(
@@ -678,6 +681,7 @@ fn run_lab_offload_inner(
             ));
         }
     }
+    mirror_agent_task_run_plan_lifecycle(request.normalized_args, &exec_output.stdout)?;
 
     let mut stderr = String::new();
     for message in messages {
@@ -692,6 +696,73 @@ fn run_lab_offload_inner(
         stderr,
         exit_code,
     })
+}
+
+fn mirror_agent_task_run_plan_lifecycle(args: &[String], stdout: &str) -> Result<()> {
+    let Some((plan_spec, run_id)) = agent_task_run_plan_recording_args(args) else {
+        return Ok(());
+    };
+    if plan_spec == "-" {
+        return Ok(());
+    }
+    let envelope: serde_json::Value = serde_json::from_str(stdout).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("parse offloaded agent-task run-plan output".to_string()),
+        )
+    })?;
+    let Some(aggregate_value) = envelope.get("data").cloned() else {
+        return Ok(());
+    };
+    let raw_plan = config::read_json_spec_to_string(&plan_spec)?;
+    let plan: AgentTaskPlan = serde_json::from_str(&raw_plan).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some(format!("read agent-task plan {plan_spec}")),
+        )
+    })?;
+    let aggregate: AgentTaskAggregate =
+        serde_json::from_value(aggregate_value).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse offloaded agent-task aggregate".to_string()),
+            )
+        })?;
+
+    agent_task_lifecycle::submit_plan(&plan, Some(&run_id))?;
+    agent_task_lifecycle::mark_running(&run_id)?;
+    agent_task_lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;
+    Ok(())
+}
+
+fn agent_task_run_plan_recording_args(args: &[String]) -> Option<(String, String)> {
+    if args.get(1).map(String::as_str) != Some("agent-task")
+        || args.get(2).map(String::as_str) != Some("run-plan")
+    {
+        return None;
+    }
+
+    let mut plan = None;
+    let mut record_run_id = None;
+    let mut iter = args.iter().skip(3);
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        match arg.as_str() {
+            "--plan" => plan = iter.next().cloned(),
+            "--record-run-id" => record_run_id = iter.next().cloned(),
+            _ => {
+                if let Some(value) = arg.strip_prefix("--plan=") {
+                    plan = Some(value.to_string());
+                } else if let Some(value) = arg.strip_prefix("--record-run-id=") {
+                    record_run_id = Some(value.to_string());
+                }
+            }
+        }
+    }
+
+    Some((plan?, record_run_id?))
 }
 
 fn hydrate_agent_task_secret_env(

--- a/src/core/runner/lab_args.rs
+++ b/src/core/runner/lab_args.rs
@@ -73,6 +73,55 @@ pub(super) fn remap_provider_config_in_args(
     out
 }
 
+pub(super) fn remap_agent_task_plan_in_args(
+    args: &[String],
+    mappings: &[LabPathRemap],
+) -> Vec<String> {
+    if mappings.is_empty() {
+        return args.to_vec();
+    }
+
+    let mut ordered: Vec<&LabPathRemap> = mappings.iter().collect();
+    ordered.sort_by_key(|mapping| std::cmp::Reverse(mapping.local.len()));
+
+    let mut out = Vec::with_capacity(args.len());
+    let mut iter = args.iter().peekable();
+    let mut passthrough = false;
+    while let Some(arg) = iter.next() {
+        if passthrough {
+            out.push(arg.clone());
+            continue;
+        }
+        if arg == "--" {
+            passthrough = true;
+            out.push(arg.clone());
+            continue;
+        }
+        if arg == "--plan" {
+            out.push(arg.clone());
+            if let Some(spec) = iter.next() {
+                out.push(remap_at_file_spec(spec, &ordered));
+            }
+            continue;
+        }
+        if let Some(spec) = arg.strip_prefix("--plan=") {
+            out.push(format!("--plan={}", remap_at_file_spec(spec, &ordered)));
+            continue;
+        }
+        out.push(arg.clone());
+    }
+    out
+}
+
+fn remap_at_file_spec(spec: &str, mappings: &[&LabPathRemap]) -> String {
+    let Some(path) = spec.strip_prefix('@') else {
+        return spec.to_string();
+    };
+    remap_local_path(path, mappings)
+        .map(|remapped| format!("@{remapped}"))
+        .unwrap_or_else(|| spec.to_string())
+}
+
 /// Resolve a provider-config spec (inline JSON / `@file` / `-`), remap its
 /// embedded local paths, and return inline JSON. Falls back to the original spec
 /// if it cannot be read or parsed so behavior is never worse than today.
@@ -372,6 +421,34 @@ mod tests {
         // No mappings -> untouched
         let unchanged = remap_provider_config_in_args(&args, &[]);
         assert_eq!(unchanged, args);
+    }
+
+    #[test]
+    fn remap_agent_task_run_plan_absolute_file_spec() {
+        let mappings = vec![LabPathRemap {
+            local: "/Users/chubes/Developer/wp-site-generator".to_string(),
+            remote: "/home/chubes/Developer/wp-site-generator".to_string(),
+        }];
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--plan".to_string(),
+            "@/Users/chubes/Developer/wp-site-generator/.ci/plan.json".to_string(),
+            "--record-run-id=loop-1".to_string(),
+        ];
+
+        assert_eq!(
+            remap_agent_task_plan_in_args(&args, &mappings),
+            vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "run-plan".to_string(),
+                "--plan".to_string(),
+                "@/home/chubes/Developer/wp-site-generator/.ci/plan.json".to_string(),
+                "--record-run-id=loop-1".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -344,14 +344,14 @@ pub(super) fn resolve_lab_runner_selection_from_default(
     if let Some(runner_id) = explicit_runner {
         if !command.portable {
             let message = command.unsupported_reason.map_or_else(
-                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop/run-plan, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this hot command. {reason}"),
             );
             return Err(Error::validation_invalid_argument(
                 "runner",
                 message,
                 Some(runner_id.to_string()),
-                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
             ));
         }
 


### PR DESCRIPTION
## Summary
- Adds `agent-task run-plan` to the portable Lab offload contract so `--runner` is accepted through the intended Homeboy Lab path.
- Remaps `--plan @/absolute/path` specs that point into synced workspaces before executing on the runner.
- Mirrors `run-plan --record-run-id` aggregate output back into the controller lifecycle store after successful offloaded execution.

Fixes #3896.

## Verification
- `cargo test remap_agent_task_run_plan_absolute_file_spec`
- `cargo test test_lab_command_contracts_cover_hot_commands`
- `cargo test test_supports_lab_runner`
- `target/debug/homeboy agent-task run-plan --runner definitely-missing-lab-runner --plan @tests/fixtures/agent_task_smoke_plan.json --record-run-id lab-run-plan-smoke` now reaches runner lookup instead of rejecting `--runner`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** GPT-5.5
- **Used for:** Drafted implementation and targeted tests; Chris reviews and owns the change.