### PR TITLE
Fix Lab offload timeout recovery guidance

### DIFF
--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -58,31 +58,18 @@ pub fn route_after_parse(
         _ => None,
     };
 
-    let lab_result = if matches!(cli.command, Commands::Trace(_)) {
-        lab_routing::route_lab_offload(LabRoutingRequest {
-            command: lab_command,
-            normalized_args,
-            explicit_runner: cli.runner.as_deref(),
-            force_hot: cli.force_hot,
-            allow_local_hot: cli.allow_local_hot,
-            allow_local_fallback: cli.allow_local_fallback,
-            allow_dirty_lab_workspace: cli.allow_dirty_lab_workspace,
-            capture_patch: cli.command.lab_offload_mutation_flag().is_some(),
-            timeout: Some(lab_routing::lab_trace_dispatch_timeout()),
-        })
-    } else {
-        lab_routing::route_lab_offload(LabRoutingRequest {
-            command: lab_command,
-            normalized_args,
-            explicit_runner: cli.runner.as_deref(),
-            force_hot: cli.force_hot,
-            allow_local_hot: cli.allow_local_hot,
-            allow_local_fallback: cli.allow_local_fallback,
-            allow_dirty_lab_workspace: cli.allow_dirty_lab_workspace,
-            capture_patch: cli.command.lab_offload_mutation_flag().is_some(),
-            timeout: None,
-        })
-    };
+    let lab_result = lab_routing::route_lab_offload(LabRoutingRequest {
+        command: lab_command,
+        normalized_args,
+        explicit_runner: cli.runner.as_deref(),
+        force_hot: cli.force_hot,
+        allow_local_hot: cli.allow_local_hot,
+        allow_local_fallback: cli.allow_local_fallback,
+        allow_dirty_lab_workspace: cli.allow_dirty_lab_workspace,
+        capture_patch: cli.command.lab_offload_mutation_flag().is_some(),
+        timeout: None,
+        active_run_id: crate::commands::trace::lab_dispatch_observation_run_id(&trace_observation),
+    });
 
     match lab_result {
         Err(err) => {

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -399,6 +399,14 @@ enum RunnerJobCommand {
         #[arg(long = "poll-ms", default_value_t = 1000)]
         poll_ms: u64,
     },
+    /// Cancel a queued or running durable runner daemon job
+    Cancel {
+        /// Runner ID with an active daemon connection
+        runner_id: String,
+
+        /// Runner daemon job ID from runner exec/Lab output or error details
+        job_id: String,
+    },
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -1004,7 +1012,43 @@ fn job(command: RunnerJobCommand) -> CmdResult<RunnerJobOutput> {
             follow,
             poll_ms,
         } => job_logs(&runner_id, &job_id, follow, poll_ms),
+        RunnerJobCommand::Cancel { runner_id, job_id } => job_cancel(&runner_id, &job_id),
     }
+}
+
+fn job_cancel(runner_id: &str, job_id: &str) -> CmdResult<RunnerJobOutput> {
+    let body = runner::daemon_api_post(runner_id, &format!("/jobs/{job_id}/cancel"))?;
+    let canonical = body.get("body").unwrap_or(&body);
+    let job: Job = serde_json::from_value(canonical["job"].clone()).map_err(|err| {
+        homeboy::core::Error::internal_json(
+            err.to_string(),
+            Some("parse runner job cancel response".to_string()),
+        )
+    })?;
+    let events = canonical
+        .get("events")
+        .cloned()
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|err| {
+            homeboy::core::Error::internal_json(
+                err.to_string(),
+                Some("parse runner job cancel events".to_string()),
+            )
+        })?
+        .unwrap_or_default();
+
+    Ok((
+        RunnerJobOutput {
+            command: "runner.job.cancel",
+            runner_id: runner_id.to_string(),
+            job_id: job_id.to_string(),
+            follow: false,
+            job,
+            events,
+        },
+        0,
+    ))
 }
 
 fn job_logs(

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -613,12 +613,15 @@ fn execute_trace_run(args: TraceArgs) -> homeboy::core::Result<TraceRunExecution
                     .build(),
             )
             .ok()
