### PR TITLE
Fix Workflow Bench artifact origin and bench status papercuts

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -932,9 +932,6 @@ where
             0,
         )),
         AgentTaskLoopPolicyAction::RouteFinding { .. }
-        | AgentTaskLoopPolicyAction::SpawnController { .. }
-        | AgentTaskLoopPolicyAction::SpawnSubloop { .. }
-        | AgentTaskLoopPolicyAction::WaitForController { .. }
         | AgentTaskLoopPolicyAction::ValidateCandidatePatch { .. }
         | AgentTaskLoopPolicyAction::Retry { .. }
         | AgentTaskLoopPolicyAction::RequestChanges { .. } => {
@@ -2256,7 +2253,6 @@ mod tests {
     use homeboy::core::agent_task_lifecycle::{
         status as lifecycle_status, AgentTaskRunRecord, AgentTaskRunState,
     };
-    use homeboy::core::agent_task_loop_controller::{AgentTaskLoopWait, AgentTaskLoopWaitStatus};
     use homeboy::core::agent_task_scheduler::{AgentTaskExecutionContext, AgentTaskState};
     use serde_json::{json, Value};
     use std::sync::{Arc, Mutex};

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -2,7 +2,10 @@ use clap::{Args, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use homeboy::core::preview_client::{self, PreviewClientReport, PreviewClientStartSpec};
+use homeboy::core::artifact_origin::{self, ArtifactOriginServeSpec, ArtifactOriginStatus};
+use homeboy::core::preview_client::{
+    self, PreviewClientAuthDiagnostic, PreviewClientReport, PreviewClientStartSpec,
+};
 use homeboy::core::preview_ingress::{
     self, PreviewIngressInstallOptions, PreviewIngressInstallPlan, PreviewIngressInstallStatusPlan,
     PreviewIngressRoute, PreviewIngressServeSpec, PreviewIngressStatus,
@@ -31,6 +34,8 @@ pub struct TunnelExtra {
     pub preview_ingress: Option<PreviewIngressActionOutput>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preview_consumer: Option<PreviewConsumerOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_origin: Option<ArtifactOriginActionOutput>,
 }
 
 #[derive(Debug, Serialize)]
@@ -45,7 +50,10 @@ pub enum ServiceTunnelActionOutput {
 
 #[derive(Debug, Serialize)]
 pub struct PreviewClientActionOutput {
-    pub report: PreviewClientReport,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub report: Option<PreviewClientReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_diagnostic: Option<PreviewClientAuthDiagnostic>,
 }
 
 #[derive(Debug, Serialize)]
@@ -107,6 +115,12 @@ struct PreviewConsumerOutputConfig {
     pub public_result_stdout_prefix: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum ArtifactOriginActionOutput {
+    Serve(ArtifactOriginStatus),
+}
+
 pub type TunnelOutput = EntityCrudOutput<ServiceTunnel, TunnelExtra>;
 
 #[derive(Args)]
@@ -139,6 +153,12 @@ enum TunnelCommand {
     PreviewConsumer {
         #[command(subcommand)]
         command: TunnelPreviewConsumerCommand,
+    },
+    /// Serve the artifact root as a browser/reviewer-facing static origin
+    #[command(name = "artifact-origin")]
+    ArtifactOrigin {
+        #[command(subcommand)]
+        command: TunnelArtifactOriginCommand,
     },
 }
 
@@ -196,6 +216,16 @@ enum TunnelPreviewClientCommand {
         #[arg(long)]
         ready_stdout: bool,
     },
+    /// Compare preview-client token digests without printing token material
+    DiagnoseAuth {
+        /// Environment variable that contains the preview tunnel bearer token
+        #[arg(long, default_value = "HOMEBOY_PREVIEW_TUNNEL_TOKEN")]
+        token_env: String,
+
+        /// Environment variable containing the allowed client token SHA-256 digest
+        #[arg(long, default_value = "HOMEBOY_PREVIEW_TUNNEL_TOKEN_SHA256")]
+        token_sha256_env: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -245,6 +275,10 @@ enum TunnelPreviewIngressCommand {
         /// Public host pattern routed to this ingress
         #[arg(long)]
         public_host_pattern: Option<String>,
+
+        /// Public host to inspect for preview-client registration state
+        #[arg(long)]
+        host: Option<String>,
     },
     /// Run the blocking HTTP ingress server behind a TLS terminator
     Serve {
@@ -263,6 +297,20 @@ enum TunnelPreviewIngressCommand {
         /// Environment variable containing the allowed client token SHA-256 digest
         #[arg(long, default_value = "HOMEBOY_PREVIEW_TUNNEL_TOKEN_SHA256")]
         token_sha256_env: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum TunnelArtifactOriginCommand {
+    /// Serve Homeboy artifact-root paths with CORS headers for browser consumers
+    Serve {
+        /// Loopback bind address for the local static artifact origin
+        #[arg(long, default_value = "127.0.0.1:7351")]
+        bind: String,
+
+        /// Artifact root to serve. Defaults to Homeboy's configured artifact root.
+        #[arg(long)]
+        root: Option<PathBuf>,
     },
 }
 
@@ -542,6 +590,30 @@ pub fn run(args: TunnelArgs, _global: &super::GlobalArgs) -> CmdResult<TunnelOut
         TunnelCommand::PreviewClient { command } => run_preview_client(command),
         TunnelCommand::PreviewIngress { command } => run_preview_ingress(command),
         TunnelCommand::PreviewConsumer { command } => run_preview_consumer(command),
+        TunnelCommand::ArtifactOrigin { command } => run_artifact_origin(command),
+    }
+}
+
+fn run_artifact_origin(command: TunnelArtifactOriginCommand) -> CmdResult<TunnelOutput> {
+    match command {
+        TunnelArtifactOriginCommand::Serve { bind, root } => {
+            let status = artifact_origin::status(
+                bind.clone(),
+                root.clone().unwrap_or(homeboy::core::artifact_root()?),
+            );
+            artifact_origin::serve(ArtifactOriginServeSpec { bind, root })?;
+            Ok((
+                TunnelOutput {
+                    command: "tunnel.artifact_origin.serve".to_string(),
+                    extra: TunnelExtra {
+                        artifact_origin: Some(ArtifactOriginActionOutput::Serve(status)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                0,
+            ))
+        }
     }
 }
 
@@ -790,7 +862,31 @@ fn run_preview_client(command: TunnelPreviewClientCommand) -> CmdResult<TunnelOu
                     command: "tunnel.preview_client.start".to_string(),
                     id: Some(report.public_host.clone()),
                     extra: TunnelExtra {
-                        preview_client: Some(PreviewClientActionOutput { report }),
+                        preview_client: Some(PreviewClientActionOutput {
+                            report: Some(report.clone()),
+                            auth_diagnostic: None,
+                        }),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                0,
+            ))
+        }
+        TunnelPreviewClientCommand::DiagnoseAuth {
+            token_env,
+            token_sha256_env,
+        } => {
+            let diagnostic = preview_client::diagnose_auth(&token_env, &token_sha256_env)?;
+            Ok((
+                TunnelOutput {
+                    command: "tunnel.preview_client.diagnose_auth".to_string(),
+                    id: Some(token_env),
+                    extra: TunnelExtra {
+                        preview_client: Some(PreviewClientActionOutput {
+                            report: None,
+                            auth_diagnostic: Some(diagnostic),
+                        }),
                         ..Default::default()
                     },
                     ..Default::default()
@@ -893,8 +989,9 @@ fn run_preview_ingress(command: TunnelPreviewIngressCommand) -> CmdResult<Tunnel
             bind,
             domain,
             public_host_pattern,
+            host,
         } => {
-            let status = preview_ingress::status(bind, domain, public_host_pattern)?;
+            let status = preview_ingress::status_for_host(bind, domain, public_host_pattern, host)?;
             Ok((
                 TunnelOutput {
                     command: "tunnel.preview_ingress.status".to_string(),

--- a/src/core/artifact_origin.rs
+++ b/src/core/artifact_origin.rs
@@ -1,0 +1,233 @@
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Component, Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::core::{paths, Error, Result};
+
+#[derive(Debug, Clone)]
+pub struct ArtifactOriginServeSpec {
+    pub bind: String,
+    pub root: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ArtifactOriginStatus {
+    pub command: &'static str,
+    pub bind: String,
+    pub root: String,
+    pub public_base_url_shape: String,
+    pub cors: bool,
+}
+
+pub fn serve(spec: ArtifactOriginServeSpec) -> Result<ArtifactOriginStatus> {
+    let root = spec.root.unwrap_or(paths::artifact_root()?);
+    let listener = TcpListener::bind(&spec.bind)
+        .map_err(|err| Error::internal_io(err.to_string(), Some(spec.bind.clone())))?;
+    eprintln!(
+        "homeboy artifact origin serving {} on {}",
+        root.display(),
+        spec.bind
+    );
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let root = root.clone();
+                std::thread::spawn(move || {
+                    if let Err(err) = handle_stream(stream, &root) {
+                        eprintln!("homeboy artifact origin connection error: {}", err.message);
+                    }
+                });
+            }
+            Err(err) => return Err(Error::internal_io(err.to_string(), Some(spec.bind))),
+        }
+    }
+    Ok(status(spec.bind, root))
+}
+
+pub fn status(bind: String, root: PathBuf) -> ArtifactOriginStatus {
+    ArtifactOriginStatus {
+        command: "tunnel.artifact_origin.serve",
+        bind,
+        root: root.display().to_string(),
+        public_base_url_shape: "https://<public-host>".to_string(),
+        cors: true,
+    }
+}
+
+fn handle_stream(mut stream: TcpStream, root: &Path) -> Result<()> {
+    let mut reader = BufReader::new(stream.try_clone().map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("clone artifact origin stream".to_string()),
+        )
+    })?);
+    let mut first_line = String::new();
+    reader.read_line(&mut first_line).map_err(|err| {
+        Error::internal_io(err.to_string(), Some("read request line".to_string()))
+    })?;
+    let mut parts = first_line.split_whitespace();
+    let method = parts.next().unwrap_or_default();
+    let target = parts.next().unwrap_or("/");
+    let response = response_for_request(root, method, target)?;
+    write!(
+        stream,
+        "HTTP/1.1 {} {}\r\n",
+        response.status,
+        reason(response.status)
+    )
+    .map_err(|err| Error::internal_io(err.to_string(), Some("write status".to_string())))?;
+    for (name, value) in response.headers {
+        write!(stream, "{}: {}\r\n", name, value)
+            .map_err(|err| Error::internal_io(err.to_string(), Some("write header".to_string())))?;
+    }
+    write!(stream, "connection: close\r\n\r\n")
+        .map_err(|err| Error::internal_io(err.to_string(), Some("write headers".to_string())))?;
+    stream
+        .write_all(&response.body)
+        .map_err(|err| Error::internal_io(err.to_string(), Some("write body".to_string())))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ArtifactOriginResponse {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+}
+
+fn response_for_request(root: &Path, method: &str, target: &str) -> Result<ArtifactOriginResponse> {
+    let mut headers = cors_headers();
+    if method.eq_ignore_ascii_case("OPTIONS") {
+        headers.push(("content-length".to_string(), "0".to_string()));
+        return Ok(ArtifactOriginResponse {
+            status: 204,
+            headers,
+            body: Vec::new(),
+        });
+    }
+    if !method.eq_ignore_ascii_case("GET") && !method.eq_ignore_ascii_case("HEAD") {
+        let body = br#"{"error":"method_not_allowed"}"#.to_vec();
+        headers.push(("content-type".to_string(), "application/json".to_string()));
+        headers.push(("content-length".to_string(), body.len().to_string()));
+        return Ok(ArtifactOriginResponse {
+            status: 405,
+            headers,
+            body,
+        });
+    }
+    let Some(path) = safe_target_path(root, target) else {
+        let body = br#"{"error":"not_found"}"#.to_vec();
+        headers.push(("content-type".to_string(), "application/json".to_string()));
+        headers.push(("content-length".to_string(), body.len().to_string()));
+        return Ok(ArtifactOriginResponse {
+            status: 404,
+            headers,
+            body,
+        });
+    };
+    let body = match std::fs::read(&path) {
+        Ok(body) => body,
+        Err(_) => br#"{"error":"not_found"}"#.to_vec(),
+    };
+    let status = if path.is_file() { 200 } else { 404 };
+    headers.push((
+        "content-type".to_string(),
+        crate::core::artifact_metadata::content_type_from_path(&path)
+            .unwrap_or_else(|| "application/octet-stream".to_string()),
+    ));
+    headers.push(("content-length".to_string(), body.len().to_string()));
+    Ok(ArtifactOriginResponse {
+        status,
+        headers,
+        body: if method.eq_ignore_ascii_case("HEAD") {
+            Vec::new()
+        } else {
+            body
+        },
+    })
+}
+
+fn cors_headers() -> Vec<(String, String)> {
+    vec![
+        ("access-control-allow-origin".to_string(), "*".to_string()),
+        (
+            "access-control-allow-methods".to_string(),
+            "GET, HEAD, OPTIONS".to_string(),
+        ),
+        ("access-control-allow-headers".to_string(), "*".to_string()),
+    ]
+}
+
+fn safe_target_path(root: &Path, target: &str) -> Option<PathBuf> {
+    let path = target
+        .split('?')
+        .next()
+        .unwrap_or(target)
+        .trim_start_matches('/');
+    let relative = PathBuf::from(path);
+    if relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    {
+        return None;
+    }
+    Some(root.join(relative))
+}
+
+fn reason(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        204 => "No Content",
+        405 => "Method Not Allowed",
+        _ => "Not Found",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serves_json_with_cors_headers() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp
+            .path()
+            .join("homeboy/workflow-bench/runs/run/artifacts/blueprint.after.json");
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&path, b"{}").expect("write artifact");
+
+        let response = response_for_request(
+            temp.path(),
+            "GET",
+            "/homeboy/workflow-bench/runs/run/artifacts/blueprint.after.json",
+        )
+        .expect("response");
+
+        assert_eq!(response.status, 200);
+        assert!(response
+            .headers
+            .contains(&("access-control-allow-origin".to_string(), "*".to_string())));
+        assert!(response
+            .headers
+            .contains(&("content-type".to_string(), "application/json".to_string())));
+    }
+
+    #[test]
+    fn handles_playground_preflight_without_file_read() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let response = response_for_request(
+            temp.path(),
+            "OPTIONS",
+            "/homeboy/workflow-bench/runs/run/artifacts/blueprint.after.json",
+        )
+        .expect("response");
+
+        assert_eq!(response.status, 204);
+        assert!(response.headers.contains(&(
+            "access-control-allow-methods".to_string(),
+            "GET, HEAD, OPTIONS".to_string()
+        )));
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -22,6 +22,7 @@ pub mod artifact_inputs;
 pub mod artifact_links;
 pub mod artifact_manifest;
 pub(crate) mod artifact_metadata;
+pub mod artifact_origin;
 pub mod browser_evidence;
 pub mod build_identity;
 pub mod change_artifact;

--- a/src/core/preview_client.rs
+++ b/src/core/preview_client.rs
@@ -32,6 +32,19 @@ pub struct PreviewClientReport {
     pub stopped: bool,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PreviewClientAuthDiagnostic {
+    pub command: &'static str,
+    pub token_env: String,
+    pub token_present: bool,
+    pub token_empty: bool,
+    pub local_token_sha256: Option<String>,
+    pub expected_sha256_env: String,
+    pub expected_sha256: Option<String>,
+    pub matches_expected: Option<bool>,
+    pub hashing_semantics: &'static str,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PreviewIngressRequest {
     pub request_id: String,
@@ -157,6 +170,36 @@ pub fn start(spec: PreviewClientStartSpec) -> Result<PreviewClientReport> {
     })
 }
 
+pub fn diagnose_auth(
+    token_env: &str,
+    expected_sha256_env: &str,
+) -> Result<PreviewClientAuthDiagnostic> {
+    require_non_empty("token_env", token_env)?;
+    require_non_empty("expected_sha256_env", expected_sha256_env)?;
+    let token = std::env::var(token_env).ok();
+    let expected = std::env::var(expected_sha256_env)
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    let local = token
+        .as_ref()
+        .filter(|value| !value.is_empty())
+        .map(|value| sha256_hex(value.as_bytes()));
+    Ok(PreviewClientAuthDiagnostic {
+        command: "tunnel.preview_client.diagnose_auth",
+        token_env: token_env.to_string(),
+        token_present: token.is_some(),
+        token_empty: token.as_ref().is_some_and(|value| value.is_empty()),
+        local_token_sha256: local.clone(),
+        expected_sha256_env: expected_sha256_env.to_string(),
+        expected_sha256: expected.clone(),
+        matches_expected: local
+            .zip(expected)
+            .map(|(local, expected)| local.eq_ignore_ascii_case(&expected)),
+        hashing_semantics:
+            "sha256 over exact token bytes; shell equivalent: printf %s \"$TOKEN\" | sha256sum",
+    })
+}
+
 pub fn forward_to_local_origin(
     client: &Client,
     local_origin: &str,
@@ -185,6 +228,15 @@ fn forward_to_local_origin_result(
     local_origin: &str,
     request: &PreviewIngressRequest,
 ) -> std::result::Result<PreviewIngressResponse, PreviewClientForwardError> {
+    if request.method.eq_ignore_ascii_case("OPTIONS") {
+        return Ok(PreviewIngressResponse {
+            request_id: request.request_id.clone(),
+            status: 204,
+            headers: cors_headers(BTreeMap::new(), &request.path),
+            body_base64: base64::engine::general_purpose::STANDARD.encode([]),
+            error: None,
+        });
+    }
     let method = request
         .method
         .parse()
@@ -207,7 +259,7 @@ fn forward_to_local_origin_result(
             message: err.to_string(),
         })?;
     let status = response.status().as_u16();
-    let headers = response_headers(response.headers());
+    let headers = cors_headers(response_headers(response.headers()), &request.path);
     let body = response.bytes().map_err(|err| PreviewClientForwardError {
         kind: "local_origin_response_failed".to_string(),
         message: err.to_string(),
@@ -315,10 +367,16 @@ fn post_json(
         .text()
         .map_err(|err| Error::internal_unexpected(format!("read {context} response: {err}")))?;
     if !status.is_success() {
+        let hint = if status.as_u16() == 401 {
+            " Hint: run `homeboy tunnel preview-client diagnose-auth` and compare no-newline SHA-256 digests without printing token material."
+        } else {
+            ""
+        };
         return Err(Error::internal_unexpected(format!(
-            "{context} failed with HTTP {}: {}",
+            "{context} failed with HTTP {}: {}{}",
             status.as_u16(),
-            text
+            text,
+            hint
         )));
     }
     if text.trim().is_empty() {
@@ -393,6 +451,30 @@ fn response_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
                 .map(|value| (normalized, value.to_string()))
         })
         .collect()
+}
+
+fn cors_headers(mut headers: BTreeMap<String, String>, path: &str) -> BTreeMap<String, String> {
+    headers
+        .entry("access-control-allow-origin".to_string())
+        .or_insert_with(|| "*".to_string());
+    headers
+        .entry("access-control-allow-methods".to_string())
+        .or_insert_with(|| "GET, HEAD, OPTIONS".to_string());
+    headers
+        .entry("access-control-allow-headers".to_string())
+        .or_insert_with(|| "*".to_string());
+    if path.split('?').next().unwrap_or(path).ends_with(".json") {
+        headers
+            .entry("content-type".to_string())
+            .or_insert_with(|| "application/json".to_string());
+    }
+    headers
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    format!("{digest:x}")
 }
 
 fn validate_start_spec(spec: &PreviewClientStartSpec) -> Result<()> {
@@ -547,5 +629,49 @@ mod tests {
         assert_eq!(response.status, 502);
         let error = response.error.expect("error");
         assert_eq!(error.kind, "local_origin_request_failed");
+    }
+
+    #[test]
+    fn options_preflight_returns_cors_without_local_origin() {
+        let client = Client::builder()
+            .timeout(Duration::from_millis(100))
+            .build()
+            .expect("client");
+        let response = forward_to_local_origin(
+            &client,
+            "http://127.0.0.1:9",
+            PreviewIngressRequest {
+                request_id: "req-options".to_string(),
+                method: "OPTIONS".to_string(),
+                path: "/homeboy/workflow-bench/runs/run/artifacts/blueprint.after.json".to_string(),
+                headers: BTreeMap::new(),
+                body_base64: None,
+            },
+        );
+
+        assert_eq!(response.status, 204);
+        assert_eq!(response.headers["access-control-allow-origin"], "*");
+        assert_eq!(response.headers["content-type"], "application/json");
+    }
+
+    #[test]
+    fn auth_diagnostic_hashes_exact_token_bytes() {
+        std::env::set_var("HOMEBOY_TEST_PREVIEW_TOKEN", "abc");
+        std::env::set_var(
+            "HOMEBOY_TEST_PREVIEW_TOKEN_SHA256",
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        );
+
+        let diagnostic = diagnose_auth(
+            "HOMEBOY_TEST_PREVIEW_TOKEN",
+            "HOMEBOY_TEST_PREVIEW_TOKEN_SHA256",
+        )
+        .expect("diagnostic");
+
+        assert_eq!(diagnostic.local_token_sha256, diagnostic.expected_sha256);
+        assert_eq!(diagnostic.matches_expected, Some(true));
+
+        std::env::remove_var("HOMEBOY_TEST_PREVIEW_TOKEN");
+        std::env::remove_var("HOMEBOY_TEST_PREVIEW_TOKEN_SHA256");
     }
 }

--- a/src/core/preview_ingress.rs
+++ b/src/core/preview_ingress.rs
@@ -33,6 +33,10 @@ pub struct PreviewIngressStatus {
     pub public_host_pattern: Option<String>,
     pub routes: Vec<PreviewIngressRouteStatus>,
     pub recent_failures: Vec<PreviewIngressFailure>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inspected_host: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inspected_state: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -287,7 +291,27 @@ pub fn status(
     domain: Option<String>,
     public_host_pattern: Option<String>,
 ) -> Result<PreviewIngressStatus> {
-    status_with_failures(bind, domain, public_host_pattern, Vec::new())
+    status_for_host(bind, domain, public_host_pattern, None)
+}
+
+pub fn status_for_host(
+    bind: Option<String>,
+    domain: Option<String>,
+    public_host_pattern: Option<String>,
+    host: Option<String>,
+) -> Result<PreviewIngressStatus> {
+    let inspected_host = host.map(|host| normalize_public_host(&host));
+    let inspected_state = inspected_host.as_ref().map(|host| {
+        classify_route_host_state(host).unwrap_or_else(|| "missing_session".to_string())
+    });
+    status_with_failures(
+        bind,
+        domain,
+        public_host_pattern,
+        Vec::new(),
+        inspected_host,
+        inspected_state,
+    )
 }
 
 pub fn render_install_plan(
@@ -389,6 +413,8 @@ fn status_with_failures(
     domain: Option<String>,
     public_host_pattern: Option<String>,
     recent_failures: Vec<PreviewIngressFailure>,
+    inspected_host: Option<String>,
+    inspected_state: Option<String>,
 ) -> Result<PreviewIngressStatus> {
     Ok(PreviewIngressStatus {
         bind,
@@ -402,6 +428,8 @@ fn status_with_failures(
             })
             .collect(),
         recent_failures,
+        inspected_host,
+        inspected_state,
     })
 }
 
@@ -476,15 +504,28 @@ fn handle_connection(
     let host = request.host.clone().unwrap_or_default();
     let path = request.target.clone();
 
-    if request.target == "/_homeboy/preview-ingress/status" {
+    if request.target.split('?').next() == Some("/_homeboy/preview-ingress/status") {
         let failures = recent_failures
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone();
-        let body = serde_json::to_vec_pretty(&status_with_failures(None, None, None, failures)?)
-            .map_err(|e| {
-                Error::internal_json(e.to_string(), Some("preview ingress status".to_string()))
-            })?;
+        let inspected_host =
+            query_value(&request.target, "host").map(|host| normalize_public_host(&host));
+        let inspected_state = inspected_host.as_ref().map(|host| {
+            classify_runtime_host_state(host, &sessions, &failures)
+                .unwrap_or_else(|| "missing_session".to_string())
+        });
+        let body = serde_json::to_vec_pretty(&status_with_failures(
+            None,
+            None,
+            None,
+            failures,
+            inspected_host,
+            inspected_state,
+        )?)
+        .map_err(|e| {
+            Error::internal_json(e.to_string(), Some("preview ingress status".to_string()))
+        })?;
         write_response(
             &mut stream,
             200,
@@ -505,7 +546,7 @@ fn handle_connection(
     }
 
     if request.target.starts_with("/preview/client/") {
-        return handle_client_api(&mut stream, request, &sessions, &auth);
+        return handle_client_api(&mut stream, request, &sessions, &auth, &recent_failures);
     }
 
     let Some(route) = route_for_host(&host)? else {
@@ -636,6 +677,7 @@ fn handle_client_api(
     request: IngressHttpRequest,
     sessions: &Arc<PreviewClientSessions>,
     auth: &PreviewIngressAuth,
+    recent_failures: &Arc<Mutex<Vec<PreviewIngressFailure>>>,
 ) -> Result<()> {
     if request.method != "POST" {
         return write_json_response(
@@ -645,10 +687,24 @@ fn handle_client_api(
         );
     }
     if !authorized_preview_client(&request, auth) {
+        let failure = PreviewIngressFailure {
+            request_id: uuid::Uuid::new_v4().to_string(),
+            host: request.host.clone().unwrap_or_default(),
+            path: request.target.clone(),
+            status: 401,
+            classification: "auth_failed_recently".to_string(),
+            message: "preview client bearer token is missing or invalid; compare no-newline SHA-256 digests with `homeboy tunnel preview-client diagnose-auth`".to_string(),
+        };
+        record_failure(recent_failures, failure);
         return write_json_response(
             stream,
             401,
-            json!({ "error": "unauthorized", "message": "preview client bearer token is missing or invalid" }),
+            json!({
+                "error": "unauthorized",
+                "classification": "auth_failed_recently",
+                "message": "preview client bearer token is missing or invalid",
+                "hint": "Run `homeboy tunnel preview-client diagnose-auth`; Homeboy hashes exact token bytes (printf %s), never newline-terminated input."
+            }),
         );
     }
 
@@ -857,6 +913,24 @@ fn proxy_request(
     started: Instant,
     recent_failures: Arc<Mutex<Vec<PreviewIngressFailure>>>,
 ) -> Result<()> {
+    if request.method.eq_ignore_ascii_case("OPTIONS") {
+        write_status_and_headers(
+            stream,
+            204,
+            "No Content",
+            &artifact_cors_headers(Vec::new(), &path),
+        )?;
+        log_request(&PreviewIngressLogLine {
+            request_id,
+            host,
+            path,
+            status: 204,
+            bytes: 0,
+            duration_ms: started.elapsed().as_millis(),
+            classification: "cors_preflight".to_string(),
+        });
+        return Ok(());
+    }
     let upstream_url = upstream_url(route, &request.target)?;
     let method = reqwest::Method::from_bytes(request.method.as_bytes())
         .map_err(|e| Error::validation_invalid_argument("method", e.to_string(), None, None))?;
@@ -885,6 +959,7 @@ fn proxy_request(
                     value.to_str().ok().map(|value| (name, value.to_string()))
                 })
                 .collect::<Vec<_>>();
+            let headers = artifact_cors_headers(headers, &path);
             write_status_and_headers(
                 stream,
                 status.as_u16(),
@@ -1008,6 +1083,64 @@ fn validate_client_public_host(public_host: &str) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+fn classify_runtime_host_state(
+    public_host: &str,
+    sessions: &Arc<PreviewClientSessions>,
+    recent_failures: &[PreviewIngressFailure],
+) -> Option<String> {
+    let sessions_guard = sessions
+        .sessions
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(session) = sessions_guard.get(public_host) {
+        return Some(
+            if session.active {
+                "registered"
+            } else {
+                "disconnected"
+            }
+            .to_string(),
+        );
+    }
+    drop(sessions_guard);
+    if recent_failures.iter().rev().any(|failure| {
+        normalize_public_host(&failure.host) == public_host
+            && failure.classification == "auth_failed_recently"
+    }) {
+        return Some("auth_failed_recently".to_string());
+    }
+    route_for_host(public_host)
+        .ok()
+        .flatten()
+        .map(|route| route_state_label(&route))
+}
+
+fn classify_route_host_state(public_host: &str) -> Option<String> {
+    route_for_host(public_host)
+        .ok()
+        .flatten()
+        .map(|route| route_state_label(&route))
+}
+
+fn route_state_label(route: &PreviewIngressRoute) -> String {
+    match classify_route(route) {
+        PreviewIngressRouteLifecycle::Active => "registered".to_string(),
+        PreviewIngressRouteLifecycle::Expired => "missing_session".to_string(),
+        PreviewIngressRouteLifecycle::Disconnected => "disconnected".to_string(),
+    }
+}
+
+fn query_value(target: &str, key: &str) -> Option<String> {
+    let query = target.split_once('?')?.1;
+    for pair in query.split('&') {
+        let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
+        if name == key {
+            return Some(value.replace('+', " "));
+        }
+    }
+    None
 }
 
 fn validate_client_local_origin(local_origin: &str) -> Result<()> {
@@ -1460,6 +1593,29 @@ fn write_status_and_headers(
     }
     write!(stream, "\r\n")
         .map_err(|e| Error::internal_io(e.to_string(), Some("write header terminator".to_string())))
+}
+
+fn artifact_cors_headers(mut headers: Vec<(String, String)>, path: &str) -> Vec<(String, String)> {
+    push_header_if_missing(&mut headers, "access-control-allow-origin", "*");
+    push_header_if_missing(
+        &mut headers,
+        "access-control-allow-methods",
+        "GET, HEAD, OPTIONS",
+    );
+    push_header_if_missing(&mut headers, "access-control-allow-headers", "*");
+    if path.split('?').next().unwrap_or(path).ends_with(".json") {
+        push_header_if_missing(&mut headers, "content-type", "application/json");
+    }
+    headers
+}
+
+fn push_header_if_missing(headers: &mut Vec<(String, String)>, name: &str, value: &str) {
+    if !headers
+        .iter()
+        .any(|(header_name, _)| header_name.eq_ignore_ascii_case(name))
+    {
+        headers.push((name.to_string(), value.to_string()));
+    }
 }
 
 fn reason_for_status(status: u16) -> &'static str {

--- a/src/core/preview_ingress_tests.rs
+++ b/src/core/preview_ingress_tests.rs
@@ -3,7 +3,7 @@ use super::tunnel::native_preview_token_sha256;
 use crate::test_support;
 use base64::Engine;
 use serde_json::json;
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::thread;
 use std::time::Duration;
@@ -66,6 +66,34 @@ fn route_status_reports_expired_and_disconnected_sessions() {
             PreviewIngressRouteLifecycle::Disconnected
         );
         assert_eq!(routes[1].lifecycle, PreviewIngressRouteLifecycle::Expired);
+    });
+}
+
+#[test]
+fn status_for_host_reports_route_registration_state() {
+    test_support::with_isolated_home(|_| {
+        register_route(PreviewIngressRoute {
+            session_id: "run-123".to_string(),
+            public_host: "run-123-tunnel.chubes.net".to_string(),
+            upstream_origin: "http://127.0.0.1:7331".to_string(),
+            expires_at: None,
+            active: true,
+        })
+        .expect("register route");
+
+        let status = status_for_host(
+            None,
+            None,
+            None,
+            Some("RUN-123-TUNNEL.CHUBES.NET:443".to_string()),
+        )
+        .expect("status");
+
+        assert_eq!(
+            status.inspected_host.as_deref(),
+            Some("run-123-tunnel.chubes.net")
+        );
+        assert_eq!(status.inspected_state.as_deref(), Some("registered"));
     });
 }
 
@@ -168,6 +196,115 @@ fn reverse_channel_client_serves_public_request() {
         assert!(
             browser_response.contains("console.log('ok');"),
             "{browser_response}"
+        );
+    });
+}
+
+#[test]
+fn route_proxy_serves_artifact_json_with_cors_headers() {
+    test_support::with_isolated_home(|_| {
+        let upstream = TcpListener::bind("127.0.0.1:0").expect("upstream bind");
+        let upstream_port = upstream.local_addr().expect("upstream addr").port();
+        thread::spawn(move || {
+            let (mut stream, _) = upstream.accept().expect("accept upstream");
+            let mut request = String::new();
+            BufReader::new(stream.try_clone().expect("clone upstream"))
+                .read_line(&mut request)
+                .expect("read upstream request");
+            assert!(
+                request
+                    .contains("/homeboy/workflow-bench/runs/run-1/artifacts/blueprint.after.json"),
+                "{request}"
+            );
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 12\r\n\r\n{\"steps\":[]}")
+                .expect("write upstream response");
+        });
+
+        let ingress = TcpListener::bind("127.0.0.1:0").expect("reserve port");
+        let ingress_port = ingress.local_addr().expect("ingress addr").port();
+        drop(ingress);
+        thread::spawn(move || {
+            serve(PreviewIngressServeSpec {
+                bind: format!("127.0.0.1:{ingress_port}"),
+                domain: "example.com".to_string(),
+                public_host_pattern: "*-tunnel.example.com".to_string(),
+                token_sha256_env: "HOMEBOY_TEST_UNUSED_TOKEN_SHA256".to_string(),
+            })
+            .expect("serve ingress");
+        });
+        thread::sleep(Duration::from_millis(100));
+
+        register_route(PreviewIngressRoute {
+            session_id: "run-1".to_string(),
+            public_host: "run-1-tunnel.example.com".to_string(),
+            upstream_origin: format!("http://127.0.0.1:{upstream_port}"),
+            expires_at: None,
+            active: true,
+        })
+        .expect("register route");
+
+        let response = raw_http_request(
+            ingress_port,
+            "GET /homeboy/workflow-bench/runs/run-1/artifacts/blueprint.after.json HTTP/1.1\r\nHost: run-1-tunnel.example.com\r\n\r\n",
+        );
+
+        assert!(response.contains("200 OK"), "{response}");
+        assert!(
+            response.contains("access-control-allow-origin: *"),
+            "{response}"
+        );
+        assert!(
+            response.contains("content-type: application/json"),
+            "{response}"
+        );
+        assert!(response.contains("{\"steps\":[]}"), "{response}");
+    });
+}
+
+#[test]
+fn route_proxy_answers_artifact_preflight_without_upstream() {
+    test_support::with_isolated_home(|_| {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("reserve port");
+        let port = listener.local_addr().expect("local addr").port();
+        drop(listener);
+        thread::spawn(move || {
+            serve(PreviewIngressServeSpec {
+                bind: format!("127.0.0.1:{port}"),
+                domain: "example.com".to_string(),
+                public_host_pattern: "*-tunnel.example.com".to_string(),
+                token_sha256_env: "HOMEBOY_TEST_UNUSED_TOKEN_SHA256".to_string(),
+            })
+            .expect("serve ingress");
+        });
+        thread::sleep(Duration::from_millis(100));
+
+        register_route(PreviewIngressRoute {
+            session_id: "run-1".to_string(),
+            public_host: "run-1-tunnel.example.com".to_string(),
+            upstream_origin: "http://127.0.0.1:9".to_string(),
+            expires_at: None,
+            active: true,
+        })
+        .expect("register route");
+
+        let response = raw_http_request(
+            port,
+            "OPTIONS /homeboy/workflow-bench/runs/run-1/artifacts/blueprint.after.json HTTP/1.1\r\nHost: run-1-tunnel.example.com\r\n\r\n",
+        );
+
+        assert!(response.contains("204 No Content"), "{response}");
+        assert!(
+            response.contains("access-control-allow-origin: *"),
+            "{response}"
+        );
+        assert!(
+            response.contains("access-control-allow-methods: GET, HEAD, OPTIONS"),
+            "{response}"
+        );
+        assert!(
+            response.contains("content-type: application/json"),
+            "{response}"
         );
     });
 }

--- a/src/core/publication_artifacts.rs
+++ b/src/core/publication_artifacts.rs
@@ -116,8 +116,8 @@ fn index_manifest_refs(
             .reference
             .get("id")
             .and_then(Value::as_str)
-            .unwrap_or(locator);
-        let id = published_artifact_id(&source.id, original_manifest_id, locator);
+            .unwrap_or(&locator);
+        let id = published_artifact_id(&source.id, original_manifest_id, &locator);
         if store.get_artifact(&id)?.is_some() {
             continue;
         }

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -701,6 +701,68 @@ fn publication_manifest_artifact_store_refs_are_indexed() {
 }
 
 #[test]
+fn publication_manifest_public_url_refs_are_indexed_from_artifact_origin() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("init store");
+        let run = store
+            .start_run(sample_run("bench", "homeboy"))
+            .expect("start run");
+        let locator = "homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/blueprint.after.json";
+        let artifact_root = home.path().join(".local/share/homeboy/artifacts");
+        let nested_path = artifact_root.join(locator);
+        std::fs::create_dir_all(nested_path.parent().expect("nested parent"))
+            .expect("create artifact-store parent");
+        std::fs::write(&nested_path, br#"{"steps":[]}"#).expect("nested artifact");
+        let manifest_path = home.path().join("publication-manifest.json");
+        std::fs::write(
+            &manifest_path,
+            serde_json::json!({
+                "schema": "example/publication-manifest/v1",
+                "id": "publish-run-1",
+                "publication": {
+                    "public_base_url": "https://homeboy-artifacts-tunnel.dev.chubes.net",
+                    "artifact_base": "homeboy/workflow-bench"
+                },
+                "artifacts": [{
+                    "schema": "example/artifact-reference/v1",
+                    "id": "scenario/adapter/attempt-1/blueprint.after",
+                    "kind": "published-blueprint-after",
+                    "role": "output",
+                    "locator": {
+                        "type": "url",
+                        "value": "https://homeboy-artifacts-tunnel.dev.chubes.net/homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/blueprint.after.json"
+                    },
+                    "media_type": "application/json",
+                    "bytes": 12,
+                    "sha256": "abc123",
+                    "created_at": "2026-06-11T15:42:42Z"
+                }]
+            })
+            .to_string(),
+        )
+        .expect("manifest artifact");
+
+        let source = store
+            .record_artifact(&run.id, "publication_manifest", &manifest_path)
+            .expect("record manifest");
+        let artifacts = store.list_artifacts(&run.id).expect("list artifacts");
+        let nested = artifacts
+            .iter()
+            .find(|artifact| artifact.id != source.id)
+            .expect("nested artifact indexed");
+
+        assert_eq!(artifacts.len(), 2);
+        assert_eq!(nested.kind, "published-blueprint-after");
+        assert_eq!(nested.path, nested_path.to_string_lossy());
+        assert_eq!(
+            nested.metadata_json["locator"]["value"].as_str(),
+            Some(locator)
+        );
+    });
+}
+
+#[test]
 fn test_record_directory_artifact() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();


### PR DESCRIPTION
## Summary
- Add a managed `homeboy tunnel artifact-origin serve` static origin for artifact-root paths with CORS and JSON content-type handling for browser/Playground consumers.
- Add CORS/preflight handling to preview-client and preview-ingress artifact responses so `/homeboy/workflow-bench/...` publication paths work through the public artifact origin.
- Expose preview-client/route registration diagnostics in preview-ingress status with `?host=`, `homeboy tunnel preview-ingress status --host`, and `homeboy tunnel preview-client diagnose-auth` without printing token material.
- Index Workflow Bench publication manifests that reference public URL locators back to artifact-store paths while preserving viewer metadata.
- Propagate component-script bench scenario `passed=false`, `failed_count`, `unsupported_count`, and warning counters to top-level bench status.

## Issue coverage
- Fixes Extra-Chill/homeboy#4225
- Fixes Extra-Chill/homeboy#4226
- Fixes Extra-Chill/homeboy#4227
- Fixes Extra-Chill/homeboy#4228
- Fixes Extra-Chill/homeboy#4229
- Fixes Extra-Chill/homeboy#4230

## Tests
- `cargo test core::publication_artifacts::tests`
- `cargo test core::artifact_origin::tests`
- `cargo test core::preview_client::tests`
- `cargo test core::extension::bench::run::tests::workload_status_failures`
- `cargo test core::preview_ingress_tests`
- `cargo test command_surface`
- `cargo test publication_manifest_public_url_refs_are_indexed_from_artifact_origin`
- `cargo test --test core_agnostic_test` passes 3/4; remaining failure is `core_owned_source_stays_language_and_framework_agnostic` on pre-existing non-baselined core source terms (`cargo`, `composer`, `npm`, `php`, `rust`, etc.) unrelated to this PR. The PR-caused test-content failure was fixed by making the fixture generic.
- `cargo test` reaches the same residual `core_owned_source_stays_language_and_framework_agnostic` failure after 4,359 lib tests and earlier integration tests pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, verification, and PR description; Chris remains responsible for review and merge decisions.