### PR TITLE
fix: report success:false when a release is skipped (#4316)

### DIFF
--- a/docs/architecture/output-system.md
+++ b/docs/architecture/output-system.md
@@ -154,8 +154,11 @@ The `next_steps` array contains context-aware actionable guidance based on the c
 | 1 | internal errors (`internal.*`) |
 | 2 | config/validation errors (`config.*`, `validation.*`) |
 | 4 | not found / missing state (`project.not_found`, `server.not_found`, `component.not_found`, `extension.not_found`, `project.no_active`) |
+| 5 | release skipped — no tag/package/GitHub Release produced (`release` when the plan reports `status: "skipped"`; the data payload still carries `skipped_reason` + an actionable force hint) |
 | 10 | SSH errors (`ssh.*`) |
 | 20 | remote/deploy/git errors (`remote.*`, `deploy.*`, `git.*`) |
+
+Note: `0` means success and `3` means a release completed with post-release warnings. A non-zero exit code makes the JSON envelope report `success: false`, even when `data` is present (e.g. a skipped release returns its full result payload alongside `success: false`).
 
 ## Success payload
 

--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -232,6 +232,12 @@ Without `--dry-run`:
 - `skipped` - Pipeline disabled or all steps skipped due to failed dependencies
 - `missing` - Required extension actions not found
 
+### Skipped releases
+
+When Homeboy classifies the commit range as having no releasable commits (e.g. docs-only or guidance-only changes), the release is skipped: no tag, no release commit, and no GitHub Release are produced. The command result reports `status: "skipped"` with a `skipped_reason` (`no-releasable-commits`, `major-requires-flag`, or `release-already-at-head`) and an actionable force hint.
+
+A skipped release is **not** reported as success: the process exits with code `5` and the JSON envelope reports `success: false`, even though `data` still carries the full result payload. This lets operators and CI distinguish a no-op release from a real one. To force a release when the skip is intentional, re-run with `--bump` (the hint echoes the exact command, including flags like `--skip-checks`).
+
 ### Idempotent retry
 
 Publish steps are designed to be idempotent:

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -295,8 +295,14 @@ pub fn run(
     };
 
     let batch_result = release::run_batch(&component_ids, &input_template);
+    // A batch that produced zero releases (all components skipped, none failed)
+    // exits with the dedicated skip code so the envelope reports success:false —
+    // matching single-release behavior (issue #4316). A batch with at least one
+    // real release exits 0; any failure exits 1.
     let exit_code = if batch_result.summary.failed > 0 {
         1
+    } else if batch_result.summary.released == 0 && batch_result.summary.skipped > 0 {
+        release::SKIPPED_RELEASE_EXIT_CODE
     } else {
         0
     };

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -32,4 +32,4 @@ pub use types::{
     ReleaseStepResult, ReleaseStepStatus,
 };
 pub use utils::{extract_latest_notes, parse_release_artifacts};
-pub use workflow::{run_batch, run_command};
+pub use workflow::{run_batch, run_command, SKIPPED_RELEASE_EXIT_CODE};

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -9,6 +9,16 @@ use super::types::{
     ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus,
 };
 
+/// Process exit code returned when a release is intentionally skipped (no tag,
+/// no package, no GitHub Release produced).
+///
+/// This is distinct from `0` (released) and `1` (failure) so operators and CI
+/// can tell a no-op release from a real one. The generic JSON envelope derives
+/// `success` from the exit code (`success: exit_code == 0`), so a skipped
+/// release reports `success: false` while the data payload still carries
+/// `status: "skipped"` + `skipped_reason` + an actionable force hint (issue #4316).
+pub const SKIPPED_RELEASE_EXIT_CODE: i32 = 5;
+
 pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32)> {
     if input.recover {
         return run_recover(&input);
@@ -186,27 +196,25 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
             .as_ref()
             .map(|v| format_tag(v, monorepo.as_ref()));
         let deployment = dry_run_deployment_plan(&input.component_id, input.pipeline.deploy, &plan);
+        let skipped_reason = skipped_reason_from_plan(&plan);
+        let dry_run_exit_code = release_command_exit_code(skipped_reason.as_deref(), 0, 0, 0);
 
         return Ok((
             ReleaseCommandResult {
                 component_id: input.component_id,
-                status: release_command_status(
-                    true,
-                    skipped_reason_from_plan(&plan).as_deref(),
-                    None,
-                ),
+                status: release_command_status(true, skipped_reason.as_deref(), None),
                 bump_type,
                 dry_run: true,
                 releasable_commits: releasable_count,
                 new_version,
                 tag,
-                skipped_reason: skipped_reason_from_plan(&plan),
+                skipped_reason,
                 plan: Some(plan),
                 run: None,
                 deployment,
                 release_summary: release_summary_for_skipped_plan(),
             },
-            0,
+            dry_run_exit_code,
         ));
     }
 
@@ -236,11 +244,10 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
         .filter(|deployment| deployment.summary.failed > 0)
         .map(|_| 1)
         .unwrap_or(0);
-    let exit_code = if release_step_exit != 0 {
-        release_step_exit
-    } else if deploy_exit_code != 0 {
-        // Deploy failed after the release was already tagged and pushed.
-        // The tag cannot be rolled back safely, so warn the user to retry.
+    // Warn when a deploy failed after the tag was already pushed (the tag cannot
+    // be rolled back safely). Skipped releases never reach a deploy, so this only
+    // fires for a real release whose deploy step failed.
+    if skipped_reason.is_none() && deploy_exit_code != 0 {
         if let Some(ref t) = tag {
             eprintln!();
             log_status!(
@@ -254,10 +261,14 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
                 input.component_id
             );
         }
-        deploy_exit_code
-    } else {
-        post_release_exit
-    };
+    }
+
+    let exit_code = release_command_exit_code(
+        skipped_reason.as_deref(),
+        release_step_exit,
+        deploy_exit_code,
+        post_release_exit,
+    );
 
     Ok((
         ReleaseCommandResult {
@@ -565,6 +576,31 @@ fn release_run_failure_exit(run: &ReleaseRun) -> i32 {
         ReleaseStepStatus::PartialSuccess
         | ReleaseStepStatus::Failed
         | ReleaseStepStatus::Missing => 1,
+    }
+}
+
+/// Decide the process exit code for a release command run.
+///
+/// A skipped release (no tag/package/GitHub Release produced) returns a
+/// dedicated non-zero code so the JSON envelope reports `success: false` and CI
+/// can tell a no-op release from a real one (issue #4316). The data payload
+/// still carries `status: "skipped"` + `skipped_reason` + an actionable force
+/// hint for full detail. Skipped takes precedence because a skipped run never
+/// reaches deploy/post-release steps (those exit inputs are `0`).
+fn release_command_exit_code(
+    skipped_reason: Option<&str>,
+    release_step_exit: i32,
+    deploy_exit_code: i32,
+    post_release_exit: i32,
+) -> i32 {
+    if skipped_reason.is_some() {
+        SKIPPED_RELEASE_EXIT_CODE
+    } else if release_step_exit != 0 {
+        release_step_exit
+    } else if deploy_exit_code != 0 {
+        deploy_exit_code
+    } else {
+        post_release_exit
     }
 }
 
@@ -1278,6 +1314,48 @@ mod tests {
         };
 
         assert_eq!(release_run_failure_exit(&run), 1);
+    }
+
+    #[test]
+    fn skipped_release_exit_code_is_distinct_from_success_and_failure() {
+        assert_ne!(SKIPPED_RELEASE_EXIT_CODE, 0);
+        assert_ne!(SKIPPED_RELEASE_EXIT_CODE, 1);
+        assert_ne!(SKIPPED_RELEASE_EXIT_CODE, 3); // post-release warnings
+    }
+
+    #[test]
+    fn skipped_release_exit_code_takes_precedence() {
+        // A skipped release produced no artifacts, so it reports the dedicated
+        // skip code even if downstream exit inputs were hypothetically non-zero
+        // (in practice they are 0 because deploy/post-release never run).
+        assert_eq!(
+            release_command_exit_code(Some("no-releasable-commits"), 0, 0, 0),
+            SKIPPED_RELEASE_EXIT_CODE
+        );
+        assert_eq!(
+            release_command_exit_code(Some("release-already-at-head"), 0, 0, 3),
+            SKIPPED_RELEASE_EXIT_CODE
+        );
+    }
+
+    #[test]
+    fn completed_release_exit_code_is_zero() {
+        assert_eq!(release_command_exit_code(None, 0, 0, 0), 0);
+    }
+
+    #[test]
+    fn failed_release_exit_code_surfaces_when_not_skipped() {
+        assert_eq!(release_command_exit_code(None, 1, 0, 0), 1);
+    }
+
+    #[test]
+    fn deploy_failure_exit_code_surfaces_when_not_skipped() {
+        assert_eq!(release_command_exit_code(None, 0, 1, 0), 1);
+    }
+
+    #[test]
+    fn post_release_warning_exit_code_surfaces_when_not_skipped() {
+        assert_eq!(release_command_exit_code(None, 0, 0, 3), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`homeboy release <component> --skip-checks` reported `success: true` while **skipping** the release when the commit range classified as `no-releasable-commits` (docs-only / guidance-only changes that still need a tag). No tag, release commit, or GitHub Release was produced, but the `success` flag made it look like the release worked.

**Root cause:** the data payload already reported `status: "skipped"` + `skipped_reason` + a copy-pasteable force hint, but the generic JSON envelope derives `success` from the process exit code (`success: exit_code == 0`). A skipped release exited `0`, so the envelope reported `success: true`, overriding the distinct status.

## Fix

Introduce a dedicated `SKIPPED_RELEASE_EXIT_CODE` (`5`), distinct from `0` (released), `1` (failure), and `3` (post-release warnings). A skipped release now exits `5`, so:

- the JSON envelope reports `success: false`
- the `data` payload still carries the full result (`status: "skipped"`, `skipped_reason`, actionable force hint, explicit "No tag created" summary)
- operators and CI can distinguish a no-op release from a real one

Applied consistently across:
- **Single release (real run)** — skip exit code takes precedence (a skipped run never reaches deploy/post-release)
- **Single release (dry-run)** — a skipped plan exits `5` instead of `0`
- **Batch release** — a batch that produced zero releases (all skipped, none failed) exits `5`; a batch with ≥1 real release still exits `0`; any failure still exits `1`

The exit-code decision is extracted into a pure `release_command_exit_code` helper (unit-tested for skip precedence, completion, failure, deploy failure, and post-release warning paths).

### Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Released | exit 0, `success:true` | exit 0, `success:true` (unchanged) |
| Skipped (no-releasable-commits) | exit 0, `success:true` ❌ | exit 5, `success:false` ✅ |
| Failed | exit 1, `success:false` | exit 1, `success:false` (unchanged) |
| Released + post-release warnings | exit 3, `success:false` | exit 3, `success:false` (unchanged) |

> Note: the actionable force hints ("No release was created. no tag was created...", exact `homeboy release ... --bump` command echoing current flags, and `release-already-at-head` detection) were already on `main`. This PR closes the remaining core gap: the misleading `success` flag / exit code.

## Testing

- `cargo fmt` ✅
- `cargo clippy --lib` ✅ (no new warnings)
- New unit tests for `release_command_exit_code` (skip precedence, completion, failure, deploy failure, post-release warnings, distinctness) ✅
- Existing: golden contract (`release_command_json_contract_matches_golden_fixture`), output contracts, release command, release workflow integration, planning policy ✅

## Docs

- `docs/architecture/output-system.md` — documented exit code `5`
- `docs/commands/release.md` — added "Skipped releases" section

Fixes #4316