### PR TITLE
Resolve agent-task default backend from policy

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -181,7 +181,7 @@ impl Commands {
 fn agent_task_provider_requires_cwd_git_checkout(command: &agent_task::AgentTaskCommand) -> bool {
     agent_task_provider_requires_cwd_git_checkout_with(
         command,
-        default_backend,
+        || default_backend().ok().flatten(),
         provider_requires_cwd_git_checkout,
     )
 }

--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use homeboy::core::agent_tasks::dispatch_service::{self, AgentTaskDispatchRequest};
-use homeboy::core::agent_tasks::provider::{default_backend, ExtensionProviderAgentTaskExecutor};
+use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_tasks::scheduler::{AgentTaskAggregate, AgentTaskExecutorAdapter};
 use homeboy::core::agent_tasks::AgentTaskAggregateReport;
 
@@ -113,13 +113,6 @@ where
 pub(crate) fn dispatch_request_from_args(
     args: DispatchArgs,
 ) -> homeboy::core::Result<AgentTaskDispatchRequest> {
-    dispatch_request_from_args_with_default(args, default_backend)
-}
-
-fn dispatch_request_from_args_with_default(
-    args: DispatchArgs,
-    default_backend: impl FnOnce() -> Option<String>,
-) -> homeboy::core::Result<AgentTaskDispatchRequest> {
     Ok(AgentTaskDispatchRequest {
         prompt: args.prompt,
         tasks: args.tasks,
@@ -128,16 +121,7 @@ fn dispatch_request_from_args_with_default(
         workspace: args.workspace,
         repo: args.repo,
         task_url: args.task_url,
-        backend: args.backend.or_else(default_backend).ok_or_else(|| {
-            homeboy::core::Error::validation_invalid_argument(
-                "backend",
-                "agent-task dispatch requires --backend because no default backend provider is declared",
-                None,
-                Some(vec![
-                    "Declare an agent_task_executors entry with default_backend=true in an extension manifest, or pass --backend explicitly.".to_string(),
-                ]),
-            )
-        })?,
+        backend: args.backend,
         selector: args.selector,
         model: args.model,
         required_capabilities: args.required_capabilities,
@@ -357,66 +341,6 @@ mod tests {
                 .expect("next action")
                 .contains("homeboy agent-task run cook-queued"));
         });
-    }
-
-    #[test]
-    fn dispatch_request_uses_declared_default_backend_when_backend_is_absent() {
-        let request = dispatch_request_from_args_with_default(
-            DispatchArgs {
-                prompt: Some("run with default".to_string()),
-                tasks: Vec::new(),
-                tasks_json: None,
-                cwd: None,
-                workspace: None,
-                repo: None,
-                task_url: None,
-                backend: None,
-                selector: None,
-                model: None,
-                required_capabilities: Vec::new(),
-                secret_env: Vec::new(),
-                provider_config: None,
-                client_context: None,
-                concurrency: 1,
-                attempts: 1,
-                run_id: None,
-                queue_only: false,
-            },
-            || Some("fake-default".to_string()),
-        )
-        .expect("default backend request");
-
-        assert_eq!(request.backend, "fake-default");
-    }
-
-    #[test]
-    fn dispatch_request_errors_when_backend_and_default_are_absent() {
-        let error = dispatch_request_from_args_with_default(
-            DispatchArgs {
-                prompt: Some("run without default".to_string()),
-                tasks: Vec::new(),
-                tasks_json: None,
-                cwd: None,
-                workspace: None,
-                repo: None,
-                task_url: None,
-                backend: None,
-                selector: None,
-                model: None,
-                required_capabilities: Vec::new(),
-                secret_env: Vec::new(),
-                provider_config: None,
-                client_context: None,
-                concurrency: 1,
-                attempts: 1,
-                run_id: None,
-                queue_only: false,
-            },
-            || None,
-        )
-        .expect_err("missing backend should fail");
-
-        assert!(error.message.contains("requires --backend"));
     }
 
     struct NoopExecutor;

--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -3,7 +3,9 @@ use serde::Serialize;
 use serde_json::Value;
 
 use homeboy::core::agent_tasks::dispatch_service::{self, AgentTaskDispatchRequest};
-use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
+use homeboy::core::agent_tasks::provider::{
+    default_backend_for_component, ExtensionProviderAgentTaskExecutor,
+};
 use homeboy::core::agent_tasks::scheduler::{AgentTaskAggregate, AgentTaskExecutorAdapter};
 use homeboy::core::agent_tasks::AgentTaskAggregateReport;
 
@@ -113,6 +115,27 @@ where
 pub(crate) fn dispatch_request_from_args(
     args: DispatchArgs,
 ) -> homeboy::core::Result<AgentTaskDispatchRequest> {
+    dispatch_request_from_args_with_default(args, default_backend_for_component)
+}
+
+fn dispatch_request_from_args_with_default(
+    args: DispatchArgs,
+    default_backend: impl FnOnce(Option<&str>) -> homeboy::core::Result<Option<String>>,
+) -> homeboy::core::Result<AgentTaskDispatchRequest> {
+    let backend = match args.backend {
+        Some(backend) => backend,
+        None => default_backend(args.repo.as_deref())?.ok_or_else(|| {
+            homeboy::core::Error::validation_invalid_argument(
+                "backend",
+                "agent-task dispatch requires --backend because no default backend policy is configured",
+                None,
+                Some(vec![
+                    "Set agent_task.default_backend in component, extension, or Homeboy config policy, or pass --backend explicitly.".to_string(),
+                ]),
+            )
+        })?,
+    };
+
     Ok(AgentTaskDispatchRequest {
         prompt: args.prompt,
         tasks: args.tasks,
@@ -121,7 +144,7 @@ pub(crate) fn dispatch_request_from_args(
         workspace: args.workspace,
         repo: args.repo,
         task_url: args.task_url,
-        backend: args.backend,
+        backend,
         selector: args.selector,
         model: args.model,
         required_capabilities: args.required_capabilities,
@@ -341,6 +364,66 @@ mod tests {
                 .expect("next action")
                 .contains("homeboy agent-task run cook-queued"));
         });
+    }
+
+    #[test]
+    fn dispatch_request_uses_declared_default_backend_when_backend_is_absent() {
+        let request = dispatch_request_from_args_with_default(
+            DispatchArgs {
+                prompt: Some("run with default".to_string()),
+                tasks: Vec::new(),
+                tasks_json: None,
+                cwd: None,
+                workspace: None,
+                repo: None,
+                task_url: None,
+                backend: None,
+                selector: None,
+                model: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                provider_config: None,
+                client_context: None,
+                concurrency: 1,
+                attempts: 1,
+                run_id: None,
+                queue_only: false,
+            },
+            |_| Ok(Some("fake-default".to_string())),
+        )
+        .expect("default backend request");
+
+        assert_eq!(request.backend, "fake-default");
+    }
+
+    #[test]
+    fn dispatch_request_errors_when_backend_and_default_are_absent() {
+        let error = dispatch_request_from_args_with_default(
+            DispatchArgs {
+                prompt: Some("run without default".to_string()),
+                tasks: Vec::new(),
+                tasks_json: None,
+                cwd: None,
+                workspace: None,
+                repo: None,
+                task_url: None,
+                backend: None,
+                selector: None,
+                model: None,
+                required_capabilities: Vec::new(),
+                secret_env: Vec::new(),
+                provider_config: None,
+                client_context: None,
+                concurrency: 1,
+                attempts: 1,
+                run_id: None,
+                queue_only: false,
+            },
+            |_| Ok(None),
+        )
+        .expect_err("missing backend should fail");
+
+        assert!(error.message.contains("requires --backend"));
     }
 
     struct NoopExecutor;

--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -171,6 +171,7 @@ mod tests {
             structured_sidecars: Default::default(),
             release_preflights: Vec::new(),
             agent_runtimes: Vec::new(),
+            agent_task: None,
             actions: Vec::new(),
             hooks: Default::default(),
             settings: Vec::new(),

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -15,7 +15,7 @@ use crate::core::agent_task_config_materialization::materialize_provider_config_
 use crate::core::agent_task_lifecycle as lifecycle;
 use crate::core::agent_task_lifecycle::{AgentTaskRunRecord, AgentTaskRunState};
 use crate::core::agent_task_provider::{
-    apply_provider_runner_secret_env_contracts, default_backend, provider_requires_cwd_git_checkout,
+    apply_provider_runner_secret_env_contracts, provider_requires_cwd_git_checkout,
 };
 use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskRetryPolicy,
@@ -36,7 +36,7 @@ pub struct AgentTaskDispatchRequest {
     pub workspace: Option<String>,
     pub repo: Option<String>,
     pub task_url: Option<String>,
-    pub backend: Option<String>,
+    pub backend: String,
     pub selector: Option<String>,
     pub model: Option<String>,
     pub required_capabilities: Vec<String>,
@@ -149,20 +149,9 @@ pub fn build_dispatch_plan_with_provider_requirements(
         ));
     }
 
-    let backend = request.backend.clone().or_else(default_backend).ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "backend",
-            "agent-task dispatch requires --backend because no default backend provider is declared",
-            None,
-            Some(vec![
-                "Declare an agent_task_executors entry with default_backend=true in an agent runtime or extension manifest, or pass --backend explicitly.".to_string(),
-            ]),
-        )
-    })?;
-
     let workspace_target = resolve_dispatch_workspace(request)?;
     validate_dispatch_workspace_target(
-        &backend,
+        &request.backend,
         request.selector.as_deref(),
         workspace_target.as_ref(),
         &provider_requires_cwd_git_checkout,
@@ -221,7 +210,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
             group_key: repo.clone(),
             parent_plan_id: None,
             executor: AgentTaskExecutor {
-                backend: backend.clone(),
+                backend: request.backend.clone(),
                 selector: request.selector.clone(),
                 required_capabilities: request.required_capabilities.clone(),
                 secret_env: secret_env.clone(),
@@ -750,7 +739,7 @@ mod tests {
     use super::*;
     use crate::core::agent_task::{
         AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_ARTIFACT_SCHEMA,
-        AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
+        AGENT_TASK_OUTCOME_SCHEMA,
     };
     use crate::core::agent_task_scheduler::AgentTaskExecutionContext;
     use crate::test_support::with_isolated_home;
@@ -799,68 +788,6 @@ mod tests {
         assert!(!serialized.contains("kimaki"));
         assert!(!serialized.contains("channel"));
         assert!(!serialized.contains("thread"));
-    }
-
-    #[test]
-    fn build_dispatch_plan_uses_runtime_declared_fake_default_backend() {
-        with_isolated_home(|home| {
-            let runtime_dir = home
-                .path()
-                .join(".config/homeboy/agent-runtimes/fake-runtime");
-            std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
-            std::fs::write(
-                runtime_dir.join("fake-runtime.json"),
-                serde_json::json!({
-                    "schema": "homeboy/agent-runtime-manifest/v1",
-                    "id": "fake-runtime",
-                    "agent_task_executors": [{
-                        "schema": "homeboy/agent-task-executor-provider/v1",
-                        "id": "fake.default",
-                        "backend": "fake-default",
-                        "default_backend": true,
-                        "command": "fake-agent-task",
-                        "request_schema": AGENT_TASK_REQUEST_SCHEMA,
-                        "outcome_schema": AGENT_TASK_OUTCOME_SCHEMA
-                    }]
-                })
-                .to_string(),
-            )
-            .expect("runtime manifest");
-
-            let plan = build_dispatch_plan(&AgentTaskDispatchRequest {
-                backend: None,
-                ..dispatch_request(DispatchRequestOverrides {
-                    prompt: Some("run with runtime default".to_string()),
-                    ..DispatchRequestOverrides::default()
-                })
-            })
-            .expect("dispatch plan");
-
-            assert_eq!(plan.tasks[0].executor.backend, "fake-default");
-        });
-    }
-
-    #[test]
-    fn build_dispatch_plan_errors_when_backend_and_runtime_default_are_absent() {
-        with_isolated_home(|_| {
-            let error = build_dispatch_plan(&AgentTaskDispatchRequest {
-                backend: None,
-                ..dispatch_request(DispatchRequestOverrides {
-                    prompt: Some("run without runtime default".to_string()),
-                    ..DispatchRequestOverrides::default()
-                })
-            })
-            .expect_err("missing backend should fail");
-
-            assert!(error.message.contains("requires --backend"));
-            assert!(error
-                .details
-                .get("tried")
-                .and_then(Value::as_array)
-                .is_some_and(|tried| tried.iter().any(|hint| hint
-                    .as_str()
-                    .is_some_and(|hint| hint.contains("default_backend=true")))));
-        });
     }
 
     #[test]
@@ -1233,7 +1160,7 @@ mod tests {
             workspace: overrides.workspace,
             repo: overrides.repo,
             task_url: overrides.task_url,
-            backend: Some(overrides.backend.unwrap_or_else(|| "fixture".to_string())),
+            backend: overrides.backend.unwrap_or_else(|| "fixture".to_string()),
             selector: None,
             model: None,
             required_capabilities: overrides.required_capabilities,

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -15,7 +15,7 @@ use crate::core::agent_task_config_materialization::materialize_provider_config_
 use crate::core::agent_task_lifecycle as lifecycle;
 use crate::core::agent_task_lifecycle::{AgentTaskRunRecord, AgentTaskRunState};
 use crate::core::agent_task_provider::{
-    apply_provider_runner_secret_env_contracts, provider_requires_cwd_git_checkout,
+    apply_provider_runner_secret_env_contracts, default_backend, provider_requires_cwd_git_checkout,
 };
 use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskRetryPolicy,
@@ -36,7 +36,7 @@ pub struct AgentTaskDispatchRequest {
     pub workspace: Option<String>,
     pub repo: Option<String>,
     pub task_url: Option<String>,
-    pub backend: String,
+    pub backend: Option<String>,
     pub selector: Option<String>,
     pub model: Option<String>,
     pub required_capabilities: Vec<String>,
@@ -149,9 +149,21 @@ pub fn build_dispatch_plan_with_provider_requirements(
         ));
     }
 
+    let backend = request.backend.clone().or_else(default_backend).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "backend",
+            "agent-task dispatch requires --backend because no default backend provider is declared",
+            None,
+            Some(vec![
+                "Declare an agent_task_executors entry with default_backend=true in an agent runtime or extension manifest, or pass --backend explicitly.".to_string(),
+            ]),
+        )
+    })?;
+
     let workspace_target = resolve_dispatch_workspace(request)?;
     validate_dispatch_workspace_target(
-        request,
+        &backend,
+        request.selector.as_deref(),
         workspace_target.as_ref(),
         &provider_requires_cwd_git_checkout,
     )?;
