### PR TITLE
Add preview asset fanout gate

### DIFF
--- a/docs/architecture/preview-metadata.md
+++ b/docs/architecture/preview-metadata.md
@@ -116,7 +116,18 @@ trace collection starts:
     "required_asset_paths": [
       "/assets/app.js",
       "/assets/app.css"
-    ]
+    ],
+    "asset_fanout": {
+      "asset_paths": [
+        "/assets/app.js?ver=1",
+        "/assets/app.css?ver=1",
+        "/assets/vendor.js?ver=1",
+        "/assets/runtime.css?ver=1"
+      ],
+      "concurrency": 16,
+      "repeat_count": 3,
+      "expected_body_contains": "fixture-asset-ok"
+    }
   }
 }
 ```
@@ -127,6 +138,23 @@ starting the trace runner. Non-2xx responses, aborted requests, and connection
 errors fail fast with `public_preview.required_asset_paths` diagnostics so a run
 does not collect baseline/candidate traces from a page whose static assets cannot
 load.
+
+`asset_fanout` is the native preview tunnel stress gate for browser/static asset
+bursts. Homeboy expands each listed path against the public preview origin,
+requests every path `repeat_count` times with up to `concurrency` concurrent
+workers, and fails before trace collection when any request aborts, times out,
+returns a non-2xx status such as `502`/`504`, or misses the optional
+`expected_body_contains` text. The preview metadata records a
+`homeboy/preview-asset-fanout/v1` report with client request totals, status
+counts, failure buckets, and per-request rows. Native ingress/client/local-origin
+implementations can populate the optional ingress and local-origin request count
+fields in the same report so reviewer artifacts can distinguish browser/client
+errors from tunnel ingress or origin delivery gaps.
+
+Use this core gate for generic HTTP asset fanout proof. Product-specific proofs,
+such as WP Codebox or WooCommerce asset lists for Extra-Chill/homeboy#4062,
+should live in the owning rig or extension and consume this generic
+`asset_fanout` contract.
 
 ## Persistence
 

--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -76,8 +76,8 @@ the public origin with bounded concurrency. Any aborted request, timeout,
 non-2xx response, or optional body-content mismatch fails the trace before it can
 produce misleading browser evidence.
 
-Use this gate before Woo Stripe real-wallet reruns that depend on WP Codebox
-static plugin assets:
+Use this gate when a trace depends on a public preview serving a burst of static
+assets reliably:
 
 ```jsonc
 {
@@ -87,9 +87,9 @@ static plugin assets:
     "require_https": true,
     "asset_fanout": {
       "asset_paths": [
-        "/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.js?ver=10.8.0",
-        "/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.css?ver=10.8.0",
-        "/wp-content/plugins/woocommerce/assets/js/frontend/add-to-cart.min.js"
+        "/assets/app.js?ver=1",
+        "/assets/app.css?ver=1",
+        "/assets/vendor.js?ver=1"
       ],
       "concurrency": 16,
       "repeat_count": 3
@@ -102,6 +102,10 @@ The emitted preview metadata includes `asset_fanout.schema =
 homeboy/preview-asset-fanout/v1`, expected/client request totals, status counts,
 failure buckets, and request rows. Native tunnel integrations may also fill
 ingress and local-origin request counts when those counters are available.
+
+Keep core fanout proof generic. WP Codebox, WooCommerce, or other product-specific
+asset lists should live in their owning rig or extension and consume this
+contract.
 
 ## Baseline/Candidate Compare
 

--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -66,6 +66,43 @@ JSON run, summary, and aggregate outputs include a `profile` object with the res
 
 Trace dependency preflight rejects stale or dirty dependency checkouts before running the expensive workflow so stale local dependencies cannot produce misleading evidence.
 
+## Public Preview Asset Gates
+
+Trace workloads can declare `public_preview.required_asset_paths` for serial asset
+preflight and `public_preview.asset_fanout` for concurrent browser/static asset
+stress proof. `asset_fanout` starts after the public preview URL is available and
+before the trace runner begins, then fetches every configured asset path through
+the public origin with bounded concurrency. Any aborted request, timeout,
+non-2xx response, or optional body-content mismatch fails the trace before it can
+produce misleading browser evidence.
+
+Use this gate before Woo Stripe real-wallet reruns that depend on WP Codebox
+static plugin assets:
+
+```jsonc
+{
+  "public_preview": {
+    "local_origin": "http://127.0.0.1:49823",
+    "public_origin": "https://preview.example.test",
+    "require_https": true,
+    "asset_fanout": {
+      "asset_paths": [
+        "/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.js?ver=10.8.0",
+        "/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.css?ver=10.8.0",
+        "/wp-content/plugins/woocommerce/assets/js/frontend/add-to-cart.min.js"
+      ],
+      "concurrency": 16,
+      "repeat_count": 3
+    }
+  }
+}
+```
+
+The emitted preview metadata includes `asset_fanout.schema =
+homeboy/preview-asset-fanout/v1`, expected/client request totals, status counts,
+failure buckets, and request rows. Native tunnel integrations may also fill
+ingress and local-origin request counts when those counters are available.
+
 ## Baseline/Candidate Compare
 
 `homeboy trace compare <component> <scenario>` can run the same trace scenario against two local paths or git refs, aggregate the span timings, write JSON artifacts, and render a Markdown summary. This is the first-class A/B browser proof workflow for trace rigs: pass baseline and candidate targets, choose `--runs`, and Homeboy preserves per-run artifacts while producing reviewer-ready span and browser evidence tables.

--- a/src/commands/trace/preview_args.rs
+++ b/src/commands/trace/preview_args.rs
@@ -65,6 +65,15 @@ fn expand_trace_public_preview(
             .iter()
             .map(|path| expand(path))
             .collect(),
+        asset_fanout: spec
+            .asset_fanout
+            .as_ref()
+            .map(|fanout| rig::TracePreviewAssetFanoutSpec {
+                asset_paths: fanout.asset_paths.iter().map(|path| expand(path)).collect(),
+                concurrency: fanout.concurrency,
+                repeat_count: fanout.repeat_count,
+                expected_body_contains: fanout.expected_body_contains.as_deref().map(expand),
+            }),
         native: spec
             .native
             .as_ref()

--- a/src/core/extension/trace/preview.rs
+++ b/src/core/extension/trace/preview.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, VecDeque};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
 
 use crate::core::error::{Error, Result};
@@ -12,6 +13,8 @@ use crate::core::rig::{
 
 const DEFAULT_STARTUP_TIMEOUT_SECONDS: u64 = 20;
 const DEFAULT_ASSET_CHECK_TIMEOUT_SECONDS: u64 = 10;
+const DEFAULT_ASSET_FANOUT_CONCURRENCY: usize = 16;
+const DEFAULT_ASSET_FANOUT_REPEAT_COUNT: usize = 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TracePreviewAssetCheck {
@@ -21,6 +24,40 @@ pub struct TracePreviewAssetCheck {
     pub ok: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TracePreviewAssetFanoutRequest {
+    pub path: String,
+    pub url: String,
+    pub status: Option<u16>,
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_bucket: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TracePreviewAssetFanoutReport {
+    pub schema: String,
+    pub concurrency: usize,
+    pub repeat_count: usize,
+    pub asset_path_count: usize,
+    pub expected_request_count: usize,
+    pub client_request_count: usize,
+    pub success_count: usize,
+    pub failure_count: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ingress_request_count: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_origin_request_count: Option<usize>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub status_counts: BTreeMap<String, usize>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub failure_buckets: BTreeMap<String, usize>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requests: Vec<TracePreviewAssetFanoutRequest>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -39,6 +76,8 @@ pub struct TracePreviewMetadata {
     pub require_https: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub required_assets: Vec<TracePreviewAssetCheck>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub asset_fanout: Option<TracePreviewAssetFanoutReport>,
     pub status: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub process_id: Option<String>,
@@ -137,6 +176,14 @@ impl TracePublicPreviewSession {
             }
         };
 
+        let asset_fanout = match validate_asset_fanout(spec, &public_origin) {
+            Ok(report) => report,
+            Err(error) => {
+                stop_child(&mut child);
+                return Err(error);
+            }
+        };
+
         let process_id = child.as_ref().map(|child| child.id().to_string());
         Ok(Self {
             child,
@@ -156,6 +203,7 @@ impl TracePublicPreviewSession {
                 window_is_secure_context: is_https,
                 require_https: spec.require_https,
                 required_assets,
+                asset_fanout,
                 status: "running".to_string(),
                 process_id,
                 cleanup_status: "pending".to_string(),
@@ -223,6 +271,14 @@ impl TracePublicPreviewSession {
             }
         };
 
+        let asset_fanout = match validate_asset_fanout(spec, &public_origin) {
+            Ok(report) => report,
+            Err(error) => {
+                stop_child(&mut child);
+                return Err(error);
+            }
+        };
+
         let process_id = child.as_ref().map(|child| child.id().to_string());
         Ok(Self {
             child,
@@ -242,6 +298,7 @@ impl TracePublicPreviewSession {
                 window_is_secure_context: is_https,
                 require_https: spec.require_https,
                 required_assets,
+                asset_fanout,
                 status: "running".to_string(),
                 process_id,
                 cleanup_status: "pending".to_string(),
@@ -672,6 +729,259 @@ fn preflight_required_assets(
     ))
 }
 
+fn validate_asset_fanout(
+    spec: &TracePublicPreviewSpec,
+    public_origin: &str,
+) -> Result<Option<TracePreviewAssetFanoutReport>> {
+    let Some(fanout) = spec.asset_fanout.as_ref() else {
+        return Ok(None);
+    };
+    if fanout.asset_paths.is_empty() {
+        return Ok(Some(empty_asset_fanout_report(fanout)));
+    }
+
+    let concurrency = fanout
+        .concurrency
+        .unwrap_or(DEFAULT_ASSET_FANOUT_CONCURRENCY)
+        .max(1);
+    let repeat_count = fanout
+        .repeat_count
+        .unwrap_or(DEFAULT_ASSET_FANOUT_REPEAT_COUNT)
+        .max(1);
+    let expected_request_count = fanout.asset_paths.len() * repeat_count;
+    let mut jobs = VecDeque::with_capacity(expected_request_count);
+    for _ in 0..repeat_count {
+        for path in &fanout.asset_paths {
+            jobs.push_back((path.clone(), preview_asset_url(public_origin, path)));
+        }
+    }
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(DEFAULT_ASSET_CHECK_TIMEOUT_SECONDS))
+        .redirect(reqwest::redirect::Policy::limited(5))
+        .build()
+        .map_err(|e| {
+            Error::internal_io(
+                format!("Failed to create trace public_preview asset fanout client: {e}"),
+                Some("trace.preview.asset_fanout_client".to_string()),
+            )
+        })?;
+    let jobs = Arc::new(Mutex::new(jobs));
+    let requests = Arc::new(Mutex::new(Vec::with_capacity(expected_request_count)));
+    let expected_body_contains = fanout.expected_body_contains.clone();
+
+    let worker_count = concurrency.min(expected_request_count);
+    let mut workers = Vec::with_capacity(worker_count);
+    for _ in 0..worker_count {
+        let client = client.clone();
+        let jobs = Arc::clone(&jobs);
+        let requests = Arc::clone(&requests);
+        let expected_body_contains = expected_body_contains.clone();
+        workers.push(std::thread::spawn(move || loop {
+            let Some((path, url)) = jobs.lock().expect("asset fanout jobs lock").pop_front() else {
+                break;
+            };
+            let request = fetch_fanout_asset(&client, path, url, expected_body_contains.as_deref());
+            requests
+                .lock()
+                .expect("asset fanout requests lock")
+                .push(request);
+        }));
+    }
+    for worker in workers {
+        worker.join().map_err(|_| {
+            Error::internal_io(
+                "trace public_preview asset fanout worker panicked".to_string(),
+                Some("trace.preview.asset_fanout".to_string()),
+            )
+        })?;
+    }
+
+    let requests = Arc::try_unwrap(requests)
+        .expect("asset fanout request handles released")
+        .into_inner()
+        .expect("asset fanout requests lock");
+    let report = asset_fanout_report(
+        concurrency,
+        repeat_count,
+        fanout.asset_paths.len(),
+        requests,
+    );
+    if report.failure_count == 0 && report.client_request_count == expected_request_count {
+        return Ok(Some(report));
+    }
+
+    let details = report
+        .failure_buckets
+        .iter()
+        .map(|(bucket, count)| format!("{bucket}={count}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(Error::validation_invalid_argument(
+        "public_preview.asset_fanout",
+        format!(
+            "trace public_preview asset fanout failed before trace collection: expected_request_count={} client_request_count={} failure_count={} failure_buckets=[{}]",
+            report.expected_request_count,
+            report.client_request_count,
+            report.failure_count,
+            details
+        ),
+        Some(public_origin.to_string()),
+        Some(report.failure_buckets.keys().cloned().collect()),
+    ))
+}
+
+fn fetch_fanout_asset(
+    client: &reqwest::blocking::Client,
+    path: String,
+    url: String,
+    expected_body_contains: Option<&str>,
+) -> TracePreviewAssetFanoutRequest {
+    match client.get(&url).send() {
+        Ok(response) => {
+            let status = response.status();
+            if !status.is_success() {
+                let failure_bucket = format!("http_{}", status.as_u16());
+                return TracePreviewAssetFanoutRequest {
+                    path,
+                    url,
+                    status: Some(status.as_u16()),
+                    ok: false,
+                    failure_bucket: Some(failure_bucket),
+                    error: None,
+                };
+            }
+            if let Some(expected) = expected_body_contains {
+                match response.text() {
+                    Ok(body) if body.contains(expected) => TracePreviewAssetFanoutRequest {
+                        path,
+                        url,
+                        status: Some(status.as_u16()),
+                        ok: true,
+                        failure_bucket: None,
+                        error: None,
+                    },
+                    Ok(_) => TracePreviewAssetFanoutRequest {
+                        path,
+                        url,
+                        status: Some(status.as_u16()),
+                        ok: false,
+                        failure_bucket: Some("body_mismatch".to_string()),
+                        error: Some("response body did not contain expected text".to_string()),
+                    },
+                    Err(error) => TracePreviewAssetFanoutRequest {
+                        path,
+                        url,
+                        status: Some(status.as_u16()),
+                        ok: false,
+                        failure_bucket: Some("body_read_error".to_string()),
+                        error: Some(error.to_string()),
+                    },
+                }
+            } else {
+                TracePreviewAssetFanoutRequest {
+                    path,
+                    url,
+                    status: Some(status.as_u16()),
+                    ok: true,
+                    failure_bucket: None,
+                    error: None,
+                }
+            }
+        }
+        Err(error) => TracePreviewAssetFanoutRequest {
+            path,
+            url,
+            status: None,
+            ok: false,
+            failure_bucket: Some(request_error_bucket(&error)),
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+fn request_error_bucket(error: &reqwest::Error) -> String {
+    if error.is_timeout() {
+        return "timeout".to_string();
+    }
+    if error.is_connect() {
+        return "connect_error".to_string();
+    }
+    if error.is_body() {
+        return "body_error".to_string();
+    }
+    if error.is_decode() {
+        return "decode_error".to_string();
+    }
+    "request_error".to_string()
+}
+
+fn asset_fanout_report(
+    concurrency: usize,
+    repeat_count: usize,
+    asset_path_count: usize,
+    requests: Vec<TracePreviewAssetFanoutRequest>,
+) -> TracePreviewAssetFanoutReport {
+    let expected_request_count = asset_path_count * repeat_count;
+    let client_request_count = requests.len();
+    let success_count = requests.iter().filter(|request| request.ok).count();
+    let failure_count = client_request_count.saturating_sub(success_count);
+    let mut status_counts = BTreeMap::new();
+    let mut failure_buckets = BTreeMap::new();
+    for request in &requests {
+        let status = request
+            .status
+            .map(|status| status.to_string())
+            .unwrap_or_else(|| "none".to_string());
+        *status_counts.entry(status).or_insert(0) += 1;
+        if let Some(bucket) = request.failure_bucket.as_ref() {
+            *failure_buckets.entry(bucket.clone()).or_insert(0) += 1;
+        }
+    }
+
+    TracePreviewAssetFanoutReport {
+        schema: "homeboy/preview-asset-fanout/v1".to_string(),
+        concurrency,
+        repeat_count,
+        asset_path_count,
+        expected_request_count,
+        client_request_count,
+        success_count,
+        failure_count,
+        ingress_request_count: None,
+        local_origin_request_count: None,
+        status_counts,
+        failure_buckets,
+        requests,
+    }
+}
+
+fn empty_asset_fanout_report(
+    fanout: &crate::core::rig::TracePreviewAssetFanoutSpec,
+) -> TracePreviewAssetFanoutReport {
+    TracePreviewAssetFanoutReport {
+        schema: "homeboy/preview-asset-fanout/v1".to_string(),
+        concurrency: fanout
+            .concurrency
+            .unwrap_or(DEFAULT_ASSET_FANOUT_CONCURRENCY)
+            .max(1),
+        repeat_count: fanout
+            .repeat_count
+            .unwrap_or(DEFAULT_ASSET_FANOUT_REPEAT_COUNT)
+            .max(1),
+        asset_path_count: 0,
+        expected_request_count: 0,
+        client_request_count: 0,
+        success_count: 0,
+        failure_count: 0,
+        ingress_request_count: None,
+        local_origin_request_count: None,
+        status_counts: BTreeMap::new(),
+        failure_buckets: BTreeMap::new(),
+        requests: Vec::new(),
+    }
+}
+
 fn preview_asset_url(public_origin: &str, path: &str) -> String {
     if path.starts_with("http://") || path.starts_with("https://") {
         return path.to_string();
@@ -707,10 +1017,13 @@ fn stop_child(child: &mut Option<Child>) -> bool {
 mod tests {
     use super::{first_https_origin, TracePublicPreviewSession};
     use crate::core::rig::{
-        TraceNativePublicPreviewSpec, TracePublicPreviewMode, TracePublicPreviewSpec,
+        TraceNativePublicPreviewSpec, TracePreviewAssetFanoutSpec, TracePublicPreviewMode,
+        TracePublicPreviewSpec,
     };
     use std::io::{Read, Write};
     use std::net::TcpListener;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
     use std::thread;
 
     #[test]
@@ -734,6 +1047,7 @@ mod tests {
             provider: Some("fixture".to_string()),
             startup_timeout_seconds: Some(2),
             required_asset_paths: Vec::new(),
+            asset_fanout: None,
             native: None,
         })
         .expect("preview starts");
@@ -763,6 +1077,7 @@ mod tests {
             provider: Some("fixture".to_string()),
             startup_timeout_seconds: None,
             required_asset_paths: vec!["/assets/frontend.js?ver=1".to_string()],
+            asset_fanout: None,
             native: None,
         })
         .expect("preview starts after asset preflight");
@@ -786,6 +1101,7 @@ mod tests {
             provider: Some("fixture".to_string()),
             startup_timeout_seconds: None,
             required_asset_paths: vec!["/assets/frontend.js?ver=1".to_string()],
+            asset_fanout: None,
             native: None,
         });
 
@@ -826,6 +1142,7 @@ mod tests {
                 provider: None,
                 startup_timeout_seconds: Some(5),
                 required_asset_paths: Vec::new(),
+                asset_fanout: None,
                 native: Some(TraceNativePublicPreviewSpec {
                     public_host: None,
                     operator_domain: Some("chubes.net".to_string()),
@@ -870,6 +1187,91 @@ mod tests {
         assert_eq!(metadata.cleanup_status, "terminated");
     }
 
+    #[test]
+    fn records_successful_concurrent_asset_fanout() {
+        let paths = vec![
+            "/assets/app.js?ver=1".to_string(),
+            "/assets/app.css?ver=1".to_string(),
+            "/assets/vendor.js?ver=1".to_string(),
+            "/assets/runtime.css?ver=1".to_string(),
+        ];
+        let expected_requests = paths.len() * 3;
+        let (origin, local_origin_count) =
+            start_fanout_fixture_server(paths.clone(), expected_requests, 200);
+
+        let session = TracePublicPreviewSession::start(&TracePublicPreviewSpec {
+            mode: TracePublicPreviewMode::External,
+            local_origin: origin.clone(),
+            public_origin: Some(origin),
+            command: None,
+            require_https: false,
+            provider: Some("homeboy-native-fixture".to_string()),
+            startup_timeout_seconds: None,
+            required_asset_paths: Vec::new(),
+            asset_fanout: Some(TracePreviewAssetFanoutSpec {
+                asset_paths: paths,
+                concurrency: Some(4),
+                repeat_count: Some(3),
+                expected_body_contains: Some("homeboy-fanout-ok".to_string()),
+            }),
+            native: None,
+        })
+        .expect("preview starts after asset fanout");
+
+        let report = session
+            .metadata()
+            .asset_fanout
+            .as_ref()
+            .expect("fanout report");
+        assert_eq!(report.schema, "homeboy/preview-asset-fanout/v1");
+        assert_eq!(report.concurrency, 4);
+        assert_eq!(report.repeat_count, 3);
+        assert_eq!(report.expected_request_count, expected_requests);
+        assert_eq!(report.client_request_count, expected_requests);
+        assert_eq!(report.success_count, expected_requests);
+        assert_eq!(report.failure_count, 0);
+        assert_eq!(report.status_counts.get("200"), Some(&expected_requests));
+        assert!(report.failure_buckets.is_empty());
+        assert_eq!(local_origin_count.load(Ordering::SeqCst), expected_requests);
+    }
+
+    #[test]
+    fn fails_fast_when_concurrent_asset_fanout_sees_bad_gateway() {
+        let paths = vec![
+            "/assets/app.js?ver=1".to_string(),
+            "/assets/app.css?ver=1".to_string(),
+        ];
+        let (origin, local_origin_count) =
+            start_fanout_fixture_server(paths.clone(), paths.len(), 502);
+
+        let result = TracePublicPreviewSession::start(&TracePublicPreviewSpec {
+            mode: TracePublicPreviewMode::External,
+            local_origin: origin.clone(),
+            public_origin: Some(origin),
+            command: None,
+            require_https: false,
+            provider: Some("homeboy-native-fixture".to_string()),
+            startup_timeout_seconds: None,
+            required_asset_paths: Vec::new(),
+            asset_fanout: Some(TracePreviewAssetFanoutSpec {
+                asset_paths: paths,
+                concurrency: Some(2),
+                repeat_count: Some(1),
+                expected_body_contains: None,
+            }),
+            native: None,
+        });
+
+        let error = match result {
+            Ok(_) => panic!("asset fanout should fail before trace starts"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+        assert!(message.contains("asset fanout failed before trace collection"));
+        assert!(message.contains("failure_buckets=[http_502=2]"));
+        assert_eq!(local_origin_count.load(Ordering::SeqCst), 2);
+    }
+
     fn start_asset_fixture_server(routes: Vec<(String, u16)>) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind fixture server");
         let addr = listener.local_addr().expect("fixture server addr");
@@ -899,5 +1301,49 @@ mod tests {
             }
         });
         format!("http://{addr}")
+    }
+
+    fn start_fanout_fixture_server(
+        paths: Vec<String>,
+        expected_requests: usize,
+        status: u16,
+    ) -> (String, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fanout fixture server");
+        let addr = listener.local_addr().expect("fanout fixture server addr");
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let server_request_count = Arc::clone(&request_count);
+        thread::spawn(move || {
+            for stream in listener.incoming().take(expected_requests) {
+                let mut stream = stream.expect("fixture connection");
+                server_request_count.fetch_add(1, Ordering::SeqCst);
+                let mut buffer = [0; 2048];
+                let len = stream.read(&mut buffer).expect("read request");
+                let request = String::from_utf8_lossy(&buffer[..len]);
+                let target = request
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_whitespace().nth(1))
+                    .unwrap_or("/");
+                let route_status = if paths.iter().any(|path| path == target) {
+                    status
+                } else {
+                    404
+                };
+                let reason = if route_status == 200 {
+                    "OK"
+                } else {
+                    "Bad Gateway"
+                };
+                let body = "homeboy-fanout-ok";
+                let response = format!(
+                    "HTTP/1.1 {route_status} {reason}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
+            }
+        });
+        (format!("http://{addr}"), request_count)
     }
 }

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -65,8 +65,8 @@ pub use spec::{
     ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, StackOp, SymlinkSpec, TimeSource,
     TraceDependencySpec, TraceExperimentArtifactSpec, TraceExperimentCommandSpec,
     TraceExperimentSpec, TraceGuardrailSpec, TraceNativePublicPreviewSpec,
-    TracePreviewAssetFanoutSpec, TraceProfileSpec, TracePublicPreviewMode,
-    TracePublicPreviewSpec, TraceVariantSpec, WorkloadSpec,
+    TracePreviewAssetFanoutSpec, TraceProfileSpec, TracePublicPreviewMode, TracePublicPreviewSpec,
+    TraceVariantSpec, WorkloadSpec,
 };
 pub use stack::{
     plan_stack_sync, run_component_sync, run_sync, RigStackPlanEntry, RigStackSyncEntry,

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -64,8 +64,9 @@ pub use spec::{
     ComponentSpec, DiscoverSpec, NewerThanSpec, PatchOp, PipelineStep, RigResourcesSpec, RigSpec,
     ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, StackOp, SymlinkSpec, TimeSource,
     TraceDependencySpec, TraceExperimentArtifactSpec, TraceExperimentCommandSpec,
-    TraceExperimentSpec, TraceGuardrailSpec, TraceNativePublicPreviewSpec, TraceProfileSpec,
-    TracePublicPreviewMode, TracePublicPreviewSpec, TraceVariantSpec, WorkloadSpec,
+    TraceExperimentSpec, TraceGuardrailSpec, TraceNativePublicPreviewSpec,
+    TracePreviewAssetFanoutSpec, TraceProfileSpec, TracePublicPreviewMode,
+    TracePublicPreviewSpec, TraceVariantSpec, WorkloadSpec,
 };
 pub use stack::{
     plan_stack_sync, run_component_sync, run_sync, RigStackPlanEntry, RigStackSyncEntry,

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -536,9 +536,33 @@ pub struct TracePublicPreviewSpec {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub required_asset_paths: Vec<String>,
 
+    /// Optional concurrent static-asset fanout check for public preview tunnels.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub asset_fanout: Option<TracePreviewAssetFanoutSpec>,
+
     /// Homeboy-native preview tunnel settings used when `mode` is `homeboy_native`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub native: Option<TraceNativePublicPreviewSpec>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TracePreviewAssetFanoutSpec {
+    /// Public-origin-relative asset URLs to fetch concurrently through the preview origin.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub asset_paths: Vec<String>,
+
+    /// Maximum number of concurrent fetch workers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<usize>,
+
+    /// Number of times to request each asset path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repeat_count: Option<usize>,
+
+    /// Optional body substring that every successful response must contain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_body_contains: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/tests/core/rig/public_preview_spec_test.rs
+++ b/tests/core/rig/public_preview_spec_test.rs
@@ -85,12 +85,4 @@ fn test_trace_public_preview_parse_homeboy_native() {
         native.token_env.as_deref(),
         Some("HOMEBOY_PREVIEW_TUNNEL_TOKEN")
     );
-    let fanout = preview.asset_fanout.as_ref().expect("asset fanout");
-    assert_eq!(fanout.asset_paths.len(), 2);
-    assert_eq!(fanout.concurrency, Some(8));
-    assert_eq!(fanout.repeat_count, Some(3));
-    assert_eq!(
-        fanout.expected_body_contains.as_deref(),
-        Some("homeboy-fanout-ok")
-    );
 }

--- a/tests/core/rig/public_preview_spec_test.rs
+++ b/tests/core/rig/public_preview_spec_test.rs
@@ -14,7 +14,16 @@ fn test_trace_public_preview_parse() {
                 "startup_timeout_seconds": 5,
                 "required_asset_paths": [
                     "/assets/app.js"
-                ]
+                ],
+                "asset_fanout": {
+                    "asset_paths": [
+                        "/assets/app.js?ver=1",
+                        "/assets/app.css?ver=1"
+                    ],
+                    "concurrency": 8,
+                    "repeat_count": 3,
+                    "expected_body_contains": "homeboy-fanout-ok"
+                }
             }
         }"#,
     )
@@ -28,6 +37,14 @@ fn test_trace_public_preview_parse() {
     assert_eq!(
         preview.required_asset_paths,
         vec!["/assets/app.js".to_string()]
+    );
+    let fanout = preview.asset_fanout.as_ref().expect("asset fanout");
+    assert_eq!(fanout.asset_paths.len(), 2);
+    assert_eq!(fanout.concurrency, Some(8));
+    assert_eq!(fanout.repeat_count, Some(3));
+    assert_eq!(
+        fanout.expected_body_contains.as_deref(),
+        Some("homeboy-fanout-ok")
     );
 }
 
@@ -67,5 +84,13 @@ fn test_trace_public_preview_parse_homeboy_native() {
     assert_eq!(
         native.token_env.as_deref(),
         Some("HOMEBOY_PREVIEW_TUNNEL_TOKEN")
+    );
+    let fanout = preview.asset_fanout.as_ref().expect("asset fanout");
+    assert_eq!(fanout.asset_paths.len(), 2);
+    assert_eq!(fanout.concurrency, Some(8));
+    assert_eq!(fanout.repeat_count, Some(3));
+    assert_eq!(
+        fanout.expected_body_contains.as_deref(),
+        Some("homeboy-fanout-ok")
     );
 }


### PR DESCRIPTION
## Summary
- Adds generic `public_preview.asset_fanout` support to trace workload specs so Homeboy can stress any public preview tunnel with concurrent HTTP static asset requests before trace collection starts.
- Records `homeboy/preview-asset-fanout/v1` metadata with expected/client request totals, status counts, failure buckets, and per-request rows for tunnel diagnostics.
- Documents the core contract with neutral `/assets/...` examples; WP Codebox/WooCommerce asset lists should live downstream in the owning rig or extension and consume this generic gate.

## Verification
- `cargo test core::extension::trace::preview`
- `cargo test core::rig::public_preview_spec_test`
- `cargo fmt --check`

## Related
- Closes #4095 for the generic Homeboy core fanout gate.
- Provides the core primitive needed for downstream WP Codebox/WooCommerce proof linked to #4062.
- Parent: #4089

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, tests, and docs; Chris remains responsible for review and validation.