### PR TITLE
fix: mirror timed-out Lab runner evidence

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -437,6 +437,8 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
 fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
     reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
+    require_run(&store, run_id)?;
+    homeboy::core::runner::refresh_mirrored_daemon_evidence(run_id)?;
     let run = require_run(&store, run_id)?;
     Ok((
         RunsOutput::Show(RunsShowOutput {
@@ -449,18 +451,53 @@ fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
 
 pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
-    require_run(&store, run_id)?;
+    let run = require_run(&store, run_id)?;
+    homeboy::core::runner::refresh_mirrored_daemon_evidence(run_id)?;
     homeboy::core::publication_artifacts::index_remote_published_artifact_refs_for_run(
         &store, run_id,
     )?;
+    let mut artifacts = store.list_artifacts(run_id)?;
+    artifacts.extend(related_lab_artifacts_for_runner_job(&store, &run)?);
     Ok((
         RunsOutput::Artifacts(RunsArtifactsOutput {
             command: "runs.artifacts",
             run_id: run_id.to_string(),
-            artifacts: enrich_artifact_links(store.list_artifacts(run_id)?),
+            artifacts: enrich_artifact_links(artifacts),
         }),
         0,
     ))
+}
+
+fn related_lab_artifacts_for_runner_job(
+    store: &ObservationStore,
+    run: &RunRecord,
+) -> homeboy::core::Result<Vec<ArtifactRecord>> {
+    let Some((_runner_id, job_id)) = homeboy::core::runner::mirrored_runner_job_identity(run)
+    else {
+        return Ok(Vec::new());
+    };
+    let mut artifacts = Vec::new();
+    for candidate in store.list_runs(RunListFilter {
+        kind: None,
+        component_id: None,
+        status: None,
+        rig_id: None,
+        limit: Some(1000),
+    })? {
+        if candidate.id == run.id {
+            continue;
+        }
+        if candidate
+            .metadata_json
+            .pointer("/lab/remote_job_id")
+            .and_then(Value::as_str)
+            != Some(job_id.as_str())
+        {
+            continue;
+        }
+        artifacts.extend(store.list_artifacts(&candidate.id)?);
+    }
+    Ok(artifacts)
 }
 
 fn artifact_command(args: RunsArtifactArgs) -> CmdResult<RunsOutput> {
@@ -930,6 +967,64 @@ mod tests {
                 output.artifacts[0].url.as_deref(),
                 Some("https://example.test/")
             );
+        });
+    }
+
+    #[test]
+    fn runner_job_artifact_listing_includes_related_lab_run_artifacts() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let job_id = "job-123";
+            let runner_run = RunRecord {
+                id: "runner-exec-lab-job-123".to_string(),
+                kind: "runner-exec".to_string(),
+                component_id: None,
+                started_at: "2026-06-12T00:00:00Z".to_string(),
+                finished_at: None,
+                status: "running".to_string(),
+                command: Some("homeboy bench".to_string()),
+                cwd: Some("/srv/homeboy/project".to_string()),
+                homeboy_version: None,
+                git_sha: None,
+                rig_id: None,
+                metadata_json: serde_json::json!({
+                    "lab": {
+                        "runner": { "id": "lab" },
+                        "remote_job": { "id": job_id }
+                    }
+                }),
+            };
+            store.upsert_imported_run(&runner_run).expect("runner run");
+            let remote_run = RunRecord {
+                id: "bench-run-1".to_string(),
+                kind: "bench".to_string(),
+                component_id: Some("homeboy".to_string()),
+                started_at: "2026-06-12T00:00:01Z".to_string(),
+                finished_at: Some("2026-06-12T00:10:00Z".to_string()),
+                status: "pass".to_string(),
+                command: Some("homeboy bench".to_string()),
+                cwd: Some("/srv/homeboy/project".to_string()),
+                homeboy_version: None,
+                git_sha: None,
+                rig_id: None,
+                metadata_json: serde_json::json!({
+                    "lab": { "remote_job_id": job_id }
+                }),
+            };
+            store.upsert_imported_run(&remote_run).expect("remote run");
+            let summary = home.path().join("homeboy-summary.json");
+            std::fs::write(&summary, br#"{"passed":true}"#).expect("summary");
+            let artifact = store
+                .record_artifact(&remote_run.id, "homeboy_summary", &summary)
+                .expect("artifact");
+
+            let artifacts = related_lab_artifacts_for_runner_job(&store, &runner_run)
+                .expect("related artifacts");
+
+            assert_eq!(artifacts.len(), 1);
+            assert_eq!(artifacts[0].id, artifact.id);
+            assert_eq!(artifacts[0].run_id, remote_run.id);
         });
     }
 

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -438,7 +438,7 @@ fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
     reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
     require_run(&store, run_id)?;
