### PR TITLE
Fix running run evidence failure state

### DIFF
--- a/src/commands/runs/evidence.rs
+++ b/src/commands/runs/evidence.rs
@@ -322,7 +322,7 @@ fn evidence_failure_summary(run: &RunRecord) -> RunsEvidenceFailureSummary {
         .and_then(|value| value.as_str())
         .map(str::to_string);
     RunsEvidenceFailureSummary {
-        failed: !matches!(run.status.as_str(), "pass" | "passed"),
+        failed: matches!(run.status.as_str(), "fail" | "failed" | "error" | "stale"),
         status: run.status.clone(),
         exit_code,
         error,
@@ -519,6 +519,34 @@ mod tests {
                     || output.disk_budget.warning.is_some()
             );
             homeboy::core::set_artifact_root_override(None);
+        });
+    }
+
+    #[test]
+    fn evidence_failure_summary_does_not_mark_running_run_failed() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run(
+                    "trace",
+                    "homeboy",
+                    "studio",
+                    serde_json::json!({
+                        "status": "running",
+                        "phase": "waiting-for-child"
+                    }),
+                ))
+                .expect("run");
+
+            let (output, _) = evidence(&run.id).expect("evidence");
+            let RunsOutput::Evidence(output) = output else {
+                panic!("expected evidence output");
+            };
+
+            assert_eq!(output.run.status, "running");
+            assert_eq!(output.failure.status, "running");
+            assert!(!output.failure.failed);
         });
     }
 }


### PR DESCRIPTION
## Summary
- Treat `runs evidence` failure state as an explicit terminal failure instead of "anything not pass".
- Add a regression test proving a persisted `running` run reports `failure.failed: false` while preserving `failure.status: running`.

Fixes #4584.

## Verification
- Offloaded runner: `homeboy-lab`
- `homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/homeboy -- bash -lc 'git fetch origin fix-runs-evidence-running-failure && git checkout fix-runs-evidence-running-failure && cargo test evidence_failure_summary_does_not_mark_running_run_failed'`
- Runner job: `39945e07-d3d7-480c-8009-a1626f8358f4`
- Mirror run: `runner-exec-homeboy-lab-39945e07-d3d7-480c-8009-a1626f8358f4`
- Result: `1 passed; 0 failed`
- `homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/homeboy -- cargo fmt --check`
- Runner job: `ab5ed130-016d-463e-8ad2-a39ad37af8b1`
- Mirror run: `runner-exec-homeboy-lab-ab5ed130-016d-463e-8ad2-a39ad37af8b1`
- Result: exit code `0`

No Cargo commands were run locally on the Studio machine.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root cause inspection, code/test drafting, remote verification orchestration, and PR description drafting. Chris remains responsible for review and merge.