### PR TITLE
runner: report managed validation dependencies

### DIFF
--- a/docs/commands/lab.md
+++ b/docs/commands/lab.md
@@ -31,6 +31,14 @@ runner. Use those commands instead of raw SSH for routine lifecycle work:
   materializes the current checkout into the Lab workspace before a replay or
   follow-up run.
 
+Component or extension settings can declare runner-managed dependency sources
+with `validation_dependencies`. Lab workspace sync resolves those dependencies,
+checks freshness, runs install/build lifecycle, materializes them beside the
+primary workspace, and returns dependency provenance in the generic
+`validation_dependencies` output field. Use that contract for eval/bench source
+overrides instead of ad-hoc workflow-specific environment exports or hardcoded
+runner paths.
+
 `homeboy lab bench` delegates to the same benchmark path while making the Lab
 intent explicit at the command surface. Its output includes the same managed
 follow-up hints so the operator can keep a failed bench inside the Homeboy

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -132,6 +132,42 @@ Programmatic runner execution can use the same generic boundary through
 remote execution starts, alongside existing required tools, components, and
 environment variables.
 
+#### Runner-managed dependency sources
+
+Portable Lab/evidence runs should declare runner dependency sources instead of
+smuggling local checkout paths through workflow-specific environment variables.
+Homeboy's generic contract is the extension/component setting
+`validation_dependencies`: each entry is a component id or explicit checkout
+path that the runner workspace sync treats as managed source input.
+
+For each declared dependency, `homeboy runner workspace sync`:
+
+- resolves a sibling checkout, registered component, or deterministic clone;
+- rejects dirty, stale, divergent, missing-upstream, or ambiguous Git state;
+- runs the dependency install/build lifecycle in a prepared copy;
+- materializes the prepared dependency beside the primary runner workspace; and
+- records source evidence in `.homeboy/lab-source-evidence.json`.
+
+The JSON output includes `validation_dependencies`, with each dependency's
+`id`, `role`, controller `local_path`, runner `remote_path`, and
+`evidence_path`. Bench, trace, eval, and provider layers can consume that
+generic output to populate their own path settings without knowing Lab
+filesystem layouts or dependency-specific environment variable names.
+
+Example manifest fragment:
+
+```json
+{
+  "extensions": {
+    "provider-id": {
+      "settings": {
+        "validation_dependencies": ["runtime-component"]
+      }
+    }
+  }
+}
+```
+
 Pass one or more `--extension <id>` values to validate extension parity before
 Lab offload. Doctor runs the same `homeboy extension show <id>` contract on the
 target runner that test offload uses at execution time. `--path` sets the probe

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -13,8 +13,10 @@ pub use bench_coverage::{
 };
 pub use browser_evidence_compare::{
     browser_evidence_compare_from_args, browser_evidence_compare_from_dirs,
-    browser_evidence_compare_from_dirs_with_visual, render_browser_evidence_compare_from_args,
-    BrowserEvidenceCompareArgs, BrowserEvidenceCompareReport, VisualCompareOptions,
+    browser_evidence_compare_from_dirs_with_visual,
+    browser_evidence_compare_from_dirs_with_visual_and_adapters,
+    render_browser_evidence_compare_from_args, BrowserEvidenceCompareArgs,
+    BrowserEvidenceCompareReport, VisualCompareOptions,
 };
 pub use failure_digest::{render_failure_digest_from_args, FailureDigestArgs};
 pub use performance_digest::{

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -800,6 +800,7 @@ mod tests {
             excludes: Vec::new(),
             includes: Vec::new(),
             workspace_cleanliness: "clean".to_string(),
+            validation_dependencies: Vec::new(),
         };
         (
             remote_spec.to_string(),

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -1622,6 +1622,7 @@ mod tests {
             excludes: Vec::new(),
             includes: Vec::new(),
             workspace_cleanliness: "snapshot_unique_workspace".to_string(),
+            validation_dependencies: Vec::new(),
         };
         let git = RunnerWorkspaceSyncOutput {
             command: "runner.workspace.sync",
@@ -1635,6 +1636,7 @@ mod tests {
             excludes: Vec::new(),
             includes: Vec::new(),
             workspace_cleanliness: "clean_remote_required".to_string(),
+            validation_dependencies: Vec::new(),
         };
 
         let entries = vec![

--- a/src/core/runner/lab_env.rs
+++ b/src/core/runner/lab_env.rs
@@ -399,6 +399,7 @@ mod tests {
                 excludes: Vec::new(),
                 includes: Vec::new(),
                 workspace_cleanliness: "snapshot_unique_workspace".to_string(),
+                validation_dependencies: Vec::new(),
             },
         )];
 

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -36,6 +36,7 @@ mod session;
 mod source_materialization;
 mod validation_dependencies;
 pub(crate) use validation_dependencies::validation_dependency_ids;
+pub use validation_dependencies::RunnerValidationDependencySyncOutput;
 mod worker;
 mod workspace;
 pub(crate) use workspace::copy_snapshot_to_directory;

--- a/src/core/runner/validation_dependencies.rs
+++ b/src/core/runner/validation_dependencies.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use serde::Serialize;
+
 use crate::core::component::{self, Component};
 use crate::core::error::{Error, Result};
 use crate::core::{git::clone_repo, paths};
@@ -10,12 +12,22 @@ use super::Runner;
 
 const PORTABLE_CONFIG_FILE: &str = concat!("homeboy", ".json");
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RunnerValidationDependencySyncOutput {
+    pub id: String,
+    pub role: String,
+    pub local_path: String,
+    pub remote_path: String,
+    pub evidence_path: String,
+}
+
 pub(super) fn sync_validation_dependency_workspaces(
     runner: &Runner,
     local_path: &Path,
     remote_path: &str,
     excludes: &[String],
-) -> Result<()> {
+) -> Result<Vec<RunnerValidationDependencySyncOutput>> {
+    let mut synced = Vec::new();
     for dependency in validation_dependency_workspaces(local_path, excludes)? {
         let remote_dependency_path = format!(
             "{}/{}",
@@ -28,13 +40,24 @@ pub(super) fn sync_validation_dependency_workspaces(
             &remote_dependency_path,
             excludes,
         )?;
+        synced.push(RunnerValidationDependencySyncOutput {
+            id: dependency.remote_name,
+            role: "validation_dependency".to_string(),
+            local_path: dependency.local_path.display().to_string(),
+            evidence_path: format!(
+                "{}/.homeboy/lab-source-evidence.json",
+                remote_dependency_path.trim_end_matches('/')
+            ),
+            remote_path: remote_dependency_path,
+        });
     }
-    Ok(())
+    Ok(synced)
 }
 
 #[derive(Debug)]
 struct PreparedValidationDependencyWorkspace {
     remote_name: String,
+    local_path: PathBuf,
     prepared_path: PathBuf,
     _tempdir: tempfile::TempDir,
 }
@@ -197,6 +220,7 @@ fn prepare_validation_dependency_workspace(
 
     Ok(PreparedValidationDependencyWorkspace {
         remote_name: component.id,
+        local_path: path,
         prepared_path,
         _tempdir: tempdir,
     })
@@ -488,9 +512,30 @@ mod tests {
             .expect("sync workspace");
 
             assert_eq!(exit_code, 0);
+            assert_eq!(output.validation_dependencies.len(), 1);
+            assert_eq!(output.validation_dependencies[0].id, "agents-api");
+            assert_eq!(
+                output.validation_dependencies[0].role,
+                "validation_dependency"
+            );
+            assert_eq!(
+                output.validation_dependencies[0].local_path,
+                dependency.canonicalize().unwrap().display().to_string()
+            );
             let remote_parent = parent_remote_path(&output.remote_path);
             assert!(Path::new(&output.remote_path).join("src/main.php").exists());
             let remote_dependency = Path::new(&remote_parent).join("agents-api");
+            assert_eq!(
+                output.validation_dependencies[0].remote_path,
+                remote_dependency.display().to_string()
+            );
+            assert_eq!(
+                output.validation_dependencies[0].evidence_path,
+                remote_dependency
+                    .join(".homeboy/lab-source-evidence.json")
+                    .display()
+                    .to_string()
+            );
             assert!(remote_dependency.join("lib/agents.php").exists());
             assert!(!remote_dependency.join(".git").exists());
             assert!(remote_dependency

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -10,6 +10,7 @@ use crate::core::engine::{shell, temp};
 use crate::core::error::{Error, Result};
 use crate::core::server::{self, Server, SshClient};
 
+use super::validation_dependencies::RunnerValidationDependencySyncOutput;
 use super::{load, Runner, RunnerKind};
 
 pub(super) const DEFAULT_EXCLUDES: &[&str] = &[
@@ -82,6 +83,7 @@ pub struct RunnerWorkspaceSyncOutput {
     pub excludes: Vec<String>,
     pub includes: Vec<String>,
     pub workspace_cleanliness: String,
+    pub validation_dependencies: Vec<RunnerValidationDependencySyncOutput>,
 }
 
 pub fn sync_workspace(
@@ -128,12 +130,13 @@ pub fn sync_workspace(
             );
             let stats = local_snapshot_stats(&local_path, &excludes, &includes)?;
             materialize_snapshot(&runner, &local_path, &remote_path, &excludes)?;
-            super::validation_dependencies::sync_validation_dependency_workspaces(
-                &runner,
-                &local_path,
-                &remote_path,
-                &excludes,
-            )?;
+            let validation_dependencies =
+                super::validation_dependencies::sync_validation_dependency_workspaces(
+                    &runner,
+                    &local_path,
+                    &remote_path,
+                    &excludes,
+                )?;
             Ok((
                 RunnerWorkspaceSyncOutput {
                     command: "runner.workspace.sync",
@@ -147,6 +150,7 @@ pub fn sync_workspace(
                     excludes,
                     includes,
                     workspace_cleanliness: "snapshot_unique_workspace".to_string(),
+                    validation_dependencies,
                 },
                 0,
             ))
@@ -192,12 +196,13 @@ pub fn sync_workspace(
                     options.allow_dirty_lab_workspace,
                 )?;
             }
-            super::validation_dependencies::sync_validation_dependency_workspaces(
-                &runner,
-                &local_path,
-                &remote_path,
-                &excludes,
-            )?;
+            let validation_dependencies =
+                super::validation_dependencies::sync_validation_dependency_workspaces(
+                    &runner,
+                    &local_path,
+                    &remote_path,
+                    &excludes,
+                )?;
             Ok((
                 RunnerWorkspaceSyncOutput {
                     command: "runner.workspace.sync",
@@ -215,6 +220,7 @@ pub fn sync_workspace(
                     } else {
                         "clean_remote_required".to_string()
                     },
+                    validation_dependencies,
                 },
                 0,
             ))


### PR DESCRIPTION
## Summary
- Adds `validation_dependencies` to `runner.workspace.sync` output so runner-managed dependency sources are visible as first-class provenance.
- Reports each managed dependency's id, role, controller source path, runner materialized path, and Lab source evidence path.
- Documents `validation_dependencies` as the generic runner dependency/source lifecycle contract for eval/bench/provider layers, instead of workflow-specific path env exports.

## Verification
- Synced branch to `homeboy-lab` with `homeboy runner workspace sync`.
- Ran on Lab runner: `cargo fmt --check && cargo test validation_dependencies --lib`.
- Passing Lab job: `2615928b-58f1-4286-b0c7-614fda94fcb6`.
- Result: 7 targeted tests passed.

## Caveat
- After rebasing onto latest `origin/main`, the follow-up managed `runner exec` rerun was blocked before command execution by missing runner secret env `HOMEBOY_PREVIEW_TUNNEL_TOKEN`.
- Tracked separately in #4551.
- The rebased branch was synced to Lab successfully; the code delta is the same change set plus the clean rebase.

Closes #4321.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the Lab dependency lifecycle gap, drafted the generic runner dependency provenance contract, implemented the code/docs changes, and ran Homeboy/Lab verification. Chris remains responsible for review and merge.