### PR TITLE
Fix source upgrades to install active binary

### DIFF
--- a/src/core/defaults/builtins.rs
+++ b/src/core/defaults/builtins.rs
@@ -33,7 +33,8 @@ pub(super) fn default_cargo_config() -> InstallMethodConfig {
 pub(super) fn default_source_config() -> InstallMethodConfig {
     InstallMethodConfig {
         path_patterns: vec!["/target/release/".to_string(), "/target/debug/".to_string()],
-        upgrade_command: "git pull && . \"$HOME/.cargo/env\" && cargo build --release".to_string(),
+        upgrade_command: "git pull && . \"$HOME/.cargo/env\" && cargo install --path . --force"
+            .to_string(),
         list_command: None,
     }
 }
@@ -191,5 +192,20 @@ pub(super) fn default_remote_permissions() -> PermissionModes {
     PermissionModes {
         file_mode: "g+w".to_string(),
         dir_mode: "g+w".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_upgrade_installs_active_binary() {
+        let config = default_source_config();
+
+        assert!(config
+            .upgrade_command
+            .contains("cargo install --path . --force"));
+        assert!(!config.upgrade_command.contains("cargo build --release"));
     }
 }


### PR DESCRIPTION
## Summary
- change the default source upgrade command to run `cargo install --path . --force`
- add a regression test so source upgrades no longer stop after only building `target/release/homeboy`

## Tests
- `cargo fmt`
- `cargo test source_upgrade_installs_active_binary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the source-upgrade failure, drafted the minimal fix and regression test, and ran targeted verification.