### PR TITLE
Split output descriptors from Lab policy

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -6,8 +6,9 @@
 //! `crate::command_contract::*` or `homeboy::command_contract::*` — and put
 //! implementation details in the matching submodule:
 //!
-//! - [`output`] owns response-mode, output-file, JSON-family, descriptor,
-//!   response-plan types, and the `Commands` impl that resolves them.
+//! - [`output`] owns response-mode, output-file, JSON-family,
+//!   output-descriptor, aggregate-descriptor, response-plan types, and the
+//!   `Commands` impl that resolves them.
 //! - [`lab`] owns Lab portability contracts and the `Commands` accessors
 //!   that surface Lab fields on a descriptor.
 //! - [`public_variants`] owns [`PublicOutputVariantContract`] and the
@@ -23,7 +24,8 @@ pub use lab::{
     LabWorkspaceModePolicy, LAB_TRACE_EXTRA_TOOLS,
 };
 pub use output::{
-    CommandDescriptor, CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
-    CommandRawOutputMode, CommandResponseMode, CommandResponsePlan, CommandStdoutMode,
+    CommandDescriptor, CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor,
+    CommandOutputFileMode, CommandRawOutputMode, CommandResponseMode, CommandResponsePlan,
+    CommandStdoutMode,
 };
 pub use public_variants::{PublicOutputVariantContract, PUBLIC_OUTPUT_VARIANT_CONTRACTS};

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -2,9 +2,10 @@
 //!
 //! This module owns the shapes that describe how a command emits output
 //! (`CommandResponseMode`, `CommandStdoutMode`, `CommandOutputFileMode`,
-//! `CommandJsonFamily`, `CommandOutputContractKind`) plus the
-//! [`CommandDescriptor`] / [`CommandResponsePlan`] aggregates and the
-//! `Commands` impl that resolves a parsed CLI command into a descriptor.
+//! `CommandJsonFamily`, `CommandOutputContractKind`) plus the output-only
+//! [`CommandOutputDescriptor`], aggregate [`CommandDescriptor`],
+//! [`CommandResponsePlan`], and the `Commands` impl that resolves a parsed CLI
+//! command into these contracts.
 //!
 //! Lab-specific fields on [`CommandDescriptor`] are populated by
 //! [`crate::command_contract::lab`], which post-processes the descriptor
