### PR TITLE
fix: support runner agent task provider discovery

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -94,6 +94,16 @@ impl Commands {
                     LAB_NO_EXTRA_TOOLS,
                 )
             }
+            Commands::AgentTask(args)
+                if matches!(args.command, agent_task::AgentTaskCommand::Providers(_)) =>
+            {
+                LabCommandContract::explicit_runner(
+                    "agent-task providers",
+                    None,
+                    false,
+                    LAB_NO_EXTRA_TOOLS,
+                )
+            }
             Commands::Audit(args) => args.lab_contract()?,
             Commands::Bench(args) => args.lab_contract()?,
             Commands::Extension(args) if args.is_update_command() => {
@@ -403,6 +413,7 @@ mod tests {
             parsed_command(&["homeboy", "agent-task", "artifacts", "agent-task-123"])
                 .supports_lab_runner()
         );
+        assert!(parsed_command(&["homeboy", "agent-task", "providers"]).supports_lab_runner());
         assert!(parsed_command(&[
             "homeboy",
             "agent-task",
@@ -518,6 +529,10 @@ mod tests {
             (
                 parsed_command(&["homeboy", "agent-task", "artifacts", "agent-task-123"]),
                 "agent-task status/logs/artifacts",
+            ),
+            (
+                parsed_command(&["homeboy", "agent-task", "providers"]),
+                "agent-task providers",
             ),
         ];
 

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -566,6 +566,27 @@ mod tests {
     }
 
     #[test]
+    fn agent_task_providers_supports_explicit_runner_discovery() {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "--runner",
+            "homeboy-lab",
+            "agent-task",
+            "providers",
+        ]);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+        assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+        assert_eq!(command.hot_label, "agent-task providers");
+        assert!(command.portable);
+        assert!(!command.default_lab_offload);
+        assert!(!command.requires_extension_parity);
+        assert!(command.required_extensions.is_empty());
+        assert!(!command.infer_source_path_tools);
+    }
+
+    #[test]
     fn lab_command_with_mutation_flag_stays_portable_for_patch_capture() {
         let cli = Cli::parse_from(["homeboy", "audit", "--baseline"]);
 

--- a/src/core/extension/bench/diagnostic.rs
+++ b/src/core/extension/bench/diagnostic.rs
@@ -179,7 +179,10 @@ mod tests {
         .expect("diagnostic with code alias parses");
 
         assert_eq!(diagnostic.class, "wordpress.bench.stdout_noise");
-        assert_eq!(diagnostic.message.as_deref(), Some("captured non-JSON stdout"));
+        assert_eq!(
+            diagnostic.message.as_deref(),
+            Some("captured non-JSON stdout")
+        );
         assert_eq!(diagnostic.severity.as_deref(), Some("warning"));
         assert_eq!(diagnostic.metadata["line_count"], 3);
 

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -163,7 +163,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             "runner",
             message,
             Some(runner_id.to_string()),
-            Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+            Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
         )
     };
     let mut plan = base_lab_plan(request.command.as_ref());
@@ -171,7 +171,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if let Some(runner_id) = request.explicit_runner {
             return Err(unsupported_runner_error(
                 runner_id,
-                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, lint, test, audit, bench, trace, and refactor source runs".to_string(),
             ));
         }
         return Ok(LabOffloadOutcome::RunLocal {
@@ -184,7 +184,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.portable {
         if let Some(runner_id) = request.explicit_runner {
             let message = contract.unsupported_reason.map_or_else(
-                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
             );
             return Err(unsupported_runner_error(runner_id, message));

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -348,14 +348,14 @@ pub(super) fn resolve_lab_runner_selection_from_default(
     if let Some(runner_id) = explicit_runner {
         if !command.portable {
             let message = command.unsupported_reason.map_or_else(
-                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this hot command. {reason}"),
             );
             return Err(Error::validation_invalid_argument(
                 "runner",
                 message,
                 Some(runner_id.to_string()),
-                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
             ));
         }
 


### PR DESCRIPTION
## Summary
- Adds an explicit-runner Lab contract for `homeboy agent-task providers`, so `--runner <id>` routes provider discovery to the selected runner.
- Keeps plain `homeboy agent-task providers` controller-local by disabling automatic/default Lab offload for this inspection command.
- Updates Lab support guidance strings and focused contract/route tests for the new provider discovery UX.

Closes #4445.

## Testing
- `cargo fmt --check`
- `cargo test command_contract::lab::tests`
- `cargo test commands::route::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected the Homeboy Lab routing/provider discovery code, drafted the focused code/test changes, ran verification, and prepared this PR for Chris to review.