### PR TITLE
core: make agent_tasks/runners facades explicit API groups

### DIFF
--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -1,61 +1,232 @@
 //! Stable facade for agent task orchestration APIs.
 //!
-//! New command/core code should import agent task contracts from this module
-//! instead of depending on the underlying implementation file layout.
+//! New command and integration code MUST import agent task contracts from this
+//! module instead of reaching into the underlying implementation files
+//! (`core::agent_task`, `core::agent_task_lifecycle`, `core::agent_task_service`,
+//! etc.). The implementation modules remain public for backward compatibility
+//! with existing external callers (see `core/mod.rs`), but new code should
+//! depend on the explicit API groups defined here so that internal layout can
+//! evolve without becoming accidental public contract.
+//!
+//! The exports are organised into nested API groups by operation:
+//!
+//! - top-level: stable request/outcome/workflow contracts that callers reach
+//!   for most often.
+//! - [`aggregate`]: aggregate reports and matrix/reconciliation types.
+//! - [`cook_loop`]: cook-loop evaluation contracts.
+//! - [`fanout`]: matrix/fanout scheduling primitives.
+//! - [`finalization`]: PR finalization contracts and backends.
+//! - [`gate`]: gate report contracts and visibility/reveal policies.
+//! - [`lifecycle`]: durable run record lifecycle helpers.
+//! - [`loop_controller`]: cook/agent-task loop controller state contracts.
+//! - [`promotion`]: promotion-report contracts and entry points.
+//! - [`provider`]: executor provider contracts used by extensions.
+//! - [`scheduler`]: scheduling/plan/concurrency primitives.
+//! - [`secrets`]: secret-env mapping helpers.
+//! - [`service`]: high-level service entry points combining lifecycle and
+//!   scheduling.
 
-#![allow(ambiguous_glob_reexports)]
+// ----------------------------------------------------------------------------
+// Stable top-level contracts
+// ----------------------------------------------------------------------------
+//
+// These names are intentionally re-exported at the facade root because they
+// form the most common surface for callers (request envelopes, outcomes, the
+// workspace contract, schema identifiers, matrix expansion, fanout aggregates).
+// Adding a new name here is an intentional API decision.
 
-pub use super::agent_task::*;
-pub use super::agent_task_aggregate::*;
-pub use super::agent_task_cook_loop::*;
-pub use super::agent_task_fanout::*;
-pub use super::agent_task_finalization::*;
-pub use super::agent_task_gate::*;
-pub use super::agent_task_lifecycle::*;
-pub use super::agent_task_loop_controller::*;
-pub use super::agent_task_promotion::*;
-pub use super::agent_task_provider::*;
-pub use super::agent_task_schedule::*;
-pub use super::agent_task_scheduler::*;
-pub use super::agent_task_secrets::*;
-pub use super::agent_task_service::*;
+pub use super::agent_task::{
+    AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskExecutionHandle,
+    AgentTaskExecutionState, AgentTaskExecutor, AgentTaskExecutorCapabilities,
+    AgentTaskFailureClassification, AgentTaskFollowUp, AgentTaskLimits, AgentTaskMatrixAggregate,
+    AgentTaskMatrixAggregateCell, AgentTaskMatrixAxis, AgentTaskMatrixCell, AgentTaskMatrixError,
+    AgentTaskMatrixPlan, AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskPolicy,
+    AgentTaskPreparedWorkspace, AgentTaskProgress, AgentTaskRequest, AgentTaskSourceRef,
+    AgentTaskStart, AgentTaskWorkflowEvidence, AgentTaskWorkflowStepEvidence,
+    AgentTaskWorkflowStepStatus, AgentTaskWorkflowStepSuggestion, AgentTaskWorkspace,
+    AgentTaskWorkspaceMode, AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_MATRIX_AGGREGATE_SCHEMA,
+    AGENT_TASK_MATRIX_PLAN_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
+    AGENT_TASK_WORKFLOW_SCHEMA,
+};
 
