### PR TITLE
fix: support manifest-declared release preflights

### DIFF
--- a/src/core/code_audit/detectors/test_topology.rs
+++ b/src/core/code_audit/detectors/test_topology.rs
@@ -388,6 +388,7 @@ JSON
             bench: None,
             trace: None,
             structured_sidecars: std::collections::BTreeMap::new(),
+            release_preflights: vec![],
             actions: vec![],
             hooks: std::collections::HashMap::new(),
             settings: vec![],

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -24,7 +24,7 @@ use super::runner_contract::RunnerStepFilter;
 use super::runtime_helper;
 use super::scope::ExtensionScope;
 
-pub(crate) use action::{execute_action, wordpress_release_publish_token_remediation};
+pub(crate) use action::execute_action;
 pub use readiness::{extension_ready_status, is_extension_compatible, ExtensionReadyStatus};
 
 /// Result of executing a extension.

--- a/src/core/extension/execution/action.rs
+++ b/src/core/extension/execution/action.rs
@@ -120,22 +120,13 @@ pub(crate) fn execute_action(
                 crate::core::engine::text::json_path_str(&payload, &["release", "local_path"])
                     .unwrap_or(extension_path);
 
-            let mut env = build_action_env(
+            let env = build_action_env(
                 extension_id,
                 project_id,
                 &payload,
                 Some(extension_path),
                 project_base_path.as_deref(),
             );
-            if let Some(response) = preflight_wordpress_release_publish_token(
-                extension_id,
-                action_id,
-                &payload,
-                &mut env,
-            ) {
-                return Ok(response);
-            }
-
             let execution = execute_extension_command(
                 command_template,
                 &vars,
@@ -152,42 +143,6 @@ pub(crate) fn execute_action(
             }))
         }
     }
-}
-
-pub(crate) fn wordpress_release_publish_token_remediation() -> &'static str {
-    "GH_TOKEN is required to push the WordPress release-latest mirror. Set GH_TOKEN with `export GH_TOKEN=\"$(gh auth token)\"`, or run `gh auth login` and rerun the release."
-}
-
-fn preflight_wordpress_release_publish_token(
-    extension_id: &str,
-    action_id: &str,
-    payload: &serde_json::Value,
-    env: &mut Vec<(String, String)>,
-) -> Option<serde_json::Value> {
-    if extension_id != "wordpress" || action_id != "release.publish" {
-        return None;
-    }
-
-    let Some(token) = crate::core::git::github_token_from_env_or_gh() else {
-        return Some(serde_json::json!({
-            "success": false,
-            "status": "missing_secret",
-            "reason": wordpress_release_publish_token_remediation(),
-            "payload": payload,
-        }));
-    };
-
-    upsert_env(env, "GH_TOKEN", token);
-    None
-}
-
-fn upsert_env(env: &mut Vec<(String, String)>, key: &str, value: String) {
-    if let Some((_, existing)) = env.iter_mut().find(|(env_key, _)| env_key == key) {
-        *existing = value;
-        return;
-    }
-
-    env.push((key.to_string(), value));
 }
 
 fn interpolate_action_payload(
@@ -266,34 +221,5 @@ fn interpolate_payload_value(
             Ok(serde_json::Value::Object(result))
         }
         _ => Ok(value.clone()),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::upsert_env;
-
-    #[test]
-    fn upsert_env_adds_missing_key() {
-        let mut env = vec![("A".to_string(), "one".to_string())];
-
-        upsert_env(&mut env, "GH_TOKEN", "token".to_string());
-
-        assert_eq!(
-            env,
-            vec![
-                ("A".to_string(), "one".to_string()),
-                ("GH_TOKEN".to_string(), "token".to_string()),
-            ]
-        );
-    }
-
-    #[test]
-    fn upsert_env_replaces_existing_key() {
-        let mut env = vec![("GH_TOKEN".to_string(), "old".to_string())];
-
-        upsert_env(&mut env, "GH_TOKEN", "new".to_string());
-
-        assert_eq!(env, vec![("GH_TOKEN".to_string(), "new".to_string())]);
     }
 }

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -389,6 +389,23 @@ pub struct ScriptsConfig {
     pub contract: Option<String>,
 }
 
