### PR TITLE
Recover stale controller child runs

### DIFF
--- a/src/core/agent_task_controller_service.rs
+++ b/src/core/agent_task_controller_service.rs
@@ -1435,7 +1435,11 @@ where
         "run_plan" => {
             let plan = plan_from_controller_request(request)?;
             let run_id = controller_request_run_id(request, dedupe_key, &action.action_id);
-            let submitted = lifecycle::submit_plan(&plan, Some(&run_id))?;
+            let submitted = if lifecycle::run_record_exists(&run_id)? {
+                lifecycle::status(&run_id)?
+            } else {
+                lifecycle::submit_plan(&plan, Some(&run_id))?
+            };
             record_controller_spawn(
                 record,
                 action,
@@ -2473,6 +2477,7 @@ mod tests {
     use crate::core::agent_task_scheduler::AgentTaskExecutionContext;
     use crate::test_support::with_isolated_home;
     use serde_json::json;
+    use std::fs;
     use std::sync::{Arc, Mutex};
 
     #[derive(Clone, Default)]
@@ -3037,6 +3042,92 @@ mod tests {
                 .clone()
                 .expect("provider saw request");
             assert_eq!(observed.task_id, "controller-service-task");
+        });
+    }
+
+    #[test]
+    fn resume_recovers_running_action_with_stale_child_run() {
+        with_isolated_home(|_| {
+            let mut record = init(ControllerInitRequest {
+                loop_id: "loop-service-stale-child".to_string(),
+                phase: "repair".to_string(),
+                config_version: "v1".to_string(),
+            })
+            .expect("controller initialized");
+
+            let plan = test_plan();
+            crate::core::agent_task_lifecycle::submit_plan(
+                &plan,
+                Some("controller-service-stale-child-a"),
+            )
+            .expect("child submitted");
+            crate::core::agent_task_lifecycle::mark_running("controller-service-stale-child-a")
+                .expect("child marked running");
+            let status_path = crate::core::paths::homeboy_data()
+                .expect("homeboy data")
+                .join("agent-task-runs")
+                .join("controller-service-stale-child-a")
+                .join("status.json");
+            let mut status_json: Value =
+                serde_json::from_str(&fs::read_to_string(&status_path).expect("child status json"))
+                    .expect("parsed child status");
+            status_json["metadata"]["runner_pid"] = json!(999999u32);
+            fs::write(
+                &status_path,
+                format!(
+                    "{}\n",
+                    serde_json::to_string_pretty(&status_json).expect("serialized child status")
+                ),
+            )
+            .expect("stale child status written");
+
+            record.record_action(
+                AgentTaskLoopPolicyAction::SpawnTask {
+                    dedupe_key: "finding:abc:repair".to_string(),
+                    entity_id: None,
+                    request: json!({
+                        "mode": "run_plan",
+                        "run_id": "controller-service-stale-child-a",
+                        "plan": plan,
+                    }),
+                },
+                "finding emitted",
+            );
+            record.next_actions[0].status = AgentTaskLoopActionStatus::Running;
+            record
+                .dedupe_keys
+                .get_mut("finding:abc:repair")
+                .expect("dedupe record")
+                .run_id = Some("controller-service-stale-child-a".to_string());
+            controller::write_controller(&record).expect("controller written");
+
+            let result = resume(
+                "loop-service-stale-child",
+                CapturingExecutor::default(),
+                &NoopDispatchHook,
+            )
+            .expect("controller resumed");
+
+            assert_eq!(result.exit_code, 0);
+            assert_eq!(result.value.results.len(), 1);
+            let loaded =
+                controller::load_controller("loop-service-stale-child").expect("controller");
+            assert_eq!(
+                loaded.next_actions[0].status,
+                AgentTaskLoopActionStatus::Completed
+            );
+            assert_eq!(
+                loaded.next_actions[0].diagnostics[0].code,
+                "stale_child_run_recovery"
+            );
+            assert!(loaded.history.iter().any(|event| {
+                event.event_type == "controller.action.stale_child_recovery"
+                    && event.payload["run_id"] == json!("controller-service-stale-child-a")
+            }));
+            let child =
+                crate::core::agent_task_lifecycle::status("controller-service-stale-child-a")
+                    .expect("child status");
+            assert_eq!(child.metadata["reclaimed_stale_running"], json!(true));
         });
     }
 

--- a/src/core/agent_task_loop_controller.rs
+++ b/src/core/agent_task_loop_controller.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::PathBuf;
 
+use crate::core::agent_task_lifecycle::AgentTaskRunState;
 use crate::core::{agent_task_lifecycle, paths, Error, Result};
 
 pub const AGENT_TASK_LOOP_CONTROLLER_SCHEMA: &str = "homeboy/agent-task-loop-controller/v1";
@@ -1611,7 +1612,9 @@ pub fn load_controller(loop_id: &str) -> Result<AgentTaskLoopControllerRecord> {
 
 pub fn controller_status(loop_id: &str) -> Result<AgentTaskLoopControllerRecord> {
     let mut record = load_controller(loop_id)?;
-    if refresh_subcontroller_statuses(&mut record)? {
+    let refreshed_child_runs = refresh_stale_running_child_actions(&mut record)?;
+    let refreshed_subcontrollers = refresh_subcontroller_statuses(&mut record)?;
+    if refreshed_child_runs || refreshed_subcontrollers {
         write_controller(&record)?;
     }
     Ok(record)
@@ -1984,6 +1987,77 @@ fn refresh_subcontroller_statuses(record: &mut AgentTaskLoopControllerRecord) ->
     if record.open_wait_count() == 0 && record.state == AgentTaskLoopControllerState::Waiting {
         record.state = AgentTaskLoopControllerState::Running;
         changed = true;
+    }
+
+    if changed {
+        record.touch();
+    }
+    Ok(changed)
+}
+
+fn refresh_stale_running_child_actions(record: &mut AgentTaskLoopControllerRecord) -> Result<bool> {
+    let mut changed = false;
+    let mut history_events = Vec::new();
+
+    for index in 0..record.next_actions.len() {
+        let action = &record.next_actions[index];
+        if action.status != AgentTaskLoopActionStatus::Running
+            || !matches!(action.action, AgentTaskLoopPolicyAction::SpawnTask { .. })
+        {
+            continue;
+        }
+
+        let Some(run_id) = action_referenced_run_id(action, record) else {
+            continue;
+        };
+        let run = agent_task_lifecycle::status(&run_id)?;
+        if run.state != AgentTaskRunState::Running
+            || run.metadata.get("stale_running").and_then(Value::as_bool) != Some(true)
+        {
+            continue;
+        }
+
+        let reason = run
+            .metadata
+            .get("stale_running_reason")
+            .and_then(Value::as_str)
+            .unwrap_or("stale_running");
+        let action = &mut record.next_actions[index];
+        action.status = AgentTaskLoopActionStatus::Pending;
+        action.reason = format!(
+            "child agent-task run '{run_id}' is stale ({reason}); action reset for recovery"
+        );
+        action.diagnostics.push(AgentTaskLoopActionDiagnostic {
+            code: "stale_child_run_recovery".to_string(),
+            message: action.reason.clone(),
+            runner: None,
+            details: json!({
+                "run_id": run_id,
+                "stale_running_reason": reason,
+            }),
+        });
+        history_events.push((
+            action.action_id.clone(),
+            action.dedupe_key.clone(),
+            run_id,
+            reason.to_string(),
+        ));
+        changed = true;
+    }
+
+    for (action_id, dedupe_key, run_id, reason) in history_events {
+        record.history.push(AgentTaskLoopHistoryEvent {
+            event_id: format!("stale-child-recovery-{}", record.history.len() + 1),
+            event_type: "controller.action.stale_child_recovery".to_string(),
+            recorded_at: now_timestamp(),
+            entity_id: None,
+            payload: json!({
+                "action_id": action_id,
+                "dedupe_key": dedupe_key,
+                "run_id": run_id,
+                "stale_running_reason": reason,
+            }),
+        });
     }
 
     if changed {


### PR DESCRIPTION
## Summary
- Recover controller actions stuck in `running` when their tracked child agent-task run is stale because the owner process is gone.
- Reset stale child spawn actions back to `pending` with a generic diagnostic/history event so normal controller resume can reclaim the durable run.
- Reuse existing child run records during recovered `run_plan` execution instead of submitting over the same run id.

Fixes #4749.

## Regression coverage
- Added `resume_recovers_running_action_with_stale_child_run`, covering a controller action stuck in `running` with a child run annotated `stale_running=true` / `owner_process_not_running`, then proving resume completes the action and the child run is reclaimed.

## Verification
- No local Cargo was run.
- Offloaded Homeboy Lab runner attempted targeted verification:
  - `homeboy test homeboy --runner homeboy-lab --allow-dirty-lab-workspace -- --lib resume_recovers_running_action_with_stale_child_run`
  - Persisted run: `runner-exec-homeboy-lab-09d3e990-d3ca-46d7-b2da-e6e79b357e1a`
  - Evidence command: `homeboy runs evidence runner-exec-homeboy-lab-09d3e990-d3ca-46d7-b2da-e6e79b357e1a`
  - Status at PR open: runner-side job remained `running` after the local command was aborted, with no terminal result yet.
- Earlier offloaded attempts reached `cargo fmt --check` and failed before tests due formatting, then formatting was applied manually from the runner diff.
- GitHub CI should provide the terminal reviewer-facing verification for this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the controller recovery implementation, regression test, and PR text; Chris requested the issue and PR workflow.
