### PR TITLE
fix(runner): preserve job terminal status across daemon restarts

### DIFF
--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -596,42 +596,109 @@ fn reconcile_stale_jobs(durable: &mut DurableJobStore, event_retention_limit: us
         .unwrap_or(0);
 
     for stored in &mut durable.jobs {
-        if matches!(stored.job.status, JobStatus::Queued | JobStatus::Running)
-            && !(stored.remote_runner.is_some() && stored.job.status == JobStatus::Queued)
+        if !matches!(stored.job.status, JobStatus::Queued | JobStatus::Running) {
+            continue;
+        }
+        // Remote-runner jobs that are still Queued are waiting for a runner to
+        // claim them; a daemon restart does not invalidate that work, so leave
+        // them enqueued for re-claim.
+        if stored.remote_runner.is_some() && stored.job.status == JobStatus::Queued {
+            continue;
+        }
+
+        // Recover the real terminal status when the underlying command already
+        // recorded a terminal Result event before the daemon restarted. Without
+        // this, a job that actually succeeded (or that recorded its own
+        // non-zero exit code) is blindly reported as a daemon-restart failure,
+        // leaving the caller without the real result for in-flight work (#4770).
+        if let Some((recovered_status, exit_code)) = recovered_terminal_from_result(&stored.events)
         {
-            let reason = "daemon restarted before the job reached a terminal status".to_string();
-            stored.job.status = JobStatus::Failed;
+            stored.job.status = recovered_status;
             stored.job.updated_at_ms = now;
             stored.job.finished_at_ms = Some(now);
-            stored.job.stale_reason = Some(reason.clone());
+            stored.job.stale_reason = None;
 
-            next_sequence += 1;
-            stored.events.push(JobEvent {
-                sequence: next_sequence,
-                job_id: stored.job.id,
-                kind: JobEventKind::Error,
-                timestamp_ms: now,
-                message: Some(reason.clone()),
-                data: Some(serde_json::json!({ "reason": "stale_after_daemon_restart" })),
-            });
             next_sequence += 1;
             stored.events.push(JobEvent {
                 sequence: next_sequence,
                 job_id: stored.job.id,
                 kind: JobEventKind::Status,
                 timestamp_ms: now,
-                message: Some("job marked failed after daemon restart".to_string()),
+                message: Some(
+                    "job terminal status recovered from recorded result after daemon restart"
+                        .to_string(),
+                ),
                 data: Some(serde_json::json!({
-                    "status": JobStatus::Failed,
-                    "reason": "stale_after_daemon_restart"
+                    "status": recovered_status,
+                    "reason": "recovered_after_daemon_restart",
+                    "exit_code": exit_code,
                 })),
             });
             apply_event_retention(&mut stored.events, event_retention_limit);
             stored.job.event_count = stored.events.len();
+            continue;
         }
+
+        let reason = "daemon restarted before the job reached a terminal status".to_string();
+        stored.job.status = JobStatus::Failed;
+        stored.job.updated_at_ms = now;
+        stored.job.finished_at_ms = Some(now);
+        stored.job.stale_reason = Some(reason.clone());
+
+        next_sequence += 1;
+        stored.events.push(JobEvent {
+            sequence: next_sequence,
+            job_id: stored.job.id,
+            kind: JobEventKind::Error,
+            timestamp_ms: now,
+            message: Some(reason.clone()),
+            data: Some(serde_json::json!({ "reason": "stale_after_daemon_restart" })),
+        });
+        next_sequence += 1;
+        stored.events.push(JobEvent {
+            sequence: next_sequence,
+            job_id: stored.job.id,
+            kind: JobEventKind::Status,
+            timestamp_ms: now,
+            message: Some("job marked failed after daemon restart".to_string()),
+            data: Some(serde_json::json!({
+                "status": JobStatus::Failed,
+                "reason": "stale_after_daemon_restart"
+            })),
+        });
+        apply_event_retention(&mut stored.events, event_retention_limit);
+        stored.job.event_count = stored.events.len();
     }
 
     next_sequence
+}
+
+/// Recover a terminal job status from a recorded `Result` event when a job was
+/// left non-terminal by a daemon restart. The daemon worker records the command
+/// result (including its `exit_code`) before transitioning the job to its
+/// terminal status; if the restart lands in that window the stored result is the
+/// authoritative outcome. Returns the recovered status and the exit code that
+/// justified it, or `None` when no terminal result was recorded.
+fn recovered_terminal_from_result(events: &[JobEvent]) -> Option<(JobStatus, i64)> {
+    let result = events
+        .iter()
+        .rev()
+        .find(|event| event.kind == JobEventKind::Result)?;
+    let data = result.data.as_ref()?;
+    // A recorded cancellation outcome is honored as Cancelled regardless of exit code.
+    if data.get("status").and_then(Value::as_str) == Some("cancelled") {
+        return Some((
+            JobStatus::Cancelled,
+            data.get("exit_code").and_then(Value::as_i64).unwrap_or(0),
+        ));
+    }
+    let exit_code = data.get("exit_code").and_then(Value::as_i64)?;
+    let status = if exit_code == 0 {
+        JobStatus::Succeeded
+    } else {
+        JobStatus::Failed
+    };
+    Some((status, exit_code))
 }
 
 fn apply_event_retention(events: &mut Vec<JobEvent>, limit: usize) {
@@ -1117,6 +1184,148 @@ mod tests {
                     .as_ref()
                     .is_some_and(|data| data["reason"] == json!("stale_after_daemon_restart"))
         }));
