### PR TITLE
core: harden artifact facade exports

### DIFF
--- a/src/core/artifacts.rs
+++ b/src/core/artifacts.rs
@@ -3,14 +3,36 @@
 //! New command/core code should import artifact APIs from this module instead of
 //! reaching into individual artifact implementation modules.
 
-pub use super::artifact_inputs::*;
-pub use super::artifact_links::*;
-pub use super::artifact_manifest::*;
-pub use super::artifact_origin::*;
-pub use super::browser_evidence::*;
-pub use super::change_artifact::*;
-pub use super::publication_artifacts::*;
-pub use super::structured_sidecar::*;
+pub use super::artifact_inputs::ResolvedArtifactInput;
+pub use super::artifact_links::{
+    annotate_public_artifact_url_validation, cached_validated_viewer_links, public_artifact_url,
+    public_artifact_url_validation_json, validate_public_artifact_url, validated_viewer_links,
+    viewer_links, PublicArtifactUrlValidation, PUBLIC_ARTIFACT_BASE_URL_ENV,
+};
+pub use super::artifact_manifest::{
+    manifest_for_existing_files, read_manifest_from_root, write_manifest_to_root, ArtifactManifest,
+    ArtifactManifestEntry, ArtifactRedactionState, ValidatedArtifactManifestEntry,
+    ARTIFACT_MANIFEST_FILE, ARTIFACT_MANIFEST_SCHEMA,
+};
+pub use super::artifact_origin::{serve, status, ArtifactOriginServeSpec, ArtifactOriginStatus};
+pub use super::browser_evidence::{
+    validate_bench_results_payload, validate_trace_results_payload, BrowserArtifactMetadata,
+    BrowserBottleneckRow, BrowserNetworkRequestRow, BrowserOriginDeclaredService,
+    BrowserOriginEvidence, BrowserPerformanceProfileEnvelope, BrowserPhaseMark, BrowserPhaseWindow,
+    BrowserRedirectEvidence, BrowserTimingRow, BrowserWindowLocationEvidence, TraceAssertion,
+    TraceAssertionStatus, TraceAssertions, TraceEnvelope, TraceEnvelopeStatus, TraceEvent,
+    TraceTimeline, BROWSER_EVIDENCE_SCHEMA_VERSION,
+};
+pub use super::change_artifact::{
+    ChangeApplyResult, ChangeApplyStatus, ChangeArtifact, ChangeArtifactDigest,
+    ChangeArtifactProvenance, ChangeArtifactSummary, ChangeDelta, ChangeDeltaFile, ChangePatch,
+    CHANGE_APPLY_RESULT_SCHEMA, CHANGE_ARTIFACT_SCHEMA,
+};
+pub use super::publication_artifacts::index_remote_published_artifact_refs_for_run;
+pub use super::structured_sidecar::{
+    default_path, default_producer, default_schema_version, registry, schema, validate_payload,
+    StructuredSidecarSchema, StructuredSidecarShape, REGISTRY,
+};
 
 /// Resolve the artifact root used for copied/downloaded run artifacts.
 pub fn root() -> super::Result<std::path::PathBuf> {

--- a/tests/architecture_core_agnostic_test.rs
+++ b/tests/architecture_core_agnostic_test.rs
@@ -370,6 +370,7 @@ fn core_facades_expose_explicit_groups_not_wildcards() {
     // modules cannot leak new public names through `pub use module::*` blocks.
     let agent_tasks = source_file("src/core/agent_tasks.rs");
     let runners = source_file("src/core/runners.rs");
+    let artifacts = source_file("src/core/artifacts.rs");
 
     let forbidden_wildcards = [
         "pub use super::agent_task::*",
@@ -401,6 +402,24 @@ fn core_facades_expose_explicit_groups_not_wildcards() {
          list the API names explicitly so the facade documents its surface."
     );
 
+    let forbidden_artifact_wildcards = [
+        "pub use super::artifact_inputs::*",
+        "pub use super::artifact_links::*",
+        "pub use super::artifact_manifest::*",
+        "pub use super::artifact_origin::*",
+        "pub use super::browser_evidence::*",
+        "pub use super::change_artifact::*",
+        "pub use super::publication_artifacts::*",
+        "pub use super::structured_sidecar::*",
+    ];
+    for wildcard in forbidden_artifact_wildcards {
+        assert!(
+            !artifacts.contains(wildcard),
+            "src/core/artifacts.rs must not re-export implementation modules via \
+             `{wildcard}`; list the API names explicitly so the facade documents its surface."
+        );
+    }
+
     assert!(
         agent_tasks.contains("pub mod scheduler")
             && agent_tasks.contains("pub mod lifecycle")
@@ -417,6 +436,16 @@ fn core_facades_expose_explicit_groups_not_wildcards() {
             && runners.contains("pub mod lab_offload"),
         "src/core/runners.rs must keep the explicit API group modules (registry, connection, \
          execution, workspace, lab_offload, ...) so callers depend on operation contracts."
+    );
+    assert!(
+        artifacts.contains("pub use super::artifact_links::{")
+            && artifacts.contains("PublicArtifactUrlValidation")
+            && artifacts.contains("pub use super::artifact_manifest::{")
+            && artifacts.contains("ArtifactManifest")
+            && artifacts.contains("pub use super::artifact_origin::{")
+            && artifacts.contains("ArtifactOriginServeSpec"),
+        "src/core/artifacts.rs must keep explicit artifact API re-export groups so callers depend on \
+         the facade without wildcard-leaking implementation modules."
     );
 }
 


### PR DESCRIPTION
## Summary
- Replaces `core::artifacts` wildcard re-exports with an explicit list of artifact facade API names.
- Extends the core facade architecture test so wildcard artifact implementation exports cannot return unnoticed.

Fixes #4324.
Refs #4303.

## Testing
- `cargo fmt --check`
- `cargo test --test architecture_core_agnostic_test`
- `cargo test artifact`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the explicit artifact facade, adding architecture coverage, running focused verification, and drafting this PR body; Chris remains responsible for review and testing.