### PR TITLE
Fix in-flight lab daemon disconnect reporting

### DIFF
--- a/src/core/runner/daemon_health.rs
+++ b/src/core/runner/daemon_health.rs
@@ -1,6 +1,13 @@
 use crate::core::error::{Error, ErrorCode};
 
-pub(super) fn runner_daemon_health_failure(err: &Error) -> Option<String> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RunnerDaemonHealthFailure {
+    pub reason: String,
+    pub runner_id: Option<String>,
+    pub job_id: Option<String>,
+}
+
+pub(super) fn runner_daemon_health_failure(err: &Error) -> Option<RunnerDaemonHealthFailure> {
     if !matches!(
         err.code,
         ErrorCode::InternalUnexpected | ErrorCode::InternalJsonError
@@ -14,7 +21,19 @@ pub(super) fn runner_daemon_health_failure(err: &Error) -> Option<String> {
         || message.contains("parse daemon exec response")
         || message.contains("daemon exec request failed");
     if daemon_transport_failure {
-        Some(format!("runner daemon health check failed: {message}"))
+        Some(RunnerDaemonHealthFailure {
+            reason: format!("runner daemon health check failed: {message}"),
+            runner_id: err
+                .details
+                .get("runner_id")
+                .and_then(|value| value.as_str())
+                .map(ToString::to_string),
+            job_id: err
+                .details
+                .get("job_id")
+                .and_then(|value| value.as_str())
+                .map(ToString::to_string),
+        })
     } else {
         None
     }
@@ -32,10 +51,34 @@ mod tests {
 
         assert_eq!(
             runner_daemon_health_failure(&err),
-            Some(
-                "runner daemon health check failed: query runner daemon: error sending request for url (http://127.0.0.1:63534/jobs/id)"
-                    .to_string()
-            )
+            Some(RunnerDaemonHealthFailure {
+                reason: "runner daemon health check failed: query runner daemon: error sending request for url (http://127.0.0.1:63534/jobs/id)"
+                    .to_string(),
+                runner_id: None,
+                job_id: None,
+            })
+        );
+    }
+
+    #[test]
+    fn includes_in_flight_daemon_job_context() {
+        let err = Error::new(
+            ErrorCode::InternalUnexpected,
+            "query runner daemon: error sending request for url (http://127.0.0.1:63534/jobs/id)",
+            serde_json::json!({
+                "runner_id": "homeboy-lab",
+                "job_id": "job-123",
+            }),
+        );
+
+        assert_eq!(
+            runner_daemon_health_failure(&err),
+            Some(RunnerDaemonHealthFailure {
+                reason: "runner daemon health check failed: query runner daemon: error sending request for url (http://127.0.0.1:63534/jobs/id)"
+                    .to_string(),
+                runner_id: Some("homeboy-lab".to_string()),
+                job_id: Some("job-123".to_string()),
+            })
         );
     }
 

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -412,9 +412,13 @@ fn exec_via_daemon(
             ));
         }
         std::thread::sleep(Duration::from_millis(200));
-        job = fetch_daemon_job(&client, local_url, &job.id.to_string())?;
+        let job_id = job.id.to_string();
+        job = fetch_daemon_job(&client, local_url, &job_id)
+            .map_err(|err| daemon_job_context_error(&runner.id, &job_id, err))?;
     }
-    let events = fetch_daemon_events(&client, local_url, &job.id.to_string())?;
+    let job_id = job.id.to_string();
+    let events = fetch_daemon_events(&client, local_url, &job_id)
+        .map_err(|err| daemon_job_context_error(&runner.id, &job_id, err))?;
 
     let result = result_event_data(&events).unwrap_or_else(|| json!({}));
     let stdout = string_field(&result, "stdout");
@@ -490,6 +494,21 @@ fn fetch_daemon_events(client: &Client, local_url: &str, job_id: &str) -> Result
     serde_json::from_value(body["events"].clone()).map_err(|err| {
         Error::internal_json(err.to_string(), Some("parse daemon job events".to_string()))
     })
