### PR TITLE
fix(upgrade): warn on stale symlinked extension clones after sudo upgrade

### DIFF
--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -184,6 +184,7 @@ mod tests {
             extensions_skipped: Vec::new(),
             runners_updated: Vec::new(),
             runners_skipped: Vec::new(),
+            extensions_unrefreshed: Vec::new(),
         }
     }
 }

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -1,7 +1,7 @@
 use crate::core::defaults;
 use crate::core::error::{Error, Result};
 use crate::core::{build_identity, extension, git};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use super::constants::{CRATES_IO_API, GITHUB_RELEASES_API, VERSION};
@@ -212,6 +212,7 @@ pub fn run_upgrade_with_method(
                 upgraded: false,
                 message: "Already at latest version".to_string(),
                 restart_required: false,
+                extensions_unrefreshed: warn_unrefreshed_symlinked_extensions(&extensions_updated),
                 extensions_updated,
                 extensions_skipped,
                 runners_updated,
@@ -277,6 +278,7 @@ pub fn run_upgrade_with_method(
             "Upgrade command completed but active binary version could not be verified".to_string()
         },
         restart_required: success && matches!(install_method, InstallMethod::Source),
+        extensions_unrefreshed: warn_unrefreshed_symlinked_extensions(&extensions_updated),
         extensions_updated,
         extensions_skipped,
         runners_updated,
@@ -373,6 +375,178 @@ fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<String>) {
     (updated, skipped)
 }
 