+pub use super::agent_task_aggregate::{
+    AgentTaskAggregateReport, AgentTaskAggregateSummary, AgentTaskArtifactInventoryItem,
+    AgentTaskDecisionRef, AgentTaskMatrixRow, AgentTaskReconciliationDecision,
+    AgentTaskReconciliationItem, AGENT_TASK_AGGREGATE_SCHEMA,
+};
+
+pub use super::agent_task_fanout::{
+    AgentTaskFanoutAggregate, AgentTaskFanoutPlan, AgentTaskFanoutPlane, AgentTaskFanoutScheduler,
+    AGENT_TASK_FANOUT_AGGREGATE_SCHEMA, AGENT_TASK_FANOUT_PLAN_SCHEMA,
+};
+
+// Plan/scheduler/execution context types are widely consumed and stay at the
+// facade root for ergonomics.
+pub use super::agent_task_schedule::{
+    AgentTaskAdaptiveConcurrencyAction, AgentTaskAdaptiveConcurrencyDecision,
+    AgentTaskAdaptiveConcurrencyInputs, AgentTaskAdaptiveConcurrencyPolicy,
+    AgentTaskAdaptiveConcurrencyStatus, AgentTaskAggregate, AgentTaskAggregateStatus,
+    AgentTaskAggregateTotals, AgentTaskArtifactBinding, AgentTaskArtifactLineage,
+    AgentTaskArtifactOutputDeclaration, AgentTaskBackpressureStatus, AgentTaskCancellationToken,
+    AgentTaskExecutionContext, AgentTaskOutputBinding, AgentTaskOutputDependencies, AgentTaskPlan,
+    AgentTaskQueueStatus, AgentTaskResourceBudget, AgentTaskResourceBudgetStatus,
+    AgentTaskResourcePressure, AgentTaskRetryPolicy, AgentTaskScheduleOptions, AgentTaskState,
+    AGENT_TASK_PLAN_SCHEMA,
+};
+
+// `AgentTaskProgressEvent` is defined in both `agent_task` and
+// `agent_task_schedule`. Historically the wildcard facade picked whichever the
+// glob resolved last; the canonical type for orchestration callers is the
+// schedule-side variant, so name it explicitly here.
+pub use super::agent_task_schedule::AgentTaskProgressEvent;
+
+pub use super::agent_task_scheduler::{AgentTaskExecutorAdapter, AgentTaskScheduler};
+
+// Matrix expansion is `pub(crate)` on the implementation module; expose it
+// through the facade for callers inside the crate that need to expand a plan
+// matrix without depending on the implementation path.
+pub(crate) use super::agent_task::expand_agent_task_matrix;
+
+// Convenience re-exports of the loop-controller state enum and lineage record
+// that appear on the loop-controller surface and the durable run surface.
+pub use super::agent_task_loop_controller::{
+    AgentTaskLoopControllerState, AgentTaskLoopTaskLineage,
+};
+
+// Secret-env status type is referenced from review/dispatch commands.
+pub use super::agent_task_secrets::{secret_env_status, AgentTaskSecretEnvStatus};
+
+// Provider helpers used directly from the facade root for common callers.
+pub use super::agent_task_provider::required_extension_ids_for_plan;
+
+// ----------------------------------------------------------------------------
+// Explicit API groups
+// ----------------------------------------------------------------------------
+//
+// Each submodule below exposes the intentional surface of one implementation
+// area. Callers can import either the top-level names above or use the group
+// modules to disambiguate where contracts overlap (e.g. `lifecycle::status`
+// vs `service::status`).
+
+/// Cook-loop evaluation contracts and entry points.
 pub mod cook_loop {
-    pub use super::super::agent_task_cook_loop::*;
+    pub use super::super::agent_task_cook_loop::{
+        evaluate_cook_loop, AgentTaskCookLoopGateFailure, AgentTaskCookLoopOptions,
+        AgentTaskCookLoopReport, AgentTaskCookLoopStatus, AGENT_TASK_COOK_LOOP_REPORT_SCHEMA,
+    };
 }
 
