### PR TITLE
fix: surface Lab status follow-up context

### DIFF
--- a/docs/commands/lab.md
+++ b/docs/commands/lab.md
@@ -19,9 +19,19 @@ replay. For normal benchmark runs, prefer `homeboy bench <component>`: Homeboy
 automatically selects a Lab runner when the component declares
 `lab.preferred_runner` or when exactly one Lab runner is configured.
 
-`homeboy lab status` returns `managed_followups` when Homeboy can select a Lab
-runner. Use those commands instead of raw SSH for routine lifecycle work:
+`homeboy lab status` resolves the default or inferred Lab runner and includes its
+readiness report in `selected_runner`. Pass `--runner <runner-id>` only when you
+need to inspect a specific non-default runner.
 
+`homeboy lab status` always returns run/artifact discovery commands in
+`managed_followups`, and adds runner diagnostics when Homeboy can select a Lab
+runner. Use those commands instead of raw SSH or runner path spelunking for
+routine lifecycle work:
+
+- `homeboy runs list --limit 5` finds recent persisted run records.
+- `homeboy runs latest-run --kind bench` resolves the latest benchmark run id.
+- `homeboy runs artifacts <run-id>` lists recorded run artifacts through
+  Homeboy.
 - `homeboy runner doctor <runner>` probes runner tools, workspace writability,
   artifact storage, and browser readiness.
 - `homeboy runner env <runner>` prints the redacted runner job environment.

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -117,8 +117,8 @@ pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabCommandOutput> {
         .map(|path| path.display().to_string());
     match args.command.unwrap_or(LabCommand::Status { runner: None }) {
         LabCommand::Status { runner } => {
-            let selected_runner = selected_lab_runner_status(runner.as_deref())?;
             let followup_runner = runner.as_deref().or(preferred_runner.as_deref());
+            let selected_runner = selected_lab_runner_status(followup_runner)?;
             let managed_followups = lab_followups(followup_runner, current_workspace.as_deref());
             Ok((
                 LabCommandOutput::Status(LabOutput {
@@ -432,11 +432,29 @@ fn extension_sync_revision_error(
 }
 
 fn lab_followups(runner_id: Option<&str>, current_workspace: Option<&str>) -> Vec<LabFollowup> {
+    let mut followups = vec![
+        LabFollowup {
+            label: "recent_runs",
+            command: "homeboy runs list --limit 5".to_string(),
+            purpose: "Find recent persisted Lab/offload runs before opening runner shells or artifact directories.",
+        },
+        LabFollowup {
+            label: "latest_bench_run",
+            command: "homeboy runs latest-run --kind bench".to_string(),
+            purpose: "Resolve the latest benchmark run id for status, evidence, and artifact inspection.",
+        },
+        LabFollowup {
+            label: "run_artifacts",
+            command: "homeboy runs artifacts <run-id>".to_string(),
+            purpose: "List recorded artifacts for a run through Homeboy instead of spelunking runner paths.",
+        },
+    ];
+
     let Some(runner_id) = runner_id else {
-        return Vec::new();
+        return followups;
     };
     let runner_arg = shell_arg(runner_id);
-    let mut followups = vec![
+    followups.extend([
         LabFollowup {
             label: "doctor",
             command: format!("homeboy runner doctor {runner_arg}"),
@@ -452,7 +470,7 @@ fn lab_followups(runner_id: Option<&str>, current_workspace: Option<&str>) -> Ve
             command: format!("homeboy runner exec {runner_arg} -- <command>"),
             purpose: "Run a managed follow-up command through Homeboy instead of opening an ad-hoc shell.",
         },
-    ];
+    ]);
 
     if let Some(path) = current_workspace {
         followups.push(LabFollowup {
@@ -633,6 +651,9 @@ Installing declared dependencies...
         let followups = lab_followups(Some("homeboy-lab"), Some("/tmp/example workspace"));
         let commands: Vec<_> = followups.iter().map(|step| step.command.as_str()).collect();
 
+        assert!(commands.contains(&"homeboy runs list --limit 5"));
+        assert!(commands.contains(&"homeboy runs latest-run --kind bench"));
+        assert!(commands.contains(&"homeboy runs artifacts <run-id>"));
         assert!(commands.contains(&"homeboy runner doctor homeboy-lab"));
         assert!(commands.contains(&"homeboy runner env homeboy-lab"));
         assert!(commands.contains(&"homeboy runner exec homeboy-lab -- <command>"));
@@ -642,7 +663,13 @@ Installing declared dependencies...
     }
 
     #[test]
-    fn lab_followups_are_empty_without_a_selected_runner() {
-        assert!(lab_followups(None, Some("/tmp/workspace")).is_empty());
+    fn lab_followups_include_run_context_without_a_selected_runner() {
+        let followups = lab_followups(None, Some("/tmp/workspace"));
+        let commands: Vec<_> = followups.iter().map(|step| step.command.as_str()).collect();
+
+        assert!(commands.contains(&"homeboy runs list --limit 5"));
+        assert!(commands.contains(&"homeboy runs latest-run --kind bench"));
+        assert!(commands.contains(&"homeboy runs artifacts <run-id>"));
+        assert!(!commands.iter().any(|command| command.starts_with("homeboy runner ")));
     }
 }

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -91,7 +91,7 @@ pub struct LabSelectedRunnerOutput {
 #[serde(untagged)]
 pub enum LabCommandOutput {
     Status(LabOutput),
-    ExtensionSync(LabExtensionSyncOutput),
+    ExtensionSync(Box<LabExtensionSyncOutput>),
 }
 
 #[derive(Serialize)]
@@ -277,7 +277,7 @@ fn sync_lab_extension(
     }
 
     Ok((
-        LabCommandOutput::ExtensionSync(LabExtensionSyncOutput {
+        LabCommandOutput::ExtensionSync(Box::new(LabExtensionSyncOutput {
             command: "lab.extension_sync",
             runner_id,
             runner_homeboy_path: homeboy_path,
@@ -289,7 +289,7 @@ fn sync_lab_extension(
             replace,
             install_command,
             execution,
-        }),
+        })),
         exit_code,
     ))
 }


### PR DESCRIPTION
## Summary
- Resolve the default/inferred Lab runner in `homeboy lab status` so `selected_runner` includes readiness without requiring operators to already know `--runner`.
- Add generic run/artifact discovery commands to `managed_followups` so routine Lab debugging starts from Homeboy run records instead of raw SSH or runner path spelunking.
- Document the status-first lifecycle path and keep this scoped away from #4318 runner execution-context parity.

## Issue
- Addresses part of #4319 by improving lifecycle/debugging ergonomics through the generic Lab status surface.
- Does not implement #4318 follow-up command execution environment parity.

## Verification
- `git diff --check`
- `homeboy runner workspace sync homeboy-lab --path . --mode snapshot` succeeded and produced a runner snapshot for this checkout.
- `homeboy test homeboy --path . --runner homeboy-lab --skip-lint -- lab_followups` was attempted through Lab and failed before targeted tests ran because an existing integration test imports missing symbol `browser_evidence_compare_from_dirs_with_visual_and_adapters`.
- `homeboy test homeboy --path . --runner homeboy-lab --skip-lint -- --lib lab_followups` was attempted through Lab and was blocked by runner daemon secret env resolution: missing `HOMEBOY_PREVIEW_TUNNEL_TOKEN`.
- `homeboy runner exec --ssh ... cargo test --lib lab_followups` was attempted after successful workspace sync and hit the same runner daemon secret env blocker.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Scoped and implemented the Lab status/context ergonomics change, drafted tests/docs, and performed Homeboy/Lab verification attempts. Chris remains responsible for review and merge.