### PR TITLE
Surface degraded tunnel service status

### DIFF
--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -176,7 +176,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             "runner",
             message,
             Some(runner_id.to_string()),
-            Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, refactor source runs, and tunnel preview-consumer run.".to_string()]),
+            Some(unsupported_runner_hints(runner_id, request.normalized_args)),
         )
     };
     let mut plan = base_lab_plan(request.command.as_ref());
@@ -335,6 +335,36 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     }
 
     run_lab_offload_inner(request, selection, contract, plan, messages)
+}
+
+fn unsupported_runner_hints(runner_id: &str, normalized_args: &[String]) -> Vec<String> {
+    let mut hints = vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, refactor source runs, tunnel preview-consumer run, and tunnel service start.".to_string()];
+
+    if let Some(service_command) = tunnel_service_command(normalized_args) {
+        hints.push(format!(
+            "`tunnel service {service_command} --runner {runner_id}` is not routed directly; inspect runner-side tunnel state with `homeboy runner exec {runner_id} --ssh --raw -- homeboy tunnel service {service_command} ...` until service inspection supports native --runner routing."
+        ));
+    }
+
+    hints
+}
+
+fn tunnel_service_command(normalized_args: &[String]) -> Option<&str> {
+    normalized_args.windows(3).find_map(|window| {
+        let [first, second, third] = window else {
+            return None;
+        };
+        if first == "tunnel" && second == "service" {
+            match third.as_str() {
+                "list" | "show" | "status" | "url" | "expose" | "set" | "remove" => {
+                    Some(third.as_str())
+                }
+                _ => None,
+            }
+        } else {
+            None
+        }
+    })
 }
 
 fn run_lab_offload_inner(
@@ -3037,5 +3067,38 @@ mod tests {
         assert_eq!(plan.steps[0].id, "lab.select_runner");
         assert_eq!(plan.steps[0].status, PlanStepStatus::Skipped);
         assert_eq!(metadata.expect("metadata")["status"], "skipped");
+    }
+
+    #[test]
+    fn unsupported_runner_error_guides_tunnel_service_inspection() {
+        let outcome = execute_lab_offload(LabOffloadRequest {
+            command: None,
+            normalized_args: &[
+                "homeboy".to_string(),
+                "tunnel".to_string(),
+                "service".to_string(),
+                "status".to_string(),
+                "wpcom-ai-manual-held".to_string(),
+            ],
+            explicit_runner: Some("homeboy-lab"),
+            force_hot: false,
+            allow_local_hot: false,
+            allow_local_fallback: false,
+            allow_dirty_lab_workspace: false,
+            capture_patch: false,
+            mutation_flag: None,
+        });
+
+        let Err(err) = outcome else {
+            panic!("unsupported --runner command should fail");
+        };
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        let tried = err.details["tried"].as_array().expect("tried hints");
+        assert!(tried.iter().any(|hint| hint
+            .as_str()
+            .is_some_and(|hint| hint.contains("homeboy runner exec homeboy-lab"))));
+        assert!(tried.iter().any(|hint| hint
+            .as_str()
+            .is_some_and(|hint| hint.contains("tunnel service status"))));
     }
 }

