### PR TITLE
ci: disable PR autofix explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
       component: homeboy
       commands: audit,lint,test
       differential-gating: true
+      # Autofix is explicitly disabled on PRs: an on-failure autofix push
+      # lands a bot commit mid-review and supersedes in-flight CI runs,
+      # which reads as a spurious failure (see #3819). Require manual fixes.
+      autofix: 'false'
       build-command: cargo build --release
       build-artifact-path: target/release/homeboy
     secrets: inherit


### PR DESCRIPTION
## Summary

Companion hardening for #3819 (substantive fix is in Extra-Chill/homeboy).

The reusable Homeboy CI workflow already defaults `autofix` to off, but relying on that default is fragile: if it ever flips upstream, an `on-failure` autofix push would silently land a bot commit mid-review and supersede in-flight CI runs (#3819).

Set `autofix: 'false'` explicitly with a comment so the decision is documented and regression-proof for this repo's own PRs.

Refs #3819