### PR TITLE
Fix runner source upgrade materialization

### DIFF
--- a/src/commands/runner/workspace/mod.rs
+++ b/src/commands/runner/workspace/mod.rs
@@ -81,6 +81,7 @@ fn sync(
         runner::RunnerWorkspaceSyncOptions {
             path,
             mode: RunnerWorkspaceSyncMode::from(mode),
+            controller_routed_git: false,
             changed_since_base: None,
             git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -597,6 +597,7 @@ fn run_lab_offload_inner(
         RunnerWorkspaceSyncOptions {
             path: source_path.display().to_string(),
             mode: sync_mode,
+            controller_routed_git: false,
             changed_since_base: changed_since_preflight.resolved_base.clone(),
             git_fetch_refs: lab_offload_git_fetch_refs(
                 &changed_since_preflight.args,
@@ -1056,6 +1057,7 @@ fn sync_inline_agent_task_plan(
         RunnerWorkspaceSyncOptions {
             path: temp.path().display().to_string(),
             mode: RunnerWorkspaceSyncMode::Snapshot,
+            controller_routed_git: false,
             changed_since_base: None,
             git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -66,6 +66,7 @@ pub(super) fn sync_extra_lab_workspaces(
             RunnerWorkspaceSyncOptions {
                 path: local_path.display().to_string(),
                 mode: RunnerWorkspaceSyncMode::Snapshot,
+                controller_routed_git: false,
                 changed_since_base: None,
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: extra.snapshot_includes.clone(),

--- a/src/core/runner/rig_materialization.rs
+++ b/src/core/runner/rig_materialization.rs
@@ -77,6 +77,7 @@ pub(super) fn sync_lab_offload_rigs(
                 RunnerWorkspaceSyncOptions {
                     path: metadata.package_path,
                     mode: RunnerWorkspaceSyncMode::Snapshot,
+                    controller_routed_git: false,
                     changed_since_base: None,
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),

--- a/src/core/runner/validation_dependencies.rs
+++ b/src/core/runner/validation_dependencies.rs
@@ -473,6 +473,7 @@ mod tests {
                 RunnerWorkspaceSyncOptions {
                     path: source.display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
+                    controller_routed_git: false,
                     changed_since_base: None,
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
@@ -546,6 +547,7 @@ mod tests {
                 RunnerWorkspaceSyncOptions {
                     path: source.display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
+                    controller_routed_git: false,
                     changed_since_base: None,
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
@@ -619,6 +621,7 @@ mod tests {
                 RunnerWorkspaceSyncOptions {
                     path: source.display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
+                    controller_routed_git: false,
                     changed_since_base: None,
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
@@ -689,6 +692,7 @@ mod tests {
                 RunnerWorkspaceSyncOptions {
                     path: source.display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
+                    controller_routed_git: false,
                     changed_since_base: None,
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
@@ -767,6 +771,7 @@ mod tests {
                 RunnerWorkspaceSyncOptions {
                     path: source.display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
+                    controller_routed_git: false,
                     changed_since_base: None,
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -164,6 +164,8 @@ pub fn sync_workspace(
                     &local_path,
                     &remote_path,
                     &git.head,
+                    git.branch.as_deref(),
+                    &git.remote_url,
                     git.changed_since_base.as_deref(),
                     &git.git_fetch_refs,
                 )?;
@@ -216,6 +218,7 @@ pub(super) struct SnapshotStats {
 struct GitSnapshot {
     remote_url: String,
     head: String,
+    branch: Option<String>,
     changed_since_base: Option<String>,
     git_fetch_refs: Vec<String>,
 }
@@ -318,6 +321,9 @@ fn git_snapshot(
         ));
     }
     let head = git_output(local_path, &["rev-parse", "HEAD"])?;
+    let branch = git_output(local_path, &["rev-parse", "--abbrev-ref", "HEAD"])
+        .ok()
+        .filter(|branch| branch != "HEAD");
     let remote_url = git_output(local_path, &["config", "--get", "remote.origin.url"])?;
     if remote_url.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
@@ -330,6 +336,7 @@ fn git_snapshot(
     Ok(GitSnapshot {
         remote_url,
         head,
+        branch,
         changed_since_base: changed_since_base.map(str::to_string),
         git_fetch_refs,
     })
@@ -623,6 +630,8 @@ fn materialize_git_from_controller_bundle(
     local_path: &Path,
     remote_path: &str,
     head: &str,
+    branch: Option<&str>,
+    remote_url: &str,
     changed_since_base: Option<&str>,
     git_fetch_refs: &[String],
 ) -> Result<()> {
@@ -661,7 +670,7 @@ fn materialize_git_from_controller_bundle(
         )));
     }
 
-    let install_command = git_bundle_install_command(remote_path, head);
+    let install_command = git_bundle_install_command(remote_path, head, branch, remote_url);
     let result = match runner.kind {
         RunnerKind::Local => materialize_git_bundle_piped(
             &bundle_path,
@@ -709,11 +718,31 @@ fn materialize_git_bundle_piped(
     run_shell_command(&command, action)
 }
 
-fn git_bundle_install_command(remote_path: &str, head: &str) -> String {
+fn git_bundle_install_command(
+    remote_path: &str,
+    head: &str,
+    branch: Option<&str>,
+    remote_url: &str,
+) -> String {
+    let checkout = if let Some(branch) = branch {
+        format!(
+            "git -C \"$tmp\" checkout -B {branch} {head} && git -C \"$tmp\" config branch.{branch}.remote origin && git -C \"$tmp\" config branch.{branch}.merge refs/heads/{branch}",
+            branch = shell::quote_arg(branch),
+            head = shell::quote_arg(head),
+        )
+    } else {
+        format!(
+            "git -C \"$tmp\" checkout --detach {head}",
+            head = shell::quote_arg(head)
+        )
+    };
+
     format!(
-        "parent={parent}; dest={dest}; tmp=\"${{dest}}.tmp.$$\"; bundle=\"${{dest}}.bundle.$$\"; mkdir -p \"$parent\" && trap 'rm -rf \"$tmp\" \"$bundle\"' EXIT; rm -rf \"$tmp\" \"$bundle\" && cat > \"$bundle\" && git clone \"$bundle\" \"$tmp\" && git -C \"$tmp\" checkout --detach {head} && git -C \"$tmp\" reset --hard {head} && git -C \"$tmp\" clean -ffdqx && rm -rf \"$dest\" && mv \"$tmp\" \"$dest\"",
+        "parent={parent}; dest={dest}; tmp=\"${{dest}}.tmp.$$\"; bundle=\"${{dest}}.bundle.$$\"; mkdir -p \"$parent\" && trap 'rm -rf \"$tmp\" \"$bundle\"' EXIT; rm -rf \"$tmp\" \"$bundle\" && cat > \"$bundle\" && git clone \"$bundle\" \"$tmp\" && git -C \"$tmp\" remote set-url origin {remote_url} && {checkout} && git -C \"$tmp\" reset --hard {head} && git -C \"$tmp\" clean -ffdqx && rm -rf \"$dest\" && mv \"$tmp\" \"$dest\"",
         parent = shell::quote_arg(parent_remote_path(remote_path).as_str()),
         dest = shell::quote_arg(remote_path),
+        remote_url = shell::quote_arg(remote_url),
+        checkout = checkout,
         head = shell::quote_arg(head),
     )
 }
@@ -1146,6 +1175,7 @@ mod tests {
             git(source.path(), &["init"]);
             git(source.path(), &["config", "user.email", "test@example.com"]);
             git(source.path(), &["config", "user.name", "Test User"]);
+            git(source.path(), &["checkout", "-b", "fix/source-upgrade"]);
             fs::write(source.path().join("file.txt"), "source-upgrade\n").expect("write file");
             git(source.path(), &["add", "."]);
             git(source.path(), &["commit", "-m", "source upgrade"]);
@@ -1187,6 +1217,14 @@ mod tests {
             assert_eq!(
                 git_output(remote, &["rev-parse", "--is-inside-work-tree"]).unwrap(),
                 "true"
+            );
+            assert_eq!(
+                git_output(remote, &["rev-parse", "--abbrev-ref", "HEAD"]).unwrap(),
+                "fix/source-upgrade"
+            );
+            assert_eq!(
+                git_output(remote, &["config", "--get", "remote.origin.url"]).unwrap(),
+                "https://github.com/Extra-Chill/homeboy.git"
             );
             assert_eq!(
                 fs::read_to_string(remote.join("file.txt")).expect("read synced file"),

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -61,6 +61,7 @@ impl RunnerWorkspaceSyncMode {
 pub struct RunnerWorkspaceSyncOptions {
     pub path: String,
     pub mode: RunnerWorkspaceSyncMode,
+    pub controller_routed_git: bool,
     pub changed_since_base: Option<String>,
     pub git_fetch_refs: Vec<String>,
     pub snapshot_includes: Vec<String>,
@@ -153,9 +154,11 @@ pub fn sync_workspace(
                 options.git_fetch_refs,
             )?;
             let remote_path = deterministic_remote_path(workspace_root, &local_path, &git.head);
-            if super::source_materialization::requires_controller_routed_workspace_sync(
-                &git.remote_url,
-            ) {
+            if options.controller_routed_git
+                || super::source_materialization::requires_controller_routed_workspace_sync(
+                    &git.remote_url,
+                )
+            {
                 materialize_git_from_controller_bundle(
                     &runner,
                     &local_path,
@@ -940,6 +943,7 @@ mod tests {
                 RunnerWorkspaceSyncOptions {
                     path: source.path().display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
+                    controller_routed_git: false,
                     changed_since_base: None,
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
@@ -984,6 +988,7 @@ mod tests {
                 RunnerWorkspaceSyncOptions {
                     path: source.path().display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
+                    controller_routed_git: false,
                     changed_since_base: None,
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
@@ -1044,6 +1049,7 @@ mod tests {
                 RunnerWorkspaceSyncOptions {
                     path: source.path().display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
+                    controller_routed_git: false,
                     changed_since_base: None,
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
@@ -1110,6 +1116,7 @@ mod tests {
                 RunnerWorkspaceSyncOptions {
                     path: source.path().display().to_string(),
                     mode: RunnerWorkspaceSyncMode::Git,
+                    controller_routed_git: false,
                     changed_since_base: None,
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
@@ -1127,6 +1134,63 @@ mod tests {
             assert_eq!(
                 fs::read_to_string(remote.join("file.txt")).expect("read synced file"),
                 "base\n"
+            );
+        });
+    }
+
+    #[test]
+    fn controller_routed_git_sync_materializes_bundle_for_public_remote() {
+        crate::test_support::with_isolated_home(|_| {
+            let source = tempfile::tempdir().expect("source tempdir");
+            let runner_root = tempfile::tempdir().expect("runner root tempdir");
+            git(source.path(), &["init"]);
+            git(source.path(), &["config", "user.email", "test@example.com"]);
+            git(source.path(), &["config", "user.name", "Test User"]);
+            fs::write(source.path().join("file.txt"), "source-upgrade\n").expect("write file");
+            git(source.path(), &["add", "."]);
+            git(source.path(), &["commit", "-m", "source upgrade"]);
+            git(
+                source.path(),
+                &[
+                    "remote",
+                    "add",
+                    "origin",
+                    "https://github.com/Extra-Chill/homeboy.git",
+                ],
+            );
+
+            super::super::create(
+                &format!(
+                    r#"{{"id":"lab-local-controller-git","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+
+            let (output, exit_code) = sync_workspace(
+                "lab-local-controller-git",
+                RunnerWorkspaceSyncOptions {
+                    path: source.path().display().to_string(),
+                    mode: RunnerWorkspaceSyncMode::Git,
+                    controller_routed_git: true,
+                    changed_since_base: None,
+                    git_fetch_refs: Vec::new(),
+                    snapshot_includes: Vec::new(),
+                },
+            )
+            .expect("sync workspace");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(output.sync_mode, RunnerWorkspaceSyncMode::Git);
+            let remote = Path::new(&output.remote_path);
+            assert_eq!(
+                git_output(remote, &["rev-parse", "--is-inside-work-tree"]).unwrap(),
+                "true"
+            );
+            assert_eq!(
+                fs::read_to_string(remote.join("file.txt")).expect("read synced file"),
+                "source-upgrade\n"
             );
         });
     }
@@ -1151,6 +1215,7 @@ mod tests {
             let options = RunnerWorkspaceSyncOptions {
                 path: source.path().display().to_string(),
                 mode: RunnerWorkspaceSyncMode::Snapshot,
+                controller_routed_git: false,
                 changed_since_base: None,
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),

--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -127,11 +127,11 @@ pub(crate) fn resolve_source_workspace(source_path: Option<&Path>) -> Result<Pat
 
     Err(Error::validation_invalid_argument(
         "source_path",
-        "Could not find a Homeboy git checkout for source build",
+        "Could not find a Homeboy source workspace for source build",
         id,
         None,
     )
-    .with_hint("Run from the Homeboy source checkout, or pass: homeboy upgrade --method source --source-path <PATH>"))
+    .with_hint("Run from the Homeboy source workspace, or pass: homeboy upgrade --method source --source-path <PATH>"))
 }
 
 fn workspace_from_exe_path(exe_path: &Path) -> Option<PathBuf> {
@@ -150,22 +150,37 @@ fn workspace_from_exe_path(exe_path: &Path) -> Option<PathBuf> {
 }
 
 fn is_homeboy_source_checkout(path: &Path) -> bool {
-    let git_dir = path.join(".git");
-    if !git_dir.exists() {
-        return false;
-    }
-
     let manifest = path.join("homeboy.json");
     let Ok(contents) = std::fs::read_to_string(manifest) else {
         return false;
     };
 
-    serde_json::from_str::<serde_json::Value>(&contents)
+    let is_homeboy_manifest = serde_json::from_str::<serde_json::Value>(&contents)
         .ok()
         .and_then(|value| {
             value
                 .get("id")
                 .and_then(|id| id.as_str())
+                .map(str::to_string)
+        })
+        .as_deref()
+        == Some("homeboy");
+
+    is_homeboy_manifest && is_homeboy_cargo_package(path)
+}
+
+fn is_homeboy_cargo_package(path: &Path) -> bool {
+    let Ok(contents) = std::fs::read_to_string(path.join("Cargo.toml")) else {
+        return false;
+    };
+
+    toml::from_str::<toml::Value>(&contents)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("package")
+                .and_then(|package| package.get("name"))
+                .and_then(|name| name.as_str())
                 .map(str::to_string)
         })
         .as_deref()
@@ -277,11 +292,20 @@ mod tests {
 
         let err = resolve_source_workspace(Some(dir.path())).expect_err("invalid checkout");
 
-        assert!(err.message.contains("Homeboy git checkout"));
+        assert!(err.message.contains("Homeboy source workspace"));
         assert!(err
             .hints
             .iter()
             .any(|hint| hint.message.contains("--source-path")));
+    }
+
+    #[test]
+    fn source_workspace_accepts_snapshot_without_git_metadata() {
+        let dir = source_workspace_with_package_name("homeboy");
+
+        let resolved = resolve_source_workspace(Some(dir.path())).expect("source snapshot");
+
+        assert_eq!(resolved, dir.path());
     }
 
     #[test]
@@ -341,8 +365,23 @@ mod tests {
     fn checkout_with_package_name(package_name: &str) -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::create_dir(dir.path().join(".git")).expect("git dir");
-        let manifest = serde_json::json!({ "id": package_name });
-        std::fs::write(dir.path().join("homeboy.json"), manifest.to_string()).expect("manifest");
+        write_source_workspace_files(dir.path(), package_name);
         dir
+    }
+
+    fn source_workspace_with_package_name(package_name: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_source_workspace_files(dir.path(), package_name);
+        dir
+    }
+
+    fn write_source_workspace_files(path: &Path, package_name: &str) {
+        let manifest = serde_json::json!({ "id": package_name });
+        std::fs::write(path.join("homeboy.json"), manifest.to_string()).expect("manifest");
+        std::fs::write(
+            path.join("Cargo.toml"),
+            format!("[package]\nname = \"{package_name}\"\nversion = \"0.0.0\"\n"),
+        )
+        .expect("cargo manifest");
     }
 }

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -402,6 +402,7 @@ fn materialize_runner_source_path(runner: &Runner, source_path: &Path) -> Result
         RunnerWorkspaceSyncOptions {
             path: source_path.display().to_string(),
             mode: RunnerWorkspaceSyncMode::Git,
+            controller_routed_git: true,
             changed_since_base: None,
             git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 
 use crate::core::runner::{
     self, Runner, RunnerCapabilityPreflight, RunnerExecOptions, RunnerKind, RunnerRequiredTool,
-    RunnerStatusReport,
+    RunnerStatusReport, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
 use crate::core::upgrade::ExtensionUpgradeEntry;
 use crate::core::Result;
@@ -63,6 +63,28 @@ fn upgrade_runners_with_executor(
     mut exec: impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
     status: impl Fn(&str) -> Result<RunnerStatusReport>,
 ) -> (Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>) {
+    upgrade_runners_with_executor_and_source_materializer(
+        runners,
+        force,
+        method_override,
+        source_path,
+        extension_updates,
+        &mut exec,
+        status,
+        materialize_runner_source_path,
+    )
+}
+
+fn upgrade_runners_with_executor_and_source_materializer(
+    runners: &[Runner],
+    force: bool,
+    method_override: Option<InstallMethod>,
+    source_path: Option<&Path>,
+    extension_updates: &[ExtensionUpgradeEntry],
+    mut exec: impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
+    status: impl Fn(&str) -> Result<RunnerStatusReport>,
+    mut materialize_source_path: impl FnMut(&Runner, &Path) -> Result<String>,
+) -> (Vec<RunnerUpgradeEntry>, Vec<RunnerUpgradeEntry>) {
     let mut updated = Vec::new();
     let mut skipped = Vec::new();
 
@@ -75,6 +97,7 @@ fn upgrade_runners_with_executor(
             extension_updates,
             &mut exec,
             &status,
+            &mut materialize_source_path,
         );
         if entry.success {
             crate::log_status!(
@@ -101,6 +124,7 @@ fn upgrade_runner_with_executor(
     extension_updates: &[ExtensionUpgradeEntry],
     exec: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
     status: &impl Fn(&str) -> Result<RunnerStatusReport>,
+    materialize_source_path: &mut impl FnMut(&Runner, &Path) -> Result<String>,
 ) -> RunnerUpgradeEntry {
     let homeboy_path = runner
         .settings
@@ -110,11 +134,42 @@ fn upgrade_runner_with_executor(
     let previous_version = runner_homeboy_version(runner, &homeboy_path, exec)
         .ok()
         .flatten();
+    let command_source_path = match runner_upgrade_source_path(
+        runner,
+        method_override,
+        source_path,
+        materialize_source_path,
+    ) {
+        Ok(path) => path,
+        Err(err) => {
+            return RunnerUpgradeEntry {
+                runner_id: runner.id.clone(),
+                homeboy_path,
+                success: false,
+                upgraded: false,
+                previous_version,
+                new_version: None,
+                bare_homeboy_version: None,
+                path_drift: None,
+                recovery_commands: runner_upgrade_recovery_commands(&runner.id),
+                extensions_synced: Vec::new(),
+                extensions_failed: Vec::new(),
+                stale_daemon: None,
+                exit_code: 1,
+                detail: err.message,
+            };
+        }
+    };
     let upgrade = exec(
         &runner.id,
         runner_exec_options(
             runner,
-            runner_upgrade_command(&homeboy_path, force, method_override, source_path),
+            runner_upgrade_command(
+                &homeboy_path,
+                force,
+                method_override,
+                command_source_path.as_deref(),
+            ),
         ),
     );
 
@@ -298,7 +353,7 @@ fn runner_upgrade_command(
     homeboy_path: &str,
     force: bool,
     method_override: Option<InstallMethod>,
-    source_path: Option<&Path>,
+    source_path: Option<&str>,
 ) -> Vec<String> {
     let mut command = vec![
         homeboy_path.to_string(),
@@ -318,10 +373,42 @@ fn runner_upgrade_command(
 
     if let Some(path) = source_path {
         command.push("--source-path".to_string());
-        command.push(path.display().to_string());
+        command.push(path.to_string());
     }
 
     command
+}
+
+fn runner_upgrade_source_path(
+    runner: &Runner,
+    method_override: Option<InstallMethod>,
+    source_path: Option<&Path>,
+    materialize_source_path: &mut impl FnMut(&Runner, &Path) -> Result<String>,
+) -> Result<Option<String>> {
+    let Some(source_path) = source_path else {
+        return Ok(None);
+    };
+
+    if method_override == Some(InstallMethod::Source) && runner.kind == RunnerKind::Ssh {
+        return materialize_source_path(runner, source_path).map(Some);
+    }
+
+    Ok(Some(source_path.display().to_string()))
+}
+
+fn materialize_runner_source_path(runner: &Runner, source_path: &Path) -> Result<String> {
+    let (output, _) = runner::sync_workspace(
+        &runner.id,
+        RunnerWorkspaceSyncOptions {
+            path: source_path.display().to_string(),
+            mode: RunnerWorkspaceSyncMode::Git,
+            changed_since_base: None,
+            git_fetch_refs: Vec::new(),
+            snapshot_includes: Vec::new(),
+        },
+    )?;
+
+    Ok(output.remote_path)
 }
 
 fn runner_extension_exists(
@@ -660,14 +747,15 @@ mod tests {
     }
 
     #[test]
-    fn forwards_forced_source_upgrade_options_to_runner() {
+    fn materializes_forced_source_upgrade_path_before_forwarding_to_runner() {
         let runner = ssh_runner("lab", Some("/home/chubes/.cargo/bin/homeboy"));
         let source_path = Path::new(
             "/Users/chubes/Developer/homeboy@fix-bench-selected-duplicate-validation-1266",
         );
         let mut commands = Vec::new();
+        let mut materialized = Vec::new();
 
-        let (updated, skipped) = upgrade_runners_with_executor(
+        let (updated, skipped) = upgrade_runners_with_executor_and_source_materializer(
             &[runner],
             true,
             Some(InstallMethod::Source),
@@ -685,12 +773,24 @@ mod tests {
                 Ok((exec_output(runner_id, options.command, stdout, "", 0), 0))
             },
             runner_status,
+            |runner, path| {
+                materialized.push((runner.id.clone(), path.display().to_string()));
+                Ok("/home/chubes/Developer/_lab_workspaces/homeboy-source".to_string())
+            },
         );
 
         assert!(skipped.is_empty());
         assert_eq!(updated.len(), 1);
         assert!(updated[0].success);
         assert!(!updated[0].upgraded);
+        assert_eq!(
+            materialized,
+            vec![(
+                "lab".to_string(),
+                "/Users/chubes/Developer/homeboy@fix-bench-selected-duplicate-validation-1266"
+                    .to_string()
+            )]
+        );
         assert_eq!(
             commands[1],
             vec![
@@ -702,7 +802,7 @@ mod tests {
                 "--method",
                 "source",
                 "--source-path",
-                "/Users/chubes/Developer/homeboy@fix-bench-selected-duplicate-validation-1266",
+                "/home/chubes/Developer/_lab_workspaces/homeboy-source",
             ]
         );
     }


### PR DESCRIPTION
## Summary
- Materialize runner source upgrades through Homeboy's runner workspace sync before forwarding `--source-path` to runner-side `homeboy upgrade`.
- Add a controller-routed git workspace sync path so runner source upgrades use the controller checkout instead of requiring the runner to fetch the source itself.
- Preserve branch/origin metadata for controller-routed git bundles so existing runner binaries can run their source upgrade command from the materialized checkout.

Fixes #3754.

## Verification
- `cargo fmt --check`
- `cargo test core::upgrade::runners`
- `cargo test controller_routed_git_sync_materializes_bundle_for_public_remote`
- `cargo test source_workspace_accepts_snapshot_without_git_metadata`
- `cargo run --bin homeboy -- upgrade --force --upgrade-runner homeboy-lab --method source --source-path <controller-homeboy-worktree> --skip-extensions`

## Notes
- Full suite not run; focused tests cover the runner upgrade forwarding/materialization path, controller-routed git bundle materialization, and source workspace validation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the runner source-upgrade materialization fix, added targeted tests, ran focused verification, and drafted this PR body for Chris to review.