### PR TITLE
fix: keep extension updates local by default

### DIFF
--- a/docs/commands/extension.md
+++ b/docs/commands/extension.md
@@ -91,6 +91,8 @@ Updates a git-cloned extension.
 
 - If the extension is symlinked, Homeboy returns an error (linked extensions are updated at the source directory).
 - Update runs without an extra confirmation flag.
+- By default, update runs against the local installed extension even when a preferred Lab runner is configured.
+- To update the extension installed on a runner, pass explicit Lab intent with the global runner flag, for example `homeboy --runner <runner-id> extension update <extension_id>`.
 - Homeboy reads `sourceUrl` from the extension's manifest to report the extension URL in JSON output.
 
 ### `uninstall`

--- a/src/cli_surface/lab_contract.rs
+++ b/src/cli_surface/lab_contract.rs
@@ -6,6 +6,7 @@ use super::{CommandDescriptor, Commands};
 pub struct LabCommandContract {
     pub hot_label: &'static str,
     pub portability: LabCommandPortability,
+    pub default_lab_offload: bool,
     pub source_path_mode: LabSourcePathMode,
     pub workspace_mode_policy: LabWorkspaceModePolicy,
     pub mutation_flag: Option<&'static str>,
@@ -102,7 +103,7 @@ impl Commands {
                 LAB_NO_EXTRA_TOOLS,
             ),
             Commands::Extension(args) if args.is_update_command() => {
-                lab_portable_workload_contract("extension update", None, false, LAB_NO_EXTRA_TOOLS)
+                lab_explicit_runner_contract("extension update", None, false, LAB_NO_EXTRA_TOOLS)
             }
             Commands::Fleet(args) if args.is_hot_resource_command() => {
                 lab_local_only_contract("fleet exec", FLEET_EXEC_LAB_UNSUPPORTED_REASON)
@@ -193,6 +194,7 @@ fn lab_portable_contract(
     LabCommandContract {
         hot_label,
         portability: LabCommandPortability::Portable,
+        default_lab_offload: true,
         source_path_mode: LabSourcePathMode::CwdOrPathFlag,
         workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
         mutation_flag,
@@ -219,10 +221,28 @@ fn lab_portable_workload_contract(
     }
 }
 
+fn lab_explicit_runner_contract(
+    hot_label: &'static str,
+    mutation_flag: Option<&'static str>,
+    requires_extension_parity: bool,
+    extra_required_tools: &'static [LabCommandRequiredTool],
+) -> LabCommandContract {
+    LabCommandContract {
+        default_lab_offload: false,
+        ..lab_portable_workload_contract(
+            hot_label,
+            mutation_flag,
+            requires_extension_parity,
+            extra_required_tools,
+        )
+    }
+}
+
 fn lab_local_only_contract(hot_label: &'static str, reason: &'static str) -> LabCommandContract {
     LabCommandContract {
         hot_label,
         portability: LabCommandPortability::LocalOnly(reason),
+        default_lab_offload: false,
         source_path_mode: LabSourcePathMode::CwdOrPathFlag,
         workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
         mutation_flag: None,

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -234,6 +234,7 @@ fn lab_offload_command(
             contract.portability,
             homeboy::cli_surface::LabCommandPortability::Portable
         ),
+        default_lab_offload: contract.default_lab_offload,
         unsupported_reason: match contract.portability {
             homeboy::cli_surface::LabCommandPortability::Portable => None,
             homeboy::cli_surface::LabCommandPortability::LocalOnly(reason) => Some(reason),
@@ -529,7 +530,7 @@ mod tests {
     }
 
     #[test]
-    fn extension_update_is_lab_portable_without_extension_parity() {
+    fn extension_update_requires_explicit_lab_runner_without_extension_parity() {
         let cli = Cli::parse_from([
             "homeboy",
             "--runner",
@@ -543,10 +544,30 @@ mod tests {
 
         assert_eq!(command.hot_label, "extension update");
         assert!(command.portable);
+        assert!(!command.default_lab_offload);
         assert!(command.unsupported_reason.is_none());
         assert!(!command.requires_extension_parity);
         assert!(command.required_extensions.is_empty());
         assert!(!command.infer_source_path_tools);
+        assert!(cli.command.supports_lab_runner());
+    }
+
+    #[test]
+    fn extension_update_routes_locally_without_explicit_lab_runner() {
+        let _env = EnvGuard::remove(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV);
+        let normalized = vec![
+            "homeboy".to_string(),
+            "extension".to_string(),
+            "update".to_string(),
+            "wordpress".to_string(),
+        ];
+        let cli = Cli::parse_from(&normalized);
+
+        let outcome = route_after_parse(&cli, &normalized, None)
+            .expect("extension update without --runner should not offload");
+
+        assert_eq!(outcome, None);
+        assert!(std::env::var(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV).is_err());
     }
 
     #[test]

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -61,6 +61,7 @@ pub struct LabOffloadRequest<'a> {
 pub struct LabOffloadCommand {
     pub hot_label: &'static str,
     pub portable: bool,
+    pub default_lab_offload: bool,
     pub unsupported_reason: Option<&'static str>,
     pub workspace_mode_policy: LabOffloadWorkspaceModePolicy,
     pub requires_extension_parity: bool,
@@ -315,6 +316,14 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
                 Some(reason),
             )),
             plan,
+            messages: Vec::new(),
+        });
+    }
+
+    if request.explicit_runner.is_none() && !contract.default_lab_offload {
+        return Ok(LabOffloadOutcome::RunLocal {
+            plan: disabled_select_runner_plan(plan, "automatic Lab offload disabled"),
+            metadata: None,
             messages: Vec::new(),
         });
     }
@@ -1925,6 +1934,7 @@ mod tests {
         LabOffloadCommand {
             hot_label: label,
             portable: true,
+            default_lab_offload: true,
             unsupported_reason: None,
             workspace_mode_policy: LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
             requires_extension_parity: true,
@@ -1938,6 +1948,7 @@ mod tests {
         LabOffloadCommand {
             hot_label: "rig up",
             portable: false,
+            default_lab_offload: false,
             unsupported_reason: Some(reason),
             workspace_mode_policy: LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
             requires_extension_parity: false,
@@ -2876,6 +2887,44 @@ mod tests {
 
         assert_eq!(selection.runner_id, "lab-default");
         assert_eq!(selection.source, LabRunnerSelectionSource::Default);
+    }
+
+    #[test]
+    fn lab_runner_selection_ignores_default_when_auto_offload_is_disabled() {
+        let mut command = portable_lab_command("extension update");
+        command.default_lab_offload = false;
+
+        let selection = resolve_lab_runner_selection_from_default(
+            &command,
+            None,
+            false,
+            false,
+            false,
+            Some("lab-default".to_string()),
+        )
+        .expect("selection");
+
+        assert!(selection.is_none());
+    }
+
+    #[test]
+    fn lab_runner_selection_honors_explicit_runner_when_auto_offload_is_disabled() {
+        let mut command = portable_lab_command("extension update");
+        command.default_lab_offload = false;
+
+        let selection = resolve_lab_runner_selection_from_default(
+            &command,
+            Some("lab-explicit"),
+            false,
+            false,
+            false,
+            Some("lab-default".to_string()),
+        )
+        .expect("selection")
+        .expect("explicit runner selected");
+
+        assert_eq!(selection.runner_id, "lab-explicit");
+        assert_eq!(selection.source, LabRunnerSelectionSource::Explicit);
     }
 
     #[test]

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -320,11 +320,12 @@ pub(super) fn resolve_lab_runner_selection(
         .bench
         .local_execution
         .is_denied();
-    let default_runner = if explicit_runner.is_none() && command.portable {
-        super::resolve_default_lab_runner()?
-    } else {
-        None
-    };
+    let default_runner =
+        if explicit_runner.is_none() && command.portable && command.default_lab_offload {
+            super::resolve_default_lab_runner()?
+        } else {
+            None
+        };
 
     resolve_lab_runner_selection_from_default(
         command,
@@ -365,15 +366,23 @@ pub(super) fn resolve_lab_runner_selection_from_default(
         }));
     }
 
-    if force_hot && command.portable && default_runner.is_some() && !allow_local_hot {
-        let runner_id = default_runner.expect("checked above");
+    if !command.default_lab_offload {
+        fail_if_local_bench_denied(command, deny_local_bench)?;
+        return Ok(None);
+    }
+
+    if force_hot && command.portable && !allow_local_hot {
+        let Some(runner_id) = default_runner.as_ref() else {
+            fail_if_local_bench_denied(command, deny_local_bench)?;
+            return Ok(None);
+        };
         return Err(Error::validation_invalid_argument(
             "force_hot",
             format!(
                 "--force-hot would run portable hot command `{}` locally, but default Lab runner `{runner_id}` is available",
                 command.hot_label
             ),
-            Some(runner_id),
+            Some(runner_id.clone()),
             Some(vec![
                 "Omit --force-hot or pass --runner to offload the command to Lab.".to_string(),
                 "Pass --force-hot --allow-local-hot only when you intentionally want this portable hot command to run on the controller machine.".to_string(),


### PR DESCRIPTION
## Summary
- Keeps `homeboy extension update <id>` local by default even when a preferred Lab runner is configured.
- Preserves explicit remote intent: `homeboy --runner <runner-id> extension update <id>` remains Lab-portable.
- Documents the local-default/explicit-runner behavior for extension updates.

Fixes #4200.

## Verification
- `cargo fmt --check` ✅
- `cargo test extension_update --lib --bins` ✅
- `cargo test lab_runner_selection --lib --bins` ✅
- `git diff --check` ✅

## Known existing gate failures
- `cargo test` fails in `tests/core_agnostic_test.rs::core_owned_source_stays_language_and_framework_agnostic` due repo-wide non-baselined ecosystem boundary findings unrelated to this change.
- `cargo clippy --all-targets -- -D warnings` fails on repo-wide existing clippy warnings/errors unrelated to this change; this patch also fixes the one new clippy warning it introduced in `src/core/runner/lab_selection.rs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Lab routing change, regression tests, docs update, and local verification. Chris remains responsible for review and merge.