### PR TITLE
Plumb generic Codebox provider stacks through runners

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -12,6 +12,7 @@ Runner configuration separates printable environment from secrets:
 
 - `env` is for non-secret values that are useful in diagnostics, such as `HOMEBOY_PUBLIC_ARTIFACT_BASE_URL`.
 - `secret_env` is for execution-time secret references like `{ "env": "NAME" }` or `{ "file": "~/.config/homeboy/secrets/name" }`.
+- `codebox_provider_stack` is a provider-agnostic Codebox runtime declaration for Lab/offload jobs. It describes provider/model defaults, provider plugin checkouts, secret env names, runtime env, and state mounts without hardcoding any provider in Homeboy.
 - Command output redacts sensitive names in `env` and prints only `secret_env` references, never resolved secret values.
 
 ## Subcommands
@@ -87,6 +88,54 @@ Configure a preferred runner with:
 ```sh
 homeboy config set /lab/preferred_runner '"<runner-id>"'
 ```
+
+### Codebox Provider Stack
+
+Runners can persist a generic provider stack for Codebox-backed Lab/offload execution. Homeboy owns runner-local configuration and forwards the stack to the offloaded command as `--setting-json codebox_provider_stack=<json>` after syncing/remapping local paths referenced by the stack. HBEX and WP Codebox consume the generic setting; Homeboy does not branch on provider names.
+
+Example runner patch:
+
+```sh
+homeboy runner set lab --json '{
+  "codebox_provider_stack": {
+    "provider": "generic-provider",
+    "model": "generic/model-default",
+    "provider_plugin_paths": ["/home/chubes/Developer/generic-provider-plugin"],
+    "secret_env": ["GENERIC_PROVIDER_API_KEY"],
+    "runtime_env": {
+      "GENERIC_PROVIDER_CONFIG": "/home/wp/.config/generic-provider/config.json",
+      "XDG_DATA_HOME": "/home/wp/.local/share",
+      "XDG_STATE_HOME": "/home/wp/.local/state"
+    },
+    "runtime_state_mounts": [
+      {
+        "source": "/home/chubes/.config/generic-provider/config.json",
+        "target": "/home/wp/.config/generic-provider/config.json",
+        "mode": "readonly"
+      }
+    ]
+  }
+}'
+```
+
+Fields:
+
+- `provider`: provider identifier passed through to downstream Codebox/HBEX contracts.
+- `model`: default model identifier for that provider stack.
+- `provider_plugin_paths`: runner-local provider plugin checkout paths. Lab offload syncs and remaps these paths when needed.
+- `secret_env`: env var names required by the provider. Values live in runner `secret_env` refs or the runner process environment; diagnostics show names/presence only.
+- `runtime_env`: non-secret runtime env values passed as provider stack data. `homeboy runner show` redacts sensitive-looking values; `homeboy runner env` redacts values by default.
+- `runtime_state_mounts`: runner-local state/config mounts for the sandbox, with `source`, `target`, and optional `mode`.
+
+Inspect the persisted stack with:
+
+```sh
+homeboy runner show lab
+homeboy runner env lab
+homeboy runner env lab --show-values
+```
+
+`runner env` always reports stack `secret_env` entries as configured names with `values_redacted: true`; it never resolves or prints secret values.
 
 ### `doctor`
 

--- a/docs/schemas/server-schema.md
+++ b/docs/schemas/server-schema.md
@@ -29,6 +29,20 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
     },
     "env": {},
     "secret_env": {},
+    "codebox_provider_stack": {
+      "provider": "string",
+      "model": "string",
+      "provider_plugin_paths": ["string"],
+      "secret_env": ["string"],
+      "runtime_env": {},
+      "runtime_state_mounts": [
+        {
+          "source": "string",
+          "target": "string",
+          "mode": "string"
+        }
+      ]
+    },
     "resources": {}
   },
   "forward_agent": boolean
