### PR TITLE
fix: classify PR CI state before merge

### DIFF
--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -453,7 +453,7 @@ pub fn pr_view(
         "-R".into(),
         repo_flag,
         "--json".into(),
-        "author,baseRefName,headRefName,headRepository".into(),
+        "author,baseRefName,headRefName,headRepository,state,mergedAt,headRefOid,reviewDecision,mergeStateStatus,statusCheckRollup".into(),
     ];
     let raw = run_gh(&args)?;
     let parsed: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
@@ -481,16 +481,34 @@ pub fn pr_view(
         .or_else(|| parsed.pointer("/headRepository/name"))
         .and_then(|v| v.as_str())
         .map(|v| v.to_string());
+    let state = string_value(&parsed, "state").unwrap_or_default();
+    let head_sha = string_value(&parsed, "headRefOid");
+    let merged_at = string_value(&parsed, "mergedAt");
+    let review_decision = string_value(&parsed, "reviewDecision");
+    let merge_state = string_value(&parsed, "mergeStateStatus");
+    let status_check_rollup = parsed
+        .get("statusCheckRollup")
+        .and_then(|v| v.as_array())
+        .map(|v| v.as_slice())
+        .unwrap_or(&[]);
+    let (ci_state, ci_summary) = classify_pr_ci(&state, merged_at.as_deref(), status_check_rollup);
 
     Ok(GithubPrView {
         component_id: id,
         owner: repo.owner,
         repo: repo.repo,
         number,
+        state,
         author,
         base,
         head,
         head_repository,
+        head_sha,
+        merged_at,
+        review_decision,
+        merge_state,
+        ci_state,
+        ci_summary,
     })
 }
 
@@ -719,6 +737,83 @@ fn parse_issue_number_from_url(url: &str) -> Option<u64> {
     url.trim_end_matches('/').rsplit('/').next()?.parse().ok()
 }
 
