### PR TITLE
Add Lab offload scope to runner doctor

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -95,6 +95,8 @@ homeboy runner doctor local
 homeboy runner doctor <runner-id>
 homeboy runner doctor <runner-id> --path <component-path> --extension rust
 homeboy runner doctor <runner-id> --require-tool zip --require-tool unzip
+homeboy runner doctor <runner-id> --scope lab-offload
+homeboy runner doctor <runner-id> --scope lab-offload --repair
 ```
 
 Diagnoses a local or configured SSH runner without mutating it. Use `local`,
@@ -104,6 +106,19 @@ The JSON payload uses `command: "runner.doctor"` and includes `runner_id`,
 
 Use `doctor` before `connect` when you need to know whether Homeboy, Git, SSH,
 and the configured workspace root are usable on the target machine.
+
+Use `--scope lab-offload` before serious Lab evidence runs. It adds checks for
+the configured runner Homeboy command, bare `homeboy` PATH resolution, preferred
+runner binaries, connected daemon exec readiness, and WP Codebox runner-path
+freshness signals. When Homeboy can identify a safe exact recovery command, the
+check includes that remediation instead of leaving the operator to infer it from
+logs.
+
+Use `--scope lab-offload --repair` for the narrow self-healing path. Today this
+reconnects a failing direct Lab runner daemon and reruns the daemon exec probe.
+It does not upgrade binaries, rewrite runner paths, or refresh WP Codebox caches;
+those remain explicit operator actions because they can be expensive or depend
+on environment-specific paths.
 
 Pass one or more `--require-tool <command>` values when a provider or job path
 knows it needs additional runner-side commands before starting expensive work.

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -243,6 +243,14 @@ enum RunnerCommand {
         /// Required command to resolve on the runner PATH. Repeat for provider/job-specific tools.
         #[arg(long = "require-tool")]
         required_tools: Vec<String>,
+
+        /// Readiness scope. `lab-offload` adds Lab-specific binary, daemon, and WP Codebox checks.
+        #[arg(long, value_enum, default_value_t = RunnerDoctorScopeArg::General)]
+        scope: RunnerDoctorScopeArg,
+
+        /// Safely repair issues in the selected scope, such as reconnecting a stale Lab daemon.
+        #[arg(long)]
+        repair: bool,
     },
     /// Connect to a runner by starting a loopback-only remote daemon and SSH tunnel
     Connect {
@@ -361,6 +369,21 @@ enum RunnerKindArg {
     Ssh,
 }
 
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum RunnerDoctorScopeArg {
+    General,
+    LabOffload,
+}
+
+impl From<RunnerDoctorScopeArg> for doctor::RunnerDoctorScope {
+    fn from(value: RunnerDoctorScopeArg) -> Self {
+        match value {
+            RunnerDoctorScopeArg::General => doctor::RunnerDoctorScope::General,
+            RunnerDoctorScopeArg::LabOffload => doctor::RunnerDoctorScope::LabOffload,
+        }
+    }
+}
+
 impl From<RunnerKindArg> for RunnerKind {
     fn from(value: RunnerKindArg) -> Self {
         match value {
@@ -466,12 +489,16 @@ pub fn run(
             path,
             required_extensions,
             required_tools,
+            scope,
+            repair,
         } => map_doctor(doctor::run_with_options(
             &runner_id,
             doctor::RunnerDoctorOptions {
                 path,
                 extensions: required_extensions,
                 required_tools,
+                scope: scope.into(),
+                repair,
             },
         )),
         RunnerCommand::Connect {

--- a/src/commands/runner/doctor.rs
+++ b/src/commands/runner/doctor.rs
@@ -20,6 +20,15 @@ pub struct RunnerDoctorOptions {
     pub path: Option<String>,
     pub extensions: Vec<String>,
     pub required_tools: Vec<String>,
+    pub scope: RunnerDoctorScope,
+    pub repair: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RunnerDoctorScope {
+    #[default]
+    General,
+    LabOffload,
 }
 
 pub fn run(runner_id: &str) -> CmdResult<RunnerDoctorOutput> {
@@ -31,7 +40,7 @@ pub fn run_with_options(
     options: RunnerDoctorOptions,
 ) -> CmdResult<RunnerDoctorOutput> {
     let target = target::resolve(runner_id)?;
-    let report = match &target {
+    let mut report = match &target {
         target::RunnerTarget::Local { id, runner } => local::report(id, runner.as_ref(), &options),
         target::RunnerTarget::Ssh {
             id,
@@ -40,6 +49,12 @@ pub fn run_with_options(
             client,
         } => remote::report(id, runner, server, client, &options),
     };
+
+    if options.repair {
+        repair::apply(&target, &options, &mut report);
+    }
+
+    report.status = checks::overall_status(&report.checks);
     Ok((report, 0))
 }
 
@@ -64,6 +79,17 @@ mod types {
         pub capabilities: RunnerCapabilities,
         pub resources: RunnerResources,
         pub checks: Vec<RunnerCheck>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        pub repairs: Vec<RunnerRepair>,
+    }
+
+    #[derive(Debug, Serialize)]
+    pub struct RunnerRepair {
+        pub id: String,
+        pub status: RunnerDoctorStatus,
+        pub message: String,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        pub commands: Vec<String>,
     }
 
     #[derive(Debug, Serialize)]
@@ -399,6 +425,7 @@ mod local {
             capabilities,
             resources,
             checks,
+            repairs: Vec::new(),
         }
     }
 }
@@ -568,6 +595,18 @@ mod remote {
             "Create the artifact root or configure HOMEBOY_ARTIFACT_ROOT to a writable directory",
         ));
 
+        if options.scope == RunnerDoctorScope::LabOffload {
+            checks.extend(probes::lab_homeboy_path_checks(
+                client,
+                runner_id,
+                &server.id,
+                homeboy_command,
+                local_homeboy_version,
+                &homeboy,
+            ));
+            checks.extend(probes::wp_codebox_checks(client));
+        }
+
         checks.extend(probes::connected_daemon_exec_checks(
             runner_id,
             &workspace_root,
@@ -612,6 +651,7 @@ mod remote {
             capabilities,
             resources,
             checks,
+            repairs: Vec::new(),
         }
     }
 
@@ -643,7 +683,7 @@ mod remote {
 
 mod probes {
     use super::*;
-    use types::{DiskProbe, MemoryProbe, RunnerCapabilities, RunnerCheck, ToolProbe};
+    use types::{DiskProbe, HomeboyProbe, MemoryProbe, RunnerCapabilities, RunnerCheck, ToolProbe};
 
     #[derive(Clone, Copy)]
     pub struct ToolSpec {
@@ -846,6 +886,194 @@ mod probes {
             version,
             error: None,
         }
+    }
+
+    pub fn lab_homeboy_path_checks(
+        client: &SshClient,
+        runner_id: &str,
+        server_id: &str,
+        configured_command: &str,
+        local_version: &str,
+        configured_probe: &HomeboyProbe,
+    ) -> Vec<RunnerCheck> {
+        let mut checks = Vec::new();
+        let bare = remote_homeboy_probe(client, "homeboy");
+        let candidate = remote_preferred_homeboy_candidate(client, local_version);
+
+        let mut configured_details = BTreeMap::new();
+        configured_details.insert(
+            "configured_command".to_string(),
+            configured_command.to_string(),
+        );
+        configured_details.insert(
+            "configured_version".to_string(),
+            configured_probe.version.clone(),
+        );
+        if let Some(path) = &configured_probe.path {
+            configured_details.insert("configured_path".to_string(), path.clone());
+        }
+        if let Some(path) = &bare.path {
+            configured_details.insert("bare_path".to_string(), path.clone());
+        }
+        if let Some(version) = &bare.version {
+            configured_details.insert("bare_version".to_string(), version.clone());
+        }
+        if let Some(candidate) = &candidate {
+            configured_details.insert("preferred_path".to_string(), candidate.path.clone());
+            configured_details.insert("preferred_version".to_string(), candidate.version.clone());
+        }
+
+        checks.push(checks::ok_with_details(
+            "lab.homeboy.configured",
+            format!(
+                "Lab runner configured Homeboy command reports {}",
+                configured_probe.version
+            ),
+            configured_details.clone(),
+        ));
+
+        if let Some(candidate) = candidate {
+            let configured_version = configured_probe.version.trim();
+            if configured_version != candidate.version.trim() {
+                checks.push(checks::warning_with_details(
+                    "lab.homeboy.path_drift",
+                    format!(
+                        "Configured runner Homeboy {configured_version} differs from preferred runner binary {} at {}",
+                        candidate.version, candidate.path
+                    ),
+                    Some(format!(
+                        "Point runner `{runner_id}` at the preferred binary with `homeboy runner set {runner_id} --json '{{\"homeboy_path\":\"{}\"}}'`",
+                        candidate.path
+                    )),
+                    configured_details.clone(),
+                ));
+            }
+        }
+
+        if configured_command == "homeboy" {
+            if let Some(bare_version) = bare.version.as_deref() {
+                if bare_version.trim() != local_version.trim() {
+                    checks.push(checks::warning_with_details(
+                        "lab.homeboy.path_shadow",
+                        format!(
+                            "Runner PATH resolves bare `homeboy` to {bare_version}, but local Homeboy is {local_version}"
+                        ),
+                        Some(format!(
+                            "Configure runner `{runner_id}` with an absolute current homeboy_path, or fix PATH ordering on server `{server_id}`"
+                        )),
+                        configured_details,
+                    ));
+                }
+            }
+        }
+
+        checks
+    }
+
+    pub fn wp_codebox_checks(client: &SshClient) -> Vec<RunnerCheck> {
+        let mut details = BTreeMap::new();
+        let bin = common::remote_line(
+            client,
+            "printf '%s\n' \"${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}\"",
+        )
+        .filter(|value| !value.trim().is_empty());
+        let Some(bin) = bin else {
+            return vec![checks::warning(
+                "lab.wp_codebox.cache",
+                "WP Codebox runner path is not configured in the Lab runner environment".to_string(),
+                Some("Set HOMEBOY_WP_CODEBOX_BIN or HOMEBOY_SETTINGS_WP_CODEBOX_BIN when Lab commands depend on WP Codebox".to_string()),
+            )];
+        };
+
+        details.insert("path".to_string(), bin.clone());
+        let exists = client
+            .execute(&format!("test -e {}", common::shell_word(&bin)))
+            .success;
+        if !exists {
+            return vec![checks::error(
+                "lab.wp_codebox.cache",
+                "Configured WP Codebox runner path does not exist on the Lab runner".to_string(),
+                Some(
+                    "Refresh the WP Codebox cache before running WP Codebox-backed Lab evidence"
+                        .to_string(),
+                ),
+                details,
+            )];
+        }
+
+        if let Some(revision) = common::remote_line(
+            client,
+            &format!(
+                "p={}; if [ -d \"$p/.git\" ]; then git -C \"$p\" rev-parse --short HEAD 2>/dev/null; elif [ -d \"$(dirname \"$p\")/.git\" ]; then git -C \"$(dirname \"$p\")\" rev-parse --short HEAD 2>/dev/null; fi",
+                common::shell_word(&bin)
+            ),
+        ) {
+            details.insert("revision".to_string(), revision);
+        }
+
+        vec![checks::ok_with_details(
+            "lab.wp_codebox.cache",
+            "WP Codebox runner path exists on the Lab runner".to_string(),
+            details,
+        )]
+    }
+
+    struct RemoteHomeboyCandidate {
+        path: String,
+        version: String,
+    }
+
+    fn remote_homeboy_probe(client: &SshClient, command: &str) -> RemoteHomeboyCandidateProbe {
+        RemoteHomeboyCandidateProbe {
+            path: common::remote_line(
+                client,
+                &format!("command -v {}", common::shell_word(command)),
+            ),
+            version: remote_homeboy_version(client, command),
+        }
+    }
+
+    struct RemoteHomeboyCandidateProbe {
+        path: Option<String>,
+        version: Option<String>,
+    }
+
+    fn remote_preferred_homeboy_candidate(
+        client: &SshClient,
+        local_version: &str,
+    ) -> Option<RemoteHomeboyCandidate> {
+        let command = "for p in \"$HOME/.cargo/bin/homeboy\" \"$HOME/.local/bin/homeboy\" /usr/local/bin/homeboy; do [ -x \"$p\" ] || continue; v=$(\"$p\" --version 2>/dev/null | awk '{print $2}'); [ -n \"$v\" ] || continue; printf '%s %s\n' \"$p\" \"$v\"; done";
+        let output = client.execute(command);
+        if !output.success {
+            return None;
+        }
+        let mut first = None;
+        for line in output
+            .stdout
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+        {
+            let mut parts = line.split_whitespace();
+            let path = parts.next()?.to_string();
+            let version = parts.next()?.to_string();
+            let candidate = RemoteHomeboyCandidate { path, version };
+            if candidate.version.trim() == local_version.trim() {
+                return Some(candidate);
+            }
+            first.get_or_insert(candidate);
+        }
+        first
+    }
+
+    fn remote_homeboy_version(client: &SshClient, command: &str) -> Option<String> {
+        common::remote_line(
+            client,
+            &format!(
+                "{} --version 2>/dev/null | awk '{{print $2}}'",
+                common::shell_word(command)
+            ),
+        )
     }
 
     pub fn local_memory_probe() -> Option<MemoryProbe> {
@@ -1341,7 +1569,7 @@ mod checks {
         }
     }
 
-    fn warning_with_details(
+    pub(super) fn warning_with_details(
         id: impl Into<String>,
         message: String,
         remediation: Option<String>,
@@ -1398,6 +1626,96 @@ mod checks {
             message,
             remediation: None,
             details,
+        }
+    }
+}
+
+mod repair {
+    use super::*;
+    use types::{RunnerDoctorOutput, RunnerDoctorStatus, RunnerRepair};
+
+    pub fn apply(
+        target: &target::RunnerTarget,
+        options: &RunnerDoctorOptions,
+        report: &mut RunnerDoctorOutput,
+    ) {
+        if options.scope != RunnerDoctorScope::LabOffload {
+            report.repairs.push(RunnerRepair {
+                id: "repair.scope".to_string(),
+                status: RunnerDoctorStatus::Warning,
+                message: "No repairs were applied because --repair is only active for --scope lab-offload".to_string(),
+                commands: Vec::new(),
+            });
+            return;
+        }
+
+        let target::RunnerTarget::Ssh {
+            id,
+            runner: runner_config,
+            ..
+        } = target
+        else {
+            report.repairs.push(RunnerRepair {
+                id: "repair.runner".to_string(),
+                status: RunnerDoctorStatus::Warning,
+                message: "No Lab daemon repair is available for local runner targets".to_string(),
+                commands: Vec::new(),
+            });
+            return;
+        };
+
+        let daemon_failed = report
+            .checks
+            .iter()
+            .any(|check| check.id == "daemon.exec" && check.status == RunnerDoctorStatus::Error);
+        if !daemon_failed {
+            report.repairs.push(RunnerRepair {
+                id: "repair.daemon".to_string(),
+                status: RunnerDoctorStatus::Ok,
+                message: "Connected Lab daemon did not require repair".to_string(),
+                commands: Vec::new(),
+            });
+            return;
+        }
+
+        let commands = vec![
+            format!("homeboy runner disconnect {id}"),
+            format!("homeboy runner connect {id}"),
+        ];
+        let disconnected = runner::disconnect(id);
+        if let Err(err) = disconnected {
+            report.repairs.push(RunnerRepair {
+                id: "repair.daemon".to_string(),
+                status: RunnerDoctorStatus::Error,
+                message: format!("Could not disconnect stale Lab daemon: {}", err.message),
+                commands,
+            });
+            return;
+        }
+
+        match runner::connect(id) {
+            Ok(_) => {
+                report.checks.retain(|check| check.id != "daemon.exec");
+                let workspace_root = runner_config.workspace_root.as_deref().unwrap_or(".");
+                report
+                    .checks
+                    .extend(probes::connected_daemon_exec_checks(id, workspace_root));
+                report.repairs.push(RunnerRepair {
+                    id: "repair.daemon".to_string(),
+                    status: RunnerDoctorStatus::Ok,
+                    message: "Reconnected the Lab runner daemon and reran the daemon exec probe"
+                        .to_string(),
+                    commands,
+                });
+            }
+            Err(err) => {
+                report.repairs.push(RunnerRepair {
+                    id: "repair.daemon".to_string(),
+                    status: RunnerDoctorStatus::Error,
+                    message: format!("Could not reconnect Lab daemon: {}", err.message),
+                    commands,
+                });
+            }
         }
     }
 }

--- a/src/commands/runner/doctor/tests.rs
+++ b/src/commands/runner/doctor/tests.rs
@@ -18,6 +18,22 @@ fn local_alias_report_has_stable_top_level_shape() {
 }
 
 #[test]
+fn doctor_options_default_to_general_read_only_scope() {
+    let options = RunnerDoctorOptions::default();
+
+    assert_eq!(options.scope, RunnerDoctorScope::General);
+    assert!(!options.repair);
+}
+
+#[test]
+fn doctor_output_omits_empty_repairs() {
+    let (report, _) = run("local").expect("local doctor report");
+    let value = serde_json::to_value(report).expect("serialize report");
+
+    assert!(value.get("repairs").is_none());
+}
+
+#[test]
 fn overall_status_promotes_errors_over_warnings() {
     let checks = vec![
         checks::warning("optional", "optional missing".to_string(), None),
@@ -186,6 +202,7 @@ fn local_doctor_honors_required_tool_errors() {
             path: None,
             extensions: Vec::new(),
             required_tools: vec!["homeboy-definitely-missing-tool".to_string()],
+            ..Default::default()
         },
     )
     .expect("local doctor report");


### PR DESCRIPTION
## Summary
- Add `homeboy runner doctor <runner> --scope lab-offload` for Lab-specific runner readiness diagnostics.
- Add a narrow `--repair` flow that reconnects failing direct Lab runner daemons and reruns the daemon exec probe.
- Document the new operator path and keep expensive binary/cache repair actions explicit.

Fixes #4332

## Testing
- `cargo fmt --check`
- `cargo test commands::runner::doctor::tests`
- `cargo test --test command_surface_test`
- `cargo run --bin homeboy -- runner doctor --help`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the runner doctor implementation, docs, and PR summary; Chris reviewed and requested the PR.