### PR TITLE
Discover standalone agent runtime packages

### DIFF
--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -1,8 +1,10 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::path::Path;
 
 use crate::core::agent_task_provider::AgentTaskExecutorProvider;
 use crate::core::extension::{load_all_extensions, ExtensionManifest};
+use crate::core::{config, paths};
 
 pub const AGENT_RUNTIME_MANIFEST_SCHEMA: &str = "homeboy/agent-runtime-manifest/v1";
 
@@ -18,10 +20,50 @@ pub struct AgentRuntimeManifest {
     pub extension_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extension_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_path: Option<String>,
 }
 
 pub fn discover_agent_runtime_manifests() -> Vec<AgentRuntimeManifest> {
-    discover_agent_runtime_manifests_from_extensions(&load_all_extensions().unwrap_or_default())
+    let mut manifests = discover_standalone_agent_runtime_manifests();
+    manifests.extend(discover_agent_runtime_manifests_from_extensions(
+        &load_all_extensions().unwrap_or_default(),
+    ));
+    manifests
+}
+
+fn discover_standalone_agent_runtime_manifests() -> Vec<AgentRuntimeManifest> {
+    let Ok(runtime_dir) = paths::agent_runtimes() else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(runtime_dir) else {
+        return Vec::new();
+    };
+
+    let mut manifests: Vec<AgentRuntimeManifest> = entries
+        .flatten()
+        .filter_map(|entry| load_standalone_agent_runtime_manifest(&entry.path()))
+        .collect();
+    manifests.sort_by(|a, b| a.id.cmp(&b.id));
+    manifests
+}
+
+fn load_standalone_agent_runtime_manifest(path: &Path) -> Option<AgentRuntimeManifest> {
+    if !path.is_dir() {
+        return None;
+    }
+    let id = path.file_name()?.to_string_lossy().to_string();
+    let manifest_path = paths::agent_runtime_manifest(&id).ok()?;
+    if !manifest_path.exists() {
+        return None;
+    }
+    let content = std::fs::read_to_string(manifest_path).ok()?;
+    let mut manifest: AgentRuntimeManifest = config::from_str(&content).ok()?;
+    manifest.id = id;
+    manifest.extension_id = None;
+    manifest.extension_path = None;
+    manifest.runtime_path = Some(path.to_string_lossy().to_string());
+    Some(manifest)
 }
 
 pub(crate) fn discover_agent_runtime_manifests_from_extensions(
@@ -41,6 +83,7 @@ pub(crate) fn discover_agent_runtime_manifests_from_extensions(
                 agent_task_executors: providers,
                 extension_id: Some(extension.id.clone()),
                 extension_path: extension.extension_path.clone(),
+                runtime_path: extension.extension_path.clone(),
             });
         }
 
@@ -62,6 +105,7 @@ pub(crate) fn discover_agent_runtime_manifests_from_extensions(
             agent_task_executors: providers,
             extension_id: Some(extension.id.clone()),
             extension_path: extension.extension_path.clone(),
+            runtime_path: extension.extension_path.clone(),
         });
     }
     runtime_manifests
@@ -73,6 +117,7 @@ pub(crate) fn discover_agent_task_executor_providers() -> Vec<AgentTaskExecutorP
         for mut provider in runtime_manifest.agent_task_executors {
             provider.extension_id = runtime_manifest.extension_id.clone();
             provider.extension_path = runtime_manifest.extension_path.clone();
+            provider.runtime_path = runtime_manifest.runtime_path.clone();
             providers.push(provider);
         }
     }
@@ -168,6 +213,10 @@ mod tests {
             Some("runtime-extension")
         );
         assert_eq!(manifests[0].agent_task_executors[0].backend, "codex");
+        assert_eq!(
+            manifests[0].runtime_path.as_deref(),
+            Some("/extensions/runtime-extension")
+        );
     }
 
     #[test]
@@ -186,5 +235,39 @@ mod tests {
             "legacy-extension.legacy-agent-task-executors"
         );
         assert_eq!(manifests[0].agent_task_executors[0].backend, "legacy");
