### PR TITLE
Fix Lab run-plan remapping for symlinked dependencies

### DIFF
--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::Path;
 
 use crate::core::agent_task_lifecycle;
@@ -532,6 +533,20 @@ fn run_lab_offload_inner(
     )?;
     let remapped_args = remap_provider_config_in_args(&changed_since_preflight.args, &path_remaps);
     let remapped_args = remap_agent_task_plan_in_args(&remapped_args, &path_remaps);
+    let (remapped_args, synced_remapped_plan) =
+        materialize_inline_agent_task_plan_arg(runner_id, &remapped_args)?;
+    if let Some(entry) = synced_remapped_plan {
+        workspace_mapping.push(entry.clone());
+        plan = with_step(
+            plan,
+            PlanStep::ready(
+                "lab.sync_remapped_agent_task_plan",
+                "lab.sync_remapped_agent_task_plan",
+            )
+            .inputs(PlanValues::new().json("workspace", &entry))
+            .build(),
+        );
+    }
 
     let mut command = command_prefix.argv;
     command.extend(
@@ -709,6 +724,108 @@ fn run_lab_offload_inner(
     })
 }
 
+fn materialize_inline_agent_task_plan_arg(
+    runner_id: &str,
+    args: &[String],
+) -> Result<(
+    Vec<String>,
+    Option<super::lab_workspaces::LabWorkspaceMappingEntry>,
+)> {
+    if args.get(1).map(String::as_str) != Some("agent-task")
+        || args.get(2).map(String::as_str) != Some("run-plan")
+    {
+        return Ok((args.to_vec(), None));
+    }
+
+    let mut out = Vec::with_capacity(args.len());
+    let mut iter = args.iter().peekable();
+    let mut passthrough = false;
+    while let Some(arg) = iter.next() {
+        if passthrough {
+            out.push(arg.clone());
+            continue;
+        }
+        if arg == "--" {
+            passthrough = true;
+            out.push(arg.clone());
+            continue;
+        }
+        if arg == "--plan" {
+            out.push(arg.clone());
+            if let Some(spec) = iter.next() {
+                if let Some((remapped_spec, entry)) = sync_inline_agent_task_plan(runner_id, spec)?
+                {
+                    out.push(remapped_spec);
+                    out.extend(iter.cloned());
+                    return Ok((out, Some(entry)));
+                }
+                out.push(spec.clone());
+            }
+            continue;
+        }
+        if let Some(spec) = arg.strip_prefix("--plan=") {
+            if let Some((remapped_spec, entry)) = sync_inline_agent_task_plan(runner_id, spec)? {
+                out.push(format!("--plan={remapped_spec}"));
+                out.extend(iter.cloned());
+                return Ok((out, Some(entry)));
+            }
+        }
+        out.push(arg.clone());
+    }
+
+    Ok((out, None))
+}
+
+fn sync_inline_agent_task_plan(
+    runner_id: &str,
+    spec: &str,
+) -> Result<Option<(String, super::lab_workspaces::LabWorkspaceMappingEntry)>> {
+    if spec == "-" || spec.starts_with('@') || !looks_like_inline_json(spec) {
+        return Ok(None);
+    }
+    serde_json::from_str::<serde_json::Value>(spec).map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("parse remapped agent-task plan".to_string()),
+        )
+    })?;
+
+    let temp = tempfile::tempdir().map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("create remapped agent-task plan workspace".to_string()),
+        )
+    })?;
+    let plan_file = temp.path().join("agent-task-plan.json");
+    fs::write(&plan_file, spec).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("write remapped agent-task plan".to_string()),
+        )
+    })?;
+    let synced = sync_workspace(
+        runner_id,
+        RunnerWorkspaceSyncOptions {
+            path: temp.path().display().to_string(),
+            mode: RunnerWorkspaceSyncMode::Snapshot,
+            changed_since_base: None,
+            snapshot_includes: Vec::new(),
+        },
+    )?
+    .0;
+    let remote_spec = format!(
+        "@{}/agent-task-plan.json",
+        synced.remote_path.trim_end_matches('/')
+    );
+    let entry = workspace_mapping_entry("agent_task_plan_remapped", &synced);
+    Ok(Some((remote_spec, entry)))
+}
+
+fn looks_like_inline_json(spec: &str) -> bool {
+    let trimmed = spec.trim_start();
+    trimmed.starts_with('{') || trimmed.starts_with('[')
+}
+
 fn in_flight_daemon_disconnect_error(
     runner_id: &str,
     job_id: &str,
@@ -748,12 +865,7 @@ fn mirror_agent_task_run_plan_lifecycle(args: &[String], stdout: &str) -> Result
     if plan_spec == "-" {
         return Ok(());
     }
-    let envelope: serde_json::Value = serde_json::from_str(stdout).map_err(|error| {
-        Error::internal_json(
-            error.to_string(),
-            Some("parse offloaded agent-task run-plan output".to_string()),
-        )
-    })?;
+    let envelope = parse_offloaded_run_plan_envelope(stdout)?;
     let Some(aggregate_value) = envelope.get("data").cloned() else {
         return Ok(());
     };
@@ -776,6 +888,26 @@ fn mirror_agent_task_run_plan_lifecycle(args: &[String], stdout: &str) -> Result
     agent_task_lifecycle::mark_running(&run_id)?;
     agent_task_lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;
     Ok(())
+}
+
+fn parse_offloaded_run_plan_envelope(stdout: &str) -> Result<serde_json::Value> {
+    if let Ok(value) = serde_json::from_str(stdout) {
+        return Ok(value);
+    }
+
+    for (index, _) in stdout.match_indices('{') {
+        let mut stream = serde_json::Deserializer::from_str(&stdout[index..]).into_iter();
+        if let Some(Ok(value)) = stream.next() {
+            return Ok(value);
+        }
+    }
+
+    serde_json::from_str(stdout).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("parse offloaded agent-task run-plan output".to_string()),
+        )
+    })
 }
 
 fn agent_task_run_plan_recording_args(args: &[String]) -> Option<(String, String)> {
@@ -1238,6 +1370,21 @@ mod tests {
         .expect("parse lab offload metadata");
 
         assert_eq!(parsed["workspace_mapping"], mapping);
+    }
+
+    #[test]
+    fn offloaded_run_plan_envelope_parser_tolerates_extension_stdout_chatter() {
+        let stdout = concat!(
+            "Setting up WordPress extension...\n",
+            "Installing npm dependencies...\n",
+            "{\"success\":false,\"data\":{\"status\":\"failed\"}}\n",
+            "trailing diagnostic\n"
+        );
+
+        let parsed = parse_offloaded_run_plan_envelope(stdout).expect("parse mixed stdout");
+
+        assert_eq!(parsed["success"], false);
+        assert_eq!(parsed["data"]["status"], "failed");
     }
 
     #[test]

--- a/src/core/runner/lab_args.rs
+++ b/src/core/runner/lab_args.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::path::PathBuf;
 
 use serde_json::Value;
@@ -181,6 +182,10 @@ fn remap_paths_in_value(value: &mut Value, mappings: &[&LabPathRemap]) {
 /// Replace a leading known local path with its remote equivalent. Matches whole
 /// path or path-prefix boundaries (so `/a/b` does not match `/a/bc`).
 fn remap_local_path(text: &str, mappings: &[&LabPathRemap]) -> Option<String> {
+    if let Some(remapped) = remap_existing_canonical_path(text, mappings) {
+        return Some(remapped);
+    }
+
     for mapping in mappings {
         if mapping.local.is_empty() {
             continue;
@@ -194,6 +199,29 @@ fn remap_local_path(text: &str, mappings: &[&LabPathRemap]) -> Option<String> {
         }
     }
     None
+}
+
+fn remap_existing_canonical_path(text: &str, mappings: &[&LabPathRemap]) -> Option<String> {
+    if !is_controller_path_like(text) {
+        return None;
+    }
+    let expanded = shellexpand::tilde(text).to_string();
+    let canonical = Path::new(&expanded).canonicalize().ok()?;
+    let canonical = canonical.to_string_lossy().to_string();
+    for mapping in mappings {
+        if canonical == mapping.local {
+            return Some(mapping.remote.clone());
+        }
+        let prefix = format!("{}/", mapping.local.trim_end_matches('/'));
+        if let Some(rest) = canonical.strip_prefix(&prefix) {
+            return Some(format!("{}/{}", mapping.remote.trim_end_matches('/'), rest));
+        }
+    }
+    None
+}
+
+fn is_controller_path_like(value: &str) -> bool {
+    value.starts_with('/') || value.starts_with("~/")
 }
 
 pub(super) fn lab_offload_source_path(args: &[String]) -> Result<PathBuf> {
@@ -493,6 +521,67 @@ mod tests {
             "/home/chubes/Developer/wp-site-generator/artifacts"
         );
         assert!(out.iter().any(|a| a == "--record-run-id=loop-1"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn remap_agent_task_run_plan_prefers_canonical_symlink_target() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let primary = temp.path().join("wp-site-generator");
+        let codebox = temp.path().join("wp-codebox");
+        let codebox_bin = codebox.join("packages/cli/dist/index.js");
+        let symlink = primary.join(".ci/wp-codebox");
+        let plan = primary.join(".ci/site-generation-loop.agent-task-plan.json");
+        std::fs::create_dir_all(symlink.parent().unwrap()).expect("ci dir");
+        std::fs::create_dir_all(codebox_bin.parent().unwrap()).expect("codebox bin dir");
+        std::fs::write(&codebox_bin, "#!/usr/bin/env node\n").expect("codebox bin");
+        std::os::unix::fs::symlink(&codebox, &symlink).expect("codebox symlink");
+        let symlinked_bin = symlink.join("packages/cli/dist/index.js");
+        std::fs::write(
+            &plan,
+            serde_json::json!({
+                "schema": "homeboy/agent-task-plan/v1",
+                "plan_id": "plan-1",
+                "tasks": [{
+                    "task_id": "task-1",
+                    "executor": {
+                        "backend": "wp-codebox",
+                        "config": { "wp_codebox_bin": symlinked_bin }
+                    },
+                    "instructions": "test"
+                }]
+            })
+            .to_string(),
+        )
+        .expect("write plan");
+
+        let mappings = vec![
+            LabPathRemap {
+                local: primary.canonicalize().unwrap().display().to_string(),
+                remote: "/home/chubes/_lab_workspaces/wp-site-generator".to_string(),
+            },
+            LabPathRemap {
+                local: codebox.canonicalize().unwrap().display().to_string(),
+                remote: "/home/chubes/_lab_workspaces/wp-codebox".to_string(),
+            },
+        ];
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--plan".to_string(),
+            format!("@{}", plan.display()),
+        ];
+
+        let out = remap_agent_task_plan_in_args(&args, &mappings);
+        let plan_idx = out.iter().position(|a| a == "--plan").unwrap() + 1;
+        let remapped: serde_json::Value =
+            serde_json::from_str(&out[plan_idx]).expect("inline plan");
+
+        assert_eq!(
+            remapped["tasks"][0]["executor"]["config"]["wp_codebox_bin"],
+            "/home/chubes/_lab_workspaces/wp-codebox/packages/cli/dist/index.js"
+        );
     }
 
     #[test]

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -899,6 +899,64 @@ mod provider_config_candidate_paths_tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn agent_task_run_plan_syncs_symlinked_dependency_target_inside_primary_workspace() {
+        let controller = tempfile::tempdir().expect("controller");
+        let source = controller.path().join("primary");
+        let codebox = controller.path().join("wp-codebox");
+        let codebox_bin = codebox.join("packages/cli/dist/index.js");
+        let symlink = source.join(".ci/wp-codebox");
+        let plan = source.join(".ci/site-generation-loop.agent-task-plan.json");
+        std::fs::create_dir_all(symlink.parent().unwrap()).expect("ci dir");
+        std::fs::create_dir_all(codebox_bin.parent().unwrap()).expect("codebox cli dir");
+        std::fs::write(&codebox_bin, "#!/usr/bin/env node\n").expect("codebox bin");
+        std::fs::write(codebox.join("package-lock.json"), "{}\n").expect("package lock");
+        std::os::unix::fs::symlink(&codebox, &symlink).expect("codebox symlink");
+        std::fs::write(
+            &plan,
+            serde_json::json!({
+                "schema": "homeboy/agent-task-plan/v1",
+                "plan_id": "site-generation-loop",
+                "tasks": [{
+                    "task_id": "task-1",
+                    "executor": {
+                        "backend": "wp-codebox",
+                        "config": {
+                            "wp_codebox_bin": symlink.join("packages/cli/dist/index.js")
+                        }
+                    },
+                    "instructions": "test"
+                }]
+            })
+            .to_string(),
+        )
+        .expect("plan file");
+        git(&codebox, &["init", "-b", "main"]);
+        git(&codebox, &["config", "user.email", "test@example.com"]);
+        git(&codebox, &["config", "user.name", "Homeboy Test"]);
+        git(&codebox, &["add", "."]);
+        git(&codebox, &["commit", "-m", "initial"]);
+
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--plan".to_string(),
+            format!("@{}", plan.display()),
+        ];
+
+        let workspaces = agent_task_plan_extra_workspaces(&args, &source).expect("workspaces");
+
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(workspaces[0].role, "agent_task_plan_config");
+        assert_eq!(workspaces[0].path, codebox.canonicalize().unwrap());
+        assert!(workspaces[0]
+            .snapshot_includes
+            .contains(&"packages/cli/dist/**".to_string()));
+        assert!(workspaces[0].bootstrap_node_dependencies);
+    }
+
+    #[test]
     fn source_cli_preflight_names_missing_workspace_package_and_importer() {
         let provider = tempfile::tempdir().expect("provider checkout");
         let cli = provider.path().join("packages/cli/dist/index.js");


### PR DESCRIPTION
## Summary
- Remap existing controller paths through their canonical target before applying Lab workspace mappings, so symlinked plan dependencies resolve to synced target workspaces.
- Stage remapped inline `agent-task run-plan` JSON as a remote `@file` to avoid giant argv payloads on the runner daemon.
- Tolerate extension/setup stdout chatter when mirroring offloaded run-plan lifecycle output.

## Verification
- `cargo test remap_agent_task --quiet`
- `cargo test provider_config_candidate_paths_tests --quiet`
- `cargo test offloaded_run_plan_envelope_parser_tolerates_extension_stdout_chatter --quiet`
- `cargo check --quiet`
- Full Lab plan `site-generation-loop-controller-after-output-parser` completed with 6 succeeded, 0 failed, 0 skipped after paired Homeboy Extensions/WP Codebox policy fixes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the path remapping/staging/parser changes, regression tests, and verification commands; Chris reviewed and directed the end-to-end Lab proof.