### PR TITLE
Add Homeboy preview ingress daemon

### DIFF
--- a/docs/commands/tunnel.md
+++ b/docs/commands/tunnel.md
@@ -7,7 +7,7 @@ homeboy tunnel service <COMMAND>
 homeboy tunnel preview-ingress <COMMAND>
 ```
 
-`tunnel` manages Homeboy-native private service tunnel declarations, local managed service lifecycle, and the VPS-side public preview ingress used by browser trace/reviewer URLs. Homeboy can start a long-running local command, record safe command/process/log evidence, report readiness, and stop the process group without relying on an external chat or tunnel wrapper.
+`tunnel` manages Homeboy-native private service tunnel declarations, local managed service lifecycle, and the VPS-side public preview ingress used by generic browser/reviewer URLs. Homeboy can start a long-running local command, record safe command/process/log evidence, report readiness, and stop the process group without relying on an external chat or tunnel wrapper.
 
 ## Service Tunnels
 
@@ -74,6 +74,8 @@ Browser
   -> local/reverse-channel HTTP origin
 ```
 
+The core contract is generic HTTP ingress: public host/session routing, reverse-channel-compatible HTTP origins, request/response streaming, status, logs, and cleanup. Workload-specific behavior such as WordPress, WP Codebox, WooCommerce, static asset health, or browser probe interpretation belongs in Homeboy Extensions or `homeboy-rigs`, not in Homeboy core.
+
 Register one active preview route:
 
 ```sh
@@ -96,7 +98,7 @@ homeboy tunnel preview-ingress serve \
 
 The daemon routes by `Host`, handles concurrent browser asset requests in separate worker threads, proxies request bodies to the configured upstream origin, streams upstream response bodies back to the browser, and preserves response status plus non-hop-by-hop headers such as `content-type` and cache headers.
 
-Diagnostics are structured so browser-trace failures can distinguish ingress and upstream problems:
+Diagnostics are structured so generic preview workloads can distinguish ingress and upstream problems:
 
 - `404 missing_session`: no active route matched the requested host.
 - `410 expired_session`: the route's RFC3339 expiry has passed.
@@ -106,7 +108,7 @@ Diagnostics are structured so browser-trace failures can distinguish ingress and
 
 Each request writes a JSON line to stderr with request ID, host, path, status, bytes, duration, and classification. `/_homeboy/preview-ingress/status` returns the current route status as JSON from the running daemon.
 
-This is the ingress side of #4089 and the first Homeboy-owned replacement path for #4062. Auth/pairing/token lifecycle and the authenticated reverse preview client are separate follow-up surfaces; the ingress route's `upstream_origin` is the seam those clients will attach to.
+This is the ingress side of #4089 and the first Homeboy-owned replacement path for #4062's current tunnel-provider blocker. Auth/pairing/token lifecycle and the authenticated reverse preview client are separate follow-up surfaces; the ingress route's `upstream_origin` is the generic HTTP seam those clients attach to.
 
 ## Subcommands
 

--- a/docs/commands/tunnel.md
+++ b/docs/commands/tunnel.md
@@ -4,9 +4,10 @@
 
 ```sh
 homeboy tunnel service <COMMAND>
