### PR TITLE
Add durable PR ownership loop

### DIFF
--- a/src/core/agent_task_controller_service.rs
+++ b/src/core/agent_task_controller_service.rs
@@ -13,13 +13,15 @@ use serde_json::Value;
 
 use crate::core::agent_task_lifecycle as lifecycle;
 use crate::core::agent_task_loop_controller::{
-    self as controller, AgentTaskLoopActionStatus, AgentTaskLoopControllerRecord,
-    AgentTaskLoopControllerState, AgentTaskLoopExternalEvent, AgentTaskLoopHistoryEvent,
-    AgentTaskLoopPolicyAction, AgentTaskLoopPolicyActionRecord, AgentTaskLoopRunRef,
-    AgentTaskLoopTaskLineage,
+    self as controller, AgentTaskLoopActionStatus, AgentTaskLoopArtifactRef,
+    AgentTaskLoopControllerRecord, AgentTaskLoopControllerState, AgentTaskLoopExternalEvent,
+    AgentTaskLoopHistoryEvent, AgentTaskLoopPolicyAction, AgentTaskLoopPolicyActionRecord,
+    AgentTaskLoopRunRef, AgentTaskLoopTaskLineage, AgentTaskPrOwnershipRequest,
+    AgentTaskPrOwnershipState, AgentTaskPrOwnershipStatusUpdate,
 };
 use crate::core::agent_task_scheduler::{AgentTaskExecutorAdapter, AgentTaskPlan};
 use crate::core::agent_task_service::{self, AgentTaskRunResult};
+use crate::core::git::{pr_find, pr_view, PrFindOptions, PrState};
 use crate::core::{Error, Result};
 
 /// Schema for the apply-event report envelope.
@@ -412,6 +414,10 @@ where
             }),
             0,
         )),
+        AgentTaskLoopPolicyAction::OwnPrUntilGreen {
+            ownership,
+            entity_id,
+        } => execute_own_pr_until_green_action(record, ownership, entity_id.as_deref()),
         AgentTaskLoopPolicyAction::MarkHumanReady { entity_id, reason } => {
             record.mark_human_ready(entity_id, reason.clone())?;
             Ok((
@@ -706,6 +712,209 @@ fn execute_wait_for_controller_action(
         }),
         0,
     ))
