### PR TITLE
fix: fail closed when release gates bypass Lab routing

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -27,6 +27,12 @@ pub struct LabCommandContract {
     pub requires_extension_parity: bool,
     pub extra_required_tools: &'static [LabCommandRequiredTool],
     pub infer_source_path_tools: bool,
+    /// Whether this command is a release gate whose routing fidelity matters
+    /// for validating a release (lint/test/audit). When true, force-local
+    /// bypass and stale-runner local fallback fail closed under the
+    /// `/release_gate/local_hot` policy if a default Lab runner is configured.
+    /// See issues #4603 / #4605.
+    pub release_gate: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -230,6 +236,7 @@ impl LabCommandContract {
             requires_extension_parity,
             extra_required_tools,
             infer_source_path_tools: true,
+            release_gate: false,
         }
     }
 
@@ -278,7 +285,16 @@ impl LabCommandContract {
             requires_extension_parity: false,
             extra_required_tools: LAB_NO_EXTRA_TOOLS,
             infer_source_path_tools: false,
+            release_gate: false,
         }
+    }
+
+    /// Mark this contract as a release gate (lint/test/audit) so that the
+    /// `/release_gate/local_hot` policy applies to force-local bypass and
+    /// stale-runner local fallback when a default Lab runner is configured.
+    pub(crate) const fn release_gate(mut self) -> Self {
+        self.release_gate = true;
+        self
     }
 }
 
