### PR TITLE
Fix release and project orchestration UX papercuts

### DIFF
--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -19,6 +19,11 @@ enum ProjectCommand {
         /// Project ID
         project_id: String,
     },
+    /// Resolve a filesystem path to its configured Homeboy project
+    ResolvePath {
+        /// Filesystem path inside a project base_path
+        path: String,
+    },
     /// Create a new project
     Create {
         /// JSON input spec for create/update (supports single or bulk)
@@ -210,6 +215,7 @@ pub fn run(args: ProjectArgs, _global: &crate::commands::GlobalArgs) -> CmdResul
     match args.command {
         ProjectCommand::List => list(),
         ProjectCommand::Show { project_id } => show(&project_id),
+        ProjectCommand::ResolvePath { path } => resolve_path(&path),
         ProjectCommand::Create {
             json,
             skip_existing,
@@ -283,6 +289,13 @@ fn list() -> CmdResult<ProjectOutput> {
 fn show(project_id: &str) -> CmdResult<ProjectOutput> {
     Ok((
         project::build_show_output(project::show_report(project_id)?),
+        0,
+    ))
+}
+
+fn resolve_path(path: &str) -> CmdResult<ProjectOutput> {
+    Ok((
+        project::build_path_resolution_output(project::resolve_path(Path::new(path))?),
         0,
     ))
 }

--- a/src/core/project/component/report.rs
+++ b/src/core/project/component/report.rs
@@ -16,6 +16,12 @@ pub struct ProjectComponentsOutput {
     pub action: String,
     pub project_id: String,
     pub component_ids: Vec<String>,
+    pub component_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attached_component_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attached_path: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub components: Vec<Component>,
 }
 
@@ -43,9 +49,15 @@ pub fn attach_component_path_report(
     project_id: &str,
     local_path: &Path,
 ) -> Result<ProjectComponentsOutput> {
-    attach_discovered_component_path(project_id, local_path)?;
+    let attached_component_id = attach_discovered_component_path(project_id, local_path)?;
     let project = load(project_id)?;
-    build_components_output(project_id, "attach_path", &project)
+    build_components_summary(
+        project_id,
+        "attach_path",
+        &project,
+        Some(attached_component_id),
+        Some(local_path.to_string_lossy().to_string()),
+    )
 }
 
 pub fn remove_components_report(
@@ -74,6 +86,60 @@ fn build_components_output(
         action: action.to_string(),
         project_id: project_id.to_string(),
         component_ids: project_component_ids(project),
+        component_count: project.components.len(),
+        attached_component_id: None,
+        attached_path: None,
         components,
     })
+}
+
+fn build_components_summary(
+    project_id: &str,
+    action: &str,
+    project: &Project,
+    attached_component_id: Option<String>,
+    attached_path: Option<String>,
+) -> Result<ProjectComponentsOutput> {
+    Ok(ProjectComponentsOutput {
+        action: action.to_string(),
+        project_id: project_id.to_string(),
+        component_ids: project_component_ids(project),
+        component_count: project.components.len(),
+        attached_component_id,
+        attached_path,
+        components: Vec::new(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_components_summary;
+    use crate::core::project::{Project, ProjectComponentAttachment};
+
+    #[test]
+    fn attach_path_summary_omits_resolved_component_payload() {
+        let project = Project {
+            id: "site".to_string(),
+            components: vec![ProjectComponentAttachment {
+                id: "plugin".to_string(),
+                local_path: "/repo/plugin".to_string(),
+                remote_path: None,
+            }],
+            ..Default::default()
+        };
+
+        let output = build_components_summary(
+            "site",
+            "attach_path",
+            &project,
+            Some("plugin".to_string()),
+            Some("/repo/plugin".to_string()),
+        )
+        .expect("summary output");
+
+        assert_eq!(output.component_ids, vec!["plugin"]);
+        assert_eq!(output.component_count, 1);
+        assert_eq!(output.attached_component_id.as_deref(), Some("plugin"));
+        assert!(output.components.is_empty());
+    }
 }

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -7,7 +7,7 @@ use crate::core::paths;
 use crate::core::server;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub mod component;
 pub mod files;
@@ -34,10 +34,11 @@ pub use pins::{
 pub use readiness::calculate_deploy_readiness;
 pub use report::{
     build_components_output, build_create_output, build_delete_output, build_init_output,
-    build_list_output, build_pin_output, build_remove_output, build_rename_output,
-    build_set_output, build_show_output, build_status_output, list_report, show_report,
-    status_report, ProjectComponentVersion, ProjectListItem, ProjectListReport, ProjectReportExtra,
-    ProjectReportOutput, ProjectShowReport, ProjectStatusReport,
+    build_list_output, build_path_resolution_output, build_pin_output, build_remove_output,
+    build_rename_output, build_set_output, build_show_output, build_status_output, list_report,
+    show_report, status_report, ProjectComponentVersion, ProjectListItem, ProjectListReport,
+    ProjectPathResolutionReport, ProjectReportExtra, ProjectReportOutput, ProjectShowReport,
+    ProjectStatusReport,
 };
 pub use status::{collect_status, ProjectComponentStatus, ProjectStatusSnapshot};
 pub use types::*;
@@ -198,6 +199,61 @@ pub fn init_project_dir(id: &str) -> Result<PathBuf> {
 /// Get the project directory path for a given project ID.
 pub fn project_dir_path(id: &str) -> Result<PathBuf> {
     paths::project_dir(id)
+}
+
+pub fn resolve_path(path: &Path) -> Result<ProjectPathResolutionReport> {
+    let requested_path = expand_path(path);
+    let requested_canonical = canonical_or_original(&requested_path);
+    let projects = list()?;
+
+    let mut matches = Vec::new();
+    for project in projects {
+        let Some(base_path) = project.base_path.as_deref() else {
+            continue;
+        };
+        let base = expand_path(Path::new(base_path));
+        let base_canonical = canonical_or_original(&base);
+
+        if requested_canonical == base_canonical || requested_canonical.starts_with(&base_canonical)
+        {
+            matches.push((project, base_canonical));
+        }
+    }
+
+    matches.sort_by(|(_, a), (_, b)| b.to_string_lossy().len().cmp(&a.to_string_lossy().len()));
+
+    let (project, matched_base_path) = matches.into_iter().next().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "path",
+            format!(
+                "No configured Homeboy project base_path contains {}",
+                requested_path.display()
+            ),
+            Some(requested_path.display().to_string()),
+            Some(vec![
+                "List configured projects with: homeboy project list".to_string(),
+                "Set a project base path with: homeboy project set <project> --json '{\"base_path\":\"/path/to/site\"}'".to_string(),
+            ]),
+        )
+    })?;
+
+    Ok(ProjectPathResolutionReport {
+        requested_path: requested_path.display().to_string(),
+        resolved_path: requested_canonical.display().to_string(),
+        project_id: project.id,
+        project_domain: project.domain,
+        base_path: matched_base_path.display().to_string(),
+    })
+}
+
+fn expand_path(path: &Path) -> PathBuf {
+    let raw = path.to_string_lossy();
+    let expanded = shellexpand::tilde(&raw);
+    PathBuf::from(expanded.as_ref())
+}
+
+fn canonical_or_original(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 pub fn pin(project_id: &str, pin_type: PinType, path: &str, options: PinOptions) -> Result<()> {

--- a/src/core/project/report.rs
+++ b/src/core/project/report.rs
@@ -46,6 +46,16 @@ pub struct ProjectStatusReport {
     pub component_versions: Option<Vec<ProjectComponentVersion>>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct ProjectPathResolutionReport {
+    pub requested_path: String,
+    pub resolved_path: String,
+    pub project_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_domain: Option<String>,
+    pub base_path: String,
+}
+
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct ProjectReportExtra {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -64,6 +74,8 @@ pub struct ProjectReportExtra {
     pub health: Option<crate::core::server::health::ServerHealth>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component_versions: Option<Vec<ProjectComponentVersion>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path_resolution: Option<ProjectPathResolutionReport>,
 }
 
 pub type ProjectReportOutput = EntityCrudOutput<Project, ProjectReportExtra>;
@@ -297,6 +309,22 @@ pub fn build_status_output(project_id: &str, report: ProjectStatusReport) -> Pro
         extra: ProjectReportExtra {
             health: report.health,
             component_versions: report.component_versions,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+pub fn build_path_resolution_output(report: ProjectPathResolutionReport) -> ProjectReportOutput {
+    ProjectReportOutput {
+        command: "project.resolve-path".to_string(),
+        id: Some(report.project_id.clone()),
+        hint: Some(format!(
+            "{} maps to project '{}'",
+            report.requested_path, report.project_id
+        )),
+        extra: ProjectReportExtra {
+            path_resolution: Some(report),
             ..Default::default()
         },
         ..Default::default()

--- a/src/core/release/execution_plan.rs
+++ b/src/core/release/execution_plan.rs
@@ -25,6 +25,18 @@ pub(super) fn build_initial_preflight_plan(
     ReleasePlan::new(component_id, true, steps, None, Vec::new(), Vec::new())
 }
 
+pub(super) fn build_dry_run_preflight_plan(
+    component_id: &str,
+    options: &ReleaseOptions,
+) -> ReleasePlan {
+    let steps = build_preflight_steps(options, None, &[])
+        .into_iter()
+        .filter(|step| dry_run_executable_preflight_ids().contains(&step.id.as_str()))
+        .collect();
+
+    ReleasePlan::new(component_id, true, steps, None, Vec::new(), Vec::new())
+}
+
 pub(super) fn initial_executable_preflight_ids() -> &'static [&'static str] {
     &[
         "preflight.default_branch",
@@ -35,6 +47,10 @@ pub(super) fn initial_executable_preflight_ids() -> &'static [&'static str] {
         "preflight.test",
         "preflight.changelog_bootstrap",
     ]
+}
+
+fn dry_run_executable_preflight_ids() -> &'static [&'static str] {
+    &["preflight.default_branch", "preflight.working_tree"]
 }
 
 pub(super) fn execute_plan_steps(
@@ -159,7 +175,8 @@ fn read_current_release_notes(component: &Component) -> Result<Option<String>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_initial_preflight_plan, execute_plan_steps, initial_executable_preflight_ids,
+        build_dry_run_preflight_plan, build_initial_preflight_plan, execute_plan_steps,
+        initial_executable_preflight_ids,
     };
     use crate::core::plan::PlanStepStatus;
     use crate::core::release::types::ReleaseOptions;
@@ -203,6 +220,27 @@ mod tests {
                 "preflight.test",
                 "preflight.changelog_bootstrap",
             ]
+        );
+    }
+
+    #[test]
+    fn test_build_dry_run_preflight_plan_only_includes_non_mutating_guards() {
+        let options = ReleaseOptions {
+            bump_type: "patch".to_string(),
+            ..Default::default()
+        };
+
+        let plan = build_dry_run_preflight_plan("fixture", &options);
+        let ids: Vec<&str> = plan
+            .plan
+            .steps
+            .iter()
+            .map(|step| step.id.as_str())
+            .collect();
+
+        assert_eq!(
+            ids,
+            vec!["preflight.default_branch", "preflight.working_tree"]
         );
     }
 

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -6,7 +6,7 @@ use super::context::load_component;
 use super::types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseBumpPolicyOptions,
     ReleaseCommandInput, ReleaseCommandResult, ReleaseOptions, ReleasePlan, ReleaseRun,
-    ReleaseStepStatus,
+    ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus,
 };
 
 pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32)> {
@@ -150,6 +150,26 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     };
 
     if options.dry_run {
+        let dry_run_preflight = run_dry_run_preflights(&input.component_id, &options)?;
+        if let Some(run) = dry_run_preflight {
+            let plan = super::plan(&input.component_id, &options).ok();
+            return Ok((
+                ReleaseCommandResult {
+                    component_id: input.component_id,
+                    bump_type,
+                    dry_run: true,
+                    releasable_commits: releasable_count,
+                    new_version: None,
+                    tag: None,
+                    skipped_reason: plan.as_ref().and_then(skipped_reason_from_plan),
+                    plan,
+                    run: Some(run),
+                    deployment: None,
+                },
+                1,
+            ));
+        }
+
         let plan = super::plan(&input.component_id, &options)?;
         let new_version = if input.pipeline.head {
             current_component_version(&component)?
@@ -240,6 +260,45 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         },
         exit_code,
     ))
+}
+
+fn run_dry_run_preflights(
+    component_id: &str,
+    options: &ReleaseOptions,
+) -> Result<Option<ReleaseRun>> {
+    use std::collections::HashSet;
+
+    let preflight_plan = super::execution_plan::build_dry_run_preflight_plan(component_id, options);
+    let mut results = Vec::new();
+    let stopped = super::execution_plan::execute_plan_steps(
+        &preflight_plan.plan.steps,
+        component_id,
+        options,
+        &mut results,
+        &HashSet::new(),
+    )?;
+
+    if stopped || results.iter().any(step_failed) {
+        return Ok(Some(ReleaseRun {
+            component_id: component_id.to_string(),
+            enabled: true,
+            result: ReleaseRunResult {
+                steps: results,
+                status: ReleaseStepStatus::Failed,
+                warnings: Vec::new(),
+                summary: None,
+            },
+        }));
+    }
+
+    Ok(None)
+}
+
+fn step_failed(step: &ReleaseStepResult) -> bool {
+    matches!(
+        step.status,
+        ReleaseStepStatus::Failed | ReleaseStepStatus::Missing
+    )
 }
 
 fn dry_run_deployment_plan(


### PR DESCRIPTION
## Summary
- Make `release --dry-run` execute non-mutating release preflights so default-branch/dirty-worktree failures surface before the real release path.
- Add concise `project components attach-path` output that reports the attached component/path without dumping full resolved component payloads.
- Add `homeboy project resolve-path <path>` to map local filesystem paths to registered projects by `base_path` containment.

Fixes #4334.

## Testing
- `cargo fmt`
- Attempted `cargo test release::execution_plan release::workflow project::component::report`, but Cargo accepts only one filter and rejected it.
- Attempted focused tests separately; parallel runs contended on Cargo locks and timed out.
- Attempted `cargo test release::execution_plan`; build was still compiling when interrupted by operator request to open the PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and PR summary; Chris directed the issue/PR flow and interrupted local verification to open the PR immediately.