### PR TITLE
Parse Lab dispatch failures from stderr

### DIFF
--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -523,6 +523,7 @@ pub fn record_remote_dispatch_failure(
                 Some("parse offloaded agent-task dispatch aggregate".to_string()),
             )
         })?;
+    enrich_remote_dispatch_aggregate(envelope, &mut aggregate);
     if aggregate.events.is_empty() {
         aggregate.events = events_for_outcomes(&aggregate.outcomes);
     }
@@ -619,6 +620,41 @@ pub fn record_remote_dispatch_failure(
 
     store::write_record(&record)?;
     Ok(Some(record))
+}
+
+fn enrich_remote_dispatch_aggregate(envelope: &Value, aggregate: &mut AgentTaskAggregate) {
+    let remote_run_id = envelope.get("run_id").and_then(Value::as_str);
+    for outcome in &mut aggregate.outcomes {
+        if outcome.outputs.get("codebox_run_result").is_none() {
+            if let Some(result) = outcome.metadata.get("codebox_run_result") {
+                let mut outputs = outcome.outputs.as_object().cloned().unwrap_or_default();
+                outputs.insert("codebox_run_result".to_string(), result.clone());
+                outcome.outputs = Value::Object(outputs);
+            }
+        }
+
+        if outcome.evidence_refs.is_empty() {
+            if let Some(remote_run_id) = remote_run_id {
+                outcome.evidence_refs.extend([
+                    AgentTaskEvidenceRef {
+                        kind: "remote-agent-task-logs".to_string(),
+                        uri: format!("homeboy://agent-task/run/{remote_run_id}/logs"),
+                        label: Some("Remote agent-task logs".to_string()),
+                    },
+                    AgentTaskEvidenceRef {
+                        kind: "remote-agent-task-review".to_string(),
+                        uri: format!("homeboy://agent-task/run/{remote_run_id}/review"),
+                        label: Some("Remote agent-task review".to_string()),
+                    },
+                    AgentTaskEvidenceRef {
+                        kind: "remote-agent-task-artifacts".to_string(),
+                        uri: format!("homeboy://agent-task/run/{remote_run_id}/artifacts"),
+                        label: Some("Remote agent-task artifacts".to_string()),
+                    },
+                ]);
+            }
+        }
+    }
 }
 
 fn synthetic_remote_dispatch_plan(
@@ -1483,6 +1519,102 @@ mod tests {
             assert!(raw_aggregate.contains("wp-codebox/agent-task-run-result/v1"));
             assert!(raw_aggregate.contains("failure_classification"));
             assert!(raw_aggregate.contains("remote_plan_ref"));
+        });
+    }
+
+    #[test]
+    fn sparse_aggregate_only_remote_dispatch_failure_adds_remote_evidence_refs() {
+        with_isolated_home(|_| {
+            let aggregate = AgentTaskAggregate {
+                schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+                plan_id: "remote-plan".to_string(),
+                status: AgentTaskAggregateStatus::Failed,
+                totals: AgentTaskAggregateTotals {
+                    failed: 1,
+                    ..AgentTaskAggregateTotals::default()
+                },
+                outcomes: vec![AgentTaskOutcome {
+                    schema: crate::core::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: "cook-conductor".to_string(),
+                    status: crate::core::agent_task::AgentTaskOutcomeStatus::Failed,
+                    summary: Some("WP Codebox agent task failed.".to_string()),
+                    failure_classification: Some(AgentTaskFailureClassification::Provider),
+                    artifacts: Vec::new(),
+                    evidence_refs: Vec::new(),
+                    diagnostics: Vec::new(),
+                    outputs: serde_json::json!({}),
+                    workflow: None,
+                    follow_up: None,
+                    metadata: serde_json::json!({
+                        "provider": "wordpress.codebox-agent-task-executor",
+                        "codebox_run_result": {
+                            "schema": "wp-codebox/agent-task-run-result/v1",
+                            "status": "failed",
+                            "failure_classification": "runtime"
+                        }
+                    }),
+                }],
+                events: Vec::new(),
+                artifact_lineage: Vec::new(),
+                queue: AgentTaskQueueStatus {
+                    max_concurrency: 1,
+                    completed: 1,
+                    ..AgentTaskQueueStatus::default()
+                },
+            };
+            let envelope = serde_json::json!({
+                "schema": "homeboy/agent-task-dispatch/v1",
+                "run_id": "remote-run",
+                "plan_id": "remote-plan",
+                "state": "failed",
+                "aggregate": aggregate,
+            });
+
+            record_remote_dispatch_failure(
+                AgentTaskRemoteDispatchFailure {
+                    run_id: "local-sparse-run",
+                    local_command: vec![
+                        "homeboy".to_string(),
+                        "agent-task".to_string(),
+                        "cook".to_string(),
+                    ],
+                    remote_command: vec![
+                        "homeboy".to_string(),
+                        "agent-task".to_string(),
+                        "cook".to_string(),
+                    ],
+                    runner_id: "lab-a",
+                    remote_workspace: "/runner/workspace/conductor",
+                    stdout: "",
+                    stderr: &envelope.to_string(),
+                    exit_code: 1,
+                },
+                &envelope,
+            )
+            .expect("sparse dispatch failure recorded")
+            .expect("dispatch envelope recognized");
+
+            let loaded = status("local-sparse-run").expect("status loaded");
+            let artifacts = artifacts("local-sparse-run").expect("artifacts loaded");
+            let (raw_aggregate, _) =
+                aggregate_source("local-sparse-run").expect("aggregate source");
+
+            assert_eq!(loaded.tasks[0].task_id, "cook-conductor");
+            assert_eq!(
+                loaded.tasks[0].backend,
+                "wordpress.codebox-agent-task-executor"
+            );
+            assert_eq!(loaded.metadata["remote_run_id"], "remote-run");
+            assert!(artifacts
+                .evidence_refs
+                .iter()
+                .any(|evidence| evidence.kind == "remote-agent-task-logs"));
+            assert!(artifacts
+                .evidence_refs
+                .iter()
+                .any(|evidence| evidence.kind == "remote-agent-task-review"));
+            assert!(raw_aggregate.contains("wp-codebox/agent-task-run-result/v1"));
+            assert!(raw_aggregate.contains("failure_classification"));
         });
     }
 

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -915,7 +915,10 @@ fn run_lab_offload_inner(
     stderr.push_str(&exec_output.stderr);
     if exit_code != 0 {
         if let Some(run_id) = agent_task_dispatch_requested_run_id(request.normalized_args) {
-            if let Some(envelope) = parse_offloaded_dispatch_envelope(&exec_output.stdout)? {
+            if let Some(envelope) = parse_offloaded_dispatch_envelope_from_outputs(
+                &exec_output.stdout,
+                &exec_output.stderr,
+            )? {
                 if let Some(record) = agent_task_lifecycle::record_remote_dispatch_failure(
                     agent_task_lifecycle::AgentTaskRemoteDispatchFailure {
                         run_id: &run_id,
@@ -1198,6 +1201,16 @@ fn parse_offloaded_dispatch_envelope(stdout: &str) -> Result<Option<serde_json::
     }
 
     Ok(None)
+}
+
+fn parse_offloaded_dispatch_envelope_from_outputs(
+    stdout: &str,
+    stderr: &str,
+) -> Result<Option<serde_json::Value>> {
+    parse_offloaded_dispatch_envelope(stdout).and_then(|parsed| match parsed {
+        Some(envelope) => Ok(Some(envelope)),
+        None => parse_offloaded_dispatch_envelope(stderr),
+    })
 }
 
 fn agent_task_dispatch_envelope_value(value: &serde_json::Value) -> Option<&serde_json::Value> {
@@ -1919,6 +1932,59 @@ mod tests {
 
         assert_eq!(parsed["run_id"], "run-1");
         assert_eq!(parsed["aggregate"]["status"], "failed");
+    }
+
+    #[test]
+    fn offloaded_dispatch_envelope_parser_selects_structured_failure_from_stderr() {
+        let stdout = "remote setup complete\n";
+        let stderr = concat!(
+            "{\n",
+            "  \"success\": false,\n",
+            "  \"data\": {\n",
+            "    \"schema\": \"homeboy/agent-task-dispatch/v1\",\n",
+            "    \"run_id\": \"conductor-full-loop-proof-retry3-20260612\",\n",
+            "    \"state\": \"failed\",\n",
+            "    \"aggregate\": {\n",
+            "      \"status\": \"failed\",\n",
+            "      \"outcomes\": [{\n",
+            "        \"task_id\": \"cook-conductor\",\n",
+            "        \"status\": \"failed\",\n",
+            "        \"summary\": \"WP Codebox agent task failed.\",\n",
+            "        \"metadata\": {\n",
+            "          \"provider\": \"wordpress.codebox-agent-task-executor\",\n",
+            "          \"codebox_run_result\": {\n",
+            "            \"schema\": \"wp-codebox/agent-task-run-result/v1\",\n",
+            "            \"status\": \"failed\",\n",
+            "            \"failure_classification\": \"runtime\"\n",
+            "          }\n",
+            "        }\n",
+            "      }]\n",
+            "    }\n",
+            "  }\n",
+            "}\n"
+        );
+
+        let parsed = parse_offloaded_dispatch_envelope_from_outputs(stdout, stderr)
+            .expect("parse dispatch outputs")
+            .expect("dispatch envelope found");
+
+        assert_eq!(
+            parsed["run_id"],
+            "conductor-full-loop-proof-retry3-20260612"
+        );
+        assert_eq!(
+            parsed["aggregate"]["outcomes"][0]["task_id"],
+            "cook-conductor"
+        );
+        assert_eq!(
+            parsed["aggregate"]["outcomes"][0]["metadata"]["provider"],
+            "wordpress.codebox-agent-task-executor"
+        );
+        assert_eq!(
+            parsed["aggregate"]["outcomes"][0]["metadata"]["codebox_run_result"]
+                ["failure_classification"],
+            "runtime"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Parse failed `homeboy/agent-task-dispatch/v1` Lab offload envelopes from `stderr` when `stdout` does not contain the structured dispatch JSON.
- Preserve sparse remote aggregate details by copying `metadata.codebox_run_result` into persisted outputs and adding remote `logs/review/artifacts` evidence refs when the remote outcome has none.
- Keep the local persisted run keyed to the remote task/provider instead of falling back to `agent-task-predispatch` with `summary: \"{\"`.

Follow-up to #4065. Fixes #4057.

## Root cause
Retry3 showed the immediate command output contained the structured dispatch envelope, but the local persistence path only parsed `exec_output.stdout`. The fallback then treated the first non-empty JSON line in the unparsed output as a pre-dispatch failure summary, producing `summary: \"{\"`.

## Tests
- `cargo test --lib offloaded_dispatch_envelope_parser_selects_structured_failure_from_stderr`
- `cargo test --lib sparse_aggregate_only_remote_dispatch_failure_adds_remote_evidence_refs`
- `cargo test --lib aggregate_only_remote_dispatch_failure_preserves_lab_outcome_details`
- `cargo test --lib remote_dispatch_failure_preserves_structured_outcome_details`
- `cargo test --lib offloaded_dispatch_envelope_parser_selects_structured_failure_from_mixed_stdout`
- `cargo fmt --check`
- `git diff --check`

## Known unrelated failures
- `cargo test --lib` still fails in existing bench-discovery tests unrelated to this change:
  - `commands::bench::tests::profile_with_unknown_scenario_lists_discovered_scenarios`
  - `commands::bench::tests::unknown_scenario_reports_discovered_ids`
- Current broad run result: 4,254 passed, 2 failed, 18 ignored.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the retry3 persistence bypass, implementing the stderr dispatch parser and sparse aggregate enrichment, adding targeted regression coverage, running verification, and drafting this PR description. Chris remains responsible for review and merge.