### PR TITLE
Fix trace parser producer fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_path",
+ "serde_path_to_error",
  "serde_yml",
  "sha2",
  "shellexpand",
@@ -2067,6 +2068,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ path = "src/bin/bench-audit-self.rs"
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_path_to_error = "0.1"
 serde_yml = "0.0.12"
 heck = "0.5"
 uuid = { version = "1.11", features = ["v4", "v5", "serde"] }

--- a/src/commands/observe.rs
+++ b/src/commands/observe.rs
@@ -167,10 +167,12 @@ pub fn run(args: ObserveArgs, _global: &GlobalArgs) -> CmdResult<ObserveOutput> 
         artifacts: vec![TraceArtifact {
             label: "observe timeline".to_string(),
             path: trace_path.to_string_lossy().to_string(),
+            kind: None,
         }],
         toolchain: None,
         components: None,
         dependencies: Vec::new(),
+        metrics: BTreeMap::new(),
         preview: None,
     };
 

--- a/src/commands/trace/experiment.rs
+++ b/src/commands/trace/experiment.rs
@@ -395,6 +395,7 @@ fn collect_trace_experiment_artifacts(
         results.artifacts.push(extension_trace::TraceArtifact {
             label,
             path: relative.to_string_lossy().to_string(),
+            kind: None,
         });
     }
     Ok(())

--- a/src/commands/trace/observations.rs
+++ b/src/commands/trace/observations.rs
@@ -302,6 +302,7 @@ mod tests {
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
+            metrics: Default::default(),
             preview: None,
         }
     }
@@ -329,6 +330,7 @@ mod tests {
             let results = sample_results(vec![TraceArtifact {
                 label: "WP Codebox browser probe".to_string(),
                 path: "artifacts/wp-codebox-artifacts/runtime-abc/files/browser".to_string(),
+                kind: None,
             }]);
 
             let outcome = record_trace_artifacts(&store, &run.id, &run_dir, Some(&results));
@@ -370,6 +372,7 @@ mod tests {
                 label: "network log".to_string(),
                 path: "artifacts/wp-codebox-artifacts/runtime-missing/files/browser/network.jsonl"
                     .to_string(),
+                kind: None,
             }]);
 
             let outcome = record_trace_artifacts(&store, &run.id, &run_dir, Some(&results));

