### PR TITLE
fix: surface Lab runner Homeboy binary refresh

### DIFF
--- a/docs/commands/lab.md
+++ b/docs/commands/lab.md
@@ -35,6 +35,11 @@ routine lifecycle work:
 - `homeboy runner doctor <runner>` probes runner tools, workspace writability,
   artifact storage, and browser readiness.
 - `homeboy runner env <runner>` prints the redacted runner job environment.
+- `homeboy runner disconnect <runner> && homeboy runner connect <runner>`
+  restarts the active runner daemon so Lab offload uses the currently configured
+  runner-side Homeboy binary.
+- `homeboy upgrade --force --upgrade-runner <runner>` refreshes the configured
+  runner-side Homeboy binary when the binary itself is behind merged fixes.
 - `homeboy runner exec <runner> -- <command>` runs a managed follow-up command
   through Homeboy.
 - `homeboy runner workspace sync <runner> --path <path> --mode snapshot`
@@ -48,6 +53,14 @@ primary workspace, and returns dependency provenance in the generic
 `validation_dependencies` output field. Use that contract for eval/bench source
 overrides instead of ad-hoc workflow-specific environment exports or hardcoded
 runner paths.
+
+Lab status and offloaded run metadata include `runner_homeboy`, which names the
+configured runner Homeboy executable, the active daemon version/build identity
+when connected, stale-daemon details, and the exact refresh/upgrade commands.
+For `agent-task run-plan --runner homeboy-lab`, check this field before assuming
+the Lab runner has picked up a merged CLI fix. If the daemon identity is stale,
+run the refresh command pair; if the configured executable is old, run the
+upgrade command first and reconnect the runner.
 
 `homeboy lab bench` delegates to the same benchmark path while making the Lab
 intent explicit at the command surface. Its output includes the same managed

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -79,12 +79,26 @@ pub struct LabSelectedRunnerOutput {
     runner_id: String,
     kind: String,
     configured_executable: String,
+    runner_homeboy: LabRunnerHomeboyOutput,
     daemon_enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     workspace_root: Option<String>,
     readiness_state: String,
     connected: bool,
     status: RunnerStatusReport,
+}
+
+#[derive(Serialize)]
+pub struct LabRunnerHomeboyOutput {
+    configured_executable: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    active_daemon_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    active_daemon_build_identity: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stale_daemon: Option<Value>,
+    refresh_commands: Vec<String>,
+    upgrade_command: String,
 }
 
 #[derive(Serialize)]
@@ -185,20 +199,57 @@ fn selected_lab_runner_status(
     };
     let runner_config = runner::load(runner_id)?;
     let status = runner::status(runner_id)?;
+    let configured_executable = runner_config
+        .settings
+        .homeboy_path
+        .clone()
+        .unwrap_or_else(|| "homeboy".to_string());
     Ok(Some(LabSelectedRunnerOutput {
         runner_id: runner_id.to_string(),
         kind: format!("{:?}", runner_config.kind).to_ascii_lowercase(),
-        configured_executable: runner_config
-            .settings
-            .homeboy_path
-            .clone()
-            .unwrap_or_else(|| "homeboy".to_string()),
+        configured_executable: configured_executable.clone(),
+        runner_homeboy: lab_runner_homeboy_output(runner_id, &configured_executable, &status),
         daemon_enabled: runner_config.settings.daemon,
         workspace_root: runner_config.workspace_root.clone(),
         readiness_state: format!("{:?}", status.state).to_ascii_lowercase(),
         connected: status.connected,
         status,
     }))
