### PR TITLE
fix(release): recover from advanced remote and expose exact release body

### DIFF
--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -38,10 +38,11 @@ pub use github_pr_comments::{pr_comment, PrCommentMode, PrCommentOptions};
 pub use operation_output::GitOutput;
 pub use operations::{
     cherry_pick, cherry_pick_at, delete_local_tag, delete_remote_tag, execute_git_for_release,
-    fetch_and_fast_forward, fetch_and_get_behind_count, get_head_commit, get_repo_snapshot,
-    get_tag_commit, is_ancestor, pull, pull_at, pull_bulk, rebase, rebase_at, remote_tag_commit,
-    short_head_revision_at, status, status_at, status_bulk, tag, tag_at, tag_exists_locally,
-    tag_exists_on_remote, CherryPickOptions, RebaseOptions, RepoSnapshot,
+    fetch_and_fast_forward, fetch_and_get_behind_count, fetch_origin, get_head_commit,
+    get_repo_snapshot, get_tag_commit, is_ancestor, pull, pull_at, pull_bulk, rebase, rebase_at,
+    remote_branch_commit, remote_tag_commit, short_head_revision_at, status, status_at,
+    status_bulk, tag, tag_at, tag_exists_locally, tag_exists_on_remote, CherryPickOptions,
+    RebaseOptions, RepoSnapshot,
 };
 pub use operations_changes::{
     build_repo_baseline_snapshot, changes, changes_at, changes_bulk, changes_project,

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -407,6 +407,35 @@ pub fn get_head_commit(path: &str) -> Result<String> {
     crate::core::engine::command::run_in(path, "git", &["rev-parse", "HEAD"], "get HEAD commit")
 }
 
+/// Get the commit SHA the `origin` remote currently has for a branch, without
+/// fetching. Returns `Ok(None)` when the branch does not exist on the remote.
+///
+/// Used to detect that the remote branch advanced after a release commit/tag
+/// were created — the partial-release state in issue #3611, where the tag push
+/// succeeded but the branch push was rejected as non-fast-forward.
+pub fn remote_branch_commit(path: &str, branch: &str) -> Result<Option<String>> {
+    let ref_name = format!("refs/heads/{}", branch);
+    Ok(crate::core::engine::command::run_in_optional(
+        path,
+        "git",
+        &["ls-remote", "--heads", "origin", &ref_name],
+    )
+    .and_then(|output| {
+        output
+            .lines()
+            .find_map(|line| line.split_whitespace().next().map(str::to_string))
+    }))
+}
+
+/// Fetch `origin` so remote-tracking refs reflect the current remote state.
+///
+/// A thin wrapper used by release recovery before it inspects how far the local
+/// branch has diverged from the advanced remote (issue #3611).
+pub fn fetch_origin(path: &str) -> Result<()> {
+    crate::core::engine::command::run_in(path, "git", &["fetch", "origin"], "git fetch origin")?;
+    Ok(())
+}
+
 /// Return true when `ancestor` is an ancestor of (i.e. reachable from)
 /// `descendant`. Used to confirm a stale tag's commit is strictly behind HEAD
 /// before moving it, so a tag is never relocated onto an unrelated/divergent
@@ -597,5 +626,50 @@ mod is_ancestor_tests {
         assert!(!is_ancestor(path, &second, &first).unwrap());
         // a commit is its own ancestor (git treats reflexive as true)
         assert!(is_ancestor(path, &second, &second).unwrap());
+    }
+
+    /// Set up a bare remote + a clone with one pushed commit on `main`.
+    /// Returns (remote_dir, clone_dir, pushed_commit_sha).
+    fn remote_and_clone() -> (tempfile::TempDir, tempfile::TempDir, String) {
+        let remote = tempfile::tempdir().expect("remote tempdir");
+        let clone = tempfile::tempdir().expect("clone tempdir");
+        run_in(
+            remote.path(),
+            &["git", "init", "--bare", "-b", "main", "-q"],
+        );
+        run_in(
+            clone.path(),
+            &["git", "clone", "-q", remote.path().to_str().unwrap(), "."],
+        );
+        run_in(clone.path(), &["git", "config", "user.email", "t@x.test"]);
+        run_in(clone.path(), &["git", "config", "user.name", "T"]);
+        run_in(clone.path(), &["git", "config", "commit.gpgsign", "false"]);
+        std::fs::write(clone.path().join("f.txt"), "one").unwrap();
+        run_in(clone.path(), &["git", "add", "."]);
+        run_in(clone.path(), &["git", "commit", "-q", "-m", "first"]);
+        run_in(clone.path(), &["git", "push", "-q", "origin", "main"]);
+        let sha = rev(clone.path(), "HEAD");
+        (remote, clone, sha)
+    }
+
+    #[test]
+    fn test_remote_branch_commit() {
+        let (_remote, clone, pushed) = remote_and_clone();
+        let path = clone.path().to_str().unwrap();
+
+        // Existing branch resolves to the pushed commit.
+        assert_eq!(
+            remote_branch_commit(path, "main").unwrap().as_deref(),
+            Some(pushed.as_str())
+        );
+        // A branch that does not exist on the remote returns None.
+        assert_eq!(remote_branch_commit(path, "does-not-exist").unwrap(), None);
+    }
+
+    #[test]
+    fn test_fetch_origin() {
+        let (_remote, clone, _pushed) = remote_and_clone();
+        // A plain fetch against a healthy remote must succeed.
+        fetch_origin(clone.path().to_str().unwrap()).expect("fetch origin should succeed");
     }
 }

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -594,7 +594,82 @@ pub(crate) fn run_git_push(component: &Component, component_id: &str) -> Result<
                 ]),
             )
         })?;
