### PR TITLE
fix: preflight trace public preview assets

### DIFF
--- a/docs/architecture/preview-metadata.md
+++ b/docs/architecture/preview-metadata.md
@@ -49,6 +49,32 @@ object does not already contain that field.
 Homeboy does not create tunnels, publish previews, or know about product-specific
 runtimes. Public access is supplied by the caller/integration.
 
+## Trace Public Preview Assets
+
+Trace workloads can declare public-preview assets that must be fetchable before
+trace collection starts:
+
+```json
+{
+  "public_preview": {
+    "local_origin": "http://127.0.0.1:49823",
+    "public_origin": "https://preview.example.test",
+    "require_https": true,
+    "required_asset_paths": [
+      "/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.js?ver=10.8.0",
+      "/wp-content/plugins/woocommerce/assets/js/frontend/add-to-cart.min.js"
+    ]
+  }
+}
+```
+
+Each entry can be a public-origin-relative path or an absolute `http`/`https`
+URL. Homeboy fetches the required assets through the public preview origin before
+starting the trace runner. Non-2xx responses, aborted requests, and connection
+errors fail fast with `public_preview.required_asset_paths` diagnostics so a run
+does not collect baseline/candidate traces from a page whose static assets cannot
+load.
+
 ## Persistence
 
 When a command records an observation run, Homeboy stores the object at

--- a/src/commands/trace/preview_args.rs
+++ b/src/commands/trace/preview_args.rs
@@ -59,5 +59,10 @@ fn expand_trace_public_preview(
         require_https: spec.require_https,
         provider: spec.provider.clone(),
         startup_timeout_seconds: spec.startup_timeout_seconds,
+        required_asset_paths: spec
+            .required_asset_paths
+            .iter()
+            .map(|path| expand(path))
+            .collect(),
     }
 }

--- a/src/core/extension/trace/preview.rs
+++ b/src/core/extension/trace/preview.rs
@@ -8,8 +8,19 @@ use crate::core::error::{Error, Result};
 use crate::core::rig::TracePublicPreviewSpec;
 
 const DEFAULT_STARTUP_TIMEOUT_SECONDS: u64 = 20;
+const DEFAULT_ASSET_CHECK_TIMEOUT_SECONDS: u64 = 10;
 const WC_STRIPE_ECE_PREVIEW_PORT_SETTING: &str = "woocommerce_stripe_ece_preview_port";
 const WC_STRIPE_ECE_PREVIEW_PORT_ENV: &str = "HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TracePreviewAssetCheck {
