### PR TITLE
fix: require git checkout for offloaded patch agents

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -213,6 +213,15 @@ homeboy agent-task dispatch \
 External workspace managers should resolve their own handles to local paths and
 call dispatch with `--cwd <resolved-path>`.
 
+When `agent-task cook` or `agent-task dispatch` is Lab-offloaded with a
+patch-producing provider, `--cwd` must point at a clean git checkout with
+`remote.origin.url` configured. Homeboy uses that contract to materialize a real
+runner-side git checkout/worktree before provider dispatch so generated files can
+come back as patch artifacts. Non-git directories, dirty worktrees, and checkouts
+without `origin` fail on the controller before offload with a supported-path
+diagnostic; use a Homeboy/Data Machine Code worktree or another clean checkout
+for write-capable agent tasks.
+
 ## Durable Loop Controllers
 
 `agent-task controller` stores domain-agnostic controller state for multi-day

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -11,7 +11,7 @@
 use crate::cli_surface::Commands;
 use crate::command_contract::CommandDescriptor;
 use crate::commands::agent_task;
-use crate::core::agent_tasks::provider::provider_requires_cwd_git_checkout;
+use crate::core::agent_tasks::provider::{default_backend, provider_requires_cwd_git_checkout};
 use crate::core::engine::execution_context::{self, ResolveOptions};
 use crate::core::extension::ExtensionCapability;
 use std::collections::BTreeSet;
@@ -184,12 +184,27 @@ impl Commands {
 }
 
 fn agent_task_provider_requires_cwd_git_checkout(command: &agent_task::AgentTaskCommand) -> bool {
+    agent_task_provider_requires_cwd_git_checkout_with(
+        command,
+        default_backend,
+        provider_requires_cwd_git_checkout,
+    )
+}
+
+fn agent_task_provider_requires_cwd_git_checkout_with(
+    command: &agent_task::AgentTaskCommand,
+    default_backend: impl FnOnce() -> Option<String>,
+    provider_requires_cwd_git_checkout: impl Fn(&str, Option<&str>) -> bool,
+) -> bool {
     match command {
         agent_task::AgentTaskCommand::Cook(args) | agent_task::AgentTaskCommand::Dispatch(args) => {
-            args.cwd.as_ref().is_some_and(|cwd| !cwd.trim().is_empty())
-                && args.backend.as_ref().is_some_and(|backend| {
-                    provider_requires_cwd_git_checkout(backend, args.selector.as_deref())
-                })
+            if !args.cwd.as_ref().is_some_and(|cwd| !cwd.trim().is_empty()) {
+                return false;
+            }
+            let backend = args.backend.clone().or_else(default_backend);
+            backend.as_ref().is_some_and(|backend| {
+                provider_requires_cwd_git_checkout(backend, args.selector.as_deref())
+            })
         }
         _ => false,
     }
@@ -738,6 +753,42 @@ mod tests {
                 .lab_contract()
                 .is_none()
         );
+    }
+
+    #[test]
+    fn agent_task_git_checkout_policy_uses_default_backend_when_backend_is_omitted() {
+        let command = parsed_command(&[
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--cwd",
+            "/work/repo",
+            "--prompt",
+            "cook",
+        ]);
+        let Commands::AgentTask(args) = command else {
+            panic!("expected agent-task command");
+        };
+
+        assert!(agent_task_provider_requires_cwd_git_checkout_with(
+            &args.command,
+            || Some("default-patch-provider".to_string()),
+            |backend, selector| backend == "default-patch-provider" && selector.is_none(),
+        ));
+    }
+
+    #[test]
+    fn agent_task_git_checkout_policy_keeps_non_cwd_dispatch_snapshot_eligible() {
+        let command = parsed_command(&["homeboy", "agent-task", "cook", "--prompt", "cook"]);
+        let Commands::AgentTask(args) = command else {
+            panic!("expected agent-task command");
+        };
+
+        assert!(!agent_task_provider_requires_cwd_git_checkout_with(
+            &args.command,
+            || Some("default-patch-provider".to_string()),
+            |backend, _| backend == "default-patch-provider",
+        ));
     }
 
     #[test]

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -170,6 +170,73 @@ fn lab_workspace_sync_mode(
     Ok(requested)
 }
 
