### PR TITLE
fix: accept bench diagnostic severity

### DIFF
--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -653,6 +653,7 @@ fn bench_artifact_diagnostic(
     BenchDiagnostic {
         class: class.to_string(),
         message: Some(message),
+        severity: None,
         source: Some(match run_index {
             Some(run_index) => BenchDiagnosticSource::ScenarioRun {
                 scenario_id: scenario_id.to_string(),

--- a/src/core/extension/bench/diagnostic.rs
+++ b/src/core/extension/bench/diagnostic.rs
@@ -15,6 +15,8 @@ pub struct BenchDiagnostic {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub severity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<BenchDiagnosticSource>,
     #[serde(default, alias = "details", skip_serializing_if = "BTreeMap::is_empty")]
     pub metadata: BTreeMap<String, serde_json::Value>,
@@ -172,16 +174,18 @@ mod tests {
     #[test]
     fn diagnostic_accepts_code_as_class_alias() {
         let diagnostic: BenchDiagnostic = serde_json::from_str(
-            r#"{"code":"wordpress.bench.stdout_noise","message":"captured non-JSON stdout","details":{"line_count":3}}"#,
+            r#"{"code":"wordpress.bench.stdout_noise","message":"captured non-JSON stdout","severity":"warning","details":{"line_count":3}}"#,
         )
         .expect("diagnostic with code alias parses");
 
         assert_eq!(diagnostic.class, "wordpress.bench.stdout_noise");
         assert_eq!(diagnostic.message.as_deref(), Some("captured non-JSON stdout"));
+        assert_eq!(diagnostic.severity.as_deref(), Some("warning"));
         assert_eq!(diagnostic.metadata["line_count"], 3);
 
         let serialized = serde_json::to_value(&diagnostic).expect("diagnostic serializes");
         assert_eq!(serialized["class"], "wordpress.bench.stdout_noise");
+        assert_eq!(serialized["severity"], "warning");
         assert_eq!(serialized["metadata"]["line_count"], 3);
         assert!(serialized.get("code").is_none());
         assert!(serialized.get("details").is_none());
@@ -191,6 +195,7 @@ mod tests {
         BenchDiagnostic {
             class: class.to_string(),
             message: None,
+            severity: None,
             source: None,
             metadata: BTreeMap::new(),
         }

--- a/tests/core/extension/bench/report_comparison_test.rs
+++ b/tests/core/extension/bench/report_comparison_test.rs
@@ -238,6 +238,7 @@ mod fixtures {
         BenchDiagnostic {
             class: class.to_string(),
             message: Some("database setup failed".to_string()),
+            severity: None,
             source: Some(BenchDiagnosticSource::Run),
             metadata: BTreeMap::new(),
         }


### PR DESCRIPTION
## Summary
- Accept `severity` on bench diagnostics as an optional first-class field.
- Keep existing `code`/`details` aliases intact while preserving canonical serialization.
- Normalize producer-owned string diagnostic `source` values into `metadata.producer_source`, keeping Homeboy's canonical `source` field reserved for run/scenario provenance.
- Update existing diagnostic initializers for the new optional field.

## Testing
- `cargo test diagnostic_accepts_code_as_class_alias`
- `cargo test parses_extension_diagnostics_with_producer_source`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WP Codebox diagnostic schema mismatch exposed by the Woo checkout evidence run, drafted the minimal schema/parser updates, and ran targeted verification. Chris remains responsible for review and merge.