### PR TITLE
fix: box Lab status output

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -90,7 +90,7 @@ pub struct LabSelectedRunnerOutput {
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum LabCommandOutput {
-    Status(LabOutput),
+    Status(Box<LabOutput>),
     ExtensionSync(Box<LabExtensionSyncOutput>),
 }
 
@@ -121,7 +121,7 @@ pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabCommandOutput> {
             let selected_runner = selected_lab_runner_status(followup_runner)?;
             let managed_followups = lab_followups(followup_runner, current_workspace.as_deref());
             Ok((
-                LabCommandOutput::Status(LabOutput {
+                LabCommandOutput::Status(Box::new(LabOutput {
                     command: "lab.status",
                     preferred_runner,
                     selected_runner,
@@ -137,7 +137,7 @@ pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabCommandOutput> {
                         "Use `homeboy config set /bench/local_execution '\"denied\"'` to make local benchmark execution fail closed.".to_string(),
                         "Use `--runner <runner-id>` only when multiple Lab runners are available and no default should be inferred.".to_string(),
                     ],
-                }),
+                })),
                 0,
             ))
         }
@@ -150,7 +150,7 @@ pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabCommandOutput> {
                 bench_command.push_str(&args.join(" "));
             }
             Ok((
-                LabCommandOutput::Status(LabOutput {
+                LabCommandOutput::Status(Box::new(LabOutput {
                     command: "lab.bench",
                     preferred_runner,
                     selected_runner: None,
@@ -163,7 +163,7 @@ pub fn run(args: LabArgs, _global: &GlobalArgs) -> CmdResult<LabCommandOutput> {
                         "Homeboy auto-routes portable benchmarks to `lab.preferred_runner`, or to the only configured SSH Lab runner when there is exactly one.".to_string(),
                         "Use `--runner <runner-id>` only to override an ambiguous or non-default Lab selection.".to_string(),
                     ],
-                }),
+                })),
                 0,
             ))
         }


### PR DESCRIPTION
## Summary
- Box the remaining large `LabCommandOutput::Status` variant after #4550/#4573 so the Lab command output enum no longer trips clippy's `large_enum_variant` finding.
- Preserves the existing untagged serde output shape while reducing enum size.

## Verification
- `git diff --check`
- GitHub CI from #4573 identified the remaining #4319-owned finding as `src/commands/lab.rs:92` `large_enum_variant`.
- I did not run Cargo locally per project constraints. Local Lab verification remains blocked by runner daemon secret env resolution for `HOMEBOY_PREVIEW_TUNNEL_TOKEN`.

## Related
- Follow-up for #4319 / #4550 / #4573.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Applied the CI-reported enum-size follow-up on the Lab command output surface. Chris remains responsible for review and merge.