### PR TITLE
fix: forward agent task global settings

### DIFF
--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -21,7 +21,7 @@ use crate::core::agent_task_scheduler::{
 };
 use crate::core::agent_task_secrets::validate_secret_env;
 use crate::core::agent_task_service::{aggregate_exit_code, AgentTaskRunResult};
-use crate::core::{config, worktree, Error, Result};
+use crate::core::{config, defaults, worktree, Error, Result};
 
 pub const DISPATCH_RESULT_SCHEMA: &str = "homeboy/agent-task-dispatch/v1";
 
@@ -518,18 +518,34 @@ fn dispatch_provider_config(
     workspace: Option<&DispatchWorkspaceTarget>,
     client_context: &Value,
 ) -> Result<Value> {
-    let config = if let Some(spec) = &request.provider_config {
+    let mut config = Value::Object(defaults::load_config().settings.into_iter().collect());
+    if let Some(spec) = &request.provider_config {
         let raw = read_text_spec(spec, "provider-config")?;
-        serde_json::from_str::<Value>(&raw).map_err(|error| {
+        let explicit = serde_json::from_str::<Value>(&raw).map_err(|error| {
             Error::validation_invalid_json(
                 error,
                 Some("agent-task dispatch provider config".to_string()),
                 Some(raw),
             )
-        })?
-    } else {
-        serde_json::json!({})
-    };
+        })?;
+
+        if !explicit.is_object() {
+            return Err(Error::validation_invalid_argument(
+                "provider-config",
+                "agent-task dispatch --provider-config must resolve to a JSON object",
+                None,
+                None,
+            ));
+        }
+
+        let map = config.as_object_mut().expect("global settings object");
+        map.extend(
+            explicit
+                .as_object()
+                .expect("explicit provider config object")
+                .clone(),
+        );
+    }
 
     if !config.is_object() {
         return Err(Error::validation_invalid_argument(
@@ -718,6 +734,7 @@ mod tests {
     };
     use crate::core::agent_task_scheduler::AgentTaskExecutionContext;
     use crate::test_support::with_isolated_home;
+    use std::collections::HashMap;
 
     #[test]
     fn builds_repo_cooking_plan_from_prompt_file_and_client_context() {
@@ -927,6 +944,44 @@ mod tests {
                 "OPENAI_API_KEY".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn dispatch_merges_global_settings_into_executor_config() {
+        with_isolated_home(|_| {
+            defaults::save_config(&defaults::HomeboyConfig {
+                settings: HashMap::from([
+                    (
+                        "provider_plugin_paths".to_string(),
+                        serde_json::json!(["/providers/openai"]),
+                    ),
+                    (
+                        "wp_codebox_provider".to_string(),
+                        serde_json::json!("codex"),
+                    ),
+                ]),
+                ..defaults::HomeboyConfig::default()
+            })
+            .expect("save config");
+
+            let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+                prompt: Some("Cook with configured provider defaults.".to_string()),
+                provider_config: Some(
+                    serde_json::json!({ "wp_codebox_provider": "opencode" }).to_string(),
+                ),
+                ..DispatchRequestOverrides::default()
+            }))
+            .expect("dispatch plan");
+
+            assert_eq!(
+                plan.tasks[0].executor.config["provider_plugin_paths"],
+                serde_json::json!(["/providers/openai"])
+            );
+            assert_eq!(
+                plan.tasks[0].executor.config["wp_codebox_provider"],
+                "opencode"
+            );
+        });
     }
 
     #[test]

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
 
@@ -30,6 +31,10 @@ pub struct HomeboyConfig {
     #[serde(default)]
     pub agent_task: AgentTaskConfig,
 
+    /// Extension and executor settings addressed through `/settings/...`.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub settings: HashMap<String, Value>,
+
     /// Directory where persisted run artifacts are copied.
     ///
     /// Defaults to the machine-local product data directory under
@@ -52,6 +57,7 @@ impl Default for HomeboyConfig {
             lab: LabConfig::default(),
             triage: TriageConfig::default(),
             agent_task: AgentTaskConfig::default(),
+            settings: HashMap::new(),
             artifact_root: None,
             update_check: true,
         }
@@ -422,6 +428,28 @@ mod tests {
         let secret = config.agent_task.secrets.get("TOKEN").unwrap();
         assert_eq!(secret.source, "config");
         assert_eq!(secret.value.as_deref(), Some("redacted-test-token"));
+    }
+
+    #[test]
+    fn homeboy_config_preserves_extension_settings() {
+        let config: HomeboyConfig = serde_json::from_str(
+            r#"{
+                "settings": {
+                    "wp_codebox_provider": "codex",
+                    "provider_plugin_paths": ["/providers/openai"]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.settings.get("wp_codebox_provider"),
+            Some(&Value::String("codex".to_string()))
+        );
+        assert_eq!(
+            config.settings["provider_plugin_paths"][0],
+            Value::String("/providers/openai".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Preserve arbitrary global `settings` entries in `homeboy.json` so `homeboy config set /settings/...` survives save/load.
- Merge global settings into agent-task executor config, while preserving explicit `--provider-config` override precedence.
- Add regression coverage for settings persistence and dispatch forwarding.

## Testing
- `cargo test settings -- --nocapture`
- `cargo build --bin homeboy`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WPSG/Homeboy E2E blocker, drafted the config persistence and dispatch-forwarding fix, and ran focused verification. Chris remains responsible for review and merge.
