### PR TITLE
Fix runner upgrade partial failure status

### DIFF
--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -96,5 +96,84 @@ pub fn run(args: UpgradeArgs, _global: &GlobalArgs) -> CmdResult<Value> {
         homeboy::log_status!("upgrade", "Please restart homeboy to use the new version.");
     }
 
-    Ok((json, 0))
+    Ok((json, upgrade_exit_code(&result, !args.runners.is_empty())))
+}
+
+fn upgrade_exit_code(result: &upgrade::UpgradeResult, targeted_runner_upgrade: bool) -> i32 {
+    if targeted_runner_upgrade && result.runners_skipped.iter().any(|runner| !runner.success) {
+        return 1;
+    }
+
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn targeted_runner_failures_return_non_zero_status() {
+        let mut result = base_upgrade_result();
+        result.runners_skipped.push(upgrade::RunnerUpgradeEntry {
+            runner_id: "homeboy-lab".to_string(),
+            homeboy_path: "/home/chubes/.cargo/bin/homeboy".to_string(),
+            success: false,
+            upgraded: true,
+            previous_version: Some("0.228.6".to_string()),
+            new_version: Some("0.228.7".to_string()),
+            bare_homeboy_version: Some("0.222.17".to_string()),
+            path_drift: Some("bare `homeboy` reports 0.222.17".to_string()),
+            recovery_commands: vec![
+                "homeboy upgrade --force --upgrade-runner homeboy-lab".to_string()
+            ],
+            extensions_synced: Vec::new(),
+            extensions_failed: Vec::new(),
+            stale_daemon: None,
+            exit_code: 0,
+            detail: "extension sync failed".to_string(),
+        });
+
+        assert_eq!(upgrade_exit_code(&result, true), 1);
+    }
+
+    #[test]
+    fn non_targeted_runner_failures_keep_best_effort_upgrade_status() {
+        let mut result = base_upgrade_result();
+        result.runners_skipped.push(upgrade::RunnerUpgradeEntry {
+            runner_id: "homeboy-lab".to_string(),
+            homeboy_path: "homeboy".to_string(),
+            success: false,
+            upgraded: false,
+            previous_version: None,
+            new_version: None,
+            bare_homeboy_version: None,
+            path_drift: None,
+            recovery_commands: vec![
+                "homeboy upgrade --force --upgrade-runner homeboy-lab".to_string()
+            ],
+            extensions_synced: Vec::new(),
+            extensions_failed: Vec::new(),
+            stale_daemon: None,
+            exit_code: 1,
+            detail: "runner unavailable".to_string(),
+        });
+
+        assert_eq!(upgrade_exit_code(&result, false), 0);
+    }
+
+    fn base_upgrade_result() -> upgrade::UpgradeResult {
+        upgrade::UpgradeResult {
+            command: "upgrade".to_string(),
+            install_method: upgrade::InstallMethod::Cargo,
+            previous_version: "0.228.6".to_string(),
+            new_version: Some("0.228.7".to_string()),
+            upgraded: true,
+            message: "Upgraded to 0.228.7".to_string(),
+            restart_required: false,
+            extensions_updated: Vec::new(),
+            extensions_skipped: Vec::new(),
+            runners_updated: Vec::new(),
+            runners_skipped: Vec::new(),
+        }
+    }
 }

--- a/src/core/extension/trace/parsing.rs
+++ b/src/core/extension/trace/parsing.rs
@@ -369,7 +369,7 @@ mod tests {
         assert_eq!(parsed.timeline[0].t_ms, 0);
         assert_eq!(parsed.span_definitions[0].id, "close_to_assertion");
         assert_eq!(parsed.assertions[0].id, "no-window-reopen");
-        assert_eq!(parsed.metrics["assertion_count"], serde_json::json!(1));
+        assert_eq!(parsed.metrics["assertion_count"], 1);
         assert_eq!(parsed.artifacts[0].path, "artifacts/main.log");
         assert_eq!(parsed.artifacts[0].kind.as_deref(), Some("log"));
     }

