### PR TITLE
Fix Lab trace compare git materialization

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1250,6 +1250,28 @@ mod tests {
         assert_eq!(trace.extra_required_tools, LAB_TRACE_EXTRA_TOOLS);
         assert!(!trace.requires_extension_parity);
         assert!(!trace.infer_source_path_tools);
+        assert_eq!(
+            trace.workspace_mode_policy,
+            LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot
+        );
+
+        let trace_compare_refs = parsed_command(&[
+            "homeboy",
+            "trace",
+            "compare",
+            "woocommerce-gateway-stripe",
+            "ece-product-page-waterfall",
+            "--baseline-target",
+            "origin/develop",
+            "--candidate",
+            "32f68bb07ac0efa1d754f78e2adc8de115ddca6f",
+        ])
+        .lab_contract()
+        .expect("trace compare contract");
+        assert_eq!(
+            trace_compare_refs.workspace_mode_policy,
+            LabWorkspaceModePolicy::Git
+        );
 
         let lint = parsed_command(&["homeboy", "lint"])
             .lab_contract()

--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -26,6 +26,7 @@ pub enum LabSourcePathMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LabWorkspaceModePolicy {
     ChangedSinceGitElseSnapshot,
+    Git,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -112,12 +113,18 @@ impl Commands {
             Commands::Test(_) => {
                 lab_local_only_contract("test", TEST_CHANGED_SINCE_LAB_UNSUPPORTED_REASON)
             }
-            Commands::Trace(args) => lab_portable_workload_contract(
-                "trace",
-                args.keep_overlay.then_some("--keep-overlay"),
-                false,
-                LAB_TRACE_EXTRA_TOOLS,
-            ),
+            Commands::Trace(args) => {
+                let mut contract = lab_portable_workload_contract(
+                    "trace",
+                    args.keep_overlay.then_some("--keep-overlay"),
+                    false,
+                    LAB_TRACE_EXTRA_TOOLS,
+                );
+                if args.is_compare_target_run() {
+                    contract.workspace_mode_policy = LabWorkspaceModePolicy::Git;
+                }
+                contract
+            }
             _ => return None,
         };
 

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -224,6 +224,9 @@ fn lab_offload_command(
             homeboy::cli_surface::LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot => {
                 homeboy::core::runner::LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot
             }
+            homeboy::cli_surface::LabWorkspaceModePolicy::Git => {
+                homeboy::core::runner::LabOffloadWorkspaceModePolicy::Git
+            }
         },
         requires_extension_parity: contract.requires_extension_parity,
         required_extensions,

--- a/src/commands/runner/workspace/mod.rs
+++ b/src/commands/runner/workspace/mod.rs
@@ -82,6 +82,7 @@ fn sync(
             path,
             mode: RunnerWorkspaceSyncMode::from(mode),
             changed_since_base: None,
+            git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),
         },
     )

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -210,6 +210,13 @@ pub struct TraceArgs {
     pub force: bool,
 }
 
+impl TraceArgs {
+    pub fn is_compare_target_run(&self) -> bool {
+        self.comp.component.as_deref() == Some("compare")
+            && (self.baseline_target.is_some() || self.candidate.is_some())
+    }
+}
+
 pub fn is_markdown_mode(args: &TraceArgs) -> bool {
     args.report.as_deref() == Some("markdown")
 }

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 use crate::core::agent_task_lifecycle;
 use crate::core::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
