### PR TITLE
fix: remap run-plan payload paths for Lab offload

### DIFF
--- a/src/core/runner/lab_args.rs
+++ b/src/core/runner/lab_args.rs
@@ -100,17 +100,36 @@ pub(super) fn remap_agent_task_plan_in_args(
         if arg == "--plan" {
             out.push(arg.clone());
             if let Some(spec) = iter.next() {
-                out.push(remap_at_file_spec(spec, &ordered));
+                out.push(remap_agent_task_plan_spec(spec, &ordered));
             }
             continue;
         }
         if let Some(spec) = arg.strip_prefix("--plan=") {
-            out.push(format!("--plan={}", remap_at_file_spec(spec, &ordered)));
+            out.push(format!(
+                "--plan={}",
+                remap_agent_task_plan_spec(spec, &ordered)
+            ));
             continue;
         }
         out.push(arg.clone());
     }
     out
+}
+
+/// Resolve an agent-task plan spec, remap every controller-local path embedded
+/// in the JSON, and inline the result so the runner never reads stale local
+/// paths from a synced-but-unmodified plan file.
+fn remap_agent_task_plan_spec(spec: &str, mappings: &[&LabPathRemap]) -> String {
+    let raw = match read_json_spec_to_string(spec) {
+        Ok(raw) => raw,
+        Err(_) => return remap_at_file_spec(spec, mappings),
+    };
+    let mut value: Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(_) => return remap_at_file_spec(spec, mappings),
+    };
+    remap_paths_in_value(&mut value, mappings);
+    serde_json::to_string(&value).unwrap_or_else(|_| remap_at_file_spec(spec, mappings))
 }
 
 fn remap_at_file_spec(spec: &str, mappings: &[&LabPathRemap]) -> String {
@@ -424,7 +443,29 @@ mod tests {
     }
 
     #[test]
-    fn remap_agent_task_run_plan_absolute_file_spec() {
+    fn remap_agent_task_run_plan_inlines_remapped_plan_json() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let plan = temp.path().join("plan.json");
+        std::fs::write(
+            &plan,
+            serde_json::json!({
+                "schema": "homeboy/agent-task-plan/v1",
+                "plan_id": "plan-1",
+                "tasks": [{
+                    "task_id": "task-1",
+                    "executor": {
+                        "backend": "wp-codebox",
+                        "config": {
+                            "wp_codebox_bin": "/Users/chubes/Developer/wp-site-generator/.ci/wp-codebox/packages/cli/dist/index.js",
+                            "artifact_root": "/Users/chubes/Developer/wp-site-generator/artifacts"
+                        }
+                    },
+                    "instructions": "test"
+                }]
+            })
+            .to_string(),
+        )
+        .expect("write plan");
         let mappings = vec![LabPathRemap {
             local: "/Users/chubes/Developer/wp-site-generator".to_string(),
             remote: "/home/chubes/Developer/wp-site-generator".to_string(),
@@ -434,20 +475,43 @@ mod tests {
             "agent-task".to_string(),
             "run-plan".to_string(),
             "--plan".to_string(),
-            "@/Users/chubes/Developer/wp-site-generator/.ci/plan.json".to_string(),
+            format!("@{}", plan.display()),
             "--record-run-id=loop-1".to_string(),
         ];
 
+        let out = remap_agent_task_plan_in_args(&args, &mappings);
+        let plan_idx = out.iter().position(|a| a == "--plan").unwrap() + 1;
+        let remapped: serde_json::Value =
+            serde_json::from_str(&out[plan_idx]).expect("inline plan");
+
         assert_eq!(
-            remap_agent_task_plan_in_args(&args, &mappings),
-            vec![
-                "homeboy".to_string(),
-                "agent-task".to_string(),
-                "run-plan".to_string(),
-                "--plan".to_string(),
-                "@/home/chubes/Developer/wp-site-generator/.ci/plan.json".to_string(),
-                "--record-run-id=loop-1".to_string(),
-            ]
+            remapped["tasks"][0]["executor"]["config"]["wp_codebox_bin"],
+            "/home/chubes/Developer/wp-site-generator/.ci/wp-codebox/packages/cli/dist/index.js"
+        );
+        assert_eq!(
+            remapped["tasks"][0]["executor"]["config"]["artifact_root"],
+            "/home/chubes/Developer/wp-site-generator/artifacts"
+        );
+        assert!(out.iter().any(|a| a == "--record-run-id=loop-1"));
+    }
+
+    #[test]
+    fn remap_agent_task_run_plan_absolute_file_spec_when_plan_unreadable() {
+        let mappings = vec![LabPathRemap {
+            local: "/Users/chubes/Developer/wp-site-generator".to_string(),
+            remote: "/home/chubes/Developer/wp-site-generator".to_string(),
+        }];
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--plan".to_string(),
+            "@/Users/chubes/Developer/wp-site-generator/.ci/missing.json".to_string(),
+        ];
+
+        assert_eq!(
+            remap_agent_task_plan_in_args(&args, &mappings)[4],
+            "@/home/chubes/Developer/wp-site-generator/.ci/missing.json"
         );
     }
 

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -161,49 +161,13 @@ pub(super) fn provider_config_extra_workspaces(
     let mut seen = BTreeSet::new();
     let mut workspaces: Vec<ExtraLabWorkspace> = Vec::new();
     for candidate in provider_config_candidate_paths(&value) {
-        let expanded = shellexpand::tilde(&candidate).to_string();
-        let path = Path::new(&expanded);
-        let (workspace_path, snapshot_includes, bootstrap_node_dependencies) = if path.is_dir() {
-            (path.to_path_buf(), Vec::new(), false)
-        } else if path.is_file() {
-            let workspace_path = containing_checkout_or_parent(path)?;
-            let snapshot_includes = provider_config_file_snapshot_includes(&workspace_path, path);
-            (
-                workspace_path,
-                snapshot_includes,
-                is_node_cli_file(path) && source_cli_workspace_has_package_lock(path),
-            )
-        } else {
-            continue;
-        };
-        let canon = match workspace_path.canonicalize() {
-            Ok(canon) => canon,
-            Err(_) => continue,
-        };
-        // The primary workspace (and paths inside it) are already synced.
-        if canon == source_canon || canon.starts_with(&source_canon) {
-            continue;
-        }
-        if !seen.insert(canon.clone()) {
-            if let Some(existing) = workspaces
-                .iter_mut()
-                .find(|workspace| workspace.path == canon)
-            {
-                for include in snapshot_includes {
-                    if !existing.snapshot_includes.contains(&include) {
-                        existing.snapshot_includes.push(include);
-                    }
-                }
-                existing.bootstrap_node_dependencies |= bootstrap_node_dependencies;
-            }
-            continue;
-        }
-        workspaces.push(ExtraLabWorkspace {
-            role: "provider_config".to_string(),
-            path: canon,
-            snapshot_includes,
-            bootstrap_node_dependencies,
-        });
+        add_candidate_extra_workspace(
+            &candidate,
+            "provider_config",
+            &source_canon,
+            &mut seen,
+            &mut workspaces,
+        )?;
     }
     Ok(workspaces)
 }
@@ -218,33 +182,50 @@ pub(super) fn agent_task_plan_extra_workspaces(
     let Some(spec) = agent_task_plan_spec(args) else {
         return Ok(Vec::new());
     };
-    let Some(path) = spec.strip_prefix('@') else {
-        return Ok(Vec::new());
-    };
-    let expanded = shellexpand::tilde(path).to_string();
-    let path = Path::new(&expanded);
-    if !path.is_file() {
-        return Ok(Vec::new());
-    }
-
-    let workspace_path = containing_checkout_or_parent(path)?;
     let source_canon = source_path
         .canonicalize()
         .unwrap_or_else(|_| source_path.to_path_buf());
-    let canon = match workspace_path.canonicalize() {
-        Ok(canon) => canon,
-        Err(_) => return Ok(Vec::new()),
-    };
-    if canon == source_canon || canon.starts_with(&source_canon) {
-        return Ok(Vec::new());
+    let mut seen = BTreeSet::new();
+    let mut workspaces = Vec::new();
+
+    if let Some(path) = spec.strip_prefix('@') {
+        let expanded = shellexpand::tilde(path).to_string();
+        let path = Path::new(&expanded);
+        if path.is_file() {
+            let workspace_path = containing_checkout_or_parent(path)?;
+            if let Ok(canon) = workspace_path.canonicalize() {
+                if canon != source_canon && !canon.starts_with(&source_canon) {
+                    seen.insert(canon.clone());
+                    workspaces.push(ExtraLabWorkspace {
+                        role: "agent_task_plan".to_string(),
+                        path: canon,
+                        snapshot_includes: Vec::new(),
+                        bootstrap_node_dependencies: false,
+                    });
+                }
+            }
+        }
     }
 
-    Ok(vec![ExtraLabWorkspace {
-        role: "agent_task_plan".to_string(),
-        path: canon,
-        snapshot_includes: Vec::new(),
-        bootstrap_node_dependencies: false,
-    }])
+    let raw = match crate::core::config::read_json_spec_to_string(&spec) {
+        Ok(raw) => raw,
+        Err(_) => return Ok(workspaces),
+    };
+    let value: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(_) => return Ok(workspaces),
+    };
+    for candidate in provider_config_candidate_paths(&value) {
+        add_candidate_extra_workspace(
+            &candidate,
+            "agent_task_plan_config",
+            &source_canon,
+            &mut seen,
+            &mut workspaces,
+        )?;
+    }
+
+    Ok(workspaces)
 }
 
 pub(super) fn preflight_provider_config_source_cli_dependencies(
@@ -341,6 +322,59 @@ fn provider_config_candidate_paths(value: &serde_json::Value) -> Vec<String> {
     let mut paths = Vec::new();
     collect_provider_config_candidate_paths(value, &mut paths);
     paths
+}
+
+fn add_candidate_extra_workspace(
+    candidate: &str,
+    role: &str,
+    source_canon: &Path,
+    seen: &mut BTreeSet<PathBuf>,
+    workspaces: &mut Vec<ExtraLabWorkspace>,
+) -> Result<()> {
+    let expanded = shellexpand::tilde(candidate).to_string();
+    let path = Path::new(&expanded);
+    let (workspace_path, snapshot_includes, bootstrap_node_dependencies) = if path.is_dir() {
+        (path.to_path_buf(), Vec::new(), false)
+    } else if path.is_file() {
+        let workspace_path = containing_checkout_or_parent(path)?;
+        let snapshot_includes = provider_config_file_snapshot_includes(&workspace_path, path);
+        (
+            workspace_path,
+            snapshot_includes,
+            is_node_cli_file(path) && source_cli_workspace_has_package_lock(path),
+        )
+    } else {
+        return Ok(());
+    };
+    let canon = match workspace_path.canonicalize() {
+        Ok(canon) => canon,
+        Err(_) => return Ok(()),
+    };
+    // The primary workspace (and paths inside it) are already synced.
+    if canon == source_canon || canon.starts_with(source_canon) {
+        return Ok(());
+    }
+    if !seen.insert(canon.clone()) {
+        if let Some(existing) = workspaces
+            .iter_mut()
+            .find(|workspace| workspace.path == canon)
+        {
+            for include in snapshot_includes {
+                if !existing.snapshot_includes.contains(&include) {
+                    existing.snapshot_includes.push(include);
+                }
+            }
+            existing.bootstrap_node_dependencies |= bootstrap_node_dependencies;
+        }
+        return Ok(());
+    }
+    workspaces.push(ExtraLabWorkspace {
+        role: role.to_string(),
+        path: canon,
+        snapshot_includes,
+        bootstrap_node_dependencies,
+    });
+    Ok(())
 }
 
 fn collect_provider_config_candidate_paths(value: &serde_json::Value, paths: &mut Vec<String>) {
@@ -778,12 +812,32 @@ mod provider_config_candidate_paths_tests {
         let controller = tempfile::tempdir().expect("controller");
         let source = controller.path().join("primary");
         let planner = controller.path().join("plan-owner");
+        let codebox = controller.path().join("wp-codebox");
+        let codebox_bin = codebox.join("packages/cli/dist/index.js");
         let plan = planner.join(".ci/site-generation-loop.agent-task-plan.json");
         std::fs::create_dir_all(&source).expect("source dir");
         std::fs::create_dir_all(plan.parent().unwrap()).expect("plan dir");
+        std::fs::create_dir_all(codebox_bin.parent().unwrap()).expect("codebox cli dir");
+        std::fs::write(&codebox_bin, "#!/usr/bin/env node\n").expect("codebox bin");
+        std::fs::write(codebox.join("package-lock.json"), "{}\n").expect("package lock");
         std::fs::write(
             &plan,
-            "{\"schema\":\"homeboy/agent-task-plan/v1\",\"tasks\":[]}\n",
+            serde_json::json!({
+                "schema": "homeboy/agent-task-plan/v1",
+                "plan_id": "site-generation-loop",
+                "tasks": [{
+                    "task_id": "task-1",
+                    "executor": {
+                        "backend": "wp-codebox",
+                        "config": {
+                            "wp_codebox_bin": codebox_bin,
+                            "artifact_root": planner.join("artifacts")
+                        }
+                    },
+                    "instructions": "test"
+                }]
+            })
+            .to_string(),
         )
         .expect("plan file");
         git(&planner, &["init", "-b", "main"]);
@@ -791,6 +845,11 @@ mod provider_config_candidate_paths_tests {
         git(&planner, &["config", "user.name", "Homeboy Test"]);
         git(&planner, &["add", "."]);
         git(&planner, &["commit", "-m", "initial"]);
+        git(&codebox, &["init", "-b", "main"]);
+        git(&codebox, &["config", "user.email", "test@example.com"]);
+        git(&codebox, &["config", "user.name", "Homeboy Test"]);
+        git(&codebox, &["add", "."]);
+        git(&codebox, &["commit", "-m", "initial"]);
 
         let args = vec![
             "homeboy".to_string(),
@@ -802,11 +861,17 @@ mod provider_config_candidate_paths_tests {
 
         let workspaces = agent_task_plan_extra_workspaces(&args, &source).expect("workspaces");
 
-        assert_eq!(workspaces.len(), 1);
+        assert_eq!(workspaces.len(), 2);
         assert_eq!(workspaces[0].role, "agent_task_plan");
         assert_eq!(workspaces[0].path, planner.canonicalize().unwrap());
         assert!(workspaces[0].snapshot_includes.is_empty());
         assert!(!workspaces[0].bootstrap_node_dependencies);
+        assert_eq!(workspaces[1].role, "agent_task_plan_config");
+        assert_eq!(workspaces[1].path, codebox.canonicalize().unwrap());
+        assert!(workspaces[1]
+            .snapshot_includes
+            .contains(&"packages/cli/dist/**".to_string()));
+        assert!(workspaces[1].bootstrap_node_dependencies);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Discover controller-local paths embedded inside `agent-task run-plan` JSON payloads before Lab offload, so referenced checkouts are synced to the runner.
- Inline a runner-safe remapped plan JSON instead of forwarding a synced-but-unmodified `@file` plan that still contains controller paths.
- Keep the existing unreadable-plan fallback by remapping the `@file` path when the plan payload cannot be parsed.

Fixes #3910.

## Tests
- `cargo test core::runner::lab_args::tests`
- `cargo test agent_task_run_plan_file_path_syncs_containing_checkout`
- `cargo test agent_task_run_plan_file_inside_primary_workspace_needs_no_extra_sync`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented and tested the run-plan Lab offload path discovery/remapping fix; Chris remains responsible for review and merge.