### PR TITLE
Route Lab agent-task bridge through facades

### DIFF
--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -11,8 +11,9 @@
 
 use std::fs;
 
-use crate::core::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
-use crate::core::{agent_task_lifecycle, config, Error, Result};
+use crate::core::agent_tasks::lifecycle as agent_task_lifecycle;
+use crate::core::agent_tasks::scheduler::{AgentTaskAggregate, AgentTaskPlan};
+use crate::core::{config, Error, Result};
 
 use super::super::lab_workspaces::{workspace_mapping_entry, LabWorkspaceMappingEntry};
 use super::super::{sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions};

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -8,8 +8,9 @@
 
 use std::collections::HashMap;
 
-use crate::core::agent_task_scheduler::AgentTaskPlan;
-use crate::core::{agent_task_secrets, config, Error, Result};
+use crate::core::agent_tasks::scheduler::AgentTaskPlan;
+use crate::core::agent_tasks::secrets as agent_task_secrets;
+use crate::core::{config, Error, Result};
 
 use super::args_util::{non_empty_arg, subcommand_index};
 


### PR DESCRIPTION
## Summary
- Route Lab AgentTask bridge imports through the explicit `core::agent_tasks` facade.
- Route Lab secret hydration imports through the same facade instead of direct implementation modules.

Fixes #4326.
Part of #4303.

## Testing
- `cargo fmt --check`
- `cargo test agent_task`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Promoting the Lab-generated patch, verifying the scoped facade import change, and drafting this PR description; Chris remains responsible for review and merge.