### PR TITLE
Fix Lab patch and release outcome reporting

### DIFF
--- a/src/commands/golden_contract_tests.rs
+++ b/src/commands/golden_contract_tests.rs
@@ -396,6 +396,7 @@ fn release_result(
 ) -> ReleaseCommandResult {
     ReleaseCommandResult {
         component_id: component_id.to_string(),
+        status: if dry_run { "planned" } else { "released" }.to_string(),
         bump_type: bump_type.to_string(),
         dry_run,
         releasable_commits: 1,
@@ -405,6 +406,15 @@ fn release_result(
         plan,
         run: None,
         deployment: None,
+        release_summary: if dry_run {
+            vec![
+                "No release commit created".to_string(),
+                "No tag created".to_string(),
+                "No GitHub Release created".to_string(),
+            ]
+        } else {
+            Vec::new()
+        },
     }
 }
 

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -58,6 +58,7 @@ pub fn route_after_parse(
         _ => None,
     };
 
+    let mutation_flag = cli.command.lab_offload_mutation_flag();
     let lab_result = lab_routing::route_lab_offload(LabRoutingRequest {
         command: lab_command,
         normalized_args,
@@ -66,7 +67,8 @@ pub fn route_after_parse(
         allow_local_hot: cli.allow_local_hot,
         allow_local_fallback: cli.allow_local_fallback,
         allow_dirty_lab_workspace: cli.allow_dirty_lab_workspace,
-        capture_patch: cli.command.lab_offload_mutation_flag().is_some(),
+        capture_patch: mutation_flag.is_some(),
+        mutation_flag,
         timeout: None,
         active_run_id: crate::commands::trace::lab_dispatch_observation_run_id(&trace_observation),
     });

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -21,6 +21,7 @@ pub struct LabRoutingRequest<'a> {
     pub allow_local_fallback: bool,
     pub allow_dirty_lab_workspace: bool,
     pub capture_patch: bool,
+    pub mutation_flag: Option<&'a str>,
     pub timeout: Option<Duration>,
     pub active_run_id: Option<&'a str>,
 }
@@ -39,6 +40,7 @@ pub fn route_lab_offload(request: LabRoutingRequest<'_>) -> Result<runners::LabO
         allow_local_fallback: request.allow_local_fallback,
         allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
         capture_patch: request.capture_patch,
+        mutation_flag: request.mutation_flag,
     })
 }
 
@@ -104,6 +106,7 @@ fn execute_lab_offload_with_timeout(
     let allow_dirty_lab_workspace = request.allow_dirty_lab_workspace;
     let capture_patch = request.capture_patch;
     let active_run_id = request.active_run_id.map(str::to_string);
+    let mutation_flag = request.mutation_flag.map(str::to_string);
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let result = runners::execute_lab_offload(runners::LabOffloadRequest {
@@ -115,6 +118,7 @@ fn execute_lab_offload_with_timeout(
             allow_local_fallback,
             allow_dirty_lab_workspace,
             capture_patch,
+            mutation_flag: mutation_flag.as_deref(),
         });
         let _ = tx.send(result);
     });
@@ -224,6 +228,7 @@ mod tests {
             allow_local_fallback: false,
             allow_dirty_lab_workspace: false,
             capture_patch: false,
+            mutation_flag: None,
             timeout: None,
             active_run_id: None,
         })

--- a/src/core/release/planner.rs
+++ b/src/core/release/planner.rs
@@ -10,8 +10,8 @@ use super::plan_steps::{build_preflight_steps, build_release_steps};
 use super::planning_changelog::{build_changelog_plan, generate_changelog_entries};
 use super::planning_policy::release_skip_plan;
 use super::planning_semver::{
-    build_semver_recommendation, current_version_tag_name, validate_current_version_tag_reachable,
-    validate_release_version_floor,
+    build_semver_recommendation, current_version_tag_at_head, current_version_tag_name,
+    validate_current_version_tag_reachable, validate_release_version_floor,
 };
 use super::planning_worktree::validate_release_worktree;
 use super::types::{ReleaseOptions, ReleasePlan};
