### PR TITLE
Fix rig check Lab component path env forwarding

### DIFF
--- a/src/commands/observe.rs
+++ b/src/commands/observe.rs
@@ -173,7 +173,6 @@ pub fn run(args: ObserveArgs, _global: &GlobalArgs) -> CmdResult<ObserveOutput> 
         toolchain: None,
         components: None,
         dependencies: Vec::new(),
-        metrics: BTreeMap::new(),
         preview: None,
     };
 

--- a/src/commands/trace/compare_targets.rs
+++ b/src/commands/trace/compare_targets.rs
@@ -320,13 +320,15 @@ impl TargetAggregateBuilder {
         let mut seen_span_ids = BTreeSet::new();
         if let Some(results) = execution.workflow.results.as_ref() {
             for (metric, value) in &results.metrics {
-                self.metric_samples.entry(metric.clone()).or_default().push(
-                    TraceAggregateMetricSample {
-                        value: *value,
-                        run_index: index,
-                        artifact_path: artifact_path.clone(),
-                    },
-                );
+                if let Some(value) = value.as_f64() {
+                    self.metric_samples.entry(metric.clone()).or_default().push(
+                        TraceAggregateMetricSample {
+                            value,
+                            run_index: index,
+                            artifact_path: artifact_path.clone(),
+                        },
+                    );
+                }
             }
             for span in &results.span_results {
                 self.all_span_ids.insert(span.id.clone());

--- a/src/commands/trace/observations.rs
+++ b/src/commands/trace/observations.rs
@@ -303,7 +303,6 @@ mod tests {
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
-            metrics: Default::default(),
             preview: None,
         }
     }

--- a/src/commands/trace/output_tests.rs
+++ b/src/commands/trace/output_tests.rs
@@ -722,7 +722,6 @@ fn trace_run_evidence_report_includes_refs_assertions_and_safe_artifacts() {
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
-            metrics: Default::default(),
             preview: None,
         }),
         span_summaries: vec![extension_trace::TraceSpanSummaryOutput {

--- a/src/commands/trace/repeat.rs
+++ b/src/commands/trace/repeat.rs
@@ -60,13 +60,15 @@ pub(super) fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
                 let mut seen_span_ids = BTreeSet::new();
                 if let Some(results) = execution.workflow.results.as_ref() {
                     for (metric, value) in &results.metrics {
-                        metric_samples.entry(metric.clone()).or_default().push(
-                            TraceAggregateMetricSample {
-                                value: *value,
-                                run_index: index,
-                                artifact_path: artifact_path.clone(),
-                            },
-                        );
+                        if let Some(value) = value.as_f64() {
+                            metric_samples.entry(metric.clone()).or_default().push(
+                                TraceAggregateMetricSample {
+                                    value,
+                                    run_index: index,
+                                    artifact_path: artifact_path.clone(),
+                                },
+                            );
+                        }
                     }
                     for span in &results.span_results {
                         all_span_ids.insert(span.id.clone());

--- a/src/core/extension/trace/assertions.rs
+++ b/src/core/extension/trace/assertions.rs
@@ -655,7 +655,6 @@ mod tests {
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
-            metrics: Default::default(),
             preview: None,
         }
     }

--- a/src/core/extension/trace/attach.rs
+++ b/src/core/extension/trace/attach.rs
@@ -529,7 +529,6 @@ mod tests {
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
-            metrics: BTreeMap::new(),
             preview: None,
         };
 

--- a/src/core/extension/trace/baseline.rs
+++ b/src/core/extension/trace/baseline.rs
@@ -400,7 +400,6 @@ mod tests {
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
-            metrics: Default::default(),
             preview: None,
         }
     }

--- a/src/core/extension/trace/canonicality.rs
+++ b/src/core/extension/trace/canonicality.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::Command;
 
@@ -104,7 +103,6 @@ pub(crate) fn refused_trace_result(
         toolchain: None,
         components: None,
         dependencies: Vec::new(),
-        metrics: BTreeMap::new(),
         preview: None,
     };
 

--- a/src/core/extension/trace/parsing.rs
+++ b/src/core/extension/trace/parsing.rs
@@ -76,8 +76,6 @@ pub struct TraceResults {
     pub span_results: Vec<TraceSpanResult>,
     #[serde(default)]
     pub assertions: Vec<TraceAssertion>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub metrics: BTreeMap<String, f64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub temporal_assertions: Vec<TraceTemporalAssertionDefinition>,
     #[serde(default)]

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -924,7 +924,6 @@ mod tests {
                 toolchain: None,
                 components: None,
                 dependencies: Vec::new(),
-                metrics: Default::default(),
                 preview: None,
             }),
             failure: None,
@@ -999,7 +998,6 @@ mod tests {
                 toolchain: None,
                 components: None,
                 dependencies: Vec::new(),
-                metrics: Default::default(),
                 preview: None,
             }),
             failure: None,
@@ -1112,7 +1110,6 @@ mod tests {
                 dependencies: Vec::new(),
             }),
             dependencies: Vec::new(),
-            metrics: Default::default(),
             preview: None,
         };
 
