### PR TITLE
Add keychain read diagnostics

### DIFF
--- a/src/core/server/auth.rs
+++ b/src/core/server/auth.rs
@@ -4,11 +4,12 @@
 //! the underlying HTTP client or keychain implementation.
 
 use super::http::ApiClient;
-use crate::core::error::Result;
+use crate::core::error::{Error, Result};
 use crate::core::keychain;
 use crate::core::project;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::io::IsTerminal;
 
 #[derive(Debug, Serialize)]
 pub struct LoginResult {
@@ -42,6 +43,9 @@ pub struct GetResult {
     pub variable: String,
     pub value: Option<String>,
     pub redacted: bool,
+    pub state: String,
+    pub source: String,
+    pub diagnostic: KeychainReadDiagnostic,
 }
 
 #[derive(Debug, Serialize)]
@@ -56,6 +60,25 @@ pub struct AuthVariableStatus {
     pub name: String,
     pub source: String,
     pub available: bool,
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<KeychainReadDiagnostic>,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct KeychainReadDiagnostic {
+    pub source: String,
+    pub backend: String,
+    pub service: String,
+    pub account: String,
+    pub value_status: String,
+    pub storage_context: String,
+    pub interactive: bool,
+    pub ssh_context: bool,
+    pub message: String,
+    pub hints: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
 }
 
 /// Authenticates with a project's API using provided credentials.
@@ -97,22 +120,24 @@ pub fn set(project_id: &str, variable: &str, value: &str) -> Result<SetResult> {
 
 /// Retrieves a project API variable from the keychain.
 pub fn get(project_id: &str, variable: &str, redacted: bool) -> Result<GetResult> {
-    let value =
-        keychain::get(project_id, variable)?.map(
-            |value| {
-                if redacted {
-                    redact(&value)
-                } else {
-                    value
-                }
-            },
-        );
+    let read = keychain::get(project_id, variable)?;
+    let state = if read.is_some() {
+        "available"
+    } else {
+        "missing"
+    }
+    .to_string();
+    let diagnostic = keychain_read_diagnostic(project_id, variable, &state, None);
+    let value = read.map(|value| if redacted { redact(&value) } else { value });
 
     Ok(GetResult {
         project_id: project_id.to_string(),
         variable: variable.to_string(),
         value,
         redacted,
+        state,
+        source: "project-keychain".to_string(),
+        diagnostic,
     })
 }
 
@@ -162,15 +187,60 @@ fn variable_statuses(project_id: &str, project: &project::Project) -> Vec<AuthVa
 
     auth.variables
         .iter()
-        .map(|(name, source)| AuthVariableStatus {
-            name: name.to_string(),
-            source: source.source.clone(),
-            available: variable_available(project_id, name, source),
-        })
+        .map(|(name, source)| variable_status(project_id, name, source))
         .collect()
 }
 
-fn variable_available(project_id: &str, name: &str, source: &project::VariableSource) -> bool {
+fn variable_status(
+    project_id: &str,
+    name: &str,
+    source: &project::VariableSource,
+) -> AuthVariableStatus {
+    let (available, state, diagnostic) = match source.source.as_str() {
+        "keychain" => match keychain::get(project_id, name) {
+            Ok(Some(_)) => (
+                true,
+                "available".to_string(),
+                Some(keychain_read_diagnostic(
+                    project_id,
+                    name,
+                    "available",
+                    None,
+                )),
+            ),
+            Ok(None) => (
+                false,
+                "missing".to_string(),
+                Some(keychain_read_diagnostic(project_id, name, "missing", None)),
+            ),
+            Err(error) => (
+                false,
+                "backend_error".to_string(),
+                Some(keychain_read_diagnostic(
+                    project_id,
+                    name,
+                    "backend_error",
+                    Some(&error),
+                )),
+            ),
+        },
+        _ => {
+            let available = variable_available(project_id, name, source);
+            let state = if available { "available" } else { "missing" };
+            (available, state.to_string(), None)
+        }
+    };
+
+    AuthVariableStatus {
+        name: name.to_string(),
+        source: source.source.clone(),
+        available,
+        state,
+        diagnostic,
+    }
+}
+
+fn variable_available(_project_id: &str, name: &str, source: &project::VariableSource) -> bool {
     match source.source.as_str() {
         "config" => source.value.is_some(),
         "env" => {
@@ -178,9 +248,61 @@ fn variable_available(project_id: &str, name: &str, source: &project::VariableSo
             let env_var = source.env_var.as_ref().unwrap_or(&default_env);
             std::env::var(env_var).is_ok()
         }
-        "keychain" => keychain::exists(project_id, name),
         _ => false,
     }
+}
+
+fn keychain_read_diagnostic(
+    project_id: &str,
+    variable: &str,
+    value_status: &str,
+    error: Option<&Error>,
+) -> KeychainReadDiagnostic {
+    let storage_context = if in_ssh_context() { "ssh" } else { "local" };
+    let interactive = std::io::stdin().is_terminal();
+    let message = match value_status {
+        "available" => {
+            "Project keychain value is available; value remains redacted by diagnostics."
+        }
+        "missing" => "Project keychain returned no value in this Homeboy storage context.",
+        "backend_error" => "Project keychain backend could not be read in this runtime context.",
+        _ => "Project keychain read completed with an unrecognized status.",
+    };
+
+    let mut hints = vec![
+        "Controller and Lab hosts use separate OS keychain storage contexts.".to_string(),
+        "For Lab jobs, prefer controller-side secret hydration and forwarding with --secret-env."
+            .to_string(),
+        "Use source: \"env\" for CI/headless environments when OS keychain access is unavailable."
+            .to_string(),
+    ];
+    if !interactive || in_ssh_context() {
+        hints.push(
+            "This command is running in a non-interactive or SSH context; OS keychain prompts may be unavailable."
+                .to_string(),
+        );
+    }
+    if let Some(error) = error {
+        hints.extend(error.hints.iter().map(|hint| hint.message.clone()));
+    }
+
+    KeychainReadDiagnostic {
+        source: "project-keychain".to_string(),
+        backend: "os-keychain".to_string(),
+        service: "homeboy".to_string(),
+        account: format!("{}:{}", project_id, variable),
+        value_status: value_status.to_string(),
+        storage_context: storage_context.to_string(),
+        interactive,
+        ssh_context: in_ssh_context(),
+        message: message.to_string(),
+        hints,
+        error_code: error.map(|error| error.code.as_str().to_string()),
+    }
+}
+
+fn in_ssh_context() -> bool {
+    std::env::var_os("SSH_CONNECTION").is_some() || std::env::var_os("SSH_CLIENT").is_some()
 }
 
 fn redact(value: &str) -> String {
@@ -210,6 +332,72 @@ mod tests {
         };
 
         assert!(variable_available("project", "token", &source));
+    }
+
+    #[test]
+    fn variable_status_config_keeps_compatibility_fields_without_diagnostic() {
+        let source = VariableSource {
+            source: "config".to_string(),
+            value: Some("value".to_string()),
+            env_var: None,
+        };
+
+        let status = variable_status("project", "token", &source);
+
+        assert_eq!(status.name, "token");
+        assert_eq!(status.source, "config");
+        assert!(status.available);
+        assert_eq!(status.state, "available");
+        assert_eq!(status.diagnostic, None);
+    }
+
+    #[test]
+    fn keychain_missing_diagnostic_is_redacted_and_actionable() {
+        let diagnostic = keychain_read_diagnostic("project", "TOKEN", "missing", None);
+
+        assert_eq!(diagnostic.source, "project-keychain");
+        assert_eq!(diagnostic.backend, "os-keychain");
+        assert_eq!(diagnostic.service, "homeboy");
+        assert_eq!(diagnostic.account, "project:TOKEN");
+        assert_eq!(diagnostic.value_status, "missing");
+        assert!(diagnostic.message.contains("returned no value"));
+        assert!(diagnostic
+            .hints
+            .iter()
+            .any(|hint| hint.contains("separate OS keychain storage contexts")));
+        assert!(diagnostic
+            .hints
+            .iter()
+            .any(|hint| hint.contains("--secret-env")));
+        assert!(!serde_json::to_string(&diagnostic)
+            .expect("serialize diagnostic")
+            .contains("secret-value"));
+    }
+
+    #[test]
+    fn keychain_error_diagnostic_reports_error_code_without_value() {
+        let error = Error::new(
+            crate::core::error::ErrorCode::InternalUnexpected,
+            "Keychain error: failed to find keychain item (-25308)",
+            serde_json::json!({ "status": -25308, "action": "find keychain item" }),
+        )
+        .with_hint("Use source: \"env\" for CI/headless environments");
+
+        let diagnostic =
+            keychain_read_diagnostic("project", "TOKEN", "backend_error", Some(&error));
+
+        assert_eq!(diagnostic.value_status, "backend_error");
+        assert_eq!(
+            diagnostic.error_code.as_deref(),
+            Some("internal.unexpected")
+        );
+        assert!(diagnostic
+            .hints
+            .iter()
+            .any(|hint| hint.contains("CI/headless")));
+        assert!(!serde_json::to_string(&diagnostic)
+            .expect("serialize diagnostic")
+            .contains("secret-value"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add redacted `auth get` diagnostics for project keychain reads so `value: null` includes source, backend, storage-context, interactivity, SSH-context, and actionable hints.
- Change `auth status` keychain checks to report `available`, `missing`, or `backend_error` instead of collapsing keychain read failures into `available: false`.
- Cover the new diagnostic shape without storing or asserting real secret values.

Closes #4114

## Tests
- `cargo fmt`
- `cargo test core::server::auth::tests`
- `cargo check --all-targets`
- `cargo run --quiet --bin homeboy -- auth get --project homeboy-issue-4114-smoke HOMEB0Y_ISSUE_4114_MISSING --redacted`

## Known verification blocker
- `cargo test` fails on two unrelated bench scenario discovery tests:
  - `commands::bench::tests::unknown_scenario_reports_discovered_ids`
  - `commands::bench::tests::profile_with_unknown_scenario_lists_discovered_scenarios`
- Both failures report `discovered ids: <none>` and do not exercise the auth/keychain diagnostics path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the auth/keychain diagnostic changes and drafted focused tests; Chris remains responsible for review and validation.