### PR TITLE
fix: surface code-production metrics in agent-task review/status

### DIFF
--- a/src/commands/agent_task_summary.rs
+++ b/src/commands/agent_task_summary.rs
@@ -40,8 +40,8 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
     let tasks_attempted = aggregate_outcome_count(payload).unwrap_or(0);
     let aggregate_path = string_value(payload, &["aggregate_path"])
         .or_else(|| string_value(payload, &["record", "aggregate_path"]));
-    let patch_candidates = patch_candidate_count(payload);
-    let state = effective_run_state(raw_state, tasks_attempted, patch_candidates);
+    let metrics = code_production_metrics(payload);
+    let state = effective_run_state(raw_state, tasks_attempted, metrics.non_empty_patches);
     let artifact_count = aggregate_artifact_count(payload);
     let first_artifact = string_value(
         payload,
@@ -60,8 +60,8 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
         format!("Status: {state}"),
         format!("Tasks planned: {tasks_planned}"),
         format!("Tasks attempted: {tasks_attempted}"),
-        format!("Patch candidates: {patch_candidates}"),
     ];
+    lines.extend(code_production_lines(&metrics));
     if let Some(path) = aggregate_path {
         lines.push(format!("Aggregate: {path}"));
     }
@@ -69,7 +69,7 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
     if let Some(artifact) = first_artifact {
         lines.push(format!("First artifact: {artifact}"));
     }
