### PR TITLE
fix: support secret-safe runner env

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -8,6 +8,12 @@ homeboy runner <COMMAND>
 
 `runner` manages durable execution backends. SSH runners are a capability on a `homeboy server` record, so the common Lab flow uses one ID for the machine and its runner. Local runners remain standalone because they describe this machine rather than an SSH server.
 
+Runner configuration separates printable environment from secrets:
+
+- `env` is for non-secret values that are useful in diagnostics, such as `HOMEBOY_PUBLIC_ARTIFACT_BASE_URL`.
+- `secret_env` is for execution-time secret references like `{ "env": "NAME" }` or `{ "file": "~/.config/homeboy/secrets/name" }`.
+- Command output redacts sensitive names in `env` and prints only `secret_env` references, never resolved secret values.
+
 ## Subcommands
 
 ### `add`

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -346,10 +346,10 @@ Path rules:
 
 Runner job environment:
 
-- `homeboy runner env <runner-id>` shows the effective environment Homeboy injects into runner jobs before command execution.
-- Values are redacted by default because runner env commonly contains tokens. Use `--show-values` only in trusted local/operator contexts.
+- `homeboy runner env <runner-id>` shows configured public runner env plus `secret_env` keys/references for runner jobs. It does not resolve or print secret values.
+- Public `env` values are redacted by default because legacy configs may still contain tokens. Use `--show-values` only in trusted local/operator contexts; `secret_env` remains references-only even with `--show-values`.
 - `homeboy ssh <server> -- printenv NAME` inspects the server login shell environment. It does not include runner job env unless the variable is also configured on the server shell.
-- Use `homeboy runner exec <runner-id> -- printenv NAME` or `homeboy runner env <runner-id> --show-values` when debugging Lab job environment.
+- Use `homeboy runner exec <runner-id> -- printenv NAME` for final execution-time proof when debugging resolved runner job environment.
 
 Runner metrics:
 

--- a/docs/schemas/server-schema.md
+++ b/docs/schemas/server-schema.md
@@ -28,6 +28,7 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
       "snapshot_excludes": ["string"]
     },
     "env": {},
+    "secret_env": {},
     "resources": {}
   },
   "forward_agent": boolean
@@ -78,6 +79,7 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
       "snapshot_excludes": ["generated-state", "generated-state/**"]
     },
     "env": {},
+    "secret_env": {},
     "resources": {}
   },
   "forward_agent": true
@@ -87,6 +89,35 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
 ## Runner Capability
 
 Use `homeboy runner enable <server_id>` to make an SSH server runner-capable. The server ID is also the runner ID, matching the common runner-machine model: one machine, one server, one runner-capable server.
+
+### Runner Environment
+
+Use `runner.env` for non-secret values that are safe to show in diagnostics, such as public artifact URLs:
+
+```json
+{
+  "runner": {
+    "env": {
+      "HOMEBOY_PUBLIC_ARTIFACT_BASE_URL": "https://artifacts.example.test"
+    }
+  }
+}
+```
+
+Use `runner.secret_env` for values that must be read at execution time instead of stored in plaintext config. Each key is the environment variable exposed to the runner process. The value references either an environment variable visible to the Homeboy process on the runner or a file on the runner machine:
+
+```json
+{
+  "runner": {
+    "secret_env": {
+      "OPENAI_API_KEY": { "env": "OPENAI_API_KEY" },
+      "SERVICE_TOKEN": { "file": "~/.config/homeboy/secrets/service-token" }
+    }
+  }
+}
+```
+
+Homeboy command output redacts sensitive names in `env` and keeps `secret_env` as references only. Secret file contents and referenced environment variable values are not printed by runner config/status diagnostics.
 
 ## Managed SSH Sessions
 

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -10,7 +10,7 @@ use homeboy::core::runner::{
     Runner, RunnerConnectReport, RunnerDisconnectReport, RunnerExecOutput, RunnerKind,
     RunnerStatusReport,
 };
