### PR TITLE
fix: recompute trace exit after result processing

### DIFF
--- a/src/commands/trace/experiment_tests.rs
+++ b/src/commands/trace/experiment_tests.rs
@@ -71,6 +71,7 @@ fn write_trace_experiment_extension(home: &tempfile::TempDir, fail: bool) {
     .expect("write extension manifest");
 
     let exit_line = if fail { "exit 9" } else { "exit 0" };
+    let trace_status = if fail { "error" } else { "pass" };
     let script_path = extension_dir.join("trace-runner.sh");
     fs::write(
         &script_path,
@@ -89,7 +90,7 @@ test -f "$HOMEBOY_TRACE_COMPONENT_PATH/experiment-state.txt"
 case "$HOMEBOY_SETTINGS_JSON" in *TEMPLATE_PATH*) ;; *) exit 8 ;; esac
 printf '%s\n' "$HOMEBOY_SETTINGS_JSON" > "$HOMEBOY_TRACE_ARTIFACT_DIR/settings.json"
 cat > "$HOMEBOY_TRACE_RESULTS_FILE" <<JSON
-{{"component_id":"$HOMEBOY_COMPONENT_ID","scenario_id":"$HOMEBOY_TRACE_SCENARIO","status":"pass","timeline":[],"span_results":[],"assertions":[],"artifacts":[{{"label":"runner settings","path":"artifacts/settings.json"}}]}}
+{{"component_id":"$HOMEBOY_COMPONENT_ID","scenario_id":"$HOMEBOY_TRACE_SCENARIO","status":"{trace_status}","timeline":[],"span_results":[],"assertions":[],"artifacts":[{{"label":"runner settings","path":"artifacts/settings.json"}}]}}
 JSON
 {exit_line}
 "#

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -390,9 +390,6 @@ fn run_trace_workflow_with_context(
     } else {
         None
     };
-    let parsed_status = results.as_ref().map(|r| r.status.as_str().to_string());
-    let failure = (!runner_output.success && parsed_status.as_deref() != Some("pass"))
-        .then(|| failure_from_output(&args, &runner_output, Some(&artifact_dir), results.as_ref()));
     if let Some(parsed) = results.as_mut() {
         parsed.toolchain = Some(toolchain.clone());
         parsed.components = Some(components.clone());
@@ -407,14 +404,19 @@ fn run_trace_workflow_with_context(
         persist_trace_results(&results_path, parsed)?;
     }
 
-    let status = parsed_status.unwrap_or_else(|| {
-        if runner_output.success {
-            "pass"
-        } else {
-            "error"
-        }
-        .to_string()
-    });
+    let status = results
+        .as_ref()
+        .map(|r| r.status.as_str().to_string())
+        .unwrap_or_else(|| {
+            if runner_output.success {
+                "pass"
+            } else {
+                "error"
+            }
+            .to_string()
+        });
+    let failure = (!runner_output.success && status != "pass")
+        .then(|| failure_from_output(&args, &runner_output, Some(&artifact_dir), results.as_ref()));
     let exit_code = if status == "pass" {
         0
     } else if runner_output.success {


### PR DESCRIPTION
## Summary
- Derive the final trace workflow status and exit code after parsed trace results have been post-processed.
- Keep parsed `status: pass` as the source of truth for noisy runner envelope failures.
- Update the experiment failure fixture so real trace failures emit `status: error` while still verifying teardown runs.

Fixes #3963.

## Verification
- `cargo test trace_experiment_runs_teardown_when_trace_fails --locked`
- `cargo test trace_run_fails_when_declared_artifact_is_missing --locked`
- `cargo test parsed_pass_result_overrides_noisy_runner_exit --locked`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the targeted trace exit-code fix, adjusted regression coverage, and ran focused verification. Chris remains responsible for review and merge.