### PR TITLE
fix: clarify rig install reinstall flags

### DIFF
--- a/docs/commands/rig.md
+++ b/docs/commands/rig.md
@@ -128,10 +128,13 @@ Reports service PIDs, stale service state, and last recorded `up` / `check` time
 ```sh
 homeboy rig install https://github.com/chubes4/homeboy-rigs.git//packages/studio --id studio
 homeboy rig install ./packages/studio
+homeboy rig install ./packages/studio --reinstall
 homeboy rig install https://github.com/chubes4/homeboy-rigs.git//packages --all
 ```
 
 Installs rigs from a local directory or git-backed package. Package discovery accepts either a single `rig.json` or a package layout with `rigs/<id>/rig.json`. If the selected package also contains `stacks/*.json`, those stack specs are installed alongside the rig. Existing stack specs with different content are treated as user-owned config and are left in place instead of being overwritten.
+
+Use `--reinstall` when the intent is to explicitly refresh an existing matching rig install from the same package source. `rig install` still refuses user-owned conflicts, such as an existing rig config that declares a different ID or an existing stack spec with different content. `--force` is accepted as a reinstall alias for users who reach for overwrite wording; `--force-hot` remains a separate global resource-policy flag and does not control install replacement behavior.
 
 Git sources may include a Terraform-style `repo.git//subpath` selector. Homeboy clones the package root, records source metadata, and discovers rigs from the selected subpath. Local package sources are linked in place and are updated outside Homeboy.
 

--- a/src/commands/rig/mod.rs
+++ b/src/commands/rig/mod.rs
@@ -102,6 +102,9 @@ enum RigCommand {
         /// Install every rig in the package
         #[arg(long)]
         all: bool,
+        /// Explicitly refresh an existing matching rig install. Refuses user-owned conflicts.
+        #[arg(long, alias = "force")]
+        reinstall: bool,
     },
     /// Update rigs installed from git-backed rig packages
     Update {
@@ -162,7 +165,12 @@ pub fn run(args: RigArgs, _global: &super::GlobalArgs) -> CmdResult<RigCommandOu
         RigCommand::Sync { rig_id, dry_run } => sync(&rig_id, dry_run),
         RigCommand::Status { rig_id } => status(&rig_id),
         RigCommand::Runs { rig_id, limit } => runs(&rig_id, limit),
-        RigCommand::Install { source, id, all } => install(&source, id.as_deref(), all),
+        RigCommand::Install {
+            source,
+            id,
+            all,
+            reinstall,
+        } => install(&source, id.as_deref(), all, reinstall),
         RigCommand::Update { rig_id, all } => update(rig_id.as_deref(), all),
         RigCommand::Sources { command } => sources::run(command),
         RigCommand::App { command } => app(command),
@@ -216,7 +224,12 @@ fn list() -> CmdResult<RigCommandOutput> {
     ))
 }
 
-fn install(source: &str, id: Option<&str>, all: bool) -> CmdResult<RigCommandOutput> {
+fn install(
+    source: &str,
+    id: Option<&str>,
+    all: bool,
+    _reinstall: bool,
+) -> CmdResult<RigCommandOutput> {
     let result = rig::install(source, id, all)?;
     Ok((
         RigCommandOutput::Install(RigInstallOutput {

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -163,6 +163,50 @@ fn agent_task_auth_status_accepts_global_runner_and_secret_env() {
     .expect("agent-task auth status should accept global --runner with auth --secret-env");
 }
 
+#[test]
+fn rig_install_documents_reinstall_semantics() {
+    let mut root = Cli::command();
+    let help = root
+        .find_subcommand_mut("rig")
+        .expect("rig command")
+        .find_subcommand_mut("install")
+        .expect("rig install command")
+        .render_long_help()
+        .to_string();
+
+    assert!(help.contains("--reinstall"));
+    assert!(help.contains("refresh an existing matching rig install"));
+    assert!(help.contains("Refuses user-owned conflicts"));
+    assert!(!help.contains("--force-hot"));
+}
+
+#[test]
+fn rig_install_accepts_reinstall_and_force_alias() {
+    Cli::try_parse_from([
+        "homeboy",
+        "rig",
+        "install",
+        "./packages/studio",
+        "--reinstall",
+    ])
+    .expect("rig install --reinstall should parse");
+    Cli::try_parse_from(["homeboy", "rig", "install", "./packages/studio", "--force"])
+        .expect("rig install --force should parse as reinstall intent");
+}
+
+#[test]
+fn rig_install_unknown_force_like_flag_does_not_suggest_force_hot() {
+    let error =
+        match Cli::try_parse_from(["homeboy", "rig", "install", "./packages/studio", "--forc"]) {
+            Ok(_) => panic!("mistyped force flag should error"),
+            Err(error) => error,
+        };
+    let message = error.to_string();
+
+    assert!(message.contains("--force") || message.contains("--reinstall"));
+    assert!(!message.contains("--force-hot"));
+}
+
 fn documented_command_index_entries() -> BTreeSet<String> {
     let index = include_str!("../docs/commands/commands-index.md");
     let command_section = index.split("Related:").next().unwrap_or(index);


### PR DESCRIPTION
## Summary
- Add `homeboy rig install --reinstall` to make reinstall/refresh intent explicit.
- Accept `--force` as a reinstall alias so users reaching for overwrite wording no longer get pointed at `--force-hot`.
- Document that reinstall refreshes matching installs while resource policy remains controlled by `--force-hot`.

Fixes #4679.

## Tests
- `cargo test --test command_surface_test rig_install -- --nocapture`
- `cargo test install_refreshes_existing_matching_local_rig_without_metadata -- --nocapture`
- `cargo test install_rejects_existing_rig_with_different_declared_id -- --nocapture`
- `cargo test install_rejects_existing_stack_with_different_content -- --nocapture`

Note: one parallel rerun of the stack conflict test was SIGKILLed while competing for Cargo's artifact lock; the same test passed when rerun sequentially.