### PR TITLE
Add native preview tunnel auth claims

### DIFF
--- a/docs/commands/tunnel.md
+++ b/docs/commands/tunnel.md
@@ -7,7 +7,7 @@ homeboy tunnel service <COMMAND>
 homeboy tunnel preview-ingress <COMMAND>
 ```
 
-`tunnel` manages Homeboy-native private service tunnel declarations, local managed service lifecycle, and the VPS-side public preview ingress used by generic browser/reviewer URLs. Homeboy can start a long-running local command, record safe command/process/log evidence, report readiness, and stop the process group without relying on an external chat or tunnel wrapper.
+`tunnel` manages Homeboy-native private service tunnel declarations, local managed service lifecycle, and the VPS-side public preview ingress used by generic preview URLs. Homeboy can start a long-running local command, record safe command/process/log evidence, report readiness, and stop the process group without relying on an external chat or tunnel wrapper.
 
 ## Service Tunnels
 
@@ -25,7 +25,7 @@ homeboy tunnel service expose site-preview \
   --preview-policy always
 ```
 
-The declaration requires an explicit auth mode and stores a private-loopback policy. It does not expose a public unauthenticated URL. `--preview-policy` defaults to `none`; workloads can opt into `always`, `on-failure`, `manual-approval`, or `keep-alive-until` when reviewer-facing preview artifacts are useful.
+The declaration requires an explicit auth mode and stores a private-loopback policy. It does not expose a public unauthenticated URL. `--preview-policy` defaults to `none`; workloads can opt into `always`, `on-failure`, `manual-approval`, or `keep-alive-until` when public preview artifacts are useful.
 
 Start a declared local service command and record lifecycle evidence:
 
@@ -63,10 +63,10 @@ When a service's preview policy is relevant, `service status` and `service start
 
 ## Preview Ingress
 
-`preview-ingress` is the VPS-side HTTP daemon surface for Homeboy-native browser preview tunnels. It is designed to run behind an operator-managed TLS/proxy layer such as Nginx, Caddy, or Cloudflare:
+`preview-ingress` is the VPS-side HTTP daemon surface for Homeboy-native public preview tunnels. It is designed to run behind an operator-managed TLS/proxy layer such as Nginx, Caddy, or Cloudflare:
 
 ```text
-Browser
+Client
   -> https://{id}-tunnel.<operator-domain>
   -> TLS/proxy layer
   -> homeboy tunnel preview-ingress serve --bind 127.0.0.1:7350
@@ -74,13 +74,13 @@ Browser
   -> local/reverse-channel HTTP origin
 ```
 
-The core contract is generic HTTP ingress: public host/session routing, reverse-channel-compatible HTTP origins, request/response streaming, status, logs, and cleanup. Workload-specific behavior such as WordPress, WP Codebox, WooCommerce, static asset health, or browser probe interpretation belongs in Homeboy Extensions or `homeboy-rigs`, not in Homeboy core.
+The core contract is generic HTTP ingress: public host/session routing, reverse-channel-compatible HTTP origins, request/response streaming, status, logs, and cleanup. Workload-specific behavior, asset health policy, and preview interpretation belongs in Homeboy Extensions or `homeboy-rigs`, not in Homeboy core.
 
 Register one active preview route:
 
 ```sh
 homeboy tunnel preview-ingress route run-123 \
-  --public-host run-123-tunnel.chubes.net \
+  --public-host run-123.preview.example.net \
   --upstream-origin http://127.0.0.1:7331 \
   --expires-at 2026-06-12T03:30:00Z
 ```
@@ -91,12 +91,12 @@ Run the ingress daemon:
 
 ```sh
 homeboy tunnel preview-ingress serve \
-  --domain chubes.net \
+  --domain preview.example.net \
   --bind 127.0.0.1:7350 \
-  --public-host-pattern '*-tunnel.chubes.net'
+  --public-host-pattern '*.preview.example.net'
 ```
 
-The daemon routes by `Host`, handles concurrent browser asset requests in separate worker threads, proxies request bodies to the configured upstream origin, streams upstream response bodies back to the browser, and preserves response status plus non-hop-by-hop headers such as `content-type` and cache headers.
+The daemon routes by `Host`, handles concurrent preview requests in separate worker threads, proxies request bodies to the configured upstream origin, streams upstream response bodies back to the client, and preserves response status plus non-hop-by-hop headers such as `content-type` and cache headers.
 
 Diagnostics are structured so generic preview workloads can distinguish ingress and upstream problems:
 
