### PR TITLE
fix: align release skip no-tag assertion

### DIFF
--- a/src/core/release/planning_policy.rs
+++ b/src/core/release/planning_policy.rs
@@ -162,7 +162,7 @@ mod tests {
             "skip hint should explicitly state no release artifacts were produced: {hint}"
         );
         assert!(
-            hint.contains("no tag"),
+            hint.contains("No tag created"),
             "skip hint should explicitly say no tag was created: {hint}"
         );
         assert!(


### PR DESCRIPTION
## Summary
- Align `test_release_skip_plan` with the canonical no-op release hint text: `No tag created`.
- Keeps the release planning contract generic and fixes the stale assertion directly.

Fixes #4581.

## Evidence
- Offloaded runner: `homeboy-lab`
- `cargo fmt --check` via `homeboy runner exec`: passed, job `b43c128a-934d-43f7-9dee-064e1e53cefd`
- `cargo test core::release::planning_policy::tests::test_release_skip_plan` via `homeboy runner exec`: passed, job `c797eee6-cc62-48aa-903e-b7462b3a5eec`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the one-line test assertion alignment and ran offloaded verification; Chris remains responsible for review and merge.