### PR TITLE
fix: normalize runner job PATH on runner host

### DIFF
--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -285,6 +285,7 @@ pub fn runner_exec_failure_error(output: &RunnerExecOutput) -> Option<Error> {
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn exec_via_reverse_broker(
     runner: &Runner,
     broker_url: &str,
@@ -412,6 +413,7 @@ fn exec_via_reverse_broker(
     ))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn exec_via_daemon(
     runner: &Runner,
     local_url: &str,

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -941,8 +941,8 @@ pub(crate) fn prepare_runner_process(
             &request.secret_env_names,
             &env,
         )?);
+        normalize_runner_command_env(&mut env);
     }
-    normalize_runner_command_env(&mut env);
 
     let source_snapshot = request
         .source_snapshot
@@ -1630,6 +1630,91 @@ mod tests {
 
             assert_eq!(plan.runner.id, "lab");
             assert_eq!(plan.cwd, "/srv/homeboy/project");
+        });
+    }
+
+    #[test]
+    fn ssh_runner_prep_leaves_default_path_to_runner_side() {
+        crate::test_support::with_isolated_home(|_| {
+            let plan = prepare_runner_process(RunnerProcessRequest {
+                runner_id: "lab".to_string(),
+                runner: Some(ssh_runner()),
+                cwd: Some("/srv/homeboy/project".to_string()),
+                project_id: None,
+                command: vec!["node".to_string(), "--version".to_string()],
+                env: Default::default(),
+                capture_patch: false,
+                raw_exec: false,
+                source_snapshot: None,
+                require_paths: Vec::new(),
+                validate_require_paths_on_host: false,
+            })
+            .expect("prepare ssh runner process");
+
+            assert!(
+                !plan.env.contains_key("PATH"),
+                "controller must not freeze PATH before daemon-side runner normalization"
+            );
+        });
+    }
+
+    #[test]
+    fn ssh_runner_prep_preserves_explicit_path() {
+        crate::test_support::with_isolated_home(|_| {
+            let mut runner = ssh_runner();
+            runner
+                .env
+                .insert("PATH".to_string(), "$HOME/custom/bin:$PATH".to_string());
+
+            let plan = prepare_runner_process(RunnerProcessRequest {
+                runner_id: "lab".to_string(),
+                runner: Some(runner),
+                cwd: Some("/srv/homeboy/project".to_string()),
+                project_id: None,
+                command: vec!["node".to_string(), "--version".to_string()],
+                env: Default::default(),
+                capture_patch: false,
+                raw_exec: false,
+                source_snapshot: None,
+                require_paths: Vec::new(),
+                validate_require_paths_on_host: false,
+            })
+            .expect("prepare ssh runner process with explicit path");
+
+            assert_eq!(
+                plan.env.get("PATH").map(String::as_str),
+                Some("$HOME/custom/bin:$PATH")
+            );
+        });
+    }
+
+    #[test]
+    fn daemon_local_prep_normalizes_default_path_on_runner_side() {
+        crate::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let workspace = temp.path().join("project");
+            std::fs::create_dir_all(&workspace).expect("workspace");
+            let workspace = workspace.display().to_string();
+
+            let plan = prepare_daemon_local_process(RunnerProcessRequest {
+                runner_id: "lab".to_string(),
+                runner: Some(ssh_runner()),
+                cwd: Some(workspace),
+                project_id: None,
+                command: vec!["node".to_string(), "--version".to_string()],
+                env: Default::default(),
+                capture_patch: false,
+                raw_exec: false,
+                source_snapshot: None,
+                require_paths: Vec::new(),
+                validate_require_paths_on_host: false,
+            })
+            .expect("prepare daemon-local runner process");
+
+            assert!(
+                plan.env.contains_key("PATH"),
+                "daemon-side runner prep should build the default job PATH from the runner host"
+            );
         });
     }
 


### PR DESCRIPTION
## Summary
- Keep SSH runner jobs from freezing a controller-derived default `PATH` before daemon submission.
- Let daemon-side runner prep build the default job `PATH` on the runner host, while preserving explicit runner/request `PATH` values.
- Adds focused coverage for controller-side SSH prep, explicit `PATH` preservation, and daemon-side default `PATH` normalization.

Fixes #4318.

## Verification
- `git diff --check`
- `homeboy runner doctor homeboy-lab --scope lab-offload` reported `node`, `npm`, workspace, artifact store, and lightweight daemon exec readiness.
- `homeboy test --runner homeboy-lab --skip-lint --allow-dirty-lab-workspace -- --lib core::runner::execution::tests::` reached Lab and initially ran the focused test module after correcting my test filter; after a concurrent runner/session state change, reruns were blocked before test execution by configured `secret_env.HOMEBOY_PREVIEW_TUNNEL_TOKEN` being unavailable in the connected daemon environment.

## Notes
- This is intentionally scoped to #4318. Broader Lab lifecycle/status ergonomics are covered separately by #4550.
- The verification blocker is runner/session configuration state, not local Cargo; no Cargo commands were run locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the Lab runner environment handoff path, drafted the minimal code/test change, and ran Homeboy/Lab verification attempts for Chris to review.