### PR TITLE
fix: forward preview bootstrap redirects

### DIFF
--- a/src/core/preview_client.rs
+++ b/src/core/preview_client.rs
@@ -1,7 +1,8 @@
 use base64::Engine;
 use reqwest::blocking::Client;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-use serde::{Deserialize, Serialize};
+use serde::de::{self, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -66,8 +67,8 @@ pub struct PreviewIngressNextResponse {
 pub struct PreviewIngressResponse {
     pub request_id: String,
     pub status: u16,
-    #[serde(default)]
-    pub headers: BTreeMap<String, String>,
+    #[serde(default, deserialize_with = "deserialize_response_headers")]
+    pub headers: Vec<(String, String)>,
     pub body_base64: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<PreviewClientForwardError>,
@@ -108,6 +109,7 @@ pub fn start(spec: PreviewClientStartSpec) -> Result<PreviewClientReport> {
         })?;
     let local_client = Client::builder()
         .timeout(Duration::from_secs(60))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|err| {
             Error::internal_unexpected(format!("build local-origin HTTP client: {err}"))
@@ -210,7 +212,7 @@ pub fn forward_to_local_origin(
         Err(error) => PreviewIngressResponse {
             request_id: request.request_id,
             status: 502,
-            headers: BTreeMap::from([("content-type".to_string(), "application/json".to_string())]),
+            headers: vec![("content-type".to_string(), "application/json".to_string())],
             body_base64: base64::engine::general_purpose::STANDARD.encode(
                 json!({
                     "error": error.kind,
@@ -232,7 +234,7 @@ fn forward_to_local_origin_result(
         return Ok(PreviewIngressResponse {
             request_id: request.request_id.clone(),
             status: 204,
-            headers: cors_headers(BTreeMap::new(), &request.path),
+            headers: cors_headers(Vec::new(), &request.path),
             body_base64: base64::engine::general_purpose::STANDARD.encode([]),
             error: None,
         });
@@ -434,7 +436,7 @@ fn forward_request_headers(headers: &BTreeMap<String, String>) -> HeaderMap {
     forwarded
 }
 
-fn response_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
+fn response_headers(headers: &HeaderMap) -> Vec<(String, String)> {
     headers
         .iter()
         .filter_map(|(name, value)| {
@@ -453,22 +455,68 @@ fn response_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
         .collect()
 }
 
-fn cors_headers(mut headers: BTreeMap<String, String>, path: &str) -> BTreeMap<String, String> {
-    headers
-        .entry("access-control-allow-origin".to_string())
-        .or_insert_with(|| "*".to_string());
-    headers
-        .entry("access-control-allow-methods".to_string())
-        .or_insert_with(|| "GET, HEAD, OPTIONS".to_string());
-    headers
-        .entry("access-control-allow-headers".to_string())
-        .or_insert_with(|| "*".to_string());
+fn cors_headers(mut headers: Vec<(String, String)>, path: &str) -> Vec<(String, String)> {
+    push_header_if_missing(&mut headers, "access-control-allow-origin", "*");
+    push_header_if_missing(
+        &mut headers,
+        "access-control-allow-methods",
+        "GET, HEAD, OPTIONS",
+    );
+    push_header_if_missing(&mut headers, "access-control-allow-headers", "*");
     if path.split('?').next().unwrap_or(path).ends_with(".json") {
-        headers
-            .entry("content-type".to_string())
-            .or_insert_with(|| "application/json".to_string());
+        push_header_if_missing(&mut headers, "content-type", "application/json");
     }
     headers
+}
+
+fn push_header_if_missing(headers: &mut Vec<(String, String)>, name: &str, value: &str) {
+    if !headers
+        .iter()
+        .any(|(header_name, _)| header_name.eq_ignore_ascii_case(name))
+    {
+        headers.push((name.to_string(), value.to_string()));
+    }
+}
+
+fn deserialize_response_headers<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Vec<(String, String)>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ResponseHeadersVisitor;
+
+    impl<'de> Visitor<'de> for ResponseHeadersVisitor {
+        type Value = Vec<(String, String)>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a header object or ordered [name, value] header pairs")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut headers = Vec::new();
+            while let Some((name, value)) = map.next_entry::<String, String>()? {
+                headers.push((name, value));
+            }
+            Ok(headers)
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            let mut headers = Vec::new();
+            while let Some((name, value)) = seq.next_element::<(String, String)>()? {
+                headers.push((name, value));
+            }
+            Ok(headers)
+        }
+    }
+
+    deserializer.deserialize_any(ResponseHeadersVisitor)
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
@@ -597,8 +645,14 @@ mod tests {
         server.join().expect("server finished");
         assert_eq!(response.request_id, "req-1");
         assert_eq!(response.status, 201);
-        assert_eq!(response.headers["content-type"], "text/plain");
-        assert_eq!(response.headers["x-origin"], "local-service");
+        assert_eq!(
+            header_value(&response.headers, "content-type"),
+            Some("text/plain")
+        );
+        assert_eq!(
+            header_value(&response.headers, "x-origin"),
+            Some("local-service")
+        );
         assert_eq!(
             base64::engine::general_purpose::STANDARD
                 .decode(response.body_base64)
@@ -650,8 +704,62 @@ mod tests {
         );
 
         assert_eq!(response.status, 204);
-        assert_eq!(response.headers["access-control-allow-origin"], "*");
-        assert_eq!(response.headers["content-type"], "application/json");
+        assert_eq!(
+            header_value(&response.headers, "access-control-allow-origin"),
+            Some("*")
+        );
+        assert_eq!(
+            header_value(&response.headers, "content-type"),
+            Some("application/json")
+        );
+    }
+
+    #[test]
+    fn forwards_redirect_location_and_multiple_set_cookie_headers_without_following() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind local origin");
+        let port = listener.local_addr().expect("local addr").port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut buffer = [0_u8; 4096];
+            let read = stream.read(&mut buffer).expect("read request");
+            let request = String::from_utf8_lossy(&buffer[..read]);
+            assert!(request
+                .starts_with("GET /__wp-codebox/reviewer-auth-bootstrap?token=redacted HTTP/1.1"));
+            stream
+                .write_all(
+                    b"HTTP/1.1 302 Found\r\nLocation: /wp-admin/\r\nSet-Cookie: reviewer_auth=one; Path=/; HttpOnly\r\nSet-Cookie: wordpress_test_cookie=WP%20Cookie%20check; Path=/\r\nContent-Length: 0\r\n\r\n",
+                )
+                .expect("write response");
+        });
+        let client = Client::builder()
+            .timeout(Duration::from_secs(5))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("client");
+
+        let response = forward_to_local_origin(
+            &client,
+            &format!("http://127.0.0.1:{port}"),
+            PreviewIngressRequest {
+                request_id: "req-bootstrap".to_string(),
+                method: "GET".to_string(),
+                path: "/__wp-codebox/reviewer-auth-bootstrap?token=redacted".to_string(),
+                headers: BTreeMap::new(),
+                body_base64: None,
+            },
+        );
+
+        server.join().expect("server finished");
+        assert_eq!(response.status, 302);
+        assert_eq!(
+            header_value(&response.headers, "location"),
+            Some("/wp-admin/")
+        );
+        let cookies = header_values(&response.headers, "set-cookie");
+        assert_eq!(cookies.len(), 2);
+        assert!(cookies[0].starts_with("reviewer_auth="));
+        assert!(cookies[1].starts_with("wordpress_test_cookie="));
+        assert!(response.error.is_none());
     }
 
     #[test]
@@ -673,5 +781,20 @@ mod tests {
 
         std::env::remove_var("HOMEBOY_TEST_PREVIEW_TOKEN");
         std::env::remove_var("HOMEBOY_TEST_PREVIEW_TOKEN_SHA256");
+    }
+
+    fn header_value<'a>(headers: &'a [(String, String)], name: &str) -> Option<&'a str> {
+        headers
+            .iter()
+            .find(|(header_name, _)| header_name.eq_ignore_ascii_case(name))
+            .map(|(_, value)| value.as_str())
+    }
+
+    fn header_values<'a>(headers: &'a [(String, String)], name: &str) -> Vec<&'a str> {
+        headers
+            .iter()
+            .filter(|(header_name, _)| header_name.eq_ignore_ascii_case(name))
+            .map(|(_, value)| value.as_str())
+            .collect()
     }
 }

--- a/src/core/preview_ingress.rs
+++ b/src/core/preview_ingress.rs
@@ -1483,7 +1483,8 @@ fn write_preview_response(
     let body = base64::engine::general_purpose::STANDARD
         .decode(response.body_base64.as_bytes())
         .map_err(|e| Error::internal_json(e.to_string(), Some(response.request_id.clone())))?;
-    let headers = response.headers.into_iter().collect::<Vec<_>>();
+    let mut headers = response.headers;
+    push_header_if_missing(&mut headers, "content-length", &body.len().to_string());
     write_status_and_headers(
         stream,
         response.status,
@@ -1860,10 +1861,15 @@ fn write_response(
     headers: &[(&String, String)],
     body: &[u8],
 ) -> Result<()> {
-    let owned_headers = headers
+    let mut owned_headers = headers
         .iter()
         .map(|(name, value)| ((*name).clone(), value.clone()))
         .collect::<Vec<_>>();
+    push_header_if_missing(
+        &mut owned_headers,
+        "content-length",
+        &body.len().to_string(),
+    );
     write_status_and_headers(stream, status, reason, &owned_headers)?;
     stream
         .write_all(body)
@@ -1917,6 +1923,8 @@ fn push_header_if_missing(headers: &mut Vec<(String, String)>, name: &str, value
 
 fn reason_for_status(status: u16) -> &'static str {
     match status {
+        204 => "No Content",
+        302 => "Found",
         404 => "Not Found",
         410 => "Gone",
         502 => "Bad Gateway",

--- a/src/core/preview_ingress_tests.rs
+++ b/src/core/preview_ingress_tests.rs
@@ -203,6 +203,107 @@ fn reverse_channel_client_serves_public_request() {
 }
 
 #[test]
+fn reverse_channel_client_forwards_bootstrap_redirect_and_repeated_cookies() {
+    test_support::with_isolated_home(|_| {
+        let token = "test-preview-token";
+        std::env::set_var(
+            "HOMEBOY_TEST_PREVIEW_TOKEN_SHA256",
+            native_preview_token_sha256(token),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").expect("reserve port");
+        let port = listener.local_addr().expect("local addr").port();
+        thread::spawn(move || {
+            serve_listener(
+                PreviewIngressServeSpec {
+                    bind: format!("127.0.0.1:{port}"),
+                    domain: "example.com".to_string(),
+                    public_host_pattern: "*-tunnel.example.com".to_string(),
+                    token_sha256_env: "HOMEBOY_TEST_PREVIEW_TOKEN_SHA256".to_string(),
+                },
+                listener,
+            )
+            .expect("serve ingress");
+        });
+        thread::sleep(Duration::from_millis(100));
+
+        let register = http_request(
+            port,
+            "POST",
+            "/preview/client/register",
+            "homeboy-health-tunnel.example.com",
+            Some(token),
+            json!({
+                "public_host": "run-1-tunnel.example.com",
+                "local_origin": "http://127.0.0.1:49999",
+                "session_id": "run-1"
+            })
+            .to_string(),
+        );
+        assert!(register.contains("200 OK"), "{register}");
+
+        let browser = thread::spawn(move || {
+            raw_http_request(
+                port,
+                "GET /__wp-codebox/reviewer-auth-bootstrap?token=fake HTTP/1.1\r\nHost: run-1-tunnel.example.com\r\n\r\n",
+            )
+        });
+        thread::sleep(Duration::from_millis(100));
+
+        let next = http_request(
+            port,
+            "POST",
+            "/preview/client/next",
+            "homeboy-health-tunnel.example.com",
+            Some(token),
+            json!({ "public_host": "run-1-tunnel.example.com", "timeout_secs": 2 }).to_string(),
+        );
+        assert!(
+            next.contains("/__wp-codebox/reviewer-auth-bootstrap?token=fake"),
+            "{next}"
+        );
+        let request_id = response_json(&next)["request"]["request_id"]
+            .as_str()
+            .expect("request id")
+            .to_string();
+
+        let respond = http_request(
+            port,
+            "POST",
+            "/preview/client/respond",
+            "homeboy-health-tunnel.example.com",
+            Some(token),
+            json!({
+                "public_host": "run-1-tunnel.example.com",
+                "response": {
+                    "request_id": request_id,
+                    "status": 302,
+                    "headers": [
+                        ["location", "/wp-admin/"],
+                        ["set-cookie", "reviewer_auth=fake; Path=/; HttpOnly"],
+                        ["set-cookie", "wordpress_test_cookie=fake; Path=/"]
+                    ],
+                    "body_base64": base64::engine::general_purpose::STANDARD.encode("")
+                }
+            })
+            .to_string(),
+        );
+        assert!(respond.contains("200 OK"), "{respond}");
+
+        let browser_response = browser.join().expect("browser response");
+        assert!(browser_response.contains("302 Found"), "{browser_response}");
+        assert!(
+            browser_response.contains("location: /wp-admin/"),
+            "{browser_response}"
+        );
+        assert_eq!(browser_response.matches("set-cookie:").count(), 2);
+        assert!(
+            browser_response.contains("content-length: 0"),
+            "{browser_response}"
+        );
+    });
+}
+
+#[test]
 fn route_proxy_serves_artifact_json_with_cors_headers() {
     test_support::with_isolated_home(|_| {
         let upstream = TcpListener::bind("127.0.0.1:0").expect("upstream bind");


### PR DESCRIPTION
## Summary
- Fixes #4659 by making the preview client return local-origin redirect responses instead of following them.
- Preserves repeated response headers across the preview client/ingress wire contract so multiple `Set-Cookie` headers survive the public reverse-channel hop.
- Adds explicit `Content-Length` on preview ingress responses so empty `302` bootstrap responses complete cleanly for HTTP/1.1 clients.

## Root Cause
The reverse-channel preview response model stored headers in a `BTreeMap<String, String>`, so repeated headers such as `Set-Cookie` were collapsed before ingress wrote the browser response. The preview client also used reqwest's default redirect policy for local-origin forwarding, which is the wrong behavior for reviewer auth bootstrap: the public client needs the original `302 Location` and auth cookies, not the followed response.

## Verification
- `cargo fmt`
- `cargo test preview` passed: 46 passed, 0 failed
- Added local-origin regression coverage for `302 Location` plus multiple `Set-Cookie` headers without following redirects.
- Added reverse-channel ingress regression coverage for `GET /__wp-codebox/reviewer-auth-bootstrap?token=...` returning `302 Found`, `Location`, two separate `set-cookie` headers, and `content-length: 0` through public ingress.

## Broader Test Note
- `cargo test --lib` compiled and ran, but failed in 5 unrelated/environment-sensitive tests outside preview code:
  - `core::extension::runner::tests::with_run_dir_tracks_resource_artifact_path` (`create homeboy runtime tmp directory`: `Invalid argument (os error 22)`)
  - 4 runner workspace materialization tests with existing shell `;;` syntax errors in generated commands