### PR TITLE
Serve run artifact URLs from artifact origin

### DIFF
--- a/src/core/artifact_origin.rs
+++ b/src/core/artifact_origin.rs
@@ -4,7 +4,7 @@ use std::path::{Component, Path, PathBuf};
 
 use serde::Serialize;
 
-use crate::core::{paths, Error, Result};
+use crate::core::{daemon, paths, Error, Result};
 
 #[derive(Debug, Clone)]
 pub struct ArtifactOriginServeSpec {
@@ -116,6 +116,9 @@ fn response_for_request(root: &Path, method: &str, target: &str) -> Result<Artif
             body,
         });
     }
+    if let Some(response) = artifact_route_response(method, target, headers.clone())? {
+        return Ok(response);
+    }
     let Some(path) = safe_target_path(root, target) else {
         let body = br#"{"error":"not_found"}"#.to_vec();
         headers.push(("content-type".to_string(), "application/json".to_string()));
@@ -176,6 +179,73 @@ fn safe_target_path(root: &Path, target: &str) -> Option<PathBuf> {
     Some(root.join(relative))
 }
 
+fn artifact_route_response(
+    method: &str,
+    target: &str,
+    mut headers: Vec<(String, String)>,
+) -> Result<Option<ArtifactOriginResponse>> {
+    let Some(response) = daemon::artifact_response_for_path(target) else {
+        return Ok(None);
+    };
+    let Some(artifact) = response.artifact else {
+        let body = serde_json::to_vec(&response.body).map_err(|err| {
+            Error::internal_json(
+                err.to_string(),
+                Some("serialize artifact route response".to_string()),
+            )
+        })?;
+        headers.push(("content-type".to_string(), "application/json".to_string()));
+        headers.push(("content-length".to_string(), body.len().to_string()));
+        return Ok(Some(ArtifactOriginResponse {
+            status: response.status_code,
+            headers,
+            body: if method.eq_ignore_ascii_case("HEAD") {
+                Vec::new()
+            } else {
+                body
+            },
+        }));
+    };
+
+    let body = std::fs::read(&artifact.path).map_err(|err| {
+        Error::internal_io(err.to_string(), Some("read routed artifact".to_string()))
+    })?;
+    headers.push(("content-type".to_string(), artifact.content_type));
+    headers.push(("content-length".to_string(), body.len().to_string()));
+    headers.push((
+        "content-disposition".to_string(),
+        format!(
+            "attachment; filename=\"{}\"",
+            sanitize_header_value(&artifact.filename)
+        ),
+    ));
+    headers.push(("x-homeboy-artifact-id".to_string(), artifact.record.id));
+    headers.push(("x-homeboy-run-id".to_string(), artifact.record.run_id));
+    headers.push((
+        "x-homeboy-artifact-kind".to_string(),
+        sanitize_header_value(&artifact.record.kind),
+    ));
+    if let Some(sha256) = artifact.record.sha256 {
+        headers.push(("x-homeboy-artifact-sha256".to_string(), sha256));
+    }
+    Ok(Some(ArtifactOriginResponse {
+        status: response.status_code,
+        headers,
+        body: if method.eq_ignore_ascii_case("HEAD") {
+            Vec::new()
+        } else {
+            body
+        },
+    }))
+}
+
+fn sanitize_header_value(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| !matches!(ch, '\r' | '\n' | '"'))
+        .collect()
+}
+
 fn reason(status: u16) -> &'static str {
     match status {
         200 => "OK",
@@ -188,6 +258,7 @@ fn reason(status: u16) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::observation::{NewRunRecord, ObservationStore};
 
     #[test]
     fn serves_json_with_cors_headers() {
@@ -229,5 +300,61 @@ mod tests {
             "access-control-allow-methods".to_string(),
             "GET, HEAD, OPTIONS".to_string()
         )));
