### PR TITLE
Fix trace compare canonical provenance

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -9,8 +9,9 @@ use homeboy::core::engine::invocation::InvocationRequirements;
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::trace as extension_trace;
 use homeboy::core::extension::trace::{
-    TraceAttachment, TraceCanonicalPolicy, TraceCommandOutput, TraceListWorkflowArgs,
-    TraceOverlayRequest, TraceRunWorkflowArgs, TraceRunnerInputs, TraceSpanDefinition,
+    TraceAttachment, TraceCanonicalPolicy, TraceCheckoutProvenance, TraceCommandOutput,
+    TraceListWorkflowArgs, TraceOverlayRequest, TraceRunWorkflowArgs, TraceRunnerInputs,
+    TraceSpanDefinition,
 };
 use homeboy::core::extension::ExtensionCapability;
 use homeboy::core::observation::{
@@ -208,6 +209,9 @@ pub struct TraceArgs {
     /// Remove stale trace overlay locks even when touched files are dirty.
     #[arg(long)]
     pub force: bool,
+
+    #[arg(skip)]
+    pub checkout_provenance: Option<TraceCheckoutProvenance>,
 }
 
 impl TraceArgs {
@@ -615,6 +619,7 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::core::Result<TraceRunExecution
                 args.canonical,
                 args.allow_local_toolchain,
             ),
+            checkout_provenance: args.checkout_provenance,
         },
         &run_dir,
         rig_state.clone(),

--- a/src/commands/trace/compare_targets.rs
+++ b/src/commands/trace/compare_targets.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use homeboy::core::component;
 use homeboy::core::extension::trace as extension_trace;
-use homeboy::core::extension::trace::TraceCommandOutput;
+use homeboy::core::extension::trace::{TraceCheckoutProvenance, TraceCommandOutput};
 use homeboy::core::git;
 
 use super::aggregate::{aggregate_span, TraceAggregateSpanSample};
@@ -81,8 +81,8 @@ pub(super) fn run_compare_targets(args: TraceArgs) -> CmdResult<TraceCommandOutp
         &proof_args,
         &component_id,
         &scenario_id,
-        &baseline_target.path,
-        &candidate_target.path,
+        &baseline_target,
+        &candidate_target,
     )?;
     let baseline_aggregate = proof.baseline;
     let candidate_aggregate = proof.candidate;