@@ -80,6 +94,22 @@ Server configuration defines SSH server connections stored in `servers/<id>.json
     },
     "env": {},
     "secret_env": {},
+    "codebox_provider_stack": {
+      "provider": "generic-provider",
+      "model": "generic/model-default",
+      "provider_plugin_paths": ["/home/deploy/Developer/generic-provider-plugin"],
+      "secret_env": ["GENERIC_PROVIDER_API_KEY"],
+      "runtime_env": {
+        "GENERIC_PROVIDER_CONFIG": "/home/wp/.config/generic-provider/config.json"
+      },
+      "runtime_state_mounts": [
+        {
+          "source": "/home/deploy/.config/generic-provider/config.json",
+          "target": "/home/wp/.config/generic-provider/config.json",
+          "mode": "readonly"
+        }
+      ]
+    },
     "resources": {}
   },
   "forward_agent": true
@@ -118,6 +148,37 @@ Use `runner.secret_env` for values that must be read at execution time instead o
 ```
 
 Homeboy command output redacts sensitive names in `env` and keeps `secret_env` as references only. Secret file contents and referenced environment variable values are not printed by runner config/status diagnostics.
+
+### Codebox Provider Stack
+
+Use `runner.codebox_provider_stack` when a runner should provide a generic runtime stack for Codebox-backed Lab/offload tasks. Homeboy stores and inspects this provider-agnostic declaration, then forwards it to offloaded Homeboy commands as the `codebox_provider_stack` JSON setting after syncing/remapping local paths. Downstream HBEX/WP Codebox adapters consume the setting; Homeboy does not branch on OpenCode, Codex, or any other provider.
+
+```json
+{
+  "runner": {
+    "codebox_provider_stack": {
+      "provider": "generic-provider",
+      "model": "generic/model-default",
+      "provider_plugin_paths": ["/home/deploy/Developer/generic-provider-plugin"],
+      "secret_env": ["GENERIC_PROVIDER_API_KEY"],
+      "runtime_env": {
+        "GENERIC_PROVIDER_CONFIG": "/home/wp/.config/generic-provider/config.json",
+        "XDG_DATA_HOME": "/home/wp/.local/share",
+        "XDG_STATE_HOME": "/home/wp/.local/state"
+      },
+      "runtime_state_mounts": [
+        {
+          "source": "/home/deploy/.config/generic-provider/config.json",
+          "target": "/home/wp/.config/generic-provider/config.json",
+          "mode": "readonly"
+        }
+      ]
+    }
+  }
+}
+```
+
+`secret_env` contains names only. Store secret values in `runner.secret_env` refs or the runner process environment. `homeboy runner show` redacts sensitive-looking `runtime_env` values, and `homeboy runner env` reports stack secret names as configured while keeping values redacted.
 
 ## Managed SSH Sessions
 

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -10,7 +10,10 @@ use homeboy::core::runner::{
     Runner, RunnerConnectReport, RunnerDisconnectReport, RunnerExecOutput, RunnerKind,
     RunnerStatusReport,
 };
-use homeboy::core::server::{RunnerPolicy, RunnerSecretEnvRef, RunnerSettings};
+use homeboy::core::server::{
+    CodeboxProviderStack, CodeboxRuntimeStateMount, RunnerPolicy, RunnerSecretEnvRef,
+    RunnerSettings,
+};
 use homeboy::core::{EntityCrudOutput, MergeOutput};
 
 use super::{CmdResult, DynamicSetArgs};
@@ -59,6 +62,8 @@ pub struct RunnerEnvOutput {
     pub env: BTreeMap<String, String>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub secret_env: BTreeMap<String, RunnerSecretEnvReferenceOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub codebox_provider_stack: Option<RunnerCodeboxProviderStackOutput>,
     pub diagnostics: RunnerEnvDiagnostics,
 }
 
