### PR TITLE
Introduce typed command adapter contract

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -1,5 +1,5 @@
 use crate::cli_surface::Commands;
-use crate::commands::{changelog, file, logs, report, review, trace};
+use crate::commands::{changelog, file, logs, report, review, trace, version};
 
 mod lab_contract;
 pub use lab_contract::{
@@ -200,6 +200,7 @@ impl Commands {
                 output_file_mode,
                 CommandOutputContractKind::JsonEnvelope,
             ),
+            Commands::Version(_) => version::adapter(output_file_mode).contract.to_descriptor(),
             Commands::AgentTask(_)
             | Commands::Project(_)
             | Commands::Component(_)
@@ -207,7 +208,6 @@ impl Commands {
             | Commands::Extension(_)
             | Commands::Changelog(_)
             | Commands::Cleanup(_)
-            | Commands::Version(_)
             | Commands::Build(_)
             | Commands::Changes(_)
             | Commands::Release(_)

--- a/src/commands/adapter.rs
+++ b/src/commands/adapter.rs
@@ -1,0 +1,141 @@
+use serde_json::Value;
+
+use crate::command_contract::{
+    CommandDescriptor, CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
+    CommandRawOutputMode, CommandResponseMode,
+};
+
+use super::GlobalArgs;
+
+pub(crate) type JsonCommandRun = (homeboy::core::Result<Value>, i32);
+pub(crate) type JsonCommandExecutor<Args> = fn(Args, &GlobalArgs) -> JsonCommandRun;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CommandLabRunnerPolicy {
+    pub supports_runner: bool,
+    pub unsupported_reason: Option<&'static str>,
+    pub mutation_flag: Option<&'static str>,
+}
+
+impl CommandLabRunnerPolicy {
+    pub const LOCAL: Self = Self {
+        supports_runner: false,
+        unsupported_reason: None,
+        mutation_flag: None,
+    };
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CommandAdapterContract {
+    pub response_mode: CommandResponseMode,
+    pub output_file_mode: CommandOutputFileMode,
+    pub json_family: CommandJsonFamily,
+    pub output_contract: CommandOutputContractKind,
+    pub lab_runner: CommandLabRunnerPolicy,
+}
+
+impl CommandAdapterContract {
+    pub fn to_descriptor(self) -> CommandDescriptor {
+        CommandDescriptor {
+            response_mode: self.response_mode,
+            output_file_mode: self.output_file_mode,
+            json_family: self.json_family,
+            supports_lab_runner: self.lab_runner.supports_runner,
+            lab_runner_unsupported_reason: self.lab_runner.unsupported_reason,
+            lab_offload_mutation_flag: self.lab_runner.mutation_flag,
+            output_contract: self.output_contract,
+        }
+    }
+}
+
+pub(crate) struct TypedCommandAdapter<Args> {
+    pub contract: CommandAdapterContract,
+    pub execute_json: Option<JsonCommandExecutor<Args>>,
+}
+
+impl<Args> TypedCommandAdapter<Args> {
+    pub fn json_only(
+        json_family: CommandJsonFamily,
+        output_file_mode: CommandOutputFileMode,
+        output_contract: CommandOutputContractKind,
+        execute_json: JsonCommandExecutor<Args>,
+    ) -> Self {
+        Self {
+            contract: CommandAdapterContract {
+                response_mode: CommandResponseMode::Json,
+                output_file_mode,
+                json_family,
+                output_contract,
+                lab_runner: CommandLabRunnerPolicy::LOCAL,
+            },
+            execute_json: Some(execute_json),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn raw_only(
+        raw_mode: CommandRawOutputMode,
+        json_family: CommandJsonFamily,
+        output_file_mode: CommandOutputFileMode,
+        output_contract: CommandOutputContractKind,
+    ) -> Self {
+        Self {
+            contract: CommandAdapterContract {
+                response_mode: CommandResponseMode::Raw(raw_mode),
+                output_file_mode,
+                json_family,
+                output_contract,
+                lab_runner: CommandLabRunnerPolicy::LOCAL,
+            },
+            execute_json: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_only_contract_maps_to_descriptor() {
+        let adapter = TypedCommandAdapter::<()>::json_only(
+            CommandJsonFamily::Workspace,
+            CommandOutputFileMode::GenericEnvelope,
+            CommandOutputContractKind::JsonEnvelope,
+            |_, _| (Ok(Value::Null), 0),
+        );
+
+        let descriptor = adapter.contract.to_descriptor();
+
+        assert_eq!(descriptor.response_mode, CommandResponseMode::Json);
+        assert_eq!(
+            descriptor.output_file_mode,
+            CommandOutputFileMode::GenericEnvelope
+        );
+        assert_eq!(descriptor.json_family, CommandJsonFamily::Workspace);
+        assert!(!descriptor.supports_lab_runner);
+        assert!(adapter.execute_json.is_some());
+    }
+
+    #[test]
+    fn raw_contract_can_express_supported_raw_modes() {
+        for raw_mode in [
+            CommandRawOutputMode::Markdown,
+            CommandRawOutputMode::PlainText,
+            CommandRawOutputMode::InteractivePassthrough,
+        ] {
+            let adapter = TypedCommandAdapter::<()>::raw_only(
+                raw_mode,
+                CommandJsonFamily::RawOnly,
+                CommandOutputFileMode::None,
+                CommandOutputContractKind::RawOnly,
+            );
+
+            assert_eq!(
+                adapter.contract.to_descriptor().response_mode,
+                CommandResponseMode::Raw(raw_mode)
+            );
+            assert!(adapter.execute_json.is_none());
+        }
+    }
+}

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -17,7 +17,11 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Docs(args) => map(docs::run(args, global)),
         Commands::Changelog(args) => map(changelog::run(args, global)),
         Commands::Cleanup(args) => map(cleanup::run(args, global)),
-        Commands::Version(args) => map(version::run(args, global)),
+        Commands::Version(args) => {
+            version::adapter(crate::command_contract::CommandOutputFileMode::None)
+                .execute_json
+                .expect("version adapter supports JSON execution")(args, global)
+        }
         Commands::Build(args) => map(build::run(args, global)),
         Commands::Changes(args) => map(changes::run(args, global)),
         Commands::Release(args) => map(release::run(args, global)),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -165,6 +165,7 @@ pub fn finalize_set_spec(
     Ok((json_string, replace_fields))
 }
 
+pub(crate) mod adapter;
 pub mod agent_task;
 pub(crate) mod agent_task_dispatch;
 pub mod api;

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -5,7 +5,9 @@ use homeboy::core::component;
 use homeboy::core::release::version::{read_component_version, read_version, VersionTargetInfo};
 
 use super::{adapter, CmdResult};
-use crate::command_contract::{CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode};
+use crate::command_contract::{
+    CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
+};
 
 #[derive(Serialize)]
 #[serde(untagged)]

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -4,7 +4,8 @@ use serde::Serialize;
 use homeboy::core::component;
 use homeboy::core::release::version::{read_component_version, read_version, VersionTargetInfo};
 
-use super::CmdResult;
+use super::{adapter, CmdResult};
+use crate::command_contract::{CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode};
 
 #[derive(Serialize)]
 #[serde(untagged)]
@@ -51,6 +52,21 @@ pub struct VersionShowOutput {
 pub fn run(args: VersionArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<VersionOutput> {
     let VersionCommand::Show { component_id, path } = args.command;
     show(VersionShowArgs { component_id, path })
+}
+
+pub(crate) fn adapter(
+    output_file_mode: CommandOutputFileMode,
+) -> adapter::TypedCommandAdapter<VersionArgs> {
+    adapter::TypedCommandAdapter::json_only(
+        CommandJsonFamily::Workspace,
+        output_file_mode,
+        CommandOutputContractKind::JsonEnvelope,
+        run_json,
+    )
+}
+
+fn run_json(args: VersionArgs, global: &crate::commands::GlobalArgs) -> adapter::JsonCommandRun {
+    crate::commands::utils::response::map_cmd_result_to_json(run(args, global))
 }
 
 fn show(args: VersionShowArgs) -> CmdResult<VersionOutput> {


### PR DESCRIPTION
## Summary
- Introduces a minimal typed command adapter contract for command execution metadata and JSON execution.
- Migrates the low-risk `version` command as the reference adapter-backed pattern while preserving its JSON behavior.
- Keeps raw markdown, raw plaintext, and interactive passthrough representable for incremental follow-up migrations.

Fixes #4256

## Tests
- `cargo fmt --check`
- `cargo test commands::adapter`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the adapter contract, migrated the `version` command reference path, resolved rebase conflicts, and ran focused verification. Chris remains responsible for review and merge.