-    homeboy::core::runner::refresh_mirrored_daemon_evidence(run_id)?;
+    refresh_mirrored_daemon_evidence_best_effort(run_id);
     let run = require_run(&store, run_id)?;
     Ok((
         RunsOutput::Show(RunsShowOutput {
@@ -452,7 +452,7 @@ fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
 pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
     let run = require_run(&store, run_id)?;
-    homeboy::core::runner::refresh_mirrored_daemon_evidence(run_id)?;
+    refresh_mirrored_daemon_evidence_best_effort(run_id);
     homeboy::core::publication_artifacts::index_remote_published_artifact_refs_for_run(
         &store, run_id,
     )?;
@@ -466,6 +466,15 @@ pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
         }),
         0,
     ))
+}
+
+fn refresh_mirrored_daemon_evidence_best_effort(run_id: &str) {
+    if let Err(err) = homeboy::core::runner::refresh_mirrored_daemon_evidence(run_id) {
+        eprintln!(
+            "Warning: could not refresh mirrored Lab runner evidence for `{run_id}`: {}",
+            err.message
+        );
+    }
 }
 
 fn related_lab_artifacts_for_runner_job(
@@ -1025,6 +1034,85 @@ mod tests {
             assert_eq!(artifacts.len(), 1);
             assert_eq!(artifacts[0].id, artifact.id);
             assert_eq!(artifacts[0].run_id, remote_run.id);
+        });
+    }
+
+    #[test]
+    fn runner_job_show_keeps_local_evidence_when_refresh_runner_is_unavailable() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = RunRecord {
+                id: "runner-exec-missing-lab-job-123".to_string(),
+                kind: "runner-exec".to_string(),
+                component_id: None,
+                started_at: "2026-06-12T00:00:00Z".to_string(),
+                finished_at: None,
+                status: "running".to_string(),
+                command: Some("homeboy bench".to_string()),
+                cwd: Some("/srv/homeboy/project".to_string()),
+                homeboy_version: None,
+                git_sha: None,
+                rig_id: None,
+                metadata_json: serde_json::json!({
+                    "lab": {
+                        "runner": { "id": "missing-lab" },
+                        "remote_job": { "id": "job-123" }
+                    }
+                }),
+            };
+            store.upsert_imported_run(&run).expect("runner run");
+
+            let (output, exit_code) = show_run(&run.id).expect("show local evidence");
+
+            assert_eq!(exit_code, 0);
+            let RunsOutput::Show(output) = output else {
+                panic!("expected show output");
+            };
+            assert_eq!(output.run.summary.id, run.id);
+            assert_eq!(output.run.summary.status, "running");
+        });
+    }
+
+    #[test]
+    fn runner_job_artifacts_keep_local_evidence_when_refresh_runner_is_unavailable() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = RunRecord {
+                id: "runner-exec-missing-lab-job-456".to_string(),
+                kind: "runner-exec".to_string(),
+                component_id: None,
+                started_at: "2026-06-12T00:00:00Z".to_string(),
+                finished_at: None,
+                status: "running".to_string(),
+                command: Some("homeboy bench".to_string()),
+                cwd: Some("/srv/homeboy/project".to_string()),
+                homeboy_version: None,
+                git_sha: None,
+                rig_id: None,
+                metadata_json: serde_json::json!({
+                    "lab": {
+                        "runner": { "id": "missing-lab" },
+                        "remote_job": { "id": "job-456" }
+                    }
+                }),
+            };
+            store.upsert_imported_run(&run).expect("runner run");
+            let local = home.path().join("timeout-note.txt");
+            std::fs::write(&local, b"still readable").expect("artifact");
+            let artifact = store
+                .record_artifact(&run.id, "timeout_note", &local)
+                .expect("artifact");
+
+            let (output, exit_code) = artifacts(&run.id).expect("artifacts local evidence");
+
+            assert_eq!(exit_code, 0);
+            let RunsOutput::Artifacts(output) = output else {
+                panic!("expected artifacts output");
+            };
+            assert_eq!(output.artifacts.len(), 1);
+            assert_eq!(output.artifacts[0].id, artifact.id);
         });
     }
 

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -297,6 +297,58 @@ impl ObservationStore {
         Ok(())
     }
 
