### PR TITLE
Fix Lab agent-task provider config materialization

### DIFF
--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -33,8 +33,9 @@ use super::super::daemon_health::runner_daemon_health_failure;
 use super::super::execution::{lab_offload_handoff_hints, DaemonJobHandoffState};
 use super::super::lab_apply::apply_lab_offload_patch;
 use super::super::lab_args::{
-    inline_agent_task_prompt_files_in_args, lab_offload_source_path, remap_agent_task_plan_in_args,
-    remap_path_settings_in_args, remap_provider_config_in_args, rewrite_lab_offload_args,
+    inject_agent_task_default_provider_config_in_args, inline_agent_task_prompt_files_in_args,
+    lab_offload_source_path, remap_agent_task_plan_in_args, remap_path_settings_in_args,
+    remap_provider_config_in_args, rewrite_lab_offload_args,
     rewrite_runner_resident_lab_offload_args, LabPathRemap,
 };
 use super::super::lab_capabilities::lab_runner_capability_contract;
@@ -929,22 +930,21 @@ fn run_lab_offload_inner(
             }
         );
     }
+    let offload_args =
+        inject_agent_task_default_provider_config_in_args(&changed_since_preflight.args)?;
     let mut extra_workspaces = lab_extra_workspaces(&source_path)?;
     // Sync any controller-local directories referenced by --provider-config
     // (runtime components, provider plugins, extra mount sources) so the cook
     // config's paths resolve on the runner after remapping.
     extra_workspaces.extend(provider_config_extra_workspaces(
-        &changed_since_preflight.args,
+        &offload_args,
         &source_path,
     )?);
     extra_workspaces.extend(agent_task_plan_extra_workspaces(
-        &changed_since_preflight.args,
+        &offload_args,
         &source_path,
     )?);
-    extra_workspaces.extend(path_setting_extra_workspaces(
-        &changed_since_preflight.args,
-        &source_path,
-    )?);
+    extra_workspaces.extend(path_setting_extra_workspaces(&offload_args, &source_path)?);
     extra_workspaces.extend(rig_component_path_env_extra_workspaces(&source_path)?);
     let synced = sync_workspace(
         runner_id,
@@ -1085,12 +1085,9 @@ fn run_lab_offload_inner(
             remote: entry.remote_path().to_string(),
         })
         .collect();
-    preflight_provider_config_source_cli_dependencies(
-        &changed_since_preflight.args,
-        &synced.excludes,
-    )?;
+    preflight_provider_config_source_cli_dependencies(&offload_args, &synced.excludes)?;
     let remapped_args = rig_materialization::remap_bench_rig_default_component_to_primary_snapshot(
-        &changed_since_preflight.args,
+        &offload_args,
         &remote_cwd,
     );
     let remapped_args = remap_provider_config_in_args(&remapped_args, &path_remaps);

--- a/src/core/runner/lab_args.rs
+++ b/src/core/runner/lab_args.rs
@@ -4,7 +4,9 @@ use std::path::PathBuf;
 
 use serde_json::Value;
 
+use crate::core::agent_task_config_materialization::materialize_provider_config_refs;
 use crate::core::config::read_json_spec_to_string;
+use crate::core::defaults;
 use crate::core::worktree;
 use crate::core::{Error, Result};
 
@@ -81,6 +83,49 @@ pub(super) fn remap_provider_config_in_args(
         out.push(arg.clone());
     }
     out
+}
+
+pub(super) fn inject_agent_task_default_provider_config_in_args(
+    args: &[String],
+) -> Result<Vec<String>> {
+    if !is_agent_task_dispatch_or_cook(args) || args_have_provider_config(args) {
+        return Ok(args.to_vec());
+    }
+
+    let settings = defaults::load_config().settings;
+    if settings.is_empty() {
+        return Ok(args.to_vec());
+    }
+
+    let config = materialize_provider_config_refs(Value::Object(settings.into_iter().collect()))?;
+    if config.as_object().is_none_or(|map| map.is_empty()) {
+        return Ok(args.to_vec());
+    }
+
+    let config = serde_json::to_string(&config).map_err(|err| {
+        Error::validation_invalid_argument(
+            "provider_config",
+            "failed to serialize materialized agent-task provider config for Lab offload",
+            Some(err.to_string()),
+            None,
+        )
+    })?;
+
+    let mut out = Vec::with_capacity(args.len() + 2);
+    let mut inserted = false;
+    for arg in args {
+        if !inserted && arg == "--" {
+            out.push("--provider-config".to_string());
+            out.push(config.clone());
+            inserted = true;
+        }
+        out.push(arg.clone());
+    }
+    if !inserted {
+        out.push("--provider-config".to_string());
+        out.push(config);
+    }
+    Ok(out)
 }
 
 pub(super) fn remap_agent_task_plan_in_args(
@@ -404,6 +449,33 @@ fn remap_path_json_setting_pair(raw: &str, mappings: &[&LabPathRemap]) -> String
         .unwrap_or_else(|_| raw.to_string())
 }
 
+fn is_agent_task_dispatch_or_cook(args: &[String]) -> bool {
+    let Some(agent_task_index) = args.iter().position(|arg| arg == "agent-task") else {
+        return false;
+    };
+    args.iter()
+        .skip(agent_task_index + 1)
+        .find(|arg| !arg.starts_with('-'))
+        .is_some_and(|command| matches!(command.as_str(), "dispatch" | "cook"))
+}
+
+fn args_have_provider_config(args: &[String]) -> bool {
+    let mut passthrough = false;
+    for arg in args {
+        if passthrough {
+            continue;
+        }
+        if arg == "--" {
+            passthrough = true;
+            continue;
+        }
+        if arg == "--provider-config" || arg.starts_with("--provider-config=") {
+            return true;
+        }
+    }
+    false
+}
+
 /// Resolve a provider-config spec (inline JSON / `@file` / `-`), remap its
 /// embedded local paths, and return inline JSON.
 ///