+/// PR finalization contracts and backends.
 pub mod finalization {
-    pub use super::super::agent_task_finalization::*;
+    pub use super::super::agent_task_finalization::{
+        finalize_pr, finalize_pr_with_backend, AgentTaskGateResult, AgentTaskPrEvidence,
+        AgentTaskPrFinalizationBackend, AgentTaskPrFinalizationOptions,
+        AgentTaskPrFinalizationReport, AgentTaskPrRef, AgentTaskPrRuntimeGuardrails,
+        AgentTaskPrSourceRelationship, AgentTaskPrVerification, RealAgentTaskPrFinalizationBackend,
+        AGENT_TASK_PR_FINALIZATION_SCHEMA,
+    };
 }
 
+/// Gate report contracts, visibility, and reveal policies.
 pub mod gate {
-    pub use super::super::agent_task_gate::*;
+    pub use super::super::agent_task_gate::{
+        AgentTaskGateEnvironment, AgentTaskGateEnvironmentVariable, AgentTaskGateFailureEvidence,
+        AgentTaskGateReport, AgentTaskGateRevealPolicy, AgentTaskGateStatus,
+        AgentTaskGateVisibility, AGENT_TASK_GATE_REPORT_SCHEMA,
+    };
 }
 
+/// Durable run lifecycle: submit, run-record state, log/artifact loaders.
 pub mod lifecycle {
-    pub use super::super::agent_task_lifecycle::*;
+    pub use super::super::agent_task_lifecycle::{
+        aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run, load_plan, logs,
+        mark_resuming, mark_running, record_completed_run, record_pre_dispatch_failure,
+        record_remote_dispatch_failure, record_run_aggregate, retry, run_record_exists, status,
+        submit_plan, AgentTaskArtifactRef, AgentTaskPreDispatchFailure,
+        AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts, AgentTaskRunLog,
+        AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState, AgentTaskRunTask,
+    };
 }
 
+/// Cook/agent-task loop controller state, events, and policy.
 pub mod loop_controller {
-    pub use super::super::agent_task_loop_controller::*;
+    pub use super::super::agent_task_loop_controller::{
+        apply_external_event, controller_status, controller_status_diagnostics,
+        controller_status_report, create_controller, list_controllers, load_controller,
+        write_controller, AgentTaskGateBundle, AgentTaskGateBundleCheck,
+        AgentTaskGateBundleCheckKind, AgentTaskGateBundleResult, AgentTaskGateBundleStatus,
+        AgentTaskGateCheckResult, AgentTaskLoopActionDiagnostic, AgentTaskLoopActionStatus,
+        AgentTaskLoopArtifactRef, AgentTaskLoopCandidateLoopLimits, AgentTaskLoopCandidatePatch,
+        AgentTaskLoopCandidateValidation, AgentTaskLoopCandidateValidationStatus,
+        AgentTaskLoopControllerDiagnosticSummary, AgentTaskLoopControllerDiagnostics,
+        AgentTaskLoopControllerRecord, AgentTaskLoopControllerState,
+        AgentTaskLoopControllerStatusReport, AgentTaskLoopDedupeRecord, AgentTaskLoopEntity,
+        AgentTaskLoopExternalEvent, AgentTaskLoopFeedbackArtifact, AgentTaskLoopFeedbackStatus,
+        AgentTaskLoopFindingPacket, AgentTaskLoopHistoryEvent, AgentTaskLoopLocalFallbackPolicy,
+        AgentTaskLoopPendingActionDiagnostic, AgentTaskLoopPolicy, AgentTaskLoopPolicyAction,
+        AgentTaskLoopPolicyActionRecord, AgentTaskLoopProvenanceRef, AgentTaskLoopReviewFinding,
+        AgentTaskLoopRunRef, AgentTaskLoopRunnerAvailability, AgentTaskLoopRunnerExecutionTarget,
+        AgentTaskLoopRunnerPolicy, AgentTaskLoopRunnerPolicyDecision,
+        AgentTaskLoopSubcontrollerRef, AgentTaskLoopTaskLineage, AgentTaskLoopTransition,
+        AgentTaskLoopWait, AgentTaskLoopWaitStatus, AGENT_TASK_LOOP_CONTROLLER_SCHEMA,
+        AGENT_TASK_LOOP_CONTROLLER_STATUS_SCHEMA,
+    };
 }
 
