### PR TITLE
feat: discover AI runtime providers

### DIFF
--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::core::agent_task_provider::AgentTaskExecutorProvider;
 use crate::core::extension::{load_all_extensions, ExtensionManifest};
@@ -33,27 +33,48 @@ pub fn discover_agent_runtime_manifests() -> Vec<AgentRuntimeManifest> {
 }
 
 fn discover_standalone_agent_runtime_manifests() -> Vec<AgentRuntimeManifest> {
-    let Ok(runtime_dir) = paths::agent_runtimes() else {
-        return Vec::new();
-    };
-    let Ok(entries) = std::fs::read_dir(runtime_dir) else {
-        return Vec::new();
-    };
-
-    let mut manifests: Vec<AgentRuntimeManifest> = entries
-        .flatten()
-        .filter_map(|entry| load_standalone_agent_runtime_manifest(&entry.path()))
-        .collect();
+    let mut manifests = Vec::new();
+    if let Ok(runtime_dir) = paths::agent_runtimes() {
+        manifests.extend(discover_standalone_agent_runtime_manifests_in(
+            runtime_dir,
+            paths::agent_runtime_manifest,
+        ));
+    }
+    if let Ok(runtime_dir) = paths::ai_runtimes() {
+        manifests.extend(discover_standalone_agent_runtime_manifests_in(
+            runtime_dir,
+            paths::ai_runtime_manifest,
+        ));
+    }
     manifests.sort_by(|a, b| a.id.cmp(&b.id));
     manifests
 }
 
-fn load_standalone_agent_runtime_manifest(path: &Path) -> Option<AgentRuntimeManifest> {
+fn discover_standalone_agent_runtime_manifests_in(
+    runtime_dir: PathBuf,
+    manifest_path_for: fn(&str) -> crate::core::Result<PathBuf>,
+) -> Vec<AgentRuntimeManifest> {
+    let Ok(entries) = std::fs::read_dir(runtime_dir) else {
+        return Vec::new();
+    };
+
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            load_standalone_agent_runtime_manifest(&entry.path(), manifest_path_for)
+        })
+        .collect()
+}
+
+fn load_standalone_agent_runtime_manifest(
+    path: &Path,
+    manifest_path_for: fn(&str) -> crate::core::Result<PathBuf>,
+) -> Option<AgentRuntimeManifest> {
     if !path.is_dir() {
         return None;
     }
     let id = path.file_name()?.to_string_lossy().to_string();
-    let manifest_path = paths::agent_runtime_manifest(&id).ok()?;
+    let manifest_path = manifest_path_for(&id).ok()?;
     if !manifest_path.exists() {
         return None;
     }
@@ -117,6 +138,7 @@ pub(crate) fn discover_agent_task_executor_providers() -> Vec<AgentTaskExecutorP
         for mut provider in runtime_manifest.agent_task_executors {
             provider.extension_id = runtime_manifest.extension_id.clone();
             provider.extension_path = runtime_manifest.extension_path.clone();
+            provider.runtime_id = Some(runtime_manifest.id.clone());
             provider.runtime_path = runtime_manifest.runtime_path.clone();
             providers.push(provider);
         }

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -50,6 +50,8 @@ pub struct AgentTaskExecutorProvider {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extension_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_path: Option<String>,
 }
 
@@ -984,6 +986,18 @@ fn provider_command_env(
                 .or_else(|| provider.extension_path.clone())
                 .unwrap_or_default(),
         ),
+        (
+            "HOMEBOY_AI_RUNTIME_ID".to_string(),
+            provider.runtime_id.clone().unwrap_or_default(),
+        ),
+        (
+            "HOMEBOY_AI_RUNTIME_PATH".to_string(),
+            provider
+                .runtime_path
+                .clone()
+                .or_else(|| provider.extension_path.clone())
+                .unwrap_or_default(),
+        ),
     ];
     env.extend(resolve_secret_env(&request.executor.secret_env)?);
     Ok(env)
