### PR TITLE
Add raw runner exec output

### DIFF
--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -5,7 +5,7 @@ use crate::command_contract::CommandJsonFamily;
 
 use super::agent_task_summary::{agent_task_summary_kind, render_agent_task_summary};
 use super::output_runtime::JsonCommandRun;
-use super::GlobalArgs;
+use super::{runner, GlobalArgs};
 
 mod ops;
 mod quality;
@@ -36,8 +36,10 @@ pub fn run_command_output(command: Commands, global: &GlobalArgs) -> JsonCommand
                 exit_code,
                 output_file_result: None,
                 human_stdout,
+                human_stderr: None,
             }
         }
+        Commands::Runner(args) => runner::run_command_output(args, global),
         command => {
             let (stdout_result, exit_code) = dispatch(command, global);
             JsonCommandRun::from_stdout_result(stdout_result, exit_code)

--- a/src/commands/output_runtime.rs
+++ b/src/commands/output_runtime.rs
@@ -11,6 +11,7 @@ pub struct JsonCommandRun {
     pub exit_code: i32,
     pub output_file_result: Option<homeboy::core::Result<Value>>,
     pub human_stdout: Option<String>,
+    pub human_stderr: Option<String>,
 }
 
 impl JsonCommandRun {
@@ -20,6 +21,7 @@ impl JsonCommandRun {
             exit_code,
             output_file_result: None,
             human_stdout: None,
+            human_stderr: None,
         }
     }
 
@@ -42,6 +44,7 @@ impl JsonCommandRun {
                 exit_code,
                 output_file_result: None,
                 human_stdout: None,
+                human_stderr: None,
             },
             raw_stdout,
         )