@@ -642,6 +658,44 @@ mod tests {
             .expect("lint contract");
         assert!(lint.requires_extension_parity);
         assert!(lint.infer_source_path_tools);
+        assert!(lint.release_gate);
+
+        let test_full = parsed_command(&["homeboy", "test"])
+            .lab_contract()
+            .expect("test contract");
+        assert!(test_full.release_gate);
+
+        let audit_full = parsed_command(&["homeboy", "audit"])
+            .lab_contract()
+            .expect("audit contract");
+        assert!(audit_full.release_gate);
+
+        // Changed-scope/local-only variants and non-gate commands are NOT
+        // release gates.
+        assert!(
+            !parsed_command(&["homeboy", "lint", "--changed-since", "origin/main"])
+                .lab_contract()
+                .expect("changed-scope lint contract")
+                .release_gate
+        );
+        assert!(
+            !parsed_command(&["homeboy", "bench"])
+                .lab_contract()
+                .expect("bench contract")
+                .release_gate
+        );
+        assert!(
+            !parsed_command(&["homeboy", "trace"])
+                .lab_contract()
+                .expect("trace contract")
+                .release_gate
+        );
+        assert!(
+            !parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"])
+                .lab_contract()
+                .expect("agent-task contract")
+                .release_gate
+        );
 
         for args in [
             ["homeboy", "agent-task", "status", "agent-task-123"].as_slice(),

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -85,13 +85,16 @@ impl AuditArgs {
             return None;
         }
 
-        Some(LabCommandContract::portable(
-            "audit",
-            (self.baseline_args.baseline || self.baseline_args.ratchet)
-                .then_some("--baseline/--ratchet"),
-            true,
-            &[],
-        ))
+        Some(
+            LabCommandContract::portable(
+                "audit",
+                (self.baseline_args.baseline || self.baseline_args.ratchet)
+                    .then_some("--baseline/--ratchet"),
+                true,
+                &[],
+            )
+            .release_gate(),
+        )
     }
 }
 

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -111,12 +111,10 @@ impl LintArgs {
 
     pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
         if self.is_full_workspace_run() {
-            return Some(LabCommandContract::portable(
-                "lint",
-                self.fix.then_some("--fix"),
-                true,
-                &[],
-            ));
+            return Some(
+                LabCommandContract::portable("lint", self.fix.then_some("--fix"), true, &[])
+                    .release_gate(),
+            );
         }
 
         (self.changed_since.is_some() || self.changed_only).then(|| {

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -105,6 +105,7 @@ impl TestArgs {
     pub(crate) fn lab_contract(&self) -> LabCommandContract {
         if self.changed_since.is_none() {
             LabCommandContract::portable("test", self.write.then_some("--write"), true, &[])
+                .release_gate()
         } else {
             LabCommandContract::local_only("test", TEST_CHANGED_SINCE_LAB_UNSUPPORTED_REASON)
         }

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -35,6 +35,15 @@ pub struct HomeboyConfig {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub settings: HashMap<String, Value>,
 
+    /// Release-gate routing safety policy.
+    ///
+    /// Controls whether release-gate hot commands (lint/test/audit) may be
+    /// bypassed to local execution via `--force-hot --allow-local-hot` or a
+    /// stale-runner local fallback when a default Lab runner is configured.
+    /// See issues #4603 / #4605.
+    #[serde(default)]
+    pub release_gate: ReleaseGateConfig,
+
     /// Directory where persisted run artifacts are copied.
     ///
     /// Defaults to the machine-local product data directory under
@@ -58,6 +67,7 @@ impl Default for HomeboyConfig {
             triage: TriageConfig::default(),
             agent_task: AgentTaskConfig::default(),
             settings: HashMap::new(),
+            release_gate: ReleaseGateConfig::default(),
             artifact_root: None,
             update_check: true,
         }
@@ -95,6 +105,74 @@ impl BenchLocalExecutionPolicy {
     pub fn is_denied(self) -> bool {
         matches!(self, Self::Denied)
     }
+}
+
+/// Release-gate routing safety policy.
+///
+/// Release gates are the quality-check hot commands (lint/test/audit) whose
+/// routing fidelity matters for validating a release. When a default Lab
+/// runner is configured, silently bypassing Lab routing to run these gates
+/// locally (via `--force-hot --allow-local-hot` or a stale-runner fallback)
+/// produces a gate result that is not faithful to the configured runner
+/// policy. This config makes such bypasses fail closed with a clear
+/// diagnostic instead of silently executing locally. See issues #4603 / #4605.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ReleaseGateConfig {
+    /// Whether release-gate hot commands may be bypassed to local execution
+    /// when a default Lab runner is configured.
+    ///
+    /// - `fail_closed` (default): the bypass is rejected with a diagnostic.
+    /// - `allowed`: the bypass runs locally and is recorded in the offload
+    ///   metadata (the operator-only override).
+    #[serde(default)]
+    pub local_hot: ReleaseGateLocalHotPolicy,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[derive(Default)]
+pub enum ReleaseGateLocalHotPolicy {
+    /// Reject force-local bypass and stale-runner local fallback for release
+    /// gates when a default Lab runner is configured.
+    #[default]
+    FailClosed,
+    /// Allow release gates to run locally; recorded in offload metadata.
+    Allowed,
+}
+
+impl ReleaseGateLocalHotPolicy {
+    pub fn is_allowed(self) -> bool {
+        matches!(self, Self::Allowed)
+    }
+}
+
+/// Environment variable override for `/release_gate/local_hot`.
+///
+/// Takes precedence over the config file so operators can re-enable a
+/// local-hot bypass for a single invocation without editing config. This is
+/// the explicit operator-only override: it must be set in the environment, not
+/// via a convenience CLI flag, so it cannot become a habit bypass.
+pub const RELEASE_GATE_LOCAL_HOT_ENV: &str = "HOMEBOY_RELEASE_GATE_LOCAL_HOT";
+
+/// Resolve the effective release-gate local-hot policy from the environment
+/// override (precedence) then the config file, falling back to the default.
+pub fn resolve_release_gate_local_hot_policy() -> ReleaseGateLocalHotPolicy {
+    resolve_release_gate_local_hot_policy_from(&load_config())
+}
+
+pub(crate) fn resolve_release_gate_local_hot_policy_from(
+    config: &HomeboyConfig,
+) -> ReleaseGateLocalHotPolicy {
+    if let Ok(raw) = std::env::var(RELEASE_GATE_LOCAL_HOT_ENV) {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "allowed" | "allow" | "true" | "1" => return ReleaseGateLocalHotPolicy::Allowed,
+            "fail_closed" | "fail-closed" | "denied" | "false" | "0" => {
+                return ReleaseGateLocalHotPolicy::FailClosed;
+            }
+            _ => {}
+        }
+    }
+    config.release_gate.local_hot
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -500,5 +578,60 @@ mod tests {
         let config = HomeboyConfig::default();
 
         assert!(config.lab.preferred_runner.is_none());
+    }
+
+    #[test]
+    fn release_gate_local_hot_defaults_to_fail_closed() {
+        let config = HomeboyConfig::default();
+
+        assert_eq!(
+            config.release_gate.local_hot,
+            ReleaseGateLocalHotPolicy::FailClosed
+        );
+    }
+
+    #[test]
+    fn release_gate_local_hot_parses_allowed_from_config() {
+        let config: HomeboyConfig =
+            serde_json::from_str(r#"{"release_gate":{"local_hot":"allowed"}}"#).unwrap();
+
+        assert_eq!(
+            config.release_gate.local_hot,
+            ReleaseGateLocalHotPolicy::Allowed
+        );
+    }
+
+    #[test]
+    fn resolve_release_gate_policy_env_overrides_config() {
+        struct EnvGuard {
+            previous: Option<String>,
+        }
+        impl EnvGuard {
+            fn set(value: &str) -> Self {
+                let previous = std::env::var(RELEASE_GATE_LOCAL_HOT_ENV).ok();
+                std::env::set_var(RELEASE_GATE_LOCAL_HOT_ENV, value);
+                Self { previous }
+            }
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.previous {
+                    Some(value) => std::env::set_var(RELEASE_GATE_LOCAL_HOT_ENV, value),
+                    None => std::env::remove_var(RELEASE_GATE_LOCAL_HOT_ENV),
+                }
+            }
+        }
+
+        let _env = EnvGuard::set("allowed");
+        assert_eq!(
+            resolve_release_gate_local_hot_policy_from(&HomeboyConfig::default()),
+            ReleaseGateLocalHotPolicy::Allowed
+        );
+
+        let _env = EnvGuard::set("fail-closed");
+        assert_eq!(
+            resolve_release_gate_local_hot_policy_from(&HomeboyConfig::default()),
+            ReleaseGateLocalHotPolicy::FailClosed
+        );
     }
 }

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -80,6 +80,7 @@ pub fn lab_offload_command_from_contract(
             .iter()
             .any(|tool| matches!(tool, LabCommandRequiredTool::Playwright)),
         infer_source_path_tools: contract.infer_source_path_tools,
+        release_gate: contract.release_gate,
     }
 }
 
@@ -201,6 +202,7 @@ mod tests {
             requires_extension_parity: true,
             extra_required_tools: LAB_TRACE_EXTRA_TOOLS,
             infer_source_path_tools: false,
+            release_gate: false,
         }
     }
 

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -46,8 +46,9 @@ use super::super::lab_env::{
 };
 use super::super::lab_plan::{base_lab_plan, disabled_select_runner_plan, with_step};
 use super::super::lab_selection::{
-    prepare_lab_runner_for_offload, resolve_lab_runner_selection, status_tunnel_mode,
-    LabRunnerPreparation, LabRunnerSelection, LabRunnerSelectionSource,
+    prepare_lab_runner_for_offload, release_gate_local_hot_denied_error,
+    resolve_lab_runner_selection, status_tunnel_mode, LabRunnerPreparation, LabRunnerSelection,
+    LabRunnerSelectionSource,
 };
 use super::super::lab_workspaces::{
     agent_task_plan_extra_workspaces, lab_extra_workspaces, lab_workspace_mapping_metadata,
@@ -104,6 +105,9 @@ pub struct LabOffloadCommand {
     pub required_extensions: Vec<String>,
     pub requires_playwright: bool,
     pub infer_source_path_tools: bool,
+    /// Whether this is a release-gate command (lint/test/audit) subject to the
+    /// `/release_gate/local_hot` fail-closed routing policy.
+    pub release_gate: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -388,6 +392,26 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
                 .skip_reason(reason.clone())
                 .build(),
             );
+            // Release-gate routing safety (#4603): when a release gate's
+            // default runner cannot be prepared for remote execution (e.g. a
+            // stale daemon / version skew or a failed connection), silently
+            // falling back to local execution produces a gate result that is
+            // not faithful to the routing policy. Fail closed with a clear
+            // diagnostic that surfaces the underlying runner reason, rather
+            // than letting a stale launcher route the gate to the controller.
+            // The operator-only override is `/release_gate/local_hot: allowed`.
+            if contract.release_gate
+                && matches!(selection.source, LabRunnerSelectionSource::Default)
+                && !crate::core::defaults::resolve_release_gate_local_hot_policy().is_allowed()
+            {
+                return Err(release_gate_local_hot_denied_error(
+                    format!(
+                        "Release gate `{}` selected default Lab runner `{}` but could not prepare it for remote execution ({}); `/release_gate/local_hot` is `fail_closed`, so the gate will not silently fall back to local execution",
+                        contract.hot_label, selection.runner_id, reason
+                    ),
+                    "release_gate",
+                ));
+            }
             if !request.allow_local_fallback {
                 return Err(selected_runner_fallback_error(
                     &selection,
@@ -2229,6 +2253,7 @@ mod tests {
             required_extensions: Vec::new(),
             requires_playwright: false,
             infer_source_path_tools: true,
+            release_gate: false,
         }
     }
 
@@ -2244,6 +2269,7 @@ mod tests {
             required_extensions: Vec::new(),
             requires_playwright: false,
             infer_source_path_tools: false,
+            release_gate: false,
         }
     }
 
@@ -3042,6 +3068,7 @@ mod tests {
             false,
             false,
             false,
+            false,
             Some("lab-default".to_string()),
         )
         .expect("selection")
@@ -3060,6 +3087,7 @@ mod tests {
             true,
             false,
             false,
+            false,
             Some("lab-default".to_string()),
         )
         .expect("selection")
@@ -3075,6 +3103,7 @@ mod tests {
         let selection = resolve_lab_runner_selection_from_default(
             &command,
             None,
+            false,
             false,
             false,
             false,
@@ -3098,6 +3127,7 @@ mod tests {
             false,
             false,
             false,
+            false,
             Some("lab-default".to_string()),
         )
         .expect("selection");
@@ -3116,6 +3146,7 @@ mod tests {
             false,
             false,
             false,
+            false,
             Some("lab-default".to_string()),
         )
         .expect("selection")
@@ -3130,7 +3161,7 @@ mod tests {
         let command = portable_lab_command("test");
 
         assert!(resolve_lab_runner_selection_from_default(
-            &command, None, false, false, false, None
+            &command, None, false, false, false, false, None
         )
         .expect("selection")
         .is_none());
@@ -3144,6 +3175,7 @@ mod tests {
             &command,
             None,
             true,
+            false,
             false,
             false,
             Some("lab-default".to_string()),
@@ -3166,7 +3198,7 @@ mod tests {
         let command = portable_lab_command("test");
 
         assert!(resolve_lab_runner_selection_from_default(
-            &command, None, true, false, false, None
+            &command, None, true, false, false, false, None
         )
         .expect("selection")
         .is_none());
@@ -3181,6 +3213,7 @@ mod tests {
             None,
             false,
             true,
+            false,
             false,
             Some("lab-default".to_string()),
         )
@@ -3206,6 +3239,7 @@ mod tests {
             true,
             true,
             false,
+            false,
             Some("lab-default".to_string()),
         )
         .expect("selection")
@@ -3217,6 +3251,7 @@ mod tests {
         let err = resolve_lab_runner_selection_from_default(
             &local_only_lab_command("current single-workspace Lab snapshot cannot safely mirror"),
             Some("lab-explicit"),
+            false,
             false,
             false,
             false,
@@ -3232,8 +3267,10 @@ mod tests {
     fn lab_runner_selection_denies_local_bench_when_host_policy_requires_lab() {
         let command = portable_lab_command("bench");
 
-        let err = resolve_lab_runner_selection_from_default(&command, None, true, true, true, None)
-            .expect_err("bench local execution should be denied by config policy");
+        let err = resolve_lab_runner_selection_from_default(
+            &command, None, true, true, true, false, None,
+        )
+        .expect_err("bench local execution should be denied by config policy");
 
         assert_eq!(err.code.as_str(), "validation.invalid_argument");
         assert!(err.message.contains("/bench/local_execution"));
@@ -3242,6 +3279,94 @@ mod tests {
         assert!(tried.iter().any(|hint| hint
             .as_str()
             .is_some_and(|hint| hint.contains("--runner <runner-id>"))));
+    }
+
+    fn release_gate_lab_command(label: &'static str) -> LabOffloadCommand {
+        let mut command = portable_lab_command(label);
+        command.release_gate = true;
+        command
+    }
+
+    #[test]
+    fn release_gate_force_hot_allow_local_hot_fails_closed_with_default_runner() {
+        // #4605: --force-hot --allow-local-hot must not silently bypass Lab
+        // routing for a release gate when a default runner is configured.
+        let command = release_gate_lab_command("lint");
+
+        let err = resolve_lab_runner_selection_from_default(
+            &command,
+            None,
+            true,
+            true,
+            false,
+            false,
+            Some("lab-default".to_string()),
+        )
+        .expect_err("release gate force-local bypass must fail closed");
+
+        assert_eq!(err.code.as_str(), "validation.invalid_argument");
+        assert!(err.message.contains("Release gate `lint`"));
+        assert!(err.message.contains("--force-hot --allow-local-hot"));
+        assert!(err.message.contains("lab-default"));
+        assert!(err.message.contains("/release_gate/local_hot"));
+        let tried = err.details["tried"].as_array().expect("tried");
+        assert!(tried.iter().any(|hint| hint
+            .as_str()
+            .is_some_and(|hint| hint.contains("/release_gate/local_hot"))));
+        assert!(tried.iter().any(|hint| hint
+            .as_str()
+            .is_some_and(|hint| hint.contains("HOMEBOY_RELEASE_GATE_LOCAL_HOT"))));
+    }
+
+    #[test]
+    fn release_gate_force_hot_allow_local_hot_allowed_by_policy() {
+        // When the operator opts in via /release_gate/local_hot=allowed, the
+        // bypass runs locally and is recorded (None selection → local run).
+        let command = release_gate_lab_command("test");
+
+        assert!(resolve_lab_runner_selection_from_default(
+            &command,
+            None,
+            true,
+            true,
+            false,
+            true,
+            Some("lab-default".to_string()),
+        )
+        .expect("selection")
+        .is_none());
+    }
+
+    #[test]
+    fn release_gate_force_hot_allow_local_hot_runs_local_without_default_runner() {
+        // No default runner configured → nothing to route to, so the gate runs
+        // locally even under fail_closed.
+        let command = release_gate_lab_command("audit");
+
+        assert!(resolve_lab_runner_selection_from_default(
+            &command, None, true, true, false, false, None
+        )
+        .expect("selection")
+        .is_none());
+    }
+
+    #[test]
+    fn non_release_gate_command_keeps_allow_local_hot_bypass() {
+        // Non-gate portable commands (e.g. agent-task) keep the existing
+        // --force-hot --allow-local-hot bypass behavior.
+        let command = portable_lab_command("agent-task dispatch/cook/loop/run-plan");
+
+        assert!(resolve_lab_runner_selection_from_default(
+            &command,
+            None,
+            true,
+            true,
+            false,
+            false,
+            Some("lab-default".to_string()),
+        )
+        .expect("selection")
+        .is_none());
     }
 
     #[test]

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -316,10 +316,10 @@ pub(super) fn resolve_lab_runner_selection(
     force_hot: bool,
     allow_local_hot: bool,
 ) -> Result<Option<LabRunnerSelection>> {
-    let deny_local_bench = crate::core::defaults::load_config()
-        .bench
-        .local_execution
-        .is_denied();
+    let config = crate::core::defaults::load_config();
+    let deny_local_bench = config.bench.local_execution.is_denied();
+    let release_gate_local_hot_allowed =
+        crate::core::defaults::resolve_release_gate_local_hot_policy_from(&config).is_allowed();
     let default_runner =
         if explicit_runner.is_none() && command.portable && command.default_lab_offload {
             super::resolve_default_lab_runner()?
@@ -333,16 +333,19 @@ pub(super) fn resolve_lab_runner_selection(
         force_hot,
         allow_local_hot,
         deny_local_bench,
+        release_gate_local_hot_allowed,
         default_runner,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn resolve_lab_runner_selection_from_default(
     command: &LabOffloadCommand,
     explicit_runner: Option<&str>,
     force_hot: bool,
     allow_local_hot: bool,
     deny_local_bench: bool,
+    release_gate_local_hot_allowed: bool,
     default_runner: Option<String>,
 ) -> Result<Option<LabRunnerSelection>> {
     if let Some(runner_id) = explicit_runner {
@@ -406,6 +409,27 @@ pub(super) fn resolve_lab_runner_selection_from_default(
         ));
     }
 
+    // Release-gate routing safety (#4603 / #4605): a force-local bypass
+    // (`--force-hot --allow-local-hot`) for a release gate silently routes the
+    // gate to the controller machine instead of the configured Lab runner,
+    // producing a gate result that is not faithful to the routing policy. Fail
+    // closed with a clear diagnostic unless the operator explicitly opts back
+    // into local-hot via config/env, in which case the override is recorded by
+    // the offload metadata (`force_hot_local_override`).
+    if command.release_gate && force_hot && allow_local_hot {
+        if let Some(runner_id) = default_runner.as_ref() {
+            if !release_gate_local_hot_allowed {
+                return Err(release_gate_local_hot_denied_error(
+                    format!(
+                        "Release gate `{}` cannot bypass Lab routing with --force-hot --allow-local-hot while default Lab runner `{}` is configured and `/release_gate/local_hot` is `fail_closed`",
+                        command.hot_label, runner_id
+                    ),
+                    "force_hot",
+                ));
+            }
+        }
+    }
+
     if force_hot || !command.portable {
         fail_if_local_bench_denied(command, deny_local_bench)?;
         return Ok(None);
@@ -443,6 +467,29 @@ fn fail_if_local_bench_denied(command: &LabOffloadCommand, denied: bool) -> Resu
             format!("Change `/bench/local_execution` in {config_path} to `allowed` before intentionally re-enabling local benchmark execution."),
         ]),
     ))
+}
+
+/// Build the fail-closed error for a release-gate routing-policy violation.
+///
+/// `message` is the already-formatted diagnostic. The remediation always
+/// points the operator at the config/env override (the explicit operator-only
+/// escape hatch) rather than a convenience CLI flag, so the bypass cannot
+/// become a habit.
+pub(super) fn release_gate_local_hot_denied_error(message: String, field: &str) -> Error {
+    let config_path = crate::core::defaults::config_path()
+        .unwrap_or_else(|_| "the global Homeboy config".to_string());
+    let env_var = crate::core::defaults::RELEASE_GATE_LOCAL_HOT_ENV;
+    Error::validation_invalid_argument(
+        field,
+        message,
+        Some("fail_closed".to_string()),
+        Some(vec![
+            "Run the gate without local-hot flags so the configured Lab runner routing applies.".to_string(),
+            format!("Reconnect or upgrade a stale runner with `homeboy runner doctor <runner-id>` before retrying the gate."),
+            format!("To intentionally run a release gate locally, set `/release_gate/local_hot` to `allowed` in {config_path} (the override is recorded in offload metadata)."),
+            format!("For a single invocation, export {env_var}=allowed instead of editing config."),
+        ]),
+    )
 }
 
 fn runner_status_tunnel_mode(runner_id: &str) -> RunnerTunnelMode {


### PR DESCRIPTION
## Summary

Release gates (lint/test/audit) whose routing fidelity matters for validating a release silently routed to local execution in two situations, both bypassing the configured Lab/offload runner:

- **Force-local bypass (#4605):** `--force-hot --allow-local-hot` ran a gate on the controller instead of the Lab runner. The escape hatch was too easy to reach by habit while getting main green.
- **Stale launcher (#4603):** when a selected default runner could not be prepared (stale daemon / version skew), the gate silently fell back to local execution instead of reporting the stale runtime.

Both produced gate results that were not faithful to the routing policy.

## Changes

- **`/release_gate/local_hot` config policy** (default `fail_closed`) with an operator-only env override `HOMEBOY_RELEASE_GATE_LOCAL_HOT`. The override is config/env-only (not a convenience CLI flag) so it cannot become a habit bypass; when used it is recorded in offload metadata.
- **`release_gate` contract marker** on lint/test/audit. Bench keeps its own `/bench/local_execution` policy; non-gate portable commands (agent-task, trace, refactor) keep the existing `--force-hot --allow-local-hot` behavior.
- **Force-local bypass guard:** a release gate with `--force-hot --allow-local-hot` fails closed with a clear diagnostic when a default Lab runner is configured, unless the operator opts in via config/env.
- **Stale-runner fallback guard (#4603):** a release gate whose default runner cannot be prepared fails closed instead of silently running locally, surfacing the underlying runner reason and reconnect/upgrade guidance.
- Both guards only trigger when a default Lab runner is configured — environments with no runner have no routing to violate and keep running locally.

## Tests

- `release_gate_force_hot_allow_local_hot_fails_closed_with_default_runner`
- `release_gate_force_hot_allow_local_hot_allowed_by_policy`
- `release_gate_force_hot_allow_local_hot_runs_local_without_default_runner`
- `non_release_gate_command_keeps_allow_local_hot_bypass`
- contract tests asserting lint/test/audit are release gates and bench/trace/agent-task are not
- config parsing + env-override tests for the policy

Closes #4603, #4605