### PR TITLE
Fail early for WordPress plugin Composer autoload gaps

### DIFF
--- a/src/core/extension/trace/preflight.rs
+++ b/src/core/extension/trace/preflight.rs
@@ -111,6 +111,29 @@ fn preflight_trace_dependency(
         }
     }
 
+    if dependency.kind == "wordpress-plugin" {
+        if let Some(missing) =
+            crate::extensions::wordpress_plugin_runtime::missing_composer_autoload_runtime(root)
+        {
+            return Err(trace_preflight_error(
+                "trace.dependencies",
+                format!(
+                    "trace dependency '{}' plugin source has composer.json autoload entries but no {}",
+                    dependency.id, missing.required_path
+                ),
+                serde_json::json!({
+                    "kind": "trace-dependency",
+                    "dependency_kind": dependency.kind,
+                    "dependency_id": dependency.id,
+                    "failure": "missing_composer_autoload_runtime",
+                    "path": root.to_string_lossy(),
+                    "required_path": missing.required_path,
+                    "composer_manifest": "composer.json"
+                }),
+            ));
+        }
+    }
+
     Ok(TraceDependencyProvenance {
         id: dependency.id.clone(),
         kind: dependency.kind.clone(),
@@ -264,6 +287,48 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("missing_required_path"));
+    }
+
+    #[test]
+    fn trace_dependency_preflight_rejects_wp_plugin_autoload_without_vendor() {
+        let temp = tempfile::tempdir().unwrap();
+        let plugin_root = temp.path().join("sample-plugin");
+        std::fs::create_dir_all(&plugin_root).unwrap();
+        std::fs::write(plugin_root.join("sample-plugin.php"), "<?php\n").unwrap();
+        std::fs::write(
+            plugin_root.join("composer.json"),
+            r#"{
+                "autoload": {
+                    "classmap": ["includes/"]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let err = preflight_trace_dependencies(&[TraceDependencySpec {
+            id: "sample-plugin".to_string(),
+            kind: "wordpress-plugin".to_string(),
+            source: "source-checkout".to_string(),
+            path: Some(plugin_root.to_string_lossy().to_string()),
+            plugin_file: Some("sample-plugin.php".to_string()),
+            requires_built_assets: false,
+            required_paths: Vec::new(),
+            source_url: None,
+            version: None,
+            r#ref: None,
+            package_marker: None,
+        }])
+        .expect_err("autoloaded WordPress plugin source should fail before runner activation");
+
+        assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+        assert_eq!(err.details["field"], "trace.dependencies");
+        assert!(err
+            .message
+            .contains("composer.json autoload entries but no vendor/autoload.php"));
+        assert!(err.details["tried"][0]
+            .as_str()
+            .unwrap()
+            .contains("missing_composer_autoload_runtime"));
     }
 
     #[test]

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1,2 +1,3 @@
 pub mod deps_provider;
 pub mod npm_deps_provider;
+pub(crate) mod wordpress_plugin_runtime;

--- a/src/extensions/wordpress_plugin_runtime.rs
+++ b/src/extensions/wordpress_plugin_runtime.rs
@@ -1,0 +1,91 @@
+use std::path::Path;
+
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MissingComposerAutoloadRuntime {
+    pub required_path: String,
+}
+
+pub(crate) fn missing_composer_autoload_runtime(
+    plugin_root: &Path,
+) -> Option<MissingComposerAutoloadRuntime> {
+    let composer_path = plugin_root.join("composer.json");
+    if !composer_path.is_file() || plugin_root.join("vendor/autoload.php").is_file() {
+        return None;
+    }
+
+    let manifest = std::fs::read_to_string(composer_path).ok()?;
+    let manifest: Value = serde_json::from_str(&manifest).ok()?;
+    if !composer_declares_runtime_autoload(&manifest) {
+        return None;
+    }
+
+    Some(MissingComposerAutoloadRuntime {
+        required_path: "vendor/autoload.php".to_string(),
+    })
+}
+
+fn composer_declares_runtime_autoload(manifest: &Value) -> bool {
+    manifest
+        .get("autoload")
+        .is_some_and(composer_section_has_entries)
+}
+
+fn composer_section_has_entries(section: &Value) -> bool {
+    match section {
+        Value::Object(entries) => !entries.is_empty(),
+        Value::Array(entries) => !entries.is_empty(),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reports_missing_vendor_autoload_for_composer_runtime_autoload() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("composer.json"),
+            r#"{
+                "autoload": {
+                    "classmap": ["includes/"]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let missing = missing_composer_autoload_runtime(temp.path())
+            .expect("autoloaded plugin source should require vendor/autoload.php");
+
+        assert_eq!(missing.required_path, "vendor/autoload.php");
+    }
+
+    #[test]
+    fn accepts_runtime_complete_composer_autoload() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("vendor")).unwrap();
+        std::fs::write(temp.path().join("vendor/autoload.php"), "<?php\n").unwrap();
+        std::fs::write(
+            temp.path().join("composer.json"),
+            r#"{"autoload":{"psr-4":{"Example\\":"src/"}}}"#,
+        )
+        .unwrap();
+
+        assert!(missing_composer_autoload_runtime(temp.path()).is_none());
+    }
+
+    #[test]
+    fn ignores_composer_without_runtime_autoload() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("composer.json"),
+            r#"{"autoload-dev":{"psr-4":{"Example\\Tests\\":"tests/"}}}"#,
+        )
+        .unwrap();
+
+        assert!(missing_composer_autoload_runtime(temp.path()).is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- Add a WordPress plugin runtime-readiness helper that detects `composer.json` runtime `autoload` entries without `vendor/autoload.php`.
- Fail trace dependency preflight before WP Codebox activation when a `wordpress-plugin` input is not Composer-runtime-complete.
- Keep the check generic to WordPress plugin runtime artifacts; no WooCommerce or Stripe-specific workaround.

Closes #4600.

## Verification
- `git diff --check`
- `rustfmt --check src/core/extension/trace/preflight.rs src/extensions/mod.rs src/extensions/wordpress_plugin_runtime.rs`
- Offloaded on `homeboy-lab`: `cargo test trace_dependency_preflight_rejects_wp_plugin_autoload_without_vendor` via runner job `ea807f7e-6c65-46f8-a606-26059125d777` / mirror run `runner-exec-homeboy-lab-ea807f7e-6c65-46f8-a606-26059125d777`
- Offloaded on `homeboy-lab`: `cargo test wordpress_plugin_runtime` via runner job `6522965f-3880-435f-97e1-cafbe13085f6` / mirror run `runner-exec-homeboy-lab-6522965f-3880-435f-97e1-cafbe13085f6`
- Offloaded source check: runner job `620ae9b7-a1e1-4770-885b-fe89cb90927c` confirmed the final synced source contains `trace_dependency_preflight_rejects_wp_plugin_autoload_without_vendor`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation and tests; Chris remains responsible for review and merge.