@@ -65,6 +68,9 @@ impl<'a> OutputService<'a> {
 
     pub fn emit_run(&self, run: JsonCommandRun, mode: CommandOutputFileMode) -> i32 {
         self.write_output_file(&run, mode);
+        if let Some(human_stderr) = run.human_stderr {
+            eprint!("{}", human_stderr);
+        }
         if let Some(human_stdout) = run.human_stdout {
             print!("{}", human_stdout);
         } else {
@@ -178,6 +184,7 @@ pub fn run_json(
                 exit_code,
                 output_file_result,
                 human_stdout: None,
+                human_stderr: None,
             }
         }
         (_, command) => super::json_output::run_command_output(command, global),
@@ -233,6 +240,7 @@ mod tests {
             exit_code: 0,
             output_file_result,
             human_stdout: None,
+            human_stderr: None,
         }
     }
 

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -15,6 +15,7 @@ use homeboy::core::runners::{
 use homeboy::core::server::{RunnerPolicy, RunnerSecretEnvRef, RunnerSettings};
 use homeboy::core::{EntityCrudOutput, MergeOutput};
 
+use super::output_runtime::JsonCommandRun;
 use super::{CmdResult, DynamicSetArgs};
 
 pub mod doctor;
@@ -319,6 +320,11 @@ enum RunnerCommand {
         #[arg(long = "require-path")]
         require_paths: Vec<String>,
 
+        /// Print remote stdout/stderr directly instead of the structured JSON envelope.
+        /// Use global --output to still write the full structured envelope to a file.
+        #[arg(long)]
+        raw: bool,
+
         /// Command and arguments to execute on the runner
         #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
         command: Vec<String>,
@@ -562,6 +568,7 @@ pub fn run(
             ssh,
             capture_patch,
             require_paths,
+            raw: _,
             command,
         } => map_execution(exec(
             &id,
@@ -597,6 +604,77 @@ pub fn run(
         })),
         RunnerCommand::Workspace { command } => workspace::run(command)
             .map(|(output, exit_code)| (RunnerCommandOutput::Workspace(output), exit_code)),
+    }
+}
+
+pub fn run_command_output(args: RunnerArgs, _global: &super::GlobalArgs) -> JsonCommandRun {
+    crate::commands::utils::tty::status("homeboy is working...");
+
+    match args.command {
+        RunnerCommand::Exec {
+            id,
+            cwd,
+            project,
+            ssh,
+            capture_patch,
+            require_paths,
+            raw: true,
+            command,
+        } => run_raw_exec(id, cwd, project, ssh, capture_patch, require_paths, command),
+        command => {
+            let (stdout_result, exit_code) =
+                crate::commands::utils::response::map_cmd_result_to_json(run(
+                    RunnerArgs { command },
+                    _global,
+                ));
+            JsonCommandRun::from_stdout_result(stdout_result, exit_code)
+        }
+    }
+}
+
+fn run_raw_exec(
+    id: String,
+    cwd: Option<String>,
+    project: Option<String>,
+    ssh: bool,
+    capture_patch: bool,
+    require_paths: Vec<String>,
+    command: Vec<String>,
+) -> JsonCommandRun {
+    match exec(
+        &id,
+        cwd,
+        project,
+        ssh,
+        capture_patch,
+        require_paths,
+        command,
+    ) {
+        Ok((output, exit_code)) => raw_exec_command_run(output, exit_code),
+        Err(err) => {
+            let (stdout_result, exit_code) =
+                crate::commands::utils::response::map_cmd_result_to_json::<RunnerCommandOutput>(
+                    Err(err),
+                );
+            JsonCommandRun::from_stdout_result(stdout_result, exit_code)
+        }
+    }
+}
+
+fn raw_exec_command_run(output: RunnerExecOutput, exit_code: i32) -> JsonCommandRun {
+    let human_stdout = output.stdout.clone();
+    let human_stderr = output.stderr.clone();
+    let (stdout_result, _) = crate::commands::utils::response::map_cmd_result_to_json(Ok((
+        RunnerCommandOutput::Execution(output),
+        exit_code,
+    )));
+
+    JsonCommandRun {
+        stdout_result,
+        exit_code,
+        output_file_result: None,
+        human_stdout: Some(human_stdout),
+        human_stderr: Some(human_stderr),
     }
 }
 
@@ -1186,6 +1264,42 @@ mod tests {
             "https://artifacts.example.test"
         );
         assert!(!value.to_string().contains("secret-token"));
+    }
+
+    #[test]
+    fn raw_exec_command_run_keeps_structured_output_and_human_streams() {
+        let run = raw_exec_command_run(
+            RunnerExecOutput {
+                command: "runner.exec",
+                runner_id: "lab".to_string(),
+                mode: runner::RunnerExecMode::Daemon,
+                argv: vec!["printf".to_string(), "hello".to_string()],
+                remote_cwd: "/workspace".to_string(),
+                exit_code: 7,
+                stdout: "hello\n".to_string(),
+                stderr: "warn\n".to_string(),
+                source_snapshot: None,
+                job: None,
+                job_id: Some("job-123".to_string()),
+                job_events: None,
+                mirror_run_id: None,
+                patch: None,
+                metrics: None,
+                capture: None,
+                diagnostics: None,
+            },
+            7,
+        );
+
+        assert_eq!(run.exit_code, 7);
+        assert_eq!(run.human_stdout.as_deref(), Some("hello\n"));
+        assert_eq!(run.human_stderr.as_deref(), Some("warn\n"));
+
+        let value = run.stdout_result.expect("structured output");
+        assert_eq!(value["command"], "runner.exec");
+        assert_eq!(value["stdout"], "hello\n");
+        assert_eq!(value["stderr"], "warn\n");
+        assert_eq!(value["job_id"], "job-123");
     }
 
     #[test]

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -132,6 +132,23 @@ fn runner_job_logs_command_parses() {
 }
 
 #[test]
+fn runner_exec_raw_command_parses_before_trailing_command() {
+    Cli::try_parse_from([
+        "homeboy",
+        "runner",
+        "exec",
+        "homeboy-lab",
+        "--raw",
+        "--cwd",
+        "/home/chubes/Developer",
+        "python3",
+        "-c",
+        "print('hello')",
+    ])
+    .expect("runner exec --raw should parse before the trailing remote command");
+}
+
+#[test]
 fn agent_task_auth_status_accepts_global_runner_and_secret_env() {
     Cli::try_parse_from([
         "homeboy",


### PR DESCRIPTION
## Summary
- Add `homeboy runner exec --raw` to print remote stdout/stderr directly for diagnostic probes.
- Preserve the existing structured `runner.exec` payload for normal JSON stdout and global `--output <path>` artifacts.
- Extend the human-output path to support stderr without changing runner-core execution contracts.

Fixes #4546.

## Verification
- `homeboy test homeboy --path . --runner homeboy-lab --skip-lint -- runner_exec_raw_command_parses_before_trailing_command` passed on `homeboy-lab` before the final adapter unit test was added.
- A later filtered rerun, `homeboy test homeboy --path . --runner homeboy-lab --skip-lint -- raw_exec`, was blocked before Cargo by the connected Lab runner daemon failing to read `HOMEBOY_PREVIEW_TUNNEL_TOKEN` from secret env. I did not run local Cargo.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and implemented the focused CLI output-mode change, added tests, and ran allowed Homeboy/Lab verification; Chris remains responsible for review and merge.