### PR TITLE
fix: remap Lab WP Codebox path settings

### DIFF
--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -23,8 +23,8 @@ use super::lab_apply::apply_lab_offload_patch;
 #[cfg(test)]
 use super::lab_args::EXPLICIT_PASSTHROUGH_SENTINEL;
 use super::lab_args::{
-    lab_offload_source_path, remap_agent_task_plan_in_args, remap_provider_config_in_args,
-    rewrite_lab_offload_args, LabPathRemap,
+    lab_offload_source_path, remap_agent_task_plan_in_args, remap_path_settings_in_args,
+    remap_provider_config_in_args, rewrite_lab_offload_args, LabPathRemap,
 };
 use super::lab_capabilities::lab_runner_capability_contract;
 use super::lab_command::lab_offload_command_prefix;
@@ -41,9 +41,10 @@ use super::lab_selection::{
 };
 use super::lab_workspaces::{
     agent_task_plan_extra_workspaces, lab_extra_workspaces, lab_workspace_mapping_metadata,
-    preflight_provider_config_source_cli_dependencies, provider_config_extra_workspaces,
-    rig_component_path_env_extra_workspaces, sync_extra_lab_workspaces,
-    workspace_mapping_entries_for_git_dependency, workspace_mapping_entry,
+    path_setting_extra_workspaces, preflight_provider_config_source_cli_dependencies,
+    provider_config_extra_workspaces, rig_component_path_env_extra_workspaces,
+    sync_extra_lab_workspaces, workspace_mapping_entries_for_git_dependency,
+    workspace_mapping_entry,
 };
 
 pub struct LabOffloadRequest<'a> {
@@ -591,6 +592,10 @@ fn run_lab_offload_inner(
         &changed_since_preflight.args,
         &source_path,
     )?);
