### PR TITLE
Clarify Lab runner wait timeout ownership

### DIFF
--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -25,7 +25,7 @@ use super::resource_metrics::{
 use super::{load, status, Runner, RunnerCapabilityPreflight, RunnerKind, RunnerTunnelMode};
 
 const DEFAULT_RUNNER_EXEC_WAIT_TIMEOUT_SECS: u64 = 20 * 60;
-const RUNNER_EXEC_WAIT_TIMEOUT_ENV: &str = "HOMEBOY_RUNNER_EXEC_WAIT_TIMEOUT_SECS";
+pub(crate) const RUNNER_EXEC_WAIT_TIMEOUT_ENV: &str = "HOMEBOY_RUNNER_EXEC_WAIT_TIMEOUT_SECS";
 
 mod extension_parity;
 mod policy;
@@ -518,6 +518,9 @@ fn cancel_daemon_job_after_timeout(
     job_id: &str,
     label: &str,
 ) -> Error {
+    let timeout_hint = format!(
+        "Set controller-side `{RUNNER_EXEC_WAIT_TIMEOUT_ENV}` before invoking homeboy to change this wait budget, e.g. `{RUNNER_EXEC_WAIT_TIMEOUT_ENV}=2400 homeboy ...`; workload settings are applied inside the remote job and cannot extend the controller wait."
+    );
     match cancel_daemon_job(client, local_url, job_id) {
         Ok(()) => Error::internal_unexpected(format!(
             "{label} {job_id} on runner {runner_id} did not finish before timeout; cancellation was requested"
@@ -525,7 +528,8 @@ fn cancel_daemon_job_after_timeout(
         .with_hint(format!(
             "Confirm cleanup with `homeboy http get {}/jobs/{job_id}`.",
             local_url.trim_end_matches('/')
-        )),
+        ))
+        .with_hint(timeout_hint),
         Err(err) => Error::internal_unexpected(format!(
             "{label} {job_id} on runner {runner_id} did not finish before timeout; automatic cancellation failed: {}",
             err.message
@@ -533,7 +537,8 @@ fn cancel_daemon_job_after_timeout(
         .with_hint(format!(
             "Run `homeboy http request POST {}/jobs/{job_id}/cancel` to cancel the remote job.",
             local_url.trim_end_matches('/')
-        )),
+        ))
+        .with_hint(timeout_hint),
     }
 }
 
@@ -1588,6 +1593,11 @@ mod tests {
             .hints
             .iter()
             .any(|hint| hint.message.contains("homeboy http get http://")));
+        assert!(err.hints.iter().any(|hint| {
+            hint.message.contains(RUNNER_EXEC_WAIT_TIMEOUT_ENV)
+                && hint.message.contains("controller-side")
+                && hint.message.contains("workload settings")
+        }));
         assert_eq!(
             seen_path.lock().expect("seen path").as_str(),
             "POST /jobs/job-123/cancel HTTP/1.1"

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -29,7 +29,8 @@ use super::lab_args::{
 use super::lab_capabilities::lab_runner_capability_contract;
 use super::lab_command::lab_offload_command_prefix;
 use super::lab_env::{
-    build_lab_offload_env, forward_env_if_present, forward_release_ci_env, settings_env_diagnostics,
+    build_lab_offload_env, forward_env_if_present, forward_release_ci_env,
+    misplaced_runner_exec_wait_timeout_warning, settings_env_diagnostics,
 };
 use super::lab_plan::{base_lab_plan, disabled_select_runner_plan, with_step};
 pub use super::lab_selection::LabRunnerSelectionSource;
@@ -376,7 +377,7 @@ fn run_lab_offload_inner(
     selection: LabRunnerSelection,
     contract: LabOffloadCommand,
     mut plan: HomeboyPlan,
-    messages: Vec<String>,
+    mut messages: Vec<String>,
 ) -> Result<LabOffloadOutcome> {
     let runner_id = &selection.runner_id;
     let runner = load(runner_id)?;
@@ -435,6 +436,9 @@ fn run_lab_offload_inner(
     })?;
 
     let source_path = lab_offload_source_path(request.normalized_args)?;
+    if let Some(warning) = misplaced_runner_exec_wait_timeout_warning(request.normalized_args) {
+        messages.push(warning);
+    }
     let homeboy_path = runner.settings.homeboy_path.as_deref().unwrap_or("homeboy");
     let command_prefix = lab_offload_command_prefix(&source_path, homeboy_path);
     let capability_contract =

--- a/src/core/runner/lab_env.rs
+++ b/src/core/runner/lab_env.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use super::execution::RUNNER_EXEC_WAIT_TIMEOUT_ENV;
 use crate::core::observation::LAB_OFFLOAD_METADATA_ENV;
 
 const SETTINGS_DIAGNOSTICS_SCHEMA: &str = "homeboy/lab-offload-settings-env/v1";
@@ -66,6 +67,23 @@ pub(super) fn settings_env_diagnostics(
         "settings": settings,
         "forwarded_environment": forwarded_environment,
     })
+}
+
+pub(super) fn misplaced_runner_exec_wait_timeout_warning(
+    normalized_args: &[String],
+) -> Option<String> {
+    if std::env::var_os(RUNNER_EXEC_WAIT_TIMEOUT_ENV).is_some() {
+        return None;
+    }
+
+    parsed_setting_args(normalized_args)
+        .into_iter()
+        .any(|setting| setting.key == RUNNER_EXEC_WAIT_TIMEOUT_ENV)
+        .then(|| {
+            format!(
+                "Lab offload: `{RUNNER_EXEC_WAIT_TIMEOUT_ENV}` was supplied as a workload setting, but runner wait timeout is controlled by the controller process. Set it before invoking homeboy instead, e.g. `{RUNNER_EXEC_WAIT_TIMEOUT_ENV}=2400 homeboy ...`."
+            )
+        })
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -283,5 +301,35 @@ mod tests {
             env.get("RELEASE_BLOCKING_COMMANDS").map(String::as_str),
             Some("lint,test")
         );
+    }
+
+    #[test]
+    fn warns_when_runner_exec_wait_timeout_is_only_a_workload_setting() {
+        std::env::remove_var(RUNNER_EXEC_WAIT_TIMEOUT_ENV);
+        let args = vec![
+            "homeboy".to_string(),
+            "bench".to_string(),
+            "--setting".to_string(),
+            format!("{RUNNER_EXEC_WAIT_TIMEOUT_ENV}=2400"),
+        ];
+
+        let warning = misplaced_runner_exec_wait_timeout_warning(&args).expect("warning");
+
+        assert!(warning.contains(RUNNER_EXEC_WAIT_TIMEOUT_ENV));
+        assert!(warning.contains("controller process"));
+        assert!(warning.contains("workload setting"));
+    }
+
+    #[test]
+    fn skips_runner_exec_wait_timeout_setting_warning_when_controller_env_is_set() {
+        let _guard = EnvVarGuard::set(RUNNER_EXEC_WAIT_TIMEOUT_ENV, "2400");
+        let args = vec![
+            "homeboy".to_string(),
+            "bench".to_string(),
+            "--setting".to_string(),
+            format!("{RUNNER_EXEC_WAIT_TIMEOUT_ENV}=2400"),
+        ];
+
+        assert_eq!(misplaced_runner_exec_wait_timeout_warning(&args), None);
     }
 }


### PR DESCRIPTION
## Summary
- Warn when `HOMEBOY_RUNNER_EXEC_WAIT_TIMEOUT_SECS` is supplied through Lab workload settings without being set in the controller environment.
- Add runner timeout error hints that explain the controller-side env var and why workload settings cannot extend the controller wait.
- Cover the warning and timeout hint with focused tests.

Closes #3984.

## Tests
- `cargo test timeout_cleanup_requests_remote_job_cancellation && cargo test warns_when_runner_exec_wait_timeout_is_only_a_workload_setting && cargo test skips_runner_exec_wait_timeout_setting_warning_when_controller_env_is_set`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Lab timeout UX changes and focused tests; Chris remains responsible for review and validation.