### PR TITLE
Add native trace preview lifecycle mode

### DIFF
--- a/docs/architecture/preview-metadata.md
+++ b/docs/architecture/preview-metadata.md
@@ -69,7 +69,7 @@ external provider command:
       "token_env": "HOMEBOY_PREVIEW_TUNNEL_TOKEN"
     },
     "required_asset_paths": [
-      "/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.js?ver=10.8.0"
+      "/assets/app.js"
     ]
   }
 }
@@ -114,8 +114,8 @@ trace collection starts:
     "public_origin": "https://preview.example.test",
     "require_https": true,
     "required_asset_paths": [
-      "/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.js?ver=10.8.0",
-      "/wp-content/plugins/woocommerce/assets/js/frontend/add-to-cart.min.js"
+      "/assets/app.js",
+      "/assets/app.css"
     ]
   }
 }

--- a/docs/architecture/preview-metadata.md
+++ b/docs/architecture/preview-metadata.md
@@ -1,6 +1,7 @@
 # Preview Metadata
 
-Homeboy preserves generic preview metadata without owning public-access setup.
+Homeboy preserves generic preview metadata and can either consume caller-supplied
+public access or own a native preview tunnel lifecycle for trace workloads.
 Commands, extensions, wrappers, or external integrations can emit preview facts
 through environment variables, and Homeboy stores them on persisted run metadata
 and renders them in report digests.
@@ -46,8 +47,60 @@ Set `HOMEBOY_PREVIEW_JSON` to a JSON object. Recommended fields:
 public access. When present, Homeboy copies it into `public_url` if the preview
 object does not already contain that field.
 
-Homeboy does not create tunnels, publish previews, or know about product-specific
-runtimes. Public access is supplied by the caller/integration.
+For the default external mode, Homeboy does not create tunnels, publish previews,
+or know about product-specific runtimes. Public access is supplied by the
+caller/integration.
+
+## Trace Native Preview Tunnels
+
+Trace workloads can request a Homeboy-native preview lifecycle instead of an
+external provider command:
+
+```json
+{
+  "public_preview": {
+    "mode": "homeboy_native",
+    "local_origin": "http://127.0.0.1:49823",
+    "require_https": true,
+    "native": {
+      "operator_domain": "chubes.net",
+      "session_id": "wc-stripe-real-wallet",
+      "ingress_url": "https://preview-broker.chubes.net",
+      "token_env": "HOMEBOY_PREVIEW_TUNNEL_TOKEN"
+    },
+    "required_asset_paths": [
+      "/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.js?ver=10.8.0"
+    ]
+  }
+}
+```
+
+`mode: "homeboy_native"` derives `https://{session_id}-tunnel.{operator_domain}`
+unless `native.public_host` or `public_origin` is supplied. Trace starts the
+native client with the minimal internal command contract:
+
+```sh
+homeboy tunnel preview-client start \
+  --public-host wc-stripe-real-wallet-tunnel.chubes.net \
+  --local-origin http://127.0.0.1:49823 \
+  --session-id wc-stripe-real-wallet \
+  --ingress https://preview-broker.chubes.net \
+  --token-env HOMEBOY_PREVIEW_TUNNEL_TOKEN \
+  --ready-stdout
+```
+
+The client must print the ready public HTTPS origin to stdout before trace
+collection starts. Trace then preflights required assets through the public URL,
+injects `HOMEBOY_PREVIEW_JSON`, `HOMEBOY_PREVIEW_PUBLIC_URL`, and
+`HOMEBOY_TRACE_PREVIEW_*` environment values into the workload, and terminates
+the client during cleanup on success or failure.
+
+Native trace metadata uses `schema: "homeboy/preview/v1"`,
+`provider: "homeboy-native"`, and includes `session_id`, `public_host`,
+`ingress_url`, `client_command`, and `log_paths` when available. The concrete
+ingress daemon and reverse client implementations are tracked by #4090 and
+#4092; this trace contract is intentionally limited to the lifecycle seam they
+must satisfy.
 
 ## Trace Public Preview Assets
 

--- a/src/commands/trace/preview_args.rs
+++ b/src/commands/trace/preview_args.rs
@@ -53,6 +53,7 @@ fn expand_trace_public_preview(
         }
     };
     rig::TracePublicPreviewSpec {
+        mode: spec.mode.clone(),
         local_origin: expand(&spec.local_origin),
         public_origin: spec.public_origin.as_deref().map(&expand),
         command: spec.command.as_deref().map(expand),
@@ -64,5 +65,16 @@ fn expand_trace_public_preview(
             .iter()
             .map(|path| expand(path))
             .collect(),
+        native: spec
+            .native
+            .as_ref()
+            .map(|native| rig::TraceNativePublicPreviewSpec {
+                public_host: native.public_host.as_deref().map(&expand),
+                operator_domain: native.operator_domain.as_deref().map(&expand),
+                session_id: native.session_id.as_deref().map(&expand),
+                ingress_url: native.ingress_url.as_deref().map(&expand),
+                token_env: native.token_env.clone(),
+                client_binary: native.client_binary.as_deref().map(&expand),
+            }),
     }
 }

