### PR TITLE
audit: enforce thin command adapters

### DIFF
--- a/docs/commands/audit-rules.md
+++ b/docs/commands/audit-rules.md
@@ -135,6 +135,20 @@ Use source policies for architecture boundaries such as core-layer purity,
 detector implementation neutrality, or product/domain terms that belong in
 component-owned config rather than generic core code.
 
+Homeboy's own `homeboy.json` also uses this primitive for the
+`thin-command-adapters` rule. The expected boundary is:
+
+```text
+src/commands/* = clap args + typed request construction + output adaptation
+src/core/* = domain policy, orchestration, persistence, execution, artifacts
+```
+
+That rule scans command modules for direct process execution, filesystem
+mutation, run-artifact persistence, and runner orchestration markers. Existing
+orchestration-heavy command modules are allowlisted as transitional extraction
+targets; new command modules should delegate those responsibilities to `core`
+services instead of adding local exceptions.
+
 Example:
 
 ```json

--- a/docs/commands/audit-rules.md
+++ b/docs/commands/audit-rules.md
@@ -135,19 +135,23 @@ Use source policies for architecture boundaries such as core-layer purity,
 detector implementation neutrality, or product/domain terms that belong in
 component-owned config rather than generic core code.
 
-Homeboy's own `homeboy.json` also uses this primitive for the
-`thin-command-adapters` rule. The expected boundary is:
+Adapter/service layer boundaries are a natural use for this generic surface:
+a component can configure adapter paths and the responsibility markers that
+belong in its service layer. Homeboy's own `homeboy.json` uses this primitive
+for the `thin-command-adapters` rule. The configured Homeboy boundary is:
 
 ```text
 src/commands/* = clap args + typed request construction + output adaptation
 src/core/* = domain policy, orchestration, persistence, execution, artifacts
 ```
 
-That rule scans command modules for direct process execution, filesystem
-mutation, run-artifact persistence, and runner orchestration markers. Existing
-orchestration-heavy command modules are allowlisted as transitional extraction
-targets; new command modules should delegate those responsibilities to `core`
-services instead of adding local exceptions.
+That Homeboy-owned config scans command modules for direct process execution,
+filesystem mutation, run-artifact persistence, and runner orchestration markers.
+Existing orchestration-heavy command modules are allowlisted as transitional
+extraction targets; new command modules should delegate those responsibilities
+to `core` services instead of adding local exceptions. Other repositories can
+define their own adapter paths, service-layer markers, and transitional
+allowlists without changing Homeboy audit code.
 
 Example:
 

--- a/homeboy.json
+++ b/homeboy.json
@@ -383,6 +383,94 @@
           }
         ],
         "type": "forbidden_terms"
+      },
+      {
+        "allow_line_contains": [
+          "homeboy-audit: allow-thin-command-adapter"
+        ],
+        "case_insensitive": false,
+        "convention": "thin_command_adapters",
+        "default_match": "regex",
+        "description": "Command adapter boundary violation: `{term}` appears at line {line} in {classification} context `{context}`",
+        "exclude_path_contains": [
+          "src/commands/agent_task.rs",
+          "src/commands/agent_task_summary.rs",
+          "src/commands/api.rs",
+          "src/commands/auth.rs",
+          "src/commands/bench.rs",
+          "src/commands/build.rs",
+          "src/commands/cargo.rs",
+          "src/commands/changelog.rs",
+          "src/commands/daemon.rs",
+          "src/commands/db.rs",
+          "src/commands/deploy.rs",
+          "src/commands/deps.rs",
+          "src/commands/file.rs",
+          "src/commands/fleet.rs",
+          "src/commands/git.rs",
+          "src/commands/http.rs",
+          "src/commands/issues.rs",
+          "src/commands/lab.rs",
+          "src/commands/logs.rs",
+          "src/commands/observe.rs",
+          "src/commands/project.rs",
+          "src/commands/refactor.rs",
+          "src/commands/release.rs",
+          "src/commands/report.rs",
+          "src/commands/review/",
+          "src/commands/rig/",
+          "src/commands/runner/",
+          "src/commands/runs/",
+          "src/commands/self_cmd.rs",
+          "src/commands/server.rs",
+          "src/commands/ssh.rs",
+          "src/commands/stack.rs",
+          "src/commands/status.rs",
+          "src/commands/test.rs",
+          "src/commands/trace.rs",
+          "src/commands/triage.rs",
+          "src/commands/undo.rs",
+          "src/commands/version.rs",
+          "src/commands/worktree.rs"
+        ],
+        "id": "thin-command-adapters",
+        "ignore_after_line_equals": [
+          "#[cfg(test)]"
+        ],
+        "ignore_line_prefixes": [
+          "//",
+          "///",
+          "//!"
+        ],
+        "include_path_contains": [
+          "src/commands/"
+        ],
+        "kind": "source_policy_violation",
+        "severity": "warning",
+        "suggestion": "Keep command modules to clap args, typed request construction, and output adaptation; move orchestration, persistence, process execution, filesystem mutation, and artifact handling into src/core/ services.",
+        "terms": [
+          {
+            "label": "direct process execution",
+            "value": "\\bstd::process::Command\\b|\\bCommand::new\\s*\\("
+          },
+          {
+            "label": "direct filesystem mutation",
+            "value": "\\bstd::fs::(write|create_dir|create_dir_all|remove_file|remove_dir|remove_dir_all|rename|copy)\\s*\\(|\\bfs::(write|create_dir|create_dir_all|remove_file|remove_dir|remove_dir_all|rename|copy)\\s*\\("
+          },
+          {
+            "label": "direct file writer construction",
+            "value": "\\b(File::create|OpenOptions::new)\\s*\\("
+          },
+          {
+            "label": "run artifact persistence",
+            "value": "\\b(RunDir::create|write_to_run_dir|ObservationBuilder|finish_run|persist_[A-Za-z0-9_]+)\\b"
+          },
+          {
+            "label": "runner execution orchestration",
+            "value": "\\b(runner::exec|execute_[A-Za-z0-9_]+|dispatch_[A-Za-z0-9_]+)\\s*\\("
+          }
+        ],
+        "type": "forbidden_terms"
       }
     ],
     "test_wiring": {

--- a/src/core/code_audit/detectors/source_policy.rs
+++ b/src/core/code_audit/detectors/source_policy.rs
@@ -446,48 +446,47 @@ mod tests { const PACKAGE: &str = "widget-package.json"; }
     }
 
     #[test]
-    fn can_express_thin_command_adapter_policy() {
+    fn can_express_configured_adapter_layer_thinness_policy() {
         let mut rule = rule();
-        rule.id = "thin-command-adapters".to_string();
-        rule.convention = "thin_command_adapters".to_string();
-        rule.include_path_contains = vec!["src/commands/".to_string()];
-        rule.exclude_path_contains = vec!["src/commands/legacy.rs".to_string()];
+        rule.id = "adapter-layer-thinness".to_string();
+        rule.convention = "adapter_layer_thinness".to_string();
+        rule.include_path_contains = vec!["src/adapters/".to_string()];
+        rule.exclude_path_contains = vec!["src/adapters/transitional.rs".to_string()];
         rule.ignore_line_prefixes = vec!["//".to_string(), "///".to_string(), "//!".to_string()];
-        rule.description =
-            "Command adapter boundary violation: `{term}` at line {line}".to_string();
-        rule.suggestion = "Move orchestration into src/core/ services.".to_string();
+        rule.description = "Adapter layer boundary violation: `{term}` at line {line}".to_string();
+        rule.suggestion = "Move orchestration into the configured service layer.".to_string();
         rule.rule = SourcePolicyRuleBody::ForbiddenTerms {
             terms: vec![SourcePolicyTerm {
-                value: r#"\bstd::process::Command\b|\bCommand::new\s*\("#.to_string(),
-                label: Some("direct process execution".to_string()),
+                value: r#"\b(orchestrate_workflow|persist_artifact)\s*\("#.to_string(),
+                label: Some("service responsibility".to_string()),
                 match_mode: Some(SourcePolicyMatchMode::Regex),
             }],
             default_match: SourcePolicyMatchMode::Regex,
             case_insensitive: false,
         };
         let violation = rust_fp(
-            "src/commands/new_feature.rs",
+            "src/adapters/new_feature.rs",
             r#"fn run() {
-    let _child = std::process::Command::new("tool");
+    orchestrate_workflow();
 }
 "#,
         );
         let allowed_transition = rust_fp(
-            "src/commands/legacy.rs",
+            "src/adapters/transitional.rs",
             r#"fn run() {
-    let _child = std::process::Command::new("tool");
+    persist_artifact();
 }
 "#,
         );
         let comment_only = rust_fp(
-            "src/commands/comment.rs",
-            "// std::process::Command remains documented here",
+            "src/adapters/comment.rs",
+            "// orchestrate_workflow remains documented here",
         );
 
         let findings = run(&[&violation, &allowed_transition, &comment_only], &[rule]);
 
         assert_eq!(findings.len(), 1);
-        assert_eq!(findings[0].file, "src/commands/new_feature.rs");
-        assert!(findings[0].description.contains("direct process execution"));
+        assert_eq!(findings[0].file, "src/adapters/new_feature.rs");
+        assert!(findings[0].description.contains("service responsibility"));
     }
 }

--- a/src/core/code_audit/detectors/source_policy.rs
+++ b/src/core/code_audit/detectors/source_policy.rs
@@ -444,4 +444,50 @@ mod tests { const PACKAGE: &str = "widget-package.json"; }
         assert_eq!(findings[0].file, "src/core/code_audit/detectors/generic.rs");
         assert!(findings[0].description.contains("WidgetLang"));
     }
+
+    #[test]
+    fn can_express_thin_command_adapter_policy() {
+        let mut rule = rule();
+        rule.id = "thin-command-adapters".to_string();
+        rule.convention = "thin_command_adapters".to_string();
+        rule.include_path_contains = vec!["src/commands/".to_string()];
+        rule.exclude_path_contains = vec!["src/commands/legacy.rs".to_string()];
+        rule.ignore_line_prefixes = vec!["//".to_string(), "///".to_string(), "//!".to_string()];
+        rule.description =
+            "Command adapter boundary violation: `{term}` at line {line}".to_string();
+        rule.suggestion = "Move orchestration into src/core/ services.".to_string();
+        rule.rule = SourcePolicyRuleBody::ForbiddenTerms {
+            terms: vec![SourcePolicyTerm {
+                value: r#"\bstd::process::Command\b|\bCommand::new\s*\("#.to_string(),
+                label: Some("direct process execution".to_string()),
+                match_mode: Some(SourcePolicyMatchMode::Regex),
+            }],
+            default_match: SourcePolicyMatchMode::Regex,
+            case_insensitive: false,
+        };
+        let violation = rust_fp(
+            "src/commands/new_feature.rs",
+            r#"fn run() {
+    let _child = std::process::Command::new("tool");
+}
+"#,
+        );
+        let allowed_transition = rust_fp(
+            "src/commands/legacy.rs",
+            r#"fn run() {
+    let _child = std::process::Command::new("tool");
+}
+"#,
+        );
+        let comment_only = rust_fp(
+            "src/commands/comment.rs",
+            "// std::process::Command remains documented here",
+        );
+
+        let findings = run(&[&violation, &allowed_transition, &comment_only], &[rule]);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].file, "src/commands/new_feature.rs");
+        assert!(findings[0].description.contains("direct process execution"));
+    }
 }


### PR DESCRIPTION
## Summary
- Add a reusable, data-driven adapter-layer thinness guard using the existing `audit.source_policies` surface instead of hard-coding Homeboy architecture into the audit engine.
- Configure Homeboy's own `thin-command-adapters` policy for `src/commands/` vs `src/core/`, with current orchestration-heavy command modules explicitly allowlisted as transitional extraction targets.
- Document the generic adapter/service boundary pattern and Homeboy's configured command/core instance.

Closes #4384.

## Tests
- `jq empty homeboy.json`
- `git diff --check -- docs/commands/audit-rules.md homeboy.json src/core/code_audit/detectors/source_policy.rs`
- `cargo test --release core::code_audit::detectors::source_policy::tests::can_express_configured_adapter_layer_thinness_policy`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and applied the configurable audit policy, docs update, and focused source-policy regression test; Chris remains responsible for review and merge.