+    }
+
+    #[test]
+    fn durable_store_recovers_succeeded_job_from_result_event_after_restart() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open(&path).expect("durable store opens");
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("job starts");
+        // Simulate the daemon worker recording its terminal result *before* the
+        // status transition, then the daemon process dying in that window.
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Result,
+                None,
+                Some(json!({ "exit_code": 0, "stdout": "ok" })),
+            )
+            .expect("result event records");
+
+        let reopened = JobStore::open(&path).expect("durable store reopens");
+        let recovered = reopened.get(job.id).expect("job persists");
+        assert_eq!(
+            recovered.status,
+            JobStatus::Succeeded,
+            "a job with a successful recorded result must not be reported as a daemon-restart failure"
+        );
+        assert!(recovered.stale_reason.is_none());
+        assert!(recovered.finished_at_ms.is_some());
+
+        let events = reopened.events(job.id).expect("events persist");
+        assert!(events.iter().any(|event| {
+            event.kind == JobEventKind::Status
+                && event
+                    .data
+                    .as_ref()
+                    .is_some_and(|data| data["reason"] == json!("recovered_after_daemon_restart"))
+        }));
+    }
+
+    #[test]
+    fn durable_store_recovers_failed_job_from_nonzero_result_after_restart() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open(&path).expect("durable store opens");
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("job starts");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Result,
+                None,
+                Some(json!({ "exit_code": 2, "stderr": "boom" })),
+            )
+            .expect("result event records");
+
+        let reopened = JobStore::open(&path).expect("durable store reopens");
+        let recovered = reopened.get(job.id).expect("job persists");
+        assert_eq!(recovered.status, JobStatus::Failed);
+        // Recovered (real) failure must not be mislabeled as a daemon-restart stale failure.
+        assert!(recovered.stale_reason.is_none());
+
+        let events = reopened.events(job.id).expect("events persist");
+        assert!(events.iter().any(|event| {
+            event.kind == JobEventKind::Status
+                && event.data.as_ref().is_some_and(|data| {
+                    data["reason"] == json!("recovered_after_daemon_restart")
+                        && data["exit_code"] == json!(2)
+                })
+        }));
+        // It must NOT carry the synthetic stale-after-restart error event.
+        assert!(!events.iter().any(|event| {
+            event
+                .data
+                .as_ref()
+                .is_some_and(|data| data["reason"] == json!("stale_after_daemon_restart"))
+        }));
+    }
+
+    #[test]
+    fn durable_store_recovers_cancelled_job_from_result_after_restart() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("jobs.json");
+        let store = JobStore::open(&path).expect("durable store opens");
+        let job = store.create("runner.exec");
+        store.start(job.id).expect("job starts");
+        store
+            .append_event(
+                job.id,
+                JobEventKind::Result,
+                None,
+                Some(json!({ "exit_code": 130, "status": "cancelled" })),
+            )
+            .expect("result event records");
+
+        let reopened = JobStore::open(&path).expect("durable store reopens");
+        let recovered = reopened.get(job.id).expect("job persists");
+        assert_eq!(recovered.status, JobStatus::Cancelled);
+        assert!(recovered.stale_reason.is_none());
+    }
+
+    #[test]
+    fn recovered_terminal_from_result_handles_missing_and_present_results() {
+        // No result event -> None (falls through to stale failure).
+        assert!(recovered_terminal_from_result(&[]).is_none());
+
+        let zero = vec![JobEvent {
+            sequence: 1,
+            job_id: Uuid::new_v4(),
+            kind: JobEventKind::Result,
+            timestamp_ms: 0,
+            message: None,
+            data: Some(json!({ "exit_code": 0 })),
+        }];
+        assert_eq!(
+            recovered_terminal_from_result(&zero),
+            Some((JobStatus::Succeeded, 0))
+        );
+
+        let nonzero = vec![JobEvent {
+            sequence: 1,
+            job_id: Uuid::new_v4(),
+            kind: JobEventKind::Result,
+            timestamp_ms: 0,
+            message: None,
+            data: Some(json!({ "exit_code": 7 })),
+        }];
+        assert_eq!(
+            recovered_terminal_from_result(&nonzero),
+            Some((JobStatus::Failed, 7))
+        );
+
+        // Result event without an exit_code is not authoritative -> None.
+        let no_code = vec![JobEvent {
+            sequence: 1,
+            job_id: Uuid::new_v4(),
+            kind: JobEventKind::Result,
+            timestamp_ms: 0,
+            message: None,
+            data: Some(json!({ "stdout": "partial" })),
+        }];
+        assert!(recovered_terminal_from_result(&no_code).is_none());
     }
 
     #[test]

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -399,7 +399,9 @@ fn exec_via_reverse_broker(
             ));
         }
         std::thread::sleep(Duration::from_millis(200));