--- a/src/core/extension/trace/preview.rs
+++ b/src/core/extension/trace/preview.rs
@@ -12,8 +12,6 @@ use crate::core::rig::{
 
 const DEFAULT_STARTUP_TIMEOUT_SECONDS: u64 = 20;
 const DEFAULT_ASSET_CHECK_TIMEOUT_SECONDS: u64 = 10;
-const WC_STRIPE_ECE_PREVIEW_PORT_SETTING: &str = "woocommerce_stripe_ece_preview_port";
-const WC_STRIPE_ECE_PREVIEW_PORT_ENV: &str = "HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TracePreviewAssetCheck {
@@ -129,11 +127,6 @@ impl TracePublicPreviewSession {
                 Some(public_origin),
                 None,
             ));
-        }
-
-        if let Err(error) = validate_preview_port_alignment(spec, &public_origin) {
-            stop_child(&mut child);
-            return Err(error);
         }
 
         let required_assets = match preflight_required_assets(spec, &public_origin) {
@@ -699,61 +692,6 @@ fn first_https_origin(line: &str) -> Option<String> {
     Some(rest[..end].trim_end_matches('/').to_string())
 }
 
-fn validate_preview_port_alignment(
-    spec: &TracePublicPreviewSpec,
-    public_origin: &str,
-) -> Result<()> {
-    let Some(expected_port) = expected_local_tunnel_port(public_origin) else {
-        return Ok(());
-    };
-    let local_port = local_origin_port(&spec.local_origin);
-    if local_port == Some(expected_port) {
-        return Ok(());
-    }
-
-    let suggested_setting =
-        format!("--setting {WC_STRIPE_ECE_PREVIEW_PORT_SETTING}={expected_port}");
-    let suggested_env = format!("{WC_STRIPE_ECE_PREVIEW_PORT_ENV}={expected_port}");
-    Err(Error::validation_invalid_argument(
-        "public_preview.local_origin",
-        format!(
-            "public preview URL routes to local port {expected_port}, but runtime local preview origin is `{}`. requested_public_url=`{public_origin}` runtime_local_preview_origin=`{}` expected_local_tunnel_port={expected_port} suggested_setting=`{suggested_setting}` suggested_env=`{suggested_env}`",
-            spec.local_origin, spec.local_origin
-        ),
-        Some(public_origin.to_string()),
-        Some(vec![suggested_setting, suggested_env]),
-    ))
-}
-
-fn expected_local_tunnel_port(public_origin: &str) -> Option<u16> {
-    let after_scheme = public_origin.split_once("://")?.1;
-    let authority = after_scheme
-        .split(['/', '?', '#'])
-        .next()
-        .unwrap_or(after_scheme)
-        .split('@')
-        .next_back()
-        .unwrap_or(after_scheme);
-    let host = authority
-        .rsplit_once(':')
-        .map_or(authority, |(host, _)| host);
-    let prefix = host.split_once("-tunnel.")?.0;
-    let digits = prefix.rsplit('-').next().unwrap_or(prefix);
-    digits.parse::<u16>().ok().filter(|port| *port > 0)
-}
-
-fn local_origin_port(local_origin: &str) -> Option<u16> {
-    let after_scheme = local_origin.split_once("://")?.1;
-    let authority = after_scheme
-        .split(['/', '?', '#'])
-        .next()
-        .unwrap_or(after_scheme)
-        .split('@')
-        .next_back()
-        .unwrap_or(after_scheme);
-    authority.rsplit_once(':')?.1.parse::<u16>().ok()
-}
-
 fn stop_child(child: &mut Option<Child>) -> bool {
     let Some(mut child) = child.take() else {
         return false;
@@ -767,7 +705,7 @@ fn stop_child(child: &mut Option<Child>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{expected_local_tunnel_port, first_https_origin, TracePublicPreviewSession};
+    use super::{first_https_origin, TracePublicPreviewSession};
     use crate::core::rig::{
         TraceNativePublicPreviewSpec, TracePublicPreviewMode, TracePublicPreviewSpec,
     };
@@ -812,53 +750,9 @@ mod tests {
     }
 
     #[test]
-    fn extracts_expected_port_from_kimaki_tunnel_origin() {
-        assert_eq!(
-            expected_local_tunnel_port("https://site-49822-tunnel.kimaki.dev/"),
-            Some(49822)
-        );
-        assert_eq!(
-            expected_local_tunnel_port("https://49822-tunnel.kimaki.dev"),
-            Some(49822)
-        );
-        assert_eq!(
-            expected_local_tunnel_port("https://preview.example.test/"),
-            None
-        );
-    }
-
-    #[test]
-    fn fails_fast_when_public_tunnel_port_does_not_match_local_origin() {
-        let result = TracePublicPreviewSession::start(&TracePublicPreviewSpec {
-            mode: TracePublicPreviewMode::External,
-            local_origin: "http://127.0.0.1:20000".to_string(),
-            public_origin: Some("https://site-49822-tunnel.kimaki.dev/".to_string()),
-            command: None,
-            require_https: true,
-            provider: Some("fixture".to_string()),
-            startup_timeout_seconds: None,
-            required_asset_paths: Vec::new(),
-            native: None,
-        });
-        let error = match result {
-            Ok(_) => panic!("mismatched preview port should fail before trace starts"),
-            Err(error) => error,
-        };
-
-        let message = error.to_string();
-        assert!(message.contains("requested_public_url=`https://site-49822-tunnel.kimaki.dev/`"));
-        assert!(message.contains("runtime_local_preview_origin=`http://127.0.0.1:20000`"));
-        assert!(message.contains("expected_local_tunnel_port=49822"));
-        assert!(message.contains("--setting woocommerce_stripe_ece_preview_port=49822"));
-        assert!(message.contains("HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT=49822"));
-    }
-
-    #[test]
     fn records_successful_required_asset_preflight() {
-        let origin = start_asset_fixture_server(vec![(
-            "/wp-content/plugins/example/build/frontend.js?ver=1".to_string(),
-            200,
-        )]);
+        let origin =
+            start_asset_fixture_server(vec![("/assets/frontend.js?ver=1".to_string(), 200)]);
 
         let session = TracePublicPreviewSession::start(&TracePublicPreviewSpec {
             mode: TracePublicPreviewMode::External,
@@ -868,9 +762,7 @@ mod tests {
             require_https: false,
             provider: Some("fixture".to_string()),
             startup_timeout_seconds: None,
-            required_asset_paths: vec![
-                "/wp-content/plugins/example/build/frontend.js?ver=1".to_string()
-            ],
+            required_asset_paths: vec!["/assets/frontend.js?ver=1".to_string()],
             native: None,
         })
         .expect("preview starts after asset preflight");
@@ -882,10 +774,8 @@ mod tests {
 
     #[test]
     fn fails_fast_when_required_asset_cannot_be_fetched() {
-        let origin = start_asset_fixture_server(vec![(
-            "/wp-content/plugins/example/build/frontend.js?ver=1".to_string(),
-            502,
-        )]);
+        let origin =
+            start_asset_fixture_server(vec![("/assets/frontend.js?ver=1".to_string(), 502)]);
 
         let result = TracePublicPreviewSession::start(&TracePublicPreviewSpec {
             mode: TracePublicPreviewMode::External,
@@ -895,9 +785,7 @@ mod tests {
             require_https: false,
             provider: Some("fixture".to_string()),
             startup_timeout_seconds: None,
-            required_asset_paths: vec![
-                "/wp-content/plugins/example/build/frontend.js?ver=1".to_string()
-            ],
+            required_asset_paths: vec!["/assets/frontend.js?ver=1".to_string()],
             native: None,
         });
 
@@ -907,7 +795,7 @@ mod tests {
         };
         let message = error.to_string();
         assert!(message.contains("required asset preflight failed before trace collection"));
-        assert!(message.contains("/wp-content/plugins/example/build/frontend.js?ver=1 -> HTTP 502"));
+        assert!(message.contains("/assets/frontend.js?ver=1 -> HTTP 502"));
     }
 
     #[test]

--- a/src/core/extension/trace/preview.rs
+++ b/src/core/extension/trace/preview.rs
@@ -1,11 +1,14 @@
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
 use std::time::Duration;
 
 use crate::core::error::{Error, Result};
-use crate::core::rig::TracePublicPreviewSpec;
+use crate::core::rig::{
+    TraceNativePublicPreviewSpec, TracePublicPreviewMode, TracePublicPreviewSpec,
+};
 
 const DEFAULT_STARTUP_TIMEOUT_SECONDS: u64 = 20;
 const DEFAULT_ASSET_CHECK_TIMEOUT_SECONDS: u64 = 10;
@@ -42,6 +45,23 @@ pub struct TracePreviewMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub process_id: Option<String>,
     pub cleanup_status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_host: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ingress_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_paths: Option<TracePreviewLogPaths>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TracePreviewLogPaths {
+    pub client_stdout_path: String,
+    pub client_stderr_path: String,
 }
 
 pub struct TracePublicPreviewSession {
@@ -49,8 +69,37 @@ pub struct TracePublicPreviewSession {
     metadata: TracePreviewMetadata,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NativePreviewClientCommand {
+    program: String,
+    args: Vec<String>,
+}
+
+impl NativePreviewClientCommand {
+    fn display(&self) -> String {
+        std::iter::once(self.program.clone())
+            .chain(self.args.clone())
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
 impl TracePublicPreviewSession {
     pub fn start(spec: &TracePublicPreviewSpec) -> Result<Self> {
+        Self::start_with_artifact_dir(spec, None)
+    }
+
+    pub fn start_with_artifact_dir(
+        spec: &TracePublicPreviewSpec,
+        artifact_dir: Option<&Path>,
+    ) -> Result<Self> {
+        match spec.mode {
+            TracePublicPreviewMode::External => Self::start_external(spec),
+            TracePublicPreviewMode::HomeboyNative => Self::start_homeboy_native(spec, artifact_dir),
+        }
+    }
+
+    fn start_external(spec: &TracePublicPreviewSpec) -> Result<Self> {
         let mut child = match spec.command.as_deref() {
             Some(command) if spec.public_origin.is_none() => Some(start_provider_command(command)?),
             _ => None,
@@ -117,6 +166,97 @@ impl TracePublicPreviewSession {
                 status: "running".to_string(),
                 process_id,
                 cleanup_status: "pending".to_string(),
+                session_id: None,
+                public_host: None,
+                ingress_url: None,
+                client_command: None,
+                log_paths: None,
+            },
+        })
+    }
+
+    fn start_homeboy_native(
+        spec: &TracePublicPreviewSpec,
+        artifact_dir: Option<&Path>,
+    ) -> Result<Self> {
+        let native = spec.native.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "public_preview.native",
+                "homeboy_native public_preview requires native settings",
+                Some(spec.local_origin.clone()),
+                None,
+            )
+        })?;
+        let public_host = native_public_host(native)?;
+        let public_origin = spec
+            .public_origin
+            .clone()
+            .unwrap_or_else(|| format!("https://{public_host}"));
+
+        let is_https = public_origin.starts_with("https://");
+        if spec.require_https && !is_https {
+            return Err(Error::validation_invalid_argument(
+                "public_preview.public_origin",
+                "trace public_preview requires an HTTPS public origin",
+                Some(public_origin),
+                None,
+            ));
+        }
+
+        let native_command = native_preview_client_command(spec, native, &public_host)?;
+        let (mut child, log_paths) = start_native_preview_client(&native_command, artifact_dir)?;
+        let ready_child = child.as_mut().ok_or_else(|| {
+            Error::internal_io(
+                "native trace public_preview client did not start".to_string(),
+                Some("trace.preview.native.child".to_string()),
+            )
+        })?;
+        if let Err(error) = read_native_client_ready(
+            ready_child,
+            &public_origin,
+            spec.startup_timeout_seconds
+                .unwrap_or(DEFAULT_STARTUP_TIMEOUT_SECONDS),
+            log_paths.as_ref(),
+        ) {
+            stop_child(&mut child);
+            return Err(error);
+        }
+
+        let required_assets = match preflight_required_assets(spec, &public_origin) {
+            Ok(checks) => checks,
+            Err(error) => {
+                stop_child(&mut child);
+                return Err(error);
+            }
+        };
+
+        let process_id = child.as_ref().map(|child| child.id().to_string());
+        Ok(Self {
+            child,
+            metadata: TracePreviewMetadata {
+                schema: "homeboy/preview/v1".to_string(),
+                requested_mode: "public-https".to_string(),
+                provider: spec
+                    .provider
+                    .clone()
+                    .unwrap_or_else(|| "homeboy-native".to_string()),
+                local_origin: spec.local_origin.clone(),
+                local_url: spec.local_origin.clone(),
+                public_origin: public_origin.clone(),
+                public_url: public_origin.clone(),
+                browser_effective_origin: public_origin.clone(),
+                window_location_origin: public_origin,
+                window_is_secure_context: is_https,
+                require_https: spec.require_https,
+                required_assets,
+                status: "running".to_string(),
+                process_id,
+                cleanup_status: "pending".to_string(),
+                session_id: native.session_id.clone(),
+                public_host: Some(public_host),
+                ingress_url: native.ingress_url.clone(),
+                client_command: Some(native_command.display()),
+                log_paths,
             },
         })
     }
@@ -160,7 +300,32 @@ impl TracePublicPreviewSession {
                 "HOMEBOY_TRACE_WINDOW_IS_SECURE_CONTEXT".to_string(),
                 self.metadata.window_is_secure_context.to_string(),
             ),
+            (
+                "HOMEBOY_TRACE_PREVIEW_PROVIDER".to_string(),
+                self.metadata.provider.clone(),
+            ),
         ])
+        .map(|mut env| {
+            if let Some(session_id) = &self.metadata.session_id {
+                env.push((
+                    "HOMEBOY_TRACE_PREVIEW_SESSION_ID".to_string(),
+                    session_id.clone(),
+                ));
+            }
+            if let Some(public_host) = &self.metadata.public_host {
+                env.push((
+                    "HOMEBOY_TRACE_PREVIEW_PUBLIC_HOST".to_string(),
+                    public_host.clone(),
+                ));
+            }
+            if let Some(ingress_url) = &self.metadata.ingress_url {
+                env.push((
+                    "HOMEBOY_TRACE_PREVIEW_INGRESS_URL".to_string(),
+                    ingress_url.clone(),
+                ));
+            }
+            env
+        })
     }
 
     pub fn finish(mut self) -> TracePreviewMetadata {
@@ -194,6 +359,200 @@ fn start_provider_command(command: &str) -> Result<Child> {
                 Some("trace.preview.start".to_string()),
             )
         })
+}
+
+fn native_public_host(native: &TraceNativePublicPreviewSpec) -> Result<String> {
+    if let Some(host) = native.public_host.as_deref() {
+        let host = host
+            .trim()
+            .trim_start_matches("https://")
+            .trim_end_matches('/');
+        if !host.is_empty() {
+            return Ok(host.to_string());
+        }
+    }
+
+    let session_id = native.session_id.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "public_preview.native.session_id",
+            "homeboy_native public_preview requires session_id when public_host is omitted",
+            None,
+            None,
+        )
+    })?;
+    let operator_domain = native.operator_domain.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "public_preview.native.operator_domain",
+            "homeboy_native public_preview requires operator_domain when public_host is omitted",
+            Some(session_id.to_string()),
+            None,
+        )
+    })?;
+    Ok(format!(
+        "{}-tunnel.{}",
+        session_id.trim().trim_matches('.'),
+        operator_domain.trim().trim_start_matches("*."),
+    ))
+}
+
+fn native_preview_client_command(
+    spec: &TracePublicPreviewSpec,
+    native: &TraceNativePublicPreviewSpec,
+    public_host: &str,
+) -> Result<NativePreviewClientCommand> {
+    let program = match native.client_binary.as_deref() {
+        Some(path) => path.to_string(),
+        None => std::env::current_exe()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|_| "homeboy".to_string()),
+    };
+    let mut args = vec![
+        "tunnel".to_string(),
+        "preview-client".to_string(),
+        "start".to_string(),
+        "--public-host".to_string(),
+        public_host.to_string(),
+        "--local-origin".to_string(),
+        spec.local_origin.clone(),
+    ];
+    if let Some(session_id) = native.session_id.as_deref() {
+        args.extend(["--session-id".to_string(), session_id.to_string()]);
+    }
+    if let Some(ingress_url) = native.ingress_url.as_deref() {
+        args.extend(["--ingress".to_string(), ingress_url.to_string()]);
+    }
+    if let Some(token_env) = native.token_env.as_deref() {
+        args.extend(["--token-env".to_string(), token_env.to_string()]);
+    }
+    args.push("--ready-stdout".to_string());
+    Ok(NativePreviewClientCommand { program, args })
+}
+
+fn start_native_preview_client(
+    native_command: &NativePreviewClientCommand,
+    artifact_dir: Option<&Path>,
+) -> Result<(Option<Child>, Option<TracePreviewLogPaths>)> {
+    let (stderr, log_paths) = match artifact_dir {
+        Some(artifact_dir) => {
+            std::fs::create_dir_all(artifact_dir).map_err(|e| {
+                Error::internal_io(
+                    format!(
+                        "Failed to create trace preview artifact dir {}: {e}",
+                        artifact_dir.display()
+                    ),
+                    Some("trace.preview.native.artifact_dir".to_string()),
+                )
+            })?;
+            let stdout_path = artifact_dir.join("preview-client.stdout.log");
+            let stderr_path = artifact_dir.join("preview-client.stderr.log");
+            let stderr = std::fs::File::create(&stderr_path).map_err(|e| {
+                Error::internal_io(
+                    format!(
+                        "Failed to create native preview client stderr log {}: {e}",
+                        stderr_path.display()
+                    ),
+                    Some("trace.preview.native.stderr".to_string()),
+                )
+            })?;
+            (
+                Stdio::from(stderr),
+                Some(TracePreviewLogPaths {
+                    client_stdout_path: stdout_path.display().to_string(),
+                    client_stderr_path: stderr_path.display().to_string(),
+                }),
+            )
+        }
+        None => (Stdio::piped(), None),
+    };
+
+    let child = Command::new(&native_command.program)
+        .args(&native_command.args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(stderr)
+        .spawn()
+        .map_err(|e| {
+            Error::internal_io(
+                format!("Failed to start native trace public_preview client: {e}"),
+                Some("trace.preview.native.start".to_string()),
+            )
+        })?;
+    Ok((Some(child), log_paths))
+}
+
+fn read_native_client_ready(
+    child: &mut Child,
+    public_origin: &str,
+    timeout_seconds: u64,
+    log_paths: Option<&TracePreviewLogPaths>,
+) -> Result<()> {
+    let stdout = child.stdout.take().ok_or_else(|| {
+        Error::internal_io(
+            "native trace public_preview client stdout was not captured".to_string(),
+            Some("trace.preview.native.stdout".to_string()),
+        )
+    })?;
+    let stdout_log = log_paths
+        .map(|paths| PathBuf::from(&paths.client_stdout_path))
+        .map(std::fs::File::create)
+        .transpose()
+        .map_err(|e| {
+            Error::internal_io(
+                format!("Failed to create native preview client stdout log: {e}"),
+                Some("trace.preview.native.stdout_log".to_string()),
+            )
+        })?;
+    let expected_origin = public_origin.trim_end_matches('/').to_string();
+    let (sender, receiver) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut stdout_log = stdout_log;
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            match line {
+                Ok(line) => {
+                    if let Some(log) = stdout_log.as_mut() {
+                        use std::io::Write;
+                        let _ = writeln!(log, "{line}");
+                    }
+                    if first_https_origin(&line).as_deref() == Some(expected_origin.as_str())
+                        || line.contains(&expected_origin)
+                    {
+                        let _ = sender.send(Ok(()));
+                        return;
+                    }
+                }
+                Err(e) => {
+                    let _ = sender.send(Err(e.to_string()));
+                    return;
+                }
+            }
+        }
+        let _ = sender.send(Err(
+            "native preview client stdout closed before readiness appeared".to_string(),
+        ));
+    });
+
+    match receiver.recv_timeout(Duration::from_secs(timeout_seconds.max(1))) {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(message)) => Err(Error::validation_invalid_argument(
+            "public_preview.native.client",
+            format!("native trace public_preview client failed to report readiness: {message}"),
+            Some(public_origin.to_string()),
+            None,
+        )),
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(Error::validation_invalid_argument(
+            "public_preview.native.client",
+            "native trace public_preview client did not report readiness before timeout",
+            Some(public_origin.to_string()),
+            None,
+        )),
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(Error::validation_invalid_argument(
+            "public_preview.native.client",
+            "native trace public_preview client readiness reader stopped before readiness appeared",
+            Some(public_origin.to_string()),
+            None,
+        )),
+    }
 }
 
 fn read_public_origin(child: &mut Child, timeout_seconds: u64) -> Result<String> {
@@ -409,7 +768,9 @@ fn stop_child(child: &mut Option<Child>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{expected_local_tunnel_port, first_https_origin, TracePublicPreviewSession};
-    use crate::core::rig::TracePublicPreviewSpec;
+    use crate::core::rig::{
+        TraceNativePublicPreviewSpec, TracePublicPreviewMode, TracePublicPreviewSpec,
+    };
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
@@ -425,6 +786,7 @@ mod tests {
     #[test]
     fn starts_provider_command_and_records_preview_metadata() {
         let session = TracePublicPreviewSession::start(&TracePublicPreviewSpec {
+            mode: TracePublicPreviewMode::External,
             local_origin: "http://127.0.0.1:8080".to_string(),
             public_origin: None,
             command: Some(
@@ -434,6 +796,7 @@ mod tests {
             provider: Some("fixture".to_string()),
             startup_timeout_seconds: Some(2),
             required_asset_paths: Vec::new(),
+            native: None,
         })
         .expect("preview starts");
 
@@ -467,6 +830,7 @@ mod tests {
     #[test]
     fn fails_fast_when_public_tunnel_port_does_not_match_local_origin() {
         let result = TracePublicPreviewSession::start(&TracePublicPreviewSpec {
+            mode: TracePublicPreviewMode::External,
             local_origin: "http://127.0.0.1:20000".to_string(),
             public_origin: Some("https://site-49822-tunnel.kimaki.dev/".to_string()),
             command: None,
@@ -474,6 +838,7 @@ mod tests {
             provider: Some("fixture".to_string()),
             startup_timeout_seconds: None,
             required_asset_paths: Vec::new(),
+            native: None,
         });
         let error = match result {
             Ok(_) => panic!("mismatched preview port should fail before trace starts"),
@@ -496,6 +861,7 @@ mod tests {
         )]);
 
         let session = TracePublicPreviewSession::start(&TracePublicPreviewSpec {
+            mode: TracePublicPreviewMode::External,
             local_origin: origin.clone(),
             public_origin: Some(origin),
             command: None,
@@ -505,6 +871,7 @@ mod tests {
             required_asset_paths: vec![
                 "/wp-content/plugins/example/build/frontend.js?ver=1".to_string()
             ],
+            native: None,
         })
         .expect("preview starts after asset preflight");
 
@@ -521,6 +888,7 @@ mod tests {
         )]);
 
         let result = TracePublicPreviewSession::start(&TracePublicPreviewSpec {
+            mode: TracePublicPreviewMode::External,
             local_origin: origin.clone(),
             public_origin: Some(origin),
             command: None,
@@ -530,6 +898,7 @@ mod tests {
             required_asset_paths: vec![
                 "/wp-content/plugins/example/build/frontend.js?ver=1".to_string()
             ],
+            native: None,
         });
 
         let error = match result {
@@ -539,6 +908,78 @@ mod tests {
         let message = error.to_string();
         assert!(message.contains("required asset preflight failed before trace collection"));
         assert!(message.contains("/wp-content/plugins/example/build/frontend.js?ver=1 -> HTTP 502"));
+    }
+
+    #[test]
+    fn starts_homeboy_native_client_and_records_lifecycle_metadata() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let client = temp.path().join("homeboy-preview-client-fixture.sh");
+        std::fs::write(
+            &client,
+            "#!/bin/sh\nprintf 'ready https://run-42-tunnel.chubes.net\\n'\nsleep 5\n",
+        )
+        .expect("write native client fixture");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(&client).expect("metadata").permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&client, permissions).expect("chmod fixture");
+        }
+
+        let artifact_dir = temp.path().join("artifacts");
+        let session = TracePublicPreviewSession::start_with_artifact_dir(
+            &TracePublicPreviewSpec {
+                mode: TracePublicPreviewMode::HomeboyNative,
+                local_origin: "http://127.0.0.1:49823".to_string(),
+                public_origin: None,
+                command: None,
+                require_https: true,
+                provider: None,
+                startup_timeout_seconds: Some(2),
+                required_asset_paths: Vec::new(),
+                native: Some(TraceNativePublicPreviewSpec {
+                    public_host: None,
+                    operator_domain: Some("chubes.net".to_string()),
+                    session_id: Some("run-42".to_string()),
+                    ingress_url: Some("https://preview-broker.chubes.net".to_string()),
+                    token_env: Some("HOMEBOY_PREVIEW_TUNNEL_TOKEN".to_string()),
+                    client_binary: Some(client.display().to_string()),
+                }),
+            },
+            Some(&artifact_dir),
+        )
+        .expect("native preview starts");
+
+        assert_eq!(session.metadata().provider, "homeboy-native");
+        assert_eq!(
+            session.metadata().public_origin,
+            "https://run-42-tunnel.chubes.net"
+        );
+        assert_eq!(
+            session.metadata().public_host.as_deref(),
+            Some("run-42-tunnel.chubes.net")
+        );
+        assert_eq!(session.metadata().session_id.as_deref(), Some("run-42"));
+        assert!(session
+            .metadata()
+            .client_command
+            .as_deref()
+            .expect("client command")
+            .contains("tunnel preview-client start"));
+        assert!(session.metadata().log_paths.is_some());
+        let env = session.env_vars().expect("env vars");
+        assert!(env.contains(&(
+            "HOMEBOY_TRACE_PREVIEW_SESSION_ID".to_string(),
+            "run-42".to_string()
+        )));
+        assert!(env.contains(&(
+            "HOMEBOY_TRACE_PREVIEW_PUBLIC_HOST".to_string(),
+            "run-42-tunnel.chubes.net".to_string()
+        )));
+
+        let metadata = session.finish();
+        assert_eq!(metadata.cleanup_status, "terminated");
     }
 
     fn start_asset_fixture_server(routes: Vec<(String, u16)>) -> String {

--- a/src/core/extension/trace/preview.rs
+++ b/src/core/extension/trace/preview.rs
@@ -936,7 +936,7 @@ mod tests {
                 command: None,
                 require_https: true,
                 provider: None,
-                startup_timeout_seconds: Some(2),
+                startup_timeout_seconds: Some(5),
                 required_asset_paths: Vec::new(),
                 native: Some(TraceNativePublicPreviewSpec {
                     public_host: None,

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -208,7 +208,7 @@ fn run_trace_workflow_with_component_script(
         Some(acquire_trace_overlay_locks(&args.overlays, run_dir)?)
     };
     let applied_overlays = apply_trace_overlays(&args.overlays, args.keep_overlay)?;
-    let preview_session = start_trace_public_preview(&mut args)?;
+    let preview_session = start_trace_public_preview(&mut args, run_dir)?;
     let mut script_env = vec![
         (
             "HOMEBOY_TRACE_SCENARIO".to_string(),
@@ -350,7 +350,7 @@ fn run_trace_workflow_with_context(
         Some(acquire_trace_overlay_locks(&args.overlays, run_dir)?)
     };
     let applied_overlays = apply_trace_overlays(&args.overlays, args.keep_overlay)?;
-    let preview_session = start_trace_public_preview(&mut args)?;
+    let preview_session = start_trace_public_preview(&mut args, run_dir)?;
     let artifact_dir = run_dir.path().join("artifacts");
     std::fs::create_dir_all(&artifact_dir).map_err(|e| {
         Error::internal_io(
@@ -1102,11 +1102,13 @@ fn last_observed_homeboy_event(results: &TraceResults) -> Option<String> {
 
 fn start_trace_public_preview(
     args: &mut TraceRunWorkflowArgs,
+    run_dir: &RunDir,
 ) -> Result<Option<TracePublicPreviewSession>> {
     let Some(spec) = args.runner_inputs.public_preview.clone() else {
         return Ok(None);
     };
-    let session = TracePublicPreviewSession::start(&spec)?;
+    let artifact_dir = run_dir.path().join("artifacts");
+    let session = TracePublicPreviewSession::start_with_artifact_dir(&spec, Some(&artifact_dir))?;
     args.runner_inputs.env.extend(session.env_vars()?);
     Ok(Some(session))
 }

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -64,8 +64,8 @@ pub use spec::{
     ComponentSpec, DiscoverSpec, NewerThanSpec, PatchOp, PipelineStep, RigResourcesSpec, RigSpec,
     ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, StackOp, SymlinkSpec, TimeSource,
     TraceDependencySpec, TraceExperimentArtifactSpec, TraceExperimentCommandSpec,
-    TraceExperimentSpec, TraceGuardrailSpec, TraceProfileSpec, TracePublicPreviewSpec,
-    TraceVariantSpec, WorkloadSpec,
+    TraceExperimentSpec, TraceGuardrailSpec, TraceNativePublicPreviewSpec, TraceProfileSpec,
+    TracePublicPreviewMode, TracePublicPreviewSpec, TraceVariantSpec, WorkloadSpec,
 };
 pub use stack::{
     plan_stack_sync, run_component_sync, run_sync, RigStackPlanEntry, RigStackSyncEntry,

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -503,6 +503,11 @@ pub struct TraceProfileSpec {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TracePublicPreviewSpec {
+    /// Preview provider lifecycle mode. Defaults to the existing external
+    /// command/public-origin behavior.
+    #[serde(default)]
+    pub mode: TracePublicPreviewMode,
+
     /// Local HTTP origin to expose, for example `http://127.0.0.1:8888`.
     pub local_origin: String,
 
@@ -530,6 +535,51 @@ pub struct TracePublicPreviewSpec {
     /// Public-origin-relative asset URLs that must load before trace collection starts.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub required_asset_paths: Vec<String>,
+
+    /// Homeboy-native preview tunnel settings used when `mode` is `homeboy_native`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native: Option<TraceNativePublicPreviewSpec>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TracePublicPreviewMode {
+    External,
+    HomeboyNative,
+}
+
+impl Default for TracePublicPreviewMode {
+    fn default() -> Self {
+        Self::External
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct TraceNativePublicPreviewSpec {
+    /// Deterministic public host reserved by the native preview ingress.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_host: Option<String>,
+
+    /// Operator-owned wildcard domain used to derive `{session}-tunnel.<domain>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operator_domain: Option<String>,
+
+    /// Stable session ID used for host generation and native client metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+
+    /// Native preview ingress/broker URL consumed by `homeboy tunnel preview-client start`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ingress_url: Option<String>,
+
+    /// Environment variable name that supplies the native preview tunnel token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_env: Option<String>,
+
+    /// Optional path to a Homeboy binary that implements the preview-client command.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_binary: Option<String>,
 }
 
 impl TraceProfileSpec {

--- a/tests/core/rig/public_preview_spec_test.rs
+++ b/tests/core/rig/public_preview_spec_test.rs
@@ -13,7 +13,7 @@ fn test_trace_public_preview_parse() {
                 "provider": "cloudflared",
                 "startup_timeout_seconds": 5,
                 "required_asset_paths": [
-                    "/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.js?ver=10.8.0"
+                    "/assets/app.js"
                 ]
             }
         }"#,
@@ -27,10 +27,7 @@ fn test_trace_public_preview_parse() {
     assert_eq!(preview.startup_timeout_seconds, Some(5));
     assert_eq!(
         preview.required_asset_paths,
-        vec![
-            "/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.js?ver=10.8.0"
-                .to_string()
-        ]
+        vec!["/assets/app.js".to_string()]
     );
 }
 

--- a/tests/core/rig/public_preview_spec_test.rs
+++ b/tests/core/rig/public_preview_spec_test.rs
@@ -6,6 +6,7 @@ fn test_trace_public_preview_parse() {
         r#"{
             "path": "/tmp/wallet.trace.mjs",
             "public_preview": {
+                "mode": "external",
                 "local_origin": "http://127.0.0.1:8080",
                 "command": "cloudflared tunnel --url http://127.0.0.1:8080",
                 "require_https": true,
@@ -30,5 +31,44 @@ fn test_trace_public_preview_parse() {
             "/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.js?ver=10.8.0"
                 .to_string()
         ]
+    );
+}
+
+#[test]
+fn test_trace_public_preview_parse_homeboy_native() {
+    let workload: WorkloadSpec = serde_json::from_str(
+        r#"{
+            "path": "/tmp/wallet.trace.mjs",
+            "public_preview": {
+                "mode": "homeboy_native",
+                "local_origin": "http://127.0.0.1:49823",
+                "require_https": true,
+                "native": {
+                    "operator_domain": "chubes.net",
+                    "session_id": "wc-stripe-real-wallet",
+                    "ingress_url": "https://preview-broker.chubes.net",
+                    "token_env": "HOMEBOY_PREVIEW_TUNNEL_TOKEN"
+                }
+            }
+        }"#,
+    )
+    .expect("parse native public preview workload");
+
+    let preview = workload.public_preview().expect("public preview");
+    assert_eq!(preview.local_origin, "http://127.0.0.1:49823");
+    assert_eq!(
+        preview.mode,
+        crate::core::rig::TracePublicPreviewMode::HomeboyNative
+    );
+    let native = preview.native.as_ref().expect("native settings");
+    assert_eq!(native.operator_domain.as_deref(), Some("chubes.net"));
+    assert_eq!(native.session_id.as_deref(), Some("wc-stripe-real-wallet"));
+    assert_eq!(
+        native.ingress_url.as_deref(),
+        Some("https://preview-broker.chubes.net")
+    );
+    assert_eq!(
+        native.token_env.as_deref(),
+        Some("HOMEBOY_PREVIEW_TUNNEL_TOKEN")
     );
 }


### PR DESCRIPTION
## Summary
- Add `mode: \"homeboy_native\"` to trace `public_preview` specs while preserving the existing external command/public-origin default.
- Start a minimal native preview client lifecycle from trace runs, inject generic preview metadata/env vars, persist client log paths, preflight declared assets, and terminate cleanup on finish/drop.
- Keep trace integration generic: Homeboy core only handles a local origin, public origin/host, native session metadata, and generic `HOMEBOY_PREVIEW_*` / `HOMEBOY_TRACE_PREVIEW_*` values.
- Remove preview-core workload-specific port/env guidance; product/runtime translation belongs in Homeboy Extensions or rig definitions.
- Document the native trace contract and its dependency on the #4090 ingress and #4092 reverse client implementations.

## Verification
- `cargo test public_preview_spec_test`
- `cargo test core::extension::trace::preview::tests`
- `cargo test` currently fails on existing bench discovery tests that also fail on clean `origin/main`: `commands::bench::tests::unknown_scenario_reports_discovered_ids` and `commands::bench::tests::profile_with_unknown_scenario_lists_discovered_scenarios`.

## Related
- Fixes #4094
- Blocks/helps #4062
- Depends on #4090 and #4092 for the concrete native ingress/client command implementations.

## #4062 consumption path
Homeboy core exposes a generic native public preview lifecycle for a declared local origin. Woo Stripe / WP Codebox-specific translation should live in Homeboy Extensions or homeboy-rigs: those layers can choose the local origin, declare required asset paths, and map generic `HOMEBOY_PREVIEW_PUBLIC_URL` / `HOMEBOY_TRACE_PREVIEW_*` metadata into any workload-specific settings or environment variables they need.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the generic trace public preview lifecycle changes, tests, documentation, and verification notes for Chris to review.