+    }
+
+    #[test]
+    fn discovers_standalone_agent_runtime_manifests() {
+        crate::test_support::with_isolated_home(|home| {
+            let runtime_dir = home
+                .path()
+                .join(".config/homeboy/agent-runtimes")
+                .join("standalone-codex");
+            std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+            std::fs::write(
+                runtime_dir.join("standalone-codex.json"),
+                json!({
+                    "schema": AGENT_RUNTIME_MANIFEST_SCHEMA,
+                    "id": "ignored-on-disk",
+                    "label": "Standalone Codex",
+                    "agent_task_executors": [provider_json("standalone-codex.default", "codex")]
+                })
+                .to_string(),
+            )
+            .expect("runtime manifest");
+
+            let manifests = discover_standalone_agent_runtime_manifests();
+
+            assert_eq!(manifests.len(), 1);
+            assert_eq!(manifests[0].id, "standalone-codex");
+            assert_eq!(manifests[0].extension_id, None);
+            assert_eq!(manifests[0].extension_path, None);
+            assert_eq!(
+                manifests[0].runtime_path.as_deref(),
+                Some(runtime_dir.to_str().expect("runtime dir utf-8"))
+            );
+            assert_eq!(manifests[0].agent_task_executors[0].backend, "codex");
+        });
     }
 }

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -47,6 +47,8 @@ pub struct AgentTaskExecutorProvider {
     pub extension_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extension_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_path: Option<String>,
 }
 
 fn is_false(value: &bool) -> bool {
@@ -837,9 +839,11 @@ fn output_value<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
 
 fn render_provider_command(provider: &AgentTaskExecutorProvider) -> String {
     let extension_path = provider.extension_path.as_deref().unwrap_or_default();
+    let runtime_path = provider.runtime_path.as_deref().unwrap_or(extension_path);
     provider
         .command
         .replace("{{extension_path}}", extension_path)
+        .replace("{{runtime_path}}", runtime_path)
 }
 
 fn provider_command_parts(command: &str) -> Option<(String, Vec<String>)> {
@@ -868,6 +872,14 @@ fn provider_command_env(
         (
             "HOMEBOY_EXTENSION_PATH".to_string(),
             provider.extension_path.clone().unwrap_or_default(),
+        ),
+        (
+            "HOMEBOY_RUNTIME_PATH".to_string(),
+            provider
+                .runtime_path
+                .clone()
+                .or_else(|| provider.extension_path.clone())
+                .unwrap_or_default(),
         ),
     ];
     env.extend(resolve_secret_env(&request.executor.secret_env)?);
@@ -943,6 +955,7 @@ mod tests {
             role_aliases: AgentTaskProviderRoleAliases::default(),
             extension_id: None,
             extension_path: None,
+            runtime_path: None,
         };
         let request = AgentTaskRequest {
             schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
@@ -1153,6 +1166,21 @@ mod tests {
             ExtensionProviderAgentTaskExecutor::with_providers(vec![provider_a, provider_b]);
 
         assert_eq!(executor.default_backend().as_deref(), Some("preferred"));
+    }
+
+    #[test]
+    fn provider_command_interpolates_runtime_path_separately_from_extension_path() {
+        let (_, mut provider) = request(
+            "task-a",
+            "{{runtime_path}}/bin/provider --extension {{extension_path}}".to_string(),
+        );
+        provider.extension_path = Some("/extensions/project-type".to_string());
+        provider.runtime_path = Some("/agent-runtimes/codex".to_string());
+
+        assert_eq!(
+            render_provider_command(&provider),
+            "/agent-runtimes/codex/bin/provider --extension /extensions/project-type"
+        );
     }
 
     #[test]

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -176,6 +176,11 @@ pub fn extensions() -> Result<PathBuf> {
     Ok(homeboy()?.join("extensions"))
 }
 
+/// Agent runtimes directory
+pub fn agent_runtimes() -> Result<PathBuf> {
+    Ok(homeboy()?.join("agent-runtimes"))
+}
+
 /// Keys directory
 pub fn keys() -> Result<PathBuf> {
     Ok(homeboy()?.join("keys"))
@@ -241,6 +246,11 @@ pub fn extension(id: &str) -> Result<PathBuf> {
 /// Extension manifest file path
 pub fn extension_manifest(id: &str) -> Result<PathBuf> {
     Ok(extensions()?.join(id).join(format!("{}.json", id)))
+}
+
+/// Agent runtime manifest file path
+pub fn agent_runtime_manifest(id: &str) -> Result<PathBuf> {
+    Ok(agent_runtimes()?.join(id).join(format!("{}.json", id)))
 }
 
 /// Key file path


### PR DESCRIPTION
## Summary
- discover standalone agent runtime manifests under an `agent-runtimes` config path
- preserve extension-embedded `agent_runtimes` and legacy executor discovery
- add `runtime_path` metadata and `{{runtime_path}}` provider command interpolation
- expose `HOMEBOY_RUNTIME_PATH` to runtime provider commands

Closes #4831.

## Tests
- `cargo fmt`
- `cargo test core::agent_runtime_manifest::tests --lib`
- `cargo test core::agent_task_provider::tests::provider_command_interpolates_runtime_path_separately_from_extension_path --lib`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added standalone runtime discovery and focused tests.