### PR TITLE
Persist Lab pre-dispatch agent task failures

### DIFF
--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -5,11 +5,15 @@ use std::path::PathBuf;
 use uuid::Uuid;
 
 use crate::core::agent_task::{
-    AgentTaskArtifact, AgentTaskEvidenceRef, AgentTaskExecutionHandle, AgentTaskOutcome,
-    AgentTaskWorkflowEvidence,
+    AgentTaskArtifact, AgentTaskEvidenceRef, AgentTaskExecutionHandle, AgentTaskExecutor,
+    AgentTaskFailureClassification, AgentTaskLimits, AgentTaskOutcome, AgentTaskOutcomeStatus,
+    AgentTaskPolicy, AgentTaskRequest, AgentTaskSourceRef, AgentTaskWorkflowEvidence,
+    AgentTaskWorkspace, AgentTaskWorkspaceMode, AGENT_TASK_OUTCOME_SCHEMA,
+    AGENT_TASK_REQUEST_SCHEMA,
 };
 use crate::core::agent_task_scheduler::{
-    AgentTaskAggregate, AgentTaskPlan, AgentTaskProgressEvent, AgentTaskState,
+    AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals, AgentTaskPlan,
+    AgentTaskProgressEvent, AgentTaskQueueStatus, AgentTaskState, AGENT_TASK_AGGREGATE_SCHEMA,
 };
 use crate::core::{paths, Error, ErrorCode, Result};
 
