### PR TITLE
Refactor Lab agent-task argv editing

### DIFF
--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -21,7 +21,7 @@ use serde::Deserialize;
 
 use super::super::lab_workspaces::{workspace_mapping_entry, LabWorkspaceMappingEntry};
 use super::super::{sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions};
-use super::args_util::subcommand_index;
+use super::args_util::{subcommand_index, ArgEditor, CommandInvocation};
 
 pub(super) fn materialize_inline_agent_task_plan_arg(
     runner_id: &str,
@@ -329,45 +329,25 @@ fn agent_task_run_plan_recording_args(args: &[String]) -> Option<(String, String
 }
 
 pub(super) fn agent_task_dispatch_requested_run_id(args: &[String]) -> Option<String> {
-    let action_index = subcommand_index(args, "agent-task").and_then(|index| {
-        args.get(index + 1)
-            .filter(|arg| matches!(arg.as_str(), "dispatch" | "cook"))
-            .map(|_| index + 1)
-    })?;
-
-    let mut iter = args.iter().skip(action_index + 1);
-    while let Some(arg) = iter.next() {
-        if arg == "--" {
-            break;
-        }
-        if arg == "--run-id" {
-            return iter.next().cloned();
-        }
-        if let Some(value) = arg.strip_prefix("--run-id=") {
-            return (!value.is_empty()).then(|| value.to_string());
-        }
-    }
-
-    None
+    let invocation = CommandInvocation::for_subcommand(args, "agent-task")?;
+    let action_index = invocation.child_index_matching(&["dispatch", "cook"])?;
+    invocation
+        .option_value_after(action_index, "--run-id")
+        .map(str::to_string)
 }
 
 pub(super) fn ensure_agent_task_dispatch_run_id(args: &[String]) -> Option<(Vec<String>, String)> {
-    let action_index = subcommand_index(args, "agent-task").and_then(|index| {
-        args.get(index + 1)
-            .filter(|arg| matches!(arg.as_str(), "dispatch" | "cook"))
-            .map(|_| index + 1)
-    })?;
+    let invocation = CommandInvocation::for_subcommand(args, "agent-task")?;
+    let action_index = invocation.child_index_matching(&["dispatch", "cook"])?;
 
     if let Some(run_id) = agent_task_dispatch_requested_run_id(args) {
         return Some((args.to_vec(), run_id));
     }
 
     let run_id = format!("agent-task-{}", uuid::Uuid::new_v4());
-    let mut out = Vec::with_capacity(args.len() + 2);
-    out.extend_from_slice(&args[..=action_index]);
-    out.push("--run-id".to_string());
-    out.push(run_id.clone());
-    out.extend_from_slice(&args[action_index + 1..]);
+    let out = ArgEditor::new(args)
+        .insert_after(action_index, ["--run-id".to_string(), run_id.clone()])
+        .into_args();
     Some((out, run_id))
 }
 

--- a/src/core/runner/lab/args_util.rs
+++ b/src/core/runner/lab/args_util.rs
@@ -11,3 +11,170 @@ pub(super) fn subcommand_index(args: &[String], subcommand: &str) -> Option<usiz
 pub(super) fn non_empty_arg(value: &str) -> Option<String> {
     (!value.trim().is_empty() && !value.starts_with('-')).then(|| value.to_string())
 }
+
+pub(super) struct CommandInvocation<'a> {
+    args: &'a [String],
+    command_index: usize,
+}
+
+impl<'a> CommandInvocation<'a> {
+    pub(super) fn for_subcommand(args: &'a [String], command: &str) -> Option<Self> {
+        subcommand_index_before_passthrough(args, command).map(|command_index| Self {
+            args,
+            command_index,
+        })
+    }
+
+    pub(super) fn child_index_matching(&self, values: &[&str]) -> Option<usize> {
+        self.args
+            .get(self.command_index + 1)
+            .filter(|arg| values.contains(&arg.as_str()))
+            .map(|_| self.command_index + 1)
+    }
+
+    pub(super) fn option_value_after(&self, start_index: usize, flag: &str) -> Option<&'a str> {
+        option_value(self.args, start_index + 1, flag)
+    }
+}
+
+pub(super) struct ArgEditor {
+    args: Vec<String>,
+}
+
+impl ArgEditor {
+    pub(super) fn new(args: &[String]) -> Self {
+        Self {
+            args: args.to_vec(),
+        }
+    }
+
+    pub(super) fn insert_after(
+        mut self,
+        index: usize,
+        values: impl IntoIterator<Item = String>,
+    ) -> Self {
+        let mut insertion_index = index + 1;
+        for value in values {
+            self.args.insert(insertion_index, value);
+            insertion_index += 1;
+        }
+        self
+    }
+
+    pub(super) fn into_args(self) -> Vec<String> {
+        self.args
+    }
+}
+
+fn subcommand_index_before_passthrough(args: &[String], subcommand: &str) -> Option<usize> {
+    args.iter()
+        .take_while(|arg| arg.as_str() != "--")
+        .position(|arg| arg == subcommand)
+}
+
+fn option_value<'a>(args: &'a [String], start_index: usize, flag: &str) -> Option<&'a str> {
+    let flag_eq = format!("{flag}=");
+    let mut iter = args.iter().enumerate().skip(start_index);
+    while let Some((index, arg)) = iter.next() {
+        if arg == "--" {
+            return None;
+        }
+        if let Some(value) = arg.strip_prefix(&flag_eq) {
+            return (!value.is_empty()).then_some(value);
+        }
+        if arg == flag {
+            return args
+                .get(index + 1)
+                .filter(|value| !value.trim().is_empty() && !value.starts_with('-'))
+                .map(String::as_str);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn command_invocation_reads_flag_value_forms() {
+        let cases = [
+            (
+                args(&["homeboy", "agent-task", "dispatch", "--run-id", "abc"]),
+                Some("abc"),
+            ),
+            (
+                args(&["homeboy", "agent-task", "dispatch", "--run-id=abc"]),
+                Some("abc"),
+            ),
+            (
+                args(&["homeboy", "agent-task", "dispatch", "--run-id"]),
+                None,
+            ),
+            (
+                args(&["homeboy", "agent-task", "dispatch", "--run-id", "--other"]),
+                None,
+            ),
+            (
+                args(&["homeboy", "agent-task", "dispatch", "--", "--run-id", "abc"]),
+                None,
+            ),
+        ];
+
+        for (input, expected) in cases {
+            let invocation = CommandInvocation::for_subcommand(&input, "agent-task").unwrap();
+            let action_index = invocation
+                .child_index_matching(&["dispatch", "cook"])
+                .unwrap();
+            assert_eq!(
+                invocation.option_value_after(action_index, "--run-id"),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn arg_editor_inserts_after_subcommand_child() {
+        let input = args(&["homeboy", "agent-task", "dispatch", "--repo", "homeboy"]);
+        let invocation = CommandInvocation::for_subcommand(&input, "agent-task").unwrap();
+        let action_index = invocation
+            .child_index_matching(&["dispatch", "cook"])
+            .unwrap();
+
+        let edited = ArgEditor::new(&input)
+            .insert_after(
+                action_index,
+                ["--run-id".to_string(), "generated".to_string()],
+            )
+            .into_args();
+
+        assert_eq!(
+            edited,
+            args(&[
+                "homeboy",
+                "agent-task",
+                "dispatch",
+                "--run-id",
+                "generated",
+                "--repo",
+                "homeboy",
+            ])
+        );
+    }
+
+    #[test]
+    fn command_invocation_detects_subcommand_before_passthrough_only() {
+        let input = args(&["homeboy", "lab", "exec", "--", "agent-task", "dispatch"]);
+
+        assert_eq!(
+            CommandInvocation::for_subcommand(&input, "lab")
+                .and_then(|invocation| invocation.child_index_matching(&["exec"])),
+            Some(2)
+        );
+        assert!(CommandInvocation::for_subcommand(&input, "agent-task").is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- Add a small Lab argv primitive for command/subcommand detection, option value lookup, and insertion.
- Cover split flags, equals flags, missing values, passthrough boundaries, insertion after subcommands, and subcommand detection with table-driven tests.
- Port the focused agent-task Lab dispatch run-id path to the shared primitive.

## Verification
- `cargo test core::runner::lab::args_util`
- `cargo test` (initial full run hit two unrelated extension run-dir/temp artifact failures; both failed tests passed when rerun individually)
- `cargo test core::extension::runner::tests::with_run_dir_tracks_resource_artifact_path`
- `cargo test core::extension::bench::run::tests::attach_memory_timeline_adds_metrics_and_artifacts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the shared argv helper, focused agent-task dispatch port, tests, and local verification under Chris's direction.