### PR TITLE
Make agent-runtimes the canonical runtime root

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -240,7 +240,7 @@ patch-producing provider, `--cwd` must point at a clean git checkout with
 runner-side git checkout/worktree before provider dispatch so generated files can
 come back as patch artifacts. Non-git directories, dirty worktrees, and checkouts
 without `origin` fail on the controller before offload with a supported-path
-diagnostic; use a Homeboy/Data Machine Code worktree or another clean checkout
+diagnostic; use a Homeboy worktree or another clean checkout
 for write-capable agent tasks.
 
 ## Durable Loop Controllers

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -193,7 +193,12 @@ fn agent_task_provider_requires_cwd_git_checkout_with(
 ) -> bool {
     match command {
         agent_task::AgentTaskCommand::Cook(args) | agent_task::AgentTaskCommand::Dispatch(args) => {
-            if !args.cwd.as_ref().is_some_and(|cwd| !cwd.trim().is_empty()) {
+            let has_workspace = args.cwd.as_ref().is_some_and(|cwd| !cwd.trim().is_empty())
+                || args
+                    .workspace
+                    .as_ref()
+                    .is_some_and(|workspace| !workspace.trim().is_empty());
+            if !has_workspace {
                 return false;
             }
             let backend = args.backend.clone().or_else(default_backend);
@@ -837,6 +842,28 @@ mod tests {
             &args.command,
             || Some("default-patch-provider".to_string()),
             |backend, _| backend == "default-patch-provider",
+        ));
+    }
+
+    #[test]
+    fn agent_task_git_checkout_policy_treats_workspace_like_cwd() {
+        let command = parsed_command(&[
+            "homeboy",
+            "agent-task",
+            "dispatch",
+            "--workspace",
+            "/work/repo",
+            "--prompt",
+            "cook",
+        ]);
+        let Commands::AgentTask(args) = command else {
+            panic!("expected agent-task command");
+        };
+
+        assert!(agent_task_provider_requires_cwd_git_checkout_with(
+            &args.command,
+            || Some("default-patch-provider".to_string()),
+            |backend, selector| backend == "default-patch-provider" && selector.is_none(),
         ));
     }
 

--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -40,12 +40,6 @@ fn discover_standalone_agent_runtime_manifests() -> Vec<AgentRuntimeManifest> {
             paths::agent_runtime_manifest,
         ));
     }
-    if let Ok(runtime_dir) = paths::ai_runtimes() {
-        manifests.extend(discover_standalone_agent_runtime_manifests_in(
-            runtime_dir,
-            paths::ai_runtime_manifest,
-        ));
-    }
     manifests.sort_by(|a, b| a.id.cmp(&b.id));
     manifests
 }
@@ -107,27 +101,6 @@ pub(crate) fn discover_agent_runtime_manifests_from_extensions(
                 runtime_path: extension.extension_path.clone(),
             });
         }
-
-        let Some(legacy_providers) = extension.extra.get("agent_task_executors") else {
-            continue;
-        };
-        let Ok(providers) =
-            serde_json::from_value::<Vec<AgentTaskExecutorProvider>>(legacy_providers.clone())
-        else {
-            continue;
-        };
-        if providers.is_empty() {
-            continue;
-        }
-        runtime_manifests.push(AgentRuntimeManifest {
-            schema: AGENT_RUNTIME_MANIFEST_SCHEMA.to_string(),
-            id: format!("{}.legacy-agent-task-executors", extension.id),
-            label: Some("Legacy agent-task executors".to_string()),
-            agent_task_executors: providers,
-            extension_id: Some(extension.id.clone()),
-            extension_path: extension.extension_path.clone(),
-            runtime_path: extension.extension_path.clone(),
-        });
     }
     runtime_manifests
 }
@@ -240,24 +213,6 @@ mod tests {
             manifests[0].runtime_path.as_deref(),
             Some("/extensions/runtime-extension")
         );