-use homeboy::core::server::{RunnerPolicy, RunnerSettings};
+use homeboy::core::server::{RunnerPolicy, RunnerSecretEnvRef, RunnerSettings};
 use homeboy::core::{EntityCrudOutput, MergeOutput};
 
 use super::{CmdResult, DynamicSetArgs};
@@ -57,7 +57,18 @@ pub struct RunnerEnvOutput {
     pub source: String,
     pub values_redacted: bool,
     pub env: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub secret_env: BTreeMap<String, RunnerSecretEnvReferenceOutput>,
     pub diagnostics: RunnerEnvDiagnostics,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunnerSecretEnvReferenceOutput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    pub values_redacted: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -860,6 +871,7 @@ fn exec(
 }
 
 fn env(runner_id: &str, show_values: bool) -> CmdResult<RunnerEnvOutput> {
+    let runner = runner::load(runner_id)?;
     let effective_env = runner::effective_env(runner_id)?;
     let env = effective_env
         .into_iter()
@@ -874,6 +886,11 @@ fn env(runner_id: &str, show_values: bool) -> CmdResult<RunnerEnvOutput> {
             )
         })
         .collect();
+    let secret_env = runner
+        .secret_env
+        .into_iter()
+        .map(|(key, reference)| (key, secret_env_reference_output(reference)))
+        .collect();
 
     Ok((
         RunnerEnvOutput {
@@ -882,13 +899,22 @@ fn env(runner_id: &str, show_values: bool) -> CmdResult<RunnerEnvOutput> {
             source: "runner_job_env".to_string(),
             values_redacted: !show_values,
             env,
+            secret_env,
             diagnostics: RunnerEnvDiagnostics {
                 server_shell_env: "Use `homeboy ssh <server> -- printenv NAME` to inspect the server login shell environment; it does not include runner job env by default.".to_string(),
-                runner_job_env: "This output is the configured env Homeboy injects into `homeboy runner exec` jobs before command execution.".to_string(),
+                runner_job_env: "This output shows configured public env Homeboy injects into runner jobs. secret_env entries are shown as refs only; their values resolve on the runner at execution time and are never printed here.".to_string(),
             },
         },
         0,
     ))
+}
+
+fn secret_env_reference_output(reference: RunnerSecretEnvRef) -> RunnerSecretEnvReferenceOutput {
+    RunnerSecretEnvReferenceOutput {
+        env: reference.env,
+        file: reference.file,
+        values_redacted: true,
+    }
 }
 
 #[cfg(test)]
