### PR TITLE
Derive repo loop artifact dependencies from consumes

### DIFF
--- a/src/core/agent_task_controller_service.rs
+++ b/src/core/agent_task_controller_service.rs
@@ -202,6 +202,10 @@ pub struct AgentTaskRepoLoopSpecWorkflow {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifacts: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub consumes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub emits: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependencies: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub gates: Vec<String>,
@@ -815,6 +819,18 @@ fn validate_loop_spec(spec: &AgentTaskRepoLoopSpec) -> Result<()> {
             &spec.artifacts,
             |artifact| &artifact.artifact_id,
         )?;
+        validate_declared_ids(
+            format!("workflows[{index}].consumes"),
+            &workflow.consumes,
+            &spec.artifacts,
+            |artifact| &artifact.artifact_id,
+        )?;
+        validate_declared_ids(
+            format!("workflows[{index}].emits"),
+            &workflow.emits,
+            &spec.artifacts,
+            |artifact| &artifact.artifact_id,
+        )?;
         validate_workflow_dependencies(
             format!("workflows[{index}].dependencies"),
             &workflow.dependencies,
@@ -1027,7 +1043,7 @@ fn workflow_client_context(
         "tools": select_by_id(&spec.tools, &workflow.tools, |tool| &tool.tool_id),
         "abilities": select_by_id(&spec.abilities, &workflow.abilities, |ability| &ability.ability_id),
         "artifacts": select_by_id(&spec.artifacts, &workflow.artifacts, |artifact| &artifact.artifact_id),
-        "artifact_dependencies": select_by_id(&spec.artifacts, &workflow.dependencies, |artifact| &artifact.artifact_id),
+        "artifact_dependencies": workflow_artifact_dependencies(spec, workflow),
         "dependencies": select_by_id(&spec.dependencies, &workflow.dependencies, |dependency| &dependency.dependency_id),
         "gates": select_by_id(&spec.gates, &workflow.gates, |gate| &gate.gate_id),
         "metrics": select_by_id(&spec.metrics, &workflow.metrics, |metric| &metric.metric_id),
@@ -1124,7 +1140,7 @@ fn workflow_declaration_context(
         "tools": select_by_id(&spec.tools, &workflow.tools, |tool| &tool.tool_id),
         "abilities": select_by_id(&spec.abilities, &workflow.abilities, |ability| &ability.ability_id),
         "artifacts": select_by_id(&spec.artifacts, &workflow.artifacts, |artifact| &artifact.artifact_id),
-        "artifact_dependencies": select_by_id(&spec.artifacts, &workflow.dependencies, |artifact| &artifact.artifact_id),
+        "artifact_dependencies": workflow_artifact_dependencies(spec, workflow),
         "dependencies": select_by_id(&spec.dependencies, &workflow.dependencies, |dependency| &dependency.dependency_id),
         "gates": select_by_id(&spec.gates, &workflow.gates, |gate| &gate.gate_id),
         "metrics": select_by_id(&spec.metrics, &workflow.metrics, |metric| &metric.metric_id),
@@ -1172,6 +1188,51 @@ where
     }
     ids.iter()
         .filter_map(|requested| items.iter().find(|item| id(item) == requested))
+        .collect()
+}
+
+fn workflow_artifact_dependencies(
+    spec: &AgentTaskRepoLoopSpec,
+    workflow: &AgentTaskRepoLoopSpecWorkflow,
+) -> Vec<Value> {
+    let mut ids = workflow.consumes.clone();
+    for dependency in &workflow.dependencies {
+        if spec
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.artifact_id == dependency.as_str())
+            && !ids.contains(dependency)
+        {
+            ids.push(dependency.clone());
+        }
+    }
+
+    ids.iter()
+        .filter_map(|id| {
+            let artifact = spec
+                .artifacts
+                .iter()
+                .find(|artifact| artifact.artifact_id == id.as_str())?;
+            let mut value = serde_json::to_value(artifact).ok()?;
+            if let Some(object) = value.as_object_mut() {
+                let producer_workflow_ids: Vec<Value> = spec
+                    .workflows
+                    .iter()
+                    .filter(|producer| producer.workflow_id != workflow.workflow_id)
+                    .filter(|producer| {
+                        producer.artifacts.contains(id) || producer.emits.contains(id)
+                    })
+                    .map(|producer| Value::String(producer.workflow_id.clone()))
+                    .collect();
+                if !producer_workflow_ids.is_empty() {
+                    object.insert(
+                        "producer_workflow_ids".to_string(),
+                        Value::Array(producer_workflow_ids),
+                    );
+                }
+            }
+            Some(value)
+        })
         .collect()
 }
 
@@ -3027,6 +3088,8 @@ mod tests {
                     tools: Vec::new(),
                     abilities: vec!["github_pull_request_publish".to_string()],
                     artifacts: vec!["static_site_pull_request".to_string()],
+                    consumes: Vec::new(),
+                    emits: Vec::new(),
                     dependencies: Vec::new(),
                     gates: Vec::new(),
                     metrics: Vec::new(),
@@ -3041,6 +3104,8 @@ mod tests {
                     tools: Vec::new(),
                     abilities: vec!["static_validation".to_string()],
                     artifacts: Vec::new(),
+                    consumes: Vec::new(),
+                    emits: Vec::new(),
                     dependencies: vec!["static_site_pull_request".to_string()],
                     gates: Vec::new(),
                     metrics: Vec::new(),
@@ -3292,6 +3357,8 @@ mod tests {
                     tools: vec!["repo-inspector".to_string()],
                     abilities: vec!["apply_patch".to_string()],
                     artifacts: vec!["patch".to_string()],
+                    consumes: Vec::new(),
+                    emits: Vec::new(),
                     dependencies: vec![
                         "source-tree".to_string(),
                         "static_site_pull_request".to_string(),
@@ -3446,6 +3513,37 @@ mod tests {
     }
 
     #[test]
+    fn init_from_spec_maps_workflow_consumes_to_artifact_dependencies() {
+        with_isolated_home(|_| {
+            let mut spec = repo_loop_reconcile_spec("repo-loop-consumes-artifacts");
+            spec.workflows
+                .iter_mut()
+                .find(|workflow| workflow.workflow_id == "generation")
+                .expect("generation workflow")
+                .emits = vec!["static_site_pull_request".to_string()];
+            spec.workflows
+                .iter_mut()
+                .find(|workflow| workflow.workflow_id == "static_validation")
+                .expect("static validation workflow")
+                .consumes = vec!["static_site_pull_request".to_string()];
+
+            let report =
+                init_from_spec(ControllerFromSpecRequest { spec }).expect("spec initialized");
+            let context = workflow_action_context(&report, "static_validation");
+
+            assert_eq!(
+                context["artifact_dependencies"],
+                json!([{
+                    "artifact_id": "static_site_pull_request",
+                    "kind": "pull_request",
+                    "required": true,
+                    "producer_workflow_ids": ["generation"]
+                }])
+            );
+        });
+    }
+
+    #[test]
     fn init_from_spec_reconciles_changed_emitted_artifacts() {
         with_isolated_home(|_| {
             let report = reapply_base_then_mutated("repo-loop-reconcile-artifacts", |spec| {
@@ -3484,6 +3582,8 @@ mod tests {
                     tools: Vec::new(),
                     abilities: vec!["static_publication".to_string()],
                     artifacts: vec!["static_site_pull_request".to_string()],
+                    consumes: Vec::new(),
+                    emits: Vec::new(),
                     dependencies: vec!["static_site_candidate".to_string()],
                     gates: Vec::new(),
                     metrics: Vec::new(),
@@ -3562,6 +3662,8 @@ mod tests {
                     tools: vec!["missing-tool".to_string()],
                     abilities: Vec::new(),
                     artifacts: Vec::new(),
+                    consumes: Vec::new(),
+                    emits: Vec::new(),
                     dependencies: Vec::new(),
                     gates: Vec::new(),
                     metrics: Vec::new(),
@@ -4177,6 +4279,8 @@ mod tests {
                     tools: vec!["repo-inspector".to_string()],
                     abilities: vec!["patch-writer".to_string()],
                     artifacts: vec!["candidate-patch".to_string()],
+                    consumes: Vec::new(),
+                    emits: Vec::new(),
                     dependencies: vec!["source-tree".to_string()],
                     gates: vec!["quality".to_string()],
                     metrics: vec!["coverage".to_string()],

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -580,6 +580,10 @@ fn dispatch_provider_config(
     });
     map.entry("client_context".to_string())
         .or_insert_with(|| client_context.clone());
+    if let Some(artifact_dependencies) = client_context.get("artifact_dependencies") {
+        map.entry("artifact_dependencies".to_string())
+            .or_insert_with(|| artifact_dependencies.clone());
+    }
     map.entry("task_url".to_string())
         .or_insert_with(|| serde_json::json!(request.task_url));
 
@@ -827,6 +831,37 @@ mod tests {
         assert_eq!(
             plan.tasks[0].metadata["required_capabilities"],
             serde_json::json!(["tool:repo-inspector"])
+        );
+    }
+
+    #[test]
+    fn dispatch_plan_promotes_client_context_artifact_dependencies_to_provider_config() {
+        let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+            prompt: Some("Run the declared workflow.".to_string()),
+            client_context: Some(
+                serde_json::json!({
+                    "schema": "homeboy/repo-loop-workflow-context/v1",
+                    "artifact_dependencies": [{
+                        "artifact_id": "concept_packet",
+                        "kind": "typed_packet",
+                        "required": true,
+                        "producer_workflow_ids": ["store-idea"]
+                    }]
+                })
+                .to_string(),
+            ),
+            ..DispatchRequestOverrides::default()
+        }))
+        .expect("dispatch plan");
+
+        assert_eq!(
+            plan.tasks[0].executor.config["artifact_dependencies"],
+            serde_json::json!([{
+                "artifact_id": "concept_packet",
+                "kind": "typed_packet",
+                "required": true,
+                "producer_workflow_ids": ["store-idea"]
+            }])
         );
     }
 


### PR DESCRIPTION
## Summary
- Parse generic repo-loop workflow `consumes` and `emits` artifact references.
- Build workflow `artifact_dependencies` from `consumes` plus artifact-valued `dependencies`, preserving artifact metadata and inferred producer workflow IDs.
- Promote client-context `artifact_dependencies` into provider config so providers receive the generic dependency contract without backend-specific behavior.

Fixes #4819.

## Tests
- `cargo test init_from_spec_maps_workflow_consumes_to_artifact_dependencies && cargo test dispatch_plan_promotes_client_context_artifact_dependencies_to_provider_config`
- `cargo test agent_task_controller_service::tests && cargo test agent_task_dispatch_service::tests`
- `cargo test --test architecture_core_agnostic_test`

Known unrelated failure observed:
- `cargo test --test core_agnostic_test` fails in `core_owned_source_stays_language_and_framework_agnostic` on existing findings in `src/core/deploy/path_roots.rs` and `src/core/release/executor.rs` for `wp-content`/`npm`; this PR does not touch those files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the generic repo-loop artifact dependency mapping and focused controller/provider boundary tests; Chris remains responsible for review and merge.
