### PR TITLE
fix(deploy): fail loudly when an artifact deploy can't be verified to land

### DIFF
--- a/src/core/deploy/effect.rs
+++ b/src/core/deploy/effect.rs
@@ -22,6 +22,19 @@ pub(super) fn remote_version_after_deploy_effect(
         .is_some_and(|targets| !targets.is_empty());
 
     if !has_version_targets {
+        // An artifact upload reshaped the remote tree but the component declares
+        // no version_targets, so Homeboy has no way to confirm the files actually
+        // landed at remote_path. Reporting `local_version` here is precisely the
+        // silent no-op bug (#3608): deploy claims success while the deployed files
+        // are untouched. If the deploy went through an extension verifier
+        // (`effect.verified`), trust that signal; otherwise refuse to fabricate a
+        // success from an unverifiable artifact deploy.
+        if effect.artifact_path.is_some() && !effect.verified {
+            return Err(format!(
+                "Deploy uploaded an artifact for '{}' at '{}', but the component declares no version_targets and no deploy verification, so Homeboy cannot confirm the files actually landed. Refusing to report success for an unverifiable artifact deploy. Add version_targets (e.g. the plugin's main file Version header) so post-deploy landing can be verified.",
+                component.id, effect.remote_path
+            ));
+        }
         return Ok(local_version.cloned());
     }
 
@@ -133,6 +146,98 @@ mod tests {
             error.contains("could not read remote_version from the applied tree"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn post_effect_artifact_deploy_without_version_targets_fails_loudly() {
+        // Reproduces issue #3608: an artifact was uploaded and extracted, but the
+        // component declares no version_targets, so Homeboy cannot confirm the
+        // files actually landed. It must refuse to fabricate a success.
+        let component = Component {
+            id: "data-machine-socials".to_string(),
+            remote_path: "wp-content/plugins/data-machine-socials".to_string(),
+            version_targets: None,
+            ..Component::default()
+        };
+        let effect = DeployEffect {
+            remote_path: "wp-content/plugins/data-machine-socials".to_string(),
+            artifact_path: Some(
+                "wp-content/plugins/data-machine-socials/.homeboy-data-machine-socials.zip"
+                    .to_string(),
+            ),
+            verified: false,
+        };
+        let expected_version = "0.14.0".to_string();
+
+        let error = remote_version_after_deploy_effect(
+            &component,
+            &Project::default(),
+            "/srv/site",
+            &local_client(),
+            Some(&effect),
+            Some(&expected_version),
+        )
+        .expect_err("unverifiable artifact deploy should fail");
+
+        assert!(
+            error.contains("cannot confirm the files actually landed"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn post_effect_artifact_deploy_without_version_targets_accepts_extension_verified() {
+        // When an extension verifier already confirmed the deploy (`verified`),
+        // the absence of version_targets is acceptable and we report local_version.
+        let component = Component {
+            id: "data-machine-socials".to_string(),
+            remote_path: "wp-content/plugins/data-machine-socials".to_string(),
+            version_targets: None,
+            ..Component::default()
+        };
+        let effect = DeployEffect {
+            remote_path: "wp-content/plugins/data-machine-socials".to_string(),
+            artifact_path: Some("/srv/staging/.homeboy-data-machine-socials.zip".to_string()),
+            verified: true,
+        };
+        let expected_version = "0.14.0".to_string();
+
+        let version = remote_version_after_deploy_effect(
+            &component,
+            &Project::default(),
+            "/srv/site",
+            &local_client(),
+            Some(&effect),
+            Some(&expected_version),
+        )
+        .expect("verified artifact deploy without version_targets should succeed");
+
+        assert_eq!(version.as_deref(), Some("0.14.0"));
+    }
+
+    #[test]
+    fn post_effect_no_effect_returns_local_version_without_verification() {
+        // Git-style deploys produce no effect; there is no artifact-landing claim
+        // to verify, so we fall back to local_version unchanged.
+        let component = Component {
+            id: "plugin".to_string(),
+            remote_path: "plugin".to_string(),
+            version_targets: None,
+            ..Component::default()
+        };
+        let expected_version = "1.0.0".to_string();
+
+        let version = remote_version_after_deploy_effect(
+            &component,
+            &Project::default(),
+            "/srv/site",
+            &local_client(),
+            None,
+            Some(&expected_version),
+        )
+        .expect("no-effect deploy should return local_version");
+
+        assert_eq!(version.as_deref(), Some("1.0.0"));
     }
 
     fn local_client() -> SshClient {


### PR DESCRIPTION
## Summary

Fixes #3608.

`homeboy deploy data-machine-socials --no-pull` reported `status: deployed`, `remote_version: 0.14.0`, `failed: 0` — but the deployed files on target were **never updated**. The deployed `.php` kept its old mtime and `DATAMACHINE_SOCIALS_VERSION` stayed at `0.8.1` across multiple "successful" deploys of v0.14.0, even though the build artifact was correct.

## Root cause

`remote_version_after_deploy_effect` (the gate that decides whether a deploy can report success) fabricated success when a component had **no `version_targets`**: it returned `local_version` without ever reading the remote tree. So a deploy that silently no-op'd (files never extracted to `remote_path`, or extracted to the wrong place) still reported `status: deployed` with the expected version.

This is the silent no-op vector behind #3608 and matches the broader cluster (#3444): *reported success without the files landing*.

## The fix

When an artifact upload produced a deploy `effect` carrying an `artifact_path` (real files were uploaded/extracted) **but** the component declares no `version_targets` and the deploy went through no extension verifier, Homeboy now **refuses to report success** instead of trusting `local_version`:

> Deploy uploaded an artifact for '...' at '...', but the component declares no version_targets and no deploy verification, so Homeboy cannot confirm the files actually landed. Refusing to report success for an unverifiable artifact deploy. Add version_targets (e.g. the plugin's main file Version header) so post-deploy landing can be verified.

- An extension verifier (`effect.verified`) is still honored — those deploys already have an independent landing signal.
- Git-style deploys with no `effect` keep returning `local_version` unchanged (no artifact-landing claim to verify).

This is the **post-extract landing verification** that gates the success report — complementary to the pre-existing checks:
- `validate_predeploy_artifact_version` — verifies the version inside the ZIP *before* deploy (#4618)
- `ensure_not_double_nested` / `flatten_double_nested_dir` — verify the on-disk layout is not double-nested

## Tests

Added 3 unit tests in `src/core/deploy/effect.rs`:
- `post_effect_artifact_deploy_without_version_targets_fails_loudly` — the #3608 repro: unverifiable artifact deploy is rejected
- `post_effect_artifact_deploy_without_version_targets_accepts_extension_verified` — verified deploys without version_targets still succeed
- `post_effect_no_effect_returns_local_version_without_verification` — git-style deploys unaffected

All `core::deploy::effect` tests pass; full `core::deploy` suite green except `test_deploy_artifact_fails_when_pre_extract_cleanup_fails`, which is a **pre-existing env-dependent failure** on `origin/main` (it PATH-injects a fake `find` binary through the SSH client, which doesn't engage in this sandbox). My change is isolated to `effect.rs` (1 file, +105 lines) and does not touch `safety_and_artifact.rs`.

```
$ cargo test --lib core::deploy::effect
test result: ok. 5 passed; 0 failed; ...
```