-    if patch_candidates > 0 {
+    if metrics.non_empty_patches > 0 {
         lines.push(format!("Next: homeboy agent-task review {run_id}"));
     } else {
         lines.push(format!("Next: homeboy agent-task logs {run_id}"));
@@ -82,8 +82,8 @@ fn render_status_summary(payload: &Value) -> Option<String> {
     let raw_state = string_value(payload, &["state"]).unwrap_or("unknown");
     let tasks_planned = array_len(payload, &["tasks"]).unwrap_or(0);
     let tasks_attempted = status_attempted_task_count(payload);
-    let patch_candidates = patch_candidate_count(payload);
-    let state = effective_run_state(raw_state, tasks_attempted, patch_candidates);
+    let metrics = code_production_metrics(payload);
+    let state = effective_run_state(raw_state, tasks_attempted, metrics.non_empty_patches);
     let artifact_count = array_len(payload, &["artifact_refs"]).unwrap_or(0);
     let aggregate_path = string_value(payload, &["aggregate_path"]);
 
@@ -93,10 +93,10 @@ fn render_status_summary(payload: &Value) -> Option<String> {
         format!("Status: {state}"),
         format!("Tasks planned: {tasks_planned}"),
         format!("Tasks attempted: {tasks_attempted}"),
-        format!("Patch candidates: {patch_candidates}"),
-        format!("Artifacts: {artifact_count}"),
     ];
-    if let Some(path) = aggregate_path.filter(|_| patch_candidates > 0) {
+    lines.extend(code_production_lines(&metrics));
+    lines.push(format!("Artifacts: {artifact_count}"));
+    if let Some(path) = aggregate_path.filter(|_| metrics.non_empty_patches > 0) {
         lines.push(format!("Aggregate: {path}"));
         lines.push(format!("Next: homeboy agent-task review {run_id}"));
     } else if state == "queued" {
@@ -111,7 +111,7 @@ fn render_review_summary(payload: &Value) -> Option<String> {
     let run_id = string_value(payload, &["run_id"])?;
     let state = string_value(payload, &["state"]).unwrap_or("unknown");
     let summary = value_at(payload, &["aggregate_review", "summary"]);
-    let apply_candidates = summary
+    let raw_apply_candidates = summary
         .and_then(|_| {
             usize_value(
                 payload,
@@ -122,17 +122,21 @@ fn render_review_summary(payload: &Value) -> Option<String> {
     let failed = summary
         .and_then(|_| usize_value(payload, &["aggregate_review", "summary", "failed"]))
         .unwrap_or(0);
-    let patch = (apply_candidates > 0)
+    let metrics = code_production_metrics(payload);
+    let promotable = metrics.non_empty_patches > 0;
+    let patch = promotable
         .then(|| string_value(payload, &["promotion_candidates", "0", "artifact_id"]))
         .flatten();
     let patch_path = patch.and_then(|artifact_id| artifact_path(payload, artifact_id));
     let next = first_string(payload, &["next_actions"]);
-    let command = (apply_candidates > 0)
+    let command = promotable
         .then(|| command_line(payload, &["promotion_candidates", "0", "command"]))
         .flatten();
 
-    let outcome = if apply_candidates > 0 {
+    let outcome = if promotable {
         "patch produced, not promoted"
+    } else if raw_apply_candidates > 0 {
+        "no-op: patch artifacts produced but empty"
     } else if failed > 0 || state == "failed" || state == "partial_failure" {
         "failed or partial failure"
     } else {
@@ -144,8 +148,8 @@ fn render_review_summary(payload: &Value) -> Option<String> {
         format!("Run: {run_id}"),
         format!("Status: {state}"),
         format!("Outcome: {outcome}"),
-        format!("Patch candidates: {apply_candidates}"),
     ];
+    lines.extend(code_production_lines(&metrics));
     if let Some(patch_path) = patch_path {
         lines.push(format!("Patch: {patch_path}"));
     } else if let Some(patch) = patch {
@@ -199,49 +203,178 @@ fn aggregate_artifact_count(payload: &Value) -> usize {
         .unwrap_or_else(|| array_len(payload, &["artifact_refs"]).unwrap_or(0))
 }
 
-fn patch_candidate_count(payload: &Value) -> usize {
-    usize_value(
-        payload,
-        &["aggregate_review", "summary", "apply_candidates"],
-    )
-    .or_else(|| usize_value(payload, &["aggregate", "summary", "apply_candidates"]))
-    .or_else(|| usize_value(payload, &["aggregate", "totals", "apply_candidates"]))
-    .unwrap_or_else(|| count_apply_artifacts(payload))
+const APPLY_ARTIFACT_KINDS: &[&str] = &[
+    "patch",
+    "diff",
+    "change_artifact",
+    "workspace_patch",
+    "artifact",
+];
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct CodeProductionMetrics {
+    non_empty_patches: usize,
+    empty_patches: usize,
+    unknown_size_patches: usize,
+    diff_bytes: u64,
+    changed_files: usize,
 }
 
-fn count_apply_artifacts(payload: &Value) -> usize {
-    let aggregate_artifacts = value_at(payload, &["aggregate", "outcomes"])
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .flat_map(|outcome| {
-            value_at(outcome, &["artifacts"])
-                .and_then(Value::as_array)
-                .into_iter()
-                .flatten()
-        });
-    let status_artifacts = value_at(payload, &["artifact_refs"])
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten();
-
-    aggregate_artifacts
-        .chain(status_artifacts)
-        .filter(|artifact| is_apply_artifact(artifact))
-        .count()
+fn code_production_lines(metrics: &CodeProductionMetrics) -> Vec<String> {
+    let patch_candidates = if metrics.unknown_size_patches > 0 {
+        format!(
+            "Patch candidates: {} non-empty / {} empty / {} unknown",
+            metrics.non_empty_patches, metrics.empty_patches, metrics.unknown_size_patches
+        )
+    } else {
+        format!(
+            "Patch candidates: {} non-empty / {} empty",
+            metrics.non_empty_patches, metrics.empty_patches
+        )
+    };
+    vec![
+        patch_candidates,
+        format!("Changed files: {}", metrics.changed_files),
+        format!("Diff bytes: {}", metrics.diff_bytes),
+    ]
 }
 
-fn is_apply_artifact(artifact: &Value) -> bool {
+fn code_production_metrics(payload: &Value) -> CodeProductionMetrics {
+    let mut metrics = CodeProductionMetrics::default();
+    for patch in collect_patch_artifacts(payload) {
+        match patch.size_bytes {
+            Some(size) if size > 0 => {
+                metrics.non_empty_patches += 1;
+                metrics.diff_bytes += size;
+                metrics.changed_files += patch.changed_files;
+            }
+            Some(_) => metrics.empty_patches += 1,
+            None => metrics.unknown_size_patches += 1,
+        }
+    }
+    metrics
+}
+
+struct PatchArtifact {
+    size_bytes: Option<u64>,
+    changed_files: usize,
+}
+
+fn collect_patch_artifacts(payload: &Value) -> Vec<PatchArtifact> {
+    if let Some(inventory) =
+        value_at(payload, &["aggregate_review", "artifact_inventory"]).and_then(Value::as_array)
+    {
+        let candidate_ids = review_apply_candidate_ids(payload);
+        return inventory
+            .iter()
+            .filter_map(|item| {
+                let artifact_id = string_value(item, &["artifact_id"])?;
+                let task_id = string_value(item, &["task_id"])?;
+                if !candidate_ids.contains(&(task_id, artifact_id)) {
+                    return None;
+                }
+                if !is_apply_kind(item) {
+                    return None;
+                }
+                Some(PatchArtifact {
+                    size_bytes: u64_value(item, &["size_bytes"]),
+                    changed_files: metadata_changed_files(item),
+                })
+            })
+            .collect();
+    }
+
+    if let Some(outcomes) = value_at(payload, &["aggregate", "outcomes"]).and_then(Value::as_array)
+    {
+        return outcomes
+            .iter()
+            .flat_map(|outcome| {
+                value_at(outcome, &["artifacts"])
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .filter(|artifact| is_display_apply_artifact(artifact))
+                    .map(|artifact| PatchArtifact {
+                        size_bytes: u64_value(artifact, &["size_bytes"]),
+                        changed_files: metadata_changed_files(artifact),
+                    })
+            })
+            .collect();
+    }
+
+    if let Some(references) = value_at(payload, &["artifact_refs"]).and_then(Value::as_array) {
+        return references
+            .iter()
+            .filter(|reference| is_apply_kind(reference))
+            .map(|reference| PatchArtifact {
+                size_bytes: u64_value(reference, &["size_bytes"]),
+                changed_files: metadata_changed_files(reference),
+            })
+            .collect();
+    }
+
+    Vec::new()
+}
+
+fn review_apply_candidate_ids(payload: &Value) -> Vec<(&str, &str)> {
+    let mut ids = Vec::new();
+    let Some(candidates) =
+        value_at(payload, &["aggregate_review", "apply_candidates"]).and_then(Value::as_array)
+    else {
+        return ids;
+    };
+    for candidate in candidates {
+        let Some(task_id) = string_value(candidate, &["task_id"]) else {
+            continue;
+        };
+        let Some(artifact_ids) = value_at(candidate, &["artifact_ids"]).and_then(Value::as_array)
+        else {
+            continue;
+        };
+        for artifact_id in artifact_ids {
+            if let Some(artifact_id) = artifact_id.as_str() {
+                ids.push((task_id, artifact_id));
+            }
+        }
+    }
+    ids
+}
+
+fn is_apply_kind(artifact: &Value) -> bool {
     let Some(kind) = string_value(artifact, &["kind"]) else {
         return false;
     };
-    let apply_kind = matches!(
-        kind,
-        "patch" | "diff" | "change_artifact" | "workspace_patch" | "artifact"
-    );
-    // Require positive evidence of content: an unknown or zero size must not be
-    // counted as a patch candidate (#4610).
-    apply_kind && matches!(usize_value(artifact, &["size_bytes"]), Some(size) if size > 0)
+    APPLY_ARTIFACT_KINDS.contains(&kind)
+}
+
+fn is_display_apply_artifact(artifact: &Value) -> bool {
+    if !is_apply_kind(artifact) {
+        return false;
+    }
+    !(artifact_flag(artifact, "rejected") || artifact_flag(artifact, "false_positive"))
+}
+
+fn artifact_flag(artifact: &Value, key: &str) -> bool {
+    value_at(artifact, &["metadata"])
+        .and_then(|metadata| metadata.get(key))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn metadata_changed_files(artifact: &Value) -> usize {
+    if let Some(files) =
+        value_at(artifact, &["metadata", "changed_files"]).and_then(Value::as_array)
+    {
+        return files.len();
+    }
+    value_at(artifact, &["metadata", "changed_file_count"])
+        .and_then(Value::as_u64)
+        .map(|count| count as usize)
+        .unwrap_or(0)
+}
+
+fn u64_value(payload: &Value, path: &[&str]) -> Option<u64> {
+    value_at(payload, path)?.as_u64()
 }
 
 /// A run whose lifecycle state is `succeeded` but that produced zero promotion
@@ -321,7 +454,8 @@ mod tests {
         assert!(summary.starts_with("Agent task cook\nRun: homeboy-4345\nStatus: succeeded"));
         assert!(summary.contains("Tasks planned: 1\n"));
         assert!(summary.contains("Tasks attempted: 1\n"));
-        assert!(summary.contains("Patch candidates: 1\n"));
+        assert!(summary.contains("Patch candidates: 1 non-empty / 0 empty\n"));
+        assert!(summary.contains("Diff bytes: 128\n"));
         assert!(summary.contains("First artifact: /tmp/patch.diff\n"));
         assert!(summary.contains("Next: homeboy agent-task review homeboy-4345\n"));
         assert!(!summary.contains("{\n"));
@@ -351,7 +485,7 @@ mod tests {
         let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
 
         assert!(summary.contains("Status: no_patch_produced\n"));
-        assert!(summary.contains("Patch candidates: 0\n"));
+        assert!(summary.contains("Patch candidates: 0 non-empty / 3 empty\n"));
         assert!(summary.contains("Next: homeboy agent-task logs agent-task-abe47e4d\n"));
         assert!(!summary.contains("Next: homeboy agent-task review"));
     }
@@ -373,12 +507,12 @@ mod tests {
         let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
 
         assert!(summary.contains("Status: no_patch_produced\n"));
-        assert!(summary.contains("Patch candidates: 0\n"));
+        assert!(summary.contains("Patch candidates: 0 non-empty / 0 empty / 1 unknown\n"));
         assert!(summary.contains("Next: homeboy agent-task logs homeboy-4345\n"));
     }
 
     #[test]
-    fn cook_summary_uses_review_totals_for_patch_candidates() {
+    fn cook_summary_counts_empty_patch_artifact_as_empty_not_candidate() {
         let payload = json!({
             "run_id": "homeboy-4345",
             "state": "succeeded",
@@ -389,14 +523,44 @@ mod tests {
             "aggregate": {
                 "outcomes": [{
                     "task_id": "homeboy-4345",
-                    "artifacts": [{ "id": "empty-patch", "path": "/tmp/patch.diff" }]
+                    "artifacts": [{ "id": "empty-patch", "kind": "patch", "path": "/tmp/patch.diff", "size_bytes": 0 }]
                 }]
             }
         });
 
         let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
 
-        assert!(summary.contains("Patch candidates: 0\n"));
+        assert!(summary.contains("Patch candidates: 0 non-empty / 1 empty\n"));
+        assert!(summary.contains("Diff bytes: 0\n"));
+        assert!(summary.contains("Next: homeboy agent-task logs homeboy-4345\n"));
+        assert!(!summary.contains("Next: homeboy agent-task review"));
+    }
+
+    #[test]
+    fn cook_summary_surfaces_changed_files_and_diff_bytes_from_metadata() {
+        let payload = json!({
+            "run_id": "homeboy-4345",
+            "state": "succeeded",
+            "task_count": 1,
+            "aggregate": {
+                "outcomes": [{
+                    "task_id": "homeboy-4345",
+                    "artifacts": [{
+                        "id": "patch",
+                        "kind": "patch",
+                        "path": "/tmp/patch.diff",
+                        "size_bytes": 256,
+                        "metadata": { "changed_files": ["src/lib.rs", "src/main.rs"] }
+                    }]
+                }]
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
+
+        assert!(summary.contains("Patch candidates: 1 non-empty / 0 empty\n"));
+        assert!(summary.contains("Changed files: 2\n"));
+        assert!(summary.contains("Diff bytes: 256\n"));
     }
 
     #[test]
@@ -420,7 +584,7 @@ mod tests {
 
         assert!(summary.contains("Tasks planned: 4\n"));
         assert!(summary.contains("Tasks attempted: 4\n"));
-        assert!(summary.contains("Patch candidates: 0\n"));
+        assert!(summary.contains("Patch candidates: 0 non-empty / 0 empty\n"));
         assert!(summary.contains("Artifacts: 0\n"));
         assert!(summary.contains("Next: homeboy agent-task logs agent-task-22bb7835\n"));
         assert!(!summary.contains("Next: homeboy agent-task review"));
@@ -436,11 +600,18 @@ mod tests {
                     "apply_candidates": 1,
                     "failed": 0
                 },
+                "apply_candidates": [{
+                    "task_id": "homeboy-4345",
+                    "decision": "apply_candidate",
+                    "reason": "succeeded with reviewable patch/artifact output",
+                    "artifact_ids": ["patch.diff"]
+                }],
                 "artifact_inventory": [{
                     "task_id": "homeboy-4345",
                     "artifact_id": "patch.diff",
                     "kind": "patch",
-                    "path": "/tmp/patch.diff"
+                    "path": "/tmp/patch.diff",
+                    "size_bytes": 128
                 }]
             },
             "promotion_candidates": [{
@@ -453,7 +624,8 @@ mod tests {
 
         assert!(summary.starts_with("Agent task review\nRun: homeboy-4345\nStatus: succeeded"));
         assert!(summary.contains("Outcome: patch produced, not promoted\n"));
-        assert!(summary.contains("Patch candidates: 1\n"));
+        assert!(summary.contains("Patch candidates: 1 non-empty / 0 empty\n"));
+        assert!(summary.contains("Diff bytes: 128\n"));
         assert!(summary.contains("Patch: /tmp/patch.diff\n"));
         assert!(summary
             .contains("Next: homeboy agent-task promote homeboy-4345 --artifact-id patch.diff\n"));
@@ -474,7 +646,8 @@ mod tests {
                     "task_id": "homeboy-4345",
                     "artifact_id": "empty-patch",
                     "kind": "patch",
-                    "path": "/tmp/patch.diff"
+                    "path": "/tmp/patch.diff",
+                    "size_bytes": 0
                 }]
             },
             "promotion_candidates": [{
@@ -486,8 +659,84 @@ mod tests {
         let summary = render_agent_task_summary(AgentTaskSummaryKind::Review, &payload).unwrap();
 
         assert!(summary.contains("Outcome: failed or partial failure\n"));
-        assert!(summary.contains("Patch candidates: 0\n"));
+        assert!(summary.contains("Patch candidates: 0 non-empty / 0 empty\n"));
         assert!(!summary.contains("patch produced"));
+        assert!(!summary.contains("Next: homeboy agent-task promote"));
+    }
+
+    #[test]
+    fn review_summary_marks_no_op_when_apply_candidates_are_empty_patches() {
+        let payload = json!({
+            "run_id": "homeboy-4345",
+            "state": "succeeded",
+            "aggregate_review": {
+                "summary": {
+                    "apply_candidates": 3,
+                    "failed": 0
+                },
+                "apply_candidates": [
+                    { "task_id": "cell-1", "decision": "apply_candidate", "reason": "succeeded with reviewable patch/artifact output", "artifact_ids": ["codebox-patch-1"] },
+                    { "task_id": "cell-2", "decision": "apply_candidate", "reason": "succeeded with reviewable patch/artifact output", "artifact_ids": ["codebox-patch-2"] },
+                    { "task_id": "cell-3", "decision": "apply_candidate", "reason": "succeeded with reviewable patch/artifact output", "artifact_ids": ["codebox-patch-3"] }
+                ],
+                "artifact_inventory": [
+                    { "task_id": "cell-1", "artifact_id": "codebox-patch-1", "kind": "patch", "path": "/tmp/patch-1.diff", "size_bytes": 0 },
+                    { "task_id": "cell-2", "artifact_id": "codebox-patch-2", "kind": "patch", "path": "/tmp/patch-2.diff", "size_bytes": 0 },
+                    { "task_id": "cell-3", "artifact_id": "codebox-patch-3", "kind": "patch", "path": "/tmp/patch-3.diff", "size_bytes": 0 }
+                ]
+            },
+            "promotion_candidates": [{
+                "artifact_id": "codebox-patch-1",
+                "command": ["homeboy", "agent-task", "promote", "homeboy-4345", "--artifact-id", "codebox-patch-1"]
+            }],
+            "next_actions": ["inspect task summaries before retrying or reporting"]
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Review, &payload).unwrap();
+
+        assert!(summary.contains("Outcome: no-op: patch artifacts produced but empty\n"));
+        assert!(summary.contains("Patch candidates: 0 non-empty / 3 empty\n"));
+        assert!(summary.contains("Diff bytes: 0\n"));
+        assert!(!summary.contains("Patch: "));
+        assert!(!summary.contains("Next: homeboy agent-task promote"));
+        assert!(summary.contains("Next: inspect task summaries before retrying or reporting"));
+    }
+
+    #[test]
+    fn review_summary_treats_unknown_size_patch_as_not_promotable() {
+        let payload = json!({
+            "run_id": "homeboy-4345",
+            "state": "succeeded",
+            "aggregate_review": {
+                "summary": { "apply_candidates": 1, "failed": 0 },
+                "apply_candidates": [{
+                    "task_id": "homeboy-4345",
+                    "decision": "apply_candidate",
+                    "reason": "succeeded with reviewable patch/artifact output",
+                    "artifact_ids": ["unmeasured-patch"]
+                }],
+                "artifact_inventory": [{
+                    "task_id": "homeboy-4345",
+                    "artifact_id": "unmeasured-patch",
+                    "kind": "patch",
+                    "path": "/tmp/patch.diff"
+                }]
+            },
+            "promotion_candidates": [{
+                "artifact_id": "unmeasured-patch",
+                "command": ["homeboy", "agent-task", "promote", "homeboy-4345", "--artifact-id", "unmeasured-patch"]
+            }]
+        });
+
+        let metrics = code_production_metrics(&payload);
+
+        assert_eq!(metrics.non_empty_patches, 0);
+        assert_eq!(metrics.empty_patches, 0);
+        assert_eq!(metrics.unknown_size_patches, 1);
+        assert_eq!(metrics.diff_bytes, 0);
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Review, &payload).unwrap();
+        assert!(summary.contains("Patch candidates: 0 non-empty / 0 empty / 1 unknown\n"));
         assert!(!summary.contains("Next: homeboy agent-task promote"));
     }
 
@@ -505,7 +754,7 @@ mod tests {
         assert!(summary.starts_with("Agent task status\nRun: homeboy-4345\nStatus: queued"));
         assert!(summary.contains("Tasks planned: 1\n"));
         assert!(summary.contains("Tasks attempted: 0\n"));
-        assert!(summary.contains("Patch candidates: 0\n"));
+        assert!(summary.contains("Patch candidates: 0 non-empty / 0 empty\n"));
         assert!(summary.contains("Artifacts: 0\n"));
         assert!(summary.contains("Next: homeboy agent-task run homeboy-4345\n"));
     }
@@ -529,8 +778,85 @@ mod tests {
 
         assert!(summary.contains("Tasks planned: 4\n"));
         assert!(summary.contains("Tasks attempted: 4\n"));
-        assert!(summary.contains("Patch candidates: 0\n"));
+        assert!(summary.contains("Patch candidates: 0 non-empty / 0 empty\n"));
         assert!(summary.contains("Next: homeboy agent-task logs agent-task-22bb7835\n"));
         assert!(!summary.contains("Next: homeboy agent-task review"));
+    }
+
+    #[test]
+    fn status_summary_surfaces_code_production_breakdown_alongside_raw_artifact_count() {
+        let mut artifact_refs = vec![
+            json!({ "task_id": "cell-1", "kind": "patch", "uri": "artifact://cell-1/patch.diff", "size_bytes": 512 }),
+            json!({ "task_id": "cell-2", "kind": "patch", "uri": "artifact://cell-2/patch.diff", "size_bytes": 0 }),
+        ];
+        for index in 0..40 {
+            artifact_refs.push(json!({
+                "task_id": "cell-1",
+                "kind": "provider-transcript",
+                "uri": format!("artifact://cell-1/transcript-{index}.log"),
+                "size_bytes": 1024
+            }));
+        }
+
+        let payload = json!({
+            "run_id": "agent-task-deadbeef",
+            "state": "succeeded",
+            "tasks": [{ "task_id": "cell-1", "state": "succeeded" }],
+            "artifact_refs": artifact_refs
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+
+        assert!(summary.contains("Artifacts: 42\n"));
+        assert!(summary.contains("Patch candidates: 1 non-empty / 1 empty\n"));
+        assert!(summary.contains("Diff bytes: 512\n"));
+    }
+
+    #[test]
+    fn status_summary_flags_no_op_when_all_patch_artifacts_are_empty() {
+        let payload = json!({
+            "run_id": "agent-task-deadbeef",
+            "state": "succeeded",
+            "tasks": [{ "task_id": "cell-1", "state": "succeeded" }],
+            "artifact_refs": [
+                { "task_id": "cell-1", "kind": "patch", "uri": "artifact://cell-1/patch-1.diff", "size_bytes": 0 },
+                { "task_id": "cell-2", "kind": "patch", "uri": "artifact://cell-2/patch-2.diff", "size_bytes": 0 },
+                { "task_id": "cell-3", "kind": "patch", "uri": "artifact://cell-3/patch-3.diff", "size_bytes": 0 },
+                { "task_id": "cell-1", "kind": "provider-transcript", "uri": "artifact://cell-1/transcript.log", "size_bytes": 4096 }
+            ]
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+
+        assert!(summary.contains("Artifacts: 4\n"));
+        assert!(summary.contains("Patch candidates: 0 non-empty / 3 empty\n"));
+        assert!(summary.contains("Diff bytes: 0\n"));
+        assert!(summary.contains("Next: homeboy agent-task logs agent-task-deadbeef\n"));
+        assert!(!summary.contains("Next: homeboy agent-task review"));
+    }
+
+    #[test]
+    fn code_production_metrics_skips_rejected_and_non_apply_artifacts_in_cook_outcomes() {
+        let payload = json!({
+            "aggregate": {
+                "outcomes": [{
+                    "task_id": "cell-1",
+                    "artifacts": [
+                        { "id": "real-patch", "kind": "patch", "size_bytes": 64 },
+                        { "id": "empty-patch", "kind": "patch", "size_bytes": 0 },
+                        { "id": "rejected-patch", "kind": "patch", "size_bytes": 64, "metadata": { "rejected": true } },
+                        { "id": "false-positive", "kind": "diff", "size_bytes": 64, "metadata": { "false_positive": true } },
+                        { "id": "transcript", "kind": "provider-transcript", "size_bytes": 4096 }
+                    ]
+                }]
+            }
+        });
+
+        let metrics = code_production_metrics(&payload);
+
+        assert_eq!(metrics.non_empty_patches, 1);
+        assert_eq!(metrics.empty_patches, 1);
+        assert_eq!(metrics.unknown_size_patches, 0);
+        assert_eq!(metrics.diff_bytes, 64);
     }
 }

--- a/src/core/agent_task_aggregate.rs
+++ b/src/core/agent_task_aggregate.rs
@@ -86,6 +86,8 @@ pub struct AgentTaskArtifactInventoryItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sha256: Option<String>,
 }
 
@@ -383,6 +385,7 @@ fn inventory_item(task_id: &str, artifact: &AgentTaskArtifact) -> AgentTaskArtif
         name: artifact.name.clone(),
         path: artifact.path.clone(),
         url: artifact.url.clone(),
+        size_bytes: artifact.size_bytes,
         sha256: artifact.sha256.clone(),
     }
 }

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -133,6 +133,8 @@ pub struct AgentTaskArtifactRef {
     pub uri: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1095,6 +1097,7 @@ fn artifact_refs_for_outcomes(outcomes: &[AgentTaskOutcome]) -> Vec<AgentTaskArt
                         kind: artifact.kind.clone(),
                         uri,
                         label: artifact.name.clone(),
+                        size_bytes: artifact.size_bytes,
                     })
             });
             let evidence_refs = outcome
@@ -1107,6 +1110,7 @@ fn artifact_refs_for_outcomes(outcomes: &[AgentTaskOutcome]) -> Vec<AgentTaskArt
                     kind: evidence.kind.clone(),
                     uri: evidence.uri.clone(),
                     label: evidence.label.clone(),
+                    size_bytes: None,
                 });
             artifact_refs.chain(evidence_refs).collect::<Vec<_>>()
         })


### PR DESCRIPTION
## Summary

Fixes two related agent-task review/status issues where the display paths counted patch artifacts by **existence rather than substance**, making an empty/no-op cook look promotable.

- **#4611** — `agent-task review` reported inflated `Patch candidates` because it trusted the raw `apply_candidates` count. Empty (zero-byte) and unmeasured-size patches were treated as promotable.
- **#4612** — `agent-task status` reported a large raw `Artifacts` count that masked zero actual code changes (the count included transcripts, manifests, logs, replay bundles).

## Root cause

Both the review and status summary renderers counted artifact *existence* instead of artifact *content*:

- The review renderer trusted `aggregate_review.summary.apply_candidates` blindly.
- The status renderer's fallback counted apply-kind `artifact_refs` regardless of size (refs carried no size info at all).
- The intermediate types (`AgentTaskArtifactInventoryItem`, `AgentTaskArtifactRef`) stripped `size_bytes`, so the display layer could not validate content even when the source artifacts measured it.

## Fix

Validate patch content in the **display layer**:

1. **Enrich data flow** — add `size_bytes` to `AgentTaskArtifactInventoryItem` and `AgentTaskArtifactRef`, populated from the source `AgentTaskArtifact`. Additive serde change (backward-compatible for deserialization).
2. **Review (#4611)** — only count non-empty patches (`size_bytes > 0`) as promotable candidates. When the raw `apply_candidates > 0` but none are non-empty, emit a `no-op: patch artifacts produced but empty` outcome and drop the promote command/patch hint. Unmeasured (`size_bytes` absent) patches are reported as `unknown` and are **not** promotable.
3. **Status (#4612)** — render a code-production breakdown alongside the raw artifact count:
   ```
   Patch candidates: 0 non-empty / 3 empty
   Changed files: 0
   Diff bytes: 0
   Artifacts: 42
   ```
   so a no-op run (many artifacts, zero patch substance) is obvious.
4. **Cook** — routed through the same validated metrics, and feeds `metrics.non_empty_patches` into the `effective_run_state` helper from #4610 (a `succeeded` run with attempted tasks but no non-empty patches is surfaced as `no_patch_produced`).

This rebases cleanly on top of the #4610 `effective_run_state` work and complements it: #4610 relabels no-patch runs in the `Status:` line; this PR adds the non-empty/empty/unknown + diff-bytes breakdown that explains *why*.

## Tests

- `review_summary_marks_no_op_when_apply_candidates_are_empty_patches` — the #4611 scenario (3 apply candidates, all zero-byte) → `Patch candidates: 0 non-empty / 3 empty`, no-op outcome, no promote hint.
- `review_summary_treats_unknown_size_patch_as_not_promotable` — unmeasured patches are not promotable.
- `status_summary_surfaces_code_production_breakdown_alongside_raw_artifact_count` — the #4612 scenario.
- `status_summary_flags_no_op_when_all_patch_artifacts_are_empty`.
- `code_production_metrics_skips_rejected_and_non_apply_artifacts_in_cook_outcomes` — rejected/false-positive and non-apply artifacts excluded.
- Existing #4610 tests (`cook_summary_reports_no_patch_produced_when_all_cells_are_empty`, `cook_summary_treats_unknown_size_patch_as_zero_candidates`) updated to the new breakdown format.

`cargo fmt --check`, `cargo clippy --lib` (no new warnings), and all affected module tests pass locally.

Closes #4611
Closes #4612