+/// Promotion reports and entry point.
 pub mod promotion {
-    pub use super::super::agent_task_promotion::*;
+    pub use super::super::agent_task_promotion::{
+        promote, AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandReport,
+        AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionSource,
+        AgentTaskPromotionStatus, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
+    };
 }
 
+/// Executor provider contracts used by extensions and routing.
 pub mod provider {
-    pub use super::super::agent_task_provider::*;
+    pub use super::super::agent_task_provider::{
+        provider_requires_cwd_git_checkout, required_extension_ids_for_plan,
+        AgentTaskExecutorProvider, AgentTaskProviderWorkspaceMaterialization,
+        ExtensionProviderAgentTaskExecutor,
+    };
 }
 
+/// Scheduling primitives: plans, scheduler, execution context, retry/concurrency.
+///
+/// Some types here (such as `AgentTaskPlan`) are also re-exported at the
+/// facade root for ergonomics. The `scheduler` group provides a stable named
+/// import location for callers that prefer the explicit grouping.
 pub mod scheduler {
-    pub use super::super::agent_task_scheduler::*;
+    pub use super::super::agent_task_schedule::{
+        AgentTaskAdaptiveConcurrencyAction, AgentTaskAdaptiveConcurrencyDecision,
+        AgentTaskAdaptiveConcurrencyInputs, AgentTaskAdaptiveConcurrencyPolicy,
+        AgentTaskAdaptiveConcurrencyStatus, AgentTaskAggregate, AgentTaskAggregateStatus,
+        AgentTaskAggregateTotals, AgentTaskArtifactBinding, AgentTaskArtifactLineage,
+        AgentTaskArtifactOutputDeclaration, AgentTaskBackpressureStatus,
+        AgentTaskCancellationToken, AgentTaskExecutionContext, AgentTaskOutputBinding,
+        AgentTaskOutputDependencies, AgentTaskPlan, AgentTaskProgressEvent, AgentTaskQueueStatus,
+        AgentTaskResourceBudget, AgentTaskResourceBudgetStatus, AgentTaskResourcePressure,
+        AgentTaskRetryPolicy, AgentTaskScheduleOptions, AgentTaskState, AGENT_TASK_PLAN_SCHEMA,
+    };
+    pub use super::super::agent_task_scheduler::{AgentTaskExecutorAdapter, AgentTaskScheduler};
 }
 
+/// Secret-env mapping and resolution helpers.
 pub mod secrets {
-    pub use super::super::agent_task_secrets::*;
+    pub use super::super::agent_task_secrets::{
+        map_secret_to_env, map_secret_to_keychain_bundle, remove_secret_mapping,
+        resolve_secret_env, secret_env_status, set_config_secret, set_keychain_bundle,
+        set_keychain_secret, validate_secret_env, AgentTaskSecretEnvStatus,
+        AgentTaskSecretResolutionError,
+    };
 }
 
+/// High-level service entry points combining lifecycle and scheduling.
 pub mod service {
-    pub use super::super::agent_task_service::*;
+    pub use super::super::agent_task_service::{
+        aggregate_exit_code, artifacts, cancel, logs, normalize_plan_workspaces, promotion_source,
+        read_plan, resume, retry, run_cook_loop, run_loaded_plan, run_next, run_submitted, status,
+        submit_plan_spec, AgentTaskLoopAttemptReport, AgentTaskLoopReport,
+        AgentTaskLoopServiceOptions, AgentTaskRetryServiceResult, AgentTaskRunResult,
+    };
 }

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -1,6 +1,130 @@
-//! Stable facade for runner configuration, connections, execution, and lab offload APIs.
+//! Stable facade for runner configuration, connection, execution, and lab
+//! offload APIs.
 //!
