### PR TITLE
fix: resolve trace secrets once for child runs

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -79,6 +79,11 @@ pub(super) use schedule::{
 };
 use workload::trace_workload_scenario_id;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ResolvedTraceSecretEnv {
+    env: Vec<(String, String)>,
+}
+
 #[cfg(test)]
 use matrix::{expand_variant_matrix, TraceVariantStackItem};
 #[derive(Args, Clone)]
@@ -710,6 +715,44 @@ fn hydrate_trace_secret_env(
     let (resolved, statuses) = homeboy::core::trace_secrets::resolve_secret_env(names, project_id)?;
     env.extend(resolved);
     Ok(homeboy::core::trace_secrets::status_metadata(statuses))
+}
+
+fn resolve_trace_secret_env_once(
+    names: &[String],
+    project_id: Option<&str>,
+) -> homeboy::core::Result<Option<ResolvedTraceSecretEnv>> {
+    if names.iter().all(|name| name.trim().is_empty()) {
+        return Ok(None);
+    }
+
+    let (env, _statuses) = homeboy::core::trace_secrets::resolve_secret_env(names, project_id)?;
+    Ok(Some(ResolvedTraceSecretEnv { env }))
+}
+
+fn apply_resolved_trace_secret_env(
+    args: &mut TraceArgs,
+    resolved: Option<&ResolvedTraceSecretEnv>,
+) {
+    apply_resolved_trace_secret_env_to_fields(&mut args.secret_env, &mut args.matrix_env, resolved);
+}
+
+fn apply_resolved_trace_secret_env_to_fields(
+    secret_env: &mut Vec<String>,
+    matrix_env: &mut Vec<(String, String)>,
+    resolved: Option<&ResolvedTraceSecretEnv>,
+) {
+    if let Some(resolved) = resolved {
+        matrix_env.extend(resolved.env.clone());
+        secret_env.clear();
+    }
+}
+
+fn trace_secret_env_project_id_for_args(args: &TraceArgs) -> homeboy::core::Result<String> {
+    let rig_context = load_rig_context(args.rig.as_deref())?;
+    resolve_component_id(
+        &args.comp,
+        rig_context.as_ref().map(|context| &context.rig_spec),
+    )
 }
 
 fn run_list(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
@@ -1658,6 +1701,52 @@ fn merge_trace_artifact_metadata(
         );
     }
     metadata
+}
+
+#[cfg(test)]
+mod secret_env_tests {
+    use super::*;
+
+    #[test]
+    fn resolved_trace_secret_env_moves_values_to_child_matrix_env() {
+        let mut secret_env = vec!["STRIPE_SECRET_KEY".to_string()];
+        let mut matrix_env = vec![("EXISTING".to_string(), "1".to_string())];
+        let resolved = ResolvedTraceSecretEnv {
+            env: vec![(
+                "STRIPE_SECRET_KEY".to_string(),
+                "redacted-test-value".to_string(),
+            )],
+        };
+
+        apply_resolved_trace_secret_env_to_fields(
+            &mut secret_env,
+            &mut matrix_env,
+            Some(&resolved),
+        );
+
+        assert!(secret_env.is_empty());
+        assert_eq!(
+            matrix_env,
+            vec![
+                ("EXISTING".to_string(), "1".to_string()),
+                (
+                    "STRIPE_SECRET_KEY".to_string(),
+                    "redacted-test-value".to_string()
+                )
+            ]
+        );
+    }
+
+    #[test]
+    fn unresolved_trace_secret_env_leaves_child_args_unchanged() {
+        let mut secret_env = vec!["STRIPE_SECRET_KEY".to_string()];
+        let mut matrix_env = Vec::new();
+
+        apply_resolved_trace_secret_env_to_fields(&mut secret_env, &mut matrix_env, None);
+
+        assert_eq!(secret_env, vec!["STRIPE_SECRET_KEY".to_string()]);
+        assert!(matrix_env.is_empty());
+    }
 }
 
 #[cfg(test)]

