### PR TITLE
Fix Workflow Bench artifact indexing and status

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -19,7 +19,7 @@ use homeboy::core::agent_task_lifecycle;
 use homeboy::core::agent_task_loop_controller::{
     self, AgentTaskLoopActionStatus, AgentTaskLoopControllerRecord, AgentTaskLoopExternalEvent,
     AgentTaskLoopHistoryEvent, AgentTaskLoopPolicyAction, AgentTaskLoopPolicyActionRecord,
-    AgentTaskLoopRunRef, AgentTaskLoopWait, AgentTaskLoopWaitStatus,
+    AgentTaskLoopRunRef,
 };
 use homeboy::core::agent_task_provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_task_scheduler::{
@@ -844,6 +844,42 @@ where
             request_template,
             executor,
         ),
+        AgentTaskLoopPolicyAction::SpawnController {
+            dedupe_key,
+            loop_id,
+            entity_id,
+            phase,
+            config_version,
+            request,
+        } => execute_spawn_controller_action(
+            record,
+            action,
+            "spawn_controller",
+            dedupe_key,
+            loop_id,
+            entity_id.as_deref(),
+            phase,
+            config_version,
+            request,
+        ),
+        AgentTaskLoopPolicyAction::SpawnSubloop {
+            dedupe_key,
+            loop_id,
+            entity_id,
+            phase,
+            config_version,
+            request,
+        } => execute_spawn_controller_action(
+            record,
+            action,
+            "spawn_subloop",
+            dedupe_key,
+            loop_id,
+            entity_id.as_deref(),
+            phase,
+            config_version,
+            request,
+        ),
         AgentTaskLoopPolicyAction::Join { wait_key } => Ok((
             serde_json::json!({ "mode": "join", "wait_key": wait_key }),
             0,
@@ -852,6 +888,17 @@ where
             serde_json::json!({ "mode": "wait_for_event", "wait_key": wait.wait_key }),
             0,
         )),
