### PR TITLE
Support Lab offload for preview consumers

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -160,6 +160,14 @@ impl Commands {
                 }
                 contract
             }
+            Commands::Tunnel(args) if args.is_preview_consumer_run() => {
+                LabCommandContract::explicit_runner(
+                    "tunnel preview-consumer run",
+                    None,
+                    false,
+                    LAB_NO_EXTRA_TOOLS,
+                )
+            }
             _ => return None,
         };
 
@@ -434,6 +442,17 @@ mod tests {
                 .supports_lab_runner()
         );
         assert!(parsed_command(&["homeboy", "agent-task", "providers"]).supports_lab_runner());
+        assert!(parsed_command(&[
+            "homeboy",
+            "tunnel",
+            "preview-consumer",
+            "run",
+            "--config",
+            "preview-consumer.json",
+            "--preview-public-url",
+            "https://preview.example.test/"
+        ])
+        .supports_lab_runner());
         assert!(parsed_command(&[
             "homeboy",
             "agent-task",

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -129,6 +129,17 @@ pub struct TunnelArgs {
     command: TunnelCommand,
 }
 
+impl TunnelArgs {
+    pub(crate) fn is_preview_consumer_run(&self) -> bool {
+        matches!(
+            self.command,
+            TunnelCommand::PreviewConsumer {
+                command: TunnelPreviewConsumerCommand::Run { .. }
+            }
+        )
+    }
+}
+
 #[derive(Subcommand)]
 enum TunnelCommand {
     /// Manage private service tunnel declarations

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -169,7 +169,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             "runner",
             message,
             Some(runner_id.to_string()),
-            Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+            Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, refactor source runs, and tunnel preview-consumer run.".to_string()]),
         )
     };
     let mut plan = base_lab_plan(request.command.as_ref());
@@ -177,7 +177,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if let Some(runner_id) = request.explicit_runner {
             return Err(unsupported_runner_error(
                 runner_id,
-                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, and tunnel preview-consumer run".to_string(),
             ));
         }
         return Ok(LabOffloadOutcome::RunLocal {
@@ -190,7 +190,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.portable {
         if let Some(runner_id) = request.explicit_runner {
             let message = contract.unsupported_reason.map_or_else(
-                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, and tunnel preview-consumer run".to_string(),
                 |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
             );
             return Err(unsupported_runner_error(runner_id, message));

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -348,14 +348,14 @@ pub(super) fn resolve_lab_runner_selection_from_default(
     if let Some(runner_id) = explicit_runner {
         if !command.portable {
             let message = command.unsupported_reason.map_or_else(
-                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, and refactor source runs".to_string(),
+                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, and tunnel preview-consumer run".to_string(),
                 |reason| format!("--runner is unavailable for this hot command. {reason}"),
             );
             return Err(Error::validation_invalid_argument(
                 "runner",
                 message,
                 Some(runner_id.to_string()),
-                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, and refactor source runs.".to_string()]),
+                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, refactor source runs, and tunnel preview-consumer run.".to_string()]),
             ));
         }
 


### PR DESCRIPTION
## Summary
- Add a Lab contract for `homeboy tunnel preview-consumer run` so callers can pass `--runner <id>` instead of falling back to local preview proof execution.
- Keep the command explicit-runner only; it does not automatically offload unless a runner is requested.
- Update Lab support diagnostics to include `tunnel preview-consumer run`.

## Verification
- `cargo test command_contract::lab::tests::test_supports_lab_runner`
- `cargo test commands::tunnel::tests::preview_consumer_run_uses_configured_public_url_and_artifacts`
- `cargo fmt --check`
- `git diff --check`
- Harmless runner probe:
  - `cargo run -- --runner homeboy-lab tunnel preview-consumer run --config runner-probe-preview-consumer.json --preview-public-url https://example.invalid/probe`
  - Confirmed command ran on `homeboy-lab` in `/home/chubes/Developer/_lab_workspaces/...` and returned `success: true`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the missing Lab contract, drafting the narrow command support change, and running targeted verification. Chris directed the end-to-end completion requirement.