### PR TITLE
Surface advisory assertion failures in browser evidence reports

### DIFF
--- a/src/commands/report/browser_evidence_compare.rs
+++ b/src/commands/report/browser_evidence_compare.rs
@@ -100,6 +100,19 @@ pub struct AssertionStats {
     pub passed: u64,
     pub failed: u64,
     pub skipped: u64,
+    #[serde(default, skip_serializing_if = "is_default_u64")]
+    pub advisory_failed: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed_advisory_assertions: Vec<AssertionFailure>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AssertionFailure {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -128,6 +141,10 @@ pub struct ArtifactComparison {
 pub struct ArtifactRef {
     pub label: String,
     pub target: String,
+}
+
+fn is_default_u64(value: &u64) -> bool {
+    value.eq(&u64::default())
 }
 
 pub fn render_browser_evidence_compare_from_args(
@@ -820,24 +837,57 @@ mod implementation {
 
     fn render_assertions(out: &mut String, variant: &BrowserEvidenceVariantComparison) {
         out.push_str("**Pass/fail assertion deltas**\n");
-        out.push_str("| Set | Total | Passed | Failed | Skipped |\n");
-        out.push_str("| --- | ---: | ---: | ---: | ---: |\n");
+        out.push_str("| Set | Total | Passed | Failed | Advisory failed | Skipped |\n");
+        out.push_str("| --- | ---: | ---: | ---: | ---: | ---: |\n");
         for (label, stats) in [
             ("Baseline", &variant.assertions.baseline),
             ("Candidate", &variant.assertions.candidate),
         ] {
             let _ = writeln!(
                 out,
-                "| {} | {} | {} | {} | {} |",
-                label, stats.total, stats.passed, stats.failed, stats.skipped
+                "| {} | {} | {} | {} | {} | {} |",
+                label,
+                stats.total,
+                stats.passed,
+                stats.failed,
+                stats.advisory_failed,
+                stats.skipped
             );
         }
         let _ = writeln!(
             out,
-            "| Delta | - | {} | {} | - |\n",
+            "| Delta | - | {} | {} | {} | - |\n",
             signed(variant.assertions.pass_delta as f64),
-            signed(variant.assertions.fail_delta as f64)
+            signed(variant.assertions.fail_delta as f64),
+            signed(
+                variant.assertions.candidate.advisory_failed as f64
+                    - variant.assertions.baseline.advisory_failed as f64
+            )
         );
+
+        render_advisory_failures(out, "Baseline", &variant.assertions.baseline);
+        render_advisory_failures(out, "Candidate", &variant.assertions.candidate);
+    }
+
+    fn render_advisory_failures(out: &mut String, label: &str, stats: &AssertionStats) {
+        if stats.failed_advisory_assertions.is_empty() {
+            return;
+        }
+        let _ = writeln!(out, "**{} failed advisory assertions**", label);
+        for failure in &stats.failed_advisory_assertions {
+            let selector = failure
+                .selector
+                .as_deref()
+                .map(|selector| format!(" selector `{}`", selector))
+                .unwrap_or_default();
+            let message = failure
+                .message
+                .as_deref()
+                .map(|message| format!(" - {}", message))
+                .unwrap_or_default();
+            let _ = writeln!(out, "- `{}`{}{}", failure.id, selector, message);
+        }
+        out.push('\n');
     }
 
     fn render_metric_section(
@@ -914,6 +964,7 @@ mod implementation {
                 passed: u64_value(object, "passed").unwrap_or_default(),
                 failed: u64_value(object, "failed").unwrap_or_default(),
                 skipped: u64_value(object, "skipped").unwrap_or_default(),
+                ..AssertionStats::default()
             };
         }
         let mut stats = AssertionStats::default();
@@ -925,12 +976,48 @@ mod implementation {
             stats.total += 1;
             match status {
                 "pass" | "passed" | "ok" | "success" => stats.passed += 1,
-                "fail" | "failed" | "error" => stats.failed += 1,
+                "fail" | "failed" | "error" => {
+                    stats.failed += 1;
+                    if is_advisory_assertion(assertion) {
+                        stats.advisory_failed += 1;
+                        stats
+                            .failed_advisory_assertions
+                            .push(assertion_failure(assertion));
+                    }
+                }
                 "skip" | "skipped" => stats.skipped += 1,
                 _ => {}
             }
         }
         stats
+    }
+
+    fn is_advisory_assertion(assertion: &Value) -> bool {
+        ["severity", "level", "kind", "type"]
+            .iter()
+            .filter_map(|key| assertion.get(*key).and_then(Value::as_str))
+            .any(|value| value.eq_ignore_ascii_case("advisory"))
+            || first_value_string(assertion, &["id"])
+                .is_some_and(|id| id.to_ascii_lowercase().starts_with("advisory:"))
+            || assertion
+                .get("details")
+                .and_then(Value::as_object)
+                .and_then(|details| first_string(details, &["severity", "level", "kind", "type"]))
+                .is_some_and(|value| value.eq_ignore_ascii_case("advisory"))
+    }
+
+    fn assertion_failure(assertion: &Value) -> AssertionFailure {
+        let id = first_value_string(assertion, &["id", "name"])
+            .unwrap_or_else(|| "advisory assertion".to_string());
+        let details = assertion.get("details").and_then(Value::as_object);
+        AssertionFailure {
+            id,
+            selector: first_value_string(assertion, &["selector"])
+                .or_else(|| details.and_then(|details| first_string(details, &["selector"]))),
+            message: first_value_string(assertion, &["message", "failure"]).or_else(|| {
+                details.and_then(|details| first_string(details, &["message", "failure"]))
+            }),
+        }
     }
 
     fn collect_requests(object: &Map<String, Value>, sample: &mut BrowserEvidenceSample) {
@@ -1049,6 +1136,9 @@ mod implementation {
                 acc.passed += sample.assertions.passed;
                 acc.failed += sample.assertions.failed;
                 acc.skipped += sample.assertions.skipped;
+                acc.advisory_failed += sample.assertions.advisory_failed;
+                acc.failed_advisory_assertions
+                    .extend(sample.assertions.failed_advisory_assertions.clone());
                 acc
             })
     }

--- a/tests/report_browser_evidence_compare_test.rs
+++ b/tests/report_browser_evidence_compare_test.rs
@@ -242,6 +242,69 @@ fn compares_browser_evidence_across_multiple_run_dirs() {
 }
 
 #[test]
+fn surfaces_failed_advisory_assertions_in_json_and_markdown() {
+    let root = tmp_dir("advisory-assertions");
+    write_fixture_file(
+        &root.join("baseline"),
+        "browser-evidence.json",
+        r##"{
+            "scenario_id":"checkout",
+            "profile":"desktop",
+            "assertions":[
+                {"id":"advisory:exists:#wc-stripe-express-checkout-element","status":"pass","selector":"#wc-stripe-express-checkout-element"}
+            ],
+            "browser_metrics":{"ready_ms":900}
+        }"##,
+    );
+    write_fixture_file(
+        &root.join("candidate"),
+        "browser-evidence.json",
+        r##"{
+            "scenario_id":"checkout",
+            "profile":"desktop",
+            "assertions":[
+                {
+                    "id":"advisory:exists:#wc-stripe-express-checkout-element",
+                    "status":"fail",
+                    "selector":"#wc-stripe-express-checkout-element",
+                    "message":"expected ECE mount to exist"
+                }
+            ],
+            "browser_metrics":{"ready_ms":900}
+        }"##,
+    );
+
+    let report = browser_evidence_compare_from_args(&args(&root, false)).expect("report renders");
+    let variant = report.variants.first().expect("variant should exist");
+
+    assert_eq!(variant.assertions.baseline.advisory_failed, 0);
+    assert_eq!(variant.assertions.candidate.advisory_failed, 1);
+    assert_eq!(
+        variant.assertions.candidate.failed_advisory_assertions[0]
+            .selector
+            .as_deref(),
+        Some("#wc-stripe-express-checkout-element")
+    );
+    assert!(report
+        .markdown
+        .contains("Candidate failed advisory assertions"));
+    assert!(report
+        .markdown
+        .contains("`advisory:exists:#wc-stripe-express-checkout-element`"));
+    assert!(report
+        .markdown
+        .contains("selector `#wc-stripe-express-checkout-element`"));
+
+    let report_json = serde_json::to_value(&report).expect("report should serialize");
+    assert_eq!(
+        report_json["variants"][0]["assertions"]["candidate"]["advisory_failed"],
+        serde_json::json!(1)
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
 fn promotes_wp_codebox_browser_summary_metrics() {
     let root = tmp_dir("wp-codebox-summary");
     write_fixture_file(


### PR DESCRIPTION
## Summary
- Count failed advisory assertions separately in browser evidence assertion stats.
- List failed advisory assertion IDs/selectors/messages in browser evidence markdown so trace compare browser proof cannot hide missing advisory DOM selectors behind a generic failed count.
- Add coverage for an `advisory:exists:#wc-stripe-express-checkout-element` failure in JSON and markdown output.

Fixes https://github.com/Extra-Chill/homeboy/issues/4041

## Verification
- `cargo fmt --check`
- `cargo test --test report_browser_evidence_compare_test`
- `cargo test --test report_browser_evidence_compare_test --test output_contracts_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the browser evidence report change, added the targeted regression test, and ran focused verification. Chris remains responsible for review and merge.