### PR TITLE
Keep doctor resources core agnostic

### DIFF
--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -20,6 +20,10 @@ Reports current machine pressure and Homeboy-adjacent hot processes. This is the
 same resource-policy signal Homeboy uses before hot commands such as benchmark,
 trace, and runner-heavy workflows.
 
+By default, process pressure includes Homeboy processes. Set
+`HOMEBOY_DOCTOR_RESOURCE_PROCESS_MATCHES` to a comma-separated list of additional
+process names or command substrings for environment-specific workloads.
+
 ## JSON output
 
 Use the global `--output <PATH>` flag to persist the command-specific structured

--- a/src/commands/doctor/resources.rs
+++ b/src/commands/doctor/resources.rs
@@ -12,22 +12,8 @@ use classification::{
     classify_load, classify_memory, classify_processes, classify_rig_leases, overall_recommendation,
 };
 
-const RELEVANT_PROCESS_EXECUTABLES: &[&str] = &[
-    "homeboy",
-    "eslint",
-    "phpstan",
-    "phpcs",
-    "cargo",
-    "rustc",
-    "node",
-    "npm",
-    "pnpm",
-    "bun",
-    "vitest",
-    "playwright",
-];
-
-const RELEVANT_PROCESS_KEYWORDS: &[&str] = &["wordpress-server-child", "playground", "studio"];
+const RELEVANT_PROCESS_EXECUTABLES: &[&str] = &["homeboy"];
+const RESOURCE_PROCESS_MATCHES_ENV: &str = "HOMEBOY_DOCTOR_RESOURCE_PROCESS_MATCHES";
 
 #[derive(Args)]
 pub struct ResourcesArgs {}
@@ -341,6 +327,10 @@ fn parse_process_row(line: &str) -> Option<ProcessRow> {
 }
 
 fn is_relevant_process(row: &ProcessRow) -> bool {
+    is_relevant_process_with_matches(row, &configured_process_matches())
+}
+
+fn is_relevant_process_with_matches(row: &ProcessRow, configured_matches: &[String]) -> bool {
     let command_name = executable_name(&row.command);
     let arg0_name = row
         .args
@@ -356,9 +346,25 @@ fn is_relevant_process(row: &ProcessRow) -> bool {
     }
 
     let haystack = format!("{} {}", row.command, row.args).to_lowercase();
-    RELEVANT_PROCESS_KEYWORDS
-        .iter()
-        .any(|needle| haystack.contains(needle))
+    configured_matches.iter().any(|needle| {
+        let needle = needle.to_lowercase();
+        command_name == needle || arg0_name == needle || haystack.contains(&needle)
+    })
+}
+
+fn configured_process_matches() -> Vec<String> {
+    std::env::var(RESOURCE_PROCESS_MATCHES_ENV)
+        .ok()
+        .into_iter()
+        .flat_map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .collect()
 }
 
 fn executable_name(path: &str) -> String {
@@ -410,7 +416,8 @@ mod tests {
 
     #[test]
     fn parses_relevant_process_rows_without_using_host_processes() {
-        let row = parse_process_row("123 88.5 1048576 /usr/bin/node node vite --host").unwrap();
+        let row =
+            parse_process_row("123 88.5 1048576 /usr/bin/homeboy homeboy worker run").unwrap();
         assert_eq!(row.pid, 123);
         assert_eq!(row.cpu_percent, 88.5);
         assert_eq!(row.rss_mb, 1024);
@@ -418,13 +425,29 @@ mod tests {
     }
 
     #[test]
-    fn ignores_unrelated_processes_that_only_mention_node_in_flags() {
+    fn configured_matches_select_additional_processes() {
         let row = ProcessRow {
             pid: 2,
             cpu_percent: 1.0,
             rss_mb: 100,
-            command: "/Applications/Discord.app/Discord Helper".to_string(),
-            args: "--enable-node-leakage-in-renderers".to_string(),
+            command: "/usr/local/bin/preview-worker".to_string(),
+            args: "serve --public".to_string(),
+        };
+
+        assert!(is_relevant_process_with_matches(
+            &row,
+            &["preview-worker".to_string()]
+        ));
+    }
+
+    #[test]
+    fn ignores_unrelated_processes_without_configured_match() {
+        let row = ProcessRow {
+            pid: 2,
+            cpu_percent: 1.0,
+            rss_mb: 100,
+            command: "/Applications/Chat.app/Chat Helper".to_string(),
+            args: "--enable-worker-mode".to_string(),
         };
 
         assert!(!is_relevant_process(&row));

--- a/src/core/artifact_links.rs
+++ b/src/core/artifact_links.rs
@@ -81,9 +81,9 @@ mod tests {
         let artifact = ArtifactRecord {
             id: "artifact-1".to_string(),
             run_id: "run-1".to_string(),
-            kind: "blueprint-after".to_string(),
+            kind: "preview-after".to_string(),
             artifact_type: "file".to_string(),
-            path: "/tmp/blueprint.after.json".to_string(),
+            path: "/tmp/preview.after.json".to_string(),
             url: None,
             public_url: None,
             viewer_url: None,
@@ -93,11 +93,11 @@ mod tests {
             mime: Some("application/json".to_string()),
             metadata_json: serde_json::json!({
                 "viewer": {
-                    "kind": "wordpress-playground-blueprint",
-                    "base": "https://playground.wordpress.net/",
+                    "kind": "artifact-preview",
+                    "base": "https://viewer.example.test/",
                     "query": {
-                        "parameter": "blueprint-url",
-                        "value": { "source": "public-artifact-url", "path": "blueprint.after.json" },
+                        "parameter": "artifact-url",
+                        "value": { "source": "public-artifact-url", "path": "preview.after.json" },
                         "encoding": "url"
                     },
                     "replay": { "status": "partial", "limitations": [] }
@@ -109,10 +109,10 @@ mod tests {
         let links = viewer_links(&artifact, Some("https://artifacts.example.test/a b.json"));
 
         assert_eq!(links.len(), 1);
-        assert_eq!(links[0].kind, "wordpress-playground-blueprint");
+        assert_eq!(links[0].kind, "artifact-preview");
         assert_eq!(
             links[0].url,
-            "https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fartifacts.example.test%2Fa%20b.json"
+            "https://viewer.example.test/?artifact-url=https%3A%2F%2Fartifacts.example.test%2Fa%20b.json"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Removes ecosystem-specific process names from `doctor resources` defaults so core only tracks Homeboy processes by default.
- Adds `HOMEBOY_DOCTOR_RESOURCE_PROCESS_MATCHES` as a generic operator extension point for environment-specific process matching.
- Replaces the artifact viewer test fixture with a neutral example so core-owned tests stay framework-agnostic.

## Verification
- `cargo fmt --check`
- `HOMEBOY_CHANGED_SINCE=origin/main SCOPE_MODE=changed cargo test --test core_agnostic_test`
- `cargo test doctor::resources`
- `cargo test artifact_links`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the core-agnostic regression, drafted the small fix, and ran the verification commands. Chris remains responsible for review and merge.