--- a/src/commands/trace/output_tests.rs
+++ b/src/commands/trace/output_tests.rs
@@ -561,6 +561,7 @@ fn trace_run_evidence_report_includes_refs_assertions_and_safe_artifacts() {
         artifacts: vec![extension_trace::TraceArtifact {
             label: "Main log".to_string(),
             path: "artifacts/main.log".to_string(),
+            kind: None,
         }],
         results: Some(extension_trace::TraceResults {
             component_id: "studio".to_string(),
@@ -584,15 +585,18 @@ fn trace_run_evidence_report_includes_refs_assertions_and_safe_artifacts() {
                 extension_trace::TraceArtifact {
                     label: "Main log".to_string(),
                     path: "artifacts/main.log".to_string(),
+                    kind: None,
                 },
                 extension_trace::TraceArtifact {
                     label: "Trace zip".to_string(),
                     path: "/Users/chubes/private/trace.zip".to_string(),
+                    kind: None,
                 },
             ],
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
+            metrics: Default::default(),
             preview: None,
         }),
         span_summaries: vec![extension_trace::TraceSpanSummaryOutput {

--- a/src/core/extension/trace/assertions.rs
+++ b/src/core/extension/trace/assertions.rs
@@ -654,6 +654,7 @@ mod tests {
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
+            metrics: Default::default(),
             preview: None,
         }
     }

--- a/src/core/extension/trace/attach.rs
+++ b/src/core/extension/trace/attach.rs
@@ -380,6 +380,7 @@ pub(super) fn append_attach_observations(
     results.artifacts.push(TraceArtifact {
         label: "Trace attachments".to_string(),
         path: format!("artifacts/{TRACE_ATTACHMENTS_ARTIFACT}"),
+        kind: None,
     });
     Ok(())
 }
@@ -527,6 +528,7 @@ mod tests {
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
+            metrics: BTreeMap::new(),
             preview: None,
         };
 

--- a/src/core/extension/trace/baseline.rs
+++ b/src/core/extension/trace/baseline.rs
@@ -399,6 +399,7 @@ mod tests {
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
+            metrics: Default::default(),
             preview: None,
         }
     }

--- a/src/core/extension/trace/canonicality.rs
+++ b/src/core/extension/trace/canonicality.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::Command;
 
@@ -98,6 +99,7 @@ pub(crate) fn refused_trace_result(
         toolchain: None,
         components: None,
         dependencies: Vec::new(),
+        metrics: BTreeMap::new(),
         preview: None,
     };
 

--- a/src/core/extension/trace/parsing.rs
+++ b/src/core/extension/trace/parsing.rs
@@ -82,6 +82,8 @@ pub struct TraceResults {
     pub artifacts: Vec<TraceArtifact>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependencies: Vec<TraceDependencyProvenance>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metrics: BTreeMap<String, serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub toolchain: Option<TraceToolchainProvenance>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -270,6 +272,8 @@ pub enum TraceTemporalAssertionDefinition {
 pub struct TraceArtifact {
     pub label: String,
     pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -315,9 +319,16 @@ pub fn parse_trace_results_file(path: &Path) -> Result<TraceResults> {
 }
 
 fn parse_trace_results_str(raw: &str) -> Result<TraceResults> {
-    serde_json::from_str(raw).map_err(|e| {
+    let mut deserializer = serde_json::Deserializer::from_str(raw);
+    serde_path_to_error::deserialize(&mut deserializer).map_err(|e| {
+        let path = e.path().to_string();
+        let path = if path == "." { "$".to_string() } else { path };
         Error::internal_json(
-            format!("Failed to parse trace results JSON: {}", e),
+            format!(
+                "Failed to parse trace results JSON at `{}`: {}",
+                path,
+                e.inner()
+            ),
             Some("trace.parsing.deserialize".to_string()),
         )
     })
@@ -347,7 +358,8 @@ mod tests {
                 "timeline":[{"t_ms":0,"source":"desktop","event":"window.closed","data":{"id":1}}],
                 "span_definitions":[{"id":"close_to_assertion","from":"desktop.window.closed","to":"assertion.checked"}],
                 "assertions":[{"id":"no-window-reopen","status":"fail","message":"Window reopened"}],
-                "artifacts":[{"label":"main log","path":"artifacts/main.log"}]
+                "metrics":{"assertion_count":1,"producer":"wp-codebox"},
+                "artifacts":[{"label":"main log","path":"artifacts/main.log","kind":"log"}]
             }"#,
         )
         .expect("minimal trace envelope should parse");
@@ -357,7 +369,9 @@ mod tests {
         assert_eq!(parsed.timeline[0].t_ms, 0);
         assert_eq!(parsed.span_definitions[0].id, "close_to_assertion");
         assert_eq!(parsed.assertions[0].id, "no-window-reopen");
+        assert_eq!(parsed.metrics["assertion_count"], 1);
         assert_eq!(parsed.artifacts[0].path, "artifacts/main.log");
+        assert_eq!(parsed.artifacts[0].kind.as_deref(), Some("log"));
     }
 
     #[test]
@@ -382,7 +396,8 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(!err.message.is_empty());
+        let detail = err.details["error"].as_str().expect("JSON error detail");
+        assert!(detail.contains("`status`"), "{}", detail);
     }
 
     #[test]
@@ -392,7 +407,8 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(!err.message.is_empty());
+        let detail = err.details["error"].as_str().expect("JSON error detail");
+        assert!(detail.contains("`timeline[0]`"), "{}", detail);
     }
 
     #[test]

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -837,10 +837,12 @@ mod tests {
                 artifacts: vec![TraceArtifact {
                     label: "main log".to_string(),
                     path: "artifacts/main.log".to_string(),
+                    kind: None,
                 }],
                 toolchain: None,
                 components: None,
                 dependencies: Vec::new(),
+                metrics: Default::default(),
                 preview: None,
             }),
             failure: None,
@@ -914,6 +916,7 @@ mod tests {
                 toolchain: None,
                 components: None,
                 dependencies: Vec::new(),
+                metrics: Default::default(),
                 preview: None,
             }),
             failure: None,
@@ -1025,6 +1028,7 @@ mod tests {
                 dependencies: Vec::new(),
             }),
             dependencies: Vec::new(),
+            metrics: Default::default(),
             preview: None,
         };
 
@@ -1071,15 +1075,18 @@ mod tests {
                 TraceArtifact {
                     label: "remote trace".to_string(),
                     path: "/srv/remote-only/trace.zip".to_string(),
+                    kind: None,
                 },
                 TraceArtifact {
                     label: "mirrored trace".to_string(),
                     path: "runner-artifact://lab/run-1/trace.zip".to_string(),
+                    kind: None,
                 },
             ],
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
+            metrics: Default::default(),
             preview: None,
         };
 

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -1155,6 +1155,7 @@ fn apply_trace_preview_metadata(
         results.artifacts.push(super::parsing::TraceArtifact {
             label: "Public preview metadata".to_string(),
             path: "artifacts/preview.json".to_string(),
+            kind: None,
         });
     }
     if preview.require_https {
@@ -1302,6 +1303,7 @@ mod tests {
             temporal_assertions: Vec::new(),
             artifacts: Vec::new(),
             dependencies: Vec::new(),
+            metrics: Default::default(),
             toolchain: None,
             components: None,
         };
@@ -1425,6 +1427,7 @@ mod tests {
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
+            metrics: Default::default(),
             preview: None,
         };
 

--- a/src/core/extension/trace/spans.rs
+++ b/src/core/extension/trace/spans.rs
@@ -140,6 +140,7 @@ mod tests {
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
+            metrics: Default::default(),
             preview: None,
         };
 


### PR DESCRIPTION
## Summary
- Preserve optional producer metadata in trace results via top-level `metrics` and artifact-level `kind` fields.
- Report trace result parse failures with the exact serde schema path in the JSON error detail.
- Add regression coverage for WP Codebox/browser-style trace JSON containing `metrics` and artifact `kind`.

Fixes #3995.

## Tests
- `cargo check`
- `cargo test trace::parsing`
- `cargo test trace`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the trace parser schema tolerance, parser diagnostics, regression tests, and local verification; Chris remains responsible for review and merge.