@@ -1171,7 +1168,6 @@ mod tests {
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
-            metrics: Default::default(),
             preview: None,
         };
 

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -1314,7 +1314,6 @@ mod tests {
             temporal_assertions: Vec::new(),
             artifacts: Vec::new(),
             dependencies: Vec::new(),
-            metrics: Default::default(),
             toolchain: None,
             components: None,
         };
@@ -1439,7 +1438,6 @@ mod tests {
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
-            metrics: Default::default(),
             preview: None,
         };
 

--- a/src/core/extension/trace/spans.rs
+++ b/src/core/extension/trace/spans.rs
@@ -141,7 +141,6 @@ mod tests {
             toolchain: None,
             components: None,
             dependencies: Vec::new(),
-            metrics: Default::default(),
             preview: None,
         };
 

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -30,7 +30,8 @@ use super::lab_capabilities::lab_runner_capability_contract;
 use super::lab_command::lab_offload_command_prefix;
 use super::lab_env::{
     build_lab_offload_env, forward_env_if_present, forward_release_ci_env,
-    misplaced_runner_exec_wait_timeout_warning, settings_env_diagnostics,
+    forward_rig_component_path_env, misplaced_runner_exec_wait_timeout_warning,
+    settings_env_diagnostics,
 };
 use super::lab_plan::{base_lab_plan, disabled_select_runner_plan, with_step};
 pub use super::lab_selection::LabRunnerSelectionSource;
@@ -41,7 +42,8 @@ use super::lab_selection::{
 use super::lab_workspaces::{
     agent_task_plan_extra_workspaces, lab_extra_workspaces, lab_workspace_mapping_metadata,
     preflight_provider_config_source_cli_dependencies, provider_config_extra_workspaces,
-    sync_extra_lab_workspaces, workspace_mapping_entry, workspace_mapping_entry_for_git_dependency,
+    rig_component_path_env_extra_workspaces, sync_extra_lab_workspaces, workspace_mapping_entry,
+    workspace_mapping_entry_for_git_dependency,
 };
 
 pub struct LabOffloadRequest<'a> {
@@ -580,6 +582,7 @@ fn run_lab_offload_inner(
         &changed_since_preflight.args,
         &source_path,
     )?);