-        job = fetch_daemon_job(&client, broker_url, &job.id.to_string())?;
+        let job_id = job.id.to_string();
+        job = fetch_daemon_job_resilient(&client, broker_url, &job_id)
+            .map_err(|err| daemon_job_context_error(&runner.id, &job_id, err))?;
     }
     let events = redact_runner_job_events(
         &fetch_daemon_events(&client, broker_url, &job.id.to_string())?,
@@ -496,21 +498,20 @@ fn exec_via_daemon(
             "require_paths": require_paths.clone(),
         }))
         .send()
-        .map_err(|err| {
-            Error::internal_unexpected(format!("submit runner daemon exec job: {err}"))
-        })?;
+        .map_err(|err| daemon_exec_transport_error(&runner.id, err))?;
     let status_code = response.status().as_u16();
     let envelope: DaemonEnvelope = response.json().map_err(|err| {
-        Error::internal_json(
-            err.to_string(),
-            Some("parse daemon exec response".to_string()),
-        )
+        // A stale/restarting daemon can answer the tunnel with a non-JSON or
+        // empty body. Surface a clear, actionable error instead of a bare parse
+        // failure so the caller knows to reconnect (#3631, #3624).
+        daemon_exec_stale_response_error(&runner.id, status_code, &err.to_string())
     })?;
     if status_code >= 400 || !envelope.success {
-        return Err(Error::internal_unexpected(format!(
-            "daemon exec request failed: {}",
-            daemon_failure_message(status_code, &envelope)
-        )));
+        return Err(daemon_exec_request_failed_error(
+            &runner.id,
+            status_code,
+            &envelope,
+        ));
     }
 
     let data = envelope
@@ -545,7 +546,7 @@ fn exec_via_daemon(
         }
         std::thread::sleep(Duration::from_millis(200));
         let job_id = job.id.to_string();
-        job = fetch_daemon_job(&client, local_url, &job_id)
+        job = fetch_daemon_job_resilient(&client, local_url, &job_id)
             .map_err(|err| daemon_job_context_error(&runner.id, &job_id, err))?;
     }
     let job_id = job.id.to_string();
