### PR TITLE
fix(deploy): make 'no deployable components' hint actionable

### DIFF
--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -45,8 +45,10 @@ pub(super) fn deploy_components(
             message,
             None,
             Some(vec![
-                "Ensure components have a buildArtifact, an extension with artifact_pattern, or deploy_strategy: \"git\"".to_string(),
-                format!("Check with: homeboy component show <id>"),
+                "A component is deployable when it has a buildArtifact, an extension that resolves an artifact_pattern, or deploy_strategy: \"git\".".to_string(),
+                "If the component builds via an extension, declare that extension in its homeboy.json (e.g. \"extensions\": { \"<ext>\": {} }) so the artifact can be resolved.".to_string(),
+                "Sync the component's homeboy.json config into the project: homeboy project components attach-path <project> <local_path>.".to_string(),
+                "Inspect the effective config with: homeboy component show <id>".to_string(),
             ]),
         ));
     }


### PR DESCRIPTION
## Summary
Addresses **Papercut 3** from #4615. When `homeboy deploy` skips a component for *"no build artifact or deploy strategy"*, the hints only restated the deployability criteria and pointed at `component show`. They didn't surface the common fix:

1. Declare the component's build extension in its `homeboy.json` (e.g. `"extensions": { "<ext>": {} }`) so the artifact can be resolved.
2. Sync that config into the project via `homeboy project components attach-path <project> <local_path>` (the source-of-truth path).

This PR extends the hint vec with those two steps.

## Platform-agnostic
Core stays platform-agnostic — **no WordPress/PHP-specific assumptions**. The hints use only core concepts (`buildArtifact`, `extension`, `artifact_pattern`, `deploy_strategy`, `homeboy.json`, `attach-path`) and a placeholder extension name (`<ext>`). Any extension (rust, nodejs, wordpress, etc.) benefits equally.

## Change
`src/core/deploy/orchestration.rs` — extend the hint vec on the "no deployable components" validation error. **Error-message text only; no behavior change.** No changelog edit (homeboy generates that at release time from commit messages).

```diff
- "Ensure components have a buildArtifact, an extension with artifact_pattern, or deploy_strategy: \"git\""
- "Check with: homeboy component show <id>"
+ "A component is deployable when it has a buildArtifact, an extension that resolves an artifact_pattern, or deploy_strategy: \"git\"."
+ "If the component builds via an extension, declare that extension in its homeboy.json (e.g. \"extensions\": { \"<ext>\": {} }) so the artifact can be resolved."
+ "Sync the component's homeboy.json config into the project: homeboy project components attach-path <project> <local_path>."
+ "Inspect the effective config with: homeboy component show <id>"
```

## Test plan
- `cargo build` — clean.
- No test asserts the hint text. The only failing deploy test (`test_deploy_artifact_fails_when_pre_extract_cleanup_fails`) is pre-existing and env-dependent (fails identically on base `f34fe768`).

Refs #4615.