### PR TITLE
fix: materialize runner-local preview services

### DIFF
--- a/docs/architecture/preview-metadata.md
+++ b/docs/architecture/preview-metadata.md
@@ -63,9 +63,9 @@ external provider command:
     "local_origin": "http://127.0.0.1:49823",
     "require_https": true,
     "native": {
-      "operator_domain": "chubes.net",
+      "operator_domain": "preview.example.test",
       "session_id": "wc-stripe-real-wallet",
-      "ingress_url": "https://preview-broker.chubes.net",
+      "ingress_url": "https://preview-broker.example.test",
       "token_env": "HOMEBOY_PREVIEW_TUNNEL_TOKEN"
     },
     "required_asset_paths": [
@@ -81,10 +81,10 @@ native client with the minimal internal command contract:
 
 ```sh
 homeboy tunnel preview-client start \
-  --public-host wc-stripe-real-wallet-tunnel.chubes.net \
+  --public-host wc-stripe-real-wallet-tunnel.preview.example.test \
   --local-origin http://127.0.0.1:49823 \
   --session-id wc-stripe-real-wallet \
-  --ingress https://preview-broker.chubes.net \
+  --ingress https://preview-broker.example.test \
   --token-env HOMEBOY_PREVIEW_TUNNEL_TOKEN \
   --ready-stdout
 ```

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -259,7 +259,7 @@ enum TunnelPreviewIngressCommand {
         /// Preview session ID
         session_id: String,
 
-        /// Public host routed by the TLS/proxy layer, e.g. run-123-tunnel.chubes.net
+        /// Public host routed by the TLS/proxy layer, e.g. run-123-tunnel.preview.example.test
         #[arg(long)]
         public_host: String,
 

--- a/src/core/extension/trace/preview.rs
+++ b/src/core/extension/trace/preview.rs
@@ -1120,7 +1120,7 @@ mod tests {
         let client = temp.path().join("homeboy-preview-client-fixture.sh");
         std::fs::write(
             &client,
-            "#!/bin/sh\nprintf 'ready https://run-42-tunnel.chubes.net\\n'\nsleep 5\n",
+            "#!/bin/sh\nprintf 'ready https://run-42-tunnel.preview.example.test\\n'\nsleep 5\n",
         )
         .expect("write native client fixture");
         #[cfg(unix)]
@@ -1145,9 +1145,9 @@ mod tests {
                 asset_fanout: None,
                 native: Some(TraceNativePublicPreviewSpec {
                     public_host: None,
-                    operator_domain: Some("chubes.net".to_string()),
+                    operator_domain: Some("preview.example.test".to_string()),
                     session_id: Some("run-42".to_string()),
-                    ingress_url: Some("https://preview-broker.chubes.net".to_string()),
+                    ingress_url: Some("https://preview-broker.example.test".to_string()),
                     token_env: Some("HOMEBOY_PREVIEW_TUNNEL_TOKEN".to_string()),
                     client_binary: Some(client.display().to_string()),
                 }),
@@ -1159,11 +1159,11 @@ mod tests {
         assert_eq!(session.metadata().provider, "homeboy-native");
         assert_eq!(
             session.metadata().public_origin,
-            "https://run-42-tunnel.chubes.net"
+            "https://run-42-tunnel.preview.example.test"
         );
         assert_eq!(
             session.metadata().public_host.as_deref(),
-            Some("run-42-tunnel.chubes.net")
+            Some("run-42-tunnel.preview.example.test")
         );
         assert_eq!(session.metadata().session_id.as_deref(), Some("run-42"));
         assert!(session
@@ -1180,7 +1180,7 @@ mod tests {
         )));
         assert!(env.contains(&(
             "HOMEBOY_TRACE_PREVIEW_PUBLIC_HOST".to_string(),
-            "run-42-tunnel.chubes.net".to_string()
+            "run-42-tunnel.preview.example.test".to_string()
         )));
 
         let metadata = session.finish();

--- a/src/core/preview_ingress_tests.rs
+++ b/src/core/preview_ingress_tests.rs
@@ -13,7 +13,7 @@ fn route_registers_host_to_upstream_origin() {
     test_support::with_isolated_home(|_| {
         let route = register_route(PreviewIngressRoute {
             session_id: "run-123".to_string(),
-            public_host: "run-123-tunnel.chubes.net".to_string(),
+            public_host: "run-123-tunnel.preview.example.test".to_string(),
             upstream_origin: "http://127.0.0.1:7331".to_string(),
             expires_at: None,
             active: true,
@@ -23,8 +23,8 @@ fn route_registers_host_to_upstream_origin() {
         assert_eq!(route.session_id, "run-123");
         let status = status(
             Some("127.0.0.1:7350".to_string()),
-            Some("chubes.net".to_string()),
-            Some("*-tunnel.chubes.net".to_string()),
+            Some("preview.example.test".to_string()),
+            Some("*-tunnel.preview.example.test".to_string()),
         )
         .expect("status");
         assert_eq!(status.routes.len(), 1);
@@ -34,7 +34,7 @@ fn route_registers_host_to_upstream_origin() {
         );
         assert_eq!(
             status.routes[0].route.public_host,
-            "run-123-tunnel.chubes.net"
+            "run-123-tunnel.preview.example.test"
         );
     });
 }
@@ -44,7 +44,7 @@ fn route_status_reports_expired_and_disconnected_sessions() {
     test_support::with_isolated_home(|_| {
         register_route(PreviewIngressRoute {
             session_id: "expired".to_string(),
-            public_host: "expired-tunnel.chubes.net".to_string(),
+            public_host: "expired-tunnel.preview.example.test".to_string(),
             upstream_origin: "http://127.0.0.1:7331".to_string(),
             expires_at: Some("2000-01-01T00:00:00Z".to_string()),
             active: true,
@@ -52,7 +52,7 @@ fn route_status_reports_expired_and_disconnected_sessions() {
         .expect("register expired route");
         register_route(PreviewIngressRoute {
             session_id: "disconnected".to_string(),
-            public_host: "disconnected-tunnel.chubes.net".to_string(),
+            public_host: "disconnected-tunnel.preview.example.test".to_string(),
             upstream_origin: "http://127.0.0.1:7332".to_string(),
             expires_at: None,
             active: false,
@@ -74,7 +74,7 @@ fn status_for_host_reports_route_registration_state() {
     test_support::with_isolated_home(|_| {
         register_route(PreviewIngressRoute {
             session_id: "run-123".to_string(),
-            public_host: "run-123-tunnel.chubes.net".to_string(),
+            public_host: "run-123-tunnel.preview.example.test".to_string(),
             upstream_origin: "http://127.0.0.1:7331".to_string(),
             expires_at: None,
             active: true,
@@ -85,13 +85,13 @@ fn status_for_host_reports_route_registration_state() {
             None,
             None,
             None,
-            Some("RUN-123-TUNNEL.CHUBES.NET:443".to_string()),
+            Some("RUN-123-TUNNEL.PREVIEW.EXAMPLE.TEST:443".to_string()),
         )
         .expect("status");
 
         assert_eq!(
             status.inspected_host.as_deref(),
-            Some("run-123-tunnel.chubes.net")
+            Some("run-123-tunnel.preview.example.test")
         );
         assert_eq!(status.inspected_state.as_deref(), Some("registered"));
     });
@@ -102,7 +102,7 @@ fn route_validation_rejects_non_http_upstream_origin() {
     test_support::with_isolated_home(|_| {
         let err = register_route(PreviewIngressRoute {
             session_id: "bad".to_string(),
-            public_host: "bad-tunnel.chubes.net".to_string(),
+            public_host: "bad-tunnel.preview.example.test".to_string(),
             upstream_origin: "ssh://127.0.0.1:22".to_string(),
             expires_at: None,
             active: true,

--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -11,11 +11,13 @@ use std::time::{Duration, Instant};
 use std::os::unix::process::CommandExt;
 
 use crate::core::config::{self, ConfigEntity};
-use crate::core::error::{Error, Result};
+use crate::core::error::{Error, ErrorCode, Result};
 use crate::core::paths;
 use crate::core::process::{pid_is_running, process_group_is_running};
 use crate::core::server;
 use crate::core::{CreateOutput, MergeOutput, RemoveResult};
+
+const RUNNER_LOCAL_SERVICE_SERVER_ID: &str = "__runner_local__";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServiceTunnel {
@@ -539,7 +541,7 @@ pub fn status(id: &str) -> Result<ServiceTunnelStatus> {
 }
 
 pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
-    let mut tunnel = load(&spec.id)?;
+    let mut tunnel = load_or_materialize_start_tunnel(&spec)?;
     validate_backend_spec(&spec)?;
 
     let existing = load_runtime_state(&tunnel.id)?;
@@ -659,6 +661,73 @@ pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
     };
     save_runtime_state(&state)?;
     status(&tunnel.id)
+}
+
+fn load_or_materialize_start_tunnel(spec: &StartServiceTunnelSpec) -> Result<ServiceTunnel> {
+    match load(&spec.id) {
+        Ok(tunnel) => Ok(tunnel),
+        Err(error) if error.code == ErrorCode::ServiceTunnelNotFound => {
+            materialize_runner_local_start_tunnel(spec)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn materialize_runner_local_start_tunnel(spec: &StartServiceTunnelSpec) -> Result<ServiceTunnel> {
+    let host = spec.host.as_deref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "host",
+            "starting an undeclared runner-local service tunnel requires --host",
+            Some(spec.id.clone()),
+            Some(vec!["Pass --host 127.0.0.1 or declare the service with `homeboy tunnel service expose` before starting it.".to_string()]),
+        )
+    })?;
+    validate_loopback_host(host, &spec.id)?;
+    let port = spec.port.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "port",
+            "starting an undeclared runner-local service tunnel requires --port",
+            Some(spec.id.clone()),
+            Some(vec!["Pass the local service port or declare the service with `homeboy tunnel service expose` before starting it.".to_string()]),
+        )
+    })?;
+    if port == 0 {
+        return Err(Error::validation_invalid_argument(
+            "port",
+            "local port must be greater than zero",
+            Some(spec.id.clone()),
+            None,
+        ));
+    }
+
+    let tunnel = ServiceTunnel {
+        id: spec.id.clone(),
+        aliases: Vec::new(),
+        description: Some("Runner-local service materialized by tunnel service start".to_string()),
+        server_id: RUNNER_LOCAL_SERVICE_SERVER_ID.to_string(),
+        target: ServiceTunnelTarget {
+            host: host.to_string(),
+            port,
+        },
+        scheme: spec.scheme.clone().unwrap_or_else(default_scheme),
+        local_host: host.to_string(),
+        local_port: Some(port),
+        auth: ServiceTunnelAuth {
+            mode: ServiceTunnelAuthMode::SshOnly,
+            env_var: None,
+            header: None,
+        },
+        policy: ServiceTunnelPolicy {
+            exposure: ServiceTunnelExposure::PrivateLoopback,
+            require_auth: true,
+            allowed_clients: Vec::new(),
+            preview: ServiceTunnelPreviewPolicy::default(),
+            native_preview_auth: Default::default(),
+        },
+    };
+    validate_service_tunnel(&tunnel)?;
+    save(&tunnel)?;
+    load(&tunnel.id)
 }
 
 pub fn stop(id: &str) -> Result<ServiceTunnelStatus> {
@@ -1010,7 +1079,7 @@ fn local_url_for(tunnel: &ServiceTunnel) -> String {
 }
 
 fn validate_service_tunnel(tunnel: &ServiceTunnel) -> Result<()> {
-    if !server::exists(&tunnel.server_id) {
+    if tunnel.server_id != RUNNER_LOCAL_SERVICE_SERVER_ID && !server::exists(&tunnel.server_id) {
         let suggestions = config::find_similar_ids::<server::Server>(&tunnel.server_id);
         return Err(Error::server_not_found(
             tunnel.server_id.clone(),
@@ -1657,5 +1726,66 @@ fn runtime_evidence(state: &ServiceTunnelRuntimeState) -> ServiceTunnelEvidence 
             .map(|path| path.display().to_string())
             .unwrap_or_default(),
         logs: state.logs.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn start_spec(id: &str) -> StartServiceTunnelSpec {
+        StartServiceTunnelSpec {
+            id: id.to_string(),
+            command: "node server.js".to_string(),
+            cwd: None,
+            env: BTreeMap::new(),
+            host: Some("127.0.0.1".to_string()),
+            port: Some(48631),
+            scheme: Some("http".to_string()),
+            health_url: None,
+            health_path: None,
+            readiness_timeout_secs: 1,
+            backend: ServiceTunnelTunnelBackend::None,
+            backend_command: None,
+            backend_public_url: None,
+            source_run_id: None,
+            source_workflow_id: None,
+            readiness_kind: ServiceTunnelReadinessKind::Process,
+            readiness_checks: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn start_materializes_runner_local_service_without_server_declaration() {
+        crate::test_support::with_isolated_home(|_| {
+            let tunnel = materialize_runner_local_start_tunnel(&start_spec("preview-service"))
+                .expect("materialize runner-local service");
+
+            assert_eq!(tunnel.id, "preview-service");
+            assert_eq!(tunnel.server_id, RUNNER_LOCAL_SERVICE_SERVER_ID);
+            assert_eq!(tunnel.target.host, "127.0.0.1");
+            assert_eq!(tunnel.target.port, 48631);
+            assert_eq!(tunnel.local_port, Some(48631));
+            assert!(load("preview-service").is_ok());
+        });
+    }
+
+    #[test]
+    fn undeclared_runner_local_service_requires_host_and_port() {
+        crate::test_support::with_isolated_home(|_| {
+            let mut missing_host = start_spec("missing-host");
+            missing_host.host = None;
+            let err =
+                materialize_runner_local_start_tunnel(&missing_host).expect_err("host required");
+            assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+            assert!(err.message.contains("requires --host"));
+
+            let mut missing_port = start_spec("missing-port");
+            missing_port.port = None;
+            let err =
+                materialize_runner_local_start_tunnel(&missing_port).expect_err("port required");
+            assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+            assert!(err.message.contains("requires --port"));
+        });
     }
 }

--- a/tests/core/rig/public_preview_spec_test.rs
+++ b/tests/core/rig/public_preview_spec_test.rs
@@ -58,9 +58,9 @@ fn test_trace_public_preview_parse_homeboy_native() {
                 "local_origin": "http://127.0.0.1:49823",
                 "require_https": true,
                 "native": {
-                    "operator_domain": "chubes.net",
+                    "operator_domain": "preview.example.test",
                     "session_id": "wc-stripe-real-wallet",
-                    "ingress_url": "https://preview-broker.chubes.net",
+                    "ingress_url": "https://preview-broker.example.test",
                     "token_env": "HOMEBOY_PREVIEW_TUNNEL_TOKEN"
                 }
             }
@@ -75,11 +75,14 @@ fn test_trace_public_preview_parse_homeboy_native() {
         crate::core::rig::TracePublicPreviewMode::HomeboyNative
     );
     let native = preview.native.as_ref().expect("native settings");
-    assert_eq!(native.operator_domain.as_deref(), Some("chubes.net"));
+    assert_eq!(
+        native.operator_domain.as_deref(),
+        Some("preview.example.test")
+    );
     assert_eq!(native.session_id.as_deref(), Some("wc-stripe-real-wallet"));
     assert_eq!(
         native.ingress_url.as_deref(),
-        Some("https://preview-broker.chubes.net")
+        Some("https://preview-broker.example.test")
     );
     assert_eq!(
         native.token_env.as_deref(),


### PR DESCRIPTION
## Summary
- Let `tunnel service start` materialize an undeclared runner-local service when the start command provides host, port, command, and related runtime details.
- Preserve existing declared service validation while avoiding duplicate runner-side service declarations for Lab-owned preview services.
- Replace Homeboy docs/tests that used Chris-specific preview domains with neutral `preview.example.test` / `preview-broker.example.test` examples.

## Verification
- `cargo fmt --check`
- `cargo test runner_local_service`
- `cargo test homeboy_native`
- `cargo test route_registers_host_to_upstream_origin`
- `cargo test status_for_host_reports_route_registration_state`
- `git diff --check`

## Runtime probe
- `tunnel service start --runner homeboy-lab` now starts the runner-local service and reports process readiness instead of failing `service_tunnel.not_found`.
- Public preview registration still depends on the operator token/broker configuration; the latest dev broker attempt reached the broker and returned HTTP 401 for token mismatch, which is separate from the service materialization bug.