### PR TITLE
Prove tunnel preview readiness

### DIFF
--- a/docs/commands/tunnel.md
+++ b/docs/commands/tunnel.md
@@ -63,6 +63,22 @@ homeboy tunnel service start context-a8c \
 
 The `command` backend is a generic adapter seam. Homeboy starts and supervises the backend command, injects `HOMEBOY_SERVICE_ID`, `HOMEBOY_SERVICE_LOCAL_URL`, and `HOMEBOY_TUNNEL_PUBLIC_URL`, records backend PID/process/log evidence, and stops it with the managed service. Provider-specific behavior such as Traforo, Cloudflare, ngrok, or a Homeboy VPS broker belongs in the backend command or a future extension, not in Homeboy core semantics.
 
+Proof/preview workflows can opt into stricter readiness before Homeboy reports the service as ready:
+
+```sh
+homeboy tunnel service start site-preview \
+  --command './tools/start-held-preview.sh' \
+  --port 7331 \
+  --readiness-kind proof \
+  --require-listener \
+  --readiness-artifact artifacts/proof.json \
+  --readiness-artifact-json-pointer /status \
+  --readiness-artifact-json-equals ready \
+  --readiness-stdout-regex 'Preview ready:'
+```
+
+Without those opt-in checks, generic services keep the existing process/health readiness behavior. With them, `service start` and `service status` include `readiness.process_running`, `readiness.preview_ready`, and `readiness.proof_ready` so callers can distinguish wrapper liveness from usable preview/proof artifacts.
+
 When a service's preview policy is relevant, `service status` and `service start` include a structured `preview` artifact with schema `homeboy/preview-url/v1`. The artifact records the service ID, local URL, optional public URL, backend, policy, cleanup/expiry metadata, and owning run/workflow IDs when the start command supplied them.
 
 ## Preview Consumer Orchestration

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -13,8 +13,8 @@ use homeboy::core::preview_ingress::{
 use homeboy::core::tunnel::{
     self, ExposeServiceTunnelSpec, ServiceTunnel, ServiceTunnelAuth, ServiceTunnelAuthMode,
     ServiceTunnelExposure, ServiceTunnelPolicy, ServiceTunnelPreviewPolicy,
-    ServiceTunnelPreviewPolicyMode, ServiceTunnelStatus, ServiceTunnelTarget,
-    ServiceTunnelTunnelBackend, StartServiceTunnelSpec,
+    ServiceTunnelPreviewPolicyMode, ServiceTunnelReadinessCheck, ServiceTunnelReadinessKind,
+    ServiceTunnelStatus, ServiceTunnelTarget, ServiceTunnelTunnelBackend, StartServiceTunnelSpec,
 };
 use homeboy::core::{EntityCrudOutput, MergeOutput};
 use std::collections::BTreeMap;
@@ -487,6 +487,30 @@ enum TunnelServiceCommand {
         #[arg(long, default_value_t = 30)]
         readiness_timeout: u64,
 
+        /// Readiness contract label reported in service status
+        #[arg(long, value_enum, default_value_t = ServiceTunnelReadinessKindArg::Process)]
+        readiness_kind: ServiceTunnelReadinessKindArg,
+
+        /// Require the declared local URL host:port to accept TCP connections
+        #[arg(long)]
+        require_listener: bool,
+
+        /// Artifact file whose JSON value proves readiness
+        #[arg(long)]
+        readiness_artifact: Option<PathBuf>,
+
+        /// JSON Pointer inside --readiness-artifact whose value must match
+        #[arg(long, requires = "readiness_artifact")]
+        readiness_artifact_json_pointer: Option<String>,
+
+        /// Expected string/JSON value for --readiness-artifact-json-pointer
+        #[arg(long, requires = "readiness_artifact_json_pointer")]
+        readiness_artifact_json_equals: Option<String>,
+
+        /// Regex that must match captured service stdout before readiness is true
+        #[arg(long)]
+        readiness_stdout_regex: Option<String>,
+
         /// Public tunnel backend adapter.
         #[arg(long, value_enum, default_value_t = ServiceTunnelBackendArg::None)]
         public_tunnel_backend: ServiceTunnelBackendArg,
@@ -538,6 +562,13 @@ enum ServiceTunnelPreviewPolicyArg {
     KeepAliveUntil,
 }
 
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum ServiceTunnelReadinessKindArg {
+    Process,
+    Preview,
+    Proof,
+}
+
 impl From<ServiceTunnelPreviewPolicyArg> for ServiceTunnelPreviewPolicyMode {
     fn from(value: ServiceTunnelPreviewPolicyArg) -> Self {
         match value {
@@ -550,6 +581,16 @@ impl From<ServiceTunnelPreviewPolicyArg> for ServiceTunnelPreviewPolicyMode {
             ServiceTunnelPreviewPolicyArg::KeepAliveUntil => {
                 ServiceTunnelPreviewPolicyMode::KeepAliveUntil
             }
+        }
+    }
+}
+
+impl From<ServiceTunnelReadinessKindArg> for ServiceTunnelReadinessKind {
+    fn from(value: ServiceTunnelReadinessKindArg) -> Self {
+        match value {
+            ServiceTunnelReadinessKindArg::Process => ServiceTunnelReadinessKind::Process,
+            ServiceTunnelReadinessKindArg::Preview => ServiceTunnelReadinessKind::Preview,
+            ServiceTunnelReadinessKindArg::Proof => ServiceTunnelReadinessKind::Proof,
         }
     }
 }
@@ -1091,30 +1132,80 @@ fn run_service(command: TunnelServiceCommand) -> CmdResult<TunnelOutput> {
             health_url,
             health_path,
             readiness_timeout,
+            readiness_kind,
+            require_listener,
+            readiness_artifact,
+            readiness_artifact_json_pointer,
+            readiness_artifact_json_equals,
+            readiness_stdout_regex,
             public_tunnel_backend,
             public_tunnel_command,
             public_tunnel_public_url,
             source_run_id,
             source_workflow_id,
-        } => start_service(StartServiceTunnelSpec {
-            id,
-            command,
-            cwd,
-            env: parse_env_assignments(env)?,
-            host,
-            port,
-            scheme,
-            health_url,
-            health_path,
-            readiness_timeout_secs: readiness_timeout,
-            backend: public_tunnel_backend.into(),
-            backend_command: public_tunnel_command,
-            backend_public_url: public_tunnel_public_url,
-            source_run_id,
-            source_workflow_id,
-        }),
+        } => {
+            let readiness_checks = build_readiness_checks(
+                require_listener,
+                readiness_artifact,
+                readiness_artifact_json_pointer,
+                readiness_artifact_json_equals,
+                readiness_stdout_regex,
+            )?;
+            start_service(StartServiceTunnelSpec {
+                id,
+                command,
+                cwd,
+                env: parse_env_assignments(env)?,
+                host,
+                port,
+                scheme,
+                health_url,
+                health_path,
+                readiness_timeout_secs: readiness_timeout,
+                backend: public_tunnel_backend.into(),
+                backend_command: public_tunnel_command,
+                backend_public_url: public_tunnel_public_url,
+                source_run_id,
+                source_workflow_id,
+                readiness_kind: readiness_kind.into(),
+                readiness_checks,
+            })
+        }
         TunnelServiceCommand::Stop { id } => stop_service(&id),
     }
+}
+
+fn build_readiness_checks(
+    require_listener: bool,
+    readiness_artifact: Option<PathBuf>,
+    readiness_artifact_json_pointer: Option<String>,
+    readiness_artifact_json_equals: Option<String>,
+    readiness_stdout_regex: Option<String>,
+) -> homeboy::core::Result<Vec<ServiceTunnelReadinessCheck>> {
+    let mut checks = Vec::new();
+    if require_listener {
+        checks.push(ServiceTunnelReadinessCheck::TcpListener);
+    }
+    if let Some(pattern) = readiness_stdout_regex {
+        checks.push(ServiceTunnelReadinessCheck::StdoutRegex { pattern });
+    }
+    if let Some(path) = readiness_artifact {
+        let Some(pointer) = readiness_artifact_json_pointer else {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "readiness_artifact_json_pointer",
+                "artifact readiness requires a JSON pointer",
+                Some(path.display().to_string()),
+                None,
+            ));
+        };
+        let equals = readiness_artifact_json_equals.unwrap_or_else(|| "ready".to_string());
+        checks.push(ServiceTunnelReadinessCheck::ArtifactJsonPointer {
+            path: path.display().to_string(),
+            pointer,
+            equals,
+        });
+    }
+    Ok(checks)
 }
 
 fn expose_service(spec: ExposeServiceTunnelSpec) -> CmdResult<TunnelOutput> {

--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -590,6 +590,8 @@ pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
         backend_process: None,
         source_run_id: spec.source_run_id,
         source_workflow_id: spec.source_workflow_id,
+        readiness_kind: spec.readiness_kind,
+        readiness_checks: spec.readiness_checks,
     };
     save_runtime_state(&state)?;
     if let Err(error) = wait_until_ready(&state, spec.readiness_timeout_secs) {
@@ -630,6 +632,7 @@ fn service_tunnel_status(tunnel: &ServiceTunnel) -> ServiceTunnelStatus {
     let state = load_runtime_state(&tunnel.id).ok().flatten();
     let running = state.as_ref().is_some_and(runtime_state_is_running);
     let health = state.as_ref().map(check_runtime_health);
+    let readiness = state.as_ref().map(check_runtime_readiness);
     let evidence = state.as_ref().map(runtime_evidence);
     let process = state.as_ref().map(|state| ServiceTunnelProcessStatus {
         pid: state.pid,
@@ -673,6 +676,7 @@ fn service_tunnel_status(tunnel: &ServiceTunnel) -> ServiceTunnelStatus {
         policy: tunnel.policy.clone(),
         process,
         health,
+        readiness,
         evidence,
         tunnel_backend: backend,
         preview,
@@ -1385,7 +1389,8 @@ fn resolve_health_url(
 fn wait_until_ready(state: &ServiceTunnelRuntimeState, timeout_secs: u64) -> Result<()> {
     let deadline = Instant::now() + Duration::from_secs(timeout_secs);
     loop {
-        if !runtime_state_is_running(state) {
+        let readiness = check_runtime_readiness(state);
+        if !readiness.process_running {
             return Err(Error::validation_invalid_argument(
                 "service",
                 "service process exited before becoming ready",
@@ -1393,20 +1398,176 @@ fn wait_until_ready(state: &ServiceTunnelRuntimeState, timeout_secs: u64) -> Res
                 None,
             ));
         }
-        let health = check_runtime_health(state);
-        if health.healthy || (!health.checked && runtime_state_is_running(state)) {
+        if readiness.ready {
             return Ok(());
         }
         if Instant::now() >= deadline {
             return Err(Error::validation_invalid_argument(
                 "readiness",
-                "service did not become healthy before readiness timeout",
+                "service did not satisfy readiness before timeout",
                 Some(state.preview_identity.service_id.clone()),
-                health.error.map(|error| vec![error]),
+                Some(
+                    readiness
+                        .checks
+                        .into_iter()
+                        .filter(|check| !check.ready)
+                        .filter_map(|check| check.detail)
+                        .collect(),
+                ),
             ));
         }
         std::thread::sleep(Duration::from_millis(200));
     }
+}
+
+fn check_runtime_readiness(state: &ServiceTunnelRuntimeState) -> ServiceTunnelReadinessStatus {
+    let process_running = runtime_state_is_running(state);
+    let mut checks = Vec::new();
+
+    if state.health_url.is_some() {
+        let health = check_runtime_health(state);
+        checks.push(ServiceTunnelReadinessCheckStatus {
+            check: "health".to_string(),
+            ready: health.healthy,
+            detail: health
+                .status_code
+                .map(|status| format!("status {status}"))
+                .or(health.error),
+        });
+    }
+
+    for check in &state.readiness_checks {
+        checks.push(evaluate_readiness_check(state, check));
+    }
+
+    let checks_ready = checks.iter().all(|check| check.ready);
+    let ready = process_running && checks_ready;
+    ServiceTunnelReadinessStatus {
+        kind: state.readiness_kind.clone(),
+        process_running,
+        ready,
+        preview_ready: matches!(state.readiness_kind, ServiceTunnelReadinessKind::Preview) && ready,
+        proof_ready: matches!(state.readiness_kind, ServiceTunnelReadinessKind::Proof) && ready,
+        checks,
+    }
+}
+
+fn evaluate_readiness_check(
+    state: &ServiceTunnelRuntimeState,
+    check: &ServiceTunnelReadinessCheck,
+) -> ServiceTunnelReadinessCheckStatus {
+    match check {
+        ServiceTunnelReadinessCheck::TcpListener => tcp_listener_readiness(state),
+        ServiceTunnelReadinessCheck::ArtifactJsonPointer {
+            path,
+            pointer,
+            equals,
+        } => artifact_json_pointer_readiness(path, pointer, equals),
+        ServiceTunnelReadinessCheck::StdoutRegex { pattern } => {
+            stdout_regex_readiness(&state.logs.stdout_path, pattern)
+        }
+    }
+}
+
+fn tcp_listener_readiness(state: &ServiceTunnelRuntimeState) -> ServiceTunnelReadinessCheckStatus {
+    let Some((host, port)) = local_url_host_port(&state.local_url) else {
+        return ServiceTunnelReadinessCheckStatus {
+            check: "tcp_listener".to_string(),
+            ready: false,
+            detail: Some(format!("could not parse local URL {}", state.local_url)),
+        };
+    };
+    let address = format!("{host}:{port}");
+    match address.to_socket_addrs() {
+        Ok(mut addresses) => {
+            let ready = addresses.any(|address| {
+                TcpStream::connect_timeout(&address, Duration::from_millis(200)).is_ok()
+            });
+            ServiceTunnelReadinessCheckStatus {
+                check: "tcp_listener".to_string(),
+                ready,
+                detail: Some(address),
+            }
+        }
+        Err(error) => ServiceTunnelReadinessCheckStatus {
+            check: "tcp_listener".to_string(),
+            ready: false,
+            detail: Some(error.to_string()),
+        },
+    }
+}
+
+fn artifact_json_pointer_readiness(
+    path: &str,
+    pointer: &str,
+    equals: &str,
+) -> ServiceTunnelReadinessCheckStatus {
+    let data = match fs::read_to_string(path) {
+        Ok(data) => data,
+        Err(error) => {
+            return ServiceTunnelReadinessCheckStatus {
+                check: "artifact_json_pointer".to_string(),
+                ready: false,
+                detail: Some(format!("{}: {error}", path)),
+            };
+        }
+    };
+    let json: serde_json::Value = match serde_json::from_str(&data) {
+        Ok(json) => json,
+        Err(error) => {
+            return ServiceTunnelReadinessCheckStatus {
+                check: "artifact_json_pointer".to_string(),
+                ready: false,
+                detail: Some(format!("{}: {error}", path)),
+            };
+        }
+    };
+    let Some(value) = json.pointer(pointer) else {
+        return ServiceTunnelReadinessCheckStatus {
+            check: "artifact_json_pointer".to_string(),
+            ready: false,
+            detail: Some(format!("{path} missing {pointer}")),
+        };
+    };
+    let actual = value
+        .as_str()
+        .map(str::to_string)
+        .unwrap_or_else(|| value.to_string());
+    ServiceTunnelReadinessCheckStatus {
+        check: "artifact_json_pointer".to_string(),
+        ready: actual == equals,
+        detail: Some(format!("{path} {pointer}={actual}")),
+    }
+}
+
+fn stdout_regex_readiness(path: &str, pattern: &str) -> ServiceTunnelReadinessCheckStatus {
+    let data = match fs::read_to_string(path) {
+        Ok(data) => data,
+        Err(error) => {
+            return ServiceTunnelReadinessCheckStatus {
+                check: "stdout_regex".to_string(),
+                ready: false,
+                detail: Some(format!("{}: {error}", path)),
+            };
+        }
+    };
+    match regex::Regex::new(pattern) {
+        Ok(regex) => ServiceTunnelReadinessCheckStatus {
+            check: "stdout_regex".to_string(),
+            ready: regex.is_match(&data),
+            detail: Some(pattern.to_string()),
+        },
+        Err(error) => ServiceTunnelReadinessCheckStatus {
+            check: "stdout_regex".to_string(),
+            ready: false,
+            detail: Some(error.to_string()),
+        },
+    }
+}
+
+fn local_url_host_port(local_url: &str) -> Option<(String, u16)> {
+    let url = reqwest::Url::parse(local_url).ok()?;
+    Some((url.host_str()?.to_string(), url.port_or_known_default()?))
 }
 
 fn check_runtime_health(state: &ServiceTunnelRuntimeState) -> ServiceTunnelHealthStatus {

--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fs::{self, File};
+use std::net::{TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -191,6 +192,8 @@ pub struct ServiceTunnelStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub health: Option<ServiceTunnelHealthStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness: Option<ServiceTunnelReadinessStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub evidence: Option<ServiceTunnelEvidence>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tunnel_backend: Option<ServiceTunnelBackendStatus>,
@@ -240,6 +243,10 @@ pub struct ServiceTunnelRuntimeState {
     pub source_run_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_workflow_id: Option<String>,
+    #[serde(default)]
+    pub readiness_kind: ServiceTunnelReadinessKind,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub readiness_checks: Vec<ServiceTunnelReadinessCheck>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -278,6 +285,53 @@ pub struct ServiceTunnelHealthStatus {
     pub status_code: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceTunnelReadinessKind {
+    Process,
+    Preview,
+    Proof,
+}
+
+impl Default for ServiceTunnelReadinessKind {
+    fn default() -> Self {
+        Self::Process
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ServiceTunnelReadinessCheck {
+    TcpListener,
+    ArtifactJsonPointer {
+        path: String,
+        pointer: String,
+        equals: String,
+    },
+    StdoutRegex {
+        pattern: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ServiceTunnelReadinessStatus {
+    pub kind: ServiceTunnelReadinessKind,
+    pub process_running: bool,
+    pub ready: bool,
+    pub preview_ready: bool,
+    pub proof_ready: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub checks: Vec<ServiceTunnelReadinessCheckStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ServiceTunnelReadinessCheckStatus {
+    pub check: String,
+    pub ready: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -358,6 +412,8 @@ pub struct StartServiceTunnelSpec {
     pub backend_public_url: Option<String>,
     pub source_run_id: Option<String>,
     pub source_workflow_id: Option<String>,
+    pub readiness_kind: ServiceTunnelReadinessKind,
+    pub readiness_checks: Vec<ServiceTunnelReadinessCheck>,
 }
 
 pub struct ExposeServiceTunnelSpec {

--- a/src/core/tunnel_tests.rs
+++ b/src/core/tunnel_tests.rs
@@ -178,6 +178,8 @@ fn start_status_and_stop_manage_local_service_runtime_state() {
             backend_public_url: None,
             source_run_id: Some("run-123".to_string()),
             source_workflow_id: Some("workflow-abc".to_string()),
+            readiness_kind: ServiceTunnelReadinessKind::Process,
+            readiness_checks: Vec::new(),
         })
         .expect("start service");
 
@@ -253,6 +255,8 @@ fn start_cleans_runtime_state_when_readiness_fails() {
             backend_public_url: None,
             source_run_id: None,
             source_workflow_id: None,
+            readiness_kind: ServiceTunnelReadinessKind::Process,
+            readiness_checks: Vec::new(),
         })
         .expect_err("readiness should fail");
 
@@ -262,6 +266,137 @@ fn start_cleans_runtime_state_when_readiness_fails() {
         assert!(!state_path.exists());
         let stopped = status("failing-preview").expect("status");
         assert!(!stopped.running);
+    });
+}
+
+#[test]
+fn proof_readiness_waits_for_stdout_signal_not_just_process_liveness() {
+    test_support::with_isolated_home(|_| {
+        create_server();
+        expose(ExposeServiceTunnelSpec {
+            id: "proof-preview".to_string(),
+            server_id: "private-host".to_string(),
+            target: ServiceTunnelTarget {
+                host: "127.0.0.1".to_string(),
+                port: 7331,
+            },
+            scheme: "http".to_string(),
+            local_port: Some(8835),
+            auth: ServiceTunnelAuth {
+                mode: ServiceTunnelAuthMode::BearerEnv,
+                env_var: Some("PROOF_PREVIEW_TOKEN".to_string()),
+                header: Some("Authorization".to_string()),
+            },
+            policy: ServiceTunnelPolicy {
+                exposure: ServiceTunnelExposure::PrivateLoopback,
+                require_auth: true,
+                allowed_clients: Vec::new(),
+                preview: ServiceTunnelPreviewPolicy::default(),
+                native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
+            },
+            description: None,
+        })
+        .expect("expose service");
+
+        let started = start(StartServiceTunnelSpec {
+            id: "proof-preview".to_string(),
+            command: "printf 'proof ready\\n'; while true; do sleep 1; done".to_string(),
+            cwd: None,
+            env: BTreeMap::new(),
+            host: Some("127.0.0.1".to_string()),
+            port: Some(8835),
+            scheme: Some("http".to_string()),
+            health_url: None,
+            health_path: None,
+            readiness_timeout_secs: 2,
+            backend: ServiceTunnelTunnelBackend::None,
+            backend_command: None,
+            backend_public_url: None,
+            source_run_id: None,
+            source_workflow_id: None,
+            readiness_kind: ServiceTunnelReadinessKind::Proof,
+            readiness_checks: vec![ServiceTunnelReadinessCheck::StdoutRegex {
+                pattern: "proof ready".to_string(),
+            }],
+        })
+        .expect("start service");
+
+        let readiness = started.readiness.expect("readiness status");
+        assert!(readiness.process_running);
+        assert!(readiness.ready);
+        assert!(!readiness.preview_ready);
+        assert!(readiness.proof_ready);
+        assert_eq!(readiness.checks[0].check, "stdout_regex");
+
+        stop("proof-preview").expect("stop service");
+    });
+}
+
+#[test]
+fn preview_readiness_can_require_artifact_status() {
+    test_support::with_isolated_home(|home| {
+        create_server();
+        let artifact = home.path().join("preview-ready.json");
+        expose(ExposeServiceTunnelSpec {
+            id: "artifact-preview".to_string(),
+            server_id: "private-host".to_string(),
+            target: ServiceTunnelTarget {
+                host: "127.0.0.1".to_string(),
+                port: 7331,
+            },
+            scheme: "http".to_string(),
+            local_port: Some(8836),
+            auth: ServiceTunnelAuth {
+                mode: ServiceTunnelAuthMode::BearerEnv,
+                env_var: Some("ARTIFACT_PREVIEW_TOKEN".to_string()),
+                header: Some("Authorization".to_string()),
+            },
+            policy: ServiceTunnelPolicy {
+                exposure: ServiceTunnelExposure::PrivateLoopback,
+                require_auth: true,
+                allowed_clients: Vec::new(),
+                preview: ServiceTunnelPreviewPolicy::default(),
+                native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
+            },
+            description: None,
+        })
+        .expect("expose service");
+
+        let started = start(StartServiceTunnelSpec {
+            id: "artifact-preview".to_string(),
+            command: format!(
+                "printf '{{\"status\":\"ready\"}}' > {}; while true; do sleep 1; done",
+                artifact.display()
+            ),
+            cwd: None,
+            env: BTreeMap::new(),
+            host: Some("127.0.0.1".to_string()),
+            port: Some(8836),
+            scheme: Some("http".to_string()),
+            health_url: None,
+            health_path: None,
+            readiness_timeout_secs: 2,
+            backend: ServiceTunnelTunnelBackend::None,
+            backend_command: None,
+            backend_public_url: None,
+            source_run_id: None,
+            source_workflow_id: None,
+            readiness_kind: ServiceTunnelReadinessKind::Preview,
+            readiness_checks: vec![ServiceTunnelReadinessCheck::ArtifactJsonPointer {
+                path: artifact.display().to_string(),
+                pointer: "/status".to_string(),
+                equals: "ready".to_string(),
+            }],
+        })
+        .expect("start service");
+
+        let readiness = started.readiness.expect("readiness status");
+        assert!(readiness.process_running);
+        assert!(readiness.preview_ready);
+        assert!(!readiness.proof_ready);
+        assert_eq!(readiness.checks[0].check, "artifact_json_pointer");
+
+        stop("artifact-preview").expect("stop service");
     });
 }
 
@@ -310,6 +445,8 @@ fn command_backend_records_public_url_and_cleans_up_backend_process() {
             backend_public_url: Some("https://preview.example.test".to_string()),
             source_run_id: None,
             source_workflow_id: None,
+            readiness_kind: ServiceTunnelReadinessKind::Process,
+            readiness_checks: Vec::new(),
         })
         .expect("start service with backend");
 
@@ -592,6 +729,8 @@ fn preview_artifact_serializes_structured_reviewer_contract() {
         backend_process: None,
         source_run_id: Some("run-1".to_string()),
         source_workflow_id: Some("workflow-1".to_string()),
+        readiness_kind: ServiceTunnelReadinessKind::Process,
+        readiness_checks: Vec::new(),
     };
     let context = ServiceTunnelPreviewDecisionContext {
         run_failed: false,


### PR DESCRIPTION
## Summary
- Add opt-in tunnel service readiness checks for TCP listener, artifact JSON Pointer value, and stdout regex.
- Report readiness separately from process liveness with `process_running`, `preview_ready`, and `proof_ready` status fields.
- Document the new held preview/proof readiness contract and add focused tunnel service tests.

Closes #4479.

## Tests
- `cargo fmt`
- `cargo test core::tunnel_tests` attempted twice locally; first timed out waiting for Cargo artifact lock, second reached compilation before user asked to stop local testing and let CI handle the full matrix.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and implementing the generic tunnel service readiness contract, focused tests, docs, and PR description. Chris requested CI handle the final test matrix.