@@ -65,9 +65,22 @@ pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan>
     };
 
     if !options.pipeline.head {
-        if let Some(skip_plan) =
-            release_skip_plan(component_id, options, semver_recommendation.clone())
-        {
+        // Catch "release vX.Y.Z already exists at HEAD" before the bump/semver
+        // gate so a forced re-run after a prior partial release sees a clear
+        // skip plan instead of a downstream changelog contract error for the
+        // next version (issue #4316).
+        let release_already_at_head = version_info.as_ref().and_then(|info| {
+            current_version_tag_at_head(&component.local_path, monorepo.as_ref(), &info.version)
+                .ok()
+                .flatten()
+        });
+
+        if let Some(skip_plan) = release_skip_plan(
+            component_id,
+            options,
+            semver_recommendation.clone(),
+            release_already_at_head.as_deref(),
+        ) {
             return Ok(skip_plan);
         }
     }

--- a/src/core/release/planning_policy.rs
+++ b/src/core/release/planning_policy.rs
@@ -6,13 +6,43 @@ pub(super) fn release_skip_plan(
     component_id: &str,
     options: &ReleaseOptions,
     semver_recommendation: Option<ReleaseSemverRecommendation>,
+    release_already_at_head: Option<&str>,
 ) -> Option<ReleasePlan> {
+    // Detect "release already exists at HEAD" before other skip reasons so a
+    // forced re-run after a prior partial release surfaces a clear message
+    // instead of a confusing next-version changelog contract error (#4316).
+    if let Some(tag) = release_already_at_head {
+        return Some(skipped_release_plan(
+            component_id,
+            "release-already-at-head",
+            &format!("Release {} already published at HEAD", tag),
+            &format!(
+                "Release {tag} already exists at HEAD: tag is published and the release commit \
+                 is checked out. No new tag, release commit, or GitHub Release is needed. \
+                 To finish/repair publish steps for this tag, run: \
+                 homeboy release {component_id} --head. \
+                 To make a new release on top, commit new work first.",
+                tag = tag,
+                component_id = component_id,
+            ),
+            None,
+        ));
+    }
+
     if semver_recommendation.is_none() && !options.bump_policy.force_empty_release {
+        // Echo the operator's currently-set flags in the actionable force hint
+        // so docs-only / guidance-only releases can be forced without guessing
+        // which flags the previous invocation passed (issue #4316).
+        let force_command = force_release_command_hint(component_id, options, "patch");
         return Some(skipped_release_plan(
             component_id,
             "no-releasable-commits",
             "No releasable commits since last tag",
-            "Use --bump to force a release when this is intentional",
+            &format!(
+                "No release was created. No tag created, no release commit created, no GitHub Release created. \
+                 Force a release when intentional with: {}",
+                force_command
+            ),
             None,
         ));
     }
@@ -22,12 +52,56 @@ pub(super) fn release_skip_plan(
             component_id,
             "major-requires-flag",
             "Breaking changes require an explicit major bump",
-            &format!("Re-run with: homeboy release {} --bump major", component_id),
+            &format!(
+                "Re-run with: {}",
+                force_release_command_hint(component_id, options, "major")
+            ),
             semver_recommendation,
         ));
     }
 
     None
