### PR TITLE
Fix runner-resident tunnel service cwd contract

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -38,6 +38,7 @@ pub enum LabCommandPortability {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LabSourcePathMode {
     CwdOrPathFlag,
+    RunnerResident,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -160,6 +161,7 @@ impl Commands {
                     false,
                     LAB_NO_EXTRA_TOOLS,
                 );
+                contract.source_path_mode = LabSourcePathMode::RunnerResident;
                 contract.workspace_mode_policy = LabWorkspaceModePolicy::RunnerResident;
                 contract
             }
@@ -663,6 +665,30 @@ mod tests {
         assert!(!auth_status.default_lab_offload);
         assert!(!auth_status.requires_extension_parity);
         assert!(!auth_status.infer_source_path_tools);
+
+        let tunnel_service_start = parsed_command(&[
+            "homeboy",
+            "tunnel",
+            "service",
+            "start",
+            "preview",
+            "--cwd",
+            "/home/chubes/Developer/_lab_workspaces/site",
+            "--command",
+            "npm run dev",
+        ])
+        .lab_contract()
+        .expect("tunnel service start contract");
+        assert_eq!(
+            tunnel_service_start.source_path_mode,
+            LabSourcePathMode::RunnerResident
+        );
+        assert_eq!(
+            tunnel_service_start.workspace_mode_policy,
+            LabWorkspaceModePolicy::RunnerResident
+        );
+        assert!(!tunnel_service_start.default_lab_offload);
+        assert!(!tunnel_service_start.infer_source_path_tools);
 
         let rig = parsed_command(&["homeboy", "rig", "up", "studio"])
             .lab_contract()

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -798,6 +798,8 @@ mod tests {
             "service",
             "start",
             "preview",
+            "--cwd",
+            "/home/chubes/Developer/_lab_workspaces/site",
             "--command",
             "npm run dev",
         ]);
@@ -808,6 +810,10 @@ mod tests {
         assert_eq!(command.hot_label, "tunnel service start");
         assert!(command.portable);
         assert!(!command.default_lab_offload);
+        assert_eq!(
+            command.source_path_mode,
+            runners::LabOffloadSourcePathMode::RunnerResident
+        );
         assert_eq!(
             command.workspace_mode_policy,
             runners::LabOffloadWorkspaceModePolicy::RunnerResident

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -3,7 +3,8 @@
 use std::time::Duration;
 
 use crate::command_contract::{
-    LabCommandContract, LabCommandPortability, LabCommandRequiredTool, LabWorkspaceModePolicy,
+    LabCommandContract, LabCommandPortability, LabCommandRequiredTool, LabSourcePathMode,
+    LabWorkspaceModePolicy,
 };
 use crate::core::runners;
 use crate::core::Result;
@@ -55,6 +56,10 @@ pub fn lab_offload_command_from_contract(
         unsupported_reason: match contract.portability {
             LabCommandPortability::Portable => None,
             LabCommandPortability::LocalOnly(reason) => Some(reason),
+        },
+        source_path_mode: match contract.source_path_mode {
+            LabSourcePathMode::CwdOrPathFlag => runners::LabOffloadSourcePathMode::CwdOrPathFlag,
+            LabSourcePathMode::RunnerResident => runners::LabOffloadSourcePathMode::RunnerResident,
         },
         workspace_mode_policy: match contract.workspace_mode_policy {
             LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot => {

--- a/src/core/runner/lab.rs
+++ b/src/core/runner/lab.rs
@@ -29,7 +29,7 @@ mod trace_fetch_refs;
 pub use super::lab_selection::LabRunnerSelectionSource;
 pub use offload::{
     execute_lab_offload, LabOffloadCommand, LabOffloadOutcome, LabOffloadRequest,
-    LabOffloadWorkspaceModePolicy,
+    LabOffloadSourcePathMode, LabOffloadWorkspaceModePolicy,
 };
 
 #[cfg(test)]

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -98,11 +98,18 @@ pub struct LabOffloadCommand {
     pub portable: bool,
     pub default_lab_offload: bool,
     pub unsupported_reason: Option<&'static str>,
+    pub source_path_mode: LabOffloadSourcePathMode,
     pub workspace_mode_policy: LabOffloadWorkspaceModePolicy,
     pub requires_extension_parity: bool,
     pub required_extensions: Vec<String>,
     pub requires_playwright: bool,
     pub infer_source_path_tools: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabOffloadSourcePathMode {
+    CwdOrPathFlag,
+    RunnerResident,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2216,6 +2223,7 @@ mod tests {
             portable: true,
             default_lab_offload: true,
             unsupported_reason: None,
+            source_path_mode: LabOffloadSourcePathMode::CwdOrPathFlag,
             workspace_mode_policy: LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
             requires_extension_parity: true,
             required_extensions: Vec::new(),
@@ -2230,6 +2238,7 @@ mod tests {
             portable: false,
             default_lab_offload: false,
             unsupported_reason: Some(reason),
+            source_path_mode: LabOffloadSourcePathMode::CwdOrPathFlag,
             workspace_mode_policy: LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
             requires_extension_parity: false,
             required_extensions: Vec::new(),

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -77,7 +77,7 @@ pub(crate) use git_dependency_materialization::{
 };
 pub use lab::{
     execute_lab_offload, LabOffloadCommand, LabOffloadOutcome, LabOffloadRequest,
-    LabOffloadWorkspaceModePolicy, LabRunnerSelectionSource,
+    LabOffloadSourcePathMode, LabOffloadWorkspaceModePolicy, LabRunnerSelectionSource,
 };
 pub use offload_changed_since::{
     lab_offload_changed_since_ref, preflight_lab_offload_changed_since,

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -36,16 +36,16 @@ pub use super::runner::{
     refresh_mirrored_daemon_evidence, reportable_artifact_evidence_path,
     resolve_default_lab_runner, run_reverse_worker, runner_artifact_store_token,
     runner_exec_failure_error, runner_job_log_snapshot, status, statuses, sync_workspace,
-    LabOffloadCommand, LabOffloadOutcome, LabOffloadRequest, LabOffloadWorkspaceModePolicy,
-    LabRunnerCapabilityContract, LabRunnerGateDecision, LabRunnerGateMode,
-    LabRunnerSelectionSource, PreparedLabRunnerCapability, RemoteArtifactDownload,
-    ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput, Runner,
-    RunnerCapabilityPreflight, RunnerConnectReport, RunnerDisconnectReport, RunnerExecMode,
-    RunnerExecOptions, RunnerExecOutput, RunnerFailureKind, RunnerKind, RunnerRequiredTool,
-    RunnerResourceMetrics, RunnerSession, RunnerSessionRole, RunnerSessionState,
-    RunnerStaleDaemonWarning, RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceApplyOptions,
-    RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus, RunnerWorkspaceSyncMode,
-    RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    LabOffloadCommand, LabOffloadOutcome, LabOffloadRequest, LabOffloadSourcePathMode,
+    LabOffloadWorkspaceModePolicy, LabRunnerCapabilityContract, LabRunnerGateDecision,
+    LabRunnerGateMode, LabRunnerSelectionSource, PreparedLabRunnerCapability,
+    RemoteArtifactDownload, ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions,
+    ReverseRunnerWorkerOutput, Runner, RunnerCapabilityPreflight, RunnerConnectReport,
+    RunnerDisconnectReport, RunnerExecMode, RunnerExecOptions, RunnerExecOutput, RunnerFailureKind,
+    RunnerKind, RunnerRequiredTool, RunnerResourceMetrics, RunnerSession, RunnerSessionRole,
+    RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport, RunnerTunnelMode,
+    RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus,
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 
 // Registry CRUD entry points (re-exported at the root for ergonomics; also
@@ -128,6 +128,7 @@ pub mod lab_offload {
         lab_offload_changed_since_ref, lab_offload_metadata,
         lab_offload_metadata_with_workspace_mapping, preflight_lab_offload_changed_since,
         prepare_git_lab_offload_changed_since, LabOffloadCommand, LabOffloadOutcome,
-        LabOffloadRequest, LabOffloadWorkspaceModePolicy, LabRunnerSelectionSource,
+        LabOffloadRequest, LabOffloadSourcePathMode, LabOffloadWorkspaceModePolicy,
+        LabRunnerSelectionSource,
     };
 }


### PR DESCRIPTION
## Summary
- Fixes #4773.
- Marks `tunnel service start` as using runner-resident source-path semantics, not generic `--cwd`/`--path` source materialization.
- Propagates the source-path mode through the Lab offload command contract so route/offload code can distinguish runner-side service cwd from controller-local sync paths.
- Adds focused regression assertions for the exact `homeboy --runner homeboy-lab tunnel service start ... --cwd /home/...` command shape.

## Verification
All Cargo/lint work was run on `homeboy-lab`; no local Cargo was run on the Studio machine.

- `homeboy --runner homeboy-lab test --path /Users/chubes/Developer/homeboy@fix-4773-runner-resident-service-cwd -- --lib command_contract::lab::tests::test_lab_command_contracts_cover_hot_commands commands::route::tests::tunnel_service_start_supports_explicit_runner_discovery core::runner::lab_args::tests::runner_resident_rewrite_preserves_runner_side_cwd`
  - Result: `cargo fmt --check` passed, `cargo clippy` passed. The final Cargo test phase used an invalid passthrough shape (`--lib` reached the test binary), so focused tests were run directly below.
- `homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/_lab_workspaces/homeboy-fix-4773-runner-resident-service-cwd-f435bfd26a79-e856c9b0-e924-42a6-838d-59b79a4d614e-1781580679440402000 -- cargo test --lib command_contract::lab::tests::test_lab_command_contracts_cover_hot_commands`
  - Result: 1 passed.
  - Evidence run: `runner-exec-homeboy-lab-6eff52e4-df1b-435b-b784-49abcf8085f9`.
- `homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/_lab_workspaces/homeboy-fix-4773-runner-resident-service-cwd-f435bfd26a79-e856c9b0-e924-42a6-838d-59b79a4d614e-1781580679440402000 -- cargo test --lib commands::route::tests::tunnel_service_start_supports_explicit_runner_discovery`
  - Result: 1 passed.
  - Evidence run: `runner-exec-homeboy-lab-8d3c940a-bb7b-49da-b51a-8a7a0ae862f6`.
- `homeboy runner exec homeboy-lab --cwd /home/chubes/Developer/_lab_workspaces/homeboy-fix-4773-runner-resident-service-cwd-f435bfd26a79-e856c9b0-e924-42a6-838d-59b79a4d614e-1781580679440402000 -- cargo test --lib core::runner::lab_args::tests::runner_resident_rewrite_preserves_runner_side_cwd`
  - Result: 1 passed.
  - Evidence run: `runner-exec-homeboy-lab-7f3f6bd4-456b-4d6c-ad99-3097cc772db8`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runner-resident contract path, drafted the code and focused regression assertions, ran offloaded verification, and prepared this PR. Chris remains responsible for review and final acceptance.