+    extra_workspaces.extend(path_setting_extra_workspaces(
+        &changed_since_preflight.args,
+        &source_path,
+    )?);
     extra_workspaces.extend(rig_component_path_env_extra_workspaces(&source_path)?);
     let synced = sync_workspace(
         runner_id,
@@ -726,6 +731,7 @@ fn run_lab_offload_inner(
     );
     let remapped_args = remap_provider_config_in_args(&remapped_args, &path_remaps);
     let remapped_args = remap_agent_task_plan_in_args(&remapped_args, &path_remaps);
+    let remapped_args = remap_path_settings_in_args(&remapped_args, &path_remaps);
     let (remapped_args, synced_remapped_plan) =
         materialize_inline_agent_task_plan_arg(runner_id, &remapped_args)?;
     if let Some(entry) = synced_remapped_plan {
@@ -783,7 +789,7 @@ fn run_lab_offload_inner(
     lab_metadata["agent_task_secret_env"] = agent_task_secret_env;
     lab_metadata["trace_secret_env"] = trace_secret_env;
     lab_metadata["rig_component_path_env"] = rig_component_path_env;
-    lab_metadata["settings_env"] = settings_env_diagnostics(&changed_since_preflight.args, &env);
+    lab_metadata["settings_env"] = settings_env_diagnostics(&remapped_args, &env);
     lab_metadata["rig_sync"] = serde_json::json!({
         "step": "lab.sync_rigs",
         "synced_count": synced_rigs.len(),

--- a/src/core/runner/lab_args.rs
+++ b/src/core/runner/lab_args.rs
@@ -127,6 +127,61 @@ pub(super) fn remap_agent_task_plan_in_args(
     out
 }
 
+pub(super) fn remap_path_settings_in_args(
+    args: &[String],
+    mappings: &[LabPathRemap],
+) -> Vec<String> {
+    if mappings.is_empty() {
+        return args.to_vec();
+    }
+
+    let mut ordered: Vec<&LabPathRemap> = mappings.iter().collect();
+    ordered.sort_by_key(|mapping| {
+        (
+            std::cmp::Reverse(mapping.local.len()),
+            std::cmp::Reverse(mapping.remote.len()),
+        )
+    });
+
+    let mut out = Vec::with_capacity(args.len());
+    let mut iter = args.iter().peekable();
+    let mut passthrough = false;
+    while let Some(arg) = iter.next() {
+        if passthrough {
+            out.push(arg.clone());
+            continue;
+        }
+        if arg == "--" {
+            passthrough = true;
+            out.push(arg.clone());
+            continue;
+        }
+        if arg == "--setting" || arg == "--setting-json" {
+            out.push(arg.clone());
+            if let Some(raw) = iter.next() {
+                out.push(remap_path_setting_pair(raw, &ordered));
+            }
+            continue;
+        }
+        if let Some(raw) = arg.strip_prefix("--setting=") {
+            out.push(format!(
+                "--setting={}",
+                remap_path_setting_pair(raw, &ordered)
+            ));
+            continue;
+        }
+        if let Some(raw) = arg.strip_prefix("--setting-json=") {
+            out.push(format!(
+                "--setting-json={}",
+                remap_path_setting_pair(raw, &ordered)
+            ));
+            continue;
+        }
+        out.push(arg.clone());
+    }
+    out
+}
+
 /// Resolve an agent-task plan spec, remap every controller-local path embedded
 /// in the JSON, and inline the result so the runner never reads stale local
 /// paths from a synced-but-unmodified plan file.
@@ -141,6 +196,22 @@ fn remap_agent_task_plan_spec(spec: &str, mappings: &[&LabPathRemap]) -> String 
     };
     remap_paths_in_value(&mut value, mappings);
     serde_json::to_string(&value).unwrap_or_else(|_| remap_at_file_spec(spec, mappings))
+}
+
+fn remap_path_setting_pair(raw: &str, mappings: &[&LabPathRemap]) -> String {
+    let Some((key, value)) = raw.split_once('=') else {
+        return raw.to_string();
+    };
+    if !is_lab_path_setting_key(key) {
+        return raw.to_string();
+    }
+    remap_local_path(value, mappings)
+        .map(|remapped| format!("{key}={remapped}"))
+        .unwrap_or_else(|| raw.to_string())
+}
+
+fn is_lab_path_setting_key(key: &str) -> bool {
+    matches!(key, "wp_codebox_bin")
 }
 
 fn remap_at_file_spec(spec: &str, mappings: &[&LabPathRemap]) -> String {
@@ -631,6 +702,30 @@ mod tests {
             remap_agent_task_plan_in_args(&args, &mappings)[4],
             "@/home/chubes/Developer/wp-site-generator/.ci/missing.json"
         );
+    }
+
+    #[test]
+    fn remap_path_settings_rewrites_wp_codebox_bin() {
+        let mappings = vec![LabPathRemap {
+            local: "/Users/chubes/Developer/wp-codebox".to_string(),
+            remote: "/home/chubes/_lab_workspaces/wp-codebox".to_string(),
+        }];
+        let args = vec![
+            "homeboy".to_string(),
+            "trace".to_string(),
+            "--setting".to_string(),
+            "wp_codebox_bin=/Users/chubes/Developer/wp-codebox/packages/cli/dist/index.js"
+                .to_string(),
+            "--setting=mode=fast".to_string(),
+        ];
+
+        let out = remap_path_settings_in_args(&args, &mappings);
+
+        assert_eq!(
+            out[3],
+            "wp_codebox_bin=/home/chubes/_lab_workspaces/wp-codebox/packages/cli/dist/index.js"
+        );
+        assert_eq!(out[4], "--setting=mode=fast");
     }
 
     #[test]

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -276,6 +276,29 @@ pub(super) fn agent_task_plan_extra_workspaces(
     Ok(workspaces)
 }
 
+pub(super) fn path_setting_extra_workspaces(
+    args: &[String],
+    source_path: &Path,
+) -> Result<Vec<ExtraLabWorkspace>> {
+    let source_canon = source_path
+        .canonicalize()
+        .unwrap_or_else(|_| source_path.to_path_buf());
+    let mut seen = BTreeSet::new();
+    let mut workspaces = Vec::new();
+
+    for value in path_setting_values(args) {
+        add_candidate_extra_workspace(
+            &value,
+            "path_setting",
+            &source_canon,
+            &mut seen,
+            &mut workspaces,
+        )?;
+    }
+
+    Ok(workspaces)
+}
+
 pub(super) fn rig_component_path_env_extra_workspaces(
     source_path: &Path,
 ) -> Result<Vec<ExtraLabWorkspace>> {
@@ -415,6 +438,43 @@ fn agent_task_plan_spec(args: &[String]) -> Option<String> {
         }
     }
     None
+}
+
+fn path_setting_values(args: &[String]) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut iter = args.iter().peekable();
+    let mut passthrough = false;
+    while let Some(arg) = iter.next() {
+        if passthrough {
+            continue;
+        }
+        if arg == "--" {
+            passthrough = true;
+            continue;
+        }
+        if arg == "--setting" || arg == "--setting-json" {
+            if let Some(raw) = iter.next() {
+                push_path_setting_value(raw, &mut values);
+            }
+            continue;
+        }
+        if let Some(raw) = arg
+            .strip_prefix("--setting=")
+            .or_else(|| arg.strip_prefix("--setting-json="))
+        {
+            push_path_setting_value(raw, &mut values);
+        }
+    }
+    values
+}
+
+fn push_path_setting_value(raw: &str, values: &mut Vec<String>) {
+    let Some((key, value)) = raw.split_once('=') else {
+        return;
+    };
+    if matches!(key, "wp_codebox_bin") && !value.trim().is_empty() {
+        values.push(value.to_string());
+    }
 }
 
 fn subcommand_index(args: &[String], subcommand: &str) -> Option<usize> {
@@ -777,7 +837,7 @@ mod provider_config_candidate_paths_tests {
     use std::process::Command;
 
     use super::{
-        agent_task_plan_extra_workspaces, agent_task_plan_spec,
+        agent_task_plan_extra_workspaces, agent_task_plan_spec, path_setting_extra_workspaces,
         preflight_provider_config_source_cli_dependencies, provider_config_candidate_paths,
         provider_config_extra_workspaces, rig_component_path_env_extra_workspaces_from_entries,
         workspace_mapping_entries_for_git_dependency,
@@ -1018,6 +1078,40 @@ mod provider_config_candidate_paths_tests {
         let workspaces = agent_task_plan_extra_workspaces(&args, &source).expect("workspaces");
 
         assert!(workspaces.is_empty());
+    }
+
+    #[test]
+    fn path_setting_wp_codebox_bin_syncs_containing_checkout() {
+        let controller = tempfile::tempdir().expect("controller");
+        let source = controller.path().join("primary");
+        let codebox = controller.path().join("wp-codebox");
+        let codebox_bin = codebox.join("packages/cli/dist/index.js");
+        std::fs::create_dir_all(&source).expect("source dir");
+        std::fs::create_dir_all(codebox_bin.parent().unwrap()).expect("codebox cli dir");
+        std::fs::write(&codebox_bin, "#!/usr/bin/env node\n").expect("codebox bin");
+        std::fs::write(codebox.join("package-lock.json"), "{}\n").expect("package lock");
+        git(&codebox, &["init", "-b", "main"]);
+        git(&codebox, &["config", "user.email", "test@example.com"]);
+        git(&codebox, &["config", "user.name", "Homeboy Test"]);
+        git(&codebox, &["add", "."]);
+        git(&codebox, &["commit", "-m", "initial"]);
+
+        let args = vec![
+            "homeboy".to_string(),
+            "trace".to_string(),
+            "--setting".to_string(),
+            format!("wp_codebox_bin={}", codebox_bin.display()),
+        ];
+
+        let workspaces = path_setting_extra_workspaces(&args, &source).expect("workspaces");
+
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(workspaces[0].role, "path_setting");
+        assert_eq!(workspaces[0].path, codebox.canonicalize().unwrap());
+        assert!(workspaces[0]
+            .snapshot_includes
+            .contains(&"packages/cli/dist/**".to_string()));
+        assert!(workspaces[0].bootstrap_node_dependencies);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Sync controller-local `wp_codebox_bin` setting paths as Lab extra workspaces before offloaded trace execution.
- Remap `--setting wp_codebox_bin=...` and `--setting-json wp_codebox_bin=...` values to the synced runner workspace path.
- Report `settings_env` diagnostics from the remapped runner argv so Lab metadata shows the WP Codebox binary path selected for offload.

Fixes #4140.

## Tests
- `cargo fmt --check`
- `cargo test remap_path_settings_rewrites_wp_codebox_bin`
- `cargo test path_setting_wp_codebox_bin_syncs_containing_checkout`
- `cargo test core::runner::lab_args::tests`
- `cargo test core::runner::lab_workspaces::provider_config_candidate_paths_tests`

## Woo Stripe real-wallet smoke
- Not rerun in this shell: `STRIPE_PUBLISHABLE_KEY`, `STRIPE_SECRET_KEY`, `HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL`, and `HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT` are not present.
- The fix is covered at the Homeboy Lab path-resolution layer and does not modify Woo Stripe PR #5530 or the rig patch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the Lab offload path selection bug, drafting the Rust fix/tests, and preparing this PR description. Chris remains responsible for review and validation.