### PR TITLE
Index nested publication artifacts

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -449,6 +449,9 @@ fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
 pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
     require_run(&store, run_id)?;
+    homeboy::core::publication_artifacts::index_remote_published_artifact_refs_for_run(
+        &store, run_id,
+    )?;
     Ok((
         RunsOutput::Artifacts(RunsArtifactsOutput {
             command: "runs.artifacts",
@@ -470,6 +473,10 @@ fn artifact_command(args: RunsArtifactArgs) -> CmdResult<RunsOutput> {
 fn artifact_get(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
     require_run(&store, &args.run_id)?;
+    homeboy::core::publication_artifacts::index_remote_published_artifact_refs_for_run(
+        &store,
+        &args.run_id,
+    )?;
     let artifact = store
         .get_artifact_for_run_token(&args.run_id, &args.artifact_id)?
         .ok_or_else(|| {

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -470,14 +470,16 @@ fn artifact_command(args: RunsArtifactArgs) -> CmdResult<RunsOutput> {
 fn artifact_get(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
     require_run(&store, &args.run_id)?;
-    let artifact = store.get_artifact(&args.artifact_id)?.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "artifact_id",
-            format!("artifact record not found: {}", args.artifact_id),
-            Some(args.artifact_id.clone()),
-            None,
-        )
-    })?;
+    let artifact = store
+        .get_artifact_for_run_token(&args.run_id, &args.artifact_id)?
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "artifact_id",
+                format!("artifact record not found: {}", args.artifact_id),
+                Some(args.artifact_id.clone()),
+                None,
+            )
+        })?;
 
     if artifact.run_id != args.run_id {
         return Err(Error::validation_invalid_argument(

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -15,7 +15,7 @@ use crate::core::error::{Error, Result};
 use crate::core::observation::{
     running_status_note, FindingListFilter, ObservationStore, RunListFilter, RunRecord,
 };
-use crate::core::{component, git, rig, stack};
+use crate::core::{component, git, paths, rig, runner, stack};
 
 mod analysis_job_runner;
 mod sandbox_tools;
@@ -425,14 +425,9 @@ fn enqueue_sandbox_tool_job(
 fn artifact_content(run_id: &str, artifact_id: &str) -> Result<Value> {
     let store = ObservationStore::open_initialized()?;
     require_run(&store, run_id)?;
-    let artifact = store.get_artifact(artifact_id)?.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "artifact_id",
-            format!("artifact record not found: {artifact_id}"),
-            Some(artifact_id.to_string()),
-            None,
-        )
-    })?;
+    let Some(artifact) = store.get_artifact(artifact_id)? else {
+        return artifact_store_content(run_id, artifact_id);
+    };
     if artifact.run_id != run_id {
         return Err(Error::validation_invalid_argument(
             "artifact_id",
@@ -473,6 +468,59 @@ fn artifact_content(run_id: &str, artifact_id: &str) -> Result<Value> {
         "sha256": artifact.sha256,
         "content_base64": base64::engine::general_purpose::STANDARD.encode(content),
     }))
+}
+
+fn artifact_store_content(run_id: &str, artifact_id: &str) -> Result<Value> {
+    let decoded_artifact_id = crate::core::execution_contract::decode_uri_component(artifact_id);
+    let locator = runner::artifact_store_locator_from_runner_artifact_id(&decoded_artifact_id)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "artifact_id",
+                format!("artifact record not found: {artifact_id}"),
+                Some(artifact_id.to_string()),
+                None,
+            )
+        })?;
+    let path = safe_artifact_store_path(&locator)?;
+    let content = std::fs::read(&path).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("read artifact-store locator {}", path.display())),
+        )
+    })?;
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(artifact_id);
+    let size_bytes = i64::try_from(content.len()).ok();
+    let sha256 = crate::core::artifact_metadata::sha256_file(&path).ok();
+    Ok(json!({
+        "command": "api.runs.artifact.content",
+        "run_id": run_id,
+        "artifact_id": artifact_id,
+        "filename": filename,
+        "mime": crate::core::artifact_metadata::content_type_from_path(&path),
+        "size_bytes": size_bytes,
+        "sha256": sha256,
+        "content_base64": base64::engine::general_purpose::STANDARD.encode(content),
+    }))
+}
+
+fn safe_artifact_store_path(locator: &str) -> Result<std::path::PathBuf> {
+    let locator_path = std::path::PathBuf::from(locator);
+    if locator_path.is_absolute()
+        || locator_path
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            "artifact-store locator must stay under the artifact root",
+            Some(locator.to_string()),
+            None,
+        ));
+    }
+    Ok(paths::artifact_root()?.join(locator_path))
 }
 
 fn path_segments(path: &str) -> Vec<String> {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -56,7 +56,7 @@ pub mod process;
 pub mod product_identity;
 pub mod project;
 pub mod proof;
-pub(crate) mod publication_artifacts;
+pub mod publication_artifacts;
 pub mod quality;
 pub mod redaction;
 pub mod refactor;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -56,6 +56,7 @@ pub mod process;
 pub mod product_identity;
 pub mod project;
 pub mod proof;
+pub(crate) mod publication_artifacts;
 pub mod quality;
 pub mod redaction;
 pub mod refactor;

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -414,14 +414,17 @@ impl ObservationStore {
             )
             .map_err(sqlite_error("insert artifact record"))?;
 
-        self.list_artifacts(run_id)?
+        let artifact = self
+            .list_artifacts(run_id)?
             .into_iter()
             .find(|artifact| artifact.id == id)
             .ok_or_else(|| {
                 Error::internal_unexpected(format!(
                     "Inserted artifact record {id} but could not read it back"
                 ))
-            })
+            })?;
+        crate::core::publication_artifacts::index_published_artifact_refs(self, &artifact)?;
+        Ok(artifact)
     }
 
     pub fn record_directory_artifact(
@@ -611,6 +614,33 @@ impl ObservationStore {
             )
             .optional()
             .map_err(sqlite_error("read artifact record"))
+    }
+
+    pub fn get_artifact_for_run_token(
+        &self,
+        run_id: &str,
+        artifact_token: &str,
+    ) -> Result<Option<ArtifactRecord>> {
+        validate_required("run_id", run_id)?;
+        validate_required("artifact_token", artifact_token)?;
+        for artifact in self.list_artifacts(run_id)? {
+            if artifact.id == artifact_token
+                || artifact.kind == artifact_token
+                || artifact
+                    .metadata_json
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|value| value == artifact_token)
+                || artifact
+                    .metadata_json
+                    .get("original_manifest_id")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|value| value == artifact_token)
+            {
+                return Ok(Some(artifact));
+            }
+        }
+        Ok(None)
     }
 
     pub fn list_artifact_cleanup_candidates(

--- a/src/core/publication_artifacts.rs
+++ b/src/core/publication_artifacts.rs
@@ -3,16 +3,15 @@ use std::path::{Component, Path, PathBuf};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
+use crate::core::execution_contract::{decode_uri_component, EXECUTION_CONTRACT};
 use crate::core::observation::{ArtifactRecord, ObservationStore};
-use crate::core::{paths, Result};
+use crate::core::{paths, runner, Result};
 
 pub(crate) fn index_published_artifact_refs(
     store: &ObservationStore,
     source: &ArtifactRecord,
 ) -> Result<()> {
-    if source.artifact_type != "file"
-        || !source.mime.as_deref().unwrap_or_default().contains("json")
-    {
+    if source.artifact_type != "file" || !json_artifact(source) {
         return Ok(());
     }
 
@@ -26,23 +25,81 @@ pub(crate) fn index_published_artifact_refs(
     };
 
     let artifact_root = paths::artifact_root()?;
+    index_manifest_refs(store, source, &manifest, |locator| {
+        artifact_store_path(&artifact_root, locator).map(|path| {
+            if path.is_file() {
+                IndexedArtifactPath::Local(path)
+            } else {
+                IndexedArtifactPath::Missing
+            }
+        })
+    })
+}
+
+pub fn index_remote_published_artifact_refs_for_run(
+    store: &ObservationStore,
+    run_id: &str,
+) -> Result<()> {
+    for artifact in store.list_artifacts(run_id)? {
+        if !is_remote_publication_manifest_candidate(&artifact) {
+            continue;
+        }
+        let Ok(download) = runner::download_remote_artifact(&artifact.path, None) else {
+            continue;
+        };
+        let Ok(content) = std::fs::read_to_string(&download.output_path) else {
+            continue;
+        };
+        let Ok(manifest) = serde_json::from_str::<Value>(&content) else {
+            continue;
+        };
+        let Some((runner_id, remote_run_id)) = remote_artifact_runner_context(&artifact.path)
+        else {
+            continue;
+        };
+        index_manifest_refs(store, &artifact, &manifest, |locator| {
+            Some(IndexedArtifactPath::Remote(
+                runner::runner_artifact_store_token(&runner_id, &remote_run_id, locator),
+            ))
+        })?;
+    }
+
+    Ok(())
+}
+
+enum IndexedArtifactPath {
+    Local(PathBuf),
+    Remote(String),
+    Missing,
+}
+
+fn index_manifest_refs(
+    store: &ObservationStore,
+    source: &ArtifactRecord,
+    manifest: &Value,
+    mut resolve_path: impl FnMut(&str) -> Option<IndexedArtifactPath>,
+) -> Result<()> {
     let manifest_id = manifest
         .get("id")
         .and_then(Value::as_str)
         .map(str::to_string);
     let mut refs = Vec::new();
-    collect_artifact_store_refs(&manifest, &mut refs);
+    collect_artifact_store_refs(manifest, &mut refs);
 
     for reference in refs {
         let Some(locator) = artifact_store_locator(reference) else {
             continue;
         };
-        let Some(path) = artifact_store_path(&artifact_root, locator) else {
+        let Some(indexed_path) = resolve_path(locator) else {
             continue;
         };
-        if !path.is_file() {
-            continue;
-        }
+        let (artifact_type, path) = match indexed_path {
+            IndexedArtifactPath::Local(path) => {
+                ("file".to_string(), path.to_string_lossy().to_string())
+            }
+            IndexedArtifactPath::Remote(path) => ("remote_file".to_string(), path),
+            IndexedArtifactPath::Missing => continue,
+        };
         let original_manifest_id = reference
             .get("id")
             .and_then(Value::as_str)
@@ -62,7 +119,7 @@ pub(crate) fn index_published_artifact_refs(
             .or_else(|| reference.get("mime"))
             .and_then(Value::as_str)
             .map(str::to_string)
-            .or_else(|| crate::core::artifact_metadata::content_type_from_path(&path));
+            .or_else(|| crate::core::artifact_metadata::content_type_from_path(Path::new(&path)));
         let size_bytes = reference
             .get("bytes")
             .or_else(|| reference.get("size_bytes"))
@@ -100,8 +157,8 @@ pub(crate) fn index_published_artifact_refs(
             id,
             run_id: source.run_id.clone(),
             kind,
-            artifact_type: "file".to_string(),
-            path: path.to_string_lossy().to_string(),
+            artifact_type,
+            path,
             url: None,
             sha256,
             size_bytes,
@@ -151,6 +208,47 @@ fn artifact_store_path(root: &Path, locator: &str) -> Option<PathBuf> {
         return None;
     }
     Some(root.join(locator_path))
+}
+
+fn is_remote_publication_manifest_candidate(artifact: &ArtifactRecord) -> bool {
+    if artifact.artifact_type != "remote_file" || !json_artifact(artifact) {
+        return false;
+    }
+    artifact
+        .metadata_json
+        .get("name")
+        .and_then(Value::as_str)
+        .is_some_and(|name| name.contains("manifest"))
+        || artifact.kind.contains("manifest")
+        || artifact
+            .metadata_json
+            .get("original_path")
+            .and_then(Value::as_str)
+            .is_some_and(|path| path.ends_with("manifest.json"))
+}
+
+fn json_artifact(artifact: &ArtifactRecord) -> bool {
+    artifact
+        .mime
+        .as_deref()
+        .unwrap_or_default()
+        .contains("json")
+}
+
+fn remote_artifact_runner_context(path: &str) -> Option<(String, String)> {
+    let token = EXECUTION_CONTRACT
+        .artifacts
+        .strip_runner_artifact_scheme(path)?;
+    let mut parts = token.split('/');
+    let runner_id = parts.next()?;
+    let run_id = parts.next()?;
+    if runner_id.is_empty() || run_id.is_empty() {
+        return None;
+    }
+    Some((
+        decode_uri_component(runner_id),
+        decode_uri_component(run_id),
+    ))
 }
 
 fn published_artifact_id(source_artifact_id: &str, manifest_id: &str, locator: &str) -> String {

--- a/src/core/publication_artifacts.rs
+++ b/src/core/publication_artifacts.rs
@@ -1,0 +1,169 @@
+use std::path::{Component, Path, PathBuf};
+
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use crate::core::observation::{ArtifactRecord, ObservationStore};
+use crate::core::{paths, Result};
+
+pub(crate) fn index_published_artifact_refs(
+    store: &ObservationStore,
+    source: &ArtifactRecord,
+) -> Result<()> {
+    if source.artifact_type != "file"
+        || !source.mime.as_deref().unwrap_or_default().contains("json")
+    {
+        return Ok(());
+    }
+
+    let content = match std::fs::read_to_string(&source.path) {
+        Ok(content) => content,
+        Err(_) => return Ok(()),
+    };
+    let manifest: Value = match serde_json::from_str(&content) {
+        Ok(manifest) => manifest,
+        Err(_) => return Ok(()),
+    };
+
+    let artifact_root = paths::artifact_root()?;
+    let manifest_id = manifest
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let mut refs = Vec::new();
+    collect_artifact_store_refs(&manifest, &mut refs);
+
+    for reference in refs {
+        let Some(locator) = artifact_store_locator(reference) else {
+            continue;
+        };
+        let Some(path) = artifact_store_path(&artifact_root, locator) else {
+            continue;
+        };
+        if !path.is_file() {
+            continue;
+        }
+        let original_manifest_id = reference
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or(locator);
+        let id = published_artifact_id(&source.id, original_manifest_id, locator);
+        if store.get_artifact(&id)?.is_some() {
+            continue;
+        }
+        let kind = reference
+            .get("kind")
+            .and_then(Value::as_str)
+            .or_else(|| reference.get("role").and_then(Value::as_str))
+            .unwrap_or("published_artifact")
+            .to_string();
+        let media_type = reference
+            .get("media_type")
+            .or_else(|| reference.get("mime"))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .or_else(|| crate::core::artifact_metadata::content_type_from_path(&path));
+        let size_bytes = reference
+            .get("bytes")
+            .or_else(|| reference.get("size_bytes"))
+            .and_then(Value::as_i64);
+        let sha256 = reference
+            .get("sha256")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let created_at = reference
+            .get("created_at")
+            .and_then(Value::as_str)
+            .unwrap_or(&source.created_at)
+            .to_string();
+        let name = artifact_name(original_manifest_id);
+        let metadata_json = json!({
+            "source": "publication_manifest",
+            "source_manifest_artifact_id": source.id,
+            "source_manifest_kind": source.kind,
+            "manifest_id": manifest_id,
+            "original_manifest_id": original_manifest_id,
+            "name": name,
+            "role": reference.get("role").cloned().unwrap_or(Value::Null),
+            "locator": {
+                "type": "artifact-store",
+                "value": locator,
+            },
+            "media_type": media_type,
+            "bytes": size_bytes,
+            "sha256": sha256,
+            "description": reference.get("description").cloned().unwrap_or(Value::Null),
+            "metadata": reference.get("metadata").cloned().unwrap_or(Value::Null),
+        });
+
+        store.import_artifact(&ArtifactRecord {
+            id,
+            run_id: source.run_id.clone(),
+            kind,
+            artifact_type: "file".to_string(),
+            path: path.to_string_lossy().to_string(),
+            url: None,
+            sha256,
+            size_bytes,
+            mime: media_type,
+            metadata_json,
+            created_at,
+        })?;
+    }
+
+    Ok(())
+}
+
+fn collect_artifact_store_refs<'a>(value: &'a Value, refs: &mut Vec<&'a Value>) {
+    match value {
+        Value::Object(object) => {
+            if artifact_store_locator(value).is_some() {
+                refs.push(value);
+            }
+            for child in object.values() {
+                collect_artifact_store_refs(child, refs);
+            }
+        }
+        Value::Array(array) => {
+            for child in array {
+                collect_artifact_store_refs(child, refs);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn artifact_store_locator(reference: &Value) -> Option<&str> {
+    let locator = reference.get("locator")?;
+    if locator.get("type").and_then(Value::as_str)? != "artifact-store" {
+        return None;
+    }
+    locator.get("value").and_then(Value::as_str)
+}
+
+fn artifact_store_path(root: &Path, locator: &str) -> Option<PathBuf> {
+    let locator_path = PathBuf::from(locator);
+    if locator_path.is_absolute()
+        || locator_path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    {
+        return None;
+    }
+    Some(root.join(locator_path))
+}
+
+fn published_artifact_id(source_artifact_id: &str, manifest_id: &str, locator: &str) -> String {
+    let hash = Sha256::digest(format!("{source_artifact_id}\0{manifest_id}\0{locator}").as_bytes());
+    let hex = format!("{hash:x}");
+    format!("{source_artifact_id}-published-{}", &hex[..16])
+}
+
+fn artifact_name(manifest_id: &str) -> String {
+    PathBuf::from(manifest_id)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or(manifest_id)
+        .to_string()
+}

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -19,6 +19,23 @@ pub fn is_remote_runner_artifact_path(path: &str) -> bool {
     EXECUTION_CONTRACT.artifacts.is_runner_artifact_ref(path)
 }
 
+pub fn runner_artifact_store_token(runner_id: &str, run_id: &str, locator: &str) -> String {
+    let encoded_locator = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(locator);
+    runner_artifact_token(
+        runner_id,
+        run_id,
+        &format!("artifact-store:{encoded_locator}"),
+    )
+}
+
+pub(crate) fn artifact_store_locator_from_runner_artifact_id(artifact_id: &str) -> Option<String> {
+    let encoded_locator = artifact_id.strip_prefix("artifact-store:")?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(encoded_locator)
+        .ok()?;
+    String::from_utf8(bytes).ok()
+}
+
 pub fn is_retrievable_runner_artifact(path: &str) -> bool {
     RemoteArtifactToken::parse(path).is_ok()
 }

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -52,6 +52,8 @@ pub(crate) use command_path::{
     normalize_runner_command_env, quote_runner_env_value, remote_shell_path_preamble,
 };
 pub use connection::{connect, connect_reverse, disconnect, status, statuses};
+pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
+pub use evidence::runner_artifact_store_token;
 pub use evidence::{
     download_remote_artifact, is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,
     is_retrievable_runner_artifact, reportable_artifact_evidence_path, RemoteArtifactDownload,

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -377,6 +377,45 @@ fn test_handle() {
 }
 
 #[test]
+fn artifact_content_serves_encoded_artifact_store_locator() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(sample_run("bench", "homeboy", "studio"))
+            .expect("bench run");
+        let locator = "homeboy/workflow-bench/runs/run-1/artifacts/blueprint.after.json";
+        let artifact_root = home.path().join(".local/share/homeboy/artifacts");
+        let path = artifact_root.join(locator);
+        std::fs::create_dir_all(path.parent().expect("artifact parent"))
+            .expect("create artifact parent");
+        std::fs::write(&path, br#"{"steps":[]}"#).expect("artifact-store file");
+        let token = homeboy::core::runner::runner_artifact_store_token("lab", &run.id, locator)
+            .rsplit('/')
+            .next()
+            .expect("artifact token")
+            .to_string();
+
+        let response = http_api::handle(HttpApiRequest {
+            method: HttpMethod::Get,
+            path: format!("/runs/{}/artifacts/{}/content", run.id, token),
+            body: None,
+        })
+        .expect("artifact-store content");
+
+        assert_eq!(response.endpoint, "runs.artifact.content");
+        assert_eq!(response.body["run_id"], run.id);
+        assert_eq!(response.body["filename"], "blueprint.after.json");
+        assert_eq!(response.body["mime"], "application/json");
+        assert_eq!(response.body["size_bytes"], 12);
+        assert_eq!(
+            response.body["content_base64"].as_str(),
+            Some("eyJzdGVwcyI6W119")
+        );
+    });
+}
+
+#[test]
 fn rejects_mutating_endpoint_shapes() {
     assert!(http_api::route(HttpMethod::Post, "/rigs/studio/up").is_err());
     assert!(http_api::route(HttpMethod::Post, "/stacks/studio/apply").is_err());

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -645,7 +645,7 @@ fn publication_manifest_artifact_store_refs_are_indexed() {
                 "artifacts": [{
                     "schema": "example/artifact-reference/v1",
                     "id": "scenario/adapter/attempt-1/blueprint.after",
-                    "kind": "wordpress-playground-blueprint-after",
+                    "kind": "published-blueprint-after",
                     "role": "output",
                     "locator": {
                         "type": "artifact-store",
@@ -671,7 +671,7 @@ fn publication_manifest_artifact_store_refs_are_indexed() {
             .expect("nested artifact indexed");
 
         assert_eq!(artifacts.len(), 2);
-        assert_eq!(nested.kind, "wordpress-playground-blueprint-after");
+        assert_eq!(nested.kind, "published-blueprint-after");
         assert_eq!(nested.artifact_type, "file");
         assert_eq!(nested.path, nested_path.to_string_lossy());
         assert_eq!(nested.mime.as_deref(), Some("application/json"));

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -623,6 +623,84 @@ fn test_record_artifact() {
 }
 
 #[test]
+fn publication_manifest_artifact_store_refs_are_indexed() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("init store");
+        let run = store
+            .start_run(sample_run("bench", "homeboy"))
+            .expect("start run");
+        let locator = "homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/blueprint.after.json";
+        let artifact_root = home.path().join(".local/share/homeboy/artifacts");
+        let nested_path = artifact_root.join(locator);
+        std::fs::create_dir_all(nested_path.parent().expect("nested parent"))
+            .expect("create artifact-store parent");
+        std::fs::write(&nested_path, br#"{"steps":[]}"#).expect("nested artifact");
+        let manifest_path = home.path().join("publication-manifest.json");
+        std::fs::write(
+            &manifest_path,
+            serde_json::json!({
+                "schema": "example/publication-manifest/v1",
+                "id": "publish-run-1",
+                "artifacts": [{
+                    "schema": "example/artifact-reference/v1",
+                    "id": "scenario/adapter/attempt-1/blueprint.after",
+                    "kind": "wordpress-playground-blueprint-after",
+                    "role": "output",
+                    "locator": {
+                        "type": "artifact-store",
+                        "value": locator,
+                    },
+                    "media_type": "application/json",
+                    "bytes": 12,
+                    "sha256": "abc123",
+                    "created_at": "2026-06-11T15:42:42Z"
+                }]
+            })
+            .to_string(),
+        )
+        .expect("manifest artifact");
+
+        let source = store
+            .record_artifact(&run.id, "publication_manifest", &manifest_path)
+            .expect("record manifest");
+        let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
+        let nested = artifacts
+            .iter()
+            .find(|artifact| artifact.id != source.id)
+            .expect("nested artifact indexed");
+
+        assert_eq!(artifacts.len(), 2);
+        assert_eq!(nested.kind, "wordpress-playground-blueprint-after");
+        assert_eq!(nested.artifact_type, "file");
+        assert_eq!(nested.path, nested_path.to_string_lossy());
+        assert_eq!(nested.mime.as_deref(), Some("application/json"));
+        assert_eq!(nested.size_bytes, Some(12));
+        assert_eq!(nested.sha256.as_deref(), Some("abc123"));
+        assert_eq!(
+            nested.metadata_json["source_manifest_artifact_id"].as_str(),
+            Some(source.id.as_str())
+        );
+        assert_eq!(
+            nested.metadata_json["original_manifest_id"].as_str(),
+            Some("scenario/adapter/attempt-1/blueprint.after")
+        );
+        assert_eq!(
+            nested.metadata_json["name"].as_str(),
+            Some("blueprint.after")
+        );
+        assert_eq!(
+            store
+                .get_artifact_for_run_token(&run.id, "blueprint.after")
+                .expect("lookup by name")
+                .expect("artifact by name")
+                .id,
+            nested.id
+        );
+    });
+}
+
+#[test]
 fn test_record_directory_artifact() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();


### PR DESCRIPTION
## Summary
- Index artifact-store references discovered inside JSON publication manifests as first-class run artifact rows.
- Preserve source manifest metadata, original manifest ids, roles, locator values, media type, byte count, and sha256 on nested artifact records.
- Let `homeboy runs artifact get <run> <token>` resolve nested artifacts by stable row id, kind, original manifest id, or derived name such as `blueprint.after`.
- Lazily index remote publication manifests during `runs artifacts` / `runs artifact get`, and fetch nested artifact-store locators through a safe encoded runner artifact token.

Closes #4036.

## Testing
- `cargo fmt`
- `cargo test publication_manifest_artifact_store_refs_are_indexed`
- `cargo test artifact_content_serves_encoded_artifact_store_locator`
- `cargo test core::observation::store::store_test`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the nested publication artifact indexing and artifact-store fetch paths, focused Rust coverage, verification, and PR drafting for Chris to review.