### PR TITLE
fix: do not report cook success when all patch artifacts are empty

### DIFF
--- a/src/commands/agent_task_summary.rs
+++ b/src/commands/agent_task_summary.rs
@@ -31,7 +31,7 @@ pub(crate) fn render_agent_task_summary(
 
 fn render_cook_summary(payload: &Value) -> Option<String> {
     let run_id = string_value(payload, &["run_id"])?;
-    let state = string_value(payload, &["state"])
+    let raw_state = string_value(payload, &["state"])
         .or_else(|| string_value(payload, &["record", "state"]))
         .unwrap_or("unknown");
     let tasks_planned = usize_value(payload, &["task_count"])
@@ -41,6 +41,7 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
     let aggregate_path = string_value(payload, &["aggregate_path"])
         .or_else(|| string_value(payload, &["record", "aggregate_path"]));
     let patch_candidates = patch_candidate_count(payload);
+    let state = effective_run_state(raw_state, tasks_attempted, patch_candidates);
     let artifact_count = aggregate_artifact_count(payload);
     let first_artifact = string_value(
         payload,
@@ -78,10 +79,11 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
 
 fn render_status_summary(payload: &Value) -> Option<String> {
     let run_id = string_value(payload, &["run_id"])?;
-    let state = string_value(payload, &["state"]).unwrap_or("unknown");
+    let raw_state = string_value(payload, &["state"]).unwrap_or("unknown");
     let tasks_planned = array_len(payload, &["tasks"]).unwrap_or(0);
     let tasks_attempted = status_attempted_task_count(payload);
     let patch_candidates = patch_candidate_count(payload);
+    let state = effective_run_state(raw_state, tasks_attempted, patch_candidates);
     let artifact_count = array_len(payload, &["artifact_refs"]).unwrap_or(0);
     let aggregate_path = string_value(payload, &["aggregate_path"]);
 
@@ -233,10 +235,24 @@ fn is_apply_artifact(artifact: &Value) -> bool {
     let Some(kind) = string_value(artifact, &["kind"]) else {
         return false;
     };
-    matches!(
+    let apply_kind = matches!(
         kind,
         "patch" | "diff" | "change_artifact" | "workspace_patch" | "artifact"
-    ) && usize_value(artifact, &["size_bytes"]) != Some(0)
+    );
+    // Require positive evidence of content: an unknown or zero size must not be
+    // counted as a patch candidate (#4610).
+    apply_kind && matches!(usize_value(artifact, &["size_bytes"]), Some(size) if size > 0)
+}
+
+/// A run whose lifecycle state is `succeeded` but that produced zero promotion
+/// candidates did not actually patch anything. Surface that honestly as
+/// `no_patch_produced` instead of advertising success (#4610).
+fn effective_run_state(raw_state: &str, tasks_attempted: usize, patch_candidates: usize) -> &str {
+    if raw_state == "succeeded" && tasks_attempted > 0 && patch_candidates == 0 {
+        "no_patch_produced"
+    } else {
+        raw_state
+    }
 }
 
 fn status_attempted_task_count(payload: &Value) -> usize {
@@ -295,7 +311,7 @@ mod tests {
             "aggregate": {
                 "outcomes": [{
                     "task_id": "homeboy-4345",
-                    "artifacts": [{ "id": "patch", "kind": "patch", "path": "/tmp/patch.diff" }]
+                    "artifacts": [{ "id": "patch", "kind": "patch", "path": "/tmp/patch.diff", "size_bytes": 128 }]
                 }]
             }
         });
@@ -309,6 +325,56 @@ mod tests {
         assert!(summary.contains("First artifact: /tmp/patch.diff\n"));
         assert!(summary.contains("Next: homeboy agent-task review homeboy-4345\n"));
         assert!(!summary.contains("{\n"));
+    }
+
+    #[test]
+    fn cook_summary_reports_no_patch_produced_when_all_cells_are_empty() {
+        // Reproduces the #4610 cook summary: 3 succeeded cells, but every patch
+        // artifact is 0 bytes. The summary must not advertise success.
+        let payload = json!({
+            "run_id": "agent-task-abe47e4d",
+            "state": "succeeded",
+            "task_count": 3,
+            "aggregate_path": "/tmp/aggregate.json",
+            "aggregate_review": {
+                "summary": { "apply_candidates": 0 }
+            },
+            "aggregate": {
+                "outcomes": [
+                    { "task_id": "cell-1", "artifacts": [{ "id": "patch", "kind": "patch", "path": "/tmp/patch.diff", "size_bytes": 0 }] },
+                    { "task_id": "cell-2", "artifacts": [{ "id": "patch", "kind": "patch", "path": "/tmp/patch.diff", "size_bytes": 0 }] },
+                    { "task_id": "cell-3", "artifacts": [{ "id": "patch", "kind": "patch", "path": "/tmp/patch.diff", "size_bytes": 0 }] }
+                ]
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
+
+        assert!(summary.contains("Status: no_patch_produced\n"));
+        assert!(summary.contains("Patch candidates: 0\n"));
+        assert!(summary.contains("Next: homeboy agent-task logs agent-task-abe47e4d\n"));
+        assert!(!summary.contains("Next: homeboy agent-task review"));
+    }
+
+    #[test]
+    fn cook_summary_treats_unknown_size_patch_as_zero_candidates() {
+        let payload = json!({
+            "run_id": "homeboy-4345",
+            "state": "succeeded",
+            "task_count": 1,
+            "aggregate": {
+                "outcomes": [{
+                    "task_id": "homeboy-4345",
+                    "artifacts": [{ "id": "patch", "kind": "patch", "path": "/tmp/patch.diff" }]
+                }]
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
+
+        assert!(summary.contains("Status: no_patch_produced\n"));
+        assert!(summary.contains("Patch candidates: 0\n"));
+        assert!(summary.contains("Next: homeboy agent-task logs homeboy-4345\n"));
     }
 
     #[test]

--- a/src/core/agent_task_aggregate.rs
+++ b/src/core/agent_task_aggregate.rs
@@ -357,9 +357,8 @@ fn reconcile_outcome(
             }
             AgentTaskOutcomeStatus::Cancelled => "cancelled task needs review".to_string(),
             AgentTaskOutcomeStatus::Failed => "failed task needs review".to_string(),
-            AgentTaskOutcomeStatus::Succeeded => {
-                "succeeded without apply-back artifact".to_string()
-            }
+            AgentTaskOutcomeStatus::Succeeded => empty_or_unknown_patch_reason(outcome)
+                .unwrap_or_else(|| "succeeded without apply-back artifact".to_string()),
             AgentTaskOutcomeStatus::ProviderError
             | AgentTaskOutcomeStatus::Timeout
             | AgentTaskOutcomeStatus::FollowUpIssue => unreachable!("handled above"),
@@ -389,11 +388,52 @@ fn inventory_item(task_id: &str, artifact: &AgentTaskArtifact) -> AgentTaskArtif
 }
 
 fn is_apply_artifact(artifact: &AgentTaskArtifact) -> bool {
-    let apply_kind = matches!(
+    is_apply_kind_artifact(artifact) && artifact_has_nonzero_size(artifact)
+}
+
+fn is_apply_kind_artifact(artifact: &AgentTaskArtifact) -> bool {
+    matches!(
         artifact.kind.as_str(),
         "patch" | "diff" | "change_artifact" | "workspace_patch" | "artifact"
-    ) || artifact_flag(artifact, "approved");
-    apply_kind && artifact.size_bytes != Some(0)
+    ) || artifact_flag(artifact, "approved")
+}
+
+fn artifact_has_nonzero_size(artifact: &AgentTaskArtifact) -> bool {
+    // A patch counts as a promotion candidate only when there is positive
+    // evidence of non-empty content. An unknown (`None`) size is treated as
+    // empty/uncertain rather than as a valid candidate, so cook runs whose
+    // provider only wrote 0-byte patches (or omitted size entirely) are not
+    // reported as successful fixes (#4610).
+    matches!(artifact.size_bytes, Some(size) if size > 0)
+}
+
+/// When a `Succeeded` outcome produced patch-shaped artifacts that were all
+/// empty or unknown-size, surface a per-cell reason explaining why no apply
+/// candidate was promoted. Returns `None` when there were no patch artifacts or
+/// when at least one had non-empty content.
+fn empty_or_unknown_patch_reason(outcome: &AgentTaskOutcome) -> Option<String> {
+    let patch_artifacts: Vec<&AgentTaskArtifact> = outcome
+        .artifacts
+        .iter()
+        .filter(|artifact| is_apply_kind_artifact(artifact))
+        .collect();
+    if patch_artifacts.is_empty() {
+        return None;
+    }
+    if patch_artifacts
+        .iter()
+        .any(|artifact| artifact_has_nonzero_size(artifact))
+    {
+        return None;
+    }
+    if patch_artifacts
+        .iter()
+        .any(|artifact| artifact.size_bytes == Some(0))
+    {
+        Some("patch artifact was empty (0 bytes); provider produced no file changes".to_string())
+    } else {
+        Some("patch artifact size unknown; cannot confirm changes were produced".to_string())
+    }
 }
 
 fn artifact_flag(artifact: &AgentTaskArtifact, key: &str) -> bool {
@@ -549,7 +589,7 @@ mod tests {
         assert_eq!(report.review_candidates[0].task_id, "empty-patch");
         assert_eq!(
             report.review_candidates[0].reason,
-            "succeeded without apply-back artifact"
+            "patch artifact was empty (0 bytes); provider produced no file changes"
         );
     }
 
@@ -573,7 +613,10 @@ mod tests {
     }
 
     #[test]
-    fn aggregate_outcomes_keeps_unknown_size_patch_apply_candidate() {
+    fn aggregate_outcomes_routes_unknown_size_patch_to_review() {
+        // An unknown-size patch cannot be confirmed non-empty, so it must not be
+        // auto-promoted as an apply candidate (#4610). It routes to review with a
+        // reason that explains the uncertainty.
         let mut unknown_size_patch = artifact("legacy-patch", "patch", json!({}));
         unknown_size_patch.size_bytes = None;
 
@@ -583,8 +626,53 @@ mod tests {
             vec![unknown_size_patch],
         )]);
 
-        assert_eq!(report.summary.apply_candidates, 1);
-        assert_eq!(report.apply_candidates[0].task_id, "legacy-patch");
+        assert!(report.apply_candidates.is_empty());
+        assert_eq!(report.summary.apply_candidates, 0);
+        assert_eq!(report.summary.review_candidates, 1);
+        assert_eq!(report.review_candidates[0].task_id, "legacy-patch");
+        assert_eq!(
+            report.review_candidates[0].reason,
+            "patch artifact size unknown; cannot confirm changes were produced"
+        );
+    }
+
+    #[test]
+    fn aggregate_outcomes_reports_no_patch_produced_when_all_cells_empty() {
+        // Reproduces the #4610 scenario: 3 succeeded cells, each with a 0-byte
+        // patch artifact. The cook run should report zero apply candidates and no
+        // succeeded apply-candidate cells.
+        let mut empty_patch_a = artifact("patch-a", "patch", json!({}));
+        empty_patch_a.size_bytes = Some(0);
+        let mut empty_patch_b = artifact("patch-b", "patch", json!({}));
+        empty_patch_b.size_bytes = Some(0);
+        let mut empty_patch_c = artifact("patch-c", "patch", json!({}));
+        empty_patch_c.size_bytes = Some(0);
+
+        let report = aggregate_agent_task_outcomes(&[
+            outcome(
+                "cell-1",
+                AgentTaskOutcomeStatus::Succeeded,
+                vec![empty_patch_a],
+            ),
+            outcome(
+                "cell-2",
+                AgentTaskOutcomeStatus::Succeeded,
+                vec![empty_patch_b],
+            ),
+            outcome(
+                "cell-3",
+                AgentTaskOutcomeStatus::Succeeded,
+                vec![empty_patch_c],
+            ),
+        ]);
+
+        assert_eq!(report.summary.total, 3);
+        assert_eq!(report.summary.apply_candidates, 0);
+        assert_eq!(report.apply_candidates.len(), 0);
+        assert_eq!(report.summary.review_candidates, 3);
+        assert!(report.review_candidates.iter().all(|candidate| candidate
+            .reason
+            .starts_with("patch artifact was empty (0 bytes)")));
     }
 
     #[test]

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -1519,10 +1519,26 @@ fn render_value_templates(value: &mut Value, bindings: &HashMap<String, Value>) 
 }
 
 fn provider_run_result_is_empty_incomplete(result: &Value) -> bool {
-    result.get("completed").and_then(Value::as_bool) == Some(false)
-        && value_text_is_empty(result.get("reply"))
-        && !has_assistant_message(result)
-        && !has_tool_calls(result)
+    // The provider run state may live at the top level of the result object or
+    // nested under an `outputs` key (the shape Codebox reports today, e.g.
+    // `{ "success": true, "status": "completed", "outputs": { "completed": false, ... } }`).
+    // Detect an incomplete, no-output run at either level so cook does not treat
+    // a cell that never produced an assistant/tool interaction as successful.
+    if empty_incomplete_run_state(result) {
+        return true;
+    }
+    result
+        .get("outputs")
+        .filter(|value| value.is_object())
+        .map(empty_incomplete_run_state)
+        .unwrap_or(false)
+}
+
+fn empty_incomplete_run_state(state: &Value) -> bool {
+    state.get("completed").and_then(Value::as_bool) == Some(false)
+        && value_text_is_empty(state.get("reply"))
+        && !has_assistant_message(state)
+        && !has_tool_calls(state)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2400,6 +2416,76 @@ mod tests {
     }
 
     #[test]
+    fn incomplete_nested_outputs_provider_result_is_detected() {
+        // Mirrors the Codebox wrapper shape reported in #4613: the provider claims
+        // top-level success/completed, but `outputs.completed` is false, the reply
+        // is empty, and `messages` only contains the initial user prompt.
+        let result = json!({
+            "success": true,
+            "status": "completed",
+            "outputs": {
+                "reply": "",
+                "messages": [{ "role": "user", "content": "cook the issue" }],
+                "completed": false,
+                "run_id": "run_abc"
+            },
+            "structured_artifacts": [],
+            "diagnostics": {}
+        });
+
+        assert!(provider_run_result_is_empty_incomplete(&result));
+    }
+
+    #[test]
+    fn completed_provider_result_with_assistant_message_is_not_flagged() {
+        let result = json!({
+            "success": true,
+            "status": "completed",
+            "outputs": {
+                "reply": "patched src/lib.rs",
+                "messages": [
+                    { "role": "user", "content": "cook the issue" },
+                    { "role": "assistant", "content": "applied the fix" }
+                ],
+                "completed": true,
+                "run_id": "run_abc"
+            }
+        });
+
+        assert!(!provider_run_result_is_empty_incomplete(&result));
+    }
+
+    #[test]
+    fn flat_incomplete_provider_result_is_still_detected() {
+        let result = json!({
+            "completed": false,
+            "reply": "",
+            "messages": [],
+            "tool_calls": []
+        });
+
+        assert!(provider_run_result_is_empty_incomplete(&result));
+    }
+
+    #[test]
+    fn incomplete_nested_outputs_executor_result_fails_when_retries_are_unavailable() {
+        let scheduler = AgentTaskScheduler::new(NestedOutputsIncompleteExecutor);
+
+        let aggregate = scheduler.run(plan_with_tasks(1));
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+        assert_eq!(aggregate.totals.failed, 1);
+        assert_eq!(
+            aggregate.outcomes[0].status,
+            AgentTaskOutcomeStatus::ProviderError
+        );
+        assert_eq!(
+            aggregate.outcomes[0].diagnostics[0].class,
+            "agent_task.executor_incomplete_empty_result"
+        );
+    }
+
+    #[test]
     fn templates_prior_output_into_downstream_task_request() {
         let observed = Arc::new(Mutex::new(Vec::new()));
         let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
@@ -2920,6 +3006,18 @@ mod tests {
         }
     }
 
+    struct NestedOutputsIncompleteExecutor;
+
+    impl AgentTaskExecutorAdapter for NestedOutputsIncompleteExecutor {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            nested_outputs_incomplete_outcome(request.task_id)
+        }
+    }
+
     impl AgentTaskExecutorAdapter for NestedFailedStatusExecutor {
         fn execute(
             &self,
@@ -3121,6 +3219,28 @@ mod tests {
                 "reply": "",
                 "messages": [],
                 "tool_calls": []
+            }
+        });
+        outcome
+    }
+
+    fn nested_outputs_incomplete_outcome(task_id: String) -> AgentTaskOutcome {
+        let mut outcome = outcome(task_id, AgentTaskOutcomeStatus::Succeeded);
+        outcome.summary = Some(
+            "Agent sandbox completed successfully without actionable file changes.".to_string(),
+        );
+        outcome.outputs = json!({
+            "provider_run_result": {
+                "success": true,
+                "status": "completed",
+                "outputs": {
+                    "reply": "",
+                    "messages": [{ "role": "user", "content": "cook the issue" }],
+                    "completed": false,
+                    "run_id": "run_abc"
+                },
+                "structured_artifacts": [],
+                "diagnostics": {}
             }
         });
         outcome


### PR DESCRIPTION
## Summary

Fixes #4610 and #4613 — agent-task cook multi-cell runs reported overall status `succeeded` and `Patch candidates: 3` even though **every** patch artifact was empty (0-byte diffs, empty `changed-files.json`) and provider runs never completed an assistant/tool interaction.

- Closes #4610
- Closes #4613

## Root cause

The cook_loop evaluation already handled `no_changes`; the gap was in **multi-cell status aggregation + patch candidate counting**:

1. `is_apply_artifact` only excluded an explicit `Some(0)` size — an **unknown** (`None`) size counted as a candidate, and the summary path repeated the same loose check.
2. A `succeeded` run with attempted tasks but zero promotion candidates was still rendered as `Status: succeeded`.
3. `provider_run_result_is_empty_incomplete` only inspected the **flat** result object. Codebox reports a nested shape (`{ "success": true, "status": "completed", "outputs": { "completed": false, "reply": "", ... } }`), so incomplete runs slipped through and were treated as successful no-op completions.

## Changes

**#4610 — empty patch detection / honest no-op status**
- `is_apply_artifact` (aggregate + summary) now requires **positive non-zero size** evidence. A `None` or zero size no longer counts as a promotion candidate — fail closed rather than advertise success on uncertain data.
- A `Succeeded` outcome whose patch-shaped artifacts were all empty/unknown now routes to **review** with an explanatory per-cell reason (`patch artifact was empty (0 bytes)...` / `patch artifact size unknown...`).
- New `effective_run_state` surfaces a `succeeded` run with attempted tasks but zero patch candidates as **`no_patch_produced`** in both cook and status summaries, and points the next step at `agent-task logs` (not `review`).

**#4613 — nested-outputs incomplete provider runs**
- `provider_run_result_is_empty_incomplete` now also inspects the nested `outputs` object, so a cell that never produced an assistant/tool interaction is reclassified to `ProviderError` (and thus a retry candidate) instead of being treated as a successful no-op completion.

## Tests

Adds regression tests across all three modules:
- `aggregate_outcomes_reports_no_patch_produced_when_all_cells_empty`
- `aggregate_outcomes_routes_unknown_size_patch_to_review` (replaces the old unknown-size-keeps-candidate test)
- `cook_summary_reports_no_patch_produced_when_all_cells_are_empty`
- `cook_summary_treats_unknown_size_patch_as_zero_candidates`
- `incomplete_nested_outputs_provider_result_is_detected`
- `completed_provider_result_with_assistant_message_is_not_flagged`
- `flat_incomplete_provider_result_is_still_detected`
- `incomplete_nested_outputs_executor_result_fails_when_retries_are_unavailable`

`cargo fmt` clean, `cargo clippy --lib` clean (no new warnings), all targeted tests pass.

## Notes

No `changelog` entry added: the installed homeboy (v0.230.0) and the current source define no `changelog add` subcommand, and recent fix PRs do not add per-PR changelog entries (the changelog is release-assembled).