-    let output = crate::core::git::push_at(
+    let output = git_push_release_branch(component, component_id, &branch)?;
+    let data = serde_json::to_value(&output)
+        .map_err(|e| Error::internal_json(e.to_string(), Some("git push output".to_string())))?;
+
+    if output.success {
+        return Ok(step_success("git.push", "git.push", Some(data), Vec::new()));
+    }
+
+    // The branch push was rejected. When the remote branch advanced after the
+    // release commit + tag were created (issue #3611), git rejects the branch
+    // ref as non-fast-forward — typically leaving the tag pushed but the branch
+    // behind. Attempt a clean, non-force recovery: fetch, rebase the release
+    // commit onto the advanced remote head, and re-push the branch.
+    if is_non_fast_forward_rejection(&output.stderr) {
+        match recover_advanced_remote_push(component, component_id, &branch) {
+            Ok(Some(recovered)) => {
+                let recovered_data = serde_json::to_value(&recovered).map_err(|e| {
+                    Error::internal_json(e.to_string(), Some("git push output".to_string()))
+                })?;
+                log_status!(
+                    "release",
+                    "Remote {} advanced during release — rebased the release commit onto the new head and re-pushed.",
+                    branch
+                );
+                return Ok(step_success(
+                    "git.push",
+                    "git.push",
+                    Some(serde_json::json!({
+                        "success": true,
+                        "recovered": "advanced-remote-rebased",
+                        "branch": branch,
+                        "push": recovered_data,
+                    })),
+                    Vec::new(),
+                ));
+            }
+            Ok(None) => {
+                // Recovery was not safe to perform automatically; fall through
+                // to the failure path with explicit recovery guidance.
+            }
+            Err(recover_err) => {
+                log_status!(
+                    "release",
+                    "⚠ Automatic recovery from advanced remote failed: {}",
+                    recover_err
+                );
+            }
+        }
+
+        let error = push_error_message(&output);
+        return Ok(step_failed(
+            "git.push",
+            "git.push",
+            Some(data),
+            Some(error),
+            non_fast_forward_recovery_hints(component_id, &branch),
+        ));
+    }
+
+    let error = push_error_message(&output);
+    Ok(step_failed(
+        "git.push",
+        "git.push",
+        Some(data),
+        Some(error),
+        Vec::new(),
+    ))
+}
+
+/// Push the release branch (and tags) to `origin`.
+fn git_push_release_branch(
+    component: &Component,
+    component_id: &str,
+    branch: &str,
+) -> Result<crate::core::git::GitOutput> {
+    crate::core::git::push_at(
         Some(component_id),
         crate::core::git::PushOptions {
             tags: true,
@@ -603,34 +678,129 @@ pub(crate) fn run_git_push(component: &Component, component_id: &str) -> Result<
             ..Default::default()
         },
         Some(&component.local_path),
-    )?;
-    let data = serde_json::to_value(output)
-        .map_err(|e| Error::internal_json(e.to_string(), Some("git push output".to_string())))?;
+    )
+}
 