+homeboy tunnel preview-ingress <COMMAND>
 ```
 
-`tunnel` manages Homeboy-native private service tunnel declarations and local managed service lifecycle. Homeboy can start a long-running local command, record safe command/process/log evidence, report readiness, and stop the process group without relying on an external chat or tunnel wrapper.
+`tunnel` manages Homeboy-native private service tunnel declarations, local managed service lifecycle, and the VPS-side public preview ingress used by browser trace/reviewer URLs. Homeboy can start a long-running local command, record safe command/process/log evidence, report readiness, and stop the process group without relying on an external chat or tunnel wrapper.
 
 ## Service Tunnels
 
@@ -60,6 +61,53 @@ The `command` backend is a generic adapter seam. Homeboy starts and supervises t
 
 When a service's preview policy is relevant, `service status` and `service start` include a structured `preview` artifact with schema `homeboy/preview-url/v1`. The artifact records the service ID, local URL, optional public URL, backend, policy, cleanup/expiry metadata, and owning run/workflow IDs when the start command supplied them.
 
+## Preview Ingress
+
+`preview-ingress` is the VPS-side HTTP daemon surface for Homeboy-native browser preview tunnels. It is designed to run behind an operator-managed TLS/proxy layer such as Nginx, Caddy, or Cloudflare:
+
+```text
+Browser
+  -> https://{id}-tunnel.<operator-domain>
+  -> TLS/proxy layer
+  -> homeboy tunnel preview-ingress serve --bind 127.0.0.1:7350
+  -> active Homeboy preview route
+  -> local/reverse-channel HTTP origin
+```
+
+Register one active preview route:
+
+```sh
+homeboy tunnel preview-ingress route run-123 \
+  --public-host run-123-tunnel.chubes.net \
+  --upstream-origin http://127.0.0.1:7331 \
+  --expires-at 2026-06-12T03:30:00Z
+```
+
+Use `--inactive` to retain a route record for diagnostics while making the ingress return `410 disconnected_session`.
+
+Run the ingress daemon:
+
+```sh
+homeboy tunnel preview-ingress serve \
+  --domain chubes.net \
+  --bind 127.0.0.1:7350 \
+  --public-host-pattern '*-tunnel.chubes.net'
+```
+
+The daemon routes by `Host`, handles concurrent browser asset requests in separate worker threads, proxies request bodies to the configured upstream origin, streams upstream response bodies back to the browser, and preserves response status plus non-hop-by-hop headers such as `content-type` and cache headers.
+
+Diagnostics are structured so browser-trace failures can distinguish ingress and upstream problems:
+
+- `404 missing_session`: no active route matched the requested host.
+- `410 expired_session`: the route's RFC3339 expiry has passed.
+- `410 disconnected_session`: the route is retained but marked inactive.
+- `502 upstream_error`: the upstream origin failed before response streaming.
+- `504 upstream_timeout`: the upstream origin timed out.
+
+Each request writes a JSON line to stderr with request ID, host, path, status, bytes, duration, and classification. `/_homeboy/preview-ingress/status` returns the current route status as JSON from the running daemon.
+
+This is the ingress side of #4089 and the first Homeboy-owned replacement path for #4062. Auth/pairing/token lifecycle and the authenticated reverse preview client are separate follow-up surfaces; the ingress route's `upstream_origin` is the seam those clients will attach to.
+
 ## Subcommands
 
 - `service expose`: create or replace a private service tunnel declaration.
@@ -71,3 +119,8 @@ When a service's preview policy is relevant, `service status` and `service start
 - `service start <id>`: start and supervise a declared local service command and optional provider-neutral public tunnel backend.
 - `service status <id>`: report declaration, process, local URL, public URL when present, health, backend, and log evidence state.
 - `service stop <id>`: terminate the managed process group and remove runtime state while leaving log evidence files in place.
+- `preview-ingress route <session-id>`: register or replace a host-routed preview session.
+- `preview-ingress unroute <session-id>`: remove a preview route.
+- `preview-ingress list`: list route records.
+- `preview-ingress status`: report route lifecycle metadata.
+- `preview-ingress serve`: run the blocking VPS-side HTTP ingress daemon.

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -1,6 +1,9 @@
 use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
 