@@ -67,6 +68,7 @@ pub struct LabOffloadCommand {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LabOffloadWorkspaceModePolicy {
     ChangedSinceGitElseSnapshot,
+    Git,
 }
 
 pub enum LabOffloadOutcome {
@@ -81,6 +83,133 @@ pub enum LabOffloadOutcome {
         stderr: String,
         exit_code: i32,
     },
+}
+
+fn lab_offload_git_fetch_refs(
+    args: &[String],
+    source_path: &Path,
+    sync_mode: RunnerWorkspaceSyncMode,
+) -> Result<Vec<String>> {
+    if sync_mode != RunnerWorkspaceSyncMode::Git {
+        return Ok(Vec::new());
+    }
+
+    let mut refs = Vec::new();
+    for target in lab_offload_trace_compare_targets(args) {
+        if trace_compare_target_is_local_path(&target) || target.starts_with("origin/") {
+            continue;
+        }
+        let git_ref = if target.starts_with("refs/") {
+            Some(target.clone())
+        } else {
+            advertised_origin_ref_for_local_target(source_path, &target)?
+        };
+        if let Some(git_ref) = git_ref {
+            if !refs.contains(&git_ref) {
+                refs.push(git_ref);
+            }
+        }
+    }
+    Ok(refs)
+}
+
+fn lab_offload_trace_compare_targets(args: &[String]) -> Vec<String> {
+    let mut targets = Vec::new();
+    let mut iter = args.iter().skip(1).peekable();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        let target = if arg == "--baseline-target" || arg == "--candidate" {
+            iter.next().cloned()
+        } else {
+            arg.strip_prefix("--baseline-target=")
+                .or_else(|| arg.strip_prefix("--candidate="))
+                .map(str::to_string)
+        };
+        if let Some(target) = target {
+            targets.push(target);
+        }
+    }
+    targets
+}
+
+fn trace_compare_target_is_local_path(target: &str) -> bool {
+    let expanded = shellexpand::tilde(target).to_string();
+    Path::new(&expanded).exists()
+}
+
+fn advertised_origin_ref_for_local_target(
+    source_path: &Path,
+    target: &str,
+) -> Result<Option<String>> {
+    let commit = match super::workspace::git_output(
+        source_path,
+        &["rev-parse", "--verify", &format!("{target}^{{commit}}")],
+    ) {
+        Ok(commit) => commit,
+        Err(_) => return Ok(None),
+    };
+    let output = Command::new("git")
+        .args(["ls-remote", "origin"])
+        .current_dir(source_path)
+        .output()
+        .map_err(|err| {
+            Error::internal_io(err.to_string(), Some("run git ls-remote".to_string()))
+        })?;
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "trace_compare_target",
+            "Lab offload could not inspect origin refs for trace compare target materialization",
+            Some(target.to_string()),
+            Some(vec![
+                String::from_utf8_lossy(&output.stderr).trim().to_string(),
+                "Run with --force-hot to execute trace compare locally while investigating remote ref availability.".to_string(),
+            ]),
+        ));
+    }
+
+    let refs = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let (sha, git_ref) = line.split_once('\t')?;
+            (sha == commit && !git_ref.ends_with("^{}")).then(|| git_ref.to_string())
+        })
+        .collect::<Vec<_>>();
+    if refs.is_empty() && is_full_hex_sha(target) {
+        return Err(Error::validation_invalid_argument(
+            "trace_compare_target",
+            "Lab offload could not find an advertised origin ref for the trace compare target commit",
+            Some(target.to_string()),
+            Some(vec![
+                "Push the candidate commit to origin or pass an advertised ref such as refs/pull/<id>/head.".to_string(),
+                "Run with --force-hot to execute trace compare locally while investigating remote ref availability.".to_string(),
+            ]),
+        ));
+    }
+
+    Ok(best_advertised_ref(refs))
+}
+
+fn best_advertised_ref(refs: Vec<String>) -> Option<String> {
+    refs.iter()
+        .find(|git_ref| git_ref.starts_with("refs/pull/") && git_ref.ends_with("/head"))
+        .cloned()
+        .or_else(|| {
+            refs.iter()
+                .find(|git_ref| git_ref.starts_with("refs/heads/"))
+                .cloned()
+        })
+        .or_else(|| {
+            refs.iter()
+                .find(|git_ref| git_ref.starts_with("refs/tags/"))
+                .cloned()
+        })
+        .or_else(|| refs.into_iter().next())
+}
+
+fn is_full_hex_sha(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadOutcome> {
@@ -391,6 +520,7 @@ fn run_lab_offload_inner(
 
     let capability_preflight: Option<RunnerCapabilityPreflight> = capability_plan.map(Into::into);
     let sync_mode = match contract.workspace_mode_policy {
+        LabOffloadWorkspaceModePolicy::Git => RunnerWorkspaceSyncMode::Git,
         LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot => {
             if lab_offload_changed_since_ref(request.normalized_args).is_some() {
                 RunnerWorkspaceSyncMode::Git
@@ -422,6 +552,11 @@ fn run_lab_offload_inner(
             path: source_path.display().to_string(),
             mode: sync_mode,
             changed_since_base: changed_since_preflight.resolved_base.clone(),
+            git_fetch_refs: lab_offload_git_fetch_refs(
+                &changed_since_preflight.args,
+                &source_path,
+                sync_mode,
+            )?,
             snapshot_includes: Vec::new(),
         },
     )?
@@ -822,6 +957,7 @@ fn sync_inline_agent_task_plan(
             path: temp.path().display().to_string(),
             mode: RunnerWorkspaceSyncMode::Snapshot,
             changed_since_base: None,
+            git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),
         },
     )?
@@ -1222,6 +1358,40 @@ mod tests {
             requires_playwright: false,
             infer_source_path_tools: false,
         }
+    }
+
+    #[test]
+    fn trace_compare_targets_are_extracted_before_passthrough_args() {
+        let args = vec![
+            "homeboy".to_string(),
+            "trace".to_string(),
+            "compare".to_string(),
+            "--baseline-target".to_string(),
+            "origin/develop".to_string(),
+            "--candidate=32f68bb07ac0efa1d754f78e2adc8de115ddca6f".to_string(),
+            "--".to_string(),
+            "--candidate".to_string(),
+            "ignored".to_string(),
+        ];
+
+        assert_eq!(
+            lab_offload_trace_compare_targets(&args),
+            vec![
+                "origin/develop".to_string(),
+                "32f68bb07ac0efa1d754f78e2adc8de115ddca6f".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn compare_target_ref_selection_prefers_pull_head_refs() {
+        let selected = best_advertised_ref(vec![
+            "refs/heads/fix-branch".to_string(),
+            "refs/pull/5530/head".to_string(),
+            "refs/tags/v1".to_string(),
+        ]);
+
+        assert_eq!(selected, Some("refs/pull/5530/head".to_string()));
     }
 
     #[test]

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -65,6 +65,7 @@ pub(super) fn sync_extra_lab_workspaces(
                 path: local_path.display().to_string(),
                 mode: RunnerWorkspaceSyncMode::Snapshot,
                 changed_since_base: None,
+                git_fetch_refs: Vec::new(),
                 snapshot_includes: extra.snapshot_includes.clone(),
             },
         )?

--- a/src/core/runner/rig_materialization.rs
+++ b/src/core/runner/rig_materialization.rs
@@ -77,6 +77,7 @@ pub(super) fn sync_lab_offload_rigs(
                     path: metadata.package_path,
                     mode: RunnerWorkspaceSyncMode::Snapshot,
                     changed_since_base: None,
+                    git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                 },
             )?

--- a/src/core/runner/validation_dependencies.rs
+++ b/src/core/runner/validation_dependencies.rs
@@ -474,6 +474,7 @@ mod tests {
                     path: source.display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
                     changed_since_base: None,
+                    git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                 },
             )
@@ -546,6 +547,7 @@ mod tests {
                     path: source.display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
                     changed_since_base: None,
+                    git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                 },
             )
@@ -618,6 +620,7 @@ mod tests {
                     path: source.display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
                     changed_since_base: None,
+                    git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                 },
             )
