### PR TITLE
Persist resumable validation progress ledgers

### DIFF
--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -9,6 +9,7 @@ homeboy runs list [--runner <runner-id>] [--kind bench|rig|trace] [--component <
 homeboy runs distribution --field <metadata.path> [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--status <status>] [--limit 20]
 homeboy runs compare [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--metric <name>] [--limit 20] [--format table|json]
 homeboy runs show <run-id>
+homeboy runs resume-plan <run-id>
 homeboy runs artifacts <run-id>
 homeboy runs artifact cleanup-downloads [--runner <runner-id>] [--run-id <run-id>] [--apply]
 homeboy runs export --run <run-id> --output <dir>
@@ -25,6 +26,8 @@ homeboy runs import --from-gh-actions --component <id> --repo <owner/repo> --run
 `homeboy runs list --runner <runner-id>` queries a connected runner daemon instead of the local observation store, preserving the normal `runs.list` JSON payload while returning evidence from the runner machine.
 
 The JSON output includes stable run fields: run id, kind, status, timestamps, component id, rig id, git SHA, command, cwd, metadata, and artifact records where relevant.
+
+`homeboy runs resume-plan <run-id>` reads generic `validation_progress` metadata from a run and reports the last completed command, any active command, and the next pending command. Homeboy core records this ledger for Homeboy-managed validation command sets without understanding npm, smoke groups, benchmarks, or implementation-specific command names; command manifests come from project configuration or extension-provided runners.
 
 `homeboy runs artifact cleanup-downloads` plans cleanup for local runner artifact downloads under Homeboy's artifact root (`<artifact-root>/runner`). By default it is a dry run; pass `--apply` to remove the planned cache subtree. Use `--runner` and `--run-id` to narrow cleanup to a specific runner or run cache.
 

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -2,25 +2,25 @@ use clap::Args;
 
 use homeboy::core::ci_profile;
 use homeboy::core::extension::lint::{
-    report, run_main_lint_workflow, run_self_check_lint_workflow, LintCommandOutput,
+    report, run_main_lint_workflow, run_self_check_lint_workflow_with_progress, LintCommandOutput,
     LintRunWorkflowArgs,
 };
 use homeboy::core::extension::ExtensionCapability;
 use homeboy::core::git;
 use homeboy::core::observation::{
-    finding_records_from_lint, NewFindingRecord, NewRunRecord, RunStatus,
+    finding_records_from_lint, merge_metadata, ActiveObservation, NewFindingRecord, NewRunRecord,
+    RunStatus,
 };
 use homeboy::core::refactor::plan::{
     collect_refactor_sources, lint_refactor_request, LintSourceOptions,
 };
+use homeboy::core::validation_progress::validation_progress_metadata;
 
 use super::source_command::{resolve_ci_job_for_command, resolve_source_context};
 use super::utils::args::{
     BaselineArgs, ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs,
 };
-use super::utils::observed_workflow::{
-    finish_adapted_observed_workflow, ObservedWorkflowRunner, WorkflowObservationAdapter,
-};
+use super::utils::observed_workflow::{ObservedWorkflowRunner, WorkflowObservationAdapter};
 use super::{CmdResult, GlobalArgs};
 use crate::command_contract::{
     CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode,
@@ -144,19 +144,28 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
         && args.ci_job.is_none()
         && source_ctx.component.has_script(ExtensionCapability::Lint)
     {
+        let runner =
+            ObservedWorkflowRunner::create(format!("lint {} self-check", source_ctx.component_id))?;
         let observation = LintObservationAdapter::new(
             source_ctx.component_id.clone(),
             &source_ctx.source_path,
             lint_command_label(&source_ctx.component_id, &args),
+            Some(runner.run_dir()),
         );
-        let workflow = finish_adapted_observed_workflow(
-            observation,
-            run_self_check_lint_workflow(
-                &source_ctx.component,
-                &source_ctx.source_path,
-                source_ctx.component_id.clone(),
-                args.json_summary,
-            ),
+        let active_observation = ActiveObservation::start_best_effort(observation.start_record());
+        let workflow = run_self_check_lint_workflow_with_progress(
+            &source_ctx.component,
+            &source_ctx.source_path,
+            source_ctx.component_id.clone(),
+            args.json_summary,
+            Some(runner.run_dir()),
+            active_observation.as_ref(),
+        );
+        let workflow = runner.finish(
+            active_observation,
+            workflow,
+            |active, workflow| finish_lint_observation(active, &observation, workflow),
+            |active, error| finish_lint_observation_error(active, &observation, error),
         )?;
 
         return Ok(report::from_main_workflow(workflow));
@@ -186,6 +195,7 @@ pub fn run(args: LintArgs, _global: &GlobalArgs) -> CmdResult<LintCommandOutput>
         ctx.component_id.clone(),
         &ctx.source_path,
         lint_command_label(&effective_id, &args),
+        Some(runner.run_dir()),
     );
 
     let workflow = run_main_lint_workflow(
@@ -227,15 +237,32 @@ struct LintObservationAdapter {
     component_id: String,
     source_path: std::path::PathBuf,
     command: String,
+    run_dir: Option<std::path::PathBuf>,
 }
 
 impl LintObservationAdapter {
-    fn new(component_id: String, source_path: &std::path::Path, command: String) -> Self {
+    fn new(
+        component_id: String,
+        source_path: &std::path::Path,
+        command: String,
+        run_dir: Option<&homeboy::core::engine::run_dir::RunDir>,
+    ) -> Self {
         Self {
             component_id,
             source_path: source_path.to_path_buf(),
             command,
+            run_dir: run_dir.map(|run_dir| run_dir.path().to_path_buf()),
         }
+    }
+
+    fn run_dir_metadata(&self) -> serde_json::Value {
+        self.run_dir
+            .as_ref()
+            .and_then(|path| {
+                homeboy::core::engine::run_dir::RunDir::from_existing(path.clone()).ok()
+            })
+            .map(|run_dir| validation_progress_metadata(&run_dir))
+            .unwrap_or_else(|| serde_json::json!({}))
     }
 }
 
@@ -248,7 +275,10 @@ impl WorkflowObservationAdapter<homeboy::core::extension::lint::LintRunWorkflowR
             .command(self.command.clone())
             .cwd_path(&self.source_path)
             .current_homeboy_version()
-            .metadata(serde_json::json!({ "source": "homeboy lint" }))
+            .metadata(serde_json::json!({
+                "source": "homeboy lint",
+                "run_dir": self.run_dir.as_ref().map(|path| path.to_string_lossy().to_string()),
+            }))
             .build()
     }
 
@@ -285,6 +315,37 @@ impl WorkflowObservationAdapter<homeboy::core::extension::lint::LintRunWorkflowR
             .map(|findings| finding_records_from_lint(run_id, findings))
             .unwrap_or_default()
     }
+}
+
+fn finish_lint_observation(
+    active: ActiveObservation,
+    adapter: &LintObservationAdapter,
+    workflow: &homeboy::core::extension::lint::LintRunWorkflowResult,
+) {
+    let mut metadata = merge_metadata(
+        active.initial_metadata().clone(),
+        adapter.success_metadata(workflow),
+    );
+    metadata = merge_metadata(metadata, adapter.run_dir_metadata());
+    let findings = adapter.success_findings(active.run_id(), workflow);
+    active.record_findings(&findings);
+    active.finish(adapter.success_status(workflow), Some(metadata));
+}
+
+fn finish_lint_observation_error(
+    active: ActiveObservation,
+    adapter: &LintObservationAdapter,
+    error: &homeboy::core::Error,
+) {
+    let mut metadata = merge_metadata(
+        active.initial_metadata().clone(),
+        serde_json::json!({
+            "observation_status": "error",
+            "error": error.to_string(),
+        }),
+    );
+    metadata = merge_metadata(metadata, adapter.run_dir_metadata());
+    active.finish_error(Some(metadata));
 }
 
 fn lint_command_label(component_id: &str, args: &LintArgs) -> String {

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -29,6 +29,7 @@ use serde_json::Value;
 
 use homeboy::core::observation::runs_service;
 use homeboy::core::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
+use homeboy::core::validation_progress::{ValidationCommandSummary, ValidationProgressLedger};
 use homeboy::core::Error;
 use homeboy::core::{api_jobs::ActiveRunnerJobSummary, api_jobs::JobStatus, runners as runner};
 
@@ -82,6 +83,8 @@ enum RunsCommand {
     Reconcile(RunsReconcileArgs),
     /// Show one persisted observation run
     Show { run_id: String },
+    /// Show a generic resume plan for a validation-progress run
+    ResumePlan { run_id: String },
     /// Show stable evidence registry data for one run
     Evidence { run_id: String },
     /// List artifacts recorded for one run
@@ -137,6 +140,7 @@ pub enum RunsOutput {
     LatestRun(RunsLatestRunOutput),
     Compare(RunsCompareOutput),
     Show(RunsShowOutput),
+    ResumePlan(RunsResumePlanOutput),
     Evidence(RunsEvidenceOutput),
     Artifacts(RunsArtifactsOutput),
     ArtifactGet(RunsArtifactGetOutput),
@@ -173,6 +177,20 @@ pub struct RunsArtifactsOutput {
     pub command: &'static str,
     pub run_id: String,
     pub artifacts: Vec<ArtifactRecord>,
+}
+
+#[derive(Serialize)]
+pub struct RunsResumePlanOutput {
+    pub command: &'static str,
+    pub run_id: String,
+    pub status: String,
+    pub completed_count: usize,
+    pub command_count: usize,
+    pub failed_count: usize,
+    pub last_completed_command: Option<ValidationCommandSummary>,
+    pub active_command: Option<ValidationCommandSummary>,
+    pub next_command: Option<ValidationCommandSummary>,
+    pub hints: Vec<String>,
 }
 
 #[derive(Args, Clone)]
@@ -306,6 +324,7 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::Compare(args) => compare_runs(args),
         RunsCommand::Reconcile(args) => reconcile_runs(args),
         RunsCommand::Show { run_id } => show_run(&run_id),
+        RunsCommand::ResumePlan { run_id } => resume_plan(&run_id),
         RunsCommand::Evidence { run_id } => evidence(&run_id),
         RunsCommand::Artifacts { run_id } => artifacts(&run_id),
         RunsCommand::Artifact(args) => artifact_command(args),
@@ -377,6 +396,7 @@ impl RunsArgs {
                 ],
             ),
             RunsCommand::Show { run_id }
+            | RunsCommand::ResumePlan { run_id }
             | RunsCommand::Evidence { run_id }
             | RunsCommand::Artifacts { run_id } => (
                 format!(
@@ -542,6 +562,51 @@ fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
         }),
         0,
     ))
+}
+
+fn resume_plan(run_id: &str) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
+    let run = runs_service::require_run(&store, run_id)?;
+    let Some(ledger) = validation_progress_ledger_for_run(&run) else {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!("run `{run_id}` does not contain validation progress metadata"),
+            Some(run_id.to_string()),
+            Some(vec![
+                "Run `homeboy runs show <run-id>` to inspect available metadata.".to_string(),
+                "Validation progress is recorded for Homeboy-managed validation command sets with a run directory.".to_string(),
+            ]),
+        ));
+    };
+
+    Ok((
+        RunsOutput::ResumePlan(RunsResumePlanOutput {
+            command: "runs.resume-plan",
+            run_id: run_id.to_string(),
+            status: ledger.status.clone(),
+            completed_count: ledger.completed_count,
+            command_count: ledger.command_count,
+            failed_count: ledger.failed_count,
+            last_completed_command: ledger.last_completed_command.clone(),
+            active_command: ledger.active_command.clone(),
+            next_command: ledger.next_command.clone(),
+            hints: ledger.resume_hints(),
+        }),
+        0,
+    ))
+}
+
+fn validation_progress_ledger_for_run(run: &RunRecord) -> Option<ValidationProgressLedger> {
+    ValidationProgressLedger::from_run(run).or_else(|| {
+        run.metadata_json
+            .get("run_dir")
+            .and_then(Value::as_str)
+            .and_then(|path| {
+                homeboy::core::engine::run_dir::RunDir::from_existing(PathBuf::from(path)).ok()
+            })
+            .and_then(|run_dir| ValidationProgressLedger::read_from_run_dir(&run_dir))
+    })
 }
 
 pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -4,7 +4,8 @@ use homeboy::core::ci_profile::{self, CiResolvedJob};
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::extension::test as extension_test;
 use homeboy::core::extension::test::{
-    detect_test_drift, report, run_self_check_test_workflow, TestCommandOutput, TestRunWorkflowArgs,
+    detect_test_drift, report, run_self_check_test_workflow_with_progress, TestCommandOutput,
+    TestRunWorkflowArgs,
 };
 use homeboy::core::extension::ExtensionCapability;
 use homeboy::core::git::short_head_revision_at;