+    pub fn upsert_imported_run(&self, run: &RunRecord) -> Result<()> {
+        validate_required("run.id", &run.id)?;
+        let metadata_json = serialize_metadata(&run.metadata_json)?;
+        self.connection
+            .execute(
+                r#"
+                INSERT INTO runs(
+                    id,
+                    kind,
+                    component_id,
+                    started_at,
+                    finished_at,
+                    status,
+                    command,
+                    cwd,
+                    homeboy_version,
+                    git_sha,
+                    rig_id,
+                    metadata_json
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                ON CONFLICT(id) DO UPDATE SET
+                    kind = excluded.kind,
+                    component_id = excluded.component_id,
+                    started_at = excluded.started_at,
+                    finished_at = excluded.finished_at,
+                    status = excluded.status,
+                    command = excluded.command,
+                    cwd = excluded.cwd,
+                    homeboy_version = excluded.homeboy_version,
+                    git_sha = excluded.git_sha,
+                    rig_id = excluded.rig_id,
+                    metadata_json = excluded.metadata_json
+                "#,
+                params![
+                    run.id,
+                    run.kind,
+                    run.component_id,
+                    run.started_at,
+                    run.finished_at,
+                    run.status,
+                    run.command,
+                    run.cwd,
+                    run.homeboy_version,
+                    run.git_sha,
+                    run.rig_id,
+                    metadata_json,
+                ],
+            )
+            .map_err(sqlite_error("upsert imported run record"))?;
+        Ok(())
+    }
+
     pub fn import_artifact(&self, artifact: &ArtifactRecord) -> Result<()> {
         validate_required("artifact.id", &artifact.id)?;
         if self.get_run(&artifact.run_id)?.is_none() {

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -13,7 +13,7 @@ use crate::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
 use crate::core::paths;
 
 use super::execution::{canonical_daemon_body, daemon_api_get};
-use super::Runner;
+use super::{load, Runner};
 
 pub fn is_remote_runner_artifact_path(path: &str) -> bool {
     EXECUTION_CONTRACT.artifacts.is_runner_artifact_ref(path)
@@ -200,6 +200,75 @@ pub fn mirror_daemon_evidence(
     }))
 }
 
+pub fn mirror_daemon_job_progress(
+    runner: &Runner,
+    cwd: &str,
+    command: &[String],
+    job: &Job,
+    events: &[JobEvent],
+) -> Result<RunRecord> {
+    let store = ObservationStore::open_initialized()?;
+    mirror_job_run(&store, runner, cwd, command, job, events, &json!({}))
+}
+
+pub fn refresh_mirrored_daemon_evidence(run_id: &str) -> Result<Option<Vec<RunRecord>>> {
+    let store = ObservationStore::open_initialized()?;
+    let Some(run) = store.get_run(run_id)? else {
+        return Ok(None);
+    };
+    let Some((runner_id, job_id)) = mirrored_runner_job_identity(&run) else {
+        return Ok(None);
+    };
+    let runner = load(&runner_id)?;
+    let job = fetch_daemon_job(&runner_id, &job_id)?;
+    let events = fetch_daemon_events(&runner_id, &job_id)?;
+    let result = result_event_data(&events).unwrap_or_else(|| json!({}));
+    let cwd = run.cwd.as_deref().unwrap_or("");
+    let command = run
+        .command
+        .as_ref()
+        .map(|command| vec![command.clone()])
+        .unwrap_or_default();
+    mirror_job_run(&store, &runner, cwd, &command, &job, &events, &result)?;
+    Ok(Some(mirror_remote_observation_runs(&store, &runner, &job)?))
+}
+
+pub fn mirrored_runner_job_identity(run: &RunRecord) -> Option<(String, String)> {
+    let lab = run.metadata_json.get("lab")?;
+    let runner_id = lab
+        .pointer("/runner/id")
+        .or_else(|| lab.get("runner_id"))
+        .and_then(Value::as_str)?;
+    let job_id = lab
+        .pointer("/remote_job/id")
+        .or_else(|| lab.get("remote_job_id"))
+        .and_then(Value::as_str)?;
+    Some((runner_id.to_string(), job_id.to_string()))
+}
+
+fn fetch_daemon_job(runner_id: &str, job_id: &str) -> Result<Job> {
+    let data = daemon_api_get(runner_id, &format!("/jobs/{job_id}"))?;
+    let body = canonical_daemon_body(&data, "daemon job response")?;
+    serde_json::from_value(body["job"].clone())
+        .map_err(|err| Error::internal_json(err.to_string(), Some("parse daemon job".to_string())))
+}
+
+fn fetch_daemon_events(runner_id: &str, job_id: &str) -> Result<Vec<JobEvent>> {
+    let data = daemon_api_get(runner_id, &format!("/jobs/{job_id}/events"))?;
+    let body = canonical_daemon_body(&data, "daemon job events response")?;
+    serde_json::from_value(body["events"].clone()).map_err(|err| {
+        Error::internal_json(err.to_string(), Some("parse daemon job events".to_string()))
+    })
+}
+
+fn result_event_data(events: &[JobEvent]) -> Option<Value> {
+    events
+        .iter()
+        .rev()
+        .find(|event| matches!(event.kind, crate::core::api_jobs::JobEventKind::Result))
+        .and_then(|event| event.data.clone())
+}
+
 fn mirrored_patch_result(
     store: &ObservationStore,
     runner: &Runner,
@@ -291,12 +360,13 @@ fn mirror_remote_observation_runs(
     store: &ObservationStore,
     runner: &Runner,
     job: &Job,
-) -> Result<()> {
+) -> Result<Vec<RunRecord>> {
     let data = daemon_api_get(&runner.id, "/runs?limit=100")?;
     let body = canonical_daemon_body(&data, "runner runs response")?;
     let Some(remote_runs) = body.get("runs").and_then(Value::as_array) else {
-        return Ok(());
+        return Ok(Vec::new());
     };
+    let mut mirrored = Vec::new();
     for summary in remote_runs {
         let Some(run_id) = summary.get("id").and_then(Value::as_str) else {
             continue;
@@ -317,15 +387,13 @@ fn mirror_remote_observation_runs(
         for artifact in remote_detail_artifacts(detail, runner, &run.id)? {
             import_artifact_if_absent(store, &artifact)?;
         }
+        mirrored.push(run);
     }
-    Ok(())
+    Ok(mirrored)
 }
 
 fn import_run_if_absent(store: &ObservationStore, run: &RunRecord) -> Result<()> {
-    if store.get_run(&run.id)?.is_some() {
-        return Ok(());
-    }
-    store.import_run(run)
+    store.upsert_imported_run(run)
 }
 
 fn import_artifact_if_absent(store: &ObservationStore, artifact: &ArtifactRecord) -> Result<()> {

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -17,7 +17,7 @@ use super::broker_http;
 use super::capabilities::{
     runner_capability_snapshot_for_preflight, validate_runner_capability_preflight,
 };
-use super::evidence::mirror_daemon_evidence;
+use super::evidence::{mirror_daemon_evidence, mirror_daemon_job_progress};
 use super::normalize_runner_command_env;
 use super::resource_metrics::{
     measured_command_output, measured_command_output_until_cancelled, RunnerResourceMetrics,
@@ -282,11 +282,14 @@ fn exec_via_reverse_broker(
         JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
     ) {
         if Instant::now() >= deadline {
-            return Err(cancel_daemon_job_after_timeout(
-                &client,
-                broker_url,
-                &runner.id,
-                &job.id.to_string(),
+            let events =
+                fetch_daemon_events(&client, broker_url, &job.id.to_string()).unwrap_or_default();
+            return Err(daemon_job_wait_timeout(
+                runner,
+                &cwd,
+                &command,
+                &job,
+                &events,
                 "reverse runner job",
             ));
         }
@@ -403,11 +406,14 @@ fn exec_via_daemon(
         JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
     ) {
         if Instant::now() >= deadline {
-            return Err(cancel_daemon_job_after_timeout(
-                &client,
-                local_url,
-                &runner.id,
-                &job.id.to_string(),
+            let events =
+                fetch_daemon_events(&client, local_url, &job.id.to_string()).unwrap_or_default();
+            return Err(daemon_job_wait_timeout(
+                runner,
+                &cwd,
+                &command,
+                &job,
+                &events,
                 "runner daemon job",
             ));
         }
@@ -511,58 +517,51 @@ fn daemon_job_context_error(runner_id: &str, job_id: &str, err: Error) -> Error 
     with_context
 }
 
-fn cancel_daemon_job_after_timeout(
-    client: &Client,
-    local_url: &str,
-    runner_id: &str,
-    job_id: &str,
+fn daemon_job_wait_timeout(
+    runner: &Runner,
+    cwd: &str,
+    command: &[String],
+    job: &Job,
+    events: &[JobEvent],
     label: &str,
 ) -> Error {
+    let job_id = job.id.to_string();
+    let mirrored = mirror_daemon_job_progress(runner, cwd, command, job, events);
     let timeout_hint = format!(
         "Set controller-side `{RUNNER_EXEC_WAIT_TIMEOUT_ENV}` before invoking homeboy to change this wait budget, e.g. `{RUNNER_EXEC_WAIT_TIMEOUT_ENV}=2400 homeboy ...`; workload settings are applied inside the remote job and cannot extend the controller wait."
     );
-    match cancel_daemon_job(client, local_url, job_id) {
-        Ok(()) => Error::internal_unexpected(format!(
-            "{label} {job_id} on runner {runner_id} did not finish before timeout; cancellation was requested"
+    let mut error = Error::internal_unexpected(format!(
+        "{label} {job_id} on runner {} did not finish before timeout; the remote job is still in flight and was not cancelled",
+        runner.id
+    ));
+    match mirrored {
+        Ok(run) => {
+            error = error
+                .with_hint(format!(
+                    "Mirrored controller timeout state as run `{}`; inspect it with `homeboy runs show {}`.",
+                    run.id, run.id
+                ))
+                .with_hint(format!(
+                    "After the remote job finishes, run `homeboy runs artifacts {}` to refresh and list mirrored Lab artifacts without SSH temp-directory spelunking.",
+                    run.id
+                ));
+        }
+        Err(err) => {
+            error = error.with_hint(format!(
+                "Could not persist a local timeout mirror for remote job `{job_id}`: {}",
+                err.message
+            ));
+        }
+    }
+    error
+        .with_hint(format!(
+            "Check remote progress with `homeboy runs list --runner {} --status running --limit 20`.",
+            runner.id
         ))
         .with_hint(format!(
-            "Confirm cleanup with `homeboy http get {}/jobs/{job_id}`.",
-            local_url.trim_end_matches('/')
+            "Runner daemon job id `{job_id}` was already dispatched; wait for it to finish or cancel it explicitly through the runner daemon if needed."
         ))
-        .with_hint(timeout_hint),
-        Err(err) => Error::internal_unexpected(format!(
-            "{label} {job_id} on runner {runner_id} did not finish before timeout; automatic cancellation failed: {}",
-            err.message
-        ))
-        .with_hint(format!(
-            "Run `homeboy http request POST {}/jobs/{job_id}/cancel` to cancel the remote job.",
-            local_url.trim_end_matches('/')
-        ))
-        .with_hint(timeout_hint),
-    }
-}
-
-fn cancel_daemon_job(client: &Client, local_url: &str, job_id: &str) -> Result<()> {
-    let response = client
-        .post(format!(
-            "{}/jobs/{job_id}/cancel",
-            local_url.trim_end_matches('/')
-        ))
-        .send()
-        .map_err(|err| Error::internal_unexpected(format!("cancel runner daemon job: {err}")))?;
-    let envelope: DaemonEnvelope = response.json().map_err(|err| {
-        Error::internal_json(
-            err.to_string(),
-            Some("parse daemon job cancellation response".to_string()),
-        )
-    })?;
-    if !envelope.success {
-        return Err(Error::internal_unexpected(format!(
-            "daemon job cancellation failed: {}",
-            envelope.error.unwrap_or(Value::Null)
-        )));
-    }
-    Ok(())
+        .with_hint(timeout_hint)
 }
 
 fn runner_exec_wait_timeout() -> Duration {
@@ -1549,59 +1548,67 @@ mod tests {
     }
 
     #[test]
-    fn timeout_cleanup_requests_remote_job_cancellation() {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
-        let addr = listener.local_addr().expect("addr");
-        let seen_path = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
-        let server_seen_path = seen_path.clone();
-        std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().expect("accept");
-            let mut buffer = [0; 4096];
-            let bytes = std::io::Read::read(&mut stream, &mut buffer).expect("read request");
-            let request = String::from_utf8_lossy(&buffer[..bytes]);
-            let request_line = request.lines().next().expect("request line");
-            *server_seen_path.lock().expect("seen path") = request_line.to_string();
-            let body = serde_json::json!({
-                "success": true,
-                "data": { "body": { "job": { "status": "cancelled" } } }
-            })
-            .to_string();
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                body.len(),
-                body
+    fn timeout_mirrors_remote_job_without_cancelling() {
+        crate::test_support::with_isolated_home(|_| {
+            let runner = ssh_runner();
+            let job_id = uuid::Uuid::new_v4();
+            let job = Job {
+                id: job_id,
+                operation: "runner.exec".to_string(),
+                status: JobStatus::Running,
+                created_at_ms: 1_700_000_000_000,
+                updated_at_ms: 1_700_000_001_000,
+                started_at_ms: Some(1_700_000_000_000),
+                finished_at_ms: None,
+                event_count: 0,
+                source_snapshot: None,
+                stale_reason: None,
+                target_runner_id: None,
+                target_project_id: None,
+                claim_id: None,
+                claimed_by_runner_id: None,
+                claimed_at_ms: None,
+                claim_expires_at_ms: None,
+                artifacts: Vec::new(),
+            };
+            let err = daemon_job_wait_timeout(
+                &runner,
+                "/srv/homeboy/project",
+                &["homeboy".to_string(), "bench".to_string()],
+                &job,
+                &[],
+                "runner daemon job",
             );
-            std::io::Write::write_all(&mut stream, response.as_bytes()).expect("write response");
+            let run_id = format!("runner-exec-lab-{job_id}");
+
+            assert!(err.message.contains("runner daemon job"));
+            assert!(err.message.contains(job_id.to_string().as_str()));
+            assert!(err.message.contains("lab"));
+            assert!(err.message.contains("was not cancelled"));
+            assert!(err.hints.iter().any(|hint| hint
+                .message
+                .contains(&format!("homeboy runs show {run_id}"))));
+            assert!(err.hints.iter().any(|hint| hint
+                .message
+                .contains(&format!("homeboy runs artifacts {run_id}"))));
+            assert!(err.hints.iter().any(|hint| {
+                hint.message.contains(RUNNER_EXEC_WAIT_TIMEOUT_ENV)
+                    && hint.message.contains("controller-side")
+                    && hint.message.contains("workload settings")
+            }));
+
+            let store =
+                crate::core::observation::ObservationStore::open_initialized().expect("store");
+            let mirrored = store
+                .get_run(&run_id)
+                .expect("get mirrored run")
+                .expect("mirrored run");
+            assert_eq!(mirrored.status, "running");
+            assert_eq!(
+                mirrored.metadata_json["lab"]["remote_job"]["id"].as_str(),
+                Some(job_id.to_string().as_str())
+            );
         });
-
-        let client = Client::builder()
-            .timeout(Duration::from_secs(10))
-            .build()
-            .expect("client");
-        let err = cancel_daemon_job_after_timeout(
-            &client,
-            &format!("http://{addr}"),
-            "homeboy-lab",
-            "job-123",
-            "runner daemon job",
-        );
-
-        assert!(err.message.contains("runner daemon job job-123"));
-        assert!(err.message.contains("homeboy-lab"));
-        assert!(err.message.contains("cancellation was requested"));
-        assert!(err
-            .hints
-            .iter()
-            .any(|hint| hint.message.contains("homeboy http get http://")));
-        assert!(err.hints.iter().any(|hint| {
-            hint.message.contains(RUNNER_EXEC_WAIT_TIMEOUT_ENV)
-                && hint.message.contains("controller-side")
-                && hint.message.contains("workload settings")
-        }));
-        assert_eq!(
-            seen_path.lock().expect("seen path").as_str(),
-            "POST /jobs/job-123/cancel HTTP/1.1"
-        );
     }
 
     #[test]

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -56,7 +56,8 @@ pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use evidence::runner_artifact_store_token;
 pub use evidence::{
     download_remote_artifact, is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,
-    is_retrievable_runner_artifact, reportable_artifact_evidence_path, RemoteArtifactDownload,
+    is_retrievable_runner_artifact, mirrored_runner_job_identity, refresh_mirrored_daemon_evidence,
+    reportable_artifact_evidence_path, RemoteArtifactDownload,
 };
 pub(crate) use execution::{
     daemon_api_get, execute_runner_process_until_cancelled, prepare_daemon_local_process,


### PR DESCRIPTION
## Summary
- Keep Lab runner daemon jobs discoverable when the local controller wait times out by mirroring a local `runner-exec-<runner>-<job>` run record instead of cancelling the remote job.
- Refresh mirrored runner evidence from `homeboy runs show <run-id>` / `homeboy runs artifacts <run-id>` so remote bench runs and artifacts become visible after the job finishes.
- Include related remote Lab run artifacts when listing artifacts for the mirrored runner job id.

Fixes #4142.

## Tests
- `cargo fmt --check`
- `cargo test core::runner::execution::tests`
- `cargo test core::runner::evidence::tests`
- `cargo test commands::runs::tests`
- `cargo test` *(fails in `tests/core_agnostic_test.rs` on pre-existing core-boundary audit baseline findings unrelated to this change; targeted affected modules pass)*

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner timeout evidence mirroring flow, added regression coverage, and ran verification; Chris remains responsible for review and merge decisions.