### PR TITLE
fix: tolerate malformed agent task status records

### DIFF
--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -810,7 +810,13 @@ pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {
 pub fn list_records() -> Result<Vec<AgentTaskRunRecord>> {
     let mut records = Vec::new();
     for record in store::read_records()? {
-        records.push(status(&record.run_id)?);
+        match status(&record.run_id) {
+            Ok(record) => records.push(record),
+            Err(error) => eprintln!(
+                "Warning: skipping malformed agent-task run status for {}: {}",
+                record.run_id, error.message
+            ),
+        }
     }
     records.sort_by(|left, right| {
         right
@@ -2105,6 +2111,61 @@ mod tests {
 
             assert!(error.message.contains("running under pid"));
             assert!(error.message.contains("provider live cancellation"));
+        });
+    }
+
+    #[test]
+    fn status_accepts_legacy_totals_without_skipped() {
+        with_isolated_home(|_| {
+            let plan = test_plan();
+            let record = submit_plan(&plan, Some("legacy-run")).expect("submitted");
+            let status_path = paths::homeboy_data()
+                .expect("homeboy data")
+                .join("agent-task-runs")
+                .join(&record.run_id)
+                .join("status.json");
+            let mut raw = serde_json::to_value(&record).expect("record json");
+            raw["totals"] = json!({
+                "queued": 1,
+                "running": 0,
+                "blocked": 0,
+                "succeeded": 0,
+                "failed": 0,
+                "cancelled": 0,
+                "timed_out": 0
+            });
+            std::fs::write(
+                &status_path,
+                format!(
+                    "{}\n",
+                    serde_json::to_string_pretty(&raw).expect("pretty json")
+                ),
+            )
+            .expect("write legacy status");
+
+            let loaded = status("legacy-run").expect("legacy status loaded");
+
+            assert_eq!(loaded.totals.expect("totals").skipped, 0);
+        });
+    }
+
+    #[test]
+    fn list_records_skips_malformed_status_files() {
+        with_isolated_home(|_| {
+            let plan = test_plan();
+            submit_plan(&plan, Some("good-run")).expect("submitted");
+            let bad_dir = paths::homeboy_data()
+                .expect("homeboy data")
+                .join("agent-task-runs")
+                .join("bad-run");
+            std::fs::create_dir_all(&bad_dir).expect("create bad run dir");
+            std::fs::write(bad_dir.join("status.json"), "{ definitely not json\n")
+                .expect("write bad status");
+
+            let records = list_records().expect("records listed");
+
+            assert_eq!(records.len(), 1);
+            assert_eq!(records[0].run_id, "good-run");
         });
     }
 

--- a/src/core/agent_task_schedule.rs
+++ b/src/core/agent_task_schedule.rs
@@ -531,13 +531,21 @@ pub enum AgentTaskAggregateStatus {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskAggregateTotals {
+    #[serde(default)]
     pub queued: usize,
+    #[serde(default)]
     pub running: usize,
+    #[serde(default)]
     pub blocked: usize,
+    #[serde(default)]
     pub skipped: usize,
+    #[serde(default)]
     pub succeeded: usize,
+    #[serde(default)]
     pub failed: usize,
+    #[serde(default)]
     pub cancelled: usize,
+    #[serde(default)]
     pub timed_out: usize,
 }
 

--- a/src/core/lifecycle_store.rs
+++ b/src/core/lifecycle_store.rs
@@ -73,7 +73,14 @@ pub(super) fn read_records() -> Result<Vec<AgentTaskRunRecord>> {
         if !path.exists() {
             continue;
         }
-        records.push(read_json(&path)?);
+        match read_json(&path) {
+            Ok(record) => records.push(record),
+            Err(error) => eprintln!(
+                "Warning: skipping malformed agent-task run status {}: {}",
+                path.display(),
+                error.message
+            ),
+        }
     }
 
     Ok(records)


### PR DESCRIPTION
## Summary
- Default legacy agent-task aggregate total fields so old `status.json` records missing `skipped` still deserialize.
- Skip malformed run status files during bulk discovery with a warning instead of failing `agent-task list`/`active` globally.
- Add lifecycle tests for missing `skipped` and malformed status-file discovery.

## Verification
- `rustfmt --check src/core/agent_task_lifecycle.rs src/core/lifecycle_store.rs src/core/agent_task_schedule.rs`
- `git diff --check`

Cargo tests intentionally not run on this host per operator constraint; CI should cover them.

Fixes #4694