### PR TITLE
Fix upgrade runner flag collision

### DIFF
--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -28,7 +28,7 @@ pub struct UpgradeArgs {
     pub skip_runners: bool,
 
     /// Upgrade only the named configured runner. Repeat to target multiple runners.
-    #[arg(long = "runner", value_name = "RUNNER_ID")]
+    #[arg(long = "upgrade-runner", value_name = "RUNNER_ID")]
     pub runners: Vec<String>,
 
     /// Override install method detection (homebrew|cargo|source|binary)

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -1,4 +1,5 @@
-use homeboy::cli_surface::current_command_surface;
+use clap::{CommandFactory, Parser};
+use homeboy::cli_surface::{current_command_surface, Cli};
 use std::collections::BTreeSet;
 
 #[test]
@@ -90,6 +91,28 @@ fn command_index_matches_top_level_command_surface() {
         stale.is_empty(),
         "docs/commands/commands-index.md lists stale top-level commands: {stale:?}"
     );
+}
+
+#[test]
+fn upgrade_runner_selector_does_not_collide_with_global_lab_runner_flag() {
+    let root = Cli::command();
+    let root_flags: BTreeSet<String> = root
+        .get_arguments()
+        .filter_map(|arg| arg.get_long().map(|long| format!("--{long}")))
+        .collect();
+    let upgrade = root
+        .find_subcommand("upgrade")
+        .expect("upgrade command")
+        .clone();
+    let upgrade_flags: BTreeSet<String> = upgrade
+        .get_arguments()
+        .filter_map(|arg| arg.get_long().map(|long| format!("--{long}")))
+        .collect();
+
+    assert!(root_flags.contains("--runner"));
+    assert!(upgrade_flags.contains("--upgrade-runner"));
+    Cli::try_parse_from(["homeboy", "upgrade", "--upgrade-runner", "homeboy-lab"])
+        .expect("upgrade runner selector should parse without colliding with global --runner");
 }
 
 fn documented_command_index_entries() -> BTreeSet<String> {


### PR DESCRIPTION
## Summary
- Rename the upgrade-specific runner target selector to `--upgrade-runner` so it no longer collides with the global Lab offload `--runner` flag.
- Add command-surface coverage proving the global `--runner` and upgrade-local `--upgrade-runner` coexist and parse.

## Testing
- `cargo run --quiet --bin homeboy -- upgrade --help`
- `cargo test upgrade --locked`
- `cargo test --test command_surface_test --locked`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the source-build CLI panic, drafted the minimal flag rename and regression coverage, and ran local verification. Chris remains responsible for review and merge.