### PR TITLE
Refactor runner tool metadata registry

### DIFF
--- a/src/commands/runner/doctor.rs
+++ b/src/commands/runner/doctor.rs
@@ -7,7 +7,9 @@ use std::process::Command;
 use homeboy::core::agent_tasks::provider::{
     AgentTaskProviderRunnerReadiness, AgentTaskProviderRunnerSource,
 };
-use homeboy::core::runners::{self as runner, Runner, RunnerKind, RunnerTunnelMode};
+use homeboy::core::runners::{
+    self as runner, Runner, RunnerKind, RunnerToolRegistry, RunnerToolSpec, RunnerTunnelMode,
+};
 use homeboy::core::server::{self, Server, SshClient};
 use serde::Serialize;
 
@@ -350,6 +352,9 @@ mod local {
         });
 
         for spec in probes::tool_specs() {
+            if spec.id == "homeboy" {
+                continue;
+            }
             let probe = probes::local_tool_probe(spec.command, spec.version_args);
             checks.push(checks::tool_check(*spec, &probe));
             tools.insert(spec.id.to_string(), probe);
@@ -559,6 +564,9 @@ mod remote {
         });
 
         for spec in probes::tool_specs() {
+            if spec.id == "homeboy" {
+                continue;
+            }
             let probe = probes::remote_tool_probe(client, spec.command, spec.version_args);
             checks.push(checks::tool_check(*spec, &probe));
             tools.insert(spec.id.to_string(), probe);
@@ -697,91 +705,8 @@ mod probes {
     use super::*;
     use types::{DiskProbe, HomeboyProbe, MemoryProbe, RunnerCapabilities, RunnerCheck, ToolProbe};
 
-    #[derive(Clone, Copy)]
-    pub struct ToolSpec {
-        pub id: &'static str,
-        pub check_id: &'static str,
-        pub command: &'static str,
-        pub version_args: &'static [&'static str],
-        pub required: bool,
-        pub remediation: &'static str,
-    }
-
-    pub fn tool_specs() -> &'static [ToolSpec] {
-        &[
-            ToolSpec {
-                id: "git",
-                check_id: "tool.git",
-                command: "git",
-                version_args: &["--version"],
-                required: true,
-                remediation: "Install git and ensure it is on PATH",
-            },
-            ToolSpec {
-                id: "gh",
-                check_id: "tool.github_cli",
-                command: "gh",
-                version_args: &["--version"],
-                required: false,
-                remediation: "Install GitHub CLI (`gh`) for PR and issue workflows",
-            },
-            ToolSpec {
-                id: "node",
-                check_id: "tool.node",
-                command: "node",
-                version_args: &["--version"],
-                required: false,
-                remediation: "Install Node.js for JavaScript/TypeScript components",
-            },
-            ToolSpec {
-                id: "npm",
-                check_id: "tool.npm",
-                command: "npm",
-                version_args: &["--version"],
-                required: false,
-                remediation: "Install npm with Node.js",
-            },
-            ToolSpec {
-                id: "pnpm",
-                check_id: "tool.pnpm",
-                command: "pnpm",
-                version_args: &["--version"],
-                required: false,
-                remediation: "Install pnpm for repos that use pnpm-lock.yaml",
-            },
-            ToolSpec {
-                id: "php",
-                check_id: "tool.php",
-                command: "php",
-                version_args: &["--version"],
-                required: false,
-                remediation: "Install PHP for WordPress/PHP components",
-            },
-            ToolSpec {
-                id: "composer",
-                check_id: "tool.composer",
-                command: "composer",
-                version_args: &["--version"],
-                required: false,
-                remediation: "Install Composer for PHP dependencies",
-            },
-            ToolSpec {
-                id: "docker",
-                check_id: "tool.docker",
-                command: "docker",
-                version_args: &["--version"],
-                required: false,
-                remediation: "Install and start Docker for container-backed rigs",
-            },
-            ToolSpec {
-                id: "playwright",
-                check_id: "tool.playwright",
-                command: "playwright",
-                version_args: &["--version"],
-                required: false,
-                remediation: "Install Playwright CLI and browsers for browser traces",
-            },
-        ]
+    pub fn tool_specs() -> &'static [RunnerToolSpec] {
+        RunnerToolRegistry::doctor_tools()
     }
 
     pub fn capabilities_from(
@@ -1732,7 +1657,7 @@ mod checks {
     use super::*;
     use types::{RunnerCheck, RunnerDoctorStatus, ToolProbe};
 
-    pub fn tool_check(spec: probes::ToolSpec, probe: &ToolProbe) -> RunnerCheck {
+    pub fn tool_check(spec: RunnerToolSpec, probe: &ToolProbe) -> RunnerCheck {
         if probe.available {
             ok(
                 spec.check_id,

--- a/src/core/runner/capabilities.rs
+++ b/src/core/runner/capabilities.rs
@@ -6,7 +6,7 @@ use crate::core::error::{Error, Result};
 use crate::core::gate::{HomeboyGateKind, HomeboyGateResult, HomeboyGateStatus};
 use crate::core::server::{self, SshClient};
 
-use super::Runner;
+use super::{Runner, RunnerToolRegistry};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RunnerCapabilityPreflight {
@@ -216,18 +216,7 @@ impl RunnerCapabilitySnapshot {
     ) -> Result<Self> {
         let client = Self::ssh_client_for_runner(runner)?;
         let mut tools = BTreeSet::new();
-        for tool in [
-            RunnerRequiredTool::Homeboy,
-            RunnerRequiredTool::Cargo,
-            RunnerRequiredTool::Git,
-            RunnerRequiredTool::Node,
-            RunnerRequiredTool::Npm,
-            RunnerRequiredTool::Pnpm,
-            RunnerRequiredTool::Php,
-            RunnerRequiredTool::Composer,
-            RunnerRequiredTool::Docker,
-            RunnerRequiredTool::Playwright,
-        ] {
+        for tool in RunnerToolRegistry::required_tools().iter().copied() {
             if Self::tool_available(runner, &client, tool) {
                 tools.insert(tool);
             }
@@ -264,19 +253,15 @@ impl RunnerCapabilitySnapshot {
     }
 
     fn tool_available(runner: &Runner, client: &SshClient, tool: RunnerRequiredTool) -> bool {
-        let command = match tool {
-            RunnerRequiredTool::Homeboy => {
-                runner.settings.homeboy_path.as_deref().unwrap_or("homeboy")
-            }
-            RunnerRequiredTool::Cargo => "cargo",
-            RunnerRequiredTool::Git => "git",
-            RunnerRequiredTool::Node => "node",
-            RunnerRequiredTool::Npm => concat!("n", "pm"),
-            RunnerRequiredTool::Pnpm => concat!("p", "n", "pm"),
-            RunnerRequiredTool::Php => concat!("p", "hp"),
-            RunnerRequiredTool::Composer => concat!("com", "poser"),
-            RunnerRequiredTool::Docker => "docker",
-            RunnerRequiredTool::Playwright => return Self::playwright_ready(client),
+        if tool == RunnerRequiredTool::Playwright {
+            return Self::playwright_ready(client);
+        }
+        let command = if tool == RunnerRequiredTool::Homeboy {
+            runner.settings.homeboy_path.as_deref().unwrap_or("homeboy")
+        } else {
+            RunnerToolRegistry::spec_for_required_tool(tool)
+                .map(|spec| spec.command)
+                .unwrap_or_else(|| tool.id())
         };
         client
             .execute(&format!(
@@ -430,57 +415,15 @@ impl RunnerCapabilityPreflight {
 
 impl RunnerRequiredTool {
     pub fn id(self) -> &'static str {
-        match self {
-            RunnerRequiredTool::Homeboy => "homeboy",
-            RunnerRequiredTool::Cargo => "cargo",
-            RunnerRequiredTool::Git => "git",
-            RunnerRequiredTool::Node => "node",
-            RunnerRequiredTool::Npm => concat!("n", "pm"),
-            RunnerRequiredTool::Pnpm => concat!("p", "n", "pm"),
-            RunnerRequiredTool::Php => concat!("p", "hp"),
-            RunnerRequiredTool::Composer => concat!("com", "poser"),
-            RunnerRequiredTool::Docker => "docker",
-            RunnerRequiredTool::Playwright => "playwright+browsers",
-        }
+        RunnerToolRegistry::spec_for_required_tool(self)
+            .map(|spec| spec.capability_id)
+            .unwrap_or("unknown")
     }
 
     pub(crate) fn remediation(self) -> &'static str {
-        match self {
-            RunnerRequiredTool::Homeboy => {
-                "Install Homeboy on the runner and ensure the configured homeboy_path works."
-            }
-            RunnerRequiredTool::Cargo => {
-                "Install Rust/Cargo and ensure cargo is on the runner PATH."
-            }
-            RunnerRequiredTool::Git => "Install git and ensure it is on the runner PATH.",
-            RunnerRequiredTool::Node => "Install Node.js and ensure node is on the runner PATH.",
-            RunnerRequiredTool::Npm => concat!(
-                "Install n",
-                "pm with Node.js and ensure n",
-                "pm is on the runner PATH."
-            ),
-            RunnerRequiredTool::Pnpm => concat!(
-                "Install p",
-                "n",
-                "pm for repositories with p",
-                "n",
-                "pm-lock.yaml."
-            ),
-            RunnerRequiredTool::Php => {
-                concat!("Install P", "HP for repositories with com", "poser.json.")
-            }
-            RunnerRequiredTool::Composer => concat!(
-                "Install Com",
-                "poser for repositories with com",
-                "poser.json."
-            ),
-            RunnerRequiredTool::Docker => {
-                "Install and start Docker for container-backed repositories."
-            }
-            RunnerRequiredTool::Playwright => {
-                "Install Playwright CLI and browser binaries on the runner."
-            }
-        }
+        RunnerToolRegistry::spec_for_required_tool(self)
+            .map(|spec| spec.capability_remediation)
+            .unwrap_or("Install the missing tool on the runner and ensure it is on PATH.")
     }
 }
 
@@ -792,6 +735,22 @@ mod tests {
 
         validate_runner_capability_preflight("lab", &preflight, &capabilities, &env)
             .expect("capability parity passes");
+    }
+
+    #[test]
+    fn every_required_runner_tool_has_doctor_metadata() {
+        for tool in RunnerToolRegistry::required_tools() {
+            let spec = RunnerToolRegistry::spec_for_required_tool(*tool)
+                .unwrap_or_else(|| panic!("missing doctor metadata for {tool:?}"));
+
+            assert_eq!(spec.tool, Some(*tool));
+            assert!(!spec.id.is_empty());
+            assert!(!spec.capability_id.is_empty());
+            assert!(!spec.check_id.is_empty());
+            assert!(!spec.command.is_empty());
+            assert!(!spec.remediation.is_empty());
+            assert!(!spec.capability_remediation.is_empty());
+        }
     }
 
     #[test]

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -39,6 +39,7 @@ mod resource_metrics;
 mod rig_materialization;
 mod session;
 mod source_materialization;
+mod tool_registry;
 mod validation_dependencies;
 pub(crate) use validation_dependencies::validation_dependency_ids;
 pub use validation_dependencies::RunnerValidationDependencySyncOutput;
@@ -97,6 +98,7 @@ pub use session::{
     RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
     RunnerStatusReport, RunnerTunnelMode,
 };
+pub use tool_registry::{RunnerToolRegistry, RunnerToolSpec};
 pub use worker::{run_reverse_worker, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput};
 pub use workspace::{
     sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,

--- a/src/core/runner/tool_registry.rs
+++ b/src/core/runner/tool_registry.rs
@@ -1,0 +1,169 @@
+use super::capabilities::RunnerRequiredTool;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RunnerToolSpec {
+    pub tool: Option<RunnerRequiredTool>,
+    pub id: &'static str,
+    pub capability_id: &'static str,
+    pub check_id: &'static str,
+    pub command: &'static str,
+    pub version_args: &'static [&'static str],
+    pub required: bool,
+    pub remediation: &'static str,
+    pub capability_remediation: &'static str,
+}
+
+pub struct RunnerToolRegistry;
+
+impl RunnerToolRegistry {
+    pub const REQUIRED_TOOLS: &'static [RunnerRequiredTool] = &[
+        RunnerRequiredTool::Homeboy,
+        RunnerRequiredTool::Cargo,
+        RunnerRequiredTool::Git,
+        RunnerRequiredTool::Node,
+        RunnerRequiredTool::Npm,
+        RunnerRequiredTool::Pnpm,
+        RunnerRequiredTool::Php,
+        RunnerRequiredTool::Composer,
+        RunnerRequiredTool::Docker,
+        RunnerRequiredTool::Playwright,
+    ];
+
+    pub const DOCTOR_TOOLS: &'static [RunnerToolSpec] = &[
+        RunnerToolSpec {
+            tool: Some(RunnerRequiredTool::Homeboy),
+            id: "homeboy",
+            capability_id: "homeboy",
+            check_id: "homeboy",
+            command: "homeboy",
+            version_args: &["--version"],
+            required: true,
+            remediation: "Install Homeboy on the remote runner or configure runner.homeboy_path/server.env.PATH",
+            capability_remediation: "Install Homeboy on the runner and ensure the configured homeboy_path works.",
+        },
+        RunnerToolSpec {
+            tool: Some(RunnerRequiredTool::Cargo),
+            id: "cargo",
+            capability_id: "cargo",
+            check_id: "tool.cargo",
+            command: "cargo",
+            version_args: &["--version"],
+            required: false,
+            remediation: "Install Rust/Cargo and ensure cargo is on PATH",
+            capability_remediation: "Install Rust/Cargo and ensure cargo is on the runner PATH.",
+        },
+        RunnerToolSpec {
+            tool: Some(RunnerRequiredTool::Git),
+            id: "git",
+            capability_id: "git",
+            check_id: "tool.git",
+            command: "git",
+            version_args: &["--version"],
+            required: true,
+            remediation: "Install git and ensure it is on PATH",
+            capability_remediation: "Install git and ensure it is on the runner PATH.",
+        },
+        RunnerToolSpec {
+            tool: None,
+            id: "gh",
+            capability_id: "gh",
+            check_id: "tool.github_cli",
+            command: "gh",
+            version_args: &["--version"],
+            required: false,
+            remediation: "Install GitHub CLI (`gh`) for PR and issue workflows",
+            capability_remediation: "Install GitHub CLI (`gh`) for PR and issue workflows",
+        },
+        RunnerToolSpec {
+            tool: Some(RunnerRequiredTool::Node),
+            id: "node",
+            capability_id: "node",
+            check_id: "tool.node",
+            command: "node",
+            version_args: &["--version"],
+            required: false,
+            remediation: "Install Node.js for JavaScript/TypeScript components",
+            capability_remediation: "Install Node.js and ensure node is on the runner PATH.",
+        },
+        RunnerToolSpec {
+            tool: Some(RunnerRequiredTool::Npm),
+            id: "npm",
+            capability_id: "npm",
+            check_id: "tool.npm",
+            command: "npm",
+            version_args: &["--version"],
+            required: false,
+            remediation: "Install npm with Node.js",
+            capability_remediation: "Install npm with Node.js and ensure npm is on the runner PATH.",
+        },
+        RunnerToolSpec {
+            tool: Some(RunnerRequiredTool::Pnpm),
+            id: "pnpm",
+            capability_id: "pnpm",
+            check_id: "tool.pnpm",
+            command: "pnpm",
+            version_args: &["--version"],
+            required: false,
+            remediation: "Install pnpm for repos that use pnpm-lock.yaml",
+            capability_remediation: "Install pnpm for repositories with pnpm-lock.yaml.",
+        },
+        RunnerToolSpec {
+            tool: Some(RunnerRequiredTool::Php),
+            id: "php",
+            capability_id: "php",
+            check_id: "tool.php",
+            command: "php",
+            version_args: &["--version"],
+            required: false,
+            remediation: "Install PHP for WordPress/PHP components",
+            capability_remediation: "Install PHP for repositories with composer.json.",
+        },
+        RunnerToolSpec {
+            tool: Some(RunnerRequiredTool::Composer),
+            id: "composer",
+            capability_id: "composer",
+            check_id: "tool.composer",
+            command: "composer",
+            version_args: &["--version"],
+            required: false,
+            remediation: "Install Composer for PHP dependencies",
+            capability_remediation: "Install Composer for repositories with composer.json.",
+        },
+        RunnerToolSpec {
+            tool: Some(RunnerRequiredTool::Docker),
+            id: "docker",
+            capability_id: "docker",
+            check_id: "tool.docker",
+            command: "docker",
+            version_args: &["--version"],
+            required: false,
+            remediation: "Install and start Docker for container-backed rigs",
+            capability_remediation: "Install and start Docker for container-backed repositories.",
+        },
+        RunnerToolSpec {
+            tool: Some(RunnerRequiredTool::Playwright),
+            id: "playwright",
+            capability_id: "playwright+browsers",
+            check_id: "tool.playwright",
+            command: "playwright",
+            version_args: &["--version"],
+            required: false,
+            remediation: "Install Playwright CLI and browsers for browser traces",
+            capability_remediation: "Install Playwright CLI and browser binaries on the runner.",
+        },
+    ];
+
+    pub fn required_tools() -> &'static [RunnerRequiredTool] {
+        Self::REQUIRED_TOOLS
+    }
+
+    pub fn doctor_tools() -> &'static [RunnerToolSpec] {
+        Self::DOCTOR_TOOLS
+    }
+
+    pub fn spec_for_required_tool(tool: RunnerRequiredTool) -> Option<&'static RunnerToolSpec> {
+        Self::DOCTOR_TOOLS
+            .iter()
+            .find(|spec| spec.tool == Some(tool))
+    }
+}

--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -45,9 +45,9 @@ pub use super::runner::{
     RunnerConnectReport, RunnerDisconnectReport, RunnerExecMode, RunnerExecOptions,
     RunnerExecOutput, RunnerFailureKind, RunnerKind, RunnerRequiredTool, RunnerResourceMetrics,
     RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
-    RunnerStatusReport, RunnerTunnelMode, RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput,
-    RunnerWorkspaceApplyStatus, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
-    RunnerWorkspaceSyncOutput,
+    RunnerStatusReport, RunnerToolRegistry, RunnerToolSpec, RunnerTunnelMode,
+    RunnerWorkspaceApplyOptions, RunnerWorkspaceApplyOutput, RunnerWorkspaceApplyStatus,
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 
 // Registry CRUD entry points (re-exported at the root for ergonomics; also


### PR DESCRIPTION
## Summary
- Add a shared runner ToolRegistry/ToolSpec primitive for required runner tools and doctor tool probes.
- Route capability tool enumeration, command lookup, IDs, and capability remediations through the registry.
- Route runner doctor tool specs through the same registry while preserving bespoke Homeboy doctor checks/remediation.
- Add a regression assertion that every required runner tool has doctor metadata.

## Verification
- cargo fmt --check
- cargo test runner::capabilities::tests
- cargo test commands::runner::doctor::tests

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the shared registry refactor, updated consumers, added regression coverage, and ran local verification; Chris remains responsible for review and final acceptance.