### PR TITLE
Require WordPress extension parity for Codebox plans

### DIFF
--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -253,10 +253,41 @@ fn lab_required_extensions(command: &Commands) -> homeboy::core::Result<Vec<Stri
             extension_ids.extend(args.extension_override.extensions.clone());
             extension_ids.extend(test_lab_extension_ids(args)?);
         }
+        Commands::AgentTask(args) => extension_ids.extend(agent_task_lab_extension_ids(args)?),
         _ => {}
     }
 
     Ok(extension_ids.into_iter().collect())
+}
+
+fn agent_task_lab_extension_ids(
+    args: &homeboy::commands::agent_task::AgentTaskArgs,
+) -> homeboy::core::Result<Vec<String>> {
+    let homeboy::commands::agent_task::AgentTaskCommand::RunPlan(run_plan) = &args.command else {
+        return Ok(Vec::new());
+    };
+    if run_plan.plan.trim() == "-" {
+        return Ok(Vec::new());
+    }
+    let raw = homeboy::core::config::read_json_spec_to_string(&run_plan.plan)?;
+    let plan: homeboy::core::agent_task_scheduler::AgentTaskPlan = serde_json::from_str(&raw)
+        .map_err(|error| {
+            homeboy::core::Error::validation_invalid_json(
+                error,
+                Some("agent-task run-plan Lab extension inference".to_string()),
+                Some(raw.clone()),
+            )
+        })?;
+
+    if plan
+        .tasks
+        .iter()
+        .any(|task| task.executor.backend == "codebox")
+    {
+        Ok(vec!["wordpress".to_string()])
+    } else {
+        Ok(Vec::new())
+    }
 }
 
 fn test_lab_extension_ids(
@@ -482,6 +513,33 @@ mod tests {
         assert!(command.portable);
         assert!(command.unsupported_reason.is_none());
         assert!(command.requires_extension_parity);
+    }
+
+    #[test]
+    fn agent_task_run_plan_requires_wordpress_extension_for_codebox_backend() {
+        let dir = tempdir().unwrap();
+        let plan_path = dir.path().join("agent-task-plan.json");
+        std::fs::write(
+            &plan_path,
+            r#"{
+                "schema":"homeboy/agent-task-plan/v1",
+                "plan_id":"codebox-plan",
+                "tasks":[{
+                    "schema":"homeboy/agent-task-request/v1",
+                    "task_id":"task-1",
+                    "executor":{"backend":"codebox"},
+                    "instructions":"Run Codebox task."
+                }]
+            }"#,
+        )
+        .unwrap();
+        let plan_spec = format!("@{}", plan_path.display());
+        let cli = Cli::parse_from(["homeboy", "agent-task", "run-plan", "--plan", &plan_spec]);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+        assert!(command.requires_extension_parity);
+        assert_eq!(command.required_extensions, vec!["wordpress".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Infer `wordpress` as a required Lab extension for `agent-task run-plan` when any task uses the `codebox` backend.
- Add route-layer coverage that a Codebox agent-task plan carries WordPress extension parity into the Lab offload contract.

## Why
#3951 made Lab extension parity compare extension revisions, but `agent-task run-plan` did not declare any required extensions. As a result, Codebox-backed proof runs could still execute on Lab with stale WordPress provider code and drop Codebox failure evidence.

Failed proof run showing the gap:
- `site-generation-loop-merged-main-20260610-parity-check`

## Tests
- `cargo test agent_task_run_plan_requires_wordpress_extension_for_codebox_backend --locked`
- `cargo test extension_parity --locked`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed why Codebox agent-task Lab runs bypassed extension parity, drafted the route inference fix and test, and ran local verification; Chris remains responsible for review and merge.