+use homeboy::core::preview_ingress::{
+    self, PreviewIngressRoute, PreviewIngressServeSpec, PreviewIngressStatus,
+};
 use homeboy::core::tunnel::{
     self, ExposeServiceTunnelSpec, ServiceTunnel, ServiceTunnelAuth, ServiceTunnelAuthMode,
     ServiceTunnelExposure, ServiceTunnelPolicy, ServiceTunnelPreviewPolicy,
@@ -17,6 +20,8 @@ use super::{CmdResult, DynamicSetArgs};
 pub struct TunnelExtra {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service: Option<ServiceTunnelActionOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preview_ingress: Option<PreviewIngressActionOutput>,
 }
 
 #[derive(Debug, Serialize)]
@@ -27,6 +32,14 @@ pub enum ServiceTunnelActionOutput {
         local_url: String,
     },
     Status(ServiceTunnelStatus),
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum PreviewIngressActionOutput {
+    Route(PreviewIngressRoute),
+    Routes { routes: Vec<PreviewIngressRoute> },
+    Status(PreviewIngressStatus),
 }
 
 pub type TunnelOutput = EntityCrudOutput<ServiceTunnel, TunnelExtra>;
@@ -43,6 +56,72 @@ enum TunnelCommand {
     Service {
         #[command(subcommand)]
         command: TunnelServiceCommand,
+    },
+    /// Run and inspect the VPS-side public preview ingress
+    #[command(name = "preview-ingress")]
+    PreviewIngress {
+        #[command(subcommand)]
+        command: TunnelPreviewIngressCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum TunnelPreviewIngressCommand {
+    /// Register or replace one active public-host route
+    Route {
+        /// Preview session ID
+        session_id: String,
+
+        /// Public host routed by the TLS/proxy layer, e.g. run-123-tunnel.chubes.net
+        #[arg(long)]
+        public_host: String,
+
+        /// Local/reverse-channel HTTP origin for this session
+        #[arg(long)]
+        upstream_origin: String,
+
+        /// RFC3339 expiry after which ingress returns 410
+        #[arg(long)]
+        expires_at: Option<String>,
+
+        /// Mark the route disconnected while preserving diagnostics
+        #[arg(long)]
+        inactive: bool,
+    },
+    /// Remove one preview ingress route
+    Unroute {
+        /// Preview session ID
+        session_id: String,
+    },
+    /// List registered preview ingress routes
+    List,
+    /// Report route lifecycle and recent server failure metadata
+    Status {
+        /// Bind address to include in the status output
+        #[arg(long)]
+        bind: Option<String>,
+
+        /// Operator-owned preview domain
+        #[arg(long)]
+        domain: Option<String>,
+
+        /// Public host pattern routed to this ingress
+        #[arg(long)]
+        public_host_pattern: Option<String>,
+    },
+    /// Run the blocking HTTP ingress server behind a TLS terminator
+    Serve {
+        /// Loopback bind address for Nginx/Caddy/Cloudflare to proxy to
+        #[arg(long, default_value = "127.0.0.1:7350")]
+        bind: String,
+
+        /// Operator-owned preview domain
+        #[arg(long)]
+        domain: String,
+
+        /// Public host pattern routed to this ingress
+        #[arg(long, default_value = "*-tunnel.{domain}")]
+        public_host_pattern: String,
     },
 }
 
@@ -269,6 +348,107 @@ impl From<ServiceTunnelAuthModeArg> for ServiceTunnelAuthMode {
 pub fn run(args: TunnelArgs, _global: &super::GlobalArgs) -> CmdResult<TunnelOutput> {
     match args.command {
         TunnelCommand::Service { command } => run_service(command),
+        TunnelCommand::PreviewIngress { command } => run_preview_ingress(command),
+    }
+}
+
+fn run_preview_ingress(command: TunnelPreviewIngressCommand) -> CmdResult<TunnelOutput> {
+    match command {
+        TunnelPreviewIngressCommand::Route {
+            session_id,
+            public_host,
+            upstream_origin,
+            expires_at,
+            inactive,
+        } => {
+            let route = preview_ingress::register_route(PreviewIngressRoute {
+                session_id: session_id.clone(),
+                public_host,
+                upstream_origin,
+                expires_at,
+                active: !inactive,
+            })?;
+            Ok((
+                TunnelOutput {
+                    command: "tunnel.preview_ingress.route".to_string(),
+                    id: Some(session_id),
+                    extra: TunnelExtra {
+                        preview_ingress: Some(PreviewIngressActionOutput::Route(route)),
+                        ..Default::default()
+                    },
+                    updated_fields: vec!["route".to_string()],
+                    ..Default::default()
+                },
+                0,
+            ))
+        }
+        TunnelPreviewIngressCommand::Unroute { session_id } => {
+            preview_ingress::remove_route(&session_id)?;
+            Ok((
+                TunnelOutput {
+                    command: "tunnel.preview_ingress.unroute".to_string(),
+                    id: Some(session_id.clone()),
+                    deleted: vec![session_id],
+                    ..Default::default()
+                },
+                0,
+            ))
+        }
+        TunnelPreviewIngressCommand::List => {
+            let routes = preview_ingress::list_routes()?;
+            Ok((
+                TunnelOutput {
+                    command: "tunnel.preview_ingress.list".to_string(),
+                    extra: TunnelExtra {
+                        preview_ingress: Some(PreviewIngressActionOutput::Routes { routes }),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                0,
+            ))
+        }
+        TunnelPreviewIngressCommand::Status {
+            bind,
+            domain,
+            public_host_pattern,
+        } => {
+            let status = preview_ingress::status(bind, domain, public_host_pattern)?;
+            Ok((
+                TunnelOutput {
+                    command: "tunnel.preview_ingress.status".to_string(),
+                    extra: TunnelExtra {
+                        preview_ingress: Some(PreviewIngressActionOutput::Status(status)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                0,
+            ))
+        }
+        TunnelPreviewIngressCommand::Serve {
+            bind,
+            domain,
+            public_host_pattern,
+        } => {
+            let pattern = public_host_pattern.replace("{domain}", &domain);
+            let status = preview_ingress::serve(PreviewIngressServeSpec {
+                bind,
+                domain,
+                public_host_pattern: pattern,
+            })?;
+            Ok((
+                TunnelOutput {
+                    command: "tunnel.preview_ingress.serve".to_string(),
+                    extra: TunnelExtra {
+                        preview_ingress: Some(PreviewIngressActionOutput::Status(status)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                0,
+            ))
+        }
     }
 }
 
@@ -456,6 +636,7 @@ fn url_service(id: &str) -> CmdResult<TunnelOutput> {
                     service_id: id.to_string(),
                     local_url,
                 }),
+                ..Default::default()
             },
             ..Default::default()
         },
@@ -471,6 +652,7 @@ fn status_service(id: &str) -> CmdResult<TunnelOutput> {
             id: Some(id.to_string()),
             extra: TunnelExtra {
                 service: Some(ServiceTunnelActionOutput::Status(report)),
+                ..Default::default()
             },
             ..Default::default()
         },
@@ -487,6 +669,7 @@ fn start_service(spec: StartServiceTunnelSpec) -> CmdResult<TunnelOutput> {
             id: Some(id),
             extra: TunnelExtra {
                 service: Some(ServiceTunnelActionOutput::Status(report)),
+                ..Default::default()
             },
             ..Default::default()
         },
@@ -502,6 +685,7 @@ fn stop_service(id: &str) -> CmdResult<TunnelOutput> {
             id: Some(id.to_string()),
             extra: TunnelExtra {
                 service: Some(ServiceTunnelActionOutput::Status(report)),
+                ..Default::default()
             },
             ..Default::default()
         },

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -55,6 +55,9 @@ pub mod observation;
 pub mod output;
 pub(crate) mod ownership;
 pub mod plan;
+pub mod preview_ingress;
+#[cfg(test)]
+mod preview_ingress_tests;
 pub mod process;
 pub mod product_identity;
 pub mod project;

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -223,6 +223,16 @@ pub fn service_tunnel_runtime_state_file(id: &str) -> Result<PathBuf> {
     Ok(service_tunnel_runtime_dir(id)?.join("state.json"))
 }
 
+/// Preview ingress route declarations (~/.config/homeboy/preview-ingress/routes/).
+pub fn preview_ingress_routes_dir() -> Result<PathBuf> {
+    Ok(homeboy()?.join("preview-ingress").join("routes"))
+}
+
+/// Preview ingress route declaration file.
+pub fn preview_ingress_route_file(id: &str) -> Result<PathBuf> {
+    Ok(preview_ingress_routes_dir()?.join(format!("{}.json", sanitize_path_segment(id))))
+}
+
 /// Extension directory path
 pub fn extension(id: &str) -> Result<PathBuf> {
     Ok(extensions()?.join(id))

--- a/src/core/preview_ingress.rs
+++ b/src/core/preview_ingress.rs
@@ -1,0 +1,678 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::core::error::{Error, Result};
+use crate::core::paths;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PreviewIngressRoute {
+    pub session_id: String,
+    pub public_host: String,
+    pub upstream_origin: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(default = "default_true")]
+    pub active: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PreviewIngressStatus {
+    pub bind: Option<String>,
+    pub domain: Option<String>,
+    pub public_host_pattern: Option<String>,
+    pub routes: Vec<PreviewIngressRouteStatus>,
+    pub recent_failures: Vec<PreviewIngressFailure>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PreviewIngressRouteStatus {
+    #[serde(flatten)]
+    pub route: PreviewIngressRoute,
+    pub lifecycle: PreviewIngressRouteLifecycle,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PreviewIngressRouteLifecycle {
+    Active,
+    Expired,
+    Disconnected,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PreviewIngressFailure {
+    pub request_id: String,
+    pub host: String,
+    pub path: String,
+    pub status: u16,
+    pub classification: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PreviewIngressServeSpec {
+    pub bind: String,
+    pub domain: String,
+    pub public_host_pattern: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct PreviewIngressLogLine {
+    request_id: String,
+    host: String,
+    path: String,
+    status: u16,
+    bytes: usize,
+    duration_ms: u128,
+    classification: String,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+pub fn register_route(route: PreviewIngressRoute) -> Result<PreviewIngressRoute> {
+    validate_route(&route)?;
+    let path = paths::preview_ingress_route_file(&route.session_id)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| Error::internal_io(e.to_string(), Some(parent.display().to_string())))?;
+    }
+    let data = serde_json::to_string_pretty(&route)
+        .map_err(|e| Error::internal_json(e.to_string(), Some(route.session_id.clone())))?;
+    fs::write(&path, data)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))?;
+    load_route(&route.session_id)
+}
+
+pub fn remove_route(session_id: &str) -> Result<()> {
+    let path = paths::preview_ingress_route_file(session_id)?;
+    if path.exists() {
+        fs::remove_file(&path)
+            .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))?;
+    }
+    Ok(())
+}
+
+pub fn load_route(session_id: &str) -> Result<PreviewIngressRoute> {
+    let path = paths::preview_ingress_route_file(session_id)?;
+    let data = fs::read_to_string(&path)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))?;
+    serde_json::from_str(&data)
+        .map_err(|e| Error::internal_json(e.to_string(), Some(path.display().to_string())))
+}
+
+pub fn list_routes() -> Result<Vec<PreviewIngressRoute>> {
+    let dir = paths::preview_ingress_routes_dir()?;
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut routes: Vec<PreviewIngressRoute> = Vec::new();
+    for entry in fs::read_dir(&dir)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(dir.display().to_string())))?
+    {
+        let entry = entry.map_err(|e| Error::internal_io(e.to_string(), None))?;
+        if entry.path().extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let data = fs::read_to_string(entry.path()).map_err(|e| {
+            Error::internal_io(e.to_string(), Some(entry.path().display().to_string()))
+        })?;
+        routes.push(serde_json::from_str(&data).map_err(|e| {
+            Error::internal_json(e.to_string(), Some(entry.path().display().to_string()))
+        })?);
+    }
+    routes.sort_by(|a, b| a.session_id.cmp(&b.session_id));
+    Ok(routes)
+}
+
+pub fn status(
+    bind: Option<String>,
+    domain: Option<String>,
+    public_host_pattern: Option<String>,
+) -> Result<PreviewIngressStatus> {
+    status_with_failures(bind, domain, public_host_pattern, Vec::new())
+}
+
+fn status_with_failures(
+    bind: Option<String>,
+    domain: Option<String>,
+    public_host_pattern: Option<String>,
+    recent_failures: Vec<PreviewIngressFailure>,
+) -> Result<PreviewIngressStatus> {
+    Ok(PreviewIngressStatus {
+        bind,
+        domain,
+        public_host_pattern,
+        routes: list_routes()?
+            .into_iter()
+            .map(|route| PreviewIngressRouteStatus {
+                lifecycle: classify_route(&route),
+                route,
+            })
+            .collect(),
+        recent_failures,
+    })
+}
+
+pub fn serve(spec: PreviewIngressServeSpec) -> Result<PreviewIngressStatus> {
+    validate_serve_spec(&spec)?;
+    let listener = TcpListener::bind(&spec.bind)
+        .map_err(|e| Error::internal_io(e.to_string(), Some(spec.bind.clone())))?;
+    eprintln!(
+        "homeboy preview ingress listening on {} for {} ({})",
+        spec.bind, spec.domain, spec.public_host_pattern
+    );
+
+    let recent_failures = Arc::new(Mutex::new(Vec::<PreviewIngressFailure>::new()));
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(60))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| Error::internal_unexpected(e.to_string()))?;
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let client = client.clone();
+                let recent_failures = Arc::clone(&recent_failures);
+                thread::spawn(move || {
+                    if let Err(error) = handle_connection(stream, client, recent_failures) {
+                        eprintln!(
+                            "homeboy preview ingress connection error: {}",
+                            error.message
+                        );
+                    }
+                });
+            }
+            Err(error) => {
+                return Err(Error::internal_io(error.to_string(), Some(spec.bind)));
+            }
+        }
+    }
+
+    status(
+        Some(spec.bind),
+        Some(spec.domain),
+        Some(spec.public_host_pattern),
+    )
+}
+
+fn handle_connection(
+    mut stream: TcpStream,
+    client: reqwest::blocking::Client,
+    recent_failures: Arc<Mutex<Vec<PreviewIngressFailure>>>,
+) -> Result<()> {
+    let started = Instant::now();
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let mut reader = BufReader::new(stream.try_clone().map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some("clone preview ingress stream".to_string()),
+        )
+    })?);
+    let request = read_http_request(&mut reader)?;
+    let host = request.host.clone().unwrap_or_default();
+    let path = request.target.clone();
+
+    if request.target == "/_homeboy/preview-ingress/status" {
+        let failures = recent_failures
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        let body = serde_json::to_vec_pretty(&status_with_failures(None, None, None, failures)?)
+            .map_err(|e| {
+                Error::internal_json(e.to_string(), Some("preview ingress status".to_string()))
+            })?;
+        write_response(
+            &mut stream,
+            200,
+            "OK",
+            &[(&"content-type".to_string(), "application/json".to_string())],
+            &body,
+        )?;
+        log_request(&PreviewIngressLogLine {
+            request_id,
+            host,
+            path,
+            status: 200,
+            bytes: body.len(),
+            duration_ms: started.elapsed().as_millis(),
+            classification: "status".to_string(),
+        });
+        return Ok(());
+    }
+
+    let Some(route) = route_for_host(&host)? else {
+        let failure = PreviewIngressFailure {
+            request_id: request_id.clone(),
+            host: host.clone(),
+            path: path.clone(),
+            status: 404,
+            classification: "missing_session".to_string(),
+            message: "No active Homeboy preview ingress route matches this host".to_string(),
+        };
+        record_failure(&recent_failures, failure.clone());
+        return write_diagnostic(&mut stream, &failure, started);
+    };
+
+    match classify_route(&route) {
+        PreviewIngressRouteLifecycle::Expired => {
+            let failure = PreviewIngressFailure {
+                request_id: request_id.clone(),
+                host: host.clone(),
+                path: path.clone(),
+                status: 410,
+                classification: "expired_session".to_string(),
+                message: "Homeboy preview ingress route is expired".to_string(),
+            };
+            record_failure(&recent_failures, failure.clone());
+            write_diagnostic(&mut stream, &failure, started)
+        }
+        PreviewIngressRouteLifecycle::Disconnected => {
+            let failure = PreviewIngressFailure {
+                request_id: request_id.clone(),
+                host: host.clone(),
+                path: path.clone(),
+                status: 410,
+                classification: "disconnected_session".to_string(),
+                message: "Homeboy preview ingress route is disconnected".to_string(),
+            };
+            record_failure(&recent_failures, failure.clone());
+            write_diagnostic(&mut stream, &failure, started)
+        }
+        PreviewIngressRouteLifecycle::Active => proxy_request(
+            &mut stream,
+            &client,
+            &route,
+            request,
+            request_id,
+            host,
+            path,
+            started,
+            recent_failures,
+        ),
+    }
+}
+
+struct IngressHttpRequest {
+    method: String,
+    target: String,
+    headers: Vec<(String, String)>,
+    host: Option<String>,
+    body: Vec<u8>,
+}
+
+fn read_http_request(reader: &mut BufReader<TcpStream>) -> Result<IngressHttpRequest> {
+    let mut first_line = String::new();
+    reader
+        .read_line(&mut first_line)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("read request line".to_string())))?;
+    let mut parts = first_line.split_whitespace();
+    let method = parts.next().unwrap_or_default().to_string();
+    let target = parts.next().unwrap_or("/").to_string();
+    if method.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "request",
+            "HTTP request line is empty",
+            None,
+            None,
+        ));
+    }
+
+    let mut headers = Vec::new();
+    let mut host = None;
+    let mut content_length = 0usize;
+    loop {
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .map_err(|e| Error::internal_io(e.to_string(), Some("read headers".to_string())))?;
+        if line == "\r\n" || line == "\n" || line.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = line.trim_end().split_once(':') {
+            let name = name.trim().to_ascii_lowercase();
+            let value = value.trim().to_string();
+            if name == "host" {
+                host = Some(
+                    value
+                        .split(':')
+                        .next()
+                        .unwrap_or_default()
+                        .to_ascii_lowercase(),
+                );
+            }
+            if name == "content-length" {
+                content_length = value.parse().unwrap_or(0);
+            }
+            headers.push((name, value));
+        }
+    }
+
+    let mut body = vec![0; content_length];
+    if content_length > 0 {
+        reader
+            .read_exact(&mut body)
+            .map_err(|e| Error::internal_io(e.to_string(), Some("read body".to_string())))?;
+    }
+
+    Ok(IngressHttpRequest {
+        method,
+        target,
+        headers,
+        host,
+        body,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn proxy_request(
+    stream: &mut TcpStream,
+    client: &reqwest::blocking::Client,
+    route: &PreviewIngressRoute,
+    request: IngressHttpRequest,
+    request_id: String,
+    host: String,
+    path: String,
+    started: Instant,
+    recent_failures: Arc<Mutex<Vec<PreviewIngressFailure>>>,
+) -> Result<()> {
+    let upstream_url = upstream_url(route, &request.target)?;
+    let method = reqwest::Method::from_bytes(request.method.as_bytes())
+        .map_err(|e| Error::validation_invalid_argument("method", e.to_string(), None, None))?;
+    let mut upstream = client.request(method, upstream_url);
+    for (name, value) in request.headers {
+        if is_hop_by_hop_header(&name) || name == "host" || name == "content-length" {
+            continue;
+        }
+        upstream = upstream.header(&name, value);
+    }
+    if !request.body.is_empty() {
+        upstream = upstream.body(request.body);
+    }
+
+    match upstream.send() {
+        Ok(mut response) => {
+            let status = response.status();
+            let headers = response
+                .headers()
+                .iter()
+                .filter_map(|(name, value)| {
+                    let name = name.as_str().to_ascii_lowercase();
+                    if is_hop_by_hop_header(&name) {
+                        return None;
+                    }
+                    value.to_str().ok().map(|value| (name, value.to_string()))
+                })
+                .collect::<Vec<_>>();
+            write_status_and_headers(
+                stream,
+                status.as_u16(),
+                status.canonical_reason().unwrap_or("OK"),
+                &headers,
+            )?;
+            let bytes = response.copy_to(stream).map_err(|e| {
+                Error::internal_io(e.to_string(), Some("stream upstream response".to_string()))
+            })? as usize;
+            log_request(&PreviewIngressLogLine {
+                request_id,
+                host,
+                path,
+                status: status.as_u16(),
+                bytes,
+                duration_ms: started.elapsed().as_millis(),
+                classification: "proxied".to_string(),
+            });
+            Ok(())
+        }
+        Err(error) => {
+            let timeout = error.is_timeout();
+            let failure = PreviewIngressFailure {
+                request_id: request_id.clone(),
+                host: host.clone(),
+                path: path.clone(),
+                status: if timeout { 504 } else { 502 },
+                classification: if timeout {
+                    "upstream_timeout"
+                } else {
+                    "upstream_error"
+                }
+                .to_string(),
+                message: error.to_string(),
+            };
+            record_failure(&recent_failures, failure.clone());
+            write_diagnostic(stream, &failure, started)
+        }
+    }
+}
+
+fn route_for_host(host: &str) -> Result<Option<PreviewIngressRoute>> {
+    Ok(list_routes()?.into_iter().find(|route| {
+        route.public_host.eq_ignore_ascii_case(host)
+            || route
+                .public_host
+                .split(':')
+                .next()
+                .is_some_and(|public_host| public_host.eq_ignore_ascii_case(host))
+    }))
+}
+
+fn classify_route(route: &PreviewIngressRoute) -> PreviewIngressRouteLifecycle {
+    if !route.active {
+        return PreviewIngressRouteLifecycle::Disconnected;
+    }
+    if route
+        .expires_at
+        .as_deref()
+        .and_then(parse_rfc3339_utc)
+        .is_some_and(|expires_at| chrono::Utc::now() > expires_at)
+    {
+        return PreviewIngressRouteLifecycle::Expired;
+    }
+    PreviewIngressRouteLifecycle::Active
+}
+
+fn validate_route(route: &PreviewIngressRoute) -> Result<()> {
+    if route.session_id.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "session_id",
+            "preview ingress session ID is required",
+            None,
+            None,
+        ));
+    }
+    if route.public_host.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "public_host",
+            "preview ingress public host is required",
+            Some(route.session_id.clone()),
+            None,
+        ));
+    }
+    if !(route.upstream_origin.starts_with("http://")
+        || route.upstream_origin.starts_with("https://"))
+    {
+        return Err(Error::validation_invalid_argument(
+            "upstream_origin",
+            "upstream origin must be an http:// or https:// URL",
+            Some(route.session_id.clone()),
+            None,
+        ));
+    }
+    if route
+        .expires_at
+        .as_deref()
+        .is_some_and(|expires_at| parse_rfc3339_utc(expires_at).is_none())
+    {
+        return Err(Error::validation_invalid_argument(
+            "expires_at",
+            "preview ingress expiry must be a valid RFC3339 timestamp",
+            Some(route.session_id.clone()),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn validate_serve_spec(spec: &PreviewIngressServeSpec) -> Result<()> {
+    if spec.bind.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "bind",
+            "bind address is required",
+            None,
+            None,
+        ));
+    }
+    if spec.domain.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "domain",
+            "operator domain is required",
+            None,
+            None,
+        ));
+    }
+    if spec.public_host_pattern.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "public_host_pattern",
+            "public host pattern is required",
+            None,
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn upstream_url(route: &PreviewIngressRoute, target: &str) -> Result<String> {
+    let base = route.upstream_origin.trim_end_matches('/');
+    let target = if target.starts_with('/') {
+        target.to_string()
+    } else {
+        format!("/{target}")
+    };
+    Ok(format!("{base}{target}"))
+}
+
+fn parse_rfc3339_utc(value: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|datetime| datetime.with_timezone(&chrono::Utc))
+}
+
+fn write_diagnostic(
+    stream: &mut TcpStream,
+    failure: &PreviewIngressFailure,
+    started: Instant,
+) -> Result<()> {
+    let body = serde_json::to_vec_pretty(failure).map_err(|e| {
+        Error::internal_json(
+            e.to_string(),
+            Some("preview ingress diagnostic".to_string()),
+        )
+    })?;
+    write_response(
+        stream,
+        failure.status,
+        reason_for_status(failure.status),
+        &[(&"content-type".to_string(), "application/json".to_string())],
+        &body,
+    )?;
+    log_request(&PreviewIngressLogLine {
+        request_id: failure.request_id.clone(),
+        host: failure.host.clone(),
+        path: failure.path.clone(),
+        status: failure.status,
+        bytes: body.len(),
+        duration_ms: started.elapsed().as_millis(),
+        classification: failure.classification.clone(),
+    });
+    Ok(())
+}
+
+fn write_response(
+    stream: &mut TcpStream,
+    status: u16,
+    reason: &str,
+    headers: &[(&String, String)],
+    body: &[u8],
+) -> Result<()> {
+    let owned_headers = headers
+        .iter()
+        .map(|(name, value)| ((*name).clone(), value.clone()))
+        .collect::<Vec<_>>();
+    write_status_and_headers(stream, status, reason, &owned_headers)?;
+    stream
+        .write_all(body)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("write response body".to_string())))
+}
+
+fn write_status_and_headers(
+    stream: &mut TcpStream,
+    status: u16,
+    reason: &str,
+    headers: &[(String, String)],
+) -> Result<()> {
+    write!(stream, "HTTP/1.1 {} {}\r\n", status, reason)
+        .map_err(|e| Error::internal_io(e.to_string(), Some("write status".to_string())))?;
+    let has_connection = headers.iter().any(|(name, _)| name == "connection");
+    for (name, value) in headers {
+        write!(stream, "{}: {}\r\n", name, value)
+            .map_err(|e| Error::internal_io(e.to_string(), Some("write header".to_string())))?;
+    }
+    if !has_connection {
+        write!(stream, "connection: close\r\n").map_err(|e| {
+            Error::internal_io(e.to_string(), Some("write connection header".to_string()))
+        })?;
+    }
+    write!(stream, "\r\n")
+        .map_err(|e| Error::internal_io(e.to_string(), Some("write header terminator".to_string())))
+}
+
+fn reason_for_status(status: u16) -> &'static str {
+    match status {
+        404 => "Not Found",
+        410 => "Gone",
+        502 => "Bad Gateway",
+        504 => "Gateway Timeout",
+        _ => "OK",
+    }
+}
+
+fn is_hop_by_hop_header(name: &str) -> bool {
+    matches!(
+        name,
+        "connection"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+    )
+}
+
+fn record_failure(
+    recent_failures: &Arc<Mutex<Vec<PreviewIngressFailure>>>,
+    failure: PreviewIngressFailure,
+) {
+    let mut failures = recent_failures
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    failures.push(failure);
+    if failures.len() > 50 {
+        failures.remove(0);
+    }
+}
+
+fn log_request(line: &PreviewIngressLogLine) {
+    match serde_json::to_string(line) {
+        Ok(line) => eprintln!("{}", line),
+        Err(_) => eprintln!("preview ingress request log serialization failed"),
+    }
+}