-    let success = data
-        .get("success")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false);
-    if !success {
-        let error = data
-            .get("stderr")
-            .and_then(serde_json::Value::as_str)
-            .filter(|stderr| !stderr.trim().is_empty())
-            .or_else(|| data.get("stdout").and_then(serde_json::Value::as_str))
-            .unwrap_or("git push failed")
-            .trim()
-            .to_string();
+/// Recover from a non-fast-forward branch rejection caused by the remote
+/// advancing after the release commit/tag were created (issue #3611).
+///
+/// Fetches `origin`, confirms the local branch is strictly ahead of a common
+/// ancestor (so a rebase is the right reconciliation, not a force-push over
+/// divergent history), rebases HEAD onto the advanced remote head, and re-pushes
+/// the branch. The already-pushed tag is left untouched. Returns:
+/// - `Ok(Some(push_output))` when the rebase + re-push succeeded,
+/// - `Ok(None)` when automatic recovery is unsafe (e.g. rebase conflict, or the
+///   remote branch is unexpectedly gone) — the caller emits manual guidance,
+/// - `Err(_)` on an unexpected git failure.
+fn recover_advanced_remote_push(
+    component: &Component,
+    component_id: &str,
+    branch: &str,
+) -> Result<Option<crate::core::git::GitOutput>> {
+    let path = &component.local_path;
+    crate::core::git::fetch_origin(path)?;
 
-        return Ok(step_failed(
-            "git.push",
-            "git.push",
-            Some(data),
-            Some(error),
-            Vec::new(),
-        ));
+    let Some(remote_commit) = crate::core::git::remote_branch_commit(path, branch)? else {
+        // The branch is not on the remote at all — non-fast-forward against a
+        // missing branch is unexpected; don't guess, defer to manual recovery.
+        return Ok(None);
+    };
+    let head_commit = crate::core::git::get_head_commit(path)?;
+
+    // Already reconciled (e.g. a retry after a manual fix): nothing to do.
+    if remote_commit == head_commit {
+        return git_push_release_branch(component, component_id, branch).map(Some);
     }
 
-    Ok(step_success("git.push", "git.push", Some(data), Vec::new()))
+    // Only rebase when the remote head is NOT already contained in HEAD — if it
+    // were, the push would have fast-forwarded. Confirm the histories share an
+    // ancestor before rebasing so we never replay onto unrelated history.
+    if crate::core::git::is_ancestor(path, &remote_commit, &head_commit)? {
+        // Remote head is an ancestor of HEAD; the rejection was spurious or
+        // already resolved. Re-push directly.
+        return git_push_release_branch(component, component_id, branch).map(Some);
+    }
+
+    log_status!(
+        "release",
+        "Rebasing release commit onto advanced remote {} ({})...",
+        branch,
+        &remote_commit[..remote_commit.len().min(8)]
+    );
+    let rebase = crate::core::git::rebase_at(
+        Some(component_id),
+        crate::core::git::RebaseOptions {
+            onto: Some(remote_commit.clone()),
+            ..Default::default()
+        },
+        Some(path),
+    )?;
+    if !rebase.success {
+        // Conflicting rebase — abort to leave the tree clean and defer to the
+        // operator. Recovery is not safe to automate here.
+        let _ = crate::core::git::rebase_at(
+            Some(component_id),
+            crate::core::git::RebaseOptions {
+                abort: true,
+                ..Default::default()
+            },
+            Some(path),
+        );
+        return Ok(None);
+    }
+
+    git_push_release_branch(component, component_id, branch).map(Some)
+}
+
+/// True when git's stderr indicates a non-fast-forward / stale-remote branch
+/// rejection — the signature of the advanced-remote race in issue #3611.
+fn is_non_fast_forward_rejection(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("[rejected]")
+        || lower.contains("non-fast-forward")
+        || lower.contains("fetch first")
+        || lower.contains("tip of your current branch is behind")
+        || lower.contains("updates were rejected")
+}
+
+fn push_error_message(output: &crate::core::git::GitOutput) -> String {
+    let stderr = output.stderr.trim();
+    if !stderr.is_empty() {
+        return stderr.to_string();
+    }
+    let stdout = output.stdout.trim();
+    if !stdout.is_empty() {
+        return stdout.to_string();
+    }
+    "git push failed".to_string()
+}
+
+/// Hints emitted when the branch push was rejected as non-fast-forward and
+/// automatic recovery did not complete. They give the operator a deterministic,
+/// non-force recovery path (issue #3611).
+fn non_fast_forward_recovery_hints(
+    component_id: &str,
+    branch: &str,
+) -> Vec<crate::core::error::Hint> {
+    vec![
+        crate::core::error::Hint {
+            message: format!(
+                "Remote '{}' advanced after the release commit/tag were created. The tag may already be pushed; the branch was rejected as non-fast-forward.",
+                branch
+            ),
+        },
+        crate::core::error::Hint {
+            message: format!(
+                "Reconcile and finish the release without re-tagging or force-pushing: homeboy release {} --recover",
+                component_id
+            ),
+        },
+        crate::core::error::Hint {
+            message: format!(
+                "Or resolve manually: git fetch origin && git rebase origin/{branch} && git push origin HEAD:{branch}",
+            ),
+        },
+    ]
 }
 
 /// Maximum number of attempts for a transient package-command failure.
@@ -1154,7 +1324,8 @@ fn package_command_failure_error(exit_code: i64, stdout: &str, stderr: &str) -> 
 #[cfg(test)]
 mod tests {
     use super::{
-        github_release, run_cleanup, run_git_push, run_package, store_artifacts_from_output,
+        github_release, is_non_fast_forward_rejection, run_cleanup, run_git_push, run_package,
+        store_artifacts_from_output,
     };
     use crate::core::component::Component;
     use crate::core::deploy::release_download::GitHubRepo;
@@ -1391,6 +1562,126 @@ mod tests {
         assert_eq!(result.status, ReleaseStepStatus::Success);
         git(remote.path(), &["show-ref", "--verify", "refs/heads/main"]);
         git(remote.path(), &["show-ref", "--verify", "refs/tags/v1.0.0"]);
+    }
+
+    #[test]
+    fn test_is_non_fast_forward_rejection() {
+        // The exact shape of git's stderr from issue #3611's failed push.
+        let stderr = " ! [rejected]        HEAD -> main (fetch first)\n\
+            error: failed to push some refs to 'https://github.com/owner/repo.git'\n\
+            hint: Updates were rejected because the remote contains work that you do not\n\
+            hint: have locally.";
+        assert!(is_non_fast_forward_rejection(stderr));
+        assert!(is_non_fast_forward_rejection("hint: non-fast-forward"));
+        assert!(is_non_fast_forward_rejection(
+            "Updates were rejected because the tip of your current branch is behind"
+        ));
+        // Unrelated failures must not trigger the rebase-recovery path.
+        assert!(!is_non_fast_forward_rejection(
+            "fatal: Authentication failed"
+        ));
+        assert!(!is_non_fast_forward_rejection(""));
+    }
+
+    /// Issue #3611: when the remote branch advances after the release commit and
+    /// tag are created, `run_git_push` must rebase the release commit onto the
+    /// advanced remote head and re-push — without force-pushing or re-tagging.
+    #[test]
+    fn run_git_push_recovers_when_remote_advanced() {
+        let remote = tempfile::tempdir().expect("remote tempdir");
+        let other = tempfile::tempdir().expect("other clone tempdir");
+        let local = tempfile::tempdir().expect("local tempdir");
+        git(remote.path(), &["init", "--bare", "-b", "main"]);
+
+        let setup_identity = |dir: &std::path::Path| {
+            git(dir, &["config", "user.name", "Homeboy Test"]);
+            git(dir, &["config", "user.email", "homeboy@example.test"]);
+            git(dir, &["config", "commit.gpgsign", "false"]);
+        };
+
+        // Seed the remote with an initial commit via the "other" clone.
+        git(
+            other.path(),
+            &["clone", remote.path().to_str().unwrap(), "."],
+        );
+        setup_identity(other.path());
+        std::fs::write(other.path().join("base.txt"), "base").unwrap();
+        git(other.path(), &["add", "."]);
+        git(other.path(), &["commit", "-m", "base"]);
+        git(other.path(), &["push", "origin", "main"]);
+
+        // The release clone starts from that base.
+        git(
+            local.path(),
+            &["clone", remote.path().to_str().unwrap(), "."],
+        );
+        setup_identity(local.path());
+
+        // The remote advances AFTER the release clone was made.
+        std::fs::write(other.path().join("advance.txt"), "advance").unwrap();
+        git(other.path(), &["add", "."]);
+        git(other.path(), &["commit", "-m", "remote advance"]);
+        git(other.path(), &["push", "origin", "main"]);
+
+        // The release commit + tag are created locally (mirroring the release
+        // pipeline state right before the racing push).
+        std::fs::write(local.path().join("release.txt"), "release").unwrap();
+        git(local.path(), &["add", "."]);
+        git(local.path(), &["commit", "-m", "release: v1.0.0"]);
+        git(
+            local.path(),
+            &["tag", "-a", "v1.0.0", "-m", "Release v1.0.0"],
+        );
+
+        let component = Component {
+            id: "fixture".to_string(),
+            local_path: local.path().to_string_lossy().to_string(),
+            ..Component::default()
+        };
+
+        let result = run_git_push(&component, "fixture").expect("push step returns a result");
+
+        assert_eq!(
+            result.status,
+            ReleaseStepStatus::Success,
+            "push should recover from the advanced remote: {:?}",
+            result.error
+        );
+        assert_eq!(
+            result
+                .data
+                .as_ref()
+                .and_then(|d| d.get("recovered").and_then(serde_json::Value::as_str)),
+            Some("advanced-remote-rebased")
+        );
+
+        // The remote main now contains BOTH the remote advance and the release
+        // commit (the release commit was rebased on top), and the tag is pushed.
+        git(remote.path(), &["show-ref", "--verify", "refs/tags/v1.0.0"]);
+        let log = Command::new("git")
+            .args(["log", "--oneline", "origin/main"])
+            .current_dir(local.path())
+            .output()
+            .expect("git log");
+        // Refresh remote-tracking ref first.
+        git(local.path(), &["fetch", "origin"]);
+        let log = Command::new("git")
+            .args(["log", "--format=%s", "origin/main"])
+            .current_dir(local.path())
+            .output()
+            .expect("git log");
+        let subjects = String::from_utf8_lossy(&log.stdout);
+        assert!(
+            subjects.contains("release: v1.0.0"),
+            "remote main must contain the release commit, got: {}",
+            subjects
+        );
+        assert!(
+            subjects.contains("remote advance"),
+            "remote main must retain the advance commit (no force-push), got: {}",
+            subjects
+        );
+        let _ = log;
     }
 
     #[test]

--- a/src/core/release/executor/github_release.rs
+++ b/src/core/release/executor/github_release.rs
@@ -17,6 +17,10 @@ pub(super) struct GitHubReleaseRepairCommands {
     pub create_command: String,
     pub view_command: String,
     pub env_hint: Option<String>,
+    /// True when `notes_file` is the persisted exact Homeboy release body
+    /// (issue #3508), so recovery reproduces the identical body rather than
+    /// regenerating notes that could diverge.
+    pub exact_body_available: bool,
 }
 
 /// Create a GitHub Release for the just-pushed tag.
@@ -94,6 +98,10 @@ pub(crate) fn run_github_release(
         .map(|artifact| artifact.path.clone())
         .collect();
     let has_artifacts = !artifact_paths.is_empty();
+    // Repair commands available before the exact body is built/persisted (gh
+    // missing / unauthenticated / upload paths). These regenerate notes since
+    // no persisted exact-body file exists yet. The create path below rebuilds a
+    // persisted-aware closure once the body is written to disk (issue #3508).
     let repair_commands = |notes_start_tag: Option<&str>| {
         github_release_repair_commands(
             &tag,
@@ -101,6 +109,7 @@ pub(crate) fn run_github_release(
             &component.github,
             &artifact_paths,
             notes_start_tag,
+            None,
         )
     };
 
@@ -204,37 +213,35 @@ pub(crate) fn run_github_release(
     let notes_start_tag = github_generated_notes_start_tag(component, &tag)?;
     let changelog_url = github_changelog_url(component, &github, &tag);
 
-    // When GitHub-generated notes fail, do NOT skip the release: a skipped
-    // release that reports success leaves downstream publish/upload steps
-    // uploading assets to a release object that does not exist (issue #3541).
-    // Fall back to creating the release with the changelog notes (or a minimal
-    // body) so the release object is still created from the pushed tag and
-    // built artifacts without a second tag. If even that fails, the step is
-    // marked Failed below.
-    let (release_notes, generated_notes_ok) = match github_generated_notes(
+    // Build the EXACT body Homeboy will post (issue #3508). This is the single
+    // source of truth for the release body — generated notes + changelog footer,
+    // or the changelog-section fallback + footer. Persisting it (below) lets the
+    // repair commands reproduce the identical body via `--notes-file` instead of
+    // re-deriving it from source and risking a divergent body.
+    let body = build_github_release_body(
+        component,
         &github,
-        &component.github,
         &tag,
+        state,
+        changelog_url.as_deref(),
         notes_start_tag.as_deref(),
-    ) {
-        Ok(generated_notes) => {
-            let notes = changelog_url
-                .as_deref()
-                .map(|url| replace_full_changelog_footer(&generated_notes, url))
-                .unwrap_or(generated_notes);
-            (notes, true)
-        }
-        Err(err) => {
-            log_status!(
-                "release",
-                "⚠ GitHub generated release notes failed: {} — falling back to changelog notes",
-                err
-            );
-            (
-                fallback_release_notes(state, changelog_url.as_deref(), &tag),
-                false,
-            )
-        }
+    );
+    let generated_notes_ok = body.generated_notes_ok;
+    let release_notes = body.body.clone();
+
+    // Persist the exact body so it is inspectable after the fact and so the
+    // repair `--notes-file` reproduces it byte-for-byte. A failure to write the
+    // artifact is non-fatal: fall back to commands that regenerate notes.
+    let persisted_notes_path = persist_release_body(component, &tag, &release_notes);
+    let repair_commands = |notes_start_tag: Option<&str>| {
+        github_release_repair_commands(
+            &tag,
+            &github,
+            &component.github,
+            &artifact_paths,
+            notes_start_tag,
+            persisted_notes_path.as_deref(),
+        )
     };
 
     log_status!(
@@ -295,7 +302,14 @@ pub(crate) fn run_github_release(
         log_status!("release", "✗ `gh release create` failed: {}", stderr.trim());
         log_repair_commands(&repair);
         return Ok(create_failed_result(
-            &tag, &github, reason, stdout, stderr, repair,
+            &tag,
+            &github,
+            reason,
+            stdout,
+            stderr,
+            repair,
+            &body,
+            persisted_notes_path.as_deref(),
         ));
     }
 
@@ -313,11 +327,121 @@ pub(crate) fn run_github_release(
             "url": url,
             "artifact_count": artifact_paths.len(),
             "generated_notes": generated_notes_ok,
-            "changelog_url": changelog_url,
+            // The changelog URL embedded in the release body footer, read back
+            // from the single body builder so step metadata and the posted body
+            // can never disagree (issue #3508).
+            "changelog_url": body.changelog_url,
             "notes_start_tag": notes_start_tag,
+            // The exact GitHub Release body Homeboy posted, plus a persisted
+            // copy on disk, so manual recovery reproduces the identical body
+            // without reconstructing it from source (issue #3508).
+            "release_body": release_notes,
+            "release_body_source": body.source_label(),
+            "release_body_file": persisted_notes_path,
         })),
         Vec::new(),
     ))
+}
+
+/// The exact GitHub Release body Homeboy posts, with provenance.
+///
+/// This is the single source of truth for the release body (issue #3508). Every
+/// path that needs the body — the live `gh release create`, the persisted notes
+/// artifact, the JSON step data, and the repair/recovery commands — reads it
+/// from here so an operator never reconstructs a divergent "equivalent" body.
+///
+/// The body is one of:
+/// - GitHub-generated notes with the `**Full Changelog**` footer rewritten to
+///   point at the component's changelog URL (`source = GeneratedNotes`), or
+/// - the changelog section text from [`ReleaseState::notes`] (or a minimal
+///   `Release <tag>` body) with the same changelog footer appended
+///   (`source = ChangelogFallback`) when generated notes are unavailable.
+#[derive(Debug, Clone)]
+pub(crate) struct GitHubReleaseBody {
+    /// The exact markdown body passed to `gh release create --notes`.
+    pub body: String,
+    /// Whether GitHub-generated notes succeeded. `false` means the changelog
+    /// fallback body was used.
+    pub generated_notes_ok: bool,
+    /// The changelog URL embedded in the footer, when one was resolved.
+    pub changelog_url: Option<String>,
+}
+
+impl GitHubReleaseBody {
+    /// Human/JSON-readable label distinguishing the body's provenance so
+    /// operators can tell generated notes from the changelog fallback.
+    pub(crate) fn source_label(&self) -> &'static str {
+        if self.generated_notes_ok {
+            "generated-notes"
+        } else {
+            "changelog-fallback"
+        }
+    }
+}
+
+/// Build the exact GitHub Release body Homeboy will post (issue #3508).
+///
+/// Distinguishing the four concepts the issue calls out:
+/// - *changelog section text* lives in [`ReleaseState::notes`],
+/// - *changelog URL* is the `changelog_url` link,
+/// - *final GitHub Release body* is what this function returns,
+/// - *structured step metadata* is the JSON emitted by the step.
+pub(crate) fn build_github_release_body(
+    component: &Component,
+    github: &GitHubRepo,
+    tag: &str,
+    state: &ReleaseState,
+    changelog_url: Option<&str>,
+    notes_start_tag: Option<&str>,
+) -> GitHubReleaseBody {
+    match github_generated_notes(github, &component.github, tag, notes_start_tag) {
+        Ok(generated_notes) => {
+            let body = changelog_url
+                .map(|url| replace_full_changelog_footer(&generated_notes, url))
+                .unwrap_or(generated_notes);
+            GitHubReleaseBody {
+                body,
+                generated_notes_ok: true,
+                changelog_url: changelog_url.map(str::to_string),
+            }
+        }
+        Err(err) => {
+            log_status!(
+                "release",
+                "⚠ GitHub generated release notes failed: {} — falling back to changelog notes",
+                err
+            );
+            GitHubReleaseBody {
+                body: fallback_release_notes(state, changelog_url, tag),
+                generated_notes_ok: false,
+                changelog_url: changelog_url.map(str::to_string),
+            }
+        }
+    }
+}
+
+/// Persist the exact release body to `build/<tag>-release-notes.md` so it is
+/// inspectable after the run and so the repair `--notes-file` reproduces the
+/// identical body. Returns the path on success; a write failure is non-fatal
+/// (the repair commands fall back to regenerating notes).
+fn persist_release_body(component: &Component, tag: &str, body: &str) -> Option<String> {
+    let build_dir = std::path::Path::new(&component.local_path).join("build");
+    if let Err(err) = std::fs::create_dir_all(&build_dir) {
+        log_status!(
+            "release",
+            "⚠ Could not create build/ to persist release body: {}",
+            err
+        );
+        return None;
+    }
+    let file = build_dir.join(format!("{}-release-notes.md", safe_filename(tag)));
+    match std::fs::write(&file, body) {
+        Ok(()) => Some(file.to_string_lossy().replace('\\', "/")),
+        Err(err) => {
+            log_status!("release", "⚠ Could not persist release body: {}", err);
+            None
+        }
+    }
 }
 
 fn github_generated_notes(
@@ -484,6 +608,8 @@ pub(super) fn create_failed_result(
     stdout: String,
     stderr: String,
     repair: GitHubReleaseRepairCommands,
+    body: &GitHubReleaseBody,
+    persisted_notes_path: Option<&str>,
 ) -> ReleaseStepResult {
     let data = serde_json::json!({
         "skipped": false,
@@ -497,6 +623,11 @@ pub(super) fn create_failed_result(
         "stderr": stderr.clone(),
         "fallback_command": repair.create_command.clone(),
         "repair": repair_data(&repair),
+        // Expose the EXACT body Homeboy attempted to post + its persisted copy
+        // so manual recovery reproduces the identical release body (issue #3508).
+        "release_body": body.body,
+        "release_body_source": body.source_label(),
+        "release_body_file": persisted_notes_path,
     });
 
     let detail = stderr.trim();
@@ -604,12 +735,14 @@ pub(super) fn github_release_repair_commands(
     config: &GithubConfig,
     artifact_paths: &[String],
     previous_tag: Option<&str>,
+    persisted_notes_path: Option<&str>,
 ) -> GitHubReleaseRepairCommands {
     github_release_repair_commands_with_env(
         tag,
         github,
         artifact_paths,
         previous_tag,
+        persisted_notes_path,
         github_cli_env(github, config),
     )
 }
@@ -639,7 +772,7 @@ pub(super) fn github_release_repair_commands_with_proxy(
                 Vec::new()
             }
         });
-    github_release_repair_commands_with_env(tag, github, artifact_paths, previous_tag, env)
+    github_release_repair_commands_with_env(tag, github, artifact_paths, previous_tag, None, env)
 }
 
 fn github_release_repair_commands_with_env(
@@ -647,11 +780,19 @@ fn github_release_repair_commands_with_env(
     github: &GitHubRepo,
     artifact_paths: &[String],
     previous_tag: Option<&str>,
+    persisted_notes_path: Option<&str>,
     env: Vec<(String, String)>,
 ) -> GitHubReleaseRepairCommands {
     let env_prefix = gh_env_prefix(&env);
     let repo_flag = format!("{}/{}", github.owner, github.repo);
-    let notes_file = format!("build/{}-release-notes.md", safe_filename(tag));
+    // When the exact Homeboy release body was persisted to disk (issue #3508),
+    // point recovery at THAT file so a manual `gh release create` reproduces the
+    // identical body. Only fall back to regenerating notes into a fresh file
+    // when no persisted body exists (gh missing/unauth paths, write failure).
+    let exact_body_available = persisted_notes_path.is_some();
+    let notes_file = persisted_notes_path
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("build/{}-release-notes.md", safe_filename(tag)));
     let endpoint = format!(
         "repos/{}/{}/releases/generate-notes",
         github.owner, github.repo
@@ -669,11 +810,22 @@ fn github_release_repair_commands_with_env(
     }
     generate_notes.push("--jq".to_string());
     generate_notes.push(shell_quote(".body"));
-    let generate_notes_command = format!(
+    let regenerate_command = format!(
         "{} > {}",
         generate_notes.join(" "),
         shell_quote(&notes_file)
     );
+    // The notes-generation step is only meaningful when there is no persisted
+    // exact body. With a persisted body, regenerating would risk a divergent
+    // result, so the "generate" step becomes a no-op note that reuses the file.
+    let generate_notes_command = if exact_body_available {
+        format!(
+            "# Exact Homeboy release body already saved at {} — use it as-is",
+            notes_file
+        )
+    } else {
+        regenerate_command
+    };
 
     let mut create = vec![
         format!("{}gh", env_prefix),
@@ -699,13 +851,23 @@ fn github_release_repair_commands_with_env(
     );
     let env_hint = gh_env_hint(github, &env);
 
+    let notes_guidance = if exact_body_available {
+        format!(
+            "The exact GitHub Release body Homeboy generated is saved at {}. Create the release straight from it (no regeneration) so the body matches byte-for-byte.",
+            notes_file
+        )
+    } else {
+        "Review the generated markdown body in the notes file before creating the release; keep it as the content passed to --notes-file.".to_string()
+    };
+
     GitHubReleaseRepairCommands {
         notes_file,
-        notes_guidance: "Review the generated markdown body in the notes file before creating the release; keep it as the content passed to --notes-file.".to_string(),
+        notes_guidance,
         generate_notes_command,
         create_command: create.join(" "),
         view_command,
         env_hint,
+        exact_body_available,
     }
 }
 
@@ -742,6 +904,7 @@ fn repair_data(repair: &GitHubReleaseRepairCommands) -> serde_json::Value {
         "create_command": repair.create_command,
         "view_command": repair.view_command,
         "env_hint": repair.env_hint,
+        "exact_body_available": repair.exact_body_available,
     })
 }
 
@@ -884,6 +1047,7 @@ mod tests {
     use super::{
         create_failed_result, fallback_release_notes, github_cli_env,
         github_release_repair_commands, not_created_result, upload_failed_result,
+        GitHubReleaseBody,
     };
 
     fn test_repo() -> GitHubRepo {
@@ -901,7 +1065,17 @@ mod tests {
             &GithubConfig::default(),
             &["build/studio-web.zip".to_string()],
             None,
+            None,
         )
+    }
+
+    fn test_body() -> GitHubReleaseBody {
+        GitHubReleaseBody {
+            body: "## What's Changed\n\n**Full Changelog**: https://example/CHANGELOG.md"
+                .to_string(),
+            generated_notes_ok: true,
+            changelog_url: Some("https://example/CHANGELOG.md".to_string()),
+        }
     }
 
     fn data_str<'a>(result: &'a super::ReleaseStepResult, key: &str) -> Option<&'a str> {
@@ -961,6 +1135,8 @@ mod tests {
             String::new(),
             "HTTP 502: bad gateway".to_string(),
             test_repair(),
+            &test_body(),
+            Some("build/v0.10.6-release-notes.md"),
         );
 
         assert_eq!(result.status, ReleaseStepStatus::Failed);
@@ -989,6 +1165,8 @@ mod tests {
             String::new(),
             "release v0.10.6 already exists".to_string(),
             test_repair(),
+            &test_body(),
+            Some("build/v0.10.6-release-notes.md"),
         );
 
         assert_eq!(result.status, ReleaseStepStatus::Failed);
@@ -1048,6 +1226,99 @@ mod tests {
         let notes = fallback_release_notes(&state, None, "v0.10.6");
 
         assert_eq!(notes, "Release v0.10.6");
+    }
+
+    // ---- Issue #3508: the exact GitHub Release body must be discoverable ----
+
+    #[test]
+    fn release_body_source_label_distinguishes_generated_from_fallback() {
+        let generated = GitHubReleaseBody {
+            body: "x".to_string(),
+            generated_notes_ok: true,
+            changelog_url: None,
+        };
+        let fallback = GitHubReleaseBody {
+            body: "x".to_string(),
+            generated_notes_ok: false,
+            changelog_url: None,
+        };
+        assert_eq!(generated.source_label(), "generated-notes");
+        assert_eq!(fallback.source_label(), "changelog-fallback");
+    }
+
+    #[test]
+    fn create_failed_result_exposes_exact_release_body_and_persisted_file() {
+        // Regression for #3508: a failed create must surface the EXACT body
+        // Homeboy attempted to post plus its persisted-file path so manual
+        // recovery reproduces the identical body instead of reconstructing it.
+        let body = test_body();
+        let result = create_failed_result(
+            "v0.10.6",
+            &test_repo(),
+            "generated-notes-failed",
+            String::new(),
+            "HTTP 502".to_string(),
+            test_repair(),
+            &body,
+            Some("build/v0.10.6-release-notes.md"),
+        );
+
+        assert_eq!(data_str(&result, "release_body"), Some(body.body.as_str()));
+        assert_eq!(
+            data_str(&result, "release_body_source"),
+            Some("generated-notes")
+        );
+        assert_eq!(
+            data_str(&result, "release_body_file"),
+            Some("build/v0.10.6-release-notes.md")
+        );
+        // The exact body must carry the changelog link footer.
+        assert!(data_str(&result, "release_body")
+            .unwrap()
+            .contains("**Full Changelog**:"));
+    }
+
+    #[test]
+    fn repair_commands_reuse_persisted_exact_body_when_available() {
+        // With the persisted exact body, recovery must `--notes-file` THAT file
+        // and must NOT regenerate notes (which could diverge) — issue #3508.
+        let repair = github_release_repair_commands(
+            "v0.10.6",
+            &test_repo(),
+            &GithubConfig::default(),
+            &["build/studio-web.zip".to_string()],
+            None,
+            Some("build/v0.10.6-release-notes.md"),
+        );
+
+        assert!(repair.exact_body_available);
+        assert_eq!(repair.notes_file, "build/v0.10.6-release-notes.md");
+        assert!(repair
+            .create_command
+            .contains("--notes-file build/v0.10.6-release-notes.md"));
+        // The generate step must not re-run note generation against the API.
+        assert!(!repair.generate_notes_command.contains("generate-notes"));
+        assert!(repair.notes_guidance.contains("byte-for-byte"));
+    }
+
+    #[test]
+    fn repair_commands_regenerate_notes_when_no_persisted_body() {
+        // Without a persisted body (gh missing / unauth), recovery falls back to
+        // regenerating notes into a fresh file.
+        let repair = github_release_repair_commands(
+            "v0.10.6",
+            &test_repo(),
+            &GithubConfig::default(),
+            &["build/studio-web.zip".to_string()],
+            None,
+            None,
+        );
+
+        assert!(!repair.exact_body_available);
+        assert!(repair.generate_notes_command.contains("generate-notes"));
+        assert!(repair
+            .create_command
+            .contains("--notes-file build/v0.10.6-release-notes.md"));
     }
 
     #[test]

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -916,6 +916,17 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
         actions.push("pushed commits and tags".to_string());
     }
 
+    // Issue #3611: the partial state where the TAG was pushed but the branch
+    // push was rejected because the remote advanced. Here the tag points at
+    // HEAD (not stale) and there are no uncommitted changes, so the checks
+    // above are all satisfied — yet the release commit is still missing from
+    // the remote branch. Detect that the local release commit is not on the
+    // remote branch and reconcile it (rebase onto the advanced remote, push)
+    // without re-tagging or force-pushing.
+    if let Some(reconcile_action) = reconcile_release_branch(&component, &input.component_id)? {
+        actions.push(reconcile_action);
+    }
+
     if actions.is_empty() {
         log_status!(
             "recover",
@@ -964,6 +975,129 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
         },
         0,
     ))
