### PR TITLE
fix: skip rig preflight during bench list discovery

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -672,10 +672,6 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
     resolve_options.extension_overrides = args.extension_override.extensions.clone();
 
     let ctx = execution_context::resolve_with_component(&resolve_options, component_override)?;
-    if let Some(spec) = rig_spec {
-        run_rig_workload_preflight(spec, ctx.extension_id.as_deref())?;
-    }
-
     let extra_workloads = rig_spec
         .as_ref()
         .and_then(|spec| {
@@ -769,27 +765,6 @@ fn resolve_list_component_id(
     }
 
     args.comp.resolve_id()
-}
-
-fn run_rig_workload_preflight(
-    spec: &RigSpec,
-    extension_id: Option<&str>,
-) -> homeboy::core::Result<()> {
-    let groups = extension_id.and_then(|id| {
-        rig::check_groups_for_extension_workloads(spec, rig::RigWorkloadKind::Bench, id)
-    });
-    let check = match groups {
-        Some(groups) => rig::run_check_groups(spec, &groups)?,
-        None => rig::run_check(spec)?,
-    };
-    if !check.success {
-        return Err(homeboy::core::Error::rig_pipeline_failed(
-            &spec.id,
-            "check",
-            "rig check failed; refusing to list bench workloads for an unhealthy rig",
-        ));
-    }
-    Ok(())
 }
 
 /// Resolve the candidate rig's `bench.default_baseline_rig` and, when

--- a/tests/core/rig/bench_prepare_pipeline_test.rs
+++ b/tests/core/rig/bench_prepare_pipeline_test.rs
@@ -176,7 +176,7 @@ fn failing_bench_prepare_aborts_before_check_and_workload() {
 }
 
 #[test]
-fn bench_list_rig_does_not_run_bench_prepare() {
+fn bench_list_rig_discovers_scenarios_without_preflight_or_bench_prepare() {
     with_isolated_home(|home| {
         let component = tempfile::TempDir::new().expect("component");
         let log_dir = tempfile::TempDir::new().expect("log dir");
@@ -195,9 +195,16 @@ fn bench_list_rig_does_not_run_bench_prepare() {
             None,
             vec!["list-rig".to_string()],
         )));
-        let (_output, exit_code) = run(args, &GlobalArgs {}).expect("bench list should run");
+        let (output, exit_code) = run(args, &GlobalArgs {}).expect("bench list should run");
 
         assert_eq!(exit_code, 0);
-        assert_eq!(log_lines(&log_path), vec!["check"]);
+        match output {
+            BenchOutput::List(result) => {
+                assert_eq!(result.count, 1);
+                assert_eq!(result.scenarios[0].id, "ordered");
+            }
+            _ => panic!("expected bench list output"),
+        }
+        assert_eq!(log_lines(&log_path), Vec::<String>::new());
     });
 }


### PR DESCRIPTION
## Summary
- Skip rig check/workload preflight for `homeboy bench list --rig`, keeping list-only scenario discovery free of non-fatal dependency preparation noise.
- Keep rig loading, default component resolution, path overrides, settings, and rig-declared workload discovery intact.
- Update targeted coverage so `bench list` proves scenario discovery succeeds without running check, workload, or `bench_prepare` side effects.

Closes #4201

## Verification
- `cargo fmt`
- `cargo test bench_list_rig_discovers_scenarios_without_preflight_or_bench_prepare` passed
- `cargo test bench_prepare_pipeline_test` passed: 4 passed
- `cargo test` failed in existing `tests/core_agnostic_test.rs::core_owned_source_stays_language_and_framework_agnostic` core-boundary baseline findings unrelated to this change; lib tests completed before that with 4337 passed / 18 ignored
- `cargo clippy --all-targets -- -D warnings` failed on existing repo-wide clippy findings unrelated to this change, including large enum variants, ptr_arg, too_many_arguments, unnecessary_sort_by, and other pre-existing lints

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the focused `bench list` preflight skip, updated targeted regression coverage, and ran verification; Chris remains responsible for review and merge.