@@ -109,6 +109,58 @@ Diagnostics are structured so generic preview workloads can distinguish ingress 
 Each request writes a JSON line to stderr with request ID, host, path, status, bytes, duration, and classification. `/_homeboy/preview-ingress/status` returns the current route status as JSON from the running daemon.
 
 This is the ingress side of #4089 and the first Homeboy-owned replacement path for #4062's current tunnel-provider blocker. Auth/pairing/token lifecycle and the authenticated reverse preview client are separate follow-up surfaces; the ingress route's `upstream_origin` is the generic HTTP seam those clients attach to.
+
+## Native Preview Tunnel Auth Model
+
+Homeboy-native preview ingress uses a separate auth contract from reverse runner jobs. Runner broker auth proves which lab can claim and finish runner work; preview tunnel auth proves which client may claim a public preview host/session and forward requests over a reverse channel to a loopback origin.
+
+The native preview auth policy lives under `policy.native_preview_auth` on a service tunnel declaration. It stores only token metadata and SHA-256 token digests, never plaintext token material:
+
+```json
+{
+  "policy": {
+    "native_preview_auth": {
+      "require_client_token": true,
+      "default_session_ttl_secs": 900,
+      "max_session_ttl_secs": 3600,
+      "allowed_public_hosts": [ "*.preview.example.net" ],
+      "allowed_session_ids": [ "run-123" ],
+      "tokens": [
+        {
+          "id": "lab-client-1",
+          "token_sha256": "<sha256 digest>",
+          "allowed_clients": [ "local-lab" ],
+          "allowed_public_hosts": [ "run-123.preview.example.net" ],
+          "allowed_session_ids": [ "run-123" ],
+          "revoked": false,
+          "expires_at": "2026-06-07T13:00:00Z"
+        }
+      ]
+    }
+  }
+}
+```
+
+An ingress/client pairing request is valid only when all of these claims match:
+
+- `client_id` is allowed by the matched token.
+- `token` hashes to a configured, unrevoked, unexpired token digest.
+- `public_host` matches both the service policy and token host scopes. Exact hostnames and glob patterns are supported.
+- `session_id` matches both the service policy and token session scopes when scopes are configured.
+- `local_origin` is an `http://` loopback origin such as `http://127.0.0.1:7331`.
+- The granted lease expires at the requested TTL capped by `max_session_ttl_secs`.
+
+Auth failures return structured validation errors for the failing claim (`token`, `client_id`, `public_host`, `session_id`, or `local_origin`). Token values are request inputs only and are not serialized in declarations, status, preview artifacts, logs, or diagnostics.
+
+Safe operator setup for a VPS wildcard domain:
+
+1. Configure wildcard DNS and TLS for the preview ingress host, for example `*.preview.example.net`.
+2. Declare the preview service with `homeboy tunnel service expose` and keep `policy.require_auth=true`.
+3. Generate high-entropy client token material outside normal logs, store the token itself in Homeboy's keychain/secret/env surface for the preview client, and store only the SHA-256 digest in `policy.native_preview_auth.tokens`.
+4. Scope each token to the smallest useful client, host pattern, and session ID.
+5. Use short `expires_at` and session TTLs for short-lived preview sessions; revoke by removing the token entry or setting `revoked=true`.
+
+The current layer validates config, token, host, session, origin, and lease semantics. The actual VPS ingress route table and reverse-channel forwarding endpoints are the integration points for the native ingress/client work tracked separately from this command contract.
 
 ## Subcommands
 

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -490,6 +490,7 @@ fn run_service(command: TunnelServiceCommand) -> CmdResult<TunnelOutput> {
                     mode: preview_policy.into(),
                     keep_alive_until: preview_keep_alive_until,
                 },
+                native_preview_auth: Default::default(),
             },
             description,
         }),

