### PR TITLE
fix: clarify allow-local-hot routing

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -25,7 +25,8 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub force_hot: bool,
 
-    /// Allow --force-hot portable Lab commands to stay local even when a default Lab runner exists.
+    /// Permit --force-hot portable Lab commands to stay local even when a default Lab runner exists.
+    /// This flag does not disable automatic Lab offload unless --force-hot is also set.
     #[arg(long, global = true)]
     pub allow_local_hot: bool,
 

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -1627,6 +1627,30 @@ mod tests {
     }
 
     #[test]
+    fn lab_runner_selection_rejects_allow_local_hot_without_force_hot() {
+        let command = portable_lab_command("rig check");
+
+        let err = resolve_lab_runner_selection_from_default(
+            &command,
+            None,
+            false,
+            true,
+            false,
+            Some("lab-default".to_string()),
+        )
+        .expect_err("allow-local-hot alone must not silently auto-offload");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("--allow-local-hot only permits"));
+        assert!(err.message.contains("--force-hot"));
+        assert!(err.message.contains("automatic Lab offload"));
+        let tried = err.details["tried"].as_array().expect("tried");
+        assert!(tried.iter().any(|hint| hint
+            .as_str()
+            .is_some_and(|hint| hint.contains("--force-hot --allow-local-hot"))));
+    }
+
+    #[test]
     fn lab_runner_selection_allow_local_hot_overrides_default_runner_gate() {
         let command = portable_lab_command("test");
 

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -366,6 +366,22 @@ pub(super) fn resolve_lab_runner_selection_from_default(
         }));
     }
 
+    if allow_local_hot && !force_hot {
+        return Err(Error::validation_invalid_argument(
+            "allow_local_hot",
+            format!(
+                "--allow-local-hot only permits an explicit --force-hot local run for portable hot command `{}`; it does not disable automatic Lab offload by itself",
+                command.hot_label
+            ),
+            Some("--allow-local-hot".to_string()),
+            Some(vec![
+                "Use --force-hot --allow-local-hot to keep the command on the controller machine.".to_string(),
+                "Omit --allow-local-hot to let Homeboy choose the configured default Lab runner.".to_string(),
+                "Use --runner <runner-id> to offload to a specific Lab runner.".to_string(),
+            ]),
+        ));
+    }
+
     if !command.default_lab_offload {
         fail_if_local_bench_denied(command, deny_local_bench)?;
         return Ok(None);


### PR DESCRIPTION
## Summary
- Clarifies that `--allow-local-hot` only permits an explicit `--force-hot` local override; it does not disable automatic Lab offload by itself.
- Rejects `--allow-local-hot` without `--force-hot` before default runner selection can silently offload the command.
- Adds coverage for the `rig check`-shaped routing case so the required local execution mode stays documented in code.

Fixes #4493.

## Verification
- `cargo fmt`
- `git diff --check`
- `cargo check` — passed; existing warning: `declared_agent_task_secret_env` is never used.

Local test suites and local hot/rig validation were intentionally not run per task instructions. No deploy was performed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the generic Lab routing path, drafted the targeted Rust change and coverage, and prepared this PR for Chris to review.