### PR TITLE
Fix trace compare shared rig lease conflicts

### DIFF
--- a/src/commands/trace/compare_targets.rs
+++ b/src/commands/trace/compare_targets.rs
@@ -33,6 +33,19 @@ pub(super) fn run_compare_targets(args: TraceArgs) -> CmdResult<TraceCommandOutp
     let baseline = required_target(args.baseline_target.as_deref(), "--baseline-target")?;
     let candidate = required_target(args.candidate.as_deref(), "--candidate")?;
     let (component_id, base_component) = compare_target_component(&args)?;
+    let _compare_lease = if let Some(rig_id) = args.rig.as_deref() {
+        load_rig_context(Some(rig_id))?
+            .map(|context| {
+                homeboy::core::rig::lease::acquire_active_run_lease(
+                    &context.rig_spec,
+                    "trace compare",
+                )
+            })
+            .transpose()?
+            .flatten()
+    } else {
+        None
+    };
     let scenario_id = args
         .scenario_arg
         .clone()
@@ -713,9 +726,25 @@ impl Drop for TemporaryGitWorktree {
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_fixture::{write_trace_extension, write_trace_rig};
     use super::*;
     use crate::commands::utils::args::{BaselineArgs, SettingArgs};
     use homeboy::core::component::ScopedExtensionConfig;
+
+    fn set_trace_rig_resources(rig_id: &str, resources: serde_json::Value) {
+        let rig_path = homeboy::core::paths::rigs()
+            .expect("rig dir")
+            .join(format!("{rig_id}.json"));
+        let mut rig_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&rig_path).expect("read rig"))
+                .expect("parse rig");
+        rig_json["resources"] = resources;
+        std::fs::write(
+            rig_path,
+            serde_json::to_string(&rig_json).expect("serialize rig"),
+        )
+        .expect("write rig");
+    }
 
     fn compare_args_for_rig(rig_id: &str, component_id: Option<&str>) -> TraceArgs {
         TraceArgs {
@@ -835,6 +864,45 @@ mod tests {
 
             assert_eq!(component_id, "only-component");
             assert_eq!(component.local_path, component_dir.path().to_string_lossy());
+        });
+    }
+
+    #[test]
+    fn compare_targets_with_same_resourceful_rig_runs_interleaved_children() {
+        crate::test_support::with_isolated_home(|home| {
+            write_trace_extension(home);
+            let component_dir = tempfile::TempDir::new().expect("component dir");
+            let baseline_dir = tempfile::TempDir::new().expect("baseline dir");
+            let candidate_dir = tempfile::TempDir::new().expect("candidate dir");
+            let output_dir = tempfile::TempDir::new().expect("output dir");
+            write_trace_rig(home, "studio-rig", "studio", component_dir.path());
+            set_trace_rig_resources(
+                "studio-rig",
+                serde_json::json!({ "exclusive": ["studio-runtime"] }),
+            );
+
+            let mut args = compare_args_for_rig("studio-rig", Some("studio"));
+            args.scenario_arg = Some("studio-app-create-site".to_string());
+            args.baseline_target = Some(baseline_dir.path().to_string_lossy().to_string());
+            args.candidate = Some(candidate_dir.path().to_string_lossy().to_string());
+            args.repeat = 2;
+            args.schedule = super::super::TraceSchedule::Interleaved;
+            args.output_dir = Some(output_dir.path().to_path_buf());
+
+            let (output, exit_code) = run_compare_targets(args).expect("compare target run");
+
+            assert_eq!(exit_code, 0);
+            let TraceCommandOutput::Compare(compare) = output else {
+                panic!("expected compare output");
+            };
+            assert_eq!(compare.proof_run_order.len(), 4);
+            assert_eq!(compare.proof_run_order[0].group, "baseline");
+            assert_eq!(compare.proof_run_order[1].group, "candidate");
+            assert_eq!(compare.proof_run_order[2].group, "baseline");
+            assert_eq!(compare.proof_run_order[3].group, "candidate");
+            assert!(homeboy::core::rig::lease::active_run_leases()
+                .expect("active leases")
+                .is_empty());
         });
     }
 }