+    }
+
+    #[test]
+    fn serves_run_scoped_artifact_routes() {
+        crate::test_support::with_isolated_home(|home| {
+            let artifact_path = home.path().join("report.json");
+            std::fs::write(&artifact_path, br#"{"ok":true}"#).expect("write artifact");
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(NewRunRecord::builder("bench").build())
+                .expect("run");
+            let artifact = store
+                .record_artifact(&run.id, "report", &artifact_path)
+                .expect("artifact");
+
+            let response = response_for_request(
+                home.path(),
+                "GET",
+                &format!("/runs/{}/artifacts/{}", run.id, artifact.id),
+            )
+            .expect("artifact route response");
+
+            assert_eq!(response.status, 200);
+            assert_eq!(response.body, br#"{"ok":true}"#);
+            assert!(response
+                .headers
+                .contains(&("x-homeboy-run-id".to_string(), run.id)));
+        });
+    }
+
+    #[test]
+    fn serves_head_for_run_scoped_artifact_routes() {
+        crate::test_support::with_isolated_home(|home| {
+            let artifact_path = home.path().join("report.json");
+            std::fs::write(&artifact_path, br#"{"ok":true}"#).expect("write artifact");
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(NewRunRecord::builder("bench").build())
+                .expect("run");
+            let artifact = store
+                .record_artifact(&run.id, "report", &artifact_path)
+                .expect("artifact");
+
+            let response = response_for_request(
+                home.path(),
+                "HEAD",
+                &format!("/runs/{}/artifacts/{}", run.id, artifact.id),
+            )
+            .expect("artifact route response");
+
+            assert_eq!(response.status, 200);
+            assert!(response.body.is_empty());
+            assert!(response
+                .headers
+                .contains(&("content-length".to_string(), "11".to_string())));
+        });
     }
 }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -531,6 +531,10 @@ pub(super) fn error_response(status_code: u16, err: Error) -> HttpResponse {
     }
 }
 
+pub(crate) fn artifact_response_for_path(path: &str) -> Option<HttpResponse> {
+    artifact_download::route(path)
+}
+
 fn config_paths_body() -> Result<serde_json::Value> {
     Ok(json!({
         "homeboy": paths::homeboy()?.display().to_string(),

--- a/src/core/daemon/artifact_download.rs
+++ b/src/core/daemon/artifact_download.rs
@@ -6,7 +6,9 @@ use std::path::PathBuf;
 
 use crate::core::artifact_links::{public_artifact_url, viewer_links};
 use crate::core::error::{Error, Result};
+use crate::core::execution_contract::decode_uri_component;
 use crate::core::observation::{ArtifactRecord, ObservationStore};
+use crate::core::paths;
 use crate::core::runner;
 
 use super::{error_response, HttpResponse};
@@ -93,25 +95,35 @@ fn resolve_artifact_download(
     artifact_token: &str,
 ) -> Result<ResolvedArtifactResponse> {
     let store = ObservationStore::open_initialized()?;
-    let artifact = store.get_artifact(artifact_token)?.ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "artifact_id",
-            format!("artifact record not found: {artifact_token}"),
-            Some(artifact_token.to_string()),
-            None,
-        )
-    })?;
-
-    if let Some(run_id) = expected_run_id {
-        if artifact.run_id != run_id {
+    let decoded_artifact_token = decode_uri_component(artifact_token);
+    let artifact = if let Some(run_id) = expected_run_id {
+        if store.get_run(run_id)?.is_none() {
             return Err(Error::validation_invalid_argument(
-                "artifact_id",
-                "artifact does not belong to requested run",
-                Some(artifact_token.to_string()),
+                "run_id",
+                format!("run record not found: {run_id}"),
+                Some(run_id.to_string()),
                 None,
             ));
         }
-    }
+        crate::core::artifacts::index_remote_published_artifact_refs_for_run(&store, run_id)?;
+        match store.get_artifact_for_run_token(run_id, &decoded_artifact_token)? {
+            Some(artifact) => artifact,
+            None => {
+                return artifact_store_download(run_id, artifact_token, &decoded_artifact_token)
+            }
+        }
+    } else {
+        store
+            .get_artifact(&decoded_artifact_token)?
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "artifact_id",
+                    format!("artifact record not found: {artifact_token}"),
+                    Some(artifact_token.to_string()),
+                    None,
+                )
+            })?
+    };
 
     if artifact.artifact_type != "file" {
         if artifact.artifact_type == "remote_file"
@@ -194,6 +206,89 @@ fn resolve_artifact_download(
             filename,
         },
     )))
