### PR TITLE
fix: use vendor-neutral API examples

### DIFF
--- a/docs/architecture/api-client.md
+++ b/docs/architecture/api-client.md
@@ -40,7 +40,7 @@ Project auth variables choose their source in `api.auth.variables`:
 {
   "api": {
     "enabled": true,
-    "base_url": "https://atomic-api.wordpress.com/api/v1.0",
+    "base_url": "https://api.example.test/v1",
     "auth": {
       "header": "Auth: {{token}}",
       "variables": {

--- a/src/core/server/http.rs
+++ b/src/core/server/http.rs
@@ -481,7 +481,7 @@ mod tests {
     fn builds_client_with_socks_proxy() {
         let config = ApiConfig {
             enabled: true,
-            base_url: "https://atomic-api.wordpress.com/api/v1.0".to_string(),
+            base_url: "https://api.example.test/v1".to_string(),
             proxy_url: Some("socks5://127.0.0.1:8080".to_string()),
             auth: None,
         };


### PR DESCRIPTION
## Summary
- Replace the WordPress.com API URL in the SOCKS proxy test fixture with a vendor-neutral example endpoint.
- Replace the same WordPress.com API URL in API client documentation with a vendor-neutral example endpoint.

## Verification
- `git grep -n "atomic-api\.wordpress\.com" -- . ':!target'`
- `cargo check --lib`
- `git diff --check`
- `cargo test builds_client_with_socks_proxy`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Replaced Homeboy policy-violating vendor-specific examples, verified the tracked source scan and focused Rust checks, and prepared the PR for Chris to review.