### PR TITLE
fix: allow lab status runner selector

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use super::{CmdResult, GlobalArgs};
 use homeboy::core::runners::{
     self as runner, runner_exec_failure_error, RunnerExecOptions, RunnerExecOutput,
-    RunnerRequiredTool, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+    RunnerRequiredTool, RunnerStatusReport, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
 };
 use homeboy::core::source_snapshot::SourceSnapshot;
 use homeboy::core::Error;
@@ -19,7 +19,11 @@ pub struct LabArgs {
 #[derive(Subcommand)]
 enum LabCommand {
     /// Show Lab routing status and benchmark commands
-    Status,
+    Status {
+        /// Runner ID to inspect. Defaults to lab.preferred_runner or inferred default Lab runner.
+        #[arg(long)]
+        runner: Option<String>,
+    },
     /// Print the runner-backed benchmark command for the provided bench args
     Bench {
         /// Arguments to pass after `homeboy bench`
@@ -51,6 +55,8 @@ pub struct LabOutput {
     command: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     preferred_runner: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    selected_runner: Option<LabSelectedRunnerOutput>,
     config_key: &'static str,
     config_path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -65,6 +71,19 @@ pub struct LabFollowup {
     label: &'static str,
     command: String,
     purpose: &'static str,
+}
+
+#[derive(Serialize)]
+pub struct LabSelectedRunnerOutput {
+    runner_id: String,
+    kind: String,
+    configured_executable: String,
+    daemon_enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_root: Option<String>,
+    readiness_state: String,
+    connected: bool,
+    status: RunnerStatusReport,
 }
 
 #[derive(Serialize)]
@@ -95,11 +114,35 @@ pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabCommandOutput> {
     let current_workspace = std::env::current_dir()
         .ok()
         .map(|path| path.display().to_string());
-    let managed_followups =
-        lab_followups(preferred_runner.as_deref(), current_workspace.as_deref());
-    let command = match args.command.unwrap_or(LabCommand::Status) {
-        LabCommand::Status => "lab.status",
+    match args.command.unwrap_or(LabCommand::Status { runner: None }) {
+        LabCommand::Status { runner } => {
+            let selected_runner = selected_lab_runner_status(runner.as_deref())?;
+            let followup_runner = runner.as_deref().or(preferred_runner.as_deref());
+            let managed_followups = lab_followups(followup_runner, current_workspace.as_deref());
+            return Ok((
+                LabCommandOutput::Status(LabOutput {
+                    command: "lab.status",
+                    preferred_runner,
+                    selected_runner,
+                    config_key: "/lab/preferred_runner",
+                    config_path,
+                    current_workspace,
+                    managed_followups,
+                    guidance: vec![
+                        "Use `homeboy bench <component>` to run benchmarks on the default Lab runner."
+                            .to_string(),
+                        "Use the `managed_followups` commands when a Lab run needs runner diagnostics, environment inspection, workspace materialization, or managed execution.".to_string(),
+                        "Use `homeboy config set /lab/preferred_runner '\"<runner-id>\"'` to set the default Lab runner.".to_string(),
+                        "Use `homeboy config set /bench/local_execution '\"denied\"'` to make local benchmark execution fail closed.".to_string(),
+                        "Use `--runner <runner-id>` only when multiple Lab runners are available and no default should be inferred.".to_string(),
+                    ],
+                }),
+                0,
+            ));
+        }
         LabCommand::Bench { args } => {
+            let managed_followups =
+                lab_followups(preferred_runner.as_deref(), current_workspace.as_deref());
             let mut bench_command = "homeboy bench".to_string();
             if !args.is_empty() {
                 bench_command.push(' ');
@@ -109,6 +152,7 @@ pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabCommandOutput> {
                 LabCommandOutput::Status(LabOutput {
                     command: "lab.bench",
                     preferred_runner,
+                    selected_runner: None,
                     config_key: "/lab/preferred_runner",
                     config_path,
                     current_workspace,
@@ -132,26 +176,30 @@ pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabCommandOutput> {
             return sync_lab_extension(runner, &source, &id, &revision, !no_replace);
         }
     };
+}
 
-    Ok((
-        LabCommandOutput::Status(LabOutput {
-            command,
-            preferred_runner,
-            config_key: "/lab/preferred_runner",
-            config_path,
-            current_workspace,
-            managed_followups,
-            guidance: vec![
-                "Use `homeboy bench <component>` to run benchmarks on the default Lab runner."
-                    .to_string(),
-                "Use the `managed_followups` commands when a Lab run needs runner diagnostics, environment inspection, workspace materialization, or managed execution.".to_string(),
-                "Use `homeboy config set /lab/preferred_runner '\"<runner-id>\"'` to set the default Lab runner.".to_string(),
-                "Use `homeboy config set /bench/local_execution '\"denied\"'` to make local benchmark execution fail closed.".to_string(),
-                "Use `--runner <runner-id>` only when multiple Lab runners are available and no default should be inferred.".to_string(),
-            ],
-        }),
-        0,
-    ))
+fn selected_lab_runner_status(
+    runner_id: Option<&str>,
+) -> homeboy::core::Result<Option<LabSelectedRunnerOutput>> {
+    let Some(runner_id) = runner_id else {
+        return Ok(None);
+    };
+    let runner_config = runner::load(runner_id)?;
+    let status = runner::status(runner_id)?;
+    Ok(Some(LabSelectedRunnerOutput {
+        runner_id: runner_id.to_string(),
+        kind: format!("{:?}", runner_config.kind).to_ascii_lowercase(),
+        configured_executable: runner_config
+            .settings
+            .homeboy_path
+            .clone()
+            .unwrap_or_else(|| "homeboy".to_string()),
+        daemon_enabled: runner_config.settings.daemon,
+        workspace_root: runner_config.workspace_root.clone(),
+        readiness_state: format!("{:?}", status.state).to_ascii_lowercase(),
+        connected: status.connected,
+        status,
+    }))
 }
 
 fn sync_lab_extension(

--- a/tests/output_errors.rs
+++ b/tests/output_errors.rs
@@ -144,6 +144,50 @@ fn command_owned_output_path_is_not_rejected_as_global_format() {
 }
 
 #[test]
+fn lab_status_accepts_command_owned_runner_selector() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    register_local_runner(dir.path());
+
+    let output = Command::new(homeboy_bin())
+        .args(["lab", "status", "--runner", "lab-local"])
+        .current_dir(dir.path())
+        .env("HOME", dir.path())
+        .output()
+        .expect("run homeboy");
+
+    assert!(
+        output.status.success(),
+        "lab status --runner should succeed; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout_json: Value = serde_json::from_slice(&output.stdout).expect("stdout json");
+    assert_eq!(stdout_json["success"], true);
+    assert_eq!(stdout_json["data"]["command"], "lab.status");
+    assert_eq!(
+        stdout_json["data"]["selected_runner"]["runner_id"],
+        "lab-local"
+    );
+    assert_eq!(
+        stdout_json["data"]["selected_runner"]["configured_executable"],
+        "homeboy"
+    );
+    assert_eq!(
+        stdout_json["data"]["selected_runner"]["workspace_root"],
+        dir.path().to_string_lossy().as_ref()
+    );
+    assert_eq!(
+        stdout_json["data"]["selected_runner"]["readiness_state"],
+        "disconnected"
+    );
+    assert_eq!(
+        stdout_json["data"]["selected_runner"]["status"]["state"],
+        "disconnected"
+    );
+}
+
+#[test]
 fn explicit_json_path_is_allowed() {
     let dir = tempfile::tempdir().expect("tempdir");
     register_local_runner(dir.path());


### PR DESCRIPTION
## Summary
- Adds a command-owned `--runner` selector to `homeboy lab status` so `homeboy lab status --runner <id>` is parsed locally instead of treated as portable-offload routing.
- Reports selected runner configuration and status details, including configured executable, daemon flag, workspace root, readiness state, and the existing runner status payload.
- Keeps existing default `lab status` behavior unchanged when no runner is selected.

Fixes #4355.

## Tests
- `cargo test lab_status_accepts_command_owned_runner_selector --test output_errors`
- `cargo test commands::lab && cargo test command_contract::lab && cargo test --test output_errors`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the scoped CLI fix, regression test, and verification commands; Chris remains responsible for review and merge.