### PR TITLE
Fix Lab cook runtime drift diagnostics

### DIFF
--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -295,10 +295,43 @@ pub(super) fn agent_task_dispatch_requested_run_id(args: &[String]) -> Option<St
 }
 
 pub(super) fn lab_pre_dispatch_failure_message(output: &str) -> Option<String> {
+    if let Some(message) = lab_pre_dispatch_dependency_failure_message(output) {
+        return Some(message);
+    }
+
     output
         .lines()
         .map(str::trim)
         .find(|line| !line.is_empty())
+        .map(str::to_string)
+}
+
+fn lab_pre_dispatch_dependency_failure_message(output: &str) -> Option<String> {
+    if !looks_like_prepared_dependency_failure(output) {
+        return None;
+    }
+
+    let missing_path = first_quoted_prepared_dependency_path(output)
+        .unwrap_or_else(|| "prepared dependency path".to_string());
+    Some(format!(
+        "Lab runtime failed before agent dispatch while staging dependency `{missing_path}`. The selected Lab runner has a stale or misconfigured runtime dependency; repair or refresh the runner runtime, then retry this cook run."
+    ))
+}
+
+fn looks_like_prepared_dependency_failure(output: &str) -> bool {
+    let lower = output.to_lowercase();
+    lower.contains("prepared-plugins/")
+        && (lower.contains("enoent")
+            || lower.contains("no such file or directory")
+            || lower.contains("lstat"))
+}
+
+fn first_quoted_prepared_dependency_path(output: &str) -> Option<String> {
+    output
+        .split(['\'', '"'])
+        .find(|part| part.contains("prepared-plugins/"))
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
         .map(str::to_string)
 }
 
@@ -366,11 +399,11 @@ mod tests {
             "      \"outcomes\": [{\n",
             "        \"task_id\": \"cook-conductor\",\n",
             "        \"status\": \"failed\",\n",
-            "        \"summary\": \"WP Codebox agent task failed.\",\n",
+            "        \"summary\": \"Remote agent task failed.\",\n",
             "        \"metadata\": {\n",
-            "          \"provider\": \"wordpress.codebox-agent-task-executor\",\n",
-            "          \"codebox_run_result\": {\n",
-            "            \"schema\": \"wp-codebox/agent-task-run-result/v1\",\n",
+            "          \"provider\": \"remote.agent-task-executor\",\n",
+            "          \"runtime_run_result\": {\n",
+            "            \"schema\": \"remote/agent-task-run-result/v1\",\n",
             "            \"status\": \"failed\",\n",
             "            \"failure_classification\": \"runtime\"\n",
             "          }\n",
@@ -395,10 +428,10 @@ mod tests {
         );
         assert_eq!(
             parsed["aggregate"]["outcomes"][0]["metadata"]["provider"],
-            "wordpress.codebox-agent-task-executor"
+            "remote.agent-task-executor"
         );
         assert_eq!(
-            parsed["aggregate"]["outcomes"][0]["metadata"]["codebox_run_result"]
+            parsed["aggregate"]["outcomes"][0]["metadata"]["runtime_run_result"]
                 ["failure_classification"],
             "runtime"
         );
@@ -464,5 +497,16 @@ mod tests {
             ]),
             Some("dispatch-run".to_string())
         );
+    }
+
+    #[test]
+    fn pre_dispatch_failure_message_summarizes_prepared_dependency_staging_failure() {
+        let output = "ENOENT: no such file or directory, lstat '/home/chubes/Developer/.tmp/homeboy-artifacts/prepared-plugins/agents-api'";
+
+        let message = lab_pre_dispatch_failure_message(output).expect("message");
+
+        assert!(message.contains("Lab runtime failed before agent dispatch"));
+        assert!(message.contains("prepared-plugins/agents-api"));
+        assert!(message.contains("repair or refresh the runner runtime"));
     }
 }

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -1075,6 +1075,7 @@ fn run_lab_offload_inner(
             let failure_message = lab_pre_dispatch_failure_message(&exec_output.stderr)
                 .or_else(|| lab_pre_dispatch_failure_message(&exec_output.stdout))
                 .unwrap_or_else(|| format!("offloaded agent-task command exited with {exit_code}"));
+            stderr.push_str(&format!("Lab pre-dispatch failure: {failure_message}\n"));
             let record = agent_task_lifecycle::record_pre_dispatch_failure(
                 agent_task_lifecycle::AgentTaskPreDispatchFailure {
                     run_id: &run_id,


### PR DESCRIPTION
## Summary
- Surface concise Lab pre-dispatch failures before persisted evidence pointers when cook dispatch fails before the agent starts.
- Classify prepared dependency staging ENOENT/lstat failures generically as stale or misconfigured Lab runner runtime dependencies.
- Keep the touched bridge parser fixture runtime-agnostic and cover the prepared dependency failure summary.

Fixes #4335

## Tests
- `cargo test core::runner::lab::agent_task_bridge::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the generic Lab pre-dispatch diagnostic path and focused test coverage; Chris reviewed the architectural boundary during the session.