### PR TITLE
Format bench run tests

### DIFF
--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -1913,15 +1913,16 @@ mod tests {
             component_id: "studio-web".to_string(),
             path_override: None,
             settings: vec![("workflow_bench_env.FOO".to_string(), "bar".to_string())],
-            settings_json: vec![
-                (
-                    "workflow_bench_env".to_string(),
-                    serde_json::json!({ "WORKFLOW_BENCH_RUN_ID": "component-script-run" }),
-                ),
-            ],
+            settings_json: vec![(
+                "workflow_bench_env".to_string(),
+                serde_json::json!({ "WORKFLOW_BENCH_RUN_ID": "component-script-run" }),
+            )],
             iterations: 10,
             warmup_iterations: None,
-            execution: BenchRunExecution { runs: 1, concurrency: 1 },
+            execution: BenchRunExecution {
+                runs: 1,
+                concurrency: 1,
+            },
             baseline_flags: BaselineFlags {
                 baseline: false,
                 ignore_baseline: true,
@@ -1958,12 +1959,10 @@ mod tests {
             component_id: "studio-web".to_string(),
             path_override: None,
             settings: Vec::new(),
-            settings_json: vec![
-                (
-                    "workflow_bench_env".to_string(),
-                    serde_json::json!({ "WORKFLOW_BENCH_SCENARIO": "plain-site-data-machine" }),
-                ),
-            ],
+            settings_json: vec![(
+                "workflow_bench_env".to_string(),
+                serde_json::json!({ "WORKFLOW_BENCH_SCENARIO": "plain-site-data-machine" }),
+            )],
             passthrough_args: Vec::new(),
             scenario_ids: Vec::new(),
             extra_workloads: Vec::new(),


### PR DESCRIPTION
## Summary
- Applies `cargo fmt` to the existing bench run test formatting drift that currently fails the whole-repo lint gate.

## Verification
- `cargo fmt --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Identified and committed the formatting-only fix needed to unblock Homeboy CI.