### PR TITLE
Verify Lab extension sync revisions

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -6,6 +6,7 @@ use homeboy::core::runners::{
     self as runner, RunnerExecOptions, RunnerExecOutput, RunnerRequiredTool,
 };
 use homeboy::core::Error;
+use serde_json::Value;
 
 #[derive(Args)]
 pub struct LabArgs {
@@ -202,6 +203,18 @@ fn sync_lab_extension(
         },
     )?;
 
+    if exit_code == 0 {
+        let installed_revision = installed_extension_source_revision(&execution.stdout)
+            .ok_or_else(|| extension_sync_revision_error(extension_id, revision, None))?;
+        if !revision_matches(revision, &installed_revision) {
+            return Err(extension_sync_revision_error(
+                extension_id,
+                revision,
+                Some(installed_revision),
+            ));
+        }
+    }
+
     Ok((
         LabCommandOutput::ExtensionSync(LabExtensionSyncOutput {
             command: "lab.extension_sync",
@@ -239,6 +252,65 @@ fn runner_extension_install_command(
         command.push("--replace".to_string());
     }
     command
+}
+
+fn installed_extension_source_revision(stdout: &str) -> Option<String> {
+    let value = parse_trailing_json(stdout)?;
+    if value.get("success").and_then(Value::as_bool) == Some(false) {
+        return None;
+    }
+
+    let extension = value
+        .get("data")
+        .and_then(|data| data.get("extension"))
+        .or_else(|| value.get("data"));
+
+    extension
+        .and_then(|data| data.get("source_revision"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|revision| !revision.is_empty())
+        .map(str::to_string)
+}
+
+fn parse_trailing_json(stdout: &str) -> Option<Value> {
+    if let Ok(value) = serde_json::from_str(stdout) {
+        return Some(value);
+    }
+
+    stdout
+        .char_indices()
+        .rev()
+        .filter(|(_, ch)| *ch == '{')
+        .find_map(|(index, _)| serde_json::from_str(&stdout[index..]).ok())
+}
+
+fn revision_matches(requested: &str, installed: &str) -> bool {
+    requested == installed || requested.starts_with(installed) || installed.starts_with(requested)
+}
+
+fn extension_sync_revision_error(
+    extension_id: &str,
+    requested: &str,
+    installed: Option<String>,
+) -> Error {
+    let installed_display = installed.as_deref().unwrap_or("<missing>");
+    Error::validation_invalid_argument(
+        "ref",
+        format!(
+            "Runner extension '{}' did not install requested ref {}; installed source revision is {}",
+            extension_id, requested, installed_display
+        ),
+        Some(requested.to_string()),
+        Some(vec![
+            "Inspect the runner command stdout/stderr before rerunning downstream Lab tasks."
+                .to_string(),
+            format!(
+                "Verify with: homeboy runner exec <runner> -- homeboy extension show {}",
+                extension_id
+            ),
+        ]),
+    )
 }
 
 fn lab_followups(runner_id: Option<&str>, current_workspace: Option<&str>) -> Vec<LabFollowup> {
@@ -290,7 +362,10 @@ fn shell_arg(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{lab_followups, runner_extension_install_command};
+    use super::{
+        installed_extension_source_revision, lab_followups, revision_matches,
+        runner_extension_install_command,
+    };
 
     #[test]
     fn lab_extension_sync_command_replaces_by_default() {
@@ -337,6 +412,74 @@ mod tests {
                 "main",
             ]
         );
+    }
+
+    #[test]
+    fn lab_extension_sync_reads_installed_revision_from_replace_output() {
+        let stdout = r#"{
+  "success": true,
+  "data": {
+    "command": "extension.replace",
+    "extension_id": "wordpress",
+    "source_revision": "941bf8c"
+  }
+}"#;
+
+        assert_eq!(
+            installed_extension_source_revision(stdout).as_deref(),
+            Some("941bf8c")
+        );
+    }
+
+    #[test]
+    fn lab_extension_sync_reads_installed_revision_after_setup_logs() {
+        let stdout = r#"Setting up WordPress extension...
+Installing npm dependencies...
+{
+  "success": true,
+  "data": {
+    "command": "extension.replace",
+    "extension_id": "wordpress",
+    "source_revision": "941bf8cf"
+  }
+}
+"#;
+
+        assert_eq!(
+            installed_extension_source_revision(stdout).as_deref(),
+            Some("941bf8cf")
+        );
+    }
+
+    #[test]
+    fn lab_extension_sync_reads_installed_revision_from_show_style_output() {
+        let stdout = r#"{
+  "success": true,
+  "data": {
+    "extension": {
+      "id": "wordpress",
+      "source_revision": "941bf8c"
+    }
+  }
+}"#;
+
+        assert_eq!(
+            installed_extension_source_revision(stdout).as_deref(),
+            Some("941bf8c")
+        );
+    }
+
+    #[test]
+    fn lab_extension_sync_accepts_short_full_revision_matches() {
+        assert!(revision_matches(
+            "941bf8cff9f88758123db837ed12bb6f6de5d00f",
+            "941bf8c"
+        ));
+        assert!(revision_matches(
+            "941bf8c",
+            "941bf8cff9f88758123db837ed12bb6f6de5d00f"
+        ));
+        assert!(!revision_matches("941bf8c", "f36543e"));
     }
 
     #[test]

--- a/src/core/extension/repair.rs
+++ b/src/core/extension/repair.rs
@@ -573,6 +573,12 @@ mod tests {
                 result.source_revision.as_deref(),
                 Some(pinned_revision.as_str())
             );
+            assert_eq!(
+                fs::read_to_string(home.join(".config/homeboy/extensions/swift/.source-revision"))
+                    .expect("source revision metadata")
+                    .trim(),
+                pinned_revision
+            );
         });
     }
 }


### PR DESCRIPTION
## Summary
- Fail `homeboy lab extension-sync` when the runner install output does not report the requested extension revision.
- Parse extension install JSON even when setup logs precede the response.
- Assert replace installs persist `.source-revision` metadata for pinned refs.

## Testing
- `cargo test lab_extension_sync`
- `cargo test test_replace_with_revision --lib`
- `cargo run --bin homeboy -- lab extension-sync --source https://github.com/Extra-Chill/homeboy-extensions.git --id wordpress --ref 941bf8cff9f88758123db837ed12bb6f6de5d00f`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the Lab sync revision validation and focused regression coverage; Chris remains responsible for review and merge.