### PR TITLE
Fail stale Lab dependency worktrees

### DIFF
--- a/src/commands/trace/rig_tests.rs
+++ b/src/commands/trace/rig_tests.rs
@@ -136,6 +136,7 @@ fn rig_component_path_and_trace_env_are_threaded() {
             triage_remote_url: None,
             stack: None,
             branch: None,
+            r#ref: None,
             extensions: Some(extensions),
         },
     );

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -967,6 +967,12 @@ pub struct ComponentSpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
 
+    /// Explicit pinned ref for Lab dependency materialization. When set,
+    /// Homeboy records the checkout as intentionally pinned instead of trying
+    /// to prove latest-branch freshness for detached or non-upstream checkouts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub r#ref: Option<String>,
+
     /// Optional extension config for rig-owned bench dispatch.
     ///
     /// This is intentionally narrower than the global component registry: rigs

--- a/src/core/runner/git_dependency_materialization.rs
+++ b/src/core/runner/git_dependency_materialization.rs
@@ -20,6 +20,19 @@ pub(crate) struct RunnerGitDependencyMaterializationOutput {
     pub remote_url: String,
     pub head: String,
     pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upstream_sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upstream: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pinned_ref: Option<String>,
+    pub used_pinned_ref: bool,
     pub sync_mode: RunnerWorkspaceSyncMode,
     pub files: usize,
     pub bytes: u64,
@@ -31,6 +44,7 @@ pub(crate) struct RunnerGitDependencyMaterializationOptions {
     pub remote_path: String,
     pub remote_url: Option<String>,
     pub required_subpath: Option<String>,
+    pub pinned_ref: Option<String>,
 }
 
 pub(crate) fn materialize_git_dependency(
@@ -58,7 +72,7 @@ pub(crate) fn materialize_git_dependency(
         Some(remote_url) if !remote_url.trim().is_empty() => remote_url,
         _ => git_output(&local_path, &["config", "--get", "remote.origin.url"]).unwrap_or_default(),
     };
-    let update_status = auto_update_clean_git_dependency(&local_path)?;
+    let freshness = ensure_git_dependency_fresh(&local_path, options.pinned_ref.as_deref())?;
     let mut excludes = DEFAULT_EXCLUDES
         .iter()
         .map(|value| value.to_string())
@@ -78,7 +92,14 @@ pub(crate) fn materialize_git_dependency(
         remote_path: options.remote_path,
         remote_url,
         head: snapshot,
-        status: update_status.label().to_string(),
+        status: freshness.status.label().to_string(),
+        branch: freshness.branch,
+        before_sha: freshness.before_sha,
+        after_sha: freshness.after_sha,
+        upstream_sha: freshness.upstream_sha,
+        upstream: freshness.upstream,
+        pinned_ref: freshness.pinned_ref,
+        used_pinned_ref: freshness.used_pinned_ref,
         sync_mode: RunnerWorkspaceSyncMode::Snapshot,
         files: stats.files,
         bytes: stats.bytes,
@@ -88,34 +109,99 @@ pub(crate) fn materialize_git_dependency(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DependencyUpdateStatus {
     NotGit,
-    DirtySkipped,
-    NoUpstreamSkipped,
+    DirtyNotUpdated,
+    NoUpstream,
+    DetachedUnpinned,
     UpToDate,
     FastForwarded,
-    FetchFailedCachedUpToDate,
+    PinnedRef,
+    FetchFailed,
+    BehindAfterFetch,
 }
 
 impl DependencyUpdateStatus {
     fn label(self) -> &'static str {
         match self {
             Self::NotGit => "snapshotted",
-            Self::DirtySkipped => "snapshotted_dirty_dependency_not_updated",
-            Self::NoUpstreamSkipped => "snapshotted_no_upstream_dependency_not_updated",
+            Self::DirtyNotUpdated => "dirty_not_updated",
+            Self::NoUpstream => "no_upstream",
+            Self::DetachedUnpinned => "detached_unpinned",
             Self::UpToDate => "snapshotted_up_to_date",
             Self::FastForwarded => "snapshotted_fast_forwarded",
-            Self::FetchFailedCachedUpToDate => "snapshotted_fetch_failed_cached_up_to_date",
+            Self::PinnedRef => "snapshotted_pinned_ref",
+            Self::FetchFailed => "fetch_failed_cached",
+            Self::BehindAfterFetch => "behind_after_fetch",
         }
+    }
+
+    fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::DirtyNotUpdated
+                | Self::NoUpstream
+                | Self::DetachedUnpinned
+                | Self::FetchFailed
+                | Self::BehindAfterFetch
+        )
     }
 }
 
-fn auto_update_clean_git_dependency(local_path: &Path) -> Result<DependencyUpdateStatus> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DependencyFreshness {
+    status: DependencyUpdateStatus,
+    branch: Option<String>,
+    before_sha: Option<String>,
+    after_sha: Option<String>,
+    upstream_sha: Option<String>,
+    upstream: Option<String>,
+    pinned_ref: Option<String>,
+    used_pinned_ref: bool,
+}
+
+fn ensure_git_dependency_fresh(
+    local_path: &Path,
+    pinned_ref: Option<&str>,
+) -> Result<DependencyFreshness> {
     if !local_path.join(".git").exists() {
-        return Ok(DependencyUpdateStatus::NotGit);
+        return Ok(DependencyFreshness {
+            status: DependencyUpdateStatus::NotGit,
+            branch: None,
+            before_sha: None,
+            after_sha: None,
+            upstream_sha: None,
+            upstream: None,
+            pinned_ref: pinned_ref.map(str::to_string),
+            used_pinned_ref: pinned_ref.is_some(),
+        });
     }
 
-    let status = git_output(local_path, &["status", "--porcelain=v1"])?;
-    if !status.trim().is_empty() {
-        return Ok(DependencyUpdateStatus::DirtySkipped);
+    let before = git_output(local_path, &["rev-parse", "HEAD"])?;
+    let branch = git_output(local_path, &["rev-parse", "--abbrev-ref", "HEAD"]).ok();
+    if branch.as_deref() == Some("HEAD") && pinned_ref.is_none() {
+        let freshness = DependencyFreshness {
+            status: DependencyUpdateStatus::DetachedUnpinned,
+            branch,
+            before_sha: Some(before.clone()),
+            after_sha: Some(before),
+            upstream_sha: None,
+            upstream: None,
+            pinned_ref: None,
+            used_pinned_ref: false,
+        };
+        return Err(terminal_dependency_error(local_path, &freshness, None));
+    }
+
+    if let Some(pinned_ref) = pinned_ref.filter(|value| !value.trim().is_empty()) {
+        return Ok(DependencyFreshness {
+            status: DependencyUpdateStatus::PinnedRef,
+            branch,
+            before_sha: Some(before.clone()),
+            after_sha: Some(before),
+            upstream_sha: None,
+            upstream: None,
+            pinned_ref: Some(pinned_ref.to_string()),
+            used_pinned_ref: true,
+        });
     }
 
     let upstream = match git_output(
@@ -123,29 +209,139 @@ fn auto_update_clean_git_dependency(local_path: &Path) -> Result<DependencyUpdat
         &["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
     ) {
         Ok(value) if !value.trim().is_empty() => value,
-        _ => return Ok(DependencyUpdateStatus::NoUpstreamSkipped),
+        _ => {
+            let freshness = DependencyFreshness {
+                status: DependencyUpdateStatus::NoUpstream,
+                branch,
+                before_sha: Some(before.clone()),
+                after_sha: Some(before),
+                upstream_sha: None,
+                upstream: None,
+                pinned_ref: None,
+                used_pinned_ref: false,
+            };
+            return Err(terminal_dependency_error(local_path, &freshness, None));
+        }
     };
     let remote = upstream.split('/').next().unwrap_or("").trim();
     if remote.is_empty() || remote == upstream {
-        return Ok(DependencyUpdateStatus::NoUpstreamSkipped);
+        let freshness = DependencyFreshness {
+            status: DependencyUpdateStatus::NoUpstream,
+            branch,
+            before_sha: Some(before.clone()),
+            after_sha: Some(before),
+            upstream_sha: None,
+            upstream: Some(upstream),
+            pinned_ref: None,
+            used_pinned_ref: false,
+        };
+        return Err(terminal_dependency_error(local_path, &freshness, None));
     }
 
-    let before = git_output(local_path, &["rev-parse", "HEAD"])?;
-    let upstream_head = git_output(local_path, &["rev-parse", "@{u}"])?;
-    if let Err(err) = run_git(local_path, &["fetch", "--prune", remote]) {
-        if before == upstream_head {
-            return Ok(DependencyUpdateStatus::FetchFailedCachedUpToDate);
-        }
-        return Err(err);
+    let fetch_error = run_git(local_path, &["fetch", "--prune", remote]).err();
+    let upstream_head = git_output(local_path, &["rev-parse", "@{u}"]).ok();
+    let status = git_output(local_path, &["status", "--porcelain=v1"])?;
+    if !status.trim().is_empty() {
+        let freshness = DependencyFreshness {
+            status: DependencyUpdateStatus::DirtyNotUpdated,
+            branch,
+            before_sha: Some(before.clone()),
+            after_sha: Some(before),
+            upstream_sha: upstream_head,
+            upstream: Some(upstream),
+            pinned_ref: None,
+            used_pinned_ref: false,
+        };
+        return Err(terminal_dependency_error(
+            local_path,
+            &freshness,
+            fetch_error,
+        ));
     }
-    run_git(local_path, &["merge", "--ff-only", "@{u}"])?;
+
+    if fetch_error.is_some() {
+        let freshness = DependencyFreshness {
+            status: DependencyUpdateStatus::FetchFailed,
+            branch,
+            before_sha: Some(before.clone()),
+            after_sha: Some(before),
+            upstream_sha: upstream_head,
+            upstream: Some(upstream),
+            pinned_ref: None,
+            used_pinned_ref: false,
+        };
+        return Err(terminal_dependency_error(
+            local_path,
+            &freshness,
+            fetch_error,
+        ));
+    }
+
+    if upstream_head.as_deref().is_some_and(|head| head != before) {
+        run_git(local_path, &["merge", "--ff-only", "@{u}"])?;
+    }
     let after = git_output(local_path, &["rev-parse", "HEAD"])?;
-
-    if before == after {
-        Ok(DependencyUpdateStatus::UpToDate)
+    let upstream_head = git_output(local_path, &["rev-parse", "@{u}"]).ok();
+    let status = if upstream_head.as_deref().is_some_and(|head| head != after) {
+        DependencyUpdateStatus::BehindAfterFetch
+    } else if before == after {
+        DependencyUpdateStatus::UpToDate
     } else {
-        Ok(DependencyUpdateStatus::FastForwarded)
+        DependencyUpdateStatus::FastForwarded
+    };
+    let freshness = DependencyFreshness {
+        status,
+        branch,
+        before_sha: Some(before),
+        after_sha: Some(after),
+        upstream_sha: upstream_head,
+        upstream: Some(upstream),
+        pinned_ref: None,
+        used_pinned_ref: false,
+    };
+
+    if freshness.status.is_terminal() {
+        return Err(terminal_dependency_error(local_path, &freshness, None));
     }
+
+    Ok(freshness)
+}
+
+fn terminal_dependency_error(
+    local_path: &Path,
+    freshness: &DependencyFreshness,
+    source_error: Option<Error>,
+) -> Error {
+    let mut hints = vec![
+        "Update, rebase, or clean the dependency checkout before rerunning the Lab proof.".to_string(),
+        "Use an explicit pinned ref in the rig/component dependency only when the stale checkout is intentional.".to_string(),
+    ];
+    if let Some(error) = &source_error {
+        hints.push(format!("Fetch failure: {}", error.message));
+    }
+    Error::validation_invalid_argument(
+        "rig_component_dependency",
+        format!(
+            "Lab offload refused stale or ambiguous git dependency `{}` with status `{}`",
+            local_path.display(),
+            freshness.status.label()
+        ),
+        Some(
+            serde_json::json!({
+                "local_path": local_path.display().to_string(),
+                "status": freshness.status.label(),
+                "branch": freshness.branch.as_deref(),
+                "before_sha": freshness.before_sha.as_deref(),
+                "after_sha": freshness.after_sha.as_deref(),
+                "upstream": freshness.upstream.as_deref(),
+                "upstream_sha": freshness.upstream_sha.as_deref(),
+                "pinned_ref": freshness.pinned_ref.as_deref(),
+                "used_pinned_ref": freshness.used_pinned_ref,
+            })
+            .to_string(),
+        ),
+        Some(hints),
+    )
 }
 
 fn run_git(local_path: &Path, args: &[&str]) -> Result<()> {
@@ -179,7 +375,7 @@ mod tests {
     use std::path::Path;
     use std::process::Command;
 
-    use super::{auto_update_clean_git_dependency, DependencyUpdateStatus};
+    use super::{ensure_git_dependency_fresh, DependencyUpdateStatus};
 
     #[test]
     fn auto_update_clean_dependency_fast_forwards_to_upstream() {
@@ -193,10 +389,13 @@ mod tests {
         fixture.push();
         let expected = fixture.head();
 
-        let status = auto_update_clean_git_dependency(checkout.path()).expect("auto update");
+        let freshness = ensure_git_dependency_fresh(checkout.path(), None).expect("auto update");
 
-        assert_eq!(status, DependencyUpdateStatus::FastForwarded);
+        assert_eq!(freshness.status, DependencyUpdateStatus::FastForwarded);
         assert_ne!(before, expected);
+        assert_eq!(freshness.before_sha.as_deref(), Some(before.as_str()));
+        assert_eq!(freshness.after_sha.as_deref(), Some(expected.as_str()));
+        assert_eq!(freshness.upstream_sha.as_deref(), Some(expected.as_str()));
         assert_eq!(
             git_output(checkout.path(), &["rev-parse", "HEAD"]),
             expected
@@ -204,7 +403,7 @@ mod tests {
     }
 
     #[test]
-    fn auto_update_dirty_dependency_leaves_checkout_unchanged() {
+    fn dirty_dependency_fails_before_snapshotting() {
         let fixture = GitFixture::new();
         fixture.commit_file("initial.txt", "initial");
         fixture.push();
@@ -215,14 +414,65 @@ mod tests {
         fixture.commit_file("next.txt", "next");
         fixture.push();
 
-        let status = auto_update_clean_git_dependency(checkout.path()).expect("auto update");
+        let err = ensure_git_dependency_fresh(checkout.path(), None).expect_err("dirty fails");
 
-        assert_eq!(status, DependencyUpdateStatus::DirtySkipped);
+        assert!(err.message.contains("dirty_not_updated"));
         assert_eq!(git_output(checkout.path(), &["rev-parse", "HEAD"]), before);
     }
 
     #[test]
-    fn auto_update_fetch_failure_uses_cached_upstream_when_checkout_matches() {
+    fn detached_dependency_without_pinned_ref_fails() {
+        let fixture = GitFixture::new();
+        fixture.commit_file("initial.txt", "initial");
+        fixture.push();
+
+        let checkout = fixture.clone_checkout();
+        let head = git_output(checkout.path(), &["rev-parse", "HEAD"]);
+        run_git(checkout.path(), &["checkout", "--detach", &head]);
+
+        let err = ensure_git_dependency_fresh(checkout.path(), None).expect_err("detached fails");
+
+        assert!(err.message.contains("detached_unpinned"));
+        assert_eq!(git_output(checkout.path(), &["rev-parse", "HEAD"]), head);
+    }
+
+    #[test]
+    fn dependency_without_upstream_fails_before_snapshotting() {
+        let repo = tempfile::tempdir().expect("repo");
+        run_git(repo.path(), &["init", "-b", "main"]);
+        run_git(
+            repo.path(),
+            &["config", "user.email", "homeboy@example.test"],
+        );
+        run_git(repo.path(), &["config", "user.name", "Homeboy Test"]);
+        fs::write(repo.path().join("initial.txt"), "initial").expect("write file");
+        run_git(repo.path(), &["add", "initial.txt"]);
+        run_git(repo.path(), &["commit", "-m", "initial"]);
+
+        let err = ensure_git_dependency_fresh(repo.path(), None).expect_err("no upstream fails");
+
+        assert!(err.message.contains("no_upstream"));
+    }
+
+    #[test]
+    fn explicit_pinned_ref_allows_detached_dependency() {
+        let fixture = GitFixture::new();
+        fixture.commit_file("initial.txt", "initial");
+        fixture.push();
+
+        let checkout = fixture.clone_checkout();
+        let head = git_output(checkout.path(), &["rev-parse", "HEAD"]);
+        run_git(checkout.path(), &["checkout", "--detach", &head]);
+
+        let freshness = ensure_git_dependency_fresh(checkout.path(), Some(&head)).expect("pinned");
+
+        assert_eq!(freshness.status, DependencyUpdateStatus::PinnedRef);
+        assert!(freshness.used_pinned_ref);
+        assert_eq!(freshness.pinned_ref.as_deref(), Some(head.as_str()));
+    }
+
+    #[test]
+    fn fetch_failure_is_terminal() {
         let fixture = GitFixture::new();
         fixture.commit_file("initial.txt", "initial");
         fixture.push();
@@ -240,9 +490,9 @@ mod tests {
             ],
         );
 
-        let status = auto_update_clean_git_dependency(checkout.path()).expect("auto update");
+        let err = ensure_git_dependency_fresh(checkout.path(), None).expect_err("fetch fails");
 
-        assert_eq!(status, DependencyUpdateStatus::FetchFailedCachedUpToDate);
+        assert!(err.message.contains("fetch_failed_cached"));
         assert_eq!(git_output(checkout.path(), &["rev-parse", "HEAD"]), before);
     }
 

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -24,6 +24,8 @@ pub(super) struct LabWorkspaceMappingEntry {
     remote_path: String,
     sync_mode: String,
     snapshot_identity: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    dependency_freshness: Option<serde_json::Value>,
 }
 
 impl LabWorkspaceMappingEntry {
@@ -90,6 +92,7 @@ pub(super) fn workspace_mapping_entry(
         remote_path: synced.remote_path.clone(),
         sync_mode: synced.sync_mode.label().to_string(),
         snapshot_identity: synced.snapshot_identity.clone(),
+        dependency_freshness: None,
     }
 }
 
@@ -103,6 +106,17 @@ pub(super) fn workspace_mapping_entry_for_git_dependency(
         remote_path: dependency.remote_path.clone(),
         sync_mode: dependency.sync_mode.label().to_string(),
         snapshot_identity: dependency.head.clone(),
+        dependency_freshness: Some(serde_json::json!({
+            "local_path": dependency.local_path.as_str(),
+            "remote": dependency.remote_url.as_str(),
+            "before_sha": dependency.before_sha.as_deref(),
+            "after_sha": dependency.after_sha.as_deref(),
+            "upstream_sha": dependency.upstream_sha.as_deref(),
+            "upstream": dependency.upstream.as_deref(),
+            "status": dependency.status.as_str(),
+            "pinned_ref": dependency.pinned_ref.as_deref(),
+            "used_pinned_ref": dependency.used_pinned_ref,
+        })),
     }
 }
 
@@ -966,6 +980,13 @@ mod provider_config_candidate_paths_tests {
             remote_url: "git@github.a8c.com:Automattic/playground-site-sync.git".to_string(),
             head: "snapshot:abc".to_string(),
             status: "snapshotted".to_string(),
+            branch: Some("main".to_string()),
+            before_sha: Some("abc".to_string()),
+            after_sha: Some("abc".to_string()),
+            upstream_sha: Some("abc".to_string()),
+            upstream: Some("origin/main".to_string()),
+            pinned_ref: None,
+            used_pinned_ref: false,
             sync_mode: RunnerWorkspaceSyncMode::Snapshot,
             files: 7,
             bytes: 42,
@@ -978,6 +999,14 @@ mod provider_config_candidate_paths_tests {
         assert_eq!(entry.remote_path, "/remote/playground-site-sync");
         assert_eq!(entry.sync_mode, "snapshot");
         assert_eq!(entry.snapshot_identity, "snapshot:abc");
+        assert_eq!(
+            entry.dependency_freshness.as_ref().unwrap()["upstream"],
+            "origin/main"
+        );
+        assert_eq!(
+            entry.dependency_freshness.as_ref().unwrap()["after_sha"],
+            "abc"
+        );
     }
 
     #[test]

--- a/src/core/runner/rig_materialization.rs
+++ b/src/core/runner/rig_materialization.rs
@@ -20,6 +20,7 @@ pub(super) struct RigComponentDependency {
     pub remote_checkout_root: String,
     pub required_subpath: Option<String>,
     pub remote_url: Option<String>,
+    pub pinned_ref: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -227,6 +228,7 @@ pub(super) fn sync_lab_offload_rig_component_dependencies(
                 remote_path: dependency.remote_checkout_root,
                 remote_url: dependency.remote_url,
                 required_subpath: dependency.required_subpath,
+                pinned_ref: dependency.pinned_ref,
             },
         )?);
     }
@@ -266,6 +268,7 @@ pub(super) fn lab_offload_rig_component_dependencies(
                 declared_checkout_root: checkout_root.to_string(),
                 required_subpath,
                 remote_url: component.remote_url.clone(),
+                pinned_ref: component.r#ref.clone(),
             });
         }
     }
@@ -693,6 +696,7 @@ mod tests {
             remote_checkout_root: primary_remote_path.to_string(),
             required_subpath: None,
             remote_url: Some("https://github.a8c.com/chubes4/studio-web.git".to_string()),
+            pinned_ref: None,
         }];
 
         assert!(dependencies

--- a/tests/core/rig/app_test.rs
+++ b/tests/core/rig/app_test.rs
@@ -21,6 +21,7 @@ fn rig_with_launcher(install_dir: &str) -> RigSpec {
             triage_remote_url: None,
             stack: None,
             branch: None,
+            r#ref: None,
             extensions: None,
         },
     );

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -54,6 +54,7 @@ fn test_expand_vars_component_path() {
             triage_remote_url: None,
             stack: None,
             branch: None,
+            r#ref: None,
             extensions: None,
         },
     );
@@ -94,6 +95,7 @@ fn test_expand_vars_package_root_from_installed_source_metadata() {
                 triage_remote_url: None,
                 stack: None,
                 branch: None,
+                r#ref: None,
                 extensions: None,
             },
         );
@@ -149,6 +151,7 @@ fn test_expand_resources_expands_string_entries() {
                 triage_remote_url: None,
                 stack: None,
                 branch: None,
+                r#ref: None,
                 extensions: None,
             },
         );

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -335,6 +335,7 @@ mod dag {
                 triage_remote_url: None,
                 stack: Some(stack_id),
                 branch: None,
+                r#ref: None,
                 extensions: None,
             },
         );
@@ -378,6 +379,7 @@ mod dag {
                 triage_remote_url: None,
                 stack: None,
                 branch: None,
+                r#ref: None,
                 extensions: None,
             },
         );
@@ -390,6 +392,7 @@ mod dag {
                 triage_remote_url: None,
                 stack: None,
                 branch: None,
+                r#ref: None,
                 extensions: None,
             },
         );
