### PR TITLE
Resolve runner secrets and force SSH exec

### DIFF
--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -82,6 +82,8 @@ pub struct RunnerSecretEnvReferenceOutput {
     pub env: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret: Option<String>,
     pub values_redacted: bool,
 }
 
@@ -1197,6 +1199,7 @@ fn secret_env_reference_output(reference: RunnerSecretEnvRef) -> RunnerSecretEnv
     RunnerSecretEnvReferenceOutput {
         env: reference.env,
         file: reference.file,
+        secret: reference.secret,
         values_redacted: true,
     }
 }
@@ -1366,6 +1369,7 @@ mod tests {
                 RunnerSecretEnvReferenceOutput {
                     env: Some("OPENAI_API_KEY".to_string()),
                     file: None,
+                    secret: None,
                     values_redacted: true,
                 },
             )]),
@@ -1387,6 +1391,42 @@ mod tests {
         );
         assert_eq!(
             value["secret_env"]["OPENAI_API_KEY"]["values_redacted"],
+            true
+        );
+        assert!(!value.to_string().contains("dummy-secret"));
+    }
+
+    #[test]
+    fn runner_env_output_reports_secret_store_refs_without_values() {
+        let output = RunnerEnvOutput {
+            command: "runner.env".to_string(),
+            runner_id: "lab".to_string(),
+            source: "runner_job_env".to_string(),
+            values_redacted: false,
+            env: BTreeMap::new(),
+            secret_env: BTreeMap::from([(
+                "HOMEBOY_PREVIEW_TUNNEL_TOKEN".to_string(),
+                RunnerSecretEnvReferenceOutput {
+                    env: None,
+                    file: None,
+                    secret: Some("HOMEBOY_PREVIEW_TUNNEL_TOKEN".to_string()),
+                    values_redacted: true,
+                },
+            )]),
+            diagnostics: RunnerEnvDiagnostics {
+                server_shell_env: "shell".to_string(),
+                runner_job_env: "runner".to_string(),
+            },
+        };
+
+        let value = serde_json::to_value(output).expect("serialize output");
+
+        assert_eq!(
+            value["secret_env"]["HOMEBOY_PREVIEW_TUNNEL_TOKEN"]["secret"],
+            "HOMEBOY_PREVIEW_TUNNEL_TOKEN"
+        );
+        assert_eq!(
+            value["secret_env"]["HOMEBOY_PREVIEW_TUNNEL_TOKEN"]["values_redacted"],
             true
         );
         assert!(!value.to_string().contains("dummy-secret"));

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -573,6 +573,7 @@ mod tests {
                         RunnerSecretEnvRef {
                             env: Some("OPENAI_API_KEY".to_string()),
                             file: None,
+                            secret: None,
                         },
                     )]),
                     ..Default::default()

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -163,13 +163,28 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
     })?;
     let runner = plan.runner.clone();
     let cwd = plan.cwd.clone();
-    let connected = status(runner_id)?;
     let request_env = plan.env.clone();
     let required_extensions =
         required_extensions_for_command(&options.command, &options.required_extensions);
 
     validate_runner_extension_parity(runner_id, &runner, &cwd, &required_extensions)?;
 