--- a/src/core/extension/trace/parsing.rs
+++ b/src/core/extension/trace/parsing.rs
@@ -369,7 +369,7 @@ mod tests {
         assert_eq!(parsed.timeline[0].t_ms, 0);
         assert_eq!(parsed.span_definitions[0].id, "close_to_assertion");
         assert_eq!(parsed.assertions[0].id, "no-window-reopen");
-        assert_eq!(parsed.metrics["assertion_count"], 1);
+        assert_eq!(parsed.metrics["assertion_count"], serde_json::json!(1));
         assert_eq!(parsed.artifacts[0].path, "artifacts/main.log");
         assert_eq!(parsed.artifacts[0].kind.as_deref(), Some("log"));
     }

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -112,6 +112,7 @@ fn upgrade_runner_with_executor(
                 new_version: None,
                 bare_homeboy_version: None,
                 path_drift: None,
+                recovery_commands: runner_upgrade_recovery_commands(&runner.id),
                 extensions_synced: Vec::new(),
                 extensions_failed: Vec::new(),
                 stale_daemon: None,
@@ -129,6 +130,7 @@ fn upgrade_runner_with_executor(
                 new_version: None,
                 bare_homeboy_version: None,
                 path_drift: None,
+                recovery_commands: runner_upgrade_recovery_commands(&runner.id),
                 extensions_synced: Vec::new(),
                 extensions_failed: Vec::new(),
                 stale_daemon: None,
@@ -149,6 +151,8 @@ fn upgrade_runner_with_executor(
         new_version.as_deref(),
         bare_homeboy_version.as_deref(),
     );
+    let recovery_commands =
+        runner_recovery_commands(&runner.id, &homeboy_path, path_drift.as_ref());
     let stale_daemon = runner_stale_daemon(runner, status);
     let upgraded = match (previous_version.as_deref(), new_version.as_deref()) {
         (Some(previous), Some(new)) => new != previous,
@@ -156,6 +160,7 @@ fn upgrade_runner_with_executor(
     };
     let success = new_version.is_some() && extensions_failed.is_empty() && stale_daemon.is_none();
     let detail = runner_upgrade_final_detail(
+        &runner.id,
         detail,
         path_drift.as_deref(),
         stale_daemon.as_ref(),
@@ -171,6 +176,7 @@ fn upgrade_runner_with_executor(
         new_version,
         bare_homeboy_version,
         path_drift,
+        recovery_commands,
         extensions_synced,
         extensions_failed,
         stale_daemon,
@@ -204,6 +210,7 @@ fn sync_runner_extensions(
                         source_revision: source_revision.to_string(),
                         synced: false,
                         detail: Some(detail),
+                        recovery_commands: runner_extension_recovery_commands(runner, homeboy_path),
                     });
                     continue;
                 }
@@ -238,6 +245,7 @@ fn sync_runner_extensions(
                     source_revision: source_revision.to_string(),
                     synced: true,
                     detail: None,
+                    recovery_commands: Vec::new(),
                 });
             }
             Ok((output, exit_code)) => {
@@ -250,6 +258,7 @@ fn sync_runner_extensions(
                         exit_code,
                         runner_upgrade_detail(&output)
                     )),
+                    recovery_commands: runner_exec_recovery_commands(runner, &command),
                 });
             }
             Err(err) => {
@@ -258,6 +267,7 @@ fn sync_runner_extensions(
                     source_revision: source_revision.to_string(),
                     synced: false,
                     detail: Some(format!("sync failed: {}", err.message)),
+                    recovery_commands: runner_exec_recovery_commands(runner, &command),
                 });
             }
         }
@@ -355,6 +365,71 @@ fn runner_path_drift(
     ))
 }
 