--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::path::PathBuf;
@@ -81,6 +82,65 @@ pub struct ServiceTunnelPolicy {
     pub allowed_clients: Vec<String>,
     #[serde(default)]
     pub preview: ServiceTunnelPreviewPolicy,
+    #[serde(
+        default,
+        skip_serializing_if = "ServiceTunnelNativePreviewAuthPolicy::is_default"
+    )]
+    pub native_preview_auth: ServiceTunnelNativePreviewAuthPolicy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceTunnelNativePreviewAuthPolicy {
+    #[serde(default = "default_true")]
+    pub require_client_token: bool,
+    #[serde(default = "default_preview_session_ttl_secs")]
+    pub default_session_ttl_secs: u64,
+    #[serde(default = "default_preview_session_max_ttl_secs")]
+    pub max_session_ttl_secs: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_public_hosts: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_session_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tokens: Vec<ServiceTunnelNativePreviewToken>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceTunnelNativePreviewToken {
+    pub id: String,
+    pub token_sha256: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_clients: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_public_hosts: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_session_ids: Vec<String>,
+    #[serde(default)]
+    pub revoked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceTunnelNativePreviewClaimRequest {
+    pub client_id: String,
+    pub token: String,
+    pub public_host: String,
+    pub session_id: String,
+    pub local_origin: String,
+    pub requested_ttl_secs: Option<u64>,
+    pub now: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ServiceTunnelNativePreviewClaim {
+    pub service_id: String,
+    pub client_id: String,
+    pub token_id: String,
+    pub public_host: String,
+    pub session_id: String,
+    pub local_origin: String,
+    pub expires_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -325,6 +385,53 @@ fn default_true() -> bool {
 
 fn default_exposure() -> ServiceTunnelExposure {
     ServiceTunnelExposure::PrivateLoopback
+}
+
+fn default_preview_session_ttl_secs() -> u64 {
+    15 * 60
+}
+
+fn default_preview_session_max_ttl_secs() -> u64 {
+    60 * 60
+}
+
+impl Default for ServiceTunnelNativePreviewAuthPolicy {
+    fn default() -> Self {
+        Self {
+            require_client_token: true,
+            default_session_ttl_secs: default_preview_session_ttl_secs(),
+            max_session_ttl_secs: default_preview_session_max_ttl_secs(),
+            allowed_public_hosts: Vec::new(),
+            allowed_session_ids: Vec::new(),
+            tokens: Vec::new(),
+        }
+    }
+}
+
+impl ServiceTunnelNativePreviewAuthPolicy {
+    fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
+pub fn native_preview_token_sha256(token: &str) -> String {
+    let digest = Sha256::digest(token.as_bytes());
+    format!("{digest:x}")
+}
+
+pub fn native_preview_token_record(
+    id: impl Into<String>,
+    token: &str,
+) -> ServiceTunnelNativePreviewToken {
+    ServiceTunnelNativePreviewToken {
+        id: id.into(),
+        token_sha256: native_preview_token_sha256(token),
+        allowed_clients: Vec::new(),
+        allowed_public_hosts: Vec::new(),
+        allowed_session_ids: Vec::new(),
+        revoked: false,
+        expires_at: None,
+    }
 }
 
 impl ConfigEntity for ServiceTunnel {
@@ -616,6 +723,194 @@ pub(super) fn preview_artifact_for(
     })
 }
 
+pub fn validate_native_preview_claim(
+    tunnel: &ServiceTunnel,
+    request: ServiceTunnelNativePreviewClaimRequest,
+) -> Result<ServiceTunnelNativePreviewClaim> {
+    let policy = &tunnel.policy.native_preview_auth;
+    if !policy.require_client_token {
+        return Err(preview_auth_error(
+            "auth",
+            "native preview ingress requires client token authentication",
+            Some(tunnel.id.clone()),
+            Some(vec!["set require_client_token=true".to_string()]),
+        ));
+    }
+    if request.client_id.trim().is_empty() {
+        return Err(preview_auth_error(
+            "client_id",
+            "preview client id is required",
+            Some(tunnel.id.clone()),
+            None,
+        ));
+    }
+    if request.token.trim().is_empty() {
+        return Err(preview_auth_error(
+            "token",
+            "preview client token is required",
+            Some(tunnel.id.clone()),
+            None,
+        ));
+    }
+    if request.public_host.trim().is_empty() {
+        return Err(preview_auth_error(
+            "public_host",
+            "preview public host claim is required",
+            Some(tunnel.id.clone()),
+            None,
+        ));
+    }
+    if request.session_id.trim().is_empty() {
+        return Err(preview_auth_error(
+            "session_id",
+            "preview session id claim is required",
+            Some(tunnel.id.clone()),
+            None,
+        ));
+    }
+    validate_native_preview_local_origin(&request.local_origin, &tunnel.id)?;
+
+    let token_hash = native_preview_token_sha256(&request.token);
+    let Some(token) = policy
+        .tokens
+        .iter()
+        .find(|candidate| candidate.token_sha256 == token_hash)
+    else {
+        return Err(preview_auth_error(
+            "token",
+            "preview client token is not recognized",
+            Some(tunnel.id.clone()),
+            None,
+        ));
+    };
+
+    if token.revoked {
+        return Err(preview_auth_error(
+            "token",
+            "preview client token is revoked",
+            Some(token.id.clone()),
+            None,
+        ));
+    }
+    if let Some(expires_at) = token.expires_at.as_deref().and_then(parse_rfc3339_utc) {
+        if request.now > expires_at {
+            return Err(preview_auth_error(
+                "token",
+                "preview client token is expired",
+                Some(token.id.clone()),
+                None,
+            ));
+        }
+    }
+    if !string_claim_allowed(&request.client_id, &token.allowed_clients) {
+        return Err(preview_auth_error(
+            "client_id",
+            "preview client is not authorized for this token",
+            Some(request.client_id),
+            Some(token.allowed_clients.clone()),
+        ));
+    }
+    if !host_claim_allowed(&request.public_host, &policy.allowed_public_hosts)
+        || !host_claim_allowed(&request.public_host, &token.allowed_public_hosts)
+    {
+        return Err(preview_auth_error(
+            "public_host",
+            "preview token is not authorized to claim this public host",
+            Some(request.public_host),
+            policy_host_suggestions(policy, token),
+        ));
+    }
+    if !string_claim_allowed(&request.session_id, &policy.allowed_session_ids)
+        || !string_claim_allowed(&request.session_id, &token.allowed_session_ids)
+    {
+        return Err(preview_auth_error(
+            "session_id",
+            "preview token is not authorized to claim this session id",
+            Some(request.session_id),
+            policy_session_suggestions(policy, token),
+        ));
+    }
+
+    let ttl_secs = request
+        .requested_ttl_secs
+        .unwrap_or(policy.default_session_ttl_secs)
+        .min(policy.max_session_ttl_secs);
+    let expires_at = request.now + chrono::Duration::seconds(ttl_secs as i64);
+
+    Ok(ServiceTunnelNativePreviewClaim {
+        service_id: tunnel.id.clone(),
+        client_id: request.client_id,
+        token_id: token.id.clone(),
+        public_host: request.public_host,
+        session_id: request.session_id,
+        local_origin: request.local_origin,
+        expires_at: expires_at.to_rfc3339(),
+    })
+}
+
+fn preview_auth_error(
+    field: &str,
+    message: impl Into<String>,
+    value: Option<String>,
+    suggestions: Option<Vec<String>>,
+) -> Error {
+    Error::validation_invalid_argument(field, message, value, suggestions)
+}
+
+fn validate_native_preview_local_origin(local_origin: &str, id: &str) -> Result<()> {
+    let Some(rest) = local_origin.strip_prefix("http://") else {
+        return Err(preview_auth_error(
+            "local_origin",
+            "preview local origin must use http:// loopback",
+            Some(id.to_string()),
+            Some(vec!["http://127.0.0.1:<port>".to_string()]),
+        ));
+    };
+    let host = rest.split(['/', ':']).next().unwrap_or_default();
+    validate_loopback_host(host, id)
+}
+
+fn string_claim_allowed(value: &str, allowed: &[String]) -> bool {
+    allowed.is_empty() || allowed.iter().any(|candidate| candidate == value)
+}
+
+fn host_claim_allowed(value: &str, allowed: &[String]) -> bool {
+    allowed.is_empty()
+        || allowed
+            .iter()
+            .any(|candidate| candidate == value || glob_match::glob_match(candidate, value))
+}
+
+fn policy_host_suggestions(
+    policy: &ServiceTunnelNativePreviewAuthPolicy,
+    token: &ServiceTunnelNativePreviewToken,
+) -> Option<Vec<String>> {
+    suggestions_from_scopes(&policy.allowed_public_hosts, &token.allowed_public_hosts)
+}
+
+fn policy_session_suggestions(
+    policy: &ServiceTunnelNativePreviewAuthPolicy,
+    token: &ServiceTunnelNativePreviewToken,
+) -> Option<Vec<String>> {
+    suggestions_from_scopes(&policy.allowed_session_ids, &token.allowed_session_ids)
+}
+
+fn suggestions_from_scopes(
+    policy_values: &[String],
+    token_values: &[String],
+) -> Option<Vec<String>> {
+    let mut suggestions = Vec::new();
+    suggestions.extend(policy_values.iter().cloned());
+    suggestions.extend(token_values.iter().cloned());
+    if suggestions.is_empty() {
+        None
+    } else {
+        suggestions.sort();
+        suggestions.dedup();
+        Some(suggestions)
+    }
+}
+
 fn preview_artifact_for_status(
     tunnel: &ServiceTunnel,
     state: &ServiceTunnelRuntimeState,
@@ -743,6 +1038,65 @@ fn validate_service_tunnel(tunnel: &ServiceTunnel) -> Result<()> {
                 "policy.preview.keep_alive_until",
                 "preview expiry must be a valid RFC3339 timestamp",
                 Some(tunnel.id.clone()),
+                None,
+            ));
+        }
+    }
+    validate_native_preview_auth_policy(&tunnel.policy.native_preview_auth, &tunnel.id)?;
+    Ok(())
+}
+
+fn validate_native_preview_auth_policy(
+    policy: &ServiceTunnelNativePreviewAuthPolicy,
+    id: &str,
+) -> Result<()> {
+    if policy.default_session_ttl_secs == 0 || policy.max_session_ttl_secs == 0 {
+        return Err(Error::validation_invalid_argument(
+            "policy.native_preview_auth.ttl",
+            "native preview session TTLs must be greater than zero",
+            Some(id.to_string()),
+            None,
+        ));
+    }
+    if policy.default_session_ttl_secs > policy.max_session_ttl_secs {
+        return Err(Error::validation_invalid_argument(
+            "policy.native_preview_auth.default_session_ttl_secs",
+            "default native preview session TTL cannot exceed max_session_ttl_secs",
+            Some(id.to_string()),
+            None,
+        ));
+    }
+    for token in &policy.tokens {
+        if token.id.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "policy.native_preview_auth.tokens.id",
+                "native preview token id is required",
+                Some(id.to_string()),
+                None,
+            ));
+        }
+        if token.token_sha256.len() != 64
+            || !token
+                .token_sha256
+                .chars()
+                .all(|character| character.is_ascii_hexdigit())
+        {
+            return Err(Error::validation_invalid_argument(
+                "policy.native_preview_auth.tokens.token_sha256",
+                "native preview tokens store a SHA-256 digest, not plaintext token material",
+                Some(token.id.clone()),
+                None,
+            ));
+        }
+        if token
+            .expires_at
+            .as_deref()
+            .is_some_and(|expires_at| parse_rfc3339_utc(expires_at).is_none())
+        {
+            return Err(Error::validation_invalid_argument(
+                "policy.native_preview_auth.tokens.expires_at",
+                "native preview token expiry must be a valid RFC3339 timestamp",
+                Some(token.id.clone()),
                 None,
             ));
         }

--- a/src/core/tunnel_tests.rs
+++ b/src/core/tunnel_tests.rs
@@ -44,6 +44,7 @@ fn expose_records_private_loopback_declaration_without_running_tunnel() {
                 require_auth: true,
                 allowed_clients: vec!["app-runtime".to_string()],
                 preview: ServiceTunnelPreviewPolicy::default(),
+                native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: Some("Private preview service".to_string()),
         })