@@ -972,6 +998,7 @@ mod tests {
             source: "runner_job_env".to_string(),
             values_redacted: true,
             env: BTreeMap::from([("TOKEN".to_string(), REDACTED_ENV_VALUE.to_string())]),
+            secret_env: BTreeMap::new(),
             diagnostics: RunnerEnvDiagnostics {
                 server_shell_env: "shell".to_string(),
                 runner_job_env: "runner".to_string(),
@@ -984,5 +1011,47 @@ mod tests {
         assert_eq!(value["source"], "runner_job_env");
         assert_eq!(value["values_redacted"], true);
         assert_eq!(value["env"]["TOKEN"], REDACTED_ENV_VALUE);
+    }
+
+    #[test]
+    fn runner_env_output_reports_secret_env_refs_without_values() {
+        let output = RunnerEnvOutput {
+            command: "runner.env".to_string(),
+            runner_id: "lab".to_string(),
+            source: "runner_job_env".to_string(),
+            values_redacted: false,
+            env: BTreeMap::from([(
+                "HOMEBOY_PUBLIC_ARTIFACT_BASE_URL".to_string(),
+                "https://artifacts.example.test".to_string(),
+            )]),
+            secret_env: BTreeMap::from([(
+                "OPENAI_API_KEY".to_string(),
+                RunnerSecretEnvReferenceOutput {
+                    env: Some("OPENAI_API_KEY".to_string()),
+                    file: None,
+                    values_redacted: true,
+                },
+            )]),
+            diagnostics: RunnerEnvDiagnostics {
+                server_shell_env: "shell".to_string(),
+                runner_job_env: "runner".to_string(),
+            },
+        };
+
+        let value = serde_json::to_value(output).expect("serialize output");
+
+        assert_eq!(
+            value["env"]["HOMEBOY_PUBLIC_ARTIFACT_BASE_URL"],
+            "https://artifacts.example.test"
+        );
+        assert_eq!(
+            value["secret_env"]["OPENAI_API_KEY"]["env"],
+            "OPENAI_API_KEY"
+        );
+        assert_eq!(
+            value["secret_env"]["OPENAI_API_KEY"]["values_redacted"],
+            true
+        );
+        assert!(!value.to_string().contains("dummy-secret"));
     }
 }

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -4,6 +4,7 @@ use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
 use serde_json::Value;
 
+use homeboy::core::redaction::RedactionPolicy;
 use homeboy::core::runner::{
     self, ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput,
     Runner, RunnerConnectReport, RunnerDisconnectReport, RunnerExecOutput, RunnerKind,
@@ -532,8 +533,13 @@ fn redact_runner_output_env(output: &mut RunnerOutput) {
 }
 
 fn redact_runner_env(runner: &mut Runner) {
-    for value in runner.env.values_mut() {
-        *value = REDACTED_ENV_VALUE.to_string();
+    let policy = RedactionPolicy::default();
+    for (key, value) in runner.env.iter_mut() {
+        if policy.is_sensitive_key(key) {
+            *value = REDACTED_ENV_VALUE.to_string();
+        } else {
+            *value = policy.redact_string(value);
+        }
     }
 }
 
@@ -589,6 +595,7 @@ fn add(input: RunnerAddInput) -> CmdResult<RunnerOutput> {
             workspace_root: input.workspace_root,
             settings: input.settings,
             env: HashMap::new(),
+            secret_env: HashMap::new(),
             resources: HashMap::<String, Value>::new(),
             policy: RunnerPolicy::default(),
         };
@@ -897,8 +904,12 @@ mod tests {
             settings: RunnerSettings::default(),
             env: HashMap::from([
                 ("OPENCODE_API_KEY".to_string(), "secret-token".to_string()),
-                ("PATH".to_string(), "/secret/bin".to_string()),
+                (
+                    "HOMEBOY_PUBLIC_ARTIFACT_BASE_URL".to_string(),
+                    "https://artifacts.example.test".to_string(),
+                ),
             ]),
+            secret_env: HashMap::new(),
             resources: HashMap::new(),
             policy: RunnerPolicy::default(),
         }
@@ -922,9 +933,11 @@ mod tests {
             value["entity"]["env"]["OPENCODE_API_KEY"],
             REDACTED_ENV_VALUE
         );
-        assert_eq!(value["entity"]["env"]["PATH"], REDACTED_ENV_VALUE);
+        assert_eq!(
+            value["entity"]["env"]["HOMEBOY_PUBLIC_ARTIFACT_BASE_URL"],
+            "https://artifacts.example.test"
+        );
         assert!(!value.to_string().contains("secret-token"));
-        assert!(!value.to_string().contains("/secret/bin"));
     }
 
     #[test]
@@ -944,9 +957,11 @@ mod tests {
             value["entities"][0]["env"]["OPENCODE_API_KEY"],
             REDACTED_ENV_VALUE
         );
-        assert_eq!(value["entities"][0]["env"]["PATH"], REDACTED_ENV_VALUE);
+        assert_eq!(
+            value["entities"][0]["env"]["HOMEBOY_PUBLIC_ARTIFACT_BASE_URL"],
+            "https://artifacts.example.test"
+        );
         assert!(!value.to_string().contains("secret-token"));
-        assert!(!value.to_string().contains("/secret/bin"));
     }
 
     #[test]

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
+use homeboy::core::redaction::RedactionPolicy;
 use homeboy::core::server::{self, Server, ServerSessionConfig, SshClient};
 use homeboy::core::{EntityCrudOutput, MergeOutput};
 
@@ -16,6 +17,8 @@ pub struct ServerExtra {
 }
 
 pub type ServerOutput = EntityCrudOutput<Server, ServerExtra>;
+
+const REDACTED_ENV_VALUE: &str = "[redacted]";
 
 #[derive(Debug, Serialize)]
 
@@ -144,7 +147,7 @@ enum KeyCommand {
 }
 
 pub fn run(args: ServerArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<ServerOutput> {
-    match args.command {
+    map_server_output(match args.command {
         ServerCommand::Create {
             json,
             skip_existing,
@@ -231,6 +234,42 @@ pub fn run(args: ServerArgs, _global: &crate::commands::GlobalArgs) -> CmdResult
         ServerCommand::Status { server_id } => session_status(&server_id),
         ServerCommand::Disconnect { server_id } => session_disconnect(&server_id),
         ServerCommand::Key(key_args) => run_key(key_args),
+    })
+}
+
+fn map_server_output(result: CmdResult<ServerOutput>) -> CmdResult<ServerOutput> {
+    result.map(|(mut output, exit_code)| {
+        redact_server_output_env(&mut output);
+        (output, exit_code)
+    })
+}
+
+fn redact_server_output_env(output: &mut ServerOutput) {
+    if let Some(server) = output.entity.as_mut() {
+        redact_server_env(server);
+    }
+    for server in &mut output.entities {
+        redact_server_env(server);
+    }
+}
+
+fn redact_server_env(server: &mut Server) {
+    let policy = RedactionPolicy::default();
+    for (key, value) in server.env.iter_mut() {
+        if policy.is_sensitive_key(key) {
+            *value = REDACTED_ENV_VALUE.to_string();
+        } else {
+            *value = policy.redact_string(value);
+        }
+    }
+    if let Some(runner) = server.runner.as_mut() {
+        for (key, value) in runner.env.iter_mut() {
+            if policy.is_sensitive_key(key) {
+                *value = REDACTED_ENV_VALUE.to_string();
+            } else {
+                *value = policy.redact_string(value);
+            }
+        }
     }
 }
 
@@ -502,4 +541,58 @@ fn key_import(server_id: &str, private_key_path: &str) -> CmdResult<ServerOutput
         },
         0,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy::core::server::{RunnerSecretEnvRef, ServerRunner};
+    use std::collections::HashMap;
+
+    #[test]
+    fn server_output_redacts_sensitive_env_but_keeps_public_runner_env_visible() {
+        let mut output = ServerOutput {
+            command: "server.show".to_string(),
+            entity: Some(Server {
+                id: "lab".to_string(),
+                aliases: Vec::new(),
+                host: "example.test".to_string(),
+                user: "runner".to_string(),
+                port: 22,
+                identity_file: None,
+                kind: None,
+                auth: None,
+                env: HashMap::from([("OPENAI_API_KEY".to_string(), "dummy-secret".to_string())]),
+                runner: Some(ServerRunner {
+                    env: HashMap::from([(
+                        "HOMEBOY_PUBLIC_ARTIFACT_BASE_URL".to_string(),
+                        "https://artifacts.example.test".to_string(),
+                    )]),
+                    secret_env: HashMap::from([(
+                        "OPENAI_API_KEY".to_string(),
+                        RunnerSecretEnvRef {
+                            env: Some("OPENAI_API_KEY".to_string()),
+                            file: None,
+                        },
+                    )]),
+                    ..Default::default()
+                }),
+            }),
+            ..Default::default()
+        };
+
+        redact_server_output_env(&mut output);
+        let value = serde_json::to_value(output).expect("serialize output");
+
+        assert_eq!(value["entity"]["env"]["OPENAI_API_KEY"], REDACTED_ENV_VALUE);
+        assert_eq!(
+            value["entity"]["runner"]["env"]["HOMEBOY_PUBLIC_ARTIFACT_BASE_URL"],
+            "https://artifacts.example.test"
+        );
+        assert_eq!(
+            value["entity"]["runner"]["secret_env"]["OPENAI_API_KEY"]["env"],
+            "OPENAI_API_KEY"
+        );
+        assert!(!value.to_string().contains("dummy-secret"));
+    }
 }

--- a/src/core/runner/capabilities.rs
+++ b/src/core/runner/capabilities.rs
@@ -550,6 +550,7 @@ mod tests {
                 ..Default::default()
             },
             env: Default::default(),
+            secret_env: Default::default(),
             resources: Default::default(),
             policy: RunnerPolicy::default(),
         }

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -646,6 +646,7 @@ mod tests {
                 ..Default::default()
             },
             env: Default::default(),
+            secret_env: Default::default(),
             resources: Default::default(),
             policy: RunnerPolicy::default(),
         }

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -745,7 +745,9 @@ pub(crate) fn prepare_runner_process(request: RunnerProcessRequest) -> Result<Ru
 
     let mut env = runner.env.clone();
     env.extend(request.env);