+fn preflight_required_git_checkout_workspace(
+    policy: LabOffloadWorkspaceModePolicy,
+    args: &[String],
+) -> Result<()> {
+    if policy != LabOffloadWorkspaceModePolicy::GitCheckoutRequired {
+        return Ok(());
+    }
+
+    let source_path = rig_materialization::lab_offload_rig_component_checkout_root(args)?
+        .unwrap_or(lab_offload_source_path(args)?);
+    preflight_patch_provider_git_checkout(&source_path)
+}
+
+fn preflight_patch_provider_git_checkout(source_path: &Path) -> Result<()> {
+    let path = source_path.display().to_string();
+    let unsupported = |message: &str, hints: Vec<String>| {
+        Error::validation_invalid_argument(
+            "cwd",
+            message.to_string(),
+            Some(path.clone()),
+            Some(hints),
+        )
+    };
+
+    let inside_work_tree =
+        super::super::workspace::git_output(source_path, &["rev-parse", "--is-inside-work-tree"])
+            .map(|value| value == "true")
+            .unwrap_or(false);
+    if !inside_work_tree {
+        return Err(unsupported(
+            "Lab offload for patch-producing agent-task providers requires --cwd to be a git checkout so generated files can be returned as a patch artifact",
+            vec![
+                "Use a Homeboy/Data Machine Code worktree or another existing git checkout for --cwd.".to_string(),
+                "Initialize the target as a git checkout before using Lab offload with a patch-producing provider.".to_string(),
+                "Use a provider without a git-checkout materialization requirement only if it has an explicit non-git apply-back artifact contract.".to_string(),
+            ],
+        ));
+    }
+
+    let remote_url =
+        super::super::workspace::git_output(source_path, &["config", "--get", "remote.origin.url"])
+            .unwrap_or_default();
+    if remote_url.trim().is_empty() {
+        return Err(unsupported(
+            "Lab offload for patch-producing agent-task providers requires --cwd to have remote.origin.url so the runner can materialize a real git checkout",
+            vec![
+                "Set remote.origin.url on the source checkout before retrying Lab offload.".to_string(),
+                "Use a Homeboy/Data Machine Code worktree or another checkout cloned from the canonical remote.".to_string(),
+            ],
+        ));
+    }
+
+    let status = super::super::workspace::git_output(source_path, &["status", "--porcelain=v1"])
+        .unwrap_or_default();
+    if !status.trim().is_empty() {
+        return Err(unsupported(
+            "Lab offload for patch-producing agent-task providers requires --cwd to be a clean git checkout before runner-side patch capture",
+            vec![
+                "Commit or stash local changes before offloading the patch-producing agent task.".to_string(),
+                "Run with --force-hot to execute locally while the worktree is dirty.".to_string(),
+            ],
+        ));
+    }
+
+    Ok(())
+}
+
 pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadOutcome> {
     let unsupported_runner_error = |runner_id: &str, message: String| {
         Error::validation_invalid_argument(
@@ -228,6 +295,11 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             messages: Vec::new(),
         });
     }
+
+    preflight_required_git_checkout_workspace(
+        contract.workspace_mode_policy,
+        request.normalized_args,
+    )?;
 
     let selection = resolve_lab_runner_selection(
         &contract,
@@ -2029,6 +2101,103 @@ mod tests {
         .expect("sync mode");
 
         assert_eq!(mode, RunnerWorkspaceSyncMode::Git);
+    }
+
+    #[test]
+    fn required_git_checkout_preflight_rejects_non_git_source_before_offload() {
+        let dir = tempfile::tempdir().expect("temp dir");
+
+        let err = preflight_patch_provider_git_checkout(dir.path())
+            .expect_err("non-git source should fail");
+
+        assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+        assert!(err.message.contains("requires --cwd to be a git checkout"));
+        assert!(err.details["tried"]
+            .as_array()
+            .expect("tried hints")
+            .iter()
+            .any(|hint| hint
+                .as_str()
+                .is_some_and(|hint| hint.contains("Data Machine Code worktree"))));
+    }
+
+    #[test]
+    fn required_git_checkout_preflight_rejects_checkout_without_origin() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .status()
+            .expect("init git repo");
+
+        let err = preflight_patch_provider_git_checkout(dir.path())
+            .expect_err("checkout without origin should fail");
+
+        assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+        assert!(err.message.contains("remote.origin.url"));
+        assert!(err.details["tried"]
+            .as_array()
+            .expect("tried hints")
+            .iter()
+            .any(|hint| hint
+                .as_str()
+                .is_some_and(|hint| hint.contains("Set remote.origin.url"))));
+    }
+
+    #[test]
+    fn required_git_checkout_preflight_rejects_dirty_checkout() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .status()
+            .expect("init git repo");
+        std::process::Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/Extra-Chill/homeboy.git",
+            ])
+            .current_dir(dir.path())
+            .status()
+            .expect("add origin");
+        std::fs::write(dir.path().join("dirty.txt"), "dirty").expect("write dirty file");
+
+        let err = preflight_patch_provider_git_checkout(dir.path())
+            .expect_err("dirty checkout should fail");
+
+        assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
+        assert!(err.message.contains("clean git checkout"));
+        assert!(err.details["tried"]
+            .as_array()
+            .expect("tried hints")
+            .iter()
+            .any(|hint| hint
+                .as_str()
+                .is_some_and(|hint| hint.contains("Commit or stash"))));
+    }
+
+    #[test]
+    fn required_git_checkout_preflight_accepts_clean_checkout_with_origin() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .status()
+            .expect("init git repo");
+        std::process::Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/Extra-Chill/homeboy.git",
+            ])
+            .current_dir(dir.path())
+            .status()
+            .expect("add origin");
+
+        preflight_patch_provider_git_checkout(dir.path()).expect("clean checkout should pass");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- require clean git checkout materialization for offloaded patch-capable agent tasks
- prevent patch providers from receiving non-git snapshot workspaces they cannot return as patch artifacts
- update the agent-task docs and Lab command contracts around git checkout policy
- add regression coverage for default backend policy and git checkout preflight rejection/acceptance cases

Fixes #4744.

## Tests
- `git diff --check`
- Offloaded on `homeboy-lab`: `homeboy test --runner homeboy-lab --skip-lint --allow-dirty-lab-workspace -- agent_task_git_checkout_policy required_git_checkout_preflight`
  - passed: 6 tests, 0 failed
  - persisted run: `runner-exec-homeboy-lab-b33aed4f-b8d1-47d3-805f-938e7195e113`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode/Kimaki (GPT-5.5)
- **Used for:** Drafted the git-checkout materialization guard, docs, and regression tests; Chris remains responsible for review and merge.