@@ -75,6 +80,29 @@ pub struct RunnerSecretEnvReferenceOutput {
 pub struct RunnerEnvDiagnostics {
     pub server_shell_env: String,
     pub runner_job_env: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunnerCodeboxProviderStackOutput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub provider_plugin_paths: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub secret_env: Vec<RunnerCodeboxSecretEnvOutput>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub runtime_env: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub runtime_state_mounts: Vec<CodeboxRuntimeStateMount>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunnerCodeboxSecretEnvOutput {
+    pub name: String,
+    pub configured: bool,
+    pub values_redacted: bool,
 }
 
 #[derive(Args)]
@@ -552,6 +580,17 @@ fn redact_runner_env(runner: &mut Runner) {
             *value = policy.redact_string(value);
         }
     }
+    redact_codebox_provider_stack(&mut runner.codebox_provider_stack, &policy);
+}
+
+fn redact_codebox_provider_stack(stack: &mut CodeboxProviderStack, policy: &RedactionPolicy) {
+    for (key, value) in stack.runtime_env.iter_mut() {
+        if policy.is_sensitive_key(key) {
+            *value = REDACTED_ENV_VALUE.to_string();
+        } else {
+            *value = policy.redact_string(value);
+        }
+    }
 }
 
 fn map_doctor(result: CmdResult<doctor::RunnerDoctorOutput>) -> CmdResult<RunnerCommandOutput> {
@@ -607,6 +646,7 @@ fn add(input: RunnerAddInput) -> CmdResult<RunnerOutput> {
             settings: input.settings,
             env: HashMap::new(),
             secret_env: HashMap::new(),
+            codebox_provider_stack: CodeboxProviderStack::default(),
             resources: HashMap::<String, Value>::new(),
             policy: RunnerPolicy::default(),
         };
@@ -891,6 +931,8 @@ fn env(runner_id: &str, show_values: bool) -> CmdResult<RunnerEnvOutput> {
         .into_iter()
         .map(|(key, reference)| (key, secret_env_reference_output(reference)))
         .collect();
+    let codebox_provider_stack = (!runner.codebox_provider_stack.is_empty())
+        .then(|| codebox_provider_stack_output(runner.codebox_provider_stack, show_values));
 
     Ok((
         RunnerEnvOutput {
@@ -900,6 +942,7 @@ fn env(runner_id: &str, show_values: bool) -> CmdResult<RunnerEnvOutput> {
             values_redacted: !show_values,
             env,
             secret_env,
+            codebox_provider_stack,
             diagnostics: RunnerEnvDiagnostics {
                 server_shell_env: "Use `homeboy ssh <server> -- printenv NAME` to inspect the server login shell environment; it does not include runner job env by default.".to_string(),
                 runner_job_env: "This output shows configured public env Homeboy injects into runner jobs. secret_env entries are shown as refs only; their values resolve on the runner at execution time and are never printed here.".to_string(),
@@ -914,6 +957,38 @@ fn secret_env_reference_output(reference: RunnerSecretEnvRef) -> RunnerSecretEnv
         env: reference.env,
         file: reference.file,
         values_redacted: true,
+    }
+}
+
+fn codebox_provider_stack_output(
+    mut stack: CodeboxProviderStack,
+    show_values: bool,
+) -> RunnerCodeboxProviderStackOutput {
+    let policy = RedactionPolicy::default();
+    redact_codebox_provider_stack(&mut stack, &policy);
+
+    let mut runtime_env = stack.runtime_env.into_iter().collect::<BTreeMap<_, _>>();
+    if !show_values {
+        for value in runtime_env.values_mut() {
+            *value = REDACTED_ENV_VALUE.to_string();
+        }
+    }
+
+    RunnerCodeboxProviderStackOutput {
+        provider: stack.provider,
+        model: stack.model,
+        provider_plugin_paths: stack.provider_plugin_paths,
+        secret_env: stack
+            .secret_env
+            .into_iter()
+            .map(|name| RunnerCodeboxSecretEnvOutput {
+                name,
+                configured: true,
+                values_redacted: true,
+            })
+            .collect(),
+        runtime_env,
+        runtime_state_mounts: stack.runtime_state_mounts,
     }
 }
 
@@ -936,6 +1011,7 @@ mod tests {
                 ),
             ]),
             secret_env: HashMap::new(),
+            codebox_provider_stack: CodeboxProviderStack::default(),
             resources: HashMap::new(),
             policy: RunnerPolicy::default(),
         }
@@ -991,6 +1067,46 @@ mod tests {
     }
 
     #[test]
+    fn registry_entity_output_redacts_codebox_provider_stack_runtime_env() {
+        let mut runner = runner_with_env("lab");
+        runner.codebox_provider_stack = CodeboxProviderStack {
+            provider: Some("generic-provider".to_string()),
+            model: Some("generic-model".to_string()),
+            provider_plugin_paths: vec!["/srv/providers/generic".to_string()],
+            secret_env: vec!["GENERIC_API_KEY".to_string()],
+            runtime_env: HashMap::from([(
+                "GENERIC_API_TOKEN".to_string(),
+                "secret-token".to_string(),
+            )]),
+            runtime_state_mounts: vec![CodeboxRuntimeStateMount {
+                source: "/srv/state/config.json".to_string(),
+                target: "/home/wp/.config/provider/config.json".to_string(),
+                mode: Some("readonly".to_string()),
+            }],
+        };
+        let (output, _) = map_registry(Ok((
+            RunnerOutput {
+                command: "runner.show".to_string(),
+                entity: Some(runner),
+                ..Default::default()
+            },
+            0,
+        )))
+        .expect("map output");
+
+        let value = serde_json::to_value(output).expect("serialize output");
+        assert_eq!(
+            value["entity"]["codebox_provider_stack"]["runtime_env"]["GENERIC_API_TOKEN"],
+            REDACTED_ENV_VALUE
+        );
+        assert_eq!(
+            value["entity"]["codebox_provider_stack"]["secret_env"][0],
+            "GENERIC_API_KEY"
+        );
+        assert!(!value.to_string().contains("secret-token"));
+    }
+
+    #[test]
     fn runner_env_output_redacts_values_by_default() {
         let output = RunnerEnvOutput {
             command: "runner.env".to_string(),
@@ -999,6 +1115,7 @@ mod tests {
             values_redacted: true,
             env: BTreeMap::from([("TOKEN".to_string(), REDACTED_ENV_VALUE.to_string())]),
             secret_env: BTreeMap::new(),
+            codebox_provider_stack: None,
             diagnostics: RunnerEnvDiagnostics {
                 server_shell_env: "shell".to_string(),
                 runner_job_env: "runner".to_string(),
@@ -1032,6 +1149,7 @@ mod tests {
                     values_redacted: true,
                 },
             )]),
+            codebox_provider_stack: None,
             diagnostics: RunnerEnvDiagnostics {
                 server_shell_env: "shell".to_string(),
                 runner_job_env: "runner".to_string(),
@@ -1053,5 +1171,30 @@ mod tests {
             true
         );
         assert!(!value.to_string().contains("dummy-secret"));
+    }
+
+    #[test]
+    fn runner_env_output_reports_codebox_provider_stack_presence() {
+        let output = codebox_provider_stack_output(
+            CodeboxProviderStack {
+                provider: Some("generic-provider".to_string()),
+                model: Some("generic-model".to_string()),
+                provider_plugin_paths: vec!["/srv/providers/generic".to_string()],
+                secret_env: vec!["GENERIC_API_KEY".to_string()],
+                runtime_env: HashMap::from([(
+                    "GENERIC_CONFIG".to_string(),
+                    "/srv/config.json".to_string(),
+                )]),
+                runtime_state_mounts: Vec::new(),
+            },
+            false,
+        );
+
+        let value = serde_json::to_value(output).expect("serialize output");
+        assert_eq!(value["provider"], "generic-provider");
+        assert_eq!(value["runtime_env"]["GENERIC_CONFIG"], REDACTED_ENV_VALUE);
+        assert_eq!(value["secret_env"][0]["name"], "GENERIC_API_KEY");
+        assert_eq!(value["secret_env"][0]["configured"], true);
+        assert_eq!(value["secret_env"][0]["values_redacted"], true);
     }
 }

--- a/src/core/runner/capabilities.rs
+++ b/src/core/runner/capabilities.rs
@@ -551,6 +551,7 @@ mod tests {
             },
             env: Default::default(),
             secret_env: Default::default(),
+            codebox_provider_stack: Default::default(),
             resources: Default::default(),
             policy: RunnerPolicy::default(),
         }

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -647,6 +647,7 @@ mod tests {
             },
             env: Default::default(),
             secret_env: Default::default(),
+            codebox_provider_stack: Default::default(),
             resources: Default::default(),
             policy: RunnerPolicy::default(),
         }

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -821,6 +821,7 @@ pub(crate) fn prepare_daemon_local_process(
             settings: server::RunnerSettings::default(),
             env: HashMap::new(),
             secret_env: HashMap::new(),
+            codebox_provider_stack: server::CodeboxProviderStack::default(),
             resources: HashMap::new(),
             policy: server::RunnerPolicy::default(),
         });
