### PR TITLE
fix: keep agent-task inspection read-only

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -70,6 +70,11 @@ This is the terminal/daemon-owned review surface for fleet cooking. Kimaki or an
 other chat UI should submit, poll, render, and call these commands rather than
 owning scheduling, state, artifacts, reconciliation, or promotion.
 
+`agent-task status`, `logs`, `artifacts`, and `review` are read-only durable
+lifecycle inspection commands. They do not start workloads and are not gated by
+warm-machine resource policy; use `homeboy runner exec <runner> -- homeboy
+agent-task status <run-id>` when the durable state lives on a Lab runner host.
+
 ## Deterministic Smoke Gate
 
 Issue #3392 is covered by a no-secret fixture plan at

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -81,22 +81,6 @@ impl Commands {
                 contract
             }
             Commands::AgentTask(args)
-                if matches!(
-                    args.command,
-                    agent_task::AgentTaskCommand::Status(_)
-                        | agent_task::AgentTaskCommand::Logs(_)
-                        | agent_task::AgentTaskCommand::Artifacts(_)
-                        | agent_task::AgentTaskCommand::Review(_)
-                ) =>
-            {
-                LabCommandContract::portable_workload(
-                    "agent-task status/logs/artifacts/review",
-                    None,
-                    false,
-                    LAB_NO_EXTRA_TOOLS,
-                )
-            }
-            Commands::AgentTask(args)
                 if matches!(args.command, agent_task::AgentTaskCommand::Providers(_)) =>
             {
                 LabCommandContract::explicit_runner(
@@ -454,19 +438,19 @@ mod tests {
                 .supports_lab_runner()
         );
         assert!(
-            parsed_command(&["homeboy", "agent-task", "status", "agent-task-123"])
+            !parsed_command(&["homeboy", "agent-task", "status", "agent-task-123"])
                 .supports_lab_runner()
         );
         assert!(
-            parsed_command(&["homeboy", "agent-task", "logs", "agent-task-123"])
+            !parsed_command(&["homeboy", "agent-task", "logs", "agent-task-123"])
                 .supports_lab_runner()
         );
         assert!(
-            parsed_command(&["homeboy", "agent-task", "artifacts", "agent-task-123"])
+            !parsed_command(&["homeboy", "agent-task", "artifacts", "agent-task-123"])
                 .supports_lab_runner()
         );
         assert!(
-            parsed_command(&["homeboy", "agent-task", "review", "agent-task-123"])
+            !parsed_command(&["homeboy", "agent-task", "review", "agent-task-123"])
                 .supports_lab_runner()
         );
         assert!(parsed_command(&["homeboy", "agent-task", "providers"]).supports_lab_runner());
@@ -595,22 +579,6 @@ mod tests {
                 "agent-task dispatch/cook/loop/run-plan",
             ),
             (
-                parsed_command(&["homeboy", "agent-task", "status", "agent-task-123"]),
-                "agent-task status/logs/artifacts/review",
-            ),
-            (
-                parsed_command(&["homeboy", "agent-task", "logs", "agent-task-123"]),
-                "agent-task status/logs/artifacts/review",
-            ),
-            (
-                parsed_command(&["homeboy", "agent-task", "artifacts", "agent-task-123"]),
-                "agent-task status/logs/artifacts/review",
-            ),
-            (
-                parsed_command(&["homeboy", "agent-task", "review", "agent-task-123"]),
-                "agent-task status/logs/artifacts/review",
-            ),
-            (
                 parsed_command(&["homeboy", "agent-task", "providers"]),
                 "agent-task providers",
             ),
@@ -675,13 +643,11 @@ mod tests {
 
         for args in [
             ["homeboy", "agent-task", "status", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "logs", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "artifacts", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "review", "agent-task-123"].as_slice(),
         ] {
-            let agent_task_inspection = parsed_command(args)
-                .lab_contract()
-                .expect("agent-task inspection contract");
-            assert!(!agent_task_inspection.requires_extension_parity);
-            assert!(!agent_task_inspection.infer_source_path_tools);
+            assert!(parsed_command(args).lab_contract().is_none());
         }
 
         let auth_status = parsed_command(&[

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -755,7 +755,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_task_inspection_commands_are_read_only_lab_portable() {
+    fn agent_task_inspection_commands_are_read_only_local_recovery() {
         for args in [
             ["homeboy", "agent-task", "status", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "logs", "agent-task-123"].as_slice(),
@@ -763,13 +763,7 @@ mod tests {
             ["homeboy", "agent-task", "review", "agent-task-123"].as_slice(),
         ] {
             let cli = Cli::parse_from(args);
-            let command = lab_offload_command(&cli.command).unwrap().unwrap();
-
-            assert_eq!(command.hot_label, "agent-task status/logs/artifacts/review");
-            assert!(command.portable);
-            assert!(!command.requires_extension_parity);
-            assert!(command.required_extensions.is_empty());
-            assert!(!command.infer_source_path_tools);
+            assert!(lab_offload_command(&cli.command).unwrap().is_none());
         }
     }
 

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -413,6 +413,19 @@ mod tests {
     }
 
     #[test]
+    fn agent_task_inspection_commands_do_not_start_hot_workloads() {
+        for args in [
+            ["homeboy", "agent-task", "status", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "logs", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "artifacts", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "review", "agent-task-123"].as_slice(),
+        ] {
+            let cli = Cli::parse_from(args);
+            assert!(hot_command(&cli.command).is_none());
+        }
+    }
+
+    #[test]
     fn does_not_warn_when_machine_is_ok() {
         assert!(evaluate(
             lab_supported_hot("bench"),


### PR DESCRIPTION
## Summary
- Remove the Lab hot-command contract for read-only `agent-task status`, `logs`, `artifacts`, and `review` recovery commands.
- Keep workload-starting `agent-task dispatch/cook/loop/run-plan` in the hot/offloadable path.
- Add regression coverage proving read-only inspection does not enter resource-policy hot-command preflight.
- Document runner-host inspection via explicit `runner exec` when the durable lifecycle state lives on a Lab runner.

Fixes #4395.

## Verification
- `homeboy lint --runner homeboy-lab --allow-dirty-lab-workspace --json-summary` passed on Lab before the final rebase.
- `homeboy test --runner homeboy-lab --allow-dirty-lab-workspace --json-summary -- command_contract::lab commands::route::tests::agent_task_inspection_commands_are_read_only_local_recovery commands::utils::resource_policy::tests::agent_task_inspection_commands_do_not_start_hot_workloads` passed on Lab before the final rebase: 8 passed, 0 failed.
- Full offloaded test run completed on Lab before the final rebase and failed in non-targeted existing tests: `commands::agent_task_dispatch::tests::cook_output_marks_patch_artifact_handoff_boundary`, `core::tunnel_tests::status_refresh_clears_exited_process_readiness`, and `core::tunnel_tests::status_reports_degraded_when_backend_outlives_service_process`.
- After rebasing onto current `main`, Lab reruns reached runner handoff but the runner daemon disconnected before terminal status. Recovery evidence: runner jobs `b0dcd661-a3e3-48bc-8333-0f4aa012b839` and `0ba68206-a641-439b-a492-b3f4e2922680` reported controller disconnect / follow-up-required, so I did not run local Cargo.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused code/test/docs changes, ran offloaded verification, and prepared this PR summary for Chris to review.
