### PR TITLE
Fix runner rig source refresh before offload

### DIFF
--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -33,6 +33,13 @@ impl RigArgs {
     pub fn is_check_command(&self) -> bool {
         matches!(self.command, RigCommand::Check { .. })
     }
+
+    pub fn is_runner_source_management_command(&self) -> bool {
+        matches!(
+            self.command,
+            RigCommand::Install { .. } | RigCommand::Sources { .. }
+        )
+    }
 }
 
 #[derive(Subcommand)]

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -1,8 +1,10 @@
 use homeboy::cli_surface::{Cli, Commands};
 use homeboy::core::lab_routing::{self, LabRoutingRequest};
 use homeboy::core::observation::RunStatus;
+use homeboy::core::runner::RunnerExecOptions;
 use homeboy::core::runners;
 use serde_json::json;
+use std::collections::HashMap;
 
 pub fn route_after_parse(
     cli: &Cli,
@@ -23,6 +25,18 @@ pub fn route_after_parse(
 
     if is_lab_command_local_runner_option(&cli.command) {
         return Ok(None);
+    }
+
+    if let (Some(runner_id), Commands::Rig(args)) = (cli.runner.as_deref(), &cli.command) {
+        if args.is_runner_source_management_command() {
+            let (stdout, stderr, exit_code) =
+                run_rig_source_management_on_runner(runner_id, normalized_args, output_file)?;
+            if !stderr.is_empty() {
+                eprint!("{stderr}");
+            }
+            print!("{stdout}");
+            return Ok(Some(exit_code));
+        }
     }
 
     let lab_command = lab_offload_command(&cli.command)?;
@@ -149,6 +163,66 @@ pub fn route_after_parse(
             }
         },
     }
+}
+
+fn run_rig_source_management_on_runner(
+    runner_id: &str,
+    normalized_args: &[String],
+    output_file: Option<&str>,
+) -> homeboy::core::Result<(String, String, i32)> {
+    let runner = runners::load(runner_id)?;
+    let homeboy_path = runner.settings.homeboy_path.as_deref().unwrap_or("homeboy");
+    let command = runner_rig_source_management_command(homeboy_path, normalized_args);
+    let (output, exit_code) = runners::exec(
+        runner_id,
+        RunnerExecOptions {
+            cwd: runner.workspace_root.clone(),
+            project_id: None,
+            allow_diagnostic_ssh: false,
+            command,
+            env: HashMap::new(),
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: None,
+            capability_preflight: None,
+            required_extensions: Vec::new(),
+            require_paths: Vec::new(),
+        },
+    )?;
+
+    if let Some(path) = output_file {
+        write_offloaded_stdout(path, &output.stdout)?;
+    }
+
+    Ok((output.stdout, output.stderr, exit_code))
+}
+
+fn runner_rig_source_management_command(
+    homeboy_path: &str,
+    normalized_args: &[String],
+) -> Vec<String> {
+    let mut command = vec![homeboy_path.to_string()];
+    let mut iter = normalized_args.iter().skip(1).peekable();
+    while let Some(arg) = iter.next() {
+        if arg == "--runner" || arg == "--output" || arg == "--artifact-root" {
+            iter.next();
+            continue;
+        }
+        if arg == "--allow-local-fallback"
+            || arg == "--allow-dirty-lab-workspace"
+            || arg == "--allow-local-hot"
+        {
+            continue;
+        }
+        if arg.starts_with("--runner=")
+            || arg.starts_with("--output=")
+            || arg.starts_with("--artifact-root=")
+        {
+            continue;
+        }
+        command.push(arg.clone());
+    }
+    command
 }
 
 fn is_runs_list_runner_option(args: &[String]) -> bool {
@@ -388,6 +462,30 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(output_path).unwrap(),
             "{\"ok\":true}\n"
+        );
+    }
+
+    #[test]
+    fn runner_rig_source_management_command_strips_controller_globals() {
+        let normalized = vec![
+            "homeboy".to_string(),
+            "rig".to_string(),
+            "sources".to_string(),
+            "list".to_string(),
+            "--runner".to_string(),
+            "homeboy-lab".to_string(),
+            "--output=./sources.json".to_string(),
+            "--allow-local-fallback".to_string(),
+        ];
+
+        assert_eq!(
+            runner_rig_source_management_command("/usr/local/bin/homeboy", &normalized),
+            vec![
+                "/usr/local/bin/homeboy".to_string(),
+                "rig".to_string(),
+                "sources".to_string(),
+                "list".to_string(),
+            ]
         );
     }
 

--- a/src/core/runner/rig_materialization.rs
+++ b/src/core/runner/rig_materialization.rs
@@ -28,6 +28,8 @@ pub(super) struct LabOffloadRigSync {
     pub rig_id: String,
     pub source: String,
     pub source_kind: LabOffloadRigSyncSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub removed_source: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -91,6 +93,9 @@ pub(super) fn sync_lab_offload_rigs(
             )
         };
 
+        let removed_source =
+            remove_runner_installed_rig_source(runner_id, command_path, remote_cwd, rig_id)?;
+
         let (output, exit_code) = exec(
             runner_id,
             RunnerExecOptions {
@@ -133,10 +138,129 @@ pub(super) fn sync_lab_offload_rigs(
             rig_id: rig_id.clone(),
             source,
             source_kind,
+            removed_source,
         });
     }
 
     Ok(synced_rigs)
