### PR TITLE
Fix bench artifact reference contract

### DIFF
--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -22,6 +22,11 @@ results file. Homeboy parses the results, compares declared numeric
 metrics against a saved baseline, and returns a structured report plus
 an exit code suitable for CI gates.
 
+Bench evidence surfaces artifact access explicitly. Entries that can be opened
+directly include `public_url`; bundle-relative or internal artifacts include
+`relative_to` and `fetch_command` so agents can fetch them with
+`homeboy runs artifact get` instead of guessing public URL shapes.
+
 `bench` is a sibling of `test`, `lint`, and `build` under homeboy's
 extension capability model. The runner contract, manifest shape, and
 baseline primitive (`homeboy.json` → `baselines.bench`) are shared with

--- a/src/commands/runs/evidence.rs
+++ b/src/commands/runs/evidence.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-use homeboy::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
+use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore, RunRecord};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -59,6 +59,10 @@ pub struct RunsEvidenceArtifact {
     pub artifact_type: String,
     pub path: String,
     pub url: Option<String>,
+    pub public: bool,
+    pub public_url: Option<String>,
+    pub relative_to: Option<String>,
+    pub fetch_command: Option<String>,
     pub size_bytes: Option<i64>,
     pub sha256: Option<String>,
     pub created_at: String,
@@ -96,7 +100,7 @@ pub struct RunsEvidenceLink {
 pub fn evidence(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
     let run = require_run(&store, run_id)?;
-    let artifacts = store.list_artifacts(run_id)?;
+    let artifacts = runs_service::enrich_artifact_links(store.list_artifacts(run_id)?);
     let artifact_root = homeboy::core::artifacts::root()?;
     let artifact_index = evidence_artifact_index(&artifacts);
     let disk_budget = disk::disk_budget(
@@ -186,6 +190,7 @@ fn evidence_artifact_index(artifacts: &[ArtifactRecord]) -> RunsEvidenceArtifact
     let artifacts = artifacts
         .iter()
         .map(|artifact| {
+            let public_url = artifact_public_url(artifact);
             let exists = artifact_exists(artifact);
             if !exists {
                 missing_count += 1;
@@ -207,6 +212,10 @@ fn evidence_artifact_index(artifacts: &[ArtifactRecord]) -> RunsEvidenceArtifact
                     .url
                     .clone()
                     .or_else(|| (artifact.artifact_type == "url").then(|| artifact.path.clone())),
+                public: public_url.is_some() || artifact.artifact_type == "url",
+                public_url,
+                relative_to: artifact_relative_to(artifact),
+                fetch_command: artifact_fetch_command(artifact),
                 size_bytes: artifact.size_bytes,
                 sha256: artifact.sha256.clone(),
                 created_at: artifact.created_at.clone(),
@@ -225,6 +234,43 @@ fn evidence_artifact_index(artifacts: &[ArtifactRecord]) -> RunsEvidenceArtifact
         total_size_bytes,
         artifacts,
     }
+}
+
+fn artifact_public_url(artifact: &ArtifactRecord) -> Option<String> {
+    if artifact.artifact_type == "url" {
+        return artifact.url.clone().or_else(|| Some(artifact.path.clone()));
+    }
+    artifact.public_url.clone().or_else(|| {
+        artifact
+            .metadata_json
+            .get("public_url")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    })
+}
+
+fn artifact_relative_to(artifact: &ArtifactRecord) -> Option<String> {
+    if artifact.artifact_type == "url" || artifact_public_url(artifact).is_some() {
+        return None;
+    }
+    if artifact.artifact_type == "file" || artifact.artifact_type == "remote_file" {
+        return Some("homeboy observation artifact store".to_string());
+    }
+    artifact
+        .metadata_json
+        .get("source")
+        .and_then(Value::as_str)
+        .map(|source| format!("{source} metadata"))
+}
+
+fn artifact_fetch_command(artifact: &ArtifactRecord) -> Option<String> {
+    if artifact.artifact_type == "file" || artifact.artifact_type == "remote_file" {
+        return Some(format!(
+            "homeboy runs artifact get {} {} -o <path>",
+            artifact.run_id, artifact.id
+        ));
+    }
+    None
 }
 
 fn artifact_exists(artifact: &ArtifactRecord) -> bool {
@@ -302,31 +348,18 @@ fn evidence_links(artifacts: &[ArtifactRecord]) -> Vec<RunsEvidenceLink> {
     artifacts
         .iter()
         .filter_map(|artifact| {
-            if artifact.artifact_type == "url" {
-                return Some(RunsEvidenceLink {
-                    kind: artifact.kind.clone(),
-                    target: artifact
-                        .url
-                        .clone()
-                        .unwrap_or_else(|| artifact.path.clone()),
-                    label: artifact.kind.clone(),
-                });
-            }
-            if artifact.path.is_empty() {
-                None
-            } else {
-                Some(RunsEvidenceLink {
-                    kind: artifact.kind.clone(),
-                    target: artifact.path.clone(),
-                    label: artifact.kind.clone(),
-                })
-            }
+            artifact_public_url(artifact).map(|target| RunsEvidenceLink {
+                kind: artifact.kind.clone(),
+                target,
+                label: artifact.kind.clone(),
+            })
         })
         .collect()
 }
 
 #[cfg(test)]
 mod tests {
+    use homeboy::core::artifact_links::PUBLIC_ARTIFACT_BASE_URL_ENV;
     use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
     use homeboy::test_support::with_isolated_home;
     use serde_json::Value;
@@ -334,6 +367,28 @@ mod tests {
     use super::*;
 
     struct XdgGuard(Option<String>);
+
+    struct EnvGuard {
+        key: &'static str,
+        prior: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn unset(key: &'static str) -> Self {
+            let prior = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     impl XdgGuard {
         fn unset() -> Self {
@@ -368,6 +423,7 @@ mod tests {
     fn evidence_command_reports_registry_artifacts_retention_and_failure_summary() {
         with_isolated_home(|home| {
             let _xdg = XdgGuard::unset();
+            let _public_artifact_base = EnvGuard::unset(PUBLIC_ARTIFACT_BASE_URL_ENV);
             let artifact_root = home.path().join("agent-readable-artifacts");
             homeboy::core::set_artifact_root_override(Some(artifact_root.clone()));
             let store = ObservationStore::open_initialized().expect("store");
@@ -410,6 +466,41 @@ mod tests {
             assert_eq!(output.artifact_index.file_count, 1);
             assert_eq!(output.artifact_index.url_count, 1);
             assert_eq!(output.artifact_index.missing_count, 0);
+            let bench_results = output
+                .artifact_index
+                .artifacts
+                .iter()
+                .find(|artifact| artifact.kind == "bench_results")
+                .expect("bench results artifact");
+            assert!(!bench_results.public);
+            assert_eq!(
+                bench_results.relative_to.as_deref(),
+                Some("homeboy observation artifact store")
+            );
+            let expected_fetch_command = format!(
+                "homeboy runs artifact get {} {} -o <path>",
+                run.id, bench_results.id
+            );
+            assert_eq!(
+                bench_results.fetch_command.as_deref(),
+                Some(expected_fetch_command.as_str())
+            );
+            let review = output
+                .artifact_index
+                .artifacts
+                .iter()
+                .find(|artifact| artifact.kind == "review")
+                .expect("review artifact");
+            assert!(review.public);
+            assert_eq!(
+                review.public_url.as_deref(),
+                Some("https://example.test/evidence")
+            );
+            assert_eq!(output.evidence_links.len(), 1);
+            assert_eq!(
+                output.evidence_links[0].target,
+                "https://example.test/evidence"
+            );
             assert_eq!(output.retention.default_retention_days, 30);
             assert!(output
                 .retention
@@ -423,7 +514,6 @@ mod tests {
             assert_eq!(output.failure.exit_code, Some(1));
             assert_eq!(output.failure.gate_failures, vec!["p95_ms exceeded"]);
             assert_eq!(output.failure.hints, vec!["inspect artifacts"]);
-            assert!(!output.evidence_links.is_empty());
             assert!(
                 output.disk_budget.available_bytes.is_some()
                     || output.disk_budget.warning.is_some()

--- a/src/core/publication_artifacts.rs
+++ b/src/core/publication_artifacts.rs
@@ -84,6 +84,7 @@ struct ManifestArtifactRef<'a> {
     reference: &'a Value,
     locator: String,
     locator_type: &'static str,
+    public_url: Option<String>,
 }
 
 fn index_manifest_refs(
@@ -169,6 +170,7 @@ fn index_manifest_refs(
                 "type": reference.locator_type,
                 "value": locator,
             },
+            "public_url": reference.public_url.clone(),
             "media_type": media_type,
             "bytes": size_bytes,
             "sha256": sha256,
@@ -212,12 +214,18 @@ fn collect_publication_artifact_refs<'a>(
                     reference: value,
                     locator: locator.to_string(),
                     locator_type: "artifact-store",
+                    public_url: None,
                 });
             } else if let Some(locator) = url_locator_artifact_store_locator(value, url_bases) {
                 refs.push(ManifestArtifactRef {
                     reference: value,
                     locator,
                     locator_type: "url",
+                    public_url: value
+                        .get("locator")
+                        .and_then(|locator| locator.get("value"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
                 });
             }
             for child in object.values() {

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -721,7 +721,7 @@ fn publication_manifest_public_url_refs_are_indexed_from_artifact_origin() {
                 "schema": "example/publication-manifest/v1",
                 "id": "publish-run-1",
                 "publication": {
-                    "public_base_url": "https://homeboy-artifacts-tunnel.dev.chubes.net",
+                    "public_base_url": "https://artifacts.example.test",
                     "artifact_base": "homeboy/workflow-bench"
                 },
                 "artifacts": [{
@@ -731,7 +731,7 @@ fn publication_manifest_public_url_refs_are_indexed_from_artifact_origin() {
                     "role": "output",
                     "locator": {
                         "type": "url",
-                        "value": "https://homeboy-artifacts-tunnel.dev.chubes.net/homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/blueprint.after.json"
+                        "value": "https://artifacts.example.test/homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/blueprint.after.json"
                     },
                     "media_type": "application/json",
                     "bytes": 12,
@@ -758,6 +758,10 @@ fn publication_manifest_public_url_refs_are_indexed_from_artifact_origin() {
         assert_eq!(
             nested.metadata_json["locator"]["value"].as_str(),
             Some(locator)
+        );
+        assert_eq!(
+            nested.metadata_json["public_url"].as_str(),
+            Some("https://artifacts.example.test/homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/blueprint.after.json")
         );
     });
 }


### PR DESCRIPTION
## Summary
- Adds explicit public/non-public access fields to `homeboy runs evidence` artifact entries so private files are not presented as public links.
- Limits `evidence_links` to directly openable public URLs and points non-public artifacts at `homeboy runs artifact get` via `fetch_command`.
- Preserves original public URLs from publication manifest URL locators while indexing them as artifact-store-relative references.

## Coordination
- Fixes #4320.
- Does not implement artifact serving or retrieval routes; #4469 owns `/runs/<id>/artifacts/<id>` serving/retrieval behavior.
- Checked the #4469 worktree before opening this PR; it was not editing these files.

## Verification
- `git diff --check` passed.
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@fix-4320-artifact-public-links --runner homeboy-lab --skip-lint --json-summary` ran on the Lab runner before the final test-only corrections. It reported 4408 passed, 10 failed, 18 skipped. The #4320-related failures were the evidence env assumption and publication manifest first-class `public_url` assertion; both were corrected in this PR.
- Final targeted Lab verification was blocked by runner infrastructure: managed Lab exec failed resolving `HOMEBOY_PREVIEW_TUNNEL_TOKEN` from `secret_env`. I did not run Cargo locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the artifact manifest/report contract, drafted the scoped fix and tests, and prepared this PR. Chris remains responsible for review and validation.