-//! New command/core code should import runner APIs from this module instead of
-//! depending directly on the runner implementation module layout.
+//! New command and integration code MUST import runner APIs from this module
+//! instead of depending directly on `core::runner::*`. The runner module tree
+//! itself only exposes a hand-picked surface (most submodules are private),
+//! but routing every consumer through this facade keeps the contract explicit
+//! and lets the underlying module layout evolve without touching external
+//! callers.
+//!
+//! The exports are organised into nested API groups by operation:
+//!
+//! - top-level: stable identity, registry, capability, and session contracts
+//!   that callers reach for most often.
+//! - [`registry`]: CRUD helpers over the runner config registry.
+//! - [`connection`]: connect/disconnect/status helpers for runner sessions.
+//! - [`execution`]: exec entry points and option/output contracts.
+//! - [`workspace`]: workspace sync and patch application contracts.
+//! - [`evidence`]: artifact evidence/mirroring helpers.
+//! - [`capabilities`]: lab runner capability evaluation contracts.
+//! - [`lab_offload`]: lab offload entry points and contracts.
 
-pub use super::runner::*;
+// ----------------------------------------------------------------------------
+// Stable top-level contracts
+// ----------------------------------------------------------------------------
+
+pub use super::runner::{
+    apply_change_artifact, apply_workspace_patch, capture_lab_offload_subprocess_metadata, connect,
+    connect_reverse, disconnect, download_remote_artifact,
+    evaluate_lab_runner_capabilities_for_runner, exec, execute_lab_offload,
+    is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,
+    is_retrievable_runner_artifact, lab_offload_changed_since_ref, lab_offload_metadata,
+    lab_offload_metadata_with_workspace_mapping, lab_runner_capability_preflight,
+    mirrored_runner_job_identity, preflight_lab_offload_changed_since,
+    prepare_git_lab_offload_changed_since, prepare_lab_runner_capability,
+    refresh_mirrored_daemon_evidence, reportable_artifact_evidence_path,
+    resolve_default_lab_runner, run_reverse_worker, runner_artifact_store_token, status, statuses,
+    sync_workspace, LabOffloadCommand, LabOffloadOutcome, LabOffloadRequest,
+    LabOffloadWorkspaceModePolicy, LabRunnerCapabilityContract, LabRunnerGateDecision,
+    LabRunnerGateMode, LabRunnerSelectionSource, PreparedLabRunnerCapability,
+    RemoteArtifactDownload, ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions,
+    ReverseRunnerWorkerOutput, Runner, RunnerCapabilityPreflight, RunnerConnectReport,
+    RunnerDisconnectReport, RunnerExecMode, RunnerExecOptions, RunnerExecOutput, RunnerFailureKind,
+    RunnerKind, RunnerRequiredTool, RunnerResourceMetrics, RunnerSession, RunnerSessionRole,
+    RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport, RunnerTunnelMode,
+    RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus,
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+};
+
+// Registry CRUD entry points (re-exported at the root for ergonomics; also
+// available via the explicit `registry` group below).
+pub use super::runner::{
+    create, delete_safe, effective_env, enable_server_runner, exists, list, load, merge,
+};
+
+// Crate-internal helpers that historically flowed through the wildcard
+// `pub use runner::*`. Keep them available so existing in-tree callers
+// (currently `commands::runs::remote`) compile, but do not expose them as
+// public API.
+pub(crate) use super::runner::daemon_api_get;
+
+// ----------------------------------------------------------------------------
+// Explicit API groups
+// ----------------------------------------------------------------------------
+
+/// CRUD helpers over the runner config registry.
+pub mod registry {
+    pub use super::super::runner::{
+        create, delete_safe, effective_env, enable_server_runner, exists, list, load, merge,
+        resolve_default_lab_runner, Runner, RunnerKind,
+    };
+}
+
+/// Connect/disconnect/status helpers for runner sessions.
+pub mod connection {
+    pub use super::super::runner::{
+        connect, connect_reverse, disconnect, run_reverse_worker, status, statuses,
+        ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput,
+        RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind, RunnerSession,
+        RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport,
+        RunnerTunnelMode,
+    };
+}
+
+/// Exec entry points and option/output contracts.
+pub mod execution {
+    pub use super::super::runner::{
+        exec, RunnerExecMode, RunnerExecOptions, RunnerExecOutput, RunnerResourceMetrics,
+    };
+}
+
+/// Workspace sync and patch application contracts.
+pub mod workspace {
+    pub use super::super::runner::{
+        apply_change_artifact, apply_workspace_patch, sync_workspace, RunnerWorkspaceApplyOptions,
+        RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus, RunnerWorkspaceSyncMode,
+        RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    };
+}
+
+/// Artifact evidence and mirroring helpers.
+pub mod evidence {
+    pub use super::super::runner::{
+        download_remote_artifact, is_remote_runner_artifact_path,
+        is_reportable_artifact_evidence_path, is_retrievable_runner_artifact,
+        mirrored_runner_job_identity, refresh_mirrored_daemon_evidence,
+        reportable_artifact_evidence_path, runner_artifact_store_token, RemoteArtifactDownload,
+    };
+}
+
+/// Lab runner capability evaluation contracts.
+pub mod capabilities {
+    pub use super::super::runner::{
+        evaluate_lab_runner_capabilities_for_runner, lab_runner_capability_preflight,
+        prepare_lab_runner_capability, LabRunnerCapabilityContract, LabRunnerGateDecision,
+        LabRunnerGateMode, PreparedLabRunnerCapability, RunnerCapabilityPreflight,
+        RunnerRequiredTool,
+    };
+}
+
+/// Lab offload entry points and contracts.
+pub mod lab_offload {
+    pub use super::super::runner::{
+        capture_lab_offload_subprocess_metadata, execute_lab_offload,
+        lab_offload_changed_since_ref, lab_offload_metadata,
+        lab_offload_metadata_with_workspace_mapping, preflight_lab_offload_changed_since,
+        prepare_git_lab_offload_changed_since, LabOffloadCommand, LabOffloadOutcome,
+        LabOffloadRequest, LabOffloadWorkspaceModePolicy, LabRunnerSelectionSource,
+    };
+}