@@ -342,6 +346,149 @@ pub fn record_run_aggregate(
 ) -> Result<AgentTaskRunRecord> {
     let mut record = store::read_record(&sanitize_run_id(run_id))?;
     record_aggregate(&mut record, plan, aggregate)
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentTaskPreDispatchFailure<'a> {
+    pub run_id: &'a str,
+    pub local_command: Vec<String>,
+    pub remote_command: Vec<String>,
+    pub runner_id: &'a str,
+    pub remote_workspace: &'a str,
+    pub failure_message: &'a str,
+    pub stdout: &'a str,
+    pub stderr: &'a str,
+    pub exit_code: i32,
+}
+
+pub fn record_pre_dispatch_failure(
+    failure: AgentTaskPreDispatchFailure<'_>,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(failure.run_id);
+    if let Ok(record) = status(&run_id) {
+        return Ok(record);
+    }
+
+    let task_id = "agent-task-predispatch".to_string();
+    let metadata = json!({
+        "kind": "lab_offload_pre_dispatch_failure",
+        "runner_id": failure.runner_id,
+        "remote_workspace": failure.remote_workspace,
+        "local_command": failure.local_command,
+        "remote_command": failure.remote_command,
+        "exit_code": failure.exit_code,
+        "failure_message": failure.failure_message,
+    });
+    let plan = AgentTaskPlan::new(
+        format!("{run_id}.predispatch"),
+        vec![AgentTaskRequest {
+            schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id: task_id.clone(),
+            group_key: Some("lab-offload".to_string()),
+            parent_plan_id: None,
+            executor: AgentTaskExecutor {
+                backend: "homeboy-lab".to_string(),
+                selector: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                model: None,
+                config: Value::Null,
+            },
+            instructions: "Persist Lab offload pre-dispatch validation failure evidence."
+                .to_string(),
+            inputs: json!({
+                "local_command": failure.local_command,
+                "remote_command": failure.remote_command,
+                "runner_id": failure.runner_id,
+                "remote_workspace": failure.remote_workspace,
+                "failure": {
+                    "message": failure.failure_message,
+                    "exit_code": failure.exit_code,
+                    "stdout": failure.stdout,
+                    "stderr": failure.stderr,
+                }
+            }),
+            source_refs: vec![AgentTaskSourceRef {
+                kind: "lab-offload-run".to_string(),
+                uri: format!("homeboy://agent-task/run/{run_id}/lab-offload"),
+                revision: None,
+            }],
+            workspace: AgentTaskWorkspace {
+                mode: AgentTaskWorkspaceMode::Existing,
+                root: Some(failure.remote_workspace.to_string()),
+                slug: None,
+                kind: Some("lab-offload".to_string()),
+                component_id: None,
+                branch: None,
+                base_ref: None,
+                task_url: None,
+                cleanup: Some("preserve".to_string()),
+                materialization: metadata.clone(),
+            },
+            policy: AgentTaskPolicy::default(),
+            limits: AgentTaskLimits::default(),
+            expected_artifacts: Vec::new(),
+            metadata: metadata.clone(),
+        }],
+    );
+    submit_plan(&plan, Some(&run_id))?;
+    let aggregate = AgentTaskAggregate {
+        schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+        plan_id: plan.plan_id.clone(),
+        status: AgentTaskAggregateStatus::Failed,
+        totals: AgentTaskAggregateTotals {
+            failed: 1,
+            ..AgentTaskAggregateTotals::default()
+        },
+        outcomes: vec![AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: task_id.clone(),
+            status: AgentTaskOutcomeStatus::Failed,
+            summary: Some(failure.failure_message.to_string()),
+            failure_classification: Some(AgentTaskFailureClassification::InvalidInput),
+            artifacts: Vec::new(),
+            evidence_refs: vec![AgentTaskEvidenceRef {
+                kind: "lab-offload-pre-dispatch-failure".to_string(),
+                uri: format!("homeboy://agent-task/run/{run_id}/logs"),
+                label: Some("Lab offload pre-dispatch failure".to_string()),
+            }],
+            diagnostics: Vec::new(),
+            outputs: json!({
+                "schema": "homeboy/agent-task-predispatch-failure/v1",
+                "runner_id": failure.runner_id,
+                "remote_workspace": failure.remote_workspace,
+                "local_command": failure.local_command,
+                "remote_command": failure.remote_command,
+                "exit_code": failure.exit_code,
+                "stdout": failure.stdout,
+                "stderr": failure.stderr,
+            }),
+            workflow: None,
+            follow_up: None,
+            metadata,
+        }],
+        events: vec![
+            AgentTaskProgressEvent {
+                task_id: task_id.clone(),
+                state: AgentTaskState::Queued,
+                attempt: 1,
+                message: Some("Lab offload selected and remote command prepared".to_string()),
+            },
+            AgentTaskProgressEvent {
+                task_id,
+                state: AgentTaskState::Failed,
+                attempt: 1,
+                message: Some(failure.failure_message.to_string()),
+            },
+        ],
+        artifact_lineage: Vec::new(),
+        queue: AgentTaskQueueStatus {
+            max_concurrency: 1,
+            completed: 1,
+            ..AgentTaskQueueStatus::default()
+        },
+    };
+    record_run_aggregate(&run_id, &plan, &aggregate)
 }
 
 fn record_aggregate(
@@ -776,6 +923,50 @@ mod tests {
             assert_eq!(
                 loaded.tasks[0].provider_ref.as_deref(),
                 Some("test:fixture")
+            );
+        });
+    }
+
+    #[test]
+    fn pre_dispatch_failure_persists_failed_run_without_provider_handle() {
+        with_isolated_home(|_| {
+            let record = record_pre_dispatch_failure(AgentTaskPreDispatchFailure {
+                run_id: "cook-lab-predispatch",
+                local_command: vec![
+                    "homeboy".to_string(),
+                    "agent-task".to_string(),
+                    "cook".to_string(),
+                    "--run-id".to_string(),
+                    "cook-lab-predispatch".to_string(),
+                ],
+                remote_command: vec![
+                    "homeboy".to_string(),
+                    "agent-task".to_string(),
+                    "cook".to_string(),
+                    "--cwd".to_string(),
+                    "/runner/workspace/repo".to_string(),
+                ],
+                runner_id: "lab-a",
+                remote_workspace: "/runner/workspace/repo",
+                failure_message: "Invalid argument 'cwd': agent-task Codebox dispatch requires --cwd to be a git checkout",
+                stdout: "",
+                stderr: "Invalid argument 'cwd': agent-task Codebox dispatch requires --cwd to be a git checkout\n",
+                exit_code: 1,
+            })
+            .expect("pre-dispatch failure recorded");
+
+            let loaded = status("cook-lab-predispatch").expect("status loaded");
+            let log = logs("cook-lab-predispatch").expect("logs loaded");
+
+            assert_eq!(record.state, AgentTaskRunState::Failed);
+            assert_eq!(loaded.state, AgentTaskRunState::Failed);
+            assert_eq!(loaded.tasks[0].state, AgentTaskState::Failed);
+            assert!(loaded.provider_handles.is_empty());
+            assert_eq!(log.events[1].state, AgentTaskState::Failed);
+            assert_eq!(loaded.metadata["provider_run_ids"], serde_json::json!([]));
+            assert_eq!(
+                loaded.artifact_refs[0].kind,
+                "lab-offload-pre-dispatch-failure"
             );
         });
     }

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -782,6 +782,7 @@ fn run_lab_offload_inner(
             .into_iter()
             .skip(1),
     );
