### PR TITLE
Keep agent runtime core fixtures generic

### DIFF
--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -192,9 +192,9 @@ mod tests {
         let mut extension = extension("runtime-extension");
         extension.agent_runtimes.push(
             serde_json::from_value(json!({
-                "id": "codex-runtime",
-                "label": "Codex Runtime",
-                "agent_task_executors": [provider_json("codex.default", "codex")]
+                "id": "example-runtime",
+                "label": "Example Runtime",
+                "agent_task_executors": [provider_json("example.default", "example")]
             }))
             .expect("runtime manifest"),
         );
@@ -203,12 +203,12 @@ mod tests {
 
         assert_eq!(manifests.len(), 1);
         assert_eq!(manifests[0].schema, AGENT_RUNTIME_MANIFEST_SCHEMA);
-        assert_eq!(manifests[0].id, "codex-runtime");
+        assert_eq!(manifests[0].id, "example-runtime");
         assert_eq!(
             manifests[0].extension_id.as_deref(),
             Some("runtime-extension")
         );
-        assert_eq!(manifests[0].agent_task_executors[0].backend, "codex");
+        assert_eq!(manifests[0].agent_task_executors[0].backend, "example");
         assert_eq!(
             manifests[0].runtime_path.as_deref(),
             Some("/extensions/runtime-extension")
@@ -221,21 +221,21 @@ mod tests {
             let runtime_dir = home
                 .path()
                 .join(".config/homeboy/agent-runtimes")
-                .join("standalone-codex");
+                .join("standalone-example");
             std::fs::create_dir_all(&runtime_dir).expect("runtime dir");
             std::fs::write(
-                runtime_dir.join("standalone-codex.json"),
+                runtime_dir.join("standalone-example.json"),
                 json!({
                     "schema": AGENT_RUNTIME_MANIFEST_SCHEMA,
                     "id": "ignored-on-disk",
-                    "name": "Standalone Codex Package",
+                    "name": "Standalone Example Package",
                     "version": "1.0.0",
                     "description": "Standalone runtime package fixture.",
-                    "label": "Standalone Codex",
+                    "label": "Standalone Example",
                     "agent_task_executors": [{
                         "schema": "homeboy/agent-task-executor-provider/v1",
-                        "id": "standalone-codex.default",
-                        "backend": "codex",
+                        "id": "standalone-example.default",
+                        "backend": "example",
                         "command": "agent-task-provider",
                         "request_schema": AGENT_TASK_REQUEST_SCHEMA,
                         "outcome_schema": AGENT_TASK_OUTCOME_SCHEMA,
@@ -243,20 +243,20 @@ mod tests {
                             "cwd": "git_checkout",
                             "requires_git": true,
                             "write_scope": "artifacts",
-                            "artifact_paths": [".homeboy/codex"]
+                            "artifact_paths": [".homeboy/example"]
                         },
                         "secret_requirements": [{
-                            "name": "CODEX_TOKEN",
+                            "name": "EXAMPLE_RUNTIME_TOKEN",
                             "required": true,
                             "purpose": "fixture"
                         }],
                         "secret_env_requirements": [{
                             "schema": "homeboy/secret-env-requirement/v1",
-                            "env": ["CODEX_REFRESH_TOKEN"],
-                            "when": { "path": "executor.config.provider", "equals": "codex" }
+                            "env": ["EXAMPLE_RUNTIME_REFRESH_TOKEN"],
+                            "when": { "path": "executor.config.provider", "equals": "example-provider" }
                         }],
                         "provider_defaults": {
-                            "codex": { "secret_env": ["CODEX_REFRESH_TOKEN"] }
+                            "example-provider": { "secret_env": ["EXAMPLE_RUNTIME_REFRESH_TOKEN"] }
                         }
                     }]
                 })
@@ -267,14 +267,14 @@ mod tests {
             let manifests = discover_standalone_agent_runtime_manifests();
 
             assert_eq!(manifests.len(), 1);
-            assert_eq!(manifests[0].id, "standalone-codex");
+            assert_eq!(manifests[0].id, "standalone-example");
             assert_eq!(manifests[0].extension_id, None);
             assert_eq!(manifests[0].extension_path, None);
             assert_eq!(
                 manifests[0].runtime_path.as_deref(),
                 Some(runtime_dir.to_str().expect("runtime dir utf-8"))
             );
-            assert_eq!(manifests[0].agent_task_executors[0].backend, "codex");
+            assert_eq!(manifests[0].agent_task_executors[0].backend, "example");
             let provider = &manifests[0].agent_task_executors[0];
             let materialization = provider
                 .workspace_materialization
@@ -282,18 +282,18 @@ mod tests {
                 .expect("workspace materialization");
             assert_eq!(materialization.requires_git, Some(true));
             assert_eq!(materialization.write_scope.as_deref(), Some("artifacts"));
-            assert_eq!(materialization.artifact_paths, vec![".homeboy/codex"]);
+            assert_eq!(materialization.artifact_paths, vec![".homeboy/example"]);
             assert_eq!(
                 provider.secret_requirements[0].name.as_deref(),
-                Some("CODEX_TOKEN")
+                Some("EXAMPLE_RUNTIME_TOKEN")
             );
             assert_eq!(
                 provider.secret_env_requirements[0].env,
-                vec!["CODEX_REFRESH_TOKEN"]
+                vec!["EXAMPLE_RUNTIME_REFRESH_TOKEN"]
             );
             assert_eq!(
-                provider.provider_defaults["codex"]["secret_env"][0],
-                "CODEX_REFRESH_TOKEN"
+                provider.provider_defaults["example-provider"]["secret_env"][0],
+                "EXAMPLE_RUNTIME_REFRESH_TOKEN"
             );
         });
     }

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -131,7 +131,7 @@ pub struct AgentTaskProviderEnvPathReadiness {
     /// stale / non-canonical checkout drift before it corrupts results.
     ///
     /// Core is runtime-agnostic: it does not know what the canonical path
-    /// represents (wp-codebox, a toolchain, etc.) — the value is supplied
+    /// represents (a runtime checkout, a toolchain, etc.) — the value is supplied
     /// entirely by the declaring extension.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub canonical_path: Option<String>,
@@ -140,7 +140,7 @@ pub struct AgentTaskProviderEnvPathReadiness {
 /// A named, extension-declared source checkout that homeboy keeps synced on the
 /// runner. Core treats this generically: it materializes/refreshes a git
 /// checkout to the intended ref/remote. It has no knowledge of what the source
-/// is (wp-codebox, a CLI, a toolchain) — extensions declare the path/remote/ref.
+/// is (a runtime checkout, a CLI, a toolchain) — extensions declare the path/remote/ref.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskProviderRunnerSource {
     pub id: String,
@@ -1586,11 +1586,11 @@ mod tests {
             "{{runtime_path}}/bin/provider --extension {{extension_path}}".to_string(),
         );
         provider.extension_path = Some("/extensions/project-type".to_string());
-        provider.runtime_path = Some("/agent-runtimes/codex".to_string());
+        provider.runtime_path = Some("/agent-runtimes/example".to_string());
 
         assert_eq!(
             render_provider_command(&provider),
-            "/agent-runtimes/codex/bin/provider --extension /extensions/project-type"
+            "/agent-runtimes/example/bin/provider --extension /extensions/project-type"
         );
     }
 
@@ -1815,7 +1815,7 @@ mod tests {
     #[test]
     fn provider_secret_contracts_are_applied_generically() {
         let (mut request, mut provider) = request("task-a", "node provider-a.js".to_string());
-        request.executor.config = json!({ "provider": "codex" });
+        request.executor.config = json!({ "provider": "example-provider" });
         provider.secret_requirements = vec![
             AgentTaskProviderSecretRequirement {
                 name: Some("REQUIRED_TOKEN".to_string()),
@@ -1829,18 +1829,18 @@ mod tests {
             },
         ];
         provider.secret_env_requirements = vec![AgentTaskProviderSecretEnvRequirement {
-            env: vec!["CODEX_TOKEN".to_string()],
+            env: vec!["EXAMPLE_PROVIDER_TOKEN".to_string()],
             when: Some(json!({
                 "any": [
-                    { "path": "executor.config.provider", "equals": "codex" },
-                    { "path": "provider", "equals": "codex" }
+                    { "path": "executor.config.provider", "equals": "example-provider" },
+                    { "path": "provider", "equals": "example-provider" }
                 ]
             })),
             ..AgentTaskProviderSecretEnvRequirement::default()
         }];
         provider.provider_defaults.insert(
-            "codex".to_string(),
-            json!({ "secret_env": ["CODEX_REFRESH_TOKEN"] }),
+            "example-provider".to_string(),
+            json!({ "secret_env": ["EXAMPLE_PROVIDER_REFRESH_TOKEN"] }),
         );
         let mut plan = AgentTaskPlan::new("plan-a", vec![request]);
 
@@ -1849,8 +1849,8 @@ mod tests {
         assert_eq!(
             plan.tasks[0].executor.secret_env,
             vec![
-                "CODEX_REFRESH_TOKEN".to_string(),
-                "CODEX_TOKEN".to_string(),
+                "EXAMPLE_PROVIDER_REFRESH_TOKEN".to_string(),
+                "EXAMPLE_PROVIDER_TOKEN".to_string(),
                 "REQUIRED_TOKEN".to_string(),
             ]
         );
@@ -1971,7 +1971,7 @@ mod tests {
     fn provider_can_return_timeout_payload_during_wrapper_grace() {
         let command = format!(
             "node {}",
-            script("let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); setTimeout(()=>process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'timeout',summary:'provider serialized timeout',failure_classification:'timeout',artifacts:[{schema:'homeboy/agent-task-artifact/v1',id:'timeout-evidence',kind:'codebox-task-runner-preflight',path:'/tmp/timeout-evidence.json'}]})), 3050);")
+            script("let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); setTimeout(()=>process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'timeout',summary:'provider serialized timeout',failure_classification:'timeout',artifacts:[{schema:'homeboy/agent-task-artifact/v1',id:'timeout-evidence',kind:'provider-task-runner-preflight',path:'/tmp/timeout-evidence.json'}]})), 3050);")
         );
         let (mut request, provider) = request("task-timeout-payload", command);
         request.limits.timeout_ms = Some(3000);

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -495,7 +495,7 @@ mod tests {
         let config: HomeboyConfig = serde_json::from_str(
             r#"{
                 "agent_task": {
-                    "default_backend": "codex",
+                    "default_backend": "example",
                     "secrets": {
                         "TOKEN": {
                             "source": "config",
@@ -507,7 +507,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(config.agent_task.default_backend.as_deref(), Some("codex"));
+        assert_eq!(
+            config.agent_task.default_backend.as_deref(),
+            Some("example")
+        );
         let secret = config.agent_task.secrets.get("TOKEN").unwrap();
         assert_eq!(secret.source, "config");
         assert_eq!(secret.value.as_deref(), Some("redacted-test-token"));


### PR DESCRIPTION
## Summary
- replace Codex-specific agent-runtime/provider fixture names with neutral example runtime/provider values
- keep core comments and provider timeout fixture artifact kinds runtime-agnostic
- use a neutral default backend value in config parsing coverage

Concrete runtime support such as Codex, OpenCode, and Codebox belongs in homeboy-extensions/agent-runtimes; core should only model the generic provider/runtime contract.

## Tests
- cargo test provider_can_return_timeout_payload_during_wrapper_grace --lib
- cargo test agent_runtime_manifest --lib
- cargo test provider_secret_contracts --lib
- cargo test homeboy_config_parses_agent_task_config_secret --lib
- /Users/chubes/.cache/opencode/bin/rg -n "codex|Codex|CODEX|opencode|OpenCode|codebox|Codebox" src/core/agent_runtime_manifest.rs src/core/agent_task_provider.rs src/core/defaults.rs