### PR TITLE
fix: discourage dependency gate bypasses

### DIFF
--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -320,7 +320,7 @@ fn dispatch_instructions(instructions: String, task_url: Option<&str>) -> String
     }
 
     format!(
-        "{instructions}\n\nGenerated change guardrails:\n- First look for nearby existing predicates, contracts, or implementation families that already cover the requested behavior.\n- Keep generated changes bounded to the source evidence and task scope; preserve evidence-specific discriminators unless the task explicitly asks for broader behavior.\n- If existing behavior plus evidence/test coverage already resolves the task, prefer evidence-only or test-only output over a broader runtime change.\n- In PR evidence, report source relationship, change kind, verification capability, and why any runtime change is not broader than the source evidence."
+        "{instructions}\n\nGenerated change guardrails:\n- First look for nearby existing predicates, contracts, or implementation families that already cover the requested behavior.\n- Keep generated changes bounded to the source evidence and task scope; preserve evidence-specific discriminators unless the task explicitly asks for broader behavior.\n- If dependency freshness, lifecycle, or validation gates fail, update and verify the relevant dependency checkout or declared component reference; do not bypass, disable, or skip the gate to reach a PR.\n- If existing behavior plus evidence/test coverage already resolves the task, prefer evidence-only or test-only output over a broader runtime change.\n- In PR evidence, report source relationship, change kind, verification capability, and why any runtime change is not broader than the source evidence."
     )
 }
 
@@ -742,6 +742,9 @@ mod tests {
         assert!(plan.tasks[0]
             .instructions
             .contains("bounded to the source evidence"));
+        assert!(plan.tasks[0]
+            .instructions
+            .contains("do not bypass, disable, or skip the gate"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Extends generated agent-task dispatch guardrails so dependency freshness, lifecycle, and validation failures direct agents to update and verify the dependency checkout or declared component reference.
- Explicitly tells agents not to bypass, disable, or skip dependency gates just to reach a PR.
- Adds coverage to the existing tracker-backed dispatch guardrail test.

## Verification
- `cargo test tracker_backed_dispatch_adds_generated_change_guardrails`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused prompt/test change and ran targeted verification; Chris requested the change and remains responsible for review.