--- a/src/core/preview_ingress_tests.rs
+++ b/src/core/preview_ingress_tests.rs
@@ -1,0 +1,79 @@
+use super::preview_ingress::*;
+use crate::test_support;
+
+#[test]
+fn route_registers_host_to_upstream_origin() {
+    test_support::with_isolated_home(|_| {
+        let route = register_route(PreviewIngressRoute {
+            session_id: "run-123".to_string(),
+            public_host: "run-123-tunnel.chubes.net".to_string(),
+            upstream_origin: "http://127.0.0.1:7331".to_string(),
+            expires_at: None,
+            active: true,
+        })
+        .expect("register route");
+
+        assert_eq!(route.session_id, "run-123");
+        let status = status(
+            Some("127.0.0.1:7350".to_string()),
+            Some("chubes.net".to_string()),
+            Some("*-tunnel.chubes.net".to_string()),
+        )
+        .expect("status");
+        assert_eq!(status.routes.len(), 1);
+        assert_eq!(
+            status.routes[0].lifecycle,
+            PreviewIngressRouteLifecycle::Active
+        );
+        assert_eq!(
+            status.routes[0].route.public_host,
+            "run-123-tunnel.chubes.net"
+        );
+    });
+}
+
+#[test]
+fn route_status_reports_expired_and_disconnected_sessions() {
+    test_support::with_isolated_home(|_| {
+        register_route(PreviewIngressRoute {
+            session_id: "expired".to_string(),
+            public_host: "expired-tunnel.chubes.net".to_string(),
+            upstream_origin: "http://127.0.0.1:7331".to_string(),
+            expires_at: Some("2000-01-01T00:00:00Z".to_string()),
+            active: true,
+        })
+        .expect("register expired route");
+        register_route(PreviewIngressRoute {
+            session_id: "disconnected".to_string(),
+            public_host: "disconnected-tunnel.chubes.net".to_string(),
+            upstream_origin: "http://127.0.0.1:7332".to_string(),
+            expires_at: None,
+            active: false,
+        })
+        .expect("register disconnected route");
+
+        let routes = status(None, None, None).expect("status").routes;
+        assert_eq!(routes.len(), 2);
+        assert_eq!(
+            routes[0].lifecycle,
+            PreviewIngressRouteLifecycle::Disconnected
+        );
+        assert_eq!(routes[1].lifecycle, PreviewIngressRouteLifecycle::Expired);
+    });
+}
+
+#[test]
+fn route_validation_rejects_non_http_upstream_origin() {
+    test_support::with_isolated_home(|_| {
+        let err = register_route(PreviewIngressRoute {
+            session_id: "bad".to_string(),
+            public_host: "bad-tunnel.chubes.net".to_string(),
+            upstream_origin: "ssh://127.0.0.1:22".to_string(),
+            expires_at: None,
+            active: true,
+        })
+        .expect_err("non-http upstream should fail");
+
+        assert!(err.message.contains("upstream origin"));
+    });
+}


