### PR TITLE
Fix declared parser test result sidecars

### DIFF
--- a/src/core/extension/runtime/sidecar-writer.sh
+++ b/src/core/extension/runtime/sidecar-writer.sh
@@ -62,6 +62,44 @@ except Exception:
 PYEOF
 }
 
+homeboy_sidecar_write_json_object() {
+    local target="${1:-}"
+    local item="${2:-}"
+
+    if [ -z "$target" ]; then
+        return 0
+    fi
+
+    local python_bin
+    python_bin="$(homeboy_sidecar_python)" || return 1
+
+    "$python_bin" - "$target" "$item" <<'PYEOF'
+import json
+import os
+import sys
+import tempfile
+
+target = sys.argv[1]
+item = json.loads(sys.argv[2])
+if not isinstance(item, dict):
+    raise ValueError("sidecar must contain a JSON object")
+directory = os.path.dirname(target) or "."
+os.makedirs(directory, exist_ok=True)
+fd, tmp = tempfile.mkstemp(prefix=".homeboy-sidecar-", suffix=".json", dir=directory)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(item, handle, separators=(",", ":"), ensure_ascii=False)
+        handle.write("\n")
+    os.replace(tmp, target)
+except Exception:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
+PYEOF
+}
+
 homeboy_sidecar_append_json() {
     local target="${1:-}"
     local item="${2:-}"
@@ -166,6 +204,9 @@ homeboy_sidecar_target_for_type() {
         test.failure|test.failures)
             printf '%s\n' "${HOMEBOY_TEST_FAILURES_FILE:-}"
             ;;
+        test.result|test.results)
+            printf '%s\n' "${HOMEBOY_TEST_RESULTS_FILE:-}"
+            ;;
         fix.result|fix.results)
             printf '%s\n' "${HOMEBOY_FIX_RESULTS_FILE:-}"
             ;;
@@ -192,6 +233,12 @@ homeboy_sidecar_write() {
 
     local target
     target="$(homeboy_sidecar_target_for_type "$type")" || return 1
+    case "$type" in
+        test.result|test.results)
+            homeboy_sidecar_write_json_object "$target" "${1:-}"
+            return $?
+            ;;
+    esac
     homeboy_sidecar_write_json_array "$target" "$@"
 }
 
@@ -232,6 +279,10 @@ homeboy_merge_lint_findings() {
 
 homeboy_write_test_failures() {
     homeboy_sidecar_write test.failures "$@"
+}
+
+homeboy_write_test_results_json() {
+    homeboy_sidecar_write test.results "$1"
 }
 
 homeboy_append_test_failure() {

--- a/src/core/extension/runtime/write-test-results.sh
+++ b/src/core/extension/runtime/write-test-results.sh
@@ -28,6 +28,7 @@ homeboy_write_test_results() {
 
     # Write JSON to file if requested
     if [ -n "${HOMEBOY_TEST_RESULTS_FILE:-}" ]; then
+        mkdir -p "$(dirname "$HOMEBOY_TEST_RESULTS_FILE")"
         if [ -n "${partial}" ]; then
             cat > "$HOMEBOY_TEST_RESULTS_FILE" << JSONEOF
 {

--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -206,6 +206,62 @@ fn sidecar_writer_supports_test_failure_and_fix_result_wrappers() {
 }
 
 #[test]
+fn sidecar_writer_supports_test_results_object() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("sidecar-writer.sh");
+    let results_path = dir.path().join("nested").join("test-results.json");
+    std::fs::write(&helper_path, assets::SIDECAR_WRITER_SH).expect("write helper");
+
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {}; HOMEBOY_TEST_RESULTS_FILE={}; homeboy_write_test_results_json '{{\"total\":5,\"passed\":3,\"failed\":1,\"skipped\":1}}'; cat {}",
+            helper_path.display(),
+            results_path.display(),
+            results_path.display()
+        ))
+        .output()
+        .expect("run bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        r#"{"total":5,"passed":3,"failed":1,"skipped":1}
+"#
+    );
+}
+
+#[test]
+fn write_test_results_creates_parent_directory() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let helper_path = dir.path().join("write-test-results.sh");
+    let results_path = dir.path().join("nested").join("test-results.json");
+    std::fs::write(&helper_path, assets::WRITE_TEST_RESULTS_SH).expect("write helper");
+
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {}; HOMEBOY_TEST_RESULTS_FILE={}; homeboy_write_test_results 5 3 1 1; cat {}",
+            helper_path.display(),
+            results_path.display(),
+            results_path.display()
+        ))
+        .output()
+        .expect("run bash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains(r#""total": 5"#));
+}
+
+#[test]
 fn sidecar_writer_supports_annotation_source_files() {
     let dir = tempfile::tempdir().expect("tempdir");
     let helper_path = dir.path().join("sidecar-writer.sh");

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -537,6 +537,13 @@ fn run_declared_result_parser(
         }
     }
 
+    std::fs::create_dir_all(run_dir.path()).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some("create declared result parser run dir".to_string()),
+        )
+    })?;
+
     let results_file = run_dir.step_file(run_dir::files::TEST_RESULTS);
     let source_file = if results_file.is_file() {
         results_file
@@ -867,6 +874,14 @@ mod tests {
 set -euo pipefail
 if [ "${2:-}" != "custom-json" ]; then
     exit 7
+fi
+if [ ! -f "$1" ]; then
+    printf 'expected parser input file to exist: %s\n' "$1" >&2
+    exit 8
+fi
+if ! grep -q 'custom-provider/test-results/v1' "$1"; then
+    printf 'expected parser input file to contain provider JSON\n' >&2
+    exit 9
 fi
 source "$HOMEBOY_RUNTIME_WRITE_TEST_RESULTS"
 parsed=$(python3 - "$1" <<'PY'


### PR DESCRIPTION
## Summary
- Ensure declared result parser fallback inputs have a live run directory before writing parser input/output files.
- Teach the generic sidecar writer to write canonical `test.results` JSON object sidecars.
- Add regression coverage for parser input materialization, test-results parent directory creation, and `test.results` object sidecars.

Fixes #4580

## Evidence
- `homeboy test homeboy --runner homeboy-lab --json-summary -- --lib declared_result_parser` passed: 5 passed, 0 failed.
- `homeboy test homeboy --runner homeboy-lab --json-summary -- --lib write_test_results_creates_parent_directory` passed: 1 passed, 0 failed.
- `homeboy runner exec --ssh homeboy-lab -- bash -lc 'cd <lab-workspace> && cargo test --lib sidecar_writer_supports_test_results_object'` passed: 1 passed, 0 failed.
- `homeboy runner exec --ssh homeboy-lab -- bash -lc 'cd <lab-workspace> && cargo fmt --check'` passed.

## Notes
- Full offloaded `homeboy test homeboy --runner homeboy-lab --json-summary` was run before the fix and reproduced the declared parser failures from this area. It also showed unrelated existing failures in deploy preflight cleanup, HTTP egress trace probe, and release skip plan tests.
- The Lab daemon disconnected twice while polling the sidecar test job; after confirming no corresponding Cargo process was active on the runner, the sidecar regression was verified through explicit Homeboy runner SSH diagnostics so Cargo still ran off the Studio machine.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the failing declared parser fixture path, drafted the generic runtime helper/test changes, and ran offloaded verification. Chris remains responsible for review and merge.