### PR TITLE
Fail fast when agent-task runner secrets are not ready

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -1382,6 +1382,37 @@ mod tests {
     }
 
     #[test]
+    fn run_plan_fails_fast_when_required_secret_env_is_missing() {
+        with_temp_home(|| {
+            let missing_secret = "HOMEBOY_AGENT_TASK_MISSING_PROVIDER_SECRET_TEST";
+            std::env::remove_var(missing_secret);
+            let mut plan = test_plan();
+            plan.tasks[0].executor.secret_env = vec![missing_secret.to_string()];
+            let executor = CapturingExecutor::default();
+            let observed_request = Arc::clone(&executor.observed_request);
+
+            let error = run_loaded_plan(plan, Some("run-plan-missing-secret"), executor)
+                .expect_err("missing secret should fail before executor dispatch");
+
+            assert!(observed_request
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .is_none());
+            assert_eq!(error.details["field"], "secret_env");
+            assert!(error.to_string().contains(missing_secret));
+            assert!(error.details["tried"]
+                .as_array()
+                .expect("remediation hints")
+                .iter()
+                .any(|hint| hint
+                    .as_str()
+                    .is_some_and(|hint| hint.contains("runner-required secret env contracts"))));
+            assert!(!error.to_string().contains("secret-value"));
+            assert!(lifecycle_status("run-plan-missing-secret").is_err());
+        });
+    }
+
+    #[test]
     fn run_next_claims_oldest_queued_run_and_leaves_later_runs_queued() {
         with_temp_home(|| {
             agent_task_lifecycle::submit_plan(&test_plan(), Some("run-next-a"))

--- a/src/commands/runner/doctor/tests.rs
+++ b/src/commands/runner/doctor/tests.rs
@@ -188,6 +188,7 @@ fn provider_readiness_renderer_uses_fake_provider_contract() {
     let contract = AgentTaskProviderRunnerReadiness {
         id: "lab.fake_runtime.cache".to_string(),
         label: "Fake runtime cache".to_string(),
+        secret_env: Vec::new(),
         env_path: Some(AgentTaskProviderEnvPathReadiness {
             env: vec!["FAKE_RUNTIME_BIN".to_string()],
             revision: Some(true),

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -14,7 +14,9 @@ use crate::core::agent_task::{
 use crate::core::agent_task_config_materialization::materialize_provider_config_refs;
 use crate::core::agent_task_lifecycle as lifecycle;
 use crate::core::agent_task_lifecycle::{AgentTaskRunRecord, AgentTaskRunState};
-use crate::core::agent_task_provider::provider_requires_cwd_git_checkout;
+use crate::core::agent_task_provider::{
+    apply_provider_runner_secret_env_contracts, provider_requires_cwd_git_checkout,
+};
 use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskRetryPolicy,
     AgentTaskScheduler,
@@ -81,10 +83,11 @@ pub fn dispatch_with_provider_requirements<E>(
 where
     E: AgentTaskExecutorAdapter,
 {
-    let plan = build_dispatch_plan_with_provider_requirements(
+    let mut plan = build_dispatch_plan_with_provider_requirements(
         &request,
         provider_requires_cwd_git_checkout,
     )?;
+    apply_provider_runner_secret_env_contracts(&mut plan);
     preflight_dispatch_provider_secrets(&plan)?;
     let submitted = lifecycle::submit_plan(&plan, request.run_id.as_deref())?;
     let run_id = submitted.run_id.clone();

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -57,6 +57,8 @@ fn is_false(value: &bool) -> bool {
 pub struct AgentTaskProviderRunnerReadiness {
     pub id: String,
     pub label: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secret_env: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub env_path: Option<AgentTaskProviderEnvPathReadiness>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -227,6 +229,16 @@ pub fn provider_requires_cwd_git_checkout(backend: &str, selector: Option<&str>)
     provider_requires_cwd_git_checkout_with_providers(&providers, backend, selector)
 }
 
+pub fn apply_provider_runner_secret_env_contracts(plan: &mut AgentTaskPlan) {
+    let providers = discover_agent_task_executor_providers();
+    apply_provider_runner_secret_env_contracts_with_providers(plan, &providers);
+}
+
+pub fn provider_runner_secret_env_for_plan(plan: &AgentTaskPlan) -> Vec<String> {
+    let providers = discover_agent_task_executor_providers();
+    provider_runner_secret_env_for_plan_with_providers(plan, &providers)
+}
+
 pub(crate) fn role_aliases_for_executor(
     backend: &str,
     selector: Option<&str>,
@@ -261,6 +273,48 @@ fn provider_requires_cwd_git_checkout_with_providers(
         .and_then(|provider| provider.workspace_materialization.as_ref())
         .and_then(|materialization| materialization.cwd.as_deref())
         == Some("git_checkout")
+}
+
+fn apply_provider_runner_secret_env_contracts_with_providers(
+    plan: &mut AgentTaskPlan,
+    providers: &[AgentTaskExecutorProvider],
+) {
+    for request in &mut plan.tasks {
+        let Some(provider) = select_provider(providers, request) else {
+            continue;
+        };
+        for name in provider_runner_secret_env(provider) {
+            if !request.executor.secret_env.contains(&name) {
+                request.executor.secret_env.push(name);
+            }
+        }
+    }
+}
+
+fn provider_runner_secret_env_for_plan_with_providers(
+    plan: &AgentTaskPlan,
+    providers: &[AgentTaskExecutorProvider],
+) -> Vec<String> {
+    let mut names = Vec::new();
+    for request in &plan.tasks {
+        let Some(provider) = select_provider(providers, request) else {
+            continue;
+        };
+        names.extend(provider_runner_secret_env(provider));
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn provider_runner_secret_env(provider: &AgentTaskExecutorProvider) -> Vec<String> {
+    let mut names = Vec::new();
+    for readiness in &provider.runner_readiness {
+        names.extend(readiness.secret_env.iter().cloned());
+    }
+    names.sort();
+    names.dedup();
+    names
 }
 
 fn default_backend_from_providers(providers: &[AgentTaskExecutorProvider]) -> Option<String> {
@@ -980,6 +1034,7 @@ mod tests {
             "runner_readiness": [{
                 "id": "custom.runtime_cache",
                 "label": "Custom runtime cache",
+                "secret_env": ["CUSTOM_RUNTIME_TOKEN"],
                 "env_path": { "env": ["CUSTOM_RUNTIME_BIN"], "revision": true },
                 "remediation": "Refresh the custom runtime cache."
             }],
@@ -994,6 +1049,10 @@ mod tests {
         .expect("provider manifest");
 
         assert_eq!(provider.runner_readiness[0].id, "custom.runtime_cache");
+        assert_eq!(
+            provider.runner_readiness[0].secret_env,
+            vec!["CUSTOM_RUNTIME_TOKEN"]
+        );
         assert_eq!(
             provider.runner_readiness[0].env_path.as_ref().unwrap().env,
             vec!["CUSTOM_RUNTIME_BIN"]
@@ -1016,6 +1075,52 @@ mod tests {
             ExtensionProviderAgentTaskExecutor::with_providers(vec![provider_a, provider_b]);
 
         assert_eq!(executor.default_backend().as_deref(), Some("preferred"));
+    }
+
+    #[test]
+    fn provider_runner_secret_env_contracts_are_applied_to_selected_plan_tasks() {
+        let (mut request_a, mut provider_a) = request("task-a", "node provider-a.js".to_string());
+        request_a.executor.backend = "provider-a".to_string();
+        provider_a.backend = "provider-a".to_string();
+        provider_a.runner_readiness = vec![AgentTaskProviderRunnerReadiness {
+            id: "provider-a.auth".to_string(),
+            label: "Provider A auth".to_string(),
+            secret_env: vec!["PROVIDER_A_TOKEN".to_string()],
+            env_path: None,
+            remediation: Some("Configure provider A auth.".to_string()),
+        }];
+        let (mut request_b, mut provider_b) = request("task-b", "node provider-b.js".to_string());
+        request_b.executor.backend = "provider-b".to_string();
+        request_b.executor.secret_env = vec!["EXPLICIT_SECRET".to_string()];
+        provider_b.backend = "provider-b".to_string();
+        provider_b.runner_readiness = vec![AgentTaskProviderRunnerReadiness {
+            id: "provider-b.auth".to_string(),
+            label: "Provider B auth".to_string(),
+            secret_env: vec![
+                "PROVIDER_B_TOKEN".to_string(),
+                "EXPLICIT_SECRET".to_string(),
+            ],
+            env_path: None,
+            remediation: None,
+        }];
+        let mut plan = AgentTaskPlan::new("plan-a", vec![request_a, request_b]);
+
+        apply_provider_runner_secret_env_contracts_with_providers(
+            &mut plan,
+            &[provider_a, provider_b],
+        );
+
+        assert_eq!(
+            plan.tasks[0].executor.secret_env,
+            vec!["PROVIDER_A_TOKEN".to_string()]
+        );
+        assert_eq!(
+            plan.tasks[1].executor.secret_env,
+            vec![
+                "EXPLICIT_SECRET".to_string(),
+                "PROVIDER_B_TOKEN".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/src/core/agent_task_service.rs
+++ b/src/core/agent_task_service.rs
@@ -16,9 +16,11 @@ use crate::core::agent_task_lifecycle::{
 use crate::core::agent_task_promotion::{
     promote, AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionStatus,
 };
+use crate::core::agent_task_provider::apply_provider_runner_secret_env_contracts;
 use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskScheduler, AgentTaskState,
 };
+use crate::core::agent_task_secrets::validate_secret_env;
 use crate::core::{config, Error, Result};
 
 #[derive(Debug, Clone)]
@@ -479,7 +481,7 @@ pub fn run_loaded_plan<E>(
 where
     E: AgentTaskExecutorAdapter,
 {
-    normalize_plan_workspaces(&mut plan)?;
+    prepare_plan_for_execution(&mut plan)?;
 
     if let Some(run_id) = record_run_id {
         agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
@@ -508,8 +510,10 @@ pub fn run_submitted<E>(
 where
     E: AgentTaskExecutorAdapter,
 {
+    let mut plan = agent_task_lifecycle::load_plan(&run_id)?;
+    prepare_plan_for_execution(&mut plan)?;
     agent_task_lifecycle::mark_running(&run_id)?;
-    run_claimed(run_id, executor)
+    run_prepared_claimed(run_id, plan, executor)
 }
 
 pub fn run_next<E>(executor: E) -> Result<AgentTaskRunResult<Option<AgentTaskAggregate>>>
@@ -581,12 +585,54 @@ fn run_claimed<E>(run_id: String, executor: E) -> Result<AgentTaskRunResult<Agen
 where
     E: AgentTaskExecutorAdapter,
 {
-    let plan = agent_task_lifecycle::load_plan(&run_id)?;
+    let mut plan = agent_task_lifecycle::load_plan(&run_id)?;
+    prepare_plan_for_execution(&mut plan)?;
+    run_prepared_claimed(run_id, plan, executor)
+}
+
+fn run_prepared_claimed<E>(
+    run_id: String,
+    plan: AgentTaskPlan,
+    executor: E,
+) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
+where
+    E: AgentTaskExecutorAdapter,
+{
     let aggregate = run_plan_with_scheduler(plan.clone(), executor);
     agent_task_lifecycle::record_run_aggregate(&run_id, &plan, &aggregate)?;
     Ok(AgentTaskRunResult {
         exit_code: aggregate_exit_code(&aggregate),
         value: aggregate,
+    })
+}
+
+fn prepare_plan_for_execution(plan: &mut AgentTaskPlan) -> Result<()> {
+    normalize_plan_workspaces(plan)?;
+    apply_provider_runner_secret_env_contracts(plan);
+    preflight_plan_secret_env(plan)
+}
+
+fn preflight_plan_secret_env(plan: &AgentTaskPlan) -> Result<()> {
+    let mut names = Vec::new();
+    for task in &plan.tasks {
+        for name in &task.executor.secret_env {
+            if !names.contains(name) {
+                names.push(name.clone());
+            }
+        }
+    }
+
+    validate_secret_env(&names).map_err(|error| {
+        Error::validation_invalid_argument(
+            "secret_env",
+            error.message,
+            None,
+            Some(vec![
+                "Agent-task executor provider manifests can declare runner-required secret env contracts; Homeboy validates those contracts before task execution.".to_string(),
+                "For local execution, configure provider credentials with `homeboy agent-task auth map-env`, `set-keychain`, or `set-keychain-bundle`.".to_string(),
+                "For delegated runner execution, configure the selected runner's secret_env references so the runner receives these names without printing values.".to_string(),
+            ]),
+        )
     })
 }
 

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -214,11 +214,11 @@ pub mod promotion {
 pub mod provider {
     pub use super::super::agent_task_provider::{
         default_backend, dependency_failure_patterns, provider_requires_cwd_git_checkout,
-        provider_runner_readiness_contracts, required_extension_ids_for_plan,
-        AgentTaskExecutorProvider, AgentTaskProviderDependencyFailurePattern,
-        AgentTaskProviderEnvPathReadiness, AgentTaskProviderRoleAliases,
-        AgentTaskProviderRunnerReadiness, AgentTaskProviderWorkspaceMaterialization,
-        ExtensionProviderAgentTaskExecutor,
+        provider_runner_readiness_contracts, provider_runner_secret_env_for_plan,
+        required_extension_ids_for_plan, AgentTaskExecutorProvider,
+        AgentTaskProviderDependencyFailurePattern, AgentTaskProviderEnvPathReadiness,
+        AgentTaskProviderRoleAliases, AgentTaskProviderRunnerReadiness,
+        AgentTaskProviderWorkspaceMaterialization, ExtensionProviderAgentTaskExecutor,
     };
 }
 

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -8,6 +8,7 @@
 
 use std::collections::HashMap;
 
+use crate::core::agent_tasks::provider::provider_runner_secret_env_for_plan;
 use crate::core::agent_tasks::scheduler::AgentTaskPlan;
 use crate::core::agent_tasks::secrets as agent_task_secrets;
 use crate::core::{config, Error, Result};
@@ -306,6 +307,7 @@ fn declared_agent_task_run_plan_secret_env(args: &[String]) -> Vec<String> {
     };
 
     let mut names = Vec::new();
+    names.extend(provider_runner_secret_env_for_plan(&plan));
     for request in plan.tasks {
         names.extend(request.executor.secret_env);
         names.extend(


### PR DESCRIPTION
## Summary
- Add a generic `runner_readiness[].secret_env` contract to agent-task executor provider manifests.
- Apply provider-declared runner secret contracts to selected plan tasks before dispatch/run-plan execution.
- Preflight the complete agent-task secret env set before scheduler/provider execution and before submitted runs are marked running.
- Include provider-declared runner secret env names in Lab `agent-task run-plan` runner secret discovery so delegated runners fail before executing the plan when mappings are missing.

Fixes #4814.

## Verification
- `homeboy test --runner homeboy-lab -- --filter=run_plan_fails_fast_when_required_secret_env_is_missing` passed.
- `homeboy test --runner homeboy-lab -- --filter=provider_runner_secret_env_contracts_are_applied_to_selected_plan_tasks` passed.
- `homeboy test --runner homeboy-lab` reached the full suite and failed on an existing unrelated core-agnostic baseline finding in `tests/core_agnostic_test.rs` for pre-existing `wp-content` / `npm` findings in `src/core/deploy/path_roots.rs` and `src/core/release/executor.rs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted implementation and focused tests; Chris reviews and owns the change.