+    pub path: String,
+    pub url: String,
+    pub status: Option<u16>,
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -25,6 +36,8 @@ pub struct TracePreviewMetadata {
     pub window_location_origin: String,
     pub window_is_secure_context: bool,
     pub require_https: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_assets: Vec<TracePreviewAssetCheck>,
     pub status: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub process_id: Option<String>,
@@ -74,6 +87,14 @@ impl TracePublicPreviewSession {
             return Err(error);
         }
 
+        let required_assets = match preflight_required_assets(spec, &public_origin) {
+            Ok(checks) => checks,
+            Err(error) => {
+                stop_child(&mut child);
+                return Err(error);
+            }
+        };
+
         let process_id = child.as_ref().map(|child| child.id().to_string());
         Ok(Self {
             child,
@@ -92,6 +113,7 @@ impl TracePublicPreviewSession {
                 window_location_origin: public_origin,
                 window_is_secure_context: is_https,
                 require_https: spec.require_https,
+                required_assets,
                 status: "running".to_string(),
                 process_id,
                 cleanup_status: "pending".to_string(),
@@ -229,6 +251,86 @@ fn read_public_origin(child: &mut Child, timeout_seconds: u64) -> Result<String>
     }
 }
 
+fn preflight_required_assets(
+    spec: &TracePublicPreviewSpec,
+    public_origin: &str,
+) -> Result<Vec<TracePreviewAssetCheck>> {
+    if spec.required_asset_paths.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(DEFAULT_ASSET_CHECK_TIMEOUT_SECONDS))
+        .redirect(reqwest::redirect::Policy::limited(5))
+        .build()
+        .map_err(|e| {
+            Error::internal_io(
+                format!("Failed to create trace public_preview asset preflight client: {e}"),
+                Some("trace.preview.asset_client".to_string()),
+            )
+        })?;
+
+    let mut checks = Vec::with_capacity(spec.required_asset_paths.len());
+    for path in &spec.required_asset_paths {
+        let url = preview_asset_url(public_origin, path);
+        let check = match client.get(&url).send() {
+            Ok(response) => {
+                let status = response.status();
+                TracePreviewAssetCheck {
+                    path: path.clone(),
+                    url,
+                    status: Some(status.as_u16()),
+                    ok: status.is_success(),
+                    error: None,
+                }
+            }
+            Err(error) => TracePreviewAssetCheck {
+                path: path.clone(),
+                url,
+                status: None,
+                ok: false,
+                error: Some(error.to_string()),
+            },
+        };
+        checks.push(check);
+    }
+
+    let failed: Vec<&TracePreviewAssetCheck> = checks.iter().filter(|check| !check.ok).collect();
+    if failed.is_empty() {
+        return Ok(checks);
+    }
+
+    let details = failed
+        .iter()
+        .map(|check| match (check.status, check.error.as_deref()) {
+            (Some(status), _) => format!("{} -> HTTP {}", check.url, status),
+            (None, Some(error)) => format!("{} -> {error}", check.url),
+            (None, None) => format!("{} -> request failed", check.url),
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    Err(Error::validation_invalid_argument(
+        "public_preview.required_asset_paths",
+        format!(
+            "trace public_preview required asset preflight failed before trace collection: {details}"
+        ),
+        Some(public_origin.to_string()),
+        Some(failed.iter().map(|check| check.url.clone()).collect()),
+    ))
+}
+
+fn preview_asset_url(public_origin: &str, path: &str) -> String {
+    if path.starts_with("http://") || path.starts_with("https://") {
+        return path.to_string();
+    }
+    format!(
+        "{}/{}",
+        public_origin.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
+}
+
 fn first_https_origin(line: &str) -> Option<String> {
     let start = line.find("https://")?;
     let rest = &line[start..];
@@ -308,6 +410,9 @@ fn stop_child(child: &mut Option<Child>) -> bool {
 mod tests {
     use super::{expected_local_tunnel_port, first_https_origin, TracePublicPreviewSession};
     use crate::core::rig::TracePublicPreviewSpec;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
 
     #[test]
     fn extracts_first_https_origin_from_provider_output() {
@@ -328,6 +433,7 @@ mod tests {
             require_https: true,
             provider: Some("fixture".to_string()),
             startup_timeout_seconds: Some(2),
+            required_asset_paths: Vec::new(),
         })
         .expect("preview starts");
 
@@ -367,6 +473,7 @@ mod tests {
             require_https: true,
             provider: Some("fixture".to_string()),
             startup_timeout_seconds: None,
+            required_asset_paths: Vec::new(),
         });
         let error = match result {
             Ok(_) => panic!("mismatched preview port should fail before trace starts"),
@@ -379,5 +486,89 @@ mod tests {
         assert!(message.contains("expected_local_tunnel_port=49822"));
         assert!(message.contains("--setting woocommerce_stripe_ece_preview_port=49822"));
         assert!(message.contains("HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT=49822"));
+    }
+
+    #[test]
+    fn records_successful_required_asset_preflight() {
+        let origin = start_asset_fixture_server(vec![(
+            "/wp-content/plugins/example/build/frontend.js?ver=1".to_string(),
+            200,
+        )]);
+
+        let session = TracePublicPreviewSession::start(&TracePublicPreviewSpec {
+            local_origin: origin.clone(),
+            public_origin: Some(origin),
+            command: None,
+            require_https: false,
+            provider: Some("fixture".to_string()),
+            startup_timeout_seconds: None,
+            required_asset_paths: vec![
+                "/wp-content/plugins/example/build/frontend.js?ver=1".to_string()
+            ],
+        })
+        .expect("preview starts after asset preflight");
+
+        assert_eq!(session.metadata().required_assets.len(), 1);
+        assert!(session.metadata().required_assets[0].ok);
+        assert_eq!(session.metadata().required_assets[0].status, Some(200));
+    }
+
+    #[test]
+    fn fails_fast_when_required_asset_cannot_be_fetched() {
+        let origin = start_asset_fixture_server(vec![(
+            "/wp-content/plugins/example/build/frontend.js?ver=1".to_string(),
+            502,
+        )]);
+
+        let result = TracePublicPreviewSession::start(&TracePublicPreviewSpec {
+            local_origin: origin.clone(),
+            public_origin: Some(origin),
+            command: None,
+            require_https: false,
+            provider: Some("fixture".to_string()),
+            startup_timeout_seconds: None,
+            required_asset_paths: vec![
+                "/wp-content/plugins/example/build/frontend.js?ver=1".to_string()
+            ],
+        });
+
+        let error = match result {
+            Ok(_) => panic!("required asset preflight should fail before trace starts"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+        assert!(message.contains("required asset preflight failed before trace collection"));
+        assert!(message.contains("/wp-content/plugins/example/build/frontend.js?ver=1 -> HTTP 502"));
+    }
+
+    fn start_asset_fixture_server(routes: Vec<(String, u16)>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fixture server");
+        let addr = listener.local_addr().expect("fixture server addr");
+        thread::spawn(move || {
+            for stream in listener.incoming().take(routes.len()) {
+                let mut stream = stream.expect("fixture connection");
+                let mut buffer = [0; 1024];
+                let len = stream.read(&mut buffer).expect("read request");
+                let request = String::from_utf8_lossy(&buffer[..len]);
+                let target = request
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_whitespace().nth(1))
+                    .unwrap_or("/");
+                let status = routes
+                    .iter()
+                    .find(|(path, _)| path == target)
+                    .map(|(_, status)| *status)
+                    .unwrap_or(404);
+                let reason = if status == 200 { "OK" } else { "Bad Gateway" };
+                let response = format!(
+                    "HTTP/1.1 {status} {reason}\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
+            }
+        });
+        format!("http://{addr}")
     }
 }

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -526,6 +526,10 @@ pub struct TracePublicPreviewSpec {
     /// Seconds to wait for the provider command to print a public HTTPS URL.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub startup_timeout_seconds: Option<u64>,
+
+    /// Public-origin-relative asset URLs that must load before trace collection starts.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_asset_paths: Vec<String>,
 }
 
 impl TraceProfileSpec {

--- a/tests/core/rig/public_preview_spec_test.rs
+++ b/tests/core/rig/public_preview_spec_test.rs
@@ -10,7 +10,10 @@ fn test_trace_public_preview_parse() {
                 "command": "cloudflared tunnel --url http://127.0.0.1:8080",
                 "require_https": true,
                 "provider": "cloudflared",
-                "startup_timeout_seconds": 5
+                "startup_timeout_seconds": 5,
+                "required_asset_paths": [
+                    "/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.js?ver=10.8.0"
+                ]
             }
         }"#,
     )
@@ -21,4 +24,11 @@ fn test_trace_public_preview_parse() {
     assert_eq!(preview.provider.as_deref(), Some("cloudflared"));
     assert!(preview.require_https);
     assert_eq!(preview.startup_timeout_seconds, Some(5));
+    assert_eq!(
+        preview.required_asset_paths,
+        vec![
+            "/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.js?ver=10.8.0"
+                .to_string()
+        ]
+    );
 }


### PR DESCRIPTION
## Summary
- Adds `public_preview.required_asset_paths` so trace workloads can declare WP Codebox/static plugin assets that must be reachable through the public preview before trace collection starts.
- Fetches each required asset through the resolved public origin and fails fast with `public_preview.required_asset_paths` diagnostics on 502s, aborted requests, connection failures, or other non-2xx responses.
- Records successful required asset checks in preview metadata and documents the contract for Woo/WP Codebox trace rigs.

Fixes #4062.
Related: chubes4/homeboy-rigs#237.

## Testing
- `cargo test public_preview -- --nocapture`
- `cargo test required_asset -- --nocapture`
- `cargo test` *(fails in existing bench scenario-discovery assertions: `commands::bench::tests::unknown_scenario_reports_discovered_ids` and `commands::bench::tests::profile_with_unknown_scenario_lists_discovered_scenarios`; both report `discovered ids: <none>` and are outside the trace public-preview path changed here.)*

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigated the trace public preview path, drafted the required-asset preflight implementation/tests/docs, and ran verification; Chris remains responsible for review and merge.