### PR TITLE
Fix stale runner daemon recovery guidance

### DIFF
--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -744,7 +744,7 @@ mod tests {
     }
 
     #[test]
-    fn stale_daemon_warning_includes_recovery_commands() {
+    fn stale_daemon_warning_includes_ordered_restart_recovery_commands() {
         let warning = RunnerStaleDaemonWarning::new(
             "homeboy-lab",
             "homeboy 0.201.3".to_string(),
@@ -754,10 +754,10 @@ mod tests {
         assert_eq!(warning.session_homeboy_version, "homeboy 0.201.3");
         assert_eq!(warning.current_homeboy_version, "homeboy 0.204.0");
         assert!(warning.message.contains("different Homeboy version"));
+        assert!(warning.message.contains("run recovery_commands in order"));
         assert_eq!(
             warning.recovery_commands,
             vec![
-                "homeboy runner connect homeboy-lab".to_string(),
                 "homeboy runner disconnect homeboy-lab".to_string(),
                 "homeboy runner connect homeboy-lab".to_string(),
             ]

--- a/src/core/runner/lab/preparation_tests.rs
+++ b/src/core/runner/lab/preparation_tests.rs
@@ -119,7 +119,7 @@ fn lab_runner_preparation_falls_back_for_stale_default_daemon_version() {
     assert_eq!(
         prepared,
         LabRunnerPreparation::FallBackLocal {
-            reason: "connected runner `lab` daemon is stale: connected daemon reports homeboy 0.218.0, but the configured runner executable reports homeboy 0.219.0; refresh the session with `homeboy runner connect lab`".to_string()
+            reason: "connected runner `lab` daemon is stale: connected daemon reports homeboy 0.218.0, but the configured runner executable reports homeboy 0.219.0; restart the active daemon with `homeboy runner disconnect lab && homeboy runner connect lab`".to_string()
         }
     );
 }
@@ -155,6 +155,9 @@ fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
     assert!(err.message.contains("daemon is stale"));
     assert!(err.message.contains("homeboy 0.218.0"));
     assert!(err.message.contains("homeboy 0.219.0"));
+    assert!(err
+        .message
+        .contains("homeboy runner disconnect lab && homeboy runner connect lab"));
     assert!(err
         .details
         .get("tried")

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -280,13 +280,14 @@ fn connected_runner_not_ready_reason(
     status: &RunnerStatusReport,
 ) -> Option<String> {
     if let Some(warning) = status.stale_daemon.as_ref() {
-        let reconnect = warning
-            .recovery_commands
-            .first()
-            .cloned()
-            .unwrap_or_else(|| format!("homeboy runner connect {runner_id}"));
+        let restart = warning.recovery_commands.join(" && ");
+        let restart = if restart.is_empty() {
+            format!("homeboy runner disconnect {runner_id} && homeboy runner connect {runner_id}")
+        } else {
+            restart
+        };
         return Some(format!(
-            "connected runner `{runner_id}` daemon is stale: connected daemon reports {}, but the configured runner executable reports {}; refresh the session with `{reconnect}`",
+            "connected runner `{runner_id}` daemon is stale: connected daemon reports {}, but the configured runner executable reports {}; restart the active daemon with `{restart}`",
             warning.session_homeboy_version, warning.current_homeboy_version
         ));
     }

--- a/src/core/runner/session.rs
+++ b/src/core/runner/session.rs
@@ -141,9 +141,8 @@ impl RunnerStaleDaemonWarning {
         Self {
             session_homeboy_version,
             current_homeboy_version,
-            message: "connected runner daemon was started by a different Homeboy version than the configured runner executable".to_string(),
+            message: "connected runner daemon was started by a different Homeboy version than the configured runner executable; run recovery_commands in order to restart the active daemon".to_string(),
             recovery_commands: vec![
-                format!("homeboy runner connect {}", runner_id),
                 format!("homeboy runner disconnect {}", runner_id),
                 format!("homeboy runner connect {}", runner_id),
             ],

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -397,13 +397,14 @@ fn runner_upgrade_final_detail(
     }
 
     if let Some(stale_daemon) = stale_daemon {
-        let remediation = stale_daemon
-            .recovery_commands
-            .first()
-            .cloned()
-            .unwrap_or_else(|| "homeboy runner connect <runner>".to_string());
+        let remediation = stale_daemon.recovery_commands.join(" && ");
+        let remediation = if remediation.is_empty() {
+            "homeboy runner disconnect <runner> && homeboy runner connect <runner>".to_string()
+        } else {
+            remediation
+        };
         parts.push(format!(
-            "connected runner daemon is stale: session reports {}, configured executable reports {}; refresh with `{}`",
+            "connected runner daemon is stale: session reports {}, configured executable reports {}; restart the active daemon with `{}`",
             stale_daemon.session_homeboy_version,
             stale_daemon.current_homeboy_version,
             remediation


### PR DESCRIPTION
## Summary
- Replace stale runner daemon recovery commands with an ordered restart sequence: disconnect, then connect.
- Update stale-daemon lab/upgrade messages to show the full restart path instead of only the first command.
- Add focused test coverage for the ordered recovery commands and lab-preparation stale-daemon messaging.

Fixes #3983.

## Tests
- `cargo test stale_daemon`
- `cargo test lab_runner_preparation`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the stale runner daemon recovery guidance fix; Chris remains responsible for review and merge.