### PR TITLE
Fail fast on trace target compare flag misuse

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -374,6 +374,8 @@ fn run_outputs(mut args: TraceArgs) -> CmdResult<(TraceCommandOutput, Option<Tra
         return Ok(((output, None), exit_code));
     }
 
+    reject_target_compare_flags_without_compare(&args)?;
+
     if args.comp.component.as_deref() == Some("matrix") {
         apply_matrix_target_args(&mut args);
         let (output, exit_code) = matrix::run_scenario_matrix(args)?;
@@ -435,6 +437,19 @@ fn run_outputs(mut args: TraceArgs) -> CmdResult<(TraceCommandOutput, Option<Tra
         attach_profile_output(output, profile);
     }
     Ok(((stdout_output, artifact_output), exit_code))
+}
+
+fn reject_target_compare_flags_without_compare(args: &TraceArgs) -> homeboy::core::Result<()> {
+    if args.baseline_target.is_none() && args.candidate.is_none() {
+        return Ok(());
+    }
+
+    Err(homeboy::core::Error::validation_invalid_argument(
+        "--baseline-target/--candidate",
+        "target compare flags are only supported by `homeboy trace compare`; use `homeboy trace compare <component> <scenario> --baseline-target <target> --candidate <target>`",
+        None,
+        None,
+    ))
 }
 
 pub(super) fn apply_command_target_component(args: &mut TraceArgs) {

--- a/src/commands/trace/tests.rs
+++ b/src/commands/trace/tests.rs
@@ -1,6 +1,7 @@
 use std::fs;
 
 use clap::Parser;
+use homeboy::core::ErrorCode;
 
 use crate::test_support::with_isolated_home;
 
@@ -24,6 +25,34 @@ fn trace_accepts_allow_local_evidence_alias() {
         .expect("trace args parse");
 
     assert!(cli.trace.allow_local_toolchain);
+}
+
+#[test]
+fn trace_rejects_target_compare_flags_without_compare_command() {
+    let cli = TestCli::try_parse_from([
+        "trace",
+        "--baseline-target",
+        "origin/develop",
+        "--candidate",
+        "HEAD",
+        "--repeat",
+        "3",
+        "woocommerce-gateway-stripe",
+        "ece-product-page-waterfall",
+    ])
+    .expect("trace args parse");
+
+    let err = match run(cli.trace, &GlobalArgs {}) {
+        Ok(_) => panic!("target compare flags should fail"),
+        Err(err) => err,
+    };
+
+    assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+    assert_eq!(err.details["field"], "--baseline-target/--candidate");
+    assert!(
+        err.to_string().contains("homeboy trace compare <component> <scenario> --baseline-target <target> --candidate <target>"),
+        "unexpected diagnostic: {err}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Reject `--baseline-target` / `--candidate` outside `homeboy trace compare` before normal trace dispatch can run a misleading aggregate.
- Add a focused regression test for the mistaken command shape from #4038 and the corrected diagnostic.

Fixes #4038.

## Verification
- `cargo test trace_rejects_target_compare_flags_without_compare_command`
- `cargo test commands::trace::`
- `cargo fmt -- --check`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the dispatch guard and regression test; Chris remains responsible for review and merge.