### PR TITLE
Add agent task artifact loop primitives

### DIFF
--- a/src/core/agent_task_fanout.rs
+++ b/src/core/agent_task_fanout.rs
@@ -216,6 +216,7 @@ mod tests {
                     AgentTaskOutputBinding {
                         task_id: "generate".to_string(),
                         path: "/outputs/artifact_id".to_string(),
+                        artifact: None,
                         required: true,
                         default: Value::Null,
                     },

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -803,6 +803,7 @@ mod tests {
                     attempt: 1,
                     message: Some("ok".to_string()),
                 }],
+                artifact_lineage: Vec::new(),
                 queue: Default::default(),
             };
 
@@ -988,6 +989,7 @@ mod tests {
                     metadata: Value::Null,
                 }],
                 events: Vec::new(),
+                artifact_lineage: Vec::new(),
                 queue: Default::default(),
             };
             record_completed_run(&plan, &aggregate, Some("run-source")).expect("recorded");
@@ -1139,6 +1141,7 @@ mod tests {
                 attempt: 1,
                 message: Some("ok".to_string()),
             }],
+            artifact_lineage: Vec::new(),
             queue: Default::default(),
         }
     }

--- a/src/core/agent_task_loop_controller.rs
+++ b/src/core/agent_task_loop_controller.rs
@@ -175,6 +175,20 @@ pub enum AgentTaskLoopPolicyAction {
         #[serde(default, skip_serializing_if = "Value::is_null")]
         request_template: Value,
     },
+    RouteFinding {
+        finding: AgentTaskLoopFindingPacket,
+        dedupe_key: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        entity_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Value::is_null")]
+        request_template: Value,
+    },
+    ValidateCandidatePatch {
+        candidate: AgentTaskLoopCandidatePatch,
+        validation: AgentTaskLoopCandidateValidation,
+        #[serde(default)]
+        limits: AgentTaskLoopCandidateLoopLimits,
+    },
     Join {
         wait_key: String,
     },