+fn runner_recovery_commands(
+    runner_id: &str,
+    homeboy_path: &str,
+    path_drift: Option<&String>,
+) -> Vec<String> {
+    let mut commands = runner_upgrade_recovery_commands(runner_id);
+    if path_drift.is_some() && homeboy_path != "homeboy" {
+        commands.push(format!(
+            "homeboy runner exec {} --ssh -- sh -lc {}",
+            shell_arg(runner_id),
+            shell_arg(&format!(
+                "ln -sf {} $(command -v homeboy)",
+                shell_arg(homeboy_path)
+            ))
+        ));
+    }
+    commands
+}
+
+fn runner_upgrade_recovery_commands(runner_id: &str) -> Vec<String> {
+    vec![format!(
+        "homeboy upgrade --force --upgrade-runner {}",
+        shell_arg(runner_id)
+    )]
+}
+
+fn runner_extension_recovery_commands(runner: &Runner, homeboy_path: &str) -> Vec<String> {
+    let command = vec![
+        homeboy_path.to_string(),
+        "extension".to_string(),
+        "list".to_string(),
+    ];
+    runner_exec_recovery_commands(runner, &command)
+}
+
+fn runner_exec_recovery_commands(runner: &Runner, command: &[String]) -> Vec<String> {
+    let mut args = vec![
+        "homeboy".to_string(),
+        "runner".to_string(),
+        "exec".to_string(),
+        runner.id.clone(),
+        "--ssh".to_string(),
+        "--".to_string(),
+    ];
+    args.extend(command.iter().cloned());
+    vec![args
+        .iter()
+        .map(|arg| shell_arg(arg))
+        .collect::<Vec<_>>()
+        .join(" ")]
+}
+
+fn shell_arg(arg: &str) -> String {
+    if !arg.is_empty()
+        && arg.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(byte, b'/' | b'.' | b'_' | b'-' | b':' | b'@' | b'=')
+        })
+    {
+        return arg.to_string();
+    }
+
+    format!("'{}'", arg.replace('\'', "'\\''"))
+}
+
 fn runner_stale_daemon(
     runner: &Runner,
     status: &impl Fn(&str) -> Result<RunnerStatusReport>,
@@ -368,6 +443,7 @@ fn runner_stale_daemon(
 }
 
 fn runner_upgrade_final_detail(
+    runner_id: &str,
     detail: String,
     path_drift: Option<&str>,
     stale_daemon: Option<&RunnerDaemonDriftEntry>,
@@ -389,6 +465,10 @@ fn runner_upgrade_final_detail(
                 ))
                 .collect::<Vec<_>>()
                 .join("; ")
+        ));
+        parts.push(format!(
+            "retry failed runner sync with `{}` or retry an individual failed extension using its recovery_commands entry",
+            runner_upgrade_recovery_commands(runner_id).join(" && ")
         ));
     }
 
@@ -723,9 +803,16 @@ mod tests {
         assert_eq!(skipped.len(), 1);
         assert_eq!(skipped[0].extensions_failed.len(), 1);
         assert_eq!(skipped[0].extensions_failed[0].extension_id, "swift");
+        assert_eq!(
+            skipped[0].extensions_failed[0].recovery_commands,
+            vec!["homeboy runner exec lab --ssh -- /home/chubes/.cargo/bin/homeboy extension install https://github.com/Extra-Chill/homeboy-extensions.git --id swift --ref 98a61eda --replace"]
+        );
         assert_eq!(skipped[0].extensions_synced.len(), 1);
         assert_eq!(skipped[0].extensions_synced[0].extension_id, "wordpress");
         assert!(skipped[0].detail.contains("swift@98a61eda"));
+        assert!(skipped[0]
+            .detail
+            .contains("homeboy upgrade --force --upgrade-runner lab"));
         assert!(commands
             .iter()
             .any(|command| command.contains(&"wordpress".to_string())));
@@ -761,6 +848,13 @@ mod tests {
             .as_deref()
             .unwrap()
             .contains("bare `homeboy` reports 0.228.4"));
+        assert!(updated[0]
+            .recovery_commands
+            .contains(&"homeboy upgrade --force --upgrade-runner lab".to_string()));
+        assert!(updated[0].recovery_commands.contains(&
+            "homeboy runner exec lab --ssh -- sh -lc 'ln -sf /home/chubes/.cargo/bin/homeboy $(command -v homeboy)'"
+                .to_string()
+        ));
         assert!(updated[0].detail.contains("runner PATH drift detected"));
     }
 

--- a/src/core/upgrade/types.rs
+++ b/src/core/upgrade/types.rs
@@ -76,6 +76,8 @@ pub struct RunnerUpgradeEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path_drift: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub recovery_commands: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extensions_synced: Vec<RunnerExtensionSyncEntry>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extensions_failed: Vec<RunnerExtensionSyncEntry>,
@@ -92,6 +94,8 @@ pub struct RunnerExtensionSyncEntry {
     pub synced: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub recovery_commands: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- Return a non-zero CLI status for targeted `homeboy upgrade --upgrade-runner` runs when any targeted runner reports `success:false`.
- Add runner and extension `recovery_commands` so partial extension sync failures and PATH drift are directly actionable in structured output.
- Repair the trace metrics struct duplication currently blocking targeted Rust tests on `main`, keeping flexible JSON metric values while numeric aggregators skip non-numeric metadata.

Fixes #4007.

## Verification
- `cargo test upgrade::runners --lib`
- `cargo test commands::upgrade --lib`
- `cargo test extension::trace::parsing::tests::test_parse_trace_results_str --lib`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the runner upgrade status/remediation change, added targeted tests, repaired the trace metrics compile blocker needed for verification, and ran the listed checks. Chris remains responsible for review and merge.