### PR TITLE
Format selected bench parser tests

### DIFF
--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -1170,12 +1170,9 @@ mod tests {
         }"#;
 
         let selected = vec!["target".to_string()];
-        let parsed = parse_bench_results_str_with_artifact_context_and_scenarios(
-            raw,
-            None,
-            &selected,
-        )
-        .unwrap();
+        let parsed =
+            parse_bench_results_str_with_artifact_context_and_scenarios(raw, None, &selected)
+                .unwrap();
 
         assert_eq!(parsed.scenarios.len(), 1);
         assert_eq!(parsed.scenarios[0].id, "target");
@@ -1203,12 +1200,8 @@ mod tests {
         }"#;
 
         let selected = vec!["target".to_string()];
-        let err = parse_bench_results_str_with_artifact_context_and_scenarios(
-            raw,
-            None,
-            &selected,
-        )
-        .unwrap_err();
+        let err = parse_bench_results_str_with_artifact_context_and_scenarios(raw, None, &selected)
+            .unwrap_err();
         let problem = err
             .details
             .get("problem")


### PR DESCRIPTION
## Summary
- Applies rustfmt output to the selected bench parser regression tests merged in #4054.
- Keeps the functional behavior unchanged.

## Tests
- `cargo fmt --check`
- `cargo test core::extension::bench::parsing::tests::selected_parse`

## Context
#4054 contains the Homeboy core fix for Extra-Chill/homeboy-extensions#1266. Updating Homeboy Extensions alone is not sufficient for the reopened duplicate-scenario failure; the runner also needs Homeboy core at or after `b610bbbc`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Identified the rustfmt-only follow-up needed after #4054 and verified targeted formatting/tests. Chris remains responsible for review and merge.