### PR TITLE
Filter selected bench scenarios before validation

### DIFF
--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -89,6 +89,14 @@ pub fn parse_bench_results_file_with_artifact_context(
     path: &Path,
     rig_id: Option<&str>,
 ) -> Result<BenchResults> {
+    parse_bench_results_file_with_artifact_context_and_scenarios(path, rig_id, &[])
+}
+
+pub fn parse_bench_results_file_with_artifact_context_and_scenarios(
+    path: &Path,
+    rig_id: Option<&str>,
+    scenario_ids: &[String],
+) -> Result<BenchResults> {
     let content = std::fs::read_to_string(path).map_err(|e| {
         Error::internal_io(
             format!(
@@ -99,7 +107,7 @@ pub fn parse_bench_results_file_with_artifact_context(
             Some("bench.parsing.read".to_string()),
         )
     })?;
-    parse_bench_results_str_with_artifact_context(&content, rig_id)
+    parse_bench_results_str_with_artifact_context_and_scenarios(&content, rig_id, scenario_ids)
 }
 
 /// Parse a raw JSON string into a `BenchResults`.
@@ -110,6 +118,14 @@ pub fn parse_bench_results_str(raw: &str) -> Result<BenchResults> {
 fn parse_bench_results_str_with_artifact_context(
     raw: &str,
     rig_id: Option<&str>,
+) -> Result<BenchResults> {
+    parse_bench_results_str_with_artifact_context_and_scenarios(raw, rig_id, &[])
+}
+
+fn parse_bench_results_str_with_artifact_context_and_scenarios(
+    raw: &str,
+    rig_id: Option<&str>,
+    scenario_ids: &[String],
 ) -> Result<BenchResults> {
     let mut value: serde_json::Value = serde_json::from_str(raw).map_err(|e| {
         Error::internal_json(
@@ -129,6 +145,7 @@ fn parse_bench_results_str_with_artifact_context(
             object.remove("provenance");
         }
     }
+    filter_value_scenarios_by_ids(&mut value, scenario_ids);
     normalize_extension_sample_metrics(&mut value);
     let mut parsed: BenchResults = serde_json::from_value(value).map_err(|e| {
         Error::internal_json(
@@ -143,6 +160,26 @@ fn parse_bench_results_str_with_artifact_context(
     evaluate_spans(&mut parsed);
     artifact_validation::validate_artifact_paths(&parsed, rig_id)?;
     Ok(parsed)
+}
+
+fn filter_value_scenarios_by_ids(value: &mut serde_json::Value, scenario_ids: &[String]) {
+    if scenario_ids.is_empty() {
+        return;
+    }
+
+    let Some(scenarios) = value
+        .get_mut("scenarios")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+
+    scenarios.retain(|scenario| {
+        scenario
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|id| scenario_ids.iter().any(|selected| selected == id))
+    });
 }
 
 fn normalize_extension_sample_metrics(value: &mut serde_json::Value) {
@@ -1103,6 +1140,82 @@ mod tests {
             err.details.get("id").and_then(|v| v.as_str()),
             Some("heavy")
         );
+    }
+
+    #[test]
+    fn selected_parse_ignores_unselected_duplicate_scenario_ids() {
+        let raw = r#"{
+            "component_id": "example",
+            "iterations": 1,
+            "scenarios": [
+                {
+                    "id": "target",
+                    "file": "tests/bench/target.php",
+                    "iterations": 1,
+                    "metrics": { "p95_ms": 5.0 }
+                },
+                {
+                    "id": "unrelated-duplicate",
+                    "file": "tests/bench/first.php",
+                    "iterations": 1,
+                    "metrics": { "p95_ms": 10.0 }
+                },
+                {
+                    "id": "unrelated-duplicate",
+                    "file": "tests/bench/second.php",
+                    "iterations": 1,
+                    "metrics": { "p95_ms": 20.0 }
+                }
+            ]
+        }"#;
+
+        let selected = vec!["target".to_string()];
+        let parsed = parse_bench_results_str_with_artifact_context_and_scenarios(
+            raw,
+            None,
+            &selected,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.scenarios.len(), 1);
+        assert_eq!(parsed.scenarios[0].id, "target");
+    }
+
+    #[test]
+    fn selected_parse_still_rejects_selected_duplicate_scenario_ids() {
+        let raw = r#"{
+            "component_id": "example",
+            "iterations": 1,
+            "scenarios": [
+                {
+                    "id": "target",
+                    "file": "tests/bench/target-one.php",
+                    "iterations": 1,
+                    "metrics": { "p95_ms": 5.0 }
+                },
+                {
+                    "id": "target",
+                    "file": "tests/bench/target-two.php",
+                    "iterations": 1,
+                    "metrics": { "p95_ms": 10.0 }
+                }
+            ]
+        }"#;
+
+        let selected = vec!["target".to_string()];
+        let err = parse_bench_results_str_with_artifact_context_and_scenarios(
+            raw,
+            None,
+            &selected,
+        )
+        .unwrap_err();
+        let problem = err
+            .details
+            .get("problem")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        assert!(problem.contains("duplicate bench scenario id `target`"));
     }
 
     #[test]

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -239,7 +239,11 @@ fn bench_list_result(
     scenario_ids: &[String],
 ) -> Result<BenchListWorkflowResult> {
     let parsed = apply_scenario_filter(
-        parsing::parse_bench_results_file(&results_file)?,
+        parsing::parse_bench_results_file_with_artifact_context_and_scenarios(
+            &results_file,
+            None,
+            scenario_ids,
+        )?,
         scenario_ids,
     )?;
     let count = parsed.scenarios.len();
@@ -356,7 +360,11 @@ fn parse_execution_results_file(
 
     if runner_success {
         return Ok(Some(apply_scenario_filter(
-            parsing::parse_bench_results_file_with_artifact_context(results_file, rig_id)?,
+            parsing::parse_bench_results_file_with_artifact_context_and_scenarios(
+                results_file,
+                rig_id,
+                scenario_ids,
+            )?,
             scenario_ids,
         )?));
     }
@@ -485,7 +493,11 @@ fn discover_bench_scenarios(
         ));
     }
 
-    parsing::parse_bench_results_file(&results_file)
+    parsing::parse_bench_results_file_with_artifact_context_and_scenarios(
+        &results_file,
+        None,
+        &args.scenario_ids,
+    )
 }
 
 fn validate_bench_run_args(args: &BenchRunWorkflowArgs) -> Result<()> {
@@ -1344,9 +1356,10 @@ fn run_concurrent_instances(
         if !path.exists() {
             continue;
         }
-        let parsed = match parsing::parse_bench_results_file_with_artifact_context(
+        let parsed = match parsing::parse_bench_results_file_with_artifact_context_and_scenarios(
             &path,
             args.rig_id.as_deref(),
+            &args.scenario_ids,
         )
         .and_then(|results| apply_scenario_filter(results, &args.scenario_ids))
         {


### PR DESCRIPTION
## Summary
- Filters bench result JSON to explicitly selected scenario IDs before parsing/duplicate validation.
- Keeps duplicate scenario ID validation strict for unfiltered runs and for duplicates of the selected scenario itself.
- Prevents unrelated duplicate scenarios from blocking targeted rig runs, continuing the fix path for Extra-Chill/homeboy-extensions#1266.

## Tests
- `cargo test core::extension::bench::parsing::tests::selected_parse`
- `cargo test core::extension::bench::parsing::tests::rejects_duplicate_scenario_ids_from_same_basename_subdirs`
- `cargo test commands::bench::tests::single_rig_selector_filters_extra_workloads_before_execution`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the selected-scenario duplicate validation path, drafted the implementation and tests, and ran targeted verification. Chris remains responsible for review and merge.

Fixes Extra-Chill/homeboy-extensions#1266