### PR TITLE
Add Lab extension sync command

### DIFF
--- a/docs/commands/lab.md
+++ b/docs/commands/lab.md
@@ -7,6 +7,7 @@ Inspect and use configured Lab runners for remote benchmark execution.
 ```bash
 homeboy lab status
 homeboy lab bench <component> [options] [-- <runner-args>]
+homeboy lab extension-sync --runner <runner-id> --source <url-or-path> --id <extension-id> --ref <ref>
 ```
 
 ## Description
@@ -20,11 +21,21 @@ configured.
 `homeboy lab bench` delegates to the same benchmark path while making the Lab
 intent explicit at the command surface.
 
+`homeboy lab extension-sync` updates a Lab runner's installed extension through
+the runner API. Use it to pin a runner-side runtime dependency, such as the
+installed Homeboy Extensions `wordpress` extension, to a specific source ref
+without writing a manual `homeboy runner exec ... extension install` command.
+When `--runner` is omitted, Homeboy uses `lab.preferred_runner` or the only
+inferable SSH Lab runner.
+
 ## Commands
 
 - `status`: Show configured Lab runners and benchmark routing guidance.
 - `bench`: Run a benchmark through the standard benchmark pipeline with Lab
   routing intent.
+- `extension-sync`: Install or replace a Lab runner extension from a source and
+  ref, returning the runner id, runner `homeboy_path`, install command, and
+  remote execution output.
 
 ## Related
 

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -2,6 +2,10 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use super::{CmdResult, GlobalArgs};
+use homeboy::core::runners::{
+    self as runner, RunnerExecOptions, RunnerExecOutput, RunnerRequiredTool,
+};
+use homeboy::core::Error;
 
 #[derive(Args)]
 pub struct LabArgs {
@@ -19,6 +23,24 @@ enum LabCommand {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Sync an extension install on a Lab runner by source and git ref
+    ExtensionSync {
+        /// Runner ID. Defaults to lab.preferred_runner or the only configured SSH Lab runner.
+        #[arg(long)]
+        runner: Option<String>,
+        /// Git URL or runner-local path to the extension source
+        #[arg(long)]
+        source: String,
+        /// Installed extension id to create or replace on the runner
+        #[arg(long)]
+        id: String,
+        /// Git ref to check out for URL installs (branch, tag, or commit)
+        #[arg(long = "ref")]
+        revision: String,
+        /// Install without replacing an existing runner extension
+        #[arg(long)]
+        no_replace: bool,
+    },
 }
 
 #[derive(Serialize)]
@@ -31,7 +53,27 @@ pub struct LabOutput {
     guidance: Vec<String>,
 }
 
-pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabOutput> {
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum LabCommandOutput {
+    Status(LabOutput),
+    ExtensionSync(LabExtensionSyncOutput),
+}
+
+#[derive(Serialize)]
+pub struct LabExtensionSyncOutput {
+    command: &'static str,
+    runner_id: String,
+    runner_homeboy_path: String,
+    extension_id: String,
+    source: String,
+    source_revision: String,
+    replace: bool,
+    install_command: Vec<String>,
+    execution: RunnerExecOutput,
+}
+
+pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabCommandOutput> {
     let preferred_runner = homeboy::core::runners::resolve_default_lab_runner()?;
     let config_path = homeboy::core::defaults::config_path()?;
     let command = match args.command.unwrap_or(LabCommand::Status) {
@@ -43,7 +85,7 @@ pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabOutput> {
                 bench_command.push_str(&args.join(" "));
             }
             return Ok((
-                LabOutput {
+                LabCommandOutput::Status(LabOutput {
                     command: "lab.bench",
                     preferred_runner,
                     config_key: "/lab/preferred_runner",
@@ -53,14 +95,23 @@ pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabOutput> {
                         "Homeboy auto-routes portable benchmarks to `lab.preferred_runner`, or to the only configured SSH Lab runner when there is exactly one.".to_string(),
                         "Use `--runner <runner-id>` only to override an ambiguous or non-default Lab selection.".to_string(),
                     ],
-                },
+                }),
                 0,
             ));
+        }
+        LabCommand::ExtensionSync {
+            runner,
+            source,
+            id,
+            revision,
+            no_replace,
+        } => {
+            return sync_lab_extension(runner, &source, &id, &revision, !no_replace);
         }
     };
 
     Ok((
-        LabOutput {
+        LabCommandOutput::Status(LabOutput {
             command,
             preferred_runner,
             config_key: "/lab/preferred_runner",
@@ -71,7 +122,151 @@ pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabOutput> {
                 "Use `homeboy config set /bench/local_execution '\"denied\"'` to make local benchmark execution fail closed.".to_string(),
                 "Use `--runner <runner-id>` only when multiple Lab runners are available and no default should be inferred.".to_string(),
             ],
-        },
+        }),
         0,
     ))
+}
+
+fn sync_lab_extension(
+    runner_id: Option<String>,
+    source: &str,
+    extension_id: &str,
+    revision: &str,
+    replace: bool,
+) -> CmdResult<LabCommandOutput> {
+    let runner_id = match runner_id {
+        Some(runner_id) => runner_id,
+        None => homeboy::core::runners::resolve_default_lab_runner()?.ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "runner",
+                "No default Lab runner is configured or inferable",
+                None,
+                Some(vec![
+                    "Pass --runner <runner-id>.".to_string(),
+                    "Set one with: homeboy config set /lab/preferred_runner '\"<runner-id>\"'"
+                        .to_string(),
+                ]),
+            )
+        })?,
+    };
+    let runner_config = runner::load(&runner_id)?;
+    let homeboy_path = runner_config
+        .settings
+        .homeboy_path
+        .clone()
+        .unwrap_or_else(|| "homeboy".to_string());
+    let install_command =
+        runner_extension_install_command(&homeboy_path, source, extension_id, revision, replace);
+    let (execution, exit_code) = runner::exec(
+        &runner_id,
+        RunnerExecOptions {
+            cwd: None,
+            project_id: None,
+            allow_diagnostic_ssh: true,
+            command: install_command.clone(),
+            env: runner_config.env.clone(),
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: None,
+            capability_preflight: Some(homeboy::core::runners::RunnerCapabilityPreflight {
+                command: "homeboy lab extension-sync".to_string(),
+                required_tools: vec![RunnerRequiredTool::Homeboy],
+                required_commands: Vec::new(),
+                required_components: Vec::new(),
+                required_env: Vec::new(),
+            }),
+            required_extensions: Vec::new(),
+            require_paths: Vec::new(),
+        },
+    )?;
+
+    Ok((
+        LabCommandOutput::ExtensionSync(LabExtensionSyncOutput {
+            command: "lab.extension_sync",
+            runner_id,
+            runner_homeboy_path: homeboy_path,
+            extension_id: extension_id.to_string(),
+            source: source.to_string(),
+            source_revision: revision.to_string(),
+            replace,
+            install_command,
+            execution,
+        }),
+        exit_code,
+    ))
+}
+
+fn runner_extension_install_command(
+    homeboy_path: &str,
+    source: &str,
+    extension_id: &str,
+    revision: &str,
+    replace: bool,
+) -> Vec<String> {
+    let mut command = vec![
+        homeboy_path.to_string(),
+        "extension".to_string(),
+        "install".to_string(),
+        source.to_string(),
+        "--id".to_string(),
+        extension_id.to_string(),
+        "--ref".to_string(),
+        revision.to_string(),
+    ];
+    if replace {
+        command.push("--replace".to_string());
+    }
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use super::runner_extension_install_command;
+
+    #[test]
+    fn lab_extension_sync_command_replaces_by_default() {
+        assert_eq!(
+            runner_extension_install_command(
+                "/home/chubes/.cargo/bin/homeboy",
+                "https://github.com/Extra-Chill/homeboy-extensions.git",
+                "wordpress",
+                "5842f0e",
+                true,
+            ),
+            vec![
+                "/home/chubes/.cargo/bin/homeboy",
+                "extension",
+                "install",
+                "https://github.com/Extra-Chill/homeboy-extensions.git",
+                "--id",
+                "wordpress",
+                "--ref",
+                "5842f0e",
+                "--replace",
+            ]
+        );
+    }
+
+    #[test]
+    fn lab_extension_sync_command_can_install_without_replace() {
+        assert_eq!(
+            runner_extension_install_command(
+                "homeboy",
+                "/home/chubes/Developer/homeboy-extensions/wordpress",
+                "wordpress",
+                "main",
+                false,
+            ),
+            vec![
+                "homeboy",
+                "extension",
+                "install",
+                "/home/chubes/Developer/homeboy-extensions/wordpress",
+                "--id",
+                "wordpress",
+                "--ref",
+                "main",
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Add `homeboy lab extension-sync` to install or replace a Lab runner extension by source and ref through the runner API.
- Return structured provenance for the runner id, runner `homeboy_path`, requested source/ref, generated install command, and remote execution output.
- Document the new Lab command and cover command construction with focused tests.

Fixes #4333

## Tests
- `cargo fmt --check`
- `cargo check`
- `cargo test commands::lab::tests`
- `cargo test --test command_surface_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Lab CLI slice, docs, and focused tests; Chris reviewed/requested the PR workflow.