### PR TITLE
fix: accept runs list runner option

### DIFF
--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -16,7 +16,11 @@ pub fn route_after_parse(
     }
 
     if let (Some(runner_id), Commands::Runs(args)) = (cli.runner.as_deref(), &cli.command) {
-        return Err(crate::commands::runs::global_runner_error(args, runner_id));
+        if !is_runs_list_runner_option(normalized_args) {
+            return Err(crate::commands::runs::global_runner_error(args, runner_id));
+        }
+
+        return Ok(None);
     }
 
     let lab_command = lab_offload_command(&cli.command)?;
@@ -142,6 +146,20 @@ pub fn route_after_parse(
             }
         },
     }
+}
+
+fn is_runs_list_runner_option(args: &[String]) -> bool {
+    let Some(runs_index) = args.iter().position(|arg| arg == "runs") else {
+        return false;
+    };
+    let Some(list_index) = args.iter().position(|arg| arg == "list") else {
+        return false;
+    };
+
+    list_index > runs_index
+        && args.iter().enumerate().any(|(index, arg)| {
+            index > list_index && (arg == "--runner" || arg.starts_with("--runner="))
+        })
 }
 
 fn execute_trace_lab_offload_with_timeout(
@@ -575,6 +593,63 @@ mod tests {
         assert_eq!(err.code.as_str(), "validation.invalid_argument");
         assert!(err.message.contains("homeboy runs show run-123"));
         assert!(err.message.contains("without --runner"));
+    }
+
+    #[test]
+    fn runs_list_runner_option_after_subcommand_routes_locally() {
+        let _env = EnvGuard::remove(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV);
+
+        for normalized in [
+            vec![
+                "homeboy".to_string(),
+                "runs".to_string(),
+                "list".to_string(),
+                "--runner".to_string(),
+                "homeboy-lab".to_string(),
+                "--status".to_string(),
+                "running".to_string(),
+                "--limit".to_string(),
+                "20".to_string(),
+            ],
+            vec![
+                "homeboy".to_string(),
+                "runs".to_string(),
+                "list".to_string(),
+                "--runner=homeboy-lab".to_string(),
+                "--status".to_string(),
+                "running".to_string(),
+                "--limit".to_string(),
+                "20".to_string(),
+            ],
+        ] {
+            let cli = Cli::parse_from(&normalized);
+
+            let outcome = route_after_parse(&cli, &normalized, None)
+                .expect("runs list subcommand runner option should not be rejected");
+
+            assert_eq!(outcome, None);
+        }
+    }
+
+    #[test]
+    fn global_runner_for_runs_list_keeps_placement_guidance() {
+        let _env = EnvGuard::remove(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV);
+        let normalized = vec![
+            "homeboy".to_string(),
+            "--runner".to_string(),
+            "homeboy-lab".to_string(),
+            "runs".to_string(),
+            "list".to_string(),
+        ];
+        let cli = Cli::parse_from(&normalized);
+
+        let err = route_after_parse(&cli, &normalized, None)
+            .expect_err("top-level runner on runs list should keep placement guidance");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err
+            .message
+            .contains("homeboy runs list --runner homeboy-lab"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Allow `homeboy runs list --runner <id>` to bypass the top-level Lab offload `--runner` rejection and reach the runner daemon listing path.
- Preserve the existing placement guidance for truly top-level `homeboy --runner <id> runs ...` usage.
- Add route regression coverage for both `--runner value` and `--runner=value` forms.

Closes #4171.

## Testing
- `cargo test commands::route::tests`
- `cargo run --quiet --bin homeboy -- runs list --runner homeboy-lab --status running --limit 20`
- `cargo run --quiet --bin homeboy -- runs list --runner=homeboy-lab --status running --limit 20`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the CLI routing collision, implementing the route guard, adding regression tests, and running verification commands. Chris remains responsible for review and merge.