--- a/tests/architecture_core_agnostic_test.rs
+++ b/tests/architecture_core_agnostic_test.rs
@@ -237,6 +237,184 @@ fn validate_and_format_writes_do_not_select_ecosystem_commands() {
 }
 
 #[test]
+fn command_layer_uses_explicit_core_facades_only() {
+    // Commands and CLI surface must depend on the explicit facade groups
+    // (`core::agent_tasks::*`, `core::runners::*`, `core::artifacts::*`) and
+    // must not reach into the underlying implementation modules. The facade
+    // modules are an intentional API contract; implementation layout below
+    // them must be free to change without breaking the command layer.
+    //
+    // Allowed imports:
+    // - `homeboy::core::agent_tasks` and its nested groups (cook_loop,
+    //   finalization, gate, lifecycle, loop_controller, promotion, provider,
+    //   scheduler, secrets, service).
+    // - `homeboy::core::runners` and its nested groups (registry, connection,
+    //   execution, workspace, evidence, capabilities, lab_offload).
+    // - `homeboy::core::artifacts`.
+    //
+    // Blocked imports (implementation files that the facades wrap):
+    // - `homeboy::core::agent_task`, `homeboy::core::agent_task_*` (any of the
+    //   per-operation implementation files such as `agent_task_lifecycle`,
+    //   `agent_task_service`, `agent_task_scheduler`, etc.).
+    // - `homeboy::core::runner` and its submodules.
+    // - `homeboy::core::artifact_*` (e.g. `artifact_links`, `artifact_manifest`).
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let scanned_roots = ["src/commands", "src/cli_runtime.rs", "src/cli_surface.rs"];
+    let forbidden = [
+        // agent task implementation modules
+        "homeboy::core::agent_task::",
+        "homeboy::core::agent_task_aggregate",
+        "homeboy::core::agent_task_cook_loop",
+        "homeboy::core::agent_task_fanout",
+        "homeboy::core::agent_task_finalization",
+        "homeboy::core::agent_task_gate",
+        "homeboy::core::agent_task_lifecycle",
+        "homeboy::core::agent_task_loop_controller",
+        "homeboy::core::agent_task_promotion",
+        "homeboy::core::agent_task_provider",
+        "homeboy::core::agent_task_schedule",
+        "homeboy::core::agent_task_scheduler",
+        "homeboy::core::agent_task_secrets",
+        "homeboy::core::agent_task_service",
+        // runner implementation module
+        "homeboy::core::runner::",
+        "homeboy::core::runner ",
+        "use homeboy::core::runner;",
+        "use homeboy::core::runner as ",
+        // artifact implementation files
+        "homeboy::core::artifact_inputs",
+        "homeboy::core::artifact_links",
+        "homeboy::core::artifact_manifest",
+        "homeboy::core::artifact_metadata",
+        "homeboy::core::artifact_origin",
+        "homeboy::core::browser_evidence",
+        "homeboy::core::change_artifact",
+        "homeboy::core::publication_artifacts",
+        "homeboy::core::structured_sidecar",
+    ];
+
+    let mut violations = Vec::new();
+    for relative in scanned_roots {
+        scan_command_layer_for_impl_imports(
+            root,
+            &root.join(relative),
+            &forbidden,
+            &mut violations,
+        );
+    }
+
+    assert!(
+        violations.is_empty(),
+        "command layer must depend on explicit core facades only. Replace these imports with \
+         `homeboy::core::agent_tasks::*`, `homeboy::core::runners::*`, or \
+         `homeboy::core::artifacts::*` (or one of their nested groups). Violations:\n{}",
+        violations.join("\n")
+    );
+}
+
+fn scan_command_layer_for_impl_imports(
+    root: &std::path::Path,
+    path: &std::path::Path,
+    forbidden: &[&str],
+    violations: &mut Vec<String>,
+) {
+    if path.is_dir() {
+        for entry in std::fs::read_dir(path).expect("read command layer directory") {
+            let entry = entry.expect("read command layer entry");
+            scan_command_layer_for_impl_imports(root, &entry.path(), forbidden, violations);
+        }
+        return;
+    }
+
+    if path.extension().is_none_or(|extension| extension != "rs") {
+        return;
+    }
+
+    let relative = relative_source_path(root, path);
+    let content = std::fs::read_to_string(path).expect("read command layer source file");
+    let mut skip_rest_as_test_module = false;
+
+    for (index, line) in content.lines().enumerate() {
+        if line.trim() == "#[cfg(test)]" {
+            skip_rest_as_test_module = true;
+            continue;
+        }
+        if skip_rest_as_test_module {
+            continue;
+        }
+
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") || trimmed.starts_with("///") || trimmed.starts_with("//!") {
+            continue;
+        }
+
+        for term in forbidden {
+            if line.contains(term) {
+                violations.push(format!("{relative}:{} contains `{term}`", index + 1));
+            }
+        }
+    }
+}
+
+#[test]
+fn core_facades_expose_explicit_groups_not_wildcards() {
+    // The `core::agent_tasks`, `core::runners`, and `core::artifacts` facade
+    // modules are the public surface that the command layer depends on. They
+    // must spell out their re-exports explicitly so that implementation
+    // modules cannot leak new public names through `pub use module::*` blocks.
+    let agent_tasks = source_file("src/core/agent_tasks.rs");
+    let runners = source_file("src/core/runners.rs");
+
+    let forbidden_wildcards = [
+        "pub use super::agent_task::*",
+        "pub use super::agent_task_aggregate::*",
+        "pub use super::agent_task_cook_loop::*",
+        "pub use super::agent_task_fanout::*",
+        "pub use super::agent_task_finalization::*",
+        "pub use super::agent_task_gate::*",
+        "pub use super::agent_task_lifecycle::*",
+        "pub use super::agent_task_loop_controller::*",
+        "pub use super::agent_task_promotion::*",
+        "pub use super::agent_task_provider::*",
+        "pub use super::agent_task_schedule::*",
+        "pub use super::agent_task_scheduler::*",
+        "pub use super::agent_task_secrets::*",
+        "pub use super::agent_task_service::*",
+    ];
+    for wildcard in forbidden_wildcards {
+        assert!(
+            !agent_tasks.contains(wildcard),
+            "src/core/agent_tasks.rs must not re-export implementation modules via \
+             `{wildcard}`; list the API names explicitly so the facade documents its surface."
+        );
+    }
+
+    assert!(
+        !runners.contains("pub use super::runner::*"),
+        "src/core/runners.rs must not re-export the runner module via `pub use super::runner::*`; \
+         list the API names explicitly so the facade documents its surface."
+    );
+
+    assert!(
+        agent_tasks.contains("pub mod scheduler")
+            && agent_tasks.contains("pub mod lifecycle")
+            && agent_tasks.contains("pub mod service")
+            && agent_tasks.contains("pub mod loop_controller"),
+        "src/core/agent_tasks.rs must keep the explicit API group modules (scheduler, lifecycle, \
+         service, loop_controller, ...) so callers can disambiguate overlapping names."
+    );
+    assert!(
+        runners.contains("pub mod registry")
+            && runners.contains("pub mod connection")
+            && runners.contains("pub mod execution")
+            && runners.contains("pub mod workspace")
+            && runners.contains("pub mod lab_offload"),
+        "src/core/runners.rs must keep the explicit API group modules (registry, connection, \
+         execution, workspace, lab_offload, ...) so callers depend on operation contracts."
+    );
+}
+
+#[test]
 fn detector_implementations_stay_domain_agnostic() {
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let findings = homeboy::core::code_audit::source_policy_findings_for_path(


### PR DESCRIPTION
## Summary
- Replace wildcard re-exports in `core::agent_tasks` and `core::runners` with explicit name lists organised into nested API groups (`cook_loop`, `finalization`, `gate`, `lifecycle`, `loop_controller`, `promotion`, `provider`, `scheduler`, `secrets`, `service` for agent tasks; `registry`, `connection`, `execution`, `workspace`, `evidence`, `capabilities`, `lab_offload` for runners).
- Existing implementation modules under `core/` stay public so external compatibility paths keep working, but the facade now documents its intentional surface and the underlying layout can evolve without becoming accidental public API.
- New command/CLI code already imports from the facades; this PR locks that contract in.

## Architecture tests
- `command_layer_uses_explicit_core_facades_only` scans `src/commands`, `src/cli_runtime.rs`, and `src/cli_surface.rs` for forbidden imports from implementation paths (`homeboy::core::agent_task_*`, `homeboy::core::runner::`, `homeboy::core::artifact_*`, etc.). The test docstring lists allowed vs blocked imports.
- `core_facades_expose_explicit_groups_not_wildcards` guards the facade files themselves so future edits cannot silently re-introduce `pub use module::*` blocks or drop the named group submodules.

## Verification
- `cargo fmt --check`
- `cargo test --test architecture_core_agnostic_test`
- `cargo test --test command_surface_test`
- `cargo test --lib agent_task` and `cargo test --lib runner` (regression spot-checks for the facade surface).

> Note: `cargo test --test core_agnostic_test` has a pre-existing failure on `main` (`core_owned_source_stays_language_and_framework_agnostic` flags `cargo` in `src/core/upgrade/mod.rs`) unrelated to this change.

Closes #4306.

## AI assistance
Tool OpenCode (openai/gpt-5.5), used for refactor implementation and tests.