### PR TITLE
Fix Lab snapshot TypeScript incremental metadata hygiene

### DIFF
--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -39,6 +39,7 @@ pub(super) const DEFAULT_EXCLUDES: &[&str] = &[
     ".turbo/**",
     ".cache",
     ".cache/**",
+    "*.tsbuildinfo",
 ];
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -1077,6 +1078,7 @@ mod tests {
                 .expect("extension scripts build dir");
             fs::create_dir_all(source.path().join(".git")).expect("git dir");
             fs::create_dir_all(source.path().join("target/debug")).expect("target dir");
+            fs::create_dir_all(source.path().join("packages/cli")).expect("package dir");
             fs::write(source.path().join("src/main.rs"), "fn main() {}\n").expect("source file");
             fs::write(source.path().join("build/bundle.js"), "artifact").expect("build file");
             fs::write(source.path().join("vendor/autoload.php"), "<?php\n").expect("vendor file");
@@ -1090,6 +1092,11 @@ mod tests {
             fs::write(source.path().join("src/._main.rs"), "appledouble").expect("sidecar file");
             fs::write(source.path().join(".env.local"), "SECRET=1\n").expect("secret file");
             fs::write(source.path().join("target/debug/homeboy"), "binary").expect("build file");
+            fs::write(
+                source.path().join("packages/cli/tsconfig.tsbuildinfo"),
+                "stale incremental state",
+            )
+            .expect("tsbuildinfo file");
 
             super::super::create(
                 &format!(
@@ -1133,6 +1140,9 @@ mod tests {
             assert!(!Path::new(&output.remote_path).join(".env.local").exists());
             assert!(!Path::new(&output.remote_path)
                 .join("target/debug/homeboy")
+                .exists());
+            assert!(!Path::new(&output.remote_path)
+                .join("packages/cli/tsconfig.tsbuildinfo")
                 .exists());
         });
     }


### PR DESCRIPTION
## Summary
- exclude `*.tsbuildinfo` from generic Lab snapshot workspace sync by default
- extend the local snapshot sync test fixture with stale `packages/cli/tsconfig.tsbuildinfo`
- assert the stale TypeScript incremental metadata is not materialized into the Lab workspace

Fixes #4274.

## Tests
- `cargo test core::runner::workspace::tests::test_sync_workspace`
- `cargo test core::runner::workspace::tests`
- `cargo fmt --check`

## Notes
- `cargo test --test core_agnostic_test` was also run and failed on pre-existing unrelated core-boundary findings across many files; the failure did not include this changed `src/core/runner/workspace.rs` path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the small snapshot hygiene fix and drafted the regression test; Chris remains responsible for review and validation.