### PR TITLE
Clarify SSH command status and runner env diagnostics

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -321,6 +321,8 @@ homeboy runner exec <runner-id> -- <command...>
 homeboy runner exec <runner-id> --project <project-id> --cwd /runner/workspace/project -- <command...>
 homeboy runner exec <runner-id> --ssh --cwd /runner/workspace/project -- <command...>
 homeboy runner exec <runner-id> --cwd /runner/workspace/project --require-path /runner/workspace/project -- <command...>
+homeboy runner env <runner-id>
+homeboy runner env <runner-id> --show-values
 ```
 
 `exec` submits the command to the connected runner daemon when `homeboy runner connect <runner-id>` has established a live loopback tunnel. If no daemon session is connected, local runners execute directly and SSH runners require explicit diagnostic `--ssh`. SSH runner raw exec is policy-denied by default until `policy.allow_raw_exec` is explicitly true.
@@ -335,6 +337,13 @@ Path rules:
 - `--ssh` is the explicit diagnostic fallback when `connect` is unavailable; daemon execution is preferred because it records job metadata and supports artifact-oriented workflows.
 - Diagnostic SSH output serializes as `mode: "diagnostic_ssh"` and does not include job/event evidence.
 - Raw SSH execution remains intentionally explicit and should not be used as production Lab/offload evidence; use connected daemon or reverse broker execution for job/event/artifact-compatible output.
+
+Runner job environment:
+
+- `homeboy runner env <runner-id>` shows the effective environment Homeboy injects into runner jobs before command execution.
+- Values are redacted by default because runner env commonly contains tokens. Use `--show-values` only in trusted local/operator contexts.
+- `homeboy ssh <server> -- printenv NAME` inspects the server login shell environment. It does not include runner job env unless the variable is also configured on the server shell.
+- Use `homeboy runner exec <runner-id> -- printenv NAME` or `homeboy runner env <runner-id> --show-values` when debugging Lab job environment.
 
 Runner metrics:
 

--- a/docs/commands/ssh.md
+++ b/docs/commands/ssh.md
@@ -61,6 +61,10 @@ The connect action uses an interactive SSH session and does not print the JSON e
 
 When a command is provided, it is executed non-interactively and Homeboy captures stdout/stderr into the JSON response.
 
+Non-interactive command responses include `exit_code`, `success`, `result_classification`, and `failure_reason` when the command fails. This makes empty-output commands unambiguous: a command that exits `0` reports `success: true`, while a no-output failure reports the actual exit code and whether Homeboy classified it as a remote command failure or SSH transport failure.
+
+`homeboy ssh` shows the server shell environment. Runner-specific job environment is injected by `homeboy runner exec`; inspect it with `homeboy runner env <runner-id>` or `homeboy runner exec <runner-id> -- printenv NAME`.
+
 Note: the CLI still computes a JSON `data` object internally for this action, but it is not printed in interactive passthrough mode.
 
 ## Exit code

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
@@ -44,8 +44,25 @@ pub enum RunnerCommandOutput {
     Registry(RunnerOutput),
     Doctor(doctor::RunnerDoctorOutput),
     Execution(RunnerExecOutput),
+    Env(RunnerEnvOutput),
     Worker(ReverseRunnerWorkerOutput),
     Workspace(workspace::RunnerWorkspaceOutput),
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunnerEnvOutput {
+    pub command: String,
+    pub runner_id: String,
+    pub source: String,
+    pub values_redacted: bool,
+    pub env: BTreeMap<String, String>,
+    pub diagnostics: RunnerEnvDiagnostics,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunnerEnvDiagnostics {
+    pub server_shell_env: String,
+    pub runner_job_env: String,
 }
 
 #[derive(Args)]
@@ -273,6 +290,15 @@ enum RunnerCommand {
         #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
         command: Vec<String>,
     },
+    /// Show the effective environment injected into runner jobs
+    Env {
+        /// Runner ID
+        id: String,
+
+        /// Print actual values instead of redacting them
+        #[arg(long)]
+        show_values: bool,
+    },
     /// Claim and execute one brokered reverse-runner job from this machine
     Work {
         /// Runner ID on this machine
@@ -461,6 +487,7 @@ pub fn run(
             require_paths,
             command,
         )),
+        RunnerCommand::Env { id, show_values } => map_env(env(&id, show_values)),
         RunnerCommand::Work {
             runner_id,
             broker_url,
@@ -516,6 +543,10 @@ fn map_doctor(result: CmdResult<doctor::RunnerDoctorOutput>) -> CmdResult<Runner
 
 fn map_execution(result: CmdResult<RunnerExecOutput>) -> CmdResult<RunnerCommandOutput> {
     result.map(|(output, exit_code)| (RunnerCommandOutput::Execution(output), exit_code))
+}
+
+fn map_env(result: CmdResult<RunnerEnvOutput>) -> CmdResult<RunnerCommandOutput> {
+    result.map(|(output, exit_code)| (RunnerCommandOutput::Env(output), exit_code))
 }
 
 fn map_worker(result: CmdResult<ReverseRunnerWorkerOutput>) -> CmdResult<RunnerCommandOutput> {
@@ -821,6 +852,38 @@ fn exec(
     )
 }
 
+fn env(runner_id: &str, show_values: bool) -> CmdResult<RunnerEnvOutput> {
+    let effective_env = runner::effective_env(runner_id)?;
+    let env = effective_env
+        .into_iter()
+        .map(|(key, value)| {
+            (
+                key,
+                if show_values {
+                    value
+                } else {
+                    REDACTED_ENV_VALUE.to_string()
+                },
+            )
+        })
+        .collect();
+
+    Ok((
+        RunnerEnvOutput {
+            command: "runner.env".to_string(),
+            runner_id: runner_id.to_string(),
+            source: "runner_job_env".to_string(),
+            values_redacted: !show_values,
+            env,
+            diagnostics: RunnerEnvDiagnostics {
+                server_shell_env: "Use `homeboy ssh <server> -- printenv NAME` to inspect the server login shell environment; it does not include runner job env by default.".to_string(),
+                runner_job_env: "This output is the configured env Homeboy injects into `homeboy runner exec` jobs before command execution.".to_string(),
+            },
+        },
+        0,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -884,5 +947,27 @@ mod tests {
         assert_eq!(value["entities"][0]["env"]["PATH"], REDACTED_ENV_VALUE);
         assert!(!value.to_string().contains("secret-token"));
         assert!(!value.to_string().contains("/secret/bin"));
+    }
+
+    #[test]
+    fn runner_env_output_redacts_values_by_default() {
+        let output = RunnerEnvOutput {
+            command: "runner.env".to_string(),
+            runner_id: "lab".to_string(),
+            source: "runner_job_env".to_string(),
+            values_redacted: true,
+            env: BTreeMap::from([("TOKEN".to_string(), REDACTED_ENV_VALUE.to_string())]),
+            diagnostics: RunnerEnvDiagnostics {
+                server_shell_env: "shell".to_string(),
+                runner_job_env: "runner".to_string(),
+            },
+        };
+
+        let value = serde_json::to_value(output).expect("serialize output");
+
+        assert_eq!(value["command"], "runner.env");
+        assert_eq!(value["source"], "runner_job_env");
+        assert_eq!(value["values_redacted"], true);
+        assert_eq!(value["env"]["TOKEN"], REDACTED_ENV_VALUE);
     }
 }

--- a/src/commands/ssh.rs
+++ b/src/commands/ssh.rs
@@ -58,6 +58,10 @@ pub struct SshConnectOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stderr: Option<String>,
     pub success: bool,
+    pub exit_code: i32,
+    pub result_classification: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_reason: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -137,6 +141,12 @@ pub fn run(args: SshArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Ss
                         stdout: Some(output.stdout),
                         stderr: Some(output.stderr),
                         success: output.success,
+                        exit_code: output.exit_code,
+                        result_classification: ssh_result_classification(
+                            output.success,
+                            output.exit_code,
+                        ),
+                        failure_reason: ssh_failure_reason(output.success, output.exit_code),
                     }),
                     output.exit_code,
                 ))
@@ -153,10 +163,78 @@ pub fn run(args: SshArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<Ss
                         stdout: None,
                         stderr: None,
                         success: exit_code == 0,
+                        exit_code,
+                        result_classification: ssh_result_classification(exit_code == 0, exit_code),
+                        failure_reason: ssh_failure_reason(exit_code == 0, exit_code),
                     }),
                     exit_code,
                 ))
             }
         }
+    }
+}
+
+fn ssh_result_classification(success: bool, exit_code: i32) -> String {
+    if success {
+        return "remote_command_success".to_string();
+    }
+
+    if exit_code == 255 || exit_code < 0 {
+        return "ssh_transport_failed".to_string();
+    }
+
+    "remote_command_failed".to_string()
+}
+
+fn ssh_failure_reason(success: bool, exit_code: i32) -> Option<String> {
+    if success {
+        return None;
+    }
+
+    if exit_code == 255 {
+        return Some("SSH transport failed with exit code 255".to_string());
+    }
+
+    if exit_code < 0 {
+        return Some("SSH process terminated without a remote exit code".to_string());
+    }
+
+    Some(format!(
+        "Remote command exited with status {exit_code}; stdout/stderr may be empty for no-output commands"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ssh_success_classification_does_not_depend_on_output() {
+        assert_eq!(ssh_result_classification(true, 0), "remote_command_success");
+        assert_eq!(ssh_failure_reason(true, 0), None);
+    }
+
+    #[test]
+    fn ssh_failure_reason_handles_empty_output_failures() {
+        assert_eq!(
+            ssh_result_classification(false, 42),
+            "remote_command_failed"
+        );
+        assert_eq!(
+            ssh_failure_reason(false, 42).as_deref(),
+            Some("Remote command exited with status 42; stdout/stderr may be empty for no-output commands")
+        );
+    }
+
+    #[test]
+    fn ssh_transport_failure_is_distinct_from_remote_command_failure() {
+        assert_eq!(
+            ssh_result_classification(false, 255),
+            "ssh_transport_failed"
+        );
+        assert_eq!(
+            ssh_failure_reason(false, 255).as_deref(),
+            Some("SSH transport failed with exit code 255")
+        );
     }
 }

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -172,6 +172,13 @@ pub fn load(id: &str) -> Result<Runner> {
     load_server_runner(id)
 }
 
+pub fn effective_env(id: &str) -> Result<HashMap<String, String>> {
+    let runner = load(id)?;
+    let mut env = runner.env.clone();
+    normalize_runner_command_env(&mut env);
+    Ok(env)
+}
+
 pub fn list() -> Result<Vec<Runner>> {
     let mut runners: Vec<Runner> = config::list::<Runner>()?
         .into_iter()


### PR DESCRIPTION
## Summary
- Add explicit `exit_code`, `result_classification`, and failure reason fields to non-interactive `homeboy ssh` output so empty-output commands report success/failure from the real exit status.
- Add `homeboy runner env <runner-id>` as a first-class way to inspect effective runner job env, redacted by default with an explicit `--show-values` diagnostic option.
- Document the distinction between server shell env inspected by `homeboy ssh` and runner job env injected into `homeboy runner exec`.

Closes #4144.
Closes #4145.

## Tests
- `cargo test commands::ssh::tests`
- `cargo test commands::runner::tests`
- `target/debug/homeboy runner --help`
- `target/debug/homeboy ssh --help`
- `target/debug/homeboy ssh homeboy-lab "true"`
- `target/debug/homeboy runner env homeboy-lab`

## Notes
- `cargo test` was also run. It failed in `tests/core_agnostic_test.rs::core_owned_source_stays_language_and_framework_agnostic` on unrelated pre-existing core-boundary audit findings across files such as `src/core/defaults/builtins.rs`, `src/core/engine/edit_op_apply/imports.rs`, and `src/core/upgrade/*`; the targeted tests and CLI smokes for this PR passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the SSH status diagnostics, runner env inspection command, tests, docs, and local verification; Chris remains responsible for review and merge.