@@ -687,6 +690,7 @@ mod tests {
                     path: source.display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
                     changed_since_base: None,
+                    git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                 },
             )
@@ -764,6 +768,7 @@ mod tests {
                     path: source.display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
                     changed_since_base: None,
+                    git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                 },
             )

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -62,6 +62,7 @@ pub struct RunnerWorkspaceSyncOptions {
     pub path: String,
     pub mode: RunnerWorkspaceSyncMode,
     pub changed_since_base: Option<String>,
+    pub git_fetch_refs: Vec<String>,
     pub snapshot_includes: Vec<String>,
 }
 
@@ -146,7 +147,11 @@ pub fn sync_workspace(
             ))
         }
         RunnerWorkspaceSyncMode::Git => {
-            let git = git_snapshot(&local_path, options.changed_since_base.as_deref())?;
+            let git = git_snapshot(
+                &local_path,
+                options.changed_since_base.as_deref(),
+                options.git_fetch_refs,
+            )?;
             if runner.kind != RunnerKind::Local {
                 super::source_materialization::validate_runner_git_materialization(
                     &git.remote_url,
@@ -160,6 +165,7 @@ pub fn sync_workspace(
                 &git.remote_url,
                 &git.head,
                 git.changed_since_base.as_deref(),
+                &git.git_fetch_refs,
             )?;
             super::validation_dependencies::sync_validation_dependency_workspaces(
                 &runner,
@@ -195,6 +201,7 @@ struct GitSnapshot {
     remote_url: String,
     head: String,
     changed_since_base: Option<String>,
+    git_fetch_refs: Vec<String>,
 }
 
 pub(super) fn canonical_workspace_path(path: &str) -> Result<PathBuf> {
@@ -264,7 +271,11 @@ pub(super) fn snapshot_identity(
     Ok(format!("snapshot:{}", hex_prefix(&hasher.finalize(), 16)))
 }
 
-fn git_snapshot(local_path: &Path, changed_since_base: Option<&str>) -> Result<GitSnapshot> {
+fn git_snapshot(
+    local_path: &Path,
+    changed_since_base: Option<&str>,
+    git_fetch_refs: Vec<String>,
+) -> Result<GitSnapshot> {
     let status = git_output(local_path, &["status", "--porcelain=v1"])?;
     if !status.trim().is_empty() {
         if changed_since_base.is_some() {
@@ -304,6 +315,7 @@ fn git_snapshot(local_path: &Path, changed_since_base: Option<&str>) -> Result<G
         remote_url,
         head,
         changed_since_base: changed_since_base.map(str::to_string),
+        git_fetch_refs,
     })
 }
 
@@ -557,8 +569,15 @@ fn materialize_git(
     remote_url: &str,
     head: &str,
     changed_since_base: Option<&str>,
+    git_fetch_refs: &[String],
 ) -> Result<()> {
-    let command = materialize_git_command(remote_path, remote_url, head, changed_since_base);
+    let command = materialize_git_command(
+        remote_path,
+        remote_url,
+        head,
+        changed_since_base,
+        git_fetch_refs,
+    );
     match runner.kind {
         RunnerKind::Local => run_shell_command(&command, "materialize local git workspace"),
         RunnerKind::Ssh => {
@@ -588,6 +607,7 @@ fn materialize_git_command(
     remote_url: &str,
     head: &str,
     changed_since_base: Option<&str>,
+    git_fetch_refs: &[String],
 ) -> String {
     let dest = shell::quote_arg(remote_path);
     let fetch_changed_since = changed_since_base
@@ -599,14 +619,24 @@ fn materialize_git_command(
             )
         })
         .unwrap_or_default();
+    let fetch_extra_refs = git_fetch_refs
+        .iter()
+        .map(|git_ref| {
+            format!(
+                " && git -C {dest} fetch origin {}",
+                shell::quote_arg(git_ref)
+            )
+        })
+        .collect::<String>();
 
     format!(
-        "mkdir -p {parent} && if [ -d {dest}/.git ]; then git -C {dest} reset --hard && git -C {dest} clean -ffdqx && git -C {dest} fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf {dest} && git clone {url} {dest} && git -C {dest} fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_changed_since} && git -C {dest} checkout --detach {head} && git -C {dest} reset --hard {head} && git -C {dest} clean -ffdqx",
+        "mkdir -p {parent} && if [ -d {dest}/.git ]; then git -C {dest} reset --hard && git -C {dest} clean -ffdqx && git -C {dest} fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf {dest} && git clone {url} {dest} && git -C {dest} fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_changed_since}{fetch_extra_refs} && git -C {dest} checkout --detach {head} && git -C {dest} reset --hard {head} && git -C {dest} clean -ffdqx",
         parent = shell::quote_arg(parent_remote_path(remote_path).as_str()),
         dest = dest,
         url = shell::quote_arg(remote_url),
         head = shell::quote_arg(head),
         fetch_changed_since = fetch_changed_since,
+        fetch_extra_refs = fetch_extra_refs,
     )
 }
 
@@ -798,6 +828,7 @@ mod tests {
                     path: source.path().display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
                     changed_since_base: None,
+                    git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                 },
             )
@@ -841,6 +872,7 @@ mod tests {
                     path: source.path().display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
                     changed_since_base: None,
+                    git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                 },
             )
@@ -900,6 +932,7 @@ mod tests {
                     path: source.path().display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
                     changed_since_base: None,
+                    git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                 },
             )
@@ -950,6 +983,7 @@ mod tests {
                 path: source.path().display().to_string(),
                 mode: RunnerWorkspaceSyncMode::Snapshot,
                 changed_since_base: None,
+                git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
             };
             let (first, _) = sync_workspace("lab-local", options.clone()).expect("first sync");
@@ -975,6 +1009,7 @@ mod tests {
             "https://github.com/Extra-Chill/homeboy.git",
             "abc123",
             Some("def456"),
+            &[],
         );
 
         assert!(command.contains("fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'"));
@@ -986,10 +1021,24 @@ mod tests {
     }
 
     #[test]
+    fn git_materialization_fetches_extra_refs_before_checkout() {
+        let command = materialize_git_command(
+            "/srv/homeboy/_lab_workspaces/homeboy-abc",
+            "https://github.com/Extra-Chill/homeboy.git",
+            "abc123",
+            None,
+            &["refs/pull/5530/head".to_string()],
+        );
+
+        assert!(command.contains("fetch origin refs/pull/5530/head"));
+        assert!(command.contains("checkout --detach abc123"));
+    }
+
+    #[test]
     fn dirty_git_sync_without_changed_since_suggests_snapshot_mode() {
         let source = dirty_git_repo();
 
-        let err = match git_snapshot(source.path(), None) {
+        let err = match git_snapshot(source.path(), None, Vec::new()) {
             Ok(_) => panic!("dirty git sync should fail"),
             Err(err) => err,
         };
@@ -1001,7 +1050,7 @@ mod tests {
     fn dirty_changed_since_git_sync_explains_snapshot_is_unavailable() {
         let source = dirty_git_repo();
 
-        let err = match git_snapshot(source.path(), Some("abc123")) {
+        let err = match git_snapshot(source.path(), Some("abc123"), Vec::new()) {
             Ok(_) => panic!("dirty changed-since git sync should fail"),
             Err(err) => err,
         };


### PR DESCRIPTION
## Summary
- Force git-backed Lab workspace sync for `trace compare --baseline-target/--candidate` so remote target checkout keeps `.git` metadata.
- Fetch advertised origin refs for compare targets, including raw SHA candidates reachable through refs such as `refs/pull/<id>/head`, before creating remote target worktrees.
- Keep ordinary trace runs on the existing snapshot-friendly policy and cover the new routing/materialization behavior with targeted tests.

## Testing
- `cargo test test_lab_command_contracts_cover_hot_commands`
- `cargo test trace_compare_targets_are_extracted_before_passthrough_args`
- `cargo test compare_target_ref_selection_prefers_pull_head_refs`
- `cargo test git_materialization_fetches_extra_refs_before_checkout`
- `cargo test core::runner::offload_changed_since::tests`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the Lab offload materialization failure, drafting the Rust changes and tests, and running targeted verification. Chris remains responsible for review and merge.