### PR TITLE
fix: resolve runner-side observation runs

### DIFF
--- a/src/core/observation/runs_service.rs
+++ b/src/core/observation/runs_service.rs
@@ -48,14 +48,60 @@ pub struct ArtifactFetchOutcome {
 /// Look up a run and surface a stable validation error when it doesn't
 /// exist. Used by every observation command that takes a `run_id`.
 pub fn require_run(store: &ObservationStore, run_id: &str) -> Result<RunRecord> {
-    store.get_run(run_id)?.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "run_id",
-            format!("run record not found: {run_id}"),
-            Some(run_id.to_string()),
-            None,
-        )
-    })
+    if let Some(run) = store.get_run(run_id)? {
+        return Ok(run);
+    }
+    if let Ok(Some(run)) = crate::core::runners::mirror_connected_runner_run(run_id) {
+        return Ok(run);
+    }
+    Err(missing_run_error(run_id))
+}
+
+fn missing_run_error(run_id: &str) -> Error {
+    Error::validation_invalid_argument(
+        "run_id",
+        format!("run record not found: {run_id}"),
+        Some(run_id.to_string()),
+        Some(missing_run_guidance(run_id)),
+    )
+}
+
+fn missing_run_guidance(run_id: &str) -> Vec<String> {
+    let mut hints = Vec::new();
+    let connected = crate::core::runners::statuses()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|report| report.connected)
+        .map(|report| report.runner_id)
+        .collect::<Vec<_>>();
+
+    if connected.is_empty() {
+        hints.push(
+            "No connected runner daemon is available for controller-side lookup; connect the offload runner or inspect it with `homeboy runner exec <runner-id> -- homeboy runs list --limit 100`.".to_string(),
+        );
+        return hints;
+    }
+
+    missing_run_guidance_for_runner_ids(run_id, connected)
+}
+
+fn missing_run_guidance_for_runner_ids(run_id: &str, runner_ids: Vec<String>) -> Vec<String> {
+    let mut hints = Vec::new();
+    for runner_id in runner_ids {
+        hints.push(format!(
+            "Check runner `{runner_id}` from the controller: `homeboy runs list --runner {runner_id} --limit 100`."
+        ));
+        hints.push(format!(
+            "Inspect run `{run_id}` directly on runner `{runner_id}`: `homeboy runner exec {runner_id} -- homeboy runs show {run_id}`."
+        ));
+        hints.push(format!(
+            "List artifacts for run `{run_id}` directly on runner `{runner_id}`: `homeboy runner exec {runner_id} -- homeboy runs artifacts {run_id}`."
+        ));
+        hints.push(format!(
+            "Export run `{run_id}` directly on runner `{runner_id}`: `homeboy runner exec {runner_id} -- homeboy runs export --run {run_id} --output <dir>`."
+        ));
+    }
+    hints
 }
 
 /// Best-effort refresh of mirrored Lab runner evidence for a run.
@@ -840,6 +886,20 @@ mod tests {
             assert_eq!(err.code.as_str(), "validation.invalid_argument");
             assert!(err.message.contains("run record not found"));
         });
+    }
+
+    #[test]
+    fn missing_run_guidance_prints_runner_routed_retrieval_commands() {
+        let hints = missing_run_guidance_for_runner_ids("run-123", vec!["homeboy-lab".to_string()]);
+        assert_eq!(
+            hints,
+            vec![
+                "Check runner `homeboy-lab` from the controller: `homeboy runs list --runner homeboy-lab --limit 100`.",
+                "Inspect run `run-123` directly on runner `homeboy-lab`: `homeboy runner exec homeboy-lab -- homeboy runs show run-123`.",
+                "List artifacts for run `run-123` directly on runner `homeboy-lab`: `homeboy runner exec homeboy-lab -- homeboy runs artifacts run-123`.",
+                "Export run `run-123` directly on runner `homeboy-lab`: `homeboy runner exec homeboy-lab -- homeboy runs export --run run-123 --output <dir>`.",
+            ]
+        );
     }
 
     #[test]

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -239,6 +239,34 @@ pub fn refresh_mirrored_daemon_evidence(run_id: &str) -> Result<Option<Vec<RunRe
     Ok(Some(mirror_remote_observation_runs(&store, &runner, &job)?))
 }
 
