### PR TITLE
Harden command contract facade boundaries

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -11,7 +11,7 @@
 use crate::cli_surface::Commands;
 use crate::command_contract::CommandDescriptor;
 use crate::commands::agent_task;
-use crate::core::agent_task_provider::provider_requires_cwd_git_checkout;
+use crate::core::agent_tasks::provider::provider_requires_cwd_git_checkout;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LabCommandContract {

--- a/tests/architecture_core_agnostic_test.rs
+++ b/tests/architecture_core_agnostic_test.rs
@@ -259,7 +259,13 @@ fn command_layer_uses_explicit_core_facades_only() {
     // - `homeboy::core::runner` and its submodules.
     // - `homeboy::core::artifact_*` (e.g. `artifact_links`, `artifact_manifest`).
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let scanned_roots = ["src/commands", "src/cli_runtime.rs", "src/cli_surface.rs"];
+    let scanned_roots = [
+        "src/commands",
+        "src/cli_runtime.rs",
+        "src/cli_surface.rs",
+        "src/command_contract.rs",
+        "src/command_contract",
+    ];
     let forbidden = [
         // agent task implementation modules
         "homeboy::core::agent_task::",


### PR DESCRIPTION
## Summary
- Route Lab command contract provider checks through the explicit `core::agent_tasks::provider` facade.
- Extend the command-layer facade-boundary architecture test to scan `src/command_contract*`.

Fixes #4325.
Part of #4303.

## Testing
- `cargo fmt --check`
- `cargo test command_layer_uses_explicit_core_facades_only`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Promoting the Lab-generated patch, verifying the scoped boundary change, and drafting this PR description; Chris remains responsible for review and merge.