### PR TITLE
fix: preserve dotted bench matrix settings

### DIFF
--- a/src/commands/bench/settings_matrix.rs
+++ b/src/commands/bench/settings_matrix.rs
@@ -231,53 +231,11 @@ fn expand_setting_matrix_cells(
 }
 
 fn apply_matrix_settings(child_args: &mut BenchRunArgs, settings: &BTreeMap<String, String>) {
-    let mut json_roots = BTreeMap::<String, serde_json::Value>::new();
-
     for (name, value) in settings {
-        if let Some((root, path)) = name.split_once('.') {
-            if root.is_empty() || path.is_empty() {
-                child_args
-                    .setting_args
-                    .setting
-                    .push((name.clone(), value.clone()));
-                continue;
-            }
-            let root_value = json_roots
-                .entry(root.to_string())
-                .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
-            insert_json_path(root_value, path.split('.'), value.clone());
-        } else {
-            child_args
-                .setting_args
-                .setting
-                .push((name.clone(), value.clone()));
-        }
-    }
-
-    child_args.setting_args.setting_json.extend(json_roots);
-}
-
-fn insert_json_path<'a, I>(target: &mut serde_json::Value, mut path: I, value: String)
-where
-    I: Iterator<Item = &'a str>,
-{
-    let Some(segment) = path.next() else {
-        *target = serde_json::Value::String(value);
-        return;
-    };
-
-    if path.size_hint().0 == 0 {
-        if let serde_json::Value::Object(map) = target {
-            map.insert(segment.to_string(), serde_json::Value::String(value));
-        }
-        return;
-    }
-
-    if let serde_json::Value::Object(map) = target {
-        let child = map
-            .entry(segment.to_string())
-            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
-        insert_json_path(child, path, value);
+        child_args
+            .setting_args
+            .setting
+            .push((name.clone(), value.clone()));
     }
 }
 
@@ -395,7 +353,7 @@ mod tests {
     }
 
     #[test]
-    fn applies_dotted_setting_axes_as_typed_json_settings() {
+    fn applies_dotted_setting_axes_as_string_settings() {
         #[derive(Parser)]
         struct MatrixCli {
             #[command(flatten)]
@@ -427,17 +385,19 @@ mod tests {
 
         assert_eq!(
             args.setting_args.setting,
-            vec![("wp_codebox_bin".to_string(), "/tmp/wp-codebox".to_string())]
+            vec![
+                (
+                    "bench_env.GUTENBERG_RTC_BATCH_SIZE".to_string(),
+                    "25".to_string()
+                ),
+                (
+                    "bench_env.GUTENBERG_RTC_CLIENTS".to_string(),
+                    "100".to_string()
+                ),
+                ("wp_codebox_bin".to_string(), "/tmp/wp-codebox".to_string())
+            ]
         );
-        assert_eq!(args.setting_args.setting_json.len(), 1);
-        assert_eq!(args.setting_args.setting_json[0].0, "bench_env");
-        assert_eq!(
-            args.setting_args.setting_json[0].1,
-            serde_json::json!({
-                "GUTENBERG_RTC_BATCH_SIZE": "25",
-                "GUTENBERG_RTC_CLIENTS": "100"
-            })
-        );
+        assert!(args.setting_args.setting_json.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Preserve `bench matrix --setting-matrix bench_env.FOO=bar` axes as dotted string settings instead of converting them into root `--setting-json` overrides.
- Reuse the existing dotted setting merge path so nested settings like `bench_env` are merged consistently for local and Lab-offloaded child runs.
- Update the matrix unit test to assert dotted axes remain in `setting_args.setting` and continue into the normal settings pipeline.

Closes #4166.

## Verification
- `cargo fmt --check` — passed
- `cargo test commands::bench::settings_matrix::tests --lib` — passed
- `cargo test commands::bench::settings_matrix::tests::applies_dotted_setting_axes_as_string_settings --lib` — passed
- `cargo test core::engine::execution_context::tests::dotted_settings_merge_into_object_settings --lib` — passed

## Live smoke note
- Attempted a live offloaded WooCommerce matrix smoke with this patched binary.
- The patched binary compiled and started, but local rig source config blocked before dispatch: `woocommerce-performance` points at missing source path `/Users/chubes/Developer/homeboy-rigs@issue-242-session-guardrails/woocommerce/woocommerce`.
- I did not mutate local rig-source config as part of this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosing the live matrix setting mismatch, implementing the focused fix, updating regression coverage, running verification, and drafting this PR summary under Chris review.