+/// Detect unrefreshed symlinked extension clones and log a loud, actionable
+/// warning for each before returning them in the upgrade result.
+fn warn_unrefreshed_symlinked_extensions(
+    refreshed: &[ExtensionUpgradeEntry],
+) -> Vec<UnrefreshedExtensionWarning> {
+    let warnings = detect_unrefreshed_symlinked_extensions(refreshed);
+    if warnings.is_empty() {
+        return warnings;
+    }
+
+    log_status!(
+        "upgrade",
+        "WARNING: {} symlinked extension clone(s) owned by '{}' were NOT refreshed by this privileged upgrade.",
+        warnings.len(),
+        warnings
+            .first()
+            .map(|w| w.invoking_user.as_str())
+            .unwrap_or("the invoking user"),
+    );
+    log_status!(
+        "upgrade",
+        "  Extension resolution is $HOME-scoped, so a sudo upgrade only refreshes root's copies. Run each recovery command below to bring the symlinked clone(s) current:",
+    );
+    for w in &warnings {
+        let behind = w
+            .behind
+            .map(|n| format!("{} commit(s) behind", n))
+            .unwrap_or_else(|| "behind upstream".to_string());
+        log_status!(
+            "upgrade",
+            "  {} ({}) -> {}: {}",
+            w.extension_id,
+            behind,
+            w.source_path,
+            w.recovery_command,
+        );
+    }
+
+    warnings
+}
+
+/// Detect symlinked extension clones in the *invoking* user's config dir that
+/// this upgrade could not refresh.
+///
+/// Extension resolution is `$HOME`-scoped (`core::paths::extension`). When the
+/// upgrade runs under `sudo`, `$HOME` is root's, so `update_all_extensions()`
+/// only ever visits root's own extension copies. Any non-root user whose
+/// extension entry is a symlink into a workspace-managed git clone is therefore
+/// silently left stale — the upgraded binary ships a fix the user can never
+/// execute because the extension they actually run was never updated.
+///
+/// We do not refresh those clones here: they are owned by a different user and
+/// may carry dirty/unpushed state, so mutating them from a privileged process
+/// is unsafe. Instead we emit a loud, actionable warning with the exact
+/// recovery command. Returns an empty vec when not running under `sudo`, when
+/// the invoking user's config dir is absent, or when nothing is stale.
+fn detect_unrefreshed_symlinked_extensions(
+    refreshed: &[ExtensionUpgradeEntry],
+) -> Vec<UnrefreshedExtensionWarning> {
+    let Some(sudo_user) = std::env::var("SUDO_USER").ok().filter(|u| !u.is_empty()) else {
+        return Vec::new();
+    };
+    // Never re-warn about root's own extensions if SUDO_USER somehow resolves to root.
+    if sudo_user == "root" {
+        return Vec::new();
+    }
+
+    let Some(invoking_home) = home_dir_for_user(&sudo_user) else {
+        return Vec::new();
+    };
+    let extensions_dir = invoking_home
+        .join(".config")
+        .join(crate::core::product_identity::PRODUCT_IDENTITY.config_dirname)
+        .join("extensions");
+    let Ok(entries) = std::fs::read_dir(&extensions_dir) else {
+        return Vec::new();
+    };
+
+    // Git roots already refreshed by the privileged run (canonicalized), so we
+    // don't warn about a clone the upgrade actually updated.
+    let refreshed_roots: std::collections::HashSet<PathBuf> = refreshed
+        .iter()
+        .filter_map(|e| e.git_root.as_deref())
+        .map(|root| {
+            let p = PathBuf::from(root);
+            p.canonicalize().unwrap_or(p)
+        })
+        .collect();
+
+    let mut warnings = Vec::new();
+    for entry in entries.flatten() {
+        let symlink_path = entry.path();
+        let Ok(meta) = std::fs::symlink_metadata(&symlink_path) else {
+            continue;
+        };
+        if !meta.file_type().is_symlink() {
+            continue;
+        }
+        let extension_id = match symlink_path.file_name().and_then(|n| n.to_str()) {
+            Some(name) => name.to_string(),
+            None => continue,
+        };
+        // Extension manifests live in `extensions/<id>.json`; the symlink target
+        // is the source dir. Resolve the symlink to its git working tree.
+        let Ok(target) = std::fs::canonicalize(&symlink_path) else {
+            continue;
+        };
+        let Ok(git_root_str) = git::get_git_root(&target.to_string_lossy()) else {
+            continue;
+        };
+        let git_root = PathBuf::from(&git_root_str);
+        let git_root = git_root.canonicalize().unwrap_or(git_root);
+
+        if refreshed_roots.contains(&git_root) {
+            continue;
+        }
+
+        let behind = git_commits_behind_upstream(&git_root);
+        // Only warn when we can confirm the clone is actually behind. If we
+        // can't determine drift, stay quiet rather than crying wolf.
+        if behind.is_some_and(|n| n > 0) {
+            warnings.push(UnrefreshedExtensionWarning {
+                extension_id,
+                invoking_user: sudo_user.clone(),
+                symlink_path: symlink_path.to_string_lossy().to_string(),
+                source_path: git_root.to_string_lossy().to_string(),
+                behind,
+                recovery_command: format!(
+                    "sudo -u {} git -C {} pull --ff-only",
+                    sudo_user,
+                    git_root.display()
+                ),
+            });
+        }
+    }
+
+    warnings
+}
+
+/// Resolve a user's home directory without pulling in extra crates: prefer the
+/// `getent passwd` database, fall back to `/home/<user>` only if it exists.
+fn home_dir_for_user(user: &str) -> Option<PathBuf> {
+    if let Ok(output) = Command::new("getent").args(["passwd", user]).output() {
+        if output.status.success() {
+            let line = String::from_utf8_lossy(&output.stdout);
+            // passwd format: name:passwd:uid:gid:gecos:home:shell
+            if let Some(home) = line.trim_end().split(':').nth(5) {
+                if !home.is_empty() {
+                    return Some(PathBuf::from(home));
+                }
+            }
+        }
+    }
+    let fallback = PathBuf::from("/home").join(user);
+    fallback.is_dir().then_some(fallback)
+}
+
+/// Number of commits the checked-out branch is behind its upstream, after a
+/// fetch. Returns `None` when the count can't be determined (no upstream, not a
+/// repo, fetch failed). Best-effort and read-only — never mutates the worktree.
+fn git_commits_behind_upstream(git_root: &Path) -> Option<u32> {
+    // Read-only fetch to learn upstream state without touching the worktree.
+    let _ = git::run_git(git_root, &["fetch", "origin"], "git fetch origin");
+    let count = git::run_git(
+        git_root,
+        &["rev-list", "--count", "HEAD..@{upstream}"],
+        "git rev-list behind upstream",
+    )
+    .ok()?;
+    count.trim().parse::<u32>().ok()
+}
+
 fn portable_extension_source_url(result: &crate::core::extension::UpdateResult) -> Option<String> {
     if let Some(git_root) = result.git_root.as_ref() {
         return git::remote_origin_url(git_root);
@@ -408,4 +582,71 @@ pub fn restart_with_new_binary() -> ! {
         err
     );
     std::process::exit(0);
+}
+
+#[cfg(test)]
+mod symlinked_extension_tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    // Serialize SUDO_USER mutation across tests in this module.
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct SudoUserGuard {
+        prior: Option<String>,
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl SudoUserGuard {
+        fn set(value: Option<&str>) -> Self {
+            let guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+            let prior = std::env::var("SUDO_USER").ok();
+            match value {
+                Some(v) => std::env::set_var("SUDO_USER", v),
+                None => std::env::remove_var("SUDO_USER"),
+            }
+            Self {
+                prior,
+                _guard: guard,
+            }
+        }
+    }
+
+    impl Drop for SudoUserGuard {
+        fn drop(&mut self) {
+            match self.prior.take() {
+                Some(v) => std::env::set_var("SUDO_USER", v),
+                None => std::env::remove_var("SUDO_USER"),
+            }
+        }
+    }
+
+    #[test]
+    fn no_warning_when_not_running_under_sudo() {
+        let _guard = SudoUserGuard::set(None);
+        assert!(detect_unrefreshed_symlinked_extensions(&[]).is_empty());
+    }
+
+    #[test]
+    fn no_warning_when_sudo_user_is_root() {
+        let _guard = SudoUserGuard::set(Some("root"));
+        assert!(detect_unrefreshed_symlinked_extensions(&[]).is_empty());
+    }
+
+    #[test]
+    fn no_warning_when_sudo_user_is_empty() {
+        let _guard = SudoUserGuard::set(Some(""));
+        assert!(detect_unrefreshed_symlinked_extensions(&[]).is_empty());
+    }
+
+    #[test]
+    fn no_warning_when_invoking_user_has_no_config_dir() {
+        // A user that exists in passwd but has no homeboy extensions dir must
+        // not produce warnings (and must not panic on the missing directory).
+        let _guard = SudoUserGuard::set(Some("definitely-not-a-real-user-xyz"));
+        assert!(detect_unrefreshed_symlinked_extensions(&[]).is_empty());
+    }
 }

--- a/src/core/upgrade/types.rs
+++ b/src/core/upgrade/types.rs
@@ -74,6 +74,31 @@ pub struct UpgradeResult {
     pub runners_updated: Vec<RunnerUpgradeEntry>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub runners_skipped: Vec<RunnerUpgradeEntry>,
+    /// Symlinked extension clones owned by the invoking (sudo) user that this
+    /// upgrade could not refresh because it ran under a different `$HOME`.
+    /// Each entry carries the exact recovery command to bring the clone current.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub extensions_unrefreshed: Vec<UnrefreshedExtensionWarning>,
+}
+
+/// A symlinked extension in the invoking user's config dir that a privileged
+/// (sudo) upgrade left stale, because extension resolution is `$HOME`-scoped
+/// and the privileged run only ever sees root's own extension copies.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UnrefreshedExtensionWarning {
+    /// Extension id (e.g. `wordpress`).
+    pub extension_id: String,
+    /// The invoking user (value of `SUDO_USER`).
+    pub invoking_user: String,
+    /// The symlink path in the invoking user's config dir.
+    pub symlink_path: String,
+    /// The resolved git working tree the symlink points at.
+    pub source_path: String,
+    /// How many commits the clone is behind its upstream, if determinable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub behind: Option<u32>,
+    /// The exact command the user should run to refresh the clone.
+    pub recovery_command: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Fixes a silent-staleness bug where `sudo homeboy upgrade` leaves a non-root user's symlinked extension clone stale, so the upgraded binary ships a fix the user can never execute.

Closes #4743.

## The bug (reproduced live on the extrachill.com VPS)

- `sudo homeboy upgrade` upgraded the binary **0.229.11 → 0.232.0** and (as root, `HOME=/root`) refreshed `/root/homeboy-extensions/wordpress` to v2.121.54.
- But the opencode user's `~/.config/homeboy/extensions/wordpress` is a **symlink** → `/var/lib/datamachine/workspace/homeboy-extensions/wordpress` (a workspace clone). The upgrade left that clone **618 commits stale** (stuck at v2.114.7).
- Net effect: the harness fix (#1402 / `runner-steps.sh` path bug, #4718) shipped in the new binary but `homeboy lint` kept failing with `runner-steps.sh: No such file or directory`, because the extension the user actually runs was never refreshed. Manual workaround was `wp datamachine-code workspace git pull homeboy-extensions --allow-primary-refresh`.

## Root cause

`core::paths::extension()` resolves strictly under the running user's `$HOME`. `update_all_extensions()` iterates only that user's manifests. Under `sudo`, `HOME=/root`, so the upgrade only ever sees root's own extension copies (not symlinks → plain `git pull` on root's clone). The invoking user's symlinked extension lives in a config dir the root process never visits, so it's never refreshed and the staleness is never reported.

## The fix (scoped to the gap)

When `SUDO_USER` is set, detect symlinked extension entries in the **invoking user's** `~/.config/homeboy/extensions` whose git working tree this upgrade did **not** refresh and that are confirmed behind their upstream, then emit a loud, actionable warning for each with the exact recovery command.

- **Warn, don't mutate.** Refreshing a clone owned by another user (possibly dirty/unpushed) from a privileged process is unsafe, so the conservative path is a precise `sudo -u <user> git -C <root> pull --ff-only` recovery line rather than a forced refresh. This respects existing primary-refresh safety.
- Warnings are surfaced both in the upgrade result JSON (new `extensions_unrefreshed` field) and via loud `log_status!` output.
- Quiet by default: returns empty when not under `sudo`, when `SUDO_USER` is root/empty, when the invoking user has no extensions dir, or when drift can't be confirmed (no crying wolf).

## Files

- `src/core/upgrade/types.rs` — new `UnrefreshedExtensionWarning` type + `extensions_unrefreshed` field on `UpgradeResult`.
- `src/core/upgrade/helpers.rs` — detection (`detect_unrefreshed_symlinked_extensions`), loud warning logging (`warn_unrefreshed_symlinked_extensions`), `getent`-based home resolution, and a read-only `git rev-list` behind-count; wired into both upgrade return paths.
- `src/commands/upgrade.rs` — test fixture updated for the new field.

## Testing

- `cargo check` — clean.
- `cargo test --lib upgrade` — 58 passed, including 4 new tests covering the `SUDO_USER` short-circuits (unset / root / empty / missing config dir).
- clippy/rustfmt components are not installed in this environment, so those gates were not run locally; the new `behind` check uses `is_some_and` to stay clippy-clean.

## Not done (per task scope)

PR only — not merged, not released, not deployed.
