### PR TITLE
Fix empty agent-task patch candidate reporting

### DIFF
--- a/src/commands/agent_task_summary.rs
+++ b/src/commands/agent_task_summary.rs
@@ -39,8 +39,7 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
         .unwrap_or(0);
     let aggregate_path = string_value(payload, &["aggregate_path"])
         .or_else(|| string_value(payload, &["record", "aggregate_path"]));
-    let apply_candidates = usize_value(payload, &["aggregate", "totals", "apply_candidates"])
-        .or_else(|| array_len(payload, &["aggregate", "outcomes"]));
+    let apply_candidates = usize_value(payload, &["aggregate", "totals", "apply_candidates"]);
     let artifact_count = array_len(payload, &["aggregate", "outcomes", "0", "artifacts"]);
     let first_artifact = string_value(
         payload,
@@ -111,14 +110,18 @@ fn render_review_summary(payload: &Value) -> Option<String> {
                 &["aggregate_review", "summary", "apply_candidates"],
             )
         })
-        .unwrap_or_else(|| array_len(payload, &["promotion_candidates"]).unwrap_or(0));
+        .unwrap_or(0);
     let failed = summary
         .and_then(|_| usize_value(payload, &["aggregate_review", "summary", "failed"]))
         .unwrap_or(0);
-    let patch = string_value(payload, &["promotion_candidates", "0", "artifact_id"]);
+    let patch = (apply_candidates > 0)
+        .then(|| string_value(payload, &["promotion_candidates", "0", "artifact_id"]))
+        .flatten();
     let patch_path = patch.and_then(|artifact_id| artifact_path(payload, artifact_id));
     let next = first_string(payload, &["next_actions"]);
