### PR TITLE
fix(agent-task): surface failure diagnostics

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -11,8 +11,11 @@ use homeboy::core::agent_tasks::controller_service::{
     AgentTaskRepoLoopSpec, ControllerApplyEventRequest, ControllerDispatchHook,
     ControllerFromSpecRequest, ControllerInitRequest, ControllerMarkHumanReadyRequest,
 };
+use homeboy::core::agent_tasks::lifecycle as agent_task_lifecycle;
 use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
-use homeboy::core::agent_tasks::scheduler::{AgentTaskExecutorAdapter, AgentTaskPlan};
+use homeboy::core::agent_tasks::scheduler::{
+    AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan,
+};
 use homeboy::core::agent_tasks::secrets as agent_task_secrets;
 use homeboy::core::agent_tasks::service as agent_task_service;
 use homeboy::core::config;
@@ -1193,7 +1196,9 @@ fn submit(args: SubmitArgs) -> CmdResult<Value> {
 
 fn status(args: StatusArgs) -> CmdResult<Value> {
     let record = agent_task_service::status(&args.run_id)?;
-    Ok((serde_json::to_value(record).unwrap_or(Value::Null), 0))
+    let mut value = serde_json::to_value(record).unwrap_or(Value::Null);
+    enrich_with_diagnostic_summary(&mut value, &args.run_id)?;
+    Ok((value, 0))
 }
 
 fn list_runs(filter: agent_task_service::AgentTaskDiscoveryFilter) -> CmdResult<Value> {
@@ -1203,7 +1208,46 @@ fn list_runs(filter: agent_task_service::AgentTaskDiscoveryFilter) -> CmdResult<
 
 fn logs(args: StatusArgs) -> CmdResult<Value> {
     let log = agent_task_service::logs(&args.run_id)?;
-    Ok((serde_json::to_value(log).unwrap_or(Value::Null), 0))
+    let mut value = serde_json::to_value(log).unwrap_or(Value::Null);
+    enrich_with_diagnostic_summary(&mut value, &args.run_id)?;
+    Ok((value, 0))
+}
+
+fn enrich_with_diagnostic_summary(value: &mut Value, run_id: &str) -> homeboy::core::Result<()> {
+    let Some(aggregate) = completed_run_aggregate(run_id).transpose()? else {
+        return Ok(());
+    };
+    if let Some(summary) = diagnostic_summary_from_aggregate(&aggregate) {
+        value["diagnostic_summary"] = summary;
+    }
+    Ok(())
+}
+
+pub(crate) fn completed_run_aggregate(
+    run_id: &str,
+) -> Option<homeboy::core::Result<AgentTaskAggregate>> {
+    match agent_task_lifecycle::aggregate_source(run_id) {
+        Ok((raw, _path)) => Some(serde_json::from_str(&raw).map_err(|error| {
+            homeboy::core::Error::validation_invalid_json(
+                error,
+                Some("agent-task aggregate".to_string()),
+                Some(raw),
+            )
+        })),
+        Err(error) if error.code == homeboy::core::ErrorCode::ValidationInvalidArgument => None,
+        Err(error) => Some(Err(error)),
+    }
+}
+
+pub(crate) fn diagnostic_summary_from_aggregate(aggregate: &AgentTaskAggregate) -> Option<Value> {
+    aggregate.outcomes.iter().find_map(|outcome| {
+        let diagnostic = outcome.diagnostics.first()?;
+        Some(serde_json::json!({
+            "task_id": outcome.task_id,
+            "class": diagnostic.class,
+            "message": diagnostic.message,
+        }))
+    })
 }
 
 fn artifacts(args: StatusArgs) -> CmdResult<Value> {
@@ -1258,10 +1302,10 @@ mod tests {
     };
     use homeboy::core::agent_tasks::scheduler::{AgentTaskExecutionContext, AgentTaskState};
     use homeboy::core::agent_tasks::{
-        AgentTaskArtifact, AgentTaskEvidenceRef, AgentTaskExecutor, AgentTaskLimits,
-        AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest,
-        AgentTaskWorkspace, AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA,
-        AGENT_TASK_REQUEST_SCHEMA,
+        AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskExecutor,
+        AgentTaskFailureClassification, AgentTaskLimits, AgentTaskOutcome, AgentTaskOutcomeStatus,
+        AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace, AGENT_TASK_ARTIFACT_SCHEMA,
+        AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
     };
     use serde_json::{json, Value};
     use std::sync::{Arc, Mutex};
@@ -1526,6 +1570,39 @@ mod tests {
             assert_eq!(record.state, AgentTaskRunState::Failed);
             assert_eq!(record.tasks[0].state, AgentTaskState::Failed);
             assert_eq!(record.totals.expect("totals").failed, 1);
+        });
+    }
+
+    #[test]
+    fn failed_run_status_logs_and_review_include_outcome_diagnostic_summary() {
+        with_temp_home(|| {
+            let run_id = "run-cli-diagnostic-summary";
+            run_loaded_plan(test_plan(), Some(run_id), DiagnosticFailureExecutor)
+                .expect("run completed with failed outcome");
+
+            let (status_value, _) = status(StatusArgs {
+                run_id: run_id.to_string(),
+            })
+            .expect("status loaded");
+            let (logs_value, _) = logs(StatusArgs {
+                run_id: run_id.to_string(),
+            })
+            .expect("logs loaded");
+            let (review_value, _) = review::review(ReviewArgs {
+                run_id: run_id.to_string(),
+                to_worktree: None,
+                provider_command: None,
+            })
+            .expect("review loaded");
+
+            for value in [&status_value, &logs_value, &review_value] {
+                assert_eq!(
+                    value["diagnostic_summary"]["message"],
+                    "Requested provider \"codex\" is not registered. Registered provider plugins: []"
+                );
+                assert_eq!(value["diagnostic_summary"]["class"], "provider_discovery");
+                assert_eq!(value["diagnostic_summary"]["task_id"], "task-a");
+            }
         });
     }
 
@@ -2129,6 +2206,36 @@ mod tests {
                 artifacts: Vec::new(),
                 evidence_refs: Vec::new(),
                 diagnostics: Vec::new(),
+                outputs: Value::Null,
+                workflow: None,
+                follow_up: None,
+                metadata: Value::Null,
+            }
+        }
+    }
+
+    struct DiagnosticFailureExecutor;
+
+    impl AgentTaskExecutorAdapter for DiagnosticFailureExecutor {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            AgentTaskOutcome {
+                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: request.task_id,
+                status: AgentTaskOutcomeStatus::ProviderError,
+                summary: Some("Embedded agent runtime failed.".to_string()),
+                failure_classification: Some(AgentTaskFailureClassification::Provider),
+                artifacts: Vec::new(),
+                evidence_refs: Vec::new(),
+                diagnostics: vec![AgentTaskDiagnostic {
+                    class: "provider_discovery".to_string(),
+                    message: "Requested provider \"codex\" is not registered. Registered provider plugins: []"
+                        .to_string(),
+                    data: json!({ "registered_provider_plugins": [] }),
+                }],
                 outputs: Value::Null,
                 workflow: None,
                 follow_up: None,

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -11,7 +11,6 @@ use homeboy::core::agent_tasks::promotion::{
     promote, AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionStatus,
 };
 use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
-use homeboy::core::agent_tasks::scheduler::AgentTaskAggregate;
 use homeboy::core::agent_tasks::service as agent_task_service;
 use homeboy::core::agent_tasks::{AgentTaskAggregateReport, AgentTaskRequest};
 use homeboy::core::config;
@@ -129,10 +128,13 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
     let record = agent_task_lifecycle::status(&args.run_id)?;
     let log = agent_task_lifecycle::logs(&args.run_id)?;
     let artifacts = agent_task_lifecycle::artifacts(&args.run_id)?;
-    let aggregate = completed_run_aggregate(&args.run_id).transpose()?;
+    let aggregate = super::completed_run_aggregate(&args.run_id).transpose()?;
     let aggregate_review = aggregate
         .as_ref()
         .map(|aggregate| AgentTaskAggregateReport::from(aggregate.outcomes.clone()));
+    let diagnostic_summary = aggregate
+        .as_ref()
+        .and_then(super::diagnostic_summary_from_aggregate);
     let promotion_candidates = aggregate_review
         .as_ref()
         .map(|review| {
@@ -163,6 +165,7 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
             "logs": log,
             "artifacts": artifacts,
             "aggregate_review": aggregate_review,
+            "diagnostic_summary": diagnostic_summary,
             "promotion_candidates": promotion_candidates,
             "next_actions": next_actions,
             "transport": {
@@ -289,20 +292,6 @@ pub(crate) fn default_protected_branches() -> Vec<String> {
         "master".to_string(),
         "trunk".to_string(),
     ]
-}
-
-fn completed_run_aggregate(run_id: &str) -> Option<homeboy::core::Result<AgentTaskAggregate>> {
-    match agent_task_lifecycle::aggregate_source(run_id) {
-        Ok((raw, _path)) => Some(serde_json::from_str(&raw).map_err(|error| {
-            homeboy::core::Error::validation_invalid_json(
-                error,
-                Some("agent-task aggregate".to_string()),
-                Some(raw),
-            )
-        })),
-        Err(error) if error.code == homeboy::core::ErrorCode::ValidationInvalidArgument => None,
-        Err(error) => Some(Err(error)),
-    }
 }
 
 fn promotion_candidates(

--- a/src/commands/agent_task_summary.rs
+++ b/src/commands/agent_task_summary.rs
@@ -6,6 +6,7 @@ use super::agent_task::{AgentTaskArgs, AgentTaskCommand};
 pub(crate) enum AgentTaskSummaryKind {
     Cook,
     Status,
+    Logs,
     Review,
 }
 
@@ -13,6 +14,7 @@ pub(crate) fn agent_task_summary_kind(args: &AgentTaskArgs) -> Option<AgentTaskS
     match args.command {
         AgentTaskCommand::Cook(_) => Some(AgentTaskSummaryKind::Cook),
         AgentTaskCommand::Status(_) => Some(AgentTaskSummaryKind::Status),
+        AgentTaskCommand::Logs(_) => Some(AgentTaskSummaryKind::Logs),
         AgentTaskCommand::Review(_) => Some(AgentTaskSummaryKind::Review),
         _ => None,
     }
@@ -25,6 +27,7 @@ pub(crate) fn render_agent_task_summary(
     match kind {
         AgentTaskSummaryKind::Cook => render_cook_summary(payload),
         AgentTaskSummaryKind::Status => render_status_summary(payload),
+        AgentTaskSummaryKind::Logs => render_logs_summary(payload),
         AgentTaskSummaryKind::Review => render_review_summary(payload),
     }
 }
@@ -95,6 +98,9 @@ fn render_status_summary(payload: &Value) -> Option<String> {
         format!("Tasks attempted: {tasks_attempted}"),
     ];
     lines.extend(code_production_lines(&metrics));
+    if let Some(diagnostic) = first_actionable_diagnostic(payload) {
+        lines.push(format!("Diagnostic: {diagnostic}"));
+    }
     lines.push(format!("Artifacts: {artifact_count}"));
     if let Some(path) = aggregate_path.filter(|_| metrics.non_empty_patches > 0) {
         lines.push(format!("Aggregate: {path}"));
@@ -103,6 +109,20 @@ fn render_status_summary(payload: &Value) -> Option<String> {
         lines.push(format!("Next: homeboy agent-task run {run_id}"));
     } else {
         lines.push(format!("Next: homeboy agent-task logs {run_id}"));
+    }
+    Some(finish(lines))
+}
+
+fn render_logs_summary(payload: &Value) -> Option<String> {
+    let run_id = string_value(payload, &["run_id"])?;
+    let event_count = array_len(payload, &["events"]).unwrap_or(0);
+    let mut lines = vec![
+        "Agent task logs".to_string(),
+        format!("Run: {run_id}"),
+        format!("Events: {event_count}"),
+    ];
+    if let Some(diagnostic) = first_actionable_diagnostic(payload) {
+        lines.push(format!("Diagnostic: {diagnostic}"));
     }
     Some(finish(lines))
 }
@@ -150,6 +170,9 @@ fn render_review_summary(payload: &Value) -> Option<String> {
         format!("Outcome: {outcome}"),
     ];
     lines.extend(code_production_lines(&metrics));
+    if let Some(diagnostic) = first_actionable_diagnostic(payload) {
+        lines.push(format!("Diagnostic: {diagnostic}"));
+    }
     if let Some(patch_path) = patch_path {
         lines.push(format!("Patch: {patch_path}"));
     } else if let Some(patch) = patch {
@@ -161,6 +184,24 @@ fn render_review_summary(payload: &Value) -> Option<String> {
         lines.push(format!("Next: {next}"));
     }
     Some(finish(lines))
+}
+
+fn first_actionable_diagnostic(payload: &Value) -> Option<&str> {
+    string_value(payload, &["diagnostic_summary", "message"])
+        .or_else(|| first_diagnostic_message(payload, &["aggregate", "outcomes"]))
+        .or_else(|| first_diagnostic_message(payload, &["aggregate_review", "tasks"]))
+}
+
+fn first_diagnostic_message<'a>(payload: &'a Value, path: &[&str]) -> Option<&'a str> {
+    value_at(payload, path)?
+        .as_array()?
+        .iter()
+        .find_map(|item| {
+            value_at(item, &["diagnostics"])?
+                .as_array()?
+                .iter()
+                .find_map(|diagnostic| string_value(diagnostic, &["message"]))
+        })
 }
 
 fn value_at<'a>(payload: &'a Value, path: &[&str]) -> Option<&'a Value> {
@@ -741,6 +782,31 @@ mod tests {
     }
 
     #[test]
+    fn review_summary_surfaces_first_outcome_diagnostic() {
+        let payload = json!({
+            "run_id": "agent-task-d1622a44",
+            "state": "failed",
+            "aggregate_review": {
+                "summary": { "apply_candidates": 0, "failed": 1 },
+                "tasks": [{
+                    "task_id": "agent-task-d1622a44",
+                    "status": "provider_error",
+                    "diagnostics": [{
+                        "class": "provider_discovery",
+                        "message": "Requested provider \"codex\" is not registered. Registered provider plugins: []"
+                    }]
+                }]
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Review, &payload).unwrap();
+
+        assert!(summary.contains(
+            "Diagnostic: Requested provider \"codex\" is not registered. Registered provider plugins: []\n"
+        ));
+    }
+
+    #[test]
     fn status_summary_points_queued_runs_at_run_command() {
         let payload = json!({
             "run_id": "homeboy-4345",
@@ -833,6 +899,52 @@ mod tests {
         assert!(summary.contains("Diff bytes: 0\n"));
         assert!(summary.contains("Next: homeboy agent-task logs agent-task-deadbeef\n"));
         assert!(!summary.contains("Next: homeboy agent-task review"));
+    }
+
+    #[test]
+    fn status_summary_surfaces_diagnostic_summary() {
+        let payload = json!({
+            "run_id": "agent-task-d1622a44",
+            "state": "failed",
+            "tasks": [{ "task_id": "agent-task-d1622a44", "state": "failed" }],
+            "artifact_refs": [],
+            "diagnostic_summary": {
+                "task_id": "agent-task-d1622a44",
+                "class": "provider_discovery",
+                "message": "Requested provider \"codex\" is not registered. Registered provider plugins: []"
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+
+        assert!(summary.contains(
+            "Diagnostic: Requested provider \"codex\" is not registered. Registered provider plugins: []\n"
+        ));
+    }
+
+    #[test]
+    fn logs_summary_surfaces_diagnostic_summary() {
+        let payload = json!({
+            "run_id": "agent-task-d1622a44",
+            "events": [{
+                "task_id": "agent-task-d1622a44",
+                "state": "failed",
+                "attempt": 1,
+                "message": "Embedded agent runtime failed."
+            }],
+            "diagnostic_summary": {
+                "task_id": "agent-task-d1622a44",
+                "class": "provider_discovery",
+                "message": "Requested provider \"codex\" is not registered. Registered provider plugins: []"
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Logs, &payload).unwrap();
+
+        assert!(summary.starts_with("Agent task logs\nRun: agent-task-d1622a44\nEvents: 1\n"));
+        assert!(summary.contains(
+            "Diagnostic: Requested provider \"codex\" is not registered. Registered provider plugins: []\n"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a generic diagnostic_summary to agent-task status, logs, and review output from completed aggregate outcome diagnostics.
- Render the first actionable diagnostic in status, logs, and review human summaries so provider/runtime failures do not require artifact spelunking.
- Add regression coverage with a synthetic failed provider outcome diagnostic.

## Verification
- cargo test failed_run_status_logs_and_review_include_outcome_diagnostic_summary --lib
- cargo test agent_task_summary --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the diagnostic surfacing fix and regression tests; Chris remains responsible for review and final acceptance.