@@ -461,6 +464,7 @@ mod git_steps {
                 triage_remote_url: None,
                 stack: None,
                 branch: None,
+                r#ref: None,
                 extensions: None,
             },
         );
@@ -580,6 +584,7 @@ mod extension_lifecycle {
                 triage_remote_url: None,
                 stack: None,
                 branch: None,
+                r#ref: None,
                 extensions: Some(extensions),
             },
         );
@@ -818,6 +823,7 @@ mod patch {
                 triage_remote_url: None,
                 stack: None,
                 branch: None,
+                r#ref: None,
                 extensions: None,
             },
         );

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -198,6 +198,7 @@ fn test_run_up_persists_step_order_source_and_component_snapshot() {
                 triage_remote_url: None,
                 stack: None,
                 branch: None,
+                r#ref: None,
                 extensions: None,
             },
         );

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -711,6 +711,7 @@ fn test_snapshot_state() {
             triage_remote_url: None,
             stack: None,
             branch: None,
+            r#ref: None,
             extensions: None,
         },
     );
@@ -723,6 +724,7 @@ fn test_snapshot_state() {
             triage_remote_url: None,
             stack: None,
             branch: None,
+            r#ref: None,
             extensions: None,
         },
     );

--- a/tests/core/rig/stack_test.rs
+++ b/tests/core/rig/stack_test.rs
@@ -17,6 +17,7 @@ fn component(path: &str, stack: Option<&str>) -> ComponentSpec {
         triage_remote_url: None,
         stack: stack.map(str::to_string),
         branch: None,
+        r#ref: None,
         extensions: None,
     }
 }


### PR DESCRIPTION
## Summary
- Fail Lab/offloaded rig dependency materialization before execution when a git dependency is dirty, detached without an explicit pin, missing upstream, fetch-failed, or still behind upstream.
- Fast-forward clean dependencies before snapshotting and record freshness evidence including before/after/upstream SHAs, upstream, status, and pinned-ref usage.
- Add `component.ref` as the explicit pinned-ref opt-in for intentionally pinned rig dependencies.

Fixes #3939.

## Tests
- `cargo fmt --check`
- `cargo test core::runner::git_dependency_materialization`
- `cargo test rig_dependency_workspace_mapping_uses_dependency_sync_mode`
- `cargo test primary_workspace_dependency_is_not_materialized_again`
- `cargo test core::extension::bench::run::tests::attach_memory_timeline_adds_metrics_and_artifacts`
- `cargo test` ran 4,197 tests: 4,178 passed, 18 ignored, 1 failed. The failing test was `core::extension::bench::run::tests::attach_memory_timeline_adds_metrics_and_artifacts`; it passed when rerun directly, so this appears order/state-sensitive and unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the dependency freshness enforcement, metadata plumbing, tests, and PR description; Chris remains responsible for review and merge.