### PR TITLE
Compare Codebox browser evidence metrics

### DIFF
--- a/src/commands/report/browser_evidence_compare.rs
+++ b/src/commands/report/browser_evidence_compare.rs
@@ -407,6 +407,8 @@ mod implementation {
             "browser_metrics",
             "lifecycle_metrics",
             "dom_lifecycle",
+            "summary",
+            "files",
             "console_errors",
             "page_errors",
             "errors",
@@ -438,7 +440,12 @@ mod implementation {
             source_artifact: Some(source.clone()),
             ..BrowserEvidenceSample::default()
         };
-        sample.assertions = assertion_stats(object.get("assertions"));
+        sample.assertions = assertion_stats(object.get("assertions").or_else(|| {
+            object
+                .get("summary")
+                .and_then(Value::as_object)
+                .and_then(|summary| summary.get("assertions"))
+        }));
         collect_requests(object, &mut sample);
         collect_metric_object(
             object.get("browser_metrics"),
@@ -447,6 +454,14 @@ mod implementation {
         );
         collect_metric_object(
             object.get("metrics"),
+            &mut sample.browser_metrics,
+            &browser_metric_names(),
+        );
+        collect_metric_object(
+            object
+                .get("summary")
+                .and_then(Value::as_object)
+                .and_then(|summary| summary.get("metrics")),
             &mut sample.browser_metrics,
             &browser_metric_names(),
         );
@@ -466,9 +481,17 @@ mod implementation {
             &mut sample.lifecycle_metrics,
             &lifecycle_metric_names(),
         );
-        sample.console_errors = error_count(object, &["console_errors", "consoleErrors"]);
-        sample.page_errors = error_count(object, &["page_errors", "pageErrors", "errors"]);
+        if let Some(summary) = object.get("summary").and_then(Value::as_object) {
+            collect_wp_codebox_summary(summary, &mut sample);
+        }
+        sample.console_errors = sample
+            .console_errors
+            .or_else(|| error_count(object, &["console_errors", "consoleErrors"]));
+        sample.page_errors = sample
+            .page_errors
+            .or_else(|| error_count(object, &["page_errors", "pageErrors", "errors"]));
         collect_artifacts(object, &mut sample.artifacts);
+        collect_wp_codebox_files(object.get("files"), &mut sample.artifacts);
         if sample.browser_metrics.is_empty() && sample.lifecycle_metrics.is_empty() {
             sample
                 .notes
@@ -809,6 +832,27 @@ mod implementation {
         }
     }
 
+    fn collect_wp_codebox_summary(
+        summary: &Map<String, Value>,
+        sample: &mut BrowserEvidenceSample,
+    ) {
+        if sample.request_total.is_none() {
+            sample.request_total = first_number(summary, &["networkEvents"]);
+        }
+        sample.page_errors = sample
+            .page_errors
+            .or_else(|| first_number(summary, &["errors"]));
+        for (metric, keys) in [
+            ("browser_console_message_count", ["consoleMessages"]),
+            ("browser_page_error_count", ["errors"]),
+            ("browser_network_event_count", ["networkEvents"]),
+        ] {
+            if let Some(value) = first_number(summary, &keys) {
+                sample.browser_metrics.insert(metric.to_string(), value);
+            }
+        }
+    }
+
     fn collect_artifacts(object: &Map<String, Value>, artifacts: &mut BTreeSet<ArtifactRef>) {
         let Some(values) = object.get("artifacts").and_then(Value::as_array) else {
             return;
@@ -819,6 +863,35 @@ mod implementation {
             let target = first_value_string(artifact, &["url", "href", "path", "target"]);
             if let Some(target) = target {
                 artifacts.insert(ArtifactRef { label, target });
+            }
+        }
+    }
+
+    fn collect_wp_codebox_files(value: Option<&Value>, artifacts: &mut BTreeSet<ArtifactRef>) {
+        let Some(files) = value.and_then(Value::as_object) else {
+            return;
+        };
+        for (label, value) in files {
+            match value {
+                Value::String(target) if !target.is_empty() => {
+                    artifacts.insert(ArtifactRef {
+                        label: label.clone(),
+                        target: target.clone(),
+                    });
+                }
+                Value::Array(values) => {
+                    for target in values
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .filter(|target| !target.is_empty())
+                    {
+                        artifacts.insert(ArtifactRef {
+                            label: label.clone(),
+                            target: target.to_string(),
+                        });
+                    }
+                }
+                _ => {}
             }
         }
     }
@@ -944,6 +1017,13 @@ mod implementation {
                 out.insert((*name).to_string(), value);
             }
         }
+        for (name, value) in object {
+            if name.starts_with("browser_") {
+                if let Some(value) = value.as_f64() {
+                    out.insert(name.clone(), value);
+                }
+            }
+        }
     }
 
     fn collect_count_map(value: Option<&Value>, out: &mut BTreeMap<String, f64>) {
@@ -1064,6 +1144,34 @@ mod implementation {
             "load_ms",
             "duration_ms",
             "ready_ms",
+            "browser_peak_used_js_heap_bytes",
+            "browser_final_used_js_heap_bytes",
+            "browser_checkpoint_count",
+            "browser_dom_node_count",
+            "browser_iframe_count",
+            "browser_resource_count",
+            "browser_transfer_size_bytes",
+            "browser_nav_duration_ms",
+            "browser_dom_content_loaded_ms",
+            "browser_load_event_ms",
+            "browser_response_start_ms",
+            "browser_response_end_ms",
+            "browser_request_start_ms",
+            "browser_ttfb_ms",
+            "browser_redirect_ms",
+            "browser_first_paint_ms",
+            "browser_fcp_ms",
+            "browser_lcp_ms",
+            "browser_lcp_size",
+            "browser_long_task_count",
+            "browser_long_task_total_ms",
+            "browser_cls",
+            "browser_layout_shift_count",
+            "browser_layout_shift_max",
+            "browser_evidence_summary_present",
+            "browser_console_message_count",
+            "browser_page_error_count",
+            "browser_network_event_count",
         ]
     }
 

--- a/tests/report_browser_evidence_compare_test.rs
+++ b/tests/report_browser_evidence_compare_test.rs
@@ -240,3 +240,96 @@ fn compares_browser_evidence_across_multiple_run_dirs() {
 
     let _ = fs::remove_dir_all(&root);
 }
+
+#[test]
+fn promotes_wp_codebox_browser_summary_metrics() {
+    let root = tmp_dir("wp-codebox-summary");
+    write_fixture_file(
+        &root.join("baseline"),
+        "summary.json",
+        r#"{
+            "schema":"wp-codebox/browser-probe/v1",
+            "summary": {
+                "assertions": {"total": 1, "passed": 1, "failed": 0, "skipped": 0},
+                "consoleMessages": 0,
+                "errors": 0,
+                "networkEvents": 12,
+                "metrics": {
+                    "browser_lcp_ms": 1200,
+                    "browser_peak_used_js_heap_bytes": 64000,
+                    "browser_transfer_size_bytes": 100000,
+                    "browser_dom_node_count": 320
+                }
+            },
+            "files": {
+                "summary": "files/browser/summary.json",
+                "performance": "files/browser/performance.json",
+                "memory": "files/browser/memory.json",
+                "screenshot": "files/browser/screenshot.png"
+            }
+        }"#,
+    );
+    write_fixture_file(
+        &root.join("candidate"),
+        "summary.json",
+        r#"{
+            "schema":"wp-codebox/browser-probe/v1",
+            "summary": {
+                "assertions": {"total": 1, "passed": 1, "failed": 0, "skipped": 0},
+                "consoleMessages": 1,
+                "errors": 1,
+                "networkEvents": 14,
+                "metrics": {
+                    "browser_lcp_ms": 1500,
+                    "browser_peak_used_js_heap_bytes": 96000,
+                    "browser_transfer_size_bytes": 140000,
+                    "browser_dom_node_count": 400
+                }
+            },
+            "files": {
+                "summary": "files/browser/summary.json",
+                "performance": "files/browser/performance.json",
+                "memory": "files/browser/memory.json",
+                "screenshot": "files/browser/screenshot.png"
+            }
+        }"#,
+    );
+
+    let report = browser_evidence_compare_from_args(&args(&root, false)).expect("report renders");
+    let variant = report.variants.first().expect("variant should exist");
+
+    assert_eq!(report.totals.baseline_samples, 1);
+    assert_eq!(report.totals.candidate_samples, 1);
+    assert_eq!(variant.assertions.pass_delta, 0);
+    assert_eq!(variant.request_totals.median_delta, Some(2.0));
+    assert_eq!(variant.console_errors.median_delta, None);
+    assert_eq!(variant.page_errors.median_delta, Some(1.0));
+    assert_eq!(
+        variant.browser_metrics["browser_lcp_ms"].median_delta,
+        Some(300.0)
+    );
+    assert_eq!(
+        variant.browser_metrics["browser_peak_used_js_heap_bytes"].median_delta,
+        Some(32000.0)
+    );
+    assert_eq!(
+        variant.browser_metrics["browser_console_message_count"].median_delta,
+        Some(1.0)
+    );
+    assert_eq!(
+        variant.browser_metrics["browser_network_event_count"].median_delta,
+        Some(2.0)
+    );
+    assert!(variant
+        .artifacts
+        .baseline
+        .iter()
+        .any(|artifact| artifact.label == "performance"));
+    assert!(variant
+        .artifacts
+        .candidate
+        .iter()
+        .any(|artifact| artifact.target == "files/browser/screenshot.png"));
+
+    let _ = fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
## Summary
- Teach browser evidence comparison to read WP Codebox browser summary envelopes.
- Promote Codebox `browser_*` metrics, request counts, page errors, assertions, and browser artifact refs into baseline/candidate reports.
- Add fixture coverage for `wp-codebox/browser-probe/v1` summaries.

## Verification
- `cargo fmt --check`
- `cargo test --test report_browser_evidence_compare_test --quiet`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the generic Codebox browser evidence comparison parser and tests; Chris remains responsible for review and merge.