### PR TITLE
Rename internal non-workflow plan structs

### DIFF
--- a/src/commands/runs/remote_artifact.rs
+++ b/src/commands/runs/remote_artifact.rs
@@ -291,7 +291,7 @@ fn persisted_artifact_remove_error(path: &Path, err: io::Error) -> crate::core::
 }
 
 #[derive(Debug, Default)]
-struct RunnerDownloadCleanupPlan {
+struct RunnerDownloadCleanupPreview {
     file_count: usize,
     directory_count: usize,
     size_bytes: u64,
@@ -332,8 +332,8 @@ fn cleanup_path_component(name: &str, value: Option<&str>) -> crate::core::Resul
     Ok(Some(value.to_string()))
 }
 
-fn plan_runner_download_cleanup(root: &Path) -> crate::core::Result<RunnerDownloadCleanupPlan> {
-    let mut plan = RunnerDownloadCleanupPlan::default();
+fn plan_runner_download_cleanup(root: &Path) -> crate::core::Result<RunnerDownloadCleanupPreview> {
+    let mut plan = RunnerDownloadCleanupPreview::default();
     if !root.exists() {
         return Ok(plan);
     }
@@ -364,7 +364,7 @@ fn plan_runner_download_cleanup(root: &Path) -> crate::core::Result<RunnerDownlo
 fn collect_runner_download_cleanup(
     root: &Path,
     path: &Path,
-    plan: &mut RunnerDownloadCleanupPlan,
+    plan: &mut RunnerDownloadCleanupPreview,
 ) -> crate::core::Result<()> {
     let metadata = fs::symlink_metadata(path).map_err(|err| {
         crate::core::Error::internal_io(

--- a/src/core/runner/capabilities.rs
+++ b/src/core/runner/capabilities.rs
@@ -18,7 +18,7 @@ pub struct RunnerCapabilityPreflight {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LabRunnerCapabilityPlan {
+pub struct PreparedLabRunnerCapability {
     pub command: &'static str,
     pub required_tools: Vec<RunnerRequiredTool>,
 }
@@ -62,9 +62,9 @@ pub enum RunnerRequiredTool {
     Playwright,
 }
 
-pub fn lab_runner_capability_plan(
+pub fn prepare_lab_runner_capability(
     contract: LabRunnerCapabilityContract,
-) -> LabRunnerCapabilityPlan {
+) -> PreparedLabRunnerCapability {
     let mut required_tools = vec![RunnerRequiredTool::Git];
     for tool in contract.required_tools {
         push_unique(&mut required_tools, tool);
@@ -74,7 +74,7 @@ pub fn lab_runner_capability_plan(
         push_unique(&mut required_tools, RunnerRequiredTool::Playwright);
     }
 
-    LabRunnerCapabilityPlan {
+    PreparedLabRunnerCapability {
         command: contract.command,
         required_tools,
     }
@@ -83,12 +83,12 @@ pub fn lab_runner_capability_plan(
 pub fn lab_runner_capability_preflight(
     contract: LabRunnerCapabilityContract,
 ) -> RunnerCapabilityPreflight {
-    lab_runner_capability_plan(contract).into()
+    prepare_lab_runner_capability(contract).into()
 }
 
 pub fn evaluate_lab_runner_capabilities_for_runner(
     runner: &Runner,
-    plan: &LabRunnerCapabilityPlan,
+    plan: &PreparedLabRunnerCapability,
     mode: LabRunnerGateMode,
 ) -> Result<LabRunnerGateDecision> {
     let capabilities = RunnerCapabilitySnapshot::from_runner_probe_with_commands(runner, &[])?;
@@ -321,7 +321,7 @@ impl RunnerCapabilitySnapshot {
 
 fn evaluate_lab_runner_capabilities(
     runner_id: &str,
-    plan: &LabRunnerCapabilityPlan,
+    plan: &PreparedLabRunnerCapability,
     capabilities: &RunnerCapabilitySnapshot,
     mode: LabRunnerGateMode,
 ) -> LabRunnerGateDecision {
@@ -413,8 +413,8 @@ fn tool_list(tools: &[RunnerRequiredTool]) -> String {
         .join(", ")
 }
 
-impl From<LabRunnerCapabilityPlan> for RunnerCapabilityPreflight {
-    fn from(plan: LabRunnerCapabilityPlan) -> Self {
+impl From<PreparedLabRunnerCapability> for RunnerCapabilityPreflight {
+    fn from(plan: PreparedLabRunnerCapability) -> Self {
         Self {
             command: plan.command.to_string(),
             required_tools: plan.required_tools,
@@ -557,8 +557,8 @@ mod tests {
     }
 
     #[test]
-    fn lab_runner_capability_plan_detects_project_tool_needs() {
-        let plan = lab_runner_capability_plan(LabRunnerCapabilityContract {
+    fn prepare_lab_runner_capability_detects_project_tool_needs() {
+        let plan = prepare_lab_runner_capability(LabRunnerCapabilityContract {
             command: "lint",
             required_tools: vec![
                 RunnerRequiredTool::Node,
@@ -608,7 +608,7 @@ mod tests {
 
     #[test]
     fn lab_runner_gate_allows_capable_runner() {
-        let plan = LabRunnerCapabilityPlan {
+        let plan = PreparedLabRunnerCapability {
             command: "lint",
             required_tools: vec![
                 RunnerRequiredTool::Git,
@@ -641,7 +641,7 @@ mod tests {
 
     #[test]
     fn lab_runner_gate_reports_missing_tool_for_explicit_runner() {
-        let plan = LabRunnerCapabilityPlan {
+        let plan = PreparedLabRunnerCapability {
             command: "test",
             required_tools: vec![RunnerRequiredTool::Git, RunnerRequiredTool::Pnpm],
         };
@@ -711,7 +711,7 @@ mod tests {
 
     #[test]
     fn lab_runner_gate_reports_local_fallback_for_auto_runner() {
-        let plan = LabRunnerCapabilityPlan {
+        let plan = PreparedLabRunnerCapability {
             command: "trace",
             required_tools: vec![RunnerRequiredTool::Git, RunnerRequiredTool::Playwright],
         };

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -114,7 +114,7 @@ pub(crate) struct RunnerProcessRequest {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct RunnerProcessPlan {
+pub(crate) struct PreparedRunnerProcess {
     pub runner: Runner,
     pub cwd: String,
     pub command: Vec<String>,
@@ -634,7 +634,7 @@ fn result_event_data(events: &[JobEvent]) -> Option<Value> {
         .and_then(|event| event.data.clone())
 }
 
-fn exec_local(plan: RunnerProcessPlan) -> Result<(RunnerExecOutput, i32)> {
+fn exec_local(plan: PreparedRunnerProcess) -> Result<(RunnerExecOutput, i32)> {
     let output = execute_runner_process(&plan)?;
     Ok(exec_output(
         &plan.runner,
@@ -704,7 +704,9 @@ pub(crate) struct ProcessOutput {
     pub capture: Option<CommandCaptureMetadata>,
 }
 
-pub(crate) fn prepare_runner_process(request: RunnerProcessRequest) -> Result<RunnerProcessPlan> {
+pub(crate) fn prepare_runner_process(
+    request: RunnerProcessRequest,
+) -> Result<PreparedRunnerProcess> {
     if request.command.is_empty() {
         return Err(Error::validation_invalid_argument(
             "command",
@@ -769,7 +771,7 @@ pub(crate) fn prepare_runner_process(request: RunnerProcessRequest) -> Result<Ru
         request.validate_require_paths_on_host,
     )?;
 
-    Ok(RunnerProcessPlan {
+    Ok(PreparedRunnerProcess {
         runner,
         cwd,
         command: request.command,
@@ -781,7 +783,7 @@ pub(crate) fn prepare_runner_process(request: RunnerProcessRequest) -> Result<Ru
 
 pub(crate) fn prepare_daemon_local_process(
     request: RunnerProcessRequest,
-) -> Result<RunnerProcessPlan> {
+) -> Result<PreparedRunnerProcess> {
     if request.command.is_empty() {
         return Err(Error::validation_invalid_argument(
             "command",
@@ -839,7 +841,7 @@ pub(crate) fn prepare_daemon_local_process(
         SourceSnapshot::collect_local(&runner.id, Path::new(&cwd), Some(&cwd), "existing_remote")
     });
 
-    Ok(RunnerProcessPlan {
+    Ok(PreparedRunnerProcess {
         runner,
         cwd,
         command: request.command,
@@ -931,7 +933,7 @@ fn validate_runner_process_cwd(runner: &Runner, cwd: &str) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn execute_runner_process(plan: &RunnerProcessPlan) -> Result<ProcessOutput> {
+pub(crate) fn execute_runner_process(plan: &PreparedRunnerProcess) -> Result<ProcessOutput> {
     let mut command = std::process::Command::new(&plan.command[0]);
     command.args(&plan.command[1..]).current_dir(&plan.cwd);
     apply_runner_process_env(&mut command, plan);
@@ -940,7 +942,7 @@ pub(crate) fn execute_runner_process(plan: &RunnerProcessPlan) -> Result<Process
 }
 
 pub(crate) fn execute_runner_process_until_cancelled(
-    plan: &RunnerProcessPlan,
+    plan: &PreparedRunnerProcess,
     is_cancelled: impl FnMut() -> bool,
 ) -> Result<ProcessOutput> {
     let mut command = std::process::Command::new(&plan.command[0]);
@@ -950,7 +952,7 @@ pub(crate) fn execute_runner_process_until_cancelled(
     command_output_until_cancelled(&mut command, is_cancelled)
 }
 
-fn apply_runner_process_env(command: &mut std::process::Command, plan: &RunnerProcessPlan) {
+fn apply_runner_process_env(command: &mut std::process::Command, plan: &PreparedRunnerProcess) {
     command.env_clear();
     for key in inherited_runner_process_env_keys() {
         if !plan.env.contains_key(*key) {

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -11,11 +11,11 @@ use crate::core::{agent_task_secrets, config, Error, ErrorCode, Result};
 
 use super::{
     evaluate_lab_runner_capabilities_for_runner, exec, lab_offload_changed_since_ref,
-    lab_offload_metadata, lab_offload_metadata_with_workspace_mapping, lab_runner_capability_plan,
-    load, preflight_lab_offload_changed_since, prepare_git_lab_offload_changed_since,
-    rig_materialization, status, sync_workspace, LabRunnerGateDecision, RunnerCapabilityPreflight,
-    RunnerExecOptions, RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceSyncMode,
-    RunnerWorkspaceSyncOptions,
+    lab_offload_metadata, lab_offload_metadata_with_workspace_mapping, load,
+    preflight_lab_offload_changed_since, prepare_git_lab_offload_changed_since,
+    prepare_lab_runner_capability, rig_materialization, status, sync_workspace,
+    LabRunnerGateDecision, RunnerCapabilityPreflight, RunnerExecOptions, RunnerStatusReport,
+    RunnerTunnelMode, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
 
 use super::daemon_health::runner_daemon_health_failure;
@@ -564,7 +564,9 @@ fn run_lab_offload_inner(
     let command_prefix = lab_offload_command_prefix(&source_path, homeboy_path);
     let capability_contract =
         lab_runner_capability_contract(&contract, &source_path, &command_prefix.required_tools);
-    let capability_plan = capability_contract.clone().map(lab_runner_capability_plan);
+    let capability_plan = capability_contract
+        .clone()
+        .map(prepare_lab_runner_capability);
     if let Some(capability_plan) = &capability_plan {
         let decision = match evaluate_lab_runner_capabilities_for_runner(
             &runner,

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -44,9 +44,9 @@ pub use apply::{
     RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus,
 };
 pub use capabilities::{
-    evaluate_lab_runner_capabilities_for_runner, lab_runner_capability_plan,
-    lab_runner_capability_preflight, LabRunnerCapabilityContract, LabRunnerCapabilityPlan,
-    LabRunnerGateDecision, LabRunnerGateMode, RunnerCapabilityPreflight, RunnerRequiredTool,
+    evaluate_lab_runner_capabilities_for_runner, lab_runner_capability_preflight,
+    prepare_lab_runner_capability, LabRunnerCapabilityContract, LabRunnerGateDecision,
+    LabRunnerGateMode, PreparedLabRunnerCapability, RunnerCapabilityPreflight, RunnerRequiredTool,
 };
 pub(crate) use command_path::{
     normalize_runner_command_env, quote_runner_env_value, remote_shell_path_preamble,


### PR DESCRIPTION
## Summary
- Rename internal prepared runner process and lab capability plan structs away from `*Plan` terminology.
- Rename the runner download cleanup accumulator to avoid implying it is a workflow plan.
- Leave user-facing workflow/operator plan types unchanged.

Fixes #4254

## Verification
- `cargo fmt --check`
- `cargo test runner_capability`
- `cargo test runner_download_cleanup`
- `cargo check`

Full local `cargo test` / `cargo test --lib` attempts exceeded local timeouts after compiling and running a large portion of the suite; no failures were observed before timeout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5
- **Used for:** Drafted and validated the rename refactor, checks, and PR description; Chris remains responsible for review and merge.