### PR TITLE
feat(release): add guarded --retag to recover a stale release tag

### DIFF
--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -39,6 +39,14 @@ pub struct ReleaseArgs {
     #[arg(long)]
     recover: bool,
 
+    /// With --recover: if the release tag exists but points at a commit behind
+    /// HEAD (e.g. config-only commits landed after tagging), move the tag to
+    /// HEAD instead of refusing. Guarded — the tagged commit must be an
+    /// ancestor of HEAD, HEAD must satisfy the version targets, and no GitHub
+    /// Release may exist for the tag.
+    #[arg(long)]
+    retag: bool,
+
     /// Finish the release pipeline for an already-versioned, already-tagged HEAD.
     /// Skips changelog/version/git mutation steps and runs package, GitHub Release,
     /// publish, cleanup, and post-release hooks against the tag pointing at HEAD.
@@ -135,6 +143,7 @@ impl ReleaseArgs {
             dry_run_args: DryRunArgs { dry_run },
             deploy,
             recover,
+            retag: false,
             head,
             from_artifacts,
             skip_checks,
@@ -162,6 +171,7 @@ pub fn run(
             path_override: args.path.clone(),
             dry_run: args.dry_run_args.dry_run,
             recover: args.recover,
+            retag: args.retag,
             skip_checks: args.skip_checks,
             bump_override: bump_override.clone(),
             force_lower_bump: args.force_lower_bump,
@@ -215,6 +225,7 @@ pub fn run(
         path_override: None,
         dry_run: args.dry_run_args.dry_run,
         recover: false,
+        retag: false,
         skip_checks: args.skip_checks,
         bump_override,
         force_lower_bump: args.force_lower_bump,

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -37,11 +37,11 @@ pub use github::{
 pub use github_pr_comments::{pr_comment, PrCommentMode, PrCommentOptions};
 pub use operation_output::GitOutput;
 pub use operations::{
-    cherry_pick, cherry_pick_at, execute_git_for_release, fetch_and_fast_forward,
-    fetch_and_get_behind_count, get_head_commit, get_repo_snapshot, get_tag_commit, pull, pull_at,
-    pull_bulk, rebase, rebase_at, remote_tag_commit, short_head_revision_at, status, status_at,
-    status_bulk, tag, tag_at, tag_exists_locally, tag_exists_on_remote, CherryPickOptions,
-    RebaseOptions, RepoSnapshot,
+    cherry_pick, cherry_pick_at, delete_local_tag, delete_remote_tag, execute_git_for_release,
+    fetch_and_fast_forward, fetch_and_get_behind_count, get_head_commit, get_repo_snapshot,
+    get_tag_commit, is_ancestor, pull, pull_at, pull_bulk, rebase, rebase_at, remote_tag_commit,
+    short_head_revision_at, status, status_at, status_bulk, tag, tag_at, tag_exists_locally,
+    tag_exists_on_remote, CherryPickOptions, RebaseOptions, RepoSnapshot,
 };
 pub use operations_changes::{
     build_repo_baseline_snapshot, changes, changes_at, changes_bulk, changes_project,

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -412,19 +412,17 @@ pub fn get_head_commit(path: &str) -> Result<String> {
 /// before moving it, so a tag is never relocated onto an unrelated/divergent
 /// history.
 pub fn is_ancestor(path: &str, ancestor: &str, descendant: &str) -> Result<bool> {
-    let output = execute_git_for_release(
-        path,
-        &["merge-base", "--is-ancestor", ancestor, descendant],
-    )
-    .map_err(|e| {
-        Error::internal_io(
-            format!("Failed to check ancestry: {}", e),
-            Some(format!(
-                "git merge-base --is-ancestor {} {}",
-                ancestor, descendant
-            )),
-        )
-    })?;
+    let output =
+        execute_git_for_release(path, &["merge-base", "--is-ancestor", ancestor, descendant])
+            .map_err(|e| {
+                Error::internal_io(
+                    format!("Failed to check ancestry: {}", e),
+                    Some(format!(
+                        "git merge-base --is-ancestor {} {}",
+                        ancestor, descendant
+                    )),
+                )
+            })?;
     // `--is-ancestor` exits 0 when true, 1 when false. Any other code is an error.
     match output.status.code() {
         Some(0) => Ok(true),

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -407,6 +407,58 @@ pub fn get_head_commit(path: &str) -> Result<String> {
     crate::core::engine::command::run_in(path, "git", &["rev-parse", "HEAD"], "get HEAD commit")
 }
 
+/// Return true when `ancestor` is an ancestor of (i.e. reachable from)
+/// `descendant`. Used to confirm a stale tag's commit is strictly behind HEAD
+/// before moving it, so a tag is never relocated onto an unrelated/divergent
+/// history.
+pub fn is_ancestor(path: &str, ancestor: &str, descendant: &str) -> Result<bool> {
+    let output = execute_git_for_release(
+        path,
+        &["merge-base", "--is-ancestor", ancestor, descendant],
+    )
+    .map_err(|e| {
+        Error::internal_io(
+            format!("Failed to check ancestry: {}", e),
+            Some(format!(
+                "git merge-base --is-ancestor {} {}",
+                ancestor, descendant
+            )),
+        )
+    })?;
+    // `--is-ancestor` exits 0 when true, 1 when false. Any other code is an error.
+    match output.status.code() {
+        Some(0) => Ok(true),
+        Some(1) => Ok(false),
+        other => Err(Error::git_command_failed(format!(
+            "git merge-base --is-ancestor exited with {:?}: {}",
+            other,
+            String::from_utf8_lossy(&output.stderr)
+        ))),
+    }
+}
+
+/// Delete a local tag. No-op-safe: returns the git output for inspection.
+pub fn delete_local_tag(path: &str, tag_name: &str) -> Result<GitOutput> {
+    let (id, resolved) = resolve_target(None, Some(path))?;
+    let output = execute_git(&resolved, &["tag", "-d", tag_name])
+        .map_err(|e| Error::git_command_failed(e.to_string()))?;
+    Ok(GitOutput::from_output(id, resolved, "tag.delete", output))
+}
+
+/// Delete a tag on the `origin` remote.
+pub fn delete_remote_tag(path: &str, tag_name: &str) -> Result<GitOutput> {
+    let (id, resolved) = resolve_target(None, Some(path))?;
+    let refspec = format!(":refs/tags/{}", tag_name);
+    let output = execute_git(&resolved, &["push", "origin", &refspec])
+        .map_err(|e| Error::git_command_failed(e.to_string()))?;
+    Ok(GitOutput::from_output(
+        id,
+        resolved,
+        "tag.delete_remote",
+        output,
+    ))
+}
+
 /// Get the current HEAD short commit SHA, returning `None` outside git checkouts.
 pub fn short_head_revision_at(path: &Path) -> Option<String> {
     let output = Command::new("git")
@@ -487,5 +539,65 @@ pub fn fetch_and_fast_forward(path: &str) -> Result<Option<u32>> {
 
             Ok(Some(n))
         }
+    }
+}
+
+#[cfg(test)]
+mod is_ancestor_tests {
+    use super::*;
+
+    fn run_in(dir: &std::path::Path, args: &[&str]) {
+        let output = Command::new(args[0])
+            .args(&args[1..])
+            .current_dir(dir)
+            .output()
+            .expect("spawn git");
+        assert!(
+            output.status.success(),
+            "command {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn rev(dir: &std::path::Path, refname: &str) -> String {
+        let output = Command::new("git")
+            .args(["rev-parse", refname])
+            .current_dir(dir)
+            .output()
+            .expect("spawn git");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    /// A linear two-commit history: the first commit must be an ancestor of the
+    /// second, but not vice versa. This is the exact safety check that gates a
+    /// stale-tag retag (the tagged commit must be strictly behind HEAD).
+    #[test]
+    fn test_is_ancestor() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let dir = temp.path();
+        run_in(dir, &["git", "init", "-q"]);
+        run_in(dir, &["git", "config", "user.email", "t@example.com"]);
+        run_in(dir, &["git", "config", "user.name", "T"]);
+        run_in(dir, &["git", "config", "commit.gpgsign", "false"]);
+
+        std::fs::write(dir.join("f.txt"), "one").unwrap();
+        run_in(dir, &["git", "add", "."]);
+        run_in(dir, &["git", "commit", "-q", "-m", "first"]);
+        let first = rev(dir, "HEAD");
+
+        std::fs::write(dir.join("f.txt"), "two").unwrap();
+        run_in(dir, &["git", "add", "."]);
+        run_in(dir, &["git", "commit", "-q", "-m", "second"]);
+        let second = rev(dir, "HEAD");
+
+        let path = dir.to_str().unwrap();
+
+        // first is behind second -> ancestor
+        assert!(is_ancestor(path, &first, &second).unwrap());
+        // second is ahead -> NOT an ancestor of first
+        assert!(!is_ancestor(path, &second, &first).unwrap());
+        // a commit is its own ancestor (git treats reflexive as true)
+        assert!(is_ancestor(path, &second, &second).unwrap());
     }
 }

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -28,7 +28,7 @@ mod github_release;
 pub(crate) mod package_preflight;
 pub(crate) mod prepare;
 mod publish;
-mod version_targets;
+pub(crate) mod version_targets;
 
 pub(crate) use github_release::run_github_release;
 pub(crate) use publish::{publish_response_output, run_publish};
@@ -454,6 +454,42 @@ fn inspect_release_tag_state(component: &Component, tag_name: &str) -> Result<Re
         remote_tag_commit,
         github_release,
     })
+}
+
+/// Best-effort check for whether a published GitHub Release exists for `tag_name`.
+///
+/// Returns `Some(true)`/`Some(false)` when GitHub is reachable and the
+/// repository resolves, or `None` when it cannot be determined (no remote, `gh`
+/// unavailable/unauthenticated, or a non-GitHub remote). Callers that must not
+/// move a published release should treat `None` conservatively.
+pub(crate) fn github_release_exists_for_tag(
+    component: &Component,
+    tag_name: &str,
+) -> Option<bool> {
+    component
+        .remote_url
+        .clone()
+        .or_else(|| {
+            crate::core::deploy::release_download::detect_remote_url(std::path::Path::new(
+                &component.local_path,
+            ))
+        })
+        .and_then(|remote_url| crate::core::deploy::release_download::parse_github_url(&remote_url))
+        .and_then(|github| {
+            if !github_release::gh_is_available()
+                || !github_release::gh_is_authenticated(&github, &component.github)
+            {
+                return None;
+            }
+
+            let repo_flag = format!("{}/{}", github.owner, github.repo);
+            Some(github_release::gh_release_exists(
+                &github,
+                &component.github,
+                tag_name,
+                &repo_flag,
+            ))
+        })
 }
 
 fn build_existing_tag_failure(

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -462,10 +462,7 @@ fn inspect_release_tag_state(component: &Component, tag_name: &str) -> Result<Re
 /// repository resolves, or `None` when it cannot be determined (no remote, `gh`
 /// unavailable/unauthenticated, or a non-GitHub remote). Callers that must not
 /// move a published release should treat `None` conservatively.
-pub(crate) fn github_release_exists_for_tag(
-    component: &Component,
-    tag_name: &str,
-) -> Option<bool> {
+pub(crate) fn github_release_exists_for_tag(component: &Component, tag_name: &str) -> Option<bool> {
     component
         .remote_url
         .clone()

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -306,6 +306,13 @@ pub struct ReleaseCommandInput {
     pub dry_run: bool,
     #[serde(default)]
     pub recover: bool,
+    /// During `--recover`, when the release tag exists but points at a commit
+    /// strictly behind HEAD (e.g. config-only commits landed after tagging),
+    /// move the tag to HEAD instead of refusing. Guarded: the tagged commit
+    /// must be an ancestor of HEAD, HEAD must satisfy the version targets, and
+    /// no GitHub Release may exist for the tag.
+    #[serde(default)]
+    pub retag: bool,
     #[serde(default)]
     pub skip_checks: bool,
     /// Explicit bump override: "major", "minor", "patch", or a version string like "2.0.0".

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -611,13 +611,177 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
     };
     let remote_tag_commit = git::remote_tag_commit(&component.local_path, &tag_name)?;
 
-    if local_tag_commit
+    let tag_is_stale = local_tag_commit
         .as_deref()
         .is_some_and(|commit| commit != head_commit)
         || remote_tag_commit
             .as_deref()
-            .is_some_and(|commit| commit != head_commit)
-    {
+            .is_some_and(|commit| commit != head_commit);
+
+    if tag_is_stale && input.retag {
+        // Guarded retag: only move the tag forward to HEAD when it is safe.
+        //   1. Every existing tag commit (local + remote) is a strict ancestor
+        //      of HEAD — never relocate onto divergent/unrelated history.
+        //   2. HEAD satisfies all version targets at the current version —
+        //      preserves the orphan-tag invariant (#2234): the tag must land on
+        //      a commit whose tree actually shows this version.
+        //   3. No GitHub Release exists for the tag — moving a published
+        //      release is destructive to consumers and must be done explicitly.
+        for candidate in [local_tag_commit.as_deref(), remote_tag_commit.as_deref()]
+            .into_iter()
+            .flatten()
+        {
+            let is_ancestor = git::is_ancestor(&component.local_path, candidate, &head_commit)?;
+            if !is_ancestor {
+                return Err(Error::validation_invalid_argument(
+                    "retag",
+                    format!(
+                        "Refusing to retag '{}': existing tag commit {} is not an ancestor of HEAD {}",
+                        tag_name,
+                        short_sha(candidate),
+                        short_sha(&head_commit)
+                    ),
+                    None,
+                    Some(vec![
+                        "The tag points at divergent history. Resolve manually before retagging.".to_string(),
+                    ]),
+                ));
+            }
+        }
+
+        if let Some(mismatches) =
+            crate::core::release::executor::version_targets::collect_head_version_mismatches(
+                &component,
+                current_version,
+            )
+        {
+            let detail = mismatches
+                .iter()
+                .map(|m| {
+                    format!(
+                        "{} = {}",
+                        m.file,
+                        m.found.as_deref().unwrap_or("<unreadable>")
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(Error::validation_invalid_argument(
+                "retag",
+                format!(
+                    "Refusing to retag '{}': HEAD does not show version {} for {} target(s): {}",
+                    tag_name,
+                    current_version,
+                    mismatches.len(),
+                    detail
+                ),
+                None,
+                Some(vec![
+                    "Bump the version targets at HEAD first, or run a normal release.".to_string(),
+                ]),
+            ));
+        }
+
+        if crate::core::release::executor::github_release_exists_for_tag(&component, &tag_name)
+            == Some(true)
+        {
+            return Err(Error::validation_invalid_argument(
+                "retag",
+                format!(
+                    "Refusing to retag '{}': a GitHub Release already exists for this tag",
+                    tag_name
+                ),
+                None,
+                Some(vec![
+                    format!(
+                        "Moving a published release is destructive. Delete it deliberately if intended: gh release delete {}",
+                        tag_name
+                    ),
+                ]),
+            ));
+        }
+
+        // Safe to move: delete the stale tag (local + remote) and re-create at HEAD.
+        log_status!(
+            "recover",
+            "Retagging {} from {} to HEAD {}...",
+            tag_name,
+            local_tag_commit
+                .as_deref()
+                .or(remote_tag_commit.as_deref())
+                .map(short_sha)
+                .unwrap_or("<unknown>"),
+            short_sha(&head_commit)
+        );
+
+        if tag_exists_local {
+            git::delete_local_tag(&component.local_path, &tag_name)?;
+        }
+        if tag_exists_remote {
+            git::delete_remote_tag(&component.local_path, &tag_name)?;
+        }
+
+        let tag_result = git::tag(
+            Some(&input.component_id),
+            Some(&tag_name),
+            Some(&format!("Release {}", tag_name)),
+        )?;
+        if !tag_result.success {
+            return Err(Error::git_command_failed(format!(
+                "Failed to re-create tag at HEAD: {}",
+                tag_result.stderr
+            )));
+        }
+
+        let push_result = git::push(
+            Some(&input.component_id),
+            git::PushOptions {
+                tags: true,
+                ..Default::default()
+            },
+        )?;
+        if !push_result.success {
+            return Err(Error::git_command_failed(format!(
+                "Failed to push retagged {}: {}",
+                tag_name, push_result.stderr
+            )));
+        }
+
+        let actions = vec![format!("retagged {} to HEAD", tag_name)];
+        log_status!(
+            "recover",
+            "Recovery complete for v{}: {}",
+            current_version,
+            actions.join(", ")
+        );
+        return Ok((
+            ReleaseCommandResult {
+                component_id: input.component_id.clone(),
+                status: "recovered".to_string(),
+                bump_type: "recover".to_string(),
+                dry_run: false,
+                releasable_commits: 0,
+                new_version: None,
+                tag: Some(tag_name.clone()),
+                skipped_reason: None,
+                plan: Some(recovery_release_plan(
+                    &input.component_id,
+                    current_version,
+                    &tag_name,
+                    false,
+                    true,
+                    true,
+                    &actions,
+                )),
+                run: None,
+                deployment: None,
+                release_summary: actions.clone(),
+            },
+            0,
+        ));
+    }
+
+    if tag_is_stale {
         return Err(Error::validation_invalid_argument(
             "tag",
             format!("Tag '{}' exists but does not point to HEAD", tag_name),
@@ -644,6 +808,10 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
                 ),
                 format!(
                     "If the tag is an abandoned partial release, delete the GitHub release/tag explicitly, then run: homeboy release {} --recover",
+                    input.component_id
+                ),
+                format!(
+                    "If config-only commits landed after tagging (tag is behind HEAD, version unchanged, no GitHub Release), move the tag to HEAD: homeboy release {} --recover --retag",
                     input.component_id
                 ),
             ]),
@@ -896,6 +1064,7 @@ pub fn run_batch(
             path_override: None,
             dry_run: input_template.dry_run,
             recover: input_template.recover,
+            retag: input_template.retag,
             skip_checks: input_template.skip_checks,
             bump_override: input_template.bump_override.clone(),
             force_lower_bump: input_template.force_lower_bump,


### PR DESCRIPTION
## Summary
Resolves **Papercut 4** from #4615 — the stale-tag chicken/egg.

When config-only commits land *after* a release tag (e.g. a `homeboy.json`/changelog tweak), the version file is unchanged, so the expected tag stays `vX.Y.Z` but now points **behind** HEAD. Every existing path then refuses:

| Command | Refusal |
|---------|---------|
| `homeboy deploy` | "HEAD has unreleased commits" |
| `homeboy release --head` | "requires tag to point at HEAD; found: none" |
| `homeboy release --recover` | "Tag exists but does not point to HEAD" |

...leaving only manual `git tag -d` + force-push surgery. That's exactly what I had to do wiring `docsync`.

## What this adds
`homeboy release <id> --recover --retag` — moves the tag **forward** to HEAD, but **only when all safety preconditions hold**:

1. **Ancestry** — every existing tag commit (local + remote) is a *strict ancestor* of HEAD. Never relocate onto divergent/unrelated history. (new `git::is_ancestor`)
2. **Version invariant** — HEAD satisfies the component's version targets at the current version. Preserves the orphan-tag guard from #2234 (tag must land on a commit whose tree actually shows this version).
3. **No published release** — refuses if a GitHub Release already exists for the tag (moving a published release is destructive; must be done deliberately).

If any precondition fails, it refuses with a targeted error. The existing stale-tag `--recover` refusal now also **hints at `--retag`** for discoverability.

## Safety stance
This is deliberately conservative — it does **not** force-move arbitrary tags. It only fast-forwards a tag that is provably behind HEAD with an unchanged version and no consumer-facing release. Anything outside that envelope still refuses.

## Changes
- `git::is_ancestor`, `git::delete_local_tag`, `git::delete_remote_tag` (+ re-exports)
- `github_release_exists_for_tag` factored out of `inspect_release_tag_state` for reuse
- `--retag` CLI flag + `ReleaseCommandInput.retag` plumbing
- retag branch in `run_recover` with the three guards
- Platform-agnostic wording — no WordPress/PHP assumptions in core

## Test plan
- `cargo build` — clean
- `cargo clippy --lib` — clean (no new warnings)
- `cargo test --lib release` — 237 pass; unit test added for `git::is_ancestor`
- The only failing lib test (`trace_overlay_run_failure_reverts_patch_and_releases_lock`, in `extension::trace`) is pre-existing and env-dependent — fails identically on base `426aef90` with this change stashed

Refs #4615.