### PR TITLE
fix: preserve runner-side tunnel service paths

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -45,6 +45,7 @@ pub enum LabWorkspaceModePolicy {
     ChangedSinceGitElseSnapshot,
     Git,
     GitCheckoutRequired,
+    RunnerResident,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -169,12 +170,14 @@ impl Commands {
                 )
             }
             Commands::Tunnel(args) if args.is_service_start() => {
-                LabCommandContract::explicit_runner(
+                let mut contract = LabCommandContract::explicit_runner(
                     "tunnel service start",
                     None,
                     false,
                     LAB_NO_EXTRA_TOOLS,
-                )
+                );
+                contract.workspace_mode_policy = LabWorkspaceModePolicy::RunnerResident;
+                contract
             }
             _ => return None,
         };

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -814,6 +814,10 @@ mod tests {
         assert_eq!(command.hot_label, "tunnel service start");
         assert!(command.portable);
         assert!(!command.default_lab_offload);
+        assert_eq!(
+            command.workspace_mode_policy,
+            runners::LabOffloadWorkspaceModePolicy::RunnerResident
+        );
         assert!(!command.requires_extension_parity);
         assert!(command.required_extensions.is_empty());
         assert!(!command.infer_source_path_tools);

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -64,6 +64,9 @@ pub fn lab_offload_command_from_contract(
             LabWorkspaceModePolicy::GitCheckoutRequired => {
                 runners::LabOffloadWorkspaceModePolicy::GitCheckoutRequired
             }
+            LabWorkspaceModePolicy::RunnerResident => {
+                runners::LabOffloadWorkspaceModePolicy::RunnerResident
+            }
         },
         requires_extension_parity: contract.requires_extension_parity,
         required_extensions,

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -35,7 +35,7 @@ use super::super::lab_apply::apply_lab_offload_patch;
 use super::super::lab_args::{
     inline_agent_task_prompt_files_in_args, lab_offload_source_path, remap_agent_task_plan_in_args,
     remap_path_settings_in_args, remap_provider_config_in_args, rewrite_lab_offload_args,
-    LabPathRemap,
+    rewrite_runner_resident_lab_offload_args, LabPathRemap,
 };
 use super::super::lab_capabilities::lab_runner_capability_contract;
 use super::super::lab_command::lab_offload_command_prefix;
@@ -110,6 +110,7 @@ pub enum LabOffloadWorkspaceModePolicy {
     ChangedSinceGitElseSnapshot,
     Git,
     GitCheckoutRequired,
+    RunnerResident,
 }
 
 pub enum LabOffloadOutcome {
@@ -141,6 +142,7 @@ fn requested_lab_workspace_sync_mode(
                 RunnerWorkspaceSyncMode::Snapshot
             }
         }
+        LabOffloadWorkspaceModePolicy::RunnerResident => RunnerWorkspaceSyncMode::Snapshot,
     }
 }
 
