### PR TITLE
refactor: centralize command output and contracts

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -12,6 +12,9 @@ use crate::cli_surface::Commands;
 use crate::command_contract::CommandDescriptor;
 use crate::commands::agent_task;
 use crate::core::agent_tasks::provider::provider_requires_cwd_git_checkout;
+use crate::core::engine::execution_context::{self, ResolveOptions};
+use crate::core::extension::ExtensionCapability;
+use std::collections::BTreeSet;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LabCommandContract {
@@ -51,11 +54,7 @@ pub enum LabCommandRequiredTool {
 
 pub const LAB_TRACE_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[LabCommandRequiredTool::Playwright];
 const LAB_NO_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[];
-const AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON: &str = "`audit --changed-since` is not Lab-portable yet because changed-since audit depends on git base refs that the current Lab workspace sync may not have fetched.";
-const LINT_CHANGED_SCOPE_LAB_UNSUPPORTED_REASON: &str = "Changed-scope lint runs stay local because changed-file scopes are not represented in the current Lab portability contract yet.";
-const TEST_CHANGED_SINCE_LAB_UNSUPPORTED_REASON: &str = "`test --changed-since` is not Lab-portable yet because changed-since test selection depends on git base refs that the current Lab workspace sync may not have fetched.";
 const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.";
-const FLEET_EXEC_LAB_UNSUPPORTED_REASON: &str = "`fleet exec` stays local because it depends on local fleet, project, and server configuration before opening SSH sessions to each project; runner-side config parity is not guaranteed.";
 
 impl Commands {
     pub fn lab_contract(&self) -> Option<LabCommandContract> {
@@ -69,7 +68,7 @@ impl Commands {
                         | agent_task::AgentTaskCommand::RunPlan(_)
                 ) =>
             {
-                let mut contract = lab_portable_contract(
+                let mut contract = LabCommandContract::portable(
                     "agent-task dispatch/cook/loop/run-plan",
                     None,
                     true,
@@ -88,70 +87,43 @@ impl Commands {
                         | agent_task::AgentTaskCommand::Artifacts(_)
                 ) =>
             {
-                lab_portable_workload_contract(
+                LabCommandContract::portable_workload(
                     "agent-task status/logs/artifacts",
                     None,
                     false,
                     LAB_NO_EXTRA_TOOLS,
                 )
             }
-            Commands::Audit(args) if args.changed_since.is_some() => {
-                lab_local_only_contract("audit", AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON)
-            }
-            Commands::Audit(args) if args.conventions => return None,
-            Commands::Audit(args) => lab_portable_contract(
-                "audit",
-                (args.baseline_args.baseline || args.baseline_args.ratchet)
-                    .then_some("--baseline/--ratchet"),
-                true,
-                LAB_NO_EXTRA_TOOLS,
-            ),
-            Commands::Bench(args) if args.is_lab_offload_command() => lab_portable_contract(
-                "bench",
-                args.lab_offload_writes_local_state()
-                    .then_some("--baseline/--ratchet"),
-                true,
-                LAB_NO_EXTRA_TOOLS,
-            ),
+            Commands::Audit(args) => args.lab_contract()?,
+            Commands::Bench(args) => args.lab_contract()?,
             Commands::Extension(args) if args.is_update_command() => {
-                lab_explicit_runner_contract("extension update", None, false, LAB_NO_EXTRA_TOOLS)
+                LabCommandContract::explicit_runner(
+                    "extension update",
+                    None,
+                    false,
+                    LAB_NO_EXTRA_TOOLS,
+                )
             }
-            Commands::Fleet(args) if args.is_hot_resource_command() => {
-                lab_local_only_contract("fleet exec", FLEET_EXEC_LAB_UNSUPPORTED_REASON)
+            Commands::Fleet(args) => args.lab_contract()?,
+            Commands::Lint(args) => args.lab_contract()?,
+            Commands::Refactor(args) if args.is_hot_resource_command() => {
+                LabCommandContract::portable(
+                    "refactor",
+                    args.lab_offload_writes_local_state()
+                        .then_some("--write/--commit"),
+                    false,
+                    LAB_NO_EXTRA_TOOLS,
+                )
             }
-            Commands::Lint(args) if args.is_full_workspace_run() => lab_portable_contract(
-                "lint",
-                args.fix.then_some("--fix"),
-                true,
-                LAB_NO_EXTRA_TOOLS,
-            ),
-            Commands::Lint(args) if args.changed_since.is_some() || args.changed_only => {
-                lab_local_only_contract("lint", LINT_CHANGED_SCOPE_LAB_UNSUPPORTED_REASON)
-            }
-            Commands::Refactor(args) if args.is_hot_resource_command() => lab_portable_contract(
-                "refactor",
-                args.lab_offload_writes_local_state()
-                    .then_some("--write/--commit"),
-                false,
-                LAB_NO_EXTRA_TOOLS,
-            ),
             Commands::Rig(args) if args.is_check_command() => {
-                lab_portable_workload_contract("rig check", None, false, LAB_NO_EXTRA_TOOLS)
+                LabCommandContract::portable_workload("rig check", None, false, LAB_NO_EXTRA_TOOLS)
             }
             Commands::Rig(args) if args.is_hot_resource_command() => {
-                lab_local_only_contract("rig up", RIG_UP_LAB_UNSUPPORTED_REASON)
+                LabCommandContract::local_only("rig up", RIG_UP_LAB_UNSUPPORTED_REASON)
             }
-            Commands::Test(args) if args.changed_since.is_none() => lab_portable_contract(
-                "test",
-                args.write.then_some("--write"),
-                true,
-                LAB_NO_EXTRA_TOOLS,
-            ),
-            Commands::Test(_) => {
-                lab_local_only_contract("test", TEST_CHANGED_SINCE_LAB_UNSUPPORTED_REASON)
-            }
+            Commands::Test(args) => args.lab_contract(),
             Commands::Trace(args) => {
-                let mut contract = lab_portable_workload_contract(
+                let mut contract = LabCommandContract::portable_workload(
                     "trace",
                     args.keep_overlay.then_some("--keep-overlay"),
                     false,
@@ -193,70 +165,72 @@ pub(super) fn apply_lab_contract_to_descriptor(
     descriptor.lab_offload_mutation_flag = contract.and_then(|contract| contract.mutation_flag);
 }
 
-fn lab_portable_contract(
-    hot_label: &'static str,
-    mutation_flag: Option<&'static str>,
-    requires_extension_parity: bool,
-    extra_required_tools: &'static [LabCommandRequiredTool],
-) -> LabCommandContract {
-    LabCommandContract {
-        hot_label,
-        portability: LabCommandPortability::Portable,
-        default_lab_offload: true,
-        source_path_mode: LabSourcePathMode::CwdOrPathFlag,
-        workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
-        mutation_flag,
-        requires_extension_parity,
-        extra_required_tools,
-        infer_source_path_tools: true,
-    }
-}
-
-fn lab_portable_workload_contract(
-    hot_label: &'static str,
-    mutation_flag: Option<&'static str>,
-    requires_extension_parity: bool,
-    extra_required_tools: &'static [LabCommandRequiredTool],
-) -> LabCommandContract {
-    LabCommandContract {
-        infer_source_path_tools: false,
-        ..lab_portable_contract(
+impl LabCommandContract {
+    pub(crate) fn portable(
+        hot_label: &'static str,
+        mutation_flag: Option<&'static str>,
+        requires_extension_parity: bool,
+        extra_required_tools: &'static [LabCommandRequiredTool],
+    ) -> Self {
+        Self {
             hot_label,
+            portability: LabCommandPortability::Portable,
+            default_lab_offload: true,
+            source_path_mode: LabSourcePathMode::CwdOrPathFlag,
+            workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
             mutation_flag,
             requires_extension_parity,
             extra_required_tools,
-        )
+            infer_source_path_tools: true,
+        }
     }
-}
 
-fn lab_explicit_runner_contract(
-    hot_label: &'static str,
-    mutation_flag: Option<&'static str>,
-    requires_extension_parity: bool,
-    extra_required_tools: &'static [LabCommandRequiredTool],
-) -> LabCommandContract {
-    LabCommandContract {
-        default_lab_offload: false,
-        ..lab_portable_workload_contract(
+    pub(crate) fn portable_workload(
+        hot_label: &'static str,
+        mutation_flag: Option<&'static str>,
+        requires_extension_parity: bool,
+        extra_required_tools: &'static [LabCommandRequiredTool],
+    ) -> Self {
+        Self {
+            infer_source_path_tools: false,
+            ..Self::portable(
+                hot_label,
+                mutation_flag,
+                requires_extension_parity,
+                extra_required_tools,
+            )
+        }
+    }
+
+    pub(crate) fn explicit_runner(
+        hot_label: &'static str,
+        mutation_flag: Option<&'static str>,
+        requires_extension_parity: bool,
+        extra_required_tools: &'static [LabCommandRequiredTool],
+    ) -> Self {
+        Self {
+            default_lab_offload: false,
+            ..Self::portable_workload(
+                hot_label,
+                mutation_flag,
+                requires_extension_parity,
+                extra_required_tools,
+            )
+        }
+    }
+
+    pub(crate) fn local_only(hot_label: &'static str, reason: &'static str) -> Self {
+        Self {
             hot_label,
-            mutation_flag,
-            requires_extension_parity,
-            extra_required_tools,
-        )
-    }
-}
-
-fn lab_local_only_contract(hot_label: &'static str, reason: &'static str) -> LabCommandContract {
-    LabCommandContract {
-        hot_label,
-        portability: LabCommandPortability::LocalOnly(reason),
-        default_lab_offload: false,
-        source_path_mode: LabSourcePathMode::CwdOrPathFlag,
-        workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
-        mutation_flag: None,
-        requires_extension_parity: false,
-        extra_required_tools: LAB_NO_EXTRA_TOOLS,
-        infer_source_path_tools: false,
+            portability: LabCommandPortability::LocalOnly(reason),
+            default_lab_offload: false,
+            source_path_mode: LabSourcePathMode::CwdOrPathFlag,
+            workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
+            mutation_flag: None,
+            requires_extension_parity: false,
+            extra_required_tools: LAB_NO_EXTRA_TOOLS,
+            infer_source_path_tools: false,
+        }
     }
 }
 
@@ -278,6 +252,85 @@ impl Commands {
         self.lab_contract()
             .and_then(|contract| contract.mutation_flag)
     }
+
+    pub fn lab_required_extensions(&self) -> crate::core::Result<Vec<String>> {
+        let Some(contract) = self.lab_contract() else {
+            return Ok(Vec::new());
+        };
+        if !contract.requires_extension_parity {
+            return Ok(Vec::new());
+        }
+
+        let mut extension_ids = BTreeSet::new();
+        match self {
+            Commands::Audit(args) => {
+                extension_ids.extend(args.extension_override.extensions.clone())
+            }
+            Commands::Bench(args) => {
+                extension_ids.extend(args.extension_override_ids().iter().cloned())
+            }
+            Commands::Lint(args) => {
+                extension_ids.extend(args.extension_override.extensions.clone())
+            }
+            Commands::Test(args) => {
+                extension_ids.extend(args.extension_override.extensions.clone());
+                extension_ids.extend(test_lab_extension_ids(args)?);
+            }
+            Commands::AgentTask(args) => extension_ids.extend(agent_task_lab_extension_ids(args)?),
+            _ => {}
+        }
+
+        Ok(extension_ids.into_iter().collect())
+    }
+}
+
+fn agent_task_lab_extension_ids(
+    args: &agent_task::AgentTaskArgs,
+) -> crate::core::Result<Vec<String>> {
+    let agent_task::AgentTaskCommand::RunPlan(run_plan) = &args.command else {
+        return Ok(Vec::new());
+    };
+    if run_plan.plan.trim() == "-" {
+        return Ok(Vec::new());
+    }
+
+    let plan = crate::core::agent_tasks::service::read_plan(&run_plan.plan)?;
+    Ok(crate::core::agent_tasks::required_extension_ids_for_plan(
+        &plan,
+    ))
+}
+
+fn test_lab_extension_ids(
+    args: &crate::commands::test::TestArgs,
+) -> crate::core::Result<Vec<String>> {
+    let source_context = execution_context::resolve(&ResolveOptions {
+        component_id: args.comp.component.clone(),
+        path_override: args.comp.path.clone(),
+        capability: None,
+        settings_overrides: args.setting_args.setting.clone(),
+        settings_json_overrides: args.setting_args.setting_json.clone(),
+        extension_overrides: args.extension_override.extensions.clone(),
+    })?;
+
+    if !args.drift
+        && args.ci_job.is_none()
+        && source_context
+            .component
+            .has_script(ExtensionCapability::Test)
+    {
+        return Ok(Vec::new());
+    }
+
+    let context = execution_context::resolve(&ResolveOptions {
+        component_id: args.comp.component.clone(),
+        path_override: args.comp.path.clone(),
+        capability: Some(ExtensionCapability::Test),
+        settings_overrides: args.setting_args.setting.clone(),
+        settings_json_overrides: args.setting_args.setting_json.clone(),
+        extension_overrides: args.extension_override.extensions.clone(),
+    })?;
+
+    Ok(context.extension_id.into_iter().collect())
 }
 
 #[cfg(test)]

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -152,28 +152,13 @@ impl Commands {
                 lab_offload_mutation_flag: None,
                 output_contract: CommandOutputContractKind::RawOnly,
             },
-            Commands::Test(args) => quality_json_descriptor(
+            Commands::Test(args) => args.output_descriptor(output_file_mode),
+            Commands::Bench(args) => args.output_descriptor(output_file_mode),
+            Commands::Lint(args) => args.output_descriptor(output_file_mode),
+            Commands::Audit(args) => args.output_descriptor(output_file_mode),
+            Commands::Observe(_) => quality_json_descriptor(
                 output_file_mode,
-                true,
-                args.write.then_some("--write"),
-                CommandOutputContractKind::JsonEnvelope,
-            ),
-            Commands::Bench(args) => quality_json_descriptor(
-                output_file_mode,
-                args.is_lab_offload_command(),
-                args.lab_offload_writes_local_state()
-                    .then_some("--baseline/--ratchet"),
-                CommandOutputContractKind::JsonEnvelope,
-            ),
-            Commands::Lint(args) => quality_json_descriptor(
-                output_file_mode,
-                true,
-                args.fix.then_some("--fix"),
-                CommandOutputContractKind::JsonEnvelope,
-            ),
-            Commands::Audit(_) | Commands::Observe(_) => quality_json_descriptor(
-                output_file_mode,
-                matches!(self, Commands::Audit(_)),
+                false,
                 None,
                 CommandOutputContractKind::JsonEnvelope,
             ),
@@ -255,12 +240,7 @@ impl Commands {
             | Commands::Http(_)
             | Commands::Upgrade(_)
             | Commands::Ssh(_) => ops_json_descriptor(output_file_mode, None),
-            Commands::Fleet(args) => ops_json_descriptor(
-                output_file_mode,
-                args.is_hot_resource_command().then_some(
-                    "`fleet exec` stays local because it depends on local fleet, project, and server configuration before opening SSH sessions to each project; runner-side config parity is not guaranteed.",
-                ),
-            ),
+            Commands::Fleet(args) => args.output_descriptor(output_file_mode),
             Commands::Triage(_) => ops_json_descriptor(output_file_mode, None),
         };
 

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -18,6 +18,11 @@ use super::utils::observed_workflow::{
     finish_adapted_observed_workflow, WorkflowObservationAdapter,
 };
 use super::{CmdResult, GlobalArgs};
+use crate::command_contract::{
+    CommandDescriptor, CommandOutputContractKind, CommandOutputFileMode, LabCommandContract,
+};
+
+const AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON: &str = "`audit --changed-since` is not Lab-portable yet because changed-since audit depends on git base refs that the current Lab workspace sync may not have fetched.";
 
 #[derive(Args)]
 pub struct AuditArgs {
@@ -54,6 +59,44 @@ pub struct AuditArgs {
     /// runs the refactor planner after audit completes.
     #[arg(long)]
     pub fixability: bool,
+}
+
+impl AuditArgs {
+    pub(crate) fn output_descriptor(
+        &self,
+        output_file_mode: CommandOutputFileMode,
+    ) -> CommandDescriptor {
+        CommandDescriptor {
+            response_mode: crate::command_contract::CommandResponseMode::Json,
+            output_file_mode,
+            json_family: crate::command_contract::CommandJsonFamily::Quality,
+            supports_lab_runner: true,
+            lab_runner_unsupported_reason: None,
+            lab_offload_mutation_flag: (self.baseline_args.baseline || self.baseline_args.ratchet)
+                .then_some("--baseline/--ratchet"),
+            output_contract: CommandOutputContractKind::JsonEnvelope,
+        }
+    }
+
+    pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
+        if self.changed_since.is_some() {
+            return Some(LabCommandContract::local_only(
+                "audit",
+                AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON,
+            ));
+        }
+        if self.conventions {
+            return None;
+        }
+
+        Some(LabCommandContract::portable(
+            "audit",
+            (self.baseline_args.baseline || self.baseline_args.ratchet)
+                .then_some("--baseline/--ratchet"),
+            true,
+            &[],
+        ))
+    }
 }
 
 fn parse_finding_kinds(

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -20,6 +20,10 @@ use super::utils::args::{
     PositionalComponentArgs, SettingArgs,
 };
 use super::{runs, CmdResult, GlobalArgs};
+use crate::command_contract::{
+    CommandDescriptor, CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
+    CommandResponseMode, LabCommandContract,
+};
 
 mod fanout;
 mod matrix;
@@ -36,6 +40,35 @@ pub struct BenchArgs {
 }
 
 impl BenchArgs {
+    pub(crate) fn output_descriptor(
+        &self,
+        output_file_mode: CommandOutputFileMode,
+    ) -> CommandDescriptor {
+        CommandDescriptor {
+            response_mode: CommandResponseMode::Json,
+            output_file_mode,
+            json_family: CommandJsonFamily::Quality,
+            supports_lab_runner: self.is_lab_offload_command(),
+            lab_runner_unsupported_reason: None,
+            lab_offload_mutation_flag: self
+                .lab_offload_writes_local_state()
+                .then_some("--baseline/--ratchet"),
+            output_contract: CommandOutputContractKind::JsonEnvelope,
+        }
+    }
+
+    pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
+        self.is_lab_offload_command().then(|| {
+            LabCommandContract::portable(
+                "bench",
+                self.lab_offload_writes_local_state()
+                    .then_some("--baseline/--ratchet"),
+                true,
+                &[],
+            )
+        })
+    }
+
     pub fn is_lab_offload_command(&self) -> bool {
         matches!(
             self.command,

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -8,6 +8,9 @@ use homeboy::core::project::Project;
 use homeboy::core::EntityCrudOutput;
 
 use super::{CmdResult, DynamicSetArgs};
+use crate::command_contract::{CommandDescriptor, CommandOutputFileMode, LabCommandContract};
+
+const FLEET_EXEC_LAB_UNSUPPORTED_REASON: &str = "`fleet exec` stays local because it depends on local fleet, project, and server configuration before opening SSH sessions to each project; runner-side config parity is not guaranteed.";
 
 #[derive(Args)]
 pub struct FleetArgs {
@@ -16,6 +19,29 @@ pub struct FleetArgs {
 }
 
 impl FleetArgs {
+    pub(crate) fn output_descriptor(
+        &self,
+        output_file_mode: CommandOutputFileMode,
+    ) -> CommandDescriptor {
+        CommandDescriptor {
+            response_mode: crate::command_contract::CommandResponseMode::Json,
+            output_file_mode,
+            json_family: crate::command_contract::CommandJsonFamily::Ops,
+            supports_lab_runner: false,
+            lab_runner_unsupported_reason: self
+                .is_hot_resource_command()
+                .then_some(FLEET_EXEC_LAB_UNSUPPORTED_REASON),
+            lab_offload_mutation_flag: None,
+            output_contract: crate::command_contract::CommandOutputContractKind::JsonEnvelope,
+        }
+    }
+
+    pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
+        self.is_hot_resource_command().then(|| {
+            LabCommandContract::local_only("fleet exec", FLEET_EXEC_LAB_UNSUPPORTED_REASON)
+        })
+    }
+
     pub fn is_hot_resource_command(&self) -> bool {
         matches!(self.command, FleetCommand::Exec { check: false, .. })
     }

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -3,6 +3,8 @@ use serde_json::Value;
 use crate::cli_surface::Commands;
 use crate::command_contract::CommandJsonFamily;
 
+use super::agent_task_summary::{agent_task_summary_kind, render_agent_task_summary};
+use super::output_runtime::JsonCommandRun;
 use super::GlobalArgs;
 
 mod ops;
@@ -16,6 +18,31 @@ pub fn run(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Val
     crate::commands::utils::tty::status("homeboy is working...");
 
     dispatch(command, global)
+}
+
+pub fn run_command_output(command: Commands, global: &GlobalArgs) -> JsonCommandRun {
+    crate::commands::utils::tty::status("homeboy is working...");
+
+    match command {
+        Commands::AgentTask(args) => {
+            let summary_kind = agent_task_summary_kind(&args);
+            let (stdout_result, exit_code) = dispatch(Commands::AgentTask(args), global);
+            let human_stdout = stdout_result.as_ref().ok().and_then(|payload| {
+                summary_kind.and_then(|kind| render_agent_task_summary(kind, payload))
+            });
+
+            JsonCommandRun {
+                stdout_result,
+                exit_code,
+                output_file_result: None,
+                human_stdout,
+            }
+        }
+        command => {
+            let (stdout_result, exit_code) = dispatch(command, global);
+            JsonCommandRun::from_stdout_result(stdout_result, exit_code)
+        }
+    }
 }
 
 fn dispatch(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Value>, i32) {

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -22,6 +22,12 @@ use super::utils::observed_workflow::{
     finish_adapted_observed_workflow, ObservedWorkflowRunner, WorkflowObservationAdapter,
 };
 use super::{CmdResult, GlobalArgs};
+use crate::command_contract::{
+    CommandDescriptor, CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
+    CommandResponseMode, LabCommandContract,
+};
+
+const LINT_CHANGED_SCOPE_LAB_UNSUPPORTED_REASON: &str = "Changed-scope lint runs stay local because changed-file scopes are not represented in the current Lab portability contract yet.";
 
 #[derive(Args)]
 pub struct LintArgs {
@@ -91,6 +97,36 @@ pub struct LintArgs {
 }
 
 impl LintArgs {
+    pub(crate) fn output_descriptor(
+        &self,
+        output_file_mode: CommandOutputFileMode,
+    ) -> CommandDescriptor {
+        CommandDescriptor {
+            response_mode: CommandResponseMode::Json,
+            output_file_mode,
+            json_family: CommandJsonFamily::Quality,
+            supports_lab_runner: true,
+            lab_runner_unsupported_reason: None,
+            lab_offload_mutation_flag: self.fix.then_some("--fix"),
+            output_contract: CommandOutputContractKind::JsonEnvelope,
+        }
+    }
+
+    pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
+        if self.is_full_workspace_run() {
+            return Some(LabCommandContract::portable(
+                "lint",
+                self.fix.then_some("--fix"),
+                true,
+                &[],
+            ));
+        }
+
+        (self.changed_since.is_some() || self.changed_only).then(|| {
+            LabCommandContract::local_only("lint", LINT_CHANGED_SCOPE_LAB_UNSUPPORTED_REASON)
+        })
+    }
+
     pub fn is_full_workspace_run(&self) -> bool {
         self.changed_since.is_none()
             && !self.changed_only

--- a/src/commands/output_runtime.rs
+++ b/src/commands/output_runtime.rs
@@ -3,7 +3,6 @@ use serde_json::Value;
 use crate::cli_surface::Commands;
 use crate::command_contract::CommandOutputFileMode;
 
-use super::agent_task_summary::{agent_task_summary_kind, render_agent_task_summary};
 use super::utils::response as output;
 use super::{review, trace, GlobalArgs};
 
@@ -23,6 +22,80 @@ impl JsonCommandRun {
             human_stdout: None,
         }
     }
+
+    pub fn from_raw(
+        raw_run: super::raw_output::RawCommandRun,
+    ) -> (Self, homeboy::core::Result<String>) {
+        let exit_code = raw_run.exit_code;
+        let raw_stdout = raw_run.stdout_result;
+        let output_file_result = match raw_run.output_file_result {
+            Some(result) => result,
+            None => match raw_stdout.as_ref() {
+                Ok(content) => Ok(Value::String(content.clone())),
+                Err(err) => Err(err.clone()),
+            },
+        };
+
+        (
+            Self {
+                stdout_result: output_file_result,
+                exit_code,
+                output_file_result: None,
+                human_stdout: None,
+            },
+            raw_stdout,
+        )
+    }
+}
+
+pub struct OutputService<'a> {
+    output_file: Option<&'a str>,
+}
+
+impl<'a> OutputService<'a> {
+    pub fn new(output_file: Option<&'a str>) -> Self {
+        Self { output_file }
+    }
+
+    pub fn emit_json_result(&self, result: homeboy::core::Result<Value>, exit_code: i32) {
+        let run = JsonCommandRun::from_stdout_result(result, exit_code);
+        self.write_output_file(&run, CommandOutputFileMode::GenericEnvelope);
+        output::print_json_result(run.stdout_result, run.exit_code).ok();
+    }
+
+    pub fn emit_run(&self, run: JsonCommandRun, mode: CommandOutputFileMode) -> i32 {
+        self.write_output_file(&run, mode);
+        if let Some(human_stdout) = run.human_stdout {
+            print!("{}", human_stdout);
+        } else {
+            output::print_json_result(run.stdout_result, run.exit_code).ok();
+        }
+
+        run.exit_code
+    }
+
+    pub fn emit_raw_run(
+        &self,
+        raw_run: super::raw_output::RawCommandRun,
+        mode: CommandOutputFileMode,
+    ) -> i32 {
+        let (json_run, raw_stdout) = JsonCommandRun::from_raw(raw_run);
+        let exit_code = json_run.exit_code;
+        self.write_output_file(&json_run, mode);
+
+        match raw_stdout {
+            Ok(content) => print!("{}", content),
+            Err(err) => {
+                output::print_result::<Value>(Err(err)).ok();
+            }
+        }
+
+        exit_code
+    }
+
+    pub fn write_output_file(&self, run: &JsonCommandRun, mode: CommandOutputFileMode) {
+        write_output_file(run, mode, self.output_file);
+    }
 }
 
 pub fn run_command(
@@ -32,39 +105,16 @@ pub fn run_command(
 ) -> i32 {
     let output_file = command_runtime_output_file(&command, requested_output_file);
     let plan = command.response_plan(output_file.is_some());
+    let output_service = OutputService::new(output_file);
 
     match super::raw_output::prepare_command_run(command, global, plan.stdout) {
         super::raw_output::CommandRunPreparation::Handled(exit_code) => exit_code,
         super::raw_output::CommandRunPreparation::Json(command) => {
             let run = run_json(*command, global, plan.output_file);
-            emit_run(run, plan.output_file, output_file)
+            output_service.emit_run(run, plan.output_file)
         }
         super::raw_output::CommandRunPreparation::Raw(raw_run) => {
-            let exit_code = raw_run.exit_code;
-            let output_file_result = match raw_run.output_file_result {
-                Some(result) => result,
-                None => match raw_run.stdout_result.as_ref() {
-                    Ok(content) => Ok(Value::String(content.clone())),
-                    Err(err) => Err(err.clone()),
-                },
-            };
-            let json_run = JsonCommandRun {
-                stdout_result: output_file_result,
-                exit_code,
-                output_file_result: None,
-                human_stdout: None,
-            };
-
-            write_output_file(&json_run, plan.output_file, output_file);
-
-            match raw_run.stdout_result {
-                Ok(content) => print!("{}", content),
-                Err(err) => {
-                    output::print_result::<Value>(Err(err)).ok();
-                }
-            }
-
-            exit_code
+            output_service.emit_raw_run(raw_run, plan.output_file)
         }
     }
 }
@@ -74,9 +124,7 @@ pub fn emit_json_result(
     output_file: Option<&str>,
     exit_code: i32,
 ) {
-    let run = JsonCommandRun::from_stdout_result(result, exit_code);
-    write_output_file(&run, CommandOutputFileMode::GenericEnvelope, output_file);
-    output::print_json_result(run.stdout_result, run.exit_code).ok();
+    OutputService::new(output_file).emit_json_result(result, exit_code);
 }
 
 pub fn validate_output_file_path(path: &str) -> Option<homeboy::core::Error> {
@@ -132,38 +180,8 @@ pub fn run_json(
                 human_stdout: None,
             }
         }
-        (_, Commands::AgentTask(args)) => {
-            let summary_kind = agent_task_summary_kind(&args);
-            let (stdout_result, exit_code) =
-                super::json_output::run(Commands::AgentTask(args), global);
-            let human_stdout = stdout_result.as_ref().ok().and_then(|payload| {
-                summary_kind.and_then(|kind| render_agent_task_summary(kind, payload))
-            });
-
-            JsonCommandRun {
-                stdout_result,
-                exit_code,
-                output_file_result: None,
-                human_stdout,
-            }
-        }
-        (_, command) => {
-            let (stdout_result, exit_code) = super::json_output::run(command, global);
-
-            JsonCommandRun::from_stdout_result(stdout_result, exit_code)
-        }
+        (_, command) => super::json_output::run_command_output(command, global),
     }
-}
-
-fn emit_run(run: JsonCommandRun, mode: CommandOutputFileMode, output_file: Option<&str>) -> i32 {
-    write_output_file(&run, mode, output_file);
-    if let Some(human_stdout) = run.human_stdout {
-        print!("{}", human_stdout);
-    } else {
-        output::print_json_result(run.stdout_result, run.exit_code).ok();
-    }
-
-    run.exit_code
 }
 
 pub fn write_output_file(run: &JsonCommandRun, mode: CommandOutputFileMode, path: Option<&str>) {
@@ -216,6 +234,34 @@ mod tests {
             output_file_result,
             human_stdout: None,
         }
+    }
+
+    #[test]
+    fn raw_command_run_without_artifact_uses_raw_stdout_for_file_payload() {
+        let raw_run = super::super::raw_output::RawCommandRun {
+            stdout_result: Ok("plain output".to_string()),
+            exit_code: 0,
+            output_file_result: None,
+        };
+
+        let (json_run, raw_stdout) = JsonCommandRun::from_raw(raw_run);
+
+        assert_eq!(raw_stdout.unwrap(), "plain output");
+        assert_eq!(json_run.stdout_result.unwrap(), json!("plain output"));
+    }
+
+    #[test]
+    fn raw_command_run_with_artifact_uses_artifact_for_file_payload() {
+        let raw_run = super::super::raw_output::RawCommandRun {
+            stdout_result: Ok("markdown output".to_string()),
+            exit_code: 0,
+            output_file_result: Some(Ok(json!({ "artifact": true }))),
+        };
+
+        let (json_run, raw_stdout) = JsonCommandRun::from_raw(raw_run);
+
+        assert_eq!(raw_stdout.unwrap(), "markdown output");
+        assert_eq!(json_run.stdout_result.unwrap(), json!({ "artifact": true }));
     }
 
     #[test]

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -1,21 +1,15 @@
 use homeboy::cli_surface::{Cli, Commands};
-use homeboy::command_contract::{
-    LabCommandPortability, LabCommandRequiredTool, LabWorkspaceModePolicy,
-};
+use homeboy::core::lab_routing::{self, LabRoutingRequest};
 use homeboy::core::observation::RunStatus;
 use homeboy::core::runners;
 use serde_json::json;
-use std::time::Duration;
-
-const DEFAULT_LAB_TRACE_DISPATCH_TIMEOUT_SECS: u64 = 9 * 60;
-const LAB_TRACE_DISPATCH_TIMEOUT_ENV: &str = "HOMEBOY_LAB_TRACE_DISPATCH_TIMEOUT_SECS";
 
 pub fn route_after_parse(
     cli: &Cli,
     normalized_args: &[String],
     output_file: Option<&str>,
 ) -> homeboy::core::Result<Option<i32>> {
-    if is_lab_offload_subprocess() {
+    if lab_routing::is_lab_offload_subprocess() {
         return Ok(None);
     }
 
@@ -51,19 +45,7 @@ pub fn route_after_parse(
     };
 
     let lab_result = if matches!(cli.command, Commands::Trace(_)) {
-        execute_trace_lab_offload_with_timeout(
-            lab_command,
-            normalized_args.to_vec(),
-            cli.runner.clone(),
-            cli.force_hot,
-            cli.allow_local_hot,
-            cli.allow_local_fallback,
-            cli.allow_dirty_lab_workspace,
-            cli.command.lab_offload_mutation_flag().is_some(),
-            lab_trace_dispatch_timeout(),
-        )
-    } else {
-        runners::execute_lab_offload(runners::LabOffloadRequest {
+        lab_routing::route_lab_offload(LabRoutingRequest {
             command: lab_command,
             normalized_args,
             explicit_runner: cli.runner.as_deref(),
@@ -72,6 +54,19 @@ pub fn route_after_parse(
             allow_local_fallback: cli.allow_local_fallback,
             allow_dirty_lab_workspace: cli.allow_dirty_lab_workspace,
             capture_patch: cli.command.lab_offload_mutation_flag().is_some(),
+            timeout: Some(lab_routing::lab_trace_dispatch_timeout()),
+        })
+    } else {
+        lab_routing::route_lab_offload(LabRoutingRequest {
+            command: lab_command,
+            normalized_args,
+            explicit_runner: cli.runner.as_deref(),
+            force_hot: cli.force_hot,
+            allow_local_hot: cli.allow_local_hot,
+            allow_local_fallback: cli.allow_local_fallback,
+            allow_dirty_lab_workspace: cli.allow_dirty_lab_workspace,
+            capture_patch: cli.command.lab_offload_mutation_flag().is_some(),
+            timeout: None,
         })
     };
 
@@ -174,56 +169,6 @@ fn is_lab_command_local_runner_option(command: &Commands) -> bool {
     matches!(command, Commands::Lab(_))
 }
 
-fn execute_trace_lab_offload_with_timeout(
-    command: Option<runners::LabOffloadCommand>,
-    normalized_args: Vec<String>,
-    explicit_runner: Option<String>,
-    force_hot: bool,
-    allow_local_hot: bool,
-    allow_local_fallback: bool,
-    allow_dirty_lab_workspace: bool,
-    capture_patch: bool,
-    timeout: Duration,
-) -> homeboy::core::Result<runners::LabOffloadOutcome> {
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let result = runners::execute_lab_offload(runners::LabOffloadRequest {
-            command,
-            normalized_args: &normalized_args,
-            explicit_runner: explicit_runner.as_deref(),
-            force_hot,
-            allow_local_hot,
-            allow_local_fallback,
-            allow_dirty_lab_workspace,
-            capture_patch,
-        });
-        let _ = tx.send(result);
-    });
-
-    rx.recv_timeout(timeout).map_err(|_| {
-        homeboy::core::Error::internal_unexpected(format!(
-            "Lab trace dispatch did not finish before timeout after {}s",
-            timeout.as_secs()
-        ))
-        .with_hint("Inspect the controller trace run record for the last Lab dispatch phase.".to_string())
-        .with_hint("Run `homeboy runner doctor <runner-id>` and retry after the runner is healthy.".to_string())
-        .with_hint("Use `--force-hot --allow-local-hot` only for development-only investigation while fixing Lab routing.".to_string())
-    })?
-}
-
-fn lab_trace_dispatch_timeout() -> Duration {
-    std::env::var(LAB_TRACE_DISPATCH_TIMEOUT_ENV)
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .map(Duration::from_secs)
-        .unwrap_or_else(|| Duration::from_secs(DEFAULT_LAB_TRACE_DISPATCH_TIMEOUT_SECS))
-}
-
-fn is_lab_offload_subprocess() -> bool {
-    std::env::var(homeboy::core::observation::LAB_OFFLOAD_METADATA_ENV)
-        .is_ok_and(|value| !value.trim().is_empty())
-}
-
 fn write_offloaded_stdout(path: &str, stdout: &str) -> homeboy::core::Result<()> {
     std::fs::write(path, stdout).map_err(|err| {
         homeboy::core::Error::internal_io(err.to_string(), Some(format!("write {path}")))
@@ -236,117 +181,11 @@ fn lab_offload_command(
     let Some(contract) = command.lab_contract() else {
         return Ok(None);
     };
-    let required_extensions = if contract.requires_extension_parity {
-        lab_required_extensions(command)?
-    } else {
-        Vec::new()
-    };
-    Ok(Some(runners::LabOffloadCommand {
-        hot_label: contract.hot_label,
-        portable: matches!(contract.portability, LabCommandPortability::Portable),
-        default_lab_offload: contract.default_lab_offload,
-        unsupported_reason: match contract.portability {
-            LabCommandPortability::Portable => None,
-            LabCommandPortability::LocalOnly(reason) => Some(reason),
-        },
-        workspace_mode_policy: match contract.workspace_mode_policy {
-            LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot => {
-                runners::LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot
-            }
-            LabWorkspaceModePolicy::Git => runners::LabOffloadWorkspaceModePolicy::Git,
-            LabWorkspaceModePolicy::GitCheckoutRequired => {
-                runners::LabOffloadWorkspaceModePolicy::GitCheckoutRequired
-            }
-        },
-        requires_extension_parity: contract.requires_extension_parity,
+    let required_extensions = command.lab_required_extensions()?;
+    Ok(Some(lab_routing::lab_offload_command_from_contract(
+        contract,
         required_extensions,
-        requires_playwright: contract
-            .extra_required_tools
-            .iter()
-            .any(|tool| matches!(tool, LabCommandRequiredTool::Playwright)),
-        infer_source_path_tools: contract.infer_source_path_tools,
-    }))
-}
-
-fn lab_required_extensions(command: &Commands) -> homeboy::core::Result<Vec<String>> {
-    let mut extension_ids = std::collections::BTreeSet::new();
-
-    match command {
-        Commands::Audit(args) => extension_ids.extend(args.extension_override.extensions.clone()),
-        Commands::Bench(args) => {
-            extension_ids.extend(args.extension_override_ids().iter().cloned())
-        }
-        Commands::Lint(args) => extension_ids.extend(args.extension_override.extensions.clone()),
-        Commands::Test(args) => {
-            extension_ids.extend(args.extension_override.extensions.clone());
-            extension_ids.extend(test_lab_extension_ids(args)?);
-        }
-        Commands::AgentTask(args) => extension_ids.extend(agent_task_lab_extension_ids(args)?),
-        _ => {}
-    }
-
-    Ok(extension_ids.into_iter().collect())
-}
-
-fn agent_task_lab_extension_ids(
-    args: &homeboy::commands::agent_task::AgentTaskArgs,
-) -> homeboy::core::Result<Vec<String>> {
-    let homeboy::commands::agent_task::AgentTaskCommand::RunPlan(run_plan) = &args.command else {
-        return Ok(Vec::new());
-    };
-    if run_plan.plan.trim() == "-" {
-        return Ok(Vec::new());
-    }
-    let raw = homeboy::core::config::read_json_spec_to_string(&run_plan.plan)?;
-    let plan: homeboy::core::agent_tasks::AgentTaskPlan =
-        serde_json::from_str(&raw).map_err(|error| {
-            homeboy::core::Error::validation_invalid_json(
-                error,
-                Some("agent-task run-plan Lab extension inference".to_string()),
-                Some(raw.clone()),
-            )
-        })?;
-
-    Ok(homeboy::core::agent_tasks::required_extension_ids_for_plan(
-        &plan,
-    ))
-}
-
-fn test_lab_extension_ids(
-    args: &homeboy::commands::test::TestArgs,
-) -> homeboy::core::Result<Vec<String>> {
-    let source_context = homeboy::core::engine::execution_context::resolve(
-        &homeboy::core::engine::execution_context::ResolveOptions {
-            component_id: args.comp.component.clone(),
-            path_override: args.comp.path.clone(),
-            capability: None,
-            settings_overrides: args.setting_args.setting.clone(),
-            settings_json_overrides: args.setting_args.setting_json.clone(),
-            extension_overrides: args.extension_override.extensions.clone(),
-        },
-    )?;
-
-    if !args.drift
-        && args.ci_job.is_none()
-        && source_context
-            .component
-            .has_script(homeboy::core::extension::ExtensionCapability::Test)
-    {
-        return Ok(Vec::new());
-    }
-
-    let context = homeboy::core::engine::execution_context::resolve(
-        &homeboy::core::engine::execution_context::ResolveOptions {
-            component_id: args.comp.component.clone(),
-            path_override: args.comp.path.clone(),
-            capability: Some(homeboy::core::extension::ExtensionCapability::Test),
-            settings_overrides: args.setting_args.setting.clone(),
-            settings_json_overrides: args.setting_args.setting_json.clone(),
-            extension_overrides: args.extension_override.extensions.clone(),
-        },
-    )?;
-
-    Ok(context.extension_id.into_iter().collect())
+    )))
 }
 
 #[cfg(test)]
@@ -531,9 +370,12 @@ mod tests {
 
     #[test]
     fn trace_lab_dispatch_timeout_reads_env_override() {
-        let _env = EnvGuard::set(LAB_TRACE_DISPATCH_TIMEOUT_ENV, "7");
+        let _env = EnvGuard::set(lab_routing::LAB_TRACE_DISPATCH_TIMEOUT_ENV, "7");
 
-        assert_eq!(lab_trace_dispatch_timeout(), Duration::from_secs(7));
+        assert_eq!(
+            lab_routing::lab_trace_dispatch_timeout(),
+            std::time::Duration::from_secs(7)
+        );
     }
 
     #[test]

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -21,6 +21,12 @@ use super::utils::args::{
 };
 use super::utils::observed_workflow::{finish_observed_workflow, ObservedWorkflowRunner};
 use super::{CmdResult, GlobalArgs};
+use crate::command_contract::{
+    CommandDescriptor, CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
+    CommandResponseMode, LabCommandContract,
+};
+
+const TEST_CHANGED_SINCE_LAB_UNSUPPORTED_REASON: &str = "`test --changed-since` is not Lab-portable yet because changed-since test selection depends on git base refs that the current Lab workspace sync may not have fetched.";
 
 #[derive(Args)]
 pub struct TestArgs {
@@ -79,6 +85,31 @@ pub struct TestArgs {
     /// Print compact machine-readable summary (for CI wrappers)
     #[arg(long)]
     pub json_summary: bool,
+}
+
+impl TestArgs {
+    pub(crate) fn output_descriptor(
+        &self,
+        output_file_mode: CommandOutputFileMode,
+    ) -> CommandDescriptor {
+        CommandDescriptor {
+            response_mode: CommandResponseMode::Json,
+            output_file_mode,
+            json_family: CommandJsonFamily::Quality,
+            supports_lab_runner: true,
+            lab_runner_unsupported_reason: None,
+            lab_offload_mutation_flag: self.write.then_some("--write"),
+            output_contract: CommandOutputContractKind::JsonEnvelope,
+        }
+    }
+
+    pub(crate) fn lab_contract(&self) -> LabCommandContract {
+        if self.changed_since.is_none() {
+            LabCommandContract::portable("test", self.write.then_some("--write"), true, &[])
+        } else {
+            LabCommandContract::local_only("test", TEST_CHANGED_SINCE_LAB_UNSUPPORTED_REASON)
+        }
+    }
 }
 
 /// Filter out homeboy-owned flags from trailing args before passing to extension scripts.

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -1,0 +1,226 @@
+//! Core Lab routing service used by the CLI route adapter.
+
+use std::time::Duration;
+
+use crate::command_contract::{
+    LabCommandContract, LabCommandPortability, LabCommandRequiredTool, LabWorkspaceModePolicy,
+};
+use crate::core::runners;
+use crate::core::Result;
+
+pub const DEFAULT_LAB_TRACE_DISPATCH_TIMEOUT_SECS: u64 = 9 * 60;
+pub const LAB_TRACE_DISPATCH_TIMEOUT_ENV: &str = "HOMEBOY_LAB_TRACE_DISPATCH_TIMEOUT_SECS";
+
+pub struct LabRoutingRequest<'a> {
+    pub command: Option<runners::LabOffloadCommand>,
+    pub normalized_args: &'a [String],
+    pub explicit_runner: Option<&'a str>,
+    pub force_hot: bool,
+    pub allow_local_hot: bool,
+    pub allow_local_fallback: bool,
+    pub allow_dirty_lab_workspace: bool,
+    pub capture_patch: bool,
+    pub timeout: Option<Duration>,
+}
+
+pub fn route_lab_offload(request: LabRoutingRequest<'_>) -> Result<runners::LabOffloadOutcome> {
+    if let Some(timeout) = request.timeout {
+        return execute_lab_offload_with_timeout(request, timeout);
+    }
+
+    runners::execute_lab_offload(runners::LabOffloadRequest {
+        command: request.command,
+        normalized_args: request.normalized_args,
+        explicit_runner: request.explicit_runner,
+        force_hot: request.force_hot,
+        allow_local_hot: request.allow_local_hot,
+        allow_local_fallback: request.allow_local_fallback,
+        allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
+        capture_patch: request.capture_patch,
+    })
+}
+
+pub fn lab_offload_command_from_contract(
+    contract: LabCommandContract,
+    required_extensions: Vec<String>,
+) -> runners::LabOffloadCommand {
+    runners::LabOffloadCommand {
+        hot_label: contract.hot_label,
+        portable: matches!(contract.portability, LabCommandPortability::Portable),
+        default_lab_offload: contract.default_lab_offload,
+        unsupported_reason: match contract.portability {
+            LabCommandPortability::Portable => None,
+            LabCommandPortability::LocalOnly(reason) => Some(reason),
+        },
+        workspace_mode_policy: match contract.workspace_mode_policy {
+            LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot => {
+                runners::LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot
+            }
+            LabWorkspaceModePolicy::Git => runners::LabOffloadWorkspaceModePolicy::Git,
+            LabWorkspaceModePolicy::GitCheckoutRequired => {
+                runners::LabOffloadWorkspaceModePolicy::GitCheckoutRequired
+            }
+        },
+        requires_extension_parity: contract.requires_extension_parity,
+        required_extensions,
+        requires_playwright: contract
+            .extra_required_tools
+            .iter()
+            .any(|tool| matches!(tool, LabCommandRequiredTool::Playwright)),
+        infer_source_path_tools: contract.infer_source_path_tools,
+    }
+}
+
+pub fn lab_trace_dispatch_timeout() -> Duration {
+    std::env::var(LAB_TRACE_DISPATCH_TIMEOUT_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(DEFAULT_LAB_TRACE_DISPATCH_TIMEOUT_SECS))
+}
+
+pub fn is_lab_offload_subprocess() -> bool {
+    std::env::var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV)
+        .is_ok_and(|value| !value.trim().is_empty())
+}
+
+fn execute_lab_offload_with_timeout(
+    request: LabRoutingRequest<'_>,
+    timeout: Duration,
+) -> Result<runners::LabOffloadOutcome> {
+    let command = request.command;
+    let normalized_args = request.normalized_args.to_vec();
+    let explicit_runner = request.explicit_runner.map(str::to_string);
+    let force_hot = request.force_hot;
+    let allow_local_hot = request.allow_local_hot;
+    let allow_local_fallback = request.allow_local_fallback;
+    let allow_dirty_lab_workspace = request.allow_dirty_lab_workspace;
+    let capture_patch = request.capture_patch;
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let result = runners::execute_lab_offload(runners::LabOffloadRequest {
+            command,
+            normalized_args: &normalized_args,
+            explicit_runner: explicit_runner.as_deref(),
+            force_hot,
+            allow_local_hot,
+            allow_local_fallback,
+            allow_dirty_lab_workspace,
+            capture_patch,
+        });
+        let _ = tx.send(result);
+    });
+
+    rx.recv_timeout(timeout).map_err(|_| {
+        crate::core::Error::internal_unexpected(format!(
+            "Lab trace dispatch did not finish before timeout after {}s",
+            timeout.as_secs()
+        ))
+        .with_hint("Inspect the controller trace run record for the last Lab dispatch phase.".to_string())
+        .with_hint("Run `homeboy runner doctor <runner-id>` and retry after the runner is healthy.".to_string())
+        .with_hint("Use `--force-hot --allow-local-hot` only for development-only investigation while fixing Lab routing.".to_string())
+    })?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command_contract::{
+        LabCommandContract, LabCommandPortability, LabSourcePathMode, LAB_TRACE_EXTRA_TOOLS,
+    };
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    struct EnvGuard {
+        previous: Option<String>,
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl EnvGuard {
+        fn set(value: &str) -> Self {
+            let guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
+            let previous = std::env::var(LAB_TRACE_DISPATCH_TIMEOUT_ENV).ok();
+            std::env::set_var(LAB_TRACE_DISPATCH_TIMEOUT_ENV, value);
+            Self {
+                previous,
+                _guard: guard,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(LAB_TRACE_DISPATCH_TIMEOUT_ENV, value),
+                None => std::env::remove_var(LAB_TRACE_DISPATCH_TIMEOUT_ENV),
+            }
+        }
+    }
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn lab_contract() -> LabCommandContract {
+        LabCommandContract {
+            hot_label: "trace",
+            portability: LabCommandPortability::Portable,
+            default_lab_offload: true,
+            source_path_mode: LabSourcePathMode::CwdOrPathFlag,
+            workspace_mode_policy: LabWorkspaceModePolicy::GitCheckoutRequired,
+            mutation_flag: Some("--keep-overlay"),
+            requires_extension_parity: true,
+            extra_required_tools: LAB_TRACE_EXTRA_TOOLS,
+            infer_source_path_tools: false,
+        }
+    }
+
+    #[test]
+    fn lab_offload_command_from_contract_preserves_routing_shape() {
+        let command = lab_offload_command_from_contract(
+            lab_contract(),
+            vec!["wordpress".to_string(), "playwright".to_string()],
+        );
+
+        assert_eq!(command.hot_label, "trace");
+        assert!(command.portable);
+        assert!(command.default_lab_offload);
+        assert_eq!(command.unsupported_reason, None);
+        assert_eq!(
+            command.workspace_mode_policy,
+            runners::LabOffloadWorkspaceModePolicy::GitCheckoutRequired
+        );
+        assert!(command.requires_extension_parity);
+        assert_eq!(command.required_extensions, vec!["wordpress", "playwright"]);
+        assert!(command.requires_playwright);
+        assert!(!command.infer_source_path_tools);
+    }
+
+    #[test]
+    fn route_lab_offload_runs_non_lab_contract_locally() {
+        let outcome = route_lab_offload(LabRoutingRequest {
+            command: None,
+            normalized_args: &["homeboy".to_string(), "status".to_string()],
+            explicit_runner: None,
+            force_hot: false,
+            allow_local_hot: false,
+            allow_local_fallback: false,
+            allow_dirty_lab_workspace: false,
+            capture_patch: false,
+            timeout: None,
+        })
+        .unwrap();
+
+        assert!(matches!(
+            outcome,
+            runners::LabOffloadOutcome::RunLocal { .. }
+        ));
+    }
+
+    #[test]
+    fn trace_dispatch_timeout_reads_env_override() {
+        let _env = EnvGuard::set("7");
+
+        assert_eq!(lab_trace_dispatch_timeout(), Duration::from_secs(7));
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce an `OutputService` that owns JSON stdout, raw stdout, human summary stdout, and `--output` file emission.
- Route raw output through the same command-output shape used by JSON output.
- Move output and Lab contract decisions for audit, bench, lint, test, and fleet closer to their command modules while preserving `homeboy::command_contract::*` imports.
- Keep command contract aggregation as the stable resolver surface instead of expanding central `Commands` routing tables.

Fixes #4380.
Fixes #4383.

## Testing
- `cargo fmt`
- `git diff --check -- src/command_contract/lab.rs src/command_contract/output.rs src/commands/audit.rs src/commands/bench.rs src/commands/fleet.rs src/commands/lint.rs src/commands/test.rs`
- `cargo test --release command_contract` *(timed out after compiling through the edited contract modules)*
- `cargo test --release command_contract --no-run` *(blocked by unrelated existing compile failures in `src/core/agent_task_service.rs`: missing `AgentTaskDiscoveryFilter` and `discover_runs` in tests)*
- `cargo test --release output_contracts_test` *(blocked by unrelated existing compile failures before contract assertions ran)*

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the command contract refactor, updated PR metadata, and ran formatting/test commands. Chris remains responsible for review and merge readiness.