+}
+
+fn artifact_store_download(
+    run_id: &str,
+    artifact_token: &str,
+    decoded_artifact_token: &str,
+) -> Result<ResolvedArtifactResponse> {
+    let locator = runner::artifact_store_locator_from_runner_artifact_id(decoded_artifact_token)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "artifact_id",
+                format!("artifact record not found: {artifact_token}"),
+                Some(artifact_token.to_string()),
+                None,
+            )
+        })?;
+    let path = safe_artifact_store_path(&locator)?;
+    let metadata = fs::metadata(&path).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("read artifact-store metadata {locator}")),
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!("artifact-store locator is not a file: {locator}"),
+            Some(artifact_token.to_string()),
+            None,
+        ));
+    }
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(artifact_token)
+        .to_string();
+    let content_type = crate::core::artifact_metadata::content_type_from_path(&path)
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+    let record = ArtifactRecord {
+        id: artifact_token.to_string(),
+        run_id: run_id.to_string(),
+        kind: "artifact_store".to_string(),
+        artifact_type: "file".to_string(),
+        path: locator.clone(),
+        url: None,
+        public_url: None,
+        viewer_url: None,
+        viewer_links: Vec::new(),
+        sha256: crate::core::artifact_metadata::sha256_file(&path).ok(),
+        size_bytes: i64::try_from(metadata.len()).ok(),
+        mime: Some(content_type.clone()),
+        metadata_json: json!({
+            "source": "artifact_store",
+            "locator": locator,
+        }),
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    Ok(ResolvedArtifactResponse::Download(Box::new(
+        ArtifactDownload {
+            record,
+            path,
+            content_type,
+            size_bytes: metadata.len(),
+            filename,
+        },
+    )))
+}
+
+fn safe_artifact_store_path(locator: &str) -> Result<PathBuf> {
+    let locator_path = PathBuf::from(locator);
+    if locator_path.is_absolute()
+        || locator_path
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            "artifact-store locator must stay under the artifact root",
+            Some(locator.to_string()),
+            None,
+        ));
+    }
+    Ok(paths::artifact_root()?.join(locator_path))
 }
 
 fn artifact_sync_manifest(run_id: &str) -> Result<ResolvedArtifactResponse> {

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -185,6 +185,12 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
                 artifact_id: (*artifact_id).to_string(),
             })
         }
+        (HttpMethod::Get, ["runs", id, "artifacts", artifact_id]) => {
+            Ok(HttpEndpoint::RunArtifactContent {
+                id: (*id).to_string(),
+                artifact_id: (*artifact_id).to_string(),
+            })
+        }
         (HttpMethod::Get, ["runs", id, "findings"]) => Ok(HttpEndpoint::RunFindings {
             id: (*id).to_string(),
         }),
@@ -237,6 +243,7 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
                 "GET /runs".to_string(),
                 "GET /runs/:id".to_string(),
                 "GET /runs/:id/artifacts".to_string(),
+                "GET /runs/:id/artifacts/:artifact_id".to_string(),
                 "GET /runs/:id/artifacts/:artifact_id/content".to_string(),
                 "GET /runs/:id/findings".to_string(),
                 "GET /audit/runs".to_string(),