+}
+
+/// Build the exact `homeboy release` command the operator should run to force a
+/// release, echoing the flags already passed on the current invocation. This is
+/// what the issue asks for: when `--skip-checks` was used and the only blocker
+/// is `no-releasable-commits`, the hint should be copy-pasteable instead of a
+/// vague "Use --bump to force a release".
+fn force_release_command_hint(
+    component_id: &str,
+    options: &ReleaseOptions,
+    bump_keyword: &str,
+) -> String {
+    let mut parts: Vec<String> = vec![
+        "homeboy release".to_string(),
+        component_id.to_string(),
+        format!("--bump {}", bump_keyword),
+    ];
+    if let Some(ref path) = options.path_override {
+        parts.push(format!("--path {}", quote_if_needed(path)));
+    }
+    if options.skip_checks {
+        parts.push("--skip-checks".to_string());
+    }
+    if options.pipeline.skip_publish {
+        parts.push("--skip-publish".to_string());
+    }
+    if options.skip_github_release {
+        parts.push("--no-github-release".to_string());
+    }
+    if let Some(ref identity) = options.git_identity {
+        parts.push(format!("--git-identity {}", quote_if_needed(identity)));
+    }
+    parts.join(" ")
+}
+
+fn quote_if_needed(value: &str) -> String {
+    if value.chars().any(|c| c.is_whitespace() || c == '"') {
+        format!("\"{}\"", value.replace('"', "\\\""))
+    } else {
+        value.to_string()
+    }
 }
 
 fn skipped_release_plan(
@@ -61,7 +135,7 @@ mod tests {
 
     #[test]
     fn test_release_skip_plan() {
-        let plan = release_skip_plan("demo", &ReleaseOptions::default(), None)
+        let plan = release_skip_plan("demo", &ReleaseOptions::default(), None, None)
             .expect("no releasable commits should skip");
 
         assert!(!plan.enabled());
@@ -77,9 +151,54 @@ mod tests {
                 .and_then(|v| v.as_str()),
             Some("no-releasable-commits")
         );
-        assert_eq!(
-            plan.plan.hints,
-            vec!["Use --bump to force a release when this is intentional"]
+        let hint = plan
+            .plan
+            .hints
+            .first()
+            .expect("skip plan should ship one hint")
+            .as_str();
+        assert!(
+            hint.contains("No release was created"),
+            "skip hint should explicitly state no release artifacts were produced: {hint}"
+        );
+        assert!(
+            hint.contains("no tag"),
+            "skip hint should explicitly say no tag was created: {hint}"
+        );
+        assert!(
+            hint.contains("homeboy release demo --bump patch"),
+            "skip hint should provide the exact force command: {hint}"
+        );
+    }
+
+    #[test]
+    fn skip_hint_echoes_currently_set_flags_for_docs_only_release() {
+        let options = ReleaseOptions {
+            path_override: Some("/tmp/dm-worktree".to_string()),
+            skip_checks: true,
+            ..Default::default()
+        };
+
+        let plan = release_skip_plan("data-machine-code", &options, None, None)
+            .expect("docs-only invocation should still skip");
+
+        let hint = plan
+            .plan
+            .hints
+            .first()
+            .expect("skip plan should ship one hint")
+            .as_str();
+        assert!(
+            hint.contains("--skip-checks"),
+            "skip hint should echo --skip-checks: {hint}"
+        );
+        assert!(
+            hint.contains("--path /tmp/dm-worktree"),
+            "skip hint should echo --path: {hint}"
+        );
+        assert!(
+            hint.contains("homeboy release data-machine-code --bump patch"),
+            "skip hint should provide a fully-qualified force command: {hint}"
         );
     }
 
@@ -93,7 +212,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert!(release_skip_plan("demo", &options, None).is_none());
+        assert!(release_skip_plan("demo", &options, None, None).is_none());
     }
 
     #[test]
@@ -107,7 +226,7 @@ mod tests {
         };
         let recommendation = semver_recommendation("major", "major");
 
-        let plan = release_skip_plan("demo", &options, Some(recommendation))
+        let plan = release_skip_plan("demo", &options, Some(recommendation), None)
             .expect("implicit major should skip");
 
         assert!(!plan.enabled());
@@ -122,6 +241,84 @@ mod tests {
         assert_eq!(
             plan.plan.hints,
             vec!["Re-run with: homeboy release demo --bump major"]
+        );
+    }
+
+    #[test]
+    fn major_skip_hint_echoes_currently_set_flags() {
+        let options = ReleaseOptions {
+            skip_checks: true,
+            bump_policy: ReleaseBumpPolicyOptions {
+                require_explicit_major: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let recommendation = semver_recommendation("major", "major");
+
+        let plan = release_skip_plan("demo", &options, Some(recommendation), None)
+            .expect("implicit major should skip");
+
+        let hint = plan
+            .plan
+            .hints
+            .first()
+            .expect("major-requires-flag plan should ship one hint")
+            .as_str();
+        assert!(
+            hint.contains("homeboy release demo --bump major"),
+            "major hint should provide a fully-qualified force command: {hint}"
+        );
+        assert!(
+            hint.contains("--skip-checks"),
+            "major hint should echo --skip-checks when set: {hint}"
+        );
+    }
+
+    #[test]
+    fn skip_plan_detects_release_already_at_head_before_other_reasons() {
+        // Even when there are no releasable commits and a forced bump is set —
+        // exactly the state that produced the confusing next-version changelog
+        // contract error in issue #4316 — the planner should report
+        // "release-already-at-head" as the primary skip reason.
+        let options = ReleaseOptions {
+            skip_checks: true,
+            bump_policy: ReleaseBumpPolicyOptions {
+                force_empty_release: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let plan = release_skip_plan("data-machine-code", &options, None, Some("v0.47.121"))
+            .expect("tag-already-at-HEAD should produce a skip plan");
+
+        assert!(!plan.enabled());
+        assert_eq!(
+            plan.plan.steps[0]
+                .inputs
+                .get("reason")
+                .and_then(|v| v.as_str()),
+            Some("release-already-at-head"),
+            "release-already-at-head takes precedence over no-releasable-commits / forced empty"
+        );
+        let hint = plan
+            .plan
+            .hints
+            .first()
+            .expect("release-already-at-head plan should ship a hint")
+            .as_str();
+        assert!(
+            hint.contains("v0.47.121"),
+            "hint should name the existing tag: {hint}"
+        );
+        assert!(
+            hint.contains("--head"),
+            "hint should point operator at --head finalization: {hint}"
+        );
+        assert!(
+            hint.contains("homeboy release data-machine-code --head"),
+            "hint should provide an actionable command: {hint}"
         );
     }
 

--- a/src/core/release/planning_semver.rs
+++ b/src/core/release/planning_semver.rs
@@ -127,6 +127,37 @@ pub(super) fn current_version_tag_name(
         .unwrap_or_else(|| format!("v{}", current_version))
 }
 
+/// Detect whether the release for `current_version` is already published at
+/// HEAD: the expected tag exists locally and points at the same commit as HEAD.
+///
+/// Used by the planner to short-circuit forced re-runs after a prior release
+/// already created the tag/release commit, so the operator sees a clear
+/// "release already exists" message instead of a downstream changelog
+/// contract error for the next version (issue #4316).
+pub(super) fn current_version_tag_at_head(
+    local_path: &str,
+    monorepo: Option<&git::MonorepoContext>,
+    current_version: &str,
+) -> Result<Option<String>> {
+    let git_root = monorepo
+        .map(|ctx| ctx.git_root.as_str())
+        .unwrap_or(local_path);
+    let tag_name = current_version_tag_name(monorepo, current_version);
+
+    if !git::tag_exists_locally(git_root, &tag_name)? {
+        return Ok(None);
+    }
+
+    let tag_commit = git::get_tag_commit(git_root, &tag_name)?;
+    let head_commit = git::get_head_commit(git_root)?;
+
+    if tag_commit == head_commit {
+        Ok(Some(tag_name))
+    } else {
+        Ok(None)
+    }
+}
+
 /// Resolve the latest tag and commits since that tag for a component.
 ///
 /// In a monorepo, uses component-prefixed tags and path-scoped commits.

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -356,6 +356,7 @@ pub struct ReleaseDeploymentResult {
 #[derive(Debug, Clone, Serialize)]
 pub struct ReleaseCommandResult {
     pub component_id: String,
+    pub status: String,
     pub bump_type: String,
     pub dry_run: bool,
     pub releasable_commits: usize,
@@ -371,6 +372,8 @@ pub struct ReleaseCommandResult {
     pub run: Option<ReleaseRun>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deployment: Option<ReleaseDeploymentResult>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub release_summary: Vec<String>,
 }
 
 /// Result of a batch release across multiple components.

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -153,18 +153,23 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         let dry_run_preflight = run_dry_run_preflights(&input.component_id, &options)?;
         if let Some(run) = dry_run_preflight {
             let plan = super::plan(&input.component_id, &options).ok();
+            let skipped_reason = plan.as_ref().and_then(skipped_reason_from_plan);
+            let status = release_command_status(true, skipped_reason.as_deref(), Some(&run));
+            let release_summary = release_summary_from_run(&run);
             return Ok((
                 ReleaseCommandResult {
                     component_id: input.component_id,
+                    status,
                     bump_type,
                     dry_run: true,
                     releasable_commits: releasable_count,
                     new_version: None,
                     tag: None,
-                    skipped_reason: plan.as_ref().and_then(skipped_reason_from_plan),
+                    skipped_reason,
                     plan,
                     run: Some(run),
                     deployment: None,
+                    release_summary,
                 },
                 1,
             ));
@@ -184,6 +189,11 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         return Ok((
             ReleaseCommandResult {
                 component_id: input.component_id,
+                status: release_command_status(
+                    true,
+                    skipped_reason_from_plan(&plan).as_deref(),
+                    None,
+                ),
                 bump_type,
                 dry_run: true,
                 releasable_commits: releasable_count,
@@ -193,6 +203,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
                 plan: Some(plan),
                 run: None,
                 deployment,
+                release_summary: release_summary_for_skipped_plan(),
             },
             0,
         ));
@@ -217,6 +228,8 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     };
     let deployment = super::deployment::extract_deployment_from_run(&run_result);
     let skipped_reason = skipped_reason_from_plan(&plan);
+    let release_summary = release_summary_from_run(&run_result);
+    display_release_outcome_summary(&release_summary);
     let deploy_exit_code = deployment
         .as_ref()
         .filter(|deployment| deployment.summary.failed > 0)
@@ -248,6 +261,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     Ok((
         ReleaseCommandResult {
             component_id: input.component_id,
+            status: release_command_status(false, skipped_reason.as_deref(), Some(&run_result)),
             bump_type,
             dry_run: false,
             releasable_commits: releasable_count,
@@ -257,6 +271,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
             plan: Some(plan),
             run: Some(run_result),
             deployment,
+            release_summary,
         },
         exit_code,
     ))
@@ -398,6 +413,137 @@ fn display_release_summary(run: &ReleaseRun) {
             }
         }
     }
+}
+
+fn display_release_outcome_summary(summary: &[String]) {
+    if summary.is_empty() {
+        return;
+    }
+
+    eprintln!();
+    for line in summary {
+        log_status!("release", "{}", line);
+    }
+}
+
+fn release_command_status(
+    dry_run: bool,
+    skipped_reason: Option<&str>,
+    run: Option<&ReleaseRun>,
+) -> String {
+    if skipped_reason.is_some() {
+        return "skipped".to_string();
+    }
+    if dry_run {
+        return "planned".to_string();
+    }
+    match run.map(|run| &run.result.status) {
+        Some(ReleaseStepStatus::Success) => "released".to_string(),
+        Some(ReleaseStepStatus::PartialSuccess) => "partial".to_string(),
+        Some(ReleaseStepStatus::Failed) => "failed".to_string(),
+        Some(ReleaseStepStatus::Missing) => "missing".to_string(),
+        Some(ReleaseStepStatus::Skipped) => "skipped".to_string(),
+        None => "unknown".to_string(),
+    }
+}
+
+fn release_summary_for_skipped_plan() -> Vec<String> {
+    vec![
+        "No release commit created".to_string(),
+        "No tag created".to_string(),
+        "No GitHub Release created".to_string(),
+    ]
+}
+
+fn release_summary_from_run(run: &ReleaseRun) -> Vec<String> {
+    let mut summary = Vec::new();
+
+    if matches!(run.result.status, ReleaseStepStatus::Success) {
+        if let Some(line) = release_created_line(run) {
+            summary.push(line);
+        }
+    }
+
+    summary.push(git_commit_summary_line(run));
+    summary.push(git_tag_summary_line(run));
+    summary.push(github_release_summary_line(run));
+    summary
+}
+
+fn release_created_line(run: &ReleaseRun) -> Option<String> {
+    let tag = successful_step(run, "git.tag")
+        .and_then(|step| step.data.as_ref())
+        .and_then(|data| data.get("tag"))
+        .and_then(|value| value.as_str());
+    let url = successful_step(run, "github.release")
+        .and_then(|step| step.data.as_ref())
+        .and_then(|data| data.get("url"))
+        .and_then(|value| value.as_str());
+
+    match (tag, url) {
+        (Some(tag), Some(url)) => Some(format!("Release created: {} ({})", tag, url)),
+        (Some(tag), None) => Some(format!("Release created: {}", tag)),
+        (None, Some(url)) => Some(format!("Release created: {}", url)),
+        (None, None) => None,
+    }
+}
+
+fn git_commit_summary_line(run: &ReleaseRun) -> String {
+    let Some(step) = successful_step(run, "git.commit") else {
+        return "No release commit created".to_string();
+    };
+    if step_data_bool(step, "skipped") {
+        "No release commit created".to_string()
+    } else {
+        "Release commit created".to_string()
+    }
+}
+
+fn git_tag_summary_line(run: &ReleaseRun) -> String {
+    let Some(step) = successful_step(run, "git.tag") else {
+        return "No tag created".to_string();
+    };
+    let tag = step
+        .data
+        .as_ref()
+        .and_then(|data| data.get("tag"))
+        .and_then(|value| value.as_str());
+    if step_data_bool(step, "skipped") {
+        tag.map(|tag| format!("Tag already exists: {}", tag))
+            .unwrap_or_else(|| "No tag created".to_string())
+    } else {
+        tag.map(|tag| format!("Tag created: {}", tag))
+            .unwrap_or_else(|| "Tag created".to_string())
+    }
+}
+
+fn github_release_summary_line(run: &ReleaseRun) -> String {
+    let Some(step) = successful_step(run, "github.release") else {
+        return "No GitHub Release created".to_string();
+    };
+    if step_data_bool(step, "skipped") {
+        return "No GitHub Release created".to_string();
+    }
+    step.data
+        .as_ref()
+        .and_then(|data| data.get("url"))
+        .and_then(|value| value.as_str())
+        .map(|url| format!("GitHub Release created: {}", url))
+        .unwrap_or_else(|| "GitHub Release created".to_string())
+}
+
+fn successful_step<'a>(run: &'a ReleaseRun, step_type: &str) -> Option<&'a ReleaseStepResult> {
+    run.result.steps.iter().find(|step| {
+        step.step_type == step_type && matches!(step.status, ReleaseStepStatus::Success)
+    })
+}
+
+fn step_data_bool(step: &ReleaseStepResult, key: &str) -> bool {
+    step.data
+        .as_ref()
+        .and_then(|data| data.get(key))
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false)
 }
 
 fn has_post_release_warnings(run: &ReleaseRun) -> bool {
@@ -583,6 +729,11 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
     Ok((
         ReleaseCommandResult {
             component_id: input.component_id.clone(),
+            status: if actions.is_empty() {
+                "already_recovered".to_string()
+            } else {
+                "recovered".to_string()
+            },
             bump_type: "recover".to_string(),
             dry_run: false,
             releasable_commits: 0,
@@ -600,6 +751,11 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
             )),
             run: None,
             deployment: None,
+            release_summary: if actions.is_empty() {
+                vec![format!("Release already exists: {}", tag_name)]
+            } else {
+                actions.to_vec()
+            },
         },
         0,
     ))
@@ -951,6 +1107,48 @@ mod tests {
         };
 
         assert_eq!(release_run_failure_exit(&run), 1);
+    }
+
+    #[test]
+    fn release_summary_explicitly_reports_created_and_missing_release_surfaces() {
+        let run = ReleaseRun {
+            component_id: "demo".to_string(),
+            enabled: true,
+            result: ReleaseRunResult {
+                steps: vec![
+                    ReleaseStepResult {
+                        id: "git.commit".to_string(),
+                        step_type: "git.commit".to_string(),
+                        status: ReleaseStepStatus::Success,
+                        missing: vec![],
+                        warnings: vec![],
+                        hints: vec![],
+                        data: Some(serde_json::json!({ "success": true })),
+                        error: None,
+                    },
+                    ReleaseStepResult {
+                        id: "git.tag".to_string(),
+                        step_type: "git.tag".to_string(),
+                        status: ReleaseStepStatus::Success,
+                        missing: vec![],
+                        warnings: vec![],
+                        hints: vec![],
+                        data: Some(serde_json::json!({ "tag": "v1.2.3" })),
+                        error: None,
+                    },
+                ],
+                status: ReleaseStepStatus::Success,
+                warnings: vec![],
+                summary: None,
+            },
+        };
+
+        let summary = release_summary_from_run(&run);
+
+        assert!(summary.contains(&"Release created: v1.2.3".to_string()));
+        assert!(summary.contains(&"Release commit created".to_string()));
+        assert!(summary.contains(&"Tag created: v1.2.3".to_string()));
+        assert!(summary.contains(&"No GitHub Release created".to_string()));
     }
 
     // ----- Recover-time orphan-tag warning (issue #2234 ask #3) -----

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -78,6 +78,10 @@ pub struct LabOffloadRequest<'a> {
     pub allow_local_fallback: bool,
     pub allow_dirty_lab_workspace: bool,
     pub capture_patch: bool,