+}
+
+fn execute_own_pr_until_green_action(
+    record: &mut AgentTaskLoopControllerRecord,
+    ownership: &AgentTaskPrOwnershipRequest,
+    entity_id: Option<&str>,
+) -> Result<(Value, i32)> {
+    let pr_number = match ownership.pr_number {
+        Some(number) => Some(number),
+        None => find_pr_number(ownership)?,
+    };
+    let Some(pr_number) = pr_number else {
+        let update = AgentTaskPrOwnershipStatusUpdate {
+            missing_pr: true,
+            ..AgentTaskPrOwnershipStatusUpdate::default()
+        };
+        let status =
+            record.record_pr_ownership_status(ownership, entity_id.map(str::to_string), update);
+        return Ok((
+            serde_json::json!({
+                "mode": "own_pr_until_green",
+                "ownership": status,
+                "action": "stop",
+                "reason": "no open pull request matched the owned branch"
+            }),
+            1,
+        ));
+    };
+
+    let view = pr_view(
+        ownership.component_id.as_deref(),
+        pr_number,
+        ownership.path.clone(),
+    )?;
+    let previous_retry_count = existing_pr_retry_count(record, &ownership.ownership_id);
+    let retry_count = if pr_needs_retry(&view.ci_state, view.review_decision.as_deref()) {
+        previous_retry_count.saturating_add(1)
+    } else {
+        previous_retry_count
+    };
+    let update = AgentTaskPrOwnershipStatusUpdate {
+        pr_number: Some(view.number),
+        pr_url: Some(format!(
+            "https://github.com/{}/{}/pull/{}",
+            view.owner, view.repo, view.number
+        )),
+        head_sha: view.head_sha.clone(),
+        ci_state: Some(view.ci_state.clone()),
+        ci_summary: Some(view.ci_summary.clone()),
+        review_decision: view.review_decision.clone(),
+        merge_state: view
+            .merge_state
+            .clone()
+            .or_else(|| Some(view.state.clone())),
+        retry_count,
+        evidence: vec![AgentTaskLoopArtifactRef {
+            uri: format!("github://{}/{}/pull/{}", view.owner, view.repo, view.number),
+            kind: Some("github.pull_request".to_string()),
+            label: Some("Owned pull request".to_string()),
+        }],
+        missing_pr: false,
+    };
+    let status =
+        record.record_pr_ownership_status(ownership, entity_id.map(str::to_string), update);
+    queue_pr_ownership_follow_up(record, ownership, entity_id, &status);
+    Ok((
+        serde_json::json!({
+            "mode": "own_pr_until_green",
+            "ownership": status,
+        }),
+        0,
+    ))
+}
+
+fn pr_needs_retry(ci_state: &str, review_decision: Option<&str>) -> bool {
+    ci_state == "terminal_failed"
+        || ci_state == "stale"
+        || review_decision == Some("CHANGES_REQUESTED")
+}
+
+fn find_pr_number(ownership: &AgentTaskPrOwnershipRequest) -> Result<Option<u64>> {
+    let output = pr_find(
+        ownership.component_id.as_deref(),
+        PrFindOptions {
+            base: Some(ownership.base.clone()),
+            head: Some(ownership.head.clone()),
+            state: PrState::Open,
+            limit: 10,
+            path: ownership.path.clone(),
+        },
+    )?;
+    Ok(output.items.into_iter().next().map(|item| item.number))
+}
+
+fn existing_pr_retry_count(record: &AgentTaskLoopControllerRecord, ownership_id: &str) -> u32 {
+    record
+        .pr_ownerships
+        .iter()
+        .find(|ownership| ownership.ownership_id == ownership_id)
+        .map(|ownership| ownership.retry_count)
+        .unwrap_or_default()
+}
+
+fn queue_pr_ownership_follow_up(
+    record: &mut AgentTaskLoopControllerRecord,
+    ownership: &AgentTaskPrOwnershipRequest,
+    entity_id: Option<&str>,
+    status: &crate::core::agent_task_loop_controller::AgentTaskPrOwnershipRecord,
+) {
+    match status.state {
+        AgentTaskPrOwnershipState::ChangesRequested => {
+            let feedback_id = format!(
+                "pr-ownership:{}:retry-{}",
+                ownership.ownership_id,
+                status.retry_count + 1
+            );
+            record.record_action(
+                AgentTaskLoopPolicyAction::RequestChanges {
+                    target_run_id: ownership.ownership_id.clone(),
+                    feedback_id: Some(feedback_id),
+                },
+                "owned PR has red checks or requested changes",
+            );
+        }
+        AgentTaskPrOwnershipState::RetryLimitReached => {
+            if let Some(entity_id) = entity_id {
+                record.record_action(
+                    AgentTaskLoopPolicyAction::MarkHumanReady {
+                        entity_id: entity_id.to_string(),
+                        reason: Some(
+                            "owned PR reached retry limit with red checks or requested changes"
+                                .to_string(),
+                        ),
+                    },
+                    "owned PR retry limit reached",
+                );
+            }
+        }
+        AgentTaskPrOwnershipState::WaitingForChecks => {
+            record.record_action(
+                AgentTaskLoopPolicyAction::WaitForEvent(
+                    crate::core::agent_task_loop_controller::AgentTaskLoopWait {
+                        wait_key: format!("pr-ownership:{}:checks", ownership.ownership_id),
+                        event_type: "github.pr.checks_changed".to_string(),
+                        entity_id: entity_id.map(str::to_string),
+                        external_ref: status
+                            .pr_number
+                            .map(|number| format!("{}#{}", ownership.head, number)),
+                        timeout_at: None,
+                        escalation_policy: Some("reinspect_pr".to_string()),
+                        status:
+                            crate::core::agent_task_loop_controller::AgentTaskLoopWaitStatus::Open,
+                        satisfied_by_event_id: None,
+                    },
+                ),
+                "owned PR is waiting for checks",
+            );
+        }
+        AgentTaskPrOwnershipState::GreenReady => {
+            if let Some(entity_id) = entity_id {
+                record.record_action(
+                    AgentTaskLoopPolicyAction::MarkHumanReady {
+                        entity_id: entity_id.to_string(),
+                        reason: Some(
+                            "owned PR checks are green and merge is allowed by policy".to_string(),
+                        ),
+                    },
+                    "owned PR is green",
+                );
+            }
+        }
+        AgentTaskPrOwnershipState::WaitingForMerge => {
+            record.record_action(
+                AgentTaskLoopPolicyAction::WaitForEvent(
+                    crate::core::agent_task_loop_controller::AgentTaskLoopWait {
+                        wait_key: format!("pr-ownership:{}:merged", ownership.ownership_id),
+                        event_type: "github.pr.merged".to_string(),
+                        entity_id: entity_id.map(str::to_string),
+                        external_ref: status
+                            .pr_number
+                            .map(|number| format!("{}#{}", ownership.head, number)),
+                        timeout_at: None,
+                        escalation_policy: Some("wait_for_merge".to_string()),
+                        status:
+                            crate::core::agent_task_loop_controller::AgentTaskLoopWaitStatus::Open,
+                        satisfied_by_event_id: None,
+                    },
+                ),
+                "owned PR is green and waiting for merge",
+            );
+        }
+        AgentTaskPrOwnershipState::Merged => {
+            record.record_action(
+                AgentTaskLoopPolicyAction::Complete {
+                    reason: Some("owned PR merged".to_string()),
+                },
+                "owned PR lifecycle completed",
+            );
+        }
+        AgentTaskPrOwnershipState::MissingPr
+        | AgentTaskPrOwnershipState::Stopped
+        | AgentTaskPrOwnershipState::Tracking => {}
+    }
 }
 
 fn claim_controller_action(

--- a/src/core/agent_task_loop_controller.rs
+++ b/src/core/agent_task_loop_controller.rs
@@ -46,6 +46,8 @@ pub struct AgentTaskLoopControllerRecord {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub feedback: Vec<AgentTaskLoopFeedbackArtifact>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pr_ownerships: Vec<AgentTaskPrOwnershipRecord>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_actions: Vec<AgentTaskLoopPolicyActionRecord>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub history: Vec<AgentTaskLoopHistoryEvent>,
@@ -262,6 +264,11 @@ pub enum AgentTaskLoopPolicyAction {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         entity_id: Option<String>,
     },
+    OwnPrUntilGreen {
+        ownership: AgentTaskPrOwnershipRequest,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        entity_id: Option<String>,
+    },
     WaitForEvent(AgentTaskLoopWait),
     WaitForController {
         loop_id: String,
@@ -364,6 +371,73 @@ pub enum AgentTaskLoopCandidateValidationStatus {
 pub struct AgentTaskLoopCandidateLoopLimits {
     #[serde(default = "default_candidate_max_attempts")]
     pub max_attempts: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskPrOwnershipRequest {
+    pub ownership_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub component_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    pub base: String,
+    pub head: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_url: Option<String>,
+    #[serde(default = "default_pr_ownership_max_retries")]
+    pub max_retries: u32,
+    #[serde(default)]
+    pub merge_required: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskPrOwnershipRecord {
+    pub ownership_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entity_id: Option<String>,
+    pub state: AgentTaskPrOwnershipState,
+    pub base: String,
+    pub head: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_sha: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ci_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ci_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_decision: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merge_state: Option<String>,
+    #[serde(default)]
+    pub retry_count: u32,
+    #[serde(default = "default_pr_ownership_max_retries")]
+    pub max_retries: u32,
+    #[serde(default)]
+    pub merge_required: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_checked_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence: Vec<AgentTaskLoopArtifactRef>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskPrOwnershipState {
+    Tracking,
+    WaitingForChecks,
+    ChangesRequested,
+    RetryLimitReached,
+    GreenReady,
+    WaitingForMerge,
+    Merged,
+    MissingPr,
+    Stopped,
 }
 
 impl Default for AgentTaskLoopCandidateLoopLimits {
@@ -567,6 +641,29 @@ pub struct AgentTaskLoopReviewFinding {
     pub dedupe_key: Option<String>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AgentTaskPrOwnershipStatusUpdate {
+    pub pr_number: Option<u64>,
+    pub pr_url: Option<String>,
+    pub head_sha: Option<String>,
+    pub ci_state: Option<String>,
+    pub ci_summary: Option<String>,
+    pub review_decision: Option<String>,
+    pub merge_state: Option<String>,
+    pub retry_count: u32,
+    pub evidence: Vec<AgentTaskLoopArtifactRef>,
+    pub missing_pr: bool,
+}
+
+impl AgentTaskPrOwnershipStatusUpdate {
+    pub fn tracking() -> Self {
+        Self {
+            ci_state: Some("tracking".to_string()),
+            ..Self::default()
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskLoopExternalEvent {
     pub event_id: String,
@@ -660,6 +757,7 @@ impl AgentTaskLoopControllerRecord {
             waits: Vec::new(),
             subcontrollers: Vec::new(),
             feedback: Vec::new(),
+            pr_ownerships: Vec::new(),
             next_actions: Vec::new(),
             history: Vec::new(),
             metadata: Value::Null,
@@ -1124,6 +1222,75 @@ impl AgentTaskLoopControllerRecord {
         )
     }
 
+    pub fn record_pr_ownership_status(
+        &mut self,
+        request: &AgentTaskPrOwnershipRequest,
+        entity_id: Option<String>,
+        status: AgentTaskPrOwnershipStatusUpdate,
+    ) -> AgentTaskPrOwnershipRecord {
+        let state = pr_ownership_state_from_status(&status, request);
+        let record = AgentTaskPrOwnershipRecord {
+            ownership_id: request.ownership_id.clone(),
+            entity_id: entity_id.clone(),
+            state,
+            base: request.base.clone(),
+            head: request.head.clone(),
+            pr_number: status.pr_number.or(request.pr_number),
+            pr_url: status.pr_url.clone().or_else(|| request.pr_url.clone()),
+            head_sha: status.head_sha.clone(),
+            ci_state: status.ci_state.clone(),
+            ci_summary: status.ci_summary.clone(),
+            review_decision: status.review_decision.clone(),
+            merge_state: status.merge_state.clone(),
+            retry_count: status.retry_count,
+            max_retries: request.max_retries,
+            merge_required: request.merge_required,
+            last_checked_at: Some(now_timestamp()),
+            evidence: status.evidence.clone(),
+        };
+
+        if let Some(existing) = self
+            .pr_ownerships
+            .iter_mut()
+            .find(|existing| existing.ownership_id == record.ownership_id)
+        {
+            *existing = record.clone();
+        } else {
+            self.pr_ownerships.push(record.clone());
+        }
+
+        if let Some(entity_id) = &entity_id {
+            if let Some(entity) = self.entities.get_mut(entity_id) {
+                entity.state = Some(format!("pr_{:?}", state).to_ascii_lowercase());
+                entity.metadata = merge_json_object(
+                    entity.metadata.clone(),
+                    json!({
+                        "pr_ownership": {
+                            "ownership_id": record.ownership_id,
+                            "pr_number": record.pr_number,
+                            "pr_url": record.pr_url,
+                            "head": record.head,
+                            "ci_state": record.ci_state,
+                            "merge_state": record.merge_state,
+                            "review_decision": record.review_decision,
+                            "state": state,
+                        }
+                    }),
+                );
+            }
+        }
+
+        self.history.push(AgentTaskLoopHistoryEvent {
+            event_id: format!("pr-ownership-{}", self.history.len() + 1),
+            event_type: "github.pr.ownership_status".to_string(),
+            recorded_at: now_timestamp(),
+            entity_id,
+            payload: json!({ "ownership": record }),
+        });
+        self.touch();
+        record
+    }
+
     fn apply_action_side_effects(
         &mut self,
         action: &AgentTaskLoopPolicyAction,
@@ -1169,6 +1336,35 @@ impl AgentTaskLoopControllerRecord {
                         }
                     }
                 }
+            }
+            AgentTaskLoopPolicyAction::OwnPrUntilGreen {
+                ownership,
+                entity_id,
+            } => {
+                let key = format!(
+                    "{}#{}",
+                    ownership.head,
+                    ownership.pr_number.unwrap_or_default()
+                );
+                let pr_entity_id = entity_id.clone().unwrap_or_else(|| {
+                    self.upsert_entity(
+                        "pull_request",
+                        key,
+                        Vec::new(),
+                        json!({
+                            "ownership_id": ownership.ownership_id,
+                            "base": ownership.base,
+                            "head": ownership.head,
+                            "pr_number": ownership.pr_number,
+                            "pr_url": ownership.pr_url,
+                        }),
+                    )
+                });
+                self.record_pr_ownership_status(
+                    ownership,
+                    Some(pr_entity_id),
+                    AgentTaskPrOwnershipStatusUpdate::tracking(),
+                );
             }
             AgentTaskLoopPolicyAction::WaitForEvent(wait) => {
                 self.state = AgentTaskLoopControllerState::Waiting;
@@ -1531,6 +1727,9 @@ fn action_dedupe_key(action: &AgentTaskLoopPolicyAction) -> Option<String> {
         } => entity_id
             .as_ref()
             .map(|entity_id| format!("gate:{bundle_id}:{entity_id}")),
+        AgentTaskLoopPolicyAction::OwnPrUntilGreen { ownership, .. } => {
+            Some(format!("pr-ownership:{}", ownership.ownership_id))
+        }
         AgentTaskLoopPolicyAction::RequestChanges {
             target_run_id,
             feedback_id,
@@ -1615,7 +1814,8 @@ fn action_entity_id(action: &AgentTaskLoopPolicyAction) -> Option<String> {
         | AgentTaskLoopPolicyAction::SpawnSubloop { entity_id, .. }
         | AgentTaskLoopPolicyAction::WaitForController { entity_id, .. }
         | AgentTaskLoopPolicyAction::RouteFinding { entity_id, .. }
-        | AgentTaskLoopPolicyAction::RunGates { entity_id, .. } => entity_id.clone(),
+        | AgentTaskLoopPolicyAction::RunGates { entity_id, .. }
+        | AgentTaskLoopPolicyAction::OwnPrUntilGreen { entity_id, .. } => entity_id.clone(),
         AgentTaskLoopPolicyAction::MarkHumanReady { entity_id, .. } => Some(entity_id.clone()),
         _ => None,
     }
@@ -1633,6 +1833,7 @@ fn action_name(action: &AgentTaskLoopPolicyAction) -> &'static str {
         AgentTaskLoopPolicyAction::Retry { .. } => "retry",
         AgentTaskLoopPolicyAction::RequestChanges { .. } => "request_changes",
         AgentTaskLoopPolicyAction::RunGates { .. } => "run_gates",
+        AgentTaskLoopPolicyAction::OwnPrUntilGreen { .. } => "own_pr_until_green",
         AgentTaskLoopPolicyAction::WaitForEvent(_) => "wait_for_event",
         AgentTaskLoopPolicyAction::WaitForController { .. } => "wait_for_controller",
         AgentTaskLoopPolicyAction::MarkHumanReady { .. } => "mark_human_ready",
@@ -1846,6 +2047,77 @@ fn open_wait_status() -> AgentTaskLoopWaitStatus {
 
 fn default_candidate_max_attempts() -> u32 {
     3
+}
+
+fn default_pr_ownership_max_retries() -> u32 {
+    3
+}
+
+fn pr_ownership_state_from_status(
+    status: &AgentTaskPrOwnershipStatusUpdate,
+    request: &AgentTaskPrOwnershipRequest,
+) -> AgentTaskPrOwnershipState {
+    if status.missing_pr {
+        return AgentTaskPrOwnershipState::MissingPr;
+    }
+    if status
+        .merge_state
+        .as_deref()
+        .is_some_and(|state| state.eq_ignore_ascii_case("MERGED"))
+    {
+        return AgentTaskPrOwnershipState::Merged;
+    }
+    if status
+        .ci_state
+        .as_deref()
+        .is_some_and(|state| state == "terminal_failed" || state == "stale")
+    {
+        return if status.retry_count >= request.max_retries {
+            AgentTaskPrOwnershipState::RetryLimitReached
+        } else {
+            AgentTaskPrOwnershipState::ChangesRequested
+        };
+    }
+    if status
+        .review_decision
+        .as_deref()
+        .is_some_and(|decision| decision == "CHANGES_REQUESTED")
+    {
+        return if status.retry_count >= request.max_retries {
+            AgentTaskPrOwnershipState::RetryLimitReached
+        } else {
+            AgentTaskPrOwnershipState::ChangesRequested
+        };
+    }
+    if status
+        .ci_state
+        .as_deref()
+        .is_some_and(|state| state == "pending" || state == "no_checks" || state == "tracking")
+    {
+        return AgentTaskPrOwnershipState::WaitingForChecks;
+    }
+    if status
+        .ci_state
+        .as_deref()
+        .is_some_and(|state| state == "terminal_green")
+    {
+        return if request.merge_required {
+            AgentTaskPrOwnershipState::WaitingForMerge
+        } else {
+            AgentTaskPrOwnershipState::GreenReady
+        };
+    }
+    AgentTaskPrOwnershipState::Tracking
+}
+
+fn merge_json_object(left: Value, right: Value) -> Value {
+    let mut merged = left.as_object().cloned().unwrap_or_default();
+    if let Some(right) = right.as_object() {
+        for (key, value) in right {
+            merged.insert(key.clone(), value.clone());
+        }
+    }
+    Value::Object(merged)
 }
 
 fn now_timestamp() -> String {
@@ -2115,6 +2387,85 @@ mod tests {
             Some("feedback:run-repair-1:review-1")
         );
         assert_eq!(action.status, AgentTaskLoopActionStatus::Pending);
+    }
+
+    #[test]
+    fn own_pr_until_green_persists_generic_pr_lifecycle_state() {
+        let mut record = AgentTaskLoopControllerRecord::new("loop", "review", "v1");
+        let request = AgentTaskPrOwnershipRequest {
+            ownership_id: "run-123".to_string(),
+            component_id: None,
+            path: None,
+            base: "main".to_string(),
+            head: "fix/pr-owner".to_string(),
+            pr_number: Some(42),
+            pr_url: Some("https://github.com/Extra-Chill/homeboy/pull/42".to_string()),
+            max_retries: 2,
+            merge_required: true,
+        };
+        let action = record.record_action(
+            AgentTaskLoopPolicyAction::OwnPrUntilGreen {
+                ownership: request.clone(),
+                entity_id: None,
+            },
+            "own PR after finalization",
+        );
+
+        assert_eq!(action.status, AgentTaskLoopActionStatus::Pending);
+        assert_eq!(record.pr_ownerships.len(), 1);
+        assert_eq!(
+            record.pr_ownerships[0].state,
+            AgentTaskPrOwnershipState::WaitingForChecks
+        );
+        assert_eq!(record.pr_ownerships[0].head, "fix/pr-owner");
+        assert_eq!(record.pr_ownerships[0].pr_number, Some(42));
+        assert!(record.entities.contains_key("pull_request:fix_pr-owner_42"));
+
+        let serialized = serde_json::to_value(&action.action).expect("serialized action");
+        assert_eq!(serialized["action"], "own_pr_until_green");
+        assert_eq!(serialized["ownership"]["ownership_id"], "run-123");
+    }
+
+    #[test]
+    fn pr_ownership_red_checks_increment_until_retry_limit() {
+        let mut record = AgentTaskLoopControllerRecord::new("loop", "review", "v1");
+        let request = AgentTaskPrOwnershipRequest {
+            ownership_id: "run-123".to_string(),
+            component_id: None,
+            path: None,
+            base: "main".to_string(),
+            head: "fix/pr-owner".to_string(),
+            pr_number: Some(42),
+            pr_url: None,
+            max_retries: 2,
+            merge_required: false,
+        };
+
+        let first = record.record_pr_ownership_status(
+            &request,
+            Some("pr:42".to_string()),
+            AgentTaskPrOwnershipStatusUpdate {
+                pr_number: Some(42),
+                ci_state: Some("terminal_failed".to_string()),
+                retry_count: 1,
+                ..AgentTaskPrOwnershipStatusUpdate::default()
+            },
+        );
+        let second = record.record_pr_ownership_status(
+            &request,
+            Some("pr:42".to_string()),
+            AgentTaskPrOwnershipStatusUpdate {
+                pr_number: Some(42),
+                ci_state: Some("terminal_failed".to_string()),
+                retry_count: 2,
+                ..AgentTaskPrOwnershipStatusUpdate::default()
+            },
+        );
+
+        assert_eq!(first.state, AgentTaskPrOwnershipState::ChangesRequested);
+        assert_eq!(second.state, AgentTaskPrOwnershipState::RetryLimitReached);
+        assert_eq!(record.pr_ownerships.len(), 1);
+        assert_eq!(record.pr_ownerships[0].retry_count, 2);
     }
 
     #[test]

--- a/src/core/agent_task_loop_controller.rs
+++ b/src/core/agent_task_loop_controller.rs
@@ -2427,6 +2427,59 @@ mod tests {
     }
 
     #[test]
+    fn deterministic_policy_transition_can_start_pr_ownership_once() {
+        let mut record = AgentTaskLoopControllerRecord::new("loop", "finalize", "v1");
+        let ownership = AgentTaskPrOwnershipRequest {
+            ownership_id: "branch:fix-pr-owner".to_string(),
+            component_id: Some("homeboy".to_string()),
+            path: None,
+            base: "main".to_string(),
+            head: "fix/pr-owner".to_string(),
+            pr_number: Some(42),
+            pr_url: None,
+            max_retries: 3,
+            merge_required: false,
+        };
+        let policy = AgentTaskLoopPolicy {
+            policy_id: "own-pr-after-finalization".to_string(),
+            transitions: vec![AgentTaskLoopTransition {
+                transition_id: "finalized-branch".to_string(),
+                from_phase: Some("finalize".to_string()),
+                on_event_type: Some("agent_task.finalized".to_string()),
+                when_json_path: Some("$.event.payload.branch".to_string()),
+                actions: vec![AgentTaskLoopPolicyAction::OwnPrUntilGreen {
+                    ownership: ownership.clone(),
+                    entity_id: Some("pr:42".to_string()),
+                }],
+            }],
+        };
+        let event = AgentTaskLoopExternalEvent {
+            event_id: "event-1".to_string(),
+            event_type: "agent_task.finalized".to_string(),
+            event_key: None,
+            entity_id: None,
+            payload: json!({ "branch": "fix/pr-owner" }),
+        };
+
+        let first = record.evaluate_policy(&policy, Some(&event));
+        let second = record.evaluate_policy(&policy, Some(&event));
+
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].status, AgentTaskLoopActionStatus::Pending);
+        assert_eq!(
+            first[0].dedupe_key.as_deref(),
+            Some("pr-ownership:branch:fix-pr-owner")
+        );
+        assert_eq!(second.len(), 1);
+        assert_eq!(
+            second[0].status,
+            AgentTaskLoopActionStatus::AlreadySatisfied
+        );
+        assert_eq!(record.pr_ownerships.len(), 1);
+        assert_eq!(record.pr_ownerships[0].entity_id.as_deref(), Some("pr:42"));
+    }
+
+    #[test]
     fn pr_ownership_red_checks_increment_until_retry_limit() {
         let mut record = AgentTaskLoopControllerRecord::new("loop", "review", "v1");
         let request = AgentTaskPrOwnershipRequest {

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -887,6 +887,7 @@ mod tests {
     use super::*;
     use crate::core::component::ComponentScriptsConfig;
     use crate::core::project::ProjectComponentAttachment;
+    use crate::test_support::with_isolated_home;
     use std::collections::HashMap;
     use std::path::Path;
     use tempfile::TempDir;
@@ -1381,44 +1382,46 @@ mod tests {
 
     #[test]
     fn deploy_preflight_cleans_homeboy_build_dir_after_failed_build() {
-        let dir = TempDir::new().expect("temp dir");
-        let component = failing_build_artifact_component(
-            "failing",
-            &dir.path().to_string_lossy(),
-            ".homeboy-build/plugin.zip",
-        );
-        let project = Project {
-            id: "site".to_string(),
-            ..Project::default()
-        };
-        let mut config = base_deploy_config();
-        config.force = true;
-        config.head = true;
+        with_isolated_home(|_| {
+            let dir = TempDir::new().expect("temp dir");
+            let component = failing_build_artifact_component(
+                "failing",
+                &dir.path().to_string_lossy(),
+                ".homeboy-build/plugin.zip",
+            );
+            let project = Project {
+                id: "site".to_string(),
+                ..Project::default()
+            };
+            let mut config = base_deploy_config();
+            config.force = true;
+            config.head = true;
 
-        let (build_exit_code, build_error) = crate::core::build::build_component(&component);
-        assert_eq!(build_exit_code, Some(42));
-        assert!(
-            build_error.is_some(),
-            "fixture build must fail before deploy cleanup can validate failure handling"
-        );
+            let (build_exit_code, build_error) = crate::core::build::build_component(&component);
+            assert_eq!(build_exit_code, Some(42));
+            assert!(
+                build_error.is_some(),
+                "fixture build must fail before deploy cleanup can validate failure handling"
+            );
 
-        let failures = match prepare_component_deployments(
-            &[component],
-            &config,
-            &project,
-            "/srv/site",
-            &HashMap::new(),
-            &HashMap::new(),
-        ) {
-            Ok(_) => panic!("failed build should abort preflight"),
-            Err(failures) => failures,
-        };
+            let failures = match prepare_component_deployments(
+                &[component],
+                &config,
+                &project,
+                "/srv/site",
+                &HashMap::new(),
+                &HashMap::new(),
+            ) {
+                Ok(_) => panic!("failed build should abort preflight"),
+                Err(failures) => failures,
+            };
 
-        assert_eq!(failures.len(), 1);
-        assert_eq!(failures[0].build_exit_code, Some(42));
-        assert!(
-            !dir.path().join(".homeboy-build").exists(),
-            "deploy-context failed builds must clean Homeboy-generated build artifacts"
-        );
+            assert_eq!(failures.len(), 1);
+            assert_eq!(failures[0].build_exit_code, Some(42));
+            assert!(
+                !dir.path().join(".homeboy-build").exists(),
+                "deploy-context failed builds must clean Homeboy-generated build artifacts"
+            );
+        });
     }
 }

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -799,6 +799,7 @@ mod tests {
     use super::*;
     use crate::core::component::ComponentScriptsConfig;
     use crate::core::extension::test::TestFailure;
+    use crate::test_support::with_isolated_home;
 
     #[test]
     fn tail_lines_returns_full_text_when_under_limit() {
@@ -894,13 +895,14 @@ mod tests {
 
     #[test]
     fn declared_result_parser_script_normalizes_provider_json() {
-        let temp_dir = tempfile::tempdir().expect("temp dir");
-        let extension_dir = temp_dir.path().join("extension");
-        std::fs::create_dir_all(&extension_dir).expect("extension dir");
-        let parser_script = extension_dir.join("parse-results.sh");
-        std::fs::write(
-            &parser_script,
-            r#"#!/usr/bin/env bash
+        with_isolated_home(|_| {
+            let temp_dir = tempfile::tempdir().expect("temp dir");
+            let extension_dir = temp_dir.path().join("extension");
+            std::fs::create_dir_all(&extension_dir).expect("extension dir");
+            let parser_script = extension_dir.join("parse-results.sh");
+            std::fs::write(
+                &parser_script,
+                r#"#!/usr/bin/env bash
 set -euo pipefail
 if [ "${2:-}" != "custom-json" ]; then
     exit 7
@@ -945,43 +947,43 @@ EOF
 homeboy_write_test_results "$total" "$passed" "$failed" "$skipped"
 printf 'provider parser log line\n'
 "#,
-        )
-        .expect("parser script");
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&parser_script, std::fs::Permissions::from_mode(0o755))
-                .expect("parser script permissions");
-        }
+            )
+            .expect("parser script");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&parser_script, std::fs::Permissions::from_mode(0o755))
+                    .expect("parser script permissions");
+            }
 
-        let component = Component::new(
-            "fixture".to_string(),
-            temp_dir.path().to_string_lossy().to_string(),
-            "fixture-extension".to_string(),
-            None,
-        );
-        let context = crate::core::extension::ExtensionExecutionContext {
-            component: component.clone(),
-            capability: ExtensionCapability::Test,
-            extension_id: "fixture-extension".to_string(),
-            extension_path: extension_dir,
-            script_path: "test.sh".to_string(),
-            settings: Vec::new(),
-        };
-        let spec = ParseSpec {
-            extension_script: Some("parse-results.sh".to_string()),
-            adapters: vec!["custom-json".to_string()],
-            rules: Vec::new(),
-            defaults: std::collections::HashMap::new(),
-            derive: Vec::new(),
-        };
-        let run_dir = RunDir::create().expect("run dir");
+            let component = Component::new(
+                "fixture".to_string(),
+                temp_dir.path().to_string_lossy().to_string(),
+                "fixture-extension".to_string(),
+                None,
+            );
+            let context = crate::core::extension::ExtensionExecutionContext {
+                component: component.clone(),
+                capability: ExtensionCapability::Test,
+                extension_id: "fixture-extension".to_string(),
+                extension_path: extension_dir,
+                script_path: "test.sh".to_string(),
+                settings: Vec::new(),
+            };
+            let spec = ParseSpec {
+                extension_script: Some("parse-results.sh".to_string()),
+                adapters: vec!["custom-json".to_string()],
+                rules: Vec::new(),
+                defaults: std::collections::HashMap::new(),
+                derive: Vec::new(),
+            };
+            let run_dir = RunDir::create().expect("run dir");
 
-        run_declared_result_parser(
-            &component,
-            &context,
-            &spec,
-            r#"{
+            run_declared_result_parser(
+                &component,
+                &context,
+                &spec,
+                r#"{
                 "schema": "custom-provider/test-results/v1",
                 "summary": { "total": 0 },
                 "suites": [
@@ -989,22 +991,23 @@ printf 'provider parser log line\n'
                     { "total": 2, "passed": 1, "skipped": 1 }
                 ]
             }"#,
-            &run_dir,
-        )
-        .expect("declared parser should run");
+                &run_dir,
+            )
+            .expect("declared parser should run");
 
-        let counts = parse_test_results_file_with_spec(
-            &run_dir.step_file(run_dir::files::TEST_RESULTS),
-            Some(&spec),
-        )
-        .expect("declared parser should write normalized counts");
+            let counts = parse_test_results_file_with_spec(
+                &run_dir.step_file(run_dir::files::TEST_RESULTS),
+                Some(&spec),
+            )
+            .expect("declared parser should write normalized counts");
 
-        run_dir.cleanup();
+            run_dir.cleanup();
 
-        assert_eq!(counts.total, 5);
-        assert_eq!(counts.passed, 3);
-        assert_eq!(counts.failed, 1);
-        assert_eq!(counts.skipped, 1);
+            assert_eq!(counts.total, 5);
+            assert_eq!(counts.passed, 3);
+            assert_eq!(counts.failed, 1);
+            assert_eq!(counts.skipped, 1);
+        });
     }
 
     #[test]
@@ -1125,63 +1128,65 @@ exit 23
 
     #[test]
     fn declared_result_parser_accepts_flat_count_stdout_json() {
-        let temp_dir = tempfile::tempdir().expect("temp dir");
-        let extension_dir = temp_dir.path().join("extension");
-        std::fs::create_dir_all(&extension_dir).expect("extension dir");
-        let parser_script = extension_dir.join("parse-results.sh");
-        std::fs::write(
-            &parser_script,
-            r#"#!/usr/bin/env bash
+        with_isolated_home(|_| {
+            let temp_dir = tempfile::tempdir().expect("temp dir");
+            let extension_dir = temp_dir.path().join("extension");
+            std::fs::create_dir_all(&extension_dir).expect("extension dir");
+            let parser_script = extension_dir.join("parse-results.sh");
+            std::fs::write(
+                &parser_script,
+                r#"#!/usr/bin/env bash
 set -euo pipefail
 printf '{"total":5,"passed":3,"failed":1,"skipped":1}\n'
 "#,
-        )
-        .expect("parser script");
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&parser_script, std::fs::Permissions::from_mode(0o755))
-                .expect("parser script permissions");
-        }
+            )
+            .expect("parser script");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&parser_script, std::fs::Permissions::from_mode(0o755))
+                    .expect("parser script permissions");
+            }
 
-        let component = Component::new(
-            "fixture".to_string(),
-            temp_dir.path().to_string_lossy().to_string(),
-            "fixture-extension".to_string(),
-            None,
-        );
-        let context = crate::core::extension::ExtensionExecutionContext {
-            component: component.clone(),
-            capability: ExtensionCapability::Test,
-            extension_id: "fixture-extension".to_string(),
-            extension_path: extension_dir,
-            script_path: "test.sh".to_string(),
-            settings: Vec::new(),
-        };
-        let spec = ParseSpec {
-            extension_script: Some("parse-results.sh".to_string()),
-            adapters: vec!["fixture-json".to_string()],
-            rules: Vec::new(),
-            defaults: std::collections::HashMap::new(),
-            derive: Vec::new(),
-        };
-        let run_dir = RunDir::create().expect("run dir");
+            let component = Component::new(
+                "fixture".to_string(),
+                temp_dir.path().to_string_lossy().to_string(),
+                "fixture-extension".to_string(),
+                None,
+            );
+            let context = crate::core::extension::ExtensionExecutionContext {
+                component: component.clone(),
+                capability: ExtensionCapability::Test,
+                extension_id: "fixture-extension".to_string(),
+                extension_path: extension_dir,
+                script_path: "test.sh".to_string(),
+                settings: Vec::new(),
+            };
+            let spec = ParseSpec {
+                extension_script: Some("parse-results.sh".to_string()),
+                adapters: vec!["fixture-json".to_string()],
+                rules: Vec::new(),
+                defaults: std::collections::HashMap::new(),
+                derive: Vec::new(),
+            };
+            let run_dir = RunDir::create().expect("run dir");
 
-        run_declared_result_parser(&component, &context, &spec, "runner output", &run_dir)
-            .expect("declared parser stdout should run");
+            run_declared_result_parser(&component, &context, &spec, "runner output", &run_dir)
+                .expect("declared parser stdout should run");
 
-        let counts = parse_test_results_file_with_spec(
-            &run_dir.step_file(run_dir::files::TEST_RESULTS),
-            Some(&spec),
-        )
-        .expect("parser stdout JSON should be normalized to test-results.json");
+            let counts = parse_test_results_file_with_spec(
+                &run_dir.step_file(run_dir::files::TEST_RESULTS),
+                Some(&spec),
+            )
+            .expect("parser stdout JSON should be normalized to test-results.json");
 
-        run_dir.cleanup();
+            run_dir.cleanup();
 
-        assert_eq!(counts.total, 5);
-        assert_eq!(counts.passed, 3);
-        assert_eq!(counts.failed, 1);
-        assert_eq!(counts.skipped, 1);
+            assert_eq!(counts.total, 5);
+            assert_eq!(counts.passed, 3);
+            assert_eq!(counts.failed, 1);
+            assert_eq!(counts.skipped, 1);
+        });
     }
 
     #[test]

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -157,27 +157,29 @@ fn component_scripts_include_linked_extension_env_provider_output() {
 
 #[test]
 fn test_run_component_scripts_with_run_dir() {
-    let dir = tempfile::tempdir().expect("temp dir");
-    let run_dir = RunDir::create().expect("run dir");
-    let component = script_component(
-        dir.path(),
-        "test -n \"$HOMEBOY_RUN_DIR\" && printf ok > marker",
-    );
+    with_isolated_home(|_| {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let run_dir = RunDir::create().expect("run dir");
+        let component = script_component(
+            dir.path(),
+            "test -n \"$HOMEBOY_RUN_DIR\" && printf ok > marker",
+        );
 
-    let output = run_component_scripts_with_run_dir(
-        &component,
-        ExtensionCapability::Test,
-        dir.path(),
-        &run_dir,
-        false,
-        &[],
-        &[],
-    )
-    .expect("component script should run with run dir");
+        let output = run_component_scripts_with_run_dir(
+            &component,
+            ExtensionCapability::Test,
+            dir.path(),
+            &run_dir,
+            false,
+            &[],
+            &[],
+        )
+        .expect("component script should run with run dir");
 
-    assert!(output.success);
-    assert_eq!(fs::read_to_string(dir.path().join("marker")).unwrap(), "ok");
-    run_dir.cleanup();
+        assert!(output.success);
+        assert_eq!(fs::read_to_string(dir.path().join("marker")).unwrap(), "ok");
+        run_dir.cleanup();
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add a generic `own_pr_until_green` agent-task loop action that persists PR ownership state, polls existing GitHub PR view/find surfaces, and queues retry/wait/human-ready/complete follow-up actions.
- Persist PR ownership records and entity metadata so agent-task controllers can resume ownership across red checks, pending checks, green readiness, merge waits, and merged PRs.
- Fix validation blockers encountered while proving the change: register `test.results` in the runtime sidecar helper and isolate run-dir tests that mutate shared runtime env state.

Fixes #4578

## Validation
- `homeboy runner exec homeboy-lab --cwd <snapshot> -- cargo check` passed: `2fce685d-c91f-42a1-a5e9-e56224a85a09`
- `homeboy runner exec homeboy-lab --cwd <snapshot> -- cargo test --no-run` passed: `adf084b7-264b-4ddb-a29d-1efd9a2e656d`
- `cargo test own_pr_until_green_persists_generic_pr_lifecycle_state` passed on `homeboy-lab`: `fdc909ca-ec27-47c8-aeb4-0e56180d1a6a`
- `cargo test pr_ownership_red_checks_increment_until_retry_limit` passed on `homeboy-lab`: `16cd5daf-1110-4bd9-8362-68a2fa005117`
- `cargo test secret_env_refs` passed on `homeboy-lab`: `7400d389-1c9d-43d3-9ddb-e04d1ecc7be3`
- `cargo test test_run_component_scripts_with_run_dir` passed on `homeboy-lab`: `ed39ffa7-35bd-4b25-a1ac-57e0a1fae143`
- `cargo test declared_result_parser` passed on `homeboy-lab`: `d3059c90-700c-406b-aae4-709b21220cae`
- `cargo test deploy_preflight_cleans_homeboy_build_dir_after_failed_build` passed on `homeboy-lab`: `a2cf6d50-e06e-4293-876f-d9e021d8778c`
- Full `homeboy test homeboy --runner homeboy-lab --allow-dirty-lab-workspace` progressed to `4596 passed`, `2 failed`, `18 ignored`; remaining failures are unrelated pre-existing core-agnostic audit findings in unchanged files (`tests/core_agnostic_test.rs`, output saved locally at `/Users/chubes/.local/share/opencode/tool-output/tool_ecc55ae74001YEIS30SvDSEOtD`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, and validation notes; Chris remains responsible for review and final acceptance.