+        AgentTaskLoopPolicyAction::WaitForController {
+            loop_id,
+            entity_id,
+            wait_key,
+            terminal_states,
+        } => execute_wait_for_controller_action(
+            loop_id,
+            entity_id.as_deref(),
+            wait_key.as_deref(),
+            terminal_states,
+        ),
         AgentTaskLoopPolicyAction::RunGates {
             bundle_id,
             entity_id,
@@ -899,6 +946,93 @@ where
             ))
         }
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn execute_spawn_controller_action(
+    record: &mut AgentTaskLoopControllerRecord,
+    action: &AgentTaskLoopPolicyActionRecord,
+    mode: &str,
+    dedupe_key: &str,
+    loop_id: &str,
+    entity_id: Option<&str>,
+    phase: &str,
+    config_version: &str,
+    request: &Value,
+) -> CmdResult<Value> {
+    let mut created = false;
+    let mut child = match agent_task_loop_controller::load_controller(loop_id) {
+        Ok(child) => child,
+        Err(_) => {
+            created = true;
+            let mut child = AgentTaskLoopControllerRecord::new(loop_id, phase, config_version);
+            child.parent_loop_id = Some(record.loop_id.clone());
+            child.parent_action_id = Some(action.action_id.clone());
+            child.parent_entity_id = entity_id.map(str::to_string);
+            child.metadata = request.clone();
+            child
+        }
+    };
+    let mut child_changed = false;
+    if child.parent_loop_id.is_none() {
+        child.parent_loop_id = Some(record.loop_id.clone());
+        child_changed = true;
+    }
+    if child.parent_action_id.is_none() {
+        child.parent_action_id = Some(action.action_id.clone());
+        child_changed = true;
+    }
+    if child.parent_entity_id.is_none() {
+        child.parent_entity_id = entity_id.map(str::to_string);
+        child_changed = child.parent_entity_id.is_some();
+    }
+    if created || child_changed {
+        agent_task_loop_controller::write_controller(&child)?;
+    }
+    push_controller_history(
+        record,
+        "controller.action.spawned_controller",
+        entity_id.map(str::to_string),
+        serde_json::json!({
+            "action_id": action.action_id,
+            "dedupe_key": dedupe_key,
+            "loop_id": child.loop_id,
+            "mode": mode,
+            "created": created,
+        }),
+    );
+    Ok((
+        serde_json::json!({
+            "mode": mode,
+            "loop_id": child.loop_id,
+            "phase": child.phase,
+            "config_version": child.config_version,
+            "created": created,
+        }),
+        0,
+    ))
+}
+
+fn execute_wait_for_controller_action(
+    loop_id: &str,
+    entity_id: Option<&str>,
+    wait_key: Option<&str>,
+    terminal_states: &[homeboy::core::agent_task_loop_controller::AgentTaskLoopControllerState],
+) -> CmdResult<Value> {
+    let child_state = agent_task_loop_controller::load_controller(loop_id)
+        .ok()
+        .map(|child| format!("{:?}", child.state));
+    Ok((
+        serde_json::json!({
+            "mode": "wait_for_controller",
+            "loop_id": loop_id,
+            "entity_id": entity_id,
+            "wait_key": wait_key,
+            "terminal_states": terminal_states,
+            "child_state": child_state,
+        }),
+        0,
+    ))
 }
 
 fn execute_spawn_task_action<E>(
@@ -2469,16 +2603,18 @@ mod tests {
             )
             .expect("controller created");
             controller.record_action(
-                AgentTaskLoopPolicyAction::WaitForEvent(AgentTaskLoopWait {
-                    wait_key: "wait-a".to_string(),
-                    event_type: "task.completed".to_string(),
-                    entity_id: None,
-                    external_ref: None,
-                    timeout_at: None,
-                    escalation_policy: None,
-                    status: AgentTaskLoopWaitStatus::Open,
-                    satisfied_by_event_id: None,
-                }),
+                AgentTaskLoopPolicyAction::WaitForEvent(
+                    agent_task_loop_controller::AgentTaskLoopWait {
+                        wait_key: "wait-a".to_string(),
+                        event_type: "task.completed".to_string(),
+                        entity_id: None,
+                        external_ref: None,
+                        timeout_at: None,
+                        escalation_policy: None,
+                        status: agent_task_loop_controller::AgentTaskLoopWaitStatus::Open,
+                        satisfied_by_event_id: None,
+                    },
+                ),
                 "wait first",
             );
             controller.record_action(

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -636,10 +636,13 @@ pub fn run_main_bench_workflow(
         if let Some(results) = parsed.as_mut() {
             results.responsiveness = responsiveness.clone();
         }
-        let gate_failures = parsed
+        let mut gate_failures = parsed
             .as_mut()
             .map(super::gate::evaluate_gates)
             .unwrap_or_default();
+        if let Some(results) = parsed.as_ref() {
+            gate_failures.extend(workload_status_failures(results));
+        }
         let gate_results = parsed
             .as_ref()
             .map(super::gate::normalized_gate_results)
@@ -2139,6 +2142,101 @@ mod tests {
         .expect("parse bench results");
 
         assert!(workload_status_failures(&results).is_empty());
+    }
+
+    #[test]
+    fn component_script_bench_failed_metrics_mark_workflow_failed() {
+        let component_dir = tempfile::tempdir().expect("component dir");
+        let script_dir = component_dir.path().join("scripts");
+        fs::create_dir_all(&script_dir).expect("script dir");
+        fs::write(
+            script_dir.join("bench.sh"),
+            r#"#!/bin/sh
+cat > "$HOMEBOY_BENCH_RESULTS_FILE" <<'JSON'
+{
+  "component_id": "workflow-bench-fixture",
+  "iterations": 1,
+  "scenarios": [
+    {
+      "id": "workflow-bench",
+      "iterations": 1,
+      "metrics": {
+        "adapter_count": 1,
+        "passed_count": 0,
+        "failed_count": 1
+      },
+      "artifacts": {
+        "report": {
+          "path": "bench-report.json",
+          "kind": "json",
+          "label": "Bench report"
+        }
+      }
+    }
+  ]
+}
+JSON
+printf '{}' > "$HOMEBOY_RUN_DIR/bench-report.json"
+"#,
+        )
+        .expect("bench script");
+        let mut component = Component::new(
+            "workflow-bench-fixture".to_string(),
+            component_dir.path().to_string_lossy().to_string(),
+            String::new(),
+            None,
+        );
+        component.scripts = Some(crate::core::component::ComponentScriptsConfig {
+            bench: vec!["sh scripts/bench.sh".to_string()],
+            ..Default::default()
+        });
+        let run_dir = RunDir::create().expect("run dir");
+
+        let result = run_main_bench_workflow(
+            &component,
+            &component_dir.path().to_path_buf(),
+            BenchRunWorkflowArgs {
+                component_label: "Workflow Bench Fixture".to_string(),
+                component_id: "workflow-bench-fixture".to_string(),
+                path_override: None,
+                settings: Vec::new(),
+                settings_json: Vec::new(),
+                iterations: 1,
+                warmup_iterations: None,
+                execution: BenchRunExecution {
+                    runs: 1,
+                    concurrency: 1,
+                },
+                baseline_flags: BaselineFlags {
+                    baseline: false,
+                    ignore_baseline: true,
+                    ratchet: false,
+                },
+                regression_threshold_percent: 5.0,
+                json_summary: false,
+                ci_env: Vec::new(),
+                passthrough_args: Vec::new(),
+                scenario_ids: Vec::new(),
+                rig_id: None,
+                shared_state: None,
+                extra_workloads: Vec::new(),
+                invocation_requirements: InvocationRequirements::default(),
+            },
+            &run_dir,
+        )
+        .expect("bench workflow");
+
+        assert_eq!(result.status, "failed");
+        assert_eq!(result.exit_code, 1);
+        assert!(result.results.is_some());
+        assert!(result
+            .gate_failures
+            .iter()
+            .any(|failure| failure.contains("failed_count=1")));
+        assert!(result.results.as_ref().unwrap().scenarios[0]
+            .artifacts
+            .contains_key("report"));
+        run_dir.cleanup();
     }
 
     #[test]

--- a/src/core/publication_artifacts.rs
+++ b/src/core/publication_artifacts.rs
@@ -80,6 +80,12 @@ enum IndexedArtifactPath {
     Missing,
 }
 
+struct ManifestArtifactRef<'a> {
+    reference: &'a Value,
+    locator: String,
+    locator_type: &'static str,
+}
+
 fn index_manifest_refs(
     store: &ObservationStore,
     source: &ArtifactRecord,
@@ -91,12 +97,11 @@ fn index_manifest_refs(
         .and_then(Value::as_str)
         .map(str::to_string);
     let mut refs = Vec::new();
-    collect_artifact_store_refs(manifest, &mut refs);
+    let url_bases = publication_url_bases(manifest);
+    collect_publication_artifact_refs(manifest, &url_bases, &mut refs);
 
     for reference in refs {
-        let Some(locator) = artifact_store_locator(reference) else {
-            continue;
-        };
+        let locator = reference.locator.as_str();
         let Some(indexed_path) = resolve_path(locator)? else {
             continue;
         };
@@ -108,6 +113,7 @@ fn index_manifest_refs(
             IndexedArtifactPath::Missing => continue,
         };
         let original_manifest_id = reference
+            .reference
             .get("id")
             .and_then(Value::as_str)
             .unwrap_or(locator);
@@ -116,23 +122,27 @@ fn index_manifest_refs(
             continue;
         }
         let kind = reference
+            .reference
             .get("kind")
             .and_then(Value::as_str)
-            .or_else(|| reference.get("role").and_then(Value::as_str))
+            .or_else(|| reference.reference.get("role").and_then(Value::as_str))
             .unwrap_or("published_artifact")
             .to_string();
         let media_type = reference
+            .reference
             .get("media_type")
-            .or_else(|| reference.get("mime"))
-            .or_else(|| reference.get("contentType"))
+            .or_else(|| reference.reference.get("mime"))
+            .or_else(|| reference.reference.get("contentType"))
             .and_then(Value::as_str)
             .map(str::to_string)
             .or_else(|| crate::core::artifact_metadata::content_type_from_path(Path::new(&path)));
         let size_bytes = reference
+            .reference
             .get("bytes")
-            .or_else(|| reference.get("size_bytes"))
+            .or_else(|| reference.reference.get("size_bytes"))
             .and_then(Value::as_i64);
         let sha256 = reference
+            .reference
             .get("sha256")
             .and_then(|sha256| {
                 sha256
@@ -141,6 +151,7 @@ fn index_manifest_refs(
             })
             .map(str::to_string);
         let created_at = reference
+            .reference
             .get("created_at")
             .and_then(Value::as_str)
             .unwrap_or(&source.created_at)
@@ -153,17 +164,17 @@ fn index_manifest_refs(
             "manifest_id": manifest_id,
             "original_manifest_id": original_manifest_id,
             "name": name,
-            "role": reference.get("role").cloned().unwrap_or(Value::Null),
+            "role": reference.reference.get("role").cloned().unwrap_or(Value::Null),
             "locator": {
-                "type": "artifact-store",
+                "type": reference.locator_type,
                 "value": locator,
             },
             "media_type": media_type,
             "bytes": size_bytes,
             "sha256": sha256,
-            "description": reference.get("description").cloned().unwrap_or(Value::Null),
-            "metadata": reference.get("metadata").cloned().unwrap_or(Value::Null),
-            "viewer": reference.get("viewer").cloned().unwrap_or(Value::Null),
+            "description": reference.reference.get("description").cloned().unwrap_or(Value::Null),
+            "metadata": reference.reference.get("metadata").cloned().unwrap_or(Value::Null),
+            "viewer": reference.reference.get("viewer").cloned().unwrap_or(Value::Null),
         });
 
         let mut artifact = ArtifactRecord {
@@ -189,19 +200,33 @@ fn index_manifest_refs(
     Ok(())
 }
 
-fn collect_artifact_store_refs<'a>(value: &'a Value, refs: &mut Vec<&'a Value>) {
+fn collect_publication_artifact_refs<'a>(
+    value: &'a Value,
+    url_bases: &[String],
+    refs: &mut Vec<ManifestArtifactRef<'a>>,
+) {
     match value {
         Value::Object(object) => {
-            if artifact_store_locator(value).is_some() {
-                refs.push(value);
+            if let Some(locator) = artifact_store_locator(value) {
+                refs.push(ManifestArtifactRef {
+                    reference: value,
+                    locator: locator.to_string(),
+                    locator_type: "artifact-store",
+                });
+            } else if let Some(locator) = url_locator_artifact_store_locator(value, url_bases) {
+                refs.push(ManifestArtifactRef {
+                    reference: value,
+                    locator,
+                    locator_type: "url",
+                });
             }
             for child in object.values() {
-                collect_artifact_store_refs(child, refs);
+                collect_publication_artifact_refs(child, url_bases, refs);
             }
         }
         Value::Array(array) => {
             for child in array {
-                collect_artifact_store_refs(child, refs);
+                collect_publication_artifact_refs(child, url_bases, refs);
             }
         }
         _ => {}
@@ -214,6 +239,67 @@ fn artifact_store_locator(reference: &Value) -> Option<&str> {
         return None;
     }
     locator.get("value").and_then(Value::as_str)
+}
+
+fn url_locator_artifact_store_locator(reference: &Value, url_bases: &[String]) -> Option<String> {
+    let locator = reference.get("locator")?;
+    if locator.get("type").and_then(Value::as_str)? != "url" {
+        return None;
+    }
+    let value = locator.get("value").and_then(Value::as_str)?;
+    url_locator_relative_path(value, url_bases)
+}
+
+fn publication_url_bases(manifest: &Value) -> Vec<String> {
+    let mut bases = Vec::new();
+    for object in [manifest.get("publication"), Some(manifest)]
+        .into_iter()
+        .flatten()
+    {
+        for key in [
+            "public_base_url",
+            "publicBaseUrl",
+            "artifact_base",
+            "artifactBase",
+        ] {
+            if let Some(base) = object.get(key).and_then(Value::as_str) {
+                bases.push(base.to_string());
+            }
+        }
+    }
+    bases.sort();
+    bases.dedup();
+    bases
+}
+
+fn url_locator_relative_path(value: &str, bases: &[String]) -> Option<String> {
+    let url = reqwest::Url::parse(value).ok()?;
+    if url.query().is_some() || url.fragment().is_some() {
+        return None;
+    }
+    for base in bases {
+        let Ok(base) = reqwest::Url::parse(base) else {
+            continue;
+        };
+        if url.scheme() != base.scheme()
+            || url.host_str() != base.host_str()
+            || url.port_or_known_default() != base.port_or_known_default()
+        {
+            continue;
+        }
+        let mut base_path = base.path().to_string();
+        if !base_path.ends_with('/') {
+            base_path.push('/');
+        }
+        let Some(relative) = url.path().strip_prefix(&base_path) else {
+            continue;
+        };
+        if relative.is_empty() || artifact_store_path(Path::new(""), relative).is_none() {
+            continue;
+        }
+        return Some(relative.to_string());
+    }
+    None
 }
 
 fn artifact_store_path(root: &Path, locator: &str) -> Option<PathBuf> {
@@ -335,4 +421,109 @@ fn artifact_name(manifest_id: &str) -> String {
         .filter(|name| !name.is_empty())
         .unwrap_or(manifest_id)
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::observation::{NewRunRecord, ObservationStore};
+
+    #[test]
+    fn indexes_url_locators_under_publication_base_and_preserves_viewer() {
+        crate::test_support::with_isolated_home(|_| {
+            let publication_dir = tempfile::tempdir().expect("publication dir");
+            std::fs::write(publication_dir.path().join("blueprint.after.json"), "{}").unwrap();
+            let manifest_path = publication_dir.path().join("publication-manifest.json");
+            std::fs::write(
+                &manifest_path,
+                serde_json::json!({
+                    "id": "workflow-bench-publication",
+                    "publication": {
+                        "public_base_url": "https://artifacts.example.test/runs/e62c34cf/"
+                    },
+                    "blueprint": {
+                        "after": {
+                            "id": "blueprint.after",
+                            "kind": "blueprint",
+                            "media_type": "application/json",
+                            "locator": {
+                                "type": "url",
+                                "value": "https://artifacts.example.test/runs/e62c34cf/blueprint.after.json"
+                            },
+                            "viewer": {
+                                "url": "https://viewer.example.test/?artifact=blueprint.after"
+                            }
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .unwrap();
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(NewRunRecord::builder("bench").build())
+                .expect("run");
+            let manifest = store
+                .record_artifact(&run.id, "publication_manifest", &manifest_path)
+                .expect("manifest artifact");
+            let artifacts = store.list_artifacts(&run.id).expect("artifacts");
+            let indexed = artifacts
+                .iter()
+                .find(|artifact| artifact.id != manifest.id && artifact.kind == "blueprint")
+                .expect("indexed blueprint artifact");
+
+            assert_eq!(indexed.artifact_type, "file");
+            assert!(Path::new(&indexed.path).is_file());
+            assert_eq!(indexed.metadata_json["locator"]["type"], "url");
+            assert_eq!(
+                indexed.metadata_json["locator"]["value"],
+                "blueprint.after.json"
+            );
+            assert_eq!(
+                indexed.metadata_json["viewer"]["url"],
+                "https://viewer.example.test/?artifact=blueprint.after"
+            );
+        });
+    }
+
+    #[test]
+    fn rejects_url_locators_outside_publication_base() {
+        crate::test_support::with_isolated_home(|_| {
+            let publication_dir = tempfile::tempdir().expect("publication dir");
+            std::fs::write(publication_dir.path().join("leak.json"), "{}").unwrap();
+            let manifest_path = publication_dir.path().join("publication-manifest.json");
+            std::fs::write(
+                &manifest_path,
+                serde_json::json!({
+                    "publication": {
+                        "public_base_url": "https://artifacts.example.test/runs/e62c34cf/"
+                    },
+                    "blueprint": {
+                        "after": {
+                            "id": "blueprint.after",
+                            "kind": "blueprint",
+                            "locator": {
+                                "type": "url",
+                                "value": "https://evil.example.test/runs/e62c34cf/leak.json"
+                            }
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .unwrap();
+
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(NewRunRecord::builder("bench").build())
+                .expect("run");
+            store
+                .record_artifact(&run.id, "publication_manifest", &manifest_path)
+                .expect("manifest artifact");
+            let artifacts = store.list_artifacts(&run.id).expect("artifacts");
+
+            assert_eq!(artifacts.len(), 1);
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- Index publication-manifest URL locators as retrievable artifacts when they resolve under `publication.public_base_url` or `publication.artifact_base`.
- Preserve viewer metadata on indexed publication artifacts while rejecting out-of-base URL locators.
- Make component-script bench runs fail when parsed scenario metrics report failed, unsupported, warning, or zero-passing child counts, while keeping parsed results/artifacts attached.

## Issue coverage
- Fixes #4225
- Fixes #4230

## Tests
- `cargo fmt`
- `cargo test publication_artifacts::tests`
- `cargo test component_script_bench_failed_metrics_mark_workflow_failed`
- `cargo test workload_status_failures`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused Rust implementation and regression tests; Chris remains responsible for review and validation.