@@ -1158,6 +1159,7 @@ mod tests {
             },
             env: Default::default(),
             secret_env: Default::default(),
+            codebox_provider_stack: Default::default(),
             resources: Default::default(),
             policy: RunnerPolicy::default(),
         }

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -23,8 +23,9 @@ use super::lab_apply::apply_lab_offload_patch;
 #[cfg(test)]
 use super::lab_args::EXPLICIT_PASSTHROUGH_SENTINEL;
 use super::lab_args::{
-    lab_offload_source_path, remap_agent_task_plan_in_args, remap_path_settings_in_args,
-    remap_provider_config_in_args, rewrite_lab_offload_args, LabPathRemap,
+    append_codebox_provider_stack_setting, lab_offload_source_path, remap_agent_task_plan_in_args,
+    remap_path_settings_in_args, remap_provider_config_in_args, rewrite_lab_offload_args,
+    LabPathRemap,
 };
 use super::lab_capabilities::lab_runner_capability_contract;
 use super::lab_command::lab_offload_command_prefix;
@@ -40,11 +41,11 @@ use super::lab_selection::{
     LabRunnerPreparation, LabRunnerSelection,
 };
 use super::lab_workspaces::{
-    agent_task_plan_extra_workspaces, lab_extra_workspaces, lab_workspace_mapping_metadata,
-    path_setting_extra_workspaces, preflight_provider_config_source_cli_dependencies,
-    provider_config_extra_workspaces, rig_component_path_env_extra_workspaces,
-    sync_extra_lab_workspaces, workspace_mapping_entries_for_git_dependency,
-    workspace_mapping_entry,
+    agent_task_plan_extra_workspaces, codebox_provider_stack_extra_workspaces,
+    lab_extra_workspaces, lab_workspace_mapping_metadata, path_setting_extra_workspaces,
+    preflight_provider_config_source_cli_dependencies, provider_config_extra_workspaces,
+    rig_component_path_env_extra_workspaces, sync_extra_lab_workspaces,
+    workspace_mapping_entries_for_git_dependency, workspace_mapping_entry,
 };
 
 pub struct LabOffloadRequest<'a> {
