### PR TITLE
Derive plan wrapper fields from HomeboyPlan

### DIFF
--- a/src/core/deps/stack.rs
+++ b/src/core/deps/stack.rs
@@ -3,7 +3,8 @@ use crate::core::deps::{update, DependencyUpdateOptions};
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
 use crate::core::{Error, Result};
 use crate::extensions::deps_provider;
-use serde::{Deserialize, Serialize};
+use serde::ser::Error as SerializeError;
+use serde::{Deserialize, Serialize, Serializer};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::process::Command;
@@ -26,13 +27,36 @@ pub struct DependencyStackEdgeStatus {
     pub test: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DependencyStackPlan {
-    #[serde(flatten)]
     pub plan: HomeboyPlan,
-    pub upstream: String,
-    pub step_count: usize,
-    pub steps: Vec<DependencyStackPlanStep>,
+}
+
+impl Serialize for DependencyStackPlan {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut value = serde_json::to_value(&self.plan).map_err(S::Error::custom)?;
+        let object = value.as_object_mut().ok_or_else(|| {
+            S::Error::custom("dependency stack plan did not serialize to a JSON object")
+        })?;
+
+        object.insert(
+            "upstream".to_string(),
+            serde_json::Value::String(self.upstream().to_string()),
+        );
+        object.insert(
+            "step_count".to_string(),
+            serde_json::Value::Number(self.step_count().into()),
+        );
+        object.insert(
+            "steps".to_string(),
+            serde_json::to_value(self.planned_steps()).map_err(S::Error::custom)?,
+        );
+
+        value.serialize(serializer)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -165,7 +189,7 @@ pub fn stack_apply_plan(
     }
 
     Ok(DependencyStackApplyResult {
-        upstream: plan.upstream,
+        upstream: plan.upstream().to_string(),
         dry_run,
         step_count: steps.len(),
         steps,
@@ -310,18 +334,28 @@ impl DependencyStackPlan {
             .steps(steps.iter().map(stack_step))
             .summarize()
             .build();
-        let steps = stack_steps_from_plan(&plan);
+        Self::from_plan(plan)
+    }
 
-        Self {
-            step_count: plan
-                .summary
-                .as_ref()
-                .map(|summary| summary.total_steps)
-                .unwrap_or_else(|| plan.steps.len()),
-            plan,
-            upstream,
-            steps,
-        }
+    pub fn from_plan(plan: HomeboyPlan) -> Self {
+        Self { plan }
+    }
+
+    pub fn upstream(&self) -> &str {
+        self.plan
+            .subject
+            .component_id
+            .as_deref()
+            .or(self.plan.subject.description.as_deref())
+            .unwrap_or_default()
+    }
+
+    pub fn step_count(&self) -> usize {
+        self.plan
+            .summary
+            .as_ref()
+            .map(|summary| summary.total_steps)
+            .unwrap_or_else(|| self.plan.steps.len())
     }
 
     pub fn planned_steps(&self) -> Vec<DependencyStackPlanStep> {

--- a/src/core/issues/plan.rs
+++ b/src/core/issues/plan.rs
@@ -4,7 +4,8 @@
 //! function consumes them; [`apply_plan`](super::apply::apply_plan) turns the
 //! resulting [`ReconcilePlan`] into tracker calls.
 
-use serde::{Deserialize, Serialize};
+use serde::ser::Error as SerializeError;
+use serde::{Deserialize, Serialize, Serializer};
 
 use crate::core::code_audit::FindingConfidence;
 use crate::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus, PlanValues};
@@ -169,11 +170,29 @@ pub enum ReconcileSkipReason {
 }
 
 /// The full reconciliation plan: every action, in execution order.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
 pub struct ReconcilePlan {
-    #[serde(flatten)]
     pub plan: HomeboyPlan,
     pub actions: Vec<ReconcileAction>,
+}
+
+impl Serialize for ReconcilePlan {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut value = serde_json::to_value(&self.plan).map_err(S::Error::custom)?;
+        let object = value.as_object_mut().ok_or_else(|| {
+            S::Error::custom("issue reconcile plan did not serialize to a JSON object")
+        })?;
+
+        object.insert(
+            "actions".to_string(),
+            serde_json::to_value(self.planned_actions()).map_err(S::Error::custom)?,
+        );
+
+        value.serialize(serializer)
+    }
 }
 
 impl ReconcilePlan {
@@ -408,5 +427,23 @@ mod tests {
 
         assert_eq!(plan.actions, actions);
         assert_eq!(plan.planned_actions(), actions);
+    }
+
+    #[test]
+    fn issue_reconcile_serializes_actions_from_homeboy_plan_steps() {
+        let action = ReconcileAction::Close {
+            number: 42,
+            category: "resolved".to_string(),
+            comment: "Resolved by latest run.".to_string(),
+        };
+        let mut plan = ReconcilePlan::new("homeboy", vec![action]);
+
+        plan.actions.clear();
+
+        let json = serde_json::to_value(&plan).unwrap();
+
+        assert_eq!(json["actions"].as_array().map(Vec::len), Some(1));
+        assert_eq!(json["actions"][0]["kind"], "close");
+        assert_eq!(json["actions"][0]["number"], 42);
     }
 }

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -202,21 +202,53 @@ fn stack_plan_walks_declared_downstream_edges_in_order() {
 
     let plan = deps::stack_plan_from_components("chubes4/html-to-blocks-converter", &components).unwrap();
 
-    assert_eq!(plan.step_count, 2);
-    assert_eq!(plan.step_count, plan.plan.steps.len());
-    assert_eq!(plan.planned_steps(), plan.steps);
-    assert_eq!(plan.steps[0].downstream, "block-format-bridge");
-    assert_eq!(plan.steps[0].package, "chubes4/html-to-blocks-converter");
+    let steps = plan.planned_steps();
+
+    assert_eq!(plan.step_count(), 2);
+    assert_eq!(plan.step_count(), plan.plan.steps.len());
+    assert_eq!(steps[0].downstream, "block-format-bridge");
+    assert_eq!(steps[0].package, "chubes4/html-to-blocks-converter");
     assert_eq!(
-        plan.steps[0].update_command,
+        steps[0].update_command,
         "homeboy deps update chubes4/html-to-blocks-converter --path /repo/block-format-bridge"
     );
-    assert_eq!(plan.steps[0].post_update, vec!["composer build"]);
-    assert_eq!(plan.steps[1].downstream, "static-site-importer");
+    assert_eq!(steps[0].post_update, vec!["composer build"]);
+    assert_eq!(steps[1].downstream, "static-site-importer");
     assert_eq!(
-        plan.steps[1].update_command,
+        steps[1].update_command,
         "composer update chubes4/block-format-bridge"
     );
+}
+
+#[test]
+fn stack_plan_compatibility_fields_are_serialized_from_homeboy_plan() {
+    let components = vec![
+        stack_component(
+            "upstream",
+            "/repo/upstream",
+            vec![DependencyStackEdge {
+                upstream: "upstream".to_string(),
+                downstream: "downstream".to_string(),
+                package: "fixture/upstream".to_string(),
+                update: None,
+                rebuild: false,
+                post_update: Vec::new(),
+                test: Vec::new(),
+            }],
+        ),
+        stack_component("downstream", "/repo/downstream", Vec::new()),
+    ];
+    let mut plan = deps::stack_plan_from_components("upstream", &components).unwrap();
+
+    plan.plan.subject.component_id = Some("renamed-upstream".to_string());
+    plan.plan.steps.clear();
+    plan.plan.summary = None;
+
+    let json = serde_json::to_value(&plan).unwrap();
+
+    assert_eq!(json["upstream"], "renamed-upstream");
+    assert_eq!(json["step_count"], 0);
+    assert_eq!(json["steps"], serde_json::json!([]));
 }
 
 #[test]
@@ -257,13 +289,15 @@ fn stack_plan_derives_edges_from_provider_reported_dependency_identities() {
 
     let plan = deps::stack_plan_from_components("upstream", &components).unwrap();
 
-    assert_eq!(plan.step_count, 1);
-    assert_eq!(plan.steps[0].declaring_component_id, "downstream");
-    assert_eq!(plan.steps[0].upstream, "upstream");
-    assert_eq!(plan.steps[0].downstream, "downstream");
-    assert_eq!(plan.steps[0].package, "fixture/upstream");
+    let steps = plan.planned_steps();
+
+    assert_eq!(plan.step_count(), 1);
+    assert_eq!(steps[0].declaring_component_id, "downstream");
+    assert_eq!(steps[0].upstream, "upstream");
+    assert_eq!(steps[0].downstream, "downstream");
+    assert_eq!(steps[0].package, "fixture/upstream");
     assert_eq!(
-        plan.steps[0].update_command,
+        steps[0].update_command,
         format!(
             "homeboy deps update fixture/upstream --path {}",
             downstream_path.display()
@@ -318,10 +352,12 @@ fn stack_plan_keeps_explicit_edge_config_when_provider_edge_matches() {
 
     let plan = deps::stack_plan_from_components("upstream", &components).unwrap();
 
-    assert_eq!(plan.step_count, 1);
-    assert_eq!(plan.steps[0].update_command, "fixture-provider update fixture/upstream");
-    assert_eq!(plan.steps[0].post_update, vec!["fixture-provider build"]);
-    assert_eq!(plan.steps[0].test, vec!["fixture-provider test"]);
+    let steps = plan.planned_steps();
+
+    assert_eq!(plan.step_count(), 1);
+    assert_eq!(steps[0].update_command, "fixture-provider update fixture/upstream");
+    assert_eq!(steps[0].post_update, vec!["fixture-provider build"]);
+    assert_eq!(steps[0].test, vec!["fixture-provider test"]);
 }
 
 #[test]
@@ -357,9 +393,11 @@ fn stack_plan_dedupes_cycles_by_edge_identity() {
 
     let plan = deps::stack_plan_from_components("a", &components).unwrap();
 
-    assert_eq!(plan.step_count, 2);
-    assert_eq!(plan.steps[0].downstream, "b");
-    assert_eq!(plan.steps[1].downstream, "a");
+    let steps = plan.planned_steps();
+
+    assert_eq!(plan.step_count(), 2);
+    assert_eq!(steps[0].downstream, "b");
+    assert_eq!(steps[1].downstream, "a");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Make dependency stack and issue reconcile wrapper serialization derive compatibility fields from `HomeboyPlan`.
- Keep public JSON shape stable while reducing duplicated authoritative state.
- Add regression tests that mutate generic plan state and verify compatibility fields follow it.

Fixes #4253

## Verification
- `cargo test --test deps_test`
- `cargo test core::issues::plan::tests`
- `cargo test core::plan::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5
- **Used for:** Drafted and validated the representative wrapper refactor, tests, and PR description; Chris remains responsible for review and merge.