### PR TITLE
Fix bench artifact fetch hint

### DIFF
--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -123,7 +123,7 @@ pub(super) fn history_hints(summary: &BenchObservationSummary) -> Vec<String> {
         format!("View this run: homeboy runs show {}", summary.run_id),
         format!("List artifacts: homeboy runs artifacts {}", summary.run_id),
         format!(
-            "Fetch an artifact: homeboy runs artifact get {} <artifact-name> --to <path>",
+            "Fetch an artifact: homeboy runs artifact get {} <artifact-name> -o <path>",
             summary.run_id
         ),
         format!("List related bench runs: {list_command}"),
@@ -1363,6 +1363,9 @@ mod tests {
 
         assert!(hints.iter().any(|hint| hint
             == "List related bench runs: homeboy runs list --kind bench --component studio --rig studio-trunk"));
+        assert!(hints.iter().any(|hint| hint
+            == "Fetch an artifact: homeboy runs artifact get run-123 <artifact-name> -o <path>"));
+        assert!(!hints.iter().any(|hint| hint.contains("--to <path>")));
     }
 
     fn synthetic_resources(recommendation: ResourceRecommendation) -> DoctorOutput {


### PR DESCRIPTION
## Summary
- Update the persisted bench artifact fetch hint to use the current `homeboy runs artifact get ... -o <path>` output option.
- Extend the existing bench history hint test to assert the new flag and guard against the removed `--to <path>` hint.

Fixes #3982.

## Tests
- `cargo test commands::bench::observation::tests::history_hints_include_rig_filter_when_present`
- `cargo run --bin homeboy -- runs artifact get --help`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the minimal code/test update and ran targeted verification; Chris remains responsible for review and merge.