### PR TITLE
fix: preserve nested rig package roots

### DIFF
--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -29,6 +29,7 @@ pub struct DiscoveredStack {
 #[derive(Debug, Clone, Serialize)]
 pub struct RigInstallResult {
     pub source: String,
+    pub source_root: PathBuf,
     pub package_path: PathBuf,
     pub linked: bool,
     pub installed: Vec<InstalledRig>,
@@ -38,6 +39,7 @@ pub struct RigInstallResult {
 #[derive(Debug, Clone)]
 pub(crate) struct PreparedSource {
     pub source: String,
+    pub source_root: PathBuf,
     pub package_path: PathBuf,
     pub discovery_path: PathBuf,
     pub linked: bool,
@@ -65,6 +67,8 @@ pub struct InstalledStack {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RigSourceMetadata {
     pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_root: Option<String>,
     pub package_path: String,
     pub rig_path: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -77,6 +81,8 @@ pub struct RigSourceMetadata {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StackSourceMetadata {
     pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_root: Option<String>,
     pub package_path: String,
     pub stack_path: String,
     pub discovery_path: String,
@@ -119,6 +125,7 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
 
         let metadata = RigSourceMetadata {
             source: prepared.source.clone(),
+            source_root: Some(prepared.source_root.to_string_lossy().to_string()),
             package_path: prepared.package_path.to_string_lossy().to_string(),
             rig_path: rig.rig_path.to_string_lossy().to_string(),
             discovery_path: Some(prepared.discovery_path.to_string_lossy().to_string()),
@@ -146,6 +153,7 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
 
         let metadata = StackSourceMetadata {
             source: prepared.source.clone(),
+            source_root: Some(prepared.source_root.to_string_lossy().to_string()),
             package_path: prepared.package_path.to_string_lossy().to_string(),
             stack_path: stack.stack_path.to_string_lossy().to_string(),
             discovery_path: prepared.discovery_path.to_string_lossy().to_string(),
@@ -165,6 +173,7 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
 
     Ok(RigInstallResult {
         source: prepared.source,
+        source_root: prepared.source_root,
         package_path: prepared.package_path,
         linked: prepared.linked,
         installed,
@@ -321,9 +330,25 @@ fn prepare_git_source(source: &str) -> Result<PreparedSource> {
         Some(subpath) => package_path.join(subpath),
         None => package_path.clone(),
     };
+    if !discovery_path.exists() {
+        return Err(Error::validation_invalid_argument(
+            "source",
+            format!(
+                "Rig package path does not exist (source root: {}; resolved package root: {})",
+                package_path.display(),
+                discovery_path.display()
+            ),
+            Some(source.to_string()),
+            Some(vec![
+                format!("source root: {}", package_path.display()),
+                format!("resolved package root: {}", discovery_path.display()),
+            ]),
+        ));
+    }
     Ok(PreparedSource {
         source: root_source.to_string(),
-        package_path,
+        source_root: package_path.clone(),
+        package_path: discovery_path.clone(),
         discovery_path,
         linked: false,
         source_revision,
@@ -367,6 +392,7 @@ fn prepare_local_source(source: &str) -> Result<PreparedSource> {
     }
     Ok(PreparedSource {
         source: package_path.to_string_lossy().to_string(),
+        source_root: package_path.clone(),
         discovery_path: package_path.clone(),
         package_path,
         linked: true,

--- a/src/core/rig/source.rs
+++ b/src/core/rig/source.rs
@@ -108,12 +108,12 @@ pub fn remove_source(selector: &str) -> Result<RigSourceRemoveResult> {
     }
 
     let removed_package_path = if !source.linked {
-        let package_path = PathBuf::from(&source.package_path);
-        if package_path.exists() {
-            fs::remove_dir_all(&package_path).map_err(|e| {
+        let source_root = PathBuf::from(&source.source_root);
+        if source_root.exists() {
+            fs::remove_dir_all(&source_root).map_err(|e| {
                 Error::internal_io(e.to_string(), Some("remove rig package".into()))
             })?;
-            Some(source.package_path.clone())
+            Some(source.source_root.clone())
         } else {
             None
         }
@@ -276,19 +276,25 @@ pub fn update_source(selector: Option<&str>) -> Result<RigSourceUpdateResult> {
 }
 
 fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
-    let package_path = PathBuf::from(&source.package_path);
-    if !package_path.exists() {
+    let source_root = PathBuf::from(&source.source_root);
+    if !source_root.exists() {
         return Err(Error::validation_invalid_argument(
             "source",
-            format!("Installed rig package is missing: {}", source.package_path),
+            format!(
+                "Installed rig source root is missing: {}",
+                source.source_root
+            ),
             Some(source.source),
-            None,
+            Some(vec![
+                format!("source root: {}", source.source_root),
+                format!("resolved package root: {}", source.package_path),
+            ]),
         ));
     }
 
-    let previous_revision = git::short_head_revision(&package_path);
-    git::pull_repo(&package_path)?;
-    let source_revision = git::short_head_revision(&package_path);
+    let previous_revision = git::short_head_revision(&source_root);
+    git::pull_repo(&source_root)?;
+    let source_revision = git::short_head_revision(&source_root);
 
     let mut updated = Vec::new();
     let mut updated_stacks = Vec::new();
@@ -322,6 +328,7 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
 
         let metadata = RigSourceMetadata {
             source: source.source.clone(),
+            source_root: Some(source.source_root.clone()),
             package_path: source.package_path.clone(),
             rig_path: rig.rig_path.clone(),
             discovery_path: Some(source.discovery_path.clone()),
@@ -361,6 +368,7 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
 
         let metadata = StackSourceMetadata {
             source: source.source.clone(),
+            source_root: Some(source.source_root.clone()),
             package_path: source.package_path.clone(),
             stack_path: stack.stack_path.to_string_lossy().to_string(),
             discovery_path: source.discovery_path.clone(),
@@ -548,6 +556,7 @@ fn infer_discovery_path(rig_path: &str) -> String {
 
 fn new_source_group(
     source: &str,
+    source_root: &str,
     package_path: &str,
     discovery_path: String,
     linked: bool,
@@ -556,6 +565,7 @@ fn new_source_group(
     let package_present = Path::new(package_path).exists();
     RigSourceGroup {
         source: source.to_string(),
+        source_root: source_root.to_string(),
         package_id: package_id_from_path(package_path),
         package_path: package_path.to_string(),
         package_present,
@@ -569,8 +579,13 @@ fn new_source_group(
 }
 
 fn new_rig_source_group(metadata: &RigSourceMetadata) -> RigSourceGroup {
+    let source_root = metadata
+        .source_root
+        .as_deref()
+        .unwrap_or(&metadata.package_path);
     new_source_group(
         &metadata.source,
+        source_root,
         &metadata.package_path,
         metadata
             .discovery_path
@@ -582,8 +597,13 @@ fn new_rig_source_group(metadata: &RigSourceMetadata) -> RigSourceGroup {
 }
 
 fn new_stack_source_group(metadata: &StackSourceMetadata) -> RigSourceGroup {
+    let source_root = metadata
+        .source_root
+        .as_deref()
+        .unwrap_or(&metadata.package_path);
     new_source_group(
         &metadata.source,
+        source_root,
         &metadata.package_path,
         metadata.discovery_path.clone(),
         metadata.linked,
@@ -655,7 +675,10 @@ fn source_config_path(config_path: Option<PathBuf>) -> String {
 }
 
 fn source_matches(source: &RigSourceGroup, selector: &str) -> bool {
-    source.source == selector || source.package_path == selector || source.package_id == selector
+    source.source == selector
+        || source.source_root == selector
+        || source.package_path == selector
+        || source.package_id == selector
 }
 
 fn package_id_from_path(path: &str) -> String {

--- a/src/core/rig/source/types.rs
+++ b/src/core/rig/source/types.rs
@@ -9,6 +9,7 @@ pub struct RigSourceListResult {
 #[derive(Debug, Clone, Serialize)]
 pub struct RigSourceGroup {
     pub source: String,
+    pub source_root: String,
     pub package_path: String,
     pub package_present: bool,
     pub discovery_path: String,

--- a/src/core/runner/rig_materialization.rs
+++ b/src/core/runner/rig_materialization.rs
@@ -74,10 +74,14 @@ pub(super) fn sync_lab_offload_rigs(
                     ]),
                 )
             })?;
+            let source_root = metadata
+                .source_root
+                .clone()
+                .unwrap_or_else(|| metadata.package_path.clone());
             let synced = sync_workspace(
                 runner_id,
                 RunnerWorkspaceSyncOptions {
-                    path: metadata.package_path,
+                    path: source_root.clone(),
                     mode: RunnerWorkspaceSyncMode::Snapshot,
                     controller_routed_git: false,
                     changed_since_base: None,
@@ -87,10 +91,9 @@ pub(super) fn sync_lab_offload_rigs(
                 },
             )?
             .0;
-            (
-                synced.remote_path,
-                LabOffloadRigSyncSource::InstalledMetadata,
-            )
+            let install_source =
+                remote_package_path(&source_root, &metadata.package_path, &synced.remote_path);
+            (install_source, LabOffloadRigSyncSource::InstalledMetadata)
         };
 
         let removed_source =
@@ -144,6 +147,18 @@ pub(super) fn sync_lab_offload_rigs(
     }
 
     Ok(synced_rigs)
+}
+
+fn remote_package_path(source_root: &str, package_path: &str, remote_source_root: &str) -> String {
+    let source_root = Path::new(source_root);
+    let package_path = Path::new(package_path);
+    match package_path.strip_prefix(source_root) {
+        Ok(relative) if !relative.as_os_str().is_empty() => Path::new(remote_source_root)
+            .join(relative)
+            .to_string_lossy()
+            .to_string(),
+        _ => remote_source_root.to_string(),
+    }
 }
 
 fn remove_runner_installed_rig_source(
@@ -888,6 +903,7 @@ mod tests {
                 "studio-web-product-matrix",
                 &crate::core::rig::install::RigSourceMetadata {
                     source: checkout.display().to_string(),
+                    source_root: Some(checkout.display().to_string()),
                     package_path: checkout.display().to_string(),
                     rig_path: checkout
                         .join("rigs/studio-web-product-matrix/rig.json")

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -135,6 +135,81 @@ fn install_package_with_sibling_stacks_installs_stack_specs() {
 }
 
 #[test]
+fn install_git_source_subpath_records_nested_package_root() {
+    let _home = HomeGuard::new();
+    let repo = tempfile::tempdir().expect("repo");
+    let nested = repo.path().join("woocommerce/woocommerce-gateway-stripe");
+    fs::create_dir_all(nested.join("bench")).expect("bench dir");
+    fs::write(
+        nested.join("bench/stripe.trace.mjs"),
+        "export default {};\n",
+    )
+    .expect("trace workload");
+    write_rig(
+        &nested,
+        "woocommerce-stripe-ece-product-page",
+        r#"{
+            "id": "woocommerce-stripe-ece-product-page",
+            "trace_workloads": {
+                "woocommerce-gateway-stripe": [
+                    { "path": "${package.root}/bench/stripe.trace.mjs" }
+                ]
+            }
+        }"#,
+    );
+    let bare = bare_package(repo.path());
+    let source = format!(
+        "{}//woocommerce/woocommerce-gateway-stripe",
+        bare.path().join("rig-package.git").display()
+    );
+
+    let result = install(&source, Some("woocommerce-stripe-ece-product-page"), false)
+        .expect("install nested git package");
+    let metadata = read_source_metadata("woocommerce-stripe-ece-product-page").expect("metadata");
+    let source_root = result.source_root;
+    let package_root = source_root.join("woocommerce/woocommerce-gateway-stripe");
+
+    assert_eq!(result.package_path, package_root);
+    assert_eq!(
+        metadata.source_root.as_deref(),
+        Some(source_root.to_str().unwrap())
+    );
+    assert_eq!(metadata.package_path, package_root.to_string_lossy());
+    assert_eq!(
+        metadata.discovery_path.as_deref(),
+        Some(metadata.package_path.as_str())
+    );
+
+    let rig = load("woocommerce-stripe-ece-product-page").expect("load rig");
+    assert_eq!(
+        crate::core::rig::expand::expand_vars(&rig, "${package.root}/bench/stripe.trace.mjs"),
+        package_root
+            .join("bench/stripe.trace.mjs")
+            .to_string_lossy()
+    );
+}
+
+#[test]
+fn install_git_source_missing_subpath_reports_source_and_package_roots() {
+    let _home = HomeGuard::new();
+    let repo = tempfile::tempdir().expect("repo");
+    write_rig(repo.path(), "alpha", &minimal_rig("alpha"));
+    let bare = bare_package(repo.path());
+    let source = format!(
+        "{}//woocommerce/woocommerce-gateway-stripe",
+        bare.path().join("rig-package.git").display()
+    );
+
+    let err = install(&source, Some("alpha"), false).expect_err("missing nested package");
+
+    assert!(err.message.contains("source root:"));
+    assert!(err.message.contains("resolved package root:"));
+    assert!(err
+        .message
+        .contains("woocommerce/woocommerce-gateway-stripe"));
+}
+
+#[test]
 fn installed_rig_check_reports_package_lint_failures() {
     let _home = HomeGuard::new();
     let package = tempfile::tempdir().expect("package");

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -298,6 +298,7 @@ fn write_rig_source_metadata(rig_id: &str) {
         path,
         serde_json::to_string(&RigSourceMetadata {
             source: "https://example.com/rigs.git".to_string(),
+            source_root: Some("/tmp/rigs".to_string()),
             package_path: "/tmp/rigs".to_string(),
             rig_path: "/tmp/rigs/rig.json".to_string(),
             discovery_path: Some("/tmp/rigs".to_string()),


### PR DESCRIPTION
## Summary
- Preserve separate source root and package root metadata for nested Git rig package installs.
- Use the source root for Git update/remove/sync operations while resolving \`${package.root}\` to the nested package directory.
- Add coverage for nested Git rig package install and missing subpath diagnostics that include both source root and resolved package root.

## Testing
- Not run locally per host constraint: cargo commands freeze RAM on this host. CI should validate.

Closes #4677