### PR TITLE
Fix durable agent-task pre-dispatch status records

### DIFF
--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -292,6 +292,8 @@ mod tests {
                 .keep()
                 .display()
                 .to_string();
+            let patch_path = std::path::Path::new(&workspace).join("changes.patch");
+            std::fs::write(&patch_path, "diff --git a/file b/file\n").expect("patch fixture");
             let (value, exit_code) = cook_with_executor(
                 dispatch_args(DispatchArgOverrides {
                     prompt: Some("Cook a patch.".to_string()),
@@ -299,7 +301,7 @@ mod tests {
                     run_id: Some("cook-handoff".to_string()),
                     ..DispatchArgOverrides::default()
                 }),
-                PatchExecutor,
+                PatchExecutor { patch_path },
             )
             .expect("cook run");
 
@@ -340,7 +342,9 @@ mod tests {
                     run_id: Some("cook-queued".to_string()),
                     ..DispatchArgOverrides::default()
                 }),
-                PatchExecutor,
+                PatchExecutor {
+                    patch_path: std::path::PathBuf::new(),
+                },
             )
             .expect("queued cook");
 
@@ -440,7 +444,9 @@ mod tests {
         }
     }
 
-    struct PatchExecutor;
+    struct PatchExecutor {
+        patch_path: std::path::PathBuf,
+    }
 
     impl AgentTaskExecutorAdapter for PatchExecutor {
         fn execute(
@@ -459,10 +465,12 @@ mod tests {
                     id: "patch-1".to_string(),
                     kind: "patch".to_string(),
                     name: Some("changes.patch".to_string()),
-                    path: Some("/tmp/changes.patch".to_string()),
+                    path: Some(self.patch_path.display().to_string()),
                     url: None,
                     mime: None,
-                    size_bytes: None,
+                    size_bytes: std::fs::metadata(&self.patch_path)
+                        .ok()
+                        .map(|metadata| metadata.len()),
                     sha256: None,
                     metadata: Value::Null,
                 }],

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -1373,16 +1373,46 @@ mod tests {
 
             let loaded = status("cook-lab-predispatch").expect("status loaded");
             let log = logs("cook-lab-predispatch").expect("logs loaded");
+            let artifact_report = artifacts("cook-lab-predispatch").expect("artifacts loaded");
+            let legacy_status_path = crate::core::paths::homeboy_data()
+                .expect("homeboy data")
+                .join("agent-task-runs")
+                .join("cook-lab-predispatch")
+                .join("status.json");
+            std::fs::remove_file(
+                crate::core::paths::homeboy_data()
+                    .expect("homeboy data")
+                    .join("agent-task-runs")
+                    .join("cook-lab-predispatch")
+                    .join("aggregate.json"),
+            )
+            .expect("aggregate file removed");
+            let mirrored_log = logs("cook-lab-predispatch").expect("mirrored logs loaded");
+            let mirrored_artifacts =
+                artifacts("cook-lab-predispatch").expect("mirrored artifacts loaded");
 
             assert_eq!(record.state, AgentTaskRunState::Failed);
             assert_eq!(loaded.state, AgentTaskRunState::Failed);
             assert_eq!(loaded.tasks[0].state, AgentTaskState::Failed);
             assert!(loaded.provider_handles.is_empty());
             assert_eq!(log.events[1].state, AgentTaskState::Failed);
+            assert_eq!(mirrored_log.events[1].state, AgentTaskState::Failed);
             assert_eq!(loaded.metadata["provider_run_ids"], serde_json::json!([]));
             assert_eq!(
                 loaded.artifact_refs[0].kind,
                 "lab-offload-pre-dispatch-failure"
+            );
+            assert_eq!(
+                artifact_report.evidence_refs[0].kind,
+                "lab-offload-pre-dispatch-failure"
+            );
+            assert_eq!(
+                mirrored_artifacts.evidence_refs[0].kind,
+                "lab-offload-pre-dispatch-failure"
+            );
+            assert!(
+                !legacy_status_path.exists(),
+                "agent-task status.json is no longer the primary durable run record"
             );
         });
     }
@@ -2115,41 +2145,28 @@ mod tests {
     }
 
     #[test]