--- a/src/commands/trace/compare_targets.rs
+++ b/src/commands/trace/compare_targets.rs
@@ -12,9 +12,10 @@ use super::aggregate::{
 use super::matrix::{aggregate_to_compare_input, write_json_artifact};
 use super::output::compare_trace_aggregates_with_focus;
 use super::{
-    attach_span_metadata, classification_summaries, cli_span_definitions_for_args,
-    load_rig_context, plan_trace_run_order, resolve_component_id, rig_component_for_trace,
-    run_trace_guardrails_for_args, trace_span_metadata_for_args, TraceArgs,
+    apply_resolved_trace_secret_env, attach_span_metadata, classification_summaries,
+    cli_span_definitions_for_args, load_rig_context, plan_trace_run_order, resolve_component_id,
+    resolve_trace_secret_env_once, rig_component_for_trace, run_trace_guardrails_for_args,
+    trace_span_metadata_for_args, ResolvedTraceSecretEnv, TraceArgs,
 };
 use crate::commands::utils::args::PositionalComponentArgs;
 use crate::commands::CmdResult;
@@ -186,6 +187,8 @@ fn run_target_proof_matrix(
 ) -> homeboy::core::Result<TargetProofMatrix> {
     let repeat = args.repeat.max(1);
     let plan = plan_trace_run_order(repeat, args.schedule, &["baseline", "candidate"]);
+    let resolved_trace_secret_env =
+        resolve_trace_secret_env_once(&args.secret_env, Some(component_id))?;
     let span_metadata = trace_span_metadata_for_args(args)?;
     let declared_spans = cli_span_definitions_for_args(args)?;
     let mut baseline = TargetAggregateBuilder::new(
@@ -210,7 +213,13 @@ fn run_target_proof_matrix(
         } else {
             (candidate_target, &mut candidate)
         };
-        let run = execute_target_once(args, component_id, scenario_id, target);
+        let run = execute_target_once(
+            args,
+            component_id,
+            scenario_id,
+            target,
+            resolved_trace_secret_env.as_ref(),
+        );
         let proof_entry = builder.record(entry.index(), run);
         proof_run_order.push(extension_trace::TraceCompareRunOrderOutput {
             index: proof_entry.index,
@@ -235,6 +244,7 @@ fn execute_target_once(
     component_id: &str,
     scenario_id: &str,
     target: &ResolvedCompareTarget,
+    resolved_trace_secret_env: Option<&ResolvedTraceSecretEnv>,
 ) -> Result<super::TraceRunExecution, homeboy::core::Error> {
     let mut run_args = args.clone();
     run_args.comp.component = Some(component_id.to_string());
@@ -247,6 +257,7 @@ fn execute_target_once(
     run_args.aggregate = None;
     run_args.output_dir = None;
     run_args.checkout_provenance = target.checkout_provenance.clone();
+    apply_resolved_trace_secret_env(&mut run_args, resolved_trace_secret_env);
     super::execute_trace_run(run_args)
 }
 

--- a/src/commands/trace/compare_variant.rs
+++ b/src/commands/trace/compare_variant.rs
@@ -16,8 +16,9 @@ use super::output::{
 };
 use super::repeat::{focus_aggregate_spans, run_repeat};
 use super::{
-    apply_command_target_component, plan_trace_run_order, validate_trace_variants_for_args,
-    TraceArgs, TraceRunPlanEntry, TraceSchedule,
+    apply_command_target_component, apply_resolved_trace_secret_env, plan_trace_run_order,
+    resolve_trace_secret_env_once, trace_secret_env_project_id_for_args,
+    validate_trace_variants_for_args, TraceArgs, TraceRunPlanEntry, TraceSchedule,
 };
 use crate::commands::CmdResult;
 
@@ -62,6 +63,10 @@ pub(super) fn run_compare_variant(mut args: TraceArgs) -> CmdResult<TraceCommand
     args.report = None;
     args.compare_after = None;
     validate_trace_variants_for_args(&args)?;
+    let project_id = trace_secret_env_project_id_for_args(&args)?;
+    let resolved_trace_secret_env =
+        resolve_trace_secret_env_once(&args.secret_env, Some(&project_id))?;
+    apply_resolved_trace_secret_env(&mut args, resolved_trace_secret_env.as_ref());
     let focus_spans = args.focus_spans.clone();
     let regression_threshold = args.regression_threshold;
     let regression_min_delta_ms = args.regression_min_delta_ms;

--- a/src/commands/trace/repeat.rs
+++ b/src/commands/trace/repeat.rs
@@ -7,15 +7,19 @@ use super::aggregate::{
     aggregate_metric, aggregate_span, TraceAggregateMetricSample, TraceAggregateSpanSample,
 };
 use super::{
-    attach_span_metadata, classification_summaries, cli_span_definitions_for_args,
-    execute_trace_run, plan_trace_run_order, resolved_profile_output_for_args,
-    run_trace_guardrails_for_args, trace_scenario, TraceArgs,
+    apply_resolved_trace_secret_env, attach_span_metadata, classification_summaries,
+    cli_span_definitions_for_args, execute_trace_run, plan_trace_run_order,
+    resolve_trace_secret_env_once, resolved_profile_output_for_args, run_trace_guardrails_for_args,
+    trace_scenario, trace_secret_env_project_id_for_args, TraceArgs,
 };
 use crate::commands::CmdResult;
 
 pub(super) fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
     let repeat = args.repeat;
     let scenario_id = trace_scenario(&args)?.to_string();
+    let project_id = trace_secret_env_project_id_for_args(&args)?;
+    let resolved_trace_secret_env =
+        resolve_trace_secret_env_once(&args.secret_env, Some(&project_id))?;
     let mut runs = Vec::new();
     let mut overlays = Vec::new();
     let mut span_samples: BTreeMap<String, Vec<TraceAggregateSpanSample>> = BTreeMap::new();
@@ -36,6 +40,7 @@ pub(super) fn run_repeat(args: TraceArgs) -> CmdResult<TraceCommandOutput> {
         let index = plan_entry.index();
         let mut run_args = args.clone();
         run_args.repeat = 1;
+        apply_resolved_trace_secret_env(&mut run_args, resolved_trace_secret_env.as_ref());
         match execute_trace_run(run_args) {
             Ok(execution) => {
                 if rig_state.is_none() {


### PR DESCRIPTION
## Summary
- Resolve `trace compare`/repeat `--secret-env` names once at the outer fan-out boundary.
- Pass resolved values to child trace runs via in-memory runner env and clear child `secret_env` so children do not re-read Keychain.
- Apply the same handoff to `trace compare-variant`, which uses the same repeated child-run pattern.

Closes #4136.

## Tests
- `cargo fmt`
- `cargo test secret_env_tests --lib`
- `cargo test trace_secret_env --lib`
- `cargo test commands::trace::compare --lib`
- `cargo check`
- `cargo test --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the trace secret-env fan-out fix, added focused unit coverage, ran verification, and drafted this PR description. Chris remains responsible for review and final acceptance.