### PR TITLE
Fix Lab changed-since base materialization

### DIFF
--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -670,6 +670,29 @@ fn run_lab_offload_inner(
     } else {
         preflight_lab_offload_changed_since(request.normalized_args, sync_mode)?
     };
+    let mut git_fetch_refs = changed_since_preflight.git_fetch_refs.clone();
+    for git_ref in
+        lab_offload_git_fetch_refs(&changed_since_preflight.args, &source_path, sync_mode)?
+    {
+        if !git_fetch_refs.contains(&git_ref) {
+            git_fetch_refs.push(git_ref);
+        }
+    }
+    if let Some(resolved_base) = &changed_since_preflight.resolved_base {
+        eprintln!(
+            "Lab offload: changed-since requested `{}` resolved to `{}`; runner fetch refs: {}.",
+            changed_since_preflight
+                .requested_ref
+                .as_deref()
+                .unwrap_or(resolved_base),
+            resolved_base,
+            if git_fetch_refs.is_empty() {
+                "<none>".to_string()
+            } else {
+                git_fetch_refs.join(", ")
+            }
+        );
+    }
     let mut extra_workspaces = lab_extra_workspaces(&source_path)?;
     // Sync any controller-local directories referenced by --provider-config
     // (runtime components, provider plugins, extra mount sources) so the cook
@@ -694,11 +717,7 @@ fn run_lab_offload_inner(
             mode: sync_mode,
             controller_routed_git: false,
             changed_since_base: changed_since_preflight.resolved_base.clone(),
-            git_fetch_refs: lab_offload_git_fetch_refs(
-                &changed_since_preflight.args,
-                &source_path,
-                sync_mode,
-            )?,
+            git_fetch_refs: git_fetch_refs.clone(),
             snapshot_includes: Vec::new(),
             allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
         },
@@ -718,6 +737,15 @@ fn run_lab_offload_inner(
                         "allow_dirty_lab_workspace",
                         request.allow_dirty_lab_workspace,
                     )
+                    .json(
+                        "changed_since_requested_ref",
+                        &changed_since_preflight.requested_ref,
+                    )
+                    .json(
+                        "changed_since_resolved_base",
+                        &changed_since_preflight.resolved_base,
+                    )
+                    .json("git_fetch_refs", &git_fetch_refs)
                     .string("workspace_cleanliness", &synced.workspace_cleanliness),
             )
             .build(),

