### PR TITLE
fix(agent-task): allow lab retry runs

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -74,10 +74,14 @@ impl Commands {
                         | agent_task::AgentTaskCommand::Dispatch(_)
                         | agent_task::AgentTaskCommand::Loop(_)
                         | agent_task::AgentTaskCommand::RunPlan(_)
+                        | agent_task::AgentTaskCommand::Retry(agent_task::RetryArgs {
+                            run: true,
+                            ..
+                        })
                 ) =>
             {
                 let mut contract = LabCommandContract::portable(
-                    "agent-task dispatch/cook/loop/run-plan",
+                    "agent-task dispatch/cook/loop/run-plan/retry --run",
                     None,
                     true,
                     LAB_NO_EXTRA_TOOLS,
@@ -461,6 +465,14 @@ mod tests {
                 .supports_lab_runner()
         );
         assert!(
+            parsed_command(&["homeboy", "agent-task", "retry", "agent-task-123", "--run"])
+                .supports_lab_runner()
+        );
+        assert!(
+            !parsed_command(&["homeboy", "agent-task", "retry", "agent-task-123"])
+                .supports_lab_runner()
+        );
+        assert!(
             !parsed_command(&["homeboy", "agent-task", "status", "agent-task-123"])
                 .supports_lab_runner()
         );
@@ -577,11 +589,11 @@ mod tests {
             ),
             (
                 parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"]),
-                "agent-task dispatch/cook/loop/run-plan",
+                "agent-task dispatch/cook/loop/run-plan/retry --run",
             ),
             (
                 parsed_command(&["homeboy", "agent-task", "cook", "--prompt", "cook"]),
-                "agent-task dispatch/cook/loop/run-plan",
+                "agent-task dispatch/cook/loop/run-plan/retry --run",
             ),
             (
                 parsed_command(&[
@@ -595,11 +607,15 @@ mod tests {
                     "--prompt",
                     "cook",
                 ]),
-                "agent-task dispatch/cook/loop/run-plan",
+                "agent-task dispatch/cook/loop/run-plan/retry --run",
             ),
             (
                 parsed_command(&["homeboy", "agent-task", "run-plan", "--plan", "@plan.json"]),
-                "agent-task dispatch/cook/loop/run-plan",
+                "agent-task dispatch/cook/loop/run-plan/retry --run",
+            ),
+            (
+                parsed_command(&["homeboy", "agent-task", "retry", "agent-task-123", "--run"]),
+                "agent-task dispatch/cook/loop/run-plan/retry --run",
             ),
             (
                 parsed_command(&["homeboy", "agent-task", "providers"]),

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -795,9 +795,46 @@ mod tests {
             ["homeboy", "agent-task", "logs", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "artifacts", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "review", "agent-task-123"].as_slice(),
+            ["homeboy", "agent-task", "retry", "agent-task-123"].as_slice(),
         ] {
             let cli = Cli::parse_from(args);
             assert!(lab_offload_command(&cli.command).unwrap().is_none());
+        }
+    }
+
+    #[test]
+    fn agent_task_retry_run_supports_explicit_runner() {
+        for args in [
+            [
+                "homeboy",
+                "--runner",
+                "homeboy-lab",
+                "agent-task",
+                "retry",
+                "agent-task-123",
+                "--run",
+            ],
+            [
+                "homeboy",
+                "agent-task",
+                "retry",
+                "agent-task-123",
+                "--run",
+                "--runner",
+                "homeboy-lab",
+            ],
+        ] {
+            let cli = Cli::parse_from(args);
+
+            let command = lab_offload_command(&cli.command).unwrap().unwrap();
+
+            assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
+            assert_eq!(
+                command.hot_label,
+                "agent-task dispatch/cook/loop/run-plan/retry --run"
+            );
+            assert!(command.portable);
+            assert!(command.default_lab_offload);
         }
     }
 

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -298,7 +298,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if let Some(runner_id) = request.explicit_runner {
             return Err(unsupported_runner_error(
                 runner_id,
-                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, tunnel preview-consumer run, and tunnel service start".to_string(),
+                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, tunnel preview-consumer run, and tunnel service start".to_string(),
             ));
         }
         return Ok(LabOffloadOutcome::RunLocal {
@@ -311,7 +311,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.portable {
         if let Some(runner_id) = request.explicit_runner {
             let message = contract.unsupported_reason.map_or_else(
-                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, tunnel preview-consumer run, and tunnel service start".to_string(),
+                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, tunnel preview-consumer run, and tunnel service start".to_string(),
                 |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
             );
             return Err(unsupported_runner_error(runner_id, message));
@@ -477,7 +477,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
 }
 
 fn unsupported_runner_hints(runner_id: &str, normalized_args: &[String]) -> Vec<String> {
-    let mut hints = vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, refactor source runs, tunnel preview-consumer run, and tunnel service start.".to_string()];
+    let mut hints = vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, refactor source runs, tunnel preview-consumer run, and tunnel service start.".to_string()];
 
     if let Some(service_command) = tunnel_service_command(normalized_args) {
         hints.push(format!(

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -351,14 +351,14 @@ pub(super) fn resolve_lab_runner_selection_from_default(
     if let Some(runner_id) = explicit_runner {
         if !command.portable {
             let message = command.unsupported_reason.map_or_else(
-                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, and tunnel preview-consumer run".to_string(),
+                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, and tunnel preview-consumer run".to_string(),
                 |reason| format!("--runner is unavailable for this hot command. {reason}"),
             );
             return Err(Error::validation_invalid_argument(
                 "runner",
                 message,
                 Some(runner_id.to_string()),
-                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan/status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, refactor source runs, and tunnel preview-consumer run.".to_string()]),
+                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, refactor source runs, and tunnel preview-consumer run.".to_string()]),
             ));
         }
 


### PR DESCRIPTION
## Summary
- Allow `homeboy agent-task retry <run-id> --run` to use Lab offload with `--runner <id>`.
- Keep plain `agent-task retry <run-id>` local-only because it only queues a retry record.
- Update Lab runner support diagnostics to list `agent-task retry --run` as supported.

## Verification
- `cargo test command_contract::lab::tests`
- `cargo test commands::route::tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the Lab retry routing fix, added focused regression tests, and ran targeted verification; Chris remains responsible for review and merge.
