### PR TITLE
fix(lab): materialize rig component paths on the runner for offload (#3766, #3767, #3765)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,14 @@ All notable changes to Homeboy CLI are documented in this file.
 
 (This file is embedded into the CLI binary and is also viewable via `homeboy changelog`.)
 
+## Unreleased
+
+### Fixed
+- resolve rig component paths to the runner-side materialized checkout during Lab offload so remote `${components.<id>.path}` checks no longer fail against the controller path (#3766)
+- expand portable `~`/`~/...` rig dependency checkout roots to an absolute runner home path so the materialized remote path is never a literal `~` directory (#3767)
+- snapshot a dirty/untracked Lab rig dependency working tree as an explicit overlay under `--allow-dirty-lab-workspace` instead of refusing it, with dirty-vs-clean provenance recorded in workspace metadata (#3765)
+- surface declared-vs-resolved paths and actionable hints on remote rig check-file failures so unexpanded component-path tokens and unresolved `~` are diagnosable
+
 ## [0.233.0] - 2026-06-16
 
 ### Added

--- a/src/core/rig/check.rs
+++ b/src/core/rig/check.rs
@@ -137,9 +137,9 @@ fn file_check(rig: &RigSpec, path: &str, contains: Option<&str>) -> Result<()> {
     if !p.exists() {
         return Err(Error::validation_invalid_argument(
             "check.file",
-            format!("File does not exist: {}", resolved),
-            None,
-            None,
+            file_check_missing_message("File does not exist", path, &resolved),
+            Some(resolved.clone()),
+            file_check_path_hints(path, &resolved),
         ));
     }
 
@@ -167,6 +167,39 @@ fn file_check(rig: &RigSpec, path: &str, contains: Option<&str>) -> Result<()> {
     Ok(())
 }
 
+/// Build a check-file failure message that surfaces both the declared path
+/// (e.g. `${components.<id>.path}/...`) and the resolved filesystem path, so a
+/// remote rig check failure is diagnosable without guessing how it expanded.
+fn file_check_missing_message(prefix: &str, declared: &str, resolved: &str) -> String {
+    if declared == resolved {
+        format!("{prefix}: {resolved}")
+    } else {
+        format!("{prefix}: {resolved} (declared: {declared})")
+    }
+}
+
+/// Hints for a missing check-file, calling out unexpanded component-path tokens
+/// or a literal `~` that did not resolve against the runner home.
+fn file_check_path_hints(declared: &str, resolved: &str) -> Option<Vec<String>> {
+    let mut hints = Vec::new();
+    if declared != resolved {
+        hints.push(format!(
+            "Declared path `{declared}` resolved to `{resolved}`."
+        ));
+    }
+    if resolved.contains("${components.") {
+        hints.push(
+            "An unresolved `${components.<id>.path}` token means the rig component is not declared or not materialized; ensure the component is part of the rig and synced to the runner.".to_string(),
+        );
+    }
+    if resolved.contains("/~/") || resolved.starts_with("~/") || resolved == "~" {
+        hints.push(
+            "A literal `~` in the resolved path did not expand to a home directory; declare an absolute path or rely on Lab offload runner-path resolution.".to_string(),
+        );
+    }
+    (!hints.is_empty()).then_some(hints)
+}
+
 fn any_file_exists_check(rig: &RigSpec, paths: &[String]) -> Result<()> {
     let resolved = paths
         .iter()
@@ -177,9 +210,24 @@ fn any_file_exists_check(rig: &RigSpec, paths: &[String]) -> Result<()> {
         return Ok(());
     }
 
+    let declared_vs_resolved = paths
+        .iter()
+        .zip(resolved.iter())
+        .map(|(declared, resolved)| {
+            if declared == resolved {
+                resolved.clone()
+            } else {
+                format!("{resolved} (declared: {declared})")
+            }
+        })
+        .collect::<Vec<_>>();
+
     Err(Error::validation_invalid_argument(
         "check.any_file_exists",
-        format!("None of the candidate files exist: {}", resolved.join(", ")),
+        format!(
+            "None of the candidate files exist: {}",
+            declared_vs_resolved.join(", ")
+        ),
         None,
         None,
     ))

--- a/src/core/rig/expand.rs
+++ b/src/core/rig/expand.rs
@@ -107,6 +107,15 @@ fn resolve_token(rig: &RigSpec, token: &str) -> Option<String> {
             return None;
         }
         let component = rig.components.get(id)?;
+        // A caller may pin a component to an effective filesystem path via a
+        // generic per-component override env var. Lab offload uses this to point
+        // `${components.<id>.path}` at the runner-side materialized checkout
+        // instead of the controller path the rig spec declares. This is generic:
+        // it works for any rig/component and is a no-op when the override is
+        // unset, so local checks keep their declared-path behavior.
+        if let Some(override_path) = component_path_override_from_env(&rig.id, id) {
+            return Some(override_path);
+        }
         let expanded = expand::expand_with_tilde(&component.path, |token| match token {
             "package.root" => resolve_token(rig, token),
             token if token.starts_with("env.") => resolve_token(rig, token),
@@ -118,6 +127,49 @@ fn resolve_token(rig: &RigSpec, token: &str) -> Option<String> {
         return Some(std::env::var(name).unwrap_or_default());
     }
     None
+}
+
+/// Read a per-component effective-path override from the environment.
+///
+/// The override env var name is derived generically from the rig and component
+/// ids (see [`rig_component_path_override_env_name`]). When present and
+/// non-empty, it pins `${components.<id>.path}` to that filesystem path. Tilde
+/// is expanded against the local home of the process reading it (the runner,
+/// when the check executes on the runner), so a portable value still resolves.
+fn component_path_override_from_env(rig_id: &str, component_id: &str) -> Option<String> {
+    let name = rig_component_path_override_env_name(rig_id, component_id);
+    let value = std::env::var(name).ok()?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(expand::expand_with_tilde(trimmed, |_| None))
+}
+
+/// Build the generic override env var name for a rig component's effective path.
+///
+/// Non-alphanumeric characters in the rig/component ids are normalized to `_`
+/// and uppercased so the name is a valid shell identifier. Example:
+/// rig `studio-web`, component `studio` -> `HOMEBOY_RIG_COMPONENT_PATH__STUDIO_WEB__STUDIO`.
+pub fn rig_component_path_override_env_name(rig_id: &str, component_id: &str) -> String {
+    format!(
+        "HOMEBOY_RIG_COMPONENT_PATH__{}__{}",
+        sanitize_env_segment(rig_id),
+        sanitize_env_segment(component_id),
+    )
+}
+
+fn sanitize_env_segment(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/core/runner/git_dependency_materialization.rs
+++ b/src/core/runner/git_dependency_materialization.rs
@@ -35,6 +35,10 @@ pub(crate) struct RunnerGitDependencyMaterializationOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required_subpath: Option<String>,
     pub used_pinned_ref: bool,
+    /// True when the snapshot includes dirty tracked and/or untracked working
+    /// tree changes (explicit `--allow-dirty-lab-workspace` overlay) rather than
+    /// a clean checkout at HEAD. Makes bench artifact provenance explicit.
+    pub dirty_overlay: bool,
     pub sync_mode: RunnerWorkspaceSyncMode,
     pub files: usize,
     pub bytes: u64,
@@ -47,6 +51,10 @@ pub(crate) struct RunnerGitDependencyMaterializationOptions {
     pub remote_url: Option<String>,
     pub required_subpath: Option<String>,
     pub pinned_ref: Option<String>,
+    /// When true, a dirty/untracked working tree is snapshotted as-is (overlay)
+    /// instead of being refused. The snapshot already tars the working tree, so
+    /// the dirty overlay travels to the runner. Defaults to false (clean-HEAD).
+    pub allow_dirty: bool,
 }
 
 pub(crate) fn materialize_git_dependency(
@@ -74,7 +82,12 @@ pub(crate) fn materialize_git_dependency(
         Some(remote_url) if !remote_url.trim().is_empty() => remote_url,
         _ => git_output(&local_path, &["config", "--get", "remote.origin.url"]).unwrap_or_default(),
     };
-    let freshness = ensure_git_dependency_fresh(&local_path, options.pinned_ref.as_deref())?;
+    let freshness = ensure_git_dependency_fresh(
+        &local_path,
+        options.pinned_ref.as_deref(),
+        options.allow_dirty,
+    )?;
+    let dirty_overlay = freshness.status == DependencyUpdateStatus::DirtyOverlayAllowed;
     let mut excludes = DEFAULT_EXCLUDES
         .iter()
         .map(|value| value.to_string())
@@ -103,6 +116,7 @@ pub(crate) fn materialize_git_dependency(
         pinned_ref: freshness.pinned_ref,
         required_subpath: options.required_subpath,
         used_pinned_ref: freshness.used_pinned_ref,
+        dirty_overlay,
         sync_mode: RunnerWorkspaceSyncMode::Snapshot,
         files: stats.files,
         bytes: stats.bytes,
@@ -113,6 +127,7 @@ pub(crate) fn materialize_git_dependency(
 enum DependencyUpdateStatus {
     NotGit,
     DirtyNotUpdated,
+    DirtyOverlayAllowed,
     NoUpstream,
     DetachedUnpinned,
     UpToDate,
@@ -128,6 +143,7 @@ impl DependencyUpdateStatus {
         match self {
             Self::NotGit => "snapshotted",
             Self::DirtyNotUpdated => "dirty_not_updated",
+            Self::DirtyOverlayAllowed => "snapshotted_dirty_overlay",
             Self::NoUpstream => "no_upstream",
             Self::DetachedUnpinned => "detached_unpinned",
             Self::UpToDate => "snapshotted_up_to_date",
@@ -166,6 +182,7 @@ struct DependencyFreshness {
 fn ensure_git_dependency_fresh(
     local_path: &Path,
     pinned_ref: Option<&str>,
+    allow_dirty: bool,
 ) -> Result<DependencyFreshness> {
     if !local_path.join(".git").exists() {
         return Ok(DependencyFreshness {
@@ -247,6 +264,23 @@ fn ensure_git_dependency_fresh(
     let upstream_head = git_output(local_path, &["rev-parse", "@{u}"]).ok();
     let status = git_output(local_path, &["status", "--porcelain=v1"])?;
     if !status.trim().is_empty() {
+        // A dirty working tree (tracked changes and/or untracked files) is
+        // refused by default so bench results are reproducible from clean git.
+        // With an explicit override the dirty working tree is snapshotted as an
+        // overlay: `materialize_snapshot` tars the working directory, so the
+        // dirty files travel to the runner verbatim.
+        if allow_dirty {
+            return Ok(DependencyFreshness {
+                status: DependencyUpdateStatus::DirtyOverlayAllowed,
+                branch,
+                before_sha: Some(before.clone()),
+                after_sha: Some(before),
+                upstream_sha: upstream_head,
+                upstream: Some(upstream),
+                pinned_ref: None,
+                used_pinned_ref: false,
+            });
+        }
         let freshness = DependencyFreshness {
             status: DependencyUpdateStatus::DirtyNotUpdated,
             branch,
@@ -334,6 +368,14 @@ fn terminal_dependency_error(
         "Update, rebase, or clean the dependency checkout before rerunning the Lab proof.".to_string(),
         "Use an explicit pinned ref in the rig/component dependency only when the stale checkout is intentional.".to_string(),
     ];
+    if freshness.status == DependencyUpdateStatus::DirtyNotUpdated {
+        hints.push(
+            "Pass --allow-dirty-lab-workspace to snapshot the dirty working tree (tracked changes and untracked files) as an explicit overlay.".to_string(),
+        );
+        hints.push(
+            "Or make the dirty checkout the primary bench workspace with --path so its working tree is snapshotted directly instead of as a clean git-only rig dependency.".to_string(),
+        );
+    }
     if let Some(error) = &source_error {
         hints.push(format!("Fetch failure: {}", error.message));
     }
@@ -407,7 +449,8 @@ mod tests {
         fixture.push();
         let expected = fixture.head();
 
-        let freshness = ensure_git_dependency_fresh(checkout.path(), None).expect("auto update");
+        let freshness =
+            ensure_git_dependency_fresh(checkout.path(), None, false).expect("auto update");
 
         assert_eq!(freshness.status, DependencyUpdateStatus::FastForwarded);
         assert_ne!(before, expected);
@@ -432,7 +475,8 @@ mod tests {
         fixture.commit_file("next.txt", "next");
         fixture.push();
 
-        let err = ensure_git_dependency_fresh(checkout.path(), None).expect_err("dirty fails");
+        let err =
+            ensure_git_dependency_fresh(checkout.path(), None, false).expect_err("dirty fails");
 
         assert!(err.message.contains("dirty_not_updated"));
         assert_eq!(git_output(checkout.path(), &["rev-parse", "HEAD"]), before);
@@ -448,7 +492,8 @@ mod tests {
         let head = git_output(checkout.path(), &["rev-parse", "HEAD"]);
         run_git(checkout.path(), &["checkout", "--detach", &head]);
 
-        let err = ensure_git_dependency_fresh(checkout.path(), None).expect_err("detached fails");
+        let err =
+            ensure_git_dependency_fresh(checkout.path(), None, false).expect_err("detached fails");
 
         assert!(err.message.contains("detached_unpinned"));
         assert_eq!(git_output(checkout.path(), &["rev-parse", "HEAD"]), head);
@@ -467,7 +512,8 @@ mod tests {
         run_git(repo.path(), &["add", "initial.txt"]);
         run_git(repo.path(), &["commit", "-m", "initial"]);
 
-        let err = ensure_git_dependency_fresh(repo.path(), None).expect_err("no upstream fails");
+        let err =
+            ensure_git_dependency_fresh(repo.path(), None, false).expect_err("no upstream fails");
 
         assert!(err.message.contains("no_upstream"));
     }
@@ -482,7 +528,8 @@ mod tests {
         let head = git_output(checkout.path(), &["rev-parse", "HEAD"]);
         run_git(checkout.path(), &["checkout", "--detach", &head]);
 
-        let freshness = ensure_git_dependency_fresh(checkout.path(), Some(&head)).expect("pinned");
+        let freshness =
+            ensure_git_dependency_fresh(checkout.path(), Some(&head), false).expect("pinned");
 
         assert_eq!(freshness.status, DependencyUpdateStatus::PinnedRef);
         assert!(freshness.used_pinned_ref);
@@ -509,7 +556,7 @@ mod tests {
         );
 
         let freshness =
-            ensure_git_dependency_fresh(checkout.path(), None).expect("cached fallback");
+            ensure_git_dependency_fresh(checkout.path(), None, false).expect("cached fallback");
 
         assert_eq!(
             freshness.status,
@@ -544,7 +591,8 @@ mod tests {
             ],
         );
 
-        let err = ensure_git_dependency_fresh(checkout.path(), None).expect_err("fetch fails");
+        let err =
+            ensure_git_dependency_fresh(checkout.path(), None, false).expect_err("fetch fails");
 
         assert_ne!(before, upstream);
         assert!(err.message.contains("fetch_failed_cached"));

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -1040,12 +1040,16 @@ fn run_lab_offload_inner(
         );
     }
 
-    let synced_rig_dependencies = rig_materialization::sync_lab_offload_rig_component_dependencies(
+    let rig_component_sync = rig_materialization::sync_lab_offload_rig_component_dependencies(
         runner_id,
         &changed_since_preflight.args,
         &synced.local_path,
         &remote_cwd,
+        runner.workspace_root.as_deref(),
+        request.allow_dirty_lab_workspace,
     )?;
+    let synced_rig_dependencies = rig_component_sync.materializations;
+    let rig_component_path_overrides = rig_component_sync.component_path_env;
     if !synced_rig_dependencies.is_empty() {
         for dependency in &synced_rig_dependencies {
             workspace_mapping.extend(workspace_mapping_entries_for_git_dependency(
@@ -1169,6 +1173,7 @@ fn run_lab_offload_inner(
     forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
     forward_release_ci_env(&mut env);
     let rig_component_path_env = forward_rig_component_path_env(&mut env, &workspace_mapping)?;
+    apply_rig_component_path_overrides(&mut env, &rig_component_path_overrides);
     let agent_task_secret_env =
         hydrate_agent_task_secret_env(&changed_since_preflight.args, &mut env)?;
     let trace_secret_env = hydrate_trace_secret_env(&changed_since_preflight.args, &mut env)?;
@@ -1177,6 +1182,8 @@ fn run_lab_offload_inner(
     lab_metadata["trace_secret_env"] = trace_secret_env;
     lab_metadata["tunnel_secret_env"] = tunnel_secret_env;
     lab_metadata["rig_component_path_env"] = rig_component_path_env;
+    lab_metadata["rig_component_path_overrides"] =
+        rig_component_path_overrides_metadata(&rig_component_path_overrides);
     lab_metadata["settings_env"] = settings_env_diagnostics(&remapped_args, &env);
     lab_metadata["runner_homeboy"] = runner_homeboy.clone();
     lab_metadata["source_checkout"] = source_checkout.clone();
@@ -1199,6 +1206,7 @@ fn run_lab_offload_inner(
     forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
     forward_release_ci_env(&mut env);
     forward_rig_component_path_env(&mut env, &workspace_mapping)?;
+    apply_rig_component_path_overrides(&mut env, &rig_component_path_overrides);
     hydrate_agent_task_secret_env(&changed_since_preflight.args, &mut env)?;
     hydrate_trace_secret_env(&changed_since_preflight.args, &mut env)?;
     hydrate_tunnel_secret_env(&changed_since_preflight.args, &mut env)?;
@@ -1391,6 +1399,39 @@ fn run_lab_offload_inner(
         stdout: exec_output.stdout,
         stderr,
         exit_code,
+    })
+}
+
+/// Insert generic `${components.<id>.path}` override env vars so a remote rig
+/// check resolves component paths to the runner-side materialized checkout
+/// instead of the controller path the rig spec declares (issue #3766/#3767).
+fn apply_rig_component_path_overrides(
+    env: &mut std::collections::HashMap<String, String>,
+    overrides: &[(String, String)],
+) {
+    for (name, value) in overrides {
+        if !value.trim().is_empty() {
+            env.insert(name.clone(), value.clone());
+        }
+    }
+}
+
+/// Build diagnostics describing each rig component path override forwarded to
+/// the runner, so bench artifacts show how `${components.<id>.path}` resolved.
+fn rig_component_path_overrides_metadata(overrides: &[(String, String)]) -> serde_json::Value {
+    let forwarded = overrides
+        .iter()
+        .map(|(name, runner_path)| {
+            serde_json::json!({
+                "env_name": name,
+                "runner_path": runner_path,
+                "forwarded_to_runner": true,
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::json!({
+        "schema": "homeboy/lab-offload-rig-component-path-override/v1",
+        "overrides": forwarded,
     })
 }
 

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -119,6 +119,12 @@ pub(super) fn workspace_mapping_entry_for_git_dependency(
             "status": dependency.status.as_str(),
             "pinned_ref": dependency.pinned_ref.as_deref(),
             "used_pinned_ref": dependency.used_pinned_ref,
+            "dirty_overlay": dependency.dirty_overlay,
+            "source_provenance": if dependency.dirty_overlay {
+                "dirty_snapshot"
+            } else {
+                "clean_git"
+            },
         })),
     }
 }
@@ -1405,6 +1411,7 @@ mod provider_config_candidate_paths_tests {
             pinned_ref: None,
             required_subpath: Some("packages/component".to_string()),
             used_pinned_ref: false,
+            dirty_overlay: false,
             sync_mode: RunnerWorkspaceSyncMode::Snapshot,
             files: 7,
             bytes: 42,

--- a/src/core/runner/rig_materialization.rs
+++ b/src/core/runner/rig_materialization.rs
@@ -342,24 +342,57 @@ fn has_path_arg(args: &[String]) -> bool {
     false
 }
 
+/// Result of materializing a rig's component dependencies on the runner.
+pub(super) struct LabOffloadRigComponentSync {
+    /// Per-dependency materialization outputs (remote paths, freshness, etc.).
+    pub materializations: Vec<RunnerGitDependencyMaterializationOutput>,
+    /// Generic `${components.<id>.path}` override env vars mapping each rig
+    /// component to its runner-side materialized path, so checks that execute
+    /// on the runner resolve component paths to the runner workspace instead of
+    /// the controller path the rig spec declares.
+    pub component_path_env: Vec<(String, String)>,
+}
+
 pub(super) fn sync_lab_offload_rig_component_dependencies(
     runner_id: &str,
     args: &[String],
     primary_local_path: &str,
     primary_remote_path: &str,
-) -> Result<Vec<RunnerGitDependencyMaterializationOutput>> {
+    runner_workspace_root: Option<&str>,
+    allow_dirty_lab_workspace: bool,
+) -> Result<LabOffloadRigComponentSync> {
     let dependencies = lab_offload_rig_component_dependencies(
         args,
         Some((primary_local_path, primary_remote_path)),
+        runner_workspace_root,
     )?;
     if dependencies.is_empty() {
-        return Ok(Vec::new());
+        return Ok(LabOffloadRigComponentSync {
+            materializations: Vec::new(),
+            component_path_env: Vec::new(),
+        });
     }
 
     let runner = load(runner_id)?;
     let mut synced = Vec::new();
+    let mut component_path_env = Vec::new();
     let mut seen = HashSet::new();
     for dependency in dependencies {
+        // Always record the runner-side effective component path so a remote
+        // rig check resolves `${components.<id>.path}` to the materialized path,
+        // even when the checkout root is the already-synced primary workspace
+        // (which is not re-materialized below).
+        component_path_env.push((
+            crate::core::rig::expand::rig_component_path_override_env_name(
+                &dependency.rig_id,
+                &dependency.component_id,
+            ),
+            remote_component_path(
+                &dependency.remote_checkout_root,
+                dependency.required_subpath.as_deref(),
+            ),
+        ));
+
         if !should_materialize_dependency(&dependency, primary_remote_path) {
             continue;
         }
@@ -374,11 +407,26 @@ pub(super) fn sync_lab_offload_rig_component_dependencies(
                 remote_url: dependency.remote_url,
                 required_subpath: dependency.required_subpath,
                 pinned_ref: dependency.pinned_ref,
+                allow_dirty: allow_dirty_lab_workspace,
             },
         )?);
     }
 
-    Ok(synced)
+    Ok(LabOffloadRigComponentSync {
+        materializations: synced,
+        component_path_env,
+    })
+}
+
+/// Join a runner-side checkout root with the component's required subpath.
+fn remote_component_path(remote_checkout_root: &str, required_subpath: Option<&str>) -> String {
+    match required_subpath.filter(|value| !value.trim().is_empty()) {
+        Some(subpath) => Path::new(remote_checkout_root)
+            .join(subpath)
+            .display()
+            .to_string(),
+        None => remote_checkout_root.to_string(),
+    }
 }
 
 pub(super) fn lab_offload_rig_component_checkout_root(args: &[String]) -> Result<Option<PathBuf>> {
@@ -417,6 +465,7 @@ pub(super) fn lab_offload_rig_component_checkout_root(args: &[String]) -> Result
 pub(super) fn lab_offload_rig_component_dependencies(
     args: &[String],
     primary_workspace: Option<(&str, &str)>,
+    runner_workspace_root: Option<&str>,
 ) -> Result<Vec<RigComponentDependency>> {
     let mut dependencies = Vec::new();
     let component_path_override = component_path_override(args);
@@ -475,6 +524,7 @@ pub(super) fn lab_offload_rig_component_dependencies(
                     &checkout_root,
                     &local_checkout_root,
                     primary_workspace,
+                    runner_workspace_root,
                 ),
                 local_checkout_root,
                 declared_checkout_root: checkout_root.to_string(),
@@ -524,6 +574,7 @@ fn remote_checkout_root_for_local(
     declared_checkout_root: &str,
     local_checkout_root: &str,
     primary_workspace: Option<(&str, &str)>,
+    runner_workspace_root: Option<&str>,
 ) -> String {
     let Some((primary_local_path, primary_remote_path)) = primary_workspace else {
         return local_checkout_root.to_string();
@@ -533,8 +584,14 @@ fn remote_checkout_root_for_local(
     {
         return primary_remote_path.to_string();
     }
-    if is_portable_runner_path(declared_checkout_root) {
-        return declared_checkout_root.to_string();
+    // A declared `~/...` checkout root is portable: it should land at the same
+    // home-relative location on the runner. Expand `~` against the runner home
+    // (derived from the runner workspace root) so the materialized remote path
+    // is a real absolute path instead of a literal `~` subdirectory.
+    if let Some(portable) =
+        expand_portable_runner_path(declared_checkout_root, runner_workspace_root)
+    {
+        return portable;
     }
     let name = Path::new(local_checkout_root)
         .file_name()
@@ -549,6 +606,63 @@ fn remote_checkout_root_for_local(
 
 fn is_portable_runner_path(path: &str) -> bool {
     path == "~" || path.starts_with("~/")
+}
+
+/// Resolve a portable `~`/`~/...` checkout root to an absolute runner path.
+///
+/// Returns `None` for non-portable paths so callers fall back to deriving a
+/// materialized `_lab_workspaces` path. When the runner home cannot be derived
+/// the portable tail is left unresolved (still `None`) so we never emit a
+/// literal `~` directory on the runner.
+fn expand_portable_runner_path(path: &str, runner_workspace_root: Option<&str>) -> Option<String> {
+    if !is_portable_runner_path(path) {
+        return None;
+    }
+    let runner_home = runner_home_from_workspace_root(runner_workspace_root?)?;
+    let tail = path.strip_prefix('~').unwrap_or(path);
+    let tail = tail.strip_prefix('/').unwrap_or(tail);
+    if tail.is_empty() {
+        return Some(runner_home);
+    }
+    Some(format!("{}/{}", runner_home.trim_end_matches('/'), tail))
+}
+
+/// Derive the runner home directory from the runner workspace root.
+///
+/// Runner workspace roots are absolute (validated elsewhere). The runner home
+/// is the deepest ancestor that looks like a user home root (`/home/<user>` or
+/// `/Users/<user>`), falling back to the workspace root's parent. This stays
+/// generic: it makes no assumption about any specific runtime or component.
+fn runner_home_from_workspace_root(workspace_root: &str) -> Option<String> {
+    let root = Path::new(workspace_root);
+    if !root.is_absolute() {
+        return None;
+    }
+    let mut components: Vec<&std::ffi::OsStr> = Vec::new();
+    for component in root.components() {
+        if let std::path::Component::Normal(value) = component {
+            components.push(value);
+        }
+    }
+    // Match the common `/home/<user>` and `/Users/<user>` home roots when the
+    // workspace root nests beneath them, so `~` resolves to the user home even
+    // when the workspace root is e.g. `/home/<user>/Developer`.
+    for marker in ["home", "Users"] {
+        if let Some(position) = components.iter().position(|value| {
+            value
+                .to_str()
+                .is_some_and(|value| value.eq_ignore_ascii_case(marker))
+        }) {
+            if position + 1 < components.len() {
+                let user = components[position + 1].to_str()?;
+                return Some(format!("/{}/{}", components[position].to_str()?, user));
+            }
+        }
+    }
+    // Fall back to the workspace root's parent directory.
+    root.parent()
+        .map(|parent| parent.display().to_string())
+        .filter(|parent| !parent.is_empty())
 }
 
 fn should_materialize_dependency(
@@ -751,6 +865,7 @@ mod tests {
                     "woocommerce-performance".to_string(),
                 ],
                 None,
+                None,
             )
             .expect("dependencies");
 
@@ -810,6 +925,7 @@ mod tests {
                     "--path".to_string(),
                     override_component.display().to_string(),
                 ],
+                None,
                 None,
             )
             .expect("dependencies");
@@ -927,6 +1043,7 @@ mod tests {
                     &checkout.display().to_string(),
                     "/home/chubes/Developer/_lab_workspaces/studio-web-snapshot",
                 )),
+                None,
             )
             .expect("dependencies");
 
@@ -1055,6 +1172,7 @@ mod tests {
                 "/Users/chubes/Developer/homeboy-rigs/Automattic/studio",
                 "/home/chubes/Developer/_lab_workspaces/studio-rigs-snapshot",
             )),
+            Some("/home/chubes/Developer"),
         );
 
         assert_eq!(
@@ -1065,7 +1183,10 @@ mod tests {
     }
 
     #[test]
-    fn preserves_portable_declared_rig_dependency_path_for_runner() {
+    fn portable_declared_rig_dependency_path_expands_to_runner_home() {
+        // Regression for #3767: a portable `~/...` declared checkout root must
+        // resolve to an absolute runner path (under the runner home derived from
+        // the workspace root), never a literal `~` subdirectory.
         let remote = remote_checkout_root_for_local(
             "~/Developer/studio@fix-many-sites-memory",
             "/Users/chubes/Developer/studio@fix-many-sites-memory",
@@ -1073,9 +1194,68 @@ mod tests {
                 "/Users/chubes/Developer/homeboy-rigs/Automattic/studio",
                 "/home/chubes/Developer/_lab_workspaces/studio-rigs-snapshot",
             )),
+            Some("/home/chubes/Developer"),
         );
 
-        assert_eq!(remote, "~/Developer/studio@fix-many-sites-memory");
+        assert_eq!(
+            remote,
+            "/home/chubes/Developer/studio@fix-many-sites-memory"
+        );
+        assert!(!remote.contains('~'));
+    }
+
+    #[test]
+    fn portable_rig_dependency_without_runner_home_falls_back_to_materialized_path() {
+        // When the runner home cannot be derived we must still avoid emitting a
+        // literal `~`; fall back to the materialized `_lab_workspaces` path.
+        let remote = remote_checkout_root_for_local(
+            "~/Developer/studio@fix-many-sites-memory",
+            "/Users/chubes/Developer/studio@fix-many-sites-memory",
+            Some((
+                "/Users/chubes/Developer/homeboy-rigs/Automattic/studio",
+                "/home/chubes/Developer/_lab_workspaces/studio-rigs-snapshot",
+            )),
+            None,
+        );
+
+        assert!(!remote.contains('~'));
+        assert_eq!(
+            remote,
+            "/home/chubes/Developer/_lab_workspaces/studio-fix-many-sites-memory"
+        );
+    }
+
+    #[test]
+    fn runner_home_resolves_from_nested_workspace_root() {
+        assert_eq!(
+            runner_home_from_workspace_root("/home/chubes/Developer"),
+            Some("/home/chubes".to_string())
+        );
+        assert_eq!(
+            runner_home_from_workspace_root("/Users/chubes/Developer/lab"),
+            Some("/Users/chubes".to_string())
+        );
+        // Workspace root that is itself a home falls back to its parent.
+        assert_eq!(
+            runner_home_from_workspace_root("/srv/homeboy"),
+            Some("/srv".to_string())
+        );
+    }
+
+    #[test]
+    fn expand_portable_runner_path_joins_tail_to_runner_home() {
+        assert_eq!(
+            expand_portable_runner_path("~/Developer/x", Some("/home/chubes/Developer")),
+            Some("/home/chubes/Developer/x".to_string())
+        );
+        assert_eq!(
+            expand_portable_runner_path("~", Some("/home/chubes/Developer")),
+            Some("/home/chubes".to_string())
+        );
+        assert_eq!(
+            expand_portable_runner_path("/abs/path", Some("/home/chubes/Developer")),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Resolves the Lab offload path-materialization gap where remote rig checks evaluated `${components.<id>.path}` against the **controller** path the rig spec declares instead of the **runner-side** materialized checkout. Closes #3766, #3767, #3765.

## What changed

- **#3766 — runner-path resolution for component paths.** During Lab offload, `sync_lab_offload_rig_component_dependencies` now returns generic per-component path-override env vars (`HOMEBOY_RIG_COMPONENT_PATH__<RIG>__<COMPONENT>`) that are forwarded to the runner. On-runner rig expansion (`resolve_token`) reads these and pins `${components.<id>.path}` to the materialized checkout. The override is **runtime-agnostic**: derived purely from rig/component ids, a no-op when unset, and makes no assumption about any specific runtime, framework, or component (no WP/codebox/Studio hardcoding).
- **#3767 — `~` home expansion.** A portable `~`/`~/...` declared checkout root now expands to an absolute runner path under the runner home, which is derived generically from the runner workspace root (`/home/<user>`, `/Users/<user>`, or workspace-root parent fallback). When the home cannot be derived it falls back to the materialized `_lab_workspaces` path, so a literal `~` directory is **never** emitted on the runner.
- **#3765 — dirty-file materialization.** A dirty/untracked rig dependency working tree is snapshotted as an explicit overlay under `--allow-dirty-lab-workspace` instead of being refused, with dirty-vs-clean `source_provenance` recorded in workspace metadata for bench reproducibility.
- **Diagnostics.** Remote rig check-file failures now surface declared-vs-resolved paths plus actionable hints for unexpanded `${components.<id>.path}` tokens and unresolved `~`.

## Architecture

All materialization primitives stay **generic** — homeboy core gains no awareness of WordPress, wp-codebox, Studio, or any specific runtime. Override-env naming and `~`/home resolution are pure string/path logic driven by config-supplied ids.

## Testing

- `cargo fmt --check` clean
- `cargo clippy --lib` clean (no new warnings; my new fns introduce none)
- New unit tests cover home derivation, portable-path expansion, override-env naming, and the dirty-overlay path. All touched-module tests pass: rig_materialization (19), rig::expand (10), rig::check (18), git_dependency_materialization (7), lab::offload (50).
- Full lib suite: same 88 pre-existing environment-dependent failures (bench/extension-script/network) as clean `origin/main` — **zero regressions** introduced by this change.

Closes #3766
Closes #3767
Closes #3765