### PR TITLE
Include actionable lint findings in PR digests

### DIFF
--- a/src/commands/report/failure_digest.rs
+++ b/src/commands/report/failure_digest.rs
@@ -13,6 +13,8 @@ use audit::render_audit_section;
 use bench::render_bench_section;
 use trace::render_trace_section;
 
+const LINT_FINDING_DIGEST_LIMIT: usize = 10;
+
 #[derive(Args, Debug, Clone)]
 pub struct FailureDigestArgs {
     /// Directory containing audit.json, lint.json, test.json, etc.
@@ -218,9 +220,11 @@ fn render_lint_section(out: &mut String, output_dir: &Path, run_url: &str) {
     render_error_details(out, &error);
 
     let top_violations = string_array(&data, "top_violations");
+    let findings = array_value(&data, "findings");
+    render_lint_findings(out, &findings, &data);
     append_details_block(out, "Top lint violations", &top_violations, 10);
 
-    if !has_any_lint_detail(&data, &error) && top_violations.is_empty() {
+    if !has_any_lint_detail(&data, &error) && top_violations.is_empty() && findings.is_empty() {
         out.push_str("- No structured lint details available.\n");
     }
     render_full_log(out, "lint", run_url);
@@ -424,6 +428,63 @@ fn has_any_lint_detail(data: &Map<String, Value>, error: &Map<String, Value>) ->
             .any(|key| string_value(error, key).is_some())
 }
 
+fn render_lint_findings(out: &mut String, findings: &[&Value], data: &Map<String, Value>) {
+    if findings.is_empty() {
+        return;
+    }
+
+    let shown = findings.len().min(LINT_FINDING_DIGEST_LIMIT);
+    let _ = writeln!(out, "- Actionable lint findings ({} shown):", shown);
+    for (idx, item) in findings.iter().take(LINT_FINDING_DIGEST_LIMIT).enumerate() {
+        let _ = writeln!(out, "  - {}", summarize_lint_finding(item, idx + 1));
+    }
+    if findings.len() > shown {
+        let _ = writeln!(
+            out,
+            "- {} more lint finding(s) omitted from this comment; see `lint.json` or the full lint log.",
+            findings.len() - shown
+        );
+    }
+    if let Some(autofix) = object_value_opt(data, "autofix") {
+        let files_modified = autofix
+            .get("files_modified")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let _ = writeln!(
+            out,
+            "- Autofix applied: **{}** ({} file(s) modified)",
+            if files_modified > 0 { "yes" } else { "no" },
+            files_modified
+        );
+    }
+}
+
+fn summarize_lint_finding(item: &Value, idx: usize) -> String {
+    let Some(obj) = item.as_object() else {
+        return format!(
+            "{}. {}",
+            idx,
+            item.as_str().unwrap_or("unknown lint finding")
+        );
+    };
+
+    let file = string_value(obj, "file").unwrap_or_else(|| "unknown file".to_string());
+    let location = obj
+        .get("line")
+        .and_then(Value::as_i64)
+        .map(|line| format!("{}:{}", file, line))
+        .unwrap_or(file);
+    let severity = string_value(obj, "severity").unwrap_or_else(|| "unknown severity".to_string());
+    let tool = string_value(obj, "tool").unwrap_or_else(|| "lint".to_string());
+    let rule = string_value(obj, "rule").unwrap_or_else(|| "unknown rule".to_string());
+    let message = string_value(obj, "message").unwrap_or_else(|| "No message provided".to_string());
+
+    format!(
+        "{}. `{}` [{}] {}/{}: {}",
+        idx, location, severity, tool, rule, message
+    )
+}
+
 fn string_value(map: &Map<String, Value>, key: &str) -> Option<String> {
     match map.get(key)? {
         Value::String(s) if !s.is_empty() => Some(s.clone()),
@@ -438,6 +499,10 @@ fn object_value(map: &Map<String, Value>, key: &str) -> Map<String, Value> {
         .and_then(Value::as_object)
         .cloned()
         .unwrap_or_default()
+}
+
+fn object_value_opt<'a>(map: &'a Map<String, Value>, key: &str) -> Option<&'a Map<String, Value>> {
+    map.get(key).and_then(Value::as_object)
 }
 
 fn array_value<'a>(map: &'a Map<String, Value>, key: &str) -> Vec<&'a Value> {

--- a/tests/fixtures/failure_digest/lint.json
+++ b/tests/fixtures/failure_digest/lint.json
@@ -5,6 +5,37 @@
     "summary": "3 lint finding(s)",
     "phpcs_summary": "2 PHPCS error(s)",
     "phpstan_summary": "1 PHPStan error(s)",
+    "autofix": {
+      "files_modified": 1,
+      "rerun_recommended": true,
+      "changed_files": ["src/widget.php"]
+    },
+    "findings": [
+      {
+        "tool": "phpcs",
+        "rule": "Squiz.Commenting.FunctionComment.Missing",
+        "severity": "error",
+        "file": "src/widget.php",
+        "line": 12,
+        "message": "Missing function doc comment"
+      },
+      {
+        "tool": "phpcs",
+        "rule": "Squiz.Commenting.FunctionComment.Missing",
+        "severity": "error",
+        "file": "src/widget.php",
+        "line": 24,
+        "message": "Missing function doc comment"
+      },
+      {
+        "tool": "phpstan",
+        "rule": "undefined-method",
+        "severity": "error",
+        "file": "src/service.php",
+        "line": 7,
+        "message": "Call to undefined method App\\Service::missing()"
+      }
+    ],
     "top_violations": [
       "Squiz.Commenting.FunctionComment.Missing — 2",
       "PHPStan: Call to undefined method — 1"

--- a/tests/report_failure_digest_test.rs
+++ b/tests/report_failure_digest_test.rs
@@ -67,6 +67,28 @@ fn trace_json(status: &str, summary: &str) -> String {
     )
 }
 
+fn lint_json_with_findings(count: usize) -> String {
+    let findings = (1..=count)
+        .map(|idx| {
+            format!(
+                r#"{{"tool":"eslint","rule":"no-debugger","severity":"error","file":"src/file{idx}.js","line":{idx},"message":"Unexpected debugger statement"}}"#
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+
+    format!(
+        r#"{{
+            "success": false,
+            "data": {{
+                "passed": false,
+                "summary": "{count} lint finding(s)",
+                "findings": [{findings}]
+            }}
+        }}"#
+    )
+}
+
 fn trace_json_with_span_summaries() -> &'static str {
     r#"{
         "success": false,
@@ -248,10 +270,35 @@ fn renders_lint_failure_digest_from_fixture() {
     assert!(markdown.contains("## Failure Digest"));
     assert!(markdown.contains("### Lint Failure Digest"));
     assert!(markdown.contains("- Lint summary: **3 lint finding(s)**"));
+    assert!(markdown.contains("- Actionable lint findings (3 shown):"));
+    assert!(markdown.contains(
+        "1. `src/widget.php:12` [error] phpcs/Squiz.Commenting.FunctionComment.Missing: Missing function doc comment"
+    ));
+    assert!(markdown.contains("- Autofix applied: **yes** (1 file(s) modified)"));
     assert!(markdown.contains("<details><summary>Top lint violations</summary>"));
     assert!(markdown
         .contains("- Full lint log: https://github.com/Extra-Chill/homeboy/actions/runs/123"));
     assert!(!markdown.contains("### Test Failure Digest"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn caps_lint_findings_in_failure_digest() {
+    let dir = tmp_dir("lint-cap");
+    fs::create_dir_all(&dir).expect("temp dir should exist");
+    write_file(&dir, "lint.json", &lint_json_with_findings(12));
+
+    let markdown = render(&dir, r#"{"lint":"fail"}"#, false, false);
+
+    assert!(markdown.contains("- Actionable lint findings (10 shown):"));
+    assert!(markdown.contains(
+        "10. `src/file10.js:10` [error] eslint/no-debugger: Unexpected debugger statement"
+    ));
+    assert!(markdown.contains(
+        "- 2 more lint finding(s) omitted from this comment; see `lint.json` or the full lint log."
+    ));
+    assert!(!markdown.contains("src/file11.js"));
 
     let _ = fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary\n- Inlines the first actionable lint findings in PR failure digests with file, line, severity, rule/tool, and message.\n- Caps output and preserves artifact/deep-dive links for the full result.\n\nCloses #4879.\n\n## Verification\n- cargo fmt --check\n- cargo test --test report_failure_digest_test