### PR TITLE
Add nested controller primitives

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -215,10 +215,24 @@ homeboy agent-task controller apply-event transformer-loop \
 
 The payload may include a `policy` object using
 `homeboy/agent-task-loop-controller/v1` action names such as `spawn_task`,
-`fan_out`, `join`, `retry`, `request_changes`, `run_gates`, `wait_for_event`,
-`mark_human_ready`, `complete`, `abandon`, and `escalate`. Actions with
-deterministic `dedupe_key` values are recorded once, so replaying a resumed
-controller does not duplicate already-open tasks or PR work.
+`fan_out`, `spawn_controller`, `spawn_subloop`, `wait_for_controller`, `join`,
+`retry`, `request_changes`, `run_gates`, `wait_for_event`, `mark_human_ready`,
+`complete`, `abandon`, and `escalate`. Actions with deterministic `dedupe_key`
+values are recorded once, so replaying a resumed controller does not duplicate
+already-open tasks, child controllers, or PR work.
+
+Nested controller actions are first-class state primitives. `spawn_controller`
+and its `spawn_subloop` alias record a parent-visible child controller ref with
+the parent loop id, spawning action id, optional entity id, request payload, and
+dedupe key. Controller records also include optional `parent_loop_id`,
+`parent_action_id`, and `parent_entity_id` fields so spawned child records can
+carry their parent provenance directly. `wait_for_controller` puts the parent in
+`waiting` state and records a wait that is satisfied when `controller status`
+observes the child controller in a terminal state (`completed`, `failed`,
+`human_ready`, `abandoned`, or `escalated` by default). Autonomous execution of
+pending spawn/wait actions is still owned by #3905; until that lands, these
+primitives define the durable schema, idempotency, and status visibility that
+the runner will execute.
 
 Mark work as explicitly ready for a human handoff:
 

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -598,7 +598,7 @@ fn controller(args: AgentTaskControllerArgs) -> CmdResult<Value> {
             0,
         )),
         AgentTaskControllerCommand::Status(status_args) => Ok((
-            command_json_value(agent_task_loop_controller::load_controller(
+            command_json_value(agent_task_loop_controller::controller_status(
                 &status_args.loop_id,
             )?)?,
             0,

--- a/src/core/agent_task_loop_controller.rs
+++ b/src/core/agent_task_loop_controller.rs
@@ -18,6 +18,12 @@ pub struct AgentTaskLoopControllerRecord {
     pub phase: String,
     pub state: AgentTaskLoopControllerState,
     pub config_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_loop_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_action_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_entity_id: Option<String>,
     pub created_at: String,
     pub updated_at: String,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -32,6 +38,8 @@ pub struct AgentTaskLoopControllerRecord {
     pub gate_results: Vec<AgentTaskGateBundleResult>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub waits: Vec<AgentTaskLoopWait>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub subcontrollers: Vec<AgentTaskLoopSubcontrollerRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub feedback: Vec<AgentTaskLoopFeedbackArtifact>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -118,6 +126,28 @@ pub struct AgentTaskLoopDedupeRecord {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskLoopSubcontrollerRef {
+    pub loop_id: String,
+    pub dedupe_key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entity_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_loop_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_action_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wait_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub terminal_states: Vec<AgentTaskLoopControllerState>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<AgentTaskLoopControllerState>,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub request: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskLoopTaskLineage {
     pub run_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -175,6 +205,30 @@ pub enum AgentTaskLoopPolicyAction {
         #[serde(default, skip_serializing_if = "Value::is_null")]
         request_template: Value,
     },
+    SpawnController {
+        dedupe_key: String,
+        loop_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        entity_id: Option<String>,
+        #[serde(default = "default_controller_phase")]
+        phase: String,
+        #[serde(default = "default_config_version")]
+        config_version: String,
+        #[serde(default, skip_serializing_if = "Value::is_null")]
+        request: Value,
+    },
+    SpawnSubloop {
+        dedupe_key: String,
+        loop_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        entity_id: Option<String>,
+        #[serde(default = "default_controller_phase")]
+        phase: String,
+        #[serde(default = "default_config_version")]
+        config_version: String,
+        #[serde(default, skip_serializing_if = "Value::is_null")]
+        request: Value,
+    },
     RouteFinding {
         finding: AgentTaskLoopFindingPacket,
         dedupe_key: String,
@@ -206,6 +260,15 @@ pub enum AgentTaskLoopPolicyAction {
         entity_id: Option<String>,
     },
     WaitForEvent(AgentTaskLoopWait),
+    WaitForController {
+        loop_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        entity_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        wait_key: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        terminal_states: Vec<AgentTaskLoopControllerState>,
+    },
     MarkHumanReady {
         entity_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -485,6 +548,9 @@ impl AgentTaskLoopControllerRecord {
             phase: phase.into(),
             state: AgentTaskLoopControllerState::Running,
             config_version: config_version.into(),
+            parent_loop_id: None,
+            parent_action_id: None,
+            parent_entity_id: None,
             created_at: now.clone(),
             updated_at: now,
             entities: BTreeMap::new(),
@@ -493,6 +559,7 @@ impl AgentTaskLoopControllerRecord {
             gate_bundles: Vec::new(),
             gate_results: Vec::new(),
             waits: Vec::new(),
+            subcontrollers: Vec::new(),
             feedback: Vec::new(),
             next_actions: Vec::new(),
             history: Vec::new(),
@@ -675,9 +742,10 @@ impl AgentTaskLoopControllerRecord {
             AgentTaskLoopActionStatus::Pending
         };
 
-        self.apply_action_side_effects(&action, status);
+        let action_id = format!("action-{}", self.next_actions.len() + 1);
+        self.apply_action_side_effects(&action, status, &action_id);
         let record = AgentTaskLoopPolicyActionRecord {
-            action_id: format!("action-{}", self.next_actions.len() + 1),
+            action_id,
             action,
             status,
             reason,
@@ -811,6 +879,7 @@ impl AgentTaskLoopControllerRecord {
         &mut self,
         action: &AgentTaskLoopPolicyAction,
         status: AgentTaskLoopActionStatus,
+        action_id: &str,
     ) {
         if status == AgentTaskLoopActionStatus::AlreadySatisfied {
             return;
@@ -862,6 +931,67 @@ impl AgentTaskLoopControllerRecord {
                     self.waits.push(wait.clone());
                 }
             }
+            AgentTaskLoopPolicyAction::SpawnController {
+                dedupe_key,
+                loop_id,
+                entity_id,
+                request,
+                ..
+            }
+            | AgentTaskLoopPolicyAction::SpawnSubloop {
+                dedupe_key,
+                loop_id,
+                entity_id,
+                request,
+                ..
+            } => {
+                self.record_subcontroller_ref(
+                    loop_id,
+                    dedupe_key,
+                    entity_id.clone(),
+                    Some(action_id.to_string()),
+                    None,
+                    Vec::new(),
+                    request.clone(),
+                );
+            }
+            AgentTaskLoopPolicyAction::WaitForController {
+                loop_id,
+                entity_id,
+                wait_key,
+                terminal_states,
+            } => {
+                self.state = AgentTaskLoopControllerState::Waiting;
+                let wait_key = wait_key
+                    .clone()
+                    .unwrap_or_else(|| controller_wait_key(loop_id));
+                let terminal_states = controller_terminal_states(terminal_states);
+                self.record_subcontroller_ref(
+                    loop_id,
+                    &format!("controller:{loop_id}"),
+                    entity_id.clone(),
+                    None,
+                    Some(wait_key.clone()),
+                    terminal_states.clone(),
+                    Value::Null,
+                );
+                if !self
+                    .waits
+                    .iter()
+                    .any(|existing| existing.wait_key == wait_key)
+                {
+                    self.waits.push(AgentTaskLoopWait {
+                        wait_key,
+                        event_type: "controller.terminal".to_string(),
+                        entity_id: entity_id.clone(),
+                        external_ref: Some(loop_id.clone()),
+                        timeout_at: None,
+                        escalation_policy: None,
+                        status: AgentTaskLoopWaitStatus::Open,
+                        satisfied_by_event_id: None,
+                    });
+                }
+            }
             AgentTaskLoopPolicyAction::MarkHumanReady { entity_id, reason } => {
                 let _ = self.mark_human_ready(entity_id, reason.clone());
             }
@@ -888,6 +1018,50 @@ impl AgentTaskLoopControllerRecord {
     fn touch(&mut self) {
         self.updated_at = now_timestamp();
     }
+
+    fn record_subcontroller_ref(
+        &mut self,
+        loop_id: &str,
+        dedupe_key: &str,
+        entity_id: Option<String>,
+        parent_action_id: Option<String>,
+        wait_key: Option<String>,
+        terminal_states: Vec<AgentTaskLoopControllerState>,
+        request: Value,
+    ) {
+        if let Some(existing) = self
+            .subcontrollers
+            .iter_mut()
+            .find(|existing| existing.dedupe_key == dedupe_key || existing.loop_id == loop_id)
+        {
+            existing.entity_id = existing.entity_id.clone().or(entity_id);
+            existing.parent_action_id = existing.parent_action_id.clone().or(parent_action_id);
+            existing.wait_key = existing.wait_key.clone().or(wait_key);
+            if existing.terminal_states.is_empty() {
+                existing.terminal_states = terminal_states;
+            }
+            if existing.request.is_null() {
+                existing.request = request;
+            }
+            existing.updated_at = now_timestamp();
+            return;
+        }
+
+        let now = now_timestamp();
+        self.subcontrollers.push(AgentTaskLoopSubcontrollerRef {
+            loop_id: sanitize_loop_id(loop_id),
+            dedupe_key: dedupe_key.to_string(),
+            entity_id,
+            parent_loop_id: Some(self.loop_id.clone()),
+            parent_action_id,
+            wait_key,
+            terminal_states,
+            state: None,
+            created_at: now.clone(),
+            updated_at: now,
+            request,
+        });
+    }
 }
 
 pub fn create_controller(
@@ -902,6 +1076,14 @@ pub fn create_controller(
 
 pub fn load_controller(loop_id: &str) -> Result<AgentTaskLoopControllerRecord> {
     read_json(&controller_path(&sanitize_loop_id(loop_id))?)
+}
+
+pub fn controller_status(loop_id: &str) -> Result<AgentTaskLoopControllerRecord> {
+    let mut record = load_controller(loop_id)?;
+    if refresh_subcontroller_statuses(&mut record)? {
+        write_controller(&record)?;
+    }
+    Ok(record)
 }
 
 pub fn list_controllers() -> Result<Vec<AgentTaskLoopControllerRecord>> {
@@ -979,6 +1161,8 @@ fn action_dedupe_key(action: &AgentTaskLoopPolicyAction) -> Option<String> {
     match action {
         AgentTaskLoopPolicyAction::SpawnTask { dedupe_key, .. }
         | AgentTaskLoopPolicyAction::FanOut { dedupe_key, .. }
+        | AgentTaskLoopPolicyAction::SpawnController { dedupe_key, .. }
+        | AgentTaskLoopPolicyAction::SpawnSubloop { dedupe_key, .. }
         | AgentTaskLoopPolicyAction::RouteFinding { dedupe_key, .. } => Some(dedupe_key.clone()),
         AgentTaskLoopPolicyAction::ValidateCandidatePatch {
             candidate,
@@ -989,6 +1173,14 @@ fn action_dedupe_key(action: &AgentTaskLoopPolicyAction) -> Option<String> {
             candidate.candidate_id, validation.validation_id
         )),
         AgentTaskLoopPolicyAction::WaitForEvent(wait) => Some(format!("wait:{}", wait.wait_key)),
+        AgentTaskLoopPolicyAction::WaitForController {
+            loop_id, wait_key, ..
+        } => Some(format!(
+            "wait:{}",
+            wait_key
+                .clone()
+                .unwrap_or_else(|| controller_wait_key(loop_id))
+        )),
         AgentTaskLoopPolicyAction::RunGates {
             bundle_id,
             entity_id,
@@ -1021,6 +1213,9 @@ fn jsonpath_match_is_truthy(value: &Value) -> bool {
 fn action_entity_id(action: &AgentTaskLoopPolicyAction) -> Option<String> {
     match action {
         AgentTaskLoopPolicyAction::SpawnTask { entity_id, .. }
+        | AgentTaskLoopPolicyAction::SpawnController { entity_id, .. }
+        | AgentTaskLoopPolicyAction::SpawnSubloop { entity_id, .. }
+        | AgentTaskLoopPolicyAction::WaitForController { entity_id, .. }
         | AgentTaskLoopPolicyAction::RouteFinding { entity_id, .. }
         | AgentTaskLoopPolicyAction::RunGates { entity_id, .. } => entity_id.clone(),
         AgentTaskLoopPolicyAction::MarkHumanReady { entity_id, .. } => Some(entity_id.clone()),
@@ -1032,6 +1227,8 @@ fn action_name(action: &AgentTaskLoopPolicyAction) -> &'static str {
     match action {
         AgentTaskLoopPolicyAction::SpawnTask { .. } => "spawn_task",
         AgentTaskLoopPolicyAction::FanOut { .. } => "fan_out",
+        AgentTaskLoopPolicyAction::SpawnController { .. } => "spawn_controller",
+        AgentTaskLoopPolicyAction::SpawnSubloop { .. } => "spawn_subloop",
         AgentTaskLoopPolicyAction::RouteFinding { .. } => "route_finding",
         AgentTaskLoopPolicyAction::ValidateCandidatePatch { .. } => "validate_candidate_patch",
         AgentTaskLoopPolicyAction::Join { .. } => "join",
@@ -1039,11 +1236,85 @@ fn action_name(action: &AgentTaskLoopPolicyAction) -> &'static str {
         AgentTaskLoopPolicyAction::RequestChanges { .. } => "request_changes",
         AgentTaskLoopPolicyAction::RunGates { .. } => "run_gates",
         AgentTaskLoopPolicyAction::WaitForEvent(_) => "wait_for_event",
+        AgentTaskLoopPolicyAction::WaitForController { .. } => "wait_for_controller",
         AgentTaskLoopPolicyAction::MarkHumanReady { .. } => "mark_human_ready",
         AgentTaskLoopPolicyAction::Complete { .. } => "complete",
         AgentTaskLoopPolicyAction::Abandon { .. } => "abandon",
         AgentTaskLoopPolicyAction::Escalate { .. } => "escalate",
     }
+}
+
+fn refresh_subcontroller_statuses(record: &mut AgentTaskLoopControllerRecord) -> Result<bool> {
+    let mut changed = false;
+    let mut satisfied_waits = Vec::new();
+    for subcontroller in &mut record.subcontrollers {
+        let Ok(child) = load_controller(&subcontroller.loop_id) else {
+            continue;
+        };
+        if subcontroller.state != Some(child.state) {
+            subcontroller.state = Some(child.state);
+            subcontroller.updated_at = now_timestamp();
+            changed = true;
+        }
+        let terminal_states = controller_terminal_states(&subcontroller.terminal_states);
+        if terminal_states.contains(&child.state) {
+            if let Some(wait_key) = &subcontroller.wait_key {
+                satisfied_waits.push((wait_key.clone(), child.loop_id.clone(), child.state));
+            }
+        }
+    }
+
+    for (wait_key, child_loop_id, child_state) in satisfied_waits {
+        if let Some(wait) = record
+            .waits
+            .iter_mut()
+            .find(|wait| wait.wait_key == wait_key && wait.status == AgentTaskLoopWaitStatus::Open)
+        {
+            wait.status = AgentTaskLoopWaitStatus::Satisfied;
+            wait.satisfied_by_event_id = Some(format!(
+                "controller-terminal:{child_loop_id}:{child_state:?}"
+            ));
+            changed = true;
+        }
+    }
+
+    if record.open_wait_count() == 0 && record.state == AgentTaskLoopControllerState::Waiting {
+        record.state = AgentTaskLoopControllerState::Running;
+        changed = true;
+    }
+
+    if changed {
+        record.touch();
+    }
+    Ok(changed)
+}
+
+fn controller_wait_key(loop_id: &str) -> String {
+    format!("controller:{}:terminal", sanitize_loop_id(loop_id))
+}
+
+fn controller_terminal_states(
+    states: &[AgentTaskLoopControllerState],
+) -> Vec<AgentTaskLoopControllerState> {
+    if states.is_empty() {
+        vec![
+            AgentTaskLoopControllerState::Completed,
+            AgentTaskLoopControllerState::Failed,
+            AgentTaskLoopControllerState::HumanReady,
+            AgentTaskLoopControllerState::Abandoned,
+            AgentTaskLoopControllerState::Escalated,
+        ]
+    } else {
+        states.to_vec()
+    }
+}
+
+fn default_controller_phase() -> String {
+    "init".to_string()
+}
+
+fn default_config_version() -> String {
+    "v1".to_string()
 }
 
 fn entity_dedupe_key(entity_type: &str, key: &str) -> String {
@@ -1113,6 +1384,95 @@ mod tests {
         assert_eq!(first.status, AgentTaskLoopActionStatus::Pending);
         assert_eq!(second.status, AgentTaskLoopActionStatus::AlreadySatisfied);
         assert_eq!(record.dedupe_keys.len(), 1);
+    }
+
+    #[test]
+    fn subcontroller_spawn_records_parent_visible_child_once() {
+        let mut record = AgentTaskLoopControllerRecord::new("parent", "plan", "v1");
+        let first = record.record_action(
+            AgentTaskLoopPolicyAction::SpawnController {
+                dedupe_key: "controller:child:plan".to_string(),
+                loop_id: "child/controller".to_string(),
+                entity_id: Some("goal:4216".to_string()),
+                phase: "implement".to_string(),
+                config_version: "nested-v1".to_string(),
+                request: json!({ "issue": 4216 }),
+            },
+            "spawn child controller",
+        );
+        let second = record.record_action(
+            AgentTaskLoopPolicyAction::SpawnSubloop {
+                dedupe_key: "controller:child:plan".to_string(),
+                loop_id: "child/controller".to_string(),
+                entity_id: Some("goal:4216".to_string()),
+                phase: "implement".to_string(),
+                config_version: "nested-v1".to_string(),
+                request: json!({ "issue": 4216 }),
+            },
+            "replayed child controller spawn",
+        );
+
+        assert_eq!(first.status, AgentTaskLoopActionStatus::Pending);
+        assert_eq!(second.status, AgentTaskLoopActionStatus::AlreadySatisfied);
+        assert_eq!(record.subcontrollers.len(), 1);
+        let child = &record.subcontrollers[0];
+        assert_eq!(child.loop_id, "child_controller");
+        assert_eq!(child.parent_loop_id.as_deref(), Some("parent"));
+        assert_eq!(child.parent_action_id.as_deref(), Some("action-1"));
+        assert_eq!(child.entity_id.as_deref(), Some("goal:4216"));
+    }
+
+    #[test]
+    fn controller_status_satisfies_wait_when_child_reaches_terminal_state() {
+        with_isolated_home(|_| {
+            let mut parent = create_controller("parent-loop", "delegate", "v1").expect("parent");
+            parent.record_action(
+                AgentTaskLoopPolicyAction::SpawnController {
+                    dedupe_key: "controller:child-loop".to_string(),
+                    loop_id: "child-loop".to_string(),
+                    entity_id: Some("goal:4216".to_string()),
+                    phase: "implement".to_string(),
+                    config_version: "v1".to_string(),
+                    request: Value::Null,
+                },
+                "spawn child",
+            );
+            parent.record_action(
+                AgentTaskLoopPolicyAction::WaitForController {
+                    loop_id: "child-loop".to_string(),
+                    entity_id: Some("goal:4216".to_string()),
+                    wait_key: None,
+                    terminal_states: Vec::new(),
+                },
+                "wait for child terminal state",
+            );
+            write_controller(&parent).expect("parent written");
+
+            let mut child = create_controller("child-loop", "implement", "v1").expect("child");
+            child.record_action(
+                AgentTaskLoopPolicyAction::Complete {
+                    reason: Some("child finished".to_string()),
+                },
+                "child finished",
+            );
+            write_controller(&child).expect("child written");
+
+            let refreshed = controller_status("parent-loop").expect("refreshed");
+
+            assert_eq!(refreshed.state, AgentTaskLoopControllerState::Running);
+            assert_eq!(
+                refreshed.subcontrollers[0].state,
+                Some(AgentTaskLoopControllerState::Completed)
+            );
+            assert_eq!(
+                refreshed.waits[0].status,
+                AgentTaskLoopWaitStatus::Satisfied
+            );
+            assert_eq!(
+                refreshed.waits[0].satisfied_by_event_id.as_deref(),
+                Some("controller-terminal:child-loop:Completed")
+            );
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `spawn_controller`, `spawn_subloop`, and `wait_for_controller` as durable controller policy actions.
- Track parent/child controller provenance through parent-side `subcontrollers` refs and child-side parent fields.
- Refresh child status from `agent-task controller status` so parent waits are satisfied when a child reaches a terminal controller state.

## Notes
- This lands the schema, status, idempotency, and policy primitives for Extra-Chill/homeboy#4216.
- Autonomous execution of pending `spawn_controller` / `spawn_subloop` / `wait_for_controller` actions still depends on Extra-Chill/homeboy#3905.

## Verification
- `rustfmt --check src/core/agent_task_loop_controller.rs src/commands/agent_task.rs`
- `cargo test agent_task_loop_controller`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the nested controller primitive implementation, tests, docs, and PR description for Chris to review.

Closes Extra-Chill/homeboy#4216.