### PR TITLE
Keep Lab rig dependencies fresh

### DIFF
--- a/src/core/runner/git_dependency_materialization.rs
+++ b/src/core/runner/git_dependency_materialization.rs
@@ -1,11 +1,16 @@
+use std::path::Path;
+use std::process::Command;
+
 use serde::Serialize;
 
-use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
 
 use super::{
-    workspace::{canonical_workspace_path, git_output, ssh_client_for_runner},
-    Runner, RunnerKind,
+    workspace::{
+        canonical_workspace_path, effective_snapshot_excludes, git_output, local_snapshot_stats,
+        materialize_snapshot, snapshot_identity, DEFAULT_EXCLUDES,
+    },
+    Runner, RunnerWorkspaceSyncMode,
 };
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -15,6 +20,9 @@ pub(crate) struct RunnerGitDependencyMaterializationOutput {
     pub remote_url: String,
     pub head: String,
     pub status: String,
+    pub sync_mode: RunnerWorkspaceSyncMode,
+    pub files: usize,
+    pub bytes: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -30,154 +38,266 @@ pub(crate) fn materialize_git_dependency(
     options: RunnerGitDependencyMaterializationOptions,
 ) -> Result<RunnerGitDependencyMaterializationOutput> {
     let local_path = canonical_workspace_path(&options.local_path)?;
-    let head = git_output(&local_path, &["rev-parse", "HEAD"])?;
-    let remote_url = match options.remote_url {
-        Some(remote_url) if !remote_url.trim().is_empty() => remote_url,
-        _ => git_output(&local_path, &["config", "--get", "remote.origin.url"])?,
-    };
-    if remote_url.trim().is_empty() {
-        return Err(Error::validation_invalid_argument(
-            "remote_url",
-            "rig dependency materialization requires a git remote URL",
-            Some(local_path.display().to_string()),
-            Some(vec![
-                "Set components.<id>.remote_url in the rig spec or configure remote.origin.url on the local checkout.".to_string(),
-            ]),
-        ));
+    if let Some(subpath) = options
+        .required_subpath
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        let required_path = local_path.join(subpath);
+        if !required_path.is_dir() {
+            return Err(Error::validation_invalid_argument(
+                "rig_component_dependency",
+                "rig dependency snapshot is missing required subpath",
+                Some(required_path.display().to_string()),
+                None,
+            ));
+        }
     }
 
-    let command = materialize_git_dependency_command(
-        &options.remote_path,
-        &remote_url,
-        &head,
-        options.required_subpath.as_deref(),
-    );
-    let status = match runner.kind {
-        RunnerKind::Local => {
-            run_shell_command_with_stdout(&command, "materialize local git dependency")?
-        }
-        RunnerKind::Ssh => {
-            let (_server, client) = ssh_client_for_runner(runner)?;
-            let output = client.execute(&command);
-            if !output.success {
-                return Err(Error::validation_invalid_argument(
-                    "rig_component_dependency",
-                    "runner dispatch could not safely materialize a rig component dependency",
-                    Some(options.remote_path.clone()),
-                    Some(vec![output.stderr.trim().to_string()]),
-                ));
-            }
-            output.stdout.trim().to_string()
-        }
+    let remote_url = match options.remote_url {
+        Some(remote_url) if !remote_url.trim().is_empty() => remote_url,
+        _ => git_output(&local_path, &["config", "--get", "remote.origin.url"]).unwrap_or_default(),
     };
+    let update_status = auto_update_clean_git_dependency(&local_path)?;
+    let mut excludes = DEFAULT_EXCLUDES
+        .iter()
+        .map(|value| value.to_string())
+        .collect::<Vec<_>>();
+    for pattern in &runner.policy.snapshot_excludes {
+        if !excludes.contains(pattern) {
+            excludes.push(pattern.clone());
+        }
+    }
+    let excludes = effective_snapshot_excludes(excludes, &runner.policy.snapshot_includes);
+    let snapshot = snapshot_identity(&local_path, &excludes, &runner.policy.snapshot_includes)?;
+    let stats = local_snapshot_stats(&local_path, &excludes, &runner.policy.snapshot_includes)?;
+    materialize_snapshot(runner, &local_path, &options.remote_path, &excludes)?;
 
     Ok(RunnerGitDependencyMaterializationOutput {
         local_path: local_path.display().to_string(),
         remote_path: options.remote_path,
         remote_url,
-        head,
-        status,
+        head: snapshot,
+        status: update_status.label().to_string(),
+        sync_mode: RunnerWorkspaceSyncMode::Snapshot,
+        files: stats.files,
+        bytes: stats.bytes,
     })
 }
 
-fn materialize_git_dependency_command(
-    remote_path: &str,
-    remote_url: &str,
-    head: &str,
-    required_subpath: Option<&str>,
-) -> String {
-    let required_subpath_check = required_subpath
-        .filter(|subpath| !subpath.trim().is_empty())
-        .map(|subpath| {
-            format!(
-                " && if [ ! -d \"$dest/{}\" ]; then echo \"dependency checkout is missing required subpath: $dest/{}\" >&2; exit 23; fi",
-                shell_escape_double_quoted(subpath),
-                shell_escape_double_quoted(subpath),
-            )
-        })
-        .unwrap_or_default();
-
-    format!(
-        r#"raw={raw}; case "$raw" in '~') dest="$HOME" ;; [~]/*) suffix=${{raw#\~/}}; dest="$HOME/$suffix" ;; *) dest="$raw" ;; esac; parent=$(dirname "$dest"); mkdir -p "$parent" && if [ ! -e "$dest" ]; then git clone {url} "$dest" && git -C "$dest" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*' && git -C "$dest" checkout --detach {head} && echo cloned; elif [ ! -d "$dest/.git" ]; then echo "dependency path exists but is not a git checkout: $dest" >&2; exit 20; else actual_url=$(git -C "$dest" config --get remote.origin.url || true); if [ "$actual_url" != {url} ]; then echo "dependency checkout remote mismatch at $dest: expected {url}, found $actual_url" >&2; exit 21; fi; git -C "$dest" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; actual_head=$(git -C "$dest" rev-parse HEAD); if [ "$actual_head" != {head} ]; then echo "dependency checkout freshness mismatch at $dest: expected {head}, found $actual_head" >&2; exit 22; fi; echo reused; fi{required_subpath_check}"#,
-        raw = shell::quote_arg(remote_path),
-        url = shell::quote_arg(remote_url),
-        head = shell::quote_arg(head),
-        required_subpath_check = required_subpath_check,
-    )
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DependencyUpdateStatus {
+    NotGit,
+    DirtySkipped,
+    NoUpstreamSkipped,
+    UpToDate,
+    FastForwarded,
 }
 
-fn shell_escape_double_quoted(value: &str) -> String {
-    value
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('$', "\\$")
-        .replace('`', "\\`")
-}
-
-fn run_shell_command_with_stdout(command: &str, action: &str) -> Result<String> {
-    let output = std::process::Command::new("sh")
-        .args(["-c", command])
-        .output()
-        .map_err(|err| Error::internal_io(err.to_string(), Some(action.to_string())))?;
-    if output.status.success() {
-        return Ok(String::from_utf8_lossy(&output.stdout).trim().to_string());
+impl DependencyUpdateStatus {
+    fn label(self) -> &'static str {
+        match self {
+            Self::NotGit => "snapshotted",
+            Self::DirtySkipped => "snapshotted_dirty_dependency_not_updated",
+            Self::NoUpstreamSkipped => "snapshotted_no_upstream_dependency_not_updated",
+            Self::UpToDate => "snapshotted_up_to_date",
+            Self::FastForwarded => "snapshotted_fast_forwarded",
+        }
     }
-    Err(Error::internal_unexpected(format!(
-        "{action} failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    )))
+}
+
+fn auto_update_clean_git_dependency(local_path: &Path) -> Result<DependencyUpdateStatus> {
+    if !local_path.join(".git").exists() {
+        return Ok(DependencyUpdateStatus::NotGit);
+    }
+
+    let status = git_output(local_path, &["status", "--porcelain=v1"])?;
+    if !status.trim().is_empty() {
+        return Ok(DependencyUpdateStatus::DirtySkipped);
+    }
+
+    let upstream = match git_output(
+        local_path,
+        &["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+    ) {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => return Ok(DependencyUpdateStatus::NoUpstreamSkipped),
+    };
+    let remote = upstream.split('/').next().unwrap_or("").trim();
+    if remote.is_empty() || remote == upstream {
+        return Ok(DependencyUpdateStatus::NoUpstreamSkipped);
+    }
+
+    let before = git_output(local_path, &["rev-parse", "HEAD"])?;
+    run_git(local_path, &["fetch", "--prune", remote])?;
+    run_git(local_path, &["merge", "--ff-only", "@{u}"])?;
+    let after = git_output(local_path, &["rev-parse", "HEAD"])?;
+
+    if before == after {
+        Ok(DependencyUpdateStatus::UpToDate)
+    } else {
+        Ok(DependencyUpdateStatus::FastForwarded)
+    }
+}
+
+fn run_git(local_path: &Path, args: &[&str]) -> Result<()> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(local_path)
+        .output()
+        .map_err(|err| Error::internal_io(err.to_string(), Some("run git".to_string())))?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "rig_component_dependency",
+        format!(
+            "git dependency auto-update failed while running git {}",
+            args.join(" ")
+        ),
+        Some(String::from_utf8_lossy(&output.stderr).trim().to_string()),
+        Some(vec![
+            "Commit or stash dependency changes before Lab offload.".to_string(),
+            "If the dependency branch diverged, update or rebase it manually before rerunning."
+                .to_string(),
+        ]),
+    ))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::materialize_git_dependency_command;
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+
+    use super::{auto_update_clean_git_dependency, DependencyUpdateStatus};
 
     #[test]
-    fn dependency_materialization_clones_missing_checkout_non_destructively() {
-        let command = materialize_git_dependency_command(
-            "~/Developer/woocommerce",
-            "https://github.com/woocommerce/woocommerce.git",
-            "abc123",
-            Some("plugins/woocommerce"),
-        );
+    fn auto_update_clean_dependency_fast_forwards_to_upstream() {
+        let fixture = GitFixture::new();
+        fixture.commit_file("initial.txt", "initial");
+        fixture.push();
 
-        assert!(command.contains("if [ ! -e \"$dest\" ]; then git clone"));
-        assert!(command.contains("checkout --detach"));
-        assert!(command.contains("abc123"));
-        assert!(command.contains("elif [ ! -d \"$dest/.git\" ]; then"));
-        assert!(command.contains("dependency path exists but is not a git checkout"));
-        assert!(command.contains("dependency checkout is missing required subpath"));
-        assert!(!command.contains("rm -rf"));
-        assert!(!command.contains("reset --hard"));
-        assert!(!command.contains("clean -ffdqx"));
+        let checkout = fixture.clone_checkout();
+        let before = git_output(checkout.path(), &["rev-parse", "HEAD"]);
+        fixture.commit_file("next.txt", "next");
+        fixture.push();
+        let expected = fixture.head();
+
+        let status = auto_update_clean_git_dependency(checkout.path()).expect("auto update");
+
+        assert_eq!(status, DependencyUpdateStatus::FastForwarded);
+        assert_ne!(before, expected);
+        assert_eq!(
+            git_output(checkout.path(), &["rev-parse", "HEAD"]),
+            expected
+        );
     }
 
     #[test]
-    fn dependency_materialization_diagnoses_remote_and_freshness_mismatches() {
-        let command = materialize_git_dependency_command(
-            "/home/chubes/Developer/woocommerce",
-            "https://github.com/woocommerce/woocommerce.git",
-            "abc123",
-            None,
-        );
+    fn auto_update_dirty_dependency_leaves_checkout_unchanged() {
+        let fixture = GitFixture::new();
+        fixture.commit_file("initial.txt", "initial");
+        fixture.push();
 
-        assert!(command.contains("dependency checkout remote mismatch"));
-        assert!(command.contains("dependency checkout freshness mismatch"));
-        assert!(command.contains("git -C \"$dest\" fetch --prune origin"));
-        assert!(command.contains("actual_head=$(git -C \"$dest\" rev-parse HEAD)"));
+        let checkout = fixture.clone_checkout();
+        let before = git_output(checkout.path(), &["rev-parse", "HEAD"]);
+        fs::write(checkout.path().join("dirty.txt"), "dirty").expect("write dirty file");
+        fixture.commit_file("next.txt", "next");
+        fixture.push();
+
+        let status = auto_update_clean_git_dependency(checkout.path()).expect("auto update");
+
+        assert_eq!(status, DependencyUpdateStatus::DirtySkipped);
+        assert_eq!(git_output(checkout.path(), &["rev-parse", "HEAD"]), before);
     }
 
-    #[test]
-    fn dependency_materialization_preserves_runner_tilde_expansion() {
-        let command = materialize_git_dependency_command(
-            "~/Developer/woocommerce",
-            "https://github.com/woocommerce/woocommerce.git",
-            "abc123",
-            None,
-        );
+    struct GitFixture {
+        remote: tempfile::TempDir,
+        work: tempfile::TempDir,
+    }
 
-        assert!(command.contains("case \"$raw\" in '~')"));
-        assert!(command.contains("[~]/*) suffix=${raw#\\~/}; dest=\"$HOME/$suffix\""));
-        assert!(!command.contains("$HOME/~/"));
+    impl GitFixture {
+        fn new() -> Self {
+            let remote = tempfile::tempdir().expect("remote");
+            run_git(remote.path(), &["init", "--bare"]);
+
+            let work = tempfile::tempdir().expect("work");
+            run_git(work.path(), &["init"]);
+            run_git(
+                work.path(),
+                &["config", "user.email", "homeboy@example.test"],
+            );
+            run_git(work.path(), &["config", "user.name", "Homeboy Test"]);
+            run_git(
+                work.path(),
+                &[
+                    "remote",
+                    "add",
+                    "origin",
+                    remote.path().to_str().expect("remote path"),
+                ],
+            );
+
+            Self { remote, work }
+        }
+
+        fn commit_file(&self, name: &str, contents: &str) {
+            fs::write(self.work.path().join(name), contents).expect("write file");
+            run_git(self.work.path(), &["add", name]);
+            run_git(self.work.path(), &["commit", "-m", name]);
+        }
+
+        fn push(&self) {
+            run_git(self.work.path(), &["push", "-u", "origin", "HEAD:main"]);
+        }
+
+        fn head(&self) -> String {
+            git_output(self.work.path(), &["rev-parse", "HEAD"])
+        }
+
+        fn clone_checkout(&self) -> tempfile::TempDir {
+            let checkout = tempfile::tempdir().expect("checkout");
+            run_git(
+                Path::new("/"),
+                &[
+                    "clone",
+                    self.remote.path().to_str().expect("remote path"),
+                    checkout.path().to_str().expect("checkout path"),
+                ],
+            );
+            run_git(checkout.path(), &["checkout", "main"]);
+            checkout
+        }
+    }
+
+    fn run_git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_output(path: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
     }
 }

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -101,7 +101,7 @@ pub(super) fn workspace_mapping_entry_for_git_dependency(
         role: role.into(),
         local_path: dependency.local_path.clone(),
         remote_path: dependency.remote_path.clone(),
-        sync_mode: "git".to_string(),
+        sync_mode: dependency.sync_mode.label().to_string(),
         snapshot_identity: dependency.head.clone(),
     }
 }
@@ -676,7 +676,9 @@ mod provider_config_candidate_paths_tests {
     use super::{
         agent_task_plan_extra_workspaces, preflight_provider_config_source_cli_dependencies,
         provider_config_candidate_paths, provider_config_extra_workspaces,
+        workspace_mapping_entry_for_git_dependency,
     };
+    use crate::core::runner::{RunnerGitDependencyMaterializationOutput, RunnerWorkspaceSyncMode};
 
     fn git(path: &Path, args: &[&str]) {
         let output = Command::new("git")
@@ -954,6 +956,28 @@ mod provider_config_candidate_paths_tests {
             .snapshot_includes
             .contains(&"packages/cli/dist/**".to_string()));
         assert!(workspaces[0].bootstrap_node_dependencies);
+    }
+
+    #[test]
+    fn rig_dependency_workspace_mapping_uses_dependency_sync_mode() {
+        let dependency = RunnerGitDependencyMaterializationOutput {
+            local_path: "/local/playground-site-sync".to_string(),
+            remote_path: "/remote/playground-site-sync".to_string(),
+            remote_url: "git@github.a8c.com:Automattic/playground-site-sync.git".to_string(),
+            head: "snapshot:abc".to_string(),
+            status: "snapshotted".to_string(),
+            sync_mode: RunnerWorkspaceSyncMode::Snapshot,
+            files: 7,
+            bytes: 42,
+        };
+
+        let entry =
+            workspace_mapping_entry_for_git_dependency("rig_component_dependency", &dependency);
+
+        assert_eq!(entry.local_path, "/local/playground-site-sync");
+        assert_eq!(entry.remote_path, "/remote/playground-site-sync");
+        assert_eq!(entry.sync_mode, "snapshot");
+        assert_eq!(entry.snapshot_identity, "snapshot:abc");
     }
 
     #[test]

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -186,9 +186,9 @@ pub fn sync_workspace(
     }
 }
 
-struct SnapshotStats {
-    files: usize,
-    bytes: u64,
+pub(super) struct SnapshotStats {
+    pub(super) files: usize,
+    pub(super) bytes: u64,
 }
 
 struct GitSnapshot {
@@ -242,7 +242,7 @@ fn deterministic_remote_path(workspace_root: &str, local_path: &Path, snapshot: 
     )
 }
 
-fn snapshot_identity(
+pub(super) fn snapshot_identity(
     local_path: &Path,
     excludes: &[String],
     includes: &[String],
@@ -323,7 +323,7 @@ pub(super) fn git_output(local_path: &Path, args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-fn local_snapshot_stats(
+pub(super) fn local_snapshot_stats(
     path: &Path,
     excludes: &[String],
     includes: &[String],
@@ -512,7 +512,10 @@ fn materialize_snapshot_piped(
     run_shell_command(&command, action)
 }
 
-fn effective_snapshot_excludes(excludes: Vec<String>, includes: &[String]) -> Vec<String> {
+pub(super) fn effective_snapshot_excludes(
+    excludes: Vec<String>,
+    includes: &[String],
+) -> Vec<String> {
     if includes.is_empty() {
         return excludes;
     }


### PR DESCRIPTION
## Summary
- Snapshot declared rig component dependencies instead of cloning/fetching them directly on the Lab runner, so private/local dependency state comes from the controller.
- Auto-fast-forward clean git dependency checkouts before snapshotting; dirty, detached, or no-upstream dependencies are left untouched and reported in materialization status.
- Preserve dependency sync metadata in Lab workspace mappings so evidence shows snapshot mode and snapshot identity.

## Tests
- `cargo test core::runner::git_dependency_materialization`
- `cargo test rig_dependency_workspace_mapping_uses_dependency_sync_mode`
- `cargo build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing stale Lab rig dependency behavior, drafting the Rust implementation/tests, and running verification. Chris remains responsible for review and validation.