+fn string_value(value: &serde_json::Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(str::to_string)
+}
+
+fn classify_pr_ci(
+    pr_state: &str,
+    merged_at: Option<&str>,
+    checks: &[serde_json::Value],
+) -> (String, String) {
+    if checks.is_empty() {
+        return (
+            "no_checks".to_string(),
+            "GitHub reported no status checks for this PR head.".to_string(),
+        );
+    }
+
+    let mut pending = 0usize;
+    let mut failed = 0usize;
+    let mut green = 0usize;
+    let mut unknown = 0usize;
+
+    for check in checks {
+        let status = check.get("status").and_then(serde_json::Value::as_str);
+        let conclusion = check
+            .get("conclusion")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|v| !v.is_empty());
+
+        match (status, conclusion) {
+            (
+                _,
+                Some("FAILURE" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED" | "STARTUP_FAILURE"),
+            ) => {
+                failed += 1;
+            }
+            (Some("COMPLETED"), Some("SUCCESS" | "SKIPPED" | "NEUTRAL")) => {
+                green += 1;
+            }
+            (Some("COMPLETED"), Some(_)) => {
+                unknown += 1;
+            }
+            (Some("COMPLETED"), None) => {
+                unknown += 1;
+            }
+            _ => {
+                pending += 1;
+            }
+        }
+    }
+
+    let state = if failed > 0 || unknown > 0 {
+        "terminal_failed"
+    } else if pending > 0 && (pr_state == "MERGED" || merged_at.is_some()) {
+        "stale"
+    } else if pending > 0 {
+        "pending"
+    } else {
+        "terminal_green"
+    };
+
+    let summary = format!(
+        "{} check(s): {} terminal-green, {} failed/unknown, {} pending",
+        checks.len(),
+        green,
+        failed + unknown,
+        pending
+    );
+
+    (state.to_string(), summary)
+}
+
 fn parse_issue_list_json(raw: &str, options: &IssueFindOptions) -> Result<Vec<GithubFindItem>> {
     #[derive(serde::Deserialize)]
     struct RawIssue {
@@ -862,6 +957,56 @@ mod tests {
             parse_issue_number_from_url("https://github.com/owner/repo/issues/not-a-number"),
             None
         );
+    }
+
+    #[test]
+    fn classify_pr_ci_distinguishes_terminal_green() {
+        let checks = serde_json::json!([
+            {"status":"COMPLETED","conclusion":"SUCCESS"},
+            {"status":"COMPLETED","conclusion":"SKIPPED"}
+        ]);
+        let (state, summary) = classify_pr_ci("OPEN", None, checks.as_array().unwrap());
+
+        assert_eq!(state, "terminal_green");
+        assert!(summary.contains("2 terminal-green"));
+    }
+
+    #[test]
+    fn classify_pr_ci_distinguishes_terminal_failed() {
+        let checks = serde_json::json!([
+            {"status":"COMPLETED","conclusion":"SUCCESS"},
+            {"status":"COMPLETED","conclusion":"FAILURE"}
+        ]);
+        let (state, summary) = classify_pr_ci("OPEN", None, checks.as_array().unwrap());
+
+        assert_eq!(state, "terminal_failed");
+        assert!(summary.contains("1 failed/unknown"));
+    }
+
+    #[test]
+    fn classify_pr_ci_distinguishes_pending_open_pr() {
+        let checks = serde_json::json!([
+            {"status":"IN_PROGRESS","conclusion":""}
+        ]);
+        let (state, summary) = classify_pr_ci("OPEN", None, checks.as_array().unwrap());
+
+        assert_eq!(state, "pending");
+        assert!(summary.contains("1 pending"));
+    }
+
+    #[test]
+    fn classify_pr_ci_marks_merged_pending_checks_as_stale() {
+        let checks = serde_json::json!([
+            {"name":"homeboy / Test","status":"IN_PROGRESS","conclusion":""}
+        ]);
+        let (state, summary) = classify_pr_ci(
+            "MERGED",
+            Some("2026-06-15T12:47:01Z"),
+            checks.as_array().unwrap(),
+        );
+
+        assert_eq!(state, "stale");
+        assert!(summary.contains("1 pending"));
     }
 
     #[test]

--- a/src/core/git/github_types.rs
+++ b/src/core/git/github_types.rs
@@ -54,10 +54,21 @@ pub struct GithubPrView {
     pub owner: String,
     pub repo: String,
     pub number: u64,
+    pub state: String,
     pub author: Option<String>,
     pub base: String,
     pub head: String,
     pub head_repository: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merged_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_decision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merge_state: Option<String>,
+    pub ci_state: String,
+    pub ci_summary: String,
 }
 
 /// Result of a find-many operation (list of matches).

--- a/src/core/git/pr_policy.rs
+++ b/src/core/git/pr_policy.rs
@@ -74,6 +74,10 @@ pub struct PrPolicyDecision {
     pub changed_file_count: usize,
     pub files: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_summary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub merged: Option<bool>,
 }
 
@@ -214,6 +218,7 @@ pub fn evaluate_merge_policy(options: PrPolicyMergeOptions) -> Result<PrPolicyDe
             ..Default::default()
         },
     );
