### PR TITLE
fix: accept forced source upgrades with new build identity

### DIFF
--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -8,6 +8,7 @@ use crate::commands::output_runtime;
 use crate::commands::utils::{args, entity_suggest, resource_policy, response as output};
 use crate::commands::GlobalArgs;
 use crate::core::extension::load_all_extensions;
+use crate::core::upgrade;
 
 pub struct CliRuntime {
     extension_info: Vec<ExtensionCliInfo>,
@@ -36,6 +37,11 @@ impl CliRuntime {
     }
 
     pub fn run_from_args(&self, args: Vec<String>) -> std::process::ExitCode {
+        if is_top_level_version_request(&args) {
+            println!("{}", upgrade::current_build_version());
+            return std::process::ExitCode::SUCCESS;
+        }
+
         let normalized = args::normalize(args);
         let matches = self.parse_matches(normalized.clone());
         self.run_matches(matches, normalized)
@@ -166,6 +172,10 @@ impl CliRuntime {
     fn try_parse_extension_cli_command(&self, matches: &ArgMatches) -> Option<ExtensionCliCommand> {
         try_parse_extension_cli_command(matches, &self.extension_info)
     }
+}
+
+fn is_top_level_version_request(args: &[String]) -> bool {
+    matches!(args, [_, flag] if flag == "--version" || flag == "-V")
 }
 
 impl Default for CliRuntime {

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -169,6 +169,8 @@ mod tests {
             install_method: upgrade::InstallMethod::Cargo,
             previous_version: "0.228.6".to_string(),
             new_version: Some("0.228.7".to_string()),
+            previous_build_identity: None,
+            new_build_identity: None,
             upgraded: true,
             message: "Upgraded to 0.228.7".to_string(),
             restart_required: false,

--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -4,12 +4,21 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use super::helpers::{current_version, version_is_newer};
+use super::planning::resolve_binary_on_path;
 use super::types::InstallMethod;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ActiveBinaryInfo {
+    pub version: Option<String>,
+    pub build_identity: Option<String>,
+}
 
 pub(crate) fn execute_upgrade(
     method: InstallMethod,
     source_path: Option<&Path>,
-) -> Result<(bool, Option<String>)> {
+    force: bool,
+    previous_build_identity: Option<&str>,
+) -> Result<(bool, Option<String>, Option<String>)> {
     let defaults = defaults::load_defaults();
 
     let output = match method {
@@ -67,10 +76,19 @@ pub(crate) fn execute_upgrade(
         return Err(upgrade_failure_error(method, &error_detail));
     }
 
-    let new_version = active_binary_version().ok().flatten();
-    let success = upgrade_verification_result(current_version(), new_version.as_deref());
+    let active_binary = active_binary_info().ok().flatten();
+    let new_version = active_binary.as_ref().and_then(|info| info.version.clone());
+    let new_build_identity = active_binary.and_then(|info| info.build_identity);
+    let success = upgrade_verification_result(
+        method,
+        force,
+        current_version(),
+        new_version.as_deref(),
+        previous_build_identity,
+        new_build_identity.as_deref(),
+    );
 
-    Ok((success, new_version))
+    Ok((success, new_version, new_build_identity))
 }
 
 fn upgrade_failure_error(method: InstallMethod, error_detail: &str) -> Error {
@@ -193,13 +211,8 @@ fn find_homeboy_source_checkout(path: &Path) -> Option<PathBuf> {
         .map(Path::to_path_buf)
 }
 
-fn active_binary_version() -> Result<Option<String>> {
-    let exe_path = std::env::current_exe().map_err(|e| {
-        Error::internal_io(
-            e.to_string(),
-            Some("get current executable path".to_string()),
-        )
-    })?;
+fn active_binary_info() -> Result<Option<ActiveBinaryInfo>> {
+    let exe_path = active_binary_path()?;
 
     let output = Command::new(exe_path)
         .arg("--version")
@@ -215,23 +228,67 @@ fn active_binary_version() -> Result<Option<String>> {
         return Ok(None);
     }
 
-    Ok(parse_cli_version_output(&String::from_utf8_lossy(
+    Ok(Some(parse_cli_version_info(&String::from_utf8_lossy(
         &output.stdout,
-    )))
+    ))))
+}
+
+fn active_binary_path() -> Result<PathBuf> {
+    if let Some(path) = resolve_binary_on_path() {
+        return Ok(path);
+    }
+
+    std::env::current_exe().map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some("get current executable path".to_string()),
+        )
+    })
 }
 
 pub(crate) fn upgrade_verification_result(
+    method: InstallMethod,
+    force: bool,
     previous_version: &str,
     active_version: Option<&str>,
+    previous_build_identity: Option<&str>,
+    active_build_identity: Option<&str>,
 ) -> bool {
-    active_version
-        .map(|version| version_is_newer(version, previous_version))
-        .unwrap_or(false)
+    let Some(active_version) = active_version else {
+        return false;
+    };
+
+    if version_is_newer(active_version, previous_version) {
+        return true;
+    }
+
+    method == InstallMethod::Source
+        && force
+        && active_version == previous_version
+        && previous_build_identity.is_some()
+        && active_build_identity.is_some()
+        && previous_build_identity != active_build_identity
+}
+
+fn parse_cli_version_info(output: &str) -> ActiveBinaryInfo {
+    ActiveBinaryInfo {
+        version: parse_cli_version_output(output),
+        build_identity: parse_cli_build_identity_output(output),
+    }
 }
 
 fn parse_cli_version_output(output: &str) -> Option<String> {
     let re = regex::Regex::new(r"(\d+\.\d+\.\d+)").ok()?;
     re.find(output).map(|m| m.as_str().to_string())
+}
+
+fn parse_cli_build_identity_output(output: &str) -> Option<String> {
+    let identity = output.trim();
+    if identity.is_empty() || !identity.contains('+') {
+        None
+    } else {
+        Some(identity.to_string())
+    }
 }
 
 #[cfg(test)]
@@ -252,29 +309,113 @@ mod tests {
             parse_cli_version_output("homeboy 0.158.0").as_deref(),
             Some("0.158.0")
         );
-        assert!(!upgrade_verification_result("0.157.1", Some("0.157.1")));
+        assert!(!upgrade_verification_result(
+            InstallMethod::Source,
+            false,
+            "0.157.1",
+            Some("0.157.1"),
+            Some("commit old, dirty=false"),
+            Some("commit new, dirty=false"),
+        ));
     }
 
     #[test]
     fn test_upgrade_verification_result() {
-        assert!(upgrade_verification_result("0.157.1", Some("0.158.0")));
-        assert!(!upgrade_verification_result("0.157.1", Some("0.157.1")));
-        assert!(!upgrade_verification_result("0.157.1", None));
+        assert!(upgrade_verification_result(
+            InstallMethod::Cargo,
+            false,
+            "0.157.1",
+            Some("0.158.0"),
+            None,
+            None,
+        ));
+        assert!(!upgrade_verification_result(
+            InstallMethod::Cargo,
+            true,
+            "0.157.1",
+            Some("0.157.1"),
+            Some("commit old, dirty=false"),
+            Some("commit new, dirty=false"),
+        ));
+        assert!(!upgrade_verification_result(
+            InstallMethod::Source,
+            true,
+            "0.157.1",
+            None,
+            Some("commit old, dirty=false"),
+            Some("commit new, dirty=false"),
+        ));
     }
 
     #[test]
     fn verification_rejects_unchanged_active_binary() {
-        assert!(!upgrade_verification_result("0.157.1", Some("0.157.1")));
+        assert!(!upgrade_verification_result(
+            InstallMethod::Source,
+            true,
+            "0.157.1",
+            Some("0.157.1"),
+            Some("commit same, dirty=false"),
+            Some("commit same, dirty=false"),
+        ));
     }
 
     #[test]
     fn verification_accepts_newer_active_binary() {
-        assert!(upgrade_verification_result("0.157.1", Some("0.158.0")));
+        assert!(upgrade_verification_result(
+            InstallMethod::Cargo,
+            false,
+            "0.157.1",
+            Some("0.158.0"),
+            None,
+            None,
+        ));
     }
 
     #[test]
     fn verification_rejects_missing_active_binary_version() {
-        assert!(!upgrade_verification_result("0.157.1", None));
+        assert!(!upgrade_verification_result(
+            InstallMethod::Source,
+            true,
+            "0.157.1",
+            None,
+            Some("commit old, dirty=false"),
+            Some("commit new, dirty=false"),
+        ));
+    }
+
+    #[test]
+    fn forced_source_upgrade_accepts_same_version_with_new_build_identity() {
+        assert!(upgrade_verification_result(
+            InstallMethod::Source,
+            true,
+            "0.157.1",
+            Some("0.157.1"),
+            Some("homeboy 0.157.1+old"),
+            Some("homeboy 0.157.1+new"),
+        ));
+    }
+
+    #[test]
+    fn forced_source_upgrade_requires_build_identity_for_same_version() {
+        assert!(!upgrade_verification_result(
+            InstallMethod::Source,
+            true,
+            "0.157.1",
+            Some("0.157.1"),
+            None,
+            Some("homeboy 0.157.1+new"),
+        ));
+    }
+
+    #[test]
+    fn parses_homeboy_version_output_with_build_identity() {
+        let info = parse_cli_version_info("homeboy 0.158.0+abc123-dirty");
+
+        assert_eq!(info.version.as_deref(), Some("0.158.0"));
+        assert_eq!(
+            info.build_identity.as_deref(),
+            Some("homeboy 0.158.0+abc123-dirty")
+        );
     }
 
     #[test]

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -1,6 +1,6 @@
 use crate::core::defaults;
 use crate::core::error::{Error, Result};
-use crate::core::{extension, git};
+use crate::core::{build_identity, extension, git};
 use std::path::Path;
 use std::process::Command;
 
@@ -13,6 +13,10 @@ use super::validation::check_for_updates;
 
 pub fn current_version() -> &'static str {
     VERSION
+}
+
+pub fn current_build_version() -> String {
+    build_identity::current().display
 }
 
 pub(crate) fn fetch_latest_crates_io_version() -> Result<String> {
@@ -160,6 +164,7 @@ pub fn run_upgrade_with_method(
 ) -> Result<UpgradeResult> {
     let install_method = method_override.unwrap_or_else(detect_install_method);
     let previous_version = current_version().to_string();
+    let previous_build_identity = Some(build_identity::current().display);
 
     if install_method == InstallMethod::Unknown {
         return Err(Error::validation_invalid_argument(
@@ -199,6 +204,8 @@ pub fn run_upgrade_with_method(
                 install_method,
                 previous_version: previous_version.clone(),
                 new_version: Some(previous_version),
+                previous_build_identity,
+                new_build_identity: None,
                 upgraded: false,
                 message: "Already at latest version".to_string(),
                 restart_required: false,
@@ -211,7 +218,12 @@ pub fn run_upgrade_with_method(
     }
 
     // Execute the upgrade
-    let (success, new_version) = execute_upgrade(install_method, source_path)?;
+    let (success, new_version, new_build_identity) = execute_upgrade(
+        install_method,
+        source_path,
+        force,
+        previous_build_identity.as_deref(),
+    )?;
     let upgrade_completed = should_sync_after_upgrade(new_version.as_deref());
 
     // Auto-update all installed extensions after the upgrade command completes.
@@ -240,9 +252,19 @@ pub fn run_upgrade_with_method(
         install_method,
         previous_version,
         new_version: new_version.clone(),
+        previous_build_identity,
+        new_build_identity: new_build_identity.clone(),
         upgraded: success,
         message: if success {
-            format!("Upgraded to {}", new_version.as_deref().unwrap_or("latest"))
+            if let Some(identity) = &new_build_identity {
+                format!(
+                    "Upgraded to {} ({})",
+                    new_version.as_deref().unwrap_or("latest"),
+                    identity
+                )
+            } else {
+                format!("Upgraded to {}", new_version.as_deref().unwrap_or("latest"))
+            }
         } else if let Some(version) = &new_version {
             format!(
                 "Upgrade command completed but active binary is still {}",

--- a/src/core/upgrade/mod.rs
+++ b/src/core/upgrade/mod.rs
@@ -9,8 +9,8 @@ mod validation;
 
 pub(crate) use constants::VERSION;
 pub use helpers::{
-    current_version, detect_install_method, fetch_latest_version, restart_with_new_binary,
-    run_upgrade_with_method,
+    current_build_version, current_version, detect_install_method, fetch_latest_version,
+    restart_with_new_binary, run_upgrade_with_method,
 };
 pub use planning::resolve_binary_on_path;
 pub use types::{

--- a/src/core/upgrade/types.rs
+++ b/src/core/upgrade/types.rs
@@ -30,6 +30,10 @@ pub struct UpgradeResult {
     pub install_method: InstallMethod,
     pub previous_version: String,
     pub new_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_build_identity: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_build_identity: Option<String>,
     pub upgraded: bool,
     pub message: String,
     pub restart_required: bool,


### PR DESCRIPTION
## Summary
- Accept forced source upgrades when the active binary reports the same semver but a different embedded build identity.
- Expose the build identity through `homeboy --version` and upgrade result fields so same-version source activation can be proven.
- Add targeted unit coverage for same-version source verification behavior.

Fixes #4466.

## Verification
- `homeboy runner workspace sync homeboy-lab --path '/Users/chubes/Developer/homeboy@fix-source-force-same-semver' --mode snapshot` succeeded with remote path `/home/chubes/Developer/_lab_workspaces/homeboy-fix-source-force-same-semver-99e544ed8e25-ddbd1e22-ccc6-4bc4-9834-a008ed8d3181-1781530944715054000`.
- `homeboy runner exec homeboy-lab --cwd '/home/chubes/Developer/_lab_workspaces/homeboy-fix-source-force-same-semver-99e544ed8e25-ddbd1e22-ccc6-4bc4-9834-a008ed8d3181-1781530944715054000' -- cargo fmt --check` passed with exit code 0. Runner job: `a3ce73a3-9aba-4bbd-9098-9258c657e091`.
- Local test suites, local Cargo tests, and local hot validation were not run per operator constraint.
- Targeted test execution was intentionally not rerun after the final cleanup per operator constraint. An earlier offloaded targeted run before the cleanup passed `core::upgrade::execution::tests` with 16 passed, 0 failed in runner job `c77e30bb-84ee-4d0b-ad71-7d5ae9bd7400`; the final cleanup reused existing `core::build_identity` formatting and was covered by the final offloaded formatting check only.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the Homeboy source-upgrade path, drafted the generic same-version source upgrade fix and targeted test coverage, and ran the documented offloaded verification. Chris remains responsible for review and merge.