### PR TITLE
Fix Codebox cook cwd materialization in Lab offload

### DIFF
--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -246,6 +246,7 @@ fn lab_workspace_sync_mode(
     }
 
     if agent_task_codebox_cwd_requires_git_checkout(args) {
+        preflight_agent_task_codebox_cwd_git_checkout(source_path)?;
         return Ok(RunnerWorkspaceSyncMode::Git);
     }
 
@@ -256,6 +257,22 @@ fn lab_workspace_sync_mode(
     }
 
     Ok(requested)
+}
+
+fn preflight_agent_task_codebox_cwd_git_checkout(source_path: &Path) -> Result<()> {
+    if super::workspace::git_output(source_path, &["rev-parse", "--is-inside-work-tree"]).is_ok() {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "cwd",
+        "Lab offload cannot materialize agent-task Codebox --cwd as a git checkout because --cwd is not inside a git worktree",
+        Some(source_path.display().to_string()),
+        Some(vec![
+            "Pass --cwd <git-worktree> for Codebox cook tasks so Lab can rematerialize the checkout on the runner.".to_string(),
+            "Create an isolated Homeboy/Data Machine Code worktree before running agent-task cook --backend codebox.".to_string(),
+        ]),
+    ))
 }
 
 fn agent_task_codebox_cwd_requires_git_checkout(args: &[String]) -> bool {
@@ -1588,6 +1605,35 @@ mod tests {
         .expect("sync mode");
 
         assert_eq!(mode, RunnerWorkspaceSyncMode::Git);
+    }
+
+    #[test]
+    fn agent_task_cook_codebox_cwd_requires_git_checkout_before_lab_dispatch() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--cwd".to_string(),
+            dir.path().display().to_string(),
+            "--backend".to_string(),
+            "codebox".to_string(),
+            "--prompt".to_string(),
+            "prove it".to_string(),
+        ];
+
+        let err = lab_workspace_sync_mode(
+            LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+            &args,
+            dir.path(),
+        )
+        .expect_err("non-git cwd must fail before Lab dispatch");
+
+        assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(err.details["field"], "cwd");
+        assert!(err
+            .message
+            .contains("cannot materialize agent-task Codebox --cwd as a git checkout"));
     }
 
     #[test]

--- a/src/core/runner/lab_arg_tests.rs
+++ b/src/core/runner/lab_arg_tests.rs
@@ -33,6 +33,80 @@ fn rewrites_lab_offload_path_and_strips_runner_and_output_flags() {
 }
 
 #[test]
+fn rewrites_agent_task_cook_codebox_cwd_to_materialized_checkout() {
+    let input = args(&[
+        "homeboy",
+        "agent-task",
+        "cook",
+        "--cwd",
+        "/Users/chubes/Developer/homeboy@fix-issue-4010-cook-cwd-materialization",
+        "--backend",
+        "codebox",
+        "--runner",
+        "lab",
+        "--prompt",
+        "fix issue 4010",
+    ]);
+
+    assert_eq!(
+        rewrite_lab_offload_args(
+            &input,
+            "/home/chubes/_lab_workspaces/homeboy@fix-issue-4010-cook-cwd-materialization-abc",
+            &[],
+        ),
+        args(&[
+            "homeboy",
+            "--force-hot",
+            "agent-task",
+            "cook",
+            "--cwd",
+            "/home/chubes/_lab_workspaces/homeboy@fix-issue-4010-cook-cwd-materialization-abc",
+            "--backend",
+            "codebox",
+            "--prompt",
+            "fix issue 4010",
+        ])
+    );
+}
+
+#[test]
+fn rewrites_agent_task_cook_codebox_cwd_equals_with_workspace_mapping() {
+    let input = args(&[
+        "homeboy",
+        "agent-task",
+        "cook",
+        "--cwd=/Users/chubes/Developer/homeboy@fix-issue-4010-cook-cwd-materialization/packages/demo",
+        "--backend=codebox",
+        "--prompt",
+        "fix issue 4010",
+    ]);
+    let mappings = vec![LabPathRemap {
+        local: "/Users/chubes/Developer/homeboy@fix-issue-4010-cook-cwd-materialization"
+            .to_string(),
+        remote: "/home/chubes/_lab_workspaces/homeboy@fix-issue-4010-cook-cwd-materialization-abc"
+            .to_string(),
+    }];
+
+    assert_eq!(
+        rewrite_lab_offload_args(
+            &input,
+            "/home/chubes/_lab_workspaces/homeboy@fix-issue-4010-cook-cwd-materialization-abc",
+            &mappings,
+        ),
+        args(&[
+            "homeboy",
+            "--force-hot",
+            "agent-task",
+            "cook",
+            "--cwd=/home/chubes/_lab_workspaces/homeboy@fix-issue-4010-cook-cwd-materialization-abc/packages/demo",
+            "--backend=codebox",
+            "--prompt",
+            "fix issue 4010",
+        ])
+    );
+}
+
+#[test]
 fn leaves_passthrough_path_args_untouched() {
     let input = args(&[
         "homeboy",


### PR DESCRIPTION
## Summary
- Keep `agent-task cook --cwd <git-worktree> --backend codebox` on Lab's git workspace sync path so the runner receives a materialized git checkout.
- Add a controller-side preflight error when Codebox `--cwd` is not inside a git worktree, before dispatching to Lab.
- Cover cook-specific `--cwd` path rewriting/materialization for both split and equals forms.

Fixes #4010

## Tests
- `cargo fmt --check`
- `cargo test rewrites_agent_task_cook_codebox_cwd`
- `cargo test agent_task_cook_codebox_cwd`
- `cargo test lab_arg_tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted implementation and targeted tests; Chris reviews and owns the change.