### PR TITLE
fix: reject malformed agent-task totals in listings

### DIFF
--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -2115,16 +2115,17 @@ mod tests {
     }
 
     #[test]
-    fn status_accepts_legacy_totals_without_skipped() {
+    fn list_records_skips_malformed_status_files() {
         with_isolated_home(|_| {
             let plan = test_plan();
-            let record = submit_plan(&plan, Some("legacy-run")).expect("submitted");
-            let status_path = paths::homeboy_data()
+            submit_plan(&plan, Some("good-run")).expect("submitted");
+            let invalid_shape = submit_plan(&plan, Some("missing-skipped-run")).expect("submitted");
+            let invalid_shape_path = paths::homeboy_data()
                 .expect("homeboy data")
                 .join("agent-task-runs")
-                .join(&record.run_id)
+                .join(&invalid_shape.run_id)
                 .join("status.json");
-            let mut raw = serde_json::to_value(&record).expect("record json");
+            let mut raw = serde_json::to_value(&invalid_shape).expect("record json");
             raw["totals"] = json!({
                 "queued": 1,
                 "running": 0,
@@ -2135,25 +2136,13 @@ mod tests {
                 "timed_out": 0
             });
             std::fs::write(
-                &status_path,
+                &invalid_shape_path,
                 format!(
                     "{}\n",
                     serde_json::to_string_pretty(&raw).expect("pretty json")
                 ),
             )
-            .expect("write legacy status");
-
-            let loaded = status("legacy-run").expect("legacy status loaded");
-
-            assert_eq!(loaded.totals.expect("totals").skipped, 0);
-        });
-    }
-
-    #[test]
-    fn list_records_skips_malformed_status_files() {
-        with_isolated_home(|_| {
-            let plan = test_plan();
-            submit_plan(&plan, Some("good-run")).expect("submitted");
+            .expect("write invalid-shape status");
             let bad_dir = paths::homeboy_data()
                 .expect("homeboy data")
                 .join("agent-task-runs")

--- a/src/core/agent_task_schedule.rs
+++ b/src/core/agent_task_schedule.rs
@@ -537,7 +537,6 @@ pub struct AgentTaskAggregateTotals {
     pub running: usize,
     #[serde(default)]
     pub blocked: usize,
-    #[serde(default)]
     pub skipped: usize,
     #[serde(default)]
     pub succeeded: usize,

--- a/src/core/agent_task_service.rs
+++ b/src/core/agent_task_service.rs
@@ -900,6 +900,60 @@ mod tests {
     }
 
     #[test]
+    fn discovery_accepts_active_legacy_totals_without_skipped() {
+        with_isolated_home(|_| {
+            let record = agent_task_lifecycle::submit_plan(
+                &discovery_plan(),
+                Some("run-active-legacy-totals"),
+            )
+            .expect("submitted");
+            agent_task_lifecycle::mark_running(&record.run_id).expect("marked running");
+            let status_path = crate::core::paths::homeboy_data()
+                .expect("homeboy data")
+                .join("agent-task-runs")
+                .join(&record.run_id)
+                .join("status.json");
+            let mut raw = serde_json::to_value(
+                agent_task_lifecycle::status(&record.run_id).expect("status loaded"),
+            )
+            .expect("record json");
+            raw["totals"] = serde_json::json!({
+                "queued": 0,
+                "running": 1,
+                "blocked": 0,
+                "succeeded": 0,
+                "failed": 0,
+                "cancelled": 0,
+                "timed_out": 0
+            });
+            std::fs::write(
+                &status_path,
+                format!(
+                    "{}\n",
+                    serde_json::to_string_pretty(&raw).expect("pretty json")
+                ),
+            )
+            .expect("write legacy status");
+
+            let active = discover_runs(AgentTaskDiscoveryFilter::Active).expect("active listed");
+            let all = discover_runs(AgentTaskDiscoveryFilter::All).expect("all listed");
+
+            assert_eq!(active.count, 1);
+            assert_eq!(active.runs[0].run_id, "run-active-legacy-totals");
+            assert_eq!(all.count, 1);
+            assert_eq!(all.runs[0].run_id, "run-active-legacy-totals");
+            assert_eq!(
+                agent_task_lifecycle::status(&record.run_id)
+                    .expect("legacy status loaded")
+                    .totals
+                    .expect("totals")
+                    .skipped,
+                0
+            );
+        });
+    }
+
+    #[test]
     fn discovery_latest_returns_only_newest_run() {
         with_isolated_home(|_| {
             agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-latest-a"))

--- a/src/core/agent_task_service.rs
+++ b/src/core/agent_task_service.rs
@@ -900,60 +900,6 @@ mod tests {
     }
 
     #[test]
-    fn discovery_accepts_active_legacy_totals_without_skipped() {
-        with_isolated_home(|_| {
-            let record = agent_task_lifecycle::submit_plan(
-                &discovery_plan(),
-                Some("run-active-legacy-totals"),
-            )
-            .expect("submitted");
-            agent_task_lifecycle::mark_running(&record.run_id).expect("marked running");
-            let status_path = crate::core::paths::homeboy_data()
-                .expect("homeboy data")
-                .join("agent-task-runs")
-                .join(&record.run_id)
-                .join("status.json");
-            let mut raw = serde_json::to_value(
-                agent_task_lifecycle::status(&record.run_id).expect("status loaded"),
-            )
-            .expect("record json");
-            raw["totals"] = serde_json::json!({
-                "queued": 0,
-                "running": 1,
-                "blocked": 0,
-                "succeeded": 0,
-                "failed": 0,
-                "cancelled": 0,
-                "timed_out": 0
-            });
-            std::fs::write(
-                &status_path,
-                format!(
-                    "{}\n",
-                    serde_json::to_string_pretty(&raw).expect("pretty json")
-                ),
-            )
-            .expect("write legacy status");
-
-            let active = discover_runs(AgentTaskDiscoveryFilter::Active).expect("active listed");
-            let all = discover_runs(AgentTaskDiscoveryFilter::All).expect("all listed");
-
-            assert_eq!(active.count, 1);
-            assert_eq!(active.runs[0].run_id, "run-active-legacy-totals");
-            assert_eq!(all.count, 1);
-            assert_eq!(all.runs[0].run_id, "run-active-legacy-totals");
-            assert_eq!(
-                agent_task_lifecycle::status(&record.run_id)
-                    .expect("legacy status loaded")
-                    .totals
-                    .expect("totals")
-                    .skipped,
-                0
-            );
-        });
-    }
-
-    #[test]
     fn discovery_latest_returns_only_newest_run() {
         with_isolated_home(|_| {
             agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-latest-a"))


### PR DESCRIPTION
## Summary
- Removes legacy support for `totals.skipped` being absent from agent-task aggregate totals.
- Treats status records missing required `totals.skipped` as malformed so `agent-task active` / `list` can skip them instead of repairing or loading old schema shapes.
- Removes the legacy acceptance regression and folds the missing-field case into malformed status listing coverage.

## Validation
- `rustfmt src/core/agent_task_schedule.rs src/core/agent_task_service.rs src/core/agent_task_lifecycle.rs`
- `git diff --check`
- `git diff --check origin/main...HEAD`

Cargo was not run locally per issue constraints.

Fixes #4721