### PR TITLE
Fix Lab agent-task inspection routing

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1127,6 +1127,18 @@ mod tests {
             parsed_command(&["homeboy", "agent-task", "run-plan", "--plan", "@plan.json"])
                 .supports_lab_runner()
         );
+        assert!(
+            parsed_command(&["homeboy", "agent-task", "status", "agent-task-123"])
+                .supports_lab_runner()
+        );
+        assert!(
+            parsed_command(&["homeboy", "agent-task", "logs", "agent-task-123"])
+                .supports_lab_runner()
+        );
+        assert!(
+            parsed_command(&["homeboy", "agent-task", "artifacts", "agent-task-123"])
+                .supports_lab_runner()
+        );
         assert!(parsed_command(&[
             "homeboy",
             "agent-task",
@@ -1231,6 +1243,18 @@ mod tests {
                 parsed_command(&["homeboy", "agent-task", "run-plan", "--plan", "@plan.json"]),
                 "agent-task dispatch/cook/loop/run-plan",
             ),
+            (
+                parsed_command(&["homeboy", "agent-task", "status", "agent-task-123"]),
+                "agent-task status/logs/artifacts",
+            ),
+            (
+                parsed_command(&["homeboy", "agent-task", "logs", "agent-task-123"]),
+                "agent-task status/logs/artifacts",
+            ),
+            (
+                parsed_command(&["homeboy", "agent-task", "artifacts", "agent-task-123"]),
+                "agent-task status/logs/artifacts",
+            ),
         ];
 
         for (command, label) in supported {
@@ -1278,6 +1302,13 @@ mod tests {
             .expect("lint contract");
         assert!(lint.requires_extension_parity);
         assert!(lint.infer_source_path_tools);
+
+        let agent_task_status =
+            parsed_command(&["homeboy", "agent-task", "status", "agent-task-123"])
+                .lab_contract()
+                .expect("agent-task status contract");
+        assert!(!agent_task_status.requires_extension_parity);
+        assert!(!agent_task_status.infer_source_path_tools);
 
         let rig = parsed_command(&["homeboy", "rig", "up", "studio"])
             .lab_contract()

--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -61,6 +61,21 @@ impl Commands {
                     LAB_NO_EXTRA_TOOLS,
                 )
             }
+            Commands::AgentTask(args)
+                if matches!(
+                    args.command,
+                    super::agent_task::AgentTaskCommand::Status(_)
+                        | super::agent_task::AgentTaskCommand::Logs(_)
+                        | super::agent_task::AgentTaskCommand::Artifacts(_)
+                ) =>
+            {
+                lab_portable_workload_contract(
+                    "agent-task status/logs/artifacts",
+                    None,
+                    false,
+                    LAB_NO_EXTRA_TOOLS,
+                )
+            }
             Commands::Audit(args) if args.changed_since.is_some() => {
                 lab_local_only_contract("audit", AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON)
             }

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -539,6 +539,24 @@ mod tests {
     }
 
     #[test]
+    fn agent_task_inspection_commands_are_read_only_lab_portable() {
+        for args in [
+            ["homeboy", "agent-task", "status", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "logs", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "artifacts", "agent-task-123"].as_slice(),
+        ] {
+            let cli = Cli::parse_from(args);
+            let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+            assert_eq!(command.hot_label, "agent-task status/logs/artifacts");
+            assert!(command.portable);
+            assert!(!command.requires_extension_parity);
+            assert!(command.required_extensions.is_empty());
+            assert!(!command.infer_source_path_tools);
+        }
+    }
+
+    #[test]
     fn lab_command_with_mutation_flag_stays_portable_for_patch_capture() {
         let cli = Cli::parse_from(["homeboy", "audit", "--baseline"]);
 

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -218,7 +218,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             "runner",
             message,
             Some(runner_id.to_string()),
-            Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+            Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
         )
     };
     let mut plan = base_lab_plan(request.command.as_ref());
@@ -226,7 +226,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if let Some(runner_id) = request.explicit_runner {
             return Err(unsupported_runner_error(
                 runner_id,
-                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts, lint, test, audit, bench, trace, and refactor source runs".to_string(),
             ));
         }
         return Ok(LabOffloadOutcome::RunLocal {
@@ -239,7 +239,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.portable {
         if let Some(runner_id) = request.explicit_runner {
             let message = contract.unsupported_reason.map_or_else(
-                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
             );
             return Err(unsupported_runner_error(runner_id, message));

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -344,14 +344,14 @@ pub(super) fn resolve_lab_runner_selection_from_default(
     if let Some(runner_id) = explicit_runner {
         if !command.portable {
             let message = command.unsupported_reason.map_or_else(
-                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop/run-plan, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this hot command. {reason}"),
             );
             return Err(Error::validation_invalid_argument(
                 "runner",
                 message,
                 Some(runner_id.to_string()),
-                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
             ));
         }
 


### PR DESCRIPTION
## Summary
- Fixes #3975 by marking `agent-task status`, `agent-task logs`, and `agent-task artifacts` as Lab-portable read-only commands.
- Keeps execution commands (`dispatch`, `cook`, `loop`, `run-plan`) on the existing extension-parity contract, while inspection skips provider extension parity.
- Updates runner gate guidance so `--runner` support lists the inspection subcommands.

## Expected UX
Operators can inspect a run that lives on a Lab runner explicitly:

```bash
homeboy --runner homeboy-lab agent-task status <run-id>
homeboy --runner homeboy-lab agent-task logs <run-id>
homeboy --runner homeboy-lab agent-task artifacts <run-id>
```

This PR intentionally does not add automatic runner inference or local status mirroring; the minimal safe contract is explicit remote inspection.

## Tests
- `cargo fmt`
- `git diff --check`
- `cargo test agent_task_inspection_commands_are_read_only_lab_portable --lib`
- `cargo test test_supports_lab_runner --lib`
- `cargo test test_lab_command_contracts_cover_hot_commands --lib`

## Risks
- The explicit `--runner` path still uses the generic Lab offload pipeline, so it requires a connected Lab runner and a mappable current workspace. That matches existing Lab command behavior but is not as seamless as automatic run-id provenance lookup.
- Automatic proxying based on returned run metadata would require persisting runner provenance for agent-task run ids on the controller side; that is left out to keep this fix narrow.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the Lab routing failure, drafted the implementation and tests; Chris reviews and owns the change.