### PR TITLE
Fix no-op release planning bump handling

### DIFF
--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -13,8 +13,10 @@ pub use bench_coverage::{
 };
 pub use browser_evidence_compare::{
     browser_evidence_compare_from_args, browser_evidence_compare_from_dirs,
-    browser_evidence_compare_from_dirs_with_visual, render_browser_evidence_compare_from_args,
-    BrowserEvidenceCompareArgs, BrowserEvidenceCompareReport, VisualCompareOptions,
+    browser_evidence_compare_from_dirs_with_visual,
+    browser_evidence_compare_from_dirs_with_visual_and_adapters,
+    render_browser_evidence_compare_from_args, BrowserEvidenceCompareArgs,
+    BrowserEvidenceCompareReport, VisualCompareOptions,
 };
 pub use failure_digest::{render_failure_digest_from_args, FailureDigestArgs};
 pub use performance_digest::{

--- a/src/core/release/planning_semver.rs
+++ b/src/core/release/planning_semver.rs
@@ -22,6 +22,10 @@ pub(super) fn build_semver_recommendation(
 
     let recommended = git::recommended_bump_from_commits(&commits);
 
+    if requested_bump == "none" && recommended.is_none() {
+        return Ok(None);
+    }
+
     if is_explicit_version {
         return Ok(Some(ReleaseSemverRecommendation {
             latest_tag: latest_tag.clone(),
@@ -332,6 +336,32 @@ mod tests {
         assert_eq!(recommendation.requested_bump, "2.0.0");
         assert!(!recommendation.is_underbump);
         assert!(recommendation.reasons.is_empty());
+    }
+
+    #[test]
+    fn none_request_with_only_non_releasable_commits_returns_no_recommendation() {
+        let temp = git_repo();
+        let dir = temp.path();
+        commit_file(dir, "README.md", "initial", "chore: initial");
+        run_git(dir, &["tag", "v1.0.0"]);
+        commit_file(
+            dir,
+            "baseline.txt",
+            "baseline",
+            "chore: refresh lint baseline",
+        );
+        let component = Component {
+            local_path: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+
+        let recommendation = build_semver_recommendation(&component, "none", None)
+            .expect("no-op recommendation should be valid");
+
+        assert!(
+            recommendation.is_none(),
+            "internal no-op bump sentinel should let the planner build a skip plan"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Treat Homeboy's internal `none` bump sentinel as a valid no-op planning signal when commits exist but none require a semantic version bump.
- Keep `none` out of the public bump contract: explicit bump parsing still accepts only `patch`, `minor`, `major`, or explicit versions.
- Add a regression test for chore-only commits after the latest tag so release planning can return the existing no-release skip plan instead of failing validation.
- Re-export the existing browser-evidence compare adapter helper so the repository's external test target compiles in CI; this is a CI unblocker only and does not change release planning or report behavior.

Fixes https://github.com/Extra-Chill/homeboy/issues/4535

## Verification
- Passed before rebase: `homeboy test homeboy --path /Users/chubes/Developer/homeboy@fix-release-noop-bump-none --runner homeboy-lab --allow-dirty-lab-workspace --skip-lint -- --lib none_request_with_only_non_releasable_commits_returns_no_recommendation`
- Full Lab test before the CI unblocker was blocked by the missing re-export now fixed in this PR: unresolved import `browser_evidence_compare_from_dirs_with_visual_and_adapters`.
- Current local Lab offload is blocked before execution by runner configuration: missing secret env ref `HOMEBOY_PREVIEW_TUNNEL_TOKEN` on runner `homeboy-lab`.
- I did not run Cargo locally, per task constraint.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the release planner/bump contract, drafting the minimal code change and regression test, diagnosing the CI compile blocker, and running Homeboy/Lab verification where available.