@@ -164,8 +164,8 @@ fn run_target_proof_matrix(
     args: &TraceArgs,
     component_id: &str,
     scenario_id: &str,
-    baseline_path: &Path,
-    candidate_path: &Path,
+    baseline_target: &ResolvedCompareTarget,
+    candidate_target: &ResolvedCompareTarget,
 ) -> homeboy::core::Result<TargetProofMatrix> {
     let repeat = args.repeat.max(1);
     let plan = plan_trace_run_order(repeat, args.schedule, &["baseline", "candidate"]);
@@ -188,12 +188,12 @@ fn run_target_proof_matrix(
     let mut proof_run_order = Vec::new();
 
     for entry in plan {
-        let (path, builder) = if entry.group() == "baseline" {
-            (baseline_path, &mut baseline)
+        let (target, builder) = if entry.group() == "baseline" {
+            (baseline_target, &mut baseline)
         } else {
-            (candidate_path, &mut candidate)
+            (candidate_target, &mut candidate)
         };
-        let run = execute_target_once(args, component_id, scenario_id, path);
+        let run = execute_target_once(args, component_id, scenario_id, target);
         let proof_entry = builder.record(entry.index(), run);
         proof_run_order.push(extension_trace::TraceCompareRunOrderOutput {
             index: proof_entry.index,
@@ -217,11 +217,11 @@ fn execute_target_once(
     args: &TraceArgs,
     component_id: &str,
     scenario_id: &str,
-    path: &Path,
+    target: &ResolvedCompareTarget,
 ) -> Result<super::TraceRunExecution, homeboy::core::Error> {
     let mut run_args = args.clone();
     run_args.comp.component = Some(component_id.to_string());
-    run_args.comp.path = Some(path.to_string_lossy().to_string());
+    run_args.comp.path = Some(target.path.to_string_lossy().to_string());
     run_args.scenario = Some(scenario_id.to_string());
     run_args.compare_after = None;
     run_args.baseline_target = None;
@@ -229,6 +229,7 @@ fn execute_target_once(
     run_args.repeat = 1;
     run_args.aggregate = None;
     run_args.output_dir = None;
+    run_args.checkout_provenance = target.checkout_provenance.clone();
     super::execute_trace_run(run_args)
 }
 
@@ -557,6 +558,7 @@ struct ResolvedCompareTarget {
     input: String,
     path: PathBuf,
     git_sha: Option<String>,
+    checkout_provenance: Option<TraceCheckoutProvenance>,
     _worktree: Option<TemporaryGitWorktree>,
 }
 
@@ -578,6 +580,7 @@ fn resolve_target(
             input: input.to_string(),
             path,
             git_sha,
+            checkout_provenance: None,
             _worktree: None,
         });
     }
@@ -585,18 +588,36 @@ fn resolve_target(
     let source_root = git::get_git_root(source_path)?;
     let source_root = PathBuf::from(source_root);
     let component_prefix = git::get_component_path_prefix(source_path);
-    let worktree = TemporaryGitWorktree::add(role, &source_root, input)?;
+    let resolved_sha = resolve_git_ref_to_full_sha(&source_root, input)?;
+    let worktree = TemporaryGitWorktree::add(role, &source_root, &resolved_sha)?;
     let path = component_prefix
         .as_deref()
         .map(|prefix| worktree.path.join(prefix))
         .unwrap_or_else(|| worktree.path.clone());
     let git_sha = git::short_head_revision_at(&path);
+    let checkout_provenance = Some(TraceCheckoutProvenance {
+        source: "homeboy-trace-compare".to_string(),
+        path: path.to_string_lossy().to_string(),
+        requested_ref: input.to_string(),
+        resolved_sha,
+    });
     Ok(ResolvedCompareTarget {
         input: input.to_string(),
         path,
         git_sha,
+        checkout_provenance,
         _worktree: Some(worktree),
     })
+}
+
+fn resolve_git_ref_to_full_sha(source_root: &Path, git_ref: &str) -> homeboy::core::Result<String> {
+    let commit_ref = format!("{git_ref}^{{commit}}");
+    git::run_git(
+        source_root,
+        &["rev-parse", "--verify", &commit_ref],
+        "git rev-parse trace compare target",
+    )
+    .map(|sha| sha.trim().to_string())
 }
 
 struct TemporaryGitWorktree {

--- a/src/commands/trace/compare_variant_tests.rs
+++ b/src/commands/trace/compare_variant_tests.rs
@@ -75,6 +75,7 @@ fn trace_compare_variant_interleaves_run_order_and_reports_focus_spans() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )
@@ -218,6 +219,7 @@ fn trace_compare_variant_uses_component_arg_for_multi_component_named_variants()
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )
@@ -310,6 +312,7 @@ fn trace_compare_variant_reports_unknown_named_variant_for_component_arg() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         ) {

--- a/src/commands/trace/experiment_tests.rs
+++ b/src/commands/trace/experiment_tests.rs
@@ -49,6 +49,7 @@ fn trace_args_for_rig(rig_id: &str, scenario: &str) -> TraceArgs {
         force: false,
         canonical: false,
         allow_local_toolchain: true,
+        checkout_provenance: None,
     }
 }
 

--- a/src/commands/trace/generic_tests.rs
+++ b/src/commands/trace/generic_tests.rs
@@ -63,6 +63,7 @@ JSON
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )

--- a/src/commands/trace/guardrail_tests.rs
+++ b/src/commands/trace/guardrail_tests.rs
@@ -46,6 +46,7 @@ fn trace_args_for_rig(rig_id: &str) -> TraceArgs {
         force: false,
         canonical: false,
         allow_local_toolchain: true,
+        checkout_provenance: None,
     }
 }
 

--- a/src/commands/trace/matrix_tests.rs
+++ b/src/commands/trace/matrix_tests.rs
@@ -122,6 +122,7 @@ fn trace_matrix_reports_failed_cells_and_cell_artifacts() {
             force: false,
             canonical: false,
             allow_local_toolchain: true,
+            checkout_provenance: None,
         })
         .expect("matrix run");
 