+}
+
+fn remove_runner_installed_rig_source(
+    runner_id: &str,
+    command_path: &str,
+    remote_cwd: &str,
+    rig_id: &str,
+) -> Result<Option<String>> {
+    let (list_output, list_exit_code) = exec(
+        runner_id,
+        RunnerExecOptions {
+            cwd: Some(remote_cwd.to_string()),
+            project_id: None,
+            allow_diagnostic_ssh: false,
+            command: vec![
+                command_path.to_string(),
+                "rig".to_string(),
+                "sources".to_string(),
+                "list".to_string(),
+            ],
+            env: HashMap::new(),
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: None,
+            capability_preflight: None,
+            required_extensions: Vec::new(),
+            require_paths: Vec::new(),
+        },
+    )?;
+    if list_exit_code != 0 {
+        return Err(Error::validation_invalid_argument(
+            "rig",
+            format!(
+                "runner dispatch could not inspect installed rig sources on runner `{runner_id}`"
+            ),
+            Some(rig_id.to_string()),
+            Some(vec![list_output.stderr.trim().to_string()]),
+        ));
+    }
+
+    let Some(selector) = installed_source_selector_for_rig(&list_output.stdout, rig_id)? else {
+        return Ok(None);
+    };
+
+    let (remove_output, remove_exit_code) = exec(
+        runner_id,
+        RunnerExecOptions {
+            cwd: Some(remote_cwd.to_string()),
+            project_id: None,
+            allow_diagnostic_ssh: false,
+            command: vec![
+                command_path.to_string(),
+                "rig".to_string(),
+                "sources".to_string(),
+                "remove".to_string(),
+                selector.clone(),
+            ],
+            env: HashMap::new(),
+            capture_patch: false,
+            raw_exec: false,
+            source_snapshot: None,
+            capability_preflight: None,
+            required_extensions: Vec::new(),
+            require_paths: Vec::new(),
+        },
+    )?;
+    if remove_exit_code != 0 {
+        return Err(Error::validation_invalid_argument(
+            "rig",
+            format!("runner dispatch could not remove stale rig source for `{rig_id}` on runner `{runner_id}`"),
+            Some(rig_id.to_string()),
+            Some(vec![remove_output.stderr.trim().to_string()]),
+        ));
+    }
+
+    Ok(Some(selector))
+}
+
+fn installed_source_selector_for_rig(stdout: &str, rig_id: &str) -> Result<Option<String>> {
+    let value: serde_json::Value = serde_json::from_str(stdout).map_err(|e| {
+        Error::validation_invalid_json(
+            e,
+            Some("parse runner rig sources list output".to_string()),
+            Some(stdout.chars().take(200).collect()),
+        )
+    })?;
+    let sources = value
+        .get("data")
+        .and_then(|data| data.get("report"))
+        .and_then(|report| report.get("sources"))
+        .and_then(|sources| sources.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    for source in sources {
+        let has_rig = source
+            .get("rigs")
+            .and_then(|rigs| rigs.as_array())
+            .is_some_and(|rigs| {
+                rigs.iter().any(|rig| {
+                    rig.get("id")
+                        .and_then(|id| id.as_str())
+                        .is_some_and(|id| id == rig_id)
+                })
+            });
+        if !has_rig {
+            continue;
+        }
+        for key in ["package_id", "package_path", "source"] {
+            if let Some(selector) = source.get(key).and_then(|value| value.as_str()) {
+                if !selector.trim().is_empty() {
+                    return Ok(Some(selector.to_string()));
+                }
+            }
+        }
+    }
+
+    Ok(None)
 }
 
 pub(super) fn remap_bench_rig_default_component_to_primary_snapshot(
@@ -488,6 +612,57 @@ fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn installed_source_selector_prefers_package_id_for_matching_rig() {
+        let stdout = serde_json::json!({
+            "success": true,
+            "data": {
+                "command": "rig.sources.list",
+                "report": {
+                    "sources": [
+                        {
+                            "source": "/runner/old-source",
+                            "package_id": "old-source",
+                            "package_path": "/runner/old-source",
+                            "rigs": [{ "id": "target-rig" }]
+                        }
+                    ]
+                }
+            }
+        })
+        .to_string();
+
+        assert_eq!(
+            installed_source_selector_for_rig(&stdout, "target-rig").unwrap(),
+            Some("old-source".to_string())
+        );
+    }
+
+    #[test]
+    fn installed_source_selector_ignores_unrelated_sources() {
+        let stdout = serde_json::json!({
+            "success": true,
+            "data": {
+                "report": {
+                    "sources": [
+                        {
+                            "source": "/runner/old-source",
+                            "package_id": "old-source",
+                            "package_path": "/runner/old-source",
+                            "rigs": [{ "id": "other-rig" }]
+                        }
+                    ]
+                }
+            }
+        })
+        .to_string();
+
+        assert_eq!(
+            installed_source_selector_for_rig(&stdout, "target-rig").unwrap(),
+            None
+        );
+    }
 
     #[test]
     fn extracts_unique_bench_rig_ids_for_lab_materialization() {


### PR DESCRIPTION
## Summary
- Route `homeboy rig install` and `homeboy rig sources` commands through the selected runner when `--runner` is provided.
- Refresh stale runner-side rig source ownership before offloaded rig materialization reinstalls the current synced rig package.
- Record the removed runner source in Lab offload rig sync metadata for troubleshooting.

Fixes #4441.
Fixes #4442.

## Testing
- `cargo fmt`
- `cargo test commands::route::tests`
- `cargo test core::runner::rig_materialization::tests`
- `cargo test --test output_errors`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner routing and stale-source refresh fix, added targeted tests, and ran verification. Chris remains responsible for review and merge.