### PR TITLE
fix: bundle agent task keychain secrets

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -172,10 +172,12 @@ pub enum AgentTaskAuthCommand {
     Status(AgentTaskAuthStatusArgs),
     /// Store a provider secret in the OS keychain and map it to a required env name.
     SetKeychain(AgentTaskAuthSetKeychainArgs),
+    /// Store a JSON secret bundle in one OS keychain item.
+    SetKeychainBundle(AgentTaskAuthSetKeychainBundleArgs),
     /// Map a required provider env name to another process env var.
     MapEnv(AgentTaskAuthMapEnvArgs),
-    /// Map Claude Code provider secrets to Kimaki/OpenCode's active Anthropic OAuth auth file.
-    MapClaudeCodeKimaki,
+    /// Map a required provider env name to a field in a JSON keychain bundle.
+    MapKeychainBundle(AgentTaskAuthMapKeychainBundleArgs),
     /// Remove a provider secret source mapping.
     Remove(AgentTaskAuthRemoveArgs),
 }
@@ -211,6 +213,29 @@ pub struct AgentTaskAuthSetKeychainArgs {
 }
 
 #[derive(Args, Debug)]
+pub struct AgentTaskAuthSetKeychainBundleArgs {
+    /// Logical bundle id to store.
+    #[arg(value_name = "BUNDLE")]
+    pub bundle: String,
+
+    /// JSON bundle value. Omit to prompt securely.
+    #[arg(value_name = "JSON")]
+    pub value: Option<String>,
+
+    /// Read the JSON bundle value from stdin.
+    #[arg(long)]
+    pub value_stdin: bool,
+
+    /// Keychain scope. Defaults to agent-task.
+    #[arg(long, value_name = "SCOPE")]
+    pub scope: Option<String>,
+
+    /// Keychain entry name. Defaults to BUNDLE.
+    #[arg(long = "name", value_name = "NAME")]
+    pub keychain_name: Option<String>,
+}
+
+#[derive(Args, Debug)]
 pub struct AgentTaskAuthMapEnvArgs {
     /// Required provider environment variable name to satisfy.
     #[arg(value_name = "ENV")]
@@ -219,6 +244,29 @@ pub struct AgentTaskAuthMapEnvArgs {
     /// Source process environment variable. Defaults to ENV.
     #[arg(long = "from", value_name = "ENV")]
     pub source_env: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskAuthMapKeychainBundleArgs {
+    /// Required provider environment variable name to satisfy.
+    #[arg(value_name = "ENV")]
+    pub secret_env: String,
+
+    /// Logical bundle id to read.
+    #[arg(long, value_name = "BUNDLE")]
+    pub bundle: String,
+
+    /// Field path inside the JSON bundle, using dots for nested objects.
+    #[arg(long, value_name = "FIELD")]
+    pub field: String,
+
+    /// Keychain scope. Defaults to agent-task.
+    #[arg(long, value_name = "SCOPE")]
+    pub scope: Option<String>,
+
+    /// Keychain entry name. Defaults to BUNDLE.
+    #[arg(long = "name", value_name = "NAME")]
+    pub keychain_name: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -621,6 +669,24 @@ fn auth(args: AgentTaskAuthArgs) -> CmdResult<Value> {
                 0,
             ))
         }
+        AgentTaskAuthCommand::SetKeychainBundle(set_args) => {
+            let value = read_agent_task_secret_value(set_args.value, set_args.value_stdin)?;
+            let keychain_name = agent_task_secrets::set_keychain_bundle(
+                &set_args.bundle,
+                &value,
+                set_args.scope.as_deref(),
+                set_args.keychain_name.as_deref(),
+            )?;
+            Ok((
+                serde_json::json!({
+                    "schema": "homeboy/agent-task-auth-bundle-configured/v1",
+                    "bundle": set_args.bundle,
+                    "source": "keychain-bundle",
+                    "keychain_name": keychain_name,
+                }),
+                0,
+            ))
+        }
         AgentTaskAuthCommand::MapEnv(map_args) => {
             let status = agent_task_secrets::map_secret_to_env(
                 &map_args.secret_env,
@@ -634,8 +700,14 @@ fn auth(args: AgentTaskAuthArgs) -> CmdResult<Value> {
                 0,
             ))
         }
-        AgentTaskAuthCommand::MapClaudeCodeKimaki => {
-            let status = agent_task_secrets::map_claude_code_to_opencode_anthropic()?;
+        AgentTaskAuthCommand::MapKeychainBundle(map_args) => {
+            let status = agent_task_secrets::map_secret_to_keychain_bundle(
+                &map_args.secret_env,
+                &map_args.bundle,
+                &map_args.field,
+                map_args.scope.as_deref(),
+                map_args.keychain_name.as_deref(),
+            )?;
             Ok((
                 serde_json::json!({
                     "schema": "homeboy/agent-task-auth-configured/v1",

--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -191,6 +191,7 @@ fn build_dispatch_plan(args: &DispatchArgs) -> homeboy::core::Result<AgentTaskPl
     let client_context = dispatch_client_context(args)?;
     let provider_config =
         dispatch_provider_config(args, &repo, workspace_target.as_ref(), &client_context)?;
+    let secret_env = dispatch_secret_env(args, &provider_config);
     let mut tasks = Vec::new();
     for (index, prompt_spec) in prompt_specs.iter().enumerate() {
         let instructions = dispatch_instructions(
@@ -216,7 +217,7 @@ fn build_dispatch_plan(args: &DispatchArgs) -> homeboy::core::Result<AgentTaskPl
                 backend: args.backend.clone(),
                 selector: args.selector.clone(),
                 required_capabilities: Vec::new(),
-                secret_env: args.secret_env.clone(),
+                secret_env: secret_env.clone(),
                 model: args.model.clone(),
                 config: provider_config.clone(),
             },
@@ -524,6 +525,38 @@ fn dispatch_provider_config(
     Ok(config)
 }
 
+fn dispatch_secret_env(args: &DispatchArgs, provider_config: &Value) -> Vec<String> {
+    let mut names = args.secret_env.clone();
+    names.extend(provider_config_secret_env(provider_config));
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn provider_config_secret_env(provider_config: &Value) -> Vec<String> {
+    let Some(config) = provider_config.as_object() else {
+        return Vec::new();
+    };
+
+    let mut names = Vec::new();
+    for key in ["secret_env", "secretEnv"] {
+        match config.get(key) {
+            Some(Value::Array(items)) => {
+                names.extend(
+                    items
+                        .iter()
+                        .filter_map(|item| item.as_str().map(str::to_string)),
+                );
+            }
+            Some(Value::String(name)) => names.push(name.clone()),
+            _ => {}
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
 fn read_text_spec(spec: &str, label: &str) -> homeboy::core::Result<String> {
     config::read_json_spec_to_string(spec).map_err(|error| {
         homeboy::core::Error::internal_unexpected(format!(
@@ -801,6 +834,33 @@ mod tests {
     }
 
     #[test]
+    fn dispatch_promotes_provider_config_secret_env() {
+        let plan = build_dispatch_plan(&dispatch_args(DispatchArgOverrides {
+            prompt: Some("Cook with provider-config auth.".to_string()),
+            provider_config: Some(
+                serde_json::json!({
+                    "provider": "example",
+                    "secret_env": ["HOMEBOY_PROVIDER_ACCESS_TOKEN"],
+                    "secretEnv": "HOMEBOY_PROVIDER_REFRESH_TOKEN"
+                })
+                .to_string(),
+            ),
+            secret_env: vec!["OPENAI_API_KEY".to_string()],
+            ..DispatchArgOverrides::default()
+        }))
+        .expect("dispatch plan");
+
+        assert_eq!(
+            plan.tasks[0].executor.secret_env,
+            vec![
+                "HOMEBOY_PROVIDER_ACCESS_TOKEN".to_string(),
+                "HOMEBOY_PROVIDER_REFRESH_TOKEN".to_string(),
+                "OPENAI_API_KEY".to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn resolves_workspace_path_without_specialized_coupling() {
         let worktree = tempfile::tempdir().expect("workspace");
 
@@ -926,6 +986,7 @@ mod tests {
         repo: Option<String>,
         task_url: Option<String>,
         secret_env: Vec<String>,
+        provider_config: Option<String>,
         client_context: Option<String>,
         concurrency: usize,
         attempts: u32,
@@ -946,7 +1007,7 @@ mod tests {
             selector: None,
             model: None,
             secret_env: overrides.secret_env,
-            provider_config: None,
+            provider_config: overrides.provider_config,
             client_context: overrides.client_context,
             concurrency: if overrides.concurrency == 0 {
                 1

--- a/src/core/agent_task_secrets.rs
+++ b/src/core/agent_task_secrets.rs
@@ -3,12 +3,11 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-
 use crate::core::keychain;
 use crate::core::paths;
 use crate::core::Error;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentTaskSecretResolutionError {
@@ -45,6 +44,7 @@ pub fn map_secret_to_env(
             env_var: env_var.map(str::to_string),
             scope: None,
             name: None,
+            field: None,
         },
     );
     config.save()?;
@@ -72,6 +72,7 @@ pub fn set_keychain_secret(
             env_var: None,
             scope: Some(scope.to_string()),
             name: Some(keychain_name.to_string()),
+            field: None,
         },
     );
     config.save()?;
@@ -79,6 +80,52 @@ pub fn set_keychain_secret(
         .into_iter()
         .next()
         .expect("single status"))
+}
+
+pub fn set_keychain_bundle(
+    bundle: &str,
+    value: &str,
+    scope: Option<&str>,
+    keychain_name: Option<&str>,
+) -> crate::core::Result<String> {
+    let _: Value = serde_json::from_str(value).map_err(|error| {
+        Error::validation_invalid_argument(
+            "value",
+            format!("agent-task keychain bundle value must be JSON: {error}"),
+            None,
+            None,
+        )
+    })?;
+    let scope = scope.unwrap_or("agent-task");
+    let keychain_name = keychain_name.unwrap_or(bundle);
+    keychain::set(scope, keychain_name, value)?;
+    Ok(keychain_name.to_string())
+}
+
+pub fn map_secret_to_keychain_bundle(
+    name: &str,
+    bundle: &str,
+    field: &str,
+    scope: Option<&str>,
+    keychain_name: Option<&str>,
+) -> crate::core::Result<AgentTaskSecretEnvStatus> {
+    let mut config = AgentTaskSecretConfig::load();
+    config.secrets.insert(
+        name.to_string(),
+        AgentTaskSecretSource {
+            source: "keychain-bundle".to_string(),
+            env_var: None,
+            scope: Some(scope.unwrap_or("agent-task").to_string()),
+            name: Some(keychain_name.unwrap_or(bundle).to_string()),
+            field: Some(field.to_string()),
+        },
+    );
+    config.save()?;
+    Ok(AgentTaskSecretEnvStatus {
+        name: name.to_string(),
+        configured: true,
+        source: "keychain-bundle".to_string(),
+    })
 }
 
 pub fn remove_secret_mapping(
@@ -104,35 +151,6 @@ pub fn remove_secret_mapping(
         .expect("single status"))
 }
 
-pub fn map_claude_code_to_opencode_anthropic() -> crate::core::Result<Vec<AgentTaskSecretEnvStatus>>
-{
-    let mut config = AgentTaskSecretConfig::load();
-    for (env_name, field_name) in [
-        ("AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN", "access"),
-        ("AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN", "refresh"),
-        ("AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT", "expires"),
-    ] {
-        config.secrets.insert(
-            env_name.to_string(),
-            AgentTaskSecretSource {
-                source: "opencode-anthropic-auth".to_string(),
-                env_var: None,
-                scope: None,
-                name: Some(field_name.to_string()),
-            },
-        );
-    }
-    config.save()?;
-    Ok(secret_env_status_with_config(
-        &[
-            "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN".to_string(),
-            "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN".to_string(),
-            "AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT".to_string(),
-        ],
-        &config,
-    ))
-}
-
 pub fn validate_secret_env(names: &[String]) -> Result<(), AgentTaskSecretResolutionError> {
     resolve_secret_env(names).map(|_| ())
 }
@@ -141,6 +159,7 @@ fn secret_env_status_with_config(
     names: &[String],
     config: &AgentTaskSecretConfig,
 ) -> Vec<AgentTaskSecretEnvStatus> {
+    let mut bundle_cache = HashMap::new();
     names
         .iter()
         .map(|name| {
@@ -155,7 +174,9 @@ fn secret_env_status_with_config(
             let source = config.secrets.get(name);
             AgentTaskSecretEnvStatus {
                 name: name.clone(),
-                configured: source.is_some_and(|source| source.resolve(name).is_some()),
+                configured: source
+                    .and_then(|source| source.resolve(name, &mut bundle_cache))
+                    .is_some(),
                 source: source
                     .map(|source| source.source.clone())
                     .unwrap_or_else(|| "missing".to_string()),
@@ -174,6 +195,7 @@ fn resolve_secret_env_with_config(
 
     let mut resolved = Vec::new();
     let mut missing = Vec::new();
+    let mut bundle_cache = HashMap::new();
 
     for name in names {
         if let Ok(value) = env::var(name) {
@@ -184,7 +206,7 @@ fn resolve_secret_env_with_config(
         match config
             .secrets
             .get(name)
-            .and_then(|source| source.resolve(name))
+            .and_then(|source| source.resolve(name, &mut bundle_cache))
         {
             Some(value) => resolved.push((name.clone(), value)),
             None => missing.push(name.clone()),
@@ -264,10 +286,16 @@ struct AgentTaskSecretSource {
     scope: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    field: Option<String>,
 }
 
 impl AgentTaskSecretSource {
-    fn resolve(&self, requested_name: &str) -> Option<String> {
+    fn resolve(
+        &self,
+        requested_name: &str,
+        bundle_cache: &mut HashMap<String, Option<Value>>,
+    ) -> Option<String> {
         match self.source.as_str() {
             "env" => env::var(self.env_var.as_deref().unwrap_or(requested_name)).ok(),
             "keychain" => keychain::get(
@@ -276,45 +304,44 @@ impl AgentTaskSecretSource {
             )
             .ok()
             .flatten(),
-            "opencode-anthropic-auth" => {
-                opencode_anthropic_auth_value(self.name.as_deref().unwrap_or(requested_name))
-            }
+            "keychain-bundle" => self.resolve_keychain_bundle(requested_name, bundle_cache),
             _ => None,
         }
     }
+
+    fn resolve_keychain_bundle(
+        &self,
+        requested_name: &str,
+        bundle_cache: &mut HashMap<String, Option<Value>>,
+    ) -> Option<String> {
+        let scope = self.scope.as_deref().unwrap_or("agent-task");
+        let keychain_name = self.name.as_deref().unwrap_or(requested_name);
+        let cache_key = format!("{scope}\0{keychain_name}");
+        let bundle = bundle_cache
+            .entry(cache_key)
+            .or_insert_with(|| {
+                keychain::get(scope, keychain_name)
+                    .ok()
+                    .flatten()
+                    .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+            })
+            .as_ref()?;
+        let field = self.field.as_deref().unwrap_or(requested_name);
+        bundle_field_value(bundle, field)
+    }
 }
 
-fn opencode_anthropic_auth_value(field_name: &str) -> Option<String> {
-    let path = opencode_auth_file_path()?;
-    let raw = fs::read_to_string(path).ok()?;
-    let data: Value = serde_json::from_str(&raw).ok()?;
-    let auth = data.get("anthropic")?;
-    if auth.get("type").and_then(Value::as_str) != Some("oauth") {
-        return None;
+fn bundle_field_value(bundle: &Value, field: &str) -> Option<String> {
+    let mut value = bundle;
+    for part in field.split('.') {
+        value = value.get(part)?;
     }
-
-    match field_name {
-        "access" | "refresh" => auth
-            .get(field_name)
-            .and_then(Value::as_str)
-            .map(str::to_string),
-        "expires" => auth.get("expires").and_then(|value| {
-            value
-                .as_i64()
-                .map(|number| number.to_string())
-                .or_else(|| value.as_str().map(str::to_string))
-        }),
+    match value {
+        Value::String(text) => Some(text.clone()),
+        Value::Bool(flag) => Some(flag.to_string()),
+        Value::Number(number) => Some(number.to_string()),
         _ => None,
     }
-}
-
-fn opencode_auth_file_path() -> Option<PathBuf> {
-    if let Ok(data_home) = env::var("XDG_DATA_HOME") {
-        return Some(PathBuf::from(data_home).join("opencode/auth.json"));
-    }
-    env::var("HOME")
-        .ok()
-        .map(|home| PathBuf::from(home).join(".local/share/opencode/auth.json"))
 }
 
 fn default_source() -> String {
@@ -387,6 +414,7 @@ mod tests {
                 env_var: Some(source_name.clone()),
                 scope: None,
                 name: None,
+                field: None,
             },
         );
         let config = AgentTaskSecretConfig { secrets };
@@ -445,48 +473,74 @@ mod tests {
     }
 
     #[test]
-    fn maps_claude_code_to_opencode_anthropic_auth_file() {
-        crate::test_support::with_isolated_home(|home| {
-            let auth_path = home.path().join(".local/share/opencode/auth.json");
-            std::fs::create_dir_all(auth_path.parent().expect("auth parent")).expect("mkdir auth");
-            std::fs::write(
-                &auth_path,
-                r#"{"anthropic":{"type":"oauth","access":"access-token","refresh":"refresh-token","expires":12345}}"#,
+    fn resolves_keychain_bundle_fields_from_cached_bundle() {
+        let source = AgentTaskSecretSource {
+            source: "keychain-bundle".to_string(),
+            env_var: None,
+            scope: Some("agent-task".to_string()),
+            name: Some("provider-oauth".to_string()),
+            field: Some("tokens.access".to_string()),
+        };
+        let mut cache = HashMap::new();
+        cache.insert(
+            "agent-task\0provider-oauth".to_string(),
+            Some(serde_json::json!({
+                "tokens": {
+                    "access": "access-token",
+                    "expires": 12345,
+                    "fedramp": false
+                }
+            })),
+        );
+
+        assert_eq!(
+            source.resolve("PROVIDER_ACCESS_TOKEN", &mut cache),
+            Some("access-token".to_string())
+        );
+
+        let numeric_source = AgentTaskSecretSource {
+            field: Some("tokens.expires".to_string()),
+            ..source.clone()
+        };
+        assert_eq!(
+            numeric_source.resolve("PROVIDER_EXPIRES_AT", &mut cache),
+            Some("12345".to_string())
+        );
+
+        let bool_source = AgentTaskSecretSource {
+            field: Some("tokens.fedramp".to_string()),
+            ..source
+        };
+        assert_eq!(
+            bool_source.resolve("PROVIDER_FEDRAMP", &mut cache),
+            Some("false".to_string())
+        );
+    }
+
+    #[test]
+    fn maps_secret_to_keychain_bundle_without_reading_keychain() {
+        crate::test_support::with_isolated_home(|_| {
+            let status = map_secret_to_keychain_bundle(
+                "PROVIDER_ACCESS_TOKEN",
+                "provider-oauth",
+                "tokens.access",
+                None,
+                None,
             )
-            .expect("write auth");
+            .expect("bundle mapping saved");
 
-            let status = map_claude_code_to_opencode_anthropic().expect("mapping saved");
+            assert_eq!(status.name, "PROVIDER_ACCESS_TOKEN");
+            assert!(status.configured);
+            assert_eq!(status.source, "keychain-bundle");
 
-            assert_eq!(status.len(), 3);
-            assert!(status.iter().all(|status| status.configured));
-            assert!(status
-                .iter()
-                .all(|status| status.source == "opencode-anthropic-auth"));
-
-            let resolved = resolve_secret_env(&[
-                "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN".to_string(),
-                "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN".to_string(),
-                "AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT".to_string(),
-            ])
-            .expect("mapped auth resolves");
-
-            assert_eq!(
-                resolved,
-                vec![
-                    (
-                        "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN".to_string(),
-                        "access-token".to_string()
-                    ),
-                    (
-                        "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN".to_string(),
-                        "refresh-token".to_string()
-                    ),
-                    (
-                        "AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT".to_string(),
-                        "12345".to_string()
-                    ),
-                ]
-            );
+            let config = AgentTaskSecretConfig::load();
+            let source = config
+                .secrets
+                .get("PROVIDER_ACCESS_TOKEN")
+                .expect("mapping stored");
+            assert_eq!(source.source, "keychain-bundle");
+            assert_eq!(source.name.as_deref(), Some("provider-oauth"));
+            assert_eq!(source.field.as_deref(), Some("tokens.access"));
         });
     }
 }

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -1131,7 +1131,7 @@ fn hydrate_agent_task_secret_env(
             error.message,
             None,
             Some(vec![
-                "Configure provider secrets with `homeboy agent-task auth status` and `homeboy agent-task auth map-claude-code-kimaki`.".to_string(),
+                "Configure provider secrets with Homeboy's global agent-task secret config, for example `homeboy agent-task auth map-env` or `homeboy agent-task auth set-keychain`.".to_string(),
             ]),
         )
     })?;
@@ -1160,11 +1160,52 @@ fn declared_agent_task_secret_env(args: &[String]) -> Vec<String> {
         if let Some(name) = arg.strip_prefix("--secret-env=") {
             names.push(name.to_string());
         }
+        if arg == "--provider-config" {
+            if let Some(spec) = args.get(index + 1) {
+                names.extend(declared_provider_config_secret_env(spec));
+            }
+            index += 2;
+            continue;
+        }
+        if let Some(spec) = arg.strip_prefix("--provider-config=") {
+            names.extend(declared_provider_config_secret_env(spec));
+        }
         index += 1;
     }
     names.extend(declared_agent_task_run_plan_secret_env(args));
     names.sort();
     names.dedup();
+    names
+}
+
+fn declared_provider_config_secret_env(spec: &str) -> Vec<String> {
+    let raw = match config::read_json_spec_to_string(spec) {
+        Ok(raw) => raw,
+        Err(_) => return Vec::new(),
+    };
+    let value: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(_) => return Vec::new(),
+    };
+    let Some(config) = value.as_object() else {
+        return Vec::new();
+    };
+
+    let mut names = Vec::new();
+    for key in ["secret_env", "secretEnv"] {
+        match config.get(key) {
+            Some(serde_json::Value::Array(items)) => {
+                names.extend(
+                    items
+                        .iter()
+                        .filter_map(serde_json::Value::as_str)
+                        .map(str::to_string),
+                );
+            }
+            Some(serde_json::Value::String(name)) => names.push(name.clone()),
+            _ => {}
+        }
+    }
     names
 }
 
@@ -1631,17 +1672,47 @@ mod tests {
             "agent-task".to_string(),
             "dispatch".to_string(),
             "--secret-env".to_string(),
-            "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN".to_string(),
-            "--secret-env=AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN".to_string(),
+            "HOMEBOY_TEST_REFRESH_TOKEN".to_string(),
+            "--secret-env=HOMEBOY_TEST_ACCESS_TOKEN".to_string(),
             "--secret-env".to_string(),
-            "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN".to_string(),
+            "HOMEBOY_TEST_ACCESS_TOKEN".to_string(),
         ]);
 
         assert_eq!(
             names,
             vec![
-                "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN".to_string(),
-                "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN".to_string(),
+                "HOMEBOY_TEST_ACCESS_TOKEN".to_string(),
+                "HOMEBOY_TEST_REFRESH_TOKEN".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn declared_agent_task_secret_env_includes_provider_config_secrets() {
+        let names = declared_agent_task_secret_env(&[
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "dispatch".to_string(),
+            "--provider-config".to_string(),
+            serde_json::json!({
+                "provider": "example",
+                "secret_env": [
+                    "HOMEBOY_PROVIDER_ACCESS_TOKEN",
+                    "HOMEBOY_PROVIDER_REFRESH_TOKEN"
+                ],
+                "secretEnv": "HOMEBOY_PROVIDER_ACCOUNT_ID"
+            })
+            .to_string(),
+            "--secret-env=OPENAI_API_KEY".to_string(),
+        ]);
+
+        assert_eq!(
+            names,
+            vec![
+                "HOMEBOY_PROVIDER_ACCESS_TOKEN".to_string(),
+                "HOMEBOY_PROVIDER_ACCOUNT_ID".to_string(),
+                "HOMEBOY_PROVIDER_REFRESH_TOKEN".to_string(),
+                "OPENAI_API_KEY".to_string(),
             ]
         );
     }


### PR DESCRIPTION
## Summary
- Add generic agent-task keychain JSON bundles so related secret fields can be stored in one keychain item.
- Add generic mappings from env names to bundle fields, with per-process bundle caching during status/resolution.
- Promote `secret_env` declared in provider config into dispatch plans and Lab offload hydration, and remove the provider-specific Claude/Kimaki auth mapper from Homeboy core.

## Tests
- `cargo fmt`
- `cargo test core::agent_task_secrets::tests`
- `cargo test dispatch_promotes_provider_config_secret_env`
- `cargo test declared_agent_task_secret_env_includes_provider_config_secrets`

## Smoke proof
- Patched Homeboy binary dispatched a read-only WP Codebox Codex task through Lab offload successfully.
- Run ID: `agent-task-b8f6e825-7f37-4d35-84f0-47927f851899`
- Outcome: `WP Codebox agent task succeeded.`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted implementation, tests, and PR description; Chris reviewed behavior and provided architecture direction that Homeboy core must remain provider-generic.