--- a/src/commands/trace/output_tests.rs
+++ b/src/commands/trace/output_tests.rs
@@ -329,6 +329,7 @@ fn trace_compare_exits_nonzero_for_guardrail_failures() {
         force: false,
         canonical: false,
         allow_local_toolchain: true,
+        checkout_provenance: None,
     })
     .expect("compare should run");
 

--- a/src/commands/trace/profile_tests.rs
+++ b/src/commands/trace/profile_tests.rs
@@ -46,6 +46,7 @@ fn trace_args_for_profile(profile: &str) -> TraceArgs {
         force: false,
         canonical: false,
         allow_local_toolchain: true,
+        checkout_provenance: None,
     }
 }
 
@@ -187,6 +188,7 @@ fn trace_list_profiles_lists_rig_profiles() {
             force: false,
             canonical: false,
             allow_local_toolchain: true,
+            checkout_provenance: None,
         })
         .expect("profile list should run");
 

--- a/src/commands/trace/rig_tests.rs
+++ b/src/commands/trace/rig_tests.rs
@@ -66,6 +66,7 @@ fn trace_args_for_rig(rig_id: &str, component_id: &str, scenario_id: &str) -> Tr
         force: false,
         canonical: false,
         allow_local_toolchain: true,
+        checkout_provenance: None,
     }
 }
 

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -118,6 +118,7 @@ fn trace_args_for_rig(rig_id: &str, component_id: &str, scenario_id: &str) -> Tr
         force: false,
         canonical: false,
         allow_local_toolchain: true,
+        checkout_provenance: None,
     }
 }
 
@@ -170,6 +171,7 @@ fn rig_trace_run_uses_rig_owned_workload_extension_without_component_link() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )
@@ -266,6 +268,7 @@ fn trace_run_persists_observation_history() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )
@@ -436,6 +439,7 @@ fn trace_repeat_aggregates_span_timings_and_preserves_artifacts() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )
@@ -537,6 +541,7 @@ fn trace_repeat_loads_span_metadata_and_reports_unknown_ids() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )
@@ -720,6 +725,7 @@ fn trace_repeat_reports_overlay_touched_files_at_top_level() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )
@@ -803,6 +809,7 @@ fn trace_run_resolves_named_variants_and_reports_unknown_names() {
             force: false,
             canonical: false,
             allow_local_toolchain: true,
+            checkout_provenance: None,
         };
 
         let (output, exit_code) =
@@ -920,6 +927,7 @@ fn trace_compare_variant_writes_experiment_bundle() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )
@@ -1002,6 +1010,7 @@ fn trace_compare_variant_resolves_named_variants() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )
@@ -1099,6 +1108,7 @@ fn trace_compare_variant_reports_unknown_named_variants() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         ) {
@@ -1174,6 +1184,7 @@ fn trace_run_expands_phase_chain_into_adjacent_and_total_spans() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )
@@ -1250,6 +1261,7 @@ fn trace_run_expands_named_workload_phase_preset() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )
@@ -1326,6 +1338,7 @@ fn trace_aggregate_spans_uses_workload_default_phase_preset() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )
@@ -1398,6 +1411,7 @@ fn trace_repeat_counts_failed_runs_as_span_failures() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )
@@ -1474,6 +1488,7 @@ fn failed_trace_run_persists_observation_history() {
                 force: false,
                 canonical: false,
                 allow_local_toolchain: true,
+                checkout_provenance: None,
             },
             &GlobalArgs {},
         )