@@ -218,6 +232,68 @@ pub struct AgentTaskLoopPolicyActionRecord {
     pub created_at: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dedupe_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskLoopFindingPacket {
+    pub finding_id: String,
+    pub severity: String,
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_transformer: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reproduction_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lineage: Vec<AgentTaskLoopArtifactRef>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub payload: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskLoopCandidatePatch {
+    pub candidate_id: String,
+    pub patch: AgentTaskLoopArtifactRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finding_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<String>,
+    #[serde(default)]
+    pub attempt: u32,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lineage: Vec<AgentTaskLoopArtifactRef>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskLoopCandidateValidation {
+    pub validation_id: String,
+    pub status: AgentTaskLoopCandidateValidationStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence: Vec<AgentTaskLoopArtifactRef>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub details: Value,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskLoopCandidateValidationStatus {
+    Passed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskLoopCandidateLoopLimits {
+    #[serde(default = "default_candidate_max_attempts")]
+    pub max_attempts: u32,
+}
+
+impl Default for AgentTaskLoopCandidateLoopLimits {
+    fn default() -> Self {
+        Self {
+            max_attempts: default_candidate_max_attempts(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -636,6 +712,101 @@ impl AgentTaskLoopControllerRecord {
         Ok(())
     }
 
+    pub fn route_finding_packet(
+        &mut self,
+        finding: AgentTaskLoopFindingPacket,
+        request_template: Value,
+    ) -> AgentTaskLoopPolicyActionRecord {
+        let dedupe_key = format!(
+            "finding:{}",
+            finding
+                .reproduction_key
+                .as_deref()
+                .unwrap_or(&finding.finding_id)
+        );
+        if self.dedupe_keys.contains_key(&dedupe_key) {
+            return self.record_action(
+                AgentTaskLoopPolicyAction::RouteFinding {
+                    finding,
+                    dedupe_key,
+                    entity_id: None,
+                    request_template,
+                },
+                "finding packet route already satisfied",
+            );
+        }
+
+        let entity_id = self.upsert_entity(
+            "finding",
+            finding
+                .reproduction_key
+                .as_deref()
+                .unwrap_or(&finding.finding_id),
+            Vec::new(),
+            json!({
+                "severity": finding.severity.clone(),
+                "owner": finding.owner.clone(),
+                "source_transformer": finding.source_transformer.clone(),
+            }),
+        );
+        if let Some(entity) = self.entities.get_mut(&entity_id) {
+            entity.artifact_refs.extend(finding.lineage.clone());
+            entity
+                .provenance
+                .extend(finding.lineage.iter().map(|artifact| {
+                    AgentTaskLoopProvenanceRef {
+                        kind: artifact
+                            .kind
+                            .clone()
+                            .unwrap_or_else(|| "artifact".to_string()),
+                        uri: artifact.uri.clone(),
+                        caused_by: Some(finding.finding_id.clone()),
+                    }
+                }));
+        }
+        self.record_action(
+            AgentTaskLoopPolicyAction::RouteFinding {
+                finding,
+                dedupe_key,
+                entity_id: Some(entity_id),
+                request_template,
+            },
+            "finding packet routed to follow-up task",
+        )
+    }
+
+    pub fn record_candidate_patch_validation(
+        &mut self,
+        candidate: AgentTaskLoopCandidatePatch,
+        validation: AgentTaskLoopCandidateValidation,
+        limits: AgentTaskLoopCandidateLoopLimits,
+    ) -> AgentTaskLoopPolicyActionRecord {
+        let entity_id = self.upsert_entity(
+            "candidate_patch",
+            &candidate.candidate_id,
+            candidate.finding_id.clone().into_iter().collect(),
+            json!({
+                "worktree": candidate.worktree.clone(),
+                "attempt": candidate.attempt,
+                "finding_id": candidate.finding_id.clone(),
+            }),
+        );
+        if let Some(entity) = self.entities.get_mut(&entity_id) {
+            entity.artifact_refs.push(candidate.patch.clone());
+            entity.artifact_refs.extend(candidate.lineage.clone());
+            entity.artifact_refs.extend(validation.evidence.clone());
+        }
+
+        self.record_action(
+            AgentTaskLoopPolicyAction::ValidateCandidatePatch {
+                candidate,
+                validation,
+                limits,
+            },
+            "candidate patch validation recorded",
+        )
+    }
+
     fn apply_action_side_effects(
         &mut self,
         action: &AgentTaskLoopPolicyAction,
@@ -645,6 +816,42 @@ impl AgentTaskLoopControllerRecord {
             return;
         }
         match action {
+            AgentTaskLoopPolicyAction::RouteFinding { entity_id, .. } => {
+                if let Some(entity_id) = entity_id {
+                    if let Some(entity) = self.entities.get_mut(entity_id) {
+                        entity.state = Some("routed".to_string());
+                    }
+                }
+            }
+            AgentTaskLoopPolicyAction::ValidateCandidatePatch {
+                candidate,
+                validation,
+                limits,
+            } => {
+                let entity_id = format!(
+                    "candidate_patch:{}",
+                    sanitize_loop_id(&candidate.candidate_id)
+                );
+                if let Some(entity) = self.entities.get_mut(&entity_id) {
+                    match validation.status {
+                        AgentTaskLoopCandidateValidationStatus::Passed => {
+                            entity.state = Some("validated".to_string());
+                            entity.human_ready = true;
+                            self.state = AgentTaskLoopControllerState::HumanReady;
+                        }
+                        AgentTaskLoopCandidateValidationStatus::Failed
+                            if candidate.attempt >= limits.max_attempts =>
+                        {
+                            entity.state = Some("retry_limit_reached".to_string());
+                            entity.human_ready = true;
+                            self.state = AgentTaskLoopControllerState::HumanReady;
+                        }
+                        AgentTaskLoopCandidateValidationStatus::Failed => {
+                            entity.state = Some("needs_retry".to_string());
+                        }
+                    }
+                }
+            }
             AgentTaskLoopPolicyAction::WaitForEvent(wait) => {
                 self.state = AgentTaskLoopControllerState::Waiting;
                 if !self
@@ -771,7 +978,16 @@ fn controllers_root() -> Result<PathBuf> {
 fn action_dedupe_key(action: &AgentTaskLoopPolicyAction) -> Option<String> {
     match action {
         AgentTaskLoopPolicyAction::SpawnTask { dedupe_key, .. }
-        | AgentTaskLoopPolicyAction::FanOut { dedupe_key, .. } => Some(dedupe_key.clone()),
+        | AgentTaskLoopPolicyAction::FanOut { dedupe_key, .. }
+        | AgentTaskLoopPolicyAction::RouteFinding { dedupe_key, .. } => Some(dedupe_key.clone()),
+        AgentTaskLoopPolicyAction::ValidateCandidatePatch {
+            candidate,
+            validation,
+            ..
+        } => Some(format!(
+            "candidate-validation:{}:{}",
+            candidate.candidate_id, validation.validation_id
+        )),
         AgentTaskLoopPolicyAction::WaitForEvent(wait) => Some(format!("wait:{}", wait.wait_key)),
         AgentTaskLoopPolicyAction::RunGates {
             bundle_id,
@@ -805,6 +1021,7 @@ fn jsonpath_match_is_truthy(value: &Value) -> bool {
 fn action_entity_id(action: &AgentTaskLoopPolicyAction) -> Option<String> {
     match action {
         AgentTaskLoopPolicyAction::SpawnTask { entity_id, .. }
+        | AgentTaskLoopPolicyAction::RouteFinding { entity_id, .. }
         | AgentTaskLoopPolicyAction::RunGates { entity_id, .. } => entity_id.clone(),
         AgentTaskLoopPolicyAction::MarkHumanReady { entity_id, .. } => Some(entity_id.clone()),
         _ => None,
@@ -815,6 +1032,8 @@ fn action_name(action: &AgentTaskLoopPolicyAction) -> &'static str {
     match action {
         AgentTaskLoopPolicyAction::SpawnTask { .. } => "spawn_task",
         AgentTaskLoopPolicyAction::FanOut { .. } => "fan_out",
+        AgentTaskLoopPolicyAction::RouteFinding { .. } => "route_finding",
+        AgentTaskLoopPolicyAction::ValidateCandidatePatch { .. } => "validate_candidate_patch",
         AgentTaskLoopPolicyAction::Join { .. } => "join",
         AgentTaskLoopPolicyAction::Retry { .. } => "retry",
         AgentTaskLoopPolicyAction::RequestChanges { .. } => "request_changes",
@@ -841,6 +1060,10 @@ fn controller_schema() -> String {
 
 fn open_wait_status() -> AgentTaskLoopWaitStatus {
     AgentTaskLoopWaitStatus::Open
+}
+
+fn default_candidate_max_attempts() -> u32 {
+    3
 }
 
 fn now_timestamp() -> String {
@@ -983,6 +1206,120 @@ mod tests {
     }
 
     #[test]
+    fn finding_packets_route_once_with_lineage() {
+        let mut record = AgentTaskLoopControllerRecord::new("loop", "validate", "v1");
+        let finding = AgentTaskLoopFindingPacket {
+            finding_id: "finding-1".to_string(),
+            severity: "high".to_string(),
+            summary: "layout drift".to_string(),
+            owner: Some("transformer".to_string()),
+            source_transformer: Some("hero".to_string()),
+            reproduction_key: Some("page:/#hero".to_string()),
+            lineage: vec![AgentTaskLoopArtifactRef {
+                uri: "artifact://candidate/site".to_string(),
+                kind: Some("static_site_candidate".to_string()),
+                label: Some("candidate".to_string()),
+            }],
+            payload: json!({ "selector": ".hero" }),
+        };
+
+        let first = record.route_finding_packet(
+            finding.clone(),
+            json!({ "task": "iterate-transformer", "finding": finding }),
+        );
+        let second = record.route_finding_packet(
+            AgentTaskLoopFindingPacket {
+                finding_id: "finding-1b".to_string(),
+                reproduction_key: Some("page:/#hero".to_string()),
+                ..match first.action.clone() {
+                    AgentTaskLoopPolicyAction::RouteFinding { finding, .. } => finding,
+                    _ => unreachable!("route finding action"),
+                }
+            },
+            json!({ "task": "iterate-transformer" }),
+        );
+
+        assert_eq!(first.status, AgentTaskLoopActionStatus::Pending);
+        assert_eq!(second.status, AgentTaskLoopActionStatus::AlreadySatisfied);
+        assert_eq!(first.dedupe_key.as_deref(), Some("finding:page:/#hero"));
+        let entity = record.entities.get("finding:page___hero").expect("entity");
+        assert_eq!(entity.state.as_deref(), Some("routed"));
+        assert_eq!(entity.artifact_refs.len(), 1);
+        assert_eq!(entity.provenance[0].uri, "artifact://candidate/site");
+    }
+
+    #[test]
+    fn candidate_patch_validation_promotes_passes_to_human_ready() {
+        let mut record = AgentTaskLoopControllerRecord::new("loop", "repair", "v1");
+        let action = record.record_candidate_patch_validation(
+            candidate_patch(1),
+            AgentTaskLoopCandidateValidation {
+                validation_id: "validation-1".to_string(),
+                status: AgentTaskLoopCandidateValidationStatus::Passed,
+                evidence: vec![artifact_ref("artifact://validation/report")],
+                details: json!({ "passed": true }),
+            },
+            AgentTaskLoopCandidateLoopLimits { max_attempts: 2 },
+        );
+
+        assert_eq!(action.status, AgentTaskLoopActionStatus::Pending);
+        assert_eq!(record.state, AgentTaskLoopControllerState::HumanReady);
+        let entity = record
+            .entities
+            .get("candidate_patch:candidate-1")
+            .expect("candidate entity");
+        assert_eq!(entity.state.as_deref(), Some("validated"));
+        assert!(entity.human_ready);
+        assert_eq!(entity.artifact_refs.len(), 3);
+    }
+
+    #[test]
+    fn candidate_patch_validation_marks_retry_limit_stop_condition() {
+        let mut record = AgentTaskLoopControllerRecord::new("loop", "repair", "v1");
+        record.record_candidate_patch_validation(
+            candidate_patch(2),
+            AgentTaskLoopCandidateValidation {
+                validation_id: "validation-2".to_string(),
+                status: AgentTaskLoopCandidateValidationStatus::Failed,
+                evidence: vec![artifact_ref("artifact://validation/failure")],
+                details: json!({ "passed": false }),
+            },
+            AgentTaskLoopCandidateLoopLimits { max_attempts: 2 },
+        );
+
+        assert_eq!(record.state, AgentTaskLoopControllerState::HumanReady);
+        let entity = record
+            .entities
+            .get("candidate_patch:candidate-1")
+            .expect("candidate entity");
+        assert_eq!(entity.state.as_deref(), Some("retry_limit_reached"));
+        assert!(entity.human_ready);
+    }
+
+    #[test]
+    fn candidate_patch_validation_keeps_failed_candidate_retryable() {
+        let mut record = AgentTaskLoopControllerRecord::new("loop", "repair", "v1");
+        record.record_candidate_patch_validation(
+            candidate_patch(1),
+            AgentTaskLoopCandidateValidation {
+                validation_id: "validation-1".to_string(),
+                status: AgentTaskLoopCandidateValidationStatus::Failed,
+                evidence: vec![artifact_ref("artifact://validation/failure")],
+                details: json!({ "passed": false }),
+            },
+            AgentTaskLoopCandidateLoopLimits { max_attempts: 2 },
+        );
+
+        assert_eq!(record.state, AgentTaskLoopControllerState::Running);
+        let entity = record
+            .entities
+            .get("candidate_patch:candidate-1")
+            .expect("candidate entity");
+        assert_eq!(entity.state.as_deref(), Some("needs_retry"));
+        assert!(!entity.human_ready);
+    }
+
+    #[test]
     fn verify_commands_are_reusable_gate_bundle_checks() {
         let bundle = AgentTaskGateBundle::from_verify_commands(
             "candidate-gates",
@@ -993,5 +1330,24 @@ mod tests {
         assert_eq!(bundle.checks[0].kind, AgentTaskGateBundleCheckKind::Command);
         assert_eq!(bundle.checks[0].input["command"], json!("cargo test --lib"));
         assert!(bundle.checks[0].retryable);
+    }
+
+    fn candidate_patch(attempt: u32) -> AgentTaskLoopCandidatePatch {
+        AgentTaskLoopCandidatePatch {
+            candidate_id: "candidate-1".to_string(),
+            patch: artifact_ref("artifact://patch/fix.diff"),
+            finding_id: Some("finding-1".to_string()),
+            worktree: Some("/tmp/homeboy-candidate".to_string()),
+            attempt,
+            lineage: vec![artifact_ref("artifact://finding/finding-1")],
+        }
+    }
+
+    fn artifact_ref(uri: &str) -> AgentTaskLoopArtifactRef {
+        AgentTaskLoopArtifactRef {
+            uri: uri.to_string(),
+            kind: Some("artifact".to_string()),
+            label: None,
+        }
     }
 }

--- a/src/core/agent_task_schedule.rs
+++ b/src/core/agent_task_schedule.rs
@@ -19,6 +19,8 @@ pub struct AgentTaskPlan {
     pub tasks: Vec<AgentTaskRequest>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub output_dependencies: HashMap<String, AgentTaskOutputDependencies>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub artifact_outputs: HashMap<String, Vec<AgentTaskArtifactOutputDeclaration>>,
     #[serde(default)]
     pub options: AgentTaskScheduleOptions,
     #[serde(default, skip_serializing_if = "Value::is_null")]
@@ -33,6 +35,7 @@ impl AgentTaskPlan {
             group_key: None,
             tasks,
             output_dependencies: HashMap::new(),
+            artifact_outputs: HashMap::new(),
             options: AgentTaskScheduleOptions::default(),
             metadata: Value::Null,
         }
@@ -51,11 +54,37 @@ pub struct AgentTaskOutputDependencies {
 pub struct AgentTaskOutputBinding {
     pub task_id: String,
     /// JSON Pointer into the prior `homeboy/agent-task-outcome/v1` object.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact: Option<AgentTaskArtifactBinding>,
     #[serde(default = "default_required_output")]
     pub required: bool,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub default: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskArtifactOutputDeclaration {
+    pub name: String,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskArtifactBinding {
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -137,8 +166,29 @@ pub struct AgentTaskAggregate {
     pub outcomes: Vec<AgentTaskOutcome>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub events: Vec<AgentTaskProgressEvent>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_lineage: Vec<AgentTaskArtifactLineage>,
     #[serde(default)]
     pub queue: AgentTaskQueueStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskArtifactLineage {
+    pub task_id: String,
+    pub name: String,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub payload: Value,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -6,11 +6,12 @@ use std::time::{Duration, Instant};
 use serde_json::{Map, Value};
 
 use crate::core::agent_task::{
-    AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskFailureClassification, AgentTaskOutcome,
-    AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_OUTCOME_SCHEMA,
+    AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskFailureClassification,
+    AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_OUTCOME_SCHEMA,
 };
 pub use crate::core::agent_task_schedule::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
+    AgentTaskArtifactBinding, AgentTaskArtifactLineage, AgentTaskArtifactOutputDeclaration,
     AgentTaskBackpressureStatus, AgentTaskCancellationToken, AgentTaskExecutionContext,
     AgentTaskOutputBinding, AgentTaskOutputDependencies, AgentTaskPlan, AgentTaskProgressEvent,
     AgentTaskQueueStatus, AgentTaskResourceBudget, AgentTaskResourceBudgetStatus,
@@ -341,6 +342,9 @@ where
             }
         }
 
+        let artifact_lineage =
+            AgentTaskScheduleSupport::artifact_lineage(&outcomes, &plan.artifact_outputs);
+
         AgentTaskAggregate {
             schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
             plan_id: plan.plan_id,
@@ -360,6 +364,7 @@ where
             ),
             outcomes,
             events,
+            artifact_lineage,
         }
     }
 }
@@ -565,6 +570,63 @@ impl AgentTaskScheduleSupport {
             ));
         };
 
+        if let Some(artifact_binding) = &binding.artifact {
+            let Some(artifact) = outcome.artifacts.iter().find(|artifact| {
+                artifact.kind == artifact_binding.kind
+                    && artifact_binding
+                        .artifact_id
+                        .as_ref()
+                        .map(|artifact_id| artifact.id == *artifact_id)
+                        .unwrap_or(true)
+                    && artifact_binding
+                        .schema
+                        .as_ref()
+                        .map(|schema| {
+                            artifact
+                                .metadata
+                                .get("payload_schema")
+                                .and_then(Value::as_str)
+                                == Some(schema.as_str())
+                        })
+                        .unwrap_or(true)
+            }) else {
+                if !binding.default.is_null() {
+                    return Ok(binding.default.clone());
+                }
+                if binding.required {
+                    return Err(format!(
+                        "task '{}' skipped because required artifact binding '{}' with kind '{}' was missing from task '{}'",
+                        request.task_id, name, artifact_binding.kind, binding.task_id
+                    ));
+                }
+                return Ok(Value::String(String::new()));
+            };
+
+            let artifact_value = serde_json::to_value(artifact).unwrap_or(Value::Null);
+            if let Some(payload_path) = &artifact_binding.payload_path {
+                if let Some(value) = artifact
+                    .metadata
+                    .get("payload")
+                    .and_then(|payload| payload.pointer(payload_path))
+                    .or_else(|| artifact_value.pointer(payload_path))
+                {
+                    return Ok(value.clone());
+                }
+                if !binding.default.is_null() {
+                    return Ok(binding.default.clone());
+                }
+                if binding.required {
+                    return Err(format!(
+                        "task '{}' skipped because required artifact binding '{}' payload was missing at '{}' from task '{}'",
+                        request.task_id, name, payload_path, binding.task_id
+                    ));
+                }
+                return Ok(Value::String(String::new()));
+            }
+
+            return Ok(artifact_value);
+        }
+
         let outcome_value = serde_json::to_value(outcome).unwrap_or(Value::Null);
         if let Some(value) = outcome_value.pointer(&binding.path) {
             return Ok(value.clone());
@@ -607,6 +669,53 @@ impl AgentTaskScheduleSupport {
             follow_up: None,
             metadata: serde_json::json!({ "skipped": true, "skip_reason": "output_dependency_missing" }),
         }
+    }
+
+    fn artifact_lineage(
+        outcomes: &[AgentTaskOutcome],
+        declarations_by_task: &HashMap<String, Vec<AgentTaskArtifactOutputDeclaration>>,
+    ) -> Vec<AgentTaskArtifactLineage> {
+        let mut lineage = Vec::new();
+        for outcome in outcomes {
+            let Some(declarations) = declarations_by_task.get(&outcome.task_id) else {
+                continue;
+            };
+            for declaration in declarations {
+                if let Some(artifact) = outcome.artifacts.iter().find(|artifact| {
+                    artifact.kind == declaration.kind
+                        && declaration
+                            .artifact_id
+                            .as_ref()
+                            .map(|artifact_id| artifact.id == *artifact_id)
+                            .unwrap_or(true)
+                }) {
+                    let payload = declaration
+                        .payload_path
+                        .as_ref()
+                        .and_then(|payload_path| select_artifact_payload(artifact, payload_path))
+                        .unwrap_or(Value::Null);
+
+                    lineage.push(AgentTaskArtifactLineage {
+                        task_id: outcome.task_id.clone(),
+                        name: declaration.name.clone(),
+                        kind: artifact.kind.clone(),
+                        schema: declaration.schema.clone().or_else(|| {
+                            artifact
+                                .metadata
+                                .get("payload_schema")
+                                .and_then(Value::as_str)
+                                .map(str::to_string)
+                        }),
+                        artifact_id: Some(artifact.id.clone()),
+                        path: artifact.path.clone(),
+                        url: artifact.url.clone(),
+                        sha256: artifact.sha256.clone(),
+                        payload,
+                    });
+                }
+            }
+        }
+        lineage
     }
 
     fn backpressure_kind(
@@ -1046,6 +1155,19 @@ impl AgentTaskScheduleSupport {
 
         totals
     }
+}
+
+fn select_artifact_payload(artifact: &AgentTaskArtifact, payload_path: &str) -> Option<Value> {
+    artifact
+        .metadata
+        .get("payload")
+        .and_then(|payload| payload.pointer(payload_path))
+        .cloned()
+        .or_else(|| {
+            serde_json::to_value(artifact)
+                .ok()
+                .and_then(|artifact_value| artifact_value.pointer(payload_path).cloned())
+        })
 }
 
 fn executor_key(request: &AgentTaskRequest) -> String {
@@ -1694,6 +1816,7 @@ mod tests {
                     AgentTaskOutputBinding {
                         task_id: "idea".to_string(),
                         path: "/outputs/issue_number".to_string(),
+                        artifact: None,
                         required: true,
                         default: Value::Null,
                     },
@@ -1732,6 +1855,159 @@ mod tests {
     }
 
     #[test]
+    fn binds_typed_artifact_payload_into_downstream_task_request() {
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
+            observed: Arc::clone(&observed),
+            include_issue_number: true,
+        });
+        let mut plan = AgentTaskPlan::new(
+            "plan-artifact-dag",
+            vec![request("idea"), request("design")],
+        );
+        plan.options.max_concurrency = 2;
+        plan.tasks[1].inputs = json!({ "packet": "{{outputs.concept_packet}}" });
+        plan.artifact_outputs.insert(
+            "idea".to_string(),
+            vec![AgentTaskArtifactOutputDeclaration {
+                name: "concept_packet".to_string(),
+                kind: "concept_packet".to_string(),
+                schema: Some("example/concept-packet/v1".to_string()),
+                artifact_id: None,
+                payload_path: Some("/title".to_string()),
+            }],
+        );
+        plan.output_dependencies.insert(
+            "design".to_string(),
+            AgentTaskOutputDependencies {
+                depends_on: Vec::new(),
+                bindings: HashMap::from([(
+                    "concept_packet".to_string(),
+                    AgentTaskOutputBinding {
+                        task_id: "idea".to_string(),
+                        path: String::new(),
+                        artifact: Some(AgentTaskArtifactBinding {
+                            kind: "concept_packet".to_string(),
+                            schema: Some("example/concept-packet/v1".to_string()),
+                            artifact_id: Some("concept".to_string()),
+                            payload_path: Some("/title".to_string()),
+                        }),
+                        required: true,
+                        default: Value::Null,
+                    },
+                )]),
+            },
+        );
+
+        let aggregate = scheduler.run(plan);
+        let observed = observed.lock().expect("observed requests");
+        let design = observed
+            .iter()
+            .find(|request| request.task_id == "design")
+            .expect("design request dispatched");
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(design.inputs["packet"], json!("Demo concept"));
+        assert_eq!(aggregate.artifact_lineage.len(), 1);
+        assert_eq!(aggregate.artifact_lineage[0].name, "concept_packet");
+        assert_eq!(aggregate.artifact_lineage[0].payload, json!("Demo concept"));
+    }
+
+    #[test]
+    fn skips_required_typed_artifact_binding_when_artifact_is_missing() {
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
+            observed: Arc::clone(&observed),
+            include_issue_number: false,
+        });
+        let mut plan = AgentTaskPlan::new(
+            "plan-artifact-skip",
+            vec![request("idea"), request("design")],
+        );
+        plan.output_dependencies.insert(
+            "design".to_string(),
+            AgentTaskOutputDependencies {
+                depends_on: Vec::new(),
+                bindings: HashMap::from([(
+                    "finding_packet".to_string(),
+                    AgentTaskOutputBinding {
+                        task_id: "idea".to_string(),
+                        path: String::new(),
+                        artifact: Some(AgentTaskArtifactBinding {
+                            kind: "finding_packet".to_string(),
+                            schema: None,
+                            artifact_id: None,
+                            payload_path: None,
+                        }),
+                        required: true,
+                        default: Value::Null,
+                    },
+                )]),
+            },
+        );
+
+        let aggregate = scheduler.run(plan);
+        let observed = observed.lock().expect("observed requests");
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::PartialFailure);
+        assert!(observed.iter().all(|request| request.task_id != "design"));
+        let skipped = aggregate
+            .outcomes
+            .iter()
+            .find(|outcome| outcome.task_id == "design")
+            .expect("skipped outcome");
+        assert!(skipped.diagnostics.iter().any(|diagnostic| {
+            diagnostic.class == "output_dependency_missing"
+                && diagnostic.message.contains("required artifact binding")
+        }));
+    }
+
+    #[test]
+    fn optional_typed_artifact_binding_uses_default() {
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
+            observed: Arc::clone(&observed),
+            include_issue_number: false,
+        });
+        let mut plan = AgentTaskPlan::new(
+            "plan-artifact-default",
+            vec![request("idea"), request("design")],
+        );
+        plan.tasks[1].inputs = json!({ "packet": "{{outputs.finding_packet}}" });
+        plan.output_dependencies.insert(
+            "design".to_string(),
+            AgentTaskOutputDependencies {
+                depends_on: Vec::new(),
+                bindings: HashMap::from([(
+                    "finding_packet".to_string(),
+                    AgentTaskOutputBinding {
+                        task_id: "idea".to_string(),
+                        path: String::new(),
+                        artifact: Some(AgentTaskArtifactBinding {
+                            kind: "finding_packet".to_string(),
+                            schema: None,
+                            artifact_id: None,
+                            payload_path: None,
+                        }),
+                        required: false,
+                        default: json!({ "findings": [] }),
+                    },
+                )]),
+            },
+        );
+
+        let aggregate = scheduler.run(plan);
+        let observed = observed.lock().expect("observed requests");
+        let design = observed
+            .iter()
+            .find(|request| request.task_id == "design")
+            .expect("design request dispatched");
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(design.inputs["packet"], json!({ "findings": [] }));
+    }
+
+    #[test]
     fn skips_downstream_task_when_required_output_is_missing() {
         let observed = Arc::new(Mutex::new(Vec::new()));
         let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
@@ -1751,6 +2027,7 @@ mod tests {
                     AgentTaskOutputBinding {
                         task_id: "idea".to_string(),
                         path: "/outputs/issue_number".to_string(),
+                        artifact: None,
                         required: true,
                         default: Value::Null,
                     },
@@ -1884,13 +2161,33 @@ mod tests {
                 Value::Null
             };
 
+            let artifacts = if request.task_id == "idea" && self.include_issue_number {
+                vec![AgentTaskArtifact {
+                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                    id: "concept".to_string(),
+                    kind: "concept_packet".to_string(),
+                    name: Some("concept.json".to_string()),
+                    path: Some("artifacts/concept.json".to_string()),
+                    url: None,
+                    mime: Some("application/json".to_string()),
+                    size_bytes: None,
+                    sha256: Some("sha256:concept".to_string()),
+                    metadata: json!({
+                        "payload_schema": "example/concept-packet/v1",
+                        "payload": { "title": "Demo concept" }
+                    }),
+                }]
+            } else {
+                Vec::new()
+            };
+
             AgentTaskOutcome {
                 schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
                 task_id: request.task_id,
                 status: AgentTaskOutcomeStatus::Succeeded,
                 summary: Some("ok".to_string()),
                 failure_classification: None,
-                artifacts: Vec::new(),
+                artifacts,
                 evidence_refs: Vec::new(),
                 diagnostics: Vec::new(),
                 outputs,


### PR DESCRIPTION
## Summary
- Adds typed artifact output declarations and artifact-aware output bindings for `agent-task` plans while preserving existing `{{outputs.*}}` JSON Pointer bindings.
- Records artifact lineage on schedule aggregates so controller loops can route retries, review, and promotion from structured artifacts.
- Adds generic controller primitives for finding packet routing and validation-gated candidate patch promotion, including dedupe, lineage, pass/fail, and retry-limit states.

Fixes #3929.
Fixes #3930.
Fixes #3931.

## Verification
- `cargo fmt`
- `cargo test agent_task_scheduler::tests::`
- `cargo test agent_task_loop_controller::tests::`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the schema additions, scheduler/controller implementation, and targeted Rust tests; Chris remains responsible for review and validation.