-    let command = command_line(payload, &["promotion_candidates", "0", "command"]);
+    let command = (apply_candidates > 0)
+        .then(|| command_line(payload, &["promotion_candidates", "0", "command"]))
+        .flatten();
 
     let outcome = if apply_candidates > 0 {
         "patch produced, not promoted"
@@ -220,9 +223,30 @@ mod tests {
 
         assert!(summary.starts_with("Agent task cook\nRun: homeboy-4345\nStatus: succeeded"));
         assert!(summary.contains("Tasks: 1\n"));
+        assert!(!summary.contains("Patch candidates:"));
         assert!(summary.contains("First artifact: /tmp/patch.diff\n"));
         assert!(summary.contains("Next: homeboy agent-task review homeboy-4345\n"));
         assert!(!summary.contains("{\n"));
+    }
+
+    #[test]
+    fn cook_summary_uses_aggregate_totals_for_patch_candidates() {
+        let payload = json!({
+            "run_id": "homeboy-4345",
+            "state": "succeeded",
+            "task_count": 1,
+            "aggregate": {
+                "totals": { "apply_candidates": 0 },
+                "outcomes": [{
+                    "task_id": "homeboy-4345",
+                    "artifacts": [{ "id": "empty-patch", "path": "/tmp/patch.diff" }]
+                }]
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
+
+        assert!(summary.contains("Patch candidates: 0\n"));
     }
 
     #[test]
@@ -257,6 +281,37 @@ mod tests {
         assert!(summary
             .contains("Next: homeboy agent-task promote homeboy-4345 --artifact-id patch.diff\n"));
         assert!(!summary.contains("promotion_candidates"));
+    }
+
+    #[test]
+    fn review_summary_does_not_treat_stale_promotion_candidates_as_patches() {
+        let payload = json!({
+            "run_id": "homeboy-4345",
+            "state": "failed",
+            "aggregate_review": {
+                "summary": {
+                    "apply_candidates": 0,
+                    "failed": 1
+                },
+                "artifact_inventory": [{
+                    "task_id": "homeboy-4345",
+                    "artifact_id": "empty-patch",
+                    "kind": "patch",
+                    "path": "/tmp/patch.diff"
+                }]
+            },
+            "promotion_candidates": [{
+                "artifact_id": "empty-patch",
+                "command": ["homeboy", "agent-task", "promote", "homeboy-4345", "--artifact-id", "empty-patch"]
+            }]
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Review, &payload).unwrap();
+
+        assert!(summary.contains("Outcome: failed or partial failure\n"));
+        assert!(summary.contains("Patch candidates: 0\n"));
+        assert!(!summary.contains("patch produced"));
+        assert!(!summary.contains("Next: homeboy agent-task promote"));
     }
 
     #[test]

--- a/src/core/agent_task_aggregate.rs
+++ b/src/core/agent_task_aggregate.rs
@@ -389,10 +389,11 @@ fn inventory_item(task_id: &str, artifact: &AgentTaskArtifact) -> AgentTaskArtif
 }
 
 fn is_apply_artifact(artifact: &AgentTaskArtifact) -> bool {
-    matches!(
+    let apply_kind = matches!(
         artifact.kind.as_str(),
         "patch" | "diff" | "change_artifact" | "workspace_patch" | "artifact"
-    ) || artifact_flag(artifact, "approved")
+    ) || artifact_flag(artifact, "approved");
+    apply_kind && artifact.size_bytes != Some(0)
 }
 
 fn artifact_flag(artifact: &AgentTaskArtifact, key: &str) -> bool {
@@ -529,6 +530,61 @@ mod tests {
             report.issue_report_candidates[0].reason,
             "artifact marked rejected or false-positive"
         );
+    }
+
+    #[test]
+    fn aggregate_outcomes_does_not_apply_empty_patch_artifacts() {
+        let mut empty_patch = artifact("codebox-patch", "patch", json!({}));
+        empty_patch.size_bytes = Some(0);
+
+        let report = aggregate_agent_task_outcomes(&[outcome(
+            "empty-patch",
+            AgentTaskOutcomeStatus::Succeeded,
+            vec![empty_patch],
+        )]);
+
+        assert!(report.apply_candidates.is_empty());
+        assert_eq!(report.summary.apply_candidates, 0);
+        assert_eq!(report.summary.review_candidates, 1);
+        assert_eq!(report.review_candidates[0].task_id, "empty-patch");
+        assert_eq!(
+            report.review_candidates[0].reason,
+            "succeeded without apply-back artifact"
+        );
+    }
+
+    #[test]
+    fn aggregate_outcomes_keeps_non_empty_patch_apply_candidate() {
+        let mut non_empty_patch = artifact("codebox-patch", "patch", json!({}));
+        non_empty_patch.size_bytes = Some(128);
+
+        let report = aggregate_agent_task_outcomes(&[outcome(
+            "non-empty-patch",
+            AgentTaskOutcomeStatus::Succeeded,
+            vec![non_empty_patch],
+        )]);
+
+        assert_eq!(report.summary.apply_candidates, 1);
+        assert_eq!(report.apply_candidates[0].task_id, "non-empty-patch");
+        assert_eq!(
+            report.apply_candidates[0].artifact_ids,
+            vec!["codebox-patch"]
+        );
+    }
+
+    #[test]
+    fn aggregate_outcomes_keeps_unknown_size_patch_apply_candidate() {
+        let mut unknown_size_patch = artifact("legacy-patch", "patch", json!({}));
+        unknown_size_patch.size_bytes = None;
+
+        let report = aggregate_agent_task_outcomes(&[outcome(
+            "legacy-patch",
+            AgentTaskOutcomeStatus::Succeeded,
+            vec![unknown_size_patch],
+        )]);
+
+        assert_eq!(report.summary.apply_candidates, 1);
+        assert_eq!(report.apply_candidates[0].task_id, "legacy-patch");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Stop classifying zero-byte patch artifacts as agent-task apply candidates.
- Stop cook/review summaries from deriving patch candidates from raw outcome or stale promotion candidate counts.
- Add regression tests for empty, non-empty, and legacy unknown-size patch artifacts plus stale promotion summary output.

## Testing
- `cargo test agent_task_aggregate`
- `cargo test agent_task_summary`
- `cargo fmt --check`
- `git diff --check`

## Notes
This addresses the misleading reporting observed while investigating #4613: empty Codebox patches were surfaced as patch candidates even when changed-files and diff bytes were zero. It does not fully fix the provider polling bug where `metadata.status=processing` is captured as completed; that remains tracked in #4613.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed artifact/summary behavior, implemented the Rust guard and tests, and ran verification commands. Chris remains responsible for review and merge.