--- a/src/core/extension/trace/canonicality.rs
+++ b/src/core/extension/trace/canonicality.rs
@@ -9,7 +9,11 @@ use super::parsing::{
     TraceAssertion, TraceAssertionStatus, TraceCanonicalCheck, TraceEvidenceMetadata, TraceResults,
     TraceStatus,
 };
-use super::run::{TraceRunFailure, TraceRunWorkflowArgs, TraceRunWorkflowResult};
+use super::run::{
+    TraceCheckoutProvenance, TraceRunFailure, TraceRunWorkflowArgs, TraceRunWorkflowResult,
+};
+
+const HOMEBOY_TRACE_COMPARE_PROVENANCE_SOURCE: &str = "homeboy-trace-compare";
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum TraceCanonicalPolicy {
@@ -146,8 +150,15 @@ pub(crate) fn evaluate_trace_canonicality(
         .as_deref()
         .unwrap_or(component.local_path.as_str());
 
+    let checkout_provenance = args
+        .checkout_provenance
+        .as_ref()
+        .filter(|provenance| canonical_paths_equal(&provenance.path, component_path));
+
     if let Some(path_override) = args.path_override.as_deref() {
-        if !canonical_paths_equal(path_override, &component.local_path) {
+        if !canonical_paths_equal(path_override, &component.local_path)
+            && checkout_provenance.is_none()
+        {
             reasons.push(format!(
                 "component path resolved through local override `{}` instead of declared binding `{}`",
                 path_override, component.local_path
@@ -158,6 +169,7 @@ pub(crate) fn evaluate_trace_canonicality(
     checks.push(check_git_checkout(
         "component",
         Path::new(component_path),
+        checkout_provenance,
         &mut reasons,
     ));
     if let Some(artifact) = component.build_artifact.as_deref() {
@@ -179,6 +191,7 @@ pub(crate) fn evaluate_trace_canonicality(
         checks.push(check_git_checkout(
             &format!("extension:{}", context.extension_id),
             &context.extension_path,
+            None,
             &mut reasons,
         ));
     }
@@ -202,6 +215,7 @@ pub(crate) fn evaluate_trace_canonicality(
                 Some(path) if !path.trim().is_empty() => checks.push(check_git_checkout(
                     &format!("toolchain:wp-codebox ({key}, {source})"),
                     &git_probe_path(Path::new(path)),
+                    None,
                     &mut reasons,
                 )),
                 _ => reasons.push(format!(
@@ -235,7 +249,12 @@ fn canonical_paths_equal(left: &str, right: &str) -> bool {
     matches!((left, right), (Ok(left), Ok(right)) if left == right)
 }
 
-fn check_git_checkout(target: &str, path: &Path, reasons: &mut Vec<String>) -> TraceCanonicalCheck {
+fn check_git_checkout(
+    target: &str,
+    path: &Path,
+    provenance: Option<&TraceCheckoutProvenance>,
+    reasons: &mut Vec<String>,
+) -> TraceCanonicalCheck {
     if !path.exists() {
         reasons.push(format!(
             "{} checkout path is missing: {}",
@@ -269,6 +288,12 @@ fn check_git_checkout(target: &str, path: &Path, reasons: &mut Vec<String>) -> T
         })
         .and_then(|counts| parse_ahead_behind(&counts))
         .unwrap_or((None, None));
+    let trusted_exact_sha = match provenance {
+        Some(provenance) => {
+            validate_exact_sha_provenance(target, path, sha.as_deref(), provenance, reasons)
+        }
+        None => false,
+    };
 
     push_git_reasons(
         target,
@@ -278,19 +303,71 @@ fn check_git_checkout(target: &str, path: &Path, reasons: &mut Vec<String>) -> T
         upstream.as_deref(),
         ahead,
         behind,
+        trusted_exact_sha,
         reasons,
     );
 
     TraceCanonicalCheck {
         target: target.to_string(),
         path: path.to_string_lossy().to_string(),
-        status: checkout_status(dirty, branch.as_deref(), upstream.as_deref(), ahead, behind),
+        status: checkout_status(
+            dirty,
+            branch.as_deref(),
+            upstream.as_deref(),
+            ahead,
+            behind,
+            trusted_exact_sha,
+        ),
         sha,
         branch,
         upstream,
         commits_ahead: ahead,
         commits_behind: behind,
     }
+}
+
+fn validate_exact_sha_provenance(
+    target: &str,
+    path: &Path,
+    sha: Option<&str>,
+    provenance: &TraceCheckoutProvenance,
+    reasons: &mut Vec<String>,
+) -> bool {
+    if provenance.source != HOMEBOY_TRACE_COMPARE_PROVENANCE_SOURCE {
+        reasons.push(format!(
+            "{} checkout exact-SHA provenance source is not trusted: {}",
+            target, provenance.source
+        ));
+        return false;
+    }
+    if !canonical_paths_equal(&provenance.path, &path.to_string_lossy()) {
+        reasons.push(format!(
+            "{} checkout exact-SHA provenance path does not match checkout: {} != {}",
+            target,
+            provenance.path,
+            path.display()
+        ));
+        return false;
+    }
+    if provenance.requested_ref.trim().is_empty() || provenance.resolved_sha.trim().is_empty() {
+        reasons.push(format!(
+            "{} checkout exact-SHA provenance is incomplete for {}",
+            target,
+            path.display()
+        ));
+        return false;
+    }
+    if sha != Some(provenance.resolved_sha.as_str()) {
+        reasons.push(format!(
+            "{} checkout HEAD does not match recorded exact-SHA provenance for `{}`: expected {}, got {}",
+            target,
+            provenance.requested_ref,
+            provenance.resolved_sha,
+            sha.unwrap_or("unknown")
+        ));
+        return false;
+    }
+    true
 }
 
 fn empty_check(target: &str, path: &Path, status: &str) -> TraceCanonicalCheck {
@@ -314,19 +391,20 @@ fn push_git_reasons(
     upstream: Option<&str>,
     ahead: Option<u32>,
     behind: Option<u32>,
+    trusted_exact_sha: bool,
     reasons: &mut Vec<String>,
 ) {
     if dirty {
         reasons.push(format!("{} checkout is dirty: {}", target, path.display()));
     }
-    if branch == Some("HEAD") {
+    if branch == Some("HEAD") && !trusted_exact_sha {
         reasons.push(format!(
             "{} checkout is detached: {}",
             target,
             path.display()
         ));
     }
-    if upstream.is_none() {
+    if upstream.is_none() && !trusted_exact_sha {
         reasons.push(format!(
             "{} checkout has no upstream branch: {}",
             target,
@@ -357,10 +435,11 @@ fn checkout_status(
     upstream: Option<&str>,
     ahead: Option<u32>,
     behind: Option<u32>,
+    trusted_exact_sha: bool,
 ) -> String {
     if dirty
-        || branch == Some("HEAD")
-        || upstream.is_none()
+        || (branch == Some("HEAD") && !trusted_exact_sha)
+        || (upstream.is_none() && !trusted_exact_sha)
         || ahead.unwrap_or(0) > 0
         || behind.unwrap_or(0) > 0
     {
@@ -588,6 +667,120 @@ mod tests {
     }
 
     #[test]
+    fn canonical_trace_accepts_homeboy_compare_exact_sha_worktree() {
+        let source = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        init_git_repo(source.path());
+        let sha = git_stdout(source.path(), &["rev-parse", "HEAD"]).unwrap();
+        git(
+            source.path(),
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                target.path().to_str().unwrap(),
+                &sha,
+            ],
+        );
+        let component = test_component(source.path());
+        let mut args = test_run_args(target.path());
+        args.checkout_provenance = Some(TraceCheckoutProvenance {
+            source: HOMEBOY_TRACE_COMPARE_PROVENANCE_SOURCE.to_string(),
+            path: target.path().to_string_lossy().to_string(),
+            requested_ref: "main".to_string(),
+            resolved_sha: sha,
+        });
+
+        let report = evaluate_trace_canonicality(None, &component, &args).unwrap();
+
+        assert!(report.is_canonical());
+        assert!(report.reasons.is_empty());
+    }
+
+    #[test]
+    fn canonical_trace_refuses_arbitrary_detached_checkout() {
+        let source = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        init_git_repo(source.path());
+        let sha = git_stdout(source.path(), &["rev-parse", "HEAD"]).unwrap();
+        git(
+            source.path(),
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                target.path().to_str().unwrap(),
+                &sha,
+            ],
+        );
+        let component = test_component(source.path());
+        let args = test_run_args(target.path());
+
+        let report = evaluate_trace_canonicality(None, &component, &args).unwrap();
+
+        assert!(!report.is_canonical());
+        assert!(report
+            .reasons
+            .iter()
+            .any(|reason| reason.contains("local override")));
+        assert!(report
+            .reasons
+            .iter()
+            .any(|reason| reason.contains("checkout is detached")));
+        assert!(report
+            .reasons
+            .iter()
+            .any(|reason| reason.contains("no upstream branch")));
+    }
+
+    #[test]
+    fn canonical_trace_refuses_dirty_homeboy_compare_exact_sha_worktree() {
+        let source = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        init_git_repo(source.path());
+        let sha = git_stdout(source.path(), &["rev-parse", "HEAD"]).unwrap();
+        git(
+            source.path(),
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                target.path().to_str().unwrap(),
+                &sha,
+            ],
+        );
+        std::fs::write(target.path().join("dirty.txt"), "dirty\n").unwrap();
+        let component = test_component(source.path());
+        let mut args = test_run_args(target.path());
+        args.checkout_provenance = Some(TraceCheckoutProvenance {
+            source: HOMEBOY_TRACE_COMPARE_PROVENANCE_SOURCE.to_string(),
+            path: target.path().to_string_lossy().to_string(),
+            requested_ref: "main".to_string(),
+            resolved_sha: sha,
+        });
+
+        let report = evaluate_trace_canonicality(None, &component, &args).unwrap();
+
+        assert!(!report.is_canonical());
+        assert_eq!(
+            report
+                .reasons
+                .iter()
+                .filter(|reason| reason.contains("checkout is dirty"))
+                .count(),
+            1
+        );
+        assert!(!report
+            .reasons
+            .iter()
+            .any(|reason| reason.contains("checkout is detached")));
+        assert!(!report
+            .reasons
+            .iter()
+            .any(|reason| reason.contains("no upstream branch")));
+    }
+
+    #[test]
     fn allow_local_toolchain_marks_result_non_canonical_without_refusing() {
         let temp = tempfile::tempdir().unwrap();
         init_git_repo(temp.path());
@@ -648,6 +841,18 @@ mod tests {
         );
     }
 
+    fn git_stdout(path: &std::path::Path, args: &[&str]) -> Option<String> {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .ok()?;
+        output
+            .status
+            .success()
+            .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
     fn test_run_args(path: &std::path::Path) -> TraceRunWorkflowArgs {
         TraceRunWorkflowArgs {
             component_label: "example".to_string(),
@@ -671,6 +876,7 @@ mod tests {
             regression_min_delta_ms:
                 crate::core::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
             canonical_policy: TraceCanonicalPolicy::Development,
+            checkout_provenance: None,
         }
     }
 }

--- a/src/core/extension/trace/mod.rs
+++ b/src/core/extension/trace/mod.rs
@@ -60,7 +60,9 @@ pub use run::{
     resolve_declared_trace_artifact_path, run_trace_list_workflow, run_trace_workflow,
     trace_is_unclaimed, TraceListWorkflowArgs,
 };
-pub use run::{TraceRunWorkflowArgs, TraceRunWorkflowResult, TraceRunnerInputs};
+pub use run::{
+    TraceCheckoutProvenance, TraceRunWorkflowArgs, TraceRunWorkflowResult, TraceRunnerInputs,
+};
 pub use span_summary::{
     attach_span_summary_metadata, format_span_summary_metadata, format_span_summary_status,
     TraceSpanSummaryOutput,

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -60,6 +60,15 @@ pub struct TraceRunWorkflowArgs {
     pub regression_threshold_percent: f64,
     pub regression_min_delta_ms: u64,
     pub canonical_policy: TraceCanonicalPolicy,
+    pub checkout_provenance: Option<TraceCheckoutProvenance>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceCheckoutProvenance {
+    pub source: String,
+    pub path: String,
+    pub requested_ref: String,
+    pub resolved_sha: String,
 }
 
 #[derive(Debug, Clone)]
@@ -827,6 +836,7 @@ pub fn run_trace_list_workflow(
         regression_threshold_percent: super::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
         regression_min_delta_ms: super::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         canonical_policy: TraceCanonicalPolicy::Development,
+        checkout_provenance: None,
     };
     let output = build_trace_runner(
         execution_context.as_ref(),
@@ -1581,6 +1591,7 @@ mod tests {
                 super::super::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
             regression_min_delta_ms: super::super::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
             canonical_policy: TraceCanonicalPolicy::Development,
+            checkout_provenance: None,
         }
     }
 }

--- a/src/core/extension/trace/run_tests.inc
+++ b/src/core/extension/trace/run_tests.inc
@@ -103,6 +103,7 @@ JSON
             regression_min_delta_ms:
                 crate::core::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
             canonical_policy: TraceCanonicalPolicy::Development,
+            checkout_provenance: None,
         };
 
         let output =
@@ -177,6 +178,7 @@ JSON
             regression_min_delta_ms:
                 crate::core::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
             canonical_policy: TraceCanonicalPolicy::Development,
+            checkout_provenance: None,
         };
 
         let output = build_trace_runner(Some(&context), &component, &args, &run_dir, true).unwrap();
@@ -272,6 +274,7 @@ JSON
             regression_min_delta_ms:
                 crate::core::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
             canonical_policy: TraceCanonicalPolicy::Development,
+            checkout_provenance: None,
         };
         let output = RunnerOutput {
             success: false,
@@ -359,6 +362,7 @@ JSON
             regression_min_delta_ms:
                 crate::core::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
             canonical_policy: TraceCanonicalPolicy::Development,
+            checkout_provenance: None,
         };
 
         let output =
@@ -426,6 +430,7 @@ exit 1
             regression_min_delta_ms:
                 crate::core::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
             canonical_policy: TraceCanonicalPolicy::Development,
+            checkout_provenance: None,
         };
 
         let output =
@@ -517,7 +522,8 @@ JSON
                     crate::core::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
                 regression_min_delta_ms:
                     crate::core::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
-            canonical_policy: TraceCanonicalPolicy::Development,
+                canonical_policy: TraceCanonicalPolicy::Development,
+                checkout_provenance: None,
             },
             &run_dir,
             None,
@@ -711,6 +717,7 @@ JSON
             regression_min_delta_ms:
                 crate::core::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
             canonical_policy: TraceCanonicalPolicy::Development,
+            checkout_provenance: None,
         };
         OverlayFixture {
             _temp: temp,


### PR DESCRIPTION
## Summary
- Resolve trace compare target refs to full commit SHAs before creating temporary detached worktrees.
- Carry explicit Homeboy trace compare checkout provenance into canonical trace validation.
- Accept only clean Homeboy-created exact-SHA compare worktrees while continuing to reject arbitrary detached or dirty checkouts.

Fixes #3996.

## Tests
- `cargo test core::extension::trace::canonicality::tests`
- `cargo test trace_compare`
- `cargo fmt -- --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the provenance model, canonicality validation changes, and tests; Chris remains responsible for review and validation.