### PR TITLE
fix(deploy): skip extension-gated components in --check instead of aborting the whole pass

### DIFF
--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -14,6 +14,7 @@ use super::generated_artifacts::unexpected_uncommitted_files_excluding_generated
 use super::path_roots::{project_with_detected_path_roots, resolve_effective_remote_path};
 use super::planning::{
     calculate_component_status, calculate_release_state, load_project_components, plan_components,
+    ExtensionSkippedComponent,
 };
 use super::types::{
     ComponentDeployResult, ComponentStatus, DeployConfig, DeployOrchestrationResult, DeploySummary,
@@ -28,8 +29,27 @@ pub(super) fn deploy_components(
     ctx: &RemoteProjectContext,
     base_path: &str,
 ) -> Result<DeployOrchestrationResult> {
-    let loaded = load_project_components(project, &config.component_ids)?;
+    let loaded = load_project_components(project, &config.component_ids, config.check)?;
     validate_supported_build_configs(&loaded.deployable)?;
+
+    // In check mode, components whose required extensions are missing are skipped
+    // (not hard-failed) so the read-only diff still reports everything else.
+    // If nothing is deployable but components were extension-skipped, surface those
+    // as skipped check results instead of erroring with "no deployable components".
+    if config.check && loaded.deployable.is_empty() && !loaded.extension_skipped.is_empty() {
+        let results = extension_skipped_results(&loaded.extension_skipped, &project, base_path);
+        let skipped = results.len() as u32;
+        return Ok(DeployOrchestrationResult {
+            results,
+            summary: DeploySummary {
+                total: skipped,
+                succeeded: 0,
+                failed: 0,
+                skipped,
+            },
+        });
+    }
+
     if loaded.deployable.is_empty() {
         let message = if loaded.skipped.is_empty() {
             "No components configured for project".to_string()
@@ -97,6 +117,7 @@ pub(super) fn deploy_components(
             &components,
             &local_versions,
             &remote_versions,
+            &loaded.extension_skipped,
             &project,
             base_path,
             config,
@@ -292,11 +313,12 @@ fn run_check_mode(
     components: &[Component],
     local_versions: &HashMap<String, String>,
     remote_versions: &HashMap<String, String>,
+    extension_skipped: &[ExtensionSkippedComponent],
     project: &Project,
     base_path: &str,
     config: &DeployConfig,
 ) -> DeployOrchestrationResult {
-    let results: Vec<ComponentDeployResult> = components
+    let mut results: Vec<ComponentDeployResult> = components
         .iter()
         .map(|c| {
             let status = calculate_component_status(c, remote_versions);
@@ -316,6 +338,12 @@ fn run_check_mode(
         })
         .collect();
 
+    // Append components skipped because a required extension is not installed, so the
+    // check-mode diff reports per-component status for the whole project (issue #4587).
+    let skipped_results = extension_skipped_results(extension_skipped, project, base_path);
+    let skipped = skipped_results.len() as u32;
+    results.extend(skipped_results);
+
     let total = results.len() as u32;
     DeployOrchestrationResult {
         results,
@@ -323,9 +351,33 @@ fn run_check_mode(
             total,
             succeeded: 0,
             failed: 0,
-            skipped: 0,
+            skipped,
         },
     }
+}
+
+/// Build check-mode result rows for components skipped due to missing extensions.
+///
+/// Each row is `status: "skipped"` with a warning explaining the missing extension,
+/// so operators see `skipped: missing extension <id>` instead of the whole pass aborting.
+fn extension_skipped_results(
+    extension_skipped: &[ExtensionSkippedComponent],
+    project: &Project,
+    base_path: &str,
+) -> Vec<ComponentDeployResult> {
+    extension_skipped
+        .iter()
+        .map(|skip| {
+            let component = Component {
+                id: skip.id.clone(),
+                ..Default::default()
+            };
+            let mut result = ComponentDeployResult::new_for_project(&component, project, base_path)
+                .with_status("skipped");
+            result.warnings.push(format!("skipped: {}", skip.reason));
+            result
+        })
+        .collect()
 }
 
 /// Dry-run mode: return planned results without building or deploying.
@@ -1089,7 +1141,7 @@ mod tests {
             ("selected", selected.path()),
             ("unrelated", unrelated.path()),
         ]);
-        let loaded = load_project_components(&project, &["selected".to_string()])
+        let loaded = load_project_components(&project, &["selected".to_string()], false)
             .expect("targeted component load should ignore unrelated invalid config");
 
         assert_eq!(
@@ -1115,7 +1167,7 @@ mod tests {
             ("selected", selected.path()),
             ("unrelated", unrelated.path()),
         ]);
-        let loaded = load_project_components(&project, &["selected".to_string()])
+        let loaded = load_project_components(&project, &["selected".to_string()], false)
             .expect("targeted component load should include selected component");
 
         let err = validate_supported_build_configs(&loaded.deployable)
@@ -1123,6 +1175,105 @@ mod tests {
 
         assert!(err.message.contains("unsupported legacy build_command"));
         assert_eq!(err.details["field"].as_str(), Some("build_command"));
+    }
+
+    /// Write a component manifest that declares a (missing) required extension.
+    fn write_component_manifest_with_extension(dir: &Path, id: &str, extension_id: &str) {
+        let manifest = serde_json::json!({
+            "id": id,
+            "remote_path": format!("wp-content/plugins/{id}"),
+            "build_artifact": "dist/plugin.zip",
+            "extensions": { extension_id: {} },
+        });
+        std::fs::write(dir.join("homeboy.json"), manifest.to_string()).expect("write manifest");
+    }
+
+    #[test]
+    fn check_mode_skips_component_with_missing_extension_instead_of_aborting() {
+        with_isolated_home(|_| {
+            let gated = TempDir::new().expect("gated dir");
+            let wp = TempDir::new().expect("wp dir");
+            // One component requires an uninstalled extension; the other is a plain
+            // deployable WP component the operator actually cares about.
+            write_component_manifest_with_extension(
+                gated.path(),
+                "gated",
+                "nonexistent-extension-xyz789",
+            );
+            write_component_manifest(wp.path(), "wp", None);
+
+            let project =
+                project_with_component_dirs(&[("gated", gated.path()), ("wp", wp.path())]);
+
+            // --all --check: requested_ids empty, check = true.
+            let loaded = load_project_components(&project, &[], true)
+                .expect("check mode must not hard-fail on missing extension");
+
+            // The WP component is still deployable/inspectable.
+            assert_eq!(
+                loaded
+                    .deployable
+                    .iter()
+                    .map(|c| c.id.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["wp"]
+            );
+
+            // The extension-gated component is recorded with a reason, not dropped silently.
+            assert_eq!(loaded.extension_skipped.len(), 1);
+            let skip = &loaded.extension_skipped[0];
+            assert_eq!(skip.id, "gated");
+            assert!(
+                skip.reason.contains("nonexistent-extension-xyz789"),
+                "reason should name the missing extension, got: {}",
+                skip.reason
+            );
+        });
+    }
+
+    #[test]
+    fn non_check_mode_still_hard_fails_on_missing_extension() {
+        with_isolated_home(|_| {
+            let gated = TempDir::new().expect("gated dir");
+            write_component_manifest_with_extension(
+                gated.path(),
+                "gated",
+                "nonexistent-extension-xyz789",
+            );
+
+            let project = project_with_component_dirs(&[("gated", gated.path())]);
+
+            // --all (deploy, not check): a missing extension must still abort.
+            let err = match load_project_components(&project, &[], false) {
+                Ok(_) => panic!("non-check mode must hard-fail on missing extension"),
+                Err(err) => err,
+            };
+
+            assert_eq!(err.code, crate::core::error::ErrorCode::ExtensionNotFound);
+            assert!(err.message.contains("nonexistent-extension-xyz789"));
+        });
+    }
+
+    #[test]
+    fn extension_skipped_results_report_skipped_status_with_reason() {
+        let project = Project {
+            id: "site".to_string(),
+            ..Default::default()
+        };
+        let skipped = vec![ExtensionSkippedComponent {
+            id: "gated".to_string(),
+            reason: "missing extension rust".to_string(),
+        }];
+
+        let results = extension_skipped_results(&skipped, &project, "/var/www/site");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "gated");
+        assert_eq!(results[0].status, "skipped");
+        assert!(results[0]
+            .warnings
+            .iter()
+            .any(|w| w.contains("missing extension rust")));
     }
 
     #[test]

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -548,10 +548,22 @@ where
     buckets
 }
 
+/// A component skipped during loading because a required extension is not installed.
+///
+/// Carries the human-readable reason so check-mode output can report
+/// `skipped: missing extension <id>` per component instead of aborting.
+pub(super) struct ExtensionSkippedComponent {
+    pub id: String,
+    pub reason: String,
+}
+
 /// Result of loading project components, including skipped (non-deployable) component IDs.
 pub(super) struct LoadedComponents {
     pub deployable: Vec<Component>,
     pub skipped: Vec<String>,
+    /// Components skipped because a required extension is missing. Only populated
+    /// in check mode; otherwise a missing extension is a hard error.
+    pub extension_skipped: Vec<ExtensionSkippedComponent>,
 }
 
 /// Load effective project components, resolve artifact paths via extension patterns,
@@ -561,14 +573,20 @@ pub(super) struct LoadedComponents {
 /// Returns an actionable error with install instructions when extensions are missing,
 /// rather than silently skipping the component.
 ///
+/// In `check` mode (read-only diff), a component requiring an uninstalled extension is
+/// *not* a hard error: it is skipped, recorded in `extension_skipped`, and reported so
+/// operators can see the project-wide diff without installing every build toolchain.
+///
 /// Returns both the deployable components and the IDs of skipped (non-deployable) ones,
 /// so callers can produce accurate error messages.
 pub(super) fn load_project_components(
     project: &Project,
     requested_ids: &[String],
+    check: bool,
 ) -> Result<LoadedComponents> {
     let mut deployable = Vec::new();
     let mut skipped = Vec::new();
+    let mut extension_skipped = Vec::new();
 
     for attachment in project
         .components
@@ -585,9 +603,29 @@ pub(super) fn load_project_components(
         // Validate required extensions are installed before attempting artifact resolution.
         // Without this check, missing extensions cause resolve_artifact() to silently
         // return None, and the component gets skipped with a vague "no artifact" message.
-        if is_requested {
-            extension::validate_required_extensions(&loaded)?;
-        } else if extension::validate_required_extensions(&loaded).is_err() {
+        if let Err(err) = extension::validate_required_extensions(&loaded) {
+            if check {
+                // Read-only diff: a missing extension must not poison the whole pass.
+                // Skip-and-warn so operators still see the diff for the components they
+                // actually care about (see issue #4587).
+                let reason = missing_extension_reason(&err);
+                log_status!(
+                    "deploy",
+                    "Skipping '{}' in check mode: {}",
+                    loaded.id,
+                    reason
+                );
+                extension_skipped.push(ExtensionSkippedComponent {
+                    id: loaded.id.clone(),
+                    reason,
+                });
+                continue;
+            }
+
+            if is_requested {
+                return Err(err);
+            }
+
             log_status!(
                 "deploy",
                 "Skipping '{}': missing required extension (not requested for deploy)",
@@ -635,7 +673,34 @@ pub(super) fn load_project_components(
     Ok(LoadedComponents {
         deployable,
         skipped,
+        extension_skipped,
     })
+}
+
+/// Build a concise, operator-facing reason string from a missing-extension error.
+///
+/// Prefers the list of missing extension IDs from the error details
+/// (`skipped: missing extension <id>`), falling back to the full error message.
+fn missing_extension_reason(err: &crate::core::error::Error) -> String {
+    if let Some(missing) = err
+        .details
+        .get("missing_extensions")
+        .and_then(|v| v.as_array())
+    {
+        let ids: Vec<String> = missing
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect();
+        if !ids.is_empty() {
+            let label = if ids.len() == 1 {
+                "extension"
+            } else {
+                "extensions"
+            };
+            return format!("missing {} {}", label, ids.join(", "));
+        }
+    }
+    format!("missing required extension ({})", err.message)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`homeboy deploy <project> --all --check` aborted the **entire** read-only diff when one component (e.g. `homeboy` itself) required an uninstalled extension (`extension.not_found`). A single extension-gated component poisoned the project-wide `--check`, so operators had no way to see the real deploy diff without installing every build toolchain.

This PR makes `--check` (read-only) **skip + warn** components whose required extensions are missing, while reporting the rest — instead of hard-failing.

## Changes

- **`load_project_components`** now takes a `check: bool`. In check mode, a component with a missing required extension is recorded in a new `LoadedComponents.extension_skipped` list (with a human-readable reason) and skipped, rather than returning an `Err`. Non-check deploys still hard-fail; targeted deploys still validate the selected component.
- **`run_check_mode`** appends `extension_skipped` components as `status: "skipped"` results carrying a `skipped: missing extension <id>` warning, so the per-component status (`outdated` / `current` / `skipped`) is visible in one call.
- Handles the all-components-gated edge case: if nothing is deployable but components were extension-skipped, `--check` returns the skipped report instead of erroring with "no deployable components".

## Behavior

| Mode | Component missing extension | Behavior |
|------|------------------------------|----------|
| `--check` (--all or targeted) | skipped + warned in results | ✅ reports the rest |
| deploy (no `--check`) | **hard-fail** (unchanged) | aborts with install hint |
| targeted deploy of the gated component | **hard-fail** (unchanged) | aborts with install hint |

## Tests

Added 3 tests in `deploy::orchestration`:
- `check_mode_skips_component_with_missing_extension_instead_of_aborting` — a mixed project (one extension-gated + one plain WP component); `--all --check` returns the WP component as deployable/inspectable and records the gated one with a reason naming the missing extension.
- `non_check_mode_still_hard_fails_on_missing_extension` — guards the regression: a real deploy still aborts on a missing extension.
- `extension_skipped_results_report_skipped_status_with_reason` — result rows carry `status="skipped"` + the reason warning.

`cargo fmt` clean, `cargo clippy --lib` clean (no new warnings), `deploy::orchestration` (21) + `deploy::planning` (12) tests green.

## Notes

- **No changelog edit** in this PR — the VPS `homeboy` binary (v0.230.0) predates the `homeboy changelog add` subcommand, and manual CHANGELOG edits are disallowed. The release entry (`skip extension-gated components in --check mode`) should be added via `homeboy changelog add` from a machine with current tooling.

Fixes #4587
