### PR TITLE
Infer Lab extension parity from agent-task providers

### DIFF
--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -253,10 +253,33 @@ fn lab_required_extensions(command: &Commands) -> homeboy::core::Result<Vec<Stri
             extension_ids.extend(args.extension_override.extensions.clone());
             extension_ids.extend(test_lab_extension_ids(args)?);
         }
+        Commands::AgentTask(args) => extension_ids.extend(agent_task_lab_extension_ids(args)?),
         _ => {}
     }
 
     Ok(extension_ids.into_iter().collect())
+}
+
+fn agent_task_lab_extension_ids(
+    args: &homeboy::commands::agent_task::AgentTaskArgs,
+) -> homeboy::core::Result<Vec<String>> {
+    let homeboy::commands::agent_task::AgentTaskCommand::RunPlan(run_plan) = &args.command else {
+        return Ok(Vec::new());
+    };
+    if run_plan.plan.trim() == "-" {
+        return Ok(Vec::new());
+    }
+    let raw = homeboy::core::config::read_json_spec_to_string(&run_plan.plan)?;
+    let plan: homeboy::core::agent_task_scheduler::AgentTaskPlan = serde_json::from_str(&raw)
+        .map_err(|error| {
+            homeboy::core::Error::validation_invalid_json(
+                error,
+                Some("agent-task run-plan Lab extension inference".to_string()),
+                Some(raw.clone()),
+            )
+        })?;
+
+    Ok(homeboy::core::agent_task_provider::required_extension_ids_for_plan(&plan))
 }
 
 fn test_lab_extension_ids(

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -10,7 +11,9 @@ use crate::core::agent_task::{
     AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_ARTIFACT_SCHEMA,
     AGENT_TASK_OUTCOME_SCHEMA,
 };
-use crate::core::agent_task_scheduler::{AgentTaskExecutionContext, AgentTaskExecutorAdapter};
+use crate::core::agent_task_scheduler::{
+    AgentTaskExecutionContext, AgentTaskExecutorAdapter, AgentTaskPlan,
+};
 use crate::core::agent_task_secrets::{resolve_secret_env, AgentTaskSecretResolutionError};
 use crate::core::agent_task_timeout::timeout_with_grace;
 use crate::core::extension::load_all_extensions;
@@ -53,6 +56,14 @@ impl ExtensionProviderAgentTaskExecutor {
     pub fn providers(&self) -> &[AgentTaskExecutorProvider] {
         &self.providers
     }
+
+    pub fn required_extension_ids_for_plan(&self, plan: &AgentTaskPlan) -> Vec<String> {
+        required_extension_ids_for_plan_with_providers(plan, &self.providers)
+    }
+}
+
+pub fn required_extension_ids_for_plan(plan: &AgentTaskPlan) -> Vec<String> {
+    ExtensionProviderAgentTaskExecutor::discover().required_extension_ids_for_plan(plan)
 }
 
 impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
@@ -312,6 +323,22 @@ fn select_provider<'a>(
                 .as_ref()
                 .is_none_or(|selector| provider.id == *selector)
     })
+}
+
+fn required_extension_ids_for_plan_with_providers(
+    plan: &AgentTaskPlan,
+    providers: &[AgentTaskExecutorProvider],
+) -> Vec<String> {
+    let mut extension_ids = BTreeSet::new();
+    for request in &plan.tasks {
+        if let Some(extension_id) = select_provider(providers, request)
+            .and_then(|provider| provider.extension_id.as_ref())
+            .filter(|extension_id| !extension_id.trim().is_empty())
+        {
+            extension_ids.insert(extension_id.clone());
+        }
+    }
+    extension_ids.into_iter().collect()
 }
 
 fn run_provider_command(
@@ -590,6 +617,26 @@ mod tests {
             metadata: Value::Null,
         };
         (request, provider)
+    }
+
+    #[test]
+    fn required_extension_ids_follow_selected_agent_task_providers() {
+        let (request_a, mut provider_a) = request("task-a", "node provider-a.js".to_string());
+        provider_a.id = "provider-a".to_string();
+        provider_a.extension_id = Some("extension-a".to_string());
+        let (mut request_b, mut provider_b) = request("task-b", "node provider-b.js".to_string());
+        request_b.executor.selector = Some("provider-b".to_string());
+        provider_b.id = "provider-b".to_string();
+        provider_b.extension_id = Some("extension-b".to_string());
+        let executor =
+            ExtensionProviderAgentTaskExecutor::with_providers(vec![provider_a, provider_b]);
+
+        let extension_ids = executor.required_extension_ids_for_plan(&AgentTaskPlan::new(
+            "plan-a",
+            vec![request_a, request_b],
+        ));
+
+        assert_eq!(extension_ids, vec!["extension-a", "extension-b"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Infer Lab-required extensions for `agent-task run-plan` from the selected extension-owned executor providers.
- Preserve Homeboy core's generic boundary: no backend-specific or WordPress-specific assumptions.
- Add provider-layer coverage proving extension inference follows backend/selector provider selection.

## Why
#3951 made Lab extension parity compare local and runner extension revisions, but agent-task run-plan was not declaring required extensions. The correct generic fix is to ask the selected executor providers which extension owns them, then run parity for those extension IDs.

## Tests
- `cargo test required_extension_ids_follow_selected_agent_task_providers --locked`
- `cargo test extension_parity --locked`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Reworked the previous incorrect backend-specific attempt into provider-owned extension inference, added focused coverage, and ran local verification; Chris remains responsible for review and merge.