+    apply_ci_gate(&mut decision, &pr.ci_state, &pr.ci_summary);
 
     if options.merge && decision.allowed {
         pr_merge(
@@ -232,6 +237,33 @@ pub fn evaluate_merge_policy(options: PrPolicyMergeOptions) -> Result<PrPolicyDe
     }
 
     Ok(decision)
+}
+
+fn apply_ci_gate(decision: &mut PrPolicyDecision, ci_state: &str, ci_summary: &str) {
+    decision.ci_state = Some(ci_state.to_string());
+    decision.ci_summary = Some(ci_summary.to_string());
+    decision.report = format!(
+        "{}\n\nCI status: `{}` - {}.",
+        decision.report, ci_state, ci_summary
+    );
+
+    let failure = match ci_state {
+        "terminal_green" | "no_checks" => None,
+        "terminal_failed" => Some("CI checks are terminal-failed"),
+        "pending" => Some("CI checks are still pending"),
+        "stale" => Some("CI check rollup is stale or eventually consistent after merge"),
+        _ => Some("CI check state is unknown"),
+    };
+
+    if let Some(failure) = failure {
+        decision.allowed = false;
+        decision.safe = false;
+        decision.reason = if decision.reason == "safe" {
+            failure.to_string()
+        } else {
+            format!("{}; {}", decision.reason, failure)
+        };
+    }
 }
 
 fn non_empty(value: Option<String>) -> Option<String> {
@@ -376,6 +408,8 @@ fn evaluate_rules(rules: &PrPolicyRules, context: PrPolicyContext) -> PrPolicyDe
         report,
         changed_file_count: context.files.len(),
         files: context.files,
+        ci_state: None,
+        ci_summary: None,
         merged: None,
     }
 }
@@ -539,5 +573,58 @@ mod tests {
         });
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn ci_gate_allows_terminal_green() {
+        let mut decision = PrPolicyDecision {
+            mode: "merge".into(),
+            allowed: true,
+            safe: true,
+            reason: "safe".into(),
+            report: "## Policy\n\nSafe".into(),
+            changed_file_count: 0,
+            files: Vec::new(),
+            ci_state: None,
+            ci_summary: None,
+            merged: None,
+        };
+
+        apply_ci_gate(
+            &mut decision,
+            "terminal_green",
+            "1 check(s): 1 terminal-green, 0 failed/unknown, 0 pending",
+        );
+
+        assert!(decision.allowed);
+        assert_eq!(decision.ci_state.as_deref(), Some("terminal_green"));
+        assert!(decision.report.contains("CI status: `terminal_green`"));
+    }
+
+    #[test]
+    fn ci_gate_blocks_stale_or_pending_checks_before_merge() {
+        let mut decision = PrPolicyDecision {
+            mode: "merge".into(),
+            allowed: true,
+            safe: true,
+            reason: "safe".into(),
+            report: "## Policy\n\nSafe".into(),
+            changed_file_count: 0,
+            files: Vec::new(),
+            ci_state: None,
+            ci_summary: None,
+            merged: None,
+        };
+
+        apply_ci_gate(
+            &mut decision,
+            "stale",
+            "1 check(s): 0 terminal-green, 0 failed/unknown, 1 pending",
+        );
+
+        assert!(!decision.allowed);
+        assert!(!decision.safe);
+        assert!(decision.reason.contains("stale"));
+        assert_eq!(decision.ci_state.as_deref(), Some("stale"));
     }
 }


### PR DESCRIPTION
## Summary
- Extend generic GitHub PR metadata with `statusCheckRollup`-derived CI classification: `terminal_green`, `terminal_failed`, `pending`, `stale`, or `no_checks`.
- Add the CI state/summary to PR merge policy output and block merge-policy merges when GitHub reports failed, pending, stale, or unknown CI.
- Add targeted unit coverage for terminal-green, terminal-failed, pending, and merged-plus-pending stale/API-eventual states.

Fixes #4484.

## Verification
- `cargo fmt --check` passed.
- `cargo test classify_pr_ci --lib && cargo test ci_gate --lib` did not complete locally because this machine had many concurrent Homeboy Rust builds and the targeted test run timed out/interrupted before completion.

## Generic behavior
- The classifier uses only GitHub-native PR fields (`state`, `mergedAt`, and `statusCheckRollup`).
- It does not inspect repository names, workflow names, job names, Cargo/Rust conventions, or Homeboy-specific CI labels.
- `MERGED` plus non-terminal check rollup is reported as `stale`, making GitHub API eventual consistency explicit instead of conflating merge state with terminal-green CI.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the generic GitHub PR/status workflow, drafted the CI-state classifier and merge-policy wiring, and added targeted unit tests. Chris remains responsible for review and merge.