### PR TITLE
Allow Lab runner extension updates

### DIFF
--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -101,6 +101,9 @@ impl Commands {
                 true,
                 LAB_NO_EXTRA_TOOLS,
             ),
+            Commands::Extension(args) if args.is_update_command() => {
+                lab_portable_workload_contract("extension update", None, false, LAB_NO_EXTRA_TOOLS)
+            }
             Commands::Fleet(args) if args.is_hot_resource_command() => {
                 lab_local_only_contract("fleet exec", FLEET_EXEC_LAB_UNSUPPORTED_REASON)
             }

--- a/src/commands/extension.rs
+++ b/src/commands/extension.rs
@@ -213,6 +213,12 @@ pub fn run(
     }
 }
 
+impl ExtensionArgs {
+    pub(crate) fn is_update_command(&self) -> bool {
+        matches!(self.command, ExtensionCommand::Update { .. })
+    }
+}
+
 #[derive(Serialize)]
 #[serde(tag = "command")]
 #[allow(clippy::large_enum_variant)]

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -511,6 +511,42 @@ mod tests {
     }
 
     #[test]
+    fn extension_update_is_lab_portable_without_extension_parity() {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "--runner",
+            "lab",
+            "extension",
+            "update",
+            "wordpress",
+        ]);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+        assert_eq!(command.hot_label, "extension update");
+        assert!(command.portable);
+        assert!(command.unsupported_reason.is_none());
+        assert!(!command.requires_extension_parity);
+        assert!(command.required_extensions.is_empty());
+        assert!(!command.infer_source_path_tools);
+    }
+
+    #[test]
+    fn other_extension_commands_stay_local_only() {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "--runner",
+            "lab",
+            "extension",
+            "show",
+            "wordpress",
+        ]);
+
+        assert!(lab_offload_command(&cli.command).unwrap().is_none());
+        assert!(!cli.command.supports_lab_runner());
+    }
+
+    #[test]
     fn global_runner_for_runs_show_has_local_mirror_guidance() {
         let _env = EnvGuard::remove(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV);
         let cli = Cli::parse_from([


### PR DESCRIPTION
## Summary
- Fixes #4053.
- Makes `homeboy extension update <id> --runner <runner>` use the existing Lab offload path so clean runner-side extension checkouts can be updated through Homeboy instead of manual SSH mutation.
- Keeps non-update extension commands local-only by exposing a narrow `extension update` Lab contract.

## Verification
- `cargo test extension_`
- `cargo test commands::route::tests::`
- `cargo fmt --check` was run and still reports pre-existing formatting drift in `src/core/extension/bench/parsing.rs`; this PR leaves that unrelated file untouched.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the narrow Lab portability contract for extension updates, added focused route tests, and ran verification for Chris to review.