@@ -427,18 +434,44 @@ fn enqueue_sandbox_tool_job(
 fn artifact_content(run_id: &str, artifact_id: &str) -> Result<Value> {
     let store = ObservationStore::open_initialized()?;
     require_run(&store, run_id)?;
-    let Some(artifact) = store.get_artifact(artifact_id)? else {
-        return artifact_store_content(run_id, artifact_id);
+    crate::core::artifacts::index_remote_published_artifact_refs_for_run(&store, run_id)?;
+    let decoded_artifact_id = crate::core::execution_contract::decode_uri_component(artifact_id);
+    let Some(artifact) = store.get_artifact_for_run_token(run_id, &decoded_artifact_id)? else {
+        return artifact_store_content(run_id, artifact_id, &decoded_artifact_id);
     };
-    if artifact.run_id != run_id {
-        return Err(Error::validation_invalid_argument(
-            "artifact_id",
-            "artifact does not belong to requested run",
-            Some(artifact_id.to_string()),
-            None,
-        ));
-    }
     if artifact.artifact_type != "file" {
+        if artifact.artifact_type == "remote_file"
+            || runner::is_remote_runner_artifact_path(&artifact.path)
+        {
+            let download = runner::download_remote_artifact(&artifact.path, None)?;
+            let content = std::fs::read(&download.output_path).map_err(|err| {
+                Error::internal_io(
+                    err.to_string(),
+                    Some(format!(
+                        "read downloaded remote artifact {}",
+                        download.output_path.display()
+                    )),
+                )
+            })?;
+            let filename = download
+                .output_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or(&artifact.id);
+            let size_bytes = download
+                .size_bytes
+                .or_else(|| i64::try_from(content.len()).ok());
+            return Ok(json!({
+                "command": "api.runs.artifact.content",
+                "run_id": run_id,
+                "artifact_id": artifact.id,
+                "filename": filename,
+                "mime": download.content_type.or_else(|| artifact.mime.clone()),
+                "size_bytes": size_bytes,
+                "sha256": download.sha256.or_else(|| artifact.sha256.clone()),
+                "content_base64": base64::engine::general_purpose::STANDARD.encode(content),
+            }));
+        }
         return Err(Error::validation_invalid_argument(
             "artifact_id",
             format!(
@@ -472,8 +505,11 @@ fn artifact_content(run_id: &str, artifact_id: &str) -> Result<Value> {
     }))
 }
 
-fn artifact_store_content(run_id: &str, artifact_id: &str) -> Result<Value> {
-    let decoded_artifact_id = crate::core::execution_contract::decode_uri_component(artifact_id);
+fn artifact_store_content(
+    run_id: &str,
+    artifact_id: &str,
+    decoded_artifact_id: &str,
+) -> Result<Value> {
     let locator = runner::artifact_store_locator_from_runner_artifact_id(&decoded_artifact_id)
         .ok_or_else(|| {
             Error::validation_invalid_argument(

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -510,7 +510,7 @@ fn artifact_store_content(
     artifact_id: &str,
     decoded_artifact_id: &str,
 ) -> Result<Value> {
-    let locator = runner::artifact_store_locator_from_runner_artifact_id(&decoded_artifact_id)
+    let locator = runner::artifact_store_locator_from_runner_artifact_id(decoded_artifact_id)
         .ok_or_else(|| {
             Error::validation_invalid_argument(
                 "artifact_id",

--- a/tests/core/daemon/artifact_download_test.rs
+++ b/tests/core/daemon/artifact_download_test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::core::observation::ArtifactRecord;
 use crate::core::observation::NewRunRecord;
 use crate::test_support::HomeGuard;
 
@@ -27,4 +28,83 @@ fn test_route() {
     assert_eq!(response.status_code, 200);
     assert!(response.artifact.is_some());
     assert_eq!(response.body["artifact"]["id"], artifact.id);
+}
+
+#[test]
+fn route_serves_run_scoped_artifact_store_tokens() {
+    let _home = HomeGuard::new();
+    let home_path = std::path::PathBuf::from(std::env::var("HOME").expect("home"));
+    let store = ObservationStore::open_initialized().expect("store");
+    let run = store
+        .start_run(
+            NewRunRecord::builder("bench")
+                .command("homeboy bench")
+                .homeboy_version("test-version")
+                .build(),
+        )
+        .expect("run");
+    let locator =
+        "homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/summary.json";
+    let artifact_root = home_path.join(".local/share/homeboy/artifacts");
+    let path = artifact_root.join(locator);
+    fs::create_dir_all(path.parent().expect("artifact parent")).expect("artifact parent");
+    fs::write(&path, br#"{"ok":true}"#).expect("artifact-store file");
+    let token = crate::core::runner::runner_artifact_store_token("lab", &run.id, locator)
+        .rsplit('/')
+        .next()
+        .expect("artifact token")
+        .to_string();
+
+    let response =
+        route(&format!("/runs/{}/artifacts/{}", run.id, token)).expect("artifact-store route");
+
+    assert_eq!(response.status_code, 200);
+    let artifact = response.artifact.expect("artifact download");
+    assert_eq!(artifact.filename, "summary.json");
+    assert_eq!(artifact.size_bytes, 11);
+    assert_eq!(response.body["artifact"]["run_id"], run.id);
+}
+
+#[test]
+fn route_serves_percent_encoded_run_scoped_artifact_ids() {
+    let _home = HomeGuard::new();
+    let home_path = std::path::PathBuf::from(std::env::var("HOME").expect("home"));
+    let store = ObservationStore::open_initialized().expect("store");
+    let run = store
+        .start_run(
+            NewRunRecord::builder("bench")
+                .command("homeboy bench")
+                .homeboy_version("test-version")
+                .build(),
+        )
+        .expect("run");
+    let artifact_path = home_path.join("summary.json");
+    fs::write(&artifact_path, br#"{"ok":true}"#).expect("artifact file");
+    let artifact = ArtifactRecord {
+        id: "report/summary".to_string(),
+        run_id: run.id.clone(),
+        kind: "summary".to_string(),
+        artifact_type: "file".to_string(),
+        path: artifact_path.to_string_lossy().to_string(),
+        url: None,
+        public_url: None,
+        viewer_url: None,
+        viewer_links: Vec::new(),
+        sha256: None,
+        size_bytes: Some(11),
+        mime: Some("application/json".to_string()),
+        metadata_json: serde_json::json!({}),
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    store.import_artifact(&artifact).expect("import artifact");
+
+    let response = route(&format!("/runs/{}/artifacts/report%2Fsummary", run.id))
+        .expect("encoded artifact route");
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.body["artifact"]["id"], artifact.id);
+    assert_eq!(
+        response.artifact.expect("artifact download").filename,
+        "summary.json"
+    );
 }

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -4,7 +4,7 @@ use homeboy::core::http_api::{
     JobReadyRunKind,
 };
 use homeboy::core::observation::{
-    NewFindingRecord, NewRunRecord, ObservationStore, RunRecord, RunStatus,
+    ArtifactRecord, NewFindingRecord, NewRunRecord, ObservationStore, RunRecord, RunStatus,
 };
 
 use crate::test_support::with_isolated_home;
@@ -486,6 +486,58 @@ fn artifact_content_serves_encoded_artifact_store_locator() {
             response.body["content_base64"].as_str(),
             Some("eyJzdGVwcyI6W119")
         );
+
+        let response = http_api::handle(HttpApiRequest {
+            method: HttpMethod::Get,
+            path: format!("/runs/{}/artifacts/{}", run.id, token),
+            body: None,
+        })
+        .expect("artifact-store public URL content");
+
+        assert_eq!(response.endpoint, "runs.artifact.content");
+        assert_eq!(response.body["run_id"], run.id);
+        assert_eq!(response.body["filename"], "blueprint.after.json");
+    });
+}
+
+#[test]
+fn artifact_content_serves_percent_encoded_stored_artifact_ids() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .start_run(sample_run("bench", "homeboy", "studio"))
+            .expect("bench run");
+        let artifact_path = home.path().join("summary.json");
+        std::fs::write(&artifact_path, br#"{"ok":true}"#).expect("artifact file");
+        let artifact = ArtifactRecord {
+            id: "report/summary".to_string(),
+            run_id: run.id.clone(),
+            kind: "summary".to_string(),
+            artifact_type: "file".to_string(),
+            path: artifact_path.to_string_lossy().to_string(),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: None,
+            size_bytes: Some(11),
+            mime: Some("application/json".to_string()),
+            metadata_json: serde_json::json!({}),
+            created_at: chrono::Utc::now().to_rfc3339(),
+        };
+        store.import_artifact(&artifact).expect("import artifact");
+
+        let response = http_api::handle(HttpApiRequest {
+            method: HttpMethod::Get,
+            path: format!("/runs/{}/artifacts/report%2Fsummary", run.id),
+            body: None,
+        })
+        .expect("encoded artifact content");
+
+        assert_eq!(response.endpoint, "runs.artifact.content");
+        assert_eq!(response.body["artifact_id"], artifact.id);
+        assert_eq!(response.body["filename"], "summary.json");
     });
 }
 


### PR DESCRIPTION
## Summary
- Teach the generic artifact origin to serve Homeboy run artifact URLs under `/runs/:run_id/artifacts/:artifact_id` instead of only static artifact-root paths.
- Reuse the daemon artifact resolver for run-scoped artifact ids, percent-encoded ids, remote published artifact refs, and artifact-store locator tokens.
- Add coverage for artifact origin GET/HEAD run artifact routes and run-scoped artifact-store retrieval.

Fixes #4469.

## Scope
This is scoped to generic artifact serving/retrieval infrastructure. It does not change Workflow Bench-specific logic, Studio Web-specific logic, or the #4320 manifest/report link contract.

## Verification
- Reproduced #4469 against the live configured origin: reported `/runs/8eb4588f-be69-4708-8bf2-bbb197938620/artifacts/...` URLs returned HTTP 404.
- Confirmed the corresponding artifact-root file remains reachable: `https://homeboy-artifacts-tunnel.dev.chubes.net/homeboy/workflow-bench/runs/homeboy-lab-studio-web-20260607t015236/artifacts/plain-site-data-machine/studio-web/attempt-1/adapter-evidence.json` returned HTTP 200.
- Ran offloaded full test suite with `homeboy test homeboy --runner homeboy-lab --path ... --skip-lint`: patched code compiled and 4476 tests passed; 12 unrelated existing tests failed in docs coverage, artifact portability audit counts, and run-dir temp handling.
- Targeted follow-up Lab test filters were blocked by runner daemon config: `HOMEBOY_PREVIEW_TUNNEL_TOKEN` secret env ref is missing on `homeboy-lab`. No local Cargo commands were run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the generic artifact serving route mismatch, implemented the artifact-origin route fallback, and drafted tests/PR notes; Chris remains responsible for review and acceptance.