+    if should_force_diagnostic_ssh(&runner, &options) {
+        preflight_runner_capability_plan(
+            &runner,
+            options.capability_preflight.as_ref(),
+            &request_env,
+        )?;
+        return exec_diagnostic_ssh(
+            &runner,
+            cwd,
+            options.command,
+            request_env,
+            options.require_paths,
+        );
+    }
+
+    let connected = status(runner_id)?;
     if connected.connected {
         if let Some(session) = connected.session {
             preflight_runner_capability_plan(
@@ -212,14 +227,6 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
 
     match runner.kind {
         RunnerKind::Local => exec_local(plan),
-        RunnerKind::Ssh if options.allow_diagnostic_ssh => {
-            preflight_runner_capability_plan(
-                &runner,
-                options.capability_preflight.as_ref(),
-                &request_env,
-            )?;
-            exec_diagnostic_ssh(&runner, cwd, options.command, request_env, options.require_paths)
-        }
         RunnerKind::Ssh => Err(Error::validation_invalid_argument(
             "runner",
             "runner is not connected to a daemon; run `homeboy runner connect <runner-id>` or pass `--ssh` for explicit SSH diagnostics",
@@ -230,6 +237,10 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
             ]),
         )),
     }
+}
+
+fn should_force_diagnostic_ssh(runner: &Runner, options: &RunnerExecOptions) -> bool {
+    runner.kind == RunnerKind::Ssh && options.allow_diagnostic_ssh
 }
 
 pub fn runner_exec_failure_error(output: &RunnerExecOutput) -> Option<Error> {
@@ -1737,6 +1748,7 @@ mod tests {
                 RunnerSecretEnvRef {
                     env: None,
                     file: Some(missing_controller_file.display().to_string()),
+                    secret: None,
                 },
             );
 
@@ -1769,6 +1781,7 @@ mod tests {
                 RunnerSecretEnvRef {
                     env: None,
                     file: Some(secret_file.display().to_string()),
+                    secret: None,
                 },
             );
 
@@ -2169,6 +2182,27 @@ mod tests {
             serde_json::to_value(RunnerExecMode::DiagnosticSsh).expect("mode json"),
             json!("diagnostic_ssh")
         );
+    }
+
+    #[test]
+    fn explicit_diagnostic_ssh_wins_for_ssh_runners() {
+        let mut options = RunnerExecOptions {
+            cwd: Some("/srv/homeboy/project".to_string()),
+            project_id: None,
+            allow_diagnostic_ssh: true,
+            command: vec!["homeboy".to_string(), "--version".to_string()],
+            env: Default::default(),
+            capture_patch: false,
+            raw_exec: true,
+            source_snapshot: None,
+            capability_preflight: None,
+            required_extensions: Vec::new(),
+            require_paths: Vec::new(),
+        };
+
+        assert!(should_force_diagnostic_ssh(&ssh_runner(), &options));
+        options.allow_diagnostic_ssh = false;
+        assert!(!should_force_diagnostic_ssh(&ssh_runner(), &options));
     }
 
     #[test]

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -1656,6 +1656,7 @@ mod tests {
                 project_id: None,
                 command: vec!["node".to_string(), "--version".to_string()],
                 env: Default::default(),
+                secret_env_names: Vec::new(),
                 capture_patch: false,
                 raw_exec: false,
                 source_snapshot: None,
@@ -1686,6 +1687,7 @@ mod tests {
                 project_id: None,
                 command: vec!["node".to_string(), "--version".to_string()],
                 env: Default::default(),
+                secret_env_names: Vec::new(),
                 capture_patch: false,
                 raw_exec: false,
                 source_snapshot: None,
@@ -1716,6 +1718,7 @@ mod tests {
                 project_id: None,
                 command: vec!["node".to_string(), "--version".to_string()],
                 env: Default::default(),
+                secret_env_names: Vec::new(),
                 capture_patch: false,
                 raw_exec: false,
                 source_snapshot: None,
@@ -1833,6 +1836,7 @@ mod tests {
                 RunnerSecretEnvRef {
                     env: Some("HOMEBOY_PREVIEW_TUNNEL_TOKEN".to_string()),
                     file: None,
+                    secret: None,
                 },
             );
             std::env::remove_var("HOMEBOY_PREVIEW_TUNNEL_TOKEN");
@@ -1880,6 +1884,7 @@ mod tests {
                 RunnerSecretEnvRef {
                     env: Some("HOMEBOY_REQUIRED_SECRET_TEST_KEY".to_string()),
                     file: None,
+                    secret: None,
                 },
             );
 
@@ -2192,6 +2197,7 @@ mod tests {
             allow_diagnostic_ssh: true,
             command: vec!["homeboy".to_string(), "--version".to_string()],
             env: Default::default(),
+            secret_env_names: Vec::new(),
             capture_patch: false,
             raw_exec: true,
             source_snapshot: None,
@@ -2570,6 +2576,7 @@ mod tests {
                 Some("extrachill".to_string()),
                 vec!["homeboy".to_string(), "test".to_string()],
                 Default::default(),
+                Vec::new(),
                 false,
                 None,
                 Vec::new(),
@@ -2621,6 +2628,7 @@ mod tests {
             None,
             vec!["homeboy".to_string(), "--version".to_string()],
             Default::default(),
+            Vec::new(),
             false,
             None,
             Vec::new(),

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -1464,7 +1464,7 @@ mod tests {
         assert!(err.message.contains("still in flight"));
         assert!(err.hints.iter().any(|hint| hint
             .message
-            .contains("homeboy runs list --runner homeboy-lab")));
+            .contains("homeboy runner exec homeboy-lab -- homeboy runs list --status running")));
         assert!(err
             .hints
             .iter()

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::core::agent_task_secrets;
 use crate::core::config::{self, ConfigEntity};
 use crate::core::defaults;
 use crate::core::error::{Error, Result};
@@ -446,8 +447,12 @@ pub(crate) fn resolve_runner_secret_env(
             .file
             .as_ref()
             .is_some_and(|value| !value.trim().is_empty());
-        match (has_env, has_file) {
-            (true, false) => {
+        let has_secret = source
+            .secret
+            .as_ref()
+            .is_some_and(|value| !value.trim().is_empty());
+        match (has_env, has_file, has_secret) {
+            (true, false, false) => {
                 let env_name = source.env.as_deref().unwrap_or_default();
                 let value = std::env::var(env_name).map_err(|err| {
                     Error::validation_invalid_argument(
@@ -462,7 +467,7 @@ pub(crate) fn resolve_runner_secret_env(
                 })?;
                 resolved.insert(name.clone(), value);
             }
-            (false, true) => {
+            (false, true, false) => {
                 let raw_path = source.file.as_deref().unwrap_or_default();
                 let path = shellexpand::tilde(raw_path).to_string();
                 let value = std::fs::read_to_string(&path).map_err(|err| {
@@ -476,18 +481,51 @@ pub(crate) fn resolve_runner_secret_env(
                     value.trim_end_matches(['\r', '\n']).to_string(),
                 );
             }
-            (false, false) => {
+            (false, false, true) => {
+                let secret_name = source.secret.as_deref().unwrap_or_default();
+                let values = agent_task_secrets::resolve_secret_env(&[secret_name.to_string()])
+                    .map_err(|err| {
+                        Error::validation_invalid_argument(
+                            "secret_env",
+                            format!(
+                                "failed to resolve Homeboy secret ref for {name}: {}",
+                                err.message
+                            ),
+                            Some(secret_name.to_string()),
+                            Some(vec![
+                                "Configure the named Homeboy secret before running this runner job."
+                                    .to_string(),
+                            ]),
+                        )
+                    })?;
+                let value = values
+                    .into_iter()
+                    .next()
+                    .map(|(_, value)| value)
+                    .ok_or_else(|| {
+                        Error::validation_invalid_argument(
+                            "secret_env",
+                            format!("Homeboy secret ref for {name} resolved no value"),
+                            Some(secret_name.to_string()),
+                            None,
+                        )
+                    })?;
+                resolved.insert(name.clone(), value);
+            }
+            (false, false, false) => {
                 return Err(Error::validation_invalid_argument(
                     "secret_env",
-                    format!("secret env ref for {name} requires env or file"),
+                    format!("secret env ref for {name} requires env, file, or secret"),
                     Some(name.clone()),
                     None,
                 ));
             }
-            (true, true) => {
+            _ => {
                 return Err(Error::validation_invalid_argument(
                     "secret_env",
-                    format!("secret env ref for {name} must use env or file, not both"),
+                    format!(
+                        "secret env ref for {name} must use exactly one of env, file, or secret"
+                    ),
                     Some(name.clone()),
                     None,
                 ));
@@ -771,6 +809,7 @@ mod tests {
                 server::RunnerSecretEnvRef {
                     env: Some("HOMEBOY_DUMMY_SECRET_REF".to_string()),
                     file: None,
+                    secret: None,
                 },
             ),
             (
@@ -778,6 +817,7 @@ mod tests {
                 server::RunnerSecretEnvRef {
                     env: None,
                     file: Some(secret_file.display().to_string()),
+                    secret: None,
                 },
             ),
         ]))
@@ -792,6 +832,48 @@ mod tests {
             Some("dummy-file-secret")
         );
         std::env::remove_var("HOMEBOY_DUMMY_SECRET_REF");
+    }
+
+    #[test]
+    fn runner_secret_env_refs_resolve_from_configured_homeboy_secret() {
+        crate::test_support::with_isolated_home(|_| {
+            crate::core::agent_task_secrets::set_config_secret(
+                "HOMEBOY_DUMMY_CONFIGURED_SECRET",
+                "dummy-configured-secret",
+            )
+            .expect("configure secret");
+
+            let resolved = resolve_runner_secret_env(&HashMap::from([(
+                "FROM_SECRET".to_string(),
+                server::RunnerSecretEnvRef {
+                    env: None,
+                    file: None,
+                    secret: Some("HOMEBOY_DUMMY_CONFIGURED_SECRET".to_string()),
+                },
+            )]))
+            .expect("resolve configured secret ref");
+
+            assert_eq!(
+                resolved.get("FROM_SECRET").map(String::as_str),
+                Some("dummy-configured-secret")
+            );
+        });
+    }
+
+    #[test]
+    fn runner_secret_env_refs_reject_multiple_sources() {
+        let err = resolve_runner_secret_env(&HashMap::from([(
+            "INVALID".to_string(),
+            server::RunnerSecretEnvRef {
+                env: Some("HOMEBOY_DUMMY_SECRET_REF".to_string()),
+                file: None,
+                secret: Some("HOMEBOY_DUMMY_CONFIGURED_SECRET".to_string()),
+            },
+        )]))
+        .expect_err("multiple sources rejected");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("exactly one"));
     }
 
     #[test]

--- a/src/core/server/mod.rs
+++ b/src/core/server/mod.rs
@@ -75,6 +75,8 @@ pub struct RunnerSecretEnvRef {
     pub env: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -761,6 +761,7 @@ fn runner_exec_rejects_requests_that_violate_runner_policy_before_daemon_dispatc
                 "printf denied".to_string(),
             ],
             env: Default::default(),
+            secret_env_names: Vec::new(),
             capture_patch: false,
             raw_exec: true,
             source_snapshot: None,

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -307,6 +307,7 @@ fn runs_list_includes_active_runner_jobs() {
                 ],
                 cwd: Some("/workspace/homeboy".to_string()),
                 env: Default::default(),
+                secret_env_names: Vec::new(),
                 capture_patch: false,
                 source_snapshot: None,
                 require_paths: Vec::new(),


### PR DESCRIPTION
## Summary
- Fixes #4552 by keeping browser evidence report formatting clean and re-exporting the adapter helper needed by its integration test.
- Fixes #4553 by allowing runner `secret_env` refs to resolve configured Homeboy secrets via `{ \"secret\": \"NAME\" }`, while keeping `runner env` output redacted.
- Fixes #4554 by making explicit `runner exec --ssh` choose diagnostic SSH before connected daemon/reverse-daemon execution.
- Updates stale runner/Lab test fixtures for current `secret_env_names` plumbing and current Lab handoff hint wording.

## Verification
Pre-final-rebase local checks run before the latest main `secret_env_names` overlap was reconciled:
- `cargo fmt --check`
- `cargo test runner_secret_env_refs --lib`
- `cargo test explicit_diagnostic_ssh_wins_for_ssh_runners --lib`
- `cargo test runner_env_output_reports_secret_store_refs_without_values --lib`
- `cargo test core::runner::lab::offload::tests::in_flight_daemon_disconnect_error_surfaces_inspection_commands --lib`
- `cargo test --test report_browser_evidence_compare_test`

Post-final-rebase local check run without cargo per follow-up instruction:
- `git diff --check`

Follow-up issues filed for unrelated surfaced failures:
- #4579
- #4580
- #4581
- #4582

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the runner secret/SSH behavior, drafting the implementation and tests, filing follow-up issues, and preparing this PR. Chris remains responsible for review and merge.