### PR TITLE
refactor(git): share core git output helpers

### DIFF
--- a/src/core/cleanup.rs
+++ b/src/core/cleanup.rs
@@ -1,11 +1,10 @@
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use serde::Serialize;
 
-use crate::core::{Error, Result};
+use crate::core::{git, Error, Result};
 
 const BUILTIN_ARTIFACT_PATHS: &[(&str, &str)] = &[
     ("target", "rust_target"),
@@ -177,7 +176,11 @@ fn resolve_root(path: Option<&Path>) -> Result<PathBuf> {
 }
 
 fn discover_worktrees(root: &Path) -> Result<Vec<WorktreeInfo>> {
-    let output = git_output(root, &["worktree", "list", "--porcelain"])?;
+    let output = git::run_git(
+        root,
+        &["worktree", "list", "--porcelain"],
+        "git worktree list",
+    )?;
     let mut worktrees = Vec::new();
     for line in output.lines() {
         if let Some(path) = line.strip_prefix("worktree ") {
@@ -239,7 +242,7 @@ fn artifact_declarations(worktree: &Path) -> Result<Vec<ArtifactDeclaration>> {
 }
 
 fn git_safety(worktree: &Path) -> Result<GitSafety> {
-    let status = git_output(worktree, &["status", "--porcelain=v1"])?;
+    let status = git::run_git(worktree, &["status", "--porcelain=v1"], "git status")?;
     let mut dirty_paths = Vec::new();
     let mut source_dirty = false;
     for line in status.lines() {
@@ -253,8 +256,11 @@ fn git_safety(worktree: &Path) -> Result<GitSafety> {
         }
     }
 
-    let unpushed_commits = match git_output(worktree, &["rev-list", "--count", "@{upstream}..HEAD"])
-    {
+    let unpushed_commits = match git::run_git(
+        worktree,
+        &["rev-list", "--count", "@{upstream}..HEAD"],
+        "git rev-list upstream",
+    ) {
         Ok(count) => count.trim().parse::<u32>().unwrap_or(0) > 0,
         Err(_) => false,
     };
@@ -353,33 +359,14 @@ fn remove_artifact_path(path: &Path) -> Result<()> {
 }
 
 fn git_root(path: &Path) -> Result<PathBuf> {
-    let output = git_output(path, &["rev-parse", "--show-toplevel"])?;
+    let output = git::run_git(path, &["rev-parse", "--show-toplevel"], "git root")?;
     Ok(PathBuf::from(output.trim()))
-}
-
-fn git_output(path: &Path, args: &[&str]) -> Result<String> {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(path)
-        .output()
-        .map_err(|e| {
-            Error::internal_io(e.to_string(), Some(format!("run git {}", args.join(" "))))
-        })?;
-    if !output.status.success() {
-        return Err(Error::git_command_failed(format!(
-            "git {} failed in {}: {}",
-            args.join(" "),
-            path.display(),
-            String::from_utf8_lossy(&output.stderr).trim()
-        )));
-    }
-    String::from_utf8(output.stdout)
-        .map_err(|e| Error::internal_unexpected(format!("git output was not UTF-8: {e}")))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
     use tempfile::TempDir;
 
     #[test]

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -57,8 +57,9 @@ pub use pr_policy::{
 };
 pub use primitives::{
     clone_repo, clone_repo_at_ref, current_branch, get_component_path_prefix, get_git_root,
-    is_workdir_clean_or_not_git, pull_repo, remote_origin_url, run_git, short_head_revision,
-    update_to_remote_default_branch,
+    head_sha, head_sha_short, is_workdir_clean_or_not_git, output_optional, output_optional_bytes,
+    pull_repo, remote_origin_url, remote_url, run_git, short_head_revision, status_porcelain,
+    status_porcelain_bytes, toplevel, update_to_remote_default_branch,
 };
 pub(crate) use primitives::{is_git_repo, list_tracked_markdown_files};
 

--- a/src/core/git/primitives.rs
+++ b/src/core/git/primitives.rs
@@ -126,26 +126,63 @@ pub fn run_git(git_root: &Path, args: &[&str], context: &str) -> Result<String> 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// Run a git command and return stdout bytes when the command succeeds.
+pub fn output_optional_bytes(git_root: &Path, args: &[&str]) -> Option<Vec<u8>> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(git_root)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+
+    output.status.success().then_some(output.stdout)
+}
+
+/// Run a git command and return trimmed stdout when the command succeeds and is non-empty.
+pub fn output_optional(git_root: &Path, args: &[&str]) -> Option<String> {
+    let output = output_optional_bytes(git_root, args)?;
+    let value = String::from_utf8_lossy(&output).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+/// Get the full HEAD commit SHA from a git directory.
+pub fn head_sha(git_root: &Path) -> Option<String> {
+    output_optional(git_root, &["rev-parse", "HEAD"])
+}
+
+/// Get the short HEAD commit SHA from a git directory.
+pub fn head_sha_short(git_root: &Path) -> Option<String> {
+    output_optional(git_root, &["rev-parse", "--short", "HEAD"])
+}
+
+/// Get porcelain status bytes from a git directory.
+pub fn status_porcelain_bytes(git_root: &Path) -> Option<Vec<u8>> {
+    output_optional_bytes(git_root, &["status", "--porcelain=v1", "-z"])
+}
+
+/// Get porcelain status text from a git directory.
+pub fn status_porcelain(git_root: &Path) -> Option<String> {
+    output_optional_bytes(git_root, &["status", "--porcelain=v1"])
+        .map(|output| String::from_utf8_lossy(&output).to_string())
+}
+
+/// Get a remote URL from a git directory.
+pub fn remote_url(git_root: &Path, remote: &str) -> Option<String> {
+    output_optional(git_root, &["remote", "get-url", remote])
+}
+
+/// Get the git repository root directory from any path within the repo.
+pub fn toplevel(git_root: &Path) -> Option<String> {
+    output_optional(git_root, &["rev-parse", "--show-toplevel"])
+}
+
 pub fn current_branch(git_root: &Path) -> Option<String> {
-    run_git(
-        git_root,
-        &["branch", "--show-current"],
-        "git current branch",
-    )
-    .ok()
-    .map(|value| value.trim().to_string())
-    .filter(|value| !value.is_empty())
+    output_optional(git_root, &["branch", "--show-current"])
 }
 
 pub fn remote_origin_url(git_root: &Path) -> Option<String> {
-    run_git(
-        git_root,
-        &["remote", "get-url", "origin"],
-        "git remote get-url origin",
-    )
-    .ok()
-    .map(|value| value.trim().to_string())
-    .filter(|value| !value.is_empty())
+    remote_url(git_root, "origin")
 }
 
 fn default_remote_branch(git_root: &Path) -> Option<String> {
@@ -208,24 +245,7 @@ pub fn update_to_remote_default_branch(git_root: &Path) -> Result<()> {
 
 /// Get the short HEAD revision from a git directory.
 pub fn short_head_revision(dir: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .current_dir(dir)
-        .stdin(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let rev = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if rev.is_empty() {
-        None
-    } else {
-        Some(rev)
-    }
+    head_sha_short(dir)
 }
 
 /// List all git-tracked markdown files in a directory.
@@ -288,6 +308,23 @@ pub fn get_component_path_prefix(local_path: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
+
+    fn git(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .stdin(std::process::Stdio::null())
+            .output()
+            .expect("run git test fixture command");
+
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 
     #[test]
     fn run_git_failure_includes_command_cwd_exit_stdout_and_stderr() {
@@ -320,5 +357,47 @@ mod tests {
         assert!(err.details["io_error"].as_str().is_some());
         assert_eq!(err.details["stdout"], "");
         assert_eq!(err.details["stderr"], "");
+    }
+
+    #[test]
+    fn optional_helpers_return_head_remote_toplevel_and_clean_status() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        git(dir.path(), &["init", "--quiet"]);
+        git(
+            dir.path(),
+            &["remote", "add", "origin", "https://example.test/repo.git"],
+        );
+        std::fs::write(dir.path().join("README.md"), "hello\n").expect("write fixture file");
+        git(dir.path(), &["add", "README.md"]);
+        git(
+            dir.path(),
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=homeboy@example.test",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        );
+
+        assert_eq!(
+            Path::new(&toplevel(dir.path()).expect("git toplevel"))
+                .canonicalize()
+                .expect("canonical git toplevel"),
+            dir.path().canonicalize().expect("canonical fixture dir")
+        );
+        assert_eq!(
+            remote_url(dir.path(), "origin").as_deref(),
+            Some("https://example.test/repo.git")
+        );
+        assert!(head_sha(dir.path()).is_some());
+        assert!(head_sha_short(dir.path()).is_some());
+        assert_eq!(status_porcelain(dir.path()).as_deref(), Some(""));
+        assert_eq!(
+            status_porcelain_bytes(dir.path()).as_deref(),
+            Some(&b""[..])
+        );
     }
 }

--- a/src/core/source_snapshot.rs
+++ b/src/core/source_snapshot.rs
@@ -1,9 +1,10 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+
+use crate::core::git;
 
 const DEFAULT_SYNC_EXCLUDES: &[&str] = &[
     ".git/",
@@ -49,13 +50,12 @@ impl SourceSnapshot {
         sync_mode: &str,
     ) -> Self {
         let local_path = path.display().to_string();
-        let git_root = git_output(path, &["rev-parse", "--show-toplevel"]);
-        let git_branch = git_output(path, &["branch", "--show-current"])
+        let git_root = git::toplevel(path);
+        let git_branch = git::current_branch(path)
             .filter(|branch| !branch.is_empty())
-            .or_else(|| git_output(path, &["rev-parse", "--abbrev-ref", "HEAD"]));
-        let git_sha = git_output(path, &["rev-parse", "HEAD"]);
-        let status =
-            git_output_bytes(path, &["status", "--porcelain=v1", "-z"]).unwrap_or_default();
+            .or_else(|| git::output_optional(path, &["rev-parse", "--abbrev-ref", "HEAD"]));
+        let git_sha = git::head_sha(path);
+        let status = git::status_porcelain_bytes(path).unwrap_or_default();
         let dirty = !status.is_empty();
         let snapshot_hash = if git_sha.is_some() {
             git_snapshot_hash(path, git_sha.as_deref(), &status)
@@ -126,17 +126,17 @@ fn git_snapshot_hash(path: &Path, git_sha: Option<&str>, status: &[u8]) -> Strin
     hasher.update(status);
 
     if status.is_empty() {
-        if let Some(tree) = git_output(path, &["rev-parse", "HEAD^{tree}"]) {
+        if let Some(tree) = git::output_optional(path, &["rev-parse", "HEAD^{tree}"]) {
             hasher.update(b"\0tree\0");
             hasher.update(tree.as_bytes());
         }
     } else {
-        if let Some(diff) = git_output_bytes(path, &["diff", "--binary", "HEAD"]) {
+        if let Some(diff) = git::output_optional_bytes(path, &["diff", "--binary", "HEAD"]) {
             hasher.update(b"\0diff\0");
             hasher.update(diff);
         }
         if let Some(untracked) =
-            git_output_bytes(path, &["ls-files", "--others", "--exclude-standard", "-z"])
+            git::output_optional_bytes(path, &["ls-files", "--others", "--exclude-standard", "-z"])
         {
             hasher.update(b"\0untracked\0");
             for relative in untracked
@@ -165,27 +165,11 @@ fn generic_snapshot_hash(identity: &str) -> String {
     format!("sha256:{:x}", hasher.finalize())
 }
 
-fn git_output(path: &Path, args: &[&str]) -> Option<String> {
-    let output = git_output_bytes(path, args)?;
-    let value = String::from_utf8_lossy(&output).trim().to_string();
-    (!value.is_empty()).then_some(value)
-}
-
-fn git_output_bytes(path: &Path, args: &[&str]) -> Option<Vec<u8>> {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(path)
-        .stdin(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()?;
-    output.status.success().then_some(output.stdout)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::process::Command;
 
     #[test]
     fn test_default_sync_excludes() {


### PR DESCRIPTION
## Summary
- add shared core git optional stdout/bytes helpers plus HEAD, status, remote URL, and toplevel helpers
- migrate source snapshot git metadata/hash collection to the shared primitives
- migrate cleanup artifact git command execution to core git primitives
- add focused coverage for the new optional helper semantics, including clean status output

## Tests
- cargo fmt --check
- cargo check
- cargo test optional_helpers_return_head_remote_toplevel_and_clean_status
- cargo test source_snapshot
- cargo test cleanup

## Follow-ups
- ToolchainPathPolicy/CommandSearchPath is intentionally left for a separate PR; modeling command lookup/search path policy touches runner/toolchain execution beyond this small git primitive cleanup.