@@ -184,7 +186,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if let Some(runner_id) = request.explicit_runner {
             return Err(unsupported_runner_error(
                 runner_id,
-                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, and tunnel preview-consumer run".to_string(),
+                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, tunnel preview-consumer run, and tunnel service start".to_string(),
             ));
         }
         return Ok(LabOffloadOutcome::RunLocal {
@@ -197,7 +199,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.portable {
         if let Some(runner_id) = request.explicit_runner {
             let message = contract.unsupported_reason.map_or_else(
-                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, and tunnel preview-consumer run".to_string(),
+                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, tunnel preview-consumer run, and tunnel service start".to_string(),
                 |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
             );
             return Err(unsupported_runner_error(runner_id, message));
@@ -367,6 +369,122 @@ fn tunnel_service_command(normalized_args: &[String]) -> Option<&str> {
     })
 }
 
+fn run_runner_resident_lab_offload(
+    request: LabOffloadRequest<'_>,
+    selection: LabRunnerSelection,
+    contract: LabOffloadCommand,
+    mut plan: HomeboyPlan,
+    mut messages: Vec<String>,
+    runner_workspace_root: &str,
+    homeboy_path: &str,
+    runner_status: &RunnerStatusReport,
+) -> Result<LabOffloadOutcome> {
+    let runner_id = &selection.runner_id;
+    let runner_homeboy = lab_runner_homeboy_metadata(runner_id, homeboy_path, runner_status);
+    plan = with_step(
+        plan,
+        PlanStep::ready("lab.runner_homeboy", "lab.runner_homeboy")
+            .inputs(PlanValues::new().json("runner_homeboy", &runner_homeboy))
+            .build(),
+    );
+
+    let remapped_args = rewrite_runner_resident_lab_offload_args(request.normalized_args);
+    let mut command = vec![homeboy_path.to_string()];
+    command.extend(remapped_args.iter().skip(1).cloned());
+    plan = with_step(
+        plan,
+        PlanStep::ready("lab.rewrite_args", "lab.rewrite_args")
+            .inputs(PlanValues::new().json("argv", &command))
+            .build(),
+    );
+
+    eprintln!(
+        "Lab offload: running runner-resident `{}` on runner `{}` in `{}`.",
+        command.join(" "),
+        runner_id,
+        runner_workspace_root
+    );
+    let mut lab_metadata = lab_offload_metadata(
+        &plan,
+        selection.source.metadata_value(),
+        Some(runner_id),
+        Some(status_tunnel_mode(runner_status).metadata_value()),
+        "offloaded",
+        Some(runner_workspace_root),
+        None,
+    );
+    lab_metadata["runner_homeboy"] = runner_homeboy;
+    lab_metadata["workspace"] = serde_json::json!({
+        "schema": "homeboy/lab-runner-resident-workspace/v1",
+        "mode": "runner_resident",
+        "runner_cwd": runner_workspace_root,
+        "command_paths": "runner_side",
+    });
+    let mut env = build_lab_offload_env(&lab_metadata);
+    forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
+    forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
+    forward_release_ci_env(&mut env);
+    let tunnel_secret_env = hydrate_tunnel_secret_env(&remapped_args, &mut env)?;
+    lab_metadata["tunnel_secret_env"] = tunnel_secret_env;
+    env = build_lab_offload_env(&lab_metadata);
+    forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
+    forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
+    forward_release_ci_env(&mut env);
+    hydrate_tunnel_secret_env(&remapped_args, &mut env)?;
+
+    let (exec_output, exit_code) = exec(
+        runner_id,
+        RunnerExecOptions {
+            cwd: Some(runner_workspace_root.to_string()),
+            project_id: None,
+            allow_diagnostic_ssh: false,
+            command,
+            env,
+            secret_env_names: Vec::new(),
+            capture_patch: request.capture_patch,
+            raw_exec: false,
+            source_snapshot: None,
+            capability_preflight: None,
+            required_extensions: contract.required_extensions,
+            require_paths: Vec::new(),
+        },
+    )?;
+    plan = with_step(
+        plan,
+        PlanStep::builder(
+            "lab.exec",
+            "lab.exec",
+            if exit_code == 0 {
+                PlanStepStatus::Success
+            } else {
+                PlanStepStatus::Failed
+            },
+        )
+        .inputs(PlanValues::new().json("exit_code", exit_code))
+        .build(),
+    );
+    if !exec_output.stderr.is_empty() {
+        messages.push(format!(
+            "Lab offload: runner-resident command wrote {} stderr bytes.",
+            exec_output.stderr.len()
+        ));
+    }
+
+    let mut stderr = String::new();
+    for message in messages {
+        stderr.push_str(&message);
+        stderr.push('\n');
+    }
+    stderr.push_str(&exec_output.stderr);
+
+    Ok(LabOffloadOutcome::Offloaded {
+        plan,
+        stdout: exec_output.stdout,
+        stderr,
+        exit_code,
+    })
+}
+
 fn run_lab_offload_inner(
     request: LabOffloadRequest<'_>,
     selection: LabRunnerSelection,
@@ -419,7 +537,7 @@ fn run_lab_offload_inner(
         return mutation_return_unavailable_outcome(plan, &selection, &runner_status, reason);
     }
 
-    runner.workspace_root.as_deref().ok_or_else(|| {
+    let runner_workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
         Error::validation_invalid_argument(
             "workspace_root",
             "Lab offload requires runner.workspace_root so the local checkout can be mapped remotely",
@@ -429,6 +547,19 @@ fn run_lab_offload_inner(
             ]),
         )
     })?;
+
+    if contract.workspace_mode_policy == LabOffloadWorkspaceModePolicy::RunnerResident {
+        return run_runner_resident_lab_offload(
+            request,
+            selection,
+            contract,
+            plan,
+            messages,
+            runner_workspace_root,
+            runner.settings.homeboy_path.as_deref().unwrap_or("homeboy"),
+            &runner_status,
+        );
+    }
 
     let source_path =
         rig_materialization::lab_offload_rig_component_checkout_root(request.normalized_args)?

--- a/src/core/runner/lab_args.rs
+++ b/src/core/runner/lab_args.rs
@@ -600,6 +600,46 @@ pub(super) fn rewrite_lab_offload_args(
     stripped
 }
 
+pub(super) fn rewrite_runner_resident_lab_offload_args(args: &[String]) -> Vec<String> {
+    let mut stripped = Vec::with_capacity(args.len());
+    let mut iter = args.iter().peekable();
+    let mut passthrough = false;
+    let has_force_hot = args.iter().any(|arg| arg == "--force-hot");
+    while let Some(arg) = iter.next() {
+        if arg == EXPLICIT_PASSTHROUGH_SENTINEL {
+            continue;
+        }
+        if passthrough {
+            stripped.push(arg.clone());
+            continue;
+        }
+        if arg == "--" {
+            passthrough = true;
+            stripped.push(arg.clone());
+            continue;
+        }
+        if arg == "--runner" {
+            let _ = iter.next();
+            continue;
+        }
+        if arg.starts_with("--runner=") {
+            continue;
+        }
+        if arg == "--output" {
+            let _ = iter.next();
+            continue;
+        }
+        if arg.starts_with("--output=") {
+            continue;
+        }
+        stripped.push(arg.clone());
+    }
+    if !has_force_hot {
+        stripped.insert(1, "--force-hot".to_string());
+    }
+    stripped
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -619,6 +659,39 @@ mod tests {
         assert_eq!(
             lab_offload_source_path(&args).expect("source path"),
             PathBuf::from("/Users/chubes/Developer/wp-site-generator")
+        );
+    }
+
+    #[test]
+    fn runner_resident_rewrite_preserves_runner_side_cwd() {
+        let args = vec![
+            "homeboy".to_string(),
+            "--runner".to_string(),
+            "homeboy-lab".to_string(),
+            "tunnel".to_string(),
+            "service".to_string(),
+            "start".to_string(),
+            "preview".to_string(),
+            "--cwd".to_string(),
+            "/home/chubes/Developer/_lab_workspaces/site".to_string(),
+            "--command".to_string(),
+            "npm run dev".to_string(),
+        ];
+
+        assert_eq!(
+            rewrite_runner_resident_lab_offload_args(&args),
+            vec![
+                "homeboy".to_string(),
+                "--force-hot".to_string(),
+                "tunnel".to_string(),
+                "service".to_string(),
+                "start".to_string(),
+                "preview".to_string(),
+                "--cwd".to_string(),
+                "/home/chubes/Developer/_lab_workspaces/site".to_string(),
+                "--command".to_string(),
+                "npm run dev".to_string(),
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary
- Treat `tunnel service start` Lab offload as runner-resident instead of syncing a controller workspace.
- Preserve command-level `--cwd` as a runner-side path while stripping only controller routing globals.
- Hydrate tunnel secrets for the runner-resident command and keep stale support messaging aligned with the native runner contract.

Fixes #4740.

## Tests
- `git diff --check` — passed.
- `homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/_lab_workspaces/homeboy-fix-4740-runner-tunnel-cwd-6891d864d3ff-f81a805a-22a5-4e33-a758-fd3df0eaa19d-1781577323809972000 -- cargo fmt --check` — passed; persisted run `runner-exec-homeboy-lab-e5535fcb-bcbc-412c-ad98-ba12eb739262`.
- `homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/_lab_workspaces/homeboy-fix-4740-runner-tunnel-cwd-6891d864d3ff-f81a805a-22a5-4e33-a758-fd3df0eaa19d-1781577323809972000 -- cargo test runner_resident_rewrite_preserves_runner_side_cwd` — passed; persisted run `runner-exec-homeboy-lab-c3c476ef-5829-414c-93d0-97291420565f`.
- `homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/_lab_workspaces/homeboy-fix-4740-runner-tunnel-cwd-6891d864d3ff-f81a805a-22a5-4e33-a758-fd3df0eaa19d-1781577323809972000 -- cargo test tunnel_service_start_supports_explicit_runner_discovery` — passed; persisted run `runner-exec-homeboy-lab-92844523-f797-41b8-a738-d86923555a72`.

## Notes
- Did not run cargo locally on the Studio machine; all cargo/fmt/test work ran through `homeboy-lab`.
- Invalid combined Cargo test invocation failed before running tests because Cargo accepts one test-name filter: `runner-exec-homeboy-lab-82fba137-5dce-406f-8b95-2086dcffc16e`.
- Recursive `homeboy --runner homeboy-lab --force-hot test ...` verification attempt was cancelled after it stayed in flight: `runner-exec-homeboy-lab-75ab74dc-9395-4db9-a3af-69c2e7be8654`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode/Kimaki (GPT-5.5)
- **Used for:** Drafted the runner-resident Lab offload contract, path rewrite, and regression tests; Chris remains responsible for review and validation.
