### PR TITLE
Preserve detached runner git workspace revisions

### DIFF
--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -155,6 +155,7 @@ pub fn sync_workspace(
             )?;
             let remote_path = deterministic_remote_path(workspace_root, &local_path, &git.head);
             if options.controller_routed_git
+                || git.branch.is_none()
                 || super::source_materialization::requires_controller_routed_workspace_sync(
                     &git.remote_url,
                 )
@@ -1256,6 +1257,98 @@ mod tests {
             assert_eq!(
                 fs::read_to_string(remote.join("file.txt")).expect("read synced file"),
                 "source-upgrade\n"
+            );
+        });
+    }
+
+    #[test]
+    fn git_sync_of_detached_extension_source_preserves_source_revision() {
+        crate::test_support::with_isolated_home(|_| {
+            let source = tempfile::tempdir().expect("source tempdir");
+            let runner_root = tempfile::tempdir().expect("runner root tempdir");
+            git(source.path(), &["init"]);
+            git(source.path(), &["config", "user.email", "test@example.com"]);
+            git(source.path(), &["config", "user.name", "Test User"]);
+            fs::create_dir_all(source.path().join("wordpress")).expect("extension dir");
+            fs::write(
+                source.path().join("wordpress/wordpress.json"),
+                r#"{"name":"WordPress","version":"1.0.0"}"#,
+            )
+            .expect("write extension manifest");
+            git(source.path(), &["add", "."]);
+            git(source.path(), &["commit", "-m", "base"]);
+            git(source.path(), &["checkout", "--detach", "HEAD"]);
+            fs::write(
+                source.path().join("wordpress/wordpress.json"),
+                r#"{"name":"WordPress","version":"2.0.0"}"#,
+            )
+            .expect("write detached extension manifest");
+            git(source.path(), &["add", "."]);
+            git(
+                source.path(),
+                &["commit", "-m", "detached extension update"],
+            );
+            git(
+                source.path(),
+                &[
+                    "remote",
+                    "add",
+                    "origin",
+                    "https://github.com/Extra-Chill/homeboy-extensions.git",
+                ],
+            );
+            let detached_head = git_output(source.path(), &["rev-parse", "HEAD"]).unwrap();
+            let detached_short =
+                git_output(source.path(), &["rev-parse", "--short", "HEAD"]).unwrap();
+
+            super::super::create(
+                &format!(
+                    r#"{{"id":"lab-local-detached-extension","kind":"local","workspace_root":"{}"}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+
+            let (output, exit_code) = sync_workspace(
+                "lab-local-detached-extension",
+                RunnerWorkspaceSyncOptions {
+                    path: source.path().display().to_string(),
+                    mode: RunnerWorkspaceSyncMode::Git,
+                    controller_routed_git: false,
+                    changed_since_base: None,
+                    git_fetch_refs: Vec::new(),
+                    snapshot_includes: Vec::new(),
+                },
+            )
+            .expect("sync workspace");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(output.sync_mode, RunnerWorkspaceSyncMode::Git);
+            assert_eq!(output.snapshot_identity, detached_head);
+            let remote = Path::new(&output.remote_path);
+            assert_eq!(
+                git_output(remote, &["rev-parse", "HEAD"]).unwrap(),
+                detached_head
+            );
+            assert_eq!(
+                git_output(remote, &["rev-parse", "--abbrev-ref", "HEAD"]).unwrap(),
+                "HEAD"
+            );
+
+            let install = crate::core::extension::install(
+                &remote.join("wordpress").display().to_string(),
+                Some("wordpress"),
+            )
+            .expect("install extension from synced detached workspace");
+
+            assert_eq!(
+                install.source_revision.as_deref(),
+                Some(detached_short.as_str())
+            );
+            assert_eq!(
+                crate::core::extension::read_source_revision("wordpress").as_deref(),
+                Some(detached_short.as_str())
             );
         });
     }


### PR DESCRIPTION
## Summary
- Route detached-HEAD `runner workspace sync --mode git` through the existing controller git bundle materialization path so the exact local commit is preserved.
- Keep branch-based public git sync behavior unchanged.
- Add coverage that syncs a detached local extension source and verifies the installed extension reports the same `source_revision` as the controller-side detached worktree.

Closes #4280

## Tests
- `cargo test core::runner::workspace::tests`
- `cargo test core::upgrade::runners::tests`
- `cargo test core::runner::workspace::tests::git_sync_of_detached_extension_source_preserves_source_revision`
- `cargo test core::runner::workspace::tests::controller_routed_git_sync_materializes_bundle_for_public_remote`
- `cargo test core::extension::lifecycle::tests::test_install_with_revision`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the detached workspace sync fix and drafted the regression coverage; Chris retains responsibility for review and testing.