+    /// Human-readable flag (e.g. `--write`, `--fix`) that requested the
+    /// source-tree mutation. Used to render actionable diagnostics when the
+    /// remote runner finishes cleanly but returns no patch to apply.
+    pub mutation_flag: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -931,6 +935,13 @@ fn run_lab_offload_inner(
     }
     if request.capture_patch && exit_code == 0 {
         let apply_output = apply_lab_offload_patch(&exec_output)?;
+        if apply_output.is_none() {
+            return Err(missing_mutation_patch_error(
+                request.normalized_args,
+                request.mutation_flag,
+                &exec_output,
+            ));
+        }
         plan = with_lab_apply_patch_step(plan, apply_output);
     }
     mirror_agent_task_run_plan_lifecycle(request.normalized_args, &exec_output.stdout)?;
@@ -1131,6 +1142,71 @@ fn selected_runner_fallback_error(
     )
 }
 
+/// Build an actionable diagnostic when a Lab offload write/fix command
+/// finished cleanly but the runner returned no source-tree patch.
+fn missing_mutation_patch_error(
+    normalized_args: &[String],
+    mutation_flag: Option<&str>,
+    exec_output: &super::super::RunnerExecOutput,
+) -> Error {
+    let flag_label = mutation_flag.unwrap_or("write");
+    let original_command = normalized_args.join(" ");
+    let remote_command = exec_output.argv.join(" ");
+    let patch_artifact_id = exec_output
+        .patch
+        .as_ref()
+        .and_then(|patch| patch.get("patch_artifact_id"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.trim().is_empty());
+    let patch_artifact_path = exec_output
+        .patch
+        .as_ref()
+        .and_then(|patch| patch.get("patch_artifact_path"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|path| !path.trim().is_empty());
+    let mut error = Error::new(
+        ErrorCode::ValidationInvalidArgument,
+        format!(
+            "Lab offload write command completed on runner `{}` but returned no source-tree patch to apply for `{flag_label}`",
+            exec_output.runner_id
+        ),
+        serde_json::json!({
+            "field": "lab_offload_patch",
+            "problem": "missing required source-tree mutation patch",
+            "runner_id": exec_output.runner_id,
+            "job_id": exec_output.job_id,
+            "mirror_run_id": exec_output.mirror_run_id,
+            "remote_workspace": exec_output.remote_cwd,
+            "remote_command": remote_command,
+            "original_command": original_command,
+            "mutation_flag": mutation_flag,
+            "patch_artifact_id": patch_artifact_id,
+            "patch_artifact_path": patch_artifact_path,
+            "patch": exec_output.patch,
+        }),
+    );
+
+    if let Some(run_id) = exec_output.mirror_run_id.as_deref() {
+        error = error
+            .with_hint(format!("Inspect the Lab run with `homeboy runs show {run_id}`."))
+            .with_hint(format!(
+                "List mirrored Lab artifacts with `homeboy runs artifacts {run_id}` and verify the runner produced a lint/refactor patch artifact."
+            ));
+    } else if let Some(job_id) = exec_output.job_id.as_deref() {
+        error = error.with_hint(format!(
+            "Runner daemon job `{job_id}` finished without a patch artifact; inspect runner job evidence before retrying."
+        ));
+    }
+
+    if !original_command.is_empty() {
+        error = error.with_hint(format!(
+            "After runner patch capture is available, retry the intended Homeboy write path: `{original_command}`."
+        ));
+    }
+
+    error
+}
+
 fn mutation_return_unavailable_outcome(
     plan: HomeboyPlan,
     selection: &LabRunnerSelection,
@@ -1169,8 +1245,8 @@ mod tests {
     use crate::core::observation::LAB_OFFLOAD_METADATA_ENV;
     use crate::core::plan::PlanKind;
     use crate::core::runner::{
-        RunnerRequiredTool, RunnerSession, RunnerSessionState, RunnerTunnelMode,
-        RunnerWorkspaceSyncOutput,
+        RunnerExecMode, RunnerExecOutput, RunnerRequiredTool, RunnerSession, RunnerSessionState,
+        RunnerTunnelMode, RunnerWorkspaceSyncOutput,
     };
 
     pub(super) fn portable_lab_command(label: &'static str) -> LabOffloadCommand {
@@ -1773,6 +1849,72 @@ mod tests {
     }
 
     #[test]
+    fn missing_mutation_patch_error_points_to_runner_evidence_and_retry() {
+        let exec_output = RunnerExecOutput {
+            command: "runner.exec",
+            runner_id: "lab-default".to_string(),
+            mode: RunnerExecMode::Daemon,
+            argv: vec![
+                "homeboy".to_string(),
+                "refactor".to_string(),
+                "--from".to_string(),
+                "lint".to_string(),
+                "--write".to_string(),
+                "data-machine-code".to_string(),
+            ],
+            remote_cwd: "/srv/homeboy/_lab_workspaces/data-machine-code".to_string(),
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            source_snapshot: None,
+            job: None,
+            job_id: Some("job-123".to_string()),
+            job_events: None,
+            mirror_run_id: Some("runner-exec-lab-default-job-123".to_string()),
+            patch: None,
+            metrics: None,
+            capture: None,
+            diagnostics: None,
+        };
+
+        let err = missing_mutation_patch_error(
+            &[
+                "homeboy".to_string(),
+                "refactor".to_string(),
+                "--from".to_string(),
+                "lint".to_string(),
+                "--write".to_string(),
+                "data-machine-code".to_string(),
+            ],
+            Some("--write"),
+            &exec_output,
+        );
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("returned no source-tree patch"));
+        assert_eq!(err.details["runner_id"], "lab-default");
+        assert_eq!(err.details["job_id"], "job-123");
+        assert_eq!(
+            err.details["mirror_run_id"],
+            "runner-exec-lab-default-job-123"
+        );
+        let hints = err
+            .hints
+            .iter()
+            .map(|hint| hint.message.as_str())
+            .collect::<Vec<_>>();
+        assert!(hints
+            .iter()
+            .any(|hint| hint.contains("homeboy runs show runner-exec-lab-default-job-123")));
+        assert!(hints
+            .iter()
+            .any(|hint| hint.contains("homeboy runs artifacts runner-exec-lab-default-job-123")));
+        assert!(hints
+            .iter()
+            .any(|hint| hint.contains("homeboy refactor --from lint --write data-machine-code")));
+    }
+
+    #[test]
     fn default_runner_missing_capabilities_fails_without_local_fallback_opt_in() {
         let plan = base_lab_plan(Some(&portable_lab_command("trace")));
         let selection = LabRunnerSelection {
@@ -1847,6 +1989,7 @@ mod tests {
             allow_local_fallback: false,
             allow_dirty_lab_workspace: false,
             capture_patch: false,
+            mutation_flag: None,
         })
         .expect("outcome");
 

--- a/tests/cargo_manifest_test.rs
+++ b/tests/cargo_manifest_test.rs
@@ -27,9 +27,6 @@ fn manifest_keeps_self_audit_bench_binary_available() {
         .expect("Cargo.toml should declare binaries");
 
     assert!(binaries.iter().any(|binary| {
-        binary
-            .get("name")
-            .and_then(|name| name.as_str())
-            == Some("bench-audit-self")
+        binary.get("name").and_then(|name| name.as_str()) == Some("bench-audit-self")
     }));
 }

--- a/tests/fixtures/golden_json_contracts/release_contract.json
+++ b/tests/fixtures/golden_json_contracts/release_contract.json
@@ -63,7 +63,13 @@
                 "dry run only"
               ]
             },
+            "release_summary": [
+              "No release commit created",
+              "No tag created",
+              "No GitHub Release created"
+            ],
             "releasable_commits": 1,
+            "status": "planned",
             "tag": "v0.198.0"
           }
         },
@@ -138,7 +144,13 @@
                       "dry run only"
                     ]
                   },
+                  "release_summary": [
+                    "No release commit created",
+                    "No tag created",
+                    "No GitHub Release created"
+                  ],
                   "releasable_commits": 1,
+                  "status": "planned",
                   "tag": "v0.198.0"
                 },
                 "status": "planned"


### PR DESCRIPTION
## Summary
- Surface actionable Lab offload diagnostics when write/fix commands finish successfully on a runner but return no source-tree patch.
- Add release command status and outcome summaries so skipped/planned/recovered release paths report what happened to commits, tags, and GitHub releases.
- Detect already-published release tags at HEAD before later release planning gates and improve force-release hints.

## Testing
- `cargo test lab_routing`
- `cargo test missing_mutation_patch_error_points_to_runner_evidence_and_retry`
- `cargo test release_summary_explicitly_reports_created_and_missing_release_surfaces`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Rebasing existing local fixes onto current `main`, resolving conflicts across the newer Lab routing/release workflow boundaries, and drafting the PR description. Chris remains responsible for review and merge.