### PR TITLE
Project bench artifact viewer links

### DIFF
--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -2,13 +2,15 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 
+use homeboy::core::artifact_links;
 use homeboy::core::engine::run_dir::{self, RunDir};
 use homeboy::core::extension::bench::{
     BenchDiagnostic, BenchDiagnosticSource, BenchResults, BenchRunWorkflowResult,
 };
 use homeboy::core::git::short_head_revision_at;
 use homeboy::core::observation::{
-    finding_records_from_budget, merge_metadata, ActiveObservation, NewRunRecord, RunStatus,
+    finding_records_from_budget, merge_metadata, ActiveObservation, ArtifactRecord, NewRunRecord,
+    RunStatus,
 };
 use homeboy::core::rig::RigStateSnapshot;
 
@@ -487,7 +489,7 @@ fn persist_bench_artifact(
             metadata,
         ) {
             Ok(record) => {
-                artifact.observation_artifact_id = Some(record.id);
+                apply_recorded_bench_artifact_links(artifact, &record);
                 None
             }
             Err(error) => Some(bench_artifact_diagnostic(
@@ -549,8 +551,8 @@ fn persist_bench_artifact(
 
     match record {
         Ok(record) => {
-            artifact.path = Some(record.path);
-            artifact.observation_artifact_id = Some(record.id);
+            artifact.path = Some(record.path.clone());
+            apply_recorded_bench_artifact_links(artifact, &record);
             None
         }
         Err(error) => Some(bench_artifact_diagnostic(
@@ -565,6 +567,19 @@ fn persist_bench_artifact(
             }),
         )),
     }
+}
+
+fn apply_recorded_bench_artifact_links(
+    artifact: &mut homeboy::core::extension::bench::BenchArtifact,
+    record: &ArtifactRecord,
+) {
+    artifact.observation_artifact_id = Some(record.id.clone());
+    let Some(public_url) = artifact_links::public_artifact_url(record) else {
+        return;
+    };
+    artifact.public_url = Some(public_url.clone());
+    artifact.viewer_links = artifact_links::viewer_links(record, Some(&public_url));
+    artifact.viewer_url = artifact.viewer_links.first().map(|link| link.url.clone());
 }
 
 fn bench_artifact_metadata(
@@ -582,6 +597,7 @@ fn bench_artifact_metadata(
         "label": artifact.label,
         "original_path": artifact.path,
         "url": artifact.url,
+        "viewer": artifact.viewer,
     })
 }
 
@@ -718,6 +734,11 @@ mod tests {
 
     pub(super) struct XdgGuard(Option<String>);
 
+    struct EnvGuard {
+        key: &'static str,
+        prior: Option<String>,
+    }
+
     impl XdgGuard {
         pub(super) fn unset() -> Self {
             let prior = std::env::var("XDG_DATA_HOME").ok();
@@ -731,6 +752,23 @@ mod tests {
             match &self.0 {
                 Some(value) => std::env::set_var("XDG_DATA_HOME", value),
                 None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+        }
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prior = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
             }
         }
     }
@@ -791,6 +829,10 @@ mod tests {
     fn bench_observation_persists_success_with_metrics_and_artifacts() {
         with_isolated_home(|home| {
             let _xdg = XdgGuard::unset();
+            let _public_artifact_base = EnvGuard::set(
+                homeboy::core::artifact_links::PUBLIC_ARTIFACT_BASE_URL_ENV,
+                "https://artifacts.example.test/homeboy",
+            );
             let run_dir = RunDir::create().expect("run dir");
             fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
             fs::write(run_dir.step_file(run_dir::files::RESOURCE_SUMMARY), b"{}")
@@ -809,6 +851,15 @@ mod tests {
                     kind: Some("json".to_string()),
                     label: Some("Transcript".to_string()),
                     observation_artifact_id: None,
+                    viewer: Some(serde_json::json!({
+                        "kind": "wordpress-playground-blueprint",
+                        "base": "https://playground.wordpress.net/",
+                        "query": {
+                            "parameter": "blueprint-url",
+                            "value": { "source": "public-artifact-url" },
+                            "encoding": "url"
+                        }
+                    })),
                     ..BenchArtifact::default()
                 },
             );
@@ -916,6 +967,26 @@ mod tests {
             assert_eq!(transcript_record.metadata_json["scenario_id"], "cold");
             assert_eq!(transcript_record.metadata_json["name"], "transcript");
             assert_eq!(transcript_record.metadata_json["kind"], "json");
+            assert_eq!(
+                transcript_record.metadata_json["viewer"]["query"]["value"]["source"],
+                "public-artifact-url"
+            );
+            let transcript_artifact =
+                &workflow.results.as_ref().unwrap().scenarios[0].artifacts["transcript"];
+            assert!(transcript_artifact
+                .public_url
+                .as_deref()
+                .expect("public url")
+                .starts_with("https://artifacts.example.test/homeboy/runs/"));
+            assert!(transcript_artifact
+                .viewer_url
+                .as_deref()
+                .expect("viewer url")
+                .starts_with("https://playground.wordpress.net/?blueprint-url="));
+            assert_eq!(
+                transcript_artifact.viewer_links[0].kind,
+                "wordpress-playground-blueprint"
+            );
             assert!(
                 workflow.results.as_ref().unwrap().scenarios[0].artifacts["admin"]
                     .observation_artifact_id

--- a/src/core/extension/bench/artifact.rs
+++ b/src/core/extension/bench/artifact.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::core::observation::ArtifactViewerLink;
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct BenchPreviewLifecycleMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -35,6 +37,12 @@ pub struct BenchArtifact {
     pub preview_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub public_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub viewer: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub viewer_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub viewer_links: Vec<ArtifactViewerLink>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub local_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/core/extension/bench/report.rs
+++ b/src/core/extension/bench/report.rs
@@ -10,6 +10,7 @@ use super::run::{BenchRunFailure, BenchRunWorkflowResult};
 use crate::core::ci_profile::CiContext;
 use crate::core::finding::HomeboyFinding;
 use crate::core::gate::HomeboyGateResult;
+use crate::core::observation::ArtifactViewerLink;
 use crate::core::rig::RigStateSnapshot;
 use crate::core::runner::reportable_artifact_evidence_path;
 
@@ -145,6 +146,10 @@ pub struct BenchArtifactRef {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub public_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub viewer_url: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub viewer_links: Vec<ArtifactViewerLink>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub local_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
@@ -191,6 +196,8 @@ fn artifact_ref(
         role: artifact.role.clone(),
         preview_url: artifact.preview_url.clone(),
         public_url: artifact.public_url.clone(),
+        viewer_url: artifact.viewer_url.clone(),
+        viewer_links: artifact.viewer_links.clone(),
         local_url: artifact.local_url.clone(),
         status: artifact.status.clone(),
         preview_lifecycle: artifact.preview_lifecycle.clone(),

--- a/src/core/extension/bench/side_by_side.rs
+++ b/src/core/extension/bench/side_by_side.rs
@@ -162,6 +162,7 @@ fn side_by_side_preview_link(
     let url = artifact
         .preview_url
         .clone()
+        .or_else(|| artifact.viewer_url.clone())
         .or_else(|| artifact.public_url.clone())
         .or_else(|| artifact.url.clone())
         .or_else(|| artifact.path.as_deref().and_then(url_from_artifact_path))?;
@@ -187,6 +188,8 @@ fn side_by_side_preview_link(
 
 fn is_preview_artifact(artifact: &BenchArtifactRef) -> bool {
     artifact.preview_url.is_some()
+        || artifact.viewer_url.is_some()
+        || !artifact.viewer_links.is_empty()
         || artifact.public_url.is_some()
         || artifact.local_url.is_some()
         || artifact.status.is_some()

--- a/tests/core/extension/bench/report_comparison_test.rs
+++ b/tests/core/extension/bench/report_comparison_test.rs
@@ -171,6 +171,9 @@ mod fixtures {
             role: role.map(str::to_string),
             preview_url: Some(preview_url.to_string()),
             public_url: Some(preview_url.to_string()),
+            viewer: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
             local_url: Some("http://127.0.0.1:8080".to_string()),
             status: Some(status.to_string()),
             preview_lifecycle: BenchPreviewLifecycleMetadata {
@@ -322,6 +325,42 @@ fn comparison_side_by_side_renders_baseline_and_candidate_preview_links() {
     assert_eq!(
         value["reports"]["side_by_side"]["rigs"][1]["preview_links"][0]["url"],
         "https://candidate-preview.example.test/"
+    );
+}
+
+#[test]
+fn comparison_side_by_side_uses_viewer_url_as_preview_link() {
+    let mut candidate_scenario = scenario("site-build", &[("elapsed_ms", 8_000.0)]);
+    candidate_scenario.artifacts.insert(
+        "blueprint.after".to_string(),
+        BenchArtifact {
+            path: Some("artifacts/blueprint.after.json".to_string()),
+            kind: Some("json".to_string()),
+            label: Some("Generated site replay".to_string()),
+            public_url: Some("https://artifacts.example.test/runs/1/blueprint.after".to_string()),
+            viewer_url: Some(
+                "https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fartifacts.example.test%2Fruns%2F1%2Fblueprint.after"
+                    .to_string(),
+            ),
+            ..BenchArtifact::default()
+        },
+    );
+
+    let entries = vec![entry(
+        "candidate-rig",
+        true,
+        Some(results(vec![candidate_scenario])),
+    )];
+
+    let (out, exit) = aggregate_comparison("studio".into(), 10, entries);
+    let preview_link = &out.reports.side_by_side.rigs[0].preview_links[0];
+
+    assert_eq!(exit, 0);
+    assert_eq!(preview_link.name, "blueprint.after");
+    assert_eq!(preview_link.role, "baseline");
+    assert_eq!(
+        preview_link.url,
+        "https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fartifacts.example.test%2Fruns%2F1%2Fblueprint.after"
     );
 }
 


### PR DESCRIPTION
## Summary
- Preserve producer-supplied bench artifact `viewer` metadata when Homeboy records observation artifacts.
- Project Homeboy-derived `public_url`, `viewer_url`, and `viewer_links` back into BenchResults/report artifacts after artifact IDs are assigned.
- Treat viewer URLs as previewable side-by-side report links so generated-site replay artifacts can surface clickable viewers.

## Testing
- `cargo test bench_observation_persists_success_with_metrics_and_artifacts`
- `cargo test test_validate_artifact_paths`
- `cargo test comparison_side_by_side_uses_viewer_url_as_preview_link`
- `cargo test artifact_links`
- `cargo test comparison_side_by_side`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the bench artifact viewer-link projection and focused tests; Chris remains responsible for review and validation.