### PR TITLE
Support runner-owned preview tunnel orchestration

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -168,6 +168,14 @@ impl Commands {
                     LAB_NO_EXTRA_TOOLS,
                 )
             }
+            Commands::Tunnel(args) if args.is_service_start() => {
+                LabCommandContract::explicit_runner(
+                    "tunnel service start",
+                    None,
+                    false,
+                    LAB_NO_EXTRA_TOOLS,
+                )
+            }
             _ => return None,
         };
 

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -795,6 +795,53 @@ mod tests {
     }
 
     #[test]
+    fn tunnel_service_start_supports_explicit_runner_discovery() {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "--runner",
+            "homeboy-lab",
+            "tunnel",
+            "service",
+            "start",
+            "preview",
+            "--command",
+            "npm run dev",
+        ]);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+        assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+        assert_eq!(command.hot_label, "tunnel service start");
+        assert!(command.portable);
+        assert!(!command.default_lab_offload);
+        assert!(!command.requires_extension_parity);
+        assert!(command.required_extensions.is_empty());
+        assert!(!command.infer_source_path_tools);
+    }
+
+    #[test]
+    fn tunnel_preview_consumer_run_keeps_explicit_runner_contract() {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "--runner",
+            "homeboy-lab",
+            "tunnel",
+            "preview-consumer",
+            "run",
+            "--config",
+            "consumer.json",
+            "--preview-public-url",
+            "https://preview.example.test/run",
+        ]);
+
+        let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+        assert_eq!(command.hot_label, "tunnel preview-consumer run");
+        assert!(command.portable);
+        assert!(!command.default_lab_offload);
+    }
+
+    #[test]
     fn lab_command_with_mutation_flag_stays_portable_for_patch_capture() {
         let cli = Cli::parse_from(["homeboy", "audit", "--baseline"]);
 

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -138,6 +138,15 @@ impl TunnelArgs {
             }
         )
     }
+
+    pub(crate) fn is_service_start(&self) -> bool {
+        matches!(
+            self.command,
+            TunnelCommand::Service {
+                command: TunnelServiceCommand::Start { .. }
+            }
+        )
+    }
 }
 
 #[derive(Subcommand)]

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -1091,6 +1091,7 @@ fn runner_exec_secret_env_names(
     }
     names.extend(super::lab::secrets::declared_agent_task_secret_env(command));
     names.extend(super::lab::secrets::declared_trace_secret_env(command));
+    names.extend(super::lab::secrets::declared_tunnel_secret_env(command));
     names.sort();
     names.dedup();
     names
