### PR TITLE
Fix invocation temp root user collisions

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -384,9 +384,9 @@ The structured context currently has this substrate-agnostic shape:
 ```json
 {
   "id": "inv-0123456789",
-  "state_dir": "/tmp/hb/0123456789",
-  "artifact_dir": "/tmp/hb/0123456789.a",
-  "tmp_dir": "/tmp/hb/0123456789.t",
+  "state_dir": "/tmp/hb-501/0123456789",
+  "artifact_dir": "/tmp/hb-501/0123456789.a",
+  "tmp_dir": "/tmp/hb-501/0123456789.t",
   "port_range": { "base": 20000, "max": 20007 },
   "named_leases": ["playground-browser-profile"]
 }
@@ -421,8 +421,9 @@ own the path-length budget at that point.
 
 - `HOMEBOY_INVOCATION_RUNTIME_DIR` env override (tests and unusual host
   configurations).
-- `/tmp/hb` on every Unix host when `/tmp` is a writable directory. macOS
-  apps that respect `$TMPDIR` get per-user isolation under
+- `/tmp/hb-<uid>` on every Unix host when `/tmp` is a writable directory. The
+  UID suffix keeps root and unprivileged invocations from colliding on one
+  runtime root. macOS apps that respect `$TMPDIR` get per-user isolation under
   `/var/folders/<14>/T/...` (~50 bytes), which leaves no realistic
   `sockaddr_un` budget. Anchoring to `/tmp` saves ~35 bytes of headroom and
   is writable on every standard macOS / Linux configuration.

--- a/src/core/engine/invocation.rs
+++ b/src/core/engine/invocation.rs
@@ -5,6 +5,9 @@ use crate::core::error::{Error, Result};
 use crate::core::paths;
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::io;
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, SystemTime};
@@ -131,12 +134,8 @@ impl InvocationGuard {
         }
 
         for dir in [&state_dir, &artifact_dir, &tmp_dir] {
-            fs::create_dir_all(dir).map_err(|e| {
-                Error::internal_io(
-                    format!("Failed to create invocation dir {}: {}", dir.display(), e),
-                    Some("invocation.dir".to_string()),
-                )
-            })?;
+            fs::create_dir_all(dir)
+                .map_err(|e| invocation_dir_create_error(dir, &runtime_root, e))?;
         }
 
         let needs_lease =
@@ -280,6 +279,60 @@ impl InvocationGuard {
             crate::core::artifact_manifest::manifest_for_existing_files(target)?
         };
         crate::core::artifact_manifest::write_manifest_to_root(target, &manifest)
+    }
+}
+
+fn invocation_dir_create_error(dir: &Path, runtime_root: &Path, error: io::Error) -> Error {
+    if error.kind() == io::ErrorKind::PermissionDenied {
+        return Error::internal_unexpected(format!(
+            "Homeboy cannot create invocation dir {} because runtime temp root {} is not writable by the current user ({}). {} Remediation: remove or chown the runtime temp root, or set {} to a writable short path.",
+            dir.display(),
+            runtime_root.display(),
+            current_user_label(),
+            runtime_root_owner_label(runtime_root),
+            HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+        ));
+    }
+
+    Error::internal_io(
+        format!(
+            "Failed to create invocation dir {}: {}",
+            dir.display(),
+            error
+        ),
+        Some("invocation.dir".to_string()),
+    )
+}
+
+fn current_user_label() -> String {
+    let name = std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+
+    #[cfg(unix)]
+    {
+        let uid = unsafe { libc::getuid() };
+        match name {
+            Some(name) => format!("{name}, uid {uid}"),
+            None => format!("uid {uid}"),
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        name.unwrap_or_else(|| "unknown user".to_string())
+    }
+}
+
+fn runtime_root_owner_label(runtime_root: &Path) -> String {
+    match fs::metadata(runtime_root) {
+        #[cfg(unix)]
+        Ok(metadata) => format!("Runtime temp root owner: uid {}.", metadata.uid()),
+        #[cfg(not(unix))]
+        Ok(_) => "Runtime temp root exists but ownership could not be inspected on this platform."
+            .to_string(),
+        Err(e) => format!("Runtime temp root owner could not be inspected: {e}."),
     }
 }
 

--- a/src/core/engine/invocation/runtime.rs
+++ b/src/core/engine/invocation/runtime.rs
@@ -11,8 +11,8 @@
 //!
 //! In priority order:
 //! 1. `HOMEBOY_INVOCATION_RUNTIME_DIR` env override (tests, advanced users).
-//! 2. `/tmp/hb` on macOS / Linux when `/tmp` is a writable directory. macOS
-//!    apps that respect `$TMPDIR` get per-user isolation under
+//! 2. `/tmp/hb-<uid>` on macOS / Linux when `/tmp` is a writable directory.
+//!    macOS apps that respect `$TMPDIR` get per-user isolation under
 //!    `/var/folders/<14>/T/...` which is already ~50 bytes — anchoring the
 //!    runtime root to `/tmp` saves ~35 bytes of `sockaddr_un` budget per
 //!    invocation, the difference between "fits" and "EINVAL on bind".
@@ -92,14 +92,14 @@ pub fn invocation_runtime_root() -> Result<PathBuf> {
 
     #[cfg(unix)]
     {
-        // Prefer `/tmp/hb` on every Unix host. On macOS the per-user
+        // Prefer a per-user `/tmp/hb-<uid>` root on every Unix host. On macOS the per-user
         // `$TMPDIR` (`/var/folders/<14>/T/...`) is already ~50 bytes long,
         // which leaves no realistic `sockaddr_un` budget after appending a
         // short id and a typical workload-relative socket name. `/tmp` is
         // ~5 bytes, gives us ~35 extra bytes of headroom, and is writable
         // on every standard macOS / Linux configuration.
         if Path::new("/tmp").is_dir() {
-            return Ok(PathBuf::from("/tmp/hb"));
+            return Ok(PathBuf::from(format!("/tmp/hb-{}", current_uid())));
         }
 
         // Fallbacks for unusual hosts where `/tmp` is missing or not a
@@ -159,6 +159,11 @@ fn cache_fallback_root() -> Result<PathBuf> {
             .join("homeboy")
             .join("inv"))
     }
+}
+
+#[cfg(unix)]
+fn current_uid() -> libc::uid_t {
+    unsafe { libc::getuid() }
 }
 
 /// Verify that handing out `path` leaves room for a realistic
@@ -226,7 +231,10 @@ mod tests {
         env::set_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, "   ");
 
         let root = invocation_runtime_root().expect("root resolves");
-        assert!(root.ends_with("hb") || root.ends_with("inv"));
+        assert!(root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("hb-") || name == "inv"));
 
         match prior {
             Some(value) => env::set_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, value),
@@ -256,8 +264,26 @@ mod tests {
 
     #[test]
     fn budget_accepts_short_path() {
-        let path = PathBuf::from("/tmp/hb/abc1234567/state");
+        let path = PathBuf::from("/tmp/hb-501/abc1234567/state");
         enforce_path_budget(&path).expect("short path fits");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_tmp_root_is_scoped_by_uid() {
+        let _guard = home_env_guard();
+        let prior = env::var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV).ok();
+        env::remove_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV);
+
+        let root = invocation_runtime_root().expect("root resolves");
+        if Path::new("/tmp").is_dir() {
+            assert_eq!(root, PathBuf::from(format!("/tmp/hb-{}", current_uid())));
+        }
+
+        match prior {
+            Some(value) => env::set_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV, value),
+            None => env::remove_var(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV),
+        }
     }
 
     #[test]

--- a/tests/core/engine/invocation_test.rs
+++ b/tests/core/engine/invocation_test.rs
@@ -388,6 +388,24 @@ fn enforce_path_budget_rejects_overlong_paths() {
 }
 
 #[test]
+fn invocation_dir_permission_error_names_runtime_root_and_remediation() {
+    let runtime_root = std::path::Path::new("/tmp/hb-owned-by-another-user");
+    let dir = runtime_root.join("abc1234567");
+    let err = invocation_dir_create_error(
+        &dir,
+        runtime_root,
+        std::io::Error::new(std::io::ErrorKind::PermissionDenied, "permission denied"),
+    );
+    let message = err.to_string();
+
+    assert!(message.contains("Homeboy cannot create invocation dir"));
+    assert!(message.contains("/tmp/hb-owned-by-another-user"));
+    assert!(message.contains("current user"));
+    assert!(message.contains(HOMEBOY_INVOCATION_RUNTIME_DIR_ENV));
+    assert!(message.contains("remove or chown"));
+}
+
+#[test]
 fn invocation_drop_cleans_up_root_directory() {
     with_isolated_home(|_| {
         let run_dir = RunDir::create().expect("run dir");


### PR DESCRIPTION
## Summary
- Scope the default Unix invocation runtime root to the current UID (`/tmp/hb-<uid>`) so root and unprivileged users do not collide on `/tmp/hb`.
- Surface an actionable permission-denied message that names the runtime root, current user, owner UID when available, and remediation.
- Update invocation runtime docs/examples and cover the new root/error behavior with tests.

Closes #4273

## Verification
- `cargo test core::engine::invocation::`
- `cargo run --bin homeboy -- lint`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the code, tests, docs, and verification commands; Chris remains responsible for review and merge.
