### PR TITLE
fix: route agent-task auth status to runners

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -104,6 +104,21 @@ impl Commands {
                     LAB_NO_EXTRA_TOOLS,
                 )
             }
+            Commands::AgentTask(args)
+                if matches!(
+                    args.command,
+                    agent_task::AgentTaskCommand::Auth(agent_task::AgentTaskAuthArgs {
+                        command: agent_task::AgentTaskAuthCommand::Status(_),
+                    })
+                ) =>
+            {
+                LabCommandContract::explicit_runner(
+                    "agent-task auth status",
+                    None,
+                    false,
+                    LAB_NO_EXTRA_TOOLS,
+                )
+            }
             Commands::Audit(args) => args.lab_contract()?,
             Commands::Bench(args) => args.lab_contract()?,
             Commands::Extension(args) if args.is_update_command() => {
@@ -534,6 +549,17 @@ mod tests {
                 parsed_command(&["homeboy", "agent-task", "providers"]),
                 "agent-task providers",
             ),
+            (
+                parsed_command(&[
+                    "homeboy",
+                    "agent-task",
+                    "auth",
+                    "status",
+                    "--secret-env",
+                    "OPENAI_API_KEY",
+                ]),
+                "agent-task auth status",
+            ),
         ];
 
         for (command, label) in supported {
@@ -631,6 +657,16 @@ mod tests {
         assert!(parsed_command(&["homeboy", "audit", "--conventions"])
             .lab_contract()
             .is_none());
+        assert!(parsed_command(&[
+            "homeboy",
+            "agent-task",
+            "auth",
+            "map-env",
+            "OPENAI_API_KEY",
+            "OPENAI_API_KEY",
+        ])
+        .lab_contract()
+        .is_none());
         assert!(
             parsed_command(&["homeboy", "lint", "--file", "src/main.rs"])
                 .lab_contract()

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -164,7 +164,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             "runner",
             message,
             Some(runner_id.to_string()),
-            Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+            Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, agent-task auth status, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
         )
     };
     let mut plan = base_lab_plan(request.command.as_ref());
@@ -172,7 +172,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if let Some(runner_id) = request.explicit_runner {
             return Err(unsupported_runner_error(
                 runner_id,
-                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, agent-task auth status, lint, test, audit, bench, trace, and refactor source runs".to_string(),
             ));
         }
         return Ok(LabOffloadOutcome::RunLocal {
@@ -185,7 +185,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.portable {
         if let Some(runner_id) = request.explicit_runner {
             let message = contract.unsupported_reason.map_or_else(
-                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, agent-task auth status, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
             );
             return Err(unsupported_runner_error(runner_id, message));

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -348,14 +348,14 @@ pub(super) fn resolve_lab_runner_selection_from_default(
     if let Some(runner_id) = explicit_runner {
         if !command.portable {
             let message = command.unsupported_reason.map_or_else(
-                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, agent-task auth status, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this hot command. {reason}"),
             );
             return Err(Error::validation_invalid_argument(
                 "runner",
                 message,
                 Some(runner_id.to_string()),
-                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, agent-task auth status, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
             ));
         }
 

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -131,6 +131,21 @@ fn runner_job_logs_command_parses() {
     .expect("runner job logs command should parse");
 }
 
+#[test]
+fn agent_task_auth_status_accepts_global_runner_and_secret_env() {
+    Cli::try_parse_from([
+        "homeboy",
+        "--runner",
+        "homeboy-lab",
+        "agent-task",
+        "auth",
+        "status",
+        "--secret-env",
+        "OPENAI_API_KEY",
+    ])
+    .expect("agent-task auth status should accept global --runner with auth --secret-env");
+}
+
 fn documented_command_index_entries() -> BTreeSet<String> {
     let index = include_str!("../docs/commands/commands-index.md");
     let command_section = index.split("Related:").next().unwrap_or(index);


### PR DESCRIPTION
## Summary
- Adds a Lab explicit-runner command contract for `homeboy agent-task auth status`.
- Keeps auth mutation commands local while allowing `--runner <runner> --secret-env <name>` readiness checks to execute in runner context.
- Updates generic Lab support text and focused command-surface tests.

Fixes #4476.

## Testing
- `cargo fmt`
- Local `cargo test` was intentionally stopped after build contention/timeouts; CI is the verification path for this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the command-contract change, focused tests, and PR description; Chris directed CI-based verification instead of local tests.