### PR TITLE
Fix runner-hosted agent-task resource preflight

### DIFF
--- a/docs/cli/homeboy-root-command.md
+++ b/docs/cli/homeboy-root-command.md
@@ -34,11 +34,12 @@ homeboy --output /tmp/homeboy-results/review.json review my-component --changed-
 Resource policy warnings are stderr-only preflight notices. They currently apply
 to hot commands such as `bench`, `rig up`, `fleet exec`, full-workspace
 `audit` / `lint` / `test` runs, and changed-scope `audit` / `lint` / `test`
-runs when `homeboy doctor resources` sees a warm or hot machine. They do not
-block execution; pass `--force-hot` when the extra load is intentional. For
-portable hot commands with a default Lab runner, `--force-hot` does not
-implicitly keep execution local; pass `--runner <id>` to offload or add
-`--allow-local-hot` only when local controller-machine execution is intentional.
+runs when `homeboy doctor resources` sees a warm or hot machine. Non-interactive
+hot commands fail fast unless the work is routed through Lab/runner-hosted
+execution or the caller explicitly accepts local pressure. For portable hot
+commands with a default Lab runner, `--force-hot` does not implicitly keep
+execution local; pass `--runner <id>` to offload or add `--allow-local-hot` only
+when local controller-machine execution is intentional.
 
 Not every hot command is offloadable. Lab offload only applies to commands with
 a portable runner contract; local-only hot commands keep running locally and

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -191,6 +191,22 @@ plugin paths, workspace roots, and path-valued settings. Lab offload evidence
 records the original and remapped paths in `workspace_mapping.workspaces` using
 the `component_contract` role.
 
