### PR TITLE
Preserve workspace ownership for root materialization

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -52,6 +52,7 @@ pub mod issues;
 pub mod keychain;
 pub mod observation;
 pub mod output;
+pub(crate) mod ownership;
 pub mod plan;
 pub mod process;
 pub mod product_identity;

--- a/src/core/ownership.rs
+++ b/src/core/ownership.rs
@@ -1,0 +1,112 @@
+use std::path::Path;
+use std::process::Command;
+
+use crate::core::error::{Error, Result};
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FileOwner {
+    uid: u32,
+    gid: u32,
+}
+
+impl FileOwner {
+    fn is_root(self) -> bool {
+        self.uid == 0 && self.gid == 0
+    }
+
+    fn spec(self) -> String {
+        format!("{}:{}", self.uid, self.gid)
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn owner_for_path_or_ancestor(path: &Path) -> Result<Option<FileOwner>> {
+    for candidate in path.ancestors() {
+        if !candidate.exists() {
+            continue;
+        }
+        let metadata = candidate.metadata().map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("read ownership for {}", candidate.display())),
+            )
+        })?;
+        return Ok(Some(FileOwner {
+            uid: metadata.uid(),
+            gid: metadata.gid(),
+        }));
+    }
+    Ok(None)
+}
+
+#[cfg(not(unix))]
+pub(crate) fn owner_for_path_or_ancestor(_path: &Path) -> Result<Option<FileOwner>> {
+    Ok(None)
+}
+
+#[cfg(unix)]
+pub(crate) fn normalize_created_path(
+    path: &Path,
+    owner: Option<FileOwner>,
+    recursive: bool,
+    action: &str,
+) -> Result<()> {
+    let Some(owner) = owner else {
+        return Ok(());
+    };
+    if unsafe { libc::geteuid() } != 0 || owner.is_root() || !path.exists() {
+        return Ok(());
+    }
+
+    let mut command = Command::new("chown");
+    if recursive {
+        command.arg("-R");
+    }
+    let output = command
+        .arg(owner.spec())
+        .arg(path)
+        .output()
+        .map_err(|err| {
+            Error::internal_io(err.to_string(), Some(format!("chown after {action}")))
+        })?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    Err(Error::internal_unexpected(format!(
+        "failed to restore ownership after {action}: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    )))
+}
+
+#[cfg(not(unix))]
+pub(crate) fn normalize_created_path(
+    _path: &Path,
+    _owner: Option<FileOwner>,
+    _recursive: bool,
+    _action: &str,
+) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn owner_resolution_uses_nearest_existing_ancestor() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let owner =
+            owner_for_path_or_ancestor(&root.path().join("missing").join("child").join("file.txt"))
+                .expect("owner lookup")
+                .expect("owner");
+        let root_metadata = root.path().metadata().expect("metadata");
+
+        assert_eq!(owner.uid, root_metadata.uid());
+        assert_eq!(owner.gid, root_metadata.gid());
+    }
+}

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -579,10 +579,13 @@ fn includes_override_exclude(includes: &[String], exclude: &str) -> bool {
 }
 
 fn snapshot_install_command(remote_path: &str) -> String {
+    let parent = parent_remote_path(remote_path);
     format!(
-        "parent={parent}; dest={dest}; tmp=\"${{dest}}.tmp.$$\"; mkdir -p \"$parent\" && trap 'rm -rf \"$tmp\"' EXIT; rm -rf \"$tmp\" && mkdir -p \"$tmp\" && tar -C \"$tmp\" -xf - && rm -rf \"$dest\" && mv \"$tmp\" \"$dest\"",
-        parent = shell::quote_arg(parent_remote_path(remote_path).as_str()),
+        "parent={parent}; dest={dest}; tmp=\"${{dest}}.tmp.$$\"; {owner_capture}; mkdir -p \"$parent\" && trap 'rm -rf \"$tmp\"' EXIT; rm -rf \"$tmp\" && mkdir -p \"$tmp\" && tar -C \"$tmp\" -xf - && rm -rf \"$dest\" && mv \"$tmp\" \"$dest\" && {owner_restore}",
+        parent = shell::quote_arg(parent.as_str()),
         dest = shell::quote_arg(remote_path),
+        owner_capture = owner_capture_shell("$parent"),
+        owner_restore = owner_restore_shell("$parent", "$dest"),
     )
 }
 
@@ -724,6 +727,7 @@ fn git_bundle_install_command(
     branch: Option<&str>,
     remote_url: &str,
 ) -> String {
+    let parent = parent_remote_path(remote_path);
     let checkout = if let Some(branch) = branch {
         format!(
             "git -C \"$tmp\" checkout -B {branch} {head} && git -C \"$tmp\" config branch.{branch}.remote origin && git -C \"$tmp\" config branch.{branch}.merge refs/heads/{branch}",
@@ -738,12 +742,14 @@ fn git_bundle_install_command(
     };
 
     format!(
-        "parent={parent}; dest={dest}; tmp=\"${{dest}}.tmp.$$\"; bundle=\"${{dest}}.bundle.$$\"; mkdir -p \"$parent\" && trap 'rm -rf \"$tmp\" \"$bundle\"' EXIT; rm -rf \"$tmp\" \"$bundle\" && cat > \"$bundle\" && git clone \"$bundle\" \"$tmp\" && git -C \"$tmp\" remote set-url origin {remote_url} && {checkout} && git -C \"$tmp\" reset --hard {head} && git -C \"$tmp\" clean -ffdqx && rm -rf \"$dest\" && mv \"$tmp\" \"$dest\"",
-        parent = shell::quote_arg(parent_remote_path(remote_path).as_str()),
+        "parent={parent}; dest={dest}; tmp=\"${{dest}}.tmp.$$\"; bundle=\"${{dest}}.bundle.$$\"; {owner_capture}; mkdir -p \"$parent\" && trap 'rm -rf \"$tmp\" \"$bundle\"' EXIT; rm -rf \"$tmp\" \"$bundle\" && cat > \"$bundle\" && git clone \"$bundle\" \"$tmp\" && git -C \"$tmp\" remote set-url origin {remote_url} && {checkout} && git -C \"$tmp\" reset --hard {head} && git -C \"$tmp\" clean -ffdqx && rm -rf \"$dest\" && mv \"$tmp\" \"$dest\" && {owner_restore}",
+        parent = shell::quote_arg(parent.as_str()),
         dest = shell::quote_arg(remote_path),
         remote_url = shell::quote_arg(remote_url),
         checkout = checkout,
         head = shell::quote_arg(head),
+        owner_capture = owner_capture_shell("$parent"),
+        owner_restore = owner_restore_shell("$parent", "$dest"),
     )
 }
 
@@ -754,6 +760,7 @@ fn materialize_git_command(
     changed_since_base: Option<&str>,
     git_fetch_refs: &[String],
 ) -> String {
+    let parent = parent_remote_path(remote_path);
     let dest = shell::quote_arg(remote_path);
     let fetch_changed_since = changed_since_base
         .map(|base| {
@@ -775,13 +782,27 @@ fn materialize_git_command(
         .collect::<String>();
 
     format!(
-        "mkdir -p {parent} && if [ -d {dest}/.git ]; then git -C {dest} reset --hard && git -C {dest} clean -ffdqx && git -C {dest} fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf {dest} && git clone {url} {dest} && git -C {dest} fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_changed_since}{fetch_extra_refs} && git -C {dest} checkout --detach {head} && git -C {dest} reset --hard {head} && git -C {dest} clean -ffdqx",
-        parent = shell::quote_arg(parent_remote_path(remote_path).as_str()),
+        "parent={parent}; dest={dest}; {owner_capture}; mkdir -p \"$parent\" && if [ -d \"$dest\"/.git ]; then git -C \"$dest\" reset --hard && git -C \"$dest\" clean -ffdqx && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf \"$dest\" && git clone {url} \"$dest\" && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_changed_since}{fetch_extra_refs} && git -C \"$dest\" checkout --detach {head} && git -C \"$dest\" reset --hard {head} && git -C \"$dest\" clean -ffdqx && {owner_restore}",
+        parent = shell::quote_arg(parent.as_str()),
         dest = dest,
         url = shell::quote_arg(remote_url),
         head = shell::quote_arg(head),
         fetch_changed_since = fetch_changed_since,
         fetch_extra_refs = fetch_extra_refs,
+        owner_capture = owner_capture_shell("$parent"),
+        owner_restore = owner_restore_shell("$parent", "$dest"),
+    )
+}
+
+fn owner_capture_shell(reference: &str) -> String {
+    format!(
+        "owner_path={reference}; while [ ! -e \"$owner_path\" ] && [ \"$owner_path\" != \"/\" ]; do owner_path=$(dirname \"$owner_path\"); done; owner=\"\"; if [ -e \"$owner_path\" ]; then owner=$(stat -c '%u:%g' \"$owner_path\" 2>/dev/null || stat -f '%u:%g' \"$owner_path\" 2>/dev/null || true); fi",
+    )
+}
+
+fn owner_restore_shell(parent: &str, dest: &str) -> String {
+    format!(
+        "if [ \"$(id -u)\" = \"0\" ] && [ -n \"$owner\" ] && [ \"$owner\" != \"0:0\" ]; then chown \"$owner\" {parent} && chown -R \"$owner\" {dest}; fi",
     )
 }
 
@@ -1290,6 +1311,36 @@ mod tests {
         assert!(command.contains("checkout --detach abc123"));
         assert!(command.contains("reset --hard"));
         assert!(command.contains("reset --hard abc123"));
+    }
+
+    #[test]
+    fn git_materialization_restores_workspace_owner_after_root_run() {
+        let command = materialize_git_command(
+            "/var/lib/datamachine/workspace/_lab_workspaces/homeboy-abc",
+            "https://github.com/Extra-Chill/homeboy.git",
+            "abc123",
+            None,
+            &[],
+        );
+
+        assert!(command.contains("owner_path=$parent"));
+        assert!(command.contains("stat -c '%u:%g'"));
+        assert!(command.contains("stat -f '%u:%g'"));
+        assert!(command.contains("[ \"$(id -u)\" = \"0\" ]"));
+        assert!(command.contains("[ \"$owner\" != \"0:0\" ]"));
+        assert!(command.contains("chown \"$owner\" $parent"));
+        assert!(command.contains("chown -R \"$owner\" $dest"));
+    }
+
+    #[test]
+    fn snapshot_install_restores_workspace_owner_after_root_run() {
+        let command =
+            snapshot_install_command("/var/lib/datamachine/workspace/_lab_workspaces/homeboy-abc");
+
+        assert!(command.contains("owner_path=$parent"));
+        assert!(command.contains("mkdir -p \"$parent\""));
+        assert!(command.contains("mv \"$tmp\" \"$dest\" && if"));
+        assert!(command.contains("chown -R \"$owner\" $dest"));
     }
 
     #[test]

--- a/src/core/worktree.rs
+++ b/src/core/worktree.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::core::component::{self, TargetSpec};
 use crate::core::error::{Error, Result};
+use crate::core::ownership;
 use crate::core::{git, paths};
 
 mod types {
@@ -201,6 +202,7 @@ fn create_with_store(
         ));
     }
 
+    let worktree_owner = ownership::owner_for_path_or_ancestor(parent)?;
     let base_ref = options.from.unwrap_or_else(|| "HEAD".to_string());
     git::run_git(
         &source_checkout,
@@ -214,6 +216,7 @@ fn create_with_store(
         ],
         "git worktree add",
     )?;
+    ownership::normalize_created_path(&worktree_path, worktree_owner, true, "git worktree add")?;
 
     let record = TaskWorktreeRecord {
         id,
@@ -379,13 +382,18 @@ fn record_path(store_dir: &Path, id: &str) -> PathBuf {
 }
 
 fn write_record(store_dir: &Path, record: &TaskWorktreeRecord) -> Result<()> {
+    let store_owner = ownership::owner_for_path_or_ancestor(store_dir)?;
     fs::create_dir_all(store_dir).map_err(|err| {
         Error::internal_io(err.to_string(), Some(store_dir.display().to_string()))
     })?;
     let json = serde_json::to_string_pretty(record)
         .map_err(|err| Error::internal_json(err.to_string(), Some(record.id.clone())))?;
-    fs::write(record_path(store_dir, &record.id), format!("{json}\n"))
-        .map_err(|err| Error::internal_io(err.to_string(), Some(record.id.clone())))
+    let path = record_path(store_dir, &record.id);
+    fs::write(&path, format!("{json}\n"))
+        .map_err(|err| Error::internal_io(err.to_string(), Some(record.id.clone())))?;
+    ownership::normalize_created_path(store_dir, store_owner, false, "write worktree metadata")?;
+    ownership::normalize_created_path(&path, store_owner, false, "write worktree metadata")?;
+    Ok(())
 }
 
 fn read_record(store_dir: &Path, id: &str) -> Result<TaskWorktreeRecord> {


### PR DESCRIPTION
## Summary
- Preserve the owner of existing workspace parents/ancestors when Homeboy creates task worktrees, task-worktree metadata, and runner materialized workspaces from root-run commands.
- Add Unix ownership helper logic and runner shell command guards so root-created artifacts are chowned back to the workspace owner instead of becoming unmanaged root-owned state.
- Cover the owner resolution and runner materialization shell contract with focused tests.

Fixes #4075.

## Tests
- `cargo fmt --check`
- `cargo check`
- `cargo test --lib owner_resolution_uses_nearest_existing_ancestor`
- `cargo test --lib workspace_owner_after_root_run`
- `cargo test --lib core::runner::workspace`
- `cargo test --lib core::worktree`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Code changes, targeted tests, and verification commands; Chris remains responsible for review and merge.