### PR TITLE
Add runner job log tailing

### DIFF
--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -1,10 +1,13 @@
 use std::collections::{BTreeMap, HashMap};
+use std::time::Duration;
 
 use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
 use serde_json::Value;
 
+use homeboy::core::api_jobs::{Job, JobEvent, JobStatus};
 use homeboy::core::redaction::RedactionPolicy;
+use homeboy::core::runner::runner_job_log_snapshot;
 use homeboy::core::runners::{
     self as runner, ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions,
     ReverseRunnerWorkerOutput, Runner, RunnerConnectReport, RunnerDisconnectReport,
@@ -46,8 +49,19 @@ pub enum RunnerCommandOutput {
     Doctor(doctor::RunnerDoctorOutput),
     Execution(RunnerExecOutput),
     Env(RunnerEnvOutput),
+    Job(RunnerJobOutput),
     Worker(ReverseRunnerWorkerOutput),
     Workspace(workspace::RunnerWorkspaceOutput),
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunnerJobOutput {
+    pub command: &'static str,
+    pub runner_id: String,
+    pub job_id: String,
+    pub follow: bool,
+    pub job: Job,
+    pub events: Vec<JobEvent>,
 }
 
 #[derive(Debug, Serialize)]
@@ -319,6 +333,11 @@ enum RunnerCommand {
         #[arg(long)]
         show_values: bool,
     },
+    /// Inspect or follow a runner daemon job stream
+    Job {
+        #[command(subcommand)]
+        command: RunnerJobCommand,
+    },
     /// Claim and execute one brokered reverse-runner job from this machine
     Work {
         /// Runner ID on this machine
@@ -360,6 +379,26 @@ enum RunnerCommand {
     Workspace {
         #[command(subcommand)]
         command: workspace::RunnerWorkspaceCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum RunnerJobCommand {
+    /// Show or follow durable runner daemon job events
+    Logs {
+        /// Runner ID with an active daemon connection
+        runner_id: String,
+
+        /// Runner daemon job ID from runner exec/Lab output or error details
+        job_id: String,
+
+        /// Poll until the remote job reaches a terminal state, printing new events to stderr
+        #[arg(long)]
+        follow: bool,
+
+        /// Poll interval in milliseconds when --follow is set
+        #[arg(long = "poll-ms", default_value_t = 1000)]
+        poll_ms: u64,
     },
 }
 
@@ -527,6 +566,7 @@ pub fn run(
             command,
         )),
         RunnerCommand::Env { id, show_values } => map_env(env(&id, show_values)),
+        RunnerCommand::Job { command } => map_job(job(command)),
         RunnerCommand::Work {
             runner_id,
             broker_url,
@@ -591,6 +631,10 @@ fn map_execution(result: CmdResult<RunnerExecOutput>) -> CmdResult<RunnerCommand
 
 fn map_env(result: CmdResult<RunnerEnvOutput>) -> CmdResult<RunnerCommandOutput> {
     result.map(|(output, exit_code)| (RunnerCommandOutput::Env(output), exit_code))
+}
+
+fn map_job(result: CmdResult<RunnerJobOutput>) -> CmdResult<RunnerCommandOutput> {
+    result.map(|(output, exit_code)| (RunnerCommandOutput::Job(output), exit_code))
 }
 
 fn map_worker(result: CmdResult<ReverseRunnerWorkerOutput>) -> CmdResult<RunnerCommandOutput> {
@@ -936,6 +980,80 @@ fn env(runner_id: &str, show_values: bool) -> CmdResult<RunnerEnvOutput> {
     ))
 }
 
+fn job(command: RunnerJobCommand) -> CmdResult<RunnerJobOutput> {
+    match command {
+        RunnerJobCommand::Logs {
+            runner_id,
+            job_id,
+            follow,
+            poll_ms,
+        } => job_logs(&runner_id, &job_id, follow, poll_ms),
+    }
+}
+
+fn job_logs(
+    runner_id: &str,
+    job_id: &str,
+    follow: bool,
+    poll_ms: u64,
+) -> CmdResult<RunnerJobOutput> {
+    let poll_interval = Duration::from_millis(poll_ms.max(100));
+    let mut emitted_sequence = 0;
+    let mut snapshot = runner_job_log_snapshot(runner_id, job_id)?;
+
+    emit_new_job_events(&snapshot.events, &mut emitted_sequence);
+    while follow && !runner_job_terminal(snapshot.job.status) {
+        std::thread::sleep(poll_interval);
+        snapshot = runner_job_log_snapshot(runner_id, job_id)?;
+        emit_new_job_events(&snapshot.events, &mut emitted_sequence);
+    }
+
+    Ok((
+        RunnerJobOutput {
+            command: "runner.job.logs",
+            runner_id: runner_id.to_string(),
+            job_id: job_id.to_string(),
+            follow,
+            job: snapshot.job,
+            events: snapshot.events,
+        },
+        0,
+    ))
+}
+
+fn emit_new_job_events(events: &[JobEvent], emitted_sequence: &mut u64) {
+    for event in events {
+        if event.sequence <= *emitted_sequence {
+            continue;
+        }
+        eprintln!("{}", format_job_event(event));
+        *emitted_sequence = event.sequence;
+    }
+}
+
+fn format_job_event(event: &JobEvent) -> String {
+    let kind = format!("{:?}", event.kind).to_ascii_lowercase();
+    let message = event.message.as_deref().unwrap_or("");
+    let data = event
+        .data
+        .as_ref()
+        .map(|data| serde_json::to_string(data).unwrap_or_else(|_| "null".to_string()))
+        .unwrap_or_default();
+    match (message.is_empty(), data.is_empty()) {
+        (true, true) => format!("#{:04} {}", event.sequence, kind),
+        (false, true) => format!("#{:04} {} {}", event.sequence, kind, message),
+        (true, false) => format!("#{:04} {} {}", event.sequence, kind, data),
+        (false, false) => format!("#{:04} {} {} {}", event.sequence, kind, message, data),
+    }
+}
+
+fn runner_job_terminal(status: JobStatus) -> bool {
+    matches!(
+        status,
+        JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
+    )
+}
+
 fn secret_env_reference_output(reference: RunnerSecretEnvRef) -> RunnerSecretEnvReferenceOutput {
     RunnerSecretEnvReferenceOutput {
         env: reference.env,
@@ -966,6 +1084,23 @@ mod tests {
             resources: HashMap::new(),
             policy: RunnerPolicy::default(),
         }
+    }
+
+    #[test]
+    fn runner_job_event_format_includes_sequence_kind_message_and_data() {
+        let event = JobEvent {
+            sequence: 7,
+            job_id: uuid::Uuid::nil(),
+            kind: homeboy::core::api_jobs::JobEventKind::Progress,
+            timestamp_ms: 123,
+            message: Some("cell started".to_string()),
+            data: Some(serde_json::json!({ "cell": "audit" })),
+        };
+
+        assert_eq!(
+            format_job_event(&event),
+            "#0007 progress cell started {\"cell\":\"audit\"}"
+        );
     }
 
     #[test]

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -136,6 +136,12 @@ pub struct MirroredDaemonEvidence {
 }
 
 #[derive(Debug, Clone)]
+pub struct RunnerJobLogSnapshot {
+    pub job: Job,
+    pub events: Vec<JobEvent>,
+}
+
+#[derive(Debug, Clone)]
 struct RemoteArtifactToken {
     runner_id: String,
     run_id: String,
@@ -231,6 +237,13 @@ pub fn refresh_mirrored_daemon_evidence(run_id: &str) -> Result<Option<Vec<RunRe
         .unwrap_or_default();
     mirror_job_run(&store, &runner, cwd, &command, &job, &events, &result)?;
     Ok(Some(mirror_remote_observation_runs(&store, &runner, &job)?))
+}
+
+pub fn runner_job_log_snapshot(runner_id: &str, job_id: &str) -> Result<RunnerJobLogSnapshot> {
+    Ok(RunnerJobLogSnapshot {
+        job: fetch_daemon_job(runner_id, job_id)?,
+        events: fetch_daemon_events(runner_id, job_id)?,
+    })
 }
 
 pub fn mirrored_runner_job_identity(run: &RunRecord) -> Option<(String, String)> {

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -612,6 +612,10 @@ fn daemon_job_wait_timeout(
             runner.id
         ))
         .with_hint(format!(
+            "Tail the dispatched runner daemon job with `homeboy runner job logs {} {job_id} --follow`.",
+            runner.id
+        ))
+        .with_hint(format!(
             "Runner daemon job id `{job_id}` was already dispatched; wait for it to finish or cancel it explicitly through the runner daemon if needed."
         ))
         .with_hint(timeout_hint)

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -1032,7 +1032,7 @@ fn in_flight_daemon_disconnect_error(
         "If daemon polling is unavailable, inspect from the runner with `homeboy runner exec {runner_id} -- homeboy runs list --status running --limit 20`."
     ))
     .with_hint(format!(
-        "Runner daemon job id `{job_id}` was already dispatched; use runner/job logs to decide whether to wait, cancel, or clean up."
+        "Runner daemon job id `{job_id}` was already dispatched; tail it with `homeboy runner job logs {runner_id} {job_id} --follow` to decide whether to wait, cancel, or clean up."
     ));
     disconnected.retryable = Some(false);
     disconnected

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -58,7 +58,8 @@ pub use evidence::runner_artifact_store_token;
 pub use evidence::{
     download_remote_artifact, is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,
     is_retrievable_runner_artifact, mirrored_runner_job_identity, refresh_mirrored_daemon_evidence,
-    reportable_artifact_evidence_path, RemoteArtifactDownload,
+    reportable_artifact_evidence_path, runner_job_log_snapshot, RemoteArtifactDownload,
+    RunnerJobLogSnapshot,
 };
 pub(crate) use execution::{
     daemon_api_get, execute_runner_process_until_cancelled, prepare_daemon_local_process,

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -39,6 +39,7 @@ fn includes_first_level_subcommands() {
     assert!(surface.contains_path(&["file", "upload"]));
     assert!(surface.contains_path(&["file", "copy"]));
     assert!(surface.contains_path(&["file", "sync"]));
+    assert!(surface.contains_path(&["runner", "job"]));
     assert!(surface.contains_path(&["agent-task", "loop"]));
     assert!(surface.contains_path(&["version", "show"]));
     assert!(surface.contains_path(&["worktree", "create"]));
@@ -114,6 +115,20 @@ fn upgrade_runner_selector_does_not_collide_with_global_lab_runner_flag() {
     assert!(upgrade_flags.contains("--upgrade-runner"));
     Cli::try_parse_from(["homeboy", "upgrade", "--upgrade-runner", "homeboy-lab"])
         .expect("upgrade runner selector should parse without colliding with global --runner");
+}
+
+#[test]
+fn runner_job_logs_command_parses() {
+    Cli::try_parse_from([
+        "homeboy",
+        "runner",
+        "job",
+        "logs",
+        "homeboy-lab",
+        "00000000-0000-0000-0000-000000000000",
+        "--follow",
+    ])
+    .expect("runner job logs command should parse");
 }
 
 fn documented_command_index_entries() -> BTreeSet<String> {


### PR DESCRIPTION
## Summary
- Add `homeboy runner job logs <runner-id> <job-id> --follow` to reattach to runner daemon job progress after a controller interruption.
- Expose a typed runner job log snapshot helper and include the tail command in timeout/disconnect hints.
- Add command-surface and event-format coverage for the new path.

Fixes #4387.

## Tests
- `cargo fmt --check`
- `cargo test --release --test command_surface_test`
- `cargo test --release commands::runner::tests::runner_job_event_format_includes_sequence_kind_message_and_data`
- `./target/release/homeboy runner job logs --help`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the runner job log tailing command, added focused tests, and drafted this PR summary. Chris remains responsible for review and validation.