@@ -1645,6 +1646,7 @@ mod tests {
                 project_id: None,
                 command: vec!["node".to_string(), "--version".to_string()],
                 env: Default::default(),
+                secret_env_names: Vec::new(),
                 capture_patch: false,
                 raw_exec: false,
                 source_snapshot: None,
@@ -1675,6 +1677,7 @@ mod tests {
                 project_id: None,
                 command: vec!["node".to_string(), "--version".to_string()],
                 env: Default::default(),
+                secret_env_names: Vec::new(),
                 capture_patch: false,
                 raw_exec: false,
                 source_snapshot: None,
@@ -1705,6 +1708,7 @@ mod tests {
                 project_id: None,
                 command: vec!["node".to_string(), "--version".to_string()],
                 env: Default::default(),
+                secret_env_names: Vec::new(),
                 capture_patch: false,
                 raw_exec: false,
                 source_snapshot: None,
@@ -1901,6 +1905,28 @@ mod tests {
             assert_eq!(err.details["field"], "secret_env");
             assert!(err.message.contains("HOMEBOY_REQUIRED_SECRET_TEST_KEY"));
         });
+    }
+
+    #[test]
+    fn runner_exec_secret_env_names_include_tunnel_preview_client_token() {
+        let names = runner_exec_secret_env_names(
+            &[
+                "homeboy".to_string(),
+                "tunnel".to_string(),
+                "preview-client".to_string(),
+                "start".to_string(),
+                "--ingress".to_string(),
+                "https://preview-broker.example.test".to_string(),
+                "--public-host".to_string(),
+                "preview.example.test".to_string(),
+                "--local-origin".to_string(),
+                "http://127.0.0.1:8888".to_string(),
+            ],
+            None,
+            &[],
+        );
+
+        assert_eq!(names, vec!["HOMEBOY_PREVIEW_TUNNEL_TOKEN".to_string()]);
     }
 
     #[test]
@@ -2536,6 +2562,7 @@ mod tests {
                 Some("extrachill".to_string()),
                 vec!["homeboy".to_string(), "test".to_string()],
                 Default::default(),
+                Vec::new(),
                 false,
                 None,
                 Vec::new(),
@@ -2587,6 +2614,7 @@ mod tests {
             None,
             vec!["homeboy".to_string(), "--version".to_string()],
             Default::default(),
+            Vec::new(),
             false,
             None,
             Vec::new(),

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -67,7 +67,9 @@ use super::agent_task_bridge::{
     mirror_agent_task_run_plan_lifecycle, parse_offloaded_dispatch_envelope_from_outputs,
 };
 use super::evidence::terminal_lab_run_evidence;
-use super::secrets::{hydrate_agent_task_secret_env, hydrate_trace_secret_env};
+use super::secrets::{
+    hydrate_agent_task_secret_env, hydrate_trace_secret_env, hydrate_tunnel_secret_env,
+};
 use super::trace_fetch_refs::lab_offload_git_fetch_refs;
 
 pub struct LabOffloadRequest<'a> {
@@ -817,8 +819,10 @@ fn run_lab_offload_inner(
     let agent_task_secret_env =
         hydrate_agent_task_secret_env(&changed_since_preflight.args, &mut env)?;
     let trace_secret_env = hydrate_trace_secret_env(&changed_since_preflight.args, &mut env)?;
+    let tunnel_secret_env = hydrate_tunnel_secret_env(&changed_since_preflight.args, &mut env)?;
     lab_metadata["agent_task_secret_env"] = agent_task_secret_env;
     lab_metadata["trace_secret_env"] = trace_secret_env;
+    lab_metadata["tunnel_secret_env"] = tunnel_secret_env;
     lab_metadata["rig_component_path_env"] = rig_component_path_env;
     lab_metadata["settings_env"] = settings_env_diagnostics(&remapped_args, &env);
     lab_metadata["rig_sync"] = serde_json::json!({
@@ -842,6 +846,7 @@ fn run_lab_offload_inner(
     forward_rig_component_path_env(&mut env, &workspace_mapping)?;
     hydrate_agent_task_secret_env(&changed_since_preflight.args, &mut env)?;
     hydrate_trace_secret_env(&changed_since_preflight.args, &mut env)?;
+    hydrate_tunnel_secret_env(&changed_since_preflight.args, &mut env)?;
     let exec_result = exec(
         runner_id,
         RunnerExecOptions {

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -78,6 +78,23 @@ pub(super) fn hydrate_trace_secret_env(
     Ok(crate::core::trace_secrets::status_metadata(statuses))
 }
 
+pub(super) fn hydrate_tunnel_secret_env(
+    args: &[String],
+    _env: &mut HashMap<String, String>,
+) -> Result<serde_json::Value> {
+    let names = declared_tunnel_secret_env(args);
+    Ok(serde_json::json!({
+        "schema": "homeboy/lab-tunnel-secret-env/v1",
+        "runner_deferred_secret_env": names
+            .into_iter()
+            .map(|name| serde_json::json!({
+                "name": name,
+                "source": "runner",
+            }))
+            .collect::<Vec<_>>(),
+    }))
+}
+
 pub(crate) fn declared_agent_task_secret_env(args: &[String]) -> Vec<String> {
     let mut names = declared_agent_task_controller_secret_env(args);
     names.extend(declared_agent_task_run_plan_secret_env(args));
@@ -128,6 +145,73 @@ pub(crate) fn declared_trace_secret_env(args: &[String]) -> Vec<String> {
     }
 
     declared_secret_env_args(args)
+}
+
+pub(crate) fn declared_tunnel_secret_env(args: &[String]) -> Vec<String> {
+    let Some(tunnel_index) = subcommand_index(args, "tunnel") else {
+        return Vec::new();
+    };
+
+    match (
+        args.get(tunnel_index + 1).map(String::as_str),
+        args.get(tunnel_index + 2).map(String::as_str),
+    ) {
+        (Some("preview-client"), Some("start")) => declared_tunnel_preview_client_token_env(args),
+        (Some("service"), Some("start")) if tunnel_service_start_uses_preview_client(args) => {
+            vec!["HOMEBOY_PREVIEW_TUNNEL_TOKEN".to_string()]
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn declared_tunnel_preview_client_token_env(args: &[String]) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--token-env" {
+            if let Some(name) = args.get(index + 1) {
+                names.push(name.clone());
+            }
+            index += 2;
+            continue;
+        }
+        if let Some(name) = arg.strip_prefix("--token-env=") {
+            names.push(name.to_string());
+        }
+        index += 1;
+    }
+
+    if names.is_empty() {
+        names.push("HOMEBOY_PREVIEW_TUNNEL_TOKEN".to_string());
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn tunnel_service_start_uses_preview_client(args: &[String]) -> bool {
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--public-tunnel-command" {
+            if args
+                .get(index + 1)
+                .is_some_and(|command| command.contains("preview-client start"))
+            {
+                return true;
+            }
+            index += 2;
+            continue;
+        }
+        if let Some(command) = arg.strip_prefix("--public-tunnel-command=") {
+            if command.contains("preview-client start") {
+                return true;
+            }
+        }
+        index += 1;
+    }
+    false
 }
 
 pub(super) fn trace_project_id_from_args(args: &[String]) -> Option<String> {
@@ -419,6 +503,79 @@ mod tests {
         assert!(!rendered.contains("sk_test_fake_not_real"));
 
         std::env::remove_var("HOMEBOY_TRACE_SECRET_TEST_KEY");
+    }
+
+    #[test]
+    fn declared_tunnel_secret_env_reads_preview_client_default_and_override() {
+        assert_eq!(
+            declared_tunnel_secret_env(&[
+                "homeboy".to_string(),
+                "tunnel".to_string(),
+                "preview-client".to_string(),
+                "start".to_string(),
+                "--ingress".to_string(),
+                "https://preview-broker.example.test".to_string(),
+            ]),
+            vec!["HOMEBOY_PREVIEW_TUNNEL_TOKEN".to_string()]
+        );
+
+        assert_eq!(
+            declared_tunnel_secret_env(&[
+                "homeboy".to_string(),
+                "tunnel".to_string(),
+                "preview-client".to_string(),
+                "start".to_string(),
+                "--token-env=RUNNER_PREVIEW_TOKEN".to_string(),
+            ]),
+            vec!["RUNNER_PREVIEW_TOKEN".to_string()]
+        );
+    }
+
+    #[test]
+    fn declared_tunnel_secret_env_detects_service_preview_client_backend() {
+        let names = declared_tunnel_secret_env(&[
+            "homeboy".to_string(),
+            "--runner".to_string(),
+            "homeboy-lab".to_string(),
+            "tunnel".to_string(),
+            "service".to_string(),
+            "start".to_string(),
+            "runner-preview".to_string(),
+            "--command".to_string(),
+            "npm run dev".to_string(),
+            "--public-tunnel-backend".to_string(),
+            "command".to_string(),
+            "--public-tunnel-command".to_string(),
+            "homeboy tunnel preview-client start --ready-stdout".to_string(),
+        ]);
+
+        assert_eq!(names, vec!["HOMEBOY_PREVIEW_TUNNEL_TOKEN".to_string()]);
+    }
+
+    #[test]
+    fn hydrate_tunnel_secret_env_reports_runner_deferred_names_without_values() {
+        let args = vec![
+            "homeboy".to_string(),
+            "tunnel".to_string(),
+            "preview-client".to_string(),
+            "start".to_string(),
+            "--ingress".to_string(),
+            "https://preview-broker.example.test".to_string(),
+            "--public-host".to_string(),
+            "preview.example.test".to_string(),
+            "--local-origin".to_string(),
+            "http://127.0.0.1:8888".to_string(),
+        ];
+        let mut env = std::collections::HashMap::new();
+
+        let diagnostics =
+            hydrate_tunnel_secret_env(&args, &mut env).expect("hydrate tunnel secret");
+
+        assert!(env.is_empty());
+        let rendered = diagnostics.to_string();
+        assert!(rendered.contains("homeboy/lab-tunnel-secret-env/v1"));
+        assert!(rendered.contains("HOMEBOY_PREVIEW_TUNNEL_TOKEN"));
+        assert!(rendered.contains("runner"));
     }
 
     #[test]

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -761,6 +761,7 @@ fn runner_exec_rejects_requests_that_violate_runner_policy_before_daemon_dispatc
                 "printf denied".to_string(),
             ],
             env: Default::default(),
+            secret_env_names: Vec::new(),
             capture_patch: false,
             raw_exec: true,
             source_snapshot: None,

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -307,6 +307,7 @@ fn runs_list_includes_active_runner_jobs() {
                 ],
                 cwd: Some("/workspace/homeboy".to_string()),
                 env: Default::default(),
+                secret_env_names: Vec::new(),
                 capture_patch: false,
                 source_snapshot: None,
                 require_paths: Vec::new(),


### PR DESCRIPTION
## Summary
- Add an explicit Lab runner contract for `tunnel service start` so held preview services can be started on Lab runners.
- Teach runner exec secret discovery about tunnel preview-client token env so native preview tunnel credentials are resolved runner-side and not leaked through command args or output.
- Record runner-deferred tunnel secret metadata in Lab offload evidence and cover the command/secret contracts with focused tests.

Fixes #4548.

## Testing
- `cargo test --lib tunnel_service_start_supports_explicit_runner_discovery`
- `cargo test --lib tunnel_preview_consumer_run_keeps_explicit_runner_contract`
- `cargo test --lib declared_tunnel_secret_env`
- `cargo test --lib hydrate_tunnel_secret_env_reports_runner_deferred_names_without_values`
- `cargo test --lib runner_exec_secret_env_names_include_tunnel_preview_client_token`
- `cargo test --lib` completed after rerun with a longer timeout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Homeboy Lab/tunnel command contract, runner secret-name plumbing, tests, and verification; Chris requested the issue and PR.