### PR TITLE
Fix bench scenario discovery diagnostics

### DIFF
--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -239,11 +239,7 @@ fn bench_list_result(
     scenario_ids: &[String],
 ) -> Result<BenchListWorkflowResult> {
     let parsed = apply_scenario_filter(
-        parsing::parse_bench_results_file_with_artifact_context_and_scenarios(
-            &results_file,
-            None,
-            scenario_ids,
-        )?,
+        parsing::parse_bench_results_file_with_artifact_context(&results_file, None)?,
         scenario_ids,
     )?;
     let count = parsed.scenarios.len();
@@ -497,11 +493,7 @@ fn discover_bench_scenarios(
         ));
     }
 
-    parsing::parse_bench_results_file_with_artifact_context_and_scenarios(
-        &results_file,
-        None,
-        &args.scenario_ids,
-    )
+    parsing::parse_bench_results_file_with_artifact_context(&results_file, None)
 }
 
 fn validate_bench_run_args(args: &BenchRunWorkflowArgs) -> Result<()> {


### PR DESCRIPTION
## Summary
- Parses bench discovery/list output unfiltered before validating requested scenario IDs.
- Restores diagnostics that list discovered scenario IDs when a requested scenario is missing.
- Fixes the post-merge red Test job from #4100 without changing preview tunnel semantics.

## Root cause
`bench_list_result()` and `discover_bench_scenarios()` passed selected scenario IDs into the parser before `apply_scenario_filter()` ran. The parser filtered out all non-selected scenarios first, so an unknown selection produced `discovered ids: <none>` even though the list command had discovered valid scenarios.

## Verification
- `cargo test unknown_scenario_reports_discovered_ids --lib`
- `cargo test profile_with_unknown_scenario_lists_discovered_scenarios --lib`
- `cargo test bench::tests --lib`
- `cargo test preview_client --lib`
- `cargo test preview_ingress --lib`
- `cargo fmt --check && git diff --check`
- `cargo test` passed library/bin tests, then failed local integration audit tests for pre-existing core-agnostic baseline drift unrelated to this bench fix.

## Links
- Follow-up to #4100
- Failed run: https://github.com/Extra-Chill/homeboy/actions/runs/27393594740/job/80956555575

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the post-merge CI failure, implemented the minimal bench discovery fix, and ran verification.