@@ -1059,6 +1073,7 @@ mod tests {
             role_aliases: AgentTaskProviderRoleAliases::default(),
             extension_id: None,
             extension_path: None,
+            runtime_id: None,
             runtime_path: None,
         };
         let request = AgentTaskRequest {
@@ -1472,6 +1487,72 @@ mod tests {
                 "EXPLICIT_SECRET".to_string(),
                 "PROVIDER_B_TOKEN".to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn discovers_agent_task_providers_from_ai_runtime_manifests() {
+        crate::test_support::with_isolated_home(|home| {
+            let runtime_dir = home
+                .path()
+                .join(".config/homeboy/ai-runtimes/custom-runtime");
+            fs::create_dir_all(&runtime_dir).expect("runtime dir");
+            fs::write(
+                runtime_dir.join("custom-runtime.json"),
+                serde_json::to_string(&json!({
+                    "schema": agent_runtime_manifest::AGENT_RUNTIME_MANIFEST_SCHEMA,
+                    "id": "custom-runtime",
+                    "name": "Custom Runtime",
+                    "version": "1.0.0",
+                    "agent_task_executors": [{
+                        "schema": "homeboy/agent-task-executor-provider/v1",
+                        "id": "custom.runtime.executor",
+                        "backend": "custom",
+                        "command": "node {{runtime_path}}/runner.cjs",
+                        "request_schema": AGENT_TASK_REQUEST_SCHEMA,
+                        "outcome_schema": AGENT_TASK_OUTCOME_SCHEMA
+                    }]
+                }))
+                .unwrap(),
+            )
+            .expect("runtime manifest");
+
+            let providers = discover_agent_task_executor_providers();
+
+            assert_eq!(providers.len(), 1);
+            assert_eq!(providers[0].id, "custom.runtime.executor");
+            assert_eq!(providers[0].runtime_id.as_deref(), Some("custom-runtime"));
+            assert_eq!(
+                providers[0].runtime_path.as_deref(),
+                Some(runtime_dir.to_string_lossy().as_ref())
+            );
+            assert_eq!(
+                render_provider_command(&providers[0]),
+                format!("node {}/runner.cjs", runtime_dir.display())
+            );
+        });
+    }
+
+    #[test]
+    fn provider_command_env_includes_ai_runtime_identity() {
+        let (request, mut provider) =
+            request("task-a", "node {{runtime_path}}/provider.js".to_string());
+        provider.runtime_id = Some("custom-runtime".to_string());
+        provider.runtime_path = Some("/tmp/custom-runtime".to_string());
+
+        let env = provider_command_env(&request, &provider).expect("provider env");
+
+        assert!(env.contains(&(
+            "HOMEBOY_AI_RUNTIME_ID".to_string(),
+            "custom-runtime".to_string()
+        )));
+        assert!(env.contains(&(
+            "HOMEBOY_AI_RUNTIME_PATH".to_string(),
+            "/tmp/custom-runtime".to_string()
+        )));
+        assert_eq!(
+            render_provider_command(&provider),
+            "node /tmp/custom-runtime/provider.js"
         );
     }
 

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -316,7 +316,7 @@ fn install_shared_assets_from_root(source_root: &Path, extension_dir: &Path) -> 
         return Ok(());
     };
 
-    for shared_dir in ["scripts", "agent-runtimes"] {
+    for shared_dir in ["scripts", "agent-runtimes", "ai-runtimes"] {
         let source = source_root.join(shared_dir);
         if !source.is_dir() {
             continue;

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -181,6 +181,11 @@ pub fn agent_runtimes() -> Result<PathBuf> {
     Ok(homeboy()?.join("agent-runtimes"))
 }
 
+/// First-class AI runtimes directory.
+pub fn ai_runtimes() -> Result<PathBuf> {
+    Ok(homeboy()?.join("ai-runtimes"))
+}
+
 /// Keys directory
 pub fn keys() -> Result<PathBuf> {
     Ok(homeboy()?.join("keys"))
@@ -251,6 +256,11 @@ pub fn extension_manifest(id: &str) -> Result<PathBuf> {
 /// Agent runtime manifest file path
 pub fn agent_runtime_manifest(id: &str) -> Result<PathBuf> {
     Ok(agent_runtimes()?.join(id).join(format!("{}.json", id)))
+}
+
+/// AI runtime manifest file path
+pub fn ai_runtime_manifest(id: &str) -> Result<PathBuf> {
+    Ok(ai_runtimes()?.join(id).join(format!("{}.json", id)))
 }
 
 /// Key file path


### PR DESCRIPTION
## Summary
- discover standalone AI runtime manifests from ~/.config/homeboy/ai-runtimes
- preserve existing agent-runtime discovery while adding AI runtime paths and manifest helpers
- expose AI runtime identity/path to provider commands
- materialize shared ai-runtimes assets during extension monorepo installs

## Tests
- cargo test core::agent_task_provider
- cargo test core::agent_runtime_manifest