-            .map(|run| ActiveTraceObservation {
-                store,
-                run_id: run.id,
-                component_id: ctx.component_id.clone(),
-                rig_id: rig_id.clone(),
-                scenario_id: scenario_id.clone(),
+            .map(|run| {
+                std::env::set_var(homeboy::core::observation::ACTIVE_RUN_ID_ENV, &run.id);
+                ActiveTraceObservation {
+                    store,
+                    run_id: run.id,
+                    component_id: ctx.component_id.clone(),
+                    rig_id: rig_id.clone(),
+                    scenario_id: scenario_id.clone(),
+                }
             })
     });
     let (extra_workloads, trace_dependencies, runner_capabilities, invocation_requirements) =
@@ -1545,6 +1548,14 @@ pub(super) fn finish_lab_dispatch_observation(
     let _ = observation
         .store
         .finish_run(&observation.run_id, status, Some(metadata));
+}
+
+pub(super) fn lab_dispatch_observation_run_id(
+    observation: &Option<LabTraceDispatchObservation>,
+) -> Option<&str> {
+    observation
+        .as_ref()
+        .map(|observation| observation.run_id.as_str())
 }
 
 fn persist_trace_workflow_result(

--- a/src/core/error/mod.rs
+++ b/src/core/error/mod.rs
@@ -209,6 +209,8 @@ pub struct RigResourceConflictInfo {
     pub held_by_command: String,
     pub held_by_pid: u32,
     pub held_since: String,
+    pub held_by_run_id: Option<String>,
+    pub held_by_runner_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -530,7 +532,9 @@ impl Error {
     }
 
     pub fn rig_resource_conflict(info: RigResourceConflictInfo) -> Self {
-        Self::new(
+        let held_by_run_id = info.held_by_run_id.clone();
+        let held_by_runner_id = info.held_by_runner_id.clone();
+        let mut error = Self::new(
             ErrorCode::RigResourceConflict,
             format!(
                 "Rig '{}' cannot run '{}': {} resource '{}' is already held by rig '{}' running '{}' (pid {}, since {})",
@@ -553,13 +557,34 @@ impl Error {
                     "command": info.held_by_command,
                     "pid": info.held_by_pid,
                     "since": info.held_since,
+                    "run_id": info.held_by_run_id,
+                    "runner_id": info.held_by_runner_id,
                 }
             }),
         )
         .with_hint(
             "If this parallel run is intentional, give each run a distinct namespace or port range so their rig resources no longer overlap."
                 .to_string(),
-        )
+        );
+        if let Some(run_id) = held_by_run_id {
+            error = error
+                .with_hint(format!(
+                    "Active holding run `{run_id}` is discoverable with `homeboy runs show {run_id}`."
+                ))
+                .with_hint(format!(
+                    "Wait for the holding run with `homeboy runs show {run_id}` or `homeboy runs list --status running --limit 20` before retrying."
+                ));
+        } else {
+            error = error.with_hint(
+                "No active run id was recorded for the holding lease; inspect running work with `homeboy runs list --status running --limit 20`.".to_string(),
+            );
+        }
+        if let Some(runner_id) = held_by_runner_id {
+            error = error.with_hint(format!(
+                "If the conflict came from a Lab daemon job, inspect active jobs with `homeboy runs list --runner {runner_id} --status running --limit 20`; cancel a known job with `homeboy runner job cancel {runner_id} <job-id>`."
+            ));
+        }
+        error
     }
 
     pub fn docs_topic_not_found(topic: impl Into<String>) -> Self {

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -8,7 +8,8 @@ use crate::command_contract::{
 use crate::core::runners;
 use crate::core::Result;
 
-pub const DEFAULT_LAB_TRACE_DISPATCH_TIMEOUT_SECS: u64 = 9 * 60;
+pub const DEFAULT_LAB_DISPATCH_TIMEOUT_SECS: u64 = 9 * 60;
+pub const LAB_DISPATCH_TIMEOUT_ENV: &str = "HOMEBOY_LAB_DISPATCH_TIMEOUT_SECS";
 pub const LAB_TRACE_DISPATCH_TIMEOUT_ENV: &str = "HOMEBOY_LAB_TRACE_DISPATCH_TIMEOUT_SECS";
 
 pub struct LabRoutingRequest<'a> {
@@ -21,6 +22,7 @@ pub struct LabRoutingRequest<'a> {
     pub allow_dirty_lab_workspace: bool,
     pub capture_patch: bool,
     pub timeout: Option<Duration>,
+    pub active_run_id: Option<&'a str>,
 }
 
 pub fn route_lab_offload(request: LabRoutingRequest<'_>) -> Result<runners::LabOffloadOutcome> {
@@ -72,11 +74,16 @@ pub fn lab_offload_command_from_contract(
 }
 
 pub fn lab_trace_dispatch_timeout() -> Duration {
-    std::env::var(LAB_TRACE_DISPATCH_TIMEOUT_ENV)
+    lab_dispatch_timeout()
+}
+
+pub fn lab_dispatch_timeout() -> Duration {
+    std::env::var(LAB_DISPATCH_TIMEOUT_ENV)
+        .or_else(|_| std::env::var(LAB_TRACE_DISPATCH_TIMEOUT_ENV))
         .ok()
         .and_then(|value| value.parse::<u64>().ok())
         .map(Duration::from_secs)
-        .unwrap_or_else(|| Duration::from_secs(DEFAULT_LAB_TRACE_DISPATCH_TIMEOUT_SECS))
+        .unwrap_or_else(|| Duration::from_secs(DEFAULT_LAB_DISPATCH_TIMEOUT_SECS))
 }
 
 pub fn is_lab_offload_subprocess() -> bool {
@@ -96,6 +103,7 @@ fn execute_lab_offload_with_timeout(
     let allow_local_fallback = request.allow_local_fallback;
     let allow_dirty_lab_workspace = request.allow_dirty_lab_workspace;
     let capture_patch = request.capture_patch;
+    let active_run_id = request.active_run_id.map(str::to_string);
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let result = runners::execute_lab_offload(runners::LabOffloadRequest {
@@ -112,13 +120,22 @@ fn execute_lab_offload_with_timeout(
     });
 
     rx.recv_timeout(timeout).map_err(|_| {
-        crate::core::Error::internal_unexpected(format!(
-            "Lab trace dispatch did not finish before timeout after {}s",
+        let mut error = crate::core::Error::internal_unexpected(format!(
+            "Lab offload dispatch did not finish before timeout after {}s",
             timeout.as_secs()
         ))
-        .with_hint("Inspect the controller trace run record for the last Lab dispatch phase.".to_string())
-        .with_hint("Run `homeboy runner doctor <runner-id>` and retry after the runner is healthy.".to_string())
-        .with_hint("Use `--force-hot --allow-local-hot` only for development-only investigation while fixing Lab routing.".to_string())
+        .with_hint("The Lab worker thread may still be dispatching or waiting on the remote runner; do not retry blindly while rig resources may still be leased.".to_string())
+        .with_hint("Inspect active remote work with `homeboy runs list --status running --limit 20` and `homeboy runs list --status running --runner <runner-id> --limit 20`.".to_string())
+        .with_hint("Wait/reconnect by following the runner daemon job when known: `homeboy runner job logs <runner-id> <job-id> --follow`.".to_string())
+        .with_hint("Cancel a known daemon job with `homeboy runner job cancel <runner-id> <job-id>`; then confirm the rig lease clears before retrying.".to_string())
+        .with_hint("Run `homeboy runner doctor <runner-id>` if the runner daemon no longer responds.".to_string());
+        if let Some(run_id) = active_run_id {
+            error.details["active_run_id"] = serde_json::Value::String(run_id.clone());
+            error = error.with_hint(format!(
+                "Controller dispatch run `{run_id}` remains discoverable; inspect it with `homeboy runs show {run_id}`."
+            ));
+        }
+        error
     })?
 }
 
@@ -208,6 +225,7 @@ mod tests {
             allow_dirty_lab_workspace: false,
             capture_patch: false,
             timeout: None,
+            active_run_id: None,
         })
         .unwrap();
 

--- a/src/core/observation/lifecycle.rs
+++ b/src/core/observation/lifecycle.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use super::{NewFindingRecord, NewRunRecord, ObservationStore, RunRecord, RunStatus};
 
 const RUN_OWNER_METADATA_KEY: &str = "homeboy_run_owner";
+pub const ACTIVE_RUN_ID_ENV: &str = "HOMEBOY_ACTIVE_RUN_ID";
 
 pub struct ActiveObservation {
     store: ObservationStore,
@@ -15,6 +16,7 @@ impl ActiveObservation {
         let store = ObservationStore::open_initialized()?;
         let initial_metadata = record.metadata_json.clone();
         let run = store.start_run(record)?;
+        std::env::set_var(ACTIVE_RUN_ID_ENV, &run.id);
 
         Ok(Self {
             store,

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -13,7 +13,9 @@ pub mod store;
 mod test_findings;
 pub mod timeline;
 
-pub use lifecycle::{merge_metadata, run_owner_pid, running_status_note, ActiveObservation};
+pub use lifecycle::{
+    merge_metadata, run_owner_pid, running_status_note, ActiveObservation, ACTIVE_RUN_ID_ENV,
+};
 
 pub use budget_findings::finding_records_from_budget;
 pub use context::{RunContext, RunProvenance};

--- a/src/core/rig/lease.rs
+++ b/src/core/rig/lease.rs
@@ -25,6 +25,10 @@ pub struct RigRunLease {
     pub command: String,
     pub pid: u32,
     pub started_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_id: Option<String>,
     pub resources: RigResourcesSpec,
 }
 
@@ -79,6 +83,8 @@ pub fn acquire_active_run_lease(rig: &RigSpec, command: &str) -> Result<Option<A
             held_by_command: conflict.lease.command,
             held_by_pid: conflict.lease.pid,
             held_since: conflict.lease.started_at,
+            held_by_run_id: conflict.lease.run_id,
+            held_by_runner_id: conflict.lease.runner_id,
         }));
     }
 
@@ -88,6 +94,8 @@ pub fn acquire_active_run_lease(rig: &RigSpec, command: &str) -> Result<Option<A
         command: command.to_string(),
         pid,
         started_at: now_rfc3339(),
+        run_id: active_run_id(),
+        runner_id: active_lab_runner_id(),
         resources,
     };
     let json = serde_json::to_string_pretty(&lease)
@@ -143,6 +151,51 @@ fn has_covering_parent_lease(rig: &RigSpec, command: &str) -> Result<bool> {
 
 fn lease_allows_child_command(lease: &RigRunLease, command: &str) -> bool {
     lease.pid == std::process::id() && lease.command == "trace compare" && command == "trace"
+}
+
+fn active_run_id() -> Option<String> {
+    non_empty_env(crate::core::observation::ACTIVE_RUN_ID_ENV)
+        .or_else(|| non_empty_env("HOMEBOY_RUN_ID"))
+        .or_else(|| lab_metadata_string("run_id"))
+        .or_else(|| lab_metadata_string_pointer("/proof/provenance/run_id"))
+}
+
+fn active_lab_runner_id() -> Option<String> {
+    lab_metadata_string("runner_id")
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn lab_metadata_string(key: &str) -> Option<String> {
+    lab_metadata_value()
+        .and_then(|metadata| {
+            metadata
+                .get(key)
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn lab_metadata_string_pointer(pointer: &str) -> Option<String> {
+    lab_metadata_value()
+        .and_then(|metadata| {
+            metadata
+                .pointer(pointer)
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn lab_metadata_value() -> Option<serde_json::Value> {
+    std::env::var(crate::core::observation::LAB_OFFLOAD_METADATA_ENV)
+        .ok()
+        .and_then(|value| serde_json::from_str(&value).ok())
 }
 
 fn overlapping_resource(

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -587,8 +587,13 @@ fn daemon_job_wait_timeout(
         "{label} {job_id} on runner {} did not finish before timeout; the remote job is still in flight and was not cancelled",
         runner.id
     ));
+    error.details["runner_id"] = Value::String(runner.id.clone());
+    error.details["job_id"] = Value::String(job_id.clone());
+    error.details["remote_cwd"] = Value::String(cwd.to_string());
+    error.details["command"] = json!(command);
     match mirrored {
         Ok(run) => {
+            error.details["active_run_id"] = Value::String(run.id.clone());
             error = error
                 .with_hint(format!(
                     "Mirrored controller timeout state as run `{}`; inspect it with `homeboy runs show {}`.",
@@ -616,7 +621,8 @@ fn daemon_job_wait_timeout(
             runner.id
         ))
         .with_hint(format!(
-            "Runner daemon job id `{job_id}` was already dispatched; wait for it to finish or cancel it explicitly through the runner daemon if needed."
+            "Runner daemon job id `{job_id}` was already dispatched; wait for it to finish or cancel it with `homeboy runner job cancel {} {job_id}` if needed.",
+            runner.id
         ))
         .with_hint(timeout_hint)
 }
@@ -654,6 +660,14 @@ fn daemon_get(client: &Client, local_url: &str, path: &str) -> Result<Value> {
 }
 
 pub(crate) fn daemon_api_get(runner_id: &str, path: &str) -> Result<Value> {
+    daemon_api_request(runner_id, path, "GET")
+}
+
+pub fn daemon_api_post(runner_id: &str, path: &str) -> Result<Value> {
+    daemon_api_request(runner_id, path, "POST")
+}
+
+fn daemon_api_request(runner_id: &str, path: &str, method: &str) -> Result<Value> {
     let runner = load(runner_id)?;
     let connected = status(runner_id)?;
     let Some(session) = connected.session.filter(|_| connected.connected) else {
@@ -680,7 +694,32 @@ pub(crate) fn daemon_api_get(runner_id: &str, path: &str) -> Result<Value> {
             ]),
         ));
     };
-    daemon_get(&client, local_url, path)
+    match method {
+        "GET" => daemon_get(&client, local_url, path),
+        "POST" => daemon_post(&client, local_url, path),
+        _ => Err(Error::internal_unexpected(format!(
+            "unsupported daemon API method {method}"
+        ))),
+    }
+}
+
+fn daemon_post(client: &Client, local_url: &str, path: &str) -> Result<Value> {
+    let response = client
+        .post(format!("{}{}", local_url.trim_end_matches('/'), path))
+        .send()
+        .map_err(|err| Error::internal_unexpected(format!("query runner daemon: {err}")))?;
+    let envelope: DaemonEnvelope = response.json().map_err(|err| {
+        Error::internal_json(err.to_string(), Some("parse daemon response".to_string()))
+    })?;
+    if !envelope.success {
+        return Err(Error::internal_unexpected(format!(
+            "daemon request failed: {}",
+            envelope.error.unwrap_or(Value::Null)
+        )));
+    }
+    envelope
+        .data
+        .ok_or_else(|| Error::internal_unexpected("daemon response missing data"))
 }
 
 fn result_event_data(events: &[JobEvent]) -> Option<Value> {

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -66,7 +66,8 @@ pub(crate) use execution::{
     RunnerProcessRequest,
 };
 pub use execution::{
-    exec, runner_exec_failure_error, RunnerExecMode, RunnerExecOptions, RunnerExecOutput,
+    daemon_api_post, exec, runner_exec_failure_error, RunnerExecMode, RunnerExecOptions,
+    RunnerExecOutput,
 };
 pub(crate) use git_dependency_materialization::{
     materialize_git_dependency, RunnerGitDependencyMaterializationOptions,

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -58,7 +58,7 @@ pub use super::runner::{
 // `pub use runner::*`. Keep them available so existing in-tree callers
 // (currently `commands::runs::remote`) compile, but do not expose them as
 // public API.
-pub(crate) use super::runner::daemon_api_get;
+pub(crate) use super::runner::{daemon_api_get, daemon_api_post};
 
 // ----------------------------------------------------------------------------
 // Explicit API groups

--- a/tests/core/rig/lease_test.rs
+++ b/tests/core/rig/lease_test.rs
@@ -6,6 +6,28 @@ use crate::core::rig::spec::{RigResourcesSpec, RigSpec};
 use crate::core::rig::{run_up, RigRunLease};
 use crate::test_support::with_isolated_home;
 
+struct EnvVarGuard {
+    name: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(name: &'static str, value: &str) -> Self {
+        let previous = std::env::var(name).ok();
+        std::env::set_var(name, value);
+        Self { name, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var(self.name, value),
+            None => std::env::remove_var(self.name),
+        }
+    }
+}
+
 fn rig(id: &str, resources: RigResourcesSpec) -> RigSpec {
     RigSpec {
         id: id.to_string(),
@@ -66,6 +88,38 @@ fn test_acquire_active_run_lease_blocks_overlapping_resources_until_drop() {
         assert!(acquire_active_run_lease(&studio_bfb, "up")
             .expect("lease after drop")
             .is_some());
+    });
+}
+
+#[test]
+fn test_resource_conflict_reports_active_run_context_when_available() {
+    with_isolated_home(|_| {
+        let _run_id =
+            EnvVarGuard::set(crate::core::observation::ACTIVE_RUN_ID_ENV, "trace-run-123");
+        let _lab_metadata = EnvVarGuard::set(
+            crate::core::observation::LAB_OFFLOAD_METADATA_ENV,
+            r#"{"runner_id":"lab-runner-1"}"#,
+        );
+        let studio = rig("studio", resources());
+        let studio_bfb = rig("studio-bfb", resources());
+
+        let lease = acquire_active_run_lease(&studio, "trace")
+            .expect("first lease")
+            .expect("resourceful rig leases");
+        let conflict =
+            acquire_active_run_lease(&studio_bfb, "trace").expect_err("second lease conflicts");
+
+        assert_eq!(conflict.details["held_by"]["run_id"], "trace-run-123");
+        assert_eq!(conflict.details["held_by"]["runner_id"], "lab-runner-1");
+        assert!(conflict
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("homeboy runs show trace-run-123")));
+        assert!(conflict.hints.iter().any(|hint| hint
+            .message
+            .contains("homeboy runner job cancel lab-runner-1 <job-id>")));
+
+        drop(lease);
     });
 }
 
@@ -173,6 +227,8 @@ fn test_acquire_active_run_lease_prunes_stale_pid() {
             command: "up".to_string(),
             pid: u32::MAX,
             started_at: "2026-04-27T00:00:00Z".to_string(),
+            run_id: None,
+            runner_id: None,
             resources: resources(),
         };
         let lease_dir = crate::core::paths::rig_leases_dir().expect("lease dir");


### PR DESCRIPTION
## Summary
- Removes the trace-specific 540s Lab dispatch wait from normal routing so long-running offloaded trace/bench work stays on the generic runner job wait path, where job ids and mirrored run records are available.
- Adds runner daemon job cancellation via `homeboy runner job cancel <runner-id> <job-id>` and includes structured runner/job/active-run details in timeout errors.
- Persists active run/runner context in rig leases and surfaces inspect/wait/cancel guidance on resource conflicts.

## Verification
- `cargo fmt` completed successfully.
- Local tests, local test suites, and local hot validation were not run per hard constraint for this Studio machine.
- Lab/offloaded validation was not run because this change affects timeout/cancellation UX and would require deliberately holding a long-running runner job/rig lock; the PR includes targeted coverage for lease conflict guidance where feasible without executing it locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the generic Lab routing/runner job/rig lease paths and drafted the implementation and PR description for Chris to review.

Fixes #4489.