### PR TITLE
Fix Lab cook run id visibility before execution

### DIFF
--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -295,6 +295,26 @@ pub(super) fn agent_task_dispatch_requested_run_id(args: &[String]) -> Option<St
     None
 }
 
+pub(super) fn ensure_agent_task_dispatch_run_id(args: &[String]) -> Option<(Vec<String>, String)> {
+    let action_index = subcommand_index(args, "agent-task").and_then(|index| {
+        args.get(index + 1)
+            .filter(|arg| matches!(arg.as_str(), "dispatch" | "cook"))
+            .map(|_| index + 1)
+    })?;
+
+    if let Some(run_id) = agent_task_dispatch_requested_run_id(args) {
+        return Some((args.to_vec(), run_id));
+    }
+
+    let run_id = format!("agent-task-{}", uuid::Uuid::new_v4());
+    let mut out = Vec::with_capacity(args.len() + 2);
+    out.extend_from_slice(&args[..=action_index]);
+    out.push("--run-id".to_string());
+    out.push(run_id.clone());
+    out.extend_from_slice(&args[action_index + 1..]);
+    Some((out, run_id))
+}
+
 pub(super) fn lab_pre_dispatch_failure_message(output: &str) -> Option<String> {
     if let Some(message) = lab_pre_dispatch_dependency_failure_message(output) {
         return Some(message);
@@ -498,6 +518,59 @@ mod tests {
             ]),
             Some("dispatch-run".to_string())
         );
+    }
+
+    #[test]
+    fn ensure_agent_task_dispatch_run_id_preserves_existing_id() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--run-id".to_string(),
+            "cook-run".to_string(),
+            "--repo".to_string(),
+            "homeboy".to_string(),
+        ];
+
+        let (out, run_id) = ensure_agent_task_dispatch_run_id(&args).expect("agent task args");
+
+        assert_eq!(out, args);
+        assert_eq!(run_id, "cook-run");
+    }
+
+    #[test]
+    fn ensure_agent_task_dispatch_run_id_injects_id_before_dispatch_options() {
+        let args = vec![
+            "homeboy".to_string(),
+            "--force-hot".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--repo".to_string(),
+            "homeboy".to_string(),
+        ];
+
+        let (out, run_id) = ensure_agent_task_dispatch_run_id(&args).expect("agent task args");
+
+        assert!(run_id.starts_with("agent-task-"));
+        assert_eq!(out[0], "homeboy");
+        assert_eq!(out[1], "--force-hot");
+        assert_eq!(out[2], "agent-task");
+        assert_eq!(out[3], "cook");
+        assert_eq!(out[4], "--run-id");
+        assert_eq!(out[5], run_id);
+        assert_eq!(out[6], "--repo");
+        assert_eq!(out[7], "homeboy");
+    }
+
+    #[test]
+    fn ensure_agent_task_dispatch_run_id_ignores_other_agent_task_commands() {
+        assert!(ensure_agent_task_dispatch_run_id(&[
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "status".to_string(),
+            "run-1".to_string(),
+        ])
+        .is_none());
     }
 
     #[test]

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -60,7 +60,7 @@ use super::super::{
 };
 
 use super::agent_task_bridge::{
-    agent_task_dispatch_requested_run_id, lab_pre_dispatch_failure_message,
+    ensure_agent_task_dispatch_run_id, lab_pre_dispatch_failure_message,
     materialize_inline_agent_task_plan_arg, mirror_agent_task_run_plan_lifecycle,
     parse_offloaded_dispatch_envelope_from_outputs,
 };
@@ -745,6 +745,8 @@ fn run_lab_offload_inner(
             .build(),
         );
     }
+    let (remapped_args, agent_task_run_id) = ensure_agent_task_dispatch_run_id(&remapped_args)
+        .map_or((remapped_args, None), |(args, run_id)| (args, Some(run_id)));
 
     let mut command = command_prefix.argv;
     command.extend(
@@ -766,6 +768,14 @@ fn run_lab_offload_inner(
         runner_id,
         remote_cwd
     );
+    if let Some(run_id) = &agent_task_run_id {
+        eprintln!(
+            "Lab offload: agent-task run id `{run_id}` will be persisted before provider execution. Inspect with `homeboy agent-task status {run_id}`."
+        );
+        messages.push(format!(
+            "Lab offload: agent-task run id `{run_id}`. Inspect with `homeboy agent-task status {run_id}`."
+        ));
+    }
     let workspace_mapping_metadata = lab_workspace_mapping_metadata(&workspace_mapping);
     let mut lab_metadata = lab_offload_metadata_with_workspace_mapping(
         &plan,
@@ -915,7 +925,7 @@ fn run_lab_offload_inner(
     }
     stderr.push_str(&exec_output.stderr);
     if exit_code != 0 {
-        if let Some(run_id) = agent_task_dispatch_requested_run_id(request.normalized_args) {
+        if let Some(run_id) = agent_task_run_id.as_deref() {
             if let Some(envelope) = parse_offloaded_dispatch_envelope_from_outputs(
                 &exec_output.stdout,
                 &exec_output.stderr,


### PR DESCRIPTION
## Summary
- Ensure Lab-offloaded `agent-task cook` and `dispatch` commands have a durable `--run-id` before remote execution starts.
- Echo the durable agent-task run id in the Lab offload preamble so interrupted controller streams remain inspectable.
- Reuse the generated/preserved run id when recording Lab offload failure evidence.

Fixes #4385.

## Tests
- `cargo fmt --check`
- `git diff --check`
- Attempted targeted `cargo test --release` runs, but the active checkout had unrelated compile blockers outside this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation and tests for early Lab agent-task run-id visibility; Chris reviews and owns the change.