--- a/src/core/rig/lease.rs
+++ b/src/core/rig/lease.rs
@@ -66,7 +66,10 @@ pub fn acquire_active_run_lease(rig: &RigSpec, command: &str) -> Result<Option<A
     })?;
 
     prune_stale_leases()?;
-    if let Some(conflict) = find_conflict(rig, &resources)? {
+    if has_covering_parent_lease(rig, command)? {
+        return Ok(None);
+    }
+    if let Some(conflict) = find_conflict(rig, command, &resources)? {
         return Err(Error::rig_resource_conflict(RigResourceConflictInfo {
             rig_id: rig.id.clone(),
             command: command.to_string(),
@@ -105,9 +108,16 @@ struct ResourceConflict {
     resource_value: String,
 }
 
-fn find_conflict(rig: &RigSpec, resources: &RigResourcesSpec) -> Result<Option<ResourceConflict>> {
+fn find_conflict(
+    rig: &RigSpec,
+    command: &str,
+    resources: &RigResourcesSpec,
+) -> Result<Option<ResourceConflict>> {
     for lease in live_leases()? {
         if lease.rig_id == rig.id {
+            if lease_allows_child_command(&lease, command) {
+                continue;
+            }
             return Ok(Some(ResourceConflict {
                 resource_kind: "rig".to_string(),
                 resource_value: rig.id.clone(),
@@ -123,6 +133,16 @@ fn find_conflict(rig: &RigSpec, resources: &RigResourcesSpec) -> Result<Option<R
         }
     }
     Ok(None)
+}
+
+fn has_covering_parent_lease(rig: &RigSpec, command: &str) -> Result<bool> {
+    Ok(live_leases()?
+        .iter()
+        .any(|lease| lease.rig_id == rig.id && lease_allows_child_command(lease, command)))
+}
+
+fn lease_allows_child_command(lease: &RigRunLease, command: &str) -> bool {
+    lease.pid == std::process::id() && lease.command == "trace compare" && command == "trace"
 }
 
 fn overlapping_resource(

--- a/tests/core/rig/lease_test.rs
+++ b/tests/core/rig/lease_test.rs
@@ -146,6 +146,26 @@ fn test_active_run_leases_lists_live_leases_without_mutating_them() {
 }
 
 #[test]
+fn test_trace_compare_lease_allows_same_process_child_trace() {
+    with_isolated_home(|_| {
+        let studio = rig("studio", resources());
+
+        let compare_lease = acquire_active_run_lease(&studio, "trace compare")
+            .expect("compare lease")
+            .expect("resourceful rig leases");
+        let child_lease = acquire_active_run_lease(&studio, "trace")
+            .expect("child trace lease should be allowed under compare");
+
+        assert!(child_lease.is_none());
+        assert_eq!(active_run_leases().expect("list active leases").len(), 1);
+        drop(compare_lease);
+        assert!(active_run_leases()
+            .expect("list active leases after drop")
+            .is_empty());
+    });
+}
+
+#[test]
 fn test_acquire_active_run_lease_prunes_stale_pid() {
     with_isolated_home(|_| {
         let stale = RigRunLease {


### PR DESCRIPTION
## Summary
- Acquire a compare-level rig lease for target-based `homeboy trace compare` runs so baseline/candidate children are covered by one owner.
- Allow same-process child `trace` acquisitions under a `trace compare` parent lease without weakening cross-process resource conflict protection.
- Add regression coverage for same-rig target compare with interleaved scheduling.

Fixes #4203.

## Verification
- `cargo fmt`
- `cargo test core::rig::lease`
- `cargo test compare_targets_with_same_resourceful_rig_runs_interleaved_children`
- Offloaded Woo Stripe smoke through `homeboy-lab`:
  `target/debug/homeboy --runner homeboy-lab trace compare woocommerce-gateway-stripe ece-product-page-waterfall --rig woocommerce-stripe-ece-product-page --profile webperf-wallet-fanout --baseline-target origin/develop --candidate 0631a0a1d5f6856c960f4224efa7d3f03787d666 --schedule interleaved --report markdown`

The offloaded compare now proceeds past the shared rig lease conflict and executes baseline/candidate. The run still exits non-zero because the trace scenario itself returns exit code 1 on both sides, which is outside this Homeboy lease fix.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the lease-boundary fix, regression tests, and verification commands; Chris remains responsible for review and merge.