### PR TITLE
Make rig trace workload expansions visible

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -571,6 +571,7 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::core::Result<TraceRunExecution
     });
     let (extra_workloads, trace_dependencies, runner_capabilities, invocation_requirements) =
         trace_workload_inputs(rig_context.as_ref(), ctx.extension_id.as_deref());
+    warn_rig_owned_trace_workload_expansion(rig_context.as_ref(), ctx.extension_id.as_deref());
     let experiment_settings = trace_experiment_settings(experiment_plan.as_ref())?;
     let mut experiment_env = trace_experiment_env(experiment_plan.as_ref())?;
     experiment_env.extend(args.matrix_env.clone());
@@ -703,6 +704,7 @@ fn run_list(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
     let run_dir = RunDir::create()?;
     let (extra_workloads, trace_dependencies, runner_capabilities, invocation_requirements) =
         trace_workload_inputs(rig_context.as_ref(), ctx.extension_id.as_deref());
+    warn_rig_owned_trace_workload_expansion(rig_context.as_ref(), ctx.extension_id.as_deref());
     let list = extension_trace::run_trace_list_workflow(
         &ctx.component,
         TraceListWorkflowArgs {
@@ -772,6 +774,67 @@ fn trace_workload_inputs(
             id,
         ),
     )
+}
+
+fn warn_rig_owned_trace_workload_expansion(
+    rig_context: Option<&TraceRigContext>,
+    extension_id: Option<&str>,
+) {
+    for warning in rig_owned_trace_workload_expansion_warnings(rig_context, extension_id) {
+        eprintln!("{warning}");
+    }
+}
+
+fn rig_owned_trace_workload_expansion_warnings(
+    rig_context: Option<&TraceRigContext>,
+    extension_id: Option<&str>,
+) -> Vec<String> {
+    let Some((context, id)) = rig_context.zip(extension_id) else {
+        return Vec::new();
+    };
+    let Some((root_label, root)) = context
+        .rig_package_root
+        .as_ref()
+        .map(|root| ("rig package root", root))
+        .or_else(|| {
+            context
+                .rig_config_root
+                .as_ref()
+                .map(|root| ("rig config root", root))
+        })
+    else {
+        return Vec::new();
+    };
+
+    rig::workload_path_expansions_for_extension(
+        &context.rig_spec,
+        rig::RigWorkloadKind::Trace,
+        context.rig_package_root.as_deref(),
+        id,
+    )
+    .into_iter()
+    .filter(|expansion| !path_is_under(&expansion.expanded_path, root))
+    .map(|expansion| {
+        let freshness = if expansion.expanded_path.is_file() {
+            " If this is stale, refresh/reinstall the rig package or sync edits to the executed path before rerunning."
+        } else {
+            " Refresh/reinstall the rig package or check the expanded path before rerunning."
+        };
+        format!(
+            "Warning: rig `{}` owns trace workload `{}`, but it expands outside the {root_label}. Rig source root: `{}`. Executed extra workload path: `{}`.{freshness}",
+            context.rig_spec.id,
+            expansion.declared_path,
+            root.display(),
+            expansion.expanded_path.display(),
+        )
+    })
+    .collect()
+}
+
+fn path_is_under(path: &Path, root: &Path) -> bool {
+    let normalized_path = path.components().collect::<PathBuf>();
+    let normalized_root = root.components().collect::<PathBuf>();
+    normalized_path == normalized_root || normalized_path.starts_with(normalized_root)
 }
 
 #[derive(Clone)]

--- a/src/commands/trace/rig_tests.rs
+++ b/src/commands/trace/rig_tests.rs
@@ -229,6 +229,76 @@ fn rig_trace_list_uses_rig_default_component_and_workloads() {
 }
 
 #[test]
+fn rig_trace_workload_expansion_warns_when_executed_path_differs_from_rig_root() {
+    let rig_root = tempfile::TempDir::new().expect("rig root");
+    let component_dir = tempfile::TempDir::new().expect("component dir");
+    let trace_path = component_dir
+        .path()
+        .join("bench/ece-product-page-waterfall.trace.mjs");
+    fs::create_dir_all(trace_path.parent().expect("trace parent")).expect("trace dir");
+    fs::write(&trace_path, "export default {};").expect("trace workload");
+    let rig_spec: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "wc-stripe-trace",
+            "components": {{
+                "stripe": {{ "path": "{}" }}
+            }},
+            "trace_workloads": {{ "{TRACE_FIXTURE_EXTENSION_ID}": [
+                {{ "path": "${{components.stripe.path}}/bench/ece-product-page-waterfall.trace.mjs" }}
+            ] }}
+        }}"#,
+        component_dir.path().display()
+    ))
+    .expect("parse rig");
+    let context = TraceRigContext {
+        rig_spec,
+        rig_package_root: Some(rig_root.path().to_path_buf()),
+        rig_config_root: None,
+    };
+
+    let warnings = rig_owned_trace_workload_expansion_warnings(
+        Some(&context),
+        Some(TRACE_FIXTURE_EXTENSION_ID),
+    );
+
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].contains("wc-stripe-trace"));
+    assert!(warnings[0]
+        .contains("${components.stripe.path}/bench/ece-product-page-waterfall.trace.mjs"));
+    assert!(warnings[0].contains(&format!("Rig source root: `{}`", rig_root.path().display())));
+    assert!(warnings[0].contains(&format!(
+        "Executed extra workload path: `{}`",
+        trace_path.display()
+    )));
+    assert!(warnings[0].contains("refresh/reinstall the rig package"));
+}
+
+#[test]
+fn rig_trace_workload_expansion_is_quiet_inside_rig_root() {
+    let rig_root = tempfile::TempDir::new().expect("rig root");
+    let rig_spec: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "package-owned-trace",
+            "trace_workloads": {{ "{TRACE_FIXTURE_EXTENSION_ID}": [
+                {{ "path": "${{package.root}}/bench/create-site.trace.mjs" }}
+            ] }}
+        }}"#
+    ))
+    .expect("parse rig");
+    let context = TraceRigContext {
+        rig_spec,
+        rig_package_root: Some(rig_root.path().to_path_buf()),
+        rig_config_root: None,
+    };
+
+    assert!(rig_owned_trace_workload_expansion_warnings(
+        Some(&context),
+        Some(TRACE_FIXTURE_EXTENSION_ID),
+    )
+    .is_empty());
+}
+
+#[test]
 fn rig_trace_list_uses_scoped_workload_preflight() {
     let spec: RigSpec = serde_json::from_str(&format!(
         r#"{{

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -77,7 +77,8 @@ pub use state::{
 pub use workloads::{
     check_groups_for_extension_workloads, extension_ids_for_workloads,
     invocation_requirements_for_extension_workloads, runner_capabilities_for_extension,
-    trace_dependencies_for_extension, workloads_for_extension, RigWorkloadKind,
+    trace_dependencies_for_extension, workload_path_expansions_for_extension,
+    workloads_for_extension, RigWorkloadKind, RigWorkloadPathExpansion,
 };
 
 use crate::core::error::{Error, Result};

--- a/src/core/rig/workloads.rs
+++ b/src/core/rig/workloads.rs
@@ -13,6 +13,12 @@ pub enum RigWorkloadKind {
     Trace,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RigWorkloadPathExpansion {
+    pub declared_path: String,
+    pub expanded_path: PathBuf,
+}
+
 pub fn extension_ids_for_workloads(rig_spec: &RigSpec, kind: RigWorkloadKind) -> Vec<String> {
     let mut ids: Vec<String> = match kind {
         RigWorkloadKind::Bench => rig_spec.bench_workloads.keys().cloned().collect(),
@@ -28,6 +34,18 @@ pub fn workloads_for_extension(
     package_root: Option<&Path>,
     extension_id: &str,
 ) -> Vec<PathBuf> {
+    workload_path_expansions_for_extension(rig_spec, kind, package_root, extension_id)
+        .into_iter()
+        .map(|expansion| expansion.expanded_path)
+        .collect()
+}
+
+pub fn workload_path_expansions_for_extension(
+    rig_spec: &RigSpec,
+    kind: RigWorkloadKind,
+    package_root: Option<&Path>,
+    extension_id: &str,
+) -> Vec<RigWorkloadPathExpansion> {
     let workloads = match kind {
         RigWorkloadKind::Bench => &rig_spec.bench_workloads,
         RigWorkloadKind::Trace => &rig_spec.trace_workloads,
@@ -37,7 +55,10 @@ pub fn workloads_for_extension(
         .get(extension_id)
         .into_iter()
         .flat_map(|paths| paths.iter())
-        .map(|workload| expand_workload_path(rig_spec, package_root, workload.path()))
+        .map(|workload| RigWorkloadPathExpansion {
+            declared_path: workload.path().to_string(),
+            expanded_path: expand_workload_path(rig_spec, package_root, workload.path()),
+        })
         .collect()
 }
 

--- a/tests/core/rig/workloads_test.rs
+++ b/tests/core/rig/workloads_test.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use crate::core::rig::spec::RigSpec;
 use crate::core::rig::{
     check_groups_for_extension_workloads, extension_ids_for_workloads,
-    runner_capabilities_for_extension, trace_dependencies_for_extension, workloads_for_extension,
-    RigWorkloadKind,
+    runner_capabilities_for_extension, trace_dependencies_for_extension,
+    workload_path_expansions_for_extension, workloads_for_extension, RigWorkloadKind,
 };
 
 #[test]
@@ -167,6 +167,42 @@ fn test_extension_workloads_expand_package_root_when_available() {
         vec![PathBuf::from(
             "/tmp/homeboy-rigs/Automattic/studio/bench/studio-app-create-site.trace.mjs"
         )]
+    );
+}
+
+#[test]
+fn test_workload_path_expansions_preserve_declared_and_expanded_paths() {
+    let rig_spec: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "wc-stripe-trace",
+            "components": {
+                "stripe": { "path": "/tmp/woocommerce-gateway-stripe" }
+            },
+            "trace_workloads": {
+                "extension-a": [
+                    { "path": "${components.stripe.path}/bench/ece-product-page-waterfall.trace.mjs" }
+                ]
+            }
+        }"#,
+    )
+    .expect("parse rig spec");
+    let package = PathBuf::from("/tmp/homeboy-rigs/wc-stripe-trace");
+
+    let expansions = workload_path_expansions_for_extension(
+        &rig_spec,
+        RigWorkloadKind::Trace,
+        Some(&package),
+        "extension-a",
+    );
+
+    assert_eq!(expansions.len(), 1);
+    assert_eq!(
+        expansions[0].declared_path,
+        "${components.stripe.path}/bench/ece-product-page-waterfall.trace.mjs"
+    );
+    assert_eq!(
+        expansions[0].expanded_path,
+        PathBuf::from("/tmp/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs")
     );
 }
 


### PR DESCRIPTION
## Summary
- Preserve declared-to-expanded rig workload path metadata while keeping the existing workload path API intact.
- Warn during rig-backed trace run/list setup when a rig-owned trace workload expands outside the rig package/config root, including the rig source root and executed extra workload path.
- Add targeted coverage for expansion metadata and the warning/no-warning trace cases.

Fixes #4039

## Verification
- `cargo fmt`
- `cargo test workloads_test`
- `cargo test commands::trace::rig_tests`
- `cargo check`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the scoped code change, added tests, ran verification, and drafted this PR description. Chris remains responsible for review and merge.