--- a/src/core/runner/offload_changed_since.rs
+++ b/src/core/runner/offload_changed_since.rs
@@ -8,7 +8,9 @@ use super::RunnerWorkspaceSyncMode;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LabOffloadChangedSincePreflight {
     pub args: Vec<String>,
+    pub requested_ref: Option<String>,
     pub resolved_base: Option<String>,
+    pub git_fetch_refs: Vec<String>,
 }
 
 pub fn preflight_lab_offload_changed_since(
@@ -18,14 +20,18 @@ pub fn preflight_lab_offload_changed_since(
     let Some(git_ref) = lab_offload_changed_since_ref(args) else {
         return Ok(LabOffloadChangedSincePreflight {
             args: args.to_vec(),
+            requested_ref: None,
             resolved_base: None,
+            git_fetch_refs: Vec::new(),
         });
     };
 
     if sync_mode != RunnerWorkspaceSyncMode::Snapshot {
         return Ok(LabOffloadChangedSincePreflight {
             args: args.to_vec(),
+            requested_ref: Some(git_ref.clone()),
             resolved_base: Some(git_ref),
+            git_fetch_refs: Vec::new(),
         });
     }
 
@@ -49,16 +55,23 @@ pub fn prepare_git_lab_offload_changed_since(
     let Some(git_ref) = lab_offload_changed_since_ref(args) else {
         return Ok(LabOffloadChangedSincePreflight {
             args: args.to_vec(),
+            requested_ref: None,
             resolved_base: None,
+            git_fetch_refs: Vec::new(),
         });
     };
 
     let resolved_base = resolve_changed_since_base(source_path, &git_ref)?;
     ensure_local_merge_base(source_path, &git_ref)?;
+    let git_fetch_refs = advertised_origin_ref_for_commit(source_path, &resolved_base)?
+        .into_iter()
+        .collect();
 
     Ok(LabOffloadChangedSincePreflight {
         args: rewrite_changed_since_ref(args, &resolved_base),
+        requested_ref: Some(git_ref),
         resolved_base: Some(resolved_base),
+        git_fetch_refs,
     })
 }
 
@@ -116,6 +129,54 @@ fn resolve_changed_since_base(path: &Path, git_ref: &str) -> Result<String> {
         path,
         &["rev-parse", "--verify", &format!("{git_ref}^{{commit}}")],
     )
+}
+
+fn advertised_origin_ref_for_commit(path: &Path, commit: &str) -> Result<Option<String>> {
+    let output = Command::new("git")
+        .args(["ls-remote", "origin"])
+        .current_dir(path)
+        .output()
+        .map_err(|err| {
+            Error::internal_io(err.to_string(), Some("run git ls-remote".to_string()))
+        })?;
+    if !output.status.success() {
+        return Err(Error::validation_invalid_argument(
+            "changed_since",
+            "Lab offload could not inspect origin refs for changed-since base materialization",
+            Some(commit.to_string()),
+            Some(vec![
+                String::from_utf8_lossy(&output.stderr).trim().to_string(),
+                "Run with --force-hot to execute the changed-since command locally while investigating remote ref availability.".to_string(),
+            ]),
+        ));
+    }
+
+    let refs = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let (sha, git_ref) = line.split_once('\t')?;
+            (sha == commit && !git_ref.ends_with("^{}")).then(|| git_ref.to_string())
+        })
+        .collect::<Vec<_>>();
+
+    Ok(best_advertised_ref(refs))
+}
+
+fn best_advertised_ref(refs: Vec<String>) -> Option<String> {
+    refs.iter()
+        .find(|git_ref| git_ref.starts_with("refs/pull/") && git_ref.ends_with("/head"))
+        .cloned()
+        .or_else(|| {
+            refs.iter()
+                .find(|git_ref| git_ref.starts_with("refs/heads/"))
+                .cloned()
+        })
+        .or_else(|| {
+            refs.iter()
+                .find(|git_ref| git_ref.starts_with("refs/tags/"))
+                .cloned()
+        })
+        .or_else(|| refs.into_iter().next())
 }
 
 fn ensure_local_merge_base(path: &Path, git_ref: &str) -> Result<()> {
@@ -237,13 +298,25 @@ mod tests {
     #[test]
     fn rewrites_changed_since_to_resolved_commit_for_git_lab_offload() {
         let dir = tempfile::tempdir().expect("repo");
+        let origin = tempfile::tempdir().expect("origin");
+        git(origin.path(), &["init", "--bare"]);
         git(dir.path(), &["init"]);
         git(dir.path(), &["config", "user.email", "test@example.com"]);
         git(dir.path(), &["config", "user.name", "Test User"]);
+        git(
+            dir.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                origin.path().to_str().expect("origin path"),
+            ],
+        );
         std::fs::write(dir.path().join("file.txt"), "base\n").expect("write base");
         git(dir.path(), &["add", "."]);
         git(dir.path(), &["commit", "-m", "base"]);
         git(dir.path(), &["branch", "base"]);
+        git(dir.path(), &["push", "origin", "base"]);
         std::fs::write(dir.path().join("file.txt"), "head\n").expect("write head");
         git(dir.path(), &["commit", "-am", "head"]);
         let base_sha = git_stdout(dir.path(), &["rev-parse", "base"]);
@@ -259,6 +332,8 @@ mod tests {
             .expect("changed-since preflight");
 
         assert_eq!(preflight.resolved_base.as_deref(), Some(base_sha.as_str()));
+        assert_eq!(preflight.requested_ref.as_deref(), Some("base"));
+        assert_eq!(preflight.git_fetch_refs, vec!["refs/heads/base"]);
         assert_eq!(
             preflight.args,
             vec![

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -815,7 +815,7 @@ fn materialize_git_command(
     let dirty_guard = dirty_lab_workspace_guard("$dest", allow_dirty_lab_workspace);
 
     format!(
-        "parent={parent}; dest={dest}; {owner_capture}; mkdir -p \"$parent\" && if [ -d \"$dest\"/.git ]; then {dirty_guard} && git -C \"$dest\" reset --hard && git -C \"$dest\" clean -ffdqx && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf \"$dest\" && git clone {url} \"$dest\" && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_changed_since}{fetch_extra_refs} && git -C \"$dest\" checkout --detach {head} && git -C \"$dest\" reset --hard {head} && git -C \"$dest\" clean -ffdqx && {owner_restore}",
+        "parent={parent}; dest={dest}; {owner_capture}; mkdir -p \"$parent\" && if [ -d \"$dest\"/.git ]; then {dirty_guard} && git -C \"$dest\" reset --hard && git -C \"$dest\" clean -ffdqx && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; else rm -rf \"$dest\" && git clone {url} \"$dest\" && git -C \"$dest\" fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'; fi{fetch_extra_refs}{fetch_changed_since} && git -C \"$dest\" checkout --detach {head} && git -C \"$dest\" reset --hard {head} && git -C \"$dest\" clean -ffdqx && {owner_restore}",
         parent = shell::quote_arg(parent.as_str()),
         dest = dest,
         url = shell::quote_arg(remote_url),
@@ -1514,6 +1514,27 @@ mod tests {
 
         assert!(command.contains("fetch origin refs/pull/5530/head"));
         assert!(command.contains("checkout --detach abc123"));
+    }
+
+    #[test]
+    fn git_materialization_fetches_extra_refs_before_changed_since_sha() {
+        let command = materialize_git_command(
+            "/srv/homeboy/_lab_workspaces/homeboy-abc",
+            "https://github.com/Extra-Chill/homeboy.git",
+            "abc123",
+            Some("def456"),
+            &["refs/heads/main".to_string()],
+            false,
+        );
+
+        let extra_ref_index = command
+            .find("fetch origin refs/heads/main")
+            .expect("fetches advertised ref");
+        let changed_since_index = command
+            .find("rev-parse --verify -q 'def456^{commit}'")
+            .expect("verifies changed-since commit");
+
+        assert!(extra_ref_index < changed_since_index);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Resolve Lab `--changed-since` bases to a stable commit while preserving the requested ref for diagnostics.
- Discover an advertised origin ref for the resolved base and pass it into runner workspace sync so pushed bases become reachable before dispatch.
- Fetch explicit runner materialization refs before falling back to arbitrary SHA fetches, and expose changed-since/ref details in Lab sync plan metadata.

Fixes #4323.

## Verification
- `cargo fmt`
- `cargo test core::runner::offload_changed_since::tests`
- `cargo test core::runner::workspace::tests::git_materialization`

Note: test runs still emit the existing warning for unused import `serde_json::Value` in `src/commands/runs/corpus_tests.rs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Lab changed-since materialization fix, added focused tests, and ran targeted verification. Chris remains responsible for review and validation.