### PR TITLE
Keep active runner job metadata generic

### DIFF
--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -472,7 +472,7 @@ fn active_runner_job_run_summary(job: ActiveRunnerJobSummary) -> RunSummary {
             .durable_run_id
             .clone()
             .unwrap_or_else(|| format!("runner-job-{}", job.job_id)),
-        kind: "lab-runner-job".to_string(),
+        kind: job.kind.clone(),
         status: active_job_status_label(job.status).to_string(),
         started_at: ms_to_rfc3339(job.started_at_ms),
         finished_at: None,
@@ -480,8 +480,10 @@ fn active_runner_job_run_summary(job: ActiveRunnerJobSummary) -> RunSummary {
         rig_id: None,
         git_sha: None,
         command: Some(format!(
-            "{} [runner={}, job={}, durable_run={}, elapsed_ms={}, active_child_count={}, active_cell_count={}]",
+            "{} [source={}, kind={}, runner={}, job={}, durable_run={}, elapsed_ms={}, active_child_count={}, active_cell_count={}]",
             job.command,
+            job.source,
+            job.kind,
             job.runner_id,
             job.job_id,
             job.durable_run_id.as_deref().unwrap_or("unknown"),
@@ -491,7 +493,9 @@ fn active_runner_job_run_summary(job: ActiveRunnerJobSummary) -> RunSummary {
         )),
         cwd: job.cwd,
         status_note: Some(format!(
-            "active Lab runner job: runner={} job={} durable_run={} elapsed_ms={} active_child_count={} active_cell_count={}",
+            "active runner job: source={} kind={} runner={} job={} durable_run={} elapsed_ms={} active_child_count={} active_cell_count={}",
+            job.source,
+            job.kind,
             job.runner_id,
             job.job_id,
             job.durable_run_id.as_deref().unwrap_or("unknown"),

--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -86,6 +86,8 @@ pub struct ActiveRunnerJobSummary {
     pub runner_id: String,
     pub job_id: String,
     pub operation: String,
+    pub source: String,
+    pub kind: String,
     pub status: JobStatus,
     pub command: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -477,20 +479,22 @@ fn active_runner_job_summary(
         runner_id: request.runner_id.clone(),
         job_id: job.id.to_string(),
         operation: job.operation.clone(),
+        source: request_metadata_string(request, "source")
+            .unwrap_or_else(|| "runner-daemon".to_string()),
+        kind: request_metadata_string(request, "kind").unwrap_or_else(|| job.operation.clone()),
         status: job.status,
         command: request.command.join(" "),
         cwd: request.cwd.clone(),
         started_at_ms,
         elapsed_ms: now_ms.saturating_sub(started_at_ms),
-        durable_run_id: durable_agent_task_run_id(&request.command).or_else(|| {
-            request
-                .metadata
-                .as_ref()
-                .and_then(|metadata| metadata.get("durable_run_id"))
-                .and_then(Value::as_str)
-                .map(str::to_string)
-        }),
-        active_child_count: None,
+        durable_run_id: request_metadata_string(request, "durable_run_id")
+            .or_else(|| request_metadata_string(request, "run_id"))
+            .or_else(|| request_metadata_string(request, "record_run_id")),
+        active_child_count: request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("active_child_count"))
+            .and_then(Value::as_u64),
         active_cell_count: request
             .metadata
             .as_ref()
@@ -499,24 +503,16 @@ fn active_runner_job_summary(
     }
 }
 
-fn durable_agent_task_run_id(command: &[String]) -> Option<String> {
-    let action_index = command.iter().position(|arg| arg == "agent-task")? + 1;
-    command
-        .get(action_index)
-        .filter(|arg| matches!(arg.as_str(), "cook" | "dispatch"))?;
-    let mut iter = command.iter().skip(action_index + 1);
-    while let Some(arg) = iter.next() {
-        if arg == "--" {
-            break;
-        }
-        if arg == "--run-id" {
-            return iter.next().cloned();
-        }
-        if let Some(value) = arg.strip_prefix("--run-id=") {
-            return (!value.is_empty()).then(|| value.to_string());
-        }
-    }
-    None
+fn request_metadata_string(
+    request: &remote_runner::RemoteRunnerJobRequest,
+    key: &str,
+) -> Option<String> {
+    request
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get(key))
+        .and_then(Value::as_str)
+        .map(str::to_string)
 }
 
 fn read_durable_store(path: &Path) -> Result<DurableJobStore> {

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -596,7 +596,7 @@ fn active_runner_job_run_summary(job: ActiveRunnerJobSummary) -> RunSummary {
             .durable_run_id
             .clone()
             .unwrap_or_else(|| format!("runner-job-{}", job.job_id)),
-        kind: "lab-runner-job".to_string(),
+        kind: job.kind.clone(),
         status: active_job_status_label(job.status).to_string(),
         started_at: ms_to_rfc3339(job.started_at_ms),
         finished_at: None,
@@ -604,8 +604,10 @@ fn active_runner_job_run_summary(job: ActiveRunnerJobSummary) -> RunSummary {
         rig_id: None,
         git_sha: None,
         command: Some(format!(
-            "{} [runner={}, job={}, durable_run={}, elapsed_ms={}, active_child_count={}, active_cell_count={}]",
+            "{} [source={}, kind={}, runner={}, job={}, durable_run={}, elapsed_ms={}, active_child_count={}, active_cell_count={}]",
             job.command,
+            job.source,
+            job.kind,
             job.runner_id,
             job.job_id,
             job.durable_run_id.as_deref().unwrap_or("unknown"),
@@ -619,7 +621,9 @@ fn active_runner_job_run_summary(job: ActiveRunnerJobSummary) -> RunSummary {
         )),
         cwd: job.cwd,
         status_note: Some(format!(
-            "active Lab runner job: runner={} job={} durable_run={} elapsed_ms={} active_child_count={} active_cell_count={}",
+            "active runner job: source={} kind={} runner={} job={} durable_run={} elapsed_ms={} active_child_count={} active_cell_count={}",
+            job.source,
+            job.kind,
             job.runner_id,
             job.job_id,
             job.durable_run_id.as_deref().unwrap_or("unknown"),

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -310,7 +310,13 @@ fn runs_list_includes_active_runner_jobs() {
                 capture_patch: false,
                 source_snapshot: None,
                 require_paths: Vec::new(),
-                metadata: None,
+                metadata: Some(serde_json::json!({
+                    "source": "lab",
+                    "kind": "agent-task-cook",
+                    "durable_run_id": "cook-durable-run",
+                    "active_child_count": 2,
+                    "active_cell_count": 1
+                })),
             })
             .expect("submit runner job");
         store.start(job.id).expect("start runner job");
@@ -328,18 +334,25 @@ fn runs_list_includes_active_runner_jobs() {
         let runs = response.body["runs"].as_array().expect("runs");
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0]["id"], "cook-durable-run");
-        assert_eq!(runs[0]["kind"], "lab-runner-job");
+        assert_eq!(runs[0]["kind"], "agent-task-cook");
         assert_eq!(runs[0]["status"], "running");
         let note = runs[0]["status_note"].as_str().expect("status note");
+        assert!(note.contains("source=lab"));
+        assert!(note.contains("kind=agent-task-cook"));
         assert!(note.contains("runner=homeboy-lab"));
         assert!(note.contains(&format!("job={}", job.id)));
         assert!(note.contains("durable_run=cook-durable-run"));
         assert!(note.contains("elapsed_ms="));
-        assert!(note.contains("active_child_count="));
-        assert!(note.contains("active_cell_count="));
+        assert!(note.contains("active_child_count=2"));
+        assert!(note.contains("active_cell_count=1"));
         assert_eq!(
             response.body["active_runner_jobs"][0]["runner_id"],
             "homeboy-lab"
+        );
+        assert_eq!(response.body["active_runner_jobs"][0]["source"], "lab");
+        assert_eq!(
+            response.body["active_runner_jobs"][0]["kind"],
+            "agent-task-cook"
         );
         assert_eq!(
             response.body["active_runner_jobs"][0]["durable_run_id"],


### PR DESCRIPTION
## Summary
- Keep active runner job summaries reusable by sourcing `source`, `kind`, durable run id, and active counts from generic runner job metadata.
- Stop deriving durable run ids from Homeboy-specific `agent-task cook/dispatch` argv patterns.
- Render synthetic active runner rows with generic `source`/`kind` labels instead of `lab-runner-job` / `active Lab runner job` wording.

## Tests
- `cargo test --release runs_list_includes_active_runner_jobs`

## Validation notes
- This follow-up branch is based on current `origin/main` after #4408 merged and contains one commit: `fix: keep active runner job metadata generic`.
- I did not rerun broad `cargo test --release http_api` in the dirty local checkout because it contains unrelated minion changes; the earlier broad failure came from the pre-merge/minion checkout state, not from a clean validation of this new branch.

Follow-up to #4408 and #4389.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the generic active runner metadata follow-up, focused validation, and PR preparation.