-    env.extend(resolve_runner_secret_env(&runner.secret_env)?);
+    if runner.kind == RunnerKind::Local {
+        env.extend(resolve_runner_secret_env(&runner.secret_env)?);
+    }
     normalize_runner_command_env(&mut env);
 
     let source_snapshot = request
@@ -1142,7 +1144,7 @@ fn daemon_failure_message(status_code: u16, envelope: &DaemonEnvelope) -> String
 mod tests {
     use super::*;
     use crate::core::error::ErrorCode;
-    use crate::core::server::{self, RunnerPolicy, RunnerSettings};
+    use crate::core::server::{self, RunnerPolicy, RunnerSecretEnvRef, RunnerSettings};
 
     fn ssh_runner() -> Runner {
         Runner {
@@ -1242,6 +1244,83 @@ mod tests {
 
             assert_eq!(plan.runner.id, "lab");
             assert_eq!(plan.cwd, "/srv/homeboy/project");
+        });
+    }
+
+    #[test]
+    fn remote_daemon_secret_env_refs_resolve_only_on_runner_side() {
+        crate::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let workspace = temp.path().join("workspace");
+            std::fs::create_dir_all(&workspace).expect("workspace");
+            let secret_file = temp.path().join("runner-secret");
+            std::fs::write(&secret_file, "dummy-runner-secret\n").expect("secret file");
+            let missing_controller_file = temp.path().join("missing-controller-secret");
+
+            let mut controller_runner = ssh_runner();
+            controller_runner.workspace_root = Some(workspace.display().to_string());
+            controller_runner.secret_env.insert(
+                "OPENAI_API_KEY".to_string(),
+                RunnerSecretEnvRef {
+                    env: None,
+                    file: Some(missing_controller_file.display().to_string()),
+                },
+            );
+
+            let controller_plan = prepare_runner_process(RunnerProcessRequest {
+                runner_id: "lab".to_string(),
+                runner: Some(controller_runner),
+                cwd: Some(workspace.display().to_string()),
+                project_id: None,
+                command: vec!["true".to_string()],
+                env: Default::default(),
+                capture_patch: false,
+                raw_exec: false,
+                source_snapshot: Some(SourceSnapshot::existing_remote(
+                    "lab",
+                    &workspace.display().to_string(),
+                    Some(&workspace.display().to_string()),
+                )),
+                require_paths: Vec::new(),
+                validate_require_paths_on_host: false,
+            })
+            .expect("controller prep keeps secret refs unresolved for SSH runner");
+
+            assert!(!controller_plan.env.contains_key("OPENAI_API_KEY"));
+
+            let mut daemon_runner = ssh_runner();
+            daemon_runner.workspace_root = Some(workspace.display().to_string());
+            daemon_runner.secret_env.insert(
+                "OPENAI_API_KEY".to_string(),
+                RunnerSecretEnvRef {
+                    env: None,
+                    file: Some(secret_file.display().to_string()),
+                },
+            );
+
+            let daemon_plan = prepare_daemon_local_process(RunnerProcessRequest {
+                runner_id: "lab".to_string(),
+                runner: Some(daemon_runner),
+                cwd: Some(workspace.display().to_string()),
+                project_id: None,
+                command: vec!["true".to_string()],
+                env: Default::default(),
+                capture_patch: false,
+                raw_exec: false,
+                source_snapshot: Some(SourceSnapshot::existing_remote(
+                    "lab",
+                    &workspace.display().to_string(),
+                    Some(&workspace.display().to_string()),
+                )),
+                require_paths: Vec::new(),
+                validate_require_paths_on_host: true,
+            })
+            .expect("daemon prep resolves secret refs on runner side");
+
+            assert_eq!(
+                daemon_plan.env.get("OPENAI_API_KEY").map(String::as_str),
+                Some("dummy-runner-secret")
+            );
         });
     }
 

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -18,11 +18,11 @@ use super::capabilities::{
     runner_capability_snapshot_for_preflight, validate_runner_capability_preflight,
 };
 use super::evidence::{mirror_daemon_evidence, mirror_daemon_job_progress};
