### PR TITLE
fix: support runner agent-task review

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -85,10 +85,11 @@ impl Commands {
                     agent_task::AgentTaskCommand::Status(_)
                         | agent_task::AgentTaskCommand::Logs(_)
                         | agent_task::AgentTaskCommand::Artifacts(_)
+                        | agent_task::AgentTaskCommand::Review(_)
                 ) =>
             {
                 LabCommandContract::portable_workload(
-                    "agent-task status/logs/artifacts",
+                    "agent-task status/logs/artifacts/review",
                     None,
                     false,
                     LAB_NO_EXTRA_TOOLS,
@@ -428,6 +429,10 @@ mod tests {
             parsed_command(&["homeboy", "agent-task", "artifacts", "agent-task-123"])
                 .supports_lab_runner()
         );
+        assert!(
+            parsed_command(&["homeboy", "agent-task", "review", "agent-task-123"])
+                .supports_lab_runner()
+        );
         assert!(parsed_command(&["homeboy", "agent-task", "providers"]).supports_lab_runner());
         assert!(parsed_command(&[
             "homeboy",
@@ -535,15 +540,19 @@ mod tests {
             ),
             (
                 parsed_command(&["homeboy", "agent-task", "status", "agent-task-123"]),
-                "agent-task status/logs/artifacts",
+                "agent-task status/logs/artifacts/review",
             ),
             (
                 parsed_command(&["homeboy", "agent-task", "logs", "agent-task-123"]),
-                "agent-task status/logs/artifacts",
+                "agent-task status/logs/artifacts/review",
             ),
             (
                 parsed_command(&["homeboy", "agent-task", "artifacts", "agent-task-123"]),
-                "agent-task status/logs/artifacts",
+                "agent-task status/logs/artifacts/review",
+            ),
+            (
+                parsed_command(&["homeboy", "agent-task", "review", "agent-task-123"]),
+                "agent-task status/logs/artifacts/review",
             ),
             (
                 parsed_command(&["homeboy", "agent-task", "providers"]),
@@ -608,12 +617,16 @@ mod tests {
         assert!(lint.requires_extension_parity);
         assert!(lint.infer_source_path_tools);
 
-        let agent_task_status =
-            parsed_command(&["homeboy", "agent-task", "status", "agent-task-123"])
+        for args in [
+            ["homeboy", "agent-task", "status", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "review", "agent-task-123"].as_slice(),
+        ] {
+            let agent_task_inspection = parsed_command(args)
                 .lab_contract()
-                .expect("agent-task status contract");
-        assert!(!agent_task_status.requires_extension_parity);
-        assert!(!agent_task_status.infer_source_path_tools);
+                .expect("agent-task inspection contract");
+            assert!(!agent_task_inspection.requires_extension_parity);
+            assert!(!agent_task_inspection.infer_source_path_tools);
+        }
 
         let rig = parsed_command(&["homeboy", "rig", "up", "studio"])
             .lab_contract()
@@ -663,6 +676,7 @@ mod tests {
             "auth",
             "map-env",
             "OPENAI_API_KEY",
+            "--from",
             "OPENAI_API_KEY",
         ])
         .lab_contract()

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -759,11 +759,12 @@ mod tests {
             ["homeboy", "agent-task", "status", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "logs", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "artifacts", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "review", "agent-task-123"].as_slice(),
         ] {
             let cli = Cli::parse_from(args);
             let command = lab_offload_command(&cli.command).unwrap().unwrap();
 
-            assert_eq!(command.hot_label, "agent-task status/logs/artifacts");
+            assert_eq!(command.hot_label, "agent-task status/logs/artifacts/review");
             assert!(command.portable);
             assert!(!command.requires_extension_parity);
             assert!(command.required_extensions.is_empty());

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -168,7 +168,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             "runner",
             message,
             Some(runner_id.to_string()),
-            Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, agent-task auth status, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+            Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
         )
     };
     let mut plan = base_lab_plan(request.command.as_ref());
@@ -176,7 +176,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if let Some(runner_id) = request.explicit_runner {
             return Err(unsupported_runner_error(
                 runner_id,
-                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, agent-task auth status, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, and refactor source runs".to_string(),
             ));
         }
         return Ok(LabOffloadOutcome::RunLocal {
@@ -189,7 +189,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.portable {
         if let Some(runner_id) = request.explicit_runner {
             let message = contract.unsupported_reason.map_or_else(
-                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, agent-task auth status, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
             );
             return Err(unsupported_runner_error(runner_id, message));

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -348,14 +348,14 @@ pub(super) fn resolve_lab_runner_selection_from_default(
     if let Some(runner_id) = explicit_runner {
         if !command.portable {
             let message = command.unsupported_reason.map_or_else(
-                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, agent-task auth status, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, and refactor source runs".to_string(),
                 |reason| format!("--runner is unavailable for this hot command. {reason}"),
             );
             return Err(Error::validation_invalid_argument(
                 "runner",
                 message,
                 Some(runner_id.to_string()),
-                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/providers, agent-task auth status, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
             ));
         }
 


### PR DESCRIPTION
## Summary
- Add `agent-task review` to the generic read-only Lab inspection command contract so runner-owned agent-task state can be reviewed through the same offload path as status/logs/artifacts.
- Update runner support/error labels to include `review`, keeping the flow generic and Codebox-agnostic.
- Extend command-contract and routing tests to cover runner-portable `agent-task review`.

Closes #4525

## Verification
- `homeboy test --runner homeboy-lab --skip-lint -- commands::route::tests::agent_task_inspection_commands_are_read_only_lab_portable` passed on `homeboy-lab`.
- `homeboy test --runner homeboy-lab --skip-lint -- command_contract::lab::tests::test_lab_command_contracts_cover_hot_commands` passed on `homeboy-lab`.
- No local `cargo` commands were run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing issue #4525, drafting the generic Lab command contract change, updating tests, and running offloaded verification. Chris remains responsible for review and merge.