### PR TITLE
fix: include service tunnel ids in list output

### DIFF
--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -18,7 +18,7 @@ use crate::core::{CreateOutput, MergeOutput, RemoveResult};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServiceTunnel {
-    #[serde(skip)]
+    #[serde(skip_deserializing, default)]
     pub id: String,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/src/core/tunnel_tests.rs
+++ b/src/core/tunnel_tests.rs
@@ -59,6 +59,44 @@ fn expose_records_private_loopback_declaration_without_running_tunnel() {
 }
 
 #[test]
+fn list_serializes_stable_service_ids() {
+    test_support::with_isolated_home(|_| {
+        create_server();
+
+        expose(ExposeServiceTunnelSpec {
+            id: "copy-paste-service".to_string(),
+            server_id: "private-host".to_string(),
+            target: ServiceTunnelTarget {
+                host: "127.0.0.1".to_string(),
+                port: 7331,
+            },
+            scheme: "http".to_string(),
+            local_port: Some(8831),
+            auth: ServiceTunnelAuth {
+                mode: ServiceTunnelAuthMode::BearerEnv,
+                env_var: Some("COPY_PASTE_TOKEN".to_string()),
+                header: Some("Authorization".to_string()),
+            },
+            policy: ServiceTunnelPolicy {
+                exposure: ServiceTunnelExposure::PrivateLoopback,
+                require_auth: true,
+                allowed_clients: Vec::new(),
+                preview: ServiceTunnelPreviewPolicy::default(),
+                native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
+            },
+            description: Some("Copy-pasteable service".to_string()),
+        })
+        .expect("expose service");
+
+        let tunnels = list().expect("list services");
+        let value = serde_json::to_value(&tunnels).expect("serialize list");
+
+        assert_eq!(value[0]["id"], "copy-paste-service");
+        assert_eq!(tunnels[0].id, "copy-paste-service");
+    });
+}
+
+#[test]
 fn validation_rejects_auth_mode_without_env_var() {
     test_support::with_isolated_home(|_| {
         create_server();


### PR DESCRIPTION
## Summary
- Include stable service tunnel `id` values when service declarations are serialized for list output.
- Keep service tunnel config input behavior unchanged by continuing to derive IDs from config filenames on load.
- Add focused coverage that listed service tunnel entities serialize with copy-pasteable IDs.

Fixes #4487

## Testing
- `cargo fmt --check`
- `cargo test core::tunnel_tests::list_serializes_stable_service_ids` timed out after dependency compilation was still in progress; no test failure was emitted.
- `cargo test --lib core::tunnel_tests::list_serializes_stable_service_ids` was started after that but stopped per request to let CI handle the full matrix.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused Rust serialization change, added targeted test coverage, and prepared the PR. Chris requested stopping local polishing and deferring the full test matrix to CI.