-use super::normalize_runner_command_env;
 use super::resource_metrics::{
     measured_command_output, measured_command_output_until_cancelled, RunnerResourceMetrics,
 };
 use super::{load, status, Runner, RunnerCapabilityPreflight, RunnerKind, RunnerTunnelMode};
+use super::{normalize_runner_command_env, resolve_runner_secret_env};
 
 const DEFAULT_RUNNER_EXEC_WAIT_TIMEOUT_SECS: u64 = 20 * 60;
 pub(crate) const RUNNER_EXEC_WAIT_TIMEOUT_ENV: &str = "HOMEBOY_RUNNER_EXEC_WAIT_TIMEOUT_SECS";
@@ -745,6 +745,7 @@ pub(crate) fn prepare_runner_process(request: RunnerProcessRequest) -> Result<Ru
 
     let mut env = runner.env.clone();
     env.extend(request.env);
+    env.extend(resolve_runner_secret_env(&runner.secret_env)?);
     normalize_runner_command_env(&mut env);
 
     let source_snapshot = request
@@ -799,16 +800,28 @@ pub(crate) fn prepare_daemon_local_process(
             ]),
         )
     })?;
-    let runner = Runner {
-        id: request.runner_id,
-        kind: RunnerKind::Local,
-        server_id: None,
-        workspace_root: Some(cwd.clone()),
-        settings: server::RunnerSettings::default(),
-        env: HashMap::new(),
-        resources: HashMap::new(),
-        policy: server::RunnerPolicy::default(),
-    };
+    let runner = request
+        .runner
+        .map(|mut runner| {
+            if runner.id.is_empty() {
+                runner.id = request.runner_id.clone();
+            }
+            runner.kind = RunnerKind::Local;
+            runner.server_id = None;
+            runner.workspace_root = runner.workspace_root.or_else(|| Some(cwd.clone()));
+            runner
+        })
+        .unwrap_or_else(|| Runner {
+            id: request.runner_id,
+            kind: RunnerKind::Local,
+            server_id: None,
+            workspace_root: Some(cwd.clone()),
+            settings: server::RunnerSettings::default(),
+            env: HashMap::new(),
+            secret_env: HashMap::new(),
+            resources: HashMap::new(),
+            policy: server::RunnerPolicy::default(),
+        });
     validate_runner_process_cwd(&runner, &cwd)?;
     validate_required_paths(
         &runner,
@@ -816,7 +829,9 @@ pub(crate) fn prepare_daemon_local_process(
         request.validate_require_paths_on_host,
     )?;
 
-    let mut env = request.env;
+    let mut env = runner.env.clone();
+    env.extend(request.env);
+    env.extend(resolve_runner_secret_env(&runner.secret_env)?);
     normalize_runner_command_env(&mut env);
     let source_snapshot = request.source_snapshot.unwrap_or_else(|| {
         SourceSnapshot::collect_local(&runner.id, Path::new(&cwd), Some(&cwd), "existing_remote")
@@ -1140,6 +1155,7 @@ mod tests {
                 ..Default::default()
             },
             env: Default::default(),
+            secret_env: Default::default(),
             resources: Default::default(),
             policy: RunnerPolicy::default(),
         }

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -7,7 +7,7 @@ use crate::core::config::{self, ConfigEntity};
 use crate::core::defaults;
 use crate::core::error::{Error, Result};
 use crate::core::output::{BatchResult, CreateOutput, CreateResult, MergeOutput, MergeResult};
-use crate::core::server::{self, RunnerPolicy, RunnerSettings, ServerRunner};
+use crate::core::server::{self, RunnerPolicy, RunnerSecretEnvRef, RunnerSettings, ServerRunner};
 
 mod apply;
 mod broker_http;
@@ -111,6 +111,8 @@ pub struct Runner {
     pub settings: RunnerSettings,
     #[serde(default)]
     pub env: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub secret_env: HashMap<String, RunnerSecretEnvRef>,
     #[serde(default)]
     pub resources: HashMap<String, Value>,
     #[serde(default, skip_serializing_if = "RunnerPolicy::is_empty")]
@@ -419,9 +421,74 @@ fn runner_from_server(server_id: &str, runner: ServerRunner) -> Runner {
         workspace_root: runner.workspace_root,
         settings: runner.settings,
         env: runner.env,
+        secret_env: runner.secret_env,
         resources: runner.resources,
         policy: runner.policy,
     }
+}
+
+pub(crate) fn resolve_runner_secret_env(
+    secret_env: &HashMap<String, RunnerSecretEnvRef>,
+) -> Result<HashMap<String, String>> {
+    let mut resolved = HashMap::new();
+    for (name, source) in secret_env {
+        let has_env = source
+            .env
+            .as_ref()
+            .is_some_and(|value| !value.trim().is_empty());
+        let has_file = source
+            .file
+            .as_ref()
+            .is_some_and(|value| !value.trim().is_empty());
+        match (has_env, has_file) {
+            (true, false) => {
+                let env_name = source.env.as_deref().unwrap_or_default();
+                let value = std::env::var(env_name).map_err(|err| {
+                    Error::validation_invalid_argument(
+                        "secret_env",
+                        format!("failed to read secret env ref for {name}: {err}"),
+                        Some(env_name.to_string()),
+                        Some(vec![
+                            "Set the referenced environment variable on the runner process."
+                                .to_string(),
+                        ]),
+                    )
+                })?;
+                resolved.insert(name.clone(), value);
+            }
+            (false, true) => {
+                let raw_path = source.file.as_deref().unwrap_or_default();
+                let path = shellexpand::tilde(raw_path).to_string();
+                let value = std::fs::read_to_string(&path).map_err(|err| {
+                    Error::internal_io(
+                        err.to_string(),
+                        Some(format!("read secret env file {path}")),
+                    )
+                })?;
+                resolved.insert(
+                    name.clone(),
+                    value.trim_end_matches(['\r', '\n']).to_string(),
+                );
+            }
+            (false, false) => {
+                return Err(Error::validation_invalid_argument(
+                    "secret_env",
+                    format!("secret env ref for {name} requires env or file"),
+                    Some(name.clone()),
+                    None,
+                ));
+            }
+            (true, true) => {
+                return Err(Error::validation_invalid_argument(
+                    "secret_env",
+                    format!("secret env ref for {name} must use env or file, not both"),
+                    Some(name.clone()),
+                    None,
+                ));
+            }
+        }
+    }
+    Ok(resolved)
 }
 
 fn merge_server_runner(
@@ -667,6 +734,7 @@ mod tests {
                 workspace_root: Some("/home/chubes/Developer".to_string()),
                 settings: RunnerSettings::default(),
                 env: HashMap::new(),
+                secret_env: HashMap::new(),
                 resources: HashMap::new(),
                 policy: RunnerPolicy::default(),
             };
@@ -682,6 +750,42 @@ mod tests {
             assert!(!exists("lab"));
             assert!(list().expect("list runners").is_empty());
         });
+    }
+
+    #[test]
+    fn runner_secret_env_refs_resolve_from_env_and_files() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let secret_file = temp.path().join("runner-token");
+        std::fs::write(&secret_file, "dummy-file-secret\n").expect("write dummy secret");
+        std::env::set_var("HOMEBOY_DUMMY_SECRET_REF", "dummy-env-secret");
+
+        let resolved = resolve_runner_secret_env(&HashMap::from([
+            (
+                "FROM_ENV".to_string(),
+                server::RunnerSecretEnvRef {
+                    env: Some("HOMEBOY_DUMMY_SECRET_REF".to_string()),
+                    file: None,
+                },
+            ),
+            (
+                "FROM_FILE".to_string(),
+                server::RunnerSecretEnvRef {
+                    env: None,
+                    file: Some(secret_file.display().to_string()),
+                },
+            ),
+        ]))
+        .expect("resolve secret refs");
+
+        assert_eq!(
+            resolved.get("FROM_ENV").map(String::as_str),
+            Some("dummy-env-secret")
+        );
+        assert_eq!(
+            resolved.get("FROM_FILE").map(String::as_str),
+            Some("dummy-file-secret")
+        );
+        std::env::remove_var("HOMEBOY_DUMMY_SECRET_REF");
     }
 
     #[test]

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -69,6 +69,14 @@ pub struct RunnerSettings {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerSecretEnvRef {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunnerPolicy {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub accepted_peer_ids: Vec<String>,
@@ -98,6 +106,8 @@ pub struct ServerRunner {
     pub settings: RunnerSettings,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub env: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub secret_env: HashMap<String, RunnerSecretEnvRef>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub resources: HashMap<String, serde_json::Value>,
     #[serde(default, skip_serializing_if = "RunnerPolicy::is_empty")]

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -1156,6 +1156,7 @@ mod tests {
                 ..Default::default()
             },
             env: HashMap::new(),
+            secret_env: HashMap::new(),
             resources: HashMap::new(),
             policy: Default::default(),
         }


### PR DESCRIPTION
## Summary
- Add `secret_env` refs to runner/server-runner config so credentials can be sourced from runner-side environment variables or files at execution time instead of stored as plaintext config.
- Make runner and server config output redact only sensitive env keys while leaving non-secret diagnostics like `HOMEBOY_PUBLIC_ARTIFACT_BASE_URL` visible.
- Document the `env` versus `secret_env` split with dummy examples.

Closes #4147.

## Tests
- `cargo test redacts --no-fail-fast`
- `cargo test secret_env --no-fail-fast`
- `cargo test --no-fail-fast` *(fails only in existing `tests/core_agnostic_test.rs::core_owned_source_stays_language_and_framework_agnostic`, which reports unrelated pre-existing ecosystem boundary findings in files not touched by this PR)*

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and implemented the runner env redaction/secret-reference changes, documentation, tests, and local verification under Chris's direction.