### PR DESCRIPTION
## Summary
- Adds `homeboy tunnel preview-ingress` route/status/list/unroute/serve commands for a Homeboy-owned VPS HTTP ingress behind an operator TLS/proxy layer.
- Stores host-routed preview session records, proxies browser requests to a generic HTTP origin, streams upstream responses, and emits structured diagnostics for missing, expired, disconnected, timeout, and upstream-failure cases.
- Documents the core contract as generic HTTP preview ingress: public host/session routing, reverse-channel-compatible origins, request/response streaming, status, logs, and cleanup.

## Scope boundary
- This PR intentionally keeps WordPress, WP Codebox, WooCommerce, static asset health, and browser probe interpretation out of Homeboy core.
- Workload-specific behavior belongs in Homeboy Extensions or `homeboy-rigs`.
- The `upstream_origin` route target is the generic HTTP seam that the authenticated reverse preview client can attach to in the broader #4089 flow.

## Links
- Closes #4090
- Part of #4089
- Unblocks the Homeboy-owned generic ingress path needed to address #4062's current tunnel-provider blocker without baking #4062's workload specifics into core.

## Verification
- `cargo fmt --check`
- `cargo test preview_ingress`
- `cargo test tunnel::tests`
- `cargo test command_surface_test`
- CLI smoke with isolated Homeboy state: `cargo run --quiet --bin homeboy -- tunnel preview-ingress route ... --inactive` followed by `cargo run --quiet --bin homeboy -- tunnel preview-ingress status ...`

## Known verification caveat
- Full `cargo test` was run and failed in two bench scenario-discovery tests that also fail when rerun individually: `commands::bench::tests::unknown_scenario_reports_discovered_ids` and `commands::bench::tests::profile_with_unknown_scenario_lists_discovered_scenarios`. Both report discovered ids as `<none>` and are outside the preview ingress path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the generic preview ingress command/server implementation, tests, docs, and PR description for Chris to review and validate.