### PR TITLE
fix: label persisted trace run ids after offload

### DIFF
--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -86,7 +86,7 @@ pub fn route_after_parse(
 
     match lab_result {
         Err(err) => {
-            crate::commands::trace::finish_lab_dispatch_observation(
+            let _ = crate::commands::trace::finish_lab_dispatch_observation(
                 trace_observation,
                 RunStatus::Error,
                 json!({
@@ -109,7 +109,7 @@ pub fn route_after_parse(
             runners::LabOffloadOutcome::RunLocal {
                 metadata, messages, ..
             } => {
-                crate::commands::trace::finish_lab_dispatch_observation(
+                let _ = crate::commands::trace::finish_lab_dispatch_observation(
                     trace_observation,
                     RunStatus::Skipped,
                     json!({
@@ -136,7 +136,7 @@ pub fn route_after_parse(
                 exit_code,
                 ..
             } => {
-                crate::commands::trace::finish_lab_dispatch_observation(
+                let retrieval = crate::commands::trace::finish_lab_dispatch_observation(
                     trace_observation,
                     if exit_code == 0 {
                         RunStatus::Pass
@@ -155,6 +155,7 @@ pub fn route_after_parse(
                 if !stderr.is_empty() {
                     eprint!("{stderr}");
                 }
+                let stdout = stdout_with_persisted_run_retrieval(&stdout, retrieval.as_ref());
                 if let Some(path) = output_file {
                     write_offloaded_stdout(path, &stdout)?;
                 }
@@ -247,6 +248,55 @@ fn write_offloaded_stdout(path: &str, stdout: &str) -> homeboy::core::Result<()>
     std::fs::write(path, stdout).map_err(|err| {
         homeboy::core::Error::internal_io(err.to_string(), Some(format!("write {path}")))
     })
+}
+
+fn stdout_with_persisted_run_retrieval(
+    stdout: &str,
+    retrieval: Option<&crate::commands::trace::PersistedRunRetrieval>,
+) -> String {
+    let Some(retrieval) = retrieval else {
+        return stdout.to_string();
+    };
+
+    if let Ok(mut json) = serde_json::from_str::<serde_json::Value>(stdout) {
+        attach_persisted_run_retrieval_json(&mut json, retrieval);
+        if let Ok(mut rendered) = serde_json::to_string_pretty(&json) {
+            rendered.push('\n');
+            return rendered;
+        }
+    }
+
+    let mut rendered = stdout.to_string();
+    if !rendered.ends_with('\n') {
+        rendered.push('\n');
+    }
+    rendered.push('\n');
+    rendered.push_str("# Homeboy persisted run\n\n");
+    rendered.push_str(&format!(
+        "- **Persisted Homeboy run ID:** `{}`\n",
+        retrieval.run_id
+    ));
+    rendered.push_str("- **ID scope:** runtime, temp, and artifact identifiers above are offload context; use the persisted Homeboy run ID for local retrieval.\n");
+    rendered.push_str("- **Retrieve evidence:** `");
+    rendered.push_str(&retrieval.evidence_command);
+    rendered.push_str("`\n");
+    rendered.push_str("- **List artifacts:** `");
+    rendered.push_str(&retrieval.artifacts_command);
+    rendered.push_str("`\n");
+    rendered.push_str("- **Export run bundle:** `");
+    rendered.push_str(&retrieval.export_command);
+    rendered.push_str("`\n");
+    rendered
+}
+
+fn attach_persisted_run_retrieval_json(
+    json: &mut serde_json::Value,
+    retrieval: &crate::commands::trace::PersistedRunRetrieval,
+) {
+    let retrieval_json = retrieval.to_json();
+    if let Some(object) = json.as_object_mut() {
+        object.insert("homeboy_persisted_run".to_string(), retrieval_json);
+    }
 }
 
 fn lab_offload_command(
@@ -463,6 +513,76 @@ mod tests {
             std::fs::read_to_string(output_path).unwrap(),
             "{\"ok\":true}\n"
         );
+    }
+
+    #[test]
+    fn offloaded_json_stdout_labels_persisted_homeboy_run_id() {
+        let retrieval = crate::commands::trace::PersistedRunRetrieval::for_run("trace-run-123");
+
+        let stdout = stdout_with_persisted_run_retrieval(
+            r#"{"success":true,"data":{"runtime_id":"runtime-abc","artifact_id":"artifact-xyz"}}"#,
+            Some(&retrieval),
+        );
+        let json: serde_json::Value = serde_json::from_str(&stdout).expect("json stdout");
+
+        assert_eq!(json["data"]["runtime_id"], "runtime-abc");
+        assert_eq!(json["data"]["artifact_id"], "artifact-xyz");
+        assert_eq!(
+            json["homeboy_persisted_run"]["persisted_run_id"],
+            "trace-run-123"
+        );
+        assert_eq!(
+            json["homeboy_persisted_run"]["retrieval_commands"]["evidence"],
+            "homeboy runs evidence trace-run-123"
+        );
+        assert_eq!(
+            json["homeboy_persisted_run"]["retrieval_commands"]["artifacts"],
+            "homeboy runs artifacts trace-run-123"
+        );
+        assert_eq!(
+            json["homeboy_persisted_run"]["retrieval_commands"]["export"],
+            "homeboy runs export --run trace-run-123 --output homeboy-run-trace-run-123"
+        );
+    }
+
+    #[test]
+    fn offloaded_error_json_stdout_labels_persisted_homeboy_run_id() {
+        let retrieval = crate::commands::trace::PersistedRunRetrieval::for_run("trace-run-err");
+
+        let stdout = stdout_with_persisted_run_retrieval(
+            r#"{"success":false,"error":{"code":"remote.command_failed","message":"failed","details":{"temp_id":"tmp-1"}}}"#,
+            Some(&retrieval),
+        );
+        let json: serde_json::Value = serde_json::from_str(&stdout).expect("json stdout");
+
+        assert_eq!(json["error"]["details"]["temp_id"], "tmp-1");
+        assert_eq!(
+            json["homeboy_persisted_run"]["persisted_run_id"],
+            "trace-run-err"
+        );
+        assert_eq!(
+            json["homeboy_persisted_run"]["id_scope"],
+            "persisted_homeboy_run"
+        );
+    }
+
+    #[test]
+    fn offloaded_text_stdout_appends_persisted_run_retrieval_commands() {
+        let retrieval = crate::commands::trace::PersistedRunRetrieval::for_run("trace-run-text");
+
+        let stdout = stdout_with_persisted_run_retrieval(
+            "runtime_id=runtime-abc\nartifact_id=artifact-xyz\n",
+            Some(&retrieval),
+        );
+
+        assert!(stdout.contains("runtime_id=runtime-abc"));
+        assert!(stdout.contains("artifact_id=artifact-xyz"));
+        assert!(stdout.contains("**Persisted Homeboy run ID:** `trace-run-text`"));
+        assert!(stdout.contains("`homeboy runs evidence trace-run-text`"));
+        assert!(stdout.contains("`homeboy runs artifacts trace-run-text`"));
+        assert!(stdout.contains(
+            "`homeboy runs export --run trace-run-text --output homeboy-run-trace-run-text`"
+        ));
     }
 
     #[test]

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -1447,6 +1447,39 @@ pub(super) struct LabTraceDispatchObservation {
     scenario_id: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PersistedRunRetrieval {
+    pub run_id: String,
+    pub evidence_command: String,
+    pub artifacts_command: String,
+    pub export_command: String,
+}
+
+impl PersistedRunRetrieval {
+    pub(super) fn for_run(run_id: &str) -> Self {
+        Self {
+            run_id: run_id.to_string(),
+            evidence_command: format!("homeboy runs evidence {run_id}"),
+            artifacts_command: format!("homeboy runs artifacts {run_id}"),
+            export_command: format!(
+                "homeboy runs export --run {run_id} --output homeboy-run-{run_id}"
+            ),
+        }
+    }
+
+    pub(super) fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "persisted_run_id": self.run_id,
+            "id_scope": "persisted_homeboy_run",
+            "retrieval_commands": {
+                "evidence": self.evidence_command,
+                "artifacts": self.artifacts_command,
+                "export": self.export_command,
+            }
+        })
+    }
+}
+
 pub(super) fn start_lab_dispatch_observation(
     args: &TraceArgs,
     normalized_args: &[String],
@@ -1527,10 +1560,11 @@ pub(super) fn finish_lab_dispatch_observation(
     observation: Option<LabTraceDispatchObservation>,
     status: RunStatus,
     metadata: serde_json::Value,
-) {
+) -> Option<PersistedRunRetrieval> {
     let Some(observation) = observation else {
-        return;
+        return None;
     };
+    let retrieval = PersistedRunRetrieval::for_run(&observation.run_id);
     let _ = observation.store.record_trace_run(
         NewTraceRunRecord::builder(
             &observation.run_id,
@@ -1545,6 +1579,7 @@ pub(super) fn finish_lab_dispatch_observation(
     let _ = observation
         .store
         .finish_run(&observation.run_id, status, Some(metadata));
+    Some(retrieval)
 }
 
 fn persist_trace_workflow_result(


### PR DESCRIPTION
## Summary
- Label the local persisted Homeboy run ID separately from offloaded runtime/temp/artifact identifiers.
- Add exact `homeboy runs evidence`, `homeboy runs artifacts`, and `homeboy runs export` retrieval commands to offloaded trace stdout when a persisted run exists.
- Preserve runtime/artifact context in JSON and text outputs while adding focused formatting coverage.

Fixes #4490.

## Verification
- `cargo fmt`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- Local tests and local hot validation were intentionally not run per task instruction.
- Lab/offloaded verification was not run because this change is controller-side output formatting around offloaded stdout and persisted local run metadata; exercising it would require a live lab trace dispatch with this unmerged branch installed on the controller path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the Homeboy trace offload output path, drafted the controller-side formatting change and focused coverage; Chris remains responsible for review and testing.