### PR TITLE
Sync runners after same-version upgrade

### DIFF
--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -206,17 +206,18 @@ pub fn run_upgrade_with_method(
 
     // Execute the upgrade
     let (success, new_version) = execute_upgrade(install_method, source_path)?;
+    let upgrade_completed = should_sync_after_upgrade(new_version.as_deref());
 
-    // Auto-update all installed extensions after a successful upgrade.
+    // Auto-update all installed extensions after the upgrade command completes.
     // This prevents CI/local extension version drift that causes baseline
     // mismatches and inconsistent audit findings.
-    let (extensions_updated, extensions_skipped) = if success && !skip_extensions {
+    let (extensions_updated, extensions_skipped) = if upgrade_completed && !skip_extensions {
         update_all_extensions()
     } else {
         (vec![], vec![])
     };
 
-    let (runners_updated, runners_skipped) = if success && !skip_runners {
+    let (runners_updated, runners_skipped) = if upgrade_completed && !skip_runners {
         runners::upgrade_configured_runners(runner_targets, &extensions_updated)?
     } else {
         (vec![], vec![])
@@ -244,6 +245,10 @@ pub fn run_upgrade_with_method(
         runners_updated,
         runners_skipped,
     })
+}
+
+pub(crate) fn should_sync_after_upgrade(new_version: Option<&str>) -> bool {
+    new_version.is_some()
 }
 
 /// Update all installed extensions. Best-effort — failures are logged and

--- a/src/core/upgrade/mod.rs
+++ b/src/core/upgrade/mod.rs
@@ -46,6 +46,12 @@ mod tests {
     }
 
     #[test]
+    fn same_version_upgrade_completion_still_syncs_extensions_and_runners() {
+        assert!(helpers::should_sync_after_upgrade(Some("0.228.5")));
+        assert!(!helpers::should_sync_after_upgrade(None));
+    }
+
+    #[test]
     fn test_current_version() {
         let version = current_version();
         assert!(!version.is_empty());


### PR DESCRIPTION
## Summary
- Run extension and configured runner sync after an upgrade command completes, even when the active Homeboy semantic version does not change.
- Preserve `upgraded: false` for same-version upgrades while still enforcing parent/Lab sync.
- Add coverage for the same-version completion case.

## Testing
- `cargo test upgrade --locked`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the same-version source-upgrade sync gap, drafted the minimal sync-condition fix and regression test, and ran local verification. Chris remains responsible for review and merge.