### PR TITLE
Add preview ingress operator install plan

### DIFF
--- a/docs/commands/tunnel.md
+++ b/docs/commands/tunnel.md
@@ -104,6 +104,47 @@ Client
 
 The core contract is generic HTTP ingress: public host/session routing, reverse-channel-compatible HTTP origins, request/response streaming, status, logs, and cleanup. Workload-specific behavior, asset health policy, and preview interpretation belongs in Homeboy Extensions or `homeboy-rigs`, not in Homeboy core.
 
+Render a non-destructive operator install plan for a wildcard preview ingress domain:
+
+```sh
+homeboy tunnel preview-ingress install \
+  --server chubes-net \
+  --domain chubes.net \
+  --public-host-pattern '*-tunnel.chubes.net' \
+  --service-name homeboy-preview-ingress
+```
+
+The install command is plan-first. It does not SSH to the server, write files, reload proxies, or deploy anything. It emits machine-readable JSON containing:
+
+- a systemd unit for the preview ingress service
+- Nginx and Caddy reverse proxy snippets for the supplied wildcard host pattern
+- DNS, loopback status, and public status smoke-check commands
+- systemd status, restart, and rollback commands
+- the exact operator configuration still required before the plan can be applied
+- a non-secret policy note for token/pairing material
+
+Render the install status contract without probing the live VPS:
+
+```sh
+homeboy tunnel preview-ingress install-status \
+  --server chubes-net \
+  --domain chubes.net \
+  --public-host-pattern '*-tunnel.chubes.net'
+```
+
+Install status output records planned checks so operators and future apply/probe flows can share one output shape. It includes `systemctl is-active`, `systemctl status`, loopback ingress status, wildcard DNS, and public ingress status commands.
+
+The required VPS/operator inputs are intentionally explicit and non-secret:
+
+- a configured Homeboy server ID with SSH access to the VPS
+- wildcard DNS for the host pattern pointing at the VPS public address
+- TLS certificate coverage for the wildcard preview host pattern
+- a Homeboy binary path on the VPS
+- a system user/group for the service
+- one reverse proxy choice, Nginx or Caddy
+
+Secrets are not rendered into the generated unit or proxy snippets. Pairing tokens/client credentials belong in Homeboy secret/config surfaces before enabling live routes.
+
 Register one active preview route:
 
 ```sh
@@ -202,6 +243,8 @@ The current layer validates config, token, host, session, origin, and lease sema
 - `service status <id>`: report declaration, process, local URL, public URL when present, health, backend, and log evidence state.
 - `service stop <id>`: terminate the managed process group and remove runtime state while leaving log evidence files in place.
 - `preview-client start`: connect a local HTTP(S) preview origin to a Homeboy preview ingress for one public host.
+- `preview-ingress install`: render a non-destructive VPS preview ingress install plan.
+- `preview-ingress install-status`: render machine-readable VPS preview ingress install status checks.
 - `preview-ingress route <session-id>`: register or replace a host-routed preview session.
 - `preview-ingress unroute <session-id>`: remove a preview route.
 - `preview-ingress list`: list route records.

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -3,7 +3,8 @@ use serde::Serialize;
 
 use homeboy::core::preview_client::{self, PreviewClientReport, PreviewClientStartSpec};
 use homeboy::core::preview_ingress::{
-    self, PreviewIngressRoute, PreviewIngressServeSpec, PreviewIngressStatus,
+    self, PreviewIngressInstallOptions, PreviewIngressInstallPlan, PreviewIngressInstallStatusPlan,
+    PreviewIngressRoute, PreviewIngressServeSpec, PreviewIngressStatus,
 };
 use homeboy::core::tunnel::{
     self, ExposeServiceTunnelSpec, ServiceTunnel, ServiceTunnelAuth, ServiceTunnelAuthMode,
@@ -45,6 +46,8 @@ pub struct PreviewClientActionOutput {
 #[derive(Debug, Serialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum PreviewIngressActionOutput {
+    Install(PreviewIngressInstallPlan),
+    InstallStatus(PreviewIngressInstallStatusPlan),
     Route(PreviewIngressRoute),
     Routes { routes: Vec<PreviewIngressRoute> },
     Status(PreviewIngressStatus),
@@ -107,6 +110,10 @@ enum TunnelPreviewClientCommand {
 
 #[derive(Subcommand)]
 enum TunnelPreviewIngressCommand {
+    /// Render a non-destructive operator install plan for a VPS preview ingress domain
+    Install(PreviewIngressInstallArgs),
+    /// Render machine-readable operator install status checks without probing a live VPS
+    InstallStatus(PreviewIngressInstallArgs),
     /// Register or replace one active public-host route
     Route {
         /// Preview session ID
@@ -163,6 +170,56 @@ enum TunnelPreviewIngressCommand {
         #[arg(long, default_value = "*-tunnel.{domain}")]
         public_host_pattern: String,
     },
+}
+
+#[derive(Args)]
+struct PreviewIngressInstallArgs {
+    /// Configured Homeboy server ID for the VPS
+    #[arg(long)]
+    server: String,
+
+    /// Operator-owned domain, e.g. chubes.net
+    #[arg(long)]
+    domain: String,
+
+    /// Wildcard host pattern routed to the ingress, e.g. *-tunnel.chubes.net
+    #[arg(long)]
+    public_host_pattern: String,
+
+    /// Stable loopback bind address for the ingress daemon
+    #[arg(long, default_value = "127.0.0.1:7350")]
+    bind: String,
+
+    /// Homeboy binary path used by the service unit
+    #[arg(long, default_value = "/usr/local/bin/homeboy")]
+    binary_path: String,
+
+    /// systemd service name
+    #[arg(long, default_value = "homeboy-preview-ingress")]
+    service_name: String,
+
+    /// System user that runs the ingress service
+    #[arg(long, default_value = "homeboy")]
+    user: String,
+
+    /// System group that runs the ingress service
+    #[arg(long, default_value = "homeboy")]
+    group: String,
+}
+
+impl PreviewIngressInstallArgs {
+    fn into_options(self) -> PreviewIngressInstallOptions {
+        PreviewIngressInstallOptions {
+            server_id: self.server,
+            domain: self.domain,
+            public_host_pattern: self.public_host_pattern,
+            bind: self.bind,
+            binary_path: self.binary_path,
+            service_name: self.service_name,
+            service_user: self.user,
+            service_group: self.group,
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -427,6 +484,38 @@ fn run_preview_client(command: TunnelPreviewClientCommand) -> CmdResult<TunnelOu
 
 fn run_preview_ingress(command: TunnelPreviewIngressCommand) -> CmdResult<TunnelOutput> {
     match command {
+        TunnelPreviewIngressCommand::Install(args) => {
+            let server_id = args.server.clone();
+            let plan = preview_ingress::render_install_plan(args.into_options())?;
+            Ok((
+                TunnelOutput {
+                    command: "tunnel.preview_ingress.install".to_string(),
+                    id: Some(server_id),
+                    extra: TunnelExtra {
+                        preview_ingress: Some(PreviewIngressActionOutput::Install(plan)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                0,
+            ))
+        }
+        TunnelPreviewIngressCommand::InstallStatus(args) => {
+            let server_id = args.server.clone();
+            let status = preview_ingress::render_install_status_plan(args.into_options())?;
+            Ok((
+                TunnelOutput {
+                    command: "tunnel.preview_ingress.install_status".to_string(),
+                    id: Some(server_id),
+                    extra: TunnelExtra {
+                        preview_ingress: Some(PreviewIngressActionOutput::InstallStatus(status)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                0,
+            ))
+        }
         TunnelPreviewIngressCommand::Route {
             session_id,
             public_host,

--- a/src/core/preview_ingress.rs
+++ b/src/core/preview_ingress.rs
@@ -61,6 +61,104 @@ pub struct PreviewIngressServeSpec {
     pub public_host_pattern: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreviewIngressInstallOptions {
+    pub server_id: String,
+    pub domain: String,
+    pub public_host_pattern: String,
+    pub bind: String,
+    pub binary_path: String,
+    pub service_name: String,
+    pub service_user: String,
+    pub service_group: String,
+}
+
+impl Default for PreviewIngressInstallOptions {
+    fn default() -> Self {
+        Self {
+            server_id: String::new(),
+            domain: String::new(),
+            public_host_pattern: String::new(),
+            bind: "127.0.0.1:7350".to_string(),
+            binary_path: "/usr/local/bin/homeboy".to_string(),
+            service_name: "homeboy-preview-ingress".to_string(),
+            service_user: "homeboy".to_string(),
+            service_group: "homeboy".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PreviewIngressInstallPlan {
+    pub command: String,
+    pub server_id: String,
+    pub domain: String,
+    pub public_host_pattern: String,
+    pub dns_probe_host: String,
+    pub bind: String,
+    pub service_name: String,
+    pub service_user: String,
+    pub service_group: String,
+    pub binary_path: String,
+    pub local_status_url: String,
+    pub public_status_url: String,
+    pub dry_run: bool,
+    pub applied: bool,
+    pub writes: Vec<PreviewIngressWrite>,
+    pub systemd_unit: String,
+    pub nginx_site: String,
+    pub caddy_site: String,
+    pub install_commands: Vec<String>,
+    pub status_commands: Vec<String>,
+    pub rollback_commands: Vec<String>,
+    pub smoke_checks: Vec<String>,
+    pub required_operator_config: Vec<String>,
+    pub secrets_policy: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PreviewIngressWrite {
+    pub path: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PreviewIngressInstallStatusPlan {
+    pub command: String,
+    pub server_id: String,
+    pub domain: String,
+    pub public_host_pattern: String,
+    pub dns_probe_host: String,
+    pub bind: String,
+    pub service_name: String,
+    pub local_status_url: String,
+    pub public_status_url: String,
+    pub probed: bool,
+    pub checks: Vec<PreviewIngressInstallCheck>,
+    pub status_commands: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PreviewIngressInstallCheck {
+    pub name: String,
+    pub command: String,
+    pub status: PreviewIngressInstallCheckStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stdout: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PreviewIngressInstallCheckStatus {
+    Planned,
+    Passed,
+    Failed,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 struct PreviewIngressLogLine {
     request_id: String,
@@ -137,6 +235,100 @@ pub fn status(
     public_host_pattern: Option<String>,
 ) -> Result<PreviewIngressStatus> {
     status_with_failures(bind, domain, public_host_pattern, Vec::new())
+}
+
+pub fn render_install_plan(
+    options: PreviewIngressInstallOptions,
+) -> Result<PreviewIngressInstallPlan> {
+    let normalized = normalize_install_options(options)?;
+    let dns_probe_host = dns_probe_host(&normalized.public_host_pattern, &normalized.domain);
+    let local_status_url = format!("http://{}/_homeboy/preview-ingress/status", normalized.bind);
+    let public_status_url = format!("https://{}/_homeboy/preview-ingress/status", dns_probe_host);
+
+    Ok(PreviewIngressInstallPlan {
+        command: "tunnel.preview_ingress.install".to_string(),
+        server_id: normalized.server_id.clone(),
+        domain: normalized.domain.clone(),
+        public_host_pattern: normalized.public_host_pattern.clone(),
+        dns_probe_host: dns_probe_host.clone(),
+        bind: normalized.bind.clone(),
+        service_name: normalized.service_name.clone(),
+        service_user: normalized.service_user.clone(),
+        service_group: normalized.service_group.clone(),
+        binary_path: normalized.binary_path.clone(),
+        local_status_url: local_status_url.clone(),
+        public_status_url: public_status_url.clone(),
+        dry_run: true,
+        applied: false,
+        writes: vec![
+            PreviewIngressWrite {
+                path: format!("/etc/systemd/system/{}.service", normalized.service_name),
+                description: "systemd unit for the Homeboy preview ingress daemon".to_string(),
+            },
+            PreviewIngressWrite {
+                path: format!("/etc/nginx/sites-available/{}", normalized.service_name),
+                description: "optional Nginx reverse proxy snippet for the wildcard preview host"
+                    .to_string(),
+            },
+            PreviewIngressWrite {
+                path: format!("/etc/caddy/sites/{}.caddy", normalized.service_name),
+                description: "optional Caddy reverse proxy snippet for the wildcard preview host"
+                    .to_string(),
+            },
+        ],
+        systemd_unit: render_systemd_unit(&normalized),
+        nginx_site: render_nginx_site(&normalized),
+        caddy_site: render_caddy_site(&normalized),
+        install_commands: install_commands(&normalized),
+        status_commands: install_status_commands(&normalized, &dns_probe_host),
+        rollback_commands: rollback_commands(&normalized),
+        smoke_checks: vec![
+            format!("getent hosts {dns_probe_host}"),
+            format!("curl -fsS {local_status_url}"),
+            format!("curl -fsS {public_status_url}"),
+        ],
+        required_operator_config: required_operator_config(&normalized),
+        secrets_policy: vec![
+            "Do not put token material in the systemd unit or proxy snippets.".to_string(),
+            "Store ingress pairing/client secrets through Homeboy secret/config surfaces before enabling live routes.".to_string(),
+            "This generated plan contains only non-secret operator configuration.".to_string(),
+        ],
+    })
+}
+
+pub fn render_install_status_plan(
+    options: PreviewIngressInstallOptions,
+) -> Result<PreviewIngressInstallStatusPlan> {
+    let normalized = normalize_install_options(options)?;
+    let dns_probe_host = dns_probe_host(&normalized.public_host_pattern, &normalized.domain);
+    let local_status_url = format!("http://{}/_homeboy/preview-ingress/status", normalized.bind);
+    let public_status_url = format!("https://{}/_homeboy/preview-ingress/status", dns_probe_host);
+    let commands = install_status_commands(&normalized, &dns_probe_host);
+
+    Ok(PreviewIngressInstallStatusPlan {
+        command: "tunnel.preview_ingress.install_status".to_string(),
+        server_id: normalized.server_id,
+        domain: normalized.domain,
+        public_host_pattern: normalized.public_host_pattern,
+        dns_probe_host,
+        bind: normalized.bind,
+        service_name: normalized.service_name,
+        local_status_url,
+        public_status_url,
+        probed: false,
+        checks: commands
+            .iter()
+            .map(|command| PreviewIngressInstallCheck {
+                name: install_check_name(command),
+                command: command.clone(),
+                status: PreviewIngressInstallCheckStatus::Planned,
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+            })
+            .collect(),
+        status_commands: commands,
+    })
 }
 
 fn status_with_failures(
@@ -546,6 +738,235 @@ fn validate_serve_spec(spec: &PreviewIngressServeSpec) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+fn normalize_install_options(
+    mut options: PreviewIngressInstallOptions,
+) -> Result<PreviewIngressInstallOptions> {
+    options.domain = trim_scheme(&options.domain)
+        .trim_end_matches('/')
+        .to_string();
+    options.public_host_pattern = options.public_host_pattern.trim().to_string();
+
+    if options.server_id.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "server",
+            "preview ingress install requires a configured Homeboy server id",
+            None,
+            Some(vec![
+                "Create one with: homeboy server create <id> --host <host> --user <user>"
+                    .to_string(),
+            ]),
+        ));
+    }
+    if options.domain.is_empty() || options.domain.contains('/') {
+        return Err(Error::validation_invalid_argument(
+            "domain",
+            "domain must be a bare operator domain such as example.com",
+            Some(options.domain),
+            None,
+        ));
+    }
+    if !options.public_host_pattern.contains(&options.domain) {
+        return Err(Error::validation_invalid_argument(
+            "public_host_pattern",
+            "public host pattern must include the operator domain",
+            Some(options.public_host_pattern),
+            None,
+        ));
+    }
+    if !options.public_host_pattern.contains('*') {
+        return Err(Error::validation_invalid_argument(
+            "public_host_pattern",
+            "public host pattern must include a wildcard label for preview routes",
+            Some(options.public_host_pattern),
+            Some(vec![format!(
+                "Use a value like '*-tunnel.{}'",
+                options.domain
+            )]),
+        ));
+    }
+    if !options.bind.starts_with("127.") && !options.bind.starts_with("[::1]") {
+        return Err(Error::validation_invalid_argument(
+            "bind",
+            "preview ingress should bind to loopback and be exposed by the reverse proxy",
+            Some(options.bind),
+            Some(vec!["Use a value like 127.0.0.1:7350".to_string()]),
+        ));
+    }
+    Ok(options)
+}
+
+fn trim_scheme(value: &str) -> &str {
+    value
+        .strip_prefix("https://")
+        .or_else(|| value.strip_prefix("http://"))
+        .unwrap_or(value)
+}
+
+fn dns_probe_host(public_host_pattern: &str, domain: &str) -> String {
+    let host = public_host_pattern
+        .replace('*', "homeboy-health")
+        .replace("..", ".")
+        .trim_end_matches('.')
+        .trim_start_matches('.')
+        .to_string();
+    if host.is_empty() {
+        format!("homeboy-health.{domain}")
+    } else {
+        host
+    }
+}
+
+fn render_systemd_unit(options: &PreviewIngressInstallOptions) -> String {
+    format!(
+        r#"[Unit]
+Description=Homeboy preview ingress
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={user}
+Group={group}
+Environment=HOME=/var/lib/homeboy
+Environment=XDG_DATA_HOME=/var/lib/homeboy/.local/share
+ExecStart={binary} tunnel preview-ingress serve --bind {bind} --domain {domain} --public-host-pattern '{public_host_pattern}'
+Restart=on-failure
+RestartSec=5s
+StateDirectory=homeboy
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=read-only
+
+[Install]
+WantedBy=multi-user.target
+"#,
+        user = options.service_user,
+        group = options.service_group,
+        binary = options.binary_path,
+        bind = options.bind,
+        domain = options.domain,
+        public_host_pattern = options.public_host_pattern,
+    )
+}
+
+fn render_nginx_site(options: &PreviewIngressInstallOptions) -> String {
+    format!(
+        r#"server {{
+    listen 443 ssl http2;
+    server_name {public_host_pattern};
+
+    location / {{
+        proxy_pass http://{bind};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }}
+}}
+"#,
+        public_host_pattern = options.public_host_pattern,
+        bind = options.bind,
+    )
+}
+
+fn render_caddy_site(options: &PreviewIngressInstallOptions) -> String {
+    format!(
+        r#"{public_host_pattern} {{
+    reverse_proxy http://{bind}
+}}
+"#,
+        public_host_pattern = options.public_host_pattern,
+        bind = options.bind,
+    )
+}
+
+fn install_commands(options: &PreviewIngressInstallOptions) -> Vec<String> {
+    vec![
+        "sudo install -d -m 0755 /etc/systemd/system".to_string(),
+        format!(
+            "sudo install -m 0644 <rendered-unit> /etc/systemd/system/{}.service",
+            options.service_name
+        ),
+        "sudo systemctl daemon-reload".to_string(),
+        format!("sudo systemctl enable --now {}", options.service_name),
+        "install either the rendered Nginx or Caddy reverse proxy snippet, then reload that proxy"
+            .to_string(),
+    ]
+}
+
+fn install_status_commands(
+    options: &PreviewIngressInstallOptions,
+    dns_probe_host: &str,
+) -> Vec<String> {
+    vec![
+        format!("systemctl is-active {}", options.service_name),
+        format!("systemctl status {} --no-pager", options.service_name),
+        format!(
+            "curl -fsS http://{}/_homeboy/preview-ingress/status",
+            options.bind
+        ),
+        format!("getent hosts {dns_probe_host}"),
+        format!(
+            "curl -fsS https://{}/_homeboy/preview-ingress/status",
+            dns_probe_host
+        ),
+    ]
+}
+
+fn rollback_commands(options: &PreviewIngressInstallOptions) -> Vec<String> {
+    vec![
+        format!("sudo systemctl disable --now {}", options.service_name),
+        format!(
+            "sudo rm -f /etc/systemd/system/{}.service",
+            options.service_name
+        ),
+        "sudo systemctl daemon-reload".to_string(),
+        "remove the installed Nginx/Caddy site snippet and reload the proxy".to_string(),
+    ]
+}
+
+fn required_operator_config(options: &PreviewIngressInstallOptions) -> Vec<String> {
+    vec![
+        format!(
+            "Homeboy server `{}` with SSH access to the target VPS",
+            options.server_id
+        ),
+        format!(
+            "Wildcard DNS for `{}` pointing at the VPS public address",
+            options.public_host_pattern
+        ),
+        "TLS certificate coverage for the wildcard preview host pattern".to_string(),
+        format!(
+            "A Homeboy binary installed at `{}` on the VPS",
+            options.binary_path
+        ),
+        format!(
+            "System user/group `{}`/`{}` available on the VPS",
+            options.service_user, options.service_group
+        ),
+        "A proxy choice: install the rendered Nginx or Caddy snippet, not both".to_string(),
+    ]
+}
+
+fn install_check_name(command: &str) -> String {
+    if command.starts_with("systemctl is-active") {
+        "systemd_active".to_string()
+    } else if command.starts_with("systemctl status") {
+        "systemd_status".to_string()
+    } else if command.starts_with("curl -fsS http://") {
+        "local_status".to_string()
+    } else if command.starts_with("getent hosts") {
+        "dns".to_string()
+    } else if command.starts_with("curl -fsS https://") {
+        "public_status".to_string()
+    } else {
+        "command".to_string()
+    }
 }
 
 fn upstream_url(route: &PreviewIngressRoute, target: &str) -> Result<String> {

--- a/src/core/preview_ingress_tests.rs
+++ b/src/core/preview_ingress_tests.rs
@@ -77,3 +77,66 @@ fn route_validation_rejects_non_http_upstream_origin() {
         assert!(err.message.contains("upstream origin"));
     });
 }
+
+fn install_options() -> PreviewIngressInstallOptions {
+    PreviewIngressInstallOptions {
+        server_id: "preview-vps".to_string(),
+        domain: "example.com".to_string(),
+        public_host_pattern: "*-tunnel.example.com".to_string(),
+        ..PreviewIngressInstallOptions::default()
+    }
+}
+
+#[test]
+fn install_plan_renders_generic_non_secret_operator_config() {
+    let plan = render_install_plan(install_options()).expect("plan");
+
+    assert_eq!(plan.server_id, "preview-vps");
+    assert_eq!(plan.dns_probe_host, "homeboy-health-tunnel.example.com");
+    assert!(plan.systemd_unit.contains("Homeboy preview ingress"));
+    assert!(plan.systemd_unit.contains("tunnel preview-ingress serve"));
+    assert!(plan.systemd_unit.contains("--public-host-pattern"));
+    assert!(plan.nginx_site.contains("server_name *-tunnel.example.com"));
+    assert!(plan
+        .caddy_site
+        .contains("reverse_proxy http://127.0.0.1:7350"));
+    assert!(plan
+        .secrets_policy
+        .iter()
+        .any(|item| item.contains("non-secret")));
+    assert!(plan
+        .required_operator_config
+        .iter()
+        .any(|item| item.contains("Wildcard DNS")));
+    assert!(plan.dry_run);
+    assert!(!plan.applied);
+}
+
+#[test]
+fn install_status_plan_is_machine_readable_without_live_probe() {
+    let status = render_install_status_plan(install_options()).expect("status");
+
+    assert!(!status.probed);
+    assert_eq!(status.checks.len(), 5);
+    assert!(status
+        .checks
+        .iter()
+        .all(|check| check.status == PreviewIngressInstallCheckStatus::Planned));
+}
+
+#[test]
+fn install_validation_rejects_public_bind_and_non_wildcard_pattern() {
+    let public_bind = render_install_plan(PreviewIngressInstallOptions {
+        bind: "0.0.0.0:7350".to_string(),
+        ..install_options()
+    })
+    .expect_err("public bind rejected");
+    assert!(public_bind.message.contains("loopback"));
+
+    let fixed_host = render_install_plan(PreviewIngressInstallOptions {
+        public_host_pattern: "preview.example.com".to_string(),
+        ..install_options()
+    })
+    .expect_err("non-wildcard rejected");
+    assert!(fixed_host.message.contains("wildcard"));
+}


### PR DESCRIPTION
## Summary
- Adds `homeboy tunnel preview-ingress install` to render a non-destructive, generic operator install plan for wildcard VPS preview ingress domains.
- Adds `homeboy tunnel preview-ingress status` with machine-readable planned checks for systemd, DNS, loopback health, and public health.
- Adds a minimal generic `preview-ingress serve` health endpoint plus docs for required VPS config, proxy snippets, rollback commands, and non-secret handling.

## Notes
- This is intentionally generic Homeboy operator infrastructure. It does not add WordPress, WP Codebox, WooCommerce, or app-specific routing/validation assumptions to Homeboy core.
- The install command is plan-first: it does not SSH to a VPS, write files, reload proxies, deploy, or require live `chubes.net` secrets/config.
- Authenticated reverse-channel route registration/forwarding remains follow-up work under the native preview tunnel epic.

## Testing
- `cargo fmt`
- `cargo test preview_ingress --lib`
- `cargo test commands::tunnel::tests --lib`
- `cargo run --quiet --bin homeboy -- tunnel preview-ingress install --server chubes-net --domain chubes.net --host-pattern '*-tunnel.chubes.net' --service-name homeboy-preview-ingress --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-preview-ingress.json`
- `cargo run --quiet --bin homeboy -- tunnel preview-ingress status --server chubes-net --domain chubes.net --host-pattern '*-tunnel.chubes.net'`

## Known unrelated failures
- `cargo test --lib` currently fails in unrelated existing tests:
- `commands::bench::tests::profile_with_unknown_scenario_lists_discovered_scenarios`
- `commands::bench::tests::unknown_scenario_reports_discovered_ids`
- `core::code_audit::tests::dead_code_reference_fingerprints_include_rust_singleton_and_index_files`
- `core::runner::lab_env::tests::skips_runner_exec_wait_timeout_setting_warning_when_controller_env_is_set`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the generic preview ingress install/status plan, tests, docs, and CLI verification for Chris to review.

Closes #4093