+}
+
+fn daemon_job_context_error(runner_id: &str, job_id: &str, err: Error) -> Error {
+    let mut with_context = Error::new(
+        err.code,
+        err.message,
+        json!({
+            "runner_id": runner_id,
+            "job_id": job_id,
+            "source": err.details,
+        }),
+    );
+    with_context.hints = err.hints;
+    with_context.retryable = err.retryable.or(Some(true));
+    with_context
 }
 
 fn cancel_daemon_job_after_timeout(
@@ -1096,6 +1115,7 @@ fn daemon_failure_message(status_code: u16, envelope: &DaemonEnvelope) -> String
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::error::ErrorCode;
     use crate::core::server::{self, RunnerPolicy, RunnerSettings};
 
     fn ssh_runner() -> Runner {
@@ -1121,6 +1141,23 @@ mod tests {
             capture_patch: options.capture_patch,
             raw_exec: options.raw_exec,
         }
+    }
+
+    #[test]
+    fn daemon_job_context_error_preserves_in_flight_job_details() {
+        let source = Error::internal_unexpected(
+            "query runner daemon: error sending request for url (http://127.0.0.1:63203/jobs/job-123)",
+        )
+        .with_hint("original hint");
+
+        let err = daemon_job_context_error("homeboy-lab", "job-123", source);
+
+        assert_eq!(err.code, ErrorCode::InternalUnexpected);
+        assert_eq!(err.retryable, Some(true));
+        assert_eq!(err.details["runner_id"], "homeboy-lab");
+        assert_eq!(err.details["job_id"], "job-123");
+        assert_eq!(err.hints[0].message, "original hint");
+        assert!(err.message.contains("query runner daemon"));
     }
 
     #[test]

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -5,7 +5,7 @@ use crate::core::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
 use crate::core::observation::{PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
 use crate::core::plan::{HomeboyPlan, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::source_snapshot::SourceSnapshot;
-use crate::core::{agent_task_secrets, config, Error, Result};
+use crate::core::{agent_task_secrets, config, Error, ErrorCode, Result};
 
 use super::{
     evaluate_lab_runner_capabilities_for_runner, exec, lab_offload_changed_since_ref,
@@ -599,13 +599,19 @@ fn run_lab_offload_inner(
     let (exec_output, exit_code) = match exec_result {
         Ok(output) => output,
         Err(err) => {
-            if let Some(reason) = runner_daemon_health_failure(&err) {
+            if let Some(health) = runner_daemon_health_failure(&err) {
+                let reason = health.reason.clone();
                 plan = with_step(
                     plan,
                     PlanStep::builder("lab.exec", "lab.exec", PlanStepStatus::Failed)
                         .skip_reason(reason.clone())
                         .build(),
                 );
+                if let Some(job_id) = health.job_id.as_deref() {
+                    return Err(in_flight_daemon_disconnect_error(
+                        runner_id, job_id, &reason, &err,
+                    ));
+                }
                 return match selection.source {
                     LabRunnerSelectionSource::Default => {
                         if !request.allow_local_fallback {
@@ -700,6 +706,38 @@ fn run_lab_offload_inner(
         stderr,
         exit_code,
     })
+}
+
+fn in_flight_daemon_disconnect_error(
+    runner_id: &str,
+    job_id: &str,
+    reason: &str,
+    err: &Error,
+) -> Error {
+    let mut disconnected = Error::new(
+        ErrorCode::InternalUnexpected,
+        format!(
+            "Lab offload controller disconnected while runner `{runner_id}` daemon job `{job_id}` was still in flight: {}",
+            err.message
+        ),
+        serde_json::json!({
+            "runner_id": runner_id,
+            "job_id": job_id,
+            "reason": reason,
+            "source": err.details,
+        }),
+    )
+    .with_hint(format!(
+        "Do not retry until checking the remote run; inspect running records with `homeboy runs list --runner {runner_id} --status running --limit 20`."
+    ))
+    .with_hint(format!(
+        "If daemon polling is unavailable, inspect from the runner with `homeboy runner exec {runner_id} -- homeboy runs list --status running --limit 20`."
+    ))
+    .with_hint(format!(
+        "Runner daemon job id `{job_id}` was already dispatched; use runner/job logs to decide whether to wait, cancel, or clean up."
+    ));
+    disconnected.retryable = Some(false);
+    disconnected
 }
 
 fn mirror_agent_task_run_plan_lifecycle(args: &[String], stdout: &str) -> Result<()> {
@@ -957,6 +995,38 @@ mod tests {
             requires_playwright: false,
             infer_source_path_tools: false,
         }
+    }
+
+    #[test]
+    fn in_flight_daemon_disconnect_error_surfaces_inspection_commands() {
+        let source = Error::new(
+            ErrorCode::InternalUnexpected,
+            "query runner daemon: error sending request for url (http://127.0.0.1:63203/jobs/job-123)",
+            serde_json::json!({
+                "runner_id": "homeboy-lab",
+                "job_id": "job-123",
+            }),
+        );
+
+        let err = in_flight_daemon_disconnect_error(
+            "homeboy-lab",
+            "job-123",
+            "runner daemon health check failed",
+            &source,
+        );
+
+        assert_eq!(err.code, ErrorCode::InternalUnexpected);
+        assert_eq!(err.retryable, Some(false));
+        assert_eq!(err.details["runner_id"], "homeboy-lab");
+        assert_eq!(err.details["job_id"], "job-123");
+        assert!(err.message.contains("still in flight"));
+        assert!(err.hints.iter().any(|hint| hint
+            .message
+            .contains("homeboy runs list --runner homeboy-lab")));
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("homeboy runner exec homeboy-lab")));
     }
 
     fn reverse_status(runner_id: &str) -> RunnerStatusReport {


### PR DESCRIPTION
## Summary
- Preserve runner/job context when daemon polling fails after a Lab offload job has already been dispatched.
- Report controller disconnects as in-flight remote jobs with inspection commands instead of retry/local-fallback guidance.
- Add targeted coverage for daemon context propagation and Lab offload disconnect messaging.

Fixes #3906

## Testing
- cargo test in_flight

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the Lab offload failure path, drafting the code change and tests, and preparing this PR; Chris remains responsible for review and validation.