@@ -634,6 +635,42 @@ fn fetch_daemon_job(client: &Client, local_url: &str, job_id: &str) -> Result<Jo
     let body = canonical_daemon_body(&data, "daemon job response")?;
     serde_json::from_value(body["job"].clone())
         .map_err(|err| Error::internal_json(err.to_string(), Some("parse daemon job".to_string())))
+}
+
+/// Grace window during which a transient daemon polling failure (connection
+/// refused while the daemon restarts, a stale tunnel returning `null`, etc.) is
+/// retried instead of aborting the wait. A daemon-managed exec job persists its
+/// status across restarts, so a brief reconnection gap should not cost the
+/// caller the real terminal result of in-flight work (#4770, #3631, #3624).
+const DAEMON_POLL_TRANSIENT_GRACE: Duration = Duration::from_secs(30);
+const DAEMON_POLL_RETRY_BACKOFF: Duration = Duration::from_millis(500);
+
+/// Poll a daemon job, tolerating transient failures within the grace window.
+///
+/// The job store is durable across daemon restarts, so a connection error or a
+/// `null` envelope during the restart window is recoverable: the daemon comes
+/// back and serves the persisted (and possibly already-terminal) job. Only after
+/// the grace window elapses without a successful read do we surface the error,
+/// and we annotate it so the caller knows the remote job may still be in flight
+/// rather than reporting a misleading hard failure.
+fn fetch_daemon_job_resilient(client: &Client, local_url: &str, job_id: &str) -> Result<Job> {
+    let transient_deadline = Instant::now() + DAEMON_POLL_TRANSIENT_GRACE;
+    loop {
+        match fetch_daemon_job(client, local_url, job_id) {
+            Ok(job) => return Ok(job),
+            Err(err) => {
+                if Instant::now() >= transient_deadline {
+                    let mut surfaced = err;
+                    surfaced.retryable = surfaced.retryable.or(Some(true));
+                    return Err(surfaced.with_hint(format!(
+                        "Lost contact with the runner daemon while polling job `{job_id}` for longer than {}s; the remote job may still be in flight. Reconnect with `homeboy runner connect <runner-id>` and inspect `homeboy runner job logs <runner-id> {job_id}`.",
+                        DAEMON_POLL_TRANSIENT_GRACE.as_secs()
+                    )));
+                }
+                std::thread::sleep(DAEMON_POLL_RETRY_BACKOFF);
+            }
+        }
+    }
 }
 
 fn fetch_daemon_events(client: &Client, local_url: &str, job_id: &str) -> Result<Vec<JobEvent>> {
@@ -1668,24 +1705,76 @@ fn homeboy_error_from_envelope(value: &Value) -> Option<Value> {
     Some(json!({ "message": error }))
 }
 
-fn daemon_failure_message(status_code: u16, envelope: &DaemonEnvelope) -> String {
+/// Returns the structured failure detail for a daemon exec response, or `None`
+/// when the daemon answered without any usable error/data payload (the classic
+/// stale-or-restarting daemon signature behind the historical
+/// `daemon exec request failed: null` symptom in #3631 / #3624).
+fn daemon_failure_payload_message(envelope: &DaemonEnvelope) -> Option<String> {
     let payload = envelope
         .error
         .as_ref()
         .or(envelope.data.as_ref())
-        .filter(|value| !value.is_null());
-    let Some(payload) = payload else {
-        return format!("HTTP {status_code} without error payload");
-    };
+        .filter(|value| !value.is_null())?;
 
     let code = payload.get("error").and_then(Value::as_str);
     let message = payload.get("message").and_then(Value::as_str);
-    match (code, message) {
+    Some(match (code, message) {
         (Some(code), Some(message)) => format!("{code}: {message}"),
         (Some(code), None) => code.to_string(),
         (None, Some(message)) => message.to_string(),
         (None, None) => payload.to_string(),
+    })
+}
+
+/// Build the controller-facing error for a daemon exec submission that came back
+/// with a failure envelope. When the daemon returned no usable error payload we
+/// treat it as a stale/restarting daemon and surface reconnect guidance instead
+/// of the historical opaque `null` (#3631, #3624).
+fn daemon_exec_request_failed_error(
+    runner_id: &str,
+    status_code: u16,
+    envelope: &DaemonEnvelope,
+) -> Error {
+    match daemon_failure_payload_message(envelope) {
+        Some(detail) => Error::internal_unexpected(format!(
+            "daemon exec request failed: {detail}"
+        ))
+        .with_hint(format!(
+            "Runner `{runner_id}` daemon rejected the exec request (HTTP {status_code})."
+        )),
+        None => Error::internal_unexpected(format!(
+            "runner `{runner_id}` daemon returned no result for the exec request (HTTP {status_code} with an empty error payload); the daemon is likely stale or was restarted"
+        ))
+        .with_hint(format!(
+            "Reconnect the runner with `homeboy runner disconnect {runner_id} && homeboy runner connect {runner_id}`, then retry. If it persists, kill any stale daemon with `homeboy runner doctor {runner_id}`."
+        ))
+        .with_hint(
+            "A daemon that reports SSH-healthy can still serve a stale process; reconnecting rebinds the tunnel to the live daemon.".to_string(),
+        ),
     }
+}
+
+/// The exec POST itself failed at the transport layer (connection refused /
+/// reset while the daemon restarts, tunnel torn down, etc.). Surface a clear
+/// reconnect path rather than a bare reqwest error string (#3631, #3624).
+fn daemon_exec_transport_error(runner_id: &str, err: reqwest::Error) -> Error {
+    Error::internal_unexpected(format!(
+        "could not reach runner `{runner_id}` daemon to submit the exec request: {err}"
+    ))
+    .with_hint(format!(
+        "The daemon tunnel may be stale or the daemon may have restarted. Reconnect with `homeboy runner disconnect {runner_id} && homeboy runner connect {runner_id}` and retry."
+    ))
+}
+
+/// The exec response body could not be parsed as a daemon envelope — typically a
+/// stale daemon answering with an empty or non-JSON body (#3631, #3624).
+fn daemon_exec_stale_response_error(runner_id: &str, status_code: u16, parse_err: &str) -> Error {
+    Error::internal_unexpected(format!(
+        "runner `{runner_id}` daemon returned an unreadable exec response (HTTP {status_code}): {parse_err}; the daemon is likely stale or was restarted mid-request"
+    ))
+    .with_hint(format!(
+        "Reconnect with `homeboy runner disconnect {runner_id} && homeboy runner connect {runner_id}` and retry; if a stale daemon PID lingers, run `homeboy runner doctor {runner_id}`."
+    ))
 }
 
 #[cfg(test)]
@@ -3114,5 +3203,91 @@ mod tests {
         assert!(err.message.contains("validation.invalid_argument"));
         assert!(err.message.contains("runner exec requires an absolute cwd"));
         assert!(!err.message.contains(": null"));
+    }
+
+    #[test]
+    fn daemon_exec_request_failed_error_surfaces_payload_detail() {
+        let envelope = DaemonEnvelope {
+            success: false,
+            data: Some(serde_json::json!({
+                "error": "validation.invalid_argument",
+                "message": "bad cwd"
+            })),
+            error: None,
+        };
+        let err = daemon_exec_request_failed_error("lab", 400, &envelope);
+        assert!(err.message.contains("daemon exec request failed"));
+        assert!(err.message.contains("validation.invalid_argument"));
+        assert!(err.message.contains("bad cwd"));
+        assert!(!err.message.contains("null"));
+    }
+
+    #[test]
+    fn daemon_exec_request_failed_error_handles_null_payload_with_reconnect_hint() {
+        // The historical #3631/#3624 symptom: a stale/restarting daemon answers
+        // with an empty/null error payload. We must never surface a bare `null`,
+        // and we must point the operator at reconnecting.
+        let envelope = DaemonEnvelope {
+            success: false,
+            data: None,
+            error: Some(Value::Null),
+        };
+        let err = daemon_exec_request_failed_error("lab", 502, &envelope);
+        assert!(!err.message.contains("null"));
+        assert!(err.message.contains("stale") || err.message.contains("restarted"));
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("homeboy runner connect lab")));
+    }
+
+    #[test]
+    fn daemon_exec_stale_response_error_is_actionable() {
+        let err = daemon_exec_stale_response_error("lab", 200, "expected value at line 1 column 1");
+        assert!(err.message.contains("unreadable exec response"));
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("homeboy runner connect lab")));
+    }
+
+    #[test]
+    fn daemon_exec_empty_envelope_over_http_is_actionable_not_null() {
+        // A stale daemon that answers `{"success": false}` with no error/data.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let addr = listener.local_addr().expect("addr");
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut buffer = [0; 4096];
+            let _ = std::io::Read::read(&mut stream, &mut buffer).expect("read request");
+            let body = serde_json::json!({ "success": false }).to_string();
+            let response = format!(
+                "HTTP/1.1 502 Bad Gateway\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            std::io::Write::write_all(&mut stream, response.as_bytes()).expect("write response");
+        });
+
+        let err = exec_via_daemon(
+            &ssh_runner(),
+            &format!("http://{addr}"),
+            "/srv/homeboy/project".to_string(),
+            None,
+            vec!["homeboy".to_string(), "--version".to_string()],
+            Default::default(),
+            Vec::new(),
+            false,
+            None,
+            Vec::new(),
+        )
+        .expect_err("daemon exec failure");
+
+        assert!(!err.message.contains(": null"));
+        assert!(err.message.contains("no result") || err.message.contains("stale"));
+        assert!(err
+            .hints
+            .iter()
+            .any(|hint| hint.message.contains("homeboy runner connect")));
     }
 }