@@ -80,6 +81,7 @@ fn validation_rejects_auth_mode_without_env_var() {
                 require_auth: true,
                 allowed_clients: Vec::new(),
                 preview: ServiceTunnelPreviewPolicy::default(),
+                native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: None,
         })
@@ -116,6 +118,7 @@ fn start_status_and_stop_manage_local_service_runtime_state() {
                     mode: ServiceTunnelPreviewPolicyMode::Always,
                     keep_alive_until: None,
                 },
+                native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: None,
         })
@@ -190,6 +193,7 @@ fn start_cleans_runtime_state_when_readiness_fails() {
                 require_auth: true,
                 allowed_clients: Vec::new(),
                 preview: ServiceTunnelPreviewPolicy::default(),
+                native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: None,
         })
@@ -246,6 +250,7 @@ fn command_backend_records_public_url_and_cleans_up_backend_process() {
                 require_auth: true,
                 allowed_clients: Vec::new(),
                 preview: ServiceTunnelPreviewPolicy::default(),
+                native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: None,
         })
@@ -367,6 +372,133 @@ fn preview_policy_decisions_match_workflow_outcomes() {
     ));
 }
 
+fn native_preview_tunnel() -> ServiceTunnel {
+    let mut token = native_preview_token_record("lab-token", "secret-token");
+    token.allowed_clients = vec!["lab-client".to_string()];
+    token.allowed_public_hosts = vec!["*.preview.example.test".to_string()];
+    token.allowed_session_ids = vec!["run-123".to_string()];
+
+    ServiceTunnel {
+        id: "site-preview".to_string(),
+        aliases: Vec::new(),
+        description: None,
+        server_id: "private-host".to_string(),
+        target: ServiceTunnelTarget {
+            host: "127.0.0.1".to_string(),
+            port: 7331,
+        },
+        scheme: "http".to_string(),
+        local_host: "127.0.0.1".to_string(),
+        local_port: Some(7331),
+        auth: ServiceTunnelAuth {
+            mode: ServiceTunnelAuthMode::BearerEnv,
+            env_var: Some("TOKEN".to_string()),
+            header: Some("Authorization".to_string()),
+        },
+        policy: ServiceTunnelPolicy {
+            exposure: ServiceTunnelExposure::PrivateLoopback,
+            require_auth: true,
+            allowed_clients: Vec::new(),
+            preview: ServiceTunnelPreviewPolicy::default(),
+            native_preview_auth: ServiceTunnelNativePreviewAuthPolicy {
+                require_client_token: true,
+                default_session_ttl_secs: 60,
+                max_session_ttl_secs: 300,
+                allowed_public_hosts: vec!["*.preview.example.test".to_string()],
+                allowed_session_ids: vec!["run-123".to_string()],
+                tokens: vec![token],
+            },
+        },
+    }
+}
+
+fn native_preview_request() -> ServiceTunnelNativePreviewClaimRequest {
+    ServiceTunnelNativePreviewClaimRequest {
+        client_id: "lab-client".to_string(),
+        token: "secret-token".to_string(),
+        public_host: "run-123.preview.example.test".to_string(),
+        session_id: "run-123".to_string(),
+        local_origin: "http://127.0.0.1:7331".to_string(),
+        requested_ttl_secs: Some(120),
+        now: chrono::DateTime::parse_from_rfc3339("2026-06-07T12:00:00Z")
+            .expect("timestamp")
+            .with_timezone(&chrono::Utc),
+    }
+}
+
+#[test]
+fn native_preview_claim_accepts_scoped_client_host_session_and_caps_lease() {
+    let tunnel = native_preview_tunnel();
+    let mut request = native_preview_request();
+    request.requested_ttl_secs = Some(600);
+
+    let claim = validate_native_preview_claim(&tunnel, request).expect("valid claim");
+
+    assert_eq!(claim.service_id, "site-preview");
+    assert_eq!(claim.client_id, "lab-client");
+    assert_eq!(claim.token_id, "lab-token");
+    assert_eq!(claim.public_host, "run-123.preview.example.test");
+    assert_eq!(claim.session_id, "run-123");
+    assert_eq!(claim.local_origin, "http://127.0.0.1:7331");
+    assert_eq!(claim.expires_at, "2026-06-07T12:05:00+00:00");
+}
+
+#[test]
+fn native_preview_claim_rejects_wrong_token_without_leaking_expected_token() {
+    let tunnel = native_preview_tunnel();
+    let mut request = native_preview_request();
+    request.token = "wrong-token".to_string();
+
+    let err = validate_native_preview_claim(&tunnel, request).expect_err("wrong token fails");
+
+    assert_eq!(err.code, crate::core::ErrorCode::ValidationInvalidArgument);
+    assert!(err.message.contains("not recognized"));
+    assert!(!err.message.contains("secret-token"));
+    assert!(!err.details.to_string().contains("secret-token"));
+}
+
+#[test]
+fn native_preview_claim_rejects_wrong_client_host_session_and_origin() {
+    let tunnel = native_preview_tunnel();
+
+    let mut request = native_preview_request();
+    request.client_id = "other-client".to_string();
+    let err = validate_native_preview_claim(&tunnel, request).expect_err("wrong client fails");
+    assert!(err.message.contains("client is not authorized"));
+
+    let mut request = native_preview_request();
+    request.public_host = "run-123.other.example.test".to_string();
+    let err = validate_native_preview_claim(&tunnel, request).expect_err("wrong host fails");
+    assert!(err.message.contains("public host"));
+
+    let mut request = native_preview_request();
+    request.session_id = "run-456".to_string();
+    let err = validate_native_preview_claim(&tunnel, request).expect_err("wrong session fails");
+    assert!(err.message.contains("session id"));
+
+    let mut request = native_preview_request();
+    request.local_origin = "http://192.168.1.5:7331".to_string();
+    let err =
+        validate_native_preview_claim(&tunnel, request).expect_err("non-loopback origin fails");
+    assert!(err.message.contains("loopback"));
+}
+
+#[test]
+fn native_preview_claim_rejects_revoked_and_expired_tokens() {
+    let mut tunnel = native_preview_tunnel();
+    tunnel.policy.native_preview_auth.tokens[0].revoked = true;
+    let err = validate_native_preview_claim(&tunnel, native_preview_request())
+        .expect_err("revoked token fails");
+    assert!(err.message.contains("revoked"));
+
+    let mut tunnel = native_preview_tunnel();
+    tunnel.policy.native_preview_auth.tokens[0].expires_at =
+        Some("2026-06-07T11:59:59Z".to_string());
+    let err = validate_native_preview_claim(&tunnel, native_preview_request())
+        .expect_err("expired token fails");
+    assert!(err.message.contains("expired"));
+}
+
 #[test]
 fn preview_artifact_serializes_structured_reviewer_contract() {
     let tunnel = ServiceTunnel {
@@ -394,6 +526,7 @@ fn preview_artifact_serializes_structured_reviewer_contract() {
                 mode: ServiceTunnelPreviewPolicyMode::KeepAliveUntil,
                 keep_alive_until: Some("2026-06-07T13:00:00Z".to_string()),
             },
+            native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
         },
     };
     let state = ServiceTunnelRuntimeState {


### PR DESCRIPTION
## Summary
- Adds a Homeboy-native preview tunnel auth policy under service tunnel declarations for client tokens, host/session scopes, revocation, expiry, and lease TTLs.
- Adds generic claim validation for ingress/client pairing without coupling preview session semantics to reverse runner jobs or platform-specific workloads.
- Documents safe operator setup for VPS wildcard domains and token digest storage.

## Verification
- `cargo fmt`
- `cargo test core::tunnel_tests`
- `cargo test` failed in unrelated bench scenario discovery tests:
  - `commands::bench::tests::unknown_scenario_reports_discovered_ids`
  - `commands::bench::tests::profile_with_unknown_scenario_lists_discovered_scenarios`
  - Both report discovered ids as `<none>` and reproduce when run individually.

## Integration boundaries
- #4090 still needs to wire this claim validation into a VPS preview ingress daemon and active route/session table.
- #4092 still needs to wire this claim validation into the outbound preview client reverse channel and unregister/cleanup lifecycle.
- This PR intentionally avoids external tunnel provider assumptions and platform-specific preview policy. WordPress, WP Codebox, WooCommerce, and other workload-specific behavior belongs in extensions/rigs, not Homeboy core auth.

Closes #4091

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the generic auth policy/claim validation layer, tests, documentation, and PR summary for Chris to review and validate.