+When the intended checkout already exists on a Lab runner, dispatch from that
+runner-side checkout through `runner exec` instead of forcing a controller-local
+hot run:
+
+```bash
+homeboy runner exec homeboy-lab \
+  --cwd /srv/homeboy/checkouts/homeboy \
+  -- homeboy agent-task cook \
+    --repo homeboy \
+    --cwd /srv/homeboy/checkouts/homeboy \
+    --prompt @task.txt
+```
+
+`runner exec` marks non-local jobs as runner-hosted, so nested `agent-task cook`
+commands pass the non-interactive resource preflight without `--force-hot`.
+
 ## Dispatch Workspaces
 
 `agent-task dispatch` accepts generic Homeboy workspace inputs and does not

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -65,6 +65,8 @@ Commands that are both resource-policy hot and portable for Lab offload (`audit`
 
 Observation metadata records the routing decision under `metadata.lab_offload` when an observed run is created. The stable contract is `schema: "homeboy/lab-offload/v1"` and keeps the existing top-level compatibility fields: `source` is `automatic` or `explicit`; `status` is `offloaded`, `skipped`, or `fallback`; successful offloads include `runner_id` plus `remote_workspace`; local fallback records the runner and `fallback_reason`; skipped local execution records why no automatic offload was used, such as `force_hot`, `force_hot_local_override`, or `no_default_runner`. The same object also carries `plan_id` and plan-derived phase fields including `sync_mode`, `capability_preflight`, `extension_parity`, and `patch_captured`.
 
+Commands launched through non-local `homeboy runner exec` run with `HOMEBOY_RUNNER_HOSTED_EXEC=1`. That marker is Homeboy's first-class runner-side dispatch signal: nested runner commands such as `homeboy agent-task cook` are allowed to pass the non-interactive resource preflight without adding `--force-hot`, because the work is already intentionally hosted on the selected runner.
+
 Lab offload support is intentionally command-specific:
 
 | Command | Auto offload | Explicit `--runner` | Decision |

--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -277,8 +277,12 @@ fn preflight_hot_command(cli: &Cli, output_file: Option<&str>) -> Option<i32> {
             crate::commands::doctor::resources::ResourcesArgs {},
         ) {
             let warning = resource_policy::evaluate(hot_command, &resources);
+            let runner_hosted = resource_policy::is_runner_hosted_exec();
+            if runner_hosted {
+                resource_policy::clear_runner_hosted_exec();
+            }
             if let Some(warning) = warning.as_ref() {
-                if !cli.force_hot {
+                if !cli.force_hot && !runner_hosted {
                     eprintln!("{}", warning.message);
                 }
             }
@@ -289,7 +293,11 @@ fn preflight_hot_command(cli: &Cli, output_file: Option<&str>) -> Option<i32> {
                 resource_policy::ResourcePolicyContext::from_evaluation(
                     hot_command,
                     &resources,
-                    warning.as_ref(),
+                    if runner_hosted {
+                        None
+                    } else {
+                        warning.as_ref()
+                    },
                     cli.force_hot,
                 ),
             );

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -220,7 +220,7 @@ pub fn non_interactive_preflight_error(
     force_hot: bool,
     interactive: bool,
 ) -> Option<crate::core::Error> {
-    if force_hot || interactive {
+    if force_hot || interactive || is_runner_hosted_exec() {
         return None;
     }
 
@@ -235,6 +235,16 @@ pub fn non_interactive_preflight_error(
         None,
         None,
     ))
+}
+
+pub fn is_runner_hosted_exec() -> bool {
+    std::env::var(crate::core::runner::RUNNER_HOSTED_EXEC_ENV)
+        .ok()
+        .is_some_and(|value| value == "1")
+}
+
+pub fn clear_runner_hosted_exec() {
+    std::env::remove_var(crate::core::runner::RUNNER_HOSTED_EXEC_ENV);
 }
 
 fn primary_action(warning: &ResourcePolicyWarning) -> &'static str {
@@ -453,6 +463,18 @@ mod tests {
     }
 
     #[test]
+    fn runner_hosted_exec_does_not_fail_non_interactive_preflight() {
+        let _guard = EnvVarGuard::set(crate::core::runner::RUNNER_HOSTED_EXEC_ENV, "1");
+        let warning = evaluate(
+            lab_supported_hot("agent-task dispatch/cook/loop/run-plan"),
+            &resources(ResourceRecommendation::Hot),
+        )
+        .expect("hot machines warn");
+
+        assert!(non_interactive_preflight_error(&warning, false, false).is_none());
+    }
+
+    #[test]
     fn interactive_or_forced_hot_warning_does_not_fail_preflight() {
         let warning = evaluate(
             lab_supported_hot("audit"),
@@ -568,5 +590,27 @@ mod tests {
         assert!(value["message"].is_string());
         assert_eq!(value["host"]["load_severity"], "hot");
         assert_eq!(value["host"]["cpu_count"], 4);
+    }
+
+    struct EnvVarGuard {
+        name: &'static str,
+        prior: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(name: &'static str, value: &str) -> Self {
+            let prior = std::env::var(name).ok();
+            std::env::set_var(name, value);
+            Self { name, prior }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.prior {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
     }
 }

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -29,6 +29,7 @@ use super::{normalize_runner_command_env, resolve_runner_secret_env};
 
 const DEFAULT_RUNNER_EXEC_WAIT_TIMEOUT_SECS: u64 = 20 * 60;
 pub(crate) const RUNNER_EXEC_WAIT_TIMEOUT_ENV: &str = "HOMEBOY_RUNNER_EXEC_WAIT_TIMEOUT_SECS";
+pub(crate) const RUNNER_HOSTED_EXEC_ENV: &str = "HOMEBOY_RUNNER_HOSTED_EXEC";
 
 mod extension_parity;
 mod policy;
@@ -1040,6 +1041,9 @@ pub(crate) fn prepare_runner_process(
 
     let mut env = runner.env.clone();
     env.extend(request.env);
+    if runner.kind != RunnerKind::Local {
+        env.insert(RUNNER_HOSTED_EXEC_ENV.to_string(), "1".to_string());
+    }
     if runner.kind == RunnerKind::Local {
         env.extend(resolve_runner_secret_env_for_command(
             &runner.secret_env,
@@ -1717,6 +1721,20 @@ mod tests {
         }
     }
 
+    fn local_runner(workspace_root: String) -> Runner {
+        Runner {
+            id: "local".to_string(),
+            kind: RunnerKind::Local,
+            server_id: None,
+            workspace_root: Some(workspace_root),
+            settings: RunnerSettings::default(),
+            env: Default::default(),
+            secret_env: Default::default(),
+            resources: Default::default(),
+            policy: RunnerPolicy::default(),
+        }
+    }
+
     fn failed_runner_exec_output(stdout: &str, stderr: &str) -> RunnerExecOutput {
         RunnerExecOutput {
             command: "runner.exec",
@@ -2005,6 +2023,67 @@ mod tests {
                 plan.env.get("PATH").map(String::as_str),
                 Some("$HOME/custom/bin:$PATH")
             );
+        });
+    }
+
+    #[test]
+    fn ssh_runner_prep_marks_commands_as_runner_hosted() {
+        crate::test_support::with_isolated_home(|_| {
+            let plan = prepare_runner_process(RunnerProcessRequest {
+                runner_id: "lab".to_string(),
+                runner: Some(ssh_runner()),
+                cwd: Some("/srv/homeboy/project".to_string()),
+                project_id: None,
+                command: vec![
+                    "homeboy".to_string(),
+                    "agent-task".to_string(),
+                    "cook".to_string(),
+                ],
+                env: Default::default(),
+                secret_env_names: Vec::new(),
+                capture_patch: false,
+                raw_exec: false,
+                source_snapshot: None,
+                require_paths: Vec::new(),
+                validate_require_paths_on_host: false,
+            })
+            .expect("prepare ssh runner process");
+
+            assert_eq!(
+                plan.env.get(RUNNER_HOSTED_EXEC_ENV).map(String::as_str),
+                Some("1")
+            );
+        });
+    }
+
+    #[test]
+    fn local_runner_prep_does_not_mark_commands_as_runner_hosted() {
+        crate::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let workspace = temp.path().join("project");
+            std::fs::create_dir_all(&workspace).expect("workspace");
+
+            let plan = prepare_runner_process(RunnerProcessRequest {
+                runner_id: "local".to_string(),
+                runner: Some(local_runner(workspace.display().to_string())),
+                cwd: Some(workspace.display().to_string()),
+                project_id: None,
+                command: vec![
+                    "homeboy".to_string(),
+                    "agent-task".to_string(),
+                    "cook".to_string(),
+                ],
+                env: Default::default(),
+                secret_env_names: Vec::new(),
+                capture_patch: false,
+                raw_exec: false,
+                source_snapshot: None,
+                require_paths: Vec::new(),
+                validate_require_paths_on_host: false,
+            })
+            .expect("prepare local runner process");
+
+            assert!(!plan.env.contains_key(RUNNER_HOSTED_EXEC_ENV));
         });
     }
 

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -65,7 +65,7 @@ pub use evidence::{
 };
 pub(crate) use execution::{
     daemon_api_get, execute_runner_process_until_cancelled, prepare_daemon_local_process,
-    RunnerProcessRequest,
+    RunnerProcessRequest, RUNNER_HOSTED_EXEC_ENV,
 };
 pub use execution::{
     daemon_api_post, exec, runner_exec_failure_error, RunnerExecMode, RunnerExecOptions,


### PR DESCRIPTION
## Summary
- Mark non-local `runner exec` jobs with a single-hop `HOMEBOY_RUNNER_HOSTED_EXEC=1` signal.
- Allow runner-hosted hot commands, including nested `agent-task cook`, to pass non-interactive resource preflight without `--force-hot`.
- Consume the marker during Homeboy startup so it does not leak into child tools/tests.
- Document runner-side checkout dispatch and clarify resource-policy behavior.

Fixes #4745.

## Verification
- Runner-side `cargo test --lib runner_hosted` passed through `homeboy runner exec homeboy-lab --ssh --cwd <runner-synced-checkout>`: 3 tests.
- Runner-side `cargo test --lib commands::agent_task_dispatch::tests::cook_output_marks_patch_artifact_handoff_boundary` passed through `homeboy runner exec homeboy-lab --ssh --cwd <runner-synced-checkout>`: 1 test.
- Runner-side `cargo fmt --check` passed through `homeboy runner exec homeboy-lab --ssh --cwd <runner-synced-checkout>`.
- Runner-side `cargo clippy --all-targets --all-features` passed before the final rebase. The final offloaded `homeboy test --runner homeboy-lab ...` also completed the pre-test clippy phase successfully on the rebased checkout before failing due to invalid passthrough syntax.

## Notes
- Full offloaded `homeboy test --runner homeboy-lab --allow-dirty-lab-workspace` on an earlier checkout ran 4,708 tests: 4,687 passed, 18 ignored, and 3 failed. The failures were two existing tunnel liveness tests plus the stale cook handoff fixture; the cook handoff fixture was fixed upstream during rebase and verified targeted here.
- Local Cargo was not run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runner-hosted execution signal, docs, tests, offloaded verification, and PR drafting for Chris to review.
