### PR TITLE
fix: format Lab follow-up assertion

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -671,6 +671,8 @@ Installing declared dependencies...
         assert!(commands.contains(&"homeboy runs list --limit 5"));
         assert!(commands.contains(&"homeboy runs latest-run --kind bench"));
         assert!(commands.contains(&"homeboy runs artifacts <run-id>"));
-        assert!(!commands.iter().any(|command| command.starts_with("homeboy runner ")));
+        assert!(!commands
+            .iter()
+            .any(|command| command.starts_with("homeboy runner ")));
     }
 }


### PR DESCRIPTION
## Summary
- Apply the rustfmt diff reported by CI after #4550 merged.
- Keeps the fix scoped to the Lab status follow-up assertion formatting only.

## Verification
- `git diff --check`
- CI from #4550 reported the exact rustfmt diff in `src/commands/lab.rs`; this PR applies that diff.
- I did not run Cargo locally per project constraints. Lab runner verification remains blocked by the connected runner daemon missing `HOMEBOY_PREVIEW_TUNNEL_TOKEN`.

## Related
- Follow-up for #4550 / #4319.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Applied the CI-reported rustfmt-only follow-up after the #4319 Lab status PR merged. Chris remains responsible for review and merge.