### PR TITLE
fix(deploy): resolve artifact version verification against shipped path (#4614)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,11 @@ All notable changes to Homeboy CLI are documented in this file.
 
 (This file is embedded into the CLI binary and is also viewable via `homeboy changelog`.)
 
+## [Unreleased]
+
+### Added
+- support `artifact_path` override on version targets so deploy artifact verification resolves against the shipped path (e.g. compiled `build/<block>/block.json`) instead of the source bump path (`blocks/<block>/block.json`)
+
 ## [0.229.11] - 2026-06-14
 
 ### Changed

--- a/docs/schemas/component-schema.md
+++ b/docs/schemas/component-schema.md
@@ -15,7 +15,8 @@ Component configuration defines buildable and deployable units stored in `compon
   "version_targets": [
     {
       "file": "string",
-      "pattern": "string"
+      "pattern": "string",
+      "artifact_path": "string"
     }
   ],
   "changelog_target": "string",
@@ -54,8 +55,9 @@ Component configuration defines buildable and deployable units stored in `compon
 - **`extract_command`** (string): Command to execute after artifact upload, runs inside target directory
   - Supports template variables: `{artifact}`, `{targetDir}`
 - **`version_targets`** (array): List of version detection patterns
-  - **`file`** (string): Path to file containing version (relative to `local_path`)
+  - **`file`** (string): Path to file containing version (relative to `local_path`). This is the **source** path that the version bump writes to.
   - **`pattern`** (string): Regex pattern to extract version (first capture group)
+  - **`artifact_path`** (string, optional): Path to verify inside the deploy artifact (ZIP) when it differs from `file`. The bump writes `file` (git-tracked source), while pre-deploy verification looks for `artifact_path` inside the shipped artifact. Use this for `@wordpress/scripts` plugins that bump source `blocks/<block>/block.json` but ship the compiled `build/<block>/block.json` (the `blocks/` source dir is excluded from the ZIP). When unset, verification falls back to `file`.
 - **`changelog_target`** (string): Path to changelog file (relative to `local_path`)
 - **`extensions`** (object): Extension-specific settings
   - Keys are extension IDs (e.g., `"wordpress"`, `"rust"`)

--- a/docs/schemas/portable-config.md
+++ b/docs/schemas/portable-config.md
@@ -13,7 +13,8 @@ A `homeboy.json` file in a repo root defines portable component configuration th
   "version_targets": [
     {
       "file": "string",
-      "pattern": "string"
+      "pattern": "string",
+      "artifact_path": "string"
     }
   ],
   "changelog_target": "string",
@@ -73,7 +74,7 @@ homeboy component create --local-path /path/to/repo --changelog-target "CHANGELO
 | `remote_path` | Deploy target relative to project `base_path` |
 | `build_artifact` | Build output path relative to repo root |
 | `extract_command` | Post-upload command (supports `{artifact}`, `{targetDir}`) |
-| `version_targets` | Version detection patterns |
+| `version_targets` | Version detection patterns (`file`, `pattern`, optional `artifact_path`) |
 | `changelog_target` | Path to changelog file |
 | `scripts` | Optional component-owned `lint`, `test`, `build`, `bench`, and `trace` shell commands |
 | `extensions` | Extension configuration (e.g., `{"wordpress": {}}`) |

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -43,12 +43,21 @@ pub use versioning::{
     validate_version_target_conflict,
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 
 pub struct VersionTarget {
     pub file: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pattern: Option<String>,
+    /// Path to verify inside the deploy artifact (ZIP), when it differs from `file`.
+    ///
+    /// `file` is bumped in the workspace (git-tracked source), while `artifact_path`
+    /// is what the verifier looks for inside the shipped artifact. This is needed for
+    /// `@wordpress/scripts` plugins that bump source `blocks/<block>/block.json` but
+    /// ship compiled `build/<block>/block.json` (the `blocks/` source dir is excluded
+    /// from the ZIP). When unset, the verifier falls back to `file`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -735,6 +744,7 @@ mod tests {
         let existing = vec![VersionTarget {
             file: "plugin.php".to_string(),
             pattern: Some("Version: (.*)".to_string()),
+            artifact_path: None,
         }];
 
         let result = validate_version_target_conflict(
@@ -802,6 +812,7 @@ mod tests {
         let existing = vec![VersionTarget {
             file: "plugin.php".to_string(),
             pattern: Some("Version: (.*)".to_string()),
+            artifact_path: None,
         }];
 
         let result =
@@ -814,6 +825,7 @@ mod tests {
         let existing = vec![VersionTarget {
             file: "plugin.php".to_string(),
             pattern: Some("Version: (.*)".to_string()),
+            artifact_path: None,
         }];
 
         let result = validate_version_target_conflict(

--- a/src/core/component/versioning.rs
+++ b/src/core/component/versioning.rs
@@ -90,11 +90,13 @@ pub fn parse_version_targets(targets: &[String]) -> Result<Vec<VersionTarget>> {
             parsed.push(VersionTarget {
                 file: file.to_string(),
                 pattern: Some(normalized),
+                artifact_path: None,
             });
         } else {
             parsed.push(VersionTarget {
                 file: file.to_string(),
                 pattern: None,
+                artifact_path: None,
             });
         }
     }

--- a/src/core/deploy/effect.rs
+++ b/src/core/deploy/effect.rs
@@ -72,6 +72,7 @@ mod tests {
             version_targets: Some(vec![VersionTarget {
                 file: "plugin.php".to_string(),
                 pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+                artifact_path: None,
             }]),
             ..Component::default()
         };
@@ -107,6 +108,7 @@ mod tests {
             version_targets: Some(vec![VersionTarget {
                 file: "plugin.php".to_string(),
                 pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+                artifact_path: None,
             }]),
             ..Component::default()
         };

--- a/src/core/deploy/execution.rs
+++ b/src/core/deploy/execution.rs
@@ -784,14 +784,19 @@ fn validate_predeploy_artifact_version(
                 )
             })?
             .replace("\\\\", "\\");
+        // The bump step writes `target.file` in the workspace (git-tracked source),
+        // but the shipped artifact may carry the bumped version at a different path
+        // (e.g. compiled `build/<block>/block.json` instead of source `blocks/...`).
+        // When `artifact_path` is set, verify against that path inside the ZIP.
+        let verify_file = target.artifact_path.as_deref().unwrap_or(&target.file);
         let Some(entry_name) = entry_names
             .iter()
-            .find(|name| zip_entry_matches_version_target(name, &target.file))
+            .find(|name| zip_entry_matches_version_target(name, verify_file))
         else {
             return Err(format!(
                 "Artifact '{}' does not contain version target '{}' for component '{}'. Refusing to deploy unverified content.",
                 artifact_path.display(),
-                target.file,
+                verify_file,
                 component.id
             ));
         };
@@ -1673,6 +1678,48 @@ mod tests {
             .expect("matching artifact version should pass");
     }
 
+    #[test]
+    fn predeploy_artifact_version_inspection_uses_artifact_path_override() {
+        // Mirrors @wordpress/scripts plugins: bump source `blocks/<block>/block.json`
+        // but ship the compiled `build/<block>/block.json` (source `blocks/` excluded
+        // from the ZIP). The verifier must check the artifact_path inside the ZIP.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact = temp.path().join("fixture.zip");
+        write_zip(
+            &artifact,
+            &[(
+                "fixture/build/login-register/block.json",
+                "{\n  \"version\": \"0.17.2\"\n}\n",
+            )],
+        );
+        let component = block_json_component(temp.path());
+
+        validate_predeploy_artifact_version(&component, &artifact, "0.17.2")
+            .expect("artifact_path override should verify against the compiled build/ path");
+    }
+
+    #[test]
+    fn predeploy_artifact_version_inspection_reports_artifact_path_when_missing() {
+        // When artifact_path is set but absent from the ZIP, the error should name the
+        // artifact path (what ships), not the source bump path.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact = temp.path().join("fixture.zip");
+        write_zip(&artifact, &[("fixture/fixture.php", "<?php\n")]);
+        let component = block_json_component(temp.path());
+
+        let error = validate_predeploy_artifact_version(&component, &artifact, "0.17.2")
+            .expect_err("missing artifact_path entry should fail preflight");
+
+        assert!(
+            error.contains("build/login-register/block.json"),
+            "error should reference the artifact_path, got: {error}"
+        );
+        assert!(
+            !error.contains("blocks/login-register/block.json"),
+            "error should not reference the source bump path, got: {error}"
+        );
+    }
+
     fn versioned_zip_component(local_path: &std::path::Path) -> Component {
         Component {
             id: "fixture".to_string(),
@@ -1680,6 +1727,22 @@ mod tests {
             version_targets: Some(vec![VersionTarget {
                 file: "fixture.php".to_string(),
                 pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+                artifact_path: None,
+            }]),
+            ..Component::default()
+        }
+    }
+
+    fn block_json_component(local_path: &std::path::Path) -> Component {
+        Component {
+            id: "fixture".to_string(),
+            local_path: local_path.to_string_lossy().to_string(),
+            version_targets: Some(vec![VersionTarget {
+                // Bumped in the workspace (git-tracked source).
+                file: "blocks/login-register/block.json".to_string(),
+                pattern: Some(r#""version":\s*"([0-9.]+)""#.to_string()),
+                // Verified inside the shipped artifact (compiled build/ output).
+                artifact_path: Some("build/login-register/block.json".to_string()),
             }]),
             ..Component::default()
         }

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -1316,6 +1316,7 @@ mod tests {
         component.version_targets = Some(vec![crate::core::component::VersionTarget {
             file: "package.json".to_string(),
             pattern: Some(r#""version"\s*:\s*"([^"]+)""#.to_string()),
+            artifact_path: None,
         }]);
 
         let err = verify_expected_version(&[component], "1.0.1")

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -708,6 +708,7 @@ mod tests {
         component.version_targets = Some(vec![VersionTarget {
             file: "VERSION".to_string(),
             pattern: Some(r"^(.+)$".to_string()),
+            artifact_path: None,
         }]);
         component
     }

--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -610,6 +610,7 @@ mod tests {
             version_targets: Some(vec![VersionTarget {
                 file: "fixture.php".to_string(),
                 pattern: Some(r"Version:\s*(\d+\.\d+\.\d+)".to_string()),
+                artifact_path: None,
             }]),
             ..Default::default()
         }
@@ -701,10 +702,12 @@ mod tests {
                 VersionTarget {
                     file: "package.json".to_string(),
                     pattern: Some(r#""version":\s*"([0-9.]+)""#.to_string()),
+                    artifact_path: None,
                 },
                 VersionTarget {
                     file: "packages/component/fixture.php".to_string(),
                     pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+                    artifact_path: None,
                 },
             ]),
             ..Default::default()

--- a/src/core/refactor/plan/sources/lint_scope.rs
+++ b/src/core/refactor/plan/sources/lint_scope.rs
@@ -416,10 +416,12 @@ mod tests {
             VersionTarget {
                 file: "Cargo.toml".to_string(),
                 pattern: None,
+                artifact_path: None,
             },
             VersionTarget {
                 file: "nested/package.json".to_string(),
                 pattern: None,
+                artifact_path: None,
             },
         ]);
 
@@ -442,6 +444,7 @@ mod tests {
         component.version_targets = Some(vec![VersionTarget {
             file: "Cargo.toml".to_string(),
             pattern: None,
+            artifact_path: None,
         }]);
 
         let snapshots = capture_release_owned_files(&component, &root).unwrap();

--- a/src/core/release/execution_dispatch.rs
+++ b/src/core/release/execution_dispatch.rs
@@ -987,6 +987,7 @@ mod tests {
             version_targets: Some(vec![VersionTarget {
                 file: "Cargo.toml".to_string(),
                 pattern: None,
+                artifact_path: None,
             }]),
             ..Default::default()
         };
@@ -1143,6 +1144,7 @@ mod tests {
             version_targets: Some(vec![VersionTarget {
                 file: "plugin.php".to_string(),
                 pattern: Some(r"(?:Version|version)[:=]\s+([0-9]+\.[0-9]+\.[0-9]+)".to_string()),
+                artifact_path: None,
             }]),
             ..Default::default()
         };

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -1447,6 +1447,7 @@ mod tests {
             version_targets: Some(vec![VersionTarget {
                 file: "plugin.php".to_string(),
                 pattern: Some(r"(?:Version|version)[:=]\s+([0-9]+\.[0-9]+\.[0-9]+)".to_string()),
+                artifact_path: None,
             }]),
             ..Component::default()
         };
@@ -1523,6 +1524,7 @@ mod tests {
             version_targets: Some(vec![VersionTarget {
                 file: "plugin.php".to_string(),
                 pattern: Some(r"(?:Version|version)[:=]\s+([0-9]+\.[0-9]+\.[0-9]+)".to_string()),
+                artifact_path: None,
             }]),
             ..Component::default()
         };

--- a/src/core/release/executor/changelog.rs
+++ b/src/core/release/executor/changelog.rs
@@ -78,6 +78,7 @@ mod tests {
             version_targets: Some(vec![VersionTarget {
                 file: "plugin.php".to_string(),
                 pattern: Some(r"(?:Version|version)[:=]\s+([0-9]+\.[0-9]+\.[0-9]+)".to_string()),
+                artifact_path: None,
             }]),
             ..Component::default()
         };

--- a/src/core/release/version.rs
+++ b/src/core/release/version.rs
@@ -730,6 +730,7 @@ mod tests {
         component.version_targets = Some(vec![VersionTarget {
             file: "package.json".to_string(),
             pattern: Some(r#""version"\s*:\s*"([^"]+)""#.to_string()),
+            artifact_path: None,
         }]);
         component.hooks.insert(
             hooks::events::POST_VERSION_BUMP.to_string(),


### PR DESCRIPTION
## Summary

Fixes #4614. `homeboy deploy` refused to deploy WordPress plugins whose `version_targets` reference **source** paths that are intentionally **excluded from the production ZIP** (the artifact ships compiled `build/<block>/block.json`, not the `blocks/<block>/block.json` source).

The root conflict: `version_targets` is consumed by two steps reading **different file sets**:

1. **version bump** — writes to **workspace** source files (`blocks/*/block.json`, git-tracked). ✓
2. **deploy artifact verification** — reads files **inside the ZIP**, where only `build/*/block.json` exists. ✗

A single source-relative list can't satisfy both, so deploy aborted with:

> Artifact '…/extrachill-users.zip' does not contain version target 'blocks/login-register/block.json' …

## Fix (Option 1 from the issue)

Adds an optional `artifact_path` field to `VersionTarget`:

- The **bump** keeps using `file` (git-tracked source).
- **Pre-deploy verification** prefers `artifact_path` when set, falling back to `file`.
- Verification error messages now reference the verified path.

```json
{
  "version_targets": [
    {
      "file": "blocks/login-register/block.json",
      "pattern": "\"version\":\\s*\"([0-9.]+)\"",
      "artifact_path": "build/login-register/block.json"
    }
  ]
}
```

This is the standard `@wordpress/scripts` layout and likely affects other EC plugins (e.g. `extrachill-events`).

## Changes

- `VersionTarget` gains `artifact_path: Option<String>` (derives `Default`); JSON config support is automatic via serde.
- `validate_predeploy_artifact_version` resolves the verify path via `artifact_path` → `file`.
- Documented in `docs/schemas/component-schema.md` and `docs/schemas/portable-config.md`.
- Changelog entry under `[Unreleased]`.

## Tests

New tests in `src/core/deploy/execution.rs`:

- `predeploy_artifact_version_inspection_uses_artifact_path_override` — source path absent from ZIP, `artifact_path` (`build/...`) present → passes.
- `predeploy_artifact_version_inspection_reports_artifact_path_when_missing` — error references the artifact path, not the source bump path.

Existing `version_target` and `deploy::execution` tests pass. Two unrelated env-dependent tests (`test_deploy_artifact_fails_when_pre_extract_cleanup_fails`, `component_env_detector_executes_extension_script`) fail identically on pristine `origin/main` in this sandbox — not introduced by this change.