### PR TITLE
Preserve Lab agent-task dispatch failures

### DIFF
--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -491,6 +491,96 @@ pub fn record_pre_dispatch_failure(
     record_run_aggregate(&run_id, &plan, &aggregate)
 }
 
+#[derive(Debug, Clone)]
+pub struct AgentTaskRemoteDispatchFailure<'a> {
+    pub run_id: &'a str,
+    pub local_command: Vec<String>,
+    pub remote_command: Vec<String>,
+    pub runner_id: &'a str,
+    pub remote_workspace: &'a str,
+    pub stdout: &'a str,
+    pub stderr: &'a str,
+    pub exit_code: i32,
+}
+
+pub fn record_remote_dispatch_failure(
+    failure: AgentTaskRemoteDispatchFailure<'_>,
+    envelope: &Value,
+) -> Result<Option<AgentTaskRunRecord>> {
+    if envelope.get("schema").and_then(Value::as_str) != Some("homeboy/agent-task-dispatch/v1") {
+        return Ok(None);
+    }
+
+    let Some(record_value) = envelope.get("record") else {
+        return Ok(None);
+    };
+    let Some(aggregate_value) = envelope.get("aggregate") else {
+        return Ok(None);
+    };
+
+    let run_id = sanitize_run_id(failure.run_id);
+    let mut record: AgentTaskRunRecord =
+        serde_json::from_value(record_value.clone()).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse offloaded agent-task dispatch record".to_string()),
+            )
+        })?;
+    let aggregate: AgentTaskAggregate =
+        serde_json::from_value(aggregate_value.clone()).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse offloaded agent-task dispatch aggregate".to_string()),
+            )
+        })?;
+
+    let remote_run_id = record.run_id.clone();
+    let remote_plan_path = record.plan_path.clone();
+    let remote_aggregate_path = record.aggregate_path.clone();
+    record.run_id = run_id.clone();
+    record.state = run_state_for_aggregate(&aggregate);
+    record.updated_at = Some(now_timestamp());
+    record.aggregate_path = Some(
+        store::write_aggregate(&run_id, &aggregate)?
+            .display()
+            .to_string(),
+    );
+    record.totals = Some(aggregate.totals.clone());
+    record.artifact_refs = artifact_refs_for_outcomes(&aggregate.outcomes);
+    record.provider_handles = provider_handles_for_outcomes(&aggregate.outcomes);
+
+    let provider_run_ids: Vec<String> = record
+        .provider_handles
+        .iter()
+        .map(|handle| handle.provider_run_id.clone())
+        .collect();
+    let metadata = record.ensure_metadata_object();
+    metadata.insert(
+        "kind".to_string(),
+        json!("lab_offload_remote_dispatch_failure"),
+    );
+    metadata.insert("runner_id".to_string(), json!(failure.runner_id));
+    metadata.insert(
+        "remote_workspace".to_string(),
+        json!(failure.remote_workspace),
+    );
+    metadata.insert("local_command".to_string(), json!(failure.local_command));
+    metadata.insert("remote_command".to_string(), json!(failure.remote_command));
+    metadata.insert("exit_code".to_string(), json!(failure.exit_code));
+    metadata.insert("stdout".to_string(), json!(failure.stdout));
+    metadata.insert("stderr".to_string(), json!(failure.stderr));
+    metadata.insert("remote_run_id".to_string(), json!(remote_run_id));
+    metadata.insert("remote_plan_path".to_string(), json!(remote_plan_path));
+    metadata.insert(
+        "remote_aggregate_path".to_string(),
+        json!(remote_aggregate_path),
+    );
+    metadata.insert("provider_run_ids".to_string(), json!(provider_run_ids));
+
+    store::write_record(&record)?;
+    Ok(Some(record))
+}
+
 fn record_aggregate(
     record: &mut AgentTaskRunRecord,
     plan: &AgentTaskPlan,
@@ -968,6 +1058,123 @@ mod tests {
                 loaded.artifact_refs[0].kind,
                 "lab-offload-pre-dispatch-failure"
             );
+        });
+    }
+
+    #[test]
+    fn remote_dispatch_failure_preserves_structured_outcome_details() {
+        with_isolated_home(|_| {
+            let plan = test_plan();
+            let aggregate = AgentTaskAggregate {
+                schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+                plan_id: plan.plan_id.clone(),
+                status: AgentTaskAggregateStatus::Failed,
+                totals: AgentTaskAggregateTotals {
+                    failed: 1,
+                    ..AgentTaskAggregateTotals::default()
+                },
+                outcomes: vec![AgentTaskOutcome {
+                    schema: crate::core::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: "task-a".to_string(),
+                    status: crate::core::agent_task::AgentTaskOutcomeStatus::Failed,
+                    summary: Some("WP Codebox agent task failed.".to_string()),
+                    failure_classification: Some(AgentTaskFailureClassification::Provider),
+                    artifacts: Vec::new(),
+                    evidence_refs: vec![AgentTaskEvidenceRef {
+                        kind: "logs".to_string(),
+                        uri: "homeboy://agent-task/run/remote-run/logs".to_string(),
+                        label: Some("remote provider logs".to_string()),
+                    }],
+                    diagnostics: Vec::new(),
+                    outputs: serde_json::json!({
+                        "codebox_run_result": {
+                            "status": "failed",
+                            "failure_classification": "runtime",
+                            "artifacts": [],
+                            "refs": { "logs": [], "transcripts": [], "runtimes": [] }
+                        }
+                    }),
+                    workflow: None,
+                    follow_up: None,
+                    metadata: serde_json::json!({
+                        "provider": "wordpress.codebox-agent-task-executor",
+                        "remote_run_id": "codebox-run-1",
+                        "remote_workspace": "/runner/workspace/repo"
+                    }),
+                }],
+                events: vec![AgentTaskProgressEvent {
+                    task_id: "task-a".to_string(),
+                    state: AgentTaskState::Failed,
+                    attempt: 1,
+                    message: Some("WP Codebox agent task failed.".to_string()),
+                }],
+                artifact_lineage: Vec::new(),
+                queue: AgentTaskQueueStatus {
+                    max_concurrency: 1,
+                    completed: 1,
+                    ..AgentTaskQueueStatus::default()
+                },
+            };
+            let remote_record =
+                record_completed_run(&plan, &aggregate, Some("remote-run")).expect("remote record");
+            let envelope = serde_json::json!({
+                "schema": "homeboy/agent-task-dispatch/v1",
+                "run_id": "remote-run",
+                "plan_id": plan.plan_id,
+                "state": "failed",
+                "record": remote_record,
+                "aggregate": aggregate,
+            });
+
+            let record = record_remote_dispatch_failure(
+                AgentTaskRemoteDispatchFailure {
+                    run_id: "local-run",
+                    local_command: vec![
+                        "homeboy".to_string(),
+                        "agent-task".to_string(),
+                        "cook".to_string(),
+                    ],
+                    remote_command: vec![
+                        "homeboy".to_string(),
+                        "agent-task".to_string(),
+                        "cook".to_string(),
+                    ],
+                    runner_id: "lab-a",
+                    remote_workspace: "/runner/workspace/repo",
+                    stdout: &envelope.to_string(),
+                    stderr: "",
+                    exit_code: 1,
+                },
+                &envelope,
+            )
+            .expect("remote dispatch failure recorded")
+            .expect("dispatch envelope recognized");
+
+            let loaded = status("local-run").expect("status loaded");
+            let log = logs("local-run").expect("logs loaded");
+            let artifacts = artifacts("local-run").expect("artifacts loaded");
+            let (raw_aggregate, _) = aggregate_source("local-run").expect("aggregate source");
+
+            assert_eq!(record.run_id, "local-run");
+            assert_eq!(loaded.state, AgentTaskRunState::Failed);
+            assert_eq!(loaded.tasks[0].task_id, "task-a");
+            assert_ne!(loaded.tasks[0].task_id, "agent-task-predispatch");
+            assert_eq!(
+                loaded.metadata["kind"],
+                "lab_offload_remote_dispatch_failure"
+            );
+            assert_eq!(loaded.metadata["runner_id"], "lab-a");
+            assert_eq!(
+                loaded.metadata["remote_workspace"],
+                "/runner/workspace/repo"
+            );
+            assert_eq!(
+                log.events[0].message.as_deref(),
+                Some("WP Codebox agent task failed.")
+            );
+            assert_eq!(artifacts.evidence_refs[0].kind, "logs");
+            assert!(raw_aggregate.contains("wordpress.codebox-agent-task-executor"));
+            assert!(raw_aggregate.contains("failure_classification"));
         });
     }
 

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -915,6 +915,32 @@ fn run_lab_offload_inner(
     stderr.push_str(&exec_output.stderr);
     if exit_code != 0 {
         if let Some(run_id) = agent_task_dispatch_requested_run_id(request.normalized_args) {
+            if let Some(envelope) = parse_offloaded_dispatch_envelope(&exec_output.stdout)? {
+                if let Some(record) = agent_task_lifecycle::record_remote_dispatch_failure(
+                    agent_task_lifecycle::AgentTaskRemoteDispatchFailure {
+                        run_id: &run_id,
+                        local_command: request.normalized_args.to_vec(),
+                        remote_command: remote_command.clone(),
+                        runner_id,
+                        remote_workspace: &remote_cwd,
+                        stdout: &exec_output.stdout,
+                        stderr: &exec_output.stderr,
+                        exit_code,
+                    },
+                    &envelope,
+                )? {
+                    stderr.push_str(&format!(
+                        "Persisted remote agent-task dispatch failure evidence for run `{}`. Inspect with `homeboy agent-task status {}` and `homeboy agent-task logs {}`.\n",
+                        record.run_id, record.run_id, record.run_id
+                    ));
+                    return Ok(LabOffloadOutcome::Offloaded {
+                        plan,
+                        stdout: exec_output.stdout,
+                        stderr,
+                        exit_code,
+                    });
+                }
+            }
             let failure_message = lab_pre_dispatch_failure_message(&exec_output.stderr)
                 .or_else(|| lab_pre_dispatch_failure_message(&exec_output.stdout))
                 .unwrap_or_else(|| format!("offloaded agent-task command exited with {exit_code}"));
@@ -1155,6 +1181,35 @@ fn is_agent_task_run_plan_envelope(value: &serde_json::Value) -> bool {
             .get("data")
             .and_then(|data| data.get("plan_id"))
             .is_some()
+}
+
+fn parse_offloaded_dispatch_envelope(stdout: &str) -> Result<Option<serde_json::Value>> {
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(stdout) {
+        return Ok(agent_task_dispatch_envelope_value(&value).cloned());
+    }
+
+    for (index, _) in stdout.match_indices('{') {
+        let mut stream = serde_json::Deserializer::from_str(&stdout[index..]).into_iter();
+        if let Some(Ok(value)) = stream.next() {
+            if let Some(envelope) = agent_task_dispatch_envelope_value(&value) {
+                return Ok(Some(envelope.clone()));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+fn agent_task_dispatch_envelope_value(value: &serde_json::Value) -> Option<&serde_json::Value> {
+    if value.get("schema").and_then(serde_json::Value::as_str)
+        == Some("homeboy/agent-task-dispatch/v1")
+    {
+        return Some(value);
+    }
+    let data = value.get("data")?;
+    (data.get("schema").and_then(serde_json::Value::as_str)
+        == Some("homeboy/agent-task-dispatch/v1"))
+    .then_some(data)
 }
 
 fn agent_task_run_plan_recording_args(args: &[String]) -> Option<(String, String)> {
@@ -1848,6 +1903,22 @@ mod tests {
 
         assert_eq!(parsed["data"]["plan_id"], "plan-1");
         assert_eq!(parsed["data"]["totals"]["succeeded"], 6);
+    }
+
+    #[test]
+    fn offloaded_dispatch_envelope_parser_selects_structured_failure_from_mixed_stdout() {
+        let stdout = concat!(
+            "remote setup complete\n",
+            "{\"success\":true,\"data\":{\"command\":\"extension.setup\"}}\n",
+            "{\"success\":false,\"data\":{\"schema\":\"homeboy/agent-task-dispatch/v1\",\"run_id\":\"run-1\",\"state\":\"failed\",\"record\":{},\"aggregate\":{\"status\":\"failed\"}}}\n"
+        );
+
+        let parsed = parse_offloaded_dispatch_envelope(stdout)
+            .expect("parse dispatch stdout")
+            .expect("dispatch envelope found");
+
+        assert_eq!(parsed["run_id"], "run-1");
+        assert_eq!(parsed["aggregate"]["status"], "failed");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Preserve structured failed `homeboy/agent-task-dispatch/v1` envelopes returned by Lab offload instead of falling back to `agent-task-predispatch`.
- Mirror the remote dispatch `record` and `aggregate` into local agent-task lifecycle storage so `status`, `logs`, `review`, and `artifacts` expose the remote provider outcome details.
- Keep unstructured remote failures on the existing pre-dispatch fallback path.

Fixes #4057.

## Tests
- `cargo test --lib remote_dispatch_failure_preserves_structured_outcome_details`
- `cargo test --lib offloaded_dispatch_envelope_parser_selects_structured_failure_from_mixed_stdout`
- `git diff --check`

## Notes
- `cargo test --lib` was also run as a broader check and hit existing/unrelated bench test failures:
  - `commands::bench::tests::profile_with_unknown_scenario_lists_discovered_scenarios`
  - `commands::bench::tests::unknown_scenario_reports_discovered_ids`
  - `core::extension::bench::run::tests::attach_memory_timeline_adds_metrics_and_artifacts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the Lab offload failure-preservation path, adding targeted tests, and preparing this PR description. Chris remains responsible for review and merge.