### PR TITLE
fix: refresh tunnel liveness after readiness

### DIFF
--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 #[cfg(unix)]
@@ -537,7 +537,7 @@ pub fn expose(spec: ExposeServiceTunnelSpec) -> Result<ServiceTunnel> {
 
 pub fn status(id: &str) -> Result<ServiceTunnelStatus> {
     let tunnel = load(id)?;
-    Ok(service_tunnel_status(&tunnel))
+    service_tunnel_status(&tunnel)
 }
 
 pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
@@ -606,7 +606,7 @@ pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
         });
     }
 
-    let child = command.spawn().map_err(|e| {
+    let mut child = command.spawn().map_err(|e| {
         Error::internal_io(
             e.to_string(),
             Some(format!("start service tunnel {}", tunnel.id)),
@@ -649,6 +649,13 @@ pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
         remove_runtime_state(&state.preview_identity.service_id)?;
         return Err(error);
     }
+
+    if let Err(error) = ensure_supervised_process_still_running(&state, &mut child) {
+        terminate_runtime_state(&state)?;
+        remove_runtime_state(&state.preview_identity.service_id)?;
+        return Err(error);
+    }
+
     let state = match start_backend_if_needed(state, &tunnel, spec.backend_command) {
         Ok(state) => state,
         Err(error) => {
@@ -659,6 +666,14 @@ pub fn start(spec: StartServiceTunnelSpec) -> Result<ServiceTunnelStatus> {
             return Err(error);
         }
     };
+
+    if let Err(error) = ensure_supervised_process_still_running(&state, &mut child) {
+        terminate_backend_state(&state)?;
+        terminate_runtime_state(&state)?;
+        remove_runtime_state(&state.preview_identity.service_id)?;
+        return Err(error);
+    }
+
     save_runtime_state(&state)?;
     status(&tunnel.id)
 }
@@ -737,7 +752,7 @@ pub fn stop(id: &str) -> Result<ServiceTunnelStatus> {
         terminate_runtime_state(&state)?;
         remove_runtime_state(id)?;
     }
-    Ok(service_tunnel_status(&tunnel))
+    service_tunnel_status(&tunnel)
 }
 
 pub fn local_url(id: &str) -> Result<String> {
@@ -745,8 +760,8 @@ pub fn local_url(id: &str) -> Result<String> {
     Ok(local_url_for(&tunnel))
 }
 
-fn service_tunnel_status(tunnel: &ServiceTunnel) -> ServiceTunnelStatus {
-    let state = load_runtime_state(&tunnel.id).ok().flatten();
+fn service_tunnel_status(tunnel: &ServiceTunnel) -> Result<ServiceTunnelStatus> {
+    let state = refresh_runtime_state(&tunnel.id)?;
     let running = state.as_ref().is_some_and(runtime_state_is_running);
     let health = state.as_ref().map(check_runtime_health);
     let readiness = state.as_ref().map(check_runtime_readiness);
@@ -780,7 +795,7 @@ fn service_tunnel_status(tunnel: &ServiceTunnel) -> ServiceTunnelStatus {
     let preview = state
         .as_ref()
         .and_then(|state| preview_artifact_for_status(tunnel, state));
-    ServiceTunnelStatus {
+    Ok(ServiceTunnelStatus {
         preview_identity: ServiceTunnelPreviewIdentity {
             service_id: tunnel.id.clone(),
             public_url,
@@ -797,7 +812,7 @@ fn service_tunnel_status(tunnel: &ServiceTunnel) -> ServiceTunnelStatus {
         evidence,
         tunnel_backend: backend,
         preview,
-    }
+    })
 }
 
 pub(super) fn preview_policy_allows(
@@ -1405,6 +1420,42 @@ fn remove_runtime_state(id: &str) -> Result<()> {
             .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))?;
     }
     Ok(())
+}
+
+fn refresh_runtime_state(id: &str) -> Result<Option<ServiceTunnelRuntimeState>> {
+    let Some(state) = load_runtime_state(id)? else {
+        return Ok(None);
+    };
+    if runtime_state_is_running(&state) {
+        return Ok(Some(state));
+    }
+
+    terminate_backend_state(&state)?;
+    remove_runtime_state(id)?;
+    Ok(None)
+}
+
+fn ensure_supervised_process_still_running(
+    state: &ServiceTunnelRuntimeState,
+    child: &mut Child,
+) -> Result<()> {
+    std::thread::sleep(Duration::from_millis(100));
+    match child.try_wait() {
+        Ok(Some(status)) => Err(Error::validation_invalid_argument(
+            "service",
+            "service process exited after becoming ready",
+            Some(state.preview_identity.service_id.clone()),
+            Some(vec![format!("exit status: {status}")]),
+        )),
+        Ok(None) => Ok(()),
+        Err(error) => Err(Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "check service tunnel process {}",
+                state.preview_identity.service_id
+            )),
+        )),
+    }
 }
 
 fn runtime_state_is_running(state: &ServiceTunnelRuntimeState) -> bool {

--- a/src/core/tunnel_tests.rs
+++ b/src/core/tunnel_tests.rs
@@ -20,6 +20,20 @@ fn create_server() {
     .expect("save server");
 }
 
+fn reserve_loopback_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("reserve loopback port")
+        .local_addr()
+        .expect("reserved port address")
+        .port()
+}
+
+fn python_listener_command(port: u16, body: &str) -> String {
+    format!(
+        "python3 -c 'import socket,time; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); s.bind((\"127.0.0.1\", {port})); s.listen(1); {body}; s.close()'"
+    )
+}
+
 #[test]
 fn expose_records_private_loopback_declaration_without_running_tunnel() {
     test_support::with_isolated_home(|_| {
@@ -397,6 +411,133 @@ fn preview_readiness_can_require_artifact_status() {
         assert_eq!(readiness.checks[0].check, "artifact_json_pointer");
 
         stop("artifact-preview").expect("stop service");
+    });
+}
+
+#[test]
+fn preview_start_fails_when_listener_process_exits_after_readiness() {
+    test_support::with_isolated_home(|_| {
+        create_server();
+        let port = reserve_loopback_port();
+        expose(ExposeServiceTunnelSpec {
+            id: "flapping-preview".to_string(),
+            server_id: "private-host".to_string(),
+            target: ServiceTunnelTarget {
+                host: "127.0.0.1".to_string(),
+                port,
+            },
+            scheme: "http".to_string(),
+            local_port: Some(port),
+            auth: ServiceTunnelAuth {
+                mode: ServiceTunnelAuthMode::BearerEnv,
+                env_var: Some("FLAPPING_PREVIEW_TOKEN".to_string()),
+                header: Some("Authorization".to_string()),
+            },
+            policy: ServiceTunnelPolicy {
+                exposure: ServiceTunnelExposure::PrivateLoopback,
+                require_auth: true,
+                allowed_clients: Vec::new(),
+                preview: ServiceTunnelPreviewPolicy::default(),
+                native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
+            },
+            description: None,
+        })
+        .expect("expose service");
+
+        let err = start(StartServiceTunnelSpec {
+            id: "flapping-preview".to_string(),
+            command: python_listener_command(port, "conn,_=s.accept(); conn.close()"),
+            cwd: None,
+            env: BTreeMap::new(),
+            host: Some("127.0.0.1".to_string()),
+            port: Some(port),
+            scheme: Some("http".to_string()),
+            health_url: None,
+            health_path: None,
+            readiness_timeout_secs: 2,
+            backend: ServiceTunnelTunnelBackend::Command,
+            backend_command: Some("while true; do sleep 1; done".to_string()),
+            backend_public_url: Some("https://flapping-preview.example.test".to_string()),
+            source_run_id: None,
+            source_workflow_id: None,
+            readiness_kind: ServiceTunnelReadinessKind::Preview,
+            readiness_checks: vec![ServiceTunnelReadinessCheck::TcpListener],
+        })
+        .expect_err("exited listener must not start successfully");
+
+        assert_eq!(err.code, crate::core::ErrorCode::ValidationInvalidArgument);
+        assert!(err.message.contains("exited after becoming ready"));
+        let refreshed = status("flapping-preview").expect("status refresh");
+        assert!(!refreshed.running);
+        assert!(refreshed.preview_identity.public_url.is_none());
+        assert!(refreshed.readiness.is_none());
+        assert!(refreshed.tunnel_backend.is_none());
+    });
+}
+
+#[test]
+fn status_refresh_clears_exited_process_readiness() {
+    test_support::with_isolated_home(|_| {
+        create_server();
+        let port = reserve_loopback_port();
+        expose(ExposeServiceTunnelSpec {
+            id: "short-lived-preview".to_string(),
+            server_id: "private-host".to_string(),
+            target: ServiceTunnelTarget {
+                host: "127.0.0.1".to_string(),
+                port,
+            },
+            scheme: "http".to_string(),
+            local_port: Some(port),
+            auth: ServiceTunnelAuth {
+                mode: ServiceTunnelAuthMode::BearerEnv,
+                env_var: Some("SHORT_PREVIEW_TOKEN".to_string()),
+                header: Some("Authorization".to_string()),
+            },
+            policy: ServiceTunnelPolicy {
+                exposure: ServiceTunnelExposure::PrivateLoopback,
+                require_auth: true,
+                allowed_clients: Vec::new(),
+                preview: ServiceTunnelPreviewPolicy::default(),
+                native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
+            },
+            description: None,
+        })
+        .expect("expose service");
+
+        let started = start(StartServiceTunnelSpec {
+            id: "short-lived-preview".to_string(),
+            command: python_listener_command(
+                port,
+                "end=time.time()+1.0\nwhile time.time()<end:\n s.settimeout(max(0.01,end-time.time()))\n try:\n  conn,_=s.accept(); conn.close()\n except Exception:\n  pass",
+            ),
+            cwd: None,
+            env: BTreeMap::new(),
+            host: Some("127.0.0.1".to_string()),
+            port: Some(port),
+            scheme: Some("http".to_string()),
+            health_url: None,
+            health_path: None,
+            readiness_timeout_secs: 2,
+            backend: ServiceTunnelTunnelBackend::None,
+            backend_command: None,
+            backend_public_url: Some("https://short-lived-preview.example.test".to_string()),
+            source_run_id: None,
+            source_workflow_id: None,
+            readiness_kind: ServiceTunnelReadinessKind::Preview,
+            readiness_checks: vec![ServiceTunnelReadinessCheck::TcpListener],
+        })
+        .expect("start short-lived service");
+
+        assert!(started.running);
+        assert!(started.readiness.expect("readiness").preview_ready);
+        std::thread::sleep(std::time::Duration::from_millis(1200));
+
+        let refreshed = status("short-lived-preview").expect("status refresh");
+        assert!(!refreshed.running);
+        assert_eq!(refreshed.lifecycle, "declared");
+        assert!(refreshed.readiness.is_none());
+        assert!(refreshed.preview_identity.public_url.is_none());
     });
 }
 


### PR DESCRIPTION
## Summary
- Revalidates the supervised service process after readiness checks and again after backend setup before reporting tunnel start success.
- Refreshes tunnel status from runtime state so exited supervised services clear stale running/readiness/public preview fields instead of reporting `preview_ready`.
- Adds focused regressions for `--require-listener`-style preview readiness where a loopback listener exits after readiness and where later status refresh observes an exited service.

## Verification
- `cargo test core::tunnel_tests` passed on the rebased branch: 16 passed, 0 failed.
- A broader `cargo test --lib` run completed far enough to cover the new tunnel regressions, but failed in existing unrelated areas: bench observation artifact URL, extension component/test parser IO/JSON expectations, and runner workspace shell materialization tests with `syntax error near unexpected token ;;`.

Fixes #4681