@@ -662,6 +663,10 @@ fn run_lab_offload_inner(
         &changed_since_preflight.args,
         &source_path,
     )?);
+    extra_workspaces.extend(codebox_provider_stack_extra_workspaces(
+        &runner.codebox_provider_stack,
+        &source_path,
+    )?);
     extra_workspaces.extend(agent_task_plan_extra_workspaces(
         &changed_since_preflight.args,
         &source_path,
@@ -807,6 +812,11 @@ fn run_lab_offload_inner(
     let remapped_args =
         remap_agent_task_plan_in_args(&remapped_args, &path_remaps, Path::new(&synced.local_path))?;
     let remapped_args = remap_path_settings_in_args(&remapped_args, &path_remaps);
+    let remapped_args = append_codebox_provider_stack_setting(
+        &remapped_args,
+        &runner.codebox_provider_stack,
+        &path_remaps,
+    )?;
     let (remapped_args, synced_remapped_plan) =
         materialize_inline_agent_task_plan_arg(runner_id, &remapped_args)?;
     if let Some(entry) = synced_remapped_plan {

--- a/src/core/runner/lab_args.rs
+++ b/src/core/runner/lab_args.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use serde_json::Value;
 
 use crate::core::config::read_json_spec_to_string;
+use crate::core::server::CodeboxProviderStack;
 use crate::core::worktree;
 use crate::core::{Error, Result};
 
@@ -185,6 +186,46 @@ pub(super) fn remap_path_settings_in_args(
         out.push(arg.clone());
     }
     out
+}
+
+pub(super) fn append_codebox_provider_stack_setting(
+    args: &[String],
+    stack: &CodeboxProviderStack,
+    mappings: &[LabPathRemap],
+) -> Result<Vec<String>> {
+    if stack.is_empty() {
+        return Ok(args.to_vec());
+    }
+
+    let mut value = serde_json::to_value(stack).map_err(|err| {
+        Error::validation_invalid_argument(
+            "codebox_provider_stack",
+            format!("failed to serialize runner Codebox provider stack: {err}"),
+            None,
+            None,
+        )
+    })?;
+    let mut ordered: Vec<&LabPathRemap> = mappings.iter().collect();
+    ordered.sort_by_key(|mapping| {
+        (
+            std::cmp::Reverse(mapping.local.len()),
+            std::cmp::Reverse(mapping.remote.len()),
+        )
+    });
+    remap_paths_in_value(&mut value, &ordered);
+    let encoded = serde_json::to_string(&value).map_err(|err| {
+        Error::validation_invalid_argument(
+            "codebox_provider_stack",
+            format!("failed to encode runner Codebox provider stack: {err}"),
+            None,
+            None,
+        )
+    })?;
+
+    let mut out = args.to_vec();
+    out.push("--setting-json".to_string());
+    out.push(format!("codebox_provider_stack={encoded}"));
+    Ok(out)
 }
 
 /// Resolve an agent-task plan spec, remap every controller-local path embedded
@@ -880,6 +921,54 @@ mod tests {
         assert_eq!(
             out[4],
             "--setting-json=depends_on={\"plugins\":[\"/home/chubes/_lab_workspaces/woocommerce-gateway-stripe/includes\"],\"token\":\"keep-secret-like-string\"}"
+        );
+    }
+
+    #[test]
+    fn append_codebox_provider_stack_setting_remaps_paths() {
+        let mappings = vec![LabPathRemap {
+            local: "/Users/chubes/Developer/generic-provider".to_string(),
+            remote: "/home/chubes/_lab_workspaces/generic-provider".to_string(),
+        }];
+        let stack = CodeboxProviderStack {
+            provider: Some("generic".to_string()),
+            model: Some("generic/model".to_string()),
+            provider_plugin_paths: vec!["/Users/chubes/Developer/generic-provider".to_string()],
+            secret_env: vec!["GENERIC_API_KEY".to_string()],
+            runtime_env: std::collections::HashMap::from([(
+                "GENERIC_CONFIG".to_string(),
+                "/Users/chubes/Developer/generic-provider/config.json".to_string(),
+            )]),
+            runtime_state_mounts: vec![crate::core::server::CodeboxRuntimeStateMount {
+                source: "/Users/chubes/Developer/generic-provider/state.json".to_string(),
+                target: "/home/wp/.config/generic/state.json".to_string(),
+                mode: Some("readonly".to_string()),
+            }],
+        };
+
+        let out = append_codebox_provider_stack_setting(
+            &["homeboy".to_string(), "agent-task".to_string()],
+            &stack,
+            &mappings,
+        )
+        .expect("append setting");
+
+        assert_eq!(out[2], "--setting-json");
+        let (_, raw) = out[3].split_once('=').expect("setting pair");
+        let value: serde_json::Value = serde_json::from_str(raw).expect("stack json");
+        assert_eq!(value["provider"], "generic");
+        assert_eq!(value["secret_env"][0], "GENERIC_API_KEY");
+        assert_eq!(
+            value["provider_plugin_paths"][0],
+            "/home/chubes/_lab_workspaces/generic-provider"
+        );
+        assert_eq!(
+            value["runtime_env"]["GENERIC_CONFIG"],
+            "/home/chubes/_lab_workspaces/generic-provider/config.json"
+        );
+        assert_eq!(
+            value["runtime_state_mounts"][0]["source"],
+            "/home/chubes/_lab_workspaces/generic-provider/state.json"
         );
     }
 

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 
 use crate::core::component::{self, TargetSpec};
+use crate::core::server::CodeboxProviderStack;
 use crate::core::{Error, Result};
 
 use super::{
@@ -212,6 +213,40 @@ pub(super) fn provider_config_extra_workspaces(
         add_candidate_extra_workspace(
             &candidate,
             "provider_config",
+            &source_canon,
+            &mut seen,
+            &mut workspaces,
+        )?;
+    }
+    Ok(workspaces)
+}
+
+pub(super) fn codebox_provider_stack_extra_workspaces(
+    stack: &CodeboxProviderStack,
+    source_path: &Path,
+) -> Result<Vec<ExtraLabWorkspace>> {
+    if stack.is_empty() {
+        return Ok(Vec::new());
+    }
+    let value = serde_json::to_value(stack).map_err(|err| {
+        Error::validation_invalid_argument(
+            "codebox_provider_stack",
+            format!("failed to inspect runner Codebox provider stack: {err}"),
+            None,
+            None,
+        )
+    })?;
+
+    let source_canon = source_path
+        .canonicalize()
+        .unwrap_or_else(|_| source_path.to_path_buf());
+
+    let mut seen = BTreeSet::new();
+    let mut workspaces: Vec<ExtraLabWorkspace> = Vec::new();
+    for candidate in provider_config_candidate_paths(&value) {
+        add_candidate_extra_workspace(
+            &candidate,
+            "codebox_provider_stack",
             &source_canon,
             &mut seen,
             &mut workspaces,

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -113,6 +113,11 @@ pub struct Runner {
     pub env: HashMap<String, String>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub secret_env: HashMap<String, RunnerSecretEnvRef>,
+    #[serde(
+        default,
+        skip_serializing_if = "server::CodeboxProviderStack::is_empty"
+    )]
+    pub codebox_provider_stack: server::CodeboxProviderStack,
     #[serde(default)]
     pub resources: HashMap<String, Value>,
     #[serde(default, skip_serializing_if = "RunnerPolicy::is_empty")]
@@ -422,6 +427,7 @@ fn runner_from_server(server_id: &str, runner: ServerRunner) -> Runner {
         settings: runner.settings,
         env: runner.env,
         secret_env: runner.secret_env,
+        codebox_provider_stack: runner.codebox_provider_stack,
         resources: runner.resources,
         policy: runner.policy,
     }
@@ -735,6 +741,7 @@ mod tests {
                 settings: RunnerSettings::default(),
                 env: HashMap::new(),
                 secret_env: HashMap::new(),
+                codebox_provider_stack: server::CodeboxProviderStack::default(),
                 resources: HashMap::new(),
                 policy: RunnerPolicy::default(),
             };

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -77,6 +77,41 @@ pub struct RunnerSecretEnvRef {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodeboxProviderStack {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provider_plugin_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secret_env: Vec<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub runtime_env: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtime_state_mounts: Vec<CodeboxRuntimeStateMount>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodeboxRuntimeStateMount {
+    pub source: String,
+    pub target: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+}
+
+impl CodeboxProviderStack {
+    pub fn is_empty(&self) -> bool {
+        self.provider.is_none()
+            && self.model.is_none()
+            && self.provider_plugin_paths.is_empty()
+            && self.secret_env.is_empty()
+            && self.runtime_env.is_empty()
+            && self.runtime_state_mounts.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunnerPolicy {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub accepted_peer_ids: Vec<String>,
@@ -110,6 +145,8 @@ pub struct ServerRunner {
     pub env: HashMap<String, String>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub secret_env: HashMap<String, RunnerSecretEnvRef>,
+    #[serde(default, skip_serializing_if = "CodeboxProviderStack::is_empty")]
+    pub codebox_provider_stack: CodeboxProviderStack,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub resources: HashMap<String, serde_json::Value>,
     #[serde(default, skip_serializing_if = "RunnerPolicy::is_empty")]

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -1429,6 +1429,7 @@ mod tests {
             },
             env: HashMap::new(),
             secret_env: HashMap::new(),
+            codebox_provider_stack: Default::default(),
             resources: HashMap::new(),
             policy: Default::default(),
         }


### PR DESCRIPTION
## Summary
- Adds a provider-agnostic `codebox_provider_stack` runner config shape for Codebox-backed Lab/offload tasks.
- Threads the stack into Lab offload as `--setting-json codebox_provider_stack=<json>` after syncing/remapping referenced local paths.
- Extends `runner show/env` inspection with secret-safe output and documents the persisted stack contract.

Closes #4246.

## Notes
- No OpenCode/Codex-specific branches were added; the stack is treated as generic runner-local data.
- This is intended to coordinate with Extra-Chill/wp-codebox#936 and Extra-Chill/homeboy-extensions#1341 by providing the Homeboy-side declaration/injection boundary.

## Testing
- `cargo test codebox_provider_stack`
- `git diff --check origin/main...HEAD`
- `cargo test` passed library/bin tests, then failed in `tests/core_agnostic_test.rs::core_owned_source_stays_language_and_framework_agnostic` on pre-existing ecosystem-term findings unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, tests, and documentation updates; Chris remains responsible for review and merge.