@@ -19,12 +20,13 @@ use super::utils::args::{
     filter_passthrough_args, BaselineArgs, ExtensionOverrideArgs, PassthroughCommand,
     PositionalComponentArgs, SettingArgs,
 };
-use super::utils::observed_workflow::{finish_observed_workflow, ObservedWorkflowRunner};
+use super::utils::observed_workflow::ObservedWorkflowRunner;
 use super::{CmdResult, GlobalArgs};
 use crate::command_contract::{
     CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode,
     CommandResponseMode, LabCommandContract,
 };
+use homeboy::core::validation_progress::validation_progress_metadata;
 
 const TEST_CHANGED_SINCE_LAB_UNSUPPORTED_REASON: &str = "`test --changed-since` is not Lab-portable yet because changed-since test selection depends on git base refs that the current Lab workspace sync may not have fetched.";
 
@@ -137,21 +139,30 @@ pub fn run(args: TestArgs, _global: &GlobalArgs) -> CmdResult<TestCommandOutput>
         && cli_passthrough_args.is_empty()
         && source_ctx.component.has_script(ExtensionCapability::Test)
     {
+        let runner =
+            ObservedWorkflowRunner::create(format!("test {} self-check", source_ctx.component_id))?;
         let observation = start_test_observation(
             &source_ctx.component_id,
             &source_ctx.source_path,
             &args,
             "self-check",
-            None,
+            Some(runner.run_dir()),
         );
-        let workflow = run_self_check_test_workflow(
+        let workflow = run_self_check_test_workflow_with_progress(
             &source_ctx.component,
             &source_ctx.source_path,
             source_ctx.component_id.clone(),
             args.json_summary,
+            Some(runner.run_dir()),
+            observation.as_ref().map(|observation| &observation.0),
         );
 
-        let workflow = finish_test_workflow_observation(observation, workflow)?;
+        let workflow = runner.finish(
+            observation,
+            workflow,
+            |observation, workflow| finish_test_observation(Some(observation), workflow),
+            |observation, error| finish_test_observation_error(Some(observation), error),
+        )?;
 
         return Ok(report::from_main_workflow(workflow));
     }
@@ -271,18 +282,6 @@ fn start_test_observation(
     .map(TestObservation)
 }
 
-fn finish_test_workflow_observation(
-    observation: Option<TestObservation>,
-    workflow: homeboy::core::Result<extension_test::TestRunWorkflowResult>,
-) -> homeboy::core::Result<extension_test::TestRunWorkflowResult> {
-    finish_observed_workflow(
-        observation,
-        workflow,
-        |observation, workflow| finish_test_observation(Some(observation), workflow),
-        |observation, error| finish_test_observation_error(Some(observation), error),
-    )
-}
-
 fn finish_test_observation(
     observation: Option<TestObservation>,
     workflow: &extension_test::TestRunWorkflowResult,
@@ -292,8 +291,9 @@ fn finish_test_observation(
     };
 
     let metadata = merge_metadata(
-        observation.0.initial_metadata().clone(),
-        serde_json::json!({
+        merge_metadata(
+            observation.0.initial_metadata().clone(),
+            serde_json::json!({
             "observation_status": workflow.status,
             "exit_code": workflow.exit_code,
             "test_counts": workflow.test_counts,
@@ -303,7 +303,9 @@ fn finish_test_observation(
             "analysis_clusters": workflow.analysis.as_ref().map(|analysis| analysis.clusters.len()).unwrap_or(0),
             "test_scope": workflow.test_scope,
             "summary": workflow.summary,
-        }),
+            }),
+        ),
+        validation_progress_metadata_from_observation(&observation),
     );
     let status = if workflow.exit_code == 0 {
         RunStatus::Pass
@@ -367,13 +369,29 @@ fn finish_test_observation_error(
     };
 
     let metadata = merge_metadata(
-        observation.0.initial_metadata().clone(),
-        serde_json::json!({
+        merge_metadata(
+            observation.0.initial_metadata().clone(),
+            serde_json::json!({
             "observation_status": "error",
             "error": error.to_string(),
-        }),
+            }),
+        ),
+        validation_progress_metadata_from_observation(&observation),
     );
     observation.0.finish_error(Some(metadata));
+}
+
+fn validation_progress_metadata_from_observation(
+    observation: &TestObservation,
+) -> serde_json::Value {
+    observation
+        .0
+        .initial_metadata()
+        .get("run_dir")
+        .and_then(|value| value.as_str())
+        .and_then(|path| RunDir::from_existing(std::path::PathBuf::from(path)).ok())
+        .map(|run_dir| validation_progress_metadata(&run_dir))
+        .unwrap_or_else(|| serde_json::json!({}))
 }
 
 fn test_observation_command(component_id: &str, args: &TestArgs) -> String {

--- a/src/core/engine/run_dir.rs
+++ b/src/core/engine/run_dir.rs
@@ -40,6 +40,7 @@ pub mod files {
     pub const TRACE_RESULTS: &str = "trace.json";
     pub const RESOURCE_SUMMARY: &str = "resource-summary.json";
     pub const PHASE_TIMINGS: &str = "phase-timings.json";
+    pub const VALIDATION_PROGRESS: &str = "validation-progress.json";
     pub const EXTENSION_CHILDREN_DIR: &str = "extension-children";
     pub const ANNOTATIONS_DIR: &str = "annotations";
 }

--- a/src/core/extension/lint/mod.rs
+++ b/src/core/extension/lint/mod.rs
@@ -8,8 +8,8 @@ use crate::core::extension::{ExtensionCapability, ExtensionExecutionContext, Ext
 pub use baseline::{BaselineComparison, LintBaseline, LintBaselineMetadata};
 pub use report::LintCommandOutput;
 pub use run::{
-    run_main_lint_workflow, run_self_check_lint_workflow, LintRunWorkflowArgs,
-    LintRunWorkflowResult,
+    run_main_lint_workflow, run_self_check_lint_workflow,
+    run_self_check_lint_workflow_with_progress, LintRunWorkflowArgs, LintRunWorkflowResult,
 };
 
 use crate::core::engine::run_dir::RunDir;

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -17,6 +17,7 @@ use crate::core::extension::{
 use crate::core::finding::{FindingProducerSummary, FindingSource, HomeboyFinding};
 use crate::core::git;
 use crate::core::refactor::AppliedRefactor;
+use crate::core::validation_progress::{write_command_artifact, ValidationProgressRecorder};
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -120,6 +121,11 @@ pub fn run_main_lint_workflow(
     let output = if let Some(ref runs) = scoped_runs {
         run_scoped_lint_runs(component, &args, run_dir, runs)?
     } else {
+        let mut progress = ValidationProgressRecorder::new(
+            run_dir,
+            None,
+            vec![("lint runner".to_string(), args.component_label.clone())],
+        )?;
         let runner = build_lint_runner(
             component,
             args.path_override.clone(),
@@ -138,14 +144,19 @@ pub fn run_main_lint_workflow(
             .ci_env
             .iter()
             .fold(runner, |runner, (key, value)| runner.env(key, value));
-        runner
+        progress.start(0)?;
+        let output = runner
             .env_if(
                 args.changed_since.is_some(),
                 "HOMEBOY_STRICT_VALIDATION_DEPENDENCIES",
                 "1",
             )
             .passthrough(!args.json_summary)
-            .run()?
+            .run()?;
+        let stdout_artifact = write_command_artifact(run_dir, 0, "stdout", &output.stdout)?;
+        let stderr_artifact = write_command_artifact(run_dir, 0, "stderr", &output.stderr)?;
+        progress.finish(0, output.exit_code, stdout_artifact, stderr_artifact)?;
+        output
     };
 
     let lint_findings_file = run_dir.step_file(run_dir::files::LINT_FINDINGS);
@@ -593,6 +604,21 @@ fn run_scoped_lint_runs(
     let mut success = true;
     let mut exit_code = 0;
     let mut extension_phase_timings = Vec::new();
+    let mut progress = ValidationProgressRecorder::new(
+        run_dir,
+        None,
+        runs.iter()
+            .enumerate()
+            .map(|(index, run)| {
+                (
+                    run.step
+                        .clone()
+                        .unwrap_or_else(|| format!("lint scoped command {}", index + 1)),
+                    run.glob.clone(),
+                )
+            })
+            .collect(),
+    )?;
 
     for (index, run) in runs.iter().enumerate() {
         let scoped_run_dir;
@@ -621,6 +647,7 @@ fn run_scoped_lint_runs(
             .ci_env
             .iter()
             .fold(runner, |runner, (key, value)| runner.env(key, value));
+        progress.start(index)?;
         let output = runner
             .env_if(
                 args.changed_since.is_some(),
@@ -629,6 +656,9 @@ fn run_scoped_lint_runs(
             )
             .passthrough(!args.json_summary)
             .run()?;
+        let stdout_artifact = write_command_artifact(run_dir, index, "stdout", &output.stdout)?;
+        let stderr_artifact = write_command_artifact(run_dir, index, "stderr", &output.stderr)?;
+        progress.finish(index, output.exit_code, stdout_artifact, stderr_artifact)?;
         extension_phase_timings.extend(output.extension_phase_timings);
 
         if !output.success {
@@ -655,11 +685,31 @@ pub fn run_self_check_lint_workflow(
     component_label: String,
     json_summary: bool,
 ) -> crate::core::Result<LintRunWorkflowResult> {
-    let output = extension::self_check::run_self_checks_with_passthrough(
+    run_self_check_lint_workflow_with_progress(
+        component,
+        source_path,
+        component_label,
+        json_summary,
+        None,
+        None,
+    )
+}
+
+pub fn run_self_check_lint_workflow_with_progress(
+    component: &Component,
+    source_path: &Path,
+    component_label: String,
+    json_summary: bool,
+    run_dir: Option<&RunDir>,
+    observation: Option<&crate::core::observation::ActiveObservation>,
+) -> crate::core::Result<LintRunWorkflowResult> {
+    let output = extension::self_check::run_self_checks_with_passthrough_and_progress(
         component,
         ExtensionCapability::Lint,
         source_path,
         !json_summary,
+        run_dir,
+        observation,
     )?;
     let status = if output.success { "passed" } else { "failed" }.to_string();
     let hints = (!output.success).then(|| {

--- a/src/core/extension/self_check.rs
+++ b/src/core/extension/self_check.rs
@@ -1,6 +1,9 @@
 use crate::core::component::Component;
+use crate::core::engine::run_dir::RunDir;
 use crate::core::error::{Error, Result};
 use crate::core::extension::ExtensionCapability;
+use crate::core::observation::ActiveObservation;
+use crate::core::validation_progress::{write_command_artifact, ValidationProgressRecorder};
 use serde::Serialize;
 use std::io::{Read, Write};
 use std::path::Path;
@@ -32,11 +35,30 @@ pub struct SelfCheckStreamCaptureMetadata {
     pub truncated: bool,
 }
 
+#[cfg(test)]
 pub(crate) fn run_self_checks_with_passthrough(
     component: &Component,
     capability: ExtensionCapability,
     source_path: &Path,
     passthrough: bool,
+) -> Result<SelfCheckOutput> {
+    run_self_checks_with_passthrough_and_progress(
+        component,
+        capability,
+        source_path,
+        passthrough,
+        None,
+        None,
+    )
+}
+
+pub(crate) fn run_self_checks_with_passthrough_and_progress(
+    component: &Component,
+    capability: ExtensionCapability,
+    source_path: &Path,
+    passthrough: bool,
+    run_dir: Option<&RunDir>,
+    observation: Option<&ActiveObservation>,
 ) -> Result<SelfCheckOutput> {
     let commands = component.script_commands(capability);
     if commands.is_empty() {
@@ -55,8 +77,26 @@ pub(crate) fn run_self_checks_with_passthrough(
     let working_dir = source_path.to_string_lossy();
     let mut stdout = BoundedCapture::new(SELF_CHECK_CAPTURE_LIMIT_BYTES);
     let mut stderr = BoundedCapture::new(SELF_CHECK_CAPTURE_LIMIT_BYTES);
+    let mut progress = if let Some(run_dir) = run_dir {
+        Some(ValidationProgressRecorder::new(
+            run_dir,
+            observation,
+            commands
+                .iter()
+                .enumerate()
+                .map(|(index, command)| {
+                    (
+                        format!("{} command {}", capability.label(), index + 1),
+                        command.clone(),
+                    )
+                })
+                .collect(),
+        )?)
+    } else {
+        None
+    };
 
-    for command in commands {
+    for (index, command) in commands.iter().enumerate() {
         if passthrough {
             crate::log_status!(
                 "self-check",
@@ -66,7 +106,23 @@ pub(crate) fn run_self_checks_with_passthrough(
                 command
             );
         }
+        if let Some(progress) = progress.as_mut() {
+            progress.start(index)?;
+        }
         let output = execute_self_check_command(command, &working_dir, passthrough);
+        let stdout_artifact = if let Some(run_dir) = run_dir {
+            write_command_artifact(run_dir, index, "stdout", &output.stdout.to_string_lossy())?
+        } else {
+            None
+        };
+        let stderr_artifact = if let Some(run_dir) = run_dir {
+            write_command_artifact(run_dir, index, "stderr", &output.stderr.to_string_lossy())?
+        } else {
+            None
+        };
+        if let Some(progress) = progress.as_mut() {
+            progress.finish(index, output.exit_code, stdout_artifact, stderr_artifact)?;
+        }
         stdout.push_capture(output.stdout);
         stderr.push_capture(output.stderr);
 

--- a/src/core/extension/test/mod.rs
+++ b/src/core/extension/test/mod.rs
@@ -41,7 +41,8 @@ pub use parsing::{
 };
 pub use report::TestCommandOutput;
 pub use run::{
-    run_main_test_workflow, run_self_check_test_workflow, RawTestOutput, TestRunWorkflowArgs,
+    run_main_test_workflow, run_self_check_test_workflow,
+    run_self_check_test_workflow_with_progress, RawTestOutput, TestRunWorkflowArgs,
     TestRunWorkflowResult,
 };
 pub use workflow::{

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -16,6 +16,7 @@ use crate::core::extension::{self, ExtensionCapability, ExtensionPhaseTiming};
 use crate::core::finding::HomeboyFinding;
 use crate::core::observation::homeboy_findings_from_test_analysis_input;
 use crate::core::refactor::AppliedRefactor;
+use crate::core::validation_progress::{write_command_artifact, ValidationProgressRecorder};
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 
@@ -237,6 +238,12 @@ pub fn run_main_test_workflow(
         .iter()
         .fold(runner, |runner, (key, value)| runner.env(key, value));
     let passthrough_args = normalize_test_passthrough_args(component, &args.passthrough_args)?;
+    let mut progress = ValidationProgressRecorder::new(
+        run_dir,
+        None,
+        vec![("test runner".to_string(), args.component_label.clone())],
+    )?;
+    progress.start(0)?;
     let output = runner
         .env_if(args.changed_since.is_some(), "SCOPE_MODE", "changed")
         .env_if(
@@ -251,6 +258,9 @@ pub fn run_main_test_workflow(
         )
         .script_args(&passthrough_args)
         .run()?;
+    let stdout_artifact = write_command_artifact(run_dir, 0, "stdout", &output.stdout)?;
+    let stderr_artifact = write_command_artifact(run_dir, 0, "stderr", &output.stderr)?;
+    progress.finish(0, output.exit_code, stdout_artifact, stderr_artifact)?;
 
     if let (Some(context), Some(spec)) = (test_context.as_ref(), result_parse.as_ref()) {
         run_declared_result_parser(component, context, spec, &output.stdout, run_dir)?;
@@ -701,11 +711,31 @@ pub fn run_self_check_test_workflow(
     component_label: String,
     json_summary: bool,
 ) -> crate::core::Result<TestRunWorkflowResult> {
-    let output = extension::self_check::run_self_checks_with_passthrough(
+    run_self_check_test_workflow_with_progress(
+        component,
+        source_path,
+        component_label,
+        json_summary,
+        None,
+        None,
+    )
+}
+
+pub fn run_self_check_test_workflow_with_progress(
+    component: &Component,
+    source_path: &Path,
+    component_label: String,
+    json_summary: bool,
+    run_dir: Option<&RunDir>,
+    observation: Option<&crate::core::observation::ActiveObservation>,
+) -> crate::core::Result<TestRunWorkflowResult> {
+    let output = extension::self_check::run_self_checks_with_passthrough_and_progress(
         component,
         ExtensionCapability::Test,
         source_path,
         !json_summary,
+        run_dir,
+        observation,
     )?;
     let status = if output.success { "passed" } else { "failed" }.to_string();
     let raw_output = (!output.success).then(|| {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -98,6 +98,7 @@ pub mod tunnel;
 mod tunnel_tests;
 pub mod update_check_cache;
 pub mod upgrade;
+pub mod validation_progress;
 pub mod worktree;
 
 // Internal path resolution helpers.

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -170,6 +170,41 @@ impl ObservationStore {
         })
     }
 
+    pub fn update_run_metadata(
+        &self,
+        run_id: &str,
+        metadata_json: serde_json::Value,
+    ) -> Result<RunRecord> {
+        validate_required("run_id", run_id)?;
+        let serialized = serialize_metadata(&metadata_json)?;
+        let rows = self
+            .connection
+            .execute(
+                r#"
+                UPDATE runs
+                SET metadata_json = ?1
+                WHERE id = ?2
+                "#,
+                params![serialized, run_id],
+            )
+            .map_err(sqlite_error("update run metadata"))?;
+
+        if rows == 0 {
+            return Err(Error::validation_invalid_argument(
+                "run_id",
+                format!("run record not found: {run_id}"),
+                Some(run_id.to_string()),
+                None,
+            ));
+        }
+
+        self.get_run(run_id)?.ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "Updated run record {run_id} but could not read it back"
+            ))
+        })
+    }
+
     pub fn get_run(&self, run_id: &str) -> Result<Option<RunRecord>> {
         validate_required("run_id", run_id)?;
         self.connection

--- a/src/core/validation_progress.rs
+++ b/src/core/validation_progress.rs
@@ -1,0 +1,396 @@
+use std::path::PathBuf;
+use std::time::Instant;
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use crate::core::engine::run_dir::{self, RunDir};
+use crate::core::error::{Error, Result};
+use crate::core::observation::{merge_metadata, ActiveObservation, RunRecord};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidationProgressLedger {
+    pub schema: String,
+    pub status: String,
+    pub command_count: usize,
+    pub completed_count: usize,
+    pub failed_count: usize,
+    pub active_command: Option<ValidationCommandSummary>,
+    pub last_completed_command: Option<ValidationCommandSummary>,
+    pub next_command: Option<ValidationCommandSummary>,
+    pub commands: Vec<ValidationCommandRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidationCommandRecord {
+    pub index: usize,
+    pub label: String,
+    pub command: String,
+    pub status: String,
+    pub started_at: Option<String>,
+    pub finished_at: Option<String>,
+    pub elapsed_ms: Option<u128>,
+    pub exit_code: Option<i32>,
+    pub stdout_artifact: Option<String>,
+    pub stderr_artifact: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidationCommandSummary {
+    pub index: usize,
+    pub label: String,
+    pub command: String,
+    pub status: String,
+    pub exit_code: Option<i32>,
+}
+
+pub struct ValidationProgressRecorder<'a> {
+    run_dir: &'a RunDir,
+    observation: Option<&'a ActiveObservation>,
+    ledger: ValidationProgressLedger,
+    active_started: Option<Instant>,
+}
+
+impl ValidationProgressLedger {
+    pub fn new(commands: Vec<(String, String)>) -> Self {
+        let command_count = commands.len();
+        let mut ledger = Self {
+            schema: "homeboy.validation_progress.v1".to_string(),
+            status: "pending".to_string(),
+            command_count,
+            completed_count: 0,
+            failed_count: 0,
+            active_command: None,
+            last_completed_command: None,
+            next_command: None,
+            commands: commands
+                .into_iter()
+                .enumerate()
+                .map(|(index, (label, command))| ValidationCommandRecord {
+                    index,
+                    label,
+                    command,
+                    status: "pending".to_string(),
+                    started_at: None,
+                    finished_at: None,
+                    elapsed_ms: None,
+                    exit_code: None,
+                    stdout_artifact: None,
+                    stderr_artifact: None,
+                })
+                .collect(),
+        };
+        ledger.recompute();
+        ledger
+    }
+
+    pub fn read_from_run_dir(run_dir: &RunDir) -> Option<Self> {
+        let value = run_dir.read_step_output(run_dir::files::VALIDATION_PROGRESS)?;
+        serde_json::from_value(value).ok()
+    }
+
+    pub fn from_run(run: &RunRecord) -> Option<Self> {
+        serde_json::from_value(run.metadata_json.get("validation_progress")?.clone()).ok()
+    }
+
+    pub fn resume_hints(&self) -> Vec<String> {
+        let mut hints = Vec::new();
+        if let Some(active) = &self.active_command {
+            hints.push(format!(
+                "Previous run stopped while command {} (`{}`) was active.",
+                active.index + 1,
+                active.label
+            ));
+        }
+        if let Some(next) = &self.next_command {
+            hints.push(format!(
+                "Resume from command {}: {}",
+                next.index + 1,
+                next.command
+            ));
+        } else if self.failed_count == 0 && self.completed_count == self.command_count {
+            hints.push("All recorded validation commands completed successfully.".to_string());
+        } else {
+            hints.push("No pending command is known from this validation manifest.".to_string());
+        }
+        hints
+    }
+
+    fn mark_started(&mut self, index: usize) {
+        if let Some(command) = self.commands.get_mut(index) {
+            command.status = "running".to_string();
+            command.started_at = Some(Utc::now().to_rfc3339());
+            command.finished_at = None;
+            command.elapsed_ms = None;
+            command.exit_code = None;
+        }
+        self.recompute();
+    }
+
+    fn mark_finished(
+        &mut self,
+        index: usize,
+        exit_code: i32,
+        elapsed_ms: u128,
+        stdout_artifact: Option<String>,
+        stderr_artifact: Option<String>,
+    ) {
+        if let Some(command) = self.commands.get_mut(index) {
+            command.status = if exit_code == 0 { "passed" } else { "failed" }.to_string();
+            command.finished_at = Some(Utc::now().to_rfc3339());
+            command.elapsed_ms = Some(elapsed_ms);
+            command.exit_code = Some(exit_code);
+            command.stdout_artifact = stdout_artifact;
+            command.stderr_artifact = stderr_artifact;
+        }
+        self.recompute();
+    }
+
+    fn recompute(&mut self) {
+        self.completed_count = self
+            .commands
+            .iter()
+            .filter(|command| command.status == "passed")
+            .count();
+        self.failed_count = self
+            .commands
+            .iter()
+            .filter(|command| command.status == "failed")
+            .count();
+        self.active_command = self
+            .commands
+            .iter()
+            .find(|command| command.status == "running")
+            .map(ValidationCommandSummary::from);
+        self.last_completed_command = self
+            .commands
+            .iter()
+            .rev()
+            .find(|command| matches!(command.status.as_str(), "passed" | "failed"))
+            .map(ValidationCommandSummary::from);
+        self.next_command = self
+            .commands
+            .iter()
+            .find(|command| command.status == "pending")
+            .map(ValidationCommandSummary::from);
+        self.status = if self.failed_count > 0 {
+            "failed".to_string()
+        } else if self.active_command.is_some() {
+            "running".to_string()
+        } else if self.completed_count == self.command_count {
+            "passed".to_string()
+        } else {
+            "pending".to_string()
+        };
+    }
+}
+
+impl From<&ValidationCommandRecord> for ValidationCommandSummary {
+    fn from(command: &ValidationCommandRecord) -> Self {
+        Self {
+            index: command.index,
+            label: command.label.clone(),
+            command: command.command.clone(),
+            status: command.status.clone(),
+            exit_code: command.exit_code,
+        }
+    }
+}
+
+impl<'a> ValidationProgressRecorder<'a> {
+    pub fn new(
+        run_dir: &'a RunDir,
+        observation: Option<&'a ActiveObservation>,
+        commands: Vec<(String, String)>,
+    ) -> Result<Self> {
+        let recorder = Self {
+            run_dir,
+            observation,
+            ledger: ValidationProgressLedger::new(commands),
+            active_started: None,
+        };
+        recorder.persist()?;
+        Ok(recorder)
+    }
+
+    pub fn start(&mut self, index: usize) -> Result<()> {
+        self.active_started = Some(Instant::now());
+        self.ledger.mark_started(index);
+        self.persist()
+    }
+
+    pub fn finish(
+        &mut self,
+        index: usize,
+        exit_code: i32,
+        stdout_artifact: Option<String>,
+        stderr_artifact: Option<String>,
+    ) -> Result<()> {
+        let elapsed_ms = self
+            .active_started
+            .take()
+            .map(|started| started.elapsed().as_millis())
+            .unwrap_or_default();
+        self.ledger.mark_finished(
+            index,
+            exit_code,
+            elapsed_ms,
+            stdout_artifact,
+            stderr_artifact,
+        );
+        self.persist()
+    }
+
+    pub fn ledger(&self) -> &ValidationProgressLedger {
+        &self.ledger
+    }
+
+    fn persist(&self) -> Result<()> {
+        let value = serde_json::to_value(&self.ledger).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize validation progress".to_string()),
+            )
+        })?;
+        std::fs::write(
+            self.run_dir.step_file(run_dir::files::VALIDATION_PROGRESS),
+            serde_json::to_string_pretty(&value).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("write validation progress".to_string()),
+                )
+            })?,
+        )
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("write validation progress".to_string()),
+            )
+        })?;
+
+        if let Some(observation) = self.observation {
+            let metadata = merge_metadata(
+                observation.initial_metadata().clone(),
+                serde_json::json!({ "validation_progress": value }),
+            );
+            observation
+                .store()
+                .update_run_metadata(observation.run_id(), metadata)?;
+        }
+
+        Ok(())
+    }
+}
+
+pub fn validation_progress_metadata(run_dir: &RunDir) -> serde_json::Value {
+    ValidationProgressLedger::read_from_run_dir(run_dir)
+        .map(|ledger| serde_json::json!({ "validation_progress": ledger }))
+        .unwrap_or_else(|| serde_json::json!({}))
+}
+
+pub fn write_command_artifact(
+    run_dir: &RunDir,
+    command_index: usize,
+    stream: &str,
+    contents: &str,
+) -> Result<Option<String>> {
+    if contents.is_empty() {
+        return Ok(None);
+    }
+    let relative = PathBuf::from("validation-progress")
+        .join(format!("command-{}-{stream}.log", command_index + 1));
+    let path = run_dir.path().join(&relative);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("create validation progress artifact dir".to_string()),
+            )
+        })?;
+    }
+    std::fs::write(&path, contents).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("write validation progress artifact".to_string()),
+        )
+    })?;
+    Ok(Some(relative.to_string_lossy().to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::observation::{NewRunRecord, RunStatus};
+    use crate::test_support::with_isolated_home;
+
+    #[test]
+    fn ledger_tracks_active_completed_and_next_commands() {
+        let mut ledger = ValidationProgressLedger::new(vec![
+            ("first".to_string(), "check one".to_string()),
+            ("second".to_string(), "check two".to_string()),
+        ]);
+
+        ledger.mark_started(0);
+
+        assert_eq!(ledger.status, "running");
+        assert_eq!(ledger.active_command.as_ref().unwrap().command, "check one");
+        assert_eq!(ledger.next_command.as_ref().unwrap().command, "check two");
+
+        ledger.mark_finished(0, 0, 25, Some("stdout.log".to_string()), None);
+
+        assert_eq!(ledger.status, "pending");
+        assert_eq!(ledger.completed_count, 1);
+        assert_eq!(
+            ledger.last_completed_command.as_ref().unwrap().command,
+            "check one"
+        );
+        assert_eq!(ledger.next_command.as_ref().unwrap().command, "check two");
+        assert!(ledger
+            .resume_hints()
+            .iter()
+            .any(|hint| hint.contains("Resume from command 2: check two")));
+    }
+
+    #[test]
+    fn recorder_mirrors_progress_into_running_observation_metadata() {
+        with_isolated_home(|_| {
+            let run_dir = RunDir::create().expect("run dir");
+            let observation = ActiveObservation::start(
+                NewRunRecord::builder("test")
+                    .component_id("fixture")
+                    .command("homeboy test fixture")
+                    .metadata(serde_json::json!({
+                        "source": "test",
+                        "run_dir": run_dir.path().to_string_lossy(),
+                    }))
+                    .build(),
+            )
+            .expect("observation");
+            let run_id = observation.run_id().to_string();
+
+            let mut recorder = ValidationProgressRecorder::new(
+                &run_dir,
+                Some(&observation),
+                vec![
+                    ("first".to_string(), "check one".to_string()),
+                    ("second".to_string(), "check two".to_string()),
+                ],
+            )
+            .expect("recorder");
+            recorder.start(0).expect("start command");
+            recorder.finish(0, 0, None, None).expect("finish command");
+
+            let stored = observation
+                .store()
+                .get_run(&run_id)
+                .expect("read run")
+                .expect("run exists");
+            let ledger = ValidationProgressLedger::from_run(&stored).expect("metadata ledger");
+            assert_eq!(ledger.completed_count, 1);
+            assert_eq!(ledger.next_command.as_ref().unwrap().command, "check two");
+
+            observation.finish(RunStatus::Pass, None);
+            run_dir.cleanup();
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a generic `validation_progress` ledger that records validation command status, timing, exit codes, output artifact refs, active command, last completed command, and next pending command.
- Wires the ledger into Homeboy-managed `test`/`lint` validation paths, including project-configured script self-checks, without hard-coding WP Codebox, npm, smoke groups, or benchmark semantics.
- Adds `homeboy runs resume-plan <run-id>` so operators/minions can inspect the persisted resume plan after interruption.
- Includes small runner test constructor updates for the existing `secret_env_names` runner contract so the branch compiles on current `main`.

Fixes https://github.com/Extra-Chill/homeboy/issues/4577

## Evidence
- Offloaded full validation via `homeboy test homeboy --runner homeboy-lab --path /Users/chubes/Developer/homeboy@fix-4577-validation-progress-ledger --json-summary` reached test execution on `homeboy-lab` and confirmed this branch compiles/formats. Current full-suite result: `4551 passed`, `8 failed`, `18 ignored`.
- Full-suite blocker failures are outside this change path and still need maintainer follow-up: daemon job status assertions, deploy preflight build exit assertion, component-script run-dir isolation, declared parser stdout handling, release skip hint casing, and lab disconnect hint assertion.
- Focused offloaded `cargo test validation_progress -- --nocapture` through `homeboy runner exec homeboy-lab` passed: `2 passed`, `0 failed`. Mirror run: `runner-exec-homeboy-lab-d2ed0948-30f3-4992-be64-076e06788b89`.
- Focused offloaded `cargo test self_check -- --nocapture` through `homeboy runner exec homeboy-lab` passed: unit self-check tests and integration `self_checks_test` matches passed. Mirror run: `runner-exec-homeboy-lab-25d99f44-6bd3-49c1-89cc-5d2cdde062cb`.

## Full-suite blocker
The PR is not marked merge-ready yet because the offloaded full suite currently has unrelated failures on current `main` after this branch rebases cleanly. I left these as reported evidence instead of hiding them with local-only Cargo or narrow smoke-test theater.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the generic validation-progress ledger, wiring Homeboy command paths, drafting tests/docs, and collecting offloaded validation evidence. Chris remains responsible for review and merge decisions.