### PR TITLE
Validate public artifact viewer URLs

### DIFF
--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -489,8 +489,7 @@ fn persist_bench_artifact(
             metadata,
         ) {
             Ok(record) => {
-                apply_recorded_bench_artifact_links(artifact, &record);
-                None
+                apply_recorded_bench_artifact_links(scenario_id, run_index, name, artifact, &record)
             }
             Err(error) => Some(bench_artifact_diagnostic(
                 scenario_id,
@@ -552,8 +551,7 @@ fn persist_bench_artifact(
     match record {
         Ok(record) => {
             artifact.path = Some(record.path.clone());
-            apply_recorded_bench_artifact_links(artifact, &record);
-            None
+            apply_recorded_bench_artifact_links(scenario_id, run_index, name, artifact, &record)
         }
         Err(error) => Some(bench_artifact_diagnostic(
             scenario_id,
@@ -570,16 +568,42 @@ fn persist_bench_artifact(
 }
 
 fn apply_recorded_bench_artifact_links(
+    scenario_id: &str,
+    run_index: Option<usize>,
+    name: &str,
     artifact: &mut homeboy::core::extension::bench::BenchArtifact,
     record: &ArtifactRecord,
-) {
+) -> Option<BenchDiagnostic> {
     artifact.observation_artifact_id = Some(record.id.clone());
     let Some(public_url) = artifact_links::public_artifact_url(record) else {
-        return;
+        return None;
     };
     artifact.public_url = Some(public_url.clone());
-    artifact.viewer_links = artifact_links::viewer_links(record, Some(&public_url));
+    let (viewer_links, validation) = artifact_links::validated_viewer_links(record, &public_url);
+    artifact.viewer_links = viewer_links;
     artifact.viewer_url = artifact.viewer_links.first().map(|link| link.url.clone());
+    validation.and_then(|validation| {
+        (!validation.reachable).then(|| {
+            let error = validation
+                .error
+                .clone()
+                .unwrap_or_else(|| "public artifact URL was not reachable".to_string());
+            bench_artifact_diagnostic(
+                scenario_id,
+                run_index,
+                name,
+                "bench_public_artifact_url_unreachable",
+                format!(
+                    "public artifact URL for bench artifact `{name}` is not reachable; viewer links were not published: {error}"
+                ),
+                serde_json::json!({
+                    "url": validation.url,
+                    "status_code": validation.status_code,
+                    "error": validation.error,
+                }),
+            )
+        })
+    })
 }
 
 fn bench_artifact_metadata(
@@ -773,6 +797,83 @@ mod tests {
         }
     }
 
+    fn serve_public_artifact_base_once(status: u16) -> String {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind public artifact server");
+        let addr = listener.local_addr().expect("server address");
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept public artifact probe");
+            let mut buffer = [0; 1024];
+            let _ = stream.read(&mut buffer);
+            let status_text = if status == 200 { "OK" } else { "Not Found" };
+            let body = if status == 200 { "{}" } else { "missing" };
+            write!(
+                stream,
+                "HTTP/1.1 {status} {status_text}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .expect("write public artifact response");
+        });
+        format!("http://{addr}/homeboy")
+    }
+
+    #[test]
+    fn recorded_bench_artifact_reports_unreachable_public_viewer_url() {
+        let public_artifact_base = serve_public_artifact_base_once(404);
+        let _public_artifact_base = EnvGuard::set(
+            homeboy::core::artifact_links::PUBLIC_ARTIFACT_BASE_URL_ENV,
+            &public_artifact_base,
+        );
+        let mut artifact = BenchArtifact::default();
+        let record = ArtifactRecord {
+            id: "artifact-1".to_string(),
+            run_id: "run-1".to_string(),
+            kind: "bench_artifact".to_string(),
+            artifact_type: "file".to_string(),
+            path: "/tmp/blueprint.after.json".to_string(),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: None,
+            size_bytes: None,
+            mime: Some("application/json".to_string()),
+            metadata_json: serde_json::json!({
+                "viewer": {
+                    "kind": "wordpress-playground-blueprint",
+                    "base": "https://playground.wordpress.net/",
+                    "query": {
+                        "parameter": "blueprint-url",
+                        "value": { "source": "public-artifact-url" },
+                        "encoding": "url"
+                    }
+                }
+            }),
+            created_at: "2026-06-12T00:00:00Z".to_string(),
+        };
+
+        let diagnostic = apply_recorded_bench_artifact_links(
+            "cold",
+            Some(0),
+            "blueprint.after",
+            &mut artifact,
+            &record,
+        )
+        .expect("unreachable diagnostic");
+
+        assert_eq!(
+            artifact.observation_artifact_id.as_deref(),
+            Some("artifact-1")
+        );
+        assert!(artifact.public_url.is_some());
+        assert!(artifact.viewer_links.is_empty());
+        assert_eq!(artifact.viewer_url, None);
+        assert_eq!(diagnostic.class, "bench_public_artifact_url_unreachable");
+        assert_eq!(diagnostic.metadata["status_code"], 404);
+    }
+
     pub(super) fn bench_results(component_id: &str, scenario_id: &str, p95: f64) -> BenchResults {
         serde_json::from_value(serde_json::json!({
             "component_id": component_id,
@@ -829,9 +930,10 @@ mod tests {
     fn bench_observation_persists_success_with_metrics_and_artifacts() {
         with_isolated_home(|home| {
             let _xdg = XdgGuard::unset();
+            let public_artifact_base = serve_public_artifact_base_once(200);
             let _public_artifact_base = EnvGuard::set(
                 homeboy::core::artifact_links::PUBLIC_ARTIFACT_BASE_URL_ENV,
-                "https://artifacts.example.test/homeboy",
+                &public_artifact_base,
             );
             let run_dir = RunDir::create().expect("run dir");
             fs::write(run_dir.step_file(run_dir::files::BENCH_RESULTS), b"{}").expect("results");
@@ -977,7 +1079,7 @@ mod tests {
                 .public_url
                 .as_deref()
                 .expect("public url")
-                .starts_with("https://artifacts.example.test/homeboy/runs/"));
+                .starts_with(&format!("{public_artifact_base}/runs/")));
             assert!(transcript_artifact
                 .viewer_url
                 .as_deref()

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -579,15 +579,20 @@ fn apply_recorded_bench_artifact_links(
         return None;
     };
     artifact.public_url = Some(public_url.clone());
-    let (viewer_links, validation) = artifact_links::validated_viewer_links(record, &public_url);
-    artifact.viewer_links = viewer_links;
+    artifact.viewer_links = artifact_links::cached_validated_viewer_links(record, &public_url);
     artifact.viewer_url = artifact.viewer_links.first().map(|link| link.url.clone());
-    validation.and_then(|validation| {
-        (!validation.reachable).then(|| {
-            let error = validation
-                .error
-                .clone()
-                .unwrap_or_else(|| "public artifact URL was not reachable".to_string());
+    let Some(validation) = record.metadata_json.get("public_url_validation") else {
+        return None;
+    };
+    let reachable = validation
+        .get("reachable")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    (!reachable).then(|| {
+        let error = validation
+            .get("error")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("public artifact URL was not reachable");
             bench_artifact_diagnostic(
                 scenario_id,
                 run_index,
@@ -597,12 +602,11 @@ fn apply_recorded_bench_artifact_links(
                     "public artifact URL for bench artifact `{name}` is not reachable; viewer links were not published: {error}"
                 ),
                 serde_json::json!({
-                    "url": validation.url,
-                    "status_code": validation.status_code,
-                    "error": validation.error,
+                    "url": validation.get("url").cloned().unwrap_or(serde_json::Value::Null),
+                    "status_code": validation.get("status_code").cloned().unwrap_or(serde_json::Value::Null),
+                    "error": validation.get("error").cloned().unwrap_or(serde_json::Value::Null),
                 }),
             )
-        })
     })
 }
 
@@ -821,10 +825,10 @@ mod tests {
 
     #[test]
     fn recorded_bench_artifact_reports_unreachable_public_viewer_url() {
-        let public_artifact_base = serve_public_artifact_base_once(404);
+        let public_artifact_base = "https://artifacts.example.test/homeboy";
         let _public_artifact_base = EnvGuard::set(
             homeboy::core::artifact_links::PUBLIC_ARTIFACT_BASE_URL_ENV,
-            &public_artifact_base,
+            public_artifact_base,
         );
         let mut artifact = BenchArtifact::default();
         let record = ArtifactRecord {
@@ -849,6 +853,12 @@ mod tests {
                         "value": { "source": "public-artifact-url" },
                         "encoding": "url"
                     }
+                },
+                "public_url_validation": {
+                    "url": "https://artifacts.example.test/homeboy/runs/run-1/artifacts/artifact-1",
+                    "reachable": false,
+                    "status_code": 404,
+                    "error": "public artifact URL returned HTTP 404"
                 }
             }),
             created_at: "2026-06-12T00:00:00Z".to_string(),

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -29,7 +29,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::core::artifact_links::{public_artifact_url, viewer_links};
+use homeboy::core::artifact_links::{public_artifact_url, validated_viewer_links};
 use homeboy::core::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
 use homeboy::core::Error;
 
@@ -621,7 +621,16 @@ fn enrich_artifact_link(mut artifact: ArtifactRecord) -> ArtifactRecord {
         public_artifact_url(&artifact).or_else(|| public_url_for_url_artifact(&artifact));
     if let Some(url) = public_url.clone() {
         artifact.public_url = Some(url.clone());
-        artifact.viewer_links = viewer_links(&artifact, Some(&url));
+        let (viewer_links, validation) = validated_viewer_links(&artifact, &url);
+        if let Some(validation) = validation {
+            artifact.metadata_json["public_url_validation"] = serde_json::json!({
+                "url": validation.url,
+                "reachable": validation.reachable,
+                "status_code": validation.status_code,
+                "error": validation.error,
+            });
+        }
+        artifact.viewer_links = viewer_links;
         artifact.viewer_url = artifact.viewer_links.first().map(|link| link.url.clone());
     }
     artifact
@@ -711,6 +720,28 @@ mod tests {
                 None => std::env::remove_var(self.key),
             }
         }
+    }
+
+    fn serve_public_artifact_base_once(status: u16) -> String {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind public artifact server");
+        let addr = listener.local_addr().expect("server address");
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept public artifact probe");
+            let mut buffer = [0; 1024];
+            let _ = stream.read(&mut buffer);
+            let status_text = if status == 200 { "OK" } else { "Not Found" };
+            let body = if status == 200 { "{}" } else { "missing" };
+            write!(
+                stream,
+                "HTTP/1.1 {status} {status_text}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .expect("write public artifact response");
+        });
+        format!("http://{addr}/homeboy")
     }
 
     fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
@@ -1047,9 +1078,10 @@ mod tests {
     fn artifacts_command_derives_viewer_links_from_public_artifact_url_metadata() {
         with_isolated_home(|home| {
             let _xdg = XdgGuard::unset();
+            let public_artifact_base = serve_public_artifact_base_once(200);
             let _artifact_url = EnvGuard::set(
                 homeboy::core::artifact_links::PUBLIC_ARTIFACT_BASE_URL_ENV,
-                "https://artifacts.example.test/homeboy",
+                &public_artifact_base,
             );
             let store = ObservationStore::open_initialized().expect("store");
             let run = store
@@ -1112,7 +1144,7 @@ mod tests {
                 .find(|artifact| artifact.kind == "replay-artifact")
                 .expect("replay artifact");
             let artifact_url = replay.public_url.as_deref().expect("public url");
-            assert!(artifact_url.starts_with("https://artifacts.example.test/homeboy/runs/"));
+            assert!(artifact_url.starts_with(&format!("{public_artifact_base}/runs/")));
             assert!(!artifact_url.ends_with("/content"));
             assert_eq!(replay.mime.as_deref(), Some("application/json"));
             assert_eq!(replay.sha256.as_deref(), Some("abc123"));
@@ -1129,7 +1161,11 @@ mod tests {
                 .starts_with("https://playground.wordpress.net/?blueprint-url="));
             assert!(replay.viewer_links[0]
                 .url
-                .contains("https%3A%2F%2Fartifacts.example.test%2Fhomeboy%2Fruns%2F"));
+                .contains("http%3A%2F%2F127.0.0.1%3A"));
+            assert_eq!(
+                replay.metadata_json["public_url_validation"]["reachable"],
+                true
+            );
             assert_eq!(
                 replay.viewer_links[0]
                     .replay
@@ -1141,6 +1177,64 @@ mod tests {
             assert_eq!(
                 replay.metadata_json["viewer"]["query"]["value"]["source"],
                 "public-artifact-url"
+            );
+        });
+    }
+
+    #[test]
+    fn artifacts_command_suppresses_viewer_links_when_public_url_is_unreachable() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let public_artifact_base = serve_public_artifact_base_once(404);
+            let _artifact_url = EnvGuard::set(
+                homeboy::core::artifact_links::PUBLIC_ARTIFACT_BASE_URL_ENV,
+                &public_artifact_base,
+            );
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
+                .expect("run");
+            let artifact_path = home.path().join("blueprint.after.json");
+            std::fs::write(&artifact_path, br#"{"steps":[]}"#).expect("artifact bytes");
+            store
+                .record_artifact_with_metadata(
+                    &run.id,
+                    "bench_artifact",
+                    &artifact_path,
+                    serde_json::json!({
+                        "viewer": {
+                            "kind": "wordpress-playground-blueprint",
+                            "base": "https://playground.wordpress.net/",
+                            "query": {
+                                "parameter": "blueprint-url",
+                                "value": { "source": "public-artifact-url" },
+                                "encoding": "url"
+                            }
+                        }
+                    }),
+                )
+                .expect("record artifact");
+
+            let (output, _) = artifacts(&run.id).expect("artifacts");
+            let RunsOutput::Artifacts(output) = output else {
+                panic!("expected artifacts output");
+            };
+            let artifact = output
+                .artifacts
+                .iter()
+                .find(|artifact| artifact.kind == "bench_artifact")
+                .expect("bench artifact");
+
+            assert!(artifact.public_url.is_some());
+            assert!(artifact.viewer_links.is_empty());
+            assert_eq!(artifact.viewer_url, None);
+            assert_eq!(
+                artifact.metadata_json["public_url_validation"]["reachable"],
+                false
+            );
+            assert_eq!(
+                artifact.metadata_json["public_url_validation"]["status_code"],
+                404
             );
         });
     }

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -29,7 +29,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::core::artifact_links::{public_artifact_url, validated_viewer_links};
+use homeboy::core::artifact_links::{cached_validated_viewer_links, public_artifact_url};
 use homeboy::core::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
 use homeboy::core::Error;
 
@@ -621,16 +621,7 @@ fn enrich_artifact_link(mut artifact: ArtifactRecord) -> ArtifactRecord {
         public_artifact_url(&artifact).or_else(|| public_url_for_url_artifact(&artifact));
     if let Some(url) = public_url.clone() {
         artifact.public_url = Some(url.clone());
-        let (viewer_links, validation) = validated_viewer_links(&artifact, &url);
-        if let Some(validation) = validation {
-            artifact.metadata_json["public_url_validation"] = serde_json::json!({
-                "url": validation.url,
-                "reachable": validation.reachable,
-                "status_code": validation.status_code,
-                "error": validation.error,
-            });
-        }
-        artifact.viewer_links = viewer_links;
+        artifact.viewer_links = cached_validated_viewer_links(&artifact, &url);
         artifact.viewer_url = artifact.viewer_links.first().map(|link| link.url.clone());
     }
     artifact

--- a/src/core/artifact_links.rs
+++ b/src/core/artifact_links.rs
@@ -1,9 +1,19 @@
 use serde_json::Value;
+use std::time::Duration;
 
 use crate::core::execution_contract::encode_uri_component;
 use crate::core::observation::{ArtifactRecord, ArtifactViewerLink};
 
 pub const PUBLIC_ARTIFACT_BASE_URL_ENV: &str = "HOMEBOY_PUBLIC_ARTIFACT_BASE_URL";
+const PUBLIC_ARTIFACT_URL_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicArtifactUrlValidation {
+    pub url: String,
+    pub reachable: bool,
+    pub status_code: Option<u16>,
+    pub error: Option<String>,
+}
 
 pub fn public_artifact_url(artifact: &ArtifactRecord) -> Option<String> {
     if !artifact_is_fetchable(artifact) {
@@ -67,8 +77,61 @@ pub fn viewer_links(
     }]
 }
 
+pub fn validated_viewer_links(
+    artifact: &ArtifactRecord,
+    public_url: &str,
+) -> (Vec<ArtifactViewerLink>, Option<PublicArtifactUrlValidation>) {
+    let links = viewer_links(artifact, Some(public_url));
+    if links.is_empty() {
+        return (links, None);
+    }
+
+    let validation = validate_public_artifact_url(public_url);
+    if validation.reachable {
+        (links, Some(validation))
+    } else {
+        (Vec::new(), Some(validation))
+    }
+}
+
+pub fn validate_public_artifact_url(public_url: &str) -> PublicArtifactUrlValidation {
+    match probe_public_artifact_url(public_url) {
+        Ok(status) if status.is_success() => PublicArtifactUrlValidation {
+            url: public_url.to_string(),
+            reachable: true,
+            status_code: Some(status.as_u16()),
+            error: None,
+        },
+        Ok(status) => PublicArtifactUrlValidation {
+            url: public_url.to_string(),
+            reachable: false,
+            status_code: Some(status.as_u16()),
+            error: Some(format!(
+                "public artifact URL returned HTTP {}",
+                status.as_u16()
+            )),
+        },
+        Err(error) => PublicArtifactUrlValidation {
+            url: public_url.to_string(),
+            reachable: false,
+            status_code: None,
+            error: Some(error.to_string()),
+        },
+    }
+}
+
 fn artifact_is_fetchable(artifact: &ArtifactRecord) -> bool {
     artifact.artifact_type == "file" || artifact.artifact_type == "remote_file"
+}
+
+fn probe_public_artifact_url(public_url: &str) -> Result<reqwest::StatusCode, reqwest::Error> {
+    reqwest::blocking::Client::builder()
+        .timeout(PUBLIC_ARTIFACT_URL_PROBE_TIMEOUT)
+        .build()?
+        .get(public_url)
+        .header(reqwest::header::RANGE, "bytes=0-0")
+        .send()
+        .map(|response| response.status())
 }
 
 #[cfg(test)]
@@ -114,5 +177,85 @@ mod tests {
             links[0].url,
             "https://viewer.example.test/?artifact-url=https%3A%2F%2Fartifacts.example.test%2Fa%20b.json"
         );
+    }
+
+    #[test]
+    fn validated_viewer_links_requires_reachable_public_url() {
+        let public_url = serve_once(404);
+        let artifact = viewer_artifact();
+
+        let (links, validation) = validated_viewer_links(&artifact, &public_url);
+
+        assert!(links.is_empty());
+        let validation = validation.expect("validation result");
+        assert!(!validation.reachable);
+        assert_eq!(validation.status_code, Some(404));
+        assert_eq!(
+            validation.error.as_deref(),
+            Some("public artifact URL returned HTTP 404")
+        );
+    }
+
+    #[test]
+    fn validated_viewer_links_emits_links_for_reachable_public_url() {
+        let public_url = serve_once(200);
+        let artifact = viewer_artifact();
+
+        let (links, validation) = validated_viewer_links(&artifact, &public_url);
+
+        assert_eq!(links.len(), 1);
+        assert!(links[0].url.contains("artifact-url="));
+        assert!(validation.expect("validation result").reachable);
+    }
+
+    fn viewer_artifact() -> ArtifactRecord {
+        ArtifactRecord {
+            id: "artifact-1".to_string(),
+            run_id: "run-1".to_string(),
+            kind: "preview-after".to_string(),
+            artifact_type: "file".to_string(),
+            path: "/tmp/preview.after.json".to_string(),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: None,
+            size_bytes: None,
+            mime: Some("application/json".to_string()),
+            metadata_json: serde_json::json!({
+                "viewer": {
+                    "kind": "artifact-preview",
+                    "base": "https://viewer.example.test/",
+                    "query": {
+                        "parameter": "artifact-url",
+                        "value": { "source": "public-artifact-url" },
+                        "encoding": "url"
+                    }
+                }
+            }),
+            created_at: "2026-06-12T00:00:00Z".to_string(),
+        }
+    }
+
+    fn serve_once(status: u16) -> String {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let addr = listener.local_addr().expect("server address");
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut buffer = [0; 1024];
+            let _ = stream.read(&mut buffer);
+            let status_text = if status == 200 { "OK" } else { "Not Found" };
+            let body = if status == 200 { "ok" } else { "missing" };
+            write!(
+                stream,
+                "HTTP/1.1 {status} {status_text}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .expect("write response");
+        });
+        format!("http://{addr}/artifact.json")
     }
 }

--- a/src/core/artifact_links.rs
+++ b/src/core/artifact_links.rs
@@ -94,6 +94,51 @@ pub fn validated_viewer_links(
     }
 }
 
+pub fn cached_validated_viewer_links(
+    artifact: &ArtifactRecord,
+    public_url: &str,
+) -> Vec<ArtifactViewerLink> {
+    let links = viewer_links(artifact, Some(public_url));
+    if links.is_empty() {
+        return links;
+    }
+    if artifact
+        .metadata_json
+        .get("public_url_validation")
+        .and_then(|validation| validation.get("reachable"))
+        .and_then(Value::as_bool)
+        == Some(true)
+    {
+        links
+    } else {
+        Vec::new()
+    }
+}
+
+pub fn annotate_public_artifact_url_validation(
+    artifact: &mut ArtifactRecord,
+) -> Option<PublicArtifactUrlValidation> {
+    let public_url = public_artifact_url(artifact)?;
+    if viewer_links(artifact, Some(&public_url)).is_empty() {
+        return None;
+    }
+    let validation = validate_public_artifact_url(&public_url);
+    artifact.metadata_json["public_url_validation"] =
+        public_artifact_url_validation_json(&validation);
+    Some(validation)
+}
+
+pub fn public_artifact_url_validation_json(
+    validation: &PublicArtifactUrlValidation,
+) -> serde_json::Value {
+    serde_json::json!({
+        "url": validation.url,
+        "reachable": validation.reachable,
+        "status_code": validation.status_code,
+        "error": validation.error,
+    })
+}
+
 pub fn validate_public_artifact_url(public_url: &str) -> PublicArtifactUrlValidation {
     match probe_public_artifact_url(public_url) {
         Ok(status) if status.is_success() => PublicArtifactUrlValidation {

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -392,6 +392,23 @@ impl ObservationStore {
         let stored_path = persisted_artifact_path(run_id, &id, path)?;
         copy_artifact_file(path, &stored_path)?;
         let path_string = stored_path.to_string_lossy().to_string();
+        let mut artifact = ArtifactRecord {
+            id: id.clone(),
+            run_id: run_id.to_string(),
+            kind: kind.to_string(),
+            artifact_type: "file".to_string(),
+            path: path_string.clone(),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: sha256.clone(),
+            size_bytes,
+            mime: mime.clone(),
+            metadata_json,
+            created_at: created_at.clone(),
+        };
+        crate::core::artifact_links::annotate_public_artifact_url_validation(&mut artifact);
 
         self.connection
             .execute(
@@ -408,7 +425,7 @@ impl ObservationStore {
                     sha256,
                     size_bytes,
                     mime,
-                    serialize_metadata(&metadata_json)?,
+                    serialize_metadata(&artifact.metadata_json)?,
                     created_at,
                 ],
             )

--- a/src/core/publication_artifacts.rs
+++ b/src/core/publication_artifacts.rs
@@ -166,7 +166,7 @@ fn index_manifest_refs(
             "viewer": reference.get("viewer").cloned().unwrap_or(Value::Null),
         });
 
-        store.import_artifact(&ArtifactRecord {
+        let mut artifact = ArtifactRecord {
             id,
             run_id: source.run_id.clone(),
             kind,
@@ -181,7 +181,9 @@ fn index_manifest_refs(
             mime: media_type,
             metadata_json,
             created_at,
-        })?;
+        };
+        crate::core::artifact_links::annotate_public_artifact_url_validation(&mut artifact);
+        store.import_artifact(&artifact)?;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Validate public artifact URLs with a bounded fetch probe before emitting viewer links that depend on `public-artifact-url`.
- Suppress dead viewer links and expose validation details in run artifact metadata when the public URL is unreachable.
- Add bench diagnostics for unreachable public artifact URLs and smoke coverage for reachable/unreachable public viewer-link paths.

Closes #4143.

## Tests
- `cargo fmt`
- `cargo test core::artifact_links::tests`
- `cargo test artifacts_command_derives_viewer_links_from_public_artifact_url_metadata`
- `cargo test artifacts_command_suppresses_viewer_links_when_public_url_is_unreachable`
- `cargo test recorded_bench_artifact_reports_unreachable_public_viewer_url`
- `cargo test bench_observation_persists_success_with_metrics_and_artifacts`
- `cargo test publication_manifest_artifact_store_refs_are_indexed`
- `cargo test artifact_content_serves_encoded_artifact_store_locator`
- `cargo test --test core_agnostic_test` (fails: existing unrelated `core_owned_source_stays_language_and_framework_agnostic` findings outside this PR's touched files; `core_owned_test_content_stays_language_and_framework_agnostic` passes)
- `cargo test` (fails at the same existing unrelated core-agnostic source guard after 4309 lib tests passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the URL validation flow, updated run/bench artifact handling, and added targeted tests for reachable and unreachable public artifact URLs. Chris remains responsible for review and final merge.