-    }
-
-    #[test]
-    fn keeps_legacy_agent_task_executor_manifest_discovery() {
-        let mut extension = extension("legacy-extension");
-        extension.extra.insert(
-            "agent_task_executors".to_string(),
-            json!([provider_json("legacy.default", "legacy")]),
-        );
-
-        let manifests = discover_agent_runtime_manifests_from_extensions(&[extension]);
-
-        assert_eq!(manifests.len(), 1);
-        assert_eq!(
-            manifests[0].id,
-            "legacy-extension.legacy-agent-task-executors"
-        );
-        assert_eq!(manifests[0].agent_task_executors[0].backend, "legacy");
     }
 
     #[test]

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -300,21 +300,24 @@ fn validate_dispatch_workspace_target(
     let Some(workspace) = workspace else {
         return Ok(());
     };
-    if workspace.kind.as_deref() != Some("cwd")
-        || !provider_requires_cwd_git_checkout(backend, selector)
-    {
+    if !provider_requires_cwd_git_checkout(backend, selector) {
         return Ok(());
     }
     if is_git_checkout(&workspace.root) {
         return Ok(());
     }
+    let argument = if workspace.kind.as_deref() == Some("cwd") {
+        "cwd"
+    } else {
+        "workspace"
+    };
 
     Err(Error::validation_invalid_argument(
-        "cwd",
-        "selected agent-task provider requires --cwd to be a git checkout so generated files can be returned as a patch artifact",
+        argument,
+        "selected agent-task provider requires the dispatch workspace to be a git checkout so generated files can be returned as a patch artifact",
         Some(workspace.root.display().to_string()),
         Some(vec![
-            "Use a Homeboy/Data Machine Code worktree for write-capable agent tasks.".to_string(),
+            "Use a Homeboy worktree or another git checkout for write-capable agent tasks.".to_string(),
             "Initialize the target as a git checkout before dispatching.".to_string(),
             "Use a provider without a git-checkout materialization requirement only if it has an explicit non-git apply-back artifact contract.".to_string(),
         ]),
@@ -1068,6 +1071,25 @@ mod tests {
             plan.tasks[0].metadata["workspace"]["kind"],
             "workspace-path"
         );
+    }
+
+    #[test]
+    fn patch_provider_requires_workspace_path_to_be_git_checkout() {
+        let worktree = tempfile::tempdir().expect("workspace");
+
+        let err = build_dispatch_plan_with_provider_requirements(
+            &dispatch_request(DispatchRequestOverrides {
+                prompt: Some("Cook generic workspace.".to_string()),
+                workspace: Some(worktree.path().display().to_string()),
+                backend: Some("patch-provider".to_string()),
+                ..DispatchRequestOverrides::default()
+            }),
+            |backend, _| backend == "patch-provider",
+        )
+        .expect_err("workspace path should require git checkout");
+
+        assert_eq!(err.details["field"], "workspace");
+        assert!(err.message.contains("dispatch workspace"));
     }
 
     struct NoopExecutor;

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -1491,11 +1491,11 @@ mod tests {
     }
 
     #[test]
-    fn discovers_agent_task_providers_from_ai_runtime_manifests() {
+    fn discovers_agent_task_providers_from_agent_runtime_manifests() {
         crate::test_support::with_isolated_home(|home| {
             let runtime_dir = home
                 .path()
-                .join(".config/homeboy/ai-runtimes/custom-runtime");
+                .join(".config/homeboy/agent-runtimes/custom-runtime");
             fs::create_dir_all(&runtime_dir).expect("runtime dir");
             fs::write(
                 runtime_dir.join("custom-runtime.json"),
@@ -1534,7 +1534,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_command_env_includes_ai_runtime_identity() {
+    fn provider_command_env_includes_runtime_identity() {
         let (request, mut provider) =
             request("task-a", "node {{runtime_path}}/provider.js".to_string());
         provider.runtime_id = Some("custom-runtime".to_string());

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -316,7 +316,7 @@ fn install_shared_assets_from_root(source_root: &Path, extension_dir: &Path) -> 
         return Ok(());
     };
 
-    for shared_dir in ["scripts", "agent-runtimes", "ai-runtimes"] {
+    for shared_dir in ["scripts", "agent-runtimes"] {
         let source = source_root.join(shared_dir);
         if !source.is_dir() {
             continue;

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -181,11 +181,6 @@ pub fn agent_runtimes() -> Result<PathBuf> {
     Ok(homeboy()?.join("agent-runtimes"))
 }
 
-/// First-class AI runtimes directory.
-pub fn ai_runtimes() -> Result<PathBuf> {
-    Ok(homeboy()?.join("ai-runtimes"))
-}
-
 /// Keys directory
 pub fn keys() -> Result<PathBuf> {
     Ok(homeboy()?.join("keys"))
@@ -256,11 +251,6 @@ pub fn extension_manifest(id: &str) -> Result<PathBuf> {
 /// Agent runtime manifest file path
 pub fn agent_runtime_manifest(id: &str) -> Result<PathBuf> {
     Ok(agent_runtimes()?.join(id).join(format!("{}.json", id)))
-}
-
-/// AI runtime manifest file path
-pub fn ai_runtime_manifest(id: &str) -> Result<PathBuf> {
-    Ok(ai_runtimes()?.join(id).join(format!("{}.json", id)))
 }
 
 /// Key file path

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use crate::core::agent_task_lifecycle;
 use crate::core::agent_task_provider::provider_available_for_backend;
 use crate::core::agent_tasks::provider::{
-    AgentTaskExecutorProvider, ExtensionProviderAgentTaskExecutor,
+    default_backend_for_component, AgentTaskExecutorProvider, ExtensionProviderAgentTaskExecutor,
 };
 use crate::core::engine::shell;
 use crate::core::observation::{PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
@@ -216,7 +216,7 @@ fn preflight_patch_provider_git_checkout(source_path: &Path) -> Result<()> {
         return Err(unsupported(
             "Lab offload for patch-producing agent-task providers requires --cwd to be a git checkout so generated files can be returned as a patch artifact",
             vec![
-                "Use a Homeboy/Data Machine Code worktree or another existing git checkout for --cwd.".to_string(),
+                "Use a Homeboy worktree or another existing git checkout for --cwd.".to_string(),
                 "Initialize the target as a git checkout before using Lab offload with a patch-producing provider.".to_string(),
                 "Use a provider without a git-checkout materialization requirement only if it has an explicit non-git apply-back artifact contract.".to_string(),
             ],
@@ -231,7 +231,7 @@ fn preflight_patch_provider_git_checkout(source_path: &Path) -> Result<()> {
             "Lab offload for patch-producing agent-task providers requires --cwd to have remote.origin.url so the runner can materialize a real git checkout",
             vec![
                 "Set remote.origin.url on the source checkout before retrying Lab offload.".to_string(),
-                "Use a Homeboy/Data Machine Code worktree or another checkout cloned from the canonical remote.".to_string(),
+                "Use a Homeboy worktree or another checkout cloned from the canonical remote.".to_string(),
             ],
         ));
     }
@@ -1619,7 +1619,7 @@ fn preflight_agent_task_provider_on_runner(
     runner_homeboy: &serde_json::Value,
     runner_status: &RunnerStatusReport,
 ) -> Result<()> {
-    let Some(selection) = agent_task_provider_selection_from_args(args) else {
+    let Some(selection) = agent_task_provider_selection_from_args(args)? else {
         return Ok(());
     };
 
@@ -1791,16 +1791,21 @@ fn refresh_runner_provider_session_if_still_safe(
     }
 }
 
-fn agent_task_provider_selection_from_args(args: &[String]) -> Option<AgentTaskProviderSelection> {
-    let action_index =
-        super::args_util::subcommand_index(args, "agent-task").and_then(|index| {
-            args.get(index + 1)
-                .filter(|arg| matches!(arg.as_str(), "dispatch" | "cook"))
-                .map(|_| index + 1)
-        })?;
+fn agent_task_provider_selection_from_args(
+    args: &[String],
+) -> Result<Option<AgentTaskProviderSelection>> {
+    let action_index = super::args_util::subcommand_index(args, "agent-task").and_then(|index| {
+        args.get(index + 1)
+            .filter(|arg| matches!(arg.as_str(), "dispatch" | "cook"))
+            .map(|_| index + 1)
+    });
+    let Some(action_index) = action_index else {
+        return Ok(None);
+    };
 
     let mut backend = None;
     let mut selector = None;
+    let mut repo = None;
     let mut iter = args.iter().skip(action_index + 1);
     while let Some(arg) = iter.next() {
         if arg == "--" {
@@ -1809,19 +1814,25 @@ fn agent_task_provider_selection_from_args(args: &[String]) -> Option<AgentTaskP
         match arg.as_str() {
             "--backend" => backend = iter.next().cloned(),
             "--selector" => selector = iter.next().cloned(),
+            "--repo" => repo = iter.next().cloned(),
             _ => {
                 if let Some(value) = arg.strip_prefix("--backend=") {
                     backend = Some(value.to_string());
                 } else if let Some(value) = arg.strip_prefix("--selector=") {
                     selector = Some(value.to_string());
+                } else if let Some(value) = arg.strip_prefix("--repo=") {
+                    repo = Some(value.to_string());
                 }
             }
         }
     }
 
-    backend
-        .filter(|backend| !backend.trim().is_empty())
-        .map(|backend| AgentTaskProviderSelection { backend, selector })
+    let backend = match backend.filter(|backend| !backend.trim().is_empty()) {
+        Some(backend) => Some(backend),
+        None => default_backend_for_component(repo.as_deref())?,
+    };
+
+    Ok(backend.map(|backend| AgentTaskProviderSelection { backend, selector }))
 }
 
 fn parse_agent_task_providers_output(
@@ -2387,7 +2398,7 @@ mod tests {
             .iter()
             .any(|hint| hint
                 .as_str()
-                .is_some_and(|hint| hint.contains("Data Machine Code worktree"))));
+                .is_some_and(|hint| hint.contains("Homeboy worktree"))));
     }
 
     #[test]
@@ -2913,7 +2924,9 @@ mod tests {
             "fix it".to_string(),
         ];
 
-        let selection = agent_task_provider_selection_from_args(&args).expect("selection");
+        let selection = agent_task_provider_selection_from_args(&args)
+            .expect("selection resolves")
+            .expect("selection");
 
         assert_eq!(selection.backend, "primary");
         assert_eq!(selection.selector.as_deref(), Some("variant-a"));
@@ -2929,7 +2942,9 @@ mod tests {
             "primary".to_string(),
         ];
 
-        assert!(agent_task_provider_selection_from_args(&args).is_none());
+        assert!(agent_task_provider_selection_from_args(&args)
+            .expect("selection resolves")
+            .is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remove `ai-runtimes` discovery/install paths from Homeboy core
- remove legacy extension `extra.agent_task_executors` discovery
- keep first-class `agent-runtimes` runtime manifest discovery
- harden agent-task workspace/default-backend preflight for patch-producing providers
- remove project-specific wording from agent-task git-checkout diagnostics

## Validation
- `cargo test agent_runtime_manifest`
- `cargo test discovers_agent_task_providers_from_agent_runtime_manifests`
- `cargo test provider_command_env_includes_runtime_identity`
- `cargo fmt`
- `cargo check`