### PR TITLE
Scope bench discovery to selected scenarios

### DIFF
--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -194,7 +194,7 @@ pub fn run_bench_list_workflow(
             json_summary: false,
             ci_env: Vec::new(),
             passthrough_args: args.passthrough_args,
-            scenario_ids: Vec::new(),
+            scenario_ids: args.scenario_ids.clone(),
             rig_id: None,
             shared_state: None,
             extra_workloads: args.extra_workloads,
@@ -478,10 +478,7 @@ fn discover_bench_scenarios(
         })?;
     }
 
-    let mut discovery_args = args.clone();
-    discovery_args.scenario_ids.clear();
-
-    let runner_output = build_runner(execution_context, component, &discovery_args, run_dir, None)?
+    let runner_output = build_runner(execution_context, component, args, run_dir, None)?
         .env("HOMEBOY_BENCH_LIST_ONLY", "1")
         .run()?;
 


### PR DESCRIPTION
## Summary
- Preserves selected `--scenario` IDs during extension-backed list-only discovery instead of clearing them.
- Ensures WP Codebox receives `HOMEBOY_BENCH_SCENARIOS` during targeted discovery, so unrelated duplicate workloads are skipped before extension-side validation can fail.
- Applies the same selected-scenario propagation to `homeboy bench --list --scenario ...` for extension-backed runners.

## Tests
- `cargo fmt --check`
- `cargo test failed_execution_parse_ignores_unselected_duplicate_scenario_ids`

## Context
The source-built repro for Extra-Chill/homeboy-extensions#1266 still failed after #4063 because the remaining error happens during list-only discovery before Homeboy parses a result artifact. `discover_bench_scenarios()` cloned args and cleared `scenario_ids`, causing WP Codebox discovery to inspect unrelated workloads like `checkout-concurrent-create-order`. Keeping the selected IDs lets the extension skip unrelated workloads before duplicate validation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Traced the remaining selected-discovery path, drafted the minimal fix, and ran targeted verification. Chris remains responsible for review and merge.

Fixes Extra-Chill/homeboy-extensions#1266