+    extra_workspaces.extend(rig_component_path_env_extra_workspaces(&source_path)?);
     let synced = sync_workspace(
         runner_id,
         RunnerWorkspaceSyncOptions {
@@ -762,9 +765,11 @@ fn run_lab_offload_inner(
     forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
     forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
     forward_release_ci_env(&mut env);
+    let rig_component_path_env = forward_rig_component_path_env(&mut env, &workspace_mapping)?;
     let agent_task_secret_env =
         hydrate_agent_task_secret_env(&changed_since_preflight.args, &mut env)?;
     lab_metadata["agent_task_secret_env"] = agent_task_secret_env;
+    lab_metadata["rig_component_path_env"] = rig_component_path_env;
     lab_metadata["settings_env"] = settings_env_diagnostics(&changed_since_preflight.args, &env);
     lab_metadata["rig_sync"] = serde_json::json!({
         "step": "lab.sync_rigs",
@@ -777,6 +782,7 @@ fn run_lab_offload_inner(
     forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
     forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
     forward_release_ci_env(&mut env);
+    forward_rig_component_path_env(&mut env, &workspace_mapping)?;
     hydrate_agent_task_secret_env(&changed_since_preflight.args, &mut env)?;
     let exec_result = exec(
         runner_id,

--- a/src/core/runner/lab_env.rs
+++ b/src/core/runner/lab_env.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
+use crate::core::{Error, Result};
+
 use super::execution::RUNNER_EXEC_WAIT_TIMEOUT_ENV;
+use super::lab_workspaces::{is_rig_component_path_env_name, LabWorkspaceMappingEntry};
 use crate::core::observation::LAB_OFFLOAD_METADATA_ENV;
 
 const SETTINGS_DIAGNOSTICS_SCHEMA: &str = "homeboy/lab-offload-settings-env/v1";
@@ -24,6 +27,90 @@ pub(super) fn build_lab_offload_env(lab_metadata: &serde_json::Value) -> HashMap
         LAB_OFFLOAD_METADATA_ENV.to_string(),
         serde_json::to_string(lab_metadata).unwrap_or_default(),
     )])
+}
+
+pub(super) fn forward_rig_component_path_env(
+    env: &mut HashMap<String, String>,
+    workspace_mapping: &[LabWorkspaceMappingEntry],
+) -> Result<serde_json::Value> {
+    forward_rig_component_path_env_entries(env, workspace_mapping, std::env::vars())
+}
+
+fn forward_rig_component_path_env_entries(
+    env: &mut HashMap<String, String>,
+    workspace_mapping: &[LabWorkspaceMappingEntry],
+    entries: impl IntoIterator<Item = (String, String)>,
+) -> Result<serde_json::Value> {
+    let mut forwarded = Vec::new();
+    let mut entries = entries
+        .into_iter()
+        .filter(|(name, value)| is_rig_component_path_env_name(name) && !value.trim().is_empty())
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+
+    for (name, value) in entries {
+        let Some(remote_value) = remap_rig_component_path_env_value(&value, workspace_mapping)
+        else {
+            return Err(Error::validation_invalid_argument(
+                name.clone(),
+                format!(
+                    "Lab offload cannot forward `{name}` because its controller-side path was not synced to the runner"
+                ),
+                Some(value.clone()),
+                Some(vec![
+                    format!("Controller-side value: {value}"),
+                    "Use an existing local checkout/component path so Lab can sync and translate it, unset the variable to use the rig default, or run with --force-hot to keep the check local.".to_string(),
+                ]),
+            ));
+        };
+        env.insert(name.clone(), remote_value.clone());
+        forwarded.push(serde_json::json!({
+            "name": name,
+            "forwarded_to_runner": true,
+            "translated": true,
+            "controller_value": value,
+            "runner_value": remote_value,
+        }));
+    }
+
+    Ok(serde_json::json!({
+        "schema": "homeboy/lab-offload-rig-component-path-env/v1",
+        "forwarded": forwarded,
+    }))
+}
+
+fn remap_rig_component_path_env_value(
+    value: &str,
+    workspace_mapping: &[LabWorkspaceMappingEntry],
+) -> Option<String> {
+    let expanded = shellexpand::tilde(value).to_string();
+    let canonical = std::path::Path::new(&expanded)
+        .canonicalize()
+        .ok()
+        .map(|path| path.to_string_lossy().to_string());
+
+    let mut ordered = workspace_mapping.iter().collect::<Vec<_>>();
+    ordered.sort_by_key(|entry| std::cmp::Reverse(entry.local_path().len()));
+    for entry in ordered {
+        let mut candidates = vec![value];
+        if let Some(canonical) = canonical.as_deref() {
+            candidates.insert(0, canonical);
+        }
+        for candidate in candidates {
+            if candidate == entry.local_path() {
+                return Some(entry.remote_path().to_string());
+            }
+            let prefix = format!("{}/", entry.local_path().trim_end_matches('/'));
+            if let Some(rest) = candidate.strip_prefix(&prefix) {
+                return Some(format!(
+                    "{}/{}",
+                    entry.remote_path().trim_end_matches('/'),
+                    rest
+                ));
+            }
+        }
+    }
+    None
 }
 
 pub(super) fn settings_env_diagnostics(
@@ -184,6 +271,8 @@ fn redacted_value_preview(value: &str, redacted: bool) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::runner::lab_workspaces::workspace_mapping_entry;
+    use crate::core::runner::{RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOutput};
 
     struct EnvVarGuard {
         name: &'static str,
@@ -286,6 +375,64 @@ mod tests {
             diagnostics["forwarded_environment"][0]["value_preview"],
             "<redacted>"
         );
+    }
+
+    #[test]
+    fn rig_component_path_env_is_forwarded_with_runner_path() {
+        let mapping = vec![workspace_mapping_entry(
+            "rig_component_path_env",
+            &RunnerWorkspaceSyncOutput {
+                command: "runner.workspace.sync",
+                runner_id: "homeboy-lab".to_string(),
+                local_path: "/Users/chubes/Developer/woocommerce-gateway-stripe".to_string(),
+                remote_path: "/home/chubes/Developer/woocommerce-gateway-stripe".to_string(),
+                sync_mode: RunnerWorkspaceSyncMode::Snapshot,
+                snapshot_identity: "snapshot".to_string(),
+                files: 1,
+                bytes: 1,
+                excludes: Vec::new(),
+                includes: Vec::new(),
+            },
+        )];
+
+        let mut env = HashMap::new();
+        let metadata = forward_rig_component_path_env_entries(
+            &mut env,
+            &mapping,
+            [(
+                "HOMEBOY_TEST_COMPONENT_PATH".to_string(),
+                "/Users/chubes/Developer/woocommerce-gateway-stripe/includes".to_string(),
+            )],
+        )
+        .expect("forward env");
+
+        assert_eq!(
+            env.get("HOMEBOY_TEST_COMPONENT_PATH").map(String::as_str),
+            Some("/home/chubes/Developer/woocommerce-gateway-stripe/includes")
+        );
+        assert_eq!(
+            metadata["forwarded"][0]["runner_value"],
+            "/home/chubes/Developer/woocommerce-gateway-stripe/includes"
+        );
+    }
+
+    #[test]
+    fn rig_component_path_env_fails_when_path_was_not_synced() {
+        let mut env = HashMap::new();
+
+        let err = forward_rig_component_path_env_entries(
+            &mut env,
+            &[],
+            [(
+                "HOMEBOY_UNSYNCED_COMPONENT_PATH".to_string(),
+                "/Users/chubes/Developer/unsynced-component".to_string(),
+            )],
+        )
+        .expect_err("unsynced path");
+
+        assert_eq!(err.details["field"], "HOMEBOY_UNSYNCED_COMPONENT_PATH");
+        assert!(err.message.contains("was not synced to the runner"));
+        assert!(!env.contains_key("HOMEBOY_UNSYNCED_COMPONENT_PATH"));
     }
 
     #[test]

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -243,6 +243,57 @@ pub(super) fn agent_task_plan_extra_workspaces(
     Ok(workspaces)
 }
 
+pub(super) fn rig_component_path_env_extra_workspaces(
+    source_path: &Path,
+) -> Result<Vec<ExtraLabWorkspace>> {
+    rig_component_path_env_extra_workspaces_from_entries(source_path, std::env::vars())
+}
+
+fn rig_component_path_env_extra_workspaces_from_entries(
+    source_path: &Path,
+    entries: impl IntoIterator<Item = (String, String)>,
+) -> Result<Vec<ExtraLabWorkspace>> {
+    let source_canon = source_path
+        .canonicalize()
+        .unwrap_or_else(|_| source_path.to_path_buf());
+    let mut seen = BTreeSet::new();
+    let mut workspaces = Vec::new();
+
+    for (name, value) in entries
+        .into_iter()
+        .filter(|(name, value)| is_rig_component_path_env_name(name) && !value.trim().is_empty())
+    {
+        let expanded = shellexpand::tilde(&value).to_string();
+        let path = Path::new(&expanded);
+        if !path.exists() {
+            return Err(Error::validation_invalid_argument(
+                name.clone(),
+                format!(
+                    "Lab offload cannot forward `{name}` because its controller-side path does not exist"
+                ),
+                Some(value.clone()),
+                Some(vec![
+                    format!("Controller-side value: {value}"),
+                    "Set the variable to an existing checkout/component path before offload, unset it to use the rig default, or run with --force-hot to keep the check local.".to_string(),
+                ]),
+            ));
+        }
+        add_candidate_extra_workspace(
+            &value,
+            "rig_component_path_env",
+            &source_canon,
+            &mut seen,
+            &mut workspaces,
+        )?;
+    }
+
+    Ok(workspaces)
+}
+
+pub(super) fn is_rig_component_path_env_name(name: &str) -> bool {
+    name.starts_with("HOMEBOY_") && name.ends_with("_COMPONENT_PATH")
+}
+
 pub(super) fn preflight_provider_config_source_cli_dependencies(
     args: &[String],
     snapshot_excludes: &[String],
@@ -691,6 +742,7 @@ mod provider_config_candidate_paths_tests {
     use super::{
         agent_task_plan_extra_workspaces, preflight_provider_config_source_cli_dependencies,
         provider_config_candidate_paths, provider_config_extra_workspaces,
+        rig_component_path_env_extra_workspaces_from_entries,
         workspace_mapping_entry_for_git_dependency,
     };
     use crate::core::runner::{RunnerGitDependencyMaterializationOutput, RunnerWorkspaceSyncMode};
@@ -913,6 +965,48 @@ mod provider_config_candidate_paths_tests {
         let workspaces = agent_task_plan_extra_workspaces(&args, &source).expect("workspaces");
 
         assert!(workspaces.is_empty());
+    }
+
+    #[test]
+    fn rig_component_path_env_extra_workspaces_syncs_existing_component_path() {
+        crate::test_support::with_isolated_home(|home| {
+            let source = home.path().join("primary");
+            std::fs::create_dir_all(&source).expect("source path");
+            let component_path = home.path().join("Developer/plugin/includes");
+            std::fs::create_dir_all(&component_path).expect("component path");
+
+            let workspaces = rig_component_path_env_extra_workspaces_from_entries(
+                &source,
+                [(
+                    "HOMEBOY_TEST_COMPONENT_PATH".to_string(),
+                    component_path.display().to_string(),
+                )],
+            )
+            .expect("workspaces");
+
+            assert_eq!(workspaces.len(), 1);
+            assert_eq!(workspaces[0].role, "rig_component_path_env");
+            assert_eq!(workspaces[0].path, component_path.canonicalize().unwrap());
+        });
+    }
+
+    #[test]
+    fn rig_component_path_env_extra_workspaces_rejects_missing_component_path() {
+        crate::test_support::with_isolated_home(|home| {
+            let missing = home.path().join("missing-plugin");
+
+            let err = rig_component_path_env_extra_workspaces_from_entries(
+                home.path(),
+                [(
+                    "HOMEBOY_MISSING_COMPONENT_PATH".to_string(),
+                    missing.display().to_string(),
+                )],
+            )
+            .expect_err("missing path");
+
+            assert_eq!(err.details["field"], "HOMEBOY_MISSING_COMPONENT_PATH");
+            assert!(err.message.contains("controller-side path does not exist"));
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fixes `homeboy rig check` Lab offload so explicit `HOMEBOY_*_COMPONENT_PATH` overrides are synced, translated, and forwarded to the runner instead of silently falling back to rig defaults.
- Fails before runner execution with the controller-side value when an explicit component path env var points at a missing or unsynced local path.
- Repairs a recent trace metrics merge conflict that blocked Cargo from compiling before the targeted tests could run.

Fixes #4006.

## Verification
- `cargo test core::runner::lab_workspaces::provider_config_candidate_paths_tests::rig_component_path_env`
- `cargo test core::runner::lab_env::tests::rig_component_path_env`
- `cargo test core::extension::trace::parsing::tests::test_parse_trace_results_str`
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the Lab offload env/path boundary, implemented the Rust fix and targeted tests, repaired the compile blocker needed to verify the change, and ran focused verification. Chris remains responsible for review and merge.