### PR TITLE
Extract Lab trace fetch refs

### DIFF
--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -5,7 +5,9 @@
 //!
 //! - `offload` — request execution + runner-selection orchestration
 //!   (`execute_lab_offload`, `LabOffloadRequest`, fallback policy, workspace
-//!   sync mode decisions, trace target git-fetch refs).
+//!   sync mode decisions).
+//! - `trace_fetch_refs` — trace compare target materialization refs for git
+//!   workspace sync.
 //! - `agent_task_bridge` — inline AgentTask plan remapping and run-plan
 //!   lifecycle mirroring.
 //! - `secrets` — command-specific secret env hydration (agent-task vs trace).
@@ -22,6 +24,7 @@ mod args_util;
 mod evidence;
 mod offload;
 mod secrets;
+mod trace_fetch_refs;
 
 pub use super::lab_selection::LabRunnerSelectionSource;
 pub use offload::{

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -13,11 +13,10 @@
 //! 4. Translating runner failures into either a structured fallback outcome or
 //!    a precise validation error, via the helpers at the bottom of the file.
 //!
-//! The trace-target git-fetch helpers also live here because they are part of
-//! the workspace-sync decision the orchestrator makes before remote exec.
+//! Trace-target git-fetch calculation lives in `trace_fetch_refs`; this module
+//! only decides when those refs participate in workspace sync.
 
 use std::path::Path;
-use std::process::Command;
 
 use crate::core::agent_task_lifecycle;
 use crate::core::observation::{PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
@@ -67,6 +66,7 @@ use super::agent_task_bridge::{
 };
 use super::evidence::terminal_lab_run_evidence;
 use super::secrets::{hydrate_agent_task_secret_env, hydrate_trace_secret_env};
+use super::trace_fetch_refs::lab_offload_git_fetch_refs;
 
 pub struct LabOffloadRequest<'a> {
     pub command: Option<LabOffloadCommand>,
@@ -111,133 +111,6 @@ pub enum LabOffloadOutcome {
         stderr: String,
         exit_code: i32,
     },
-}
-
-fn lab_offload_git_fetch_refs(
-    args: &[String],
-    source_path: &Path,
-    sync_mode: RunnerWorkspaceSyncMode,
-) -> Result<Vec<String>> {
-    if sync_mode != RunnerWorkspaceSyncMode::Git {
-        return Ok(Vec::new());
-    }
-
-    let mut refs = Vec::new();
-    for target in lab_offload_trace_compare_targets(args) {
-        if trace_compare_target_is_local_path(&target) || target.starts_with("origin/") {
-            continue;
-        }
-        let git_ref = if target.starts_with("refs/") {
-            Some(target.clone())
-        } else {
-            advertised_origin_ref_for_local_target(source_path, &target)?
-        };
-        if let Some(git_ref) = git_ref {
-            if !refs.contains(&git_ref) {
-                refs.push(git_ref);
-            }
-        }
-    }
-    Ok(refs)
-}
-
-fn lab_offload_trace_compare_targets(args: &[String]) -> Vec<String> {
-    let mut targets = Vec::new();
-    let mut iter = args.iter().skip(1).peekable();
-    while let Some(arg) = iter.next() {
-        if arg == "--" {
-            break;
-        }
-        let target = if arg == "--baseline-target" || arg == "--candidate" {
-            iter.next().cloned()
-        } else {
-            arg.strip_prefix("--baseline-target=")
-                .or_else(|| arg.strip_prefix("--candidate="))
-                .map(str::to_string)
-        };
-        if let Some(target) = target {
-            targets.push(target);
-        }
-    }
-    targets
-}
-
-fn trace_compare_target_is_local_path(target: &str) -> bool {
-    let expanded = shellexpand::tilde(target).to_string();
-    Path::new(&expanded).exists()
-}
-
-fn advertised_origin_ref_for_local_target(
-    source_path: &Path,
-    target: &str,
-) -> Result<Option<String>> {
-    let commit = match super::super::workspace::git_output(
-        source_path,
-        &["rev-parse", "--verify", &format!("{target}^{{commit}}")],
-    ) {
-        Ok(commit) => commit,
-        Err(_) => return Ok(None),
-    };
-    let output = Command::new("git")
-        .args(["ls-remote", "origin"])
-        .current_dir(source_path)
-        .output()
-        .map_err(|err| {
-            Error::internal_io(err.to_string(), Some("run git ls-remote".to_string()))
-        })?;
-    if !output.status.success() {
-        return Err(Error::validation_invalid_argument(
-            "trace_compare_target",
-            "Lab offload could not inspect origin refs for trace compare target materialization",
-            Some(target.to_string()),
-            Some(vec![
-                String::from_utf8_lossy(&output.stderr).trim().to_string(),
-                "Run with --force-hot to execute trace compare locally while investigating remote ref availability.".to_string(),
-            ]),
-        ));
-    }
-
-    let refs = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter_map(|line| {
-            let (sha, git_ref) = line.split_once('\t')?;
-            (sha == commit && !git_ref.ends_with("^{}")).then(|| git_ref.to_string())
-        })
-        .collect::<Vec<_>>();
-    if refs.is_empty() && is_full_hex_sha(target) {
-        return Err(Error::validation_invalid_argument(
-            "trace_compare_target",
-            "Lab offload could not find an advertised origin ref for the trace compare target commit",
-            Some(target.to_string()),
-            Some(vec![
-                "Push the candidate commit to origin or pass an advertised ref such as refs/pull/<id>/head.".to_string(),
-                "Run with --force-hot to execute trace compare locally while investigating remote ref availability.".to_string(),
-            ]),
-        ));
-    }
-
-    Ok(best_advertised_ref(refs))
-}
-
-fn best_advertised_ref(refs: Vec<String>) -> Option<String> {
-    refs.iter()
-        .find(|git_ref| git_ref.starts_with("refs/pull/") && git_ref.ends_with("/head"))
-        .cloned()
-        .or_else(|| {
-            refs.iter()
-                .find(|git_ref| git_ref.starts_with("refs/heads/"))
-                .cloned()
-        })
-        .or_else(|| {
-            refs.iter()
-                .find(|git_ref| git_ref.starts_with("refs/tags/"))
-                .cloned()
-        })
-        .or_else(|| refs.into_iter().next())
-}
-
-fn is_full_hex_sha(value: &str) -> bool {
-    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn requested_lab_workspace_sync_mode(
@@ -1299,40 +1172,6 @@ mod tests {
             requires_playwright: false,
             infer_source_path_tools: false,
         }
-    }
-
-    #[test]
-    fn trace_compare_targets_are_extracted_before_passthrough_args() {
-        let args = vec![
-            "homeboy".to_string(),
-            "trace".to_string(),
-            "compare".to_string(),
-            "--baseline-target".to_string(),
-            "origin/develop".to_string(),
-            "--candidate=32f68bb07ac0efa1d754f78e2adc8de115ddca6f".to_string(),
-            "--".to_string(),
-            "--candidate".to_string(),
-            "ignored".to_string(),
-        ];
-
-        assert_eq!(
-            lab_offload_trace_compare_targets(&args),
-            vec![
-                "origin/develop".to_string(),
-                "32f68bb07ac0efa1d754f78e2adc8de115ddca6f".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn compare_target_ref_selection_prefers_pull_head_refs() {
-        let selected = best_advertised_ref(vec![
-            "refs/heads/fix-branch".to_string(),
-            "refs/pull/5530/head".to_string(),
-            "refs/tags/v1".to_string(),
-        ]);
-
-        assert_eq!(selected, Some("refs/pull/5530/head".to_string()));
     }
 
     #[test]

--- a/src/core/runner/lab/trace_fetch_refs.rs
+++ b/src/core/runner/lab/trace_fetch_refs.rs
@@ -1,0 +1,128 @@
+//! Trace compare target materialization refs for Lab git workspace sync.
+
+use std::path::Path;
+
+use crate::core::{Error, Result};
+
+use super::super::origin_refs::{advertised_origin_refs_for_commit, best_advertised_ref};
+use super::super::RunnerWorkspaceSyncMode;
+
+pub(super) fn lab_offload_git_fetch_refs(
+    args: &[String],
+    source_path: &Path,
+    sync_mode: RunnerWorkspaceSyncMode,
+) -> Result<Vec<String>> {
+    if sync_mode != RunnerWorkspaceSyncMode::Git {
+        return Ok(Vec::new());
+    }
+
+    let mut refs = Vec::new();
+    for target in lab_offload_trace_compare_targets(args) {
+        if trace_compare_target_is_local_path(&target) || target.starts_with("origin/") {
+            continue;
+        }
+        let git_ref = if target.starts_with("refs/") {
+            Some(target.clone())
+        } else {
+            advertised_origin_ref_for_local_target(source_path, &target)?
+        };
+        if let Some(git_ref) = git_ref {
+            if !refs.contains(&git_ref) {
+                refs.push(git_ref);
+            }
+        }
+    }
+    Ok(refs)
+}
+
+fn lab_offload_trace_compare_targets(args: &[String]) -> Vec<String> {
+    let mut targets = Vec::new();
+    let mut iter = args.iter().skip(1).peekable();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        let target = if arg == "--baseline-target" || arg == "--candidate" {
+            iter.next().cloned()
+        } else {
+            arg.strip_prefix("--baseline-target=")
+                .or_else(|| arg.strip_prefix("--candidate="))
+                .map(str::to_string)
+        };
+        if let Some(target) = target {
+            targets.push(target);
+        }
+    }
+    targets
+}
+
+fn trace_compare_target_is_local_path(target: &str) -> bool {
+    let expanded = shellexpand::tilde(target).to_string();
+    Path::new(&expanded).exists()
+}
+
+fn advertised_origin_ref_for_local_target(
+    source_path: &Path,
+    target: &str,
+) -> Result<Option<String>> {
+    let commit = match super::super::workspace::git_output(
+        source_path,
+        &["rev-parse", "--verify", &format!("{target}^{{commit}}")],
+    ) {
+        Ok(commit) => commit,
+        Err(_) => return Ok(None),
+    };
+    let refs = advertised_origin_refs_for_commit(
+        source_path,
+        &commit,
+        "trace_compare_target",
+        "Lab offload could not inspect origin refs for trace compare target materialization",
+        target.to_string(),
+        vec!["Run with --force-hot to execute trace compare locally while investigating remote ref availability.".to_string()],
+    )?;
+    if refs.is_empty() && is_full_hex_sha(target) {
+        return Err(Error::validation_invalid_argument(
+            "trace_compare_target",
+            "Lab offload could not find an advertised origin ref for the trace compare target commit",
+            Some(target.to_string()),
+            Some(vec![
+                "Push the candidate commit to origin or pass an advertised ref such as refs/pull/<id>/head.".to_string(),
+                "Run with --force-hot to execute trace compare locally while investigating remote ref availability.".to_string(),
+            ]),
+        ));
+    }
+
+    Ok(best_advertised_ref(refs))
+}
+
+fn is_full_hex_sha(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_compare_targets_are_extracted_before_passthrough_args() {
+        let args = vec![
+            "homeboy".to_string(),
+            "trace".to_string(),
+            "compare".to_string(),
+            "--baseline-target".to_string(),
+            "origin/develop".to_string(),
+            "--candidate=32f68bb07ac0efa1d754f78e2adc8de115ddca6f".to_string(),
+            "--".to_string(),
+            "--candidate".to_string(),
+            "ignored".to_string(),
+        ];
+
+        assert_eq!(
+            lab_offload_trace_compare_targets(&args),
+            vec![
+                "origin/develop".to_string(),
+                "32f68bb07ac0efa1d754f78e2adc8de115ddca6f".to_string(),
+            ]
+        );
+    }
+}

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -29,6 +29,7 @@ mod lab_selection;
 mod lab_workspaces;
 mod offload_changed_since;
 mod offload_metadata;
+mod origin_refs;
 mod resource_metrics;
 mod rig_materialization;
 mod session;

--- a/src/core/runner/offload_changed_since.rs
+++ b/src/core/runner/offload_changed_since.rs
@@ -3,6 +3,7 @@ use std::process::Command;
 
 use crate::core::error::{Error, Result};
 
+use super::origin_refs::{advertised_origin_refs_for_commit, best_advertised_ref};
 use super::RunnerWorkspaceSyncMode;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -132,51 +133,15 @@ fn resolve_changed_since_base(path: &Path, git_ref: &str) -> Result<String> {
 }
 
 fn advertised_origin_ref_for_commit(path: &Path, commit: &str) -> Result<Option<String>> {
-    let output = Command::new("git")
-        .args(["ls-remote", "origin"])
-        .current_dir(path)
-        .output()
-        .map_err(|err| {
-            Error::internal_io(err.to_string(), Some("run git ls-remote".to_string()))
-        })?;
-    if !output.status.success() {
-        return Err(Error::validation_invalid_argument(
-            "changed_since",
-            "Lab offload could not inspect origin refs for changed-since base materialization",
-            Some(commit.to_string()),
-            Some(vec![
-                String::from_utf8_lossy(&output.stderr).trim().to_string(),
-                "Run with --force-hot to execute the changed-since command locally while investigating remote ref availability.".to_string(),
-            ]),
-        ));
-    }
-
-    let refs = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter_map(|line| {
-            let (sha, git_ref) = line.split_once('\t')?;
-            (sha == commit && !git_ref.ends_with("^{}")).then(|| git_ref.to_string())
-        })
-        .collect::<Vec<_>>();
-
+    let refs = advertised_origin_refs_for_commit(
+        path,
+        commit,
+        "changed_since",
+        "Lab offload could not inspect origin refs for changed-since base materialization",
+        commit.to_string(),
+        vec!["Run with --force-hot to execute the changed-since command locally while investigating remote ref availability.".to_string()],
+    )?;
     Ok(best_advertised_ref(refs))
-}
-
-fn best_advertised_ref(refs: Vec<String>) -> Option<String> {
-    refs.iter()
-        .find(|git_ref| git_ref.starts_with("refs/pull/") && git_ref.ends_with("/head"))
-        .cloned()
-        .or_else(|| {
-            refs.iter()
-                .find(|git_ref| git_ref.starts_with("refs/heads/"))
-                .cloned()
-        })
-        .or_else(|| {
-            refs.iter()
-                .find(|git_ref| git_ref.starts_with("refs/tags/"))
-                .cloned()
-        })
-        .or_else(|| refs.into_iter().next())
 }
 
 fn ensure_local_merge_base(path: &Path, git_ref: &str) -> Result<()> {

--- a/src/core/runner/origin_refs.rs
+++ b/src/core/runner/origin_refs.rs
@@ -1,0 +1,72 @@
+use std::path::Path;
+use std::process::Command;
+
+use crate::core::error::{Error, Result};
+
+pub(super) fn advertised_origin_refs_for_commit(
+    path: &Path,
+    commit: &str,
+    error_field: &str,
+    error_message: &str,
+    error_id: String,
+    error_hints: Vec<String>,
+) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["ls-remote", "origin"])
+        .current_dir(path)
+        .output()
+        .map_err(|err| {
+            Error::internal_io(err.to_string(), Some("run git ls-remote".to_string()))
+        })?;
+    if !output.status.success() {
+        let mut hints = vec![String::from_utf8_lossy(&output.stderr).trim().to_string()];
+        hints.extend(error_hints);
+        return Err(Error::validation_invalid_argument(
+            error_field,
+            error_message,
+            Some(error_id),
+            Some(hints),
+        ));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let (sha, git_ref) = line.split_once('\t')?;
+            (sha == commit && !git_ref.ends_with("^{}")).then(|| git_ref.to_string())
+        })
+        .collect())
+}
+
+pub(super) fn best_advertised_ref(refs: Vec<String>) -> Option<String> {
+    refs.iter()
+        .find(|git_ref| git_ref.starts_with("refs/pull/") && git_ref.ends_with("/head"))
+        .cloned()
+        .or_else(|| {
+            refs.iter()
+                .find(|git_ref| git_ref.starts_with("refs/heads/"))
+                .cloned()
+        })
+        .or_else(|| {
+            refs.iter()
+                .find(|git_ref| git_ref.starts_with("refs/tags/"))
+                .cloned()
+        })
+        .or_else(|| refs.into_iter().next())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advertised_ref_selection_prefers_pull_head_refs() {
+        let selected = best_advertised_ref(vec![
+            "refs/heads/fix-branch".to_string(),
+            "refs/pull/5530/head".to_string(),
+            "refs/tags/v1".to_string(),
+        ]);
+
+        assert_eq!(selected, Some("refs/pull/5530/head".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract Lab trace compare git-fetch ref orchestration from `offload.rs` into a focused `trace_fetch_refs` module.
- Add a shared `origin_refs` helper so trace target and changed-since materialization reuse the same `git ls-remote` filtering and advertised-ref selection logic.
- Keep `offload.rs` as the high-level Lab offload coordinator while preserving existing behavior.

Fixes #4327.
References #4303.

## Testing
- `cargo fmt -- --check`
- `cargo test core::runner::lab::offload::tests`
- `cargo test trace_compare_targets_are_extracted_before_passthrough_args`
- `cargo test advertised_ref_selection_prefers_pull_head_refs`
- `cargo test rewrites_changed_since_to_resolved_commit_for_git_lab_offload`

Note: test builds still emit the existing warning for `src/commands/runs/corpus_tests.rs` unused import `serde_json::Value`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Inspecting the existing Lab offload orchestration, drafting the minimal extraction, updating focused tests, and running verification. Chris remains responsible for review and merge decisions.