+/// Extension-declared release preflight.
+///
+/// Core schedules these before release mutation and executes the declared
+/// extension action with the standard release payload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReleasePreflightConfig {
+    /// Stable suffix for the generated plan step id.
+    pub id: String,
+    /// Human-readable plan label.
+    pub label: String,
+    /// Extension action id to execute for this preflight.
+    pub action: String,
+    /// Plan step ids that must complete before this preflight runs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub needs: Vec<String>,
+}
+
 /// Unified extension manifest decomposed into capability groups.
 ///
 /// Extension JSON files use nested capability groups that map directly to these fields.
@@ -467,6 +484,10 @@ pub struct ExtensionManifest {
     /// machine-readable contract.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub structured_sidecars: BTreeMap<String, StructuredSidecarContract>,
+
+    /// Release preflights supplied by this extension.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub release_preflights: Vec<ReleasePreflightConfig>,
 
     // Actions (cross-cutting: used by both platform and executable extensions)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -46,9 +46,7 @@ pub(crate) use compiler_warning_contract::{
     extensions_for_compiler_warning_contract, run_compiler_warning_contract_script,
     CompilerWarningContract,
 };
-pub(crate) use execution::{
-    build_settings_json_from_manifest, execute_action, wordpress_release_publish_token_remediation,
-};
+pub(crate) use execution::{build_settings_json_from_manifest, execute_action};
 pub use execution::{
     extension_ready_status, is_extension_compatible, run_action, run_extension, run_setup,
     ExtensionExecutionMode, ExtensionReadyStatus, ExtensionRunResult, ExtensionSetupResult,
@@ -74,11 +72,12 @@ pub use manifest::{
     DeployVerification, DepsConfig, DiscoveryConfig, DiscoveryMarkerConfig, DocTarget,
     ExecutableCapability, ExtensionManifest, FeatureContextRule, FileContainsCondition, HttpMethod,
     InputConfig, LintChangedFileRoute, LintConfig, OutputConfig, OutputSchema, PlatformCapability,
-    ProvidesConfig, RemotePathInferenceRule, RemotePathRootRule, RequirementsConfig, RuntimeConfig,
-    RuntimeRequirementsConfig, ScriptsConfig, SelectOption, SettingConfig, SinceTagConfig,
-    StructuredSidecarDeclaration, TestChangedFileExclusiveEnv, TestChangedFileRouting,
-    TestChangedFileRoutingStrategy, TestConfig, TestDriftConfig, TestMappingConfig,
-    TestPassthroughFilter, TestPassthroughFilterStrategy, TraceConfig, VersionPatternConfig,
+    ProvidesConfig, ReleasePreflightConfig, RemotePathInferenceRule, RemotePathRootRule,
+    RequirementsConfig, RuntimeConfig, RuntimeRequirementsConfig, ScriptsConfig, SelectOption,
+    SettingConfig, SinceTagConfig, StructuredSidecarDeclaration, TestChangedFileExclusiveEnv,
+    TestChangedFileRouting, TestChangedFileRoutingStrategy, TestConfig, TestDriftConfig,
+    TestMappingConfig, TestPassthroughFilter, TestPassthroughFilterStrategy, TraceConfig,
+    VersionPatternConfig,
 };
 pub use manifest_deploy_config::{DeployArchiveInstallPolicy, DeployRequiredHeader};
 pub use refactor_protocol::{

--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -33,9 +33,6 @@ pub(super) fn execute_release_plan_step(
         "preflight.working_tree" => Ok(Some(run_working_tree_preflight(step, context))),
         "preflight.remote_sync" => Ok(Some(run_remote_sync_preflight(step, context))),
         "preflight.bump_policy" => Ok(Some(run_bump_policy_preflight(step))),
-        "preflight.wordpress_publish_token" => {
-            Ok(Some(run_wordpress_publish_token_preflight(step)))
-        }
         "preflight.lint" => Ok(Some(run_lint_preflight(step, context))),
         "preflight.test" => Ok(Some(run_test_preflight(step, context))),
         "preflight.changelog_bootstrap" => {
@@ -61,6 +58,15 @@ pub(super) fn execute_release_plan_step(
                 tag_name,
             )
             .map(Some)
+        }
+        step_kind if step_kind.starts_with("preflight.extension.") => {
+            Ok(Some(executor::run_extension_release_preflight(
+                step,
+                context.extensions,
+                &context.state,
+                context.component_id,
+                &context.component.local_path,
+            )))
         }
         "changelog.finalize" => {
             executor::changelog::run_changelog_finalize(step, context.component, &mut context.state)
@@ -194,47 +200,14 @@ fn release_step_is_plan_only(step: &PlanStep) -> bool {
         && step.kind != "preflight.working_tree"
         && step.kind != "preflight.remote_sync"
         && step.kind != "preflight.bump_policy"
-        && step.kind != "preflight.wordpress_publish_token"
         && step.kind != "preflight.lint"
         && step.kind != "preflight.test"
         && step.kind != "preflight.changelog_bootstrap"
         && step.kind != "preflight.package"
-        && step.kind != "preflight.tag_availability")
+        && step.kind != "preflight.tag_availability"
+        && !step.kind.starts_with("preflight.extension."))
         || step.kind == "changelog.policy"
         || step.kind == "changelog.generate"
-}
-
-fn run_wordpress_publish_token_preflight(step: &PlanStep) -> ReleaseStepResult {
-    if crate::core::git::github_token_from_env_or_gh().is_some() {
-        return ReleaseStepResult {
-            id: step.id.clone(),
-            step_type: step.kind.clone(),
-            status: ReleaseStepStatus::Success,
-            missing: Vec::new(),
-            warnings: Vec::new(),
-            hints: Vec::new(),
-            data: Some(serde_json::json!({
-                "token_source": "env-or-gh-auth-token",
-            })),
-            error: None,
-        };
-    }
-
-    ReleaseStepResult {
-        id: step.id.clone(),
-        step_type: step.kind.clone(),
-        status: ReleaseStepStatus::Failed,
-        missing: Vec::new(),
-        warnings: Vec::new(),
-        hints: vec![crate::core::error::Hint {
-            message: "Run `gh auth login`, or export `GH_TOKEN=\"$(gh auth token)\"`, then rerun the release.".to_string(),
-        }],
-        data: Some(serde_json::json!({
-            "required_env": "GH_TOKEN",
-            "fallback": "gh auth token",
-        })),
-        error: Some(crate::core::extension::wordpress_release_publish_token_remediation().to_string()),
-    }
 }
 
 fn run_default_branch_preflight(
@@ -654,6 +627,9 @@ mod tests {
         assert!(!release_step_is_plan_only(&plan_step(
             "preflight.bump_policy"
         )));
+        assert!(!release_step_is_plan_only(&plan_step(
+            "preflight.extension.registry.publish_token"
+        )));
         assert!(!release_step_is_plan_only(&plan_step("preflight.lint")));
         assert!(!release_step_is_plan_only(&plan_step("preflight.test")));
         assert!(!release_step_is_plan_only(&plan_step(
@@ -862,6 +838,72 @@ mod tests {
             assert_eq!(result.data, Some(serde_json::json!({ "ran": false })));
             assert!(!release_step_is_show_stopper(&result));
         }
+    }
+
+    #[test]
+    fn extension_declared_release_preflight_executes_action() {
+        crate::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let mut extension: crate::core::extension::ExtensionManifest =
+                serde_json::from_value(serde_json::json!({
+                    "name": "Registry",
+                    "version": "1.0.0",
+                    "release_preflights": [{
+                        "id": "publish_token",
+                        "label": "Validate registry publish token",
+                        "action": "release.preflight.publish-token",
+                        "needs": ["preflight.bump_policy"]
+                    }],
+                    "actions": [{
+                        "id": "release.preflight.publish-token",
+                        "label": "Validate publish token",
+                        "type": "command",
+                        "command": "printf '{\"component\":\"%s\",\"path\":\"%s\",\"success\":true}' \"$HOMEBOY_COMPONENT_ID\" \"$HOMEBOY_COMPONENT_PATH\""
+                    }]
+                }))
+                .expect("extension manifest");
+            extension.id = "registry".to_string();
+            crate::core::extension::save_manifest(&extension).expect("save extension");
+
+            let component = Component {
+                id: "fixture".to_string(),
+                local_path: temp.path().to_string_lossy().to_string(),
+                ..Default::default()
+            };
+            let options = ReleaseOptions::default();
+            let extensions = vec![extension];
+            let mut context = ReleaseExecutionContext {
+                component: &component,
+                extensions: &extensions,
+                component_id: "fixture",
+                options: &options,
+                state: ReleaseState::default(),
+                publish_failed: false,
+            };
+            let mut step = plan_step("preflight.extension.registry.publish_token");
+            step.inputs
+                .insert("extension".to_string(), serde_json::json!("registry"));
+            step.inputs.insert(
+                "action".to_string(),
+                serde_json::json!("release.preflight.publish-token"),
+            );
+
+            let result = execute_release_plan_step(&step, &mut context)
+                .expect("dispatch")
+                .expect("result");
+
+            assert_eq!(result.status, ReleaseStepStatus::Success);
+            let stdout = result
+                .data
+                .as_ref()
+                .and_then(|data| data.get("response"))
+                .and_then(|response| response.get("stdout"))
+                .and_then(serde_json::Value::as_str)
+                .expect("preflight stdout");
+            let payload: serde_json::Value = serde_json::from_str(stdout).expect("stdout json");
+            assert_eq!(payload["component"], "fixture");
+            assert_eq!(payload["path"], temp.path().to_string_lossy().as_ref());
+        });
     }
 
     #[test]

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -658,6 +658,97 @@ pub(crate) fn run_package(
     Ok(step_success("package", "package", Some(data), Vec::new()))
 }
 
+/// Invoke an extension-declared release preflight action.
+pub(crate) fn run_extension_release_preflight(
+    step: &crate::core::plan::PlanStep,
+    extensions: &[ExtensionManifest],
+    state: &ReleaseState,
+    component_id: &str,
+    component_local_path: &str,
+) -> ReleaseStepResult {
+    let extension_id = step
+        .inputs
+        .get("extension")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    let action_id = step
+        .inputs
+        .get("action")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+
+    let Some(extension) = extensions
+        .iter()
+        .find(|extension| extension.id == extension_id)
+    else {
+        return step_failed(
+            &step.id,
+            &step.kind,
+            Some(serde_json::json!({
+                "extension": extension_id,
+                "action": action_id,
+            })),
+            Some(format!(
+                "Release preflight references missing extension '{}'",
+                extension_id
+            )),
+            Vec::new(),
+        );
+    };
+
+    if !extension
+        .actions
+        .iter()
+        .any(|action| action.id == action_id)
+    {
+        return step_failed(
+            &step.id,
+            &step.kind,
+            Some(serde_json::json!({
+                "extension": extension_id,
+                "action": action_id,
+            })),
+            Some(format!(
+                "Release preflight references missing action '{}' on extension '{}'",
+                action_id, extension_id
+            )),
+            Vec::new(),
+        );
+    }
+
+    let payload = build_release_payload(state, component_id, component_local_path, None);
+    let response =
+        match extension::execute_action(extension_id, action_id, None, None, Some(&payload)) {
+            Ok(response) => response,
+            Err(err) => {
+                return step_failed(&step.id, &step.kind, None, Some(err.message), err.hints)
+            }
+        };
+
+    let data = Some(serde_json::json!({
+        "extension": extension_id,
+        "action": action_id,
+        "response": response,
+    }));
+
+    if response.get("success").and_then(serde_json::Value::as_bool) == Some(false) {
+        let reason = response
+            .get("reason")
+            .or_else(|| response.get("error"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("extension release preflight reported failure");
+        return step_failed(
+            &step.id,
+            &step.kind,
+            data,
+            Some(reason.to_string()),
+            Vec::new(),
+        );
+    }
+
+    step_success(&step.id, &step.kind, data, Vec::new())
+}
+
 fn package_provider_error(extension_id: &str, err: Error) -> Error {
     let mut wrapped = Error::new(
         err.code,

--- a/src/core/release/plan_steps.rs
+++ b/src/core/release/plan_steps.rs
@@ -109,15 +109,7 @@ pub(super) fn build_preflight_steps(
         build_bump_policy_step(options, semver_recommendation),
     ];
 
-    if has_wordpress_release_publish_target(extensions) {
-        steps.push(ready_step(
-            "preflight.wordpress_publish_token",
-            "preflight.wordpress_publish_token",
-            "Validate WordPress release publish token",
-            vec!["preflight.bump_policy".to_string()],
-            StepConfig::new(),
-        ));
-    }
+    steps.extend(build_extension_release_preflight_steps(extensions));
 
     if let Some(identity) = options.git_identity.as_ref() {
         steps.insert(
@@ -157,14 +149,25 @@ pub(super) fn build_preflight_steps(
     steps
 }
 
-fn has_wordpress_release_publish_target(extensions: &[ExtensionManifest]) -> bool {
-    extensions.iter().any(|extension| {
-        extension.id == "wordpress"
-            && extension
-                .actions
-                .iter()
-                .any(|action| action.id == "release.publish")
-    })
+fn build_extension_release_preflight_steps(extensions: &[ExtensionManifest]) -> Vec<PlanStep> {
+    extensions
+        .iter()
+        .flat_map(|extension| {
+            extension.release_preflights.iter().map(|preflight| {
+                let step_id = format!("preflight.extension.{}.{}", extension.id, preflight.id);
+                ready_step(
+                    &step_id,
+                    &step_id,
+                    preflight.label.clone(),
+                    preflight.needs.clone(),
+                    StepConfig::new()
+                        .string("extension", extension.id.clone())
+                        .string("action", preflight.action.clone())
+                        .string("preflight", preflight.id.clone()),
+                )
+            })
+        })
+        .collect()
 }
 
 fn build_quality_steps(options: &ReleaseOptions) -> Vec<PlanStep> {
@@ -775,34 +778,57 @@ mod tests {
     }
 
     #[test]
-    fn release_plan_adds_wordpress_publish_token_preflight_for_wordpress_publish() {
+    fn release_plan_adds_extension_declared_release_preflight() {
         let options = ReleaseOptions {
             bump_type: "patch".to_string(),
             ..Default::default()
         };
         let mut extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
-            "name": "WordPress",
+            "name": "Registry",
             "version": "1.0.0",
+            "release_preflights": [
+                {
+                    "id": "publish_token",
+                    "label": "Validate registry publish token",
+                    "action": "release.preflight.publish-token",
+                    "needs": ["preflight.bump_policy"]
+                }
+            ],
             "actions": [
                 {
-                    "id": "release.publish",
-                    "label": "Publish release",
+                    "id": "release.preflight.publish-token",
+                    "label": "Validate publish token",
                     "type": "command",
                     "command": "true"
                 }
             ]
         }))
         .expect("extension manifest");
-        extension.id = "wordpress".to_string();
+        extension.id = "registry".to_string();
 
         let steps = build_preflight_steps(&options, None, &[extension]);
         let token = steps
             .iter()
-            .find(|step| step.id == "preflight.wordpress_publish_token")
-            .expect("wordpress publish token preflight");
+            .find(|step| step.id == "preflight.extension.registry.publish_token")
+            .expect("extension release preflight");
 
         assert_eq!(token.status, PlanStepStatus::Ready);
+        assert_eq!(
+            token.label.as_deref(),
+            Some("Validate registry publish token")
+        );
         assert_eq!(token.needs, vec!["preflight.bump_policy"]);
+        assert_eq!(
+            token
+                .inputs
+                .get("extension")
+                .and_then(|value| value.as_str()),
+            Some("registry")
+        );
+        assert_eq!(
+            token.inputs.get("action").and_then(|value| value.as_str()),
+            Some("release.preflight.publish-token")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a generic `release_preflights` extension manifest contract for release preflight steps.
- Plans extension-declared preflights as `preflight.extension.<extension>.<id>` and executes the declared extension action with the standard release payload.
- Removes the WordPress-specific publish-token preflight and action-execution branch from Homeboy core.

Part of https://github.com/Extra-Chill/homeboy/issues/4434 and parent tracker https://github.com/Extra-Chill/homeboy/issues/4303.

## Tests
- `cargo fmt`
- `cargo test core::release::plan_steps::tests::release_plan_adds_extension_declared_release_preflight`
- `cargo test core::release::execution_dispatch::tests::extension_declared_release_preflight_executes_action`
- `cargo test core::release::execution_dispatch::tests::test_release_step_is_plan_only`

## Known existing failure
- `cargo test --test architecture_core_agnostic_test` fails on existing command-layer facade violations in `src/commands/route.rs` and `src/commands/runner.rs`; this PR does not touch those files.

## Follow-up
- Homeboy Extensions must declare the WordPress publish-token preflight and own its token fallback using this new contract.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the manifest contract, Homeboy planning/execution implementation, and targeted tests; Chris remains responsible for review and merge decisions.