### PR TITLE
Surface waiting extension phases in review output

### DIFF
--- a/docs/development/contracts/verification-phases.md
+++ b/docs/development/contracts/verification-phases.md
@@ -85,3 +85,31 @@ test       -> homeboy test
 
 This keeps each command debuggable on its own while giving CI, future `check`
 commands, and rig workflows one stable shape to aggregate.
+
+## Extension phase timings
+
+Extensions and providers may emit a generic phase timing sidecar through
+`HOMEBOY_PHASE_TIMINGS_FILE`. Homeboy core treats phase names, messages, and
+metadata as provider-owned labels; it only preserves and renders them.
+
+```json
+{
+  "phase_timings": [
+    {
+      "name": "provider-shared-resource",
+      "duration_ms": 90000,
+      "status": "waiting",
+      "message": "waiting for exclusive provider resource",
+      "metadata": {
+        "provider": "fixture"
+      }
+    }
+  ]
+}
+```
+
+`status` is optional and free-form. Review/fleet summaries highlight generic
+waiting states when providers declare `waiting`, `blocked`, or `queued`. Tool
+specific detection, such as recognizing a package manager lock message, belongs
+in the provider or extension that understands that tool; Homeboy core only
+surfaces the declared generic phase state.

--- a/src/commands/review/render.rs
+++ b/src/commands/review/render.rs
@@ -408,6 +408,22 @@ fn render_extension_phase_timings(out: &mut String, timings: &[ExtensionPhaseTim
         return;
     }
 
+    let mut waiting_timings = timings
+        .iter()
+        .filter(|timing| is_waiting_phase_status(timing.status.as_deref()))
+        .collect::<Vec<_>>();
+    waiting_timings.sort_by(|a, b| {
+        b.duration_ms
+            .cmp(&a.duration_ms)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    if !waiting_timings.is_empty() {
+        let _ = writeln!(out, "- _Waiting extension phases:_");
+        for timing in waiting_timings.into_iter().take(3) {
+            let _ = writeln!(out, "  - {}", format_extension_phase_timing(timing));
+        }
+    }
+
     let mut timings = timings.iter().collect::<Vec<_>>();
     timings.sort_by(|a, b| {
         b.duration_ms
@@ -417,17 +433,37 @@ fn render_extension_phase_timings(out: &mut String, timings: &[ExtensionPhaseTim
 
     let _ = writeln!(out, "- _Slowest extension phases:_");
     for timing in timings.into_iter().take(3) {
-        let artifacts = if timing.artifacts.is_empty() {
-            String::new()
-        } else {
-            format!("; {} artifact ref(s)", timing.artifacts.len())
-        };
-        let _ = writeln!(
-            out,
-            "  - `{}` — {} ms{}",
-            timing.name, timing.duration_ms, artifacts
-        );
+        let _ = writeln!(out, "  - {}", format_extension_phase_timing(timing));
     }
+}
+
+fn format_extension_phase_timing(timing: &ExtensionPhaseTiming) -> String {
+    let mut line = format!("`{}` — {} ms", timing.name, timing.duration_ms);
+    if let Some(status) = timing.status.as_deref().filter(|status| !status.is_empty()) {
+        let _ = write!(line, "; status: `{}`", status);
+    }
+    if let Some(message) = timing
+        .message
+        .as_deref()
+        .filter(|message| !message.is_empty())
+    {
+        let _ = write!(line, "; {}", message);
+    }
+    if !timing.artifacts.is_empty() {
+        let _ = write!(line, "; {} artifact ref(s)", timing.artifacts.len());
+    }
+    line
+}
+
+fn is_waiting_phase_status(status: Option<&str>) -> bool {
+    matches!(
+        status.map(normalize_phase_timing_status).as_deref(),
+        Some("waiting" | "blocked" | "queued")
+    )
+}
+
+fn normalize_phase_timing_status(status: &str) -> String {
+    status.trim().to_ascii_lowercase().replace('-', "_")
 }
 
 fn render_ci_body(out: &mut String, output: &CiRunOutput) {
@@ -741,12 +777,16 @@ mod tests {
             ExtensionPhaseTiming {
                 name: "provider-cache".to_string(),
                 duration_ms: 25,
+                status: None,
+                message: None,
                 artifacts: Vec::new(),
                 metadata: std::collections::BTreeMap::new(),
             },
             ExtensionPhaseTiming {
                 name: "opaque-slow-phase".to_string(),
                 duration_ms: 1200,
+                status: None,
+                message: None,
                 artifacts: vec![serde_json::json!({ "path": "artifacts/phase.json" })],
                 metadata: std::collections::BTreeMap::new(),
             },
@@ -761,6 +801,48 @@ mod tests {
             md
         );
         assert!(md.contains("  - `provider-cache` — 25 ms"), "{}", md);
+    }
+
+    #[test]
+    fn renders_waiting_extension_phases_from_generic_status() {
+        let mut env = passing_envelope();
+        let test = env.test.output.as_mut().expect("test output");
+        test.extension_phase_timings = vec![
+            ExtensionPhaseTiming {
+                name: "provider-shared-resource".to_string(),
+                duration_ms: 90_000,
+                status: Some("waiting".to_string()),
+                message: Some("waiting for exclusive provider resource".to_string()),
+                artifacts: Vec::new(),
+                metadata: std::collections::BTreeMap::from([(
+                    "provider".to_string(),
+                    serde_json::json!("fixture"),
+                )]),
+            },
+            ExtensionPhaseTiming {
+                name: "provider-active-work".to_string(),
+                duration_ms: 120_000,
+                status: Some("running".to_string()),
+                message: None,
+                artifacts: Vec::new(),
+                metadata: std::collections::BTreeMap::new(),
+            },
+        ];
+
+        let md = render_pr_comment(&env);
+
+        assert!(md.contains("- _Waiting extension phases:_"), "{}", md);
+        assert!(
+            md.contains("  - `provider-shared-resource` — 90000 ms; status: `waiting`; waiting for exclusive provider resource"),
+            "{}",
+            md
+        );
+        assert!(md.contains("- _Slowest extension phases:_"), "{}", md);
+        assert!(
+            md.contains("  - `provider-active-work` — 120000 ms; status: `running`"),
+            "{}",
+            md
+        );
     }
 
     #[test]

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -412,6 +412,8 @@ mod tests {
                         {
                             "name": "opaque-provider-phase",
                             "duration_ms": 1234,
+                            "status": "waiting",
+                            "message": "provider is waiting for a shared resource",
                             "artifacts": [{ "kind": "opaque", "path": "artifacts/timing.json" }],
                             "metadata": { "extension": "fixture" }
                         }
@@ -427,6 +429,11 @@ mod tests {
             assert_eq!(timings.len(), 1);
             assert_eq!(timings[0].name, "opaque-provider-phase");
             assert_eq!(timings[0].duration_ms, 1234);
+            assert_eq!(timings[0].status.as_deref(), Some("waiting"));
+            assert_eq!(
+                timings[0].message.as_deref(),
+                Some("provider is waiting for a shared resource")
+            );
             assert_eq!(timings[0].artifacts[0]["path"], "artifacts/timing.json");
             assert_eq!(timings[0].metadata["extension"], "fixture");
 

--- a/src/core/extension/runner_contract.rs
+++ b/src/core/extension/runner_contract.rs
@@ -53,6 +53,14 @@ pub struct PhaseFailure {
 pub struct ExtensionPhaseTiming {
     pub name: String,
     pub duration_ms: u64,
+    /// Provider-declared generic state for this phase, for example `running`,
+    /// `waiting`, `blocked`, `queued`, `passed`, or `failed`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// Human-readable provider summary for the phase. Core treats this as
+    /// opaque text and does not infer tool-specific behavior from it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifacts: Vec<serde_json::Value>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/src/core/extension/test/report.rs
+++ b/src/core/extension/test/report.rs
@@ -371,6 +371,8 @@ mod tests {
         result.extension_phase_timings = vec![crate::core::extension::ExtensionPhaseTiming {
             name: "opaque-provider-phase".to_string(),
             duration_ms: 4321,
+            status: Some("waiting".to_string()),
+            message: Some("provider is waiting for a shared resource".to_string()),
             artifacts: vec![serde_json::json!({ "url": "runner-artifact://phase.json" })],
             metadata: std::collections::BTreeMap::new(),
         }];
@@ -383,6 +385,11 @@ mod tests {
             "opaque-provider-phase"
         );
         assert_eq!(json["extension_phase_timings"][0]["duration_ms"], 4321);
+        assert_eq!(json["extension_phase_timings"][0]["status"], "waiting");
+        assert_eq!(
+            json["extension_phase_timings"][0]["message"],
+            "provider is waiting for a shared resource"
+        );
         assert_eq!(
             json["extension_phase_timings"][0]["artifacts"][0]["url"],
             "runner-artifact://phase.json"


### PR DESCRIPTION
## Summary
- Extend the generic extension phase timing contract with optional provider-declared `status` and `message` fields.
- Render provider-declared `waiting`, `blocked`, or `queued` extension phases separately in review output before the slowest phase list.
- Document that tool-specific lock detection belongs in providers/extensions while Homeboy core only surfaces generic phase state.

## Verification
- `rustfmt --check src/commands/review/render.rs src/core/extension/runner.rs src/core/extension/runner_contract.rs src/core/extension/test/report.rs`
- `CARGO_BUILD_JOBS=1 cargo test reads_extension_phase_timings_from_run_dir` with isolated target dir
- `CARGO_BUILD_JOBS=1 cargo test serializes_extension_phase_timings_as_opaque_metadata` with isolated target dir
- `CARGO_BUILD_JOBS=1 cargo test renders_slowest_extension_phases_generically` with isolated target dir
- `CARGO_BUILD_JOBS=1 cargo test renders_waiting_extension_phases_from_generic_status` with isolated target dir

Note: full `cargo fmt --check` currently reports an unrelated formatting diff in `tests/cargo_manifest_test.rs` from the rebased `main`; I left that unrelated file untouched.

Closes #4483.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic phase timing contract/rendering change, added targeted tests/docs, and ran targeted verification; Chris remains responsible for review and merge.