### PR TITLE
fix: keep agent task settings contract generic

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -323,15 +323,15 @@ mod tests {
 
     #[test]
     fn config_set_string_mode_stores_literal_string() {
-        let value = parse_config_set_value("/settings/wp_codebox_provider", "codex", true)
+        let value = parse_config_set_value("/settings/provider", "example", true)
             .expect("literal string value");
 
-        assert_eq!(value, Value::String("codex".to_string()));
+        assert_eq!(value, Value::String("example".to_string()));
     }
 
     #[test]
     fn config_set_unquoted_string_error_includes_string_hints() {
-        let err = parse_config_set_value("/settings/wp_codebox_provider", "codex", false)
+        let err = parse_config_set_value("/settings/provider", "example", false)
             .expect_err("bare string should not parse as JSON");
 
         let hints = err
@@ -341,7 +341,7 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
 
-        assert!(hints.contains("'\"codex\"'"));
+        assert!(hints.contains("'\"example\"'"));
         assert!(hints.contains("--string"));
     }
 

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -879,26 +879,26 @@ mod tests {
     }
 
     #[test]
-    fn codebox_dispatch_rejects_non_git_cwd() {
+    fn git_checkout_provider_rejects_non_git_cwd() {
         let workspace = tempfile::tempdir().expect("workspace");
 
         let error = build_dispatch_plan_with_provider_requirements(
             &dispatch_request(DispatchRequestOverrides {
                 prompt: Some("Generate files here.".to_string()),
                 cwd: Some(workspace.path().display().to_string()),
-                backend: Some("codebox".to_string()),
+                backend: Some("git-required".to_string()),
                 ..DispatchRequestOverrides::default()
             }),
-            |backend, _selector| backend == "codebox",
+            |backend, _selector| backend == "git-required",
         )
-        .expect_err("non-git Codebox cwd should be rejected");
+        .expect_err("non-git cwd should be rejected");
 
         assert!(error.to_string().contains("git checkout"));
         assert!(error.to_string().contains("patch artifact"));
     }
 
     #[test]
-    fn codebox_dispatch_accepts_git_cwd() {
+    fn git_checkout_provider_accepts_git_cwd() {
         let workspace = tempfile::tempdir().expect("workspace");
         git(workspace.path(), &["init"]);
 
@@ -906,12 +906,12 @@ mod tests {
             &dispatch_request(DispatchRequestOverrides {
                 prompt: Some("Generate files here.".to_string()),
                 cwd: Some(workspace.path().display().to_string()),
-                backend: Some("codebox".to_string()),
+                backend: Some("git-required".to_string()),
                 ..DispatchRequestOverrides::default()
             }),
-            |backend, _selector| backend == "codebox",
+            |backend, _selector| backend == "git-required",
         )
-        .expect("git Codebox cwd should be accepted");
+        .expect("git cwd should be accepted");
 
         assert_eq!(
             plan.tasks[0].workspace.root.as_deref(),
@@ -951,13 +951,14 @@ mod tests {
         with_isolated_home(|_| {
             defaults::save_config(&defaults::HomeboyConfig {
                 settings: HashMap::from([
+                    ("provider".to_string(), serde_json::json!("example")),
                     (
                         "provider_plugin_paths".to_string(),
                         serde_json::json!(["/providers/openai"]),
                     ),
                     (
-                        "wp_codebox_provider".to_string(),
-                        serde_json::json!("codex"),
+                        "runtime_overlays".to_string(),
+                        serde_json::json!([{ "repo": "owner/runtime", "ref": "main" }]),
                     ),
                 ]),
                 ..defaults::HomeboyConfig::default()
@@ -967,7 +968,7 @@ mod tests {
             let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
                 prompt: Some("Cook with configured provider defaults.".to_string()),
                 provider_config: Some(
-                    serde_json::json!({ "wp_codebox_provider": "opencode" }).to_string(),
+                    serde_json::json!({ "provider": "override" }).to_string(),
                 ),
                 ..DispatchRequestOverrides::default()
             }))
@@ -978,8 +979,12 @@ mod tests {
                 serde_json::json!(["/providers/openai"])
             );
             assert_eq!(
-                plan.tasks[0].executor.config["wp_codebox_provider"],
-                "opencode"
+                plan.tasks[0].executor.config["runtime_overlays"][0]["repo"],
+                "owner/runtime"
+            );
+            assert_eq!(
+                plan.tasks[0].executor.config["provider"],
+                "override"
             );
         });
     }

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -377,6 +377,7 @@ pub fn builtin_defaults() -> Defaults {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::with_isolated_home;
 
     #[test]
     fn homeboy_config_parses_triage_priority_labels() {
@@ -431,25 +432,54 @@ mod tests {
     }
 
     #[test]
-    fn homeboy_config_preserves_extension_settings() {
+    fn homeboy_config_preserves_global_settings() {
         let config: HomeboyConfig = serde_json::from_str(
             r#"{
                 "settings": {
-                    "wp_codebox_provider": "codex",
-                    "provider_plugin_paths": ["/providers/openai"]
+                    "provider": "example",
+                    "provider_plugin_paths": ["/providers/openai"],
+                    "runtime_overlays": [{"repo":"owner/runtime","ref":"main"}]
                 }
             }"#,
         )
         .unwrap();
 
         assert_eq!(
-            config.settings.get("wp_codebox_provider"),
-            Some(&Value::String("codex".to_string()))
+            config.settings.get("provider"),
+            Some(&Value::String("example".to_string()))
         );
         assert_eq!(
             config.settings["provider_plugin_paths"][0],
             Value::String("/providers/openai".to_string())
         );
+        assert_eq!(config.settings["runtime_overlays"][0]["repo"], "owner/runtime");
+    }
+
+    #[test]
+    fn homeboy_config_save_load_preserves_global_settings() {
+        with_isolated_home(|_| {
+            save_config(&HomeboyConfig {
+                settings: HashMap::from([
+                    ("provider".to_string(), serde_json::json!("example")),
+                    (
+                        "provider_plugin_paths".to_string(),
+                        serde_json::json!(["/providers/openai"]),
+                    ),
+                    (
+                        "runtime_overlays".to_string(),
+                        serde_json::json!([{ "repo": "owner/runtime", "ref": "main" }]),
+                    ),
+                ]),
+                ..HomeboyConfig::default()
+            })
+            .expect("save config");
+
+            let loaded = load_config();
+
+            assert_eq!(loaded.settings["provider"], "example");
+            assert_eq!(loaded.settings["provider_plugin_paths"][0], "/providers/openai");
+            assert_eq!(loaded.settings["runtime_overlays"][0]["ref"], "main");
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace WP Codebox-shaped regression fixtures from the merged settings fix with generic provider/runtime settings.
- Add save/load coverage proving arbitrary /settings values survive the homeboy.json round trip.
- Keep agent-task executor config forwarding generic while preserving explicit --provider-config override precedence.

## Testing
- `git diff --check`
- GitHub CI for PR SHA `e0f6a718`: Build passed, Audit passed; Lint/Test failed after the PR auto-merged.
- Targeted offloaded Rust verification attempted on `homeboy-lab` for current main SHA `0e3827fd` with `homeboy test homeboy --runner homeboy-lab --path /Users/chubes/Developer/homeboy@fix-4750-clean-settings-forwarding --skip-lint -- --filter=settings -- --nocapture`; runner job `b356d53c-a1c7-4df8-b65a-e479199b38cf` failed because the runner daemon restarted before terminal status.
- Accidental duplicate offload from an escaped PR-body command was cancelled: runner job `f4d63c08-b851-4e38-9022-4f1df873d18d`.
- Local Cargo was intentionally not run per issue requirement.

Closes #4750

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected the merged initial fix, drafted the generic follow-up regression coverage, and prepared the PR. Chris remains responsible for review and merge.
