### PR TITLE
Fix Workflow Bench artifact origin mapping

### DIFF
--- a/docs/commands/tunnel.md
+++ b/docs/commands/tunnel.md
@@ -7,11 +7,68 @@ homeboy tunnel service <COMMAND>
 homeboy tunnel preview-client <COMMAND>
 homeboy tunnel preview-ingress <COMMAND>
 homeboy tunnel preview-consumer <COMMAND>
+homeboy tunnel artifact-origin <COMMAND>
 ```
 
 `tunnel` manages Homeboy-native private service tunnel declarations, local managed service lifecycle, and the VPS-side public preview ingress used by generic preview URLs. Homeboy can start a long-running local command, record safe command/process/log evidence, report readiness, and stop the process group without relying on an external chat or tunnel wrapper.
 
 `preview-client` connects a local/lab preview origin to a Homeboy-owned preview ingress over an outbound authenticated reverse channel. It is the local side of native public browser preview tunnels and does not use external tunnel providers.
+
+## Artifact Origin
+
+`artifact-origin` serves the configured Homeboy artifact root as a static, CORS-enabled HTTP origin for browser/reviewer consumers. Public URLs map directly from the artifact-root-relative path:
+
+```text
+HOMEBOY_ARTIFACT_ROOT/workflow-bench/<bundle>/report.html
+  -> ${HOMEBOY_PUBLIC_ARTIFACT_BASE_URL}/workflow-bench/<bundle>/report.html
+```
+
+Inspect the configured root and URL mapping without starting or restarting the origin:
+
+```sh
+HOMEBOY_PUBLIC_ARTIFACT_BASE_URL=https://homeboy-artifacts-tunnel.dev.chubes.net \
+  homeboy tunnel artifact-origin status
+```
+
+Check one published Workflow Bench path locally before sharing a public URL:
+
+```sh
+HOMEBOY_PUBLIC_ARTIFACT_BASE_URL=https://homeboy-artifacts-tunnel.dev.chubes.net \
+  homeboy tunnel artifact-origin inspect \
+  workflow-bench/studio-web-plain-site-data-machine-live-20260615-r15-pr995-replay-export/report.html \
+  --fail-on-missing
+```
+
+Serve the artifact root behind an operator-managed TLS/proxy/tunnel:
+
+```sh
+HOMEBOY_PUBLIC_ARTIFACT_BASE_URL=https://homeboy-artifacts-tunnel.dev.chubes.net \
+  homeboy tunnel artifact-origin serve --bind 127.0.0.1:7351
+```
+
+For Lab-generated Workflow Bench artifacts, publish the bundle under the configured artifact root first, then inspect, then serve:
+
+```sh
+# 1. Keep Lab output under the configured artifact root.
+export HOMEBOY_ARTIFACT_ROOT=/home/chubes/Developer/.tmp/homeboy-artifacts
+export HOMEBOY_PUBLIC_ARTIFACT_BASE_URL=https://homeboy-artifacts-tunnel.dev.chubes.net
+
+# 2. Publish/copy the Lab-generated replay bundle preserving its workflow-bench path.
+mkdir -p "$HOMEBOY_ARTIFACT_ROOT/workflow-bench"
+cp -R \
+  /home/chubes/Developer/studio-web-eval-runs/studio-web-plain-site-data-machine-live-20260615-r15-pr995-replay-export \
+  "$HOMEBOY_ARTIFACT_ROOT/workflow-bench/"
+
+# 3. Smoke-check the exact public path before handing it to reviewers.
+homeboy tunnel artifact-origin inspect \
+  workflow-bench/studio-web-plain-site-data-machine-live-20260615-r15-pr995-replay-export/report.html \
+  --fail-on-missing
+
+# 4. Serve the root through the long-running artifact origin process.
+homeboy tunnel artifact-origin serve --bind 127.0.0.1:7351
+```
+
+The same path convention covers `report.html`, `report.md`, `evidence.json`, compact WP Codebox replay files such as `blueprint.after.json`, and external bundle files such as `files/runtime-snapshot.json`.
 
 ## Service Tunnels
 

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -1331,7 +1331,12 @@ mod tests {
                 .find(|artifact| artifact.kind == "replay-artifact")
                 .expect("replay artifact");
             let artifact_url = replay.public_url.as_deref().expect("public url");
-            assert!(artifact_url.starts_with(&format!("{public_artifact_base}/runs/")));
+            assert_eq!(
+                artifact_url,
+                format!(
+                    "{public_artifact_base}/homeboy/workflow-bench/runs/run-1/artifacts/scenario/adapter/attempt-1/replay.json"
+                )
+            );
             assert!(!artifact_url.ends_with("/content"));
             assert_eq!(replay.mime.as_deref(), Some("application/json"));
             assert_eq!(replay.sha256.as_deref(), Some("abc123"));

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -2,7 +2,9 @@ use clap::{Args, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use homeboy::core::artifacts::{self, ArtifactOriginServeSpec, ArtifactOriginStatus};
+use homeboy::core::artifacts::{
+    self, ArtifactOriginInspect, ArtifactOriginServeSpec, ArtifactOriginStatus,
+};
 use homeboy::core::preview_client::{
     self, PreviewClientAuthDiagnostic, PreviewClientReport, PreviewClientStartSpec,
 };
@@ -119,6 +121,8 @@ struct PreviewConsumerOutputConfig {
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum ArtifactOriginActionOutput {
     Serve(ArtifactOriginStatus),
+    Status(ArtifactOriginStatus),
+    Inspect(ArtifactOriginInspect),
 }
 
 pub type TunnelOutput = EntityCrudOutput<ServiceTunnel, TunnelExtra>;
@@ -331,6 +335,29 @@ enum TunnelArtifactOriginCommand {
         /// Artifact root to serve. Defaults to Homeboy's configured artifact root.
         #[arg(long)]
         root: Option<PathBuf>,
+    },
+    /// Print the artifact origin root and public URL mapping without starting a server
+    Status {
+        /// Loopback bind address expected by the local static artifact origin
+        #[arg(long, default_value = "127.0.0.1:7351")]
+        bind: String,
+
+        /// Artifact root to inspect. Defaults to Homeboy's configured artifact root.
+        #[arg(long)]
+        root: Option<PathBuf>,
+    },
+    /// Map an artifact-origin request path or file path to its served file and public URL
+    Inspect {
+        /// Request path, artifact-root-relative path, or filesystem path to inspect
+        path: String,
+
+        /// Artifact root to inspect. Defaults to Homeboy's configured artifact root.
+        #[arg(long)]
+        root: Option<PathBuf>,
+
+        /// Return a non-zero exit code when the mapped file is missing
+        #[arg(long)]
+        fail_on_missing: bool,
     },
 }
 
@@ -673,6 +700,48 @@ fn run_artifact_origin(command: TunnelArtifactOriginCommand) -> CmdResult<Tunnel
                     ..Default::default()
                 },
                 0,
+            ))
+        }
+        TunnelArtifactOriginCommand::Status { bind, root } => {
+            let status = artifacts::status_with_command(
+                "tunnel.artifact_origin.status",
+                bind,
+                root.unwrap_or(homeboy::core::artifacts::root()?),
+            );
+            Ok((
+                TunnelOutput {
+                    command: "tunnel.artifact_origin.status".to_string(),
+                    extra: TunnelExtra {
+                        artifact_origin: Some(ArtifactOriginActionOutput::Status(status)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                0,
+            ))
+        }
+        TunnelArtifactOriginCommand::Inspect {
+            path,
+            root,
+            fail_on_missing,
+        } => {
+            let output =
+                artifacts::inspect(root.unwrap_or(homeboy::core::artifacts::root()?), &path);
+            let exit_code = if fail_on_missing && !output.exists {
+                1
+            } else {
+                0
+            };
+            Ok((
+                TunnelOutput {
+                    command: "tunnel.artifact_origin.inspect".to_string(),
+                    extra: TunnelExtra {
+                        artifact_origin: Some(ArtifactOriginActionOutput::Inspect(output)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                exit_code,
             ))
         }
     }

--- a/src/core/artifact_links.rs
+++ b/src/core/artifact_links.rs
@@ -1,4 +1,5 @@
 use serde_json::Value;
+use std::path::Path;
 use std::time::Duration;
 
 use crate::core::execution_contract::encode_uri_component;
@@ -25,12 +26,40 @@ pub fn public_artifact_url(artifact: &ArtifactRecord) -> Option<String> {
         return None;
     }
 
+    if let Ok(root) = crate::core::artifacts::root() {
+        if let Some(url) = public_artifact_path_url(&root, base, Path::new(&artifact.path)) {
+            return Some(url);
+        }
+    }
+
     Some(format!(
         "{}/runs/{}/artifacts/{}",
         base,
         encode_uri_component(&artifact.run_id),
         encode_uri_component(&artifact.id)
     ))
+}
+
+pub fn public_artifact_path_url(root: &Path, base: &str, path: &Path) -> Option<String> {
+    let base = base.trim().trim_end_matches('/');
+    if base.is_empty() {
+        return None;
+    }
+    let relative = path.strip_prefix(root).ok()?;
+    let segments = relative
+        .components()
+        .map(|component| match component {
+            std::path::Component::Normal(segment) => segment
+                .to_str()
+                .map(encode_uri_component)
+                .filter(|segment| !segment.is_empty()),
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()?;
+    if segments.is_empty() {
+        return None;
+    }
+    Some(format!("{}/{}", base, segments.join("/")))
 }
 
 pub fn viewer_links(
@@ -251,6 +280,20 @@ mod tests {
         assert_eq!(links.len(), 1);
         assert!(links[0].url.contains("artifact-url="));
         assert!(validation.expect("validation result").reachable);
+    }
+
+    #[test]
+    fn public_artifact_path_url_uses_artifact_root_relative_path() {
+        let root = tempfile::tempdir().expect("artifact root");
+        let path = root
+            .path()
+            .join("workflow-bench/studio web replay/report.html");
+
+        assert_eq!(
+            public_artifact_path_url(root.path(), "https://artifacts.example.test/base/", &path)
+                .as_deref(),
+            Some("https://artifacts.example.test/base/workflow-bench/studio%20web%20replay/report.html")
+        );
     }
 
     fn viewer_artifact() -> ArtifactRecord {

--- a/src/core/artifact_origin.rs
+++ b/src/core/artifact_origin.rs
@@ -17,8 +17,31 @@ pub struct ArtifactOriginStatus {
     pub command: &'static str,
     pub bind: String,
     pub root: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_base_url: Option<String>,
     pub public_base_url_shape: String,
+    pub mapping: ArtifactOriginMapping,
     pub cors: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ArtifactOriginMapping {
+    pub request_path: String,
+    pub filesystem_path: String,
+    pub public_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ArtifactOriginInspect {
+    pub command: &'static str,
+    pub root: String,
+    pub input: String,
+    pub request_path: String,
+    pub filesystem_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
+    pub exists: bool,
+    pub status_code: u16,
 }
 
 pub fn serve(spec: ArtifactOriginServeSpec) -> Result<ArtifactOriginStatus> {
@@ -47,12 +70,60 @@ pub fn serve(spec: ArtifactOriginServeSpec) -> Result<ArtifactOriginStatus> {
 }
 
 pub fn status(bind: String, root: PathBuf) -> ArtifactOriginStatus {
+    status_with_command("tunnel.artifact_origin.serve", bind, root)
+}
+
+pub fn status_with_command(
+    command: &'static str,
+    bind: String,
+    root: PathBuf,
+) -> ArtifactOriginStatus {
+    let public_base_url = std::env::var(crate::core::artifacts::PUBLIC_ARTIFACT_BASE_URL_ENV)
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty());
+    let public_base_url_shape = public_base_url
+        .as_deref()
+        .unwrap_or("https://<public-host>")
+        .to_string();
     ArtifactOriginStatus {
-        command: "tunnel.artifact_origin.serve",
+        command,
         bind,
         root: root.display().to_string(),
-        public_base_url_shape: "https://<public-host>".to_string(),
+        public_base_url,
+        public_base_url_shape: format!("{public_base_url_shape}/<artifact-root-relative-path>"),
+        mapping: ArtifactOriginMapping {
+            request_path: "/workflow-bench/<bundle>/report.html".to_string(),
+            filesystem_path: root
+                .join("workflow-bench/<bundle>/report.html")
+                .display()
+                .to_string(),
+            public_url: format!("{public_base_url_shape}/workflow-bench/<bundle>/report.html"),
+        },
         cors: true,
+    }
+}
+
+pub fn inspect(root: PathBuf, input: &str) -> ArtifactOriginInspect {
+    let request_path = request_path_from_input(&root, input);
+    let filesystem_path = safe_target_path(&root, &request_path).unwrap_or_else(|| root.clone());
+    let public_base_url = std::env::var(crate::core::artifacts::PUBLIC_ARTIFACT_BASE_URL_ENV)
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty());
+    let public_url = public_base_url.as_deref().and_then(|base| {
+        crate::core::artifacts::public_artifact_path_url(&root, base, &filesystem_path)
+    });
+    let exists = filesystem_path.is_file();
+    ArtifactOriginInspect {
+        command: "tunnel.artifact_origin.inspect",
+        root: root.display().to_string(),
+        input: input.to_string(),
+        request_path,
+        filesystem_path: filesystem_path.display().to_string(),
+        public_url,
+        exists,
+        status_code: if exists { 200 } else { 404 },
     }
 }
 
@@ -246,6 +317,23 @@ fn sanitize_header_value(value: &str) -> String {
         .collect()
 }
 
+fn request_path_from_input(root: &Path, input: &str) -> String {
+    let trimmed = input.trim();
+    let path = if let Ok(path) = PathBuf::from(trimmed).strip_prefix(root) {
+        path.to_string_lossy().to_string()
+    } else if let Ok(url) = reqwest::Url::parse(trimmed) {
+        url.path().trim_start_matches('/').to_string()
+    } else {
+        trimmed
+            .split('?')
+            .next()
+            .unwrap_or(trimmed)
+            .trim_start_matches('/')
+            .to_string()
+    };
+    format!("/{}", path.trim_start_matches('/'))
+}
+
 fn reason(status: u16) -> &'static str {
     match status {
         200 => "OK",
@@ -356,5 +444,45 @@ mod tests {
                 .headers
                 .contains(&("content-length".to_string(), "11".to_string())));
         });
+    }
+
+    #[test]
+    fn serves_workflow_bench_bundle_paths_under_artifact_root() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp
+            .path()
+            .join("workflow-bench/studio-web-r15-replay-export/report.html");
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&path, b"<html>report</html>").expect("write report");
+
+        let response = response_for_request(
+            temp.path(),
+            "GET",
+            "/workflow-bench/studio-web-r15-replay-export/report.html",
+        )
+        .expect("response");
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, b"<html>report</html>");
+    }
+
+    #[test]
+    fn inspect_reports_404_for_missing_workflow_bench_bundle_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        let output = inspect(
+            temp.path().to_path_buf(),
+            "/workflow-bench/missing-replay-export/report.html",
+        );
+
+        assert_eq!(output.status_code, 404);
+        assert!(!output.exists);
+        assert_eq!(
+            output.filesystem_path,
+            temp.path()
+                .join("workflow-bench/missing-replay-export/report.html")
+                .display()
+                .to_string()
+        );
     }
 }

--- a/src/core/artifacts.rs
+++ b/src/core/artifacts.rs
@@ -5,16 +5,20 @@
 
 pub use super::artifact_inputs::ResolvedArtifactInput;
 pub use super::artifact_links::{
-    annotate_public_artifact_url_validation, cached_validated_viewer_links, public_artifact_url,
-    public_artifact_url_validation_json, validate_public_artifact_url, validated_viewer_links,
-    viewer_links, PublicArtifactUrlValidation, PUBLIC_ARTIFACT_BASE_URL_ENV,
+    annotate_public_artifact_url_validation, cached_validated_viewer_links,
+    public_artifact_path_url, public_artifact_url, public_artifact_url_validation_json,
+    validate_public_artifact_url, validated_viewer_links, viewer_links,
+    PublicArtifactUrlValidation, PUBLIC_ARTIFACT_BASE_URL_ENV,
 };
 pub use super::artifact_manifest::{
     manifest_for_existing_files, read_manifest_from_root, write_manifest_to_root, ArtifactManifest,
     ArtifactManifestEntry, ArtifactRedactionState, ValidatedArtifactManifestEntry,
     ARTIFACT_MANIFEST_FILE, ARTIFACT_MANIFEST_SCHEMA,
 };
-pub use super::artifact_origin::{serve, status, ArtifactOriginServeSpec, ArtifactOriginStatus};
+pub use super::artifact_origin::{
+    inspect, serve, status, status_with_command, ArtifactOriginInspect, ArtifactOriginServeSpec,
+    ArtifactOriginStatus,
+};
 pub use super::browser_evidence::{
     validate_bench_results_payload, validate_trace_results_payload, BrowserArtifactMetadata,
     BrowserBottleneckRow, BrowserNetworkRequestRow, BrowserOriginDeclaredService,


### PR DESCRIPTION
## Summary
- Map public artifact URLs from artifact-root-relative paths so published `workflow-bench/...` replay bundles resolve under `HOMEBOY_PUBLIC_ARTIFACT_BASE_URL`.
- Add read-only `homeboy tunnel artifact-origin status` and `inspect` commands, including `--fail-on-missing` smoke behavior for 404 mappings.
- Document the Lab artifact publish, inspect, and serve sequence for Workflow Bench replay bundles.

Fixes #4662.

## Validation
- `cargo test artifact_links`
- `cargo test artifact_origin`
- `cargo test artifacts_command_derives_viewer_links_from_public_artifact_url_metadata`
- `cargo test command_surface`
- `git diff --check -- docs/commands/tunnel.md src/commands/runs.rs src/commands/tunnel.rs src/core/artifact_links.rs src/core/artifact_origin.rs src/core/artifacts.rs`