### PR TITLE
fix(status): ready_to_deploy is git-state-only, not a target diff (#4588)

### DIFF
--- a/docs/architecture/output-system.md
+++ b/docs/architecture/output-system.md
@@ -74,7 +74,14 @@ The `status` object surfaces what needs attention:
 ```
 
 Fields (all arrays/counts skip serialization when empty/zero):
-- `ready_to_deploy`: Components with no uncommitted changes and no commits since version
+- `ready_to_deploy`: Components in a clean release state — no uncommitted changes
+  and no commits since the last version tag. **Git/workspace state only**: it
+  means "has a release tag that *could* be deployed", NOT "the deploy target is
+  behind the latest release". For a target-accurate diff, run
+  `homeboy status <project>` and inspect the `outdated` components. See #4588.
+- `ready_to_deploy_note`: Present only when `ready_to_deploy` is non-empty.
+  A clarifying string warning that the list is git-state-only and pointing at
+  `homeboy status <project>` for the target-accurate deploy diff.
 - `needs_release`: Components with releasable code commits since the current version baseline
 - `has_uncommitted`: Components with uncommitted changes in working directory
 - `config_gaps`: Total count of configuration gaps across all components

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -8,15 +8,41 @@ Show an actionable component status overview.
 homeboy status [PROJECT]
 ```
 
+## Two modes
+
+`homeboy status` behaves differently depending on whether you pass a project:
+
+- **`homeboy status`** (no project) — a **git/workspace** summary of the
+  components in scope. The `ready_to_deploy` list is **git-state only**.
+- **`homeboy status <project>`** — a **target-accurate** dashboard that
+  compares each component's installed-on-target version against its latest
+  release tag and reports `current` / `outdated` / `pinned_current`.
+
+## `ready_to_deploy` is git-state only (read this)
+
+In the plain `homeboy status` summary, `ready_to_deploy` lists components that
+are in a **clean release state**: no uncommitted changes and no commits since
+the last version tag — i.e. they *have a release tag that could be deployed*.
+
+It does **not** mean the deploy target is behind. A component can be
+`ready_to_deploy` while the target already runs that exact version, so acting on
+the list blindly re-deploys components that are already live (a phantom
+backlog). When `ready_to_deploy` is non-empty, the JSON output includes a
+`ready_to_deploy_note` field repeating this caveat.
+
+For the question *"what actually needs deploying right now?"*, run
+`homeboy status <project>` and look at the components reported as `outdated`
+(installed version != latest release tag). See issue #4588.
+
 ## Common filters
 
 - `--full` — show the full workspace/context report
 - `--uncommitted` — show only components with uncommitted changes
 - `--needs-release` — show only components that need a release
-- `--ready` — show only components ready to deploy
+- `--ready` — show only components in a clean release state (git state only — not a target diff)
 - `--docs-only` — show only components with docs-only changes
 - `--all` — show all components regardless of current directory context
-- `--outdated` — show only outdated components
+- `--outdated` — (project mode) show only components whose installed-on-target version is behind the latest release
 
 ## Related
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -67,6 +67,16 @@ impl UpstreamDrift {
     }
 }
 
+/// Clarifying note emitted alongside the git-state-only `ready_to_deploy` list.
+///
+/// `ready_to_deploy` reflects local git/workspace state ("has a clean release
+/// tag that *could* be deployed"), NOT whether the deploy target is actually
+/// behind. Acting on it blindly re-deploys components that may already be live.
+/// For a target-accurate diff (installed version vs latest release tag) run
+/// `homeboy status <project>`, which reports `current` / `outdated` per
+/// component. See issue #4588.
+const READY_TO_DEPLOY_NOTE: &str = "ready_to_deploy is git-state-only (components with a clean release tag that *could* be deployed); it does NOT mean the deploy target is behind. Run `homeboy status <project>` for a target-accurate diff (installed version vs latest release tag).";
+
 #[derive(Debug, Serialize)]
 pub struct StatusOutput {
     pub command: &'static str,
@@ -75,8 +85,20 @@ pub struct StatusOutput {
     pub uncommitted: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub needs_release: Vec<String>,
+    /// Components in a clean release state (no uncommitted changes, no commits
+    /// since the last version tag).
+    ///
+    /// IMPORTANT: this is git/workspace state only. It means "has a release tag
+    /// that *could* be deployed", NOT "the deployed target is behind the latest
+    /// release". For a target-accurate deploy diff, use `homeboy status
+    /// <project>` (compares installed-on-target versions against release tags).
+    /// See `ready_to_deploy_note` and issue #4588.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub ready_to_deploy: Vec<String>,
+    /// Clarifying note, emitted only when `ready_to_deploy` is non-empty, so
+    /// operators don't mistake the git-state list for a real deploy backlog.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ready_to_deploy_note: Option<&'static str>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub docs_only: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -265,6 +287,12 @@ fn summarize_components(
         }
     }
 