--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -182,6 +182,8 @@ pub struct ServiceTunnelStatus {
     pub declared: bool,
     pub running: bool,
     pub lifecycle: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub degraded_reason: Option<String>,
     pub local_url: String,
     pub remote_target: String,
     pub policy: ServiceTunnelPolicy,
@@ -339,6 +341,8 @@ pub struct ServiceTunnelEvidence {
 pub struct ServiceTunnelBackendStatus {
     pub backend: ServiceTunnelTunnelBackend,
     pub active: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub process: Option<ServiceTunnelProcessStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -763,6 +767,12 @@ pub fn local_url(id: &str) -> Result<String> {
 fn service_tunnel_status(tunnel: &ServiceTunnel) -> Result<ServiceTunnelStatus> {
     let state = refresh_runtime_state(&tunnel.id)?;
     let running = state.as_ref().is_some_and(runtime_state_is_running);
+    let backend_running = state.as_ref().is_some_and(backend_state_is_running);
+    let degraded_reason = if !running && backend_running {
+        Some("local-origin-process-exited".to_string())
+    } else {
+        None
+    };
     let health = state.as_ref().map(check_runtime_health);
     let readiness = state.as_ref().map(check_runtime_readiness);
     let evidence = state.as_ref().map(runtime_evidence);
@@ -774,7 +784,16 @@ fn service_tunnel_status(tunnel: &ServiceTunnel) -> Result<ServiceTunnelStatus> 
     });
     let backend = state.as_ref().map(|state| ServiceTunnelBackendStatus {
         backend: state.backend.clone(),
-        active: backend_state_is_running(state) || state.preview_identity.public_url.is_some(),
+        active: backend_running || state.preview_identity.public_url.is_some(),
+        active_reason: if backend_running && !running {
+            Some("backend-process-running-after-local-origin-exit".to_string())
+        } else if backend_running {
+            Some("backend-process-running".to_string())
+        } else if state.preview_identity.public_url.is_some() {
+            Some("public-url-declared".to_string())
+        } else {
+            None
+        },
         process: state.backend_process.as_ref().map(|backend| {
             let running = backend_process_is_running(backend);
             ServiceTunnelProcessStatus {
@@ -802,7 +821,15 @@ fn service_tunnel_status(tunnel: &ServiceTunnel) -> Result<ServiceTunnelStatus> 
         },
         declared: true,
         running,
-        lifecycle: if running { "running" } else { "declared" }.to_string(),
+        lifecycle: if degraded_reason.is_some() {
+            "degraded"
+        } else if running {
+            "running"
+        } else {
+            "declared"
+        }
+        .to_string(),
+        degraded_reason,
         local_url: local_url_for(tunnel),
         remote_target: format!("{}:{}", tunnel.target.host, tunnel.target.port),
         policy: tunnel.policy.clone(),
@@ -1427,6 +1454,10 @@ fn refresh_runtime_state(id: &str) -> Result<Option<ServiceTunnelRuntimeState>> 
         return Ok(None);
     };
     if runtime_state_is_running(&state) {
+        return Ok(Some(state));
+    }
+
+    if backend_state_is_running(&state) {
         return Ok(Some(state));
     }
 

--- a/src/core/tunnel_tests.rs
+++ b/src/core/tunnel_tests.rs
@@ -620,6 +620,83 @@ fn command_backend_records_public_url_and_cleans_up_backend_process() {
 }
 
 #[test]
+fn status_reports_degraded_when_backend_outlives_service_process() {
+    test_support::with_isolated_home(|_| {
+        create_server();
+        let port = reserve_loopback_port();
+        expose(ExposeServiceTunnelSpec {
+            id: "orphaned-backend-preview".to_string(),
+            server_id: "private-host".to_string(),
+            target: ServiceTunnelTarget {
+                host: "127.0.0.1".to_string(),
+                port,
+            },
+            scheme: "http".to_string(),
+            local_port: Some(port),
+            auth: ServiceTunnelAuth {
+                mode: ServiceTunnelAuthMode::BearerEnv,
+                env_var: Some("ORPHANED_BACKEND_PREVIEW_TOKEN".to_string()),
+                header: Some("Authorization".to_string()),
+            },
+            policy: ServiceTunnelPolicy {
+                exposure: ServiceTunnelExposure::PrivateLoopback,
+                require_auth: true,
+                allowed_clients: Vec::new(),
+                preview: ServiceTunnelPreviewPolicy::default(),
+                native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
+            },
+            description: None,
+        })
+        .expect("expose service");
+
+        let started = start(StartServiceTunnelSpec {
+            id: "orphaned-backend-preview".to_string(),
+            command: python_listener_command(
+                port,
+                "end=time.time()+1.0\nwhile time.time()<end:\n s.settimeout(max(0.01,end-time.time()))\n try:\n  conn,_=s.accept(); conn.close()\n except Exception:\n  pass",
+            ),
+            cwd: None,
+            env: BTreeMap::new(),
+            host: Some("127.0.0.1".to_string()),
+            port: Some(port),
+            scheme: Some("http".to_string()),
+            health_url: None,
+            health_path: None,
+            readiness_timeout_secs: 2,
+            backend: ServiceTunnelTunnelBackend::Command,
+            backend_command: Some("while true; do sleep 1; done".to_string()),
+            backend_public_url: Some("https://orphaned-backend.example.test".to_string()),
+            source_run_id: None,
+            source_workflow_id: None,
+            readiness_kind: ServiceTunnelReadinessKind::Preview,
+            readiness_checks: vec![ServiceTunnelReadinessCheck::TcpListener],
+        })
+        .expect("start preview service");
+
+        assert!(started.running);
+        std::thread::sleep(std::time::Duration::from_millis(1200));
+
+        let refreshed = status("orphaned-backend-preview").expect("status refresh");
+        assert!(!refreshed.running);
+        assert_eq!(refreshed.lifecycle, "degraded");
+        assert_eq!(
+            refreshed.degraded_reason.as_deref(),
+            Some("local-origin-process-exited")
+        );
+        let backend = refreshed.tunnel_backend.expect("backend status");
+        assert!(backend.active);
+        assert_eq!(
+            backend.active_reason.as_deref(),
+            Some("backend-process-running-after-local-origin-exit")
+        );
+
+        let stopped = stop("orphaned-backend-preview").expect("stop degraded service");
+        assert!(!stopped.running);
+        assert!(stopped.tunnel_backend.is_none());
+    });
+}
+
+#[test]
 fn preview_policy_decisions_match_workflow_outcomes() {
     let now = chrono::DateTime::parse_from_rfc3339("2026-06-07T12:00:00Z")
         .expect("timestamp")


### PR DESCRIPTION
## Summary
- report `tunnel service status` as `degraded` when the supervised local service has exited while its public tunnel backend is still running
- add explicit `degraded_reason` and backend `active_reason` fields for orphaned-preview diagnostics
- add a `--runner` validation hint for unsupported `tunnel service` inspection commands, pointing operators to `homeboy runner exec ... homeboy tunnel service ...`

Fixes #4736.
Fixes #4737.

## Tests
- `cargo fmt`
- `cargo test status_reports_degraded_when_backend_outlives_service_process`
- `cargo test unsupported_runner_error_guides_tunnel_service_inspection`
- `cargo test core::tunnel_tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Homeboy tunnel status and runner UX changes, added regression tests, and ran focused verification. Chris reviewed/requested the issue and PR flow.