### PR DESCRIPTION
## Summary

A daemon restart in the window between the worker recording a command's result and transitioning the job to a terminal state caused the reconciler to blindly mark any `Queued`/`Running` job as `Failed`, discarding the real outcome. Daemon exec failures during that window also surfaced an opaque `daemon exec request failed: null`.

This fixes:
- **#4770** — daemon restart no longer loses in-flight job terminal status
- **#3631** — null-failure handling after restart (no more bare `null`)
- **#3624** — daemon exec during bench offload now degrades gracefully

## Changes

**`src/core/api_jobs.rs`**
- `reconcile_stale_jobs` now recovers the authoritative terminal status (`Succeeded`/`Failed`/`Cancelled`) from a recorded `Result` event (`exit_code` / `status`) instead of unconditionally marking the job `Failed`.
- New `recovered_terminal_from_result` helper: honors a recorded cancellation, maps `exit_code == 0` → `Succeeded`, non-zero → `Failed`, and returns `None` (falling back to the synthetic stale-after-restart failure) only when no authoritative result exists.
- Recovered jobs clear `stale_reason` and emit a `recovered_after_daemon_restart` status event; they do **not** carry the synthetic `stale_after_daemon_restart` error event.

**`src/core/runner/execution.rs`**
- `fetch_daemon_job_resilient`: polling tolerates transient connection/`null` failures within a 30s grace window (500ms backoff) since the job store is durable across restarts; only after the window does it surface a retryable error annotated with reconnect guidance.
- Daemon exec submission/response/failure paths now produce actionable reconnect hints (`homeboy runner connect …`, `homeboy runner doctor …`) instead of a bare `null` — fixing the historical `daemon exec request failed: null` symptom.

## Tests

8 new tests, all passing:
- `durable_store_recovers_succeeded_job_from_result_event_after_restart`
- `durable_store_recovers_failed_job_from_nonzero_result_after_restart`
- `durable_store_recovers_cancelled_job_from_result_after_restart`
- `recovered_terminal_from_result_handles_missing_and_present_results`
- `daemon_exec_request_failed_error_surfaces_payload_detail`
- `daemon_exec_request_failed_error_handles_null_payload_with_reconnect_hint`
- `daemon_exec_stale_response_error_is_actionable`
- `daemon_exec_empty_envelope_over_http_is_actionable_not_null` (real TCP listener serving a stale `{"success": false}` envelope)

`cargo fmt --check`, `cargo clippy --lib` (no new warnings in changed code), and the `api_jobs::` + `core::runner::execution::tests` modules are green locally.

Refs #4770, #3631, #3624