+}
+
+fn lab_runner_homeboy_output(
+    runner_id: &str,
+    configured_executable: &str,
+    status: &RunnerStatusReport,
+) -> LabRunnerHomeboyOutput {
+    LabRunnerHomeboyOutput {
+        configured_executable: configured_executable.to_string(),
+        active_daemon_version: status
+            .session
+            .as_ref()
+            .map(|session| session.homeboy_version.clone()),
+        active_daemon_build_identity: status
+            .session
+            .as_ref()
+            .and_then(|session| session.homeboy_build_identity.clone()),
+        stale_daemon: status
+            .stale_daemon
+            .as_ref()
+            .and_then(|warning| serde_json::to_value(warning).ok()),
+        refresh_commands: lab_runner_homeboy_refresh_commands(runner_id),
+        upgrade_command: format!(
+            "homeboy upgrade --force --upgrade-runner {}",
+            shell_arg(runner_id)
+        ),
+    }
+}
+
+fn lab_runner_homeboy_refresh_commands(runner_id: &str) -> Vec<String> {
+    let runner_arg = shell_arg(runner_id);
+    vec![
+        format!("homeboy runner disconnect {runner_arg}"),
+        format!("homeboy runner connect {runner_arg}"),
+    ]
 }
 
 fn sync_lab_extension(
@@ -467,6 +518,18 @@ fn lab_followups(runner_id: Option<&str>, current_workspace: Option<&str>) -> Ve
             purpose: "Show the redacted environment Homeboy injects into runner jobs.",
         },
         LabFollowup {
+            label: "homeboy_binary_refresh",
+            command: format!(
+                "homeboy runner disconnect {runner_arg} && homeboy runner connect {runner_arg}"
+            ),
+            purpose: "Restart the runner daemon so Lab offload uses the currently configured Homeboy binary.",
+        },
+        LabFollowup {
+            label: "homeboy_binary_upgrade",
+            command: format!("homeboy upgrade --force --upgrade-runner {runner_arg}"),
+            purpose: "Upgrade the Homeboy binary configured for this runner before reconnecting stale Lab runs.",
+        },
+        LabFollowup {
             label: "exec",
             command: format!("homeboy runner exec {runner_arg} -- <command>"),
             purpose: "Run a managed follow-up command through Homeboy instead of opening an ad-hoc shell.",
@@ -501,7 +564,7 @@ fn shell_arg(value: &str) -> String {
 mod tests {
     use super::{
         controller_local_source_path, installed_extension_source_revision, lab_followups,
-        revision_matches, runner_extension_install_command,
+        lab_runner_homeboy_refresh_commands, revision_matches, runner_extension_install_command,
     };
     use std::fs;
 
@@ -657,6 +720,10 @@ Installing declared dependencies...
         assert!(commands.contains(&"homeboy runs artifacts <run-id>"));
         assert!(commands.contains(&"homeboy runner doctor homeboy-lab"));
         assert!(commands.contains(&"homeboy runner env homeboy-lab"));
+        assert!(commands.contains(
+            &"homeboy runner disconnect homeboy-lab && homeboy runner connect homeboy-lab"
+        ));
+        assert!(commands.contains(&"homeboy upgrade --force --upgrade-runner homeboy-lab"));
         assert!(commands.contains(&"homeboy runner exec homeboy-lab -- <command>"));
         assert!(commands.contains(
             &"homeboy runner workspace sync homeboy-lab --path '/tmp/example workspace' --mode snapshot"
@@ -674,5 +741,16 @@ Installing declared dependencies...
         assert!(!commands
             .iter()
             .any(|command| command.starts_with("homeboy runner ")));
+    }
+
+    #[test]
+    fn lab_runner_homeboy_refresh_commands_are_shell_quoted() {
+        assert_eq!(
+            lab_runner_homeboy_refresh_commands("homeboy lab"),
+            vec![
+                "homeboy runner disconnect 'homeboy lab'".to_string(),
+                "homeboy runner connect 'homeboy lab'".to_string(),
+            ]
+        );
     }
 }

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -19,6 +19,7 @@
 use std::path::Path;
 
 use crate::core::agent_task_lifecycle;
+use crate::core::engine::shell;
 use crate::core::observation::{PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
 use crate::core::plan::{HomeboyPlan, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::source_snapshot::SourceSnapshot;
@@ -457,6 +458,31 @@ fn run_lab_offload_inner(
         messages.push(warning);
     }
     let homeboy_path = runner.settings.homeboy_path.as_deref().unwrap_or("homeboy");
+    let runner_homeboy = lab_runner_homeboy_metadata(runner_id, homeboy_path, &runner_status);
+    plan = with_step(
+        plan,
+        PlanStep::ready("lab.runner_homeboy", "lab.runner_homeboy")
+            .inputs(PlanValues::new().json("runner_homeboy", &runner_homeboy))
+            .build(),
+    );
+    eprintln!(
+        "Lab offload: runner `{}` Homeboy binary `{}`; active daemon {}; refresh with `{}`.",
+        runner_id,
+        homeboy_path,
+        runner_homeboy_daemon_display(&runner_homeboy),
+        runner_homeboy["refresh_commands"]
+            .as_array()
+            .map(|commands| commands
+                .iter()
+                .filter_map(|command| command.as_str())
+                .collect::<Vec<_>>()
+                .join(" && "))
+            .unwrap_or_else(|| format!(
+                "homeboy runner disconnect {} && homeboy runner connect {}",
+                shell::quote_arg(runner_id),
+                shell::quote_arg(runner_id)
+            ))
+    );
     let command_prefix = lab_offload_command_prefix(&source_path, homeboy_path);
     let capability_contract =
         lab_runner_capability_contract(&contract, &source_path, &command_prefix.required_tools);
@@ -825,6 +851,7 @@ fn run_lab_offload_inner(
     lab_metadata["tunnel_secret_env"] = tunnel_secret_env;
     lab_metadata["rig_component_path_env"] = rig_component_path_env;
     lab_metadata["settings_env"] = settings_env_diagnostics(&remapped_args, &env);
+    lab_metadata["runner_homeboy"] = runner_homeboy.clone();
     lab_metadata["rig_sync"] = serde_json::json!({
         "step": "lab.sync_rigs",
         "synced_count": synced_rigs.len(),
@@ -1025,6 +1052,40 @@ fn run_lab_offload_inner(
         stderr,
         exit_code,
     })
+}
+
+fn lab_runner_homeboy_metadata(
+    runner_id: &str,
+    configured_executable: &str,
+    status: &RunnerStatusReport,
+) -> serde_json::Value {
+    let refresh_commands = vec![
+        format!("homeboy runner disconnect {}", shell::quote_arg(runner_id)),
+        format!("homeboy runner connect {}", shell::quote_arg(runner_id)),
+    ];
+    serde_json::json!({
+        "schema": "homeboy/lab-runner-homeboy/v1",
+        "runner_id": runner_id,
+        "configured_executable": configured_executable,
+        "active_daemon_version": status.session.as_ref().map(|session| session.homeboy_version.clone()),
+        "active_daemon_build_identity": status.session.as_ref().and_then(|session| session.homeboy_build_identity.clone()),
+        "stale_daemon": status.stale_daemon,
+        "refresh_commands": refresh_commands,
+        "upgrade_command": format!("homeboy upgrade --force --upgrade-runner {}", shell::quote_arg(runner_id)),
+    })
+}
+
+fn runner_homeboy_daemon_display(metadata: &serde_json::Value) -> String {
+    metadata
+        .get("active_daemon_build_identity")
+        .and_then(|value| value.as_str())
+        .or_else(|| {
+            metadata
+                .get("active_daemon_version")
+                .and_then(|value| value.as_str())
+        })
+        .unwrap_or("<not connected>")
+        .to_string()
 }
 
 fn with_lab_apply_patch_step(
@@ -1685,6 +1746,52 @@ mod tests {
         .expect("parse lab offload metadata");
 
         assert_eq!(parsed["workspace_mapping"], mapping);
+    }
+
+    #[test]
+    fn lab_runner_homeboy_metadata_names_binary_and_refresh_path() {
+        let status = reverse_status("homeboy lab");
+        let metadata = lab_runner_homeboy_metadata(
+            "homeboy lab",
+            "/tmp/_lab_workspaces/homeboy/target/debug/homeboy",
+            &status,
+        );
+
+        assert_eq!(metadata["schema"], "homeboy/lab-runner-homeboy/v1");
+        assert_eq!(metadata["runner_id"], "homeboy lab");
+        assert_eq!(
+            metadata["configured_executable"],
+            "/tmp/_lab_workspaces/homeboy/target/debug/homeboy"
+        );
+        assert_eq!(metadata["active_daemon_version"], "homeboy 0.0.0");
+        assert_eq!(
+            metadata["active_daemon_build_identity"],
+            "homeboy 0.0.0+test"
+        );
+        assert_eq!(
+            metadata["refresh_commands"],
+            serde_json::json!([
+                "homeboy runner disconnect 'homeboy lab'",
+                "homeboy runner connect 'homeboy lab'"
+            ])
+        );
+        assert_eq!(
+            metadata["upgrade_command"],
+            "homeboy upgrade --force --upgrade-runner 'homeboy lab'"
+        );
+    }
+
+    #[test]
+    fn runner_homeboy_daemon_display_prefers_build_identity() {
+        let metadata = serde_json::json!({
+            "active_daemon_version": "homeboy 0.1.0",
+            "active_daemon_build_identity": "homeboy 0.1.0+abc123",
+        });
+
+        assert_eq!(
+            runner_homeboy_daemon_display(&metadata),
+            "homeboy 0.1.0+abc123"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `runner_homeboy` diagnostics to `homeboy lab status` so the selected Lab runner reports its configured Homeboy executable, active daemon version/build identity, stale-daemon warning, refresh commands, and upgrade command.
- Include the same runner Homeboy diagnostic in Lab offload plan metadata and controller stderr before `agent-task run-plan --runner homeboy-lab` dispatches remotely.
- Document the safe refresh path: reconnect the runner daemon, or run `homeboy upgrade --force --upgrade-runner <runner>` when the configured runner binary is behind merged fixes.

Closes #4661

## Verification
- `cargo fmt`
- `cargo test lab_runner_homeboy --lib`
- `cargo test lab_followups`
- `cargo test upgrade_runner_selector_does_not_collide_with_global_lab_runner_flag --test command_surface_test`
- `git diff --check origin/main...HEAD`