+pub fn mirror_connected_runner_run(run_id: &str) -> Result<Option<RunRecord>> {
+    let store = ObservationStore::open_initialized()?;
+    for report in super::connection::statuses()? {
+        if !report.connected {
+            continue;
+        }
+        let runner_id = report.runner_id;
+        let runner = load(&runner_id)?;
+        let Ok(data) = daemon_api_get(
+            &runner_id,
+            &format!("/runs/{}", encode_uri_component(run_id)),
+        ) else {
+            continue;
+        };
+        let body = canonical_daemon_body(&data, "runner run detail response")?;
+        let Some(detail) = body.get("run") else {
+            continue;
+        };
+        let run = remote_detail_to_run_record(detail, &runner, None)?;
+        import_run_if_absent(&store, &run)?;
+        for artifact in remote_detail_artifacts(detail, &runner, &run.id)? {
+            import_artifact_if_absent(&store, &artifact)?;
+        }
+        return Ok(Some(run));
+    }
+    Ok(None)
+}
+
 pub fn runner_job_log_snapshot(runner_id: &str, job_id: &str) -> Result<RunnerJobLogSnapshot> {
     Ok(RunnerJobLogSnapshot {
         job: fetch_daemon_job(runner_id, job_id)?,
@@ -395,7 +423,7 @@ fn mirror_remote_observation_runs(
         let Some(detail) = detail_body.get("run") else {
             continue;
         };
-        let run = remote_detail_to_run_record(detail, runner, job)?;
+        let run = remote_detail_to_run_record(detail, runner, Some(job))?;
         import_run_if_absent(store, &run)?;
         for artifact in remote_detail_artifacts(detail, runner, &run.id)? {
             import_artifact_if_absent(store, &artifact)?;
@@ -416,7 +444,11 @@ fn import_artifact_if_absent(store: &ObservationStore, artifact: &ArtifactRecord
     store.import_artifact(artifact)
 }
 
-fn remote_detail_to_run_record(detail: &Value, runner: &Runner, job: &Job) -> Result<RunRecord> {
+fn remote_detail_to_run_record(
+    detail: &Value,
+    runner: &Runner,
+    job: Option<&Job>,
+) -> Result<RunRecord> {
     let id = required_str(detail, "id")?.to_string();
     let metadata = detail.get("metadata").cloned().unwrap_or_else(|| json!({}));
     Ok(RunRecord {
@@ -536,20 +568,20 @@ fn required_str<'a>(value: &'a Value, field: &str) -> Result<&'a str> {
 fn merge_lab_metadata(
     metadata: Value,
     runner: &Runner,
-    job: &Job,
+    job: Option<&Job>,
     artifact_manifest: Option<Value>,
 ) -> Value {
     let mut object = metadata.as_object().cloned().unwrap_or_default();
-    object.insert(
-        "lab".to_string(),
-        json!({
-            "runner": runner_metadata(runner),
-            "remote_job_id": job.id.to_string(),
-            "remote_job_status": job.status,
-            "source_snapshot": source_snapshot_from_result(&metadata),
-            "remote_artifact_manifest": artifact_manifest,
-        }),
-    );
+    let mut lab = json!({
+        "runner": runner_metadata(runner),
+        "source_snapshot": source_snapshot_from_result(&metadata),
+        "remote_artifact_manifest": artifact_manifest,
+    });
+    if let Some(job) = job {
+        lab["remote_job_id"] = Value::String(job.id.to_string());
+        lab["remote_job_status"] = json!(job.status);
+    }
+    object.insert("lab".to_string(), lab);
     Value::Object(object)
 }
 

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -57,9 +57,9 @@ pub(crate) use evidence::artifact_store_locator_from_runner_artifact_id;
 pub use evidence::runner_artifact_store_token;
 pub use evidence::{
     download_remote_artifact, is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,
-    is_retrievable_runner_artifact, mirrored_runner_job_identity, refresh_mirrored_daemon_evidence,
-    reportable_artifact_evidence_path, runner_job_log_snapshot, RemoteArtifactDownload,
-    RunnerJobLogSnapshot,
+    is_retrievable_runner_artifact, mirror_connected_runner_run, mirrored_runner_job_identity,
+    refresh_mirrored_daemon_evidence, reportable_artifact_evidence_path, runner_job_log_snapshot,
+    RemoteArtifactDownload, RunnerJobLogSnapshot,
 };
 pub(crate) use execution::{
     daemon_api_get, execute_runner_process_until_cancelled, prepare_daemon_local_process,

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -31,7 +31,7 @@ pub use super::runner::{
     is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,
     is_retrievable_runner_artifact, lab_offload_changed_since_ref, lab_offload_metadata,
     lab_offload_metadata_with_workspace_mapping, lab_runner_capability_preflight,
-    mirrored_runner_job_identity, preflight_lab_offload_changed_since,
+    mirror_connected_runner_run, mirrored_runner_job_identity, preflight_lab_offload_changed_since,
     prepare_git_lab_offload_changed_since, prepare_lab_runner_capability,
     refresh_mirrored_daemon_evidence, reportable_artifact_evidence_path,
     resolve_default_lab_runner, run_reverse_worker, runner_artifact_store_token,
@@ -105,8 +105,9 @@ pub mod evidence {
     pub use super::super::runner::{
         download_remote_artifact, is_remote_runner_artifact_path,
         is_reportable_artifact_evidence_path, is_retrievable_runner_artifact,
-        mirrored_runner_job_identity, refresh_mirrored_daemon_evidence,
-        reportable_artifact_evidence_path, runner_artifact_store_token, RemoteArtifactDownload,
+        mirror_connected_runner_run, mirrored_runner_job_identity,
+        refresh_mirrored_daemon_evidence, reportable_artifact_evidence_path,
+        runner_artifact_store_token, RemoteArtifactDownload,
     };
 }
 


### PR DESCRIPTION
## Summary
- Mirror a missing controller-side observation run from any connected runner daemon before failing `homeboy runs <reader> <run-id>` lookups.
- Preserve generic runner artifact handling by importing remote artifact metadata as existing `runner-artifact://` retrievable records.
- Add precise runner-routed fallback commands for missing run IDs when no connected daemon can mirror the run.

Fixes #4492.

## Verification
- `cargo fmt` — passed, no output.
- `git status --short --branch` — clean after commit; branch ahead of `origin/main` by 1 before push.
- Local test suites and local hot validation were intentionally not run per task instruction.
- Lab/offloaded verification was not run because the requested acceptance can be covered by the generic controller lookup/mirroring path without starting a fresh offloaded workload in this environment.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the Homeboy runner/run retrieval paths, drafted the generic controller-side mirroring fallback and routed-command guidance, and prepared the PR summary for Chris to review.