### PR TITLE
Persist nested publication artifact refs

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -934,6 +934,72 @@ mod tests {
     }
 
     #[test]
+    fn artifact_get_fetches_nested_publication_artifact_store_ref() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
+                .expect("run");
+            let locator = "homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/nested-result.json";
+            let package_root = home.path().join("publication-package");
+            let nested_source = package_root.join("scenario/adapter/attempt-1/nested-result.json");
+            std::fs::create_dir_all(nested_source.parent().expect("nested parent"))
+                .expect("create nested parent");
+            std::fs::write(&nested_source, br#"{"nested":true}"#).expect("nested bytes");
+            let manifest_path = package_root.join("manifest.json");
+            std::fs::write(
+                &manifest_path,
+                serde_json::json!({
+                    "id": "publication-run-1",
+                    "artifacts": [{
+                        "id": "scenario/adapter/attempt-1/nested-result",
+                        "kind": "nested-publication-artifact",
+                        "locator": {
+                            "type": "artifact-store",
+                            "value": locator,
+                        },
+                        "media_type": "application/json"
+                    }]
+                })
+                .to_string(),
+            )
+            .expect("manifest bytes");
+            let manifest_artifact = store
+                .record_artifact(&run.id, "publication_manifest", &manifest_path)
+                .expect("record manifest");
+            let artifact_root = home.path().join(".local/share/homeboy/artifacts");
+            let materialized = artifact_root.join(locator);
+
+            assert!(materialized.is_file());
+            let nested = store
+                .get_artifact_for_run_token(&run.id, "nested-result")
+                .expect("lookup nested")
+                .expect("nested artifact indexed");
+            assert_ne!(nested.id, manifest_artifact.id);
+            assert_eq!(nested.path, materialized.to_string_lossy());
+
+            let output_path = home.path().join("downloaded-nested.json");
+            let (output, _) = artifact_get(RunsArtifactGetArgs {
+                run_id: run.id.clone(),
+                artifact_id: "nested-result".to_string(),
+                output: Some(output_path.clone()),
+            })
+            .expect("get nested artifact");
+
+            let RunsOutput::ArtifactGet(output) = output else {
+                panic!("expected artifact get output");
+            };
+            assert_eq!(output.command, "runs.artifact.get");
+            assert_eq!(output.artifact_id, nested.id);
+            assert_eq!(
+                std::fs::read(&output_path).expect("downloaded nested"),
+                br#"{"nested":true}"#
+            );
+        });
+    }
+
+    #[test]
     fn findings_commands_list_and_show_records() {
         with_isolated_home(|_home| {
             let _xdg = XdgGuard::unset();

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -423,7 +423,11 @@ impl ObservationStore {
                     "Inserted artifact record {id} but could not read it back"
                 ))
             })?;
-        crate::core::publication_artifacts::index_published_artifact_refs(self, &artifact)?;
+        crate::core::publication_artifacts::index_published_artifact_refs(
+            self,
+            &artifact,
+            Some(path),
+        )?;
         Ok(artifact)
     }
 

--- a/src/core/publication_artifacts.rs
+++ b/src/core/publication_artifacts.rs
@@ -10,6 +10,7 @@ use crate::core::{paths, runner, Result};
 pub(crate) fn index_published_artifact_refs(
     store: &ObservationStore,
     source: &ArtifactRecord,
+    source_path: Option<&Path>,
 ) -> Result<()> {
     if source.artifact_type != "file" || !json_artifact(source) {
         return Ok(());
@@ -25,14 +26,20 @@ pub(crate) fn index_published_artifact_refs(
     };
 
     let artifact_root = paths::artifact_root()?;
+    let source_bases = source_path
+        .and_then(Path::parent)
+        .into_iter()
+        .map(Path::to_path_buf)
+        .collect::<Vec<_>>();
     index_manifest_refs(store, source, &manifest, |locator| {
-        artifact_store_path(&artifact_root, locator).map(|path| {
-            if path.is_file() {
-                IndexedArtifactPath::Local(path)
-            } else {
-                IndexedArtifactPath::Missing
-            }
-        })
+        let Some(path) = artifact_store_path(&artifact_root, locator) else {
+            return Ok(None);
+        };
+        if path.is_file() || materialize_artifact_store_path(&path, locator, &source_bases)? {
+            Ok(Some(IndexedArtifactPath::Local(path)))
+        } else {
+            Ok(Some(IndexedArtifactPath::Missing))
+        }
     })
 }
 
@@ -58,9 +65,9 @@ pub fn index_remote_published_artifact_refs_for_run(
             continue;
         };
         index_manifest_refs(store, &artifact, &manifest, |locator| {
-            Some(IndexedArtifactPath::Remote(
+            Ok(Some(IndexedArtifactPath::Remote(
                 runner::runner_artifact_store_token(&runner_id, &remote_run_id, locator),
-            ))
+            )))
         })?;
     }
 