@@ -209,7 +221,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
             group_key: repo.clone(),
             parent_plan_id: None,
             executor: AgentTaskExecutor {
-                backend: request.backend.clone(),
+                backend: backend.clone(),
                 selector: request.selector.clone(),
                 required_capabilities: request.required_capabilities.clone(),
                 secret_env: secret_env.clone(),
@@ -291,7 +303,8 @@ pub fn build_dispatch_plan_with_provider_requirements(
 }
 
 fn validate_dispatch_workspace_target(
-    request: &AgentTaskDispatchRequest,
+    backend: &str,
+    selector: Option<&str>,
     workspace: Option<&DispatchWorkspaceTarget>,
     provider_requires_cwd_git_checkout: &impl Fn(&str, Option<&str>) -> bool,
 ) -> Result<()> {
@@ -299,7 +312,7 @@ fn validate_dispatch_workspace_target(
         return Ok(());
     };
     if workspace.kind.as_deref() != Some("cwd")
-        || !provider_requires_cwd_git_checkout(&request.backend, request.selector.as_deref())
+        || !provider_requires_cwd_git_checkout(backend, selector)
     {
         return Ok(());
     }
@@ -737,7 +750,7 @@ mod tests {
     use super::*;
     use crate::core::agent_task::{
         AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_ARTIFACT_SCHEMA,
-        AGENT_TASK_OUTCOME_SCHEMA,
+        AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
     };
     use crate::core::agent_task_scheduler::AgentTaskExecutionContext;
     use crate::test_support::with_isolated_home;
@@ -786,6 +799,68 @@ mod tests {
         assert!(!serialized.contains("kimaki"));
         assert!(!serialized.contains("channel"));
         assert!(!serialized.contains("thread"));
+    }
+
+    #[test]
+    fn build_dispatch_plan_uses_runtime_declared_fake_default_backend() {
+        with_isolated_home(|home| {
+            let runtime_dir = home
+                .path()
+                .join(".config/homeboy/agent-runtimes/fake-runtime");
+            std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+            std::fs::write(
+                runtime_dir.join("fake-runtime.json"),
+                serde_json::json!({
+                    "schema": "homeboy/agent-runtime-manifest/v1",
+                    "id": "fake-runtime",
+                    "agent_task_executors": [{
+                        "schema": "homeboy/agent-task-executor-provider/v1",
+                        "id": "fake.default",
+                        "backend": "fake-default",
+                        "default_backend": true,
+                        "command": "fake-agent-task",
+                        "request_schema": AGENT_TASK_REQUEST_SCHEMA,
+                        "outcome_schema": AGENT_TASK_OUTCOME_SCHEMA
+                    }]
+                })
+                .to_string(),
+            )
+            .expect("runtime manifest");
+
+            let plan = build_dispatch_plan(&AgentTaskDispatchRequest {
+                backend: None,
+                ..dispatch_request(DispatchRequestOverrides {
+                    prompt: Some("run with runtime default".to_string()),
+                    ..DispatchRequestOverrides::default()
+                })
+            })
+            .expect("dispatch plan");
+
+            assert_eq!(plan.tasks[0].executor.backend, "fake-default");
+        });
+    }
+
+    #[test]
+    fn build_dispatch_plan_errors_when_backend_and_runtime_default_are_absent() {
+        with_isolated_home(|_| {
+            let error = build_dispatch_plan(&AgentTaskDispatchRequest {
+                backend: None,
+                ..dispatch_request(DispatchRequestOverrides {
+                    prompt: Some("run without runtime default".to_string()),
+                    ..DispatchRequestOverrides::default()
+                })
+            })
+            .expect_err("missing backend should fail");
+
+            assert!(error.message.contains("requires --backend"));
+            assert!(error
+                .details
+                .get("tried")
+                .and_then(Value::as_array)
+                .is_some_and(|tried| tried.iter().any(|hint| hint
+                    .as_str()
+                    .is_some_and(|hint| hint.contains("default_backend=true")))));
+        });
     }
 
     #[test]
@@ -1158,7 +1233,7 @@ mod tests {
             workspace: overrides.workspace,
             repo: overrides.repo,
             task_url: overrides.task_url,
-            backend: overrides.backend.unwrap_or_else(|| "fixture".to_string()),
+            backend: Some(overrides.backend.unwrap_or_else(|| "fixture".to_string())),
             selector: None,
             model: None,
             required_capabilities: overrides.required_capabilities,

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -6,7 +6,6 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::core::agent_runtime_manifest;
 use crate::core::agent_task::{
     AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskFailureClassification,
     AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_ARTIFACT_SCHEMA,
@@ -17,6 +16,7 @@ use crate::core::agent_task_scheduler::{
 };
 use crate::core::agent_task_secrets::{resolve_secret_env, AgentTaskSecretResolutionError};
 use crate::core::agent_task_timeout::timeout_with_grace;
+use crate::core::{agent_runtime_manifest, component, defaults, extension, Error};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskExecutorProvider {
@@ -195,8 +195,8 @@ impl ExtensionProviderAgentTaskExecutor {
         &self.providers
     }
 
-    pub fn default_backend(&self) -> Option<String> {
-        default_backend_from_providers(&self.providers)
+    pub fn default_backend(&self) -> crate::core::Result<Option<String>> {
+        default_backend_from_policy(None)
     }
 
     pub fn required_extension_ids_for_plan(&self, plan: &AgentTaskPlan) -> Vec<String> {
@@ -204,8 +204,14 @@ impl ExtensionProviderAgentTaskExecutor {
     }
 }
 
-pub fn default_backend() -> Option<String> {
-    default_backend_from_providers(&discover_agent_task_executor_providers())
+pub fn default_backend() -> crate::core::Result<Option<String>> {
+    default_backend_from_policy(None)
+}
+
+pub fn default_backend_for_component(
+    component_id: Option<&str>,
+) -> crate::core::Result<Option<String>> {
+    default_backend_from_policy(component_id)
 }
 
 pub fn provider_runner_readiness_contracts() -> Vec<AgentTaskProviderRunnerReadiness> {
@@ -317,11 +323,66 @@ fn provider_runner_secret_env(provider: &AgentTaskExecutorProvider) -> Vec<Strin
     names
 }
 
-fn default_backend_from_providers(providers: &[AgentTaskExecutorProvider]) -> Option<String> {
-    providers
-        .iter()
-        .find(|provider| provider.default_backend)
-        .map(|provider| provider.backend.clone())
+fn default_backend_from_policy(component_id: Option<&str>) -> crate::core::Result<Option<String>> {
+    if let Some(component_id) = component_id {
+        if let Ok(component) = component::load(component_id) {
+            if let Some(default_backend) = component_default_backend(&component) {
+                return Ok(Some(default_backend));
+            }
+        }
+    }
+
+    let extension_defaults: Vec<String> = extension::load_all_extensions()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|manifest| {
+            manifest
+                .agent_task
+                .and_then(|agent_task| agent_task.default_backend)
+        })
+        .filter(|backend| !backend.trim().is_empty())
+        .collect();
+
+    if extension_defaults.len() > 1 {
+        return Err(Error::validation_invalid_argument(
+            "backend",
+            "agent-task default backend is ambiguous because multiple extension policies declare agent_task.default_backend",
+            None,
+            Some(vec![
+                "Set /agent_task/default_backend in Homeboy config or pass --backend explicitly.".to_string(),
+            ]),
+        ));
+    }
+    if let Some(default_backend) = extension_defaults.into_iter().next() {
+        return Ok(Some(default_backend));
+    }
+
+    Ok(defaults::load_config()
+        .agent_task
+        .default_backend
+        .filter(|backend| !backend.trim().is_empty()))
+}
+
+fn component_default_backend(component: &component::Component) -> Option<String> {
+    component
+        .extensions
+        .as_ref()?
+        .values()
+        .find_map(|extension| {
+            extension
+                .settings
+                .get("agent_task")
+                .and_then(|value| value.get("default_backend"))
+                .and_then(Value::as_str)
+                .or_else(|| {
+                    extension
+                        .settings
+                        .get("agent_task_default_backend")
+                        .and_then(Value::as_str)
+                })
+                .filter(|backend| !backend.trim().is_empty())
+                .map(String::from)
+        })
 }
 
 impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
@@ -1154,7 +1215,7 @@ mod tests {
     }
 
     #[test]
-    fn default_backend_prefers_provider_declaration() {
+    fn default_backend_ignores_provider_declaration() {
         let (_request, mut provider_a) = request("task-a", "node provider-a.js".to_string());
         provider_a.backend = "first".to_string();
         let (_request, mut provider_b) = request("task-b", "node provider-b.js".to_string());
@@ -1164,7 +1225,136 @@ mod tests {
         let executor =
             ExtensionProviderAgentTaskExecutor::with_providers(vec![provider_a, provider_b]);
 
-        assert_eq!(executor.default_backend().as_deref(), Some("preferred"));
+        crate::test_support::with_isolated_home(|_| {
+            assert_eq!(executor.default_backend().unwrap(), None);
+        });
+    }
+
+    #[test]
+    fn default_backend_uses_global_config_policy() {
+        crate::test_support::with_isolated_home(|_| {
+            defaults::save_config(&defaults::HomeboyConfig {
+                agent_task: defaults::AgentTaskConfig {
+                    default_backend: Some("configured".to_string()),
+                    ..defaults::AgentTaskConfig::default()
+                },
+                ..defaults::HomeboyConfig::default()
+            })
+            .expect("config saved");
+
+            assert_eq!(default_backend().unwrap().as_deref(), Some("configured"));
+        });
+    }
+
+    #[test]
+    fn default_backend_uses_extension_policy() {
+        crate::test_support::with_isolated_home(|home| {
+            defaults::save_config(&defaults::HomeboyConfig {
+                agent_task: defaults::AgentTaskConfig {
+                    default_backend: Some("global-policy".to_string()),
+                    ..defaults::AgentTaskConfig::default()
+                },
+                ..defaults::HomeboyConfig::default()
+            })
+            .expect("config saved");
+            let extension_dir = home
+                .path()
+                .join(".config/homeboy/extensions/runtime-extension");
+            std::fs::create_dir_all(&extension_dir).expect("extension dir");
+            std::fs::write(
+                extension_dir.join("runtime-extension.json"),
+                json!({
+                    "name": "Runtime Extension",
+                    "version": "1.0.0",
+                    "agent_task": { "default_backend": "extension-policy" }
+                })
+                .to_string(),
+            )
+            .expect("extension manifest");
+
+            assert_eq!(
+                default_backend().unwrap().as_deref(),
+                Some("extension-policy")
+            );
+        });
+    }
+
+    #[test]
+    fn default_backend_rejects_ambiguous_extension_policy() {
+        crate::test_support::with_isolated_home(|home| {
+            for (id, backend) in [("runtime-a", "backend-a"), ("runtime-b", "backend-b")] {
+                let extension_dir = home.path().join(format!(".config/homeboy/extensions/{id}"));
+                std::fs::create_dir_all(&extension_dir).expect("extension dir");
+                std::fs::write(
+                    extension_dir.join(format!("{id}.json")),
+                    json!({
+                        "name": id,
+                        "version": "1.0.0",
+                        "agent_task": { "default_backend": backend }
+                    })
+                    .to_string(),
+                )
+                .expect("extension manifest");
+            }
+
+            let error = default_backend().expect_err("ambiguous policy should fail");
+            assert!(error.message.contains("ambiguous"));
+        });
+    }
+
+    #[test]
+    fn default_backend_reads_component_scoped_extension_policy() {
+        let mut component = component::Component::new(
+            "fixture".to_string(),
+            "/tmp/fixture".to_string(),
+            String::new(),
+            None,
+        );
+        component.extensions = Some(std::collections::HashMap::from([(
+            "runtime-extension".to_string(),
+            component::ScopedExtensionConfig {
+                settings: std::collections::HashMap::from([(
+                    "agent_task".to_string(),
+                    json!({ "default_backend": "component-policy" }),
+                )]),
+                ..component::ScopedExtensionConfig::default()
+            },
+        )]));
+
+        assert_eq!(
+            component_default_backend(&component).as_deref(),
+            Some("component-policy")
+        );
+    }
+
+    #[test]
+    fn default_backend_ignores_provider_manifest_default_backend() {
+        crate::test_support::with_isolated_home(|home| {
+            let runtime_dir = home
+                .path()
+                .join(".config/homeboy/agent-runtimes/standalone-runtime");
+            std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
+            std::fs::write(
+                runtime_dir.join("standalone-runtime.json"),
+                json!({
+                    "schema": agent_runtime_manifest::AGENT_RUNTIME_MANIFEST_SCHEMA,
+                    "id": "standalone-runtime",
+                    "agent_task_executors": [{
+                        "schema": "homeboy/agent-task-executor-provider/v1",
+                        "id": "runtime.provider",
+                        "backend": "runtime-default",
+                        "default_backend": true,
+                        "command": "runtime-provider",
+                        "request_schema": AGENT_TASK_REQUEST_SCHEMA,
+                        "outcome_schema": AGENT_TASK_OUTCOME_SCHEMA
+                    }]
+                })
+                .to_string(),
+            )
+            .expect("runtime manifest");
+
+            assert_eq!(default_backend().unwrap(), None);
+        });
     }
 
     #[test]
@@ -1177,7 +1367,7 @@ mod tests {
         let executor =
             ExtensionProviderAgentTaskExecutor::with_providers(vec![provider_a, provider_b]);
 
-        assert_eq!(executor.default_backend(), None);
+        assert_eq!(executor.default_backend().unwrap(), None);
     }
 
     #[test]

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -321,7 +321,6 @@ fn default_backend_from_providers(providers: &[AgentTaskExecutorProvider]) -> Op
     providers
         .iter()
         .find(|provider| provider.default_backend)
-        .or_else(|| providers.first())
         .map(|provider| provider.backend.clone())
 }
 
@@ -1166,6 +1165,19 @@ mod tests {
             ExtensionProviderAgentTaskExecutor::with_providers(vec![provider_a, provider_b]);
 
         assert_eq!(executor.default_backend().as_deref(), Some("preferred"));
+    }
+
+    #[test]
+    fn default_backend_is_absent_without_provider_declaration() {
+        let (_request, mut provider_a) = request("task-a", "node provider-a.js".to_string());
+        provider_a.backend = "first".to_string();
+        let (_request, mut provider_b) = request("task-b", "node provider-b.js".to_string());
+        provider_b.backend = "second".to_string();
+
+        let executor =
+            ExtensionProviderAgentTaskExecutor::with_providers(vec![provider_a, provider_b]);
+
+        assert_eq!(executor.default_backend(), None);
     }
 
     #[test]

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -213,12 +213,13 @@ pub mod promotion {
 /// Executor provider contracts used by extensions and routing.
 pub mod provider {
     pub use super::super::agent_task_provider::{
-        default_backend, dependency_failure_patterns, provider_requires_cwd_git_checkout,
-        provider_runner_readiness_contracts, provider_runner_secret_env_for_plan,
-        required_extension_ids_for_plan, AgentTaskExecutorProvider,
-        AgentTaskProviderDependencyFailurePattern, AgentTaskProviderEnvPathReadiness,
-        AgentTaskProviderRoleAliases, AgentTaskProviderRunnerReadiness,
-        AgentTaskProviderWorkspaceMaterialization, ExtensionProviderAgentTaskExecutor,
+        default_backend, default_backend_for_component, dependency_failure_patterns,
+        provider_requires_cwd_git_checkout, provider_runner_readiness_contracts,
+        provider_runner_secret_env_for_plan, required_extension_ids_for_plan,
+        AgentTaskExecutorProvider, AgentTaskProviderDependencyFailurePattern,
+        AgentTaskProviderEnvPathReadiness, AgentTaskProviderRoleAliases,
+        AgentTaskProviderRunnerReadiness, AgentTaskProviderWorkspaceMaterialization,
+        ExtensionProviderAgentTaskExecutor,
     };
 }
 

--- a/src/core/code_audit/detectors/test_topology.rs
+++ b/src/core/code_audit/detectors/test_topology.rs
@@ -390,6 +390,7 @@ JSON
             structured_sidecars: std::collections::BTreeMap::new(),
             release_preflights: vec![],
             agent_runtimes: vec![],
+            agent_task: None,
             actions: vec![],
             hooks: std::collections::HashMap::new(),
             settings: vec![],

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -189,6 +189,8 @@ pub struct TriageConfig {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_backend: Option<String>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub secrets: HashMap<String, AgentTaskSecretSource>,
 }
@@ -493,6 +495,7 @@ mod tests {
         let config: HomeboyConfig = serde_json::from_str(
             r#"{
                 "agent_task": {
+                    "default_backend": "codex",
                     "secrets": {
                         "TOKEN": {
                             "source": "config",
@@ -504,6 +507,7 @@ mod tests {
         )
         .unwrap();
 
+        assert_eq!(config.agent_task.default_backend.as_deref(), Some("codex"));
         let secret = config.agent_task.secrets.get("TOKEN").unwrap();
         assert_eq!(secret.source, "config");
         assert_eq!(secret.value.as_deref(), Some("redacted-test-token"));

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -408,6 +408,12 @@ pub struct AgentRuntimeManifestConfig {
     pub agent_task_executors: Vec<serde_json::Value>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct AgentTaskPolicyConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_backend: Option<String>,
+}
+
 /// Unified extension manifest decomposed into capability groups.
 ///
 /// Extension JSON files use nested capability groups that map directly to these fields.
@@ -494,6 +500,11 @@ pub struct ExtensionManifest {
     /// First-class agent runtime package manifests supplied by this extension.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub agent_runtimes: Vec<AgentRuntimeManifestConfig>,
+
+    /// Extension-owned agent task policy. Runtime/provider manifests declare
+    /// capabilities only; they do not select global defaults.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_task: Option<AgentTaskPolicyConfig>,
 
     // Actions (cross-cutting: used by both platform and executable extensions)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]


### PR DESCRIPTION
## Summary
- Resolve omitted agent-task backends from policy instead of provider/runtime manifests.
- Keep explicit request backend as the highest-precedence override, then component-scoped extension settings, extension manifest policy, and global Homeboy config.
- Preserve runtime/provider manifests as availability/capability declarations only; provider default_backend is ignored for default selection.
- Keep dispatch service on a concrete backend so lower-level planning does not infer runtime policy.

Fixes #4532.

## Verification
- cargo fmt
- cargo test default_backend --lib
- cargo test dispatch_request --lib
- cargo test agent_task_provider --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the code and tests for moving default backend ownership to policy; Chris remains responsible for review and validation.