### PR TITLE
Keep Lab cook task payloads out of argv

### DIFF
--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -653,6 +653,84 @@ mod tests {
     }
 
     #[test]
+    fn materializes_inline_agent_task_cook_tasks_json() {
+        let prompt = "Cook sensitive implementation details";
+        let tasks = serde_json::json!([{ "prompt": prompt }]).to_string();
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--tasks".to_string(),
+            tasks.clone(),
+            "--concurrency".to_string(),
+            "4".to_string(),
+        ];
+
+        let (rewritten, entry) = materialize_inline_agent_task_tasks_arg_with(&args, |spec| {
+            assert_eq!(spec, tasks);
+            Ok(Some(fake_synced_file(
+                "@/remote/input/agent-task-tasks.json",
+                "agent_task_tasks_remapped",
+            )))
+        })
+        .expect("rewrite tasks arg");
+
+        assert_eq!(
+            rewritten,
+            vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--tasks".to_string(),
+                "@/remote/input/agent-task-tasks.json".to_string(),
+                "--concurrency".to_string(),
+                "4".to_string(),
+            ]
+        );
+        assert!(!rewritten.join(" ").contains(prompt));
+        assert_eq!(entry.expect("mapping entry").remote_path(), "/remote/input");
+    }
+
+    #[test]
+    fn leaves_agent_task_tasks_file_specs_in_argv() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "dispatch".to_string(),
+            "--tasks=@tasks.json".to_string(),
+        ];
+
+        let (rewritten, entry) = materialize_inline_agent_task_tasks_arg_with(&args, |spec| {
+            assert_eq!(spec, "@tasks.json");
+            Ok(None)
+        })
+        .expect("rewrite tasks arg");
+
+        assert_eq!(rewritten, args);
+        assert!(entry.is_none());
+    }
+
+    fn fake_synced_file(remote_spec: &str, role: &str) -> (String, LabWorkspaceMappingEntry) {
+        let synced = crate::core::runner::RunnerWorkspaceSyncOutput {
+            command: "runner.workspace.sync",
+            runner_id: "lab".to_string(),
+            local_path: "/local/input".to_string(),
+            remote_path: "/remote/input".to_string(),
+            sync_mode: RunnerWorkspaceSyncMode::Snapshot,
+            snapshot_identity: "snapshot".to_string(),
+            files: 1,
+            bytes: 42,
+            excludes: Vec::new(),
+            includes: Vec::new(),
+            workspace_cleanliness: "clean".to_string(),
+        };
+        (
+            remote_spec.to_string(),
+            workspace_mapping_entry(role, &synced),
+        )
+    }
+
+    #[test]
     fn pre_dispatch_failure_message_summarizes_prepared_dependency_staging_failure() {
         let output = "ENOENT: no such file or directory, lstat '/home/chubes/Developer/.tmp/homeboy-artifacts/prepared-plugins/agents-api'";
 

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -61,8 +61,8 @@ use super::super::{
 
 use super::agent_task_bridge::{
     ensure_agent_task_dispatch_run_id, lab_pre_dispatch_failure_message,
-    materialize_inline_agent_task_plan_arg, mirror_agent_task_run_plan_lifecycle,
-    parse_offloaded_dispatch_envelope_from_outputs,
+    materialize_inline_agent_task_plan_arg, materialize_inline_agent_task_tasks_arg,
+    mirror_agent_task_run_plan_lifecycle, parse_offloaded_dispatch_envelope_from_outputs,
 };
 use super::evidence::terminal_lab_run_evidence;
 use super::secrets::{hydrate_agent_task_secret_env, hydrate_trace_secret_env};
@@ -731,6 +731,20 @@ fn run_lab_offload_inner(
     let remapped_args =
         remap_agent_task_plan_in_args(&remapped_args, &path_remaps, Path::new(&synced.local_path))?;
     let remapped_args = remap_path_settings_in_args(&remapped_args, &path_remaps);
+    let (remapped_args, synced_remapped_tasks) =
+        materialize_inline_agent_task_tasks_arg(runner_id, &remapped_args)?;
+    if let Some(entry) = synced_remapped_tasks {
+        workspace_mapping.push(entry.clone());
+        plan = with_step(
+            plan,
+            PlanStep::ready(
+                "lab.sync_remapped_agent_task_tasks",
+                "lab.sync_remapped_agent_task_tasks",
+            )
+            .inputs(PlanValues::new().json("workspace", &entry))
+            .build(),
+        );
+    }
     let (remapped_args, synced_remapped_plan) =
         materialize_inline_agent_task_plan_arg(runner_id, &remapped_args)?;
     if let Some(entry) = synced_remapped_plan {


### PR DESCRIPTION
## Summary
- Materialize inline `agent-task cook/dispatch --tasks` JSON into a synced Lab input file before remote command construction.
- Keep process-visible argv and Lab rewrite metadata on `--tasks @<remote-file>` instead of full prompt bodies.
- Add focused coverage for inline task JSON materialization and existing `@file` preservation.

Fixes #4388.

## Tests
- `git diff --cached --check` passed for the committed patch.
- `cargo test --release --lib core::runner::lab::agent_task_bridge::tests` was attempted but blocked by unrelated in-flight compile errors in the dirty checkout around `ActiveRunnerJobSummary` / `api_jobs::Job` fields.

## Notes
- The local checkout contained unrelated uncommitted edits, so the PR branch was built from `origin/main` with a temporary git index to include only the #4388 diff.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, focused tests, git staging isolation, and PR description; Chris remains responsible for review and final validation.