@@ -77,7 +84,7 @@ fn index_manifest_refs(
     store: &ObservationStore,
     source: &ArtifactRecord,
     manifest: &Value,
-    mut resolve_path: impl FnMut(&str) -> Option<IndexedArtifactPath>,
+    mut resolve_path: impl FnMut(&str) -> Result<Option<IndexedArtifactPath>>,
 ) -> Result<()> {
     let manifest_id = manifest
         .get("id")
@@ -90,7 +97,7 @@ fn index_manifest_refs(
         let Some(locator) = artifact_store_locator(reference) else {
             continue;
         };
-        let Some(indexed_path) = resolve_path(locator) else {
+        let Some(indexed_path) = resolve_path(locator)? else {
             continue;
         };
         let (artifact_type, path) = match indexed_path {
@@ -208,6 +215,59 @@ fn artifact_store_path(root: &Path, locator: &str) -> Option<PathBuf> {
         return None;
     }
     Some(root.join(locator_path))
+}
+
+fn materialize_artifact_store_path(
+    destination: &Path,
+    locator: &str,
+    source_bases: &[PathBuf],
+) -> Result<bool> {
+    for source_base in source_bases {
+        for source in artifact_store_source_candidates(source_base, locator) {
+            if !source.is_file() {
+                continue;
+            }
+            if let Some(parent) = destination.parent() {
+                std::fs::create_dir_all(parent).map_err(|err| {
+                    crate::core::Error::internal_io(
+                        err.to_string(),
+                        Some(format!("create {}", parent.display())),
+                    )
+                })?;
+            }
+            std::fs::copy(&source, destination).map_err(|err| {
+                crate::core::Error::internal_io(
+                    err.to_string(),
+                    Some(format!(
+                        "copy publication artifact-store ref {} to {}",
+                        source.display(),
+                        destination.display()
+                    )),
+                )
+            })?;
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn artifact_store_source_candidates(source_base: &Path, locator: &str) -> Vec<PathBuf> {
+    let segments = PathBuf::from(locator)
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(segment) => Some(segment.to_os_string()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let mut candidates = Vec::new();
+    for index in 0..segments.len() {
+        let mut candidate = source_base.to_path_buf();
+        for segment in &segments[index..] {
+            candidate.push(segment);
+        }
+        candidates.push(candidate);
+    }
+    candidates
 }
 
 fn is_remote_publication_manifest_candidate(artifact: &ArtifactRecord) -> bool {


### PR DESCRIPTION
## Summary
- Materialize missing publication manifest `artifact-store` references into the persisted Homeboy artifact root when the referenced bytes live next to the source publication package.
- Keep nested publication rows as normal file artifacts so `homeboy runs artifact get <run> <name-or-id>` can fetch them after indexing.
- Add focused coverage for a nested publication manifest `artifact-store` reference that is indexed and retrieved by `artifact get`.

Fixes #4051.

## Tests
- `cargo fmt --check`
- `cargo test artifact_get_fetches_nested_publication_artifact_store_ref`
- `cargo test publication_manifest_artifact_store_refs_are_indexed`
- `cargo test commands::runs::tests::artifact_get`
- `cargo test core::observation::store::store_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated issue #4051, implemented the generic publication artifact-store persistence fix, added regression coverage, and ran the targeted verification commands. Chris remains responsible for review and merge.