### PR TITLE
Project fanout and matrix plans through HomeboyPlan

### DIFF
--- a/src/core/agent_task/matrix.rs
+++ b/src/core/agent_task/matrix.rs
@@ -7,6 +7,7 @@ use super::{
     AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_MATRIX_AGGREGATE_SCHEMA,
     AGENT_TASK_MATRIX_PLAN_SCHEMA,
 };
+use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskMatrixAxis {
@@ -59,6 +60,119 @@ pub struct AgentTaskMatrixAggregateCell {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentTaskMatrixError {
     pub message: String,
+}
+
+impl AgentTaskMatrixPlan {
+    pub fn to_homeboy_plan(&self) -> HomeboyPlan {
+        let mut plan =
+            HomeboyPlan::for_description(PlanKind::AgentTaskMatrix, self.plan_id.clone());
+        plan.id = self.plan_id.clone();
+        plan.mode = Some("agent_task_matrix".to_string());
+        plan.inputs
+            .insert("schema".to_string(), Value::String(self.schema.clone()));
+        plan.inputs
+            .insert("plan_id".to_string(), Value::String(self.plan_id.clone()));
+        plan.inputs.insert(
+            "axes".to_string(),
+            serde_json::to_value(&self.axes).expect("matrix axes serialize"),
+        );
+        plan.steps = self
+            .cells
+            .iter()
+            .map(|cell| {
+                PlanStep::ready(cell.cell_id.clone(), "agent_task.matrix.cell")
+                    .label(cell.cell_id.clone())
+                    .input_value("cell_id", Value::String(cell.cell_id.clone()))
+                    .input_value(
+                        "axes",
+                        serde_json::to_value(&cell.axes).expect("matrix cell axes serialize"),
+                    )
+                    .input_value(
+                        "request",
+                        serde_json::to_value(&cell.task).expect("agent task request serializes"),
+                    )
+                    .build()
+            })
+            .collect();
+        plan
+    }
+
+    pub fn from_homeboy_plan(plan: &HomeboyPlan) -> Result<Self, AgentTaskMatrixError> {
+        let plan_id = plan
+            .inputs
+            .get("plan_id")
+            .and_then(Value::as_str)
+            .unwrap_or(plan.id.as_str())
+            .to_string();
+        let axes = plan
+            .inputs
+            .get("axes")
+            .cloned()
+            .ok_or_else(|| {
+                AgentTaskMatrixError::new("HomeboyPlan matrix projection is missing axes")
+            })
+            .and_then(|value| {
+                serde_json::from_value(value)
+                    .map_err(|error| AgentTaskMatrixError::new(error.to_string()))
+            })?;
+        let cells = plan
+            .steps
+            .iter()
+            .map(|step| {
+                let cell_id = step
+                    .inputs
+                    .get("cell_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or(step.id.as_str())
+                    .to_string();
+                let axes = step
+                    .inputs
+                    .get("axes")
+                    .cloned()
+                    .ok_or_else(|| {
+                        AgentTaskMatrixError::new(format!(
+                            "matrix step '{}' is missing axes",
+                            step.id
+                        ))
+                    })
+                    .and_then(|value| {
+                        serde_json::from_value(value)
+                            .map_err(|error| AgentTaskMatrixError::new(error.to_string()))
+                    })?;
+                let task = step
+                    .inputs
+                    .get("request")
+                    .cloned()
+                    .ok_or_else(|| {
+                        AgentTaskMatrixError::new(format!(
+                            "matrix step '{}' is missing request",
+                            step.id
+                        ))
+                    })
+                    .and_then(|value| {
+                        serde_json::from_value(value)
+                            .map_err(|error| AgentTaskMatrixError::new(error.to_string()))
+                    })?;
+                Ok(AgentTaskMatrixCell {
+                    cell_id,
+                    axes,
+                    task,
+                })
+            })
+            .collect::<Result<Vec<AgentTaskMatrixCell>, AgentTaskMatrixError>>()?;
+
+        Ok(Self {
+            schema: plan
+                .inputs
+                .get("schema")
+                .and_then(Value::as_str)
+                .unwrap_or(AGENT_TASK_MATRIX_PLAN_SCHEMA)
+                .to_string(),
+            plan_id,
+            axes,
+            cells,
+        })
+    }
 }
 
 impl AgentTaskMatrixError {
@@ -335,6 +449,44 @@ mod tests {
             .all(|cell| cell.task.parent_plan_id.as_deref() == Some("bench/studio-web")));
         assert_eq!(plan.cells[2].task.metadata["matrix"]["model"], "claude");
         assert_eq!(plan.cells[2].task.metadata["matrix"]["prompt"], "site-a");
+    }
+
+    #[test]
+    fn matrix_homeboy_plan_projection_preserves_expansion_compatibility() {
+        let plan = expand_agent_task_matrix(
+            "bench/studio-web",
+            vec![
+                AgentTaskMatrixAxis {
+                    name: "model".to_string(),
+                    values: vec!["gpt".to_string(), "claude".to_string()],
+                },
+                AgentTaskMatrixAxis {
+                    name: "prompt".to_string(),
+                    values: vec!["site".to_string()],
+                },
+            ],
+            template_request(),
+        )
+        .expect("expand matrix");
+
+        let homeboy_plan = plan.to_homeboy_plan();
+        let projected =
+            AgentTaskMatrixPlan::from_homeboy_plan(&homeboy_plan).expect("project matrix plan");
+
+        assert_eq!(projected, plan);
+        assert_eq!(homeboy_plan.id, "bench/studio-web");
+        assert_eq!(homeboy_plan.kind, PlanKind::AgentTaskMatrix);
+        assert_eq!(homeboy_plan.steps.len(), 2);
+        assert_eq!(homeboy_plan.steps[0].kind, "agent_task.matrix.cell");
+        assert_eq!(homeboy_plan.steps[0].inputs["axes"]["model"], json!("gpt"));
+        assert_eq!(
+            projected.cells[1].task.parent_plan_id.as_deref(),
+            Some("bench/studio-web")
+        );
+        assert_eq!(
+            projected.cells[1].task.metadata["matrix"]["model"],
+            json!("claude")
+        );
     }
 
     #[test]

--- a/src/core/agent_task_fanout.rs
+++ b/src/core/agent_task_fanout.rs
@@ -7,6 +7,7 @@ use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskOutputDependencies, AgentTaskPlan,
     AgentTaskScheduleOptions, AgentTaskScheduler,
 };
+use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep};
 
 pub const AGENT_TASK_FANOUT_PLAN_SCHEMA: &str = "homeboy/agent-task-fanout-plan/v1";
 pub const AGENT_TASK_FANOUT_AGGREGATE_SCHEMA: &str = "homeboy/agent-task-fanout-aggregate/v1";
@@ -98,6 +99,139 @@ impl AgentTaskFanoutPlan {
         plan.metadata = metadata_with_fanout(self.metadata.clone(), &self.fanout_id, self.plane);
         plan
     }
+
+    pub fn to_homeboy_plan(&self) -> HomeboyPlan {
+        let mut plan =
+            HomeboyPlan::for_description(PlanKind::AgentTaskFanout, self.fanout_id.clone());
+        plan.id = self.fanout_id.clone();
+        plan.mode = Some("agent_task_fanout".to_string());
+        plan.inputs
+            .insert("schema".to_string(), Value::String(self.schema.clone()));
+        plan.inputs.insert(
+            "fanout_id".to_string(),
+            Value::String(self.fanout_id.clone()),
+        );
+        plan.inputs.insert(
+            "plane".to_string(),
+            serde_json::to_value(self.plane).expect("fanout plane serializes"),
+        );
+        if let Some(group_key) = &self.group_key {
+            plan.inputs
+                .insert("group_key".to_string(), Value::String(group_key.clone()));
+        }
+        if !self.metadata.is_null() {
+            plan.inputs
+                .insert("metadata".to_string(), self.metadata.clone());
+        }
+        plan.policy.insert(
+            "options".to_string(),
+            serde_json::to_value(&self.options).expect("fanout options serialize"),
+        );
+        plan.steps = self
+            .tasks
+            .iter()
+            .map(|request| {
+                let mut builder =
+                    PlanStep::ready(request.task_id.clone(), "agent_task.fanout.task")
+                        .label(request.task_id.clone())
+                        .input_value(
+                            "request",
+                            serde_json::to_value(request).expect("agent task request serializes"),
+                        );
+                if let Some(dependencies) = self.output_dependencies.get(&request.task_id) {
+                    builder = builder
+                        .needs(fanout_dependency_step_ids(dependencies))
+                        .input_value(
+                            "output_dependencies",
+                            serde_json::to_value(dependencies)
+                                .expect("agent task output dependencies serialize"),
+                        );
+                }
+                builder.build()
+            })
+            .collect();
+        plan
+    }
+
+    pub fn from_homeboy_plan(plan: &HomeboyPlan) -> Result<Self, String> {
+        let fanout_id = plan
+            .inputs
+            .get("fanout_id")
+            .and_then(Value::as_str)
+            .unwrap_or(plan.id.as_str())
+            .to_string();
+        let plane = plan
+            .inputs
+            .get("plane")
+            .cloned()
+            .ok_or_else(|| "HomeboyPlan fanout projection is missing plane".to_string())
+            .and_then(|value| serde_json::from_value(value).map_err(|error| error.to_string()))?;
+        let tasks = plan
+            .steps
+            .iter()
+            .map(|step| {
+                step.inputs
+                    .get("request")
+                    .cloned()
+                    .ok_or_else(|| format!("fanout step '{}' is missing request", step.id))
+                    .and_then(|value| {
+                        serde_json::from_value(value).map_err(|error| error.to_string())
+                    })
+            })
+            .collect::<Result<Vec<AgentTaskRequest>, String>>()?;
+        let output_dependencies = plan
+            .steps
+            .iter()
+            .filter_map(|step| {
+                step.inputs
+                    .get("output_dependencies")
+                    .cloned()
+                    .map(|value| {
+                        serde_json::from_value(value)
+                            .map(|dependencies| (step.id.clone(), dependencies))
+                            .map_err(|error| error.to_string())
+                    })
+            })
+            .collect::<Result<HashMap<String, AgentTaskOutputDependencies>, String>>()?;
+        let options = plan
+            .policy
+            .get("options")
+            .cloned()
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(|error| error.to_string())?
+            .unwrap_or_default();
+
+        Ok(Self {
+            schema: plan
+                .inputs
+                .get("schema")
+                .and_then(Value::as_str)
+                .unwrap_or(AGENT_TASK_FANOUT_PLAN_SCHEMA)
+                .to_string(),
+            fanout_id,
+            plane,
+            group_key: plan
+                .inputs
+                .get("group_key")
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
+            tasks,
+            output_dependencies,
+            options,
+            metadata: plan.inputs.get("metadata").cloned().unwrap_or(Value::Null),
+        })
+    }
+}
+
+fn fanout_dependency_step_ids(dependencies: &AgentTaskOutputDependencies) -> Vec<String> {
+    let mut needs = dependencies.depends_on.clone();
+    for binding in dependencies.bindings.values() {
+        if !needs.contains(&binding.task_id) {
+            needs.push(binding.task_id.clone());
+        }
+    }
+    needs
 }
 
 impl AgentTaskFanoutAggregate {
@@ -240,6 +374,58 @@ mod tests {
         );
         assert_eq!(diagnose.metadata["fanout"]["plane"], json!("workflow"));
         assert_eq!(diagnose.metadata["generated_from_outputs"], json!(true));
+    }
+
+    #[test]
+    fn fanout_homeboy_plan_projection_preserves_schedule_compatibility() {
+        let mut plan = AgentTaskFanoutPlan::new(
+            "fanout/site-workflow",
+            AgentTaskFanoutPlane::Workflow,
+            vec![request("generate"), request("diagnose")],
+        );
+        plan.group_key = Some("site-workflow".to_string());
+        plan.options.max_concurrency = 3;
+        plan.metadata = json!({ "source": "compat-test" });
+        plan.output_dependencies.insert(
+            "diagnose".to_string(),
+            AgentTaskOutputDependencies {
+                depends_on: Vec::new(),
+                bindings: HashMap::from([(
+                    "artifact_id".to_string(),
+                    AgentTaskOutputBinding {
+                        task_id: "generate".to_string(),
+                        path: "/outputs/artifact_id".to_string(),
+                        artifact: None,
+                        required: true,
+                        default: Value::Null,
+                    },
+                )]),
+            },
+        );
+
+        let homeboy_plan = plan.to_homeboy_plan();
+        let projected =
+            AgentTaskFanoutPlan::from_homeboy_plan(&homeboy_plan).expect("project fanout plan");
+
+        assert_eq!(projected, plan);
+        assert_eq!(homeboy_plan.id, "fanout/site-workflow");
+        assert_eq!(homeboy_plan.kind, PlanKind::AgentTaskFanout);
+        assert_eq!(homeboy_plan.steps.len(), 2);
+        assert_eq!(homeboy_plan.steps[1].needs, vec!["generate".to_string()]);
+
+        let schedule = projected.to_schedule_plan();
+        assert_eq!(schedule.plan_id, "fanout/site-workflow");
+        assert_eq!(schedule.group_key.as_deref(), Some("site-workflow"));
+        assert_eq!(schedule.options.max_concurrency, 3);
+        assert_eq!(schedule.output_dependencies, plan.output_dependencies);
+        assert_eq!(
+            schedule.tasks[0].parent_plan_id.as_deref(),
+            Some("fanout/site-workflow")
+        );
+        assert_eq!(
+            schedule.tasks[0].metadata["fanout"]["plane"],
+            json!("workflow")
+        );
     }
 
     #[derive(Default)]

--- a/src/core/plan.rs
+++ b/src/core/plan.rs
@@ -172,6 +172,8 @@ pub enum PlanKind {
     Fleet,
     Trace,
     Review,
+    AgentTaskFanout,
+    AgentTaskMatrix,
     Custom,
 }
 
@@ -193,6 +195,8 @@ impl PlanKind {
             Self::Fleet => "fleet",
             Self::Trace => "trace",
             Self::Review => "review",
+            Self::AgentTaskFanout => "agent_task_fanout",
+            Self::AgentTaskMatrix => "agent_task_matrix",
             Self::Custom => "custom",
         }
     }


### PR DESCRIPTION
## Summary
- Add `AgentTaskFanoutPlan` projection to and from `HomeboyPlan`, with fanout tasks represented as plan steps and schedule options carried in plan policy.
- Add `AgentTaskMatrixPlan` projection to and from `HomeboyPlan`, with expanded cells represented as plan steps and axes carried in plan inputs.
- Add focused compatibility tests for fanout schedule conversion and matrix expansion round-trips.

## Tests
- `cargo test agent_task`
- `cargo test serializes_plan_kind_as_snake_case`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the refactor and tests; Chris remains responsible for review and merge.

Closes #4251