### PR TITLE
fix: reject empty/incomplete agent-task cook results

### DIFF
--- a/src/commands/agent_task_summary.rs
+++ b/src/commands/agent_task_summary.rs
@@ -31,7 +31,7 @@ pub(crate) fn render_agent_task_summary(
 
 fn render_cook_summary(payload: &Value) -> Option<String> {
     let run_id = string_value(payload, &["run_id"])?;
-    let state = string_value(payload, &["state"])
+    let raw_state = string_value(payload, &["state"])
         .or_else(|| string_value(payload, &["record", "state"]))
         .unwrap_or("unknown");
     let tasks_planned = usize_value(payload, &["task_count"])
@@ -41,6 +41,7 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
     let aggregate_path = string_value(payload, &["aggregate_path"])
         .or_else(|| string_value(payload, &["record", "aggregate_path"]));
     let patch_candidates = patch_candidate_count(payload);
+    let state = effective_run_state(raw_state, tasks_attempted, patch_candidates);
     let artifact_count = aggregate_artifact_count(payload);
     let first_artifact = string_value(
         payload,
@@ -78,10 +79,11 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
 
 fn render_status_summary(payload: &Value) -> Option<String> {
     let run_id = string_value(payload, &["run_id"])?;
-    let state = string_value(payload, &["state"]).unwrap_or("unknown");
+    let raw_state = string_value(payload, &["state"]).unwrap_or("unknown");
     let tasks_planned = array_len(payload, &["tasks"]).unwrap_or(0);
     let tasks_attempted = status_attempted_task_count(payload);
     let patch_candidates = patch_candidate_count(payload);
+    let state = effective_run_state(raw_state, tasks_attempted, patch_candidates);
     let artifact_count = array_len(payload, &["artifact_refs"]).unwrap_or(0);
     let aggregate_path = string_value(payload, &["aggregate_path"]);
 
@@ -233,10 +235,24 @@ fn is_apply_artifact(artifact: &Value) -> bool {
     let Some(kind) = string_value(artifact, &["kind"]) else {
         return false;
     };
-    matches!(
+    let apply_kind = matches!(
         kind,
         "patch" | "diff" | "change_artifact" | "workspace_patch" | "artifact"
-    ) && usize_value(artifact, &["size_bytes"]) != Some(0)
+    );
+    // Require positive evidence of content: an unknown or zero size must not be
+    // counted as a patch candidate (#4610).
+    apply_kind && matches!(usize_value(artifact, &["size_bytes"]), Some(size) if size > 0)
+}
+
+/// A run whose lifecycle state is `succeeded` but that produced zero promotion
+/// candidates did not actually patch anything. Surface that honestly as
+/// `no_patch_produced` instead of advertising success (#4610).
+fn effective_run_state(raw_state: &str, tasks_attempted: usize, patch_candidates: usize) -> &str {
+    if raw_state == "succeeded" && tasks_attempted > 0 && patch_candidates == 0 {
+        "no_patch_produced"
+    } else {
+        raw_state
+    }
 }
 
 fn status_attempted_task_count(payload: &Value) -> usize {
@@ -295,7 +311,7 @@ mod tests {
             "aggregate": {
                 "outcomes": [{
                     "task_id": "homeboy-4345",
-                    "artifacts": [{ "id": "patch", "kind": "patch", "path": "/tmp/patch.diff" }]
+                    "artifacts": [{ "id": "patch", "kind": "patch", "path": "/tmp/patch.diff", "size_bytes": 128 }]
                 }]
             }
         });
@@ -309,6 +325,56 @@ mod tests {
         assert!(summary.contains("First artifact: /tmp/patch.diff\n"));
         assert!(summary.contains("Next: homeboy agent-task review homeboy-4345\n"));
         assert!(!summary.contains("{\n"));
+    }
+
+    #[test]
+    fn cook_summary_reports_no_patch_produced_when_all_cells_are_empty() {
+        // Reproduces the #4610 cook summary: 3 succeeded cells, but every patch
+        // artifact is 0 bytes. The summary must not advertise success.
+        let payload = json!({
+            "run_id": "agent-task-abe47e4d",
+            "state": "succeeded",
+            "task_count": 3,
+            "aggregate_path": "/tmp/aggregate.json",
+            "aggregate_review": {
+                "summary": { "apply_candidates": 0 }
+            },
+            "aggregate": {
+                "outcomes": [
+                    { "task_id": "cell-1", "artifacts": [{ "id": "patch", "kind": "patch", "path": "/tmp/patch.diff", "size_bytes": 0 }] },
+                    { "task_id": "cell-2", "artifacts": [{ "id": "patch", "kind": "patch", "path": "/tmp/patch.diff", "size_bytes": 0 }] },
+                    { "task_id": "cell-3", "artifacts": [{ "id": "patch", "kind": "patch", "path": "/tmp/patch.diff", "size_bytes": 0 }] }
+                ]
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
+
+        assert!(summary.contains("Status: no_patch_produced\n"));
+        assert!(summary.contains("Patch candidates: 0\n"));
+        assert!(summary.contains("Next: homeboy agent-task logs agent-task-abe47e4d\n"));
+        assert!(!summary.contains("Next: homeboy agent-task review"));
+    }
+
+    #[test]
+    fn cook_summary_treats_unknown_size_patch_as_zero_candidates() {
+        let payload = json!({
+            "run_id": "homeboy-4345",
+            "state": "succeeded",
+            "task_count": 1,
+            "aggregate": {
+                "outcomes": [{
+                    "task_id": "homeboy-4345",
+                    "artifacts": [{ "id": "patch", "kind": "patch", "path": "/tmp/patch.diff" }]
+                }]
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
+
+        assert!(summary.contains("Status: no_patch_produced\n"));
+        assert!(summary.contains("Patch candidates: 0\n"));
+        assert!(summary.contains("Next: homeboy agent-task logs homeboy-4345\n"));
     }
 
     #[test]

--- a/src/core/agent_task_aggregate.rs
+++ b/src/core/agent_task_aggregate.rs
@@ -357,9 +357,8 @@ fn reconcile_outcome(
             }
             AgentTaskOutcomeStatus::Cancelled => "cancelled task needs review".to_string(),
             AgentTaskOutcomeStatus::Failed => "failed task needs review".to_string(),
-            AgentTaskOutcomeStatus::Succeeded => {
-                "succeeded without apply-back artifact".to_string()
-            }
+            AgentTaskOutcomeStatus::Succeeded => empty_or_unknown_patch_reason(outcome)
+                .unwrap_or_else(|| "succeeded without apply-back artifact".to_string()),
             AgentTaskOutcomeStatus::ProviderError
             | AgentTaskOutcomeStatus::Timeout
             | AgentTaskOutcomeStatus::FollowUpIssue => unreachable!("handled above"),
@@ -389,11 +388,52 @@ fn inventory_item(task_id: &str, artifact: &AgentTaskArtifact) -> AgentTaskArtif
 }
 
 fn is_apply_artifact(artifact: &AgentTaskArtifact) -> bool {
-    let apply_kind = matches!(
+    is_apply_kind_artifact(artifact) && artifact_has_nonzero_size(artifact)
+}
+
+fn is_apply_kind_artifact(artifact: &AgentTaskArtifact) -> bool {
+    matches!(
         artifact.kind.as_str(),
         "patch" | "diff" | "change_artifact" | "workspace_patch" | "artifact"
-    ) || artifact_flag(artifact, "approved");
-    apply_kind && artifact.size_bytes != Some(0)
+    ) || artifact_flag(artifact, "approved")
+}
+
+fn artifact_has_nonzero_size(artifact: &AgentTaskArtifact) -> bool {
+    // A patch counts as a promotion candidate only when there is positive
+    // evidence of non-empty content. An unknown (`None`) size is treated as
+    // empty/uncertain rather than as a valid candidate, so cook runs whose
+    // provider only wrote 0-byte patches (or omitted size entirely) are not
+    // reported as successful fixes (#4610).
+    matches!(artifact.size_bytes, Some(size) if size > 0)
+}
+
+/// When a `Succeeded` outcome produced patch-shaped artifacts that were all
+/// empty or unknown-size, surface a per-cell reason explaining why no apply
+/// candidate was promoted. Returns `None` when there were no patch artifacts or
+/// when at least one had non-empty content.
+fn empty_or_unknown_patch_reason(outcome: &AgentTaskOutcome) -> Option<String> {
+    let patch_artifacts: Vec<&AgentTaskArtifact> = outcome
+        .artifacts
+        .iter()
+        .filter(|artifact| is_apply_kind_artifact(artifact))
+        .collect();
+    if patch_artifacts.is_empty() {
+        return None;
+    }
+    if patch_artifacts
+        .iter()
+        .any(|artifact| artifact_has_nonzero_size(artifact))
+    {
+        return None;
+    }
+    if patch_artifacts
+        .iter()
+        .any(|artifact| artifact.size_bytes == Some(0))
+    {
+        Some("patch artifact was empty (0 bytes); provider produced no file changes".to_string())
+    } else {
+        Some("patch artifact size unknown; cannot confirm changes were produced".to_string())
+    }
 }
 
 fn artifact_flag(artifact: &AgentTaskArtifact, key: &str) -> bool {
@@ -549,7 +589,7 @@ mod tests {
         assert_eq!(report.review_candidates[0].task_id, "empty-patch");
         assert_eq!(
             report.review_candidates[0].reason,
-            "succeeded without apply-back artifact"
+            "patch artifact was empty (0 bytes); provider produced no file changes"
         );
     }
 
@@ -573,7 +613,10 @@ mod tests {
     }
 
     #[test]
-    fn aggregate_outcomes_keeps_unknown_size_patch_apply_candidate() {
+    fn aggregate_outcomes_routes_unknown_size_patch_to_review() {
+        // An unknown-size patch cannot be confirmed non-empty, so it must not be
+        // auto-promoted as an apply candidate (#4610). It routes to review with a
+        // reason that explains the uncertainty.
         let mut unknown_size_patch = artifact("legacy-patch", "patch", json!({}));
         unknown_size_patch.size_bytes = None;
 
@@ -583,8 +626,53 @@ mod tests {
             vec![unknown_size_patch],
         )]);
 
-        assert_eq!(report.summary.apply_candidates, 1);
-        assert_eq!(report.apply_candidates[0].task_id, "legacy-patch");
+        assert!(report.apply_candidates.is_empty());
+        assert_eq!(report.summary.apply_candidates, 0);
+        assert_eq!(report.summary.review_candidates, 1);
+        assert_eq!(report.review_candidates[0].task_id, "legacy-patch");
+        assert_eq!(
+            report.review_candidates[0].reason,
+            "patch artifact size unknown; cannot confirm changes were produced"
+        );
+    }
+
+    #[test]
+    fn aggregate_outcomes_reports_no_patch_produced_when_all_cells_empty() {
+        // Reproduces the #4610 scenario: 3 succeeded cells, each with a 0-byte
+        // patch artifact. The cook run should report zero apply candidates and no
+        // succeeded apply-candidate cells.
+        let mut empty_patch_a = artifact("patch-a", "patch", json!({}));
+        empty_patch_a.size_bytes = Some(0);
+        let mut empty_patch_b = artifact("patch-b", "patch", json!({}));
+        empty_patch_b.size_bytes = Some(0);
+        let mut empty_patch_c = artifact("patch-c", "patch", json!({}));
+        empty_patch_c.size_bytes = Some(0);
+
+        let report = aggregate_agent_task_outcomes(&[
+            outcome(
+                "cell-1",
+                AgentTaskOutcomeStatus::Succeeded,
+                vec![empty_patch_a],
+            ),
+            outcome(
+                "cell-2",
+                AgentTaskOutcomeStatus::Succeeded,
+                vec![empty_patch_b],
+            ),
+            outcome(
+                "cell-3",
+                AgentTaskOutcomeStatus::Succeeded,
+                vec![empty_patch_c],
+            ),
+        ]);
+
+        assert_eq!(report.summary.total, 3);
+        assert_eq!(report.summary.apply_candidates, 0);
+        assert_eq!(report.apply_candidates.len(), 0);
+        assert_eq!(report.summary.review_candidates, 3);
+        assert!(report.review_candidates.iter().all(|candidate| candidate
+            .reason
+            .starts_with("patch artifact was empty (0 bytes)")));
     }
 
     #[test]

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -1519,10 +1519,26 @@ fn render_value_templates(value: &mut Value, bindings: &HashMap<String, Value>) 
 }
 
 fn provider_run_result_is_empty_incomplete(result: &Value) -> bool {
-    result.get("completed").and_then(Value::as_bool) == Some(false)
-        && value_text_is_empty(result.get("reply"))
-        && !has_assistant_message(result)
-        && !has_tool_calls(result)
+    // The provider run state may live at the top level of the result object or
+    // nested under an `outputs` key (the shape Codebox reports today, e.g.
+    // `{ "success": true, "status": "completed", "outputs": { "completed": false, ... } }`).
+    // Detect an incomplete, no-output run at either level so cook does not treat
+    // a cell that never produced an assistant/tool interaction as successful.
+    if empty_incomplete_run_state(result) {
+        return true;
+    }
+    result
+        .get("outputs")
+        .filter(|value| value.is_object())
+        .map(empty_incomplete_run_state)
+        .unwrap_or(false)
+}
+
+fn empty_incomplete_run_state(state: &Value) -> bool {
+    state.get("completed").and_then(Value::as_bool) == Some(false)
+        && value_text_is_empty(state.get("reply"))
+        && !has_assistant_message(state)
+        && !has_tool_calls(state)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2400,6 +2416,76 @@ mod tests {
     }
 
     #[test]
+    fn incomplete_nested_outputs_provider_result_is_detected() {
+        // Mirrors the Codebox wrapper shape reported in #4613: the provider claims
+        // top-level success/completed, but `outputs.completed` is false, the reply
+        // is empty, and `messages` only contains the initial user prompt.
+        let result = json!({
+            "success": true,
+            "status": "completed",
+            "outputs": {
+                "reply": "",
+                "messages": [{ "role": "user", "content": "cook the issue" }],
+                "completed": false,
+                "run_id": "run_abc"
+            },
+            "structured_artifacts": [],
+            "diagnostics": {}
+        });
+
+        assert!(provider_run_result_is_empty_incomplete(&result));
+    }
+
+    #[test]
+    fn completed_provider_result_with_assistant_message_is_not_flagged() {
+        let result = json!({
+            "success": true,
+            "status": "completed",
+            "outputs": {
+                "reply": "patched src/lib.rs",
+                "messages": [
+                    { "role": "user", "content": "cook the issue" },
+                    { "role": "assistant", "content": "applied the fix" }
+                ],
+                "completed": true,
+                "run_id": "run_abc"
+            }
+        });
+
+        assert!(!provider_run_result_is_empty_incomplete(&result));
+    }
+
+    #[test]
+    fn flat_incomplete_provider_result_is_still_detected() {
+        let result = json!({
+            "completed": false,
+            "reply": "",
+            "messages": [],
+            "tool_calls": []
+        });
+
+        assert!(provider_run_result_is_empty_incomplete(&result));
+    }
+
+    #[test]
+    fn incomplete_nested_outputs_executor_result_fails_when_retries_are_unavailable() {
+        let scheduler = AgentTaskScheduler::new(NestedOutputsIncompleteExecutor);
+
+        let aggregate = scheduler.run(plan_with_tasks(1));
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+        assert_eq!(aggregate.totals.failed, 1);
+        assert_eq!(
+            aggregate.outcomes[0].status,
+            AgentTaskOutcomeStatus::ProviderError
+        );
+        assert_eq!(
+            aggregate.outcomes[0].diagnostics[0].class,
+            "agent_task.executor_incomplete_empty_result"
+        );
+    }
+
+    #[test]
     fn templates_prior_output_into_downstream_task_request() {
         let observed = Arc::new(Mutex::new(Vec::new()));
         let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
@@ -2920,6 +3006,18 @@ mod tests {
         }
     }
 
+    struct NestedOutputsIncompleteExecutor;
+
+    impl AgentTaskExecutorAdapter for NestedOutputsIncompleteExecutor {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            nested_outputs_incomplete_outcome(request.task_id)
+        }
+    }
+
     impl AgentTaskExecutorAdapter for NestedFailedStatusExecutor {
         fn execute(
             &self,
@@ -3121,6 +3219,28 @@ mod tests {
                 "reply": "",
                 "messages": [],
                 "tool_calls": []
+            }
+        });
+        outcome
+    }
+
+    fn nested_outputs_incomplete_outcome(task_id: String) -> AgentTaskOutcome {
+        let mut outcome = outcome(task_id, AgentTaskOutcomeStatus::Succeeded);
+        outcome.summary = Some(
+            "Agent sandbox completed successfully without actionable file changes.".to_string(),
+        );
+        outcome.outputs = json!({
+            "provider_run_result": {
+                "success": true,
+                "status": "completed",
+                "outputs": {
+                    "reply": "",
+                    "messages": [{ "role": "user", "content": "cook the issue" }],
+                    "completed": false,
+                    "run_id": "run_abc"
+                },
+                "structured_artifacts": [],
+                "diagnostics": {}
             }
         });
         outcome


### PR DESCRIPTION
## Summary

Cook runs falsely reported `succeeded` / `Patch candidates: 3` when **every** patch artifact was empty or the provider never completed an assistant/tool interaction. Both issues share a root cause: cook counted no-output cells as successful.

### #4610 — empty patch artifacts counted as promotion candidates
- Aggregate `is_apply_artifact` now requires **positive evidence of content** (`size_bytes` is `Some(n > 0)`); unknown-size (`None`) patches route to review instead of being auto-promoted (previously `None != Some(0)` treated them as valid candidates).
- **Per-cell reasons** now distinguish empty (0-byte) vs unknown-size patches.
- Cook/status summaries surface `no_patch_produced` when a `succeeded` run produced zero candidates, and stop advertising `agent-task review` for empty runs.
- Summary artifact counting made consistent with the aggregate rule (`count_apply_artifacts`).

### #4613 — incomplete provider runs treated as successful no-ops
- `provider_run_result_is_empty_incomplete` now inspects the **nested `outputs` object** the Codebox wrapper reports (`completed`/`reply`/`messages` live under `outputs`), not just the top level. A cell with `completed:false`, empty reply, and only the initial user prompt is now marked `ProviderError` instead of `Succeeded`.

## Root-cause shape (#4613)
The real provider result nests its run state under `outputs`:
```json
{ "success": true, "status": "completed",
  "outputs": { "reply": "", "messages": [{"role":"user",...}], "completed": false } }
```
The previous detector only checked top-level `completed`/`reply`, so it missed this shape entirely.

## Tests
- `agent_task_scheduler`: nested-outputs detector (unit + end-to-end scheduler), flat-shape regression, completed-with-assistant-message not flagged.
- `agent_task_aggregate`: empty/unknown-size routing to review with reasons; 3-cell all-empty scenario → 0 apply candidates.
- `agent_task_summary`: cook `no_patch_produced` status, unknown-size-as-zero-candidates, existing candidate flow preserved.

## Verification
- `cargo fmt --check` ✅
- `cargo clippy --lib` ✅ (no new warnings)
- 48 targeted tests green (aggregate, summary, scheduler #4613, promotion, review, cook-loop consumers)

## Notes
- CHANGELOG not edited manually — the installed homeboy (v0.229.0) has no `changelog changelog add` subcommand; the entry should be added via a newer homeboy on merge (consistent with prior PRs).

Refs #4610, #4613