### PR TITLE
fix: make cargo cli verification unambiguous

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,4 +19,4 @@
 
 ## Workflow reminders
 - Tests are expected to run in release mode: cargo test --release (see CLAUDE.md).
-- For CLI validation, prefer: cargo run --release -p homeboy -- <args> (per CLAUDE.md).
+- For CLI validation, prefer: cargo run --release --bin homeboy -- <args> (per CLAUDE.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ When updating documentation, keep it concise and aligned with current implementa
 When validating changes in this workspace, always run tests using the **release target**:
 
 - `cargo test --release`
-- When running the CLI for validation, prefer `cargo run --release -p homeboy -- <args>`.
+- When running the CLI for validation, prefer `cargo run --release --bin homeboy -- <args>`.
 
 ## Agent Workflow (Critical)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "homeboy"
 version = "0.229.11"
 edition = "2021"
+default-run = "homeboy"
 license = "MIT"
 authors = ["Chris Huber <chubes@extrachill.com>"]
 description = "Headless automation for agentic software engineering workflows"

--- a/tests/cargo_manifest_test.rs
+++ b/tests/cargo_manifest_test.rs
@@ -1,0 +1,35 @@
+use std::fs;
+
+#[test]
+fn manifest_default_run_selects_homeboy_cli_binary() {
+    let manifest_path = format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR"));
+    let manifest = fs::read_to_string(&manifest_path).expect("Cargo.toml should be readable");
+    let value: toml::Value = toml::from_str(&manifest).expect("Cargo.toml should parse as TOML");
+
+    assert_eq!(
+        value
+            .get("package")
+            .and_then(|package| package.get("default-run"))
+            .and_then(|default_run| default_run.as_str()),
+        Some("homeboy")
+    );
+}
+
+#[test]
+fn manifest_keeps_self_audit_bench_binary_available() {
+    let manifest_path = format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR"));
+    let manifest = fs::read_to_string(&manifest_path).expect("Cargo.toml should be readable");
+    let value: toml::Value = toml::from_str(&manifest).expect("Cargo.toml should parse as TOML");
+
+    let binaries = value
+        .get("bin")
+        .and_then(|bin| bin.as_array())
+        .expect("Cargo.toml should declare binaries");
+
+    assert!(binaries.iter().any(|binary| {
+        binary
+            .get("name")
+            .and_then(|name| name.as_str())
+            == Some("bench-audit-self")
+    }));
+}


### PR DESCRIPTION
## Summary
- Set Cargo's repo-local default run target to the `homeboy` CLI binary so `cargo run --release -- <args>` works in this multi-binary crate.
- Update agent/dev guidance to use the explicit `--bin homeboy` form for copy-pasteable CLI validation.
- Add manifest tests covering the default CLI target and keeping `bench-audit-self` available.

## Tests
- `cargo test --release --test cargo_manifest_test`

## Notes
- I started `cargo run --release -- build --help` and `cargo run --release --bin homeboy -- build --help`; the release build was still compiling when Chris asked to stop waiting and open the PR.

Closes #4482.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected the issue and repo-local guidance, drafted the manifest/docs/test changes, ran targeted verification, and prepared this PR. Chris remains responsible for review and merge.