### PR TITLE
Fix runner-hosted agent task recovery gates

### DIFF
--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -304,7 +304,7 @@ fn preflight_hot_command(cli: &Cli, output_file: Option<&str>) -> Option<i32> {
             if let Some(warning) = warning.as_ref() {
                 if let Some(err) = resource_policy::non_interactive_preflight_error(
                     warning,
-                    cli.force_hot,
+                    cli.force_hot || runner_hosted,
                     is_interactive_shell(),
                 ) {
                     output_runtime::emit_json_result(Err(err), output_file, 2);

--- a/src/commands/utils/resource_policy.rs
+++ b/src/commands/utils/resource_policy.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::cli_surface::Commands;
 use crate::command_contract::LabCommandPortability;
+use crate::commands::agent_task;
 
 use crate::commands::doctor::resources::{DoctorOutput, ResourceRecommendation};
 
@@ -194,6 +195,10 @@ pub fn reset_captured_context_for_test() {
 }
 
 pub fn hot_command(command: &Commands) -> Option<HotCommand> {
+    if is_read_only_agent_task(command) {
+        return None;
+    }
+
     let contract = command.lab_contract()?;
 
     match contract.portability {
@@ -202,6 +207,18 @@ pub fn hot_command(command: &Commands) -> Option<HotCommand> {
             Some(HotCommand::local_only(contract.hot_label, Some(reason)))
         }
     }
+}
+
+fn is_read_only_agent_task(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::AgentTask(agent_task::AgentTaskArgs {
+            command: agent_task::AgentTaskCommand::Status(_)
+                | agent_task::AgentTaskCommand::Logs(_)
+                | agent_task::AgentTaskCommand::Artifacts(_)
+                | agent_task::AgentTaskCommand::Review(_),
+        })
+    )
 }
 
 pub fn evaluate(command: HotCommand, resources: &DoctorOutput) -> Option<ResourcePolicyWarning> {


### PR DESCRIPTION
## Summary
- Stop classifying read-only agent-task inspection commands as hot workload starters.
- Mark commands launched through runner exec with a runner-hosted subprocess env flag.
- Allow runner-hosted agent-task cook/dispatch/loop/run-plan commands to pass the non-interactive resource gate without requiring operators to pass --force-hot inside the runner.

Fixes #4395.
Follows up #4745.

## Verification
- PASS: `homeboy test --runner homeboy-lab --path /Users/chubes/Developer/homeboy@fix-agent-task-runner-followups -- read_only_agent_task_inspection_is_not_hot`
  - Runner job: `2e04acba-f082-48d4-9deb-564f8e86e236`
  - Persisted run: `runner-exec-homeboy-lab-2e04acba-f082-48d4-9deb-564f8e86e236`
  - Exit code: 0
- PARTIAL/INFRA: `homeboy test --runner homeboy-lab --path /Users/chubes/Developer/homeboy@fix-agent-task-runner-followups -- test_exec_marks_runner_hosted_subprocess`
  - Runner job: `99a6741c-9322-42f5-a90a-3c3e4abcba89`
  - Focused test result: `Total: 1, Passed: 1, Failed: 0, Skipped: 0`
  - Wrapper exit code: 1 because Lab doctests failed afterward with missing `reqwest` rlib in the shared cargo target.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the scoped implementation, regression tests, and PR notes; Chris remains responsible for review and merge.
