### PR TITLE
Pin deploy cleanup build exit sentinel

### DIFF
--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -1395,6 +1395,13 @@ mod tests {
         config.force = true;
         config.head = true;
 
+        let (build_exit_code, build_error) = crate::core::build::build_component(&component);
+        assert_eq!(build_exit_code, Some(42));
+        assert!(
+            build_error.is_some(),
+            "fixture build must fail before deploy cleanup can validate failure handling"
+        );
+
         let failures = match prepare_component_deployments(
             &[component],
             &config,


### PR DESCRIPTION
## Summary
- Assert the deploy cleanup fixture's build layer preserves the sentinel exit code before cleanup runs.
- Keep the existing deploy preflight cleanup assertion so regressions distinguish build exit propagation from artifact cleanup behavior.

Fixes #4579.

## Evidence
- Lab runner targeted test: `homeboy runner exec homeboy-lab -- cargo test deploy_preflight_cleans_homeboy_build_dir_after_failed_build -- --nocapture` succeeded, job `6f0ce1de-0782-448b-94ad-5cb729dfed0c`.
- Lab runner formatting check: `homeboy runner exec homeboy-lab -- cargo fmt --check` succeeded, job `37d2bc10-b523-4c0b-8947-2c5239c73c4c`.
- Snapshot: `sha256:f03cb3b2698bdc5b4ef2979e5ec0fc29740a519882e5785afde992f56335d0cf` on runner `homeboy-lab`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated issue #4579, made the test hardening change, and ran offloaded Lab verification. Chris reviews and owns the final change.