### PR TITLE
fix(runtime): add plain helper path output

### DIFF
--- a/docs/commands/runtime.md
+++ b/docs/commands/runtime.md
@@ -12,3 +12,9 @@ homeboy runtime helper path HOMEBOY_RUNTIME_COMMAND_CAPTURE
 ```
 
 The command accepts either the helper filename or the injected `HOMEBOY_RUNTIME_*` environment variable name. Normal extension execution receives these paths automatically in the runner environment.
+
+Use `--plain` when a shell wrapper needs a sourceable path without parsing JSON:
+
+```bash
+source "$(homeboy runtime helper path --plain runner-prelude.sh)"
+```

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -12,7 +12,7 @@
 //! returned from [`Commands::descriptor`].
 
 use crate::cli_surface::Commands;
-use crate::commands::{changelog, file, logs, report, review, trace, version};
+use crate::commands::{changelog, file, logs, report, review, runtime, trace, version};
 
 use super::lab::apply_lab_contract_to_descriptor;
 
@@ -169,6 +169,9 @@ impl Commands {
                 output_file_mode,
                 CommandOutputContractKind::JsonEnvelope,
             ),
+            Commands::Runtime(args) if runtime::is_plain_mode(args) => {
+                raw_ops_descriptor(CommandRawOutputMode::PlainText, output_file_mode)
+            }
             Commands::Report(args) if report::is_markdown_mode(args) => workspace_descriptor(
                 CommandResponseMode::Raw(CommandRawOutputMode::Markdown),
                 output_file_mode,

--- a/src/commands/raw_output/mod.rs
+++ b/src/commands/raw_output/mod.rs
@@ -4,7 +4,7 @@ use crate::cli_surface::Commands;
 use crate::command_contract::{CommandRawOutputMode, CommandStdoutMode};
 
 use super::utils::{response as output, tty};
-use super::{changelog, docs, file, report, review, runs, trace, GlobalArgs};
+use super::{changelog, docs, file, report, review, runs, runtime, trace, GlobalArgs};
 
 pub enum RawExecution {
     Handled(i32),
@@ -101,6 +101,7 @@ fn run_plain_text(command: Commands, global: &GlobalArgs) -> RawCommandRun {
             )),
             Err(err) => Err(err),
         }),
+        Commands::Runtime(args) => raw_stdout_only(runtime::run_plain_text(args)),
         _ => raw_stdout_only(unsupported_output("plain text")),
     }
 }

--- a/src/commands/runtime.rs
+++ b/src/commands/runtime.rs
@@ -22,6 +22,10 @@ enum RuntimeCommand {
 enum RuntimeHelperCommand {
     /// Print the materialized path for a runtime helper.
     Path {
+        /// Print only the path, for shell bootstrap usage.
+        #[arg(long)]
+        plain: bool,
+
         /// Helper filename or HOMEBOY_RUNTIME_* env var name.
         helper: String,
     },
@@ -43,7 +47,26 @@ pub struct RuntimeHelperPathOutput {
 pub fn run(args: RuntimeArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<RuntimeOutput> {
     match args.command {
         RuntimeCommand::Helper { command } => match command {
-            RuntimeHelperCommand::Path { helper } => helper_path(&helper),
+            RuntimeHelperCommand::Path { helper, .. } => helper_path(&helper),
+        },
+    }
+}
+
+pub fn is_plain_mode(args: &RuntimeArgs) -> bool {
+    match &args.command {
+        RuntimeCommand::Helper { command } => match command {
+            RuntimeHelperCommand::Path { plain, .. } => *plain,
+        },
+    }
+}
+
+pub fn run_plain_text(args: RuntimeArgs) -> homeboy::core::Result<(String, i32)> {
+    match args.command {
+        RuntimeCommand::Helper { command } => match command {
+            RuntimeHelperCommand::Path { helper, .. } => {
+                let path = homeboy::core::extension::helper_path(&helper)?;
+                Ok((format!("{}\n", path.to_string_lossy()), 0))
+            }
         },
     }
 }
@@ -74,6 +97,26 @@ mod tests {
             let RuntimeOutput::HelperPath(output) = output;
             assert!(output.path.ends_with("command-capture.sh"));
             assert!(std::path::Path::new(&output.path).is_file());
+        });
+    }
+
+    #[test]
+    fn helper_path_plain_prints_only_path() {
+        crate::test_support::with_isolated_home(|_| {
+            let args = RuntimeArgs {
+                command: RuntimeCommand::Helper {
+                    command: RuntimeHelperCommand::Path {
+                        plain: true,
+                        helper: "runner-prelude.sh".to_string(),
+                    },
+                },
+            };
+
+            let (output, exit_code) = run_plain_text(args).unwrap();
+
+            assert_eq!(exit_code, 0);
+            assert!(output.ends_with("runner-prelude.sh\n"));
+            assert!(std::path::Path::new(output.trim()).is_file());
         });
     }
 }


### PR DESCRIPTION
## Summary
- add `homeboy runtime helper path --plain <helper>` for shell-friendly source paths
- route plain helper output through raw plain-text command output
- document direct bootstrap usage

## Tests
- `cargo fmt --check`
- `cargo test runtime`
- `./target/debug/homeboy runtime helper path --plain runner-prelude.sh`