@@ -668,6 +740,7 @@ pub(super) fn rewrite_runner_resident_lab_offload_args(args: &[String]) -> Vec<S
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn lab_source_path_uses_agent_task_dispatch_cwd() {
@@ -819,6 +892,115 @@ mod tests {
         // unrelated args preserved
         assert!(out.iter().any(|a| a == "--prompt"));
         assert!(out.iter().any(|a| a == "fix it"));
+    }
+
+    #[test]
+    fn injects_default_provider_config_for_agent_task_cook() {
+        crate::test_support::with_isolated_home(|_| {
+            defaults::save_config(&defaults::HomeboyConfig {
+                settings: HashMap::from([
+                    ("provider".to_string(), serde_json::json!("codex")),
+                    (
+                        "provider_plugin_paths".to_string(),
+                        serde_json::json!(["/Users/chubes/Developer/ai-provider-for-openai@codex"]),
+                    ),
+                ]),
+                ..defaults::HomeboyConfig::default()
+            })
+            .expect("save config");
+
+            let args = vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--prompt".to_string(),
+                "fix it".to_string(),
+            ];
+
+            let out = inject_agent_task_default_provider_config_in_args(&args).expect("inject");
+            let cfg_idx = out
+                .iter()
+                .position(|arg| arg == "--provider-config")
+                .unwrap()
+                + 1;
+            let config: serde_json::Value = serde_json::from_str(&out[cfg_idx]).expect("config");
+
+            assert_eq!(config["provider"], "codex");
+            assert_eq!(
+                config["provider_plugin_paths"][0],
+                "/Users/chubes/Developer/ai-provider-for-openai@codex"
+            );
+            assert!(out.iter().any(|arg| arg == "--prompt"));
+        });
+    }
+
+    #[test]
+    fn injected_default_provider_config_is_remappable() {
+        crate::test_support::with_isolated_home(|_| {
+            defaults::save_config(&defaults::HomeboyConfig {
+                settings: HashMap::from([(
+                    "provider_plugin_paths".to_string(),
+                    serde_json::json!(["/Users/chubes/Developer/ai-provider-for-openai@codex"]),
+                )]),
+                ..defaults::HomeboyConfig::default()
+            })
+            .expect("save config");
+
+            let args = vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "dispatch".to_string(),
+                "--prompt".to_string(),
+                "fix it".to_string(),
+            ];
+            let injected =
+                inject_agent_task_default_provider_config_in_args(&args).expect("inject");
+            let remapped = remap_provider_config_in_args(
+                &injected,
+                &[LabPathRemap {
+                    local: "/Users/chubes/Developer/ai-provider-for-openai@codex".to_string(),
+                    remote: "/home/chubes/Developer/_lab_workspaces/ai-provider-for-openai@codex"
+                        .to_string(),
+                }],
+            );
+            let cfg_idx = remapped
+                .iter()
+                .position(|arg| arg == "--provider-config")
+                .unwrap()
+                + 1;
+            let config: serde_json::Value =
+                serde_json::from_str(&remapped[cfg_idx]).expect("config");
+
+            assert_eq!(
+                config["provider_plugin_paths"][0],
+                "/home/chubes/Developer/_lab_workspaces/ai-provider-for-openai@codex"
+            );
+        });
+    }
+
+    #[test]
+    fn explicit_provider_config_prevents_default_injection() {
+        crate::test_support::with_isolated_home(|_| {
+            defaults::save_config(&defaults::HomeboyConfig {
+                settings: HashMap::from([(
+                    "provider_plugin_paths".to_string(),
+                    serde_json::json!(["/Users/chubes/Developer/ai-provider-for-openai@codex"]),
+                )]),
+                ..defaults::HomeboyConfig::default()
+            })
+            .expect("save config");
+
+            let args = vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--provider-config".to_string(),
+                "{\"provider\":\"explicit\"}".to_string(),
+            ];
+
+            let out = inject_agent_task_default_provider_config_in_args(&args).expect("inject");
+            assert_eq!(out, args);
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Materialize controller default agent-task provider settings before Lab offloads `agent-task dispatch`/`cook`.
- Inject those defaults as an inline `--provider-config` only when the command did not already provide one.
- Feed the injected config through existing extra-workspace sync and path remapping so `provider_plugin_paths` reach the runner and WP Codebox can mount/register the Codex provider plugin.

Refs Extra-Chill/homeboy#4834

## Verification
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@fix-4834-codebox-codex-provider-paths --runner homeboy-lab --skip-lint --allow-dirty-lab-workspace -- lab_args::tests::injects_default_provider_config_for_agent_task_cook lab_args::tests::injected_default_provider_config_is_remappable lab_args::tests::explicit_provider_config_prevents_default_injection`
  - Passed on Lab runner: `runner-exec-homeboy-lab-a10dd1a7-0e2d-438e-8242-c8dc63902575` (3 passed, 0 failed)
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@fix-4834-codebox-codex-provider-paths --runner homeboy-lab --allow-dirty-lab-workspace`
  - Passed on Lab runner: `runner-exec-homeboy-lab-835f7709-018b-4f80-b66e-47499a680a16` (no findings after formatting fix)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Lab offload/provider-config gap, drafted the implementation and regression tests, and ran managed Lab verification. Chris remains responsible for review and validation.