### PR TITLE
bench: surface tracker provenance

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -203,6 +203,30 @@ Omit `--rig <rig>` from the list command for unpinned bench runs.
 
 `homeboy bench compare --from-run <baseline-run-id> --to-run <candidate-run-id>` compares numeric metrics recorded in two persisted benchmark runs. It is the first useful baseline-vs-candidate comparison slice: it captures both run IDs, component state, shared bench context, selected metric deltas, and a Markdown table under `reports.markdown` in the JSON payload.
 
+Bench runners may attach generic tracker provenance to the top-level results
+envelope or to individual scenarios/workloads. Homeboy persists that metadata in
+the run record, keeps it in JSON artifacts/exports, and renders a `Provenance`
+section with clickable links in compare Markdown when present:
+
+```json
+{
+  "provenance": {
+    "labels": ["source: zendesk", "privacy: internal"],
+    "links": [
+      {
+        "url": "https://wordpress.org/support/topic/checkout-is-very-slow/",
+        "label": "WordPress.org support thread",
+        "source": "wordpress.org"
+      }
+    ]
+  }
+}
+```
+
+Use `labels` for non-public or freeform context that should stay as text, such
+as `source: zendesk`, `scenario: shortcode checkout place-order latency`, or
+`privacy: internal`. Use `links` for reviewer-clickable references.
+
 The command is read-only and exits successfully for a valid comparison even when the numbers regress. Repeat `--metric <name>` to keep the comparison focused; omit it to compare all shared numeric scenario metrics.
 
 Homeboy rejects comparisons when the stored shared benchmark context differs for settings, selected scenarios, workload fingerprints, iteration count, run count, or concurrency. This keeps manually-created baseline/candidate runs from being compared when they were not actually measuring the same scenario contract.

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -309,6 +309,7 @@ fn merge_matrix_results(
         Some(BenchResults {
             component_id: component_ids.join(","),
             iterations: iterations_seen.unwrap_or(0),
+            provenance: Default::default(),
             run_metadata: outputs
                 .iter()
                 .find_map(|output| output.results.as_ref()?.run_metadata.clone()),

--- a/src/commands/report/bench_coverage.rs
+++ b/src/commands/report/bench_coverage.rs
@@ -387,6 +387,7 @@ mod tests {
             gates: Vec::new(),
             gate_results: Vec::new(),
             metadata: BTreeMap::new(),
+            provenance: Default::default(),
             passed: true,
             memory: None,
             artifacts: BTreeMap::new(),

--- a/src/commands/runs/bench.rs
+++ b/src/commands/runs/bench.rs
@@ -52,6 +52,8 @@ pub struct BenchComparisonSharedContext {
     pub settings: BTreeMap<String, Value>,
     pub selected_scenarios: Vec<String>,
     pub workloads: Vec<BenchWorkloadFingerprint>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub provenance: Vec<BenchProvenanceEntry>,
     pub iterations: Option<u64>,
     pub runs: Option<u64>,
     pub concurrency: Option<u64>,
@@ -62,6 +64,28 @@ pub struct BenchComparisonSharedContext {
 pub struct BenchWorkloadFingerprint {
     pub id: String,
     pub sha256: Option<String>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct BenchProvenanceEntry {
+    pub scope: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scenario_id: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub links: Vec<BenchProvenanceLinkEntry>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct BenchProvenanceLinkEntry {
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub privacy: Option<String>,
 }
 
 #[derive(Serialize, Debug, Clone, PartialEq, Eq)]
@@ -278,6 +302,7 @@ fn shared_context(metadata: &Value) -> BenchComparisonSharedContext {
         .or_else(|| string_array(metadata.get("selected_scenarios")))
         .unwrap_or_default(),
         workloads: bench_workloads(run_metadata),
+        provenance: bench_provenance(metadata, run_metadata),
         iterations: run_metadata
             .and_then(|value| value.get("iterations"))
             .and_then(Value::as_u64)
@@ -293,6 +318,97 @@ fn shared_context(metadata: &Value) -> BenchComparisonSharedContext {
             .and_then(Value::as_str)
             .map(str::to_string),
     }
+}
+
+fn bench_provenance(metadata: &Value, run_metadata: Option<&Value>) -> Vec<BenchProvenanceEntry> {
+    let mut entries = Vec::new();
+    if let Some(entry) =
+        provenance_entry("run", None, run_metadata.and_then(|v| v.get("provenance")))
+    {
+        entries.push(entry);
+    }
+    if let Some(entry) = provenance_entry("run", None, metadata.get("provenance")) {
+        if !entries.contains(&entry) {
+            entries.push(entry);
+        }
+    }
+    if let Some(workloads) = run_metadata
+        .and_then(|value| value.get("workloads"))
+        .and_then(Value::as_array)
+    {
+        for workload in workloads {
+            let scenario_id = workload
+                .get("id")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            if let Some(entry) =
+                provenance_entry("workload", scenario_id, workload.get("provenance"))
+            {
+                entries.push(entry);
+            }
+        }
+    }
+    if let Some(scenarios) = metadata
+        .get("results")
+        .and_then(|results| results.get("scenarios"))
+        .and_then(Value::as_array)
+    {
+        for scenario in scenarios {
+            let scenario_id = scenario
+                .get("id")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            if let Some(entry) =
+                provenance_entry("scenario", scenario_id, scenario.get("provenance"))
+            {
+                if !entries.contains(&entry) {
+                    entries.push(entry);
+                }
+            }
+        }
+    }
+    entries
+}
+
+fn provenance_entry(
+    scope: &str,
+    scenario_id: Option<String>,
+    value: Option<&Value>,
+) -> Option<BenchProvenanceEntry> {
+    let value = value?;
+    let labels = string_array(value.get("labels")).unwrap_or_default();
+    let links = value
+        .get("links")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| {
+                    Some(BenchProvenanceLinkEntry {
+                        url: item.get("url")?.as_str()?.to_string(),
+                        label: item
+                            .get("label")
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
+                        source: item
+                            .get("source")
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
+                        privacy: item
+                            .get("privacy")
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    (!labels.is_empty() || !links.is_empty()).then(|| BenchProvenanceEntry {
+        scope: scope.to_string(),
+        scenario_id,
+        links,
+        labels,
+    })
 }
 
 fn bench_run_metadata(metadata: &Value) -> Option<&Value> {
@@ -399,6 +515,42 @@ fn render_bench_compare_markdown(
             "- **Scenarios:** `{}`\n",
             shared.selected_scenarios.join(", ")
         ));
+    }
+
+    if !shared.provenance.is_empty() {
+        out.push_str("\n## Provenance\n\n");
+        for entry in &shared.provenance {
+            let scope = match &entry.scenario_id {
+                Some(scenario_id) => format!("{} `{}`", entry.scope, scenario_id),
+                None => entry.scope.clone(),
+            };
+            for link in &entry.links {
+                let label = link
+                    .label
+                    .as_deref()
+                    .or(link.source.as_deref())
+                    .unwrap_or("reference");
+                let mut suffix = Vec::new();
+                if let Some(source) = &link.source {
+                    suffix.push(format!("source: {source}"));
+                }
+                if let Some(privacy) = &link.privacy {
+                    suffix.push(format!("privacy: {privacy}"));
+                }
+                let suffix = if suffix.is_empty() {
+                    String::new()
+                } else {
+                    format!(" ({})", suffix.join(", "))
+                };
+                out.push_str(&format!(
+                    "- **{}:** [{}]({}){}\n",
+                    scope, label, link.url, suffix
+                ));
+            }
+            for label in &entry.labels {
+                out.push_str(&format!("- **{}:** {}\n", scope, label));
+            }
+        }
     }
 
     out.push_str("\n| Scenario | Metric | Baseline | Candidate | Delta | Change |\n");
@@ -581,7 +733,27 @@ mod tests {
                             "runs": 1,
                             "concurrency": 1,
                             "shared_state": "/tmp/homeboy-bench-compare",
-                            "workloads": [{ "id": "cold", "sha256": "abc" }]
+                            "provenance": {
+                                "labels": ["source: zendesk"],
+                                "links": [{
+                                    "url": "https://automattic.zendesk.com/agent/tickets/9426116",
+                                    "label": "Zendesk ticket 9426116",
+                                    "source": "zendesk",
+                                    "privacy": "internal"
+                                }]
+                            },
+                            "workloads": [{
+                                "id": "cold",
+                                "sha256": "abc",
+                                "provenance": {
+                                    "labels": ["scenario: shortcode checkout place-order latency"],
+                                    "links": [{
+                                        "url": "https://wordpress.org/support/topic/checkout-is-very-slow/",
+                                        "label": "WordPress.org support thread",
+                                        "source": "wordpress.org"
+                                    }]
+                                }
+                            }]
                         },
                         "scenario_metrics": [{
                             "scenario_id": "cold",
@@ -623,6 +795,11 @@ mod tests {
             assert_eq!(output.candidate.run.id, to.id);
             assert_eq!(output.shared.selected_scenarios, vec!["cold".to_string()]);
             assert_eq!(output.shared.workloads[0].sha256.as_deref(), Some("abc"));
+            assert_eq!(output.shared.provenance.len(), 2);
+            assert_eq!(
+                output.shared.provenance[0].links[0].url,
+                "https://automattic.zendesk.com/agent/tickets/9426116"
+            );
             let p95 = output
                 .comparisons
                 .iter()
@@ -647,6 +824,13 @@ mod tests {
                 .reports
                 .markdown
                 .contains("| cold | p95_ms | 100 | 125 | 25 | 25% |"));
+            assert!(output.reports.markdown.contains("## Provenance"));
+            assert!(output.reports.markdown.contains(
+                "[Zendesk ticket 9426116](https://automattic.zendesk.com/agent/tickets/9426116)"
+            ));
+            assert!(output.reports.markdown.contains(
+                "[WordPress.org support thread](https://wordpress.org/support/topic/checkout-is-very-slow/)"
+            ));
 
             let (filtered, _) =
                 bench_compare(&from.id, &to.id, &["p95_ms".to_string()]).expect("filtered compare");

--- a/src/core/extension/bench/aggregation.rs
+++ b/src/core/extension/bench/aggregation.rs
@@ -58,6 +58,7 @@ pub fn aggregate_runs(runs: &[BenchResults]) -> Result<BenchResults> {
     Ok(BenchResults {
         component_id: first.component_id.clone(),
         iterations: first.iterations,
+        provenance: first.provenance.clone(),
         run_metadata: first.run_metadata.clone(),
         metadata: first.metadata.clone(),
         metric_groups: first.metric_groups.clone(),

--- a/src/core/extension/bench/artifact_validation.rs
+++ b/src/core/extension/bench/artifact_validation.rs
@@ -141,6 +141,7 @@ mod tests {
         let mut results = BenchResults {
             component_id: "studio".to_string(),
             iterations: 1,
+            provenance: Default::default(),
             run_metadata: None,
             metadata: BTreeMap::new(),
             metric_groups: BTreeMap::new(),
@@ -167,6 +168,7 @@ mod tests {
                 gates: Vec::new(),
                 gate_results: Vec::new(),
                 metadata: BTreeMap::new(),
+                provenance: Default::default(),
                 passed: true,
                 memory: None,
                 artifacts: BTreeMap::new(),

--- a/src/core/extension/bench/baseline.rs
+++ b/src/core/extension/bench/baseline.rs
@@ -337,6 +337,7 @@ mod tests {
             gates: Vec::new(),
             gate_results: Vec::new(),
             metadata: BTreeMap::new(),
+            provenance: Default::default(),
             passed: true,
             memory: None,
             artifacts: BTreeMap::new(),
@@ -370,6 +371,7 @@ mod tests {
             gates: Vec::new(),
             gate_results: Vec::new(),
             metadata: BTreeMap::new(),
+            provenance: Default::default(),
             passed: true,
             memory: None,
             artifacts: BTreeMap::new(),
@@ -395,6 +397,7 @@ mod tests {
         BenchResults {
             component_id: "demo".to_string(),
             iterations: 10,
+            provenance: Default::default(),
             run_metadata: None,
             metadata: BTreeMap::new(),
             metric_groups: BTreeMap::new(),
@@ -419,6 +422,7 @@ mod tests {
         BenchResults {
             component_id: "demo".to_string(),
             iterations: 10,
+            provenance: Default::default(),
             run_metadata: None,
             metadata: BTreeMap::new(),
             metric_groups: BTreeMap::new(),

--- a/src/core/extension/bench/diagnostic.rs
+++ b/src/core/extension/bench/diagnostic.rs
@@ -99,6 +99,7 @@ mod tests {
         let results = BenchResults {
             component_id: "demo".to_string(),
             iterations: 1,
+            provenance: Default::default(),
             run_metadata: None,
             metadata: BTreeMap::new(),
             metric_groups: BTreeMap::new(),
@@ -125,6 +126,7 @@ mod tests {
                 gates: Vec::new(),
                 gate_results: Vec::new(),
                 metadata: BTreeMap::new(),
+                provenance: Default::default(),
                 passed: false,
                 memory: None,
                 artifacts: BTreeMap::new(),

--- a/src/core/extension/bench/metrics.rs
+++ b/src/core/extension/bench/metrics.rs
@@ -339,6 +339,7 @@ mod tests {
         BenchResults {
             component_id: "demo".to_string(),
             iterations: 10,
+            provenance: Default::default(),
             run_metadata: None,
             metadata: BTreeMap::new(),
             metric_groups: BTreeMap::new(),
@@ -368,6 +369,7 @@ mod tests {
                 gates: Vec::new(),
                 gate_results: Vec::new(),
                 metadata: BTreeMap::new(),
+                provenance: Default::default(),
                 passed: true,
                 memory: None,
                 artifacts: BTreeMap::new(),

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -65,8 +65,8 @@ use super::phase_events::evaluate_phase_events;
 
 pub use super::result_types::{
     BenchMemory, BenchMetricDirection, BenchMetricPhase, BenchMetricPolicy, BenchMetrics,
-    BenchResults, BenchRunExecution, BenchRunMetadata, BenchRunSnapshot, BenchRunnerMetadata,
-    BenchScenario, BenchWorkloadMetadata, RegressionTest,
+    BenchProvenance, BenchProvenanceLink, BenchResults, BenchRunExecution, BenchRunMetadata,
+    BenchRunSnapshot, BenchRunnerMetadata, BenchScenario, BenchWorkloadMetadata, RegressionTest,
 };
 
 /// Derive scenario span results from the shared observation timeline contract.
@@ -122,7 +122,12 @@ fn parse_bench_results_str_with_artifact_context(
         object.remove("lifecycle");
         object.remove("reset_policy");
         object.remove("warmup_iterations");
-        object.remove("provenance");
+        if object
+            .get("provenance")
+            .is_some_and(|value| !is_bench_provenance_contract(value))
+        {
+            object.remove("provenance");
+        }
     }
     normalize_extension_sample_metrics(&mut value);
     let mut parsed: BenchResults = serde_json::from_value(value).map_err(|e| {
@@ -150,7 +155,12 @@ fn normalize_extension_sample_metrics(value: &mut serde_json::Value) {
 
     for scenario in scenarios {
         if let Some(object) = scenario.as_object_mut() {
-            object.remove("provenance");
+            if object
+                .get("provenance")
+                .is_some_and(|value| !is_bench_provenance_contract(value))
+            {
+                object.remove("provenance");
+            }
         }
         let Some(metrics) = scenario
             .get_mut("metrics")
@@ -189,6 +199,12 @@ fn normalize_extension_sample_metrics(value: &mut serde_json::Value) {
         }
         *metrics = normalized;
     }
+}
+
+fn is_bench_provenance_contract(value: &serde_json::Value) -> bool {
+    value
+        .as_object()
+        .is_some_and(|object| object.contains_key("links") || object.contains_key("labels"))
 }
 
 fn validate_unique_scenario_ids(results: &BenchResults) -> Result<()> {
@@ -541,6 +557,57 @@ mod tests {
         assert!(serialized.contains("\"artifacts\""));
         assert!(serialized.contains("artifacts/agent-loop/transcript.json"));
         assert!(serialized.contains("https://example.test/"));
+    }
+
+    #[test]
+    fn parses_top_level_and_scenario_provenance() {
+        let raw = r#"{
+            "component_id": "example",
+            "iterations": 1,
+            "provenance": {
+                "labels": ["source: zendesk", "privacy: internal"],
+                "links": [
+                    {
+                        "url": "https://automattic.zendesk.com/agent/tickets/9426116",
+                        "label": "Zendesk ticket 9426116",
+                        "source": "zendesk",
+                        "privacy": "internal"
+                    }
+                ]
+            },
+            "scenarios": [
+                {
+                    "id": "checkout_latency",
+                    "iterations": 1,
+                    "metrics": { "p95_ms": 250.0 },
+                    "provenance": {
+                        "labels": ["scenario: shortcode checkout place-order latency"],
+                        "links": [
+                            {
+                                "url": "https://wordpress.org/support/topic/checkout-is-very-slow/",
+                                "label": "WordPress.org support thread",
+                                "source": "wordpress.org"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }"#;
+
+        let parsed = parse_bench_results_str(raw).unwrap();
+
+        assert_eq!(parsed.provenance.labels[0], "source: zendesk");
+        assert_eq!(
+            parsed.provenance.links[0].source.as_deref(),
+            Some("zendesk")
+        );
+        assert_eq!(
+            parsed.scenarios[0].provenance.links[0].url,
+            "https://wordpress.org/support/topic/checkout-is-very-slow/"
+        );
+        let serialized = serde_json::to_string(&parsed).unwrap();
+        assert!(serialized.contains("automattic.zendesk.com"));
+        assert!(serialized.contains("wordpress.org/support"));
     }
 
     #[test]

--- a/src/core/extension/bench/result_types.rs
+++ b/src/core/extension/bench/result_types.rs
@@ -27,12 +27,18 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
+fn provenance_is_empty(value: &BenchProvenance) -> bool {
+    value.is_empty()
+}
+
 /// Full bench run output from an extension script.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct BenchResults {
     pub component_id: String,
     pub iterations: u64,
+    #[serde(default, skip_serializing_if = "provenance_is_empty")]
+    pub provenance: BenchProvenance,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub run_metadata: Option<BenchRunMetadata>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -86,6 +92,8 @@ pub struct BenchRunMetadata {
     pub env_overrides: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub workloads: Vec<BenchWorkloadMetadata>,
+    #[serde(default, skip_serializing_if = "provenance_is_empty")]
+    pub provenance: BenchProvenance,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runner: Option<BenchRunnerMetadata>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -109,6 +117,35 @@ pub struct BenchWorkloadMetadata {
     pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "provenance_is_empty")]
+    pub provenance: BenchProvenance,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchProvenance {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub links: Vec<BenchProvenanceLink>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
+}
+
+impl BenchProvenance {
+    pub fn is_empty(&self) -> bool {
+        self.links.is_empty() && self.labels.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchProvenanceLink {
+    pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub privacy: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -148,6 +185,8 @@ pub struct BenchScenario {
     pub gate_results: Vec<BenchGateResult>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub metadata: BTreeMap<String, serde_json::Value>,
+    #[serde(default, skip_serializing_if = "provenance_is_empty")]
+    pub provenance: BenchProvenance,
     #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub passed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -601,6 +601,7 @@ pub fn run_main_bench_workflow(
                 selected_scenarios: args.scenario_ids.clone(),
                 env_overrides: BTreeMap::new(),
                 workloads: Vec::new(),
+                provenance: results.provenance.clone(),
                 runner: Some(BenchRunnerMetadata {
                     extension: "component-script".to_string(),
                     path: source_path.to_string_lossy().to_string(),
@@ -1382,6 +1383,7 @@ fn run_concurrent_instances(
         Some(BenchResults {
             component_id: component_id_seen.unwrap_or_else(|| args.component_id.clone()),
             iterations: iterations_seen.unwrap_or(args.iterations),
+            provenance: Default::default(),
             run_metadata: None,
             metadata: BTreeMap::new(),
             metric_groups: BTreeMap::new(),
@@ -1989,6 +1991,7 @@ mod tests {
         let mut results = BenchResults {
             component_id: "homeboy".to_string(),
             iterations: 1,
+            provenance: Default::default(),
             run_metadata: None,
             metadata: BTreeMap::new(),
             metric_groups: BTreeMap::new(),
@@ -2015,6 +2018,7 @@ mod tests {
                 gates: Vec::new(),
                 gate_results: Vec::new(),
                 metadata: BTreeMap::new(),
+                provenance: Default::default(),
                 passed: true,
                 memory: None,
                 artifacts: BTreeMap::new(),
@@ -2156,6 +2160,7 @@ mod tests {
                 gates: Vec::new(),
                 gate_results: Vec::new(),
                 metadata: BTreeMap::new(),
+                provenance: Default::default(),
                 passed: true,
                 memory: None,
                 artifacts: BTreeMap::new(),

--- a/src/core/extension/bench/run_metadata.rs
+++ b/src/core/extension/bench/run_metadata.rs
@@ -33,6 +33,7 @@ pub(crate) fn stamp_run_metadata(
         selected_scenarios: args.scenario_ids.clone(),
         env_overrides: bench_env_overrides(),
         workloads,
+        provenance: results.provenance.clone(),
         runner: Some(BenchRunnerMetadata {
             extension: execution_context.extension_id.clone(),
             path: execution_context
@@ -68,6 +69,7 @@ fn workload_metadata(
                 .as_ref()
                 .map(|path| path.to_string_lossy().to_string()),
             sha256: resolved.as_deref().and_then(sha256_file),
+            provenance: scenario.provenance.clone(),
         });
     }
 
@@ -85,6 +87,7 @@ fn workload_metadata(
             source: Some("rig".to_string()),
             path: Some(path_string),
             sha256: sha256_file(path),
+            provenance: Default::default(),
         });
     }
 
@@ -218,6 +221,7 @@ mod tests {
         let mut results = BenchResults {
             component_id: "homeboy".to_string(),
             iterations: 7,
+            provenance: Default::default(),
             run_metadata: None,
             metadata: BTreeMap::new(),
             metric_groups: BTreeMap::new(),
@@ -247,6 +251,7 @@ mod tests {
                 gates: Vec::new(),
                 gate_results: Vec::new(),
                 metadata: BTreeMap::new(),
+                provenance: Default::default(),
                 passed: true,
                 memory: None,
                 artifacts: BTreeMap::new(),
@@ -257,6 +262,19 @@ mod tests {
             metric_policies: BTreeMap::new(),
             metric_policy_presets: BTreeMap::new(),
         };
+        results
+            .provenance
+            .labels
+            .push("source: zendesk".to_string());
+        results.scenarios[0]
+            .provenance
+            .links
+            .push(parsing::BenchProvenanceLink {
+                url: "https://wordpress.org/support/topic/checkout-is-very-slow/".to_string(),
+                label: Some("Support thread".to_string()),
+                source: Some("wordpress.org".to_string()),
+                privacy: None,
+            });
 
         stamp_run_metadata(
             &mut results,
@@ -285,6 +303,14 @@ mod tests {
             Some(workload.to_string_lossy().as_ref())
         );
         assert_eq!(metadata.workloads[0].sha256.as_ref().unwrap().len(), 64);
+        assert_eq!(
+            metadata.provenance.labels,
+            vec!["source: zendesk".to_string()]
+        );
+        assert_eq!(
+            metadata.workloads[0].provenance.links[0].url,
+            "https://wordpress.org/support/topic/checkout-is-very-slow/"
+        );
     }
 
     #[test]

--- a/src/core/extension/bench/test_support.rs
+++ b/src/core/extension/bench/test_support.rs
@@ -30,6 +30,7 @@ pub(crate) fn scenario_with_iterations(
         gates: Vec::new(),
         gate_results: Vec::new(),
         metadata: BTreeMap::new(),
+        provenance: Default::default(),
         passed: true,
         memory: None,
         artifacts: BTreeMap::new(),
@@ -47,6 +48,7 @@ pub(crate) fn results_with_scenarios(
     BenchResults {
         component_id: component_id.to_string(),
         iterations,
+        provenance: Default::default(),
         run_metadata: None,
         metadata: BTreeMap::new(),
         metric_groups: BTreeMap::new(),

--- a/src/core/extension/runtime/bench-helper.mjs
+++ b/src/core/extension/runtime/bench-helper.mjs
@@ -64,6 +64,7 @@ export function homeboyBenchScenarioInventoryEntry({
     tags = [],
     metrics = {},
     metadata,
+    provenance,
     artifacts,
 }) {
     const scenario = {
@@ -76,6 +77,7 @@ export function homeboyBenchScenarioInventoryEntry({
     if (file) scenario.file = file;
     if (source) scenario.source = source;
     if (metadata && Object.keys(metadata).length > 0) scenario.metadata = metadata;
+    if (provenance && Object.keys(provenance).length > 0) scenario.provenance = provenance;
     if (artifacts && Object.keys(artifacts).length > 0) scenario.artifacts = artifacts;
     return scenario;
 }

--- a/src/core/extension/runtime/bench-helper.php
+++ b/src/core/extension/runtime/bench-helper.php
@@ -80,7 +80,7 @@ function homeboy_bench_scenario_inventory_entry(array $scenario): array {
         $entry['default_iterations'] = (int) $scenario['default_iterations'];
     }
 
-    foreach (['file', 'source', 'metadata', 'artifacts'] as $key) {
+    foreach (['file', 'source', 'metadata', 'provenance', 'artifacts'] as $key) {
         if (isset($scenario[$key]) && $scenario[$key] !== [] && $scenario[$key] !== '') {
             $entry[$key] = $scenario[$key];
         }

--- a/tests/commands/bench/observation_artifact_test.rs
+++ b/tests/commands/bench/observation_artifact_test.rs
@@ -116,6 +116,7 @@ fn bench_observation_resolves_shared_state_mount_artifacts() {
             selected_scenarios: Vec::new(),
             env_overrides: Default::default(),
             workloads: Vec::new(),
+            provenance: Default::default(),
             runner: None,
             diagnostics: Vec::new(),
         });

--- a/tests/core/extension/bench/phase_tag_test.rs
+++ b/tests/core/extension/bench/phase_tag_test.rs
@@ -55,6 +55,7 @@ fn results_with(
     BenchResults {
         component_id: "demo".to_string(),
         iterations: 10,
+        provenance: Default::default(),
         run_metadata: None,
         metadata: BTreeMap::new(),
         metric_groups: BTreeMap::new(),

--- a/tests/core/extension/bench/report_comparison_test.rs
+++ b/tests/core/extension/bench/report_comparison_test.rs
@@ -41,6 +41,7 @@ mod fixtures {
             gates: Vec::new(),
             gate_results: Vec::new(),
             metadata: BTreeMap::new(),
+            provenance: Default::default(),
             passed: true,
             memory: None,
             artifacts: BTreeMap::new(),
@@ -107,6 +108,7 @@ mod fixtures {
         BenchResults {
             component_id: "studio".to_string(),
             iterations: 10,
+            provenance: Default::default(),
             run_metadata: None,
             metadata: BTreeMap::new(),
             metric_groups: BTreeMap::new(),


### PR DESCRIPTION
## Summary
- Add a typed, optional bench `provenance` contract with `links` and `labels` for run-level and scenario/workload-level external tracker references.
- Persist provenance into bench run metadata and surface it in `bench compare` JSON plus Markdown reports with clickable links.
- Keep legacy extension marker provenance compatible and clean up duplicate trace `metrics` fields that blocked compilation on this branch.

Closes #4004.

## Verification
- `cargo test core::extension::bench::parsing::tests::parses_top_level_and_scenario_provenance`
- `cargo test core::extension::bench::parsing::tests::parses_extension_bench_result_markers_and_sample_metrics`
- `cargo test core::extension::bench::run_metadata::tests::run_metadata_captures_reproducible_bench_context`
- `cargo test commands::runs::bench::tests::bench_compare_reports_deltas_and_missing_metrics`
- `cargo test observation_artifact`
- `cargo test core::extension::trace::parsing`

## Known verification gap
- `cargo test` passes library and binary tests, then fails `tests/core_agnostic_test.rs::core_owned_source_stays_language_and_framework_agnostic` with broad existing ecosystem-term audit findings across core files. I did not update that audit baseline in this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the bench provenance implementation, compatibility handling, tests, docs, and verification/PR workflow for Chris to review.