+    let ready_to_deploy_note = if ready_to_deploy.is_empty() {
+        None
+    } else {
+        Some(READY_TO_DEPLOY_NOTE)
+    };
+
     Ok((
         StatusResult::Summary(StatusOutput {
             command: "status",
@@ -272,6 +300,7 @@ fn summarize_components(
             uncommitted,
             needs_release,
             ready_to_deploy,
+            ready_to_deploy_note,
             docs_only,
             behind_upstream,
             upstream_drift,
@@ -724,6 +753,61 @@ mod tests {
             .status()
             .expect("git init");
         (dir, repo)
+    }
+
+    fn empty_status_output() -> StatusOutput {
+        StatusOutput {
+            command: "status",
+            total: 0,
+            uncommitted: Vec::new(),
+            needs_release: Vec::new(),
+            ready_to_deploy: Vec::new(),
+            ready_to_deploy_note: None,
+            docs_only: Vec::new(),
+            behind_upstream: Vec::new(),
+            upstream_drift: Vec::new(),
+            clean: 0,
+        }
+    }
+
+    #[test]
+    fn ready_to_deploy_note_is_omitted_when_no_components_are_clean() {
+        let output = empty_status_output();
+        let json = serde_json::to_value(&output).expect("serialize status output");
+
+        // ready_to_deploy is empty -> note must not leak into the JSON contract.
+        assert!(json.get("ready_to_deploy").is_none());
+        assert!(
+            json.get("ready_to_deploy_note").is_none(),
+            "note should be omitted when ready_to_deploy is empty"
+        );
+    }
+
+    #[test]
+    fn ready_to_deploy_note_clarifies_git_state_only_when_components_are_clean() {
+        let output = StatusOutput {
+            total: 1,
+            ready_to_deploy: vec!["data-machine".to_string()],
+            ready_to_deploy_note: Some(READY_TO_DEPLOY_NOTE),
+            ..empty_status_output()
+        };
+        let json = serde_json::to_value(&output).expect("serialize status output");
+
+        let note = json
+            .get("ready_to_deploy_note")
+            .and_then(|v| v.as_str())
+            .expect("note present when ready_to_deploy is non-empty");
+
+        // The note must steer operators away from treating git state as a
+        // target-accurate deploy backlog (issue #4588).
+        assert!(
+            note.contains("git-state-only"),
+            "note should flag the list as git-state-only"
+        );
+        assert!(
+            note.contains("homeboy status <project>"),
+            "note should point at the target-accurate project dashboard"
+        );
     }
 
     #[test]

--- a/src/core/context/report.rs
+++ b/src/core/context/report.rs
@@ -580,12 +580,12 @@ fn build_actionable_next_steps(
         let count = status.ready_to_deploy.len();
         if count == 1 {
             next_steps.push(format!(
-                "1 component ready to deploy: `{}`. Deploy with `homeboy deploy {}`.",
+                "1 component has a clean release tag: `{}`. This is git state only — run `homeboy status <project>` to confirm the deploy target is actually behind before `homeboy deploy {}`.",
                 status.ready_to_deploy[0], status.ready_to_deploy[0]
             ));
         } else {
             next_steps.push(format!(
-                "{} components ready to deploy. Run `homeboy deploy <id>`.",
+                "{} components have a clean release tag (git state only — does not mean the deploy target is behind). Run `homeboy status <project>` for a target-accurate diff before deploying.",
                 count
             ));
         }


### PR DESCRIPTION
## Summary

Fixes #4588.

`homeboy status` (no project) listed components as `ready_to_deploy` purely from git/workspace state (`ReleaseStateStatus::Clean` = has a release tag that *could* be deployed). It read as a deploy backlog, but production could already be current at that exact version — acting on it re-deploys ~34 already-live components (a phantom backlog, wasted churn / unnecessary prod writes).

The target-accurate view already exists in `homeboy status <project>` (`current` / `outdated` / `pinned_current`, comparing installed-on-target version vs latest release tag). This PR makes the git-state summary honest about that distinction.

## Changes

- **`StatusOutput`** (`src/commands/status.rs`): doc comments marking `ready_to_deploy` as git-state-only.
- **New `ready_to_deploy_note`** field, emitted only when `ready_to_deploy` is non-empty — warns it is **not** a target diff and points at `homeboy status <project>` for the real deploy diff.
- **`context/report` next-steps** (`src/core/context/report.rs`): reword the "X components ready to deploy" hint so it no longer implies a deploy backlog; steer operators to the project dashboard before `homeboy deploy`.
- **Docs**: document the two status modes and `ready_to_deploy` semantics in `docs/commands/status.md` and `docs/architecture/output-system.md`.

## Non-breaking

The existing `ready_to_deploy` JSON field is unchanged; only an optional clarifying field (`ready_to_deploy_note`, `skip_serializing_if = Option::is_none`) is added. No rename, no removed fields.

## Why option (b) from the issue

The issue offers two paths: (a) make `ready_to_deploy` itself target-accurate, or (b) document it as git-state-only and surface a clearly-named target-accurate view. The target-accurate view already exists (the project dashboard), so option (b) avoids breaking the JSON contract while removing the misleading framing. Naming stays independent of #4587 (deploy `--check` extension-abort) as requested.

## Tests

- `ready_to_deploy_note_is_omitted_when_no_components_are_clean` — note absent from JSON when list empty.
- `ready_to_deploy_note_clarifies_git_state_only_when_components_are_clean` — note present and points at the project dashboard when list non-empty.
- All 8 existing `commands::status::` tests pass; `cargo fmt --check` clean; no new clippy warnings.

## Checklist

- [x] `cargo fmt` run before push
- [x] `cargo clippy --lib` — no new warnings
- [x] targeted tests pass
- [x] no manual CHANGELOG edits (auto-generated at release)