### PR TITLE
fix: refresh stale runner daemon sessions

### DIFF
--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -967,9 +967,7 @@ mod tests {
 
             let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
                 prompt: Some("Cook with configured provider defaults.".to_string()),
-                provider_config: Some(
-                    serde_json::json!({ "provider": "override" }).to_string(),
-                ),
+                provider_config: Some(serde_json::json!({ "provider": "override" }).to_string()),
                 ..DispatchRequestOverrides::default()
             }))
             .expect("dispatch plan");
@@ -982,10 +980,7 @@ mod tests {
                 plan.tasks[0].executor.config["runtime_overlays"][0]["repo"],
                 "owner/runtime"
             );
-            assert_eq!(
-                plan.tasks[0].executor.config["provider"],
-                "override"
-            );
+            assert_eq!(plan.tasks[0].executor.config["provider"], "override");
         });
     }
 

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -452,7 +452,10 @@ mod tests {
             config.settings["provider_plugin_paths"][0],
             Value::String("/providers/openai".to_string())
         );
-        assert_eq!(config.settings["runtime_overlays"][0]["repo"], "owner/runtime");
+        assert_eq!(
+            config.settings["runtime_overlays"][0]["repo"],
+            "owner/runtime"
+        );
     }
 
     #[test]
@@ -477,7 +480,10 @@ mod tests {
             let loaded = load_config();
 
             assert_eq!(loaded.settings["provider"], "example");
-            assert_eq!(loaded.settings["provider_plugin_paths"][0], "/providers/openai");
+            assert_eq!(
+                loaded.settings["provider_plugin_paths"][0],
+                "/providers/openai"
+            );
             assert_eq!(loaded.settings["runtime_overlays"][0]["ref"], "main");
         });
     }

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -83,6 +83,7 @@ pub fn connect(runner_id: &str) -> Result<(RunnerConnectReport, i32)> {
         homeboy,
         daemon,
         &version,
+        &identity.display,
         runner_id,
         &session_path,
     ) {
@@ -274,11 +275,12 @@ fn stale_daemon_warning(
         .as_deref()
         .and_then(|local_url| daemon_http_version(local_url).ok())
         .unwrap_or_else(|| session.homeboy_version.clone());
-    let session_identity = session
+    let daemon_identity = session
         .local_url
         .as_deref()
         .and_then(|local_url| daemon_http_identity(local_url).ok())
-        .or_else(|| session.homeboy_build_identity.clone());
+        .filter(|identity| !identity.trim().is_empty());
+    let session_identity = daemon_identity.or_else(|| session.homeboy_build_identity.clone());
     if versions_match(&observed_session_version, &current_version)
         && versions_match(&session.homeboy_version, &current_version)
         && identities_match(session_identity.as_deref(), Some(&current_identity.display))
@@ -411,7 +413,7 @@ fn parse_self_identity_output(output: &str) -> Option<RemoteHomeboyIdentity> {
 fn identities_match(left: Option<&str>, right: Option<&str>) -> bool {
     match (left, right) {
         (Some(left), Some(right)) => versions_match(left, right),
-        _ => true,
+        _ => false,
     }
 }
 
@@ -852,7 +854,9 @@ pub(super) fn terminate_pid(pid: u32) {
 mod tests {
     use std::collections::HashMap;
 
-    use super::connection_daemon::{daemon_version_from_body, versions_match};
+    use super::connection_daemon::{
+        daemon_identity_from_body, daemon_version_from_body, versions_match,
+    };
     use super::*;
     use crate::test_support;
 
@@ -906,10 +910,14 @@ mod tests {
             Some("0.199.4")
         );
         assert_eq!(
-            super::connection_daemon::daemon_identity_from_body(
+            daemon_identity_from_body(
                 &serde_json::json!({"version":"0.228.13","build_identity":{"display":"homeboy 0.228.13+f7569a5e"}})
             ),
             Some("homeboy 0.228.13+f7569a5e")
+        );
+        assert_eq!(
+            daemon_identity_from_body(&serde_json::json!({"version":"0.228.13"})),
+            None
         );
     }
 
@@ -940,7 +948,7 @@ mod tests {
             warning.session_homeboy_build_identity.as_deref(),
             Some("homeboy 0.201.3+old")
         );
-        assert!(warning.message.contains("different Homeboy version"));
+        assert!(warning.message.contains("different Homeboy build"));
         assert!(warning.message.contains("run recovery_commands in order"));
         assert_eq!(
             warning.recovery_commands,

--- a/src/core/runner/connection_daemon.rs
+++ b/src/core/runner/connection_daemon.rs
@@ -19,6 +19,7 @@ pub(super) fn connect_remote_daemon(
     homeboy: &str,
     daemon: RemoteDaemon,
     expected_version: &str,
+    expected_identity: &str,
     runner_id: &str,
     session_path: &PathBuf,
 ) -> std::result::Result<(u16, Option<u32>, String, RemoteDaemon), (RunnerConnectReport, i32)> {
@@ -35,11 +36,9 @@ pub(super) fn connect_remote_daemon(
     };
     let (local_port, tunnel_pid, local_url) =
         open_daemon_tunnel(server, &daemon, runner_id, session_path)?;
-    match daemon_http_version(&local_url) {
-        Ok(running_version) if versions_match(&running_version, expected_version) => {
-            Ok((local_port, tunnel_pid, local_url, daemon))
-        }
-        Ok(_) => {
+    match daemon_freshness_mismatch(&local_url, expected_version, expected_identity) {
+        Ok(None) => Ok((local_port, tunnel_pid, local_url, daemon)),
+        Ok(Some(_)) => {
             if let Some(pid) = tunnel_pid {
                 terminate_pid(pid);
             }
@@ -64,14 +63,13 @@ pub(super) fn connect_remote_daemon(
             };
             let (local_port, tunnel_pid, local_url) =
                 open_daemon_tunnel(server, &daemon, runner_id, session_path)?;
-            match daemon_http_version(&local_url) {
-                Ok(running_version) if versions_match(&running_version, expected_version) => {}
-                Ok(running_version) => {
+            match daemon_freshness_mismatch(&local_url, expected_version, expected_identity) {
+                Ok(None) => {}
+                Ok(Some(reason)) => {
                     return Err(failed_after_tunnel(
                         tunnel_pid,
                         format!(
-                            "remote daemon restarted but still reports stale Homeboy version {} instead of {}",
-                            running_version, expected_version
+                            "remote daemon restarted but still reports stale Homeboy build: {reason}"
                         ),
                     ));
                 }
@@ -214,7 +212,31 @@ pub(super) fn daemon_identity_from_body(body: &Value) -> Option<&str> {
             body.pointer("/data/build_identity/display")
                 .and_then(Value::as_str)
         })
-        .or_else(|| daemon_version_from_body(body))
+}
+
+fn daemon_freshness_mismatch(
+    local_url: &str,
+    expected_version: &str,
+    expected_identity: &str,
+) -> std::result::Result<Option<String>, String> {
+    let running_version = daemon_http_version(local_url)?;
+    if !versions_match(&running_version, expected_version) {
+        return Ok(Some(format!(
+            "version {running_version} != configured runner version {expected_version}"
+        )));
+    }
+
+    let running_identity = match daemon_http_identity(local_url) {
+        Ok(identity) => identity,
+        Err(message) => return Ok(Some(message)),
+    };
+    if !versions_match(&running_identity, expected_identity) {
+        return Ok(Some(format!(
+            "identity {running_identity} != configured runner identity {expected_identity}"
+        )));
+    }
+
+    Ok(None)
 }
 
 fn remote_daemon_stop(client: &SshClient, homeboy: &str) -> std::result::Result<(), String> {

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -21,7 +21,9 @@ use super::evidence::{mirror_daemon_evidence, mirror_daemon_job_progress};
 use super::resource_metrics::{
     measured_command_output, measured_command_output_until_cancelled, RunnerResourceMetrics,
 };
-use super::{load, status, Runner, RunnerCapabilityPreflight, RunnerKind, RunnerTunnelMode};
+use super::{
+    connect, load, status, Runner, RunnerCapabilityPreflight, RunnerKind, RunnerTunnelMode,
+};
 use super::{normalize_runner_command_env, resolve_runner_secret_env};
 
 const DEFAULT_RUNNER_EXEC_WAIT_TIMEOUT_SECS: u64 = 20 * 60;
@@ -184,7 +186,25 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
         );
     }
 
-    let connected = status(runner_id)?;
+    let mut connected = status(runner_id)?;
+    if connected.connected && connected.stale_daemon.is_some() {
+        let (refresh, refresh_exit_code) = connect(runner_id)?;
+        if refresh_exit_code != 0 || !refresh.connected {
+            return Err(Error::internal_unexpected(
+                format!(
+                    "runner `{runner_id}` has a stale daemon session and automatic refresh failed: {}",
+                    refresh
+                        .failure_message
+                        .as_deref()
+                        .unwrap_or("runner connect did not establish a fresh daemon session")
+                )
+            )
+            .with_hint(format!(
+                "Refresh the runner session with `homeboy runner disconnect {runner_id} && homeboy runner connect {runner_id}`."
+            )));
+        }
+        connected = status(runner_id)?;
+    }
     if connected.connected {
         if let Some(session) = connected.session {
             preflight_runner_capability_plan(

--- a/src/core/runner/session.rs
+++ b/src/core/runner/session.rs
@@ -157,7 +157,7 @@ impl RunnerStaleDaemonWarning {
             current_homeboy_version,
             session_homeboy_build_identity,
             current_homeboy_build_identity,
-            message: "connected runner daemon was started by a different Homeboy version than the configured runner executable; run recovery_commands in order to restart the active daemon".to_string(),
+            message: "connected runner daemon was started by a different Homeboy build than the configured runner executable; run recovery_commands in order to restart the active daemon".to_string(),
             recovery_commands: vec![
                 format!("homeboy runner disconnect {}", runner_id),
                 format!("homeboy runner connect {}", runner_id),


### PR DESCRIPTION
## Summary
- require connected direct SSH runner daemons to match the configured runner executable build identity, not just the semver string
- make daemon-backed runner exec self-heal stale direct SSH sessions by reconnecting before dispatching work
- stop treating missing daemon/session identity as compatible freshness state
- format the provider defaults tests from latest main so `cargo fmt --check` passes after rebasing

Closes #4742

## Verification
- Offloaded via `homeboy-lab`; no local Cargo commands were run on the Studio machine.
- Final runner snapshot: `/home/chubes/Developer/_lab_workspaces/homeboy-fix-4742-runner-daemon-refresh-0adff6f76ce7-615c0ad0-c7bf-4037-8cc4-4c016b8ae098-1781576828444576000`
- Final snapshot identity: `snapshot:638e938f06d563cb`
- `homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/_lab_workspaces/homeboy-fix-4742-runner-daemon-refresh-0adff6f76ce7-615c0ad0-c7bf-4037-8cc4-4c016b8ae098-1781576828444576000 -- cargo fmt --check` succeeded; daemon job `c54c59f1-b9db-46ba-9465-ee918ef33e3a`; persisted run `runner-exec-homeboy-lab-c54c59f1-b9db-46ba-9465-ee918ef33e3a`.
- `homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/_lab_workspaces/homeboy-fix-4742-runner-daemon-refresh-0adff6f76ce7-615c0ad0-c7bf-4037-8cc4-4c016b8ae098-1781576828444576000 -- cargo test core::runner::connection` succeeded; daemon job `717daec8-77a5-4002-9e2e-1d156213f04f`; persisted run `runner-exec-homeboy-lab-717daec8-77a5-4002-9e2e-1d156213f04f`; result: 13 passed, 0 failed, 4697 filtered out.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode/Kimaki (GPT-5.5)
- **Used for:** Drafted the runner freshness implementation, rustfmt cleanup, offloaded verification workflow, and PR text; Chris remains responsible for review and merge.