+    let remote_command = command.clone();
     plan = with_step(
         plan,
         PlanStep::ready("lab.rewrite_args", "lab.rewrite_args")
@@ -948,6 +949,30 @@ fn run_lab_offload_inner(
         stderr.push('\n');
     }
     stderr.push_str(&exec_output.stderr);
+    if exit_code != 0 {
+        if let Some(run_id) = agent_task_dispatch_requested_run_id(request.normalized_args) {
+            let failure_message = lab_pre_dispatch_failure_message(&exec_output.stderr)
+                .or_else(|| lab_pre_dispatch_failure_message(&exec_output.stdout))
+                .unwrap_or_else(|| format!("offloaded agent-task command exited with {exit_code}"));
+            let record = agent_task_lifecycle::record_pre_dispatch_failure(
+                agent_task_lifecycle::AgentTaskPreDispatchFailure {
+                    run_id: &run_id,
+                    local_command: request.normalized_args.to_vec(),
+                    remote_command: remote_command.clone(),
+                    runner_id,
+                    remote_workspace: &remote_cwd,
+                    failure_message: &failure_message,
+                    stdout: &exec_output.stdout,
+                    stderr: &exec_output.stderr,
+                    exit_code,
+                },
+            )?;
+            stderr.push_str(&format!(
+                "Persisted agent-task pre-dispatch failure evidence for run `{}`. Inspect with `homeboy agent-task status {}` and `homeboy agent-task logs {}`.\n",
+                record.run_id, record.run_id, record.run_id
+            ));
+        }
+    }
 
     Ok(LabOffloadOutcome::Offloaded {
         plan,
@@ -1196,6 +1221,37 @@ fn agent_task_run_plan_recording_args(args: &[String]) -> Option<(String, String
     }
 
     Some((plan?, record_run_id?))
+}
+
+fn agent_task_dispatch_requested_run_id(args: &[String]) -> Option<String> {
+    if args.get(1).map(String::as_str) != Some("agent-task")
+        || !matches!(args.get(2).map(String::as_str), Some("dispatch" | "cook"))
+    {
+        return None;
+    }
+
+    let mut iter = args.iter().skip(3);
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--run-id" {
+            return iter.next().cloned();
+        }
+        if let Some(value) = arg.strip_prefix("--run-id=") {
+            return (!value.is_empty()).then(|| value.to_string());
+        }
+    }
+
+    None
+}
+
+fn lab_pre_dispatch_failure_message(output: &str) -> Option<String> {
+    output
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_string)
 }
 
 fn hydrate_agent_task_secret_env(
@@ -1848,6 +1904,38 @@ mod tests {
         let stdout = "{\"success\":true,\"data\":{\"command\":\"extension.setup\"}}";
 
         mirror_agent_task_run_plan_lifecycle(&args, stdout).expect("ignore non-aggregate output");
+    }
+
+    #[test]
+    fn agent_task_dispatch_requested_run_id_accepts_cook_and_dispatch() {
+        assert_eq!(
+            agent_task_dispatch_requested_run_id(&[
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--run-id".to_string(),
+                "cook-run".to_string(),
+            ]),
+            Some("cook-run".to_string())
+        );
+        assert_eq!(
+            agent_task_dispatch_requested_run_id(&[
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "dispatch".to_string(),
+                "--run-id=dispatch-run".to_string(),
+            ]),
+            Some("dispatch-run".to_string())
+        );
+        assert_eq!(
+            agent_task_dispatch_requested_run_id(&[
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "status".to_string(),
+                "dispatch-run".to_string(),
+            ]),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Persist a synthetic failed agent-task lifecycle record for offloaded `agent-task cook`/`dispatch` failures when a requested `--run-id` exists and remote dispatch exits before provider execution.
- Store local command, rewritten remote command, runner id, remote workspace, stdout/stderr, and exit code in the run aggregate/evidence surface.
- Keep provider handles empty and task state failed so no provider task is marked running when dispatch never happened.

Closes #4011.

## Tests
- `cargo test pre_dispatch_failure_persists_failed_run_without_provider_handle`
- `cargo test agent_task_dispatch_requested_run_id_accepts_cook_and_dispatch`
- `cargo test core::refactor::plan::sources::tests::lint_stage_empty_selected_files_does_not_fall_back_to_broad_lint`
- `cargo test` partially passed the library suite on retry: `4230 passed; 0 failed; 18 ignored` before integration tests continued.

## Known blocker
- `cargo test` currently fails in `tests/core_agnostic_test.rs::core_owned_source_stays_language_and_framework_agnostic` with pre-existing/non-touched core-boundary findings in files such as `src/commands/doctor/resources.rs`, `src/core/defaults/builtins.rs`, and `src/core/extension/runtime/bench-helper.php`.
- An earlier full-suite run had one transient temp-directory failure in `core::refactor::plan::sources::tests::lint_stage_empty_selected_files_does_not_fall_back_to_broad_lint`; that test passed when rerun directly.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the targeted Lab/offload lifecycle persistence fix, adding focused coverage, and running verification; Chris remains responsible for review and acceptance.