### PR TITLE
fix: redact runner exec environment output

### DIFF
--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -335,10 +335,6 @@ enum RunnerCommand {
     Env {
         /// Runner ID
         id: String,
-
-        /// Print actual values instead of redacting them
-        #[arg(long)]
-        show_values: bool,
     },
     /// Inspect or follow a runner daemon job stream
     Job {
@@ -581,7 +577,7 @@ pub fn run(
             require_paths,
             command,
         )),
-        RunnerCommand::Env { id, show_values } => map_env(env(&id, show_values)),
+        RunnerCommand::Env { id } => map_env(env(&id)),
         RunnerCommand::Job { command } => map_job(job(command)),
         RunnerCommand::Work {
             runner_id,
@@ -1046,21 +1042,12 @@ fn exec(
     )
 }
 
-fn env(runner_id: &str, show_values: bool) -> CmdResult<RunnerEnvOutput> {
+fn env(runner_id: &str) -> CmdResult<RunnerEnvOutput> {
     let runner = runner::load(runner_id)?;
     let effective_env = runner::effective_env(runner_id)?;
     let env = effective_env
         .into_iter()
-        .map(|(key, value)| {
-            (
-                key,
-                if show_values {
-                    value
-                } else {
-                    REDACTED_ENV_VALUE.to_string()
-                },
-            )
-        })
+        .map(|(key, _value)| (key, REDACTED_ENV_VALUE.to_string()))
         .collect();
     let secret_env = runner
         .secret_env
@@ -1073,7 +1060,7 @@ fn env(runner_id: &str, show_values: bool) -> CmdResult<RunnerEnvOutput> {
             command: "runner.env".to_string(),
             runner_id: runner_id.to_string(),
             source: "runner_job_env".to_string(),
-            values_redacted: !show_values,
+            values_redacted: true,
             env,
             secret_env,
             diagnostics: RunnerEnvDiagnostics {
@@ -1359,10 +1346,10 @@ mod tests {
             command: "runner.env".to_string(),
             runner_id: "lab".to_string(),
             source: "runner_job_env".to_string(),
-            values_redacted: false,
+            values_redacted: true,
             env: BTreeMap::from([(
                 "HOMEBOY_PUBLIC_ARTIFACT_BASE_URL".to_string(),
-                "https://artifacts.example.test".to_string(),
+                REDACTED_ENV_VALUE.to_string(),
             )]),
             secret_env: BTreeMap::from([(
                 "OPENAI_API_KEY".to_string(),
@@ -1383,7 +1370,7 @@ mod tests {
 
         assert_eq!(
             value["env"]["HOMEBOY_PUBLIC_ARTIFACT_BASE_URL"],
-            "https://artifacts.example.test"
+            REDACTED_ENV_VALUE
         );
         assert_eq!(
             value["secret_env"]["OPENAI_API_KEY"]["env"],
@@ -1402,7 +1389,7 @@ mod tests {
             command: "runner.env".to_string(),
             runner_id: "lab".to_string(),
             source: "runner_job_env".to_string(),
-            values_redacted: false,
+            values_redacted: true,
             env: BTreeMap::new(),
             secret_env: BTreeMap::from([(
                 "HOMEBOY_PREVIEW_TUNNEL_TOKEN".to_string(),

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -10,6 +10,7 @@ use crate::core::api_jobs::{Job, JobEvent, JobStatus, RemoteRunnerJobRequest};
 use crate::core::engine::command::CommandCaptureMetadata;
 use crate::core::engine::shell;
 use crate::core::error::{Error, ErrorCode, Result};
+use crate::core::redaction::RedactionPolicy;
 use crate::core::server::{self, SshClient};
 use crate::core::source_snapshot::SourceSnapshot;
 
@@ -316,6 +317,8 @@ fn exec_via_reverse_broker(
     let source_snapshot = source_snapshot_override.unwrap_or_else(|| {
         SourceSnapshot::existing_remote(&runner.id, &cwd, runner.workspace_root.as_deref())
     });
+    let redaction_env = env.clone();
+    let redaction_secret_env_names = secret_env_names.clone();
     let request = RemoteRunnerJobRequest {
         runner_id: runner.id.clone(),
         project_id,
@@ -360,8 +363,11 @@ fn exec_via_reverse_broker(
         JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
     ) {
         if Instant::now() >= deadline {
-            let events =
-                fetch_daemon_events(&client, broker_url, &job.id.to_string()).unwrap_or_default();
+            let events = fetch_daemon_events(&client, broker_url, &job.id.to_string())
+                .map(|events| {
+                    redact_runner_job_events(&events, &redaction_env, &redaction_secret_env_names)
+                })
+                .unwrap_or_default();
             return Err(daemon_job_wait_timeout(
                 runner,
                 &cwd,
@@ -374,11 +380,19 @@ fn exec_via_reverse_broker(
         std::thread::sleep(Duration::from_millis(200));
         job = fetch_daemon_job(&client, broker_url, &job.id.to_string())?;
     }
-    let events = fetch_daemon_events(&client, broker_url, &job.id.to_string())?;
+    let events = redact_runner_job_events(
+        &fetch_daemon_events(&client, broker_url, &job.id.to_string())?,
+        &redaction_env,
+        &redaction_secret_env_names,
+    );
 
     let result = result_event_data(&events).unwrap_or_else(|| json!({}));
-    let stdout = string_field(&result, "stdout");
-    let stderr = string_field(&result, "stderr");
+    let (stdout, stderr) = redact_runner_exec_streams(
+        string_field(&result, "stdout"),
+        string_field(&result, "stderr"),
+        &redaction_env,
+        &redaction_secret_env_names,
+    );
     let metrics = result
         .get("metrics")
         .and_then(|value| serde_json::from_value(value.clone()).ok());
@@ -496,8 +510,9 @@ fn exec_via_daemon(
         JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
     ) {
         if Instant::now() >= deadline {
-            let events =
-                fetch_daemon_events(&client, local_url, &job.id.to_string()).unwrap_or_default();
+            let events = fetch_daemon_events(&client, local_url, &job.id.to_string())
+                .map(|events| redact_runner_job_events(&events, &env, &secret_env_names))
+                .unwrap_or_default();
             return Err(daemon_job_wait_timeout(
                 runner,
                 &cwd,
@@ -513,12 +528,20 @@ fn exec_via_daemon(
             .map_err(|err| daemon_job_context_error(&runner.id, &job_id, err))?;
     }
     let job_id = job.id.to_string();
-    let events = fetch_daemon_events(&client, local_url, &job_id)
-        .map_err(|err| daemon_job_context_error(&runner.id, &job_id, err))?;
+    let events = redact_runner_job_events(
+        &fetch_daemon_events(&client, local_url, &job_id)
+            .map_err(|err| daemon_job_context_error(&runner.id, &job_id, err))?,
+        &env,
+        &secret_env_names,
+    );
 
     let result = result_event_data(&events).unwrap_or_else(|| json!({}));
-    let stdout = string_field(&result, "stdout");
-    let stderr = string_field(&result, "stderr");
+    let (stdout, stderr) = redact_runner_exec_streams(
+        string_field(&result, "stdout"),
+        string_field(&result, "stderr"),
+        &env,
+        &secret_env_names,
+    );
     let metrics = result
         .get("metrics")
         .and_then(|value| serde_json::from_value(value.clone()).ok());
@@ -889,6 +912,8 @@ fn exec_local(plan: PreparedRunnerProcess) -> Result<(RunnerExecOutput, i32)> {
         output,
         Some(plan.source_snapshot),
         plan.require_paths,
+        &plan.env,
+        &[],
     ))
 }
 
@@ -911,6 +936,7 @@ fn exec_diagnostic_ssh(
     let mut client = SshClient::from_server(&server, server_id)?;
     client.env.extend(runner.env.clone());
     client.env.extend(env);
+    let redaction_env = client.env.clone();
     validate_remote_required_paths(&mut client, &require_paths)?;
     let command_line = format!(
         "cd {} && {}",
@@ -938,6 +964,8 @@ fn exec_diagnostic_ssh(
         },
         Some(source_snapshot),
         require_paths,
+        &redaction_env,
+        &[],
     ))
 }
 
@@ -1340,8 +1368,16 @@ fn exec_output(
     output: ProcessOutput,
     source_snapshot: Option<SourceSnapshot>,
     require_paths: Vec<String>,
+    redaction_env: &HashMap<String, String>,
+    secret_env_names: &[String],
 ) -> (RunnerExecOutput, i32) {
     let exit_code = output.exit_code;
+    let (stdout, stderr) = redact_runner_exec_streams(
+        output.stdout,
+        output.stderr,
+        redaction_env,
+        secret_env_names,
+    );
     (
         RunnerExecOutput {
             command: "runner.exec",
@@ -1350,8 +1386,8 @@ fn exec_output(
             argv: command,
             remote_cwd: cwd,
             exit_code,
-            stdout: output.stdout,
-            stderr: output.stderr,
+            stdout,
+            stderr,
             source_snapshot: source_snapshot.clone(),
             job: None,
             job_id: None,
@@ -1364,6 +1400,107 @@ fn exec_output(
         },
         exit_code,
     )
+}
+
+fn redact_runner_exec_streams(
+    stdout: String,
+    stderr: String,
+    env: &HashMap<String, String>,
+    secret_env_names: &[String],
+) -> (String, String) {
+    let policy = RedactionPolicy::default();
+    let secrets = runner_exec_secret_values(env, secret_env_names, &policy);
+    (
+        redact_runner_exec_text(&stdout, &policy, &secrets),
+        redact_runner_exec_text(&stderr, &policy, &secrets),
+    )
+}
+
+fn runner_exec_secret_values(
+    env: &HashMap<String, String>,
+    secret_env_names: &[String],
+    policy: &RedactionPolicy,
+) -> Vec<String> {
+    let mut values = env
+        .iter()
+        .filter_map(|(key, value)| {
+            if value.is_empty() {
+                return None;
+            }
+            if policy.is_sensitive_key(key) || secret_env_names.iter().any(|name| name == key) {
+                Some(value.clone())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    values.sort_by_key(|value| std::cmp::Reverse(value.len()));
+    values.dedup();
+    values
+}
+
+fn redact_runner_exec_text(
+    text: &str,
+    policy: &RedactionPolicy,
+    secret_values: &[String],
+) -> String {
+    let mut redacted = policy.redact_string(text);
+    for value in secret_values {
+        redacted = redacted.replace(value, policy.replacement());
+    }
+    redacted
+}
+
+fn redact_runner_job_events(
+    events: &[JobEvent],
+    env: &HashMap<String, String>,
+    secret_env_names: &[String],
+) -> Vec<JobEvent> {
+    let policy = RedactionPolicy::default();
+    let secrets = runner_exec_secret_values(env, secret_env_names, &policy);
+    events
+        .iter()
+        .map(|event| {
+            let mut redacted = event.clone();
+            redacted.message = redacted
+                .message
+                .as_deref()
+                .map(|message| redact_runner_exec_text(message, &policy, &secrets));
+            redacted.data = redacted
+                .data
+                .as_ref()
+                .map(|data| redact_runner_exec_json(data, &policy, &secrets));
+            redacted
+        })
+        .collect()
+}
+
+fn redact_runner_exec_json(
+    value: &Value,
+    policy: &RedactionPolicy,
+    secret_values: &[String],
+) -> Value {
+    match policy.redact_json(value) {
+        Value::String(text) => Value::String(redact_runner_exec_text(&text, policy, secret_values)),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|item| redact_runner_exec_json(item, policy, secret_values))
+                .collect(),
+        ),
+        Value::Object(object) => Value::Object(
+            object
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        key.clone(),
+                        redact_runner_exec_json(value, policy, secret_values),
+                    )
+                })
+                .collect(),
+        ),
+        redacted => redacted,
+    }
 }
 
 fn runner_exec_diagnostics(
@@ -1584,6 +1721,76 @@ mod tests {
             capture: None,
             diagnostics: None,
         }
+    }
+
+    #[test]
+    fn runner_exec_redacts_env_diagnostic_assignments() {
+        let env = HashMap::from([(
+            "HOMEBOY_PREVIEW_TUNNEL_TOKEN".to_string(),
+            "preview-token-secret".to_string(),
+        )]);
+
+        let (stdout, stderr) = redact_runner_exec_streams(
+            "HOMEBOY_PREVIEW_TUNNEL_TOKEN=preview-token-secret\nSAFE=value\n".to_string(),
+            "token=preview-token-secret\n".to_string(),
+            &env,
+            &[],
+        );
+
+        assert_eq!(
+            stdout,
+            "HOMEBOY_PREVIEW_TUNNEL_TOKEN=[REDACTED]\nSAFE=value\n"
+        );
+        assert_eq!(stderr, "token=[REDACTED]\n");
+    }
+
+    #[test]
+    fn runner_exec_redacts_bare_secret_values() {
+        let env = HashMap::from([(
+            "OPENAI_API_KEY".to_string(),
+            "sk-test-secret-value".to_string(),
+        )]);
+
+        let (stdout, stderr) = redact_runner_exec_streams(
+            "sk-test-secret-value\n".to_string(),
+            "failed with sk-test-secret-value".to_string(),
+            &env,
+            &[],
+        );
+
+        assert_eq!(stdout, "[REDACTED]\n");
+        assert_eq!(stderr, "failed with [REDACTED]");
+    }
+
+    #[test]
+    fn runner_exec_redacts_daemon_job_events() {
+        let env = HashMap::from([(
+            "HOMEBOY_PREVIEW_TUNNEL_TOKEN".to_string(),
+            "preview-token-secret".to_string(),
+        )]);
+        let events = vec![crate::core::api_jobs::JobEvent {
+            sequence: 1,
+            job_id: uuid::Uuid::new_v4(),
+            kind: crate::core::api_jobs::JobEventKind::Result,
+            timestamp_ms: 1,
+            message: Some("HOMEBOY_PREVIEW_TUNNEL_TOKEN=preview-token-secret".to_string()),
+            data: Some(json!({
+                "stdout": "preview-token-secret",
+                "stderr": "token=preview-token-secret",
+            })),
+        }];
+
+        let redacted = redact_runner_job_events(&events, &env, &[]);
+
+        assert_eq!(
+            redacted[0].message.as_deref(),
+            Some("HOMEBOY_PREVIEW_TUNNEL_TOKEN=[REDACTED]")
+        );
+        assert_eq!(redacted[0].data.as_ref().unwrap()["stdout"], "[REDACTED]");
+        assert_eq!(
+            redacted[0].data.as_ref().unwrap()["stderr"],
+            "token=[REDACTED]"
+        );
     }
 
     #[test]

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -149,6 +149,14 @@ fn runner_exec_raw_command_parses_before_trailing_command() {
 }
 
 #[test]
+fn runner_env_rejects_legacy_show_values_flag() {
+    assert!(
+        Cli::try_parse_from(["homeboy", "runner", "env", "homeboy-lab", "--show-values"]).is_err(),
+        "runner env must not expose raw environment values"
+    );
+}
+
+#[test]
 fn agent_task_auth_status_accepts_global_runner_and_secret_env() {
     Cli::try_parse_from([
         "homeboy",


### PR DESCRIPTION
## Summary
- redact runner exec stdout/stderr using sensitive env keys and exact secret values before controller output, JSON output files, daemon/reverse job events, timeout mirrors, and evidence mirroring consume them
- keep runner env diagnostics key-presence/redacted-only and remove the legacy `runner env --show-values` raw-value path
- add regression coverage for env-style output, bare secret output, daemon job event redaction, and the removed show-values flag

Fixes #4741.

## Tests
- `homeboy cargo --runner homeboy-lab homeboy test runner_exec_redacts -- --nocapture` (passed: 3 tests)
- `homeboy cargo --runner homeboy-lab homeboy test runner_env_rejects_legacy_show_values_flag -- --nocapture` (passed: 1 test)
- `homeboy cargo --runner homeboy-lab homeboy test runner_env -- --nocapture` (passed before rebase: 10 tests)
- `homeboy cargo --runner homeboy-lab homeboy check` (passed)
- `homeboy cargo --runner homeboy-lab homeboy fmt -- --check` (passed before rebase; after rebasing onto current main, full-tree fmt fails only on unrelated pre-existing formatting in `src/core/agent_task_dispatch_service.rs` and `src/core/defaults.rs`)
- `git diff --check` (passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode/Kimaki (GPT-5.5)
- **Used for:** Drafted the runner output redaction changes, removed the unsafe env show-values path, and added regression tests; Chris remains responsible for review and merge.