+}
+
+/// Reconcile the release branch with an advanced remote during `--recover`
+/// (issue #3611).
+///
+/// Handles the partial state where the release tag was pushed but the branch
+/// push was rejected because `origin/<branch>` advanced. When the local release
+/// commit (HEAD) is not contained in the remote branch, this fetches, rebases
+/// HEAD onto the advanced remote head (only when histories share an ancestor —
+/// never a force-push over divergent history), and re-pushes the branch.
+///
+/// Returns `Ok(Some(description))` when it reconciled the branch, `Ok(None)`
+/// when nothing needed doing (or no remote branch / detached HEAD), and `Err`
+/// when reconciliation was attempted but failed (e.g. rebase conflict) so the
+/// operator gets a clear, non-guessing failure.
+fn reconcile_release_branch(
+    component: &crate::core::component::Component,
+    component_id: &str,
+) -> Result<Option<String>> {
+    let path = &component.local_path;
+    let Some(branch) = git::current_branch(std::path::Path::new(path)) else {
+        // Detached HEAD — no branch to reconcile.
+        return Ok(None);
+    };
+
+    git::fetch_origin(path)?;
+    let Some(remote_commit) = git::remote_branch_commit(path, &branch)? else {
+        // Branch not on remote yet; the tag-push block above already pushes the
+        // branch when it pushes tags, so there is nothing to reconcile here.
+        return Ok(None);
+    };
+    let head_commit = git::get_head_commit(path)?;
+
+    // The release commit is already on the remote branch — nothing to do.
+    if git::is_ancestor(path, &head_commit, &remote_commit)? {
+        return Ok(None);
+    }
+
+    // Remote head already contained in HEAD (a plain non-pushed branch): push.
+    if git::is_ancestor(path, &remote_commit, &head_commit)? {
+        log_status!(
+            "recover",
+            "Pushing release commit to remote {} (remote did not advance)...",
+            branch
+        );
+        let push = git::push_at(
+            Some(component_id),
+            git::PushOptions {
+                tags: true,
+                refspec: Some(format!("HEAD:refs/heads/{branch}")),
+                ..Default::default()
+            },
+            Some(path),
+        )?;
+        if !push.success {
+            return Err(Error::git_command_failed(format!(
+                "Failed to push release branch {}: {}",
+                branch, push.stderr
+            )));
+        }
+        return Ok(Some(format!("pushed release commit to {}", branch)));
+    }
+
+    // Histories diverged: the remote advanced after the release commit. Rebase
+    // the release commit onto the advanced remote head, then push. Never force.
+    log_status!(
+        "recover",
+        "Remote {} advanced — rebasing release commit onto the new head and re-pushing...",
+        branch
+    );
+    let rebase = git::rebase_at(
+        Some(component_id),
+        git::RebaseOptions {
+            onto: Some(remote_commit.clone()),
+            ..Default::default()
+        },
+        Some(path),
+    )?;
+    if !rebase.success {
+        let _ = git::rebase_at(
+            Some(component_id),
+            git::RebaseOptions {
+                abort: true,
+                ..Default::default()
+            },
+            Some(path),
+        );
+        return Err(Error::validation_invalid_argument(
+            "recover",
+            format!(
+                "Rebasing the release commit onto the advanced remote {} hit a conflict",
+                branch
+            ),
+            None,
+            Some(vec![
+                format!(
+                    "Resolve manually: git fetch origin && git rebase origin/{branch}, fix conflicts, then: homeboy release {} --recover",
+                    component_id
+                ),
+            ]),
+        ));
+    }
+
+    let push = git::push_at(
+        Some(component_id),
+        git::PushOptions {
+            tags: true,
+            refspec: Some(format!("HEAD:refs/heads/{branch}")),
+            ..Default::default()
+        },
+        Some(path),
+    )?;
+    if !push.success {
+        return Err(Error::git_command_failed(format!(
+            "Failed to push rebased release branch {}: {}",
+            branch, push.stderr
+        )));
+    }
+
+    Ok(Some(format!(
+        "rebased release commit onto advanced remote and pushed {}",
+        branch
+    )))
 }
 
 fn recovery_release_plan(
@@ -1264,6 +1398,116 @@ mod tests {
             .steps
             .iter()
             .all(|step| step.status == PlanStepStatus::Disabled));
+    }
+
+    fn git_in(dir: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn identity(dir: &std::path::Path) {
+        git_in(dir, &["config", "user.name", "Homeboy Test"]);
+        git_in(dir, &["config", "user.email", "homeboy@example.test"]);
+        git_in(dir, &["config", "commit.gpgsign", "false"]);
+    }
+
+    /// Issue #3611: the recover path must reconcile a release commit that is
+    /// missing from an advanced remote branch (tag pushed, branch rejected) by
+    /// rebasing onto the new remote head and pushing — no force, no re-tag.
+    #[test]
+    fn reconcile_release_branch_rebases_onto_advanced_remote() {
+        let remote = tempfile::tempdir().expect("remote");
+        let other = tempfile::tempdir().expect("other");
+        let local = tempfile::tempdir().expect("local");
+        git_in(remote.path(), &["init", "--bare", "-b", "main"]);
+
+        git_in(
+            other.path(),
+            &["clone", remote.path().to_str().unwrap(), "."],
+        );
+        identity(other.path());
+        std::fs::write(other.path().join("base.txt"), "base").unwrap();
+        git_in(other.path(), &["add", "."]);
+        git_in(other.path(), &["commit", "-m", "base"]);
+        git_in(other.path(), &["push", "origin", "main"]);
+
+        git_in(
+            local.path(),
+            &["clone", remote.path().to_str().unwrap(), "."],
+        );
+        identity(local.path());
+
+        // Remote advances after the release clone.
+        std::fs::write(other.path().join("advance.txt"), "advance").unwrap();
+        git_in(other.path(), &["add", "."]);
+        git_in(other.path(), &["commit", "-m", "remote advance"]);
+        git_in(other.path(), &["push", "origin", "main"]);
+
+        // Local release commit (branch NOT yet on remote; tag would already be).
+        std::fs::write(local.path().join("release.txt"), "release").unwrap();
+        git_in(local.path(), &["add", "."]);
+        git_in(local.path(), &["commit", "-m", "release: v1.0.0"]);
+
+        let component = crate::core::component::Component {
+            id: "fixture".to_string(),
+            local_path: local.path().to_string_lossy().to_string(),
+            ..crate::core::component::Component::default()
+        };
+
+        let action = reconcile_release_branch(&component, "fixture")
+            .expect("reconcile should succeed")
+            .expect("reconcile should report an action");
+        assert!(
+            action.contains("rebased release commit onto advanced remote"),
+            "unexpected action: {}",
+            action
+        );
+
+        git_in(local.path(), &["fetch", "origin"]);
+        let log = std::process::Command::new("git")
+            .args(["log", "--format=%s", "origin/main"])
+            .current_dir(local.path())
+            .output()
+            .expect("git log");
+        let subjects = String::from_utf8_lossy(&log.stdout);
+        assert!(subjects.contains("release: v1.0.0"), "got: {}", subjects);
+        assert!(subjects.contains("remote advance"), "got: {}", subjects);
+    }
+
+    /// When the release commit is already on the remote branch, reconcile is a
+    /// no-op (nothing to recover).
+    #[test]
+    fn reconcile_release_branch_noop_when_already_pushed() {
+        let remote = tempfile::tempdir().expect("remote");
+        let local = tempfile::tempdir().expect("local");
+        git_in(remote.path(), &["init", "--bare", "-b", "main"]);
+        git_in(
+            local.path(),
+            &["clone", remote.path().to_str().unwrap(), "."],
+        );
+        identity(local.path());
+        std::fs::write(local.path().join("release.txt"), "release").unwrap();
+        git_in(local.path(), &["add", "."]);
+        git_in(local.path(), &["commit", "-m", "release: v1.0.0"]);
+        git_in(local.path(), &["push", "origin", "main"]);
+
+        let component = crate::core::component::Component {
+            id: "fixture".to_string(),
+            local_path: local.path().to_string_lossy().to_string(),
+            ..crate::core::component::Component::default()
+        };
+
+        let action = reconcile_release_branch(&component, "fixture").expect("reconcile ok");
+        assert!(action.is_none(), "expected no-op, got: {:?}", action);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Two related release-executor fixes that build on the existing `--recover` / `--retag` semantics.

### #3611 — recover cleanly when remote `main` advances after the tag push
`homeboy release` can race: the tag pushes but the branch push is rejected as non-fast-forward because the remote advanced mid-release, leaving a partial state (tag on remote, release commit missing from the branch).

- `git.push` now detects a non-fast-forward branch rejection, `fetch`es, rebases the release commit onto the advanced remote head, and re-pushes the branch — **no force-push, no second tag**. The already-pushed tag is left untouched.
- `--recover` gains the same reconciliation (`reconcile_release_branch`): when the tag is pushed but the local release commit is not on the remote branch, it rebases onto the new head and pushes.
- When automatic reconciliation is unsafe (rebase conflict, missing remote branch), both paths abort the rebase to keep the tree clean and emit a deterministic, non-force recovery hint pointing at `homeboy release <id> --recover`.

### #3508 — make the exact GitHub Release body discoverable
The body Homeboy posts (`--notes`) was built inline and never persisted/exposed, so manual recovery could reconstruct a **divergent** "equivalent" body from source.

- Single source of truth: `build_github_release_body()` returns the exact body (generated notes + changelog footer, or changelog-section fallback + footer) with provenance (`generated-notes` vs `changelog-fallback`).
- The exact body is persisted to `build/<tag>-release-notes.md`.
- Step data now carries `release_body`, `release_body_source`, and `release_body_file` on both success and create-failure.
- Repair commands prefer the **persisted exact body** via `--notes-file` (reproducing it byte-for-byte) and only regenerate notes when no persisted body exists.

## Scope / architecture
All changes are generic git/GitHub release-executor logic. **No WordPress / wp-codebox literals introduced in homeboy core** — the issues reference wp-codebox/Studio Web only as the components that surfaced the bugs.

## Tests
- `run_git_push_recovers_when_remote_advanced` — fixture proving the rebase-recovery keeps both the remote-advance commit and the release commit (no force-push).
- `reconcile_release_branch_rebases_onto_advanced_remote` + `reconcile_release_branch_noop_when_already_pushed`.
- `test_is_non_fast_forward_rejection`, `test_remote_branch_commit`, `test_fetch_origin`.
- `create_failed_result_exposes_exact_release_body_and_persisted_file`, `repair_commands_reuse_persisted_exact_body_when_available`, `repair_commands_regenerate_notes_when_no_persisted_body`, `release_body_source_label_distinguishes_generated_from_fallback`.

`cargo fmt --check`, `cargo clippy --lib` (no errors), and the `release::*` / `git::operations` suites all pass. (Pre-existing env-dependent `bench`/`trace`/`npm`/`component_script` failures are unrelated and reproduce on a clean baseline.)

Closes #3611
Closes #3508