### PR TITLE
fix: pass settings to component bench scripts

### DIFF
--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -147,6 +147,7 @@ pub fn run_bench_list_workflow(
 ) -> Result<BenchListWorkflowResult> {
     let results_file = run_dir.step_file(run_dir::files::BENCH_RESULTS);
     if component.has_script(ExtensionCapability::Bench) {
+        let list_env = bench_component_script_list_env(&args)?;
         let source_path = crate::core::extension::component_script::source_path(
             component,
             args.path_override.as_deref(),
@@ -157,7 +158,7 @@ pub fn run_bench_list_workflow(
             &source_path,
             run_dir,
             true,
-            &[("HOMEBOY_BENCH_LIST_ONLY".to_string(), "1".to_string())],
+            &list_env,
             &args.passthrough_args,
         )?;
         ensure_bench_list_success(
@@ -573,6 +574,7 @@ pub fn run_main_bench_workflow(
 
     if component.has_script(ExtensionCapability::Bench) {
         clear_responsiveness_file(run_dir)?;
+        let component_env = bench_component_script_env(&args)?;
         let script_output =
             crate::core::extension::component_script::run_component_scripts_with_run_dir(
                 component,
@@ -580,7 +582,7 @@ pub fn run_main_bench_workflow(
                 source_path,
                 run_dir,
                 true,
-                &bench_component_script_env(&args),
+                &component_env,
                 &args.passthrough_args,
             )?;
         preserve_memory_timeline_artifacts(script_output.child_resource.as_ref(), run_dir, None)?;
@@ -925,7 +927,21 @@ pub fn run_main_bench_workflow(
     })
 }
 
-fn bench_component_script_env(args: &BenchRunWorkflowArgs) -> Vec<(String, String)> {
+fn bench_component_script_list_env(args: &BenchListWorkflowArgs) -> Result<Vec<(String, String)>> {
+    let mut env = vec![("HOMEBOY_BENCH_LIST_ONLY".to_string(), "1".to_string())];
+    env.push((
+        "HOMEBOY_SETTINGS_JSON".to_string(),
+        crate::core::extension::build_settings_json_from_manifest(
+            &serde_json::json!({}),
+            &[],
+            &args.settings,
+            &args.settings_json,
+        )?,
+    ));
+    Ok(env)
+}
+
+fn bench_component_script_env(args: &BenchRunWorkflowArgs) -> Result<Vec<(String, String)>> {
     let mut env = vec![
         (
             "HOMEBOY_BENCH_ITERATIONS".to_string(),
@@ -943,9 +959,18 @@ fn bench_component_script_env(args: &BenchRunWorkflowArgs) -> Vec<(String, Strin
             "HOMEBOY_BENCH_SCENARIOS".to_string(),
             args.scenario_ids.join(","),
         ),
+        (
+            "HOMEBOY_SETTINGS_JSON".to_string(),
+            crate::core::extension::build_settings_json_from_manifest(
+                &serde_json::json!({}),
+                &[],
+                &args.settings,
+                &args.settings_json,
+            )?,
+        ),
     ];
     env.extend(args.ci_env.iter().cloned());
-    env
+    Ok(env)
 }
 
 fn format_diagnostic_hint(diagnostic: &BenchDiagnostic) -> String {
@@ -1878,6 +1903,84 @@ mod tests {
                 PathBuf::from("/tmp/bench/studio-agent-runtime.bench.mjs"),
                 PathBuf::from("/tmp/bench/WpAdminLoad.php"),
             ]
+        );
+    }
+
+    #[test]
+    fn component_script_bench_env_includes_typed_settings_json() {
+        let env = bench_component_script_env(&BenchRunWorkflowArgs {
+            component_label: "studio-web".to_string(),
+            component_id: "studio-web".to_string(),
+            path_override: None,
+            settings: vec![("workflow_bench_env.FOO".to_string(), "bar".to_string())],
+            settings_json: vec![
+                (
+                    "workflow_bench_env".to_string(),
+                    serde_json::json!({ "WORKFLOW_BENCH_RUN_ID": "component-script-run" }),
+                ),
+            ],
+            iterations: 10,
+            warmup_iterations: None,
+            execution: BenchRunExecution { runs: 1, concurrency: 1 },
+            baseline_flags: BaselineFlags {
+                baseline: false,
+                ignore_baseline: true,
+                ratchet: false,
+            },
+            regression_threshold_percent: 5.0,
+            json_summary: false,
+            ci_env: Vec::new(),
+            passthrough_args: Vec::new(),
+            scenario_ids: Vec::new(),
+            rig_id: None,
+            shared_state: None,
+            extra_workloads: Vec::new(),
+            invocation_requirements: InvocationRequirements::default(),
+        })
+        .expect("component-script env");
+
+        let settings = env
+            .iter()
+            .find_map(|(key, value)| (key == "HOMEBOY_SETTINGS_JSON").then_some(value))
+            .expect("settings json env");
+        let parsed: serde_json::Value = serde_json::from_str(settings).expect("settings json");
+        assert_eq!(
+            parsed["workflow_bench_env"]["WORKFLOW_BENCH_RUN_ID"],
+            "component-script-run"
+        );
+        assert!(parsed["workflow_bench_env"]["FOO"].is_null());
+    }
+
+    #[test]
+    fn component_script_bench_list_env_includes_typed_settings_json() {
+        let env = bench_component_script_list_env(&BenchListWorkflowArgs {
+            component_label: "studio-web".to_string(),
+            component_id: "studio-web".to_string(),
+            path_override: None,
+            settings: Vec::new(),
+            settings_json: vec![
+                (
+                    "workflow_bench_env".to_string(),
+                    serde_json::json!({ "WORKFLOW_BENCH_SCENARIO": "plain-site-data-machine" }),
+                ),
+            ],
+            passthrough_args: Vec::new(),
+            scenario_ids: Vec::new(),
+            extra_workloads: Vec::new(),
+        })
+        .expect("component-script list env");
+
+        assert!(env
+            .iter()
+            .any(|(key, value)| key == "HOMEBOY_BENCH_LIST_ONLY" && value == "1"));
+        let settings = env
+            .iter()
+            .find_map(|(key, value)| (key == "HOMEBOY_SETTINGS_JSON").then_some(value))
+            .expect("settings json env");
+        let parsed: serde_json::Value = serde_json::from_str(settings).expect("settings json");
+        assert_eq!(
+            parsed["workflow_bench_env"]["WORKFLOW_BENCH_SCENARIO"],
+            "plain-site-data-machine"
         );
     }
 

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -46,7 +46,9 @@ pub(crate) use compiler_warning_contract::{
     extensions_for_compiler_warning_contract, run_compiler_warning_contract_script,
     CompilerWarningContract,
 };
-pub(crate) use execution::{execute_action, wordpress_release_publish_token_remediation};
+pub(crate) use execution::{
+    build_settings_json_from_manifest, execute_action, wordpress_release_publish_token_remediation,
+};
 pub use execution::{
     extension_ready_status, is_extension_compatible, run_action, run_extension, run_setup,
     ExtensionExecutionMode, ExtensionReadyStatus, ExtensionRunResult, ExtensionSetupResult,

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -571,7 +571,7 @@ fn runner_recovery_commands(
             "homeboy runner exec {} --ssh -- sh -lc {}",
             shell_arg(runner_id),
             shell_arg(&format!(
-                "ln -sf {} $(command -v homeboy)",
+                "ln -sf $(command -v homeboy) {}",
                 shell_arg(homeboy_path)
             ))
         ));
@@ -1339,7 +1339,7 @@ mod tests {
             .recovery_commands
             .contains(&"homeboy upgrade --force --upgrade-runner lab".to_string()));
         assert!(updated[0].recovery_commands.contains(&
-            "homeboy runner exec lab --ssh -- sh -lc 'ln -sf /home/chubes/.cargo/bin/homeboy $(command -v homeboy)'"
+            "homeboy runner exec lab --ssh -- sh -lc 'ln -sf $(command -v homeboy) /home/chubes/.cargo/bin/homeboy'"
                 .to_string()
         ));
         assert!(updated[0].detail.contains("runner PATH drift detected"));


### PR DESCRIPTION
## Summary
- Pass typed `HOMEBOY_SETTINGS_JSON` through component-script bench runs and list-only discovery.
- Fix runner path-drift recovery so the configured runner executable points to the refreshed bare `homeboy`, not the reverse.
- Add targeted regression coverage for component bench settings and path-drift recovery guidance.

## Verification
- `cargo test -q component_script_bench_ --lib`
- `cargo test -q defers_extension_failures_when_runner_refresh_leaves_path_drift --lib`
- `cargo check -q`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the component-script settings propagation gap, drafted the Rust fix/tests, and verified targeted Homeboy checks. Chris remains responsible for review and merge.