### PR TITLE
Fix trace toolchain provenance declarations

### DIFF
--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -600,6 +600,15 @@ impl ExtensionManifest {
             .unwrap_or(&[])
     }
 
+    pub fn trace_toolchain_provenance(
+        &self,
+    ) -> &[super::manifest_config::TraceToolchainProvenanceConfig] {
+        self.trace
+            .as_ref()
+            .map(|trace| trace.toolchain_provenance.as_slice())
+            .unwrap_or(&[])
+    }
+
     pub fn env_provider_script(&self) -> Option<&str> {
         self.env_provider
             .as_ref()

--- a/src/core/extension/manifest_config.rs
+++ b/src/core/extension/manifest_config.rs
@@ -294,6 +294,21 @@ pub struct TraceConfig {
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub runner_capabilities: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub toolchain_provenance: Vec<TraceToolchainProvenanceConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TraceToolchainProvenanceConfig {
+    pub id: String,
+    pub label: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legacy_field: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env_keys: Vec<String>,
 }
 
 /// Post-write verify contract for autofix. Runs from the component root after

--- a/src/core/extension/trace/canonicality.rs
+++ b/src/core/extension/trace/canonicality.rs
@@ -2,7 +2,8 @@ use std::path::Path;
 use std::process::Command;
 
 use crate::core::component::Component;
-use crate::core::error::Result;
+use crate::core::error::{ErrorCode, Result};
+use crate::core::extension::manifest_config::TraceToolchainProvenanceConfig;
 use crate::core::extension::ExtensionExecutionContext;
 
 use super::parsing::{
@@ -136,9 +137,6 @@ pub(crate) fn refused_trace_result(
     }
 }
 
-const WP_CODEBOX_BIN_ENV_KEYS: &[&str] =
-    &["HOMEBOY_WP_CODEBOX_BIN", "HOMEBOY_SETTINGS_WP_CODEBOX_BIN"];
-
 pub(crate) fn evaluate_trace_canonicality(
     execution_context: Option<&ExtensionExecutionContext>,
     component: &Component,
@@ -192,34 +190,8 @@ pub(crate) fn evaluate_trace_canonicality(
         checks.push(check_extension_checkout(context, &mut reasons));
     }
 
-    for key in WP_CODEBOX_BIN_ENV_KEYS {
-        let explicit = args.runner_inputs.env.iter().any(|(name, _)| name == key);
-        let inherited = std::env::var_os(key);
-        if explicit || inherited.is_some() {
-            let source = if explicit {
-                "trace runner env"
-            } else {
-                "process env"
-            };
-            let value = args
-                .runner_inputs
-                .env
-                .iter()
-                .find_map(|(name, value)| (name == key).then_some(value.as_str()))
-                .or_else(|| inherited.as_deref().and_then(|value| value.to_str()));
-            match value {
-                Some(path) if !path.trim().is_empty() => checks.push(check_git_checkout(
-                    &format!("toolchain:wp-codebox ({key}, {source})"),
-                    &git_probe_path(Path::new(path)),
-                    None,
-                    &mut reasons,
-                )),
-                _ => reasons.push(format!(
-                    "WP Codebox toolchain path `{}` is empty via {}",
-                    key, source
-                )),
-            }
-        }
+    for requirement in trace_toolchain_provenance_requirements(execution_context)? {
+        check_declared_toolchain_provenance(&requirement, args, &mut checks, &mut reasons);
     }
 
     Ok(TraceCanonicalityReport {
@@ -227,6 +199,58 @@ pub(crate) fn evaluate_trace_canonicality(
         reasons,
         checks,
     })
+}
+
+pub(crate) fn trace_toolchain_provenance_requirements(
+    execution_context: Option<&ExtensionExecutionContext>,
+) -> Result<Vec<TraceToolchainProvenanceConfig>> {
+    let Some(context) = execution_context else {
+        return Ok(Vec::new());
+    };
+    let manifest = match crate::core::extension::load_extension(&context.extension_id) {
+        Ok(manifest) => manifest,
+        Err(error) if error.code == ErrorCode::ExtensionNotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error),
+    };
+    Ok(manifest.trace_toolchain_provenance().to_vec())
+}
+
+fn check_declared_toolchain_provenance(
+    requirement: &TraceToolchainProvenanceConfig,
+    args: &TraceRunWorkflowArgs,
+    checks: &mut Vec<TraceCanonicalCheck>,
+    reasons: &mut Vec<String>,
+) {
+    for key in &requirement.env_keys {
+        let explicit = args.runner_inputs.env.iter().any(|(name, _)| name == key);
+        let inherited = std::env::var_os(key);
+        if !explicit && inherited.is_none() {
+            continue;
+        }
+        let source = if explicit {
+            "trace runner env"
+        } else {
+            "process env"
+        };
+        let value = args
+            .runner_inputs
+            .env
+            .iter()
+            .find_map(|(name, value)| (name == key).then_some(value.as_str()))
+            .or_else(|| inherited.as_deref().and_then(|value| value.to_str()));
+        match value {
+            Some(path) if !path.trim().is_empty() => checks.push(check_git_checkout(
+                &format!("toolchain:{} ({key}, {source})", requirement.id),
+                &git_probe_path(Path::new(path)),
+                None,
+                reasons,
+            )),
+            _ => reasons.push(format!(
+                "{} toolchain path `{}` is empty via {}",
+                requirement.label, key, source
+            )),
+        }
+    }
 }
 
 fn git_probe_path(path: &Path) -> std::path::PathBuf {
@@ -520,6 +544,7 @@ mod tests {
     use crate::core::engine::run_dir::RunDir;
     use crate::core::extension::trace::run::{run_trace_workflow, TraceRunnerInputs};
     use crate::core::extension::ExtensionCapability;
+    use std::path::Path;
 
     #[test]
     fn trace_canonical_policy_defaults_to_canonical() {
@@ -635,79 +660,80 @@ mod tests {
     }
 
     #[test]
-    fn canonical_trace_refuses_missing_wp_codebox_runner_env() {
-        let temp = tempfile::tempdir().unwrap();
-        init_git_repo(temp.path());
-        let component = test_component(temp.path());
-        let run_dir = RunDir::create().unwrap();
-        let mut args = test_run_args(temp.path());
-        args.canonical_policy = TraceCanonicalPolicy::Canonical;
-        args.runner_inputs.env.push((
-            "HOMEBOY_WP_CODEBOX_BIN".to_string(),
-            "/tmp/other-wp-codebox".to_string(),
-        ));
+    fn canonical_trace_refuses_missing_declared_toolchain_runner_env() {
+        crate::test_support::with_isolated_home(|home| {
+            let temp = tempfile::tempdir().unwrap();
+            init_git_repo(temp.path());
+            let component = test_component(temp.path());
+            let context = write_trace_extension(home.path(), &component);
+            let mut args = test_run_args(temp.path());
+            args.canonical_policy = TraceCanonicalPolicy::Canonical;
+            args.runner_inputs.env.push((
+                "FIXTURE_TOOLCHAIN_BIN".to_string(),
+                "/tmp/other-fixture-toolchain".to_string(),
+            ));
 
-        let result = run_trace_workflow(&component, args, &run_dir, None).unwrap();
+            let report = evaluate_trace_canonicality(Some(&context), &component, &args).unwrap();
 
-        assert_eq!(result.exit_code, 1);
-        assert!(result.evidence.reasons.iter().any(|reason| {
-            reason.contains("toolchain:wp-codebox (HOMEBOY_WP_CODEBOX_BIN, trace runner env) checkout path is missing")
-        }));
-        run_dir.cleanup();
+            assert!(!report.is_canonical());
+            assert!(report.reasons.iter().any(|reason| {
+                reason.contains("toolchain:fixture-toolchain (FIXTURE_TOOLCHAIN_BIN, trace runner env) checkout path is missing")
+            }));
+        });
     }
 
     #[test]
-    fn canonical_trace_accepts_clean_wp_codebox_runner_env() {
-        let component_dir = tempfile::tempdir().unwrap();
-        let component_remote = tempfile::tempdir().unwrap();
-        let codebox_dir = tempfile::tempdir().unwrap();
-        let codebox_remote = tempfile::tempdir().unwrap();
-        init_git_repo(component_dir.path());
-        init_bare_repo(component_remote.path());
-        git(
-            component_dir.path(),
-            &[
-                "remote",
-                "add",
-                "origin",
-                component_remote.path().to_str().unwrap(),
-            ],
-        );
-        git(component_dir.path(), &["push", "-u", "origin", "main"]);
-        init_git_repo(codebox_dir.path());
-        init_bare_repo(codebox_remote.path());
-        git(
-            codebox_dir.path(),
-            &[
-                "remote",
-                "add",
-                "origin",
-                codebox_remote.path().to_str().unwrap(),
-            ],
-        );
-        git(codebox_dir.path(), &["push", "-u", "origin", "main"]);
-        let bin = codebox_dir.path().join("packages/cli/dist/index.js");
-        std::fs::create_dir_all(bin.parent().unwrap()).unwrap();
-        std::fs::write(&bin, "#!/usr/bin/env node\n").unwrap();
-        git(codebox_dir.path(), &["add", "."]);
-        git(codebox_dir.path(), &["commit", "-m", "add cli bin"]);
-        git(codebox_dir.path(), &["push", "origin", "main"]);
+    fn canonical_trace_accepts_clean_declared_toolchain_runner_env() {
+        crate::test_support::with_isolated_home(|home| {
+            let component_dir = tempfile::tempdir().unwrap();
+            let component_remote = tempfile::tempdir().unwrap();
+            let toolchain_dir = tempfile::tempdir().unwrap();
+            let toolchain_remote = tempfile::tempdir().unwrap();
+            init_git_repo(component_dir.path());
+            init_bare_repo(component_remote.path());
+            git(
+                component_dir.path(),
+                &[
+                    "remote",
+                    "add",
+                    "origin",
+                    component_remote.path().to_str().unwrap(),
+                ],
+            );
+            git(component_dir.path(), &["push", "-u", "origin", "main"]);
+            init_git_repo(toolchain_dir.path());
+            init_bare_repo(toolchain_remote.path());
+            git(
+                toolchain_dir.path(),
+                &[
+                    "remote",
+                    "add",
+                    "origin",
+                    toolchain_remote.path().to_str().unwrap(),
+                ],
+            );
+            git(toolchain_dir.path(), &["push", "-u", "origin", "main"]);
+            let bin = toolchain_dir.path().join("packages/cli/dist/index.js");
+            std::fs::create_dir_all(bin.parent().unwrap()).unwrap();
+            std::fs::write(&bin, "#!/usr/bin/env node\n").unwrap();
+            git(toolchain_dir.path(), &["add", "."]);
+            git(toolchain_dir.path(), &["commit", "-m", "add cli bin"]);
+            git(toolchain_dir.path(), &["push", "origin", "main"]);
 
-        let component = test_component(component_dir.path());
-        let run_dir = RunDir::create().unwrap();
-        let mut args = test_run_args(component_dir.path());
-        args.canonical_policy = TraceCanonicalPolicy::Canonical;
-        args.runner_inputs.env.push((
-            "HOMEBOY_WP_CODEBOX_BIN".to_string(),
-            bin.to_string_lossy().to_string(),
-        ));
+            let component = test_component(component_dir.path());
+            let context = write_trace_extension(home.path(), &component);
+            let mut args = test_run_args(component_dir.path());
+            args.canonical_policy = TraceCanonicalPolicy::Canonical;
+            args.runner_inputs.env.push((
+                "FIXTURE_TOOLCHAIN_BIN".to_string(),
+                bin.to_string_lossy().to_string(),
+            ));
 
-        let result = run_trace_workflow(&component, args, &run_dir, None).unwrap();
+            let report = evaluate_trace_canonicality(Some(&context), &component, &args).unwrap();
 
-        assert_eq!(result.exit_code, 3);
-        assert!(result.evidence.canonical);
-        assert!(result.evidence.reasons.is_empty());
-        run_dir.cleanup();
+            assert!(report.is_canonical());
+            assert!(report.reasons.is_empty());
+        });
     }
 
     #[test]
@@ -891,14 +917,11 @@ mod tests {
     fn allow_local_toolchain_marks_result_non_canonical_without_refusing() {
         let temp = tempfile::tempdir().unwrap();
         init_git_repo(temp.path());
+        std::fs::write(temp.path().join("dirty.txt"), "dirty\n").unwrap();
         let component = test_component(temp.path());
         let run_dir = RunDir::create().unwrap();
         let mut args = test_run_args(temp.path());
         args.canonical_policy = TraceCanonicalPolicy::AllowLocalToolchain;
-        args.runner_inputs.env.push((
-            "HOMEBOY_WP_CODEBOX_BIN".to_string(),
-            "/tmp/other-wp-codebox".to_string(),
-        ));
 
         let result = run_trace_workflow(&component, args, &run_dir, None).unwrap();
 
@@ -917,6 +940,42 @@ mod tests {
             id: "example".to_string(),
             local_path: path.to_string_lossy().to_string(),
             ..Default::default()
+        }
+    }
+
+    fn write_trace_extension(home: &Path, component: &Component) -> ExtensionExecutionContext {
+        let extension_id = "fixture-extension";
+        let extension_dir = home.join(".config/homeboy/extensions").join(extension_id);
+        std::fs::create_dir_all(&extension_dir).expect("extension dir");
+        std::fs::write(
+            extension_dir.join(format!("{extension_id}.json")),
+            serde_json::json!({
+                "name": "Fixture Extension",
+                "version": "0.0.0",
+                "trace": {
+                    "extension_script": "trace.js",
+                    "toolchain_provenance": [
+                        {
+                            "id": "fixture-toolchain",
+                            "label": "Fixture Toolchain",
+                            "legacy_field": "wp_codebox",
+                            "env_keys": ["FIXTURE_TOOLCHAIN_BIN"]
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .expect("extension manifest");
+        std::fs::write(extension_dir.join("trace.js"), "#!/usr/bin/env node\n").unwrap();
+
+        ExtensionExecutionContext {
+            component: component.clone(),
+            capability: ExtensionCapability::Trace,
+            extension_id: extension_id.to_string(),
+            extension_path: extension_dir,
+            script_path: "trace.js".to_string(),
+            settings: Vec::new(),
         }
     }
 

--- a/src/core/extension/trace/parsing.rs
+++ b/src/core/extension/trace/parsing.rs
@@ -119,6 +119,8 @@ pub struct TraceToolchainProvenance {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub reasons: Vec<String>,
     pub homeboy: TraceGitProvenance,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub toolchains: BTreeMap<String, TraceGitProvenance>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wp_codebox: Option<TraceGitProvenance>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/core/extension/trace/report.rs
+++ b/src/core/extension/trace/report.rs
@@ -1109,6 +1109,7 @@ mod tests {
                     dirty: Some(false),
                     source: None,
                 },
+                toolchains: Default::default(),
                 wp_codebox: None,
                 node: Some("v24.0.0".to_string()),
                 runtime_assets: Default::default(),

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -30,7 +30,8 @@ use super::overlay::{
 };
 
 use super::canonicality::{
-    evaluate_trace_canonicality, refused_trace_result, TraceCanonicalPolicy,
+    evaluate_trace_canonicality, refused_trace_result, trace_toolchain_provenance_requirements,
+    TraceCanonicalPolicy,
 };
 use super::generic_runner::run_generic_trace_runner;
 #[cfg(test)]
@@ -196,7 +197,7 @@ fn run_trace_workflow_with_component_script(
         ));
     }
     let evidence = canonicality.metadata(args.canonical_policy);
-    let (mut toolchain, components) = trace_provenance(None, &component_path);
+    let (mut toolchain, components) = trace_provenance(None, &component_path, &args)?;
     mark_non_canonical(
         &mut toolchain,
         "component script trace runs do not resolve an extension runner checkout",
@@ -343,7 +344,7 @@ fn run_trace_workflow_with_context(
         ));
     }
     let evidence = canonicality.metadata(args.canonical_policy);
-    let (toolchain, components) = trace_provenance(execution_context, &component_path);
+    let (toolchain, components) = trace_provenance(execution_context, &component_path, &args)?;
     let _overlay_locks = if args.overlays.is_empty() {
         None
     } else {
@@ -540,30 +541,24 @@ fn non_canonical_evidence_hints(evidence: &TraceEvidenceMetadata) -> Vec<String>
 fn trace_provenance(
     execution_context: Option<&ExtensionExecutionContext>,
     component_path: &str,
-) -> (TraceToolchainProvenance, TraceComponentsProvenance) {
+    args: &TraceRunWorkflowArgs,
+) -> Result<(TraceToolchainProvenance, TraceComponentsProvenance)> {
     let homeboy = homeboy_git_provenance();
     let target = git_provenance(Path::new(component_path), Some("target"));
-    let env_wp_codebox_bin = wp_codebox_bin_env();
-    let wp_codebox_path = execution_context
-        .filter(|context| {
-            context.extension_id.contains("wp-codebox")
-                || context
-                    .extension_path
-                    .to_string_lossy()
-                    .contains("wp-codebox")
-        })
-        .map(|context| context.extension_path.as_path())
-        .or_else(|| {
-            env_wp_codebox_bin
-                .as_ref()
-                .map(|(_, value)| Path::new(value.as_str()))
-        });
+    let toolchain_requirements = trace_toolchain_provenance_requirements(execution_context)?;
     let mut reasons = Vec::new();
-    let mut wp_codebox = wp_codebox_path.map(|path| git_provenance(path, Some("wp_codebox")));
+    let mut toolchains = BTreeMap::new();
 
-    if let Some((key, _)) = env_wp_codebox_bin.as_ref() {
-        if let Some(provenance) = wp_codebox.as_mut() {
+    for requirement in &toolchain_requirements {
+        if let Some((key, value)) = declared_toolchain_env_value(requirement, args) {
+            let mut provenance = git_provenance(Path::new(value.as_str()), Some(&requirement.id));
             provenance.source = Some(format!("env:{key}"));
+            toolchains.insert(requirement.id.clone(), provenance);
+        } else {
+            reasons.push(format!(
+                "{} checkout was not resolved for this trace run",
+                requirement.label
+            ));
         }
     }
     if execution_context.is_none() {
@@ -572,11 +567,13 @@ fn trace_provenance(
     for (label, provenance) in [("homeboy", &homeboy), ("target", &target)] {
         push_git_provenance_reasons(label, provenance, &mut reasons);
     }
-    if let Some(provenance) = wp_codebox.as_ref() {
-        push_git_provenance_reasons("WP Codebox", provenance, &mut reasons);
-    }
-    if wp_codebox.is_none() {
-        reasons.push("WP Codebox checkout was not resolved for this trace run".to_string());
+    for (id, provenance) in &toolchains {
+        let label = toolchain_requirements
+            .iter()
+            .find(|requirement| requirement.id == *id)
+            .map(|requirement| requirement.label.as_str())
+            .unwrap_or(id.as_str());
+        push_git_provenance_reasons(label, provenance, &mut reasons);
     }
     let canonical = reasons.is_empty();
     let mut runtime_assets = BTreeMap::new();
@@ -585,7 +582,13 @@ fn trace_provenance(
         browser_runtime_asset_provenance(),
     );
 
-    (
+    let wp_codebox = toolchain_requirements.iter().find_map(|requirement| {
+        (requirement.legacy_field.as_deref() == Some("wp_codebox"))
+            .then(|| toolchains.get(&requirement.id).cloned())
+            .flatten()
+    });
+
+    Ok((
         TraceToolchainProvenance {
             canonical,
             mode: if canonical {
@@ -596,6 +599,7 @@ fn trace_provenance(
             .to_string(),
             reasons,
             homeboy,
+            toolchains,
             wp_codebox,
             node: command_version("node", &["--version"]),
             runtime_assets,
@@ -604,7 +608,7 @@ fn trace_provenance(
             target,
             dependencies: Vec::new(),
         },
-    )
+    ))
 }
 
 fn push_git_provenance_reasons(
@@ -625,14 +629,17 @@ fn push_git_provenance_reasons(
     }
 }
 
-fn wp_codebox_bin_env() -> Option<(String, String)> {
-    ["HOMEBOY_WP_CODEBOX_BIN", "HOMEBOY_SETTINGS_WP_CODEBOX_BIN"]
-        .into_iter()
-        .find_map(|key| {
-            std::env::var(key)
-                .ok()
-                .map(|value| (key.to_string(), value))
-        })
+fn declared_toolchain_env_value(
+    requirement: &crate::core::extension::manifest_config::TraceToolchainProvenanceConfig,
+    args: &TraceRunWorkflowArgs,
+) -> Option<(String, String)> {
+    requirement.env_keys.iter().find_map(|key| {
+        args.runner_inputs
+            .env
+            .iter()
+            .find_map(|(name, value)| (name == key).then_some((key.clone(), value.clone())))
+            .or_else(|| std::env::var(key).ok().map(|value| (key.clone(), value)))
+    })
 }
 
 fn mark_non_canonical(toolchain: &mut TraceToolchainProvenance, reason: &str) {
@@ -1549,6 +1556,46 @@ mod tests {
     }
 
     #[test]
+    fn trace_provenance_records_declared_toolchain_env_path() {
+        crate::test_support::with_isolated_home(|home| {
+            let component_dir = tempfile::tempdir().unwrap();
+            let toolchain_dir = tempfile::tempdir().unwrap();
+            init_git_repo(component_dir.path());
+            init_git_repo(toolchain_dir.path());
+            let bin = toolchain_dir.path().join("packages/cli/dist/index.js");
+            std::fs::create_dir_all(bin.parent().unwrap()).unwrap();
+            std::fs::write(&bin, "#!/usr/bin/env node\n").unwrap();
+            git(toolchain_dir.path(), &["add", "."]);
+            git(toolchain_dir.path(), &["commit", "-m", "add cli bin"]);
+
+            let component = test_component(component_dir.path());
+            let context = write_trace_extension(home.path(), &component);
+            let mut args = test_run_args(component_dir.path());
+            args.runner_inputs.env.push((
+                "FIXTURE_TOOLCHAIN_BIN".to_string(),
+                bin.to_string_lossy().to_string(),
+            ));
+
+            let (toolchain, _) = trace_provenance(
+                Some(&context),
+                &component_dir.path().to_string_lossy(),
+                &args,
+            )
+            .unwrap();
+
+            let provenance = toolchain
+                .toolchains
+                .get("fixture-toolchain")
+                .expect("declared toolchain provenance");
+            assert_eq!(
+                provenance.source.as_deref(),
+                Some("env:FIXTURE_TOOLCHAIN_BIN")
+            );
+            assert_eq!(toolchain.wp_codebox.as_ref(), Some(provenance));
+        });
+    }
+
+    #[test]
     fn dirty_git_provenance_makes_toolchain_non_canonical() {
         let mut reasons = Vec::new();
         let provenance = TraceGitProvenance {
@@ -1573,6 +1620,69 @@ mod tests {
             local_path: path.to_string_lossy().to_string(),
             ..Default::default()
         }
+    }
+
+    fn write_trace_extension(
+        home: &std::path::Path,
+        component: &Component,
+    ) -> ExtensionExecutionContext {
+        let extension_id = "fixture-extension";
+        let extension_dir = home.join(".config/homeboy/extensions").join(extension_id);
+        std::fs::create_dir_all(&extension_dir).expect("extension dir");
+        std::fs::write(
+            extension_dir.join(format!("{extension_id}.json")),
+            serde_json::json!({
+                "name": "Fixture Extension",
+                "version": "0.0.0",
+                "trace": {
+                    "extension_script": "trace.js",
+                    "toolchain_provenance": [
+                        {
+                            "id": "fixture-toolchain",
+                            "label": "Fixture Toolchain",
+                            "legacy_field": "wp_codebox",
+                            "env_keys": ["FIXTURE_TOOLCHAIN_BIN"]
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .expect("extension manifest");
+        std::fs::write(extension_dir.join("trace.js"), "#!/usr/bin/env node\n").unwrap();
+
+        ExtensionExecutionContext {
+            component: component.clone(),
+            capability: ExtensionCapability::Trace,
+            extension_id: extension_id.to_string(),
+            extension_path: extension_dir,
+            script_path: "trace.js".to_string(),
+            settings: Vec::new(),
+        }
+    }
+
+    fn init_git_repo(path: &std::path::Path) {
+        git(path, &["init", "-b", "main"]);
+        git(path, &["config", "user.email", "test@example.com"]);
+        git(path, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(path.join("README.md"), "test\n").unwrap();
+        git(path, &["add", "."]);
+        git(path, &["commit", "-m", "initial"]);
+    }
+
+    fn git(path: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .unwrap_or_else(|err| panic!("git {:?} failed to start: {}", args, err));
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout: {}\nstderr: {}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     fn test_run_args(path: &std::path::Path) -> TraceRunWorkflowArgs {


### PR DESCRIPTION
## Summary
- Add a generic `trace.toolchain_provenance` manifest contract for env-sourced trace toolchain paths.
- Evaluate trace canonicality/provenance from declared manifest metadata instead of hard-coded WP Codebox env keys.
- Preserve the legacy `toolchain.wp_codebox` output through declarative `legacy_field` metadata while adding generic `toolchain.toolchains` provenance.

## Context
- Fixes Extra-Chill/homeboy#4438.
- Parent tracker: Extra-Chill/homeboy#4303.
- Related operational tracker: Extra-Chill/homeboy#4140.
- Paired Homeboy Extensions manifest PR: Extra-Chill/homeboy-extensions#1378.

## Testing
- `cargo test --lib core::extension::trace`
- `git diff --check HEAD~1..HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and iterated on the trace manifest contract, core implementation, and focused tests; Chris requested and will review/own the final change.