-    fn list_records_skips_malformed_status_files() {
+    fn list_records_skips_malformed_observation_records() {
         with_isolated_home(|_| {
             let plan = test_plan();
             submit_plan(&plan, Some("good-run")).expect("submitted");
-            let invalid_shape = submit_plan(&plan, Some("missing-skipped-run")).expect("submitted");
-            let invalid_shape_path = paths::homeboy_data()
-                .expect("homeboy data")
-                .join("agent-task-runs")
-                .join(&invalid_shape.run_id)
-                .join("status.json");
-            let mut raw = serde_json::to_value(&invalid_shape).expect("record json");
-            raw["totals"] = json!({
-                "queued": 1,
-                "running": 0,
-                "blocked": 0,
-                "succeeded": 0,
-                "failed": 0,
-                "cancelled": 0,
-                "timed_out": 0
-            });
-            std::fs::write(
-                &invalid_shape_path,
-                format!(
-                    "{}\n",
-                    serde_json::to_string_pretty(&raw).expect("pretty json")
-                ),
-            )
-            .expect("write invalid-shape status");
-            let bad_dir = paths::homeboy_data()
-                .expect("homeboy data")
-                .join("agent-task-runs")
-                .join("bad-run");
-            std::fs::create_dir_all(&bad_dir).expect("create bad run dir");
-            std::fs::write(bad_dir.join("status.json"), "{ definitely not json\n")
-                .expect("write bad status");
+            let store = crate::core::observation::ObservationStore::open_initialized()
+                .expect("observation store");
+            store
+                .upsert_imported_run(&crate::core::observation::RunRecord {
+                    id: "bad-run".to_string(),
+                    kind: "agent-task".to_string(),
+                    component_id: None,
+                    started_at: "2026-01-01T00:00:00Z".to_string(),
+                    finished_at: None,
+                    status: "running".to_string(),
+                    command: None,
+                    cwd: None,
+                    homeboy_version: None,
+                    git_sha: None,
+                    rig_id: None,
+                    metadata_json: json!({ "schema": "homeboy/agent-task-observation-record/v1" }),
+                })
+                .expect("bad record inserted");
 
             let records = list_records().expect("records listed");
 

--- a/src/core/lifecycle_store.rs
+++ b/src/core/lifecycle_store.rs
@@ -1,12 +1,13 @@
 use std::fs;
-use std::io::ErrorKind;
 use std::path::PathBuf;
 
 use serde::Serialize;
+use serde_json::{json, Value};
 
-use super::{sanitize_run_id, AgentTaskRunRecord};
+use super::{sanitize_run_id, AgentTaskRunRecord, AgentTaskRunState};
 use crate::core::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
-use crate::core::{paths, Error, Result};
+use crate::core::observation::{ObservationStore, RunListFilter, RunRecord, RunStatus};
+use crate::core::{paths, Error, ErrorCode, Result};
 
 pub(super) fn write_plan(run_id: &str, plan: &AgentTaskPlan) -> Result<PathBuf> {
     let path = run_dir(run_id)?.join("plan.json");
@@ -21,11 +22,13 @@ pub(super) fn read_plan_path(path: &str) -> Result<AgentTaskPlan> {
 pub(super) fn write_aggregate(run_id: &str, aggregate: &AgentTaskAggregate) -> Result<PathBuf> {
     let path = run_dir(run_id)?.join("aggregate.json");
     write_json(&path, aggregate)?;
+    mirror_aggregate(run_id, aggregate)?;
     Ok(path)
 }
 
 pub(super) fn read_aggregate(run_id: &str) -> Result<AgentTaskAggregate> {
     read_json(&aggregate_path(run_id)?)
+        .or_else(|error| read_mirrored_aggregate(run_id)?.ok_or(error))
 }
 
 pub(super) fn aggregate_path(run_id: &str) -> Result<PathBuf> {
@@ -33,57 +36,182 @@ pub(super) fn aggregate_path(run_id: &str) -> Result<PathBuf> {
 }
 
 pub(super) fn write_record(record: &AgentTaskRunRecord) -> Result<()> {
-    write_json(&record_path(&record.run_id)?, record)
+    let store = ObservationStore::open_initialized()?;
+    let metadata_json = observation_metadata(record, read_mirrored_aggregate(&record.run_id)?)?;
+    store.upsert_imported_run(&RunRecord {
+        id: record.run_id.clone(),
+        kind: "agent-task".to_string(),
+        component_id: record.plan_id_component(),
+        started_at: record.submitted_at.clone(),
+        finished_at: terminal_finished_at(record),
+        status: run_status(record.state).to_string(),
+        command: Some("homeboy agent-task".to_string()),
+        cwd: None,
+        homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        git_sha: None,
+        rig_id: None,
+        metadata_json,
+    })
 }
 
 pub(super) fn read_record(run_id: &str) -> Result<AgentTaskRunRecord> {
-    read_json(&record_path(run_id)?)
+    let store = ObservationStore::open_initialized()?;
+    let run = store.get_run(run_id)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "run_id",
+            format!("agent-task run record not found: {run_id}"),
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    record_from_run(&run)
 }
 
 pub(super) fn record_exists(run_id: &str) -> Result<bool> {
-    match fs::metadata(record_path(run_id)?) {
-        Ok(metadata) => Ok(metadata.is_file()),
-        Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
-        Err(error) => Err(Error::internal_io(
-            error.to_string(),
-            Some(run_id.to_string()),
-        )),
-    }
+    Ok(ObservationStore::open_initialized()?
+        .get_run(run_id)?
+        .is_some())
 }
 
 pub(super) fn read_records() -> Result<Vec<AgentTaskRunRecord>> {
-    let root = paths::homeboy_data()?.join("agent-task-runs");
-    let entries = match fs::read_dir(&root) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(error) => {
-            return Err(Error::internal_io(
-                error.to_string(),
-                Some(root.display().to_string()),
-            ));
-        }
-    };
-
+    let store = ObservationStore::open_initialized()?;
+    let mut filter = RunListFilter::default();
+    filter.kind = Some("agent-task".to_string());
+    filter.limit = Some(1000);
     let mut records = Vec::new();
-    for entry in entries {
-        let entry = entry.map_err(|error| {
-            Error::internal_io(error.to_string(), Some(root.display().to_string()))
-        })?;
-        let path = entry.path().join("status.json");
-        if !path.exists() {
-            continue;
-        }
-        match read_json(&path) {
+    for run in store.list_runs(filter)? {
+        match record_from_run(&run) {
             Ok(record) => records.push(record),
             Err(error) => eprintln!(
-                "Warning: skipping malformed agent-task run status {}: {}",
-                path.display(),
-                error.message
+                "Warning: skipping malformed agent-task run record {}: {}",
+                run.id, error.message
             ),
         }
     }
 
     Ok(records)
+}
+
+fn observation_metadata(
+    record: &AgentTaskRunRecord,
+    aggregate: Option<AgentTaskAggregate>,
+) -> Result<Value> {
+    let record_json = serde_json::to_value(record).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some(format!("serialize agent-task run {}", record.run_id)),
+        )
+    })?;
+    Ok(json!({
+        "schema": "homeboy/agent-task-observation-record/v1",
+        "agent_task_run": record_json,
+        "agent_task_aggregate": aggregate,
+    }))
+}
+
+fn record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
+    let value = run.metadata_json.get("agent_task_run").ok_or_else(|| {
+        Error::new(
+            ErrorCode::InternalJsonError,
+            format!(
+                "observation run {} is missing agent_task_run metadata",
+                run.id
+            ),
+            json!({ "context": run.id }),
+        )
+    })?;
+    serde_json::from_value(value.clone()).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some(format!("parse agent-task run {}", run.id)),
+        )
+    })
+}
+
+fn mirror_aggregate(run_id: &str, aggregate: &AgentTaskAggregate) -> Result<()> {
+    let record = match read_record(run_id) {
+        Ok(record) => record,
+        Err(error) if error.code == ErrorCode::ValidationInvalidArgument => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    let store = ObservationStore::open_initialized()?;
+    let metadata_json = observation_metadata(&record, Some(aggregate.clone()))?;
+    store.upsert_imported_run(&RunRecord {
+        id: record.run_id.clone(),
+        kind: "agent-task".to_string(),
+        component_id: record.plan_id_component(),
+        started_at: record.submitted_at.clone(),
+        finished_at: terminal_finished_at(&record),
+        status: run_status(record.state).to_string(),
+        command: Some("homeboy agent-task".to_string()),
+        cwd: None,
+        homeboy_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        git_sha: None,
+        rig_id: None,
+        metadata_json,
+    })
+}
+
+fn read_mirrored_aggregate(run_id: &str) -> Result<Option<AgentTaskAggregate>> {
+    let store = ObservationStore::open_initialized()?;
+    let Some(run) = store.get_run(run_id)? else {
+        return Ok(None);
+    };
+    let Some(value) = run.metadata_json.get("agent_task_aggregate") else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    serde_json::from_value(value.clone())
+        .map(Some)
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some(format!("parse agent-task aggregate {}", run.id)),
+            )
+        })
+}
+
+fn run_status(state: AgentTaskRunState) -> &'static str {
+    match state {
+        AgentTaskRunState::Queued | AgentTaskRunState::Running => RunStatus::Running.as_str(),
+        AgentTaskRunState::Succeeded => RunStatus::Pass.as_str(),
+        AgentTaskRunState::PartialFailure | AgentTaskRunState::Failed => RunStatus::Fail.as_str(),
+        AgentTaskRunState::Cancelled => RunStatus::Skipped.as_str(),
+    }
+}
+
+fn terminal_finished_at(record: &AgentTaskRunRecord) -> Option<String> {
+    match record.state {
+        AgentTaskRunState::Succeeded
+        | AgentTaskRunState::PartialFailure
+        | AgentTaskRunState::Failed
+        | AgentTaskRunState::Cancelled => record
+            .updated_at
+            .clone()
+            .or_else(|| Some(record.submitted_at.clone())),
+        AgentTaskRunState::Queued | AgentTaskRunState::Running => None,
+    }
+}
+
+trait AgentTaskRunRecordExt {
+    fn plan_id_component(&self) -> Option<String>;
+}
+
+impl AgentTaskRunRecordExt for AgentTaskRunRecord {
+    fn plan_id_component(&self) -> Option<String> {
+        self.metadata
+            .get("repo")
+            .and_then(Value::as_str)
+            .map(ToString::to_string)
+            .or_else(|| {
+                self.metadata
+                    .get("kind")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+    }
 }
 
 fn read_json<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Result<T> {
@@ -105,10 +233,6 @@ fn write_json<T: Serialize>(path: &PathBuf, value: &T) -> Result<()> {
     })?;
     fs::write(path, format!("{json}\n"))
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))
-}
-
-fn record_path(run_id: &str) -> Result<PathBuf> {
-    Ok(run_dir(run_id)?.join("status.json"))
 }
 
 fn run_dir(run_id: &str) -> Result<PathBuf> {


### PR DESCRIPTION
## Summary
- Move agent-task run status records out of legacy `status.json` primary storage and into the observation durable store metadata.
- Mirror aggregate JSON into the durable store so `agent-task logs` and `agent-task artifacts` still work when the local aggregate file is unavailable across controller/runner boundaries.
- Update pre-dispatch/listing tests to assert the observation-store contract and no legacy `status.json` primary record.
- Update the cook handoff test fixture to declare a real non-empty patch artifact under the current apply-candidate contract.

Fixes #4747.

## Verification
All intended Cargo verification commands were run off the Studio machine on `homeboy-lab` via `homeboy runner exec`.

- `cargo fmt --check` passed, runner job `2451d2d1-5403-43bc-b12a-5663522e2161` / mirrored run `runner-exec-homeboy-lab-2451d2d1-5403-43bc-b12a-5663522e2161`.
- `cargo test agent_task_dispatch --lib` passed: 22 passed, runner job `fd09b780-88f6-45bb-9852-99dbfebd4427` / mirrored run `runner-exec-homeboy-lab-fd09b780-88f6-45bb-9852-99dbfebd4427`.
- `cargo test agent_task_lifecycle --lib` passed: 21 passed, runner job `277dffbb-e11a-4c0d-aa98-6a01d886f56e` / mirrored run `runner-exec-homeboy-lab-277dffbb-e11a-4c0d-aa98-6a01d886f56e`.
- `cargo test --lib` was run on `homeboy-lab`; it failed only on unrelated tunnel process-state tests `core::tunnel_tests::status_refresh_clears_exited_process_readiness` and `core::tunnel_tests::status_reports_degraded_when_backend_outlives_service_process`. Result: 4685 passed, 2 failed, 18 ignored. Runner job `d9d436cd-2f6e-4ba6-a857-1670fa30bc2d` / mirrored run `runner-exec-homeboy-lab-d9d436cd-2f6e-4ba6-a857-1670fa30bc2d`.

Note: an initial PR creation attempt was incorrectly shell-quoted, causing Markdown backticks in this PR body to be interpreted by the local shell before `gh` ran. That unintentionally invoked local Cargo commands; the commands did not change committed files, and the repository remained clean afterward. The verification evidence above is still the offloaded `homeboy-lab` evidence used for this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode/Kimaki (GPT-5.5)
- **Used for:** Implemented the durable agent-task lifecycle store change, updated tests, and ran offloaded verification. Chris remains responsible for review and merge.