@@ -57,6 +58,14 @@ pub enum CommandOutputContractKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandOutputDescriptor {
+    pub response_mode: CommandResponseMode,
+    pub output_file_mode: CommandOutputFileMode,
+    pub json_family: CommandJsonFamily,
+    pub output_contract: CommandOutputContractKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CommandDescriptor {
     pub response_mode: CommandResponseMode,
     pub output_file_mode: CommandOutputFileMode,
@@ -67,6 +76,25 @@ pub struct CommandDescriptor {
     pub output_contract: CommandOutputContractKind,
 }
 
+impl CommandOutputDescriptor {
+    pub fn with_lab_contract(
+        self,
+        contract: Option<super::lab::LabCommandContract>,
+    ) -> CommandDescriptor {
+        let mut descriptor = CommandDescriptor {
+            response_mode: self.response_mode,
+            output_file_mode: self.output_file_mode,
+            json_family: self.json_family,
+            supports_lab_runner: false,
+            lab_runner_unsupported_reason: None,
+            lab_offload_mutation_flag: None,
+            output_contract: self.output_contract,
+        };
+        apply_lab_contract_to_descriptor(&mut descriptor, contract);
+        descriptor
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CommandResponsePlan {
     pub stdout: CommandStdoutMode,
@@ -75,6 +103,11 @@ pub struct CommandResponsePlan {
 
 impl Commands {
     pub fn descriptor(&self, has_output_file: bool) -> CommandDescriptor {
+        self.output_descriptor(has_output_file)
+            .with_lab_contract(self.lab_contract())
+    }
+
+    pub fn output_descriptor(&self, has_output_file: bool) -> CommandOutputDescriptor {
         let output_file_mode = if !has_output_file {
             CommandOutputFileMode::None
         } else {
@@ -87,13 +120,17 @@ impl Commands {
             }
         };
 
-        let mut descriptor = match self {
+        match self {
             Commands::Ssh(args) if args.subcommand.is_none() && args.command.is_empty() => {
-                raw_ops_descriptor(CommandRawOutputMode::InteractivePassthrough, output_file_mode)
+                raw_ops_descriptor(
+                    CommandRawOutputMode::InteractivePassthrough,
+                    output_file_mode,
+                )
             }
-            Commands::Logs(args) if logs::is_interactive(args) => {
-                raw_ops_descriptor(CommandRawOutputMode::InteractivePassthrough, output_file_mode)
-            }
+            Commands::Logs(args) if logs::is_interactive(args) => raw_ops_descriptor(
+                CommandRawOutputMode::InteractivePassthrough,
+                output_file_mode,
+            ),
             Commands::File(args) if file::is_raw_read(args) => {
                 raw_ops_descriptor(CommandRawOutputMode::PlainText, output_file_mode)
             }
@@ -111,22 +148,16 @@ impl Commands {
                 output_file_mode,
                 CommandOutputContractKind::JsonEnvelope,
             ),
-            Commands::Review(args) => CommandDescriptor {
+            Commands::Review(args) => CommandOutputDescriptor {
                 response_mode: markdown_or_json_response(review::is_markdown_mode(args)),
                 output_file_mode,
                 json_family: CommandJsonFamily::Quality,
-                supports_lab_runner: false,
-                lab_runner_unsupported_reason: None,
-                lab_offload_mutation_flag: None,
                 output_contract: CommandOutputContractKind::JsonEnvelope,
             },
-            Commands::Trace(args) => CommandDescriptor {
+            Commands::Trace(args) => CommandOutputDescriptor {
                 response_mode: markdown_or_json_response(trace::is_markdown_mode(args)),
                 output_file_mode,
                 json_family: CommandJsonFamily::Quality,
-                supports_lab_runner: true,
-                lab_runner_unsupported_reason: None,
-                lab_offload_mutation_flag: args.keep_overlay.then_some("--keep-overlay"),
                 output_contract: CommandOutputContractKind::JsonEnvelope,
             },
             Commands::Runs(args) => workspace_descriptor(
@@ -143,40 +174,26 @@ impl Commands {
                 output_file_mode,
                 CommandOutputContractKind::JsonEnvelope,
             ),
-            Commands::List => CommandDescriptor {
+            Commands::List => CommandOutputDescriptor {
                 response_mode: CommandResponseMode::Raw(CommandRawOutputMode::Markdown),
                 output_file_mode,
                 json_family: CommandJsonFamily::RawOnly,
-                supports_lab_runner: false,
-                lab_runner_unsupported_reason: None,
-                lab_offload_mutation_flag: None,
                 output_contract: CommandOutputContractKind::RawOnly,
             },
             Commands::Test(args) => args.output_descriptor(output_file_mode),
             Commands::Bench(args) => args.output_descriptor(output_file_mode),
             Commands::Lint(args) => args.output_descriptor(output_file_mode),
             Commands::Audit(args) => args.output_descriptor(output_file_mode),
-            Commands::Observe(_) => quality_json_descriptor(
-                output_file_mode,
-                false,
-                None,
-                CommandOutputContractKind::JsonEnvelope,
-            ),
-            Commands::AuditBaseline(_) => quality_json_descriptor(
-                output_file_mode,
-                false,
-                None,
-                CommandOutputContractKind::JsonEnvelope,
-            ),
-            Commands::Refactor(args) => CommandDescriptor {
+            Commands::Observe(_) => {
+                quality_json_descriptor(output_file_mode, CommandOutputContractKind::JsonEnvelope)
+            }
+            Commands::AuditBaseline(_) => {
+                quality_json_descriptor(output_file_mode, CommandOutputContractKind::JsonEnvelope)
+            }
+            Commands::Refactor(_) => CommandOutputDescriptor {
                 response_mode: CommandResponseMode::Json,
                 output_file_mode,
                 json_family: CommandJsonFamily::Workspace,
-                supports_lab_runner: args.is_hot_resource_command(),
-                lab_runner_unsupported_reason: None,
-                lab_offload_mutation_flag: args
-                    .lab_offload_writes_local_state()
-                    .then_some("--write/--commit"),
                 output_contract: CommandOutputContractKind::JsonEnvelope,
             },
             Commands::Refs(_) => workspace_descriptor(
@@ -184,7 +201,9 @@ impl Commands {
                 output_file_mode,
                 CommandOutputContractKind::JsonEnvelope,
             ),
-            Commands::Version(_) => version::adapter(output_file_mode).contract.to_descriptor(),
+            Commands::Version(_) => version::adapter(output_file_mode)
+                .contract
+                .to_output_descriptor(),
             Commands::AgentTask(_)
             | Commands::Project(_)
             | Commands::Component(_)
@@ -202,24 +221,16 @@ impl Commands {
             | Commands::Worktree(_)
             | Commands::Tunnel(_)
             | Commands::Stack(_)
-            | Commands::Undo(_) => CommandDescriptor {
+            | Commands::Undo(_) => CommandOutputDescriptor {
                 response_mode: CommandResponseMode::Json,
                 output_file_mode,
                 json_family: CommandJsonFamily::Workspace,
-                supports_lab_runner: false,
-                lab_runner_unsupported_reason: None,
-                lab_offload_mutation_flag: None,
                 output_contract: CommandOutputContractKind::JsonEnvelope,
             },
-            Commands::Rig(args) => CommandDescriptor {
+            Commands::Rig(_) => CommandOutputDescriptor {
                 response_mode: CommandResponseMode::Json,
                 output_file_mode,
                 json_family: CommandJsonFamily::Workspace,
-                supports_lab_runner: false,
-                lab_runner_unsupported_reason: args.is_hot_resource_command().then_some(
-                    "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.",
-                ),
-                lab_offload_mutation_flag: None,
                 output_contract: CommandOutputContractKind::JsonEnvelope,
             },
             Commands::Status(_)
@@ -242,14 +253,11 @@ impl Commands {
             | Commands::Ssh(_) => ops_json_descriptor(output_file_mode, None),
             Commands::Fleet(args) => args.output_descriptor(output_file_mode),
             Commands::Triage(_) => ops_json_descriptor(output_file_mode, None),
-        };
-
-        apply_lab_contract_to_descriptor(&mut descriptor, self.lab_contract());
-        descriptor
+        }
     }
 
     pub fn response_plan(&self, has_output_file: bool) -> CommandResponsePlan {
-        let descriptor = self.descriptor(has_output_file);
+        let descriptor = self.output_descriptor(has_output_file);
 
         CommandResponsePlan {
             stdout: match descriptor.response_mode {
@@ -261,11 +269,11 @@ impl Commands {
     }
 
     pub fn response_mode(&self, has_output_file: bool) -> CommandResponseMode {
-        self.descriptor(has_output_file).response_mode
+        self.output_descriptor(has_output_file).response_mode
     }
 
     pub fn output_file_mode(&self, has_output_file: bool) -> CommandOutputFileMode {
-        self.descriptor(has_output_file).output_file_mode
+        self.output_descriptor(has_output_file).output_file_mode
     }
 
     pub fn consumes_output_file_as_command_arg(&self) -> bool {
@@ -276,14 +284,11 @@ impl Commands {
 fn raw_ops_descriptor(
     raw_mode: CommandRawOutputMode,
     output_file_mode: CommandOutputFileMode,
-) -> CommandDescriptor {
-    CommandDescriptor {
+) -> CommandOutputDescriptor {
+    CommandOutputDescriptor {
         response_mode: CommandResponseMode::Raw(raw_mode),
         output_file_mode,
         json_family: CommandJsonFamily::Ops,
-        supports_lab_runner: false,
-        lab_runner_unsupported_reason: None,
-        lab_offload_mutation_flag: None,
         output_contract: CommandOutputContractKind::JsonEnvelope,
     }
 }
@@ -292,14 +297,11 @@ fn workspace_descriptor(
     response_mode: CommandResponseMode,
     output_file_mode: CommandOutputFileMode,
     output_contract: CommandOutputContractKind,
-) -> CommandDescriptor {
-    CommandDescriptor {
+) -> CommandOutputDescriptor {
+    CommandOutputDescriptor {
         response_mode,
         output_file_mode,
         json_family: CommandJsonFamily::Workspace,
-        supports_lab_runner: false,
-        lab_runner_unsupported_reason: None,
-        lab_offload_mutation_flag: None,
         output_contract,
     }
 }
@@ -314,32 +316,24 @@ fn markdown_or_json_response(markdown: bool) -> CommandResponseMode {
 
 fn quality_json_descriptor(
     output_file_mode: CommandOutputFileMode,
-    supports_lab_runner: bool,
-    lab_offload_mutation_flag: Option<&'static str>,
     output_contract: CommandOutputContractKind,
-) -> CommandDescriptor {
-    CommandDescriptor {
+) -> CommandOutputDescriptor {
+    CommandOutputDescriptor {
         response_mode: CommandResponseMode::Json,
         output_file_mode,
         json_family: CommandJsonFamily::Quality,
-        supports_lab_runner,
-        lab_runner_unsupported_reason: None,
-        lab_offload_mutation_flag,
         output_contract,
     }
 }
 
 fn ops_json_descriptor(
     output_file_mode: CommandOutputFileMode,
-    lab_runner_unsupported_reason: Option<&'static str>,
-) -> CommandDescriptor {
-    CommandDescriptor {
+    _lab_runner_unsupported_reason: Option<&'static str>,
+) -> CommandOutputDescriptor {
+    CommandOutputDescriptor {
         response_mode: CommandResponseMode::Json,
         output_file_mode,
         json_family: CommandJsonFamily::Ops,
-        supports_lab_runner: false,
-        lab_runner_unsupported_reason,
-        lab_offload_mutation_flag: None,
         output_contract: CommandOutputContractKind::JsonEnvelope,
     }
 }
@@ -402,6 +396,25 @@ mod tests {
             list_descriptor.response_mode,
             CommandResponseMode::Raw(CommandRawOutputMode::Markdown)
         );
+    }
+
+    #[test]
+    fn output_descriptor_excludes_lab_policy() {
+        let scoped_lint = parsed_command(&["homeboy", "lint", "--changed-since", "origin/main"]);
+        let output_descriptor = scoped_lint.output_descriptor(false);
+
+        assert_eq!(output_descriptor.json_family, CommandJsonFamily::Quality);
+        assert_eq!(output_descriptor.response_mode, CommandResponseMode::Json);
+        assert_eq!(
+            output_descriptor.output_contract,
+            CommandOutputContractKind::JsonEnvelope
+        );
+
+        let aggregate_descriptor = scoped_lint.descriptor(false);
+        assert!(!aggregate_descriptor.supports_lab_runner);
+        assert!(aggregate_descriptor
+            .lab_runner_unsupported_reason
+            .is_some_and(|reason| reason.contains("Changed-scope lint")));
     }
 
     #[test]

--- a/src/commands/adapter.rs
+++ b/src/commands/adapter.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 
 use crate::command_contract::{
-    CommandDescriptor, CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
+    CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode,
     CommandRawOutputMode, CommandResponseMode,
 };
 
@@ -35,14 +35,11 @@ pub(crate) struct CommandAdapterContract {
 }
 
 impl CommandAdapterContract {
-    pub fn to_descriptor(self) -> CommandDescriptor {
-        CommandDescriptor {
+    pub fn to_output_descriptor(self) -> CommandOutputDescriptor {
+        CommandOutputDescriptor {
             response_mode: self.response_mode,
             output_file_mode: self.output_file_mode,
             json_family: self.json_family,
-            supports_lab_runner: self.lab_runner.supports_runner,
-            lab_runner_unsupported_reason: self.lab_runner.unsupported_reason,
-            lab_offload_mutation_flag: self.lab_runner.mutation_flag,
             output_contract: self.output_contract,
         }
     }
@@ -97,7 +94,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn json_only_contract_maps_to_descriptor() {
+    fn json_only_contract_maps_to_output_descriptor() {
         let adapter = TypedCommandAdapter::<()>::json_only(
             CommandJsonFamily::Workspace,
             CommandOutputFileMode::GenericEnvelope,
@@ -105,7 +102,7 @@ mod tests {
             |_, _| (Ok(Value::Null), 0),
         );
 
-        let descriptor = adapter.contract.to_descriptor();
+        let descriptor = adapter.contract.to_output_descriptor();
 
         assert_eq!(descriptor.response_mode, CommandResponseMode::Json);
         assert_eq!(
@@ -113,7 +110,6 @@ mod tests {
             CommandOutputFileMode::GenericEnvelope
         );
         assert_eq!(descriptor.json_family, CommandJsonFamily::Workspace);
-        assert!(!descriptor.supports_lab_runner);
         assert!(adapter.execute_json.is_some());
     }
 
@@ -132,7 +128,7 @@ mod tests {
             );
 
             assert_eq!(
-                adapter.contract.to_descriptor().response_mode,
+                adapter.contract.to_output_descriptor().response_mode,
                 CommandResponseMode::Raw(raw_mode)
             );
             assert!(adapter.execute_json.is_none());

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -19,7 +19,7 @@ use super::utils::observed_workflow::{
 };
 use super::{CmdResult, GlobalArgs};
 use crate::command_contract::{
-    CommandDescriptor, CommandOutputContractKind, CommandOutputFileMode, LabCommandContract,
+    CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode, LabCommandContract,
 };
 
 const AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON: &str = "`audit --changed-since` is not Lab-portable yet because changed-since audit depends on git base refs that the current Lab workspace sync may not have fetched.";
@@ -65,15 +65,11 @@ impl AuditArgs {
     pub(crate) fn output_descriptor(
         &self,
         output_file_mode: CommandOutputFileMode,
-    ) -> CommandDescriptor {
-        CommandDescriptor {
+    ) -> CommandOutputDescriptor {
+        CommandOutputDescriptor {
             response_mode: crate::command_contract::CommandResponseMode::Json,
             output_file_mode,
             json_family: crate::command_contract::CommandJsonFamily::Quality,
-            supports_lab_runner: true,
-            lab_runner_unsupported_reason: None,
-            lab_offload_mutation_flag: (self.baseline_args.baseline || self.baseline_args.ratchet)
-                .then_some("--baseline/--ratchet"),
             output_contract: CommandOutputContractKind::JsonEnvelope,
         }
     }

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -21,7 +21,7 @@ use super::utils::args::{
 };
 use super::{runs, CmdResult, GlobalArgs};
 use crate::command_contract::{
-    CommandDescriptor, CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
+    CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode,
     CommandResponseMode, LabCommandContract,
 };
 
@@ -43,16 +43,11 @@ impl BenchArgs {
     pub(crate) fn output_descriptor(
         &self,
         output_file_mode: CommandOutputFileMode,
-    ) -> CommandDescriptor {
-        CommandDescriptor {
+    ) -> CommandOutputDescriptor {
+        CommandOutputDescriptor {
             response_mode: CommandResponseMode::Json,
             output_file_mode,
             json_family: CommandJsonFamily::Quality,
-            supports_lab_runner: self.is_lab_offload_command(),
-            lab_runner_unsupported_reason: None,
-            lab_offload_mutation_flag: self
-                .lab_offload_writes_local_state()
-                .then_some("--baseline/--ratchet"),
             output_contract: CommandOutputContractKind::JsonEnvelope,
         }
     }

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -8,7 +8,7 @@ use homeboy::core::project::Project;
 use homeboy::core::EntityCrudOutput;
 
 use super::{CmdResult, DynamicSetArgs};
-use crate::command_contract::{CommandDescriptor, CommandOutputFileMode, LabCommandContract};
+use crate::command_contract::{CommandOutputDescriptor, CommandOutputFileMode, LabCommandContract};
 
 const FLEET_EXEC_LAB_UNSUPPORTED_REASON: &str = "`fleet exec` stays local because it depends on local fleet, project, and server configuration before opening SSH sessions to each project; runner-side config parity is not guaranteed.";
 
@@ -22,16 +22,11 @@ impl FleetArgs {
     pub(crate) fn output_descriptor(
         &self,
         output_file_mode: CommandOutputFileMode,
-    ) -> CommandDescriptor {
-        CommandDescriptor {
+    ) -> CommandOutputDescriptor {
+        CommandOutputDescriptor {
             response_mode: crate::command_contract::CommandResponseMode::Json,
             output_file_mode,
             json_family: crate::command_contract::CommandJsonFamily::Ops,
-            supports_lab_runner: false,
-            lab_runner_unsupported_reason: self
-                .is_hot_resource_command()
-                .then_some(FLEET_EXEC_LAB_UNSUPPORTED_REASON),
-            lab_offload_mutation_flag: None,
             output_contract: crate::command_contract::CommandOutputContractKind::JsonEnvelope,
         }
     }

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -46,7 +46,7 @@ pub fn run_command_output(command: Commands, global: &GlobalArgs) -> JsonCommand
 }
 
 fn dispatch(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Value>, i32) {
-    match command.descriptor(false).json_family {
+    match command.output_descriptor(false).json_family {
         CommandJsonFamily::Quality => quality::dispatch(command, global),
         CommandJsonFamily::Workspace => workspace::dispatch(command, global),
         CommandJsonFamily::Ops => ops::dispatch(command, global),

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -23,7 +23,7 @@ use super::utils::observed_workflow::{
 };
 use super::{CmdResult, GlobalArgs};
 use crate::command_contract::{
-    CommandDescriptor, CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
+    CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode,
     CommandResponseMode, LabCommandContract,
 };
 
@@ -100,14 +100,11 @@ impl LintArgs {
     pub(crate) fn output_descriptor(
         &self,
         output_file_mode: CommandOutputFileMode,
-    ) -> CommandDescriptor {
-        CommandDescriptor {
+    ) -> CommandOutputDescriptor {
+        CommandOutputDescriptor {
             response_mode: CommandResponseMode::Json,
             output_file_mode,
             json_family: CommandJsonFamily::Quality,
-            supports_lab_runner: true,
-            lab_runner_unsupported_reason: None,
-            lab_offload_mutation_flag: self.fix.then_some("--fix"),
             output_contract: CommandOutputContractKind::JsonEnvelope,
         }
     }

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -22,7 +22,7 @@ use super::utils::args::{
 use super::utils::observed_workflow::{finish_observed_workflow, ObservedWorkflowRunner};
 use super::{CmdResult, GlobalArgs};
 use crate::command_contract::{
-    CommandDescriptor, CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
+    CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode,
     CommandResponseMode, LabCommandContract,
 };
 
@@ -91,14 +91,11 @@ impl TestArgs {
     pub(crate) fn output_descriptor(
         &self,
         output_file_mode: CommandOutputFileMode,
-    ) -> CommandDescriptor {
-        CommandDescriptor {
+    ) -> CommandOutputDescriptor {
+        CommandOutputDescriptor {
             response_mode: CommandResponseMode::Json,
             output_file_mode,
             json_family: CommandJsonFamily::Quality,
-            supports_lab_runner: true,
-            lab_runner_unsupported_reason: None,
-            lab_offload_mutation_flag: self.write.then_some("--write"),
             output_contract: CommandOutputContractKind::JsonEnvelope,
         }
     }


### PR DESCRIPTION
## Summary
- Split `CommandOutputDescriptor` from the aggregate `CommandDescriptor` so output routing can validate response/output/JSON contracts without resolving Lab/provider policy.
- Route JSON output dispatch and response planning through the output-only contract while preserving the existing aggregate descriptor for callers that need Lab metadata.
- Update command adapter/output tests to prove scoped commands keep output contracts independent from Lab unsupported policy.

Fixes #4455.

## Tests
- `cargo fmt --check`
- `cargo test output_descriptor_excludes_lab_policy`
- `cargo test core_agnostic`
- `cargo test core_content_stays_free_of_concrete_extension_ids`
- `cargo test command_contract::output::tests`
- `cargo test json_only_contract_maps_to_output_descriptor`

## Notes
- Test runs still report the pre-existing warning in `src/commands/runs/corpus_tests.rs` for an unused `serde_json::Value` import; this PR does not touch that area.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Repository inspection, identifying the generic output-vs-Lab seam, drafting the implementation, and running targeted verification. Chris remains responsible for review and testing.