### PR TITLE
Store agent-task secrets in global config

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -172,6 +172,8 @@ pub enum AgentTaskAuthCommand {
     Status(AgentTaskAuthStatusArgs),
     /// Store a provider secret in the OS keychain and map it to a required env name.
     SetKeychain(AgentTaskAuthSetKeychainArgs),
+    /// Store a provider secret in Homeboy global config and map it to a required env name.
+    SetConfig(AgentTaskAuthSetConfigArgs),
     /// Store a JSON secret bundle in one OS keychain item.
     SetKeychainBundle(AgentTaskAuthSetKeychainBundleArgs),
     /// Map a required provider env name to another process env var.
@@ -210,6 +212,21 @@ pub struct AgentTaskAuthSetKeychainArgs {
     /// Keychain entry name. Defaults to ENV.
     #[arg(long = "name", value_name = "NAME")]
     pub keychain_name: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskAuthSetConfigArgs {
+    /// Required provider environment variable name to satisfy.
+    #[arg(value_name = "ENV")]
+    pub secret_env: String,
+
+    /// Secret value. Omit to prompt securely.
+    #[arg(value_name = "VALUE")]
+    pub value: Option<String>,
+
+    /// Read the secret value from stdin.
+    #[arg(long)]
+    pub value_stdin: bool,
 }
 
 #[derive(Args, Debug)]
@@ -661,6 +678,17 @@ fn auth(args: AgentTaskAuthArgs) -> CmdResult<Value> {
                 set_args.scope.as_deref(),
                 set_args.keychain_name.as_deref(),
             )?;
+            Ok((
+                serde_json::json!({
+                    "schema": "homeboy/agent-task-auth-configured/v1",
+                    "secret_env": status,
+                }),
+                0,
+            ))
+        }
+        AgentTaskAuthCommand::SetConfig(set_args) => {
+            let value = read_agent_task_secret_value(set_args.value, set_args.value_stdin)?;
+            let status = agent_task_secrets::set_config_secret(&set_args.secret_env, &value)?;
             Ok((
                 serde_json::json!({
                     "schema": "homeboy/agent-task-auth-configured/v1",

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -2,7 +2,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::core::defaults::{self, Defaults, HomeboyConfig};
+use homeboy::core::defaults::{self, Defaults};
 
 use super::CmdResult;
 
@@ -42,7 +42,7 @@ enum ConfigCommand {
 pub struct ConfigOutput {
     command: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    config: Option<HomeboyConfig>,
+    config: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     defaults: Option<Defaults>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -84,6 +84,7 @@ fn show(builtin: bool) -> CmdResult<ConfigOutput> {
         ))
     } else {
         let config = defaults::load_config();
+        let config = redacted_config_value(&config)?;
         Ok((
             ConfigOutput {
                 command: "config.show".to_string(),
@@ -142,11 +143,12 @@ fn set(pointer: &str, value_str: &str) -> CmdResult<ConfigOutput> {
 
     // Save the config
     defaults::save_config(&config)?;
+    let redacted_config = redacted_config_value(&config)?;
 
     Ok((
         ConfigOutput {
             command: "config.set".to_string(),
-            config: Some(config),
+            config: Some(redacted_config),
             defaults: None,
             path: None,
             exists: None,
@@ -191,11 +193,12 @@ fn remove(pointer: &str) -> CmdResult<ConfigOutput> {
 
     // Save the config
     defaults::save_config(&config)?;
+    let redacted_config = redacted_config_value(&config)?;
 
     Ok((
         ConfigOutput {
             command: "config.remove".to_string(),
-            config: Some(config),
+            config: Some(redacted_config),
             defaults: None,
             path: None,
             exists: None,
@@ -205,6 +208,27 @@ fn remove(pointer: &str) -> CmdResult<ConfigOutput> {
         },
         0,
     ))
+}
+
+fn redacted_config_value(config: &defaults::HomeboyConfig) -> homeboy::core::Result<Value> {
+    let mut value = serde_json::to_value(config).map_err(|e| {
+        homeboy::core::Error::internal_unexpected(format!("Failed to serialize config: {}", e))
+    })?;
+
+    if let Some(secrets) = value
+        .pointer_mut("/agent_task/secrets")
+        .and_then(Value::as_object_mut)
+    {
+        for source in secrets.values_mut() {
+            if let Some(source) = source.as_object_mut() {
+                if source.contains_key("value") {
+                    source.insert("value".to_string(), Value::String("[redacted]".to_string()));
+                }
+            }
+        }
+    }
+
+    Ok(value)
 }
 
 fn reset() -> CmdResult<ConfigOutput> {

--- a/src/core/agent_task_secrets.rs
+++ b/src/core/agent_task_secrets.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
+use crate::core::defaults::{self, AgentTaskSecretSource};
 use crate::core::keychain;
 use crate::core::paths;
 use crate::core::Error;
@@ -45,6 +46,27 @@ pub fn map_secret_to_env(
             scope: None,
             name: None,
             field: None,
+            value: None,
+        },
+    );
+    config.save()?;
+    Ok(secret_env_status_with_config(&[name.to_string()], &config)
+        .into_iter()
+        .next()
+        .expect("single status"))
+}
+
+pub fn set_config_secret(name: &str, value: &str) -> crate::core::Result<AgentTaskSecretEnvStatus> {
+    let mut config = AgentTaskSecretConfig::load();
+    config.secrets.insert(
+        name.to_string(),
+        AgentTaskSecretSource {
+            source: "config".to_string(),
+            env_var: None,
+            scope: None,
+            name: None,
+            field: None,
+            value: Some(value.to_string()),
         },
     );
     config.save()?;
@@ -73,6 +95,7 @@ pub fn set_keychain_secret(
             scope: Some(scope.to_string()),
             name: Some(keychain_name.to_string()),
             field: None,
+            value: None,
         },
     );
     config.save()?;
@@ -118,6 +141,7 @@ pub fn map_secret_to_keychain_bundle(
             scope: Some(scope.unwrap_or("agent-task").to_string()),
             name: Some(keychain_name.unwrap_or(bundle).to_string()),
             field: Some(field.to_string()),
+            value: None,
         },
     );
     config.save()?;
@@ -234,6 +258,13 @@ struct AgentTaskSecretConfig {
 
 impl AgentTaskSecretConfig {
     fn load() -> Self {
+        let config = defaults::load_config();
+        if !config.agent_task.secrets.is_empty() {
+            return Self {
+                secrets: config.agent_task.secrets,
+            };
+        }
+
         let Ok(path) = Self::path() else {
             return Self::default();
         };
@@ -248,46 +279,11 @@ impl AgentTaskSecretConfig {
     }
 
     fn save(&self) -> crate::core::Result<()> {
-        let path = Self::path()?;
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).map_err(|error| {
-                Error::internal_io(
-                    error.to_string(),
-                    Some(format!(
-                        "create agent-task secret config dir {}",
-                        parent.display()
-                    )),
-                )
-            })?;
-        }
-        let raw = serde_json::to_string_pretty(self).map_err(|error| {
-            Error::internal_json(
-                error.to_string(),
-                Some("serialize agent-task secret config".to_string()),
-            )
-        })?;
-        fs::write(&path, format!("{raw}\n")).map_err(|error| {
-            Error::internal_io(
-                error.to_string(),
-                Some(format!("write agent-task secret config {}", path.display())),
-            )
-        })?;
+        let mut config = defaults::load_config();
+        config.agent_task.secrets = self.secrets.clone();
+        defaults::save_config(&config)?;
         Ok(())
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct AgentTaskSecretSource {
-    #[serde(default = "default_source")]
-    source: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    env_var: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    scope: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    field: Option<String>,
 }
 
 impl AgentTaskSecretSource {
@@ -297,6 +293,7 @@ impl AgentTaskSecretSource {
         bundle_cache: &mut HashMap<String, Option<Value>>,
     ) -> Option<String> {
         match self.source.as_str() {
+            "config" => self.value.clone(),
             "env" => env::var(self.env_var.as_deref().unwrap_or(requested_name)).ok(),
             "keychain" => keychain::get(
                 self.scope.as_deref().unwrap_or("agent-task"),
@@ -342,10 +339,6 @@ fn bundle_field_value(bundle: &Value, field: &str) -> Option<String> {
         Value::Number(number) => Some(number.to_string()),
         _ => None,
     }
-}
-
-fn default_source() -> String {
-    "env".to_string()
 }
 
 #[cfg(test)]
@@ -415,6 +408,7 @@ mod tests {
                 scope: None,
                 name: None,
                 field: None,
+                value: None,
             },
         );
         let config = AgentTaskSecretConfig { secrets };
@@ -428,6 +422,28 @@ mod tests {
             vec![(configured_name, "configured-secret-value".to_string())]
         );
         std::env::remove_var(source_name);
+    }
+
+    #[test]
+    fn stores_and_resolves_declared_secret_from_global_config() {
+        crate::test_support::with_isolated_home(|_| {
+            let configured_name = unique_env("CONFIG_SECRET");
+            std::env::remove_var(&configured_name);
+
+            let status = set_config_secret(&configured_name, "stored-secret-value")
+                .expect("secret config saved");
+
+            assert_eq!(status.name, configured_name);
+            assert!(status.configured);
+            assert_eq!(status.source, "config");
+
+            let resolved = resolve_secret_env(std::slice::from_ref(&status.name))
+                .expect("config secret resolves");
+            assert_eq!(
+                resolved,
+                vec![(status.name, "stored-secret-value".to_string())]
+            );
+        });
     }
 
     #[test]
@@ -480,6 +496,7 @@ mod tests {
             scope: Some("agent-task".to_string()),
             name: Some("provider-oauth".to_string()),
             field: Some("tokens.access".to_string()),
+            value: None,
         };
         let mut cache = HashMap::new();
         cache.insert(

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs;
 
 use crate::core::engine::local_files;
@@ -24,6 +25,9 @@ pub struct HomeboyConfig {
     #[serde(default)]
     pub triage: TriageConfig,
 
+    #[serde(default)]
+    pub agent_task: AgentTaskConfig,
+
     /// Directory where persisted run artifacts are copied.
     ///
     /// Defaults to the machine-local product data directory under
@@ -45,6 +49,7 @@ impl Default for HomeboyConfig {
             bench: BenchConfig::default(),
             lab: LabConfig::default(),
             triage: TriageConfig::default(),
+            agent_task: AgentTaskConfig::default(),
             artifact_root: None,
             update_check: true,
         }
@@ -98,6 +103,32 @@ pub struct LabConfig {
 pub struct TriageConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub priority_labels: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskConfig {
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub secrets: HashMap<String, AgentTaskSecretSource>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskSecretSource {
+    #[serde(default = "default_agent_task_secret_source")]
+    pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env_var: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
+fn default_agent_task_secret_source() -> String {
+    "env".to_string()
 }
 
 /// All configurable defaults that can be overridden via the product config file.
@@ -334,6 +365,27 @@ mod tests {
         .unwrap();
 
         assert_eq!(config.lab.preferred_runner.as_deref(), Some("homeboy-lab"));
+    }
+
+    #[test]
+    fn homeboy_config_parses_agent_task_config_secret() {
+        let config: HomeboyConfig = serde_json::from_str(
+            r#"{
+                "agent_task": {
+                    "secrets": {
+                        "TOKEN": {
+                            "source": "config",
+                            "value": "redacted-test-token"
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let secret = config.agent_task.secrets.get("TOKEN").unwrap();
+        assert_eq!(secret.source, "config");
+        assert_eq!(secret.value.as_deref(), Some("redacted-test-token"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `homeboy agent-task auth set-config` for storing agent-task secret values in global `homeboy.json` under `agent_task.secrets`.
- Resolve `source: \"config\"` agent-task secrets through the existing secret-env path, with legacy `agent-task-secrets.json` still used as a migration fallback when global config has no entries.
- Redact `agent_task.secrets.*.value` from `homeboy config show`, `config set`, and `config remove` output so stored values are not printed in normal config inspection.

## Verification
- `cargo test agent_task_secrets --quiet`
- `cargo test homeboy_config_parses_agent_task_config_secret --quiet`
- `cargo build --quiet --bin homeboy`
- Isolated HOME CLI smoke: `agent-task auth set-config TEST_SECRET dummy-secret`, `agent-task auth status --secret-env TEST_SECRET`, and `config show`; verified status reports `source: config` and `config show` prints `[redacted]` instead of the secret value.

## Known issue
- `cargo test --quiet` ran the main suite successfully through 4,324 passing tests, then failed in `tests/core_agnostic_test.rs` on existing core-boundary baseline findings for ecosystem terms such as `cargo`, `rust`, `php`, `npm`, and `composer`. This change does not add those terms; it shifts line numbers in `src/core/defaults.rs` and exposes the existing stale baseline failure.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the config-backed secret path, redaction behavior, tests, and verification commands; Chris remains responsible for review and acceptance.