### PR TITLE
fix: preserve agent-task json during lab offload

### DIFF
--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -25,7 +25,7 @@ pub fn run_command_output(command: Commands, global: &GlobalArgs) -> JsonCommand
 
     match command {
         Commands::AgentTask(args) => {
-            let summary_kind = agent_task_summary_kind(&args);
+            let summary_kind = agent_task_summary_kind_for_output(&args);
             let (stdout_result, exit_code) = dispatch(Commands::AgentTask(args), global);
             let human_stdout = stdout_result.as_ref().ok().and_then(|payload| {
                 summary_kind.and_then(|kind| render_agent_task_summary(kind, payload))
@@ -44,6 +44,26 @@ pub fn run_command_output(command: Commands, global: &GlobalArgs) -> JsonCommand
             let (stdout_result, exit_code) = dispatch(command, global);
             JsonCommandRun::from_stdout_result(stdout_result, exit_code)
         }
+    }
+}
+
+fn agent_task_summary_kind_for_output(
+    args: &crate::commands::agent_task::AgentTaskArgs,
+) -> Option<super::agent_task_summary::AgentTaskSummaryKind> {
+    agent_task_summary_kind_for_output_mode(
+        args,
+        homeboy::core::lab_routing::is_lab_offload_subprocess(),
+    )
+}
+
+fn agent_task_summary_kind_for_output_mode(
+    args: &crate::commands::agent_task::AgentTaskArgs,
+    lab_offload_subprocess: bool,
+) -> Option<super::agent_task_summary::AgentTaskSummaryKind> {
+    if lab_offload_subprocess {
+        None
+    } else {
+        agent_task_summary_kind(args)
     }
 }
 
@@ -68,6 +88,7 @@ fn unsupported_raw_command(message: &'static str) -> JsonRun {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::agent_task::{AgentTaskArgs, AgentTaskCommand, StatusArgs};
 
     #[test]
     fn list_json_dispatch_reports_raw_output_mode() {
@@ -78,5 +99,17 @@ mod tests {
             .expect_err("list should not dispatch as JSON")
             .to_string()
             .contains("raw output mode"));
+    }
+
+    #[test]
+    fn lab_offload_agent_task_subprocess_keeps_json_stdout() {
+        let args = AgentTaskArgs {
+            command: AgentTaskCommand::Status(StatusArgs {
+                run_id: "run-1".to_string(),
+            }),
+        };
+
+        assert!(agent_task_summary_kind_for_output_mode(&args, false).is_some());
+        assert!(agent_task_summary_kind_for_output_mode(&args, true).is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Keep agent-task commands emitting structured JSON when running as a Lab offload subprocess.
- Preserve local human summaries outside Lab while allowing the controller to mirror failed remote agent-task runs and artifacts correctly.
- Add a focused regression test for the Lab subprocess output routing.

## Verification
- `cargo test lab_offload_agent_task_subprocess_keeps_json_stdout`
- `cargo test offloaded_dispatch_envelope_parser_selects_structured_failure`
- `cargo fmt --check`
- `git diff --check`
- Verified `HOMEBOY_LAB_OFFLOAD_JSON=... target/debug/homeboy --force-hot --allow-local-hot agent-task status ...` emits JSON.
- Verified offloaded `homeboy agent-task status agent-task-a2d86228-d062-4dfc-9c16-65732a190ba9` returns runner-owned failed run/artifact refs instead of the controller-side pre-dispatch wrapper.