### PR TITLE
fix: skip npm publish for private packages instead of failing on EPRIVATE (#3647)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ All notable changes to Homeboy CLI are documented in this file.
 - recover stale runner homeboy paths
 - skip repeated failed release attempts
 - materialize runner-local preview services
+- skip npm publish for packages marked `"private": true` (EPRIVATE) instead of failing the release
 
 ## [0.230.0] - 2026-06-15
 

--- a/src/core/release/executor/publish.rs
+++ b/src/core/release/executor/publish.rs
@@ -112,6 +112,10 @@ fn publish_step_result(
         .and_then(|v| v.as_bool())
         .unwrap_or(true)
     {
+        if let Some(reason) = publish_output_private_package_reason(response) {
+            return private_package_skip_result(step_id, target, extension_id, data, reason);
+        }
+
         if let Some(reason) = publish_output_auth_required_reason(response) {
             return auth_required_skip_result(step_id, target, extension_id, data, reason);
         }
@@ -168,6 +172,24 @@ fn auth_required_skip_result(
     )
 }
 
+fn private_package_skip_result(
+    step_id: &str,
+    target: &str,
+    extension_id: &str,
+    data: Option<serde_json::Value>,
+    reason: String,
+) -> ReleaseStepResult {
+    step_skipped(
+        step_id,
+        step_id,
+        data,
+        format!(
+            "Skipped publish to {} via {}: {}",
+            target, extension_id, reason
+        ),
+    )
+}
+
 fn extension_auth_required_reason(response: &serde_json::Value) -> Option<String> {
     let status = response.get("status").and_then(|v| v.as_str())?;
     if status != "auth_required" {
@@ -218,6 +240,23 @@ fn publish_output_auth_required_reason(response: &serde_json::Value) -> Option<S
 
     Some(
         "npm authentication required (ENEEDAUTH). Run `npm login` for the target registry, then retry the registry publish."
+            .to_string(),
+    )
+}
+
+/// Detect npm's EPRIVATE rejection, emitted when a package marked `"private": true`
+/// is published. Such packages must never reach a public registry, so this is treated
+/// as an intentional skip rather than a release failure.
+fn publish_output_private_package_reason(response: &serde_json::Value) -> Option<String> {
+    let output = publish_response_output(response);
+    let marked_private =
+        output.contains("EPRIVATE") || output.contains("This package has been marked as private");
+    if !marked_private {
+        return None;
+    }
+
+    Some(
+        "package marked private (\"private\": true); npm publish skipped. The build artifact is the deliverable."
             .to_string(),
     )
 }
@@ -601,6 +640,54 @@ mod tests {
 
         assert_eq!(result.status, ReleaseStepStatus::Skipped);
         assert!(result.warnings.join("\n").contains("ENEEDAUTH"));
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn publish_step_skips_when_npm_output_reports_eprivate() {
+        let response = serde_json::json!({
+            "success": false,
+            "exitCode": 1,
+            "stdout": "",
+            "stderr": "npm error code EPRIVATE\nnpm error This package has been marked as private",
+        });
+
+        let result = publish_step_result(
+            "publish.package-runtime",
+            "package-runtime",
+            "package-runtime",
+            None,
+            &response,
+            None,
+        );
+
+        assert_eq!(result.status, ReleaseStepStatus::Skipped);
+        assert!(result.warnings.join("\n").contains("marked private"));
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn publish_step_eprivate_skip_takes_precedence_over_auth_required_output() {
+        let response = serde_json::json!({
+            "success": false,
+            "exitCode": 1,
+            "stdout": "",
+            "stderr": "npm error code EPRIVATE\nnpm error This package has been marked as private\nnpm ERR! code ENEEDAUTH",
+        });
+
+        let result = publish_step_result(
+            "publish.package-runtime",
+            "package-runtime",
+            "package-runtime",
+            None,
+            &response,
+            None,
+        );
+
+        assert_eq!(result.status, ReleaseStepStatus::Skipped);
+        let warnings = result.warnings.join("\n");
+        assert!(warnings.contains("marked private"));
+        assert!(!warnings.contains("ENEEDAUTH"));
         assert!(result.error.is_none());
     }
 


### PR DESCRIPTION
## Summary

Fixes #3647 — `homeboy release` attempted `npm publish` on a `"private": true` package and failed with `EPRIVATE`, marking the entire release as failed even though the tag, version bump, changelog, and build artifact were all produced correctly.

Observed releasing **wp-codebox v0.7.1**:
```
npm error code EPRIVATE
npm error This package has been marked as private
"summary": { "failed": 1, "succeeded": 16, "total_steps": 17 }
```

`wp-codebox` is deliberately `"private": true` — the WordPress plugin zip is the real deliverable and it must never publish to public npm.

## Change

In `src/core/release/executor/publish.rs`, the publish step now detects npm's `EPRIVATE` output (and the `This package has been marked as private` message) and emits an **informational skip** instead of a failure — mirroring the existing `ENEEDAUTH` auth-required skip handling.

- New `publish_output_private_package_reason()` detects the private-package rejection.
- New `private_package_skip_result()` returns a `Skipped` step with reason `package marked private ("private": true); npm publish skipped. The build artifact is the deliverable.`
- The private-package check runs **before** the auth-required output check, so a private package is never misclassified as needing `npm login`.
- The skip warning text avoids the auth-recovery keywords (`requires authentication` / `eneedauth`), so `pipeline_summary` does **not** suggest `--skip-publish` recovery guidance for it. The release is correctly reported as succeeded.

## Tests

Added Rust unit tests in `publish.rs`:
- `publish_step_skips_when_npm_output_reports_eprivate` — EPRIVATE output produces a `Skipped` step with no error.
- `publish_step_eprivate_skip_takes_precedence_over_auth_required_output` — when both EPRIVATE and ENEEDAUTH appear, the private skip wins and ENEEDAUTH guidance is not surfaced.

All 10 publish tests and 5 pipeline_summary tests pass. `cargo fmt --check` and `cargo clippy --lib` (no new warnings on `publish.rs`) are clean.

## Notes

This is the root-cause fix for the observed EPRIVATE failure. A per-component opt-out config flag (`publish: false`) was considered as an alternative; the EPRIVATE-skip approach is preferred because it requires zero config changes and protects every private package automatically.
