### PR TITLE
feat(runner): generic managed runner-source primitive + drift doctor checks (#3818, #4140)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ All notable changes to Homeboy CLI are documented in this file.
 ### Added
 - discover standalone agent runtimes
 
+### Added
+- generic, runtime-agnostic managed runner-source primitive that keeps an extension-declared git checkout synced on the Lab runner, plus a runner doctor check that warns when a managed source is missing, tracks the wrong remote, or resolves to a non-canonical checkout outside its declared root (#3818, #4140)
+
 ### Fixed
 - resolve rig component paths to the runner-side materialized checkout during Lab offload so remote `${components.<id>.path}` checks no longer fail against the controller path (#3766)
 - expand portable `~`/`~/...` rig dependency checkout roots to an absolute runner home path so the materialized remote path is never a literal `~` directory (#3767)

--- a/src/commands/runner/doctor.rs
+++ b/src/commands/runner/doctor.rs
@@ -4,7 +4,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use homeboy::core::agent_tasks::provider::AgentTaskProviderRunnerReadiness;
+use homeboy::core::agent_tasks::provider::{
+    AgentTaskProviderRunnerReadiness, AgentTaskProviderRunnerSource,
+};
 use homeboy::core::runners::{self as runner, Runner, RunnerKind, RunnerTunnelMode};
 use homeboy::core::server::{self, Server, SshClient};
 use serde::Serialize;
@@ -611,6 +613,10 @@ mod remote {
                 client,
                 &homeboy::core::agent_tasks::provider::provider_runner_readiness_contracts(),
             ));
+            checks.extend(probes::managed_runner_source_checks(
+                client,
+                &homeboy::core::agent_tasks::provider::provider_runner_source_contracts(),
+            ));
         }
 
         checks.extend(probes::connected_daemon_exec_checks(
@@ -1083,6 +1089,106 @@ mod probes {
             .collect()
     }
 
+    /// #3818: report the state of every extension-declared managed runner
+    /// source checkout. Surfaces a missing checkout (error) or a checkout that
+    /// tracks a different remote than the declared canonical remote (warning)
+    /// so operators see drift before a cook runs against a stale source.
+    pub fn managed_runner_source_checks(
+        client: &SshClient,
+        contracts: &[AgentTaskProviderRunnerSource],
+    ) -> Vec<RunnerCheck> {
+        contracts
+            .iter()
+            .map(|contract| managed_runner_source_check(client, contract))
+            .collect()
+    }
+
+    fn managed_runner_source_check(
+        client: &SshClient,
+        contract: &AgentTaskProviderRunnerSource,
+    ) -> RunnerCheck {
+        let id = format!("lab.managed_source.{}", contract.id);
+        let mut details = BTreeMap::new();
+        // Resolve the declared path through the runner shell so `~`/`$HOME`
+        // expand to the runner user's real home.
+        let resolved_path = common::remote_line(
+            client,
+            &format!("printf '%s\n' {}", common::shell_word(&contract.path)),
+        )
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| contract.path.clone());
+        details.insert("path".to_string(), resolved_path.clone());
+        if let Some(remote_url) = contract.remote_url.as_deref() {
+            details.insert("declared_remote".to_string(), remote_url.to_string());
+        }
+        if let Some(git_ref) = contract.git_ref.as_deref() {
+            details.insert("declared_ref".to_string(), git_ref.to_string());
+        }
+
+        let is_git = client
+            .execute(&format!(
+                "test -d {}/.git",
+                common::shell_word(&resolved_path)
+            ))
+            .success;
+        if !is_git {
+            return checks::error(
+                id,
+                format!(
+                    "Managed runner source `{}` is not present as a git checkout on the Lab runner",
+                    contract.label
+                ),
+                contract.remediation.clone(),
+                details,
+            );
+        }
+
+        let actual_remote = common::remote_line(
+            client,
+            &format!(
+                "git -C {} config --get remote.origin.url 2>/dev/null",
+                common::shell_word(&resolved_path)
+            ),
+        );
+        if let Some(actual_remote) = actual_remote.as_deref() {
+            details.insert("origin_remote".to_string(), actual_remote.to_string());
+        }
+        if let Some(head) = common::remote_line(
+            client,
+            &format!(
+                "git -C {} rev-parse --short HEAD 2>/dev/null",
+                common::shell_word(&resolved_path)
+            ),
+        ) {
+            details.insert("head".to_string(), head);
+        }
+
+        if let (Some(declared_remote), Some(actual_remote)) =
+            (contract.remote_url.as_deref(), actual_remote.as_deref())
+        {
+            if declared_remote != actual_remote {
+                return checks::warning_with_details(
+                    id,
+                    format!(
+                        "Managed runner source `{}` tracks a different remote than declared on the Lab runner",
+                        contract.label
+                    ),
+                    contract.remediation.clone(),
+                    details,
+                );
+            }
+        }
+
+        checks::ok_with_details(
+            id,
+            format!(
+                "Managed runner source `{}` is present on the Lab runner",
+                contract.label
+            ),
+            details,
+        )
+    }
+
     fn provider_readiness_check(
         client: &SshClient,
         contract: &AgentTaskProviderRunnerReadiness,
@@ -1103,7 +1209,7 @@ mod probes {
         .filter(|value| !value.trim().is_empty());
         let Some(path) = path else {
             return Some(provider_env_path_readiness_check_from_probe(
-                contract, None, false, None,
+                contract, None, false, None, None,
             ));
         };
 
@@ -1118,6 +1224,7 @@ mod probes {
                 contract,
                 Some(path),
                 false,
+                None,
                 None,
             ));
         }
@@ -1134,12 +1241,47 @@ mod probes {
             }
         }
 
+        // #4140: resolve the extension-declared canonical root on the runner
+        // (expanding `~`/`$HOME` etc. via the runner shell) so we can warn when
+        // the env-resolved tool path lives outside the managed checkout.
+        let resolved_canonical = env_path
+            .canonical_path
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .and_then(|canonical| {
+                common::remote_line(
+                    client,
+                    &format!("printf '%s\n' {}", common::shell_word(canonical)),
+                )
+                .filter(|value| !value.trim().is_empty())
+            });
+
         Some(provider_env_path_readiness_check_from_probe(
             contract,
             Some(path),
             true,
             details.get("revision").cloned(),
+            resolved_canonical,
         ))
+    }
+
+    /// Returns true when `path` is the canonical root itself or lives beneath
+    /// it. Comparison is path-segment aware so `/a/source` is not treated as a
+    /// child of `/a/sour`.
+    pub(super) fn path_within_canonical_root(path: &str, canonical_root: &str) -> bool {
+        let normalize = |value: &str| {
+            let trimmed = value.trim().trim_end_matches('/');
+            trimmed.to_string()
+        };
+        let path = normalize(path);
+        let root = normalize(canonical_root);
+        if root.is_empty() {
+            return true;
+        }
+        if path == root {
+            return true;
+        }
+        path.starts_with(&format!("{root}/"))
     }
 
     pub(super) fn provider_env_path_readiness_check_from_probe(
@@ -1147,6 +1289,7 @@ mod probes {
         path: Option<String>,
         exists: bool,
         revision: Option<String>,
+        canonical_path: Option<String>,
     ) -> RunnerCheck {
         let env = contract
             .env_path
@@ -1157,11 +1300,15 @@ mod probes {
         if !env.is_empty() {
             details.insert("env".to_string(), env);
         }
+        let resolved_path = path.clone();
         if let Some(path) = path {
             details.insert("path".to_string(), path);
         }
         if let Some(revision) = revision {
             details.insert("revision".to_string(), revision);
+        }
+        if let Some(canonical_path) = canonical_path.as_deref() {
+            details.insert("canonical_path".to_string(), canonical_path.to_string());
         }
 
         if !details.contains_key("path") {
@@ -1186,6 +1333,26 @@ mod probes {
                 contract.remediation.clone(),
                 details,
             );
+        }
+
+        // #4140: the path resolves to a real checkout, but if the declaring
+        // extension pinned a canonical managed root and the resolved path lives
+        // outside it, the runner is using a stale / non-canonical checkout that
+        // can corrupt results. Surface this as a warning before it does.
+        if let (Some(resolved_path), Some(canonical_root)) =
+            (resolved_path.as_deref(), canonical_path.as_deref())
+        {
+            if !path_within_canonical_root(resolved_path, canonical_root) {
+                return checks::warning_with_details(
+                    contract.id.clone(),
+                    format!(
+                        "{} resolves to a non-canonical checkout outside the managed source root on the Lab runner",
+                        contract.label
+                    ),
+                    contract.remediation.clone(),
+                    details,
+                );
+            }
         }
 
         checks::ok_with_details(

--- a/src/commands/runner/doctor/tests.rs
+++ b/src/commands/runner/doctor/tests.rs
@@ -192,6 +192,7 @@ fn provider_readiness_renderer_uses_fake_provider_contract() {
         env_path: Some(AgentTaskProviderEnvPathReadiness {
             env: vec!["FAKE_RUNTIME_BIN".to_string()],
             revision: Some(true),
+            canonical_path: None,
         }),
         remediation: Some("Refresh the fake runtime cache".to_string()),
     };
@@ -201,6 +202,7 @@ fn provider_readiness_renderer_uses_fake_provider_contract() {
         Some("/opt/fake-runtime/bin".to_string()),
         true,
         Some("abc123".to_string()),
+        None,
     );
 
     assert_eq!(check.id, "lab.fake_runtime.cache");
@@ -214,6 +216,86 @@ fn provider_readiness_renderer_uses_fake_provider_contract() {
         check.details.get("revision").map(String::as_str),
         Some("abc123")
     );
+}
+
+#[test]
+fn provider_readiness_warns_on_non_canonical_checkout() {
+    let contract = AgentTaskProviderRunnerReadiness {
+        id: "lab.fake_runtime.cache".to_string(),
+        label: "Fake runtime cache".to_string(),
+        secret_env: Vec::new(),
+        env_path: Some(AgentTaskProviderEnvPathReadiness {
+            env: vec!["FAKE_RUNTIME_BIN".to_string()],
+            revision: Some(true),
+            canonical_path: Some("/home/runner/.cache/homeboy/source".to_string()),
+        }),
+        remediation: Some("Refresh the managed source checkout".to_string()),
+    };
+
+    let check = probes::provider_env_path_readiness_check_from_probe(
+        &contract,
+        Some("/home/runner/Developer/stale-checkout/dist/index.js".to_string()),
+        true,
+        None,
+        Some("/home/runner/.cache/homeboy/source".to_string()),
+    );
+
+    assert_eq!(check.status, RunnerDoctorStatus::Warning);
+    assert!(check.message.contains("non-canonical checkout"));
+    assert_eq!(
+        check.details.get("canonical_path").map(String::as_str),
+        Some("/home/runner/.cache/homeboy/source")
+    );
+    assert_eq!(
+        check.remediation.as_deref(),
+        contract.remediation.as_deref()
+    );
+}
+
+#[test]
+fn provider_readiness_ok_when_path_within_canonical_root() {
+    let contract = AgentTaskProviderRunnerReadiness {
+        id: "lab.fake_runtime.cache".to_string(),
+        label: "Fake runtime cache".to_string(),
+        secret_env: Vec::new(),
+        env_path: Some(AgentTaskProviderEnvPathReadiness {
+            env: vec!["FAKE_RUNTIME_BIN".to_string()],
+            revision: None,
+            canonical_path: Some("/home/runner/.cache/homeboy/source".to_string()),
+        }),
+        remediation: None,
+    };
+
+    let check = probes::provider_env_path_readiness_check_from_probe(
+        &contract,
+        Some("/home/runner/.cache/homeboy/source/dist/index.js".to_string()),
+        true,
+        None,
+        Some("/home/runner/.cache/homeboy/source".to_string()),
+    );
+
+    assert_eq!(check.status, RunnerDoctorStatus::Ok);
+}
+
+#[test]
+fn path_within_canonical_root_is_segment_aware() {
+    assert!(probes::path_within_canonical_root("/a/source", "/a/source"));
+    assert!(probes::path_within_canonical_root(
+        "/a/source/dist",
+        "/a/source"
+    ));
+    assert!(probes::path_within_canonical_root(
+        "/a/source/",
+        "/a/source"
+    ));
+    // Prefix collision must not count as containment.
+    assert!(!probes::path_within_canonical_root("/a/sour", "/a/source"));
+    assert!(!probes::path_within_canonical_root(
+        "/a/source-stale/dist",
+        "/a/source"
+    ));
+    // Empty root is treated as "no canonical constraint".
+    assert!(probes::path_within_canonical_root("/anywhere", ""));
 }
 
 #[test]

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -37,6 +37,8 @@ pub struct AgentTaskExecutorProvider {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub runner_readiness: Vec<AgentTaskProviderRunnerReadiness>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runner_sources: Vec<AgentTaskProviderRunnerSource>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependency_failure_patterns: Vec<AgentTaskProviderDependencyFailurePattern>,
     #[serde(
         default,
@@ -72,6 +74,40 @@ pub struct AgentTaskProviderEnvPathReadiness {
     pub env: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<bool>,
+    /// Optional extension-declared canonical root (e.g. a managed source clone
+    /// kept under the runner's homeboy cache). When set, doctor WARNS if the
+    /// env-resolved path does not live under this canonical root, catching
+    /// stale / non-canonical checkout drift before it corrupts results.
+    ///
+    /// Core is runtime-agnostic: it does not know what the canonical path
+    /// represents (wp-codebox, a toolchain, etc.) — the value is supplied
+    /// entirely by the declaring extension.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_path: Option<String>,
+}
+
+/// A named, extension-declared source checkout that homeboy keeps synced on the
+/// runner. Core treats this generically: it materializes/refreshes a git
+/// checkout to the intended ref/remote. It has no knowledge of what the source
+/// is (wp-codebox, a CLI, a toolchain) — extensions declare the path/remote/ref.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskProviderRunnerSource {
+    pub id: String,
+    pub label: String,
+    /// Absolute path (or `$HOME`/`~`-prefixed path) of the managed checkout on
+    /// the runner, e.g. a path under the runner's homeboy cache directory.
+    pub path: String,
+    /// Optional canonical remote URL the checkout must track. When set, homeboy
+    /// re-points `origin` if the checkout tracks a different remote (fixing the
+    /// "tracks wrong remote" drift), then fetches and fast-forwards.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_url: Option<String>,
+    /// Optional explicit ref (branch, tag, or sha) to check out and sync to.
+    /// When omitted, homeboy fast-forwards the current branch to its upstream.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remediation: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -212,6 +248,13 @@ pub fn provider_runner_readiness_contracts() -> Vec<AgentTaskProviderRunnerReadi
     discover_agent_task_executor_providers()
         .into_iter()
         .flat_map(|provider| provider.runner_readiness)
+        .collect()
+}
+
+pub fn provider_runner_source_contracts() -> Vec<AgentTaskProviderRunnerSource> {
+    discover_agent_task_executor_providers()
+        .into_iter()
+        .flat_map(|provider| provider.runner_sources)
         .collect()
 }
 
@@ -951,6 +994,7 @@ mod tests {
             capabilities: vec!["structured_outcome".to_string()],
             workspace_materialization: None,
             runner_readiness: Vec::new(),
+            runner_sources: Vec::new(),
             dependency_failure_patterns: Vec::new(),
             role_aliases: AgentTaskProviderRoleAliases::default(),
             extension_id: None,

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -215,9 +215,10 @@ pub mod provider {
     pub use super::super::agent_task_provider::{
         default_backend, dependency_failure_patterns, provider_requires_cwd_git_checkout,
         provider_runner_readiness_contracts, provider_runner_secret_env_for_plan,
-        required_extension_ids_for_plan, AgentTaskExecutorProvider,
-        AgentTaskProviderDependencyFailurePattern, AgentTaskProviderEnvPathReadiness,
-        AgentTaskProviderRoleAliases, AgentTaskProviderRunnerReadiness,
+        provider_runner_source_contracts, required_extension_ids_for_plan,
+        AgentTaskExecutorProvider, AgentTaskProviderDependencyFailurePattern,
+        AgentTaskProviderEnvPathReadiness, AgentTaskProviderRoleAliases,
+        AgentTaskProviderRunnerReadiness, AgentTaskProviderRunnerSource,
         AgentTaskProviderWorkspaceMaterialization, ExtensionProviderAgentTaskExecutor,
     };
 }

--- a/src/core/runner/managed_source.rs
+++ b/src/core/runner/managed_source.rs
@@ -1,0 +1,296 @@
+//! Generic, runtime-agnostic management of an extension-declared runner-side
+//! source checkout.
+//!
+//! Background (issue #3818): a Lab runner can execute cooks using a tool whose
+//! source lives in a git checkout on the runner (for example a path under the
+//! runner's homeboy cache directory). Iterating on fixes to that tool used to
+//! require manually `ssh`-ing into the runner and running
+//! `git reset --hard / git fetch / git checkout` by hand. The checkout drifted
+//! from its intended ref and could even track the wrong remote.
+//!
+//! This module lets homeboy keep such a checkout synced automatically. Core
+//! treats the source generically: it is a *named* checkout with an optional
+//! canonical remote URL and an optional intended ref. Core has **no knowledge**
+//! of what the source actually is (wp-codebox, a CLI, a toolchain, ...). The
+//! declaring extension supplies the path/remote/ref via the
+//! [`AgentTaskProviderRunnerSource`] manifest contract; this keeps homeboy core
+//! runtime-agnostic.
+//!
+//! The sync is expressed as a single idempotent POSIX shell script so it can be
+//! executed on the runner over the existing exec channel. The script:
+//!
+//! 1. Clones the checkout from the canonical remote when it is missing (only
+//!    possible when a remote URL is declared).
+//! 2. Re-points `origin` at the canonical remote when the checkout tracks a
+//!    different URL (fixes the "tracks wrong remote" drift).
+//! 3. Fetches `origin` and hard-resets to the intended ref when one is
+//!    declared, otherwise fast-forwards the current branch to its upstream.
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::agent_task_provider::AgentTaskProviderRunnerSource;
+
+/// A resolved, validated plan for syncing a single managed runner source. The
+/// `script` is a POSIX shell program intended to run on the runner.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ManagedRunnerSourceSyncPlan {
+    pub id: String,
+    pub label: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_ref: Option<String>,
+    pub script: String,
+}
+
+/// Build sync plans for every declared managed runner source. Invalid
+/// declarations (empty id/path) are skipped so a single malformed contract
+/// cannot break the whole sweep.
+pub fn plan_managed_runner_source_syncs(
+    sources: &[AgentTaskProviderRunnerSource],
+) -> Vec<ManagedRunnerSourceSyncPlan> {
+    sources
+        .iter()
+        .filter_map(plan_managed_runner_source_sync)
+        .collect()
+}
+
+/// Build a single sync plan, returning `None` when the declaration is unusable.
+pub fn plan_managed_runner_source_sync(
+    source: &AgentTaskProviderRunnerSource,
+) -> Option<ManagedRunnerSourceSyncPlan> {
+    let id = source.id.trim();
+    let path = source.path.trim();
+    if id.is_empty() || path.is_empty() {
+        return None;
+    }
+
+    let remote_url = source
+        .remote_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let git_ref = source
+        .git_ref
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
+    let script = render_sync_script(path, remote_url.as_deref(), git_ref.as_deref());
+
+    Some(ManagedRunnerSourceSyncPlan {
+        id: id.to_string(),
+        label: if source.label.trim().is_empty() {
+            id.to_string()
+        } else {
+            source.label.trim().to_string()
+        },
+        path: path.to_string(),
+        remote_url,
+        git_ref,
+        script,
+    })
+}
+
+/// Render the idempotent sync script for one managed source.
+///
+/// The script is intentionally conservative: it fails loudly (`set -e`) so the
+/// caller can surface a clear error rather than silently leaving a drifted
+/// checkout in place.
+fn render_sync_script(path: &str, remote_url: Option<&str>, git_ref: Option<&str>) -> String {
+    let quoted_path = sq(path);
+    let mut script = String::new();
+    script.push_str("set -e\n");
+    script.push_str(&format!("dir={quoted_path}\n"));
+
+    match remote_url {
+        Some(remote_url) => {
+            let quoted_remote = sq(remote_url);
+            script.push_str(&format!("remote={quoted_remote}\n"));
+            // Clone when the checkout (or its .git) is missing.
+            script.push_str("if [ ! -d \"$dir/.git\" ]; then\n");
+            script.push_str("  mkdir -p \"$(dirname \"$dir\")\"\n");
+            script.push_str("  git clone \"$remote\" \"$dir\"\n");
+            script.push_str("fi\n");
+            // Re-point origin if it drifted from the canonical remote.
+            script.push_str(
+                "current_remote=$(git -C \"$dir\" config --get remote.origin.url 2>/dev/null || true)\n",
+            );
+            script.push_str("if [ \"$current_remote\" != \"$remote\" ]; then\n");
+            script.push_str(
+                "  git -C \"$dir\" remote set-url origin \"$remote\" 2>/dev/null || git -C \"$dir\" remote add origin \"$remote\"\n",
+            );
+            script.push_str("fi\n");
+        }
+        None => {
+            // No remote declared: the checkout must already exist.
+            script.push_str("if [ ! -d \"$dir/.git\" ]; then\n");
+            script.push_str(
+                "  echo \"managed runner source checkout missing and no remote_url declared: $dir\" >&2\n",
+            );
+            script.push_str("  exit 1\n");
+            script.push_str("fi\n");
+        }
+    }
+
+    script.push_str("git -C \"$dir\" fetch --prune origin\n");
+
+    match git_ref {
+        Some(git_ref) => {
+            let quoted_ref = sq(git_ref);
+            script.push_str(&format!("ref={quoted_ref}\n"));
+            // Resolve the ref preferring the remote-tracking form so a declared
+            // branch syncs to origin's tip rather than a stale local branch.
+            script.push_str(
+                "target=$(git -C \"$dir\" rev-parse --verify --quiet \"origin/$ref\" || git -C \"$dir\" rev-parse --verify --quiet \"$ref\")\n",
+            );
+            script.push_str("if [ -z \"$target\" ]; then\n");
+            script.push_str("  echo \"managed runner source ref not found: $ref\" >&2\n");
+            script.push_str("  exit 1\n");
+            script.push_str("fi\n");
+            script.push_str("git -C \"$dir\" checkout --quiet --force \"$ref\" 2>/dev/null || git -C \"$dir\" checkout --quiet --force --detach \"$target\"\n");
+            script.push_str("git -C \"$dir\" reset --hard \"$target\"\n");
+        }
+        None => {
+            // No ref declared: fast-forward the current branch to its upstream
+            // when one exists; otherwise leave the checkout untouched.
+            script.push_str(
+                "upstream=$(git -C \"$dir\" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)\n",
+            );
+            script.push_str("if [ -n \"$upstream\" ]; then\n");
+            script.push_str("  git -C \"$dir\" merge --ff-only \"@{u}\"\n");
+            script.push_str("fi\n");
+        }
+    }
+
+    script
+}
+
+/// POSIX single-quote escaping: wrap in single quotes and replace embedded
+/// single quotes with the `'\''` sequence.
+fn sq(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('\'');
+    for ch in value.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source(id: &str, path: &str) -> AgentTaskProviderRunnerSource {
+        AgentTaskProviderRunnerSource {
+            id: id.to_string(),
+            label: String::new(),
+            path: path.to_string(),
+            remote_url: None,
+            git_ref: None,
+            remediation: None,
+        }
+    }
+
+    #[test]
+    fn plan_skips_declarations_without_id_or_path() {
+        assert!(plan_managed_runner_source_sync(&source("", "/x")).is_none());
+        assert!(plan_managed_runner_source_sync(&source("x", "   ")).is_none());
+    }
+
+    #[test]
+    fn plan_defaults_label_to_id() {
+        let plan = plan_managed_runner_source_sync(&source("src.cache", "/home/r/.cache/src"))
+            .expect("plan");
+        assert_eq!(plan.label, "src.cache");
+        assert_eq!(plan.path, "/home/r/.cache/src");
+    }
+
+    #[test]
+    fn plan_managed_runner_source_syncs_skips_invalid_in_batch() {
+        let plans = plan_managed_runner_source_syncs(&[
+            source("", "/x"),
+            source("ok", "/home/r/.cache/src"),
+        ]);
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].id, "ok");
+    }
+
+    #[test]
+    fn script_clones_and_repoints_when_remote_declared() {
+        let mut decl = source("src", "/home/r/.cache/src");
+        decl.remote_url = Some("https://github.com/Extra-Chill/example.git".to_string());
+        let plan = plan_managed_runner_source_sync(&decl).expect("plan");
+
+        assert!(plan.script.contains("git clone \"$remote\" \"$dir\""));
+        assert!(plan
+            .script
+            .contains("git -C \"$dir\" remote set-url origin \"$remote\""));
+        assert!(plan.script.contains("git -C \"$dir\" fetch --prune origin"));
+        // Remote URL is single-quoted into the script, not interpolated raw.
+        assert!(plan
+            .script
+            .contains("remote='https://github.com/Extra-Chill/example.git'"));
+    }
+
+    #[test]
+    fn script_requires_existing_checkout_when_no_remote_declared() {
+        let plan =
+            plan_managed_runner_source_sync(&source("src", "/home/r/.cache/src")).expect("plan");
+        assert!(plan
+            .script
+            .contains("managed runner source checkout missing and no remote_url declared"));
+        assert!(!plan.script.contains("git clone"));
+    }
+
+    #[test]
+    fn script_hard_resets_to_declared_ref() {
+        let mut decl = source("src", "/home/r/.cache/src");
+        decl.remote_url = Some("https://example.test/repo.git".to_string());
+        decl.git_ref = Some("main".to_string());
+        let plan = plan_managed_runner_source_sync(&decl).expect("plan");
+
+        assert!(plan.script.contains("ref='main'"));
+        assert!(plan
+            .script
+            .contains("rev-parse --verify --quiet \"origin/$ref\""));
+        assert!(plan
+            .script
+            .contains("git -C \"$dir\" reset --hard \"$target\""));
+    }
+
+    #[test]
+    fn script_fast_forwards_when_no_ref_declared() {
+        let mut decl = source("src", "/home/r/.cache/src");
+        decl.remote_url = Some("https://example.test/repo.git".to_string());
+        let plan = plan_managed_runner_source_sync(&decl).expect("plan");
+
+        assert!(plan.script.contains("merge --ff-only \"@{u}\""));
+        assert!(!plan.script.contains("reset --hard"));
+    }
+
+    #[test]
+    fn sq_escapes_embedded_single_quotes() {
+        assert_eq!(sq("a'b"), "'a'\\''b'");
+        assert_eq!(sq("/plain/path"), "'/plain/path'");
+    }
+
+    #[test]
+    fn script_is_runtime_agnostic_no_codebox_literals() {
+        let mut decl = source("src", "/home/r/.cache/homeboy/source");
+        decl.remote_url = Some("https://example.test/repo.git".to_string());
+        let plan = plan_managed_runner_source_sync(&decl).expect("plan");
+        let lower = plan.script.to_ascii_lowercase();
+        assert!(!lower.contains("codebox"));
+        assert!(!lower.contains("wordpress"));
+        assert!(!lower.contains("wp-"));
+    }
+}

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -28,6 +28,10 @@ mod lab_env;
 mod lab_plan;
 mod lab_selection;
 mod lab_workspaces;
+mod managed_source;
+pub use managed_source::{
+    plan_managed_runner_source_sync, plan_managed_runner_source_syncs, ManagedRunnerSourceSyncPlan,
+};
 mod offload_changed_since;
 mod offload_metadata;
 mod origin_refs;

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -31,21 +31,23 @@ pub use super::runner::{
     is_remote_runner_artifact_path, is_reportable_artifact_evidence_path,
     is_retrievable_runner_artifact, lab_offload_changed_since_ref, lab_offload_metadata,
     lab_offload_metadata_with_workspace_mapping, mirror_connected_runner_run,
-    mirrored_runner_job_identity, preflight_lab_offload_changed_since,
+    mirrored_runner_job_identity, plan_managed_runner_source_sync,
+    plan_managed_runner_source_syncs, preflight_lab_offload_changed_since,
     prepare_git_lab_offload_changed_since, prepare_lab_runner_capability,
     refresh_mirrored_daemon_evidence, reportable_artifact_evidence_path,
     resolve_default_lab_runner, run_reverse_worker, runner_artifact_store_token,
     runner_exec_failure_error, runner_job_log_snapshot, status, statuses, sync_workspace,
     LabOffloadCommand, LabOffloadOutcome, LabOffloadRequest, LabOffloadSourcePathMode,
     LabOffloadWorkspaceModePolicy, LabRunnerCapabilityContract, LabRunnerGateDecision,
-    LabRunnerGateMode, LabRunnerSelectionSource, PreparedLabRunnerCapability,
-    RemoteArtifactDownload, ReverseRunnerConnectOptions, ReverseRunnerWorkerOptions,
-    ReverseRunnerWorkerOutput, Runner, RunnerCapabilityPreflight, RunnerConnectReport,
-    RunnerDisconnectReport, RunnerExecMode, RunnerExecOptions, RunnerExecOutput, RunnerFailureKind,
-    RunnerKind, RunnerRequiredTool, RunnerResourceMetrics, RunnerSession, RunnerSessionRole,
-    RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport, RunnerTunnelMode,
-    RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus,
-    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+    LabRunnerGateMode, LabRunnerSelectionSource, ManagedRunnerSourceSyncPlan,
+    PreparedLabRunnerCapability, RemoteArtifactDownload, ReverseRunnerConnectOptions,
+    ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput, Runner, RunnerCapabilityPreflight,
+    RunnerConnectReport, RunnerDisconnectReport, RunnerExecMode, RunnerExecOptions,
+    RunnerExecOutput, RunnerFailureKind, RunnerKind, RunnerRequiredTool, RunnerResourceMetrics,
+    RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
+    RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput,
+    RunnerWorkspaceApplyStatus, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+    RunnerWorkspaceSyncOutput,
 };
 
 // Registry CRUD entry points (re-exported at the root for ergonomics; also
@@ -94,9 +96,10 @@ pub mod execution {
 /// Workspace sync and patch application contracts.
 pub mod workspace {
     pub use super::super::runner::{
-        apply_change_artifact, apply_workspace_patch, sync_workspace, RunnerWorkspaceApplyOptions,
-        RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus, RunnerWorkspaceSyncMode,
-        RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
+        apply_change_artifact, apply_workspace_patch, plan_managed_runner_source_sync,
+        plan_managed_runner_source_syncs, sync_workspace, ManagedRunnerSourceSyncPlan,
+        RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus,
+        RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
     };
 }
 


### PR DESCRIPTION
## Summary

Closes the runner wp-codebox source-drift gap (#3818) and the non-canonical-checkout detection gap (#4140) with a **generic, runtime-agnostic** primitive. Core gains the ability to keep an extension-declared git checkout synced on the Lab runner and to warn when that checkout drifts — without homeboy core knowing anything about wp-codebox / WordPress.

Previously, iterating on a tool whose source lives in a checkout on the runner required manually `ssh`-ing in and running `git reset --hard` / `git fetch` / `git checkout` by hand. The checkout silently drifted from its intended ref and could even track the wrong remote, corrupting cook results.

## What changed

**New generic primitive — `src/core/runner/managed_source.rs`**
- `AgentTaskProviderRunnerSource` contract: a named checkout with optional canonical `remote_url` and optional `git_ref`. Core has zero knowledge of what the source *is*.
- `plan_managed_runner_source_sync(s)` renders an idempotent POSIX shell sync script that:
  1. Clones from the canonical remote when the checkout is missing (only if a remote is declared).
  2. Re-points `origin` when the checkout tracks a different remote (fixes "tracks wrong remote" drift).
  3. Fetches and hard-resets to the declared ref, or fast-forwards the current branch to its upstream when no ref is declared.
- POSIX single-quote escaping for all interpolated paths/URLs.

**Runner doctor drift checks — `src/commands/runner/doctor.rs` (#4140)**
- `managed_runner_source_checks`: for each declared source, **error** if it is missing as a git checkout, **warning** if it tracks a different remote than declared, otherwise OK (with `path` / `origin_remote` / `head` details).
- `AgentTaskProviderEnvPathReadiness.canonical_path`: when an extension pins a canonical managed root, doctor **warns** if the env-resolved tool path resolves *outside* that root (segment-aware containment so `/a/sour` is not a child of `/a/source`).

## Architecture guarantee

Homeboy core stays **codebox/WordPress-agnostic**. No `codebox` / `wordpress` / `wp-` literals in core — there is even a `script_is_runtime_agnostic_no_codebox_literals` test asserting this. All concrete paths/remotes/refs are supplied by the declaring extension via the contract.

### What the WordPress extension must declare to use this

In its `AgentTaskExecutorProvider` manifest:

- `runner_sources: [ { id, label, path, remote_url?, git_ref?, remediation? } ]` — e.g. the wp-codebox source checkout under the runner's homeboy cache dir, its canonical remote URL, and the intended ref. Core will keep it synced and doctor will report drift.
- On the relevant `runner_readiness.env_path` entry, set `canonical_path` to the managed source root so doctor warns when an env var (e.g. a tool bin path) resolves to a stale checkout outside it.

## Tests

- `managed_source` module: 9 unit tests (clone+repoint, hard-reset-to-ref, ff-when-no-ref, missing-checkout-requires-remote, single-quote escaping, runtime-agnostic literal guard, batch skip-invalid, label defaulting).
- doctor: `provider_readiness_warns_on_non_canonical_checkout`, `provider_readiness_ok_when_path_within_canonical_root`, `path_within_canonical_root_is_segment_aware`.
- `cargo fmt --check` clean, `cargo clippy --lib` clean for the new code (no new warnings), all new tests green. Remaining full-suite failures are pre-existing environment-dependent tests (bench/trace/extension/deploy/npm) unrelated to this change.

Refs #3818, #4140