### PR TITLE
fix: warn on runner doctor Homeboy path drift

### DIFF
--- a/src/commands/runner/doctor.rs
+++ b/src/commands/runner/doctor.rs
@@ -1010,19 +1010,32 @@ mod probes {
             ));
         }
 
-        let configured_version = configured_probe.version.trim();
-        if configured_version.is_empty()
-            || configured_version == "unknown"
-            || !version_is_older(bare_version, configured_version)
-        {
-            return None;
-        }
-
         let configured_path = configured_probe
             .path
             .as_deref()
             .unwrap_or(configured_command);
         let bare_path = bare.path.as_deref().unwrap_or("homeboy");
+        let configured_version = configured_probe.version.trim();
+        if configured_version.is_empty()
+            || configured_version == "unknown"
+            || !version_is_older(bare_version, configured_version)
+        {
+            if configured_command != "homeboy" && configured_path != bare_path {
+                return Some(checks::warning_with_details(
+                    "lab.homeboy.path_shadow",
+                    format!(
+                        "Configured runner Homeboy at {configured_path} differs from bare PATH `homeboy` at {bare_path}"
+                    ),
+                    Some(format!(
+                        "Fix PATH ordering on server `{server_id}` or update runner `{runner_id}` so configured homeboy_path and bare `homeboy` resolve to the same binary"
+                    )),
+                    details,
+                ));
+            }
+
+            return None;
+        }
+
         Some(checks::warning_with_details(
             "lab.homeboy.path_shadow",
             format!(

--- a/src/commands/runner/doctor/tests.rs
+++ b/src/commands/runner/doctor/tests.rs
@@ -234,6 +234,59 @@ fn lab_homeboy_path_shadow_warns_when_bare_homeboy_is_older() {
 }
 
 #[test]
+fn lab_homeboy_path_shadow_warns_when_bare_homeboy_resolves_different_path() {
+    let mut details = BTreeMap::new();
+    details.insert(
+        "configured_command".to_string(),
+        "/home/chubes/.cargo/bin/homeboy".to_string(),
+    );
+    details.insert(
+        "configured_path".to_string(),
+        "/home/chubes/.cargo/bin/homeboy".to_string(),
+    );
+    details.insert("configured_version".to_string(), "0.229.9".to_string());
+    details.insert(
+        "bare_path".to_string(),
+        "/home/chubes/.local/bin/homeboy".to_string(),
+    );
+    details.insert("bare_version".to_string(), "0.229.9".to_string());
+
+    let check = probes::homeboy_path_shadow_check(
+        "homeboy-lab",
+        "lab-server",
+        "/home/chubes/.cargo/bin/homeboy",
+        "0.229.9",
+        &HomeboyProbe {
+            version: "0.229.9".to_string(),
+            path: Some("/home/chubes/.cargo/bin/homeboy".to_string()),
+        },
+        &probes::RemoteHomeboyCandidateProbe {
+            path: Some("/home/chubes/.local/bin/homeboy".to_string()),
+            version: Some("0.229.9".to_string()),
+        },
+        details,
+    )
+    .expect("different bare homeboy path warning");
+
+    assert_eq!(check.id, "lab.homeboy.path_shadow");
+    assert_eq!(check.status, RunnerDoctorStatus::Warning);
+    assert!(check.message.contains("/home/chubes/.cargo/bin/homeboy"));
+    assert!(check.message.contains("/home/chubes/.local/bin/homeboy"));
+    assert_eq!(
+        check.details.get("configured_path").map(String::as_str),
+        Some("/home/chubes/.cargo/bin/homeboy")
+    );
+    assert_eq!(
+        check.details.get("bare_path").map(String::as_str),
+        Some("/home/chubes/.local/bin/homeboy")
+    );
+    assert!(check
+        .remediation
+        .as_deref()
+        .is_some_and(|value| value.contains("configured homeboy_path and bare `homeboy`")));
+}
+
+#[test]
 fn lab_homeboy_path_shadow_accepts_matching_bare_homeboy() {
     let check = probes::homeboy_path_shadow_check(
         "homeboy-lab",


### PR DESCRIPTION
## Summary
- Warn when Lab runner doctor sees configured Homeboy and bare PATH `homeboy` resolve to different binaries.
- Preserve the existing older-version path-shadow warning while covering equal-version path drift.
- Add a regression test for `/home/chubes/.cargo/bin/homeboy` vs `/home/chubes/.local/bin/homeboy`.

Fixes #4486.

## Tests
- `cargo test commands::runner::doctor::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the focused runner doctor diagnostic fix, added the regression test, and ran targeted verification; Chris remains responsible for review and merge.