### PR TITLE
Fix Lab offload source checkout binary selection

### DIFF
--- a/docs/commands/lab.md
+++ b/docs/commands/lab.md
@@ -62,6 +62,14 @@ the Lab runner has picked up a merged CLI fix. If the daemon identity is stale,
 run the refresh command pair; if the configured executable is old, run the
 upgrade command first and reconnect the runner.
 
+Lab offload always re-enters Homeboy through the runner's configured executable.
+Synced source checkouts are task workspaces, not active Homeboy binaries. Preflight
+metadata includes `source_checkout` with the local path, Git branch, SHA, remote,
+and dirty state, and stderr prints the source checkout ref/path beside the active
+runner Homeboy command before remote execution starts. Legacy
+`lab.self_command_prefix` values in `homeboy.json` are ignored and are not
+preserved by portable config rewrites.
+
 `homeboy lab bench` delegates to the same benchmark path while making the Lab
 intent explicit at the command surface. Its output includes the same managed
 follow-up hints so the operator can keep a failed bench inside the Homeboy

--- a/homeboy.json
+++ b/homeboy.json
@@ -1628,16 +1628,6 @@
   },
   "hooks": {},
   "id": "homeboy",
-  "lab": {
-    "self_command_prefix": [
-      "cargo",
-      "run",
-      "--quiet",
-      "--bin",
-      "homeboy",
-      "--"
-    ]
-  },
   "scripts": {
     "build": [
       "cargo build --release"

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -189,17 +189,6 @@ pub struct ArtifactInput {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
-pub struct ComponentLabConfig {
-    /// Repo-owned argv prefix used when Lab offload re-enters Homeboy from this checkout.
-    ///
-    /// By default Lab uses the runner's configured Homeboy binary. Repos that need to
-    /// verify the synced checkout itself can declare the command argv needed
-    /// to re-enter the project-local binary.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub self_command_prefix: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct GithubConfig {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub hosts: HashMap<String, GithubHostConfig>,
@@ -270,9 +259,6 @@ pub struct Component {
     pub scripts: Option<ComponentScriptsConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audit: Option<AuditConfig>,
-    /// Component-owned Lab runner behavior.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lab: Option<ComponentLabConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependency_stack: Vec<DependencyStackEdge>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -361,8 +347,6 @@ struct RawComponent {
     scripts: Option<ComponentScriptsConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     audit: Option<AuditConfig>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    lab: Option<ComponentLabConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     dependency_stack: Vec<DependencyStackEdge>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -408,7 +392,6 @@ impl From<RawComponent> for Component {
             scopes: raw.scopes,
             scripts: raw.scripts,
             audit: raw.audit,
-            lab: raw.lab,
             dependency_stack: raw.dependency_stack,
             artifact_inputs: raw.artifact_inputs,
             cli_path: raw.cli_path,
@@ -449,7 +432,6 @@ impl From<Component> for RawComponent {
             scopes: c.scopes,
             scripts: c.scripts,
             audit: c.audit,
-            lab: c.lab,
             dependency_stack: c.dependency_stack,
             artifact_inputs: c.artifact_inputs,
             cli_path: c.cli_path,
@@ -533,7 +515,6 @@ impl Component {
             scopes: None,
             scripts: None,
             audit: None,
-            lab: None,
             dependency_stack: Vec::new(),
             artifact_inputs: Vec::new(),
             cli_path: None,

--- a/src/core/component/portable.rs
+++ b/src/core/component/portable.rs
@@ -299,7 +299,6 @@ pub fn try_discover_from_portable(dir: &Path) -> Result<Option<Component>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::component::ComponentLabConfig;
     use std::fs;
     use tempfile::TempDir;
 
@@ -361,39 +360,29 @@ mod tests {
     }
 
     #[test]
-    fn write_preserves_component_lab_config() {
+    fn write_drops_legacy_component_lab_config() {
         let dir = TempDir::new().expect("temp dir");
-        let mut component = Component::new(
+        fs::write(
+            dir.path().join("homeboy.json"),
+            r#"{
+                "id":"test-comp",
+                "lab":{"self_command_prefix":["cargo","run","--quiet","--bin","homeboy","--"]}
+            }"#,
+        )
+        .expect("write legacy homeboy.json");
+        let component = Component::new(
             "test-comp".to_string(),
             dir.path().to_string_lossy().to_string(),
             "wp-content/plugins/test".to_string(),
             None,
         );
-        component.lab = Some(ComponentLabConfig {
-            self_command_prefix: vec![
-                "cargo".to_string(),
-                "run".to_string(),
-                "--quiet".to_string(),
-                "--bin".to_string(),
-                "homeboy".to_string(),
-                "--".to_string(),
-            ],
-        });
 
         write_portable_config(dir.path(), &component).expect("write should succeed");
 
         let content = fs::read_to_string(dir.path().join("homeboy.json")).unwrap();
         let result: Value = serde_json::from_str(&content).unwrap();
 
-        assert_eq!(
-            result
-                .get("lab")
-                .and_then(|value| value.get("self_command_prefix"))
-                .and_then(Value::as_array)
-                .and_then(|prefix| prefix.first())
-                .and_then(Value::as_str),
-            Some("cargo")
-        );
+        assert!(result.get("lab").is_none());
     }
 
     #[test]

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -491,6 +491,7 @@ fn run_lab_offload_inner(
     if let Some(warning) = misplaced_runner_exec_wait_timeout_warning(request.normalized_args) {
         messages.push(warning);
     }
+    let source_checkout = lab_source_checkout_metadata(&source_path);
     let homeboy_path = runner.settings.homeboy_path.as_deref().unwrap_or("homeboy");
     let runner_homeboy = lab_runner_homeboy_metadata(runner_id, homeboy_path, &runner_status);
     plan = with_step(
@@ -504,7 +505,11 @@ fn run_lab_offload_inner(
                 PlanStepStatus::Ready
             },
         )
-        .inputs(PlanValues::new().json("runner_homeboy", &runner_homeboy))
+        .inputs(
+            PlanValues::new()
+                .json("runner_homeboy", &runner_homeboy)
+                .json("source_checkout", &source_checkout),
+        )
         .build(),
     );
     eprintln!(
@@ -533,6 +538,13 @@ fn run_lab_offload_inner(
         ));
     }
     let command_prefix = lab_offload_command_prefix(&source_path, homeboy_path);
+    eprintln!(
+        "Lab offload preflight: source checkout `{}` at {}; active Homeboy command `{}` from runner `{}`.",
+        source_path.display(),
+        source_checkout_ref_display(&source_checkout),
+        command_prefix.argv.join(" "),
+        runner_id,
+    );
     let capability_contract =
         lab_runner_capability_contract(&contract, &source_path, &command_prefix.required_tools);
     let capability_plan = capability_contract
@@ -901,6 +913,7 @@ fn run_lab_offload_inner(
     lab_metadata["rig_component_path_env"] = rig_component_path_env;
     lab_metadata["settings_env"] = settings_env_diagnostics(&remapped_args, &env);
     lab_metadata["runner_homeboy"] = runner_homeboy.clone();
+    lab_metadata["source_checkout"] = source_checkout.clone();
     lab_metadata["rig_sync"] = serde_json::json!({
         "step": "lab.sync_rigs",
         "synced_count": synced_rigs.len(),
@@ -1142,6 +1155,63 @@ fn lab_runner_homeboy_metadata(
         "refresh_commands": refresh_commands,
         "upgrade_command": format!("homeboy upgrade --force --upgrade-runner {}", shell::quote_arg(runner_id)),
     })
+}
+
+fn lab_source_checkout_metadata(source_path: &Path) -> serde_json::Value {
+    let git_branch =
+        super::super::workspace::git_output(source_path, &["branch", "--show-current"])
+            .ok()
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                super::super::workspace::git_output(
+                    source_path,
+                    &["rev-parse", "--abbrev-ref", "HEAD"],
+                )
+                .ok()
+            });
+    let git_sha = super::super::workspace::git_output(source_path, &["rev-parse", "HEAD"])
+        .ok()
+        .filter(|value| !value.is_empty());
+    let git_remote =
+        super::super::workspace::git_output(source_path, &["config", "--get", "remote.origin.url"])
+            .ok()
+            .filter(|value| !value.is_empty());
+    let dirty = super::super::workspace::git_output(source_path, &["status", "--porcelain=v1"])
+        .ok()
+        .map(|status| !status.is_empty());
+
+    serde_json::json!({
+        "schema": "homeboy/lab-source-checkout/v1",
+        "local_path": source_path.display().to_string(),
+        "git_branch": git_branch,
+        "git_sha": git_sha,
+        "git_remote": git_remote,
+        "dirty": dirty,
+    })
+}
+
+fn source_checkout_ref_display(metadata: &serde_json::Value) -> String {
+    let branch = metadata
+        .get("git_branch")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty());
+    let sha = metadata
+        .get("git_sha")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .map(|value| value.chars().take(12).collect::<String>());
+    let dirty = metadata
+        .get("dirty")
+        .and_then(|value| value.as_bool())
+        .map(|value| if value { " dirty" } else { " clean" })
+        .unwrap_or("");
+
+    match (branch, sha) {
+        (Some(branch), Some(sha)) => format!("{branch}@{sha}{dirty}"),
+        (Some(branch), None) => format!("{branch}{dirty}"),
+        (None, Some(sha)) => format!("{sha}{dirty}"),
+        (None, None) => format!("unknown ref{dirty}"),
+    }
 }
 
 fn stale_runner_homeboy_error(
@@ -2448,6 +2518,30 @@ mod tests {
             metadata["upgrade_command"],
             "homeboy upgrade --force --upgrade-runner 'homeboy lab'"
         );
+    }
+
+    #[test]
+    fn source_checkout_ref_display_includes_branch_sha_and_dirty_state() {
+        let metadata = serde_json::json!({
+            "git_branch": "fix/lab-source-ref-preflight",
+            "git_sha": "1234567890abcdef",
+            "dirty": true,
+        });
+
+        assert_eq!(
+            source_checkout_ref_display(&metadata),
+            "fix/lab-source-ref-preflight@1234567890ab dirty"
+        );
+    }
+
+    #[test]
+    fn source_checkout_ref_display_handles_missing_git_ref() {
+        let metadata = serde_json::json!({
+            "local_path": "/tmp/source",
+            "dirty": null,
+        });
+
+        assert_eq!(source_checkout_ref_display(&metadata), "unknown ref");
     }
 
     #[test]

--- a/src/core/runner/lab_command.rs
+++ b/src/core/runner/lab_command.rs
@@ -1,7 +1,5 @@
 use std::path::Path;
 
-use crate::core::component;
-
 use super::RunnerRequiredTool;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11,15 +9,10 @@ pub(crate) struct LabOffloadCommandPrefix {
 }
 
 pub(crate) fn lab_offload_command_prefix(
-    source_path: &Path,
+    _source_path: &Path,
     homeboy_path: &str,
 ) -> LabOffloadCommandPrefix {
-    let configured_prefix = component::discover_from_portable(source_path)
-        .and_then(|component| component.lab)
-        .map(|lab| lab.self_command_prefix)
-        .filter(|prefix| !prefix.is_empty());
-
-    let argv = configured_prefix.unwrap_or_else(|| vec![homeboy_path.to_string()]);
+    let argv = vec![homeboy_path.to_string()];
     let required_tools = required_tools_for_command_prefix(&argv);
 
     LabOffloadCommandPrefix {
@@ -49,7 +42,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn configured_self_command_prefix_overrides_runner_homeboy_path() {
+    fn ignores_legacy_self_command_prefix() {
         let dir = tempfile::tempdir().expect("temp dir");
         std::fs::write(
             dir.path().join("homeboy.json"),
@@ -59,18 +52,8 @@ mod tests {
 
         let prefix = lab_offload_command_prefix(dir.path(), "/usr/local/bin/homeboy");
 
-        assert_eq!(
-            prefix.argv,
-            vec![
-                "cargo".to_string(),
-                "run".to_string(),
-                "--quiet".to_string(),
-                "--bin".to_string(),
-                "homeboy".to_string(),
-                "--".to_string(),
-            ]
-        );
-        assert_eq!(prefix.required_tools, vec![RunnerRequiredTool::Cargo]);
+        assert_eq!(prefix.argv, vec!["/usr/local/bin/homeboy".to_string()]);
+        assert_eq!(prefix.required_tools, vec![RunnerRequiredTool::Homeboy]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remove the legacy `lab.self_command_prefix` component config so Lab offload no longer lets a synced source checkout replace the runner Homeboy binary
- always build Lab offload commands from the runner's configured Homeboy executable
- add source checkout path/ref/dirty diagnostics to Lab preflight metadata and stderr
- document the runner-binary/source-checkout boundary

Fixes #4746

## Verification
- `homeboy runner doctor homeboy-lab --scope lab-offload` (runner reachable; warnings noted for runner Homeboy path drift)
- `homeboy test --runner homeboy-lab --allow-dirty-lab-workspace` (offloaded; compiled and ran Rust tests on `homeboy-lab`; 4686 passed, 3 failed, 18 ignored. The three failures were outside this change path: `commands::agent_task_dispatch::tests::cook_output_marks_patch_artifact_handoff_boundary`, `core::tunnel_tests::status_refresh_clears_exited_process_readiness`, `core::tunnel_tests::status_reports_degraded_when_backend_outlives_service_process`. New/adjacent Lab tests passed in that run, including `lab_command` and `source_checkout_ref_display` tests.)
- GitHub Actions CI on PR #4771: Plan, Build, Audit, Lint, and Test passed.
- Did not run Cargo locally; Rust checks were executed via Homeboy Lab offload and GitHub Actions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the code changes, tests/docs, and verification workflow; Chris remains responsible for review and merge.
