### PR TITLE
Normalize agent task provider artifact roles

### DIFF
--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -229,6 +229,17 @@ Transient broker failures sleep for `--broker-failure-backoff-ms` and exit
 non-zero after `--broker-retry-limit` consecutive failures. `SIGINT` and
 `SIGTERM` request graceful shutdown after the current claim attempt or job.
 
+### `job`
+
+```sh
+homeboy runner job logs <job-id>
+homeboy runner job logs <job-id> --follow
+```
+
+Inspects durable runner daemon job events. Use `logs` to read the persisted event
+stream for a brokered or daemon-backed runner job without connecting directly to
+the runner process.
+
 Minimal Homeboy Lab systemd unit:
 
 ```ini

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -11,6 +11,7 @@ use crate::core::agent_task::{
     AgentTaskWorkspace, AgentTaskWorkspaceMode, AGENT_TASK_OUTCOME_SCHEMA,
     AGENT_TASK_REQUEST_SCHEMA,
 };
+use crate::core::agent_task_provider::{role_aliases_for_provider, AgentTaskProviderRoleAliases};
 use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals, AgentTaskPlan,
     AgentTaskProgressEvent, AgentTaskQueueStatus, AgentTaskState, AGENT_TASK_AGGREGATE_SCHEMA,
@@ -625,13 +626,7 @@ pub fn record_remote_dispatch_failure(
 fn enrich_remote_dispatch_aggregate(envelope: &Value, aggregate: &mut AgentTaskAggregate) {
     let remote_run_id = envelope.get("run_id").and_then(Value::as_str);
     for outcome in &mut aggregate.outcomes {
-        if outcome.outputs.get("codebox_run_result").is_none() {
-            if let Some(result) = outcome.metadata.get("codebox_run_result") {
-                let mut outputs = outcome.outputs.as_object().cloned().unwrap_or_default();
-                outputs.insert("codebox_run_result".to_string(), result.clone());
-                outcome.outputs = Value::Object(outputs);
-            }
-        }
+        normalize_provider_run_result(outcome);
 
         if outcome.evidence_refs.is_empty() {
             if let Some(remote_run_id) = remote_run_id {
@@ -1150,15 +1145,14 @@ fn provider_handle_from_outcome_metadata(
     outcome: &AgentTaskOutcome,
 ) -> Option<AgentTaskRunProviderHandle> {
     let provider = outcome.metadata.get("provider").and_then(Value::as_str)?;
+    let role_aliases = role_aliases_for_provider(provider);
     let provider_run_id = outcome
         .metadata
         .get("remote_run_id")
         .or_else(|| outcome.metadata.get("provider_run_id"))
         .and_then(Value::as_str)
         .or_else(|| {
-            outcome
-                .outputs
-                .get("codebox_run_result")
+            provider_run_result(outcome, &role_aliases)
                 .and_then(|result| result.get("run_id").or_else(|| result.get("id")))
                 .and_then(Value::as_str)
         })?;
@@ -1175,6 +1169,44 @@ fn provider_handle_from_outcome_metadata(
         state: Some(task_state_for_outcome_status(outcome.status)),
         metadata: outcome.metadata.clone(),
     })
+}
+
+fn normalize_provider_run_result(outcome: &mut AgentTaskOutcome) {
+    if outcome.outputs.get("provider_run_result").is_some() {
+        return;
+    }
+    let role_aliases = outcome
+        .metadata
+        .get("provider")
+        .and_then(Value::as_str)
+        .map(role_aliases_for_provider)
+        .unwrap_or_default();
+    if let Some(result) = provider_run_result(outcome, &role_aliases).cloned() {
+        let mut outputs = outcome.outputs.as_object().cloned().unwrap_or_default();
+        outputs.insert("provider_run_result".to_string(), result);
+        outcome.outputs = Value::Object(outputs);
+    }
+}
+
+fn provider_run_result<'a>(
+    outcome: &'a AgentTaskOutcome,
+    role_aliases: &AgentTaskProviderRoleAliases,
+) -> Option<&'a Value> {
+    outcome
+        .outputs
+        .get("provider_run_result")
+        .or_else(|| {
+            role_aliases
+                .output_aliases_for_role("provider_run_result")
+                .into_iter()
+                .find_map(|alias| outcome.outputs.get(alias))
+        })
+        .or_else(|| {
+            role_aliases
+                .metadata_aliases_for_role("provider_run_result")
+                .into_iter()
+                .find_map(|alias| outcome.metadata.get(alias))
+        })
 }
 
 fn provider_handle_from_value(value: &Value) -> Option<AgentTaskExecutionHandle> {
@@ -1249,6 +1281,41 @@ mod tests {
         AGENT_TASK_AGGREGATE_SCHEMA,
     };
     use crate::test_support::with_isolated_home;
+
+    #[test]
+    fn provider_run_result_reads_declared_output_alias() {
+        let role_aliases: AgentTaskProviderRoleAliases = serde_json::from_value(json!({
+            "outputs": {
+                "provider_run_result": ["custom_run_result"]
+            }
+        }))
+        .expect("role aliases");
+        let outcome = AgentTaskOutcome {
+            schema: crate::core::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: "task-a".to_string(),
+            status: crate::core::agent_task::AgentTaskOutcomeStatus::Failed,
+            summary: None,
+            failure_classification: None,
+            artifacts: Vec::new(),
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            outputs: json!({
+                "custom_run_result": {
+                    "run_id": "custom-run-1"
+                }
+            }),
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        };
+
+        assert_eq!(
+            provider_run_result(&outcome, &role_aliases)
+                .and_then(|result| result.get("run_id"))
+                .and_then(Value::as_str),
+            Some("custom-run-1")
+        );
+    }
 
     #[test]
     fn submit_plan_persists_queued_status() {

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -32,10 +32,98 @@ pub struct AgentTaskExecutorProvider {
     pub capabilities: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_materialization: Option<AgentTaskProviderWorkspaceMaterialization>,
+    #[serde(
+        default,
+        skip_serializing_if = "AgentTaskProviderRoleAliases::is_empty"
+    )]
+    pub role_aliases: AgentTaskProviderRoleAliases,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extension_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extension_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentTaskProviderRoleAliases {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub artifact_kinds: BTreeMap<String, Vec<String>>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub artifact_filenames: BTreeMap<String, Vec<String>>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub outputs: BTreeMap<String, Vec<String>>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, Vec<String>>,
+}
+
+impl AgentTaskProviderRoleAliases {
+    pub fn is_empty(&self) -> bool {
+        self.artifact_kinds.is_empty()
+            && self.artifact_filenames.is_empty()
+            && self.outputs.is_empty()
+            && self.metadata.is_empty()
+    }
+
+    pub fn artifact_kind_matches_role(&self, role: &str, kind: &str) -> bool {
+        alias_matches(self.artifact_kinds.get(role), kind)
+    }
+
+    pub fn artifact_filename_matches_role(&self, role: &str, filename: &str) -> bool {
+        alias_matches(self.artifact_filenames.get(role), filename)
+    }
+
+    pub fn role_for_artifact_kind(&self, kind: &str) -> Option<&str> {
+        self.artifact_kinds
+            .iter()
+            .find_map(|(role, aliases)| alias_matches(Some(aliases), kind).then_some(role.as_str()))
+    }
+
+    pub fn output_aliases_for_role(&self, role: &str) -> Vec<&str> {
+        aliases_for_role(&self.outputs, role)
+    }
+
+    pub fn metadata_aliases_for_role(&self, role: &str) -> Vec<&str> {
+        aliases_for_role(&self.metadata, role)
+    }
+}
+
+fn aliases_for_role<'a>(map: &'a BTreeMap<String, Vec<String>>, role: &str) -> Vec<&'a str> {
+    map.get(role)
+        .into_iter()
+        .flatten()
+        .map(String::as_str)
+        .collect()
+}
+
+fn alias_matches(aliases: Option<&Vec<String>>, value: &str) -> bool {
+    let value = value.to_ascii_lowercase();
+    aliases.into_iter().flatten().any(|alias| {
+        let alias = alias.to_ascii_lowercase();
+        alias == value || wildcard_match(&alias, &value)
+    })
+}
+
+fn wildcard_match(pattern: &str, value: &str) -> bool {
+    if !pattern.contains('*') {
+        return pattern == value;
+    }
+
+    let mut remainder = value;
+    let anchored_start = !pattern.starts_with('*');
+    let anchored_end = !pattern.ends_with('*');
+    let parts: Vec<&str> = pattern.split('*').filter(|part| !part.is_empty()).collect();
+    if parts.is_empty() {
+        return true;
+    }
+    if anchored_start && !value.starts_with(parts[0]) {
+        return false;
+    }
+    for part in &parts {
+        let Some(index) = remainder.find(part) else {
+            return false;
+        };
+        remainder = &remainder[index + part.len()..];
+    }
+    !anchored_end || value.ends_with(parts[parts.len() - 1])
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -79,6 +167,29 @@ pub fn provider_requires_cwd_git_checkout(backend: &str, selector: Option<&str>)
     provider_requires_cwd_git_checkout_with_providers(&providers, backend, selector)
 }
 
+pub(crate) fn role_aliases_for_executor(
+    backend: &str,
+    selector: Option<&str>,
+) -> AgentTaskProviderRoleAliases {
+    let providers = discover_agent_task_executor_providers();
+    select_provider_by_backend(&providers, backend, selector)
+        .map(|provider| provider.role_aliases.clone())
+        .unwrap_or_default()
+}
+
+pub(crate) fn role_aliases_for_provider(
+    provider_id_or_backend: &str,
+) -> AgentTaskProviderRoleAliases {
+    let providers = discover_agent_task_executor_providers();
+    providers
+        .iter()
+        .find(|provider| {
+            provider.id == provider_id_or_backend || provider.backend == provider_id_or_backend
+        })
+        .map(|provider| provider.role_aliases.clone())
+        .unwrap_or_default()
+}
+
 fn provider_requires_cwd_git_checkout_with_providers(
     providers: &[AgentTaskExecutorProvider],
     backend: &str,
@@ -86,9 +197,7 @@ fn provider_requires_cwd_git_checkout_with_providers(
 ) -> bool {
     providers
         .iter()
-        .find(|provider| {
-            provider.backend == backend && selector.is_none_or(|selector| provider.id == selector)
-        })
+        .find(|provider| provider_matches_backend(provider, backend, selector))
         .and_then(|provider| provider.workspace_materialization.as_ref())
         .and_then(|materialization| materialization.cwd.as_deref())
         == Some("git_checkout")
@@ -343,14 +452,29 @@ fn select_provider<'a>(
     providers: &'a [AgentTaskExecutorProvider],
     request: &AgentTaskRequest,
 ) -> Option<&'a AgentTaskExecutorProvider> {
-    providers.iter().find(|provider| {
-        provider.backend == request.executor.backend
-            && request
-                .executor
-                .selector
-                .as_ref()
-                .is_none_or(|selector| provider.id == *selector)
-    })
+    select_provider_by_backend(
+        providers,
+        &request.executor.backend,
+        request.executor.selector.as_deref(),
+    )
+}
+
+fn select_provider_by_backend<'a>(
+    providers: &'a [AgentTaskExecutorProvider],
+    backend: &str,
+    selector: Option<&str>,
+) -> Option<&'a AgentTaskExecutorProvider> {
+    providers
+        .iter()
+        .find(|provider| provider_matches_backend(provider, backend, selector))
+}
+
+fn provider_matches_backend(
+    provider: &AgentTaskExecutorProvider,
+    backend: &str,
+    selector: Option<&str>,
+) -> bool {
+    provider.backend == backend && selector.is_none_or(|selector| provider.id == selector)
 }
 
 fn required_extension_ids_for_plan_with_providers(
@@ -502,6 +626,7 @@ fn run_provider_command(
             if outcome.schema != AGENT_TASK_OUTCOME_SCHEMA {
                 outcome.schema = AGENT_TASK_OUTCOME_SCHEMA.to_string();
             }
+            normalize_provider_outcome_roles(&mut outcome, provider);
             outcome
         }
         Err(error) => failure_outcome(
@@ -516,6 +641,66 @@ fn run_provider_command(
             json!({ "provider": provider.id, "command": command, "exit_code": output.status.code(), "stderr": stderr, "stdout": stdout }),
         ),
     }
+}
+
+fn normalize_provider_outcome_roles(
+    outcome: &mut AgentTaskOutcome,
+    provider: &AgentTaskExecutorProvider,
+) {
+    normalize_provider_artifact_roles(&mut outcome.artifacts, &provider.role_aliases);
+    normalize_provider_run_result_output(outcome, &provider.role_aliases);
+}
+
+fn normalize_provider_artifact_roles(
+    artifacts: &mut [AgentTaskArtifact],
+    role_aliases: &AgentTaskProviderRoleAliases,
+) {
+    for artifact in artifacts {
+        let Some(role) = role_aliases.role_for_artifact_kind(&artifact.kind) else {
+            continue;
+        };
+        let original_kind = artifact.kind.clone();
+        artifact.kind = role.to_string();
+        if !artifact.metadata.is_object() {
+            artifact.metadata = json!({});
+        }
+        if let Some(metadata) = artifact.metadata.as_object_mut() {
+            metadata.entry("role".to_string()).or_insert(json!(role));
+            metadata
+                .entry("provider_kind".to_string())
+                .or_insert(json!(original_kind));
+        }
+    }
+}
+
+fn normalize_provider_run_result_output(
+    outcome: &mut AgentTaskOutcome,
+    role_aliases: &AgentTaskProviderRoleAliases,
+) {
+    if output_value(&outcome.outputs, "provider_run_result").is_some() {
+        return;
+    }
+
+    let value = role_aliases
+        .output_aliases_for_role("provider_run_result")
+        .into_iter()
+        .find_map(|alias| output_value(&outcome.outputs, alias))
+        .or_else(|| {
+            role_aliases
+                .metadata_aliases_for_role("provider_run_result")
+                .into_iter()
+                .find_map(|alias| output_value(&outcome.metadata, alias))
+        });
+
+    if let Some(value) = value.cloned() {
+        let mut outputs = outcome.outputs.as_object().cloned().unwrap_or_default();
+        outputs.insert("provider_run_result".to_string(), value);
+        outcome.outputs = Value::Object(outputs);
+    }
+}
+
+fn output_value<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
+    value.get(key).filter(|value| !value.is_null())
 }
 
 fn render_provider_command(provider: &AgentTaskExecutorProvider) -> String {
@@ -620,6 +805,7 @@ mod tests {
             outcome_schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
             capabilities: vec!["structured_outcome".to_string()],
             workspace_materialization: None,
+            role_aliases: AgentTaskProviderRoleAliases::default(),
             extension_id: None,
             extension_path: None,
         };
@@ -666,6 +852,101 @@ mod tests {
         ));
 
         assert_eq!(extension_ids, vec!["extension-a", "extension-b"]);
+    }
+
+    #[test]
+    fn provider_manifest_parses_role_aliases() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(json!({
+            "schema": "homeboy/agent-task-executor-provider/v1",
+            "id": "custom.provider",
+            "backend": "custom",
+            "command": "custom-agent-task",
+            "request_schema": AGENT_TASK_REQUEST_SCHEMA,
+            "outcome_schema": AGENT_TASK_OUTCOME_SCHEMA,
+            "role_aliases": {
+                "artifact_kinds": {
+                    "patch": ["custom-patch"]
+                },
+                "artifact_filenames": {
+                    "preflight_evidence": ["*-preflight.json"]
+                },
+                "outputs": {
+                    "provider_run_result": ["custom_run_result"]
+                },
+                "metadata": {
+                    "provider_run_result": ["customRunResult"]
+                }
+            }
+        }))
+        .expect("provider manifest");
+
+        assert!(provider
+            .role_aliases
+            .artifact_kind_matches_role("patch", "custom-patch"));
+        assert!(provider
+            .role_aliases
+            .artifact_filename_matches_role("preflight_evidence", "runner-preflight.json"));
+        assert_eq!(
+            provider
+                .role_aliases
+                .output_aliases_for_role("provider_run_result"),
+            vec!["custom_run_result"]
+        );
+    }
+
+    #[test]
+    fn provider_outcome_roles_normalize_from_declared_aliases() {
+        let (_, mut provider) = request("task-a", "node provider.js".to_string());
+        provider.role_aliases = serde_json::from_value(json!({
+            "artifact_kinds": {
+                "patch": ["custom-patch"]
+            },
+            "outputs": {
+                "provider_run_result": ["custom_run_result"]
+            }
+        }))
+        .expect("role aliases");
+        let patch_path = std::env::temp_dir().join("custom.patch");
+        fs::write(&patch_path, "diff --git a/a b/a\n").expect("patch");
+        let mut outcome = AgentTaskOutcome {
+            schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            task_id: "task-a".to_string(),
+            status: AgentTaskOutcomeStatus::Succeeded,
+            summary: None,
+            failure_classification: None,
+            artifacts: vec![fixture_artifact(
+                "patch",
+                "custom-patch",
+                &patch_path,
+                Some("text/x-patch"),
+            )],
+            evidence_refs: Vec::new(),
+            diagnostics: Vec::new(),
+            outputs: json!({
+                "custom_run_result": {
+                    "run_id": "custom-run-1"
+                }
+            }),
+            workflow: None,
+            follow_up: None,
+            metadata: Value::Null,
+        };
+
+        normalize_provider_outcome_roles(&mut outcome, &provider);
+
+        assert_eq!(outcome.artifacts[0].kind, "patch");
+        assert_eq!(
+            outcome.artifacts[0].metadata["provider_kind"],
+            "custom-patch"
+        );
+        assert_eq!(
+            outcome.outputs["provider_run_result"]["run_id"],
+            "custom-run-1"
+        );
+        assert_eq!(
+            outcome.outputs["custom_run_result"]["run_id"],
+            "custom-run-1"
+        );
     }
 
     #[test]
@@ -811,10 +1092,10 @@ mod tests {
     fn provider_can_return_timeout_payload_during_wrapper_grace() {
         let command = format!(
             "node {}",
-            script("let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); setTimeout(()=>process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'timeout',summary:'provider serialized timeout',failure_classification:'timeout',artifacts:[{schema:'homeboy/agent-task-artifact/v1',id:'timeout-evidence',kind:'codebox-task-runner-preflight',path:'/tmp/timeout-evidence.json'}]})), 2050);")
+            script("let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); setTimeout(()=>process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'timeout',summary:'provider serialized timeout',failure_classification:'timeout',artifacts:[{schema:'homeboy/agent-task-artifact/v1',id:'timeout-evidence',kind:'codebox-task-runner-preflight',path:'/tmp/timeout-evidence.json'}]})), 3050);")
         );
         let (mut request, provider) = request("task-timeout-payload", command);
-        request.limits.timeout_ms = Some(2000);
+        request.limits.timeout_ms = Some(3000);
 
         let outcome = run_provider_command(&request, &provider);
 

--- a/src/core/agent_task_timeout_artifacts.rs
+++ b/src/core/agent_task_timeout_artifacts.rs
@@ -9,6 +9,7 @@ use crate::core::agent_task::{
     AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_ARTIFACT_SCHEMA,
     AGENT_TASK_OUTCOME_SCHEMA,
 };
+use crate::core::agent_task_provider::{role_aliases_for_executor, AgentTaskProviderRoleAliases};
 
 const EXPECTED_RUNTIME_EVIDENCE_FILES: &[&str] = &[
     "transcript.json",
@@ -31,9 +32,20 @@ pub(crate) struct TimeoutArtifactDiscovery {
 
 impl TimeoutArtifactDiscovery {
     pub(crate) fn discover(request: &AgentTaskRequest) -> Self {
+        let role_aliases = role_aliases_for_executor(
+            &request.executor.backend,
+            request.executor.selector.as_deref(),
+        );
+        Self::discover_with_role_aliases(request, &role_aliases)
+    }
+
+    fn discover_with_role_aliases(
+        request: &AgentTaskRequest,
+        role_aliases: &AgentTaskProviderRoleAliases,
+    ) -> Self {
         let mut discovery = Self::default();
         for path in artifact_discovery_paths(request) {
-            discovery.scan_path(&path, request);
+            discovery.scan_path(&path, request, &role_aliases);
         }
         discovery
     }
@@ -42,13 +54,18 @@ impl TimeoutArtifactDiscovery {
         self.runtime_evidence_count() > 0
     }
 
-    fn scan_path(&mut self, path: &Path, request: &AgentTaskRequest) {
+    fn scan_path(
+        &mut self,
+        path: &Path,
+        request: &AgentTaskRequest,
+        role_aliases: &AgentTaskProviderRoleAliases,
+    ) {
         let Ok(metadata) = fs::metadata(path) else {
             return;
         };
 
         if metadata.is_file() {
-            self.record_file(path, request);
+            self.record_file(path, request, role_aliases);
             return;
         }
 
@@ -57,7 +74,7 @@ impl TimeoutArtifactDiscovery {
         }
 
         let runtime_evidence_count_before = self.runtime_evidence_count();
-        self.scan_directory_files(path, request, 0, &mut 0);
+        self.scan_directory_files(path, request, role_aliases, 0, &mut 0);
         self.record_directory_if_useful(
             path,
             self.runtime_evidence_count() > runtime_evidence_count_before,
@@ -112,7 +129,12 @@ impl TimeoutArtifactDiscovery {
         });
     }
 
-    fn record_file(&mut self, path: &Path, request: &AgentTaskRequest) {
+    fn record_file(
+        &mut self,
+        path: &Path,
+        request: &AgentTaskRequest,
+        role_aliases: &AgentTaskProviderRoleAliases,
+    ) {
         if let Some(outcome) = read_discovered_outcome(path, request) {
             append_unique_artifacts(&mut self.artifacts, outcome.artifacts.clone());
             append_unique_evidence_refs(&mut self.evidence_refs, outcome.evidence_refs.clone());
@@ -125,7 +147,7 @@ impl TimeoutArtifactDiscovery {
             return;
         }
 
-        let Some(kind) = artifact_kind_from_path(path) else {
+        let Some(kind) = artifact_kind_from_path(path, role_aliases) else {
             return;
         };
         let Some(id) = artifact_id_from_path(path) else {
@@ -152,6 +174,7 @@ impl TimeoutArtifactDiscovery {
         &mut self,
         path: &Path,
         request: &AgentTaskRequest,
+        role_aliases: &AgentTaskProviderRoleAliases,
         depth: usize,
         visited: &mut usize,
     ) {
@@ -172,10 +195,10 @@ impl TimeoutArtifactDiscovery {
                 continue;
             };
             if child_metadata.is_file() {
-                self.record_file(&child, request);
+                self.record_file(&child, request, role_aliases);
             } else if child_metadata.is_dir() {
                 let runtime_evidence_count_before = self.runtime_evidence_count();
-                self.scan_directory_files(&child, request, depth + 1, visited);
+                self.scan_directory_files(&child, request, role_aliases, depth + 1, visited);
                 self.record_directory_if_useful(
                     &child,
                     self.runtime_evidence_count() > runtime_evidence_count_before,
@@ -253,7 +276,6 @@ pub(crate) fn is_empty_patch_artifact(artifact: &AgentTaskArtifact) -> bool {
 fn artifact_has_patch_shape(artifact: &AgentTaskArtifact) -> bool {
     artifact.kind == "patch"
         || artifact.kind == "diff"
-        || artifact.kind == "codebox-patch"
         || artifact.mime.as_deref() == Some("text/x-patch")
         || artifact.mime.as_deref() == Some("text/x-diff")
         || artifact.metadata.get("role").and_then(Value::as_str) == Some("patch")
@@ -341,7 +363,10 @@ fn merge_outcome_metadata_actionable(metadata: Value, actionable: bool) -> Value
     }
 }
 
-fn artifact_kind_from_path(path: &Path) -> Option<String> {
+fn artifact_kind_from_path(
+    path: &Path,
+    role_aliases: &AgentTaskProviderRoleAliases,
+) -> Option<String> {
     let file_name = path.file_name()?.to_string_lossy().to_ascii_lowercase();
     let extension = path
         .extension()
@@ -361,8 +386,18 @@ fn artifact_kind_from_path(path: &Path) -> Option<String> {
     if file_name.contains("agent-result") || file_name.contains("agent_result") {
         return Some("agent_result".to_string());
     }
-    if file_name == "homeboy-codebox-task-runner.json" {
-        return Some("preflight_evidence".to_string());
+
+    for role in [
+        "patch",
+        "preflight_evidence",
+        "runtime_bundle",
+        "agent_result",
+    ] {
+        if role_aliases.artifact_filename_matches_role(role, &file_name)
+            || role_aliases.artifact_kind_matches_role(role, &file_name)
+        {
+            return Some(role.to_string());
+        }
     }
 
     None
@@ -433,9 +468,16 @@ mod tests {
         let preflight_path = artifact_root.join("homeboy-codebox-task-runner.json");
         fs::write(&preflight_path, r#"{"runner":"codebox"}"#).expect("preflight evidence");
 
-        let discovery = TimeoutArtifactDiscovery::discover(&test_request(json!({
-            "artifact_root": artifact_root,
-        })));
+        let discovery = TimeoutArtifactDiscovery::discover_with_role_aliases(
+            &test_request(json!({
+                "artifact_root": artifact_root,
+            })),
+            &role_aliases(json!({
+                "artifact_filenames": {
+                    "preflight_evidence": ["homeboy-codebox-task-runner.json"]
+                }
+            })),
+        );
 
         assert!(!discovery.has_runtime_evidence());
         assert!(discovery.artifacts.iter().any(|artifact| {
@@ -446,6 +488,31 @@ mod tests {
             diagnostic.class == "empty_runtime_bundle"
                 && diagnostic.data.get("path").and_then(Value::as_str)
                     == Some(&empty_runtime.to_string_lossy())
+        }));
+    }
+
+    #[test]
+    fn provider_declared_filename_pattern_maps_to_generic_role() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact_root = temp.path().join("task-1-artifacts");
+        fs::create_dir_all(&artifact_root).expect("artifact root");
+        let evidence_path = artifact_root.join("provider-preflight-evidence.json");
+        fs::write(&evidence_path, r#"{"provider":"custom"}"#).expect("preflight evidence");
+
+        let discovery = TimeoutArtifactDiscovery::discover_with_role_aliases(
+            &test_request(json!({
+                "artifact_root": artifact_root,
+            })),
+            &role_aliases(json!({
+                "artifact_filenames": {
+                    "preflight_evidence": ["*-preflight-evidence.json"]
+                }
+            })),
+        );
+
+        assert!(discovery.artifacts.iter().any(|artifact| {
+            artifact.kind == "preflight_evidence"
+                && artifact.path.as_deref() == Some(&evidence_path.to_string_lossy())
         }));
     }
 
@@ -472,5 +539,9 @@ mod tests {
             expected_artifacts: Vec::new(),
             metadata,
         }
+    }
+
+    fn role_aliases(value: Value) -> AgentTaskProviderRoleAliases {
+        serde_json::from_value(value).expect("role aliases")
     }
 }

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -208,8 +208,8 @@ pub mod promotion {
 pub mod provider {
     pub use super::super::agent_task_provider::{
         provider_requires_cwd_git_checkout, required_extension_ids_for_plan,
-        AgentTaskExecutorProvider, AgentTaskProviderWorkspaceMaterialization,
-        ExtensionProviderAgentTaskExecutor,
+        AgentTaskExecutorProvider, AgentTaskProviderRoleAliases,
+        AgentTaskProviderWorkspaceMaterialization, ExtensionProviderAgentTaskExecutor,
     };
 }
 


### PR DESCRIPTION
## Summary
- Add provider-declared role aliases for agent-task artifact kinds, artifact filenames, output keys, and metadata keys.
- Normalize provider-specific artifacts/results into generic roles such as `patch`, `preflight_evidence`, and `provider_run_result` without hardcoding provider names in core.
- Preserve existing Codebox behavior through the generic alias path and add targeted role-alias coverage.

## Testing
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-4435-target cargo fmt --check`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-4435-target cargo test agent_task_provider --lib`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-4435-target cargo test agent_task_timeout_artifacts --lib`
- `CARGO_TARGET_DIR=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-4435-target cargo test agent_task_lifecycle --lib`

## Links
- Fixes Extra-Chill/homeboy#4435
- Parent tracker: Extra-Chill/homeboy#4303
- Related contract history: Extra-Chill/homeboy#3088

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the provider role-alias slice, updating focused tests, and running local verification. Chris reviewed and owns the final submission.