### PR TITLE
Preserve runner agent-task observability

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -104,6 +104,25 @@ impl Commands {
             Commands::AgentTask(args)
                 if matches!(
                     args.command,
+                    agent_task::AgentTaskCommand::Status(_)
+                        | agent_task::AgentTaskCommand::Logs(_)
+                        | agent_task::AgentTaskCommand::Artifacts(_)
+                        | agent_task::AgentTaskCommand::Review(_)
+                ) =>
+            {
+                let mut contract = LabCommandContract::explicit_runner(
+                    "agent-task status/logs/artifacts/review",
+                    None,
+                    false,
+                    LAB_NO_EXTRA_TOOLS,
+                );
+                contract.source_path_mode = LabSourcePathMode::RunnerResident;
+                contract.workspace_mode_policy = LabWorkspaceModePolicy::RunnerResident;
+                contract
+            }
+            Commands::AgentTask(args)
+                if matches!(
+                    args.command,
                     agent_task::AgentTaskCommand::Auth(agent_task::AgentTaskAuthArgs {
                         command: agent_task::AgentTaskAuthCommand::Status(_),
                     })
@@ -473,19 +492,19 @@ mod tests {
                 .supports_lab_runner()
         );
         assert!(
-            !parsed_command(&["homeboy", "agent-task", "status", "agent-task-123"])
+            parsed_command(&["homeboy", "agent-task", "status", "agent-task-123"])
                 .supports_lab_runner()
         );
         assert!(
-            !parsed_command(&["homeboy", "agent-task", "logs", "agent-task-123"])
+            parsed_command(&["homeboy", "agent-task", "logs", "agent-task-123"])
                 .supports_lab_runner()
         );
         assert!(
-            !parsed_command(&["homeboy", "agent-task", "artifacts", "agent-task-123"])
+            parsed_command(&["homeboy", "agent-task", "artifacts", "agent-task-123"])
                 .supports_lab_runner()
         );
         assert!(
-            !parsed_command(&["homeboy", "agent-task", "review", "agent-task-123"])
+            parsed_command(&["homeboy", "agent-task", "review", "agent-task-123"])
                 .supports_lab_runner()
         );
         assert!(parsed_command(&["homeboy", "agent-task", "providers"]).supports_lab_runner());
@@ -724,7 +743,15 @@ mod tests {
             ["homeboy", "agent-task", "artifacts", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "review", "agent-task-123"].as_slice(),
         ] {
-            assert!(parsed_command(args).lab_contract().is_none());
+            let contract = parsed_command(args)
+                .lab_contract()
+                .expect("runner-backed agent-task inspection contract");
+            assert_eq!(contract.source_path_mode, LabSourcePathMode::RunnerResident);
+            assert_eq!(
+                contract.workspace_mode_policy,
+                LabWorkspaceModePolicy::RunnerResident
+            );
+            assert!(!contract.default_lab_offload);
         }
 
         let auth_status = parsed_command(&[

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -12,7 +12,7 @@ use homeboy::core::agent_tasks::promotion::{
 };
 use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_tasks::service as agent_task_service;
-use homeboy::core::agent_tasks::{AgentTaskAggregateReport, AgentTaskRequest};
+use homeboy::core::agent_tasks::{AgentTaskAggregate, AgentTaskAggregateReport, AgentTaskRequest};
 use homeboy::core::config;
 use homeboy::core::gate::HomeboyGateResult;
 
@@ -128,17 +128,21 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
     let record = agent_task_lifecycle::status(&args.run_id)?;
     let log = agent_task_lifecycle::logs(&args.run_id)?;
     let artifacts = agent_task_lifecycle::artifacts(&args.run_id)?;
-    let aggregate = super::completed_run_aggregate(&args.run_id).transpose()?;
-    let aggregate_review = aggregate
+    let aggregate_source = completed_run_aggregate_source(&args.run_id).transpose()?;
+    let aggregate = aggregate_source
         .as_ref()
-        .map(|aggregate| AgentTaskAggregateReport::from(aggregate.outcomes.clone()));
-    let diagnostic_summary = aggregate
-        .as_ref()
-        .and_then(super::diagnostic_summary_from_aggregate);
+        .map(|(aggregate, _path)| aggregate);
+    let aggregate_review =
+        aggregate.map(|aggregate| AgentTaskAggregateReport::from(aggregate.outcomes.clone()));
+    let diagnostic_summary = aggregate.and_then(super::diagnostic_summary_from_aggregate);
     let promotion_candidates = aggregate_review
         .as_ref()
         .map(|review| {
-            let promotion_source = record.aggregate_path.as_deref().unwrap_or(&args.run_id);
+            let promotion_source = aggregate_source
+                .as_ref()
+                .map(|(_aggregate, path)| path.as_str())
+                .or(record.aggregate_path.as_deref())
+                .unwrap_or(&args.run_id);
             promotion_candidates(
                 promotion_source,
                 args.to_worktree.as_deref(),
@@ -292,6 +296,26 @@ pub(crate) fn default_protected_branches() -> Vec<String> {
         "master".to_string(),
         "trunk".to_string(),
     ]
+}
+
+fn completed_run_aggregate_source(
+    run_id: &str,
+) -> Option<homeboy::core::Result<(AgentTaskAggregate, String)>> {
+    match agent_task_lifecycle::aggregate_source(run_id) {
+        Ok((raw, path)) => Some(
+            serde_json::from_str(&raw)
+                .map(|aggregate| (aggregate, path.display().to_string()))
+                .map_err(|error| {
+                    homeboy::core::Error::validation_invalid_json(
+                        error,
+                        Some("agent-task aggregate".to_string()),
+                        Some(raw),
+                    )
+                }),
+        ),
+        Err(error) if error.code == homeboy::core::ErrorCode::ValidationInvalidArgument => None,
+        Err(error) => Some(Err(error)),
+    }
 }
 
 fn promotion_candidates(

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -795,7 +795,6 @@ mod tests {
             ["homeboy", "agent-task", "logs", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "artifacts", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "review", "agent-task-123"].as_slice(),
-            ["homeboy", "agent-task", "retry", "agent-task-123"].as_slice(),
         ] {
             let cli = Cli::parse_from(args);
             let command = lab_offload_command(&cli.command).unwrap().unwrap();

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -789,7 +789,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_task_inspection_commands_are_read_only_local_recovery() {
+    fn agent_task_inspection_commands_support_runner_resident_recovery() {
         for args in [
             ["homeboy", "agent-task", "status", "agent-task-123"].as_slice(),
             ["homeboy", "agent-task", "logs", "agent-task-123"].as_slice(),
@@ -798,7 +798,17 @@ mod tests {
             ["homeboy", "agent-task", "retry", "agent-task-123"].as_slice(),
         ] {
             let cli = Cli::parse_from(args);
-            assert!(lab_offload_command(&cli.command).unwrap().is_none());
+            let command = lab_offload_command(&cli.command).unwrap().unwrap();
+            assert_eq!(command.hot_label, "agent-task status/logs/artifacts/review");
+            assert_eq!(
+                command.source_path_mode,
+                runners::LabOffloadSourcePathMode::RunnerResident
+            );
+            assert_eq!(
+                command.workspace_mode_policy,
+                runners::LabOffloadWorkspaceModePolicy::RunnerResident
+            );
+            assert!(!command.default_lab_offload);
         }
     }
 

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -961,20 +961,25 @@ pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {
 
 pub fn aggregate_source(run_id: &str) -> Result<(String, PathBuf)> {
     let record = store::read_record(&sanitize_run_id(run_id))?;
-    let path = record.aggregate_path.ok_or_else(|| {
+    record.aggregate_path.as_ref().ok_or_else(|| {
         Error::validation_invalid_argument(
             "run_id",
             format!(
                 "agent-task run '{}' has no aggregate artifact yet",
                 record.run_id
             ),
-            Some(record.run_id),
+            Some(record.run_id.clone()),
             None,
         )
     })?;
-    let path = PathBuf::from(path);
-    let raw = std::fs::read_to_string(&path)
-        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    let aggregate = store::read_aggregate(&record.run_id)?;
+    let raw = serde_json::to_string_pretty(&aggregate).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some(format!("serialize agent-task aggregate {}", record.run_id)),
+        )
+    })?;
+    let path = store::aggregate_path(&record.run_id)?;
     Ok((raw, path))
 }
 
@@ -2100,10 +2105,16 @@ mod tests {
                 queue: Default::default(),
             };
             record_completed_run(&plan, &aggregate, Some("run-source")).expect("recorded");
+            let local_path = store::aggregate_path("run-source").expect("local aggregate path");
+            let mut record = store::read_record("run-source").expect("record loaded");
+            record.aggregate_path = Some("/home/chubes/remote/aggregate.json".to_string());
+            store::write_record(&record).expect("remote aggregate path stored");
+            std::fs::remove_file(&local_path).expect("local aggregate removed");
 
             let (raw, path) = aggregate_source("run-source").expect("aggregate source");
 
             assert!(path.ends_with("aggregate.json"));
+            assert_ne!(path, PathBuf::from("/home/chubes/remote/aggregate.json"));
             assert!(raw.contains("task-a"));
         });
     }

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -996,6 +996,10 @@ fn run_provider_command(
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     if stdout.is_empty() {
+        if let Some(mut outcome) = parse_provider_outcome_from_mixed_output(&stderr) {
+            normalize_provider_outcome_roles(&mut outcome, provider);
+            return outcome;
+        }
         return failure_outcome(
             request,
             AgentTaskOutcomeStatus::ProviderError,
@@ -1027,6 +1031,24 @@ fn run_provider_command(
             json!({ "provider": provider.id, "command": command, "exit_code": output.status.code(), "stderr": stderr, "stdout": stdout }),
         ),
     }
+}
+
+fn parse_provider_outcome_from_mixed_output(output: &str) -> Option<AgentTaskOutcome> {
+    if output.trim().is_empty() {
+        return None;
+    }
+    if let Ok(outcome) = serde_json::from_str::<AgentTaskOutcome>(output) {
+        return Some(outcome);
+    }
+
+    for (index, _) in output.match_indices('{') {
+        let mut stream =
+            serde_json::Deserializer::from_str(&output[index..]).into_iter::<AgentTaskOutcome>();
+        if let Some(Ok(outcome)) = stream.next() {
+            return Some(outcome);
+        }
+    }
+    None
 }
 
 fn normalize_provider_outcome_roles(
@@ -1946,6 +1968,28 @@ mod tests {
             aggregate.outcomes[0].diagnostics[0].data["stdout"],
             "{not json"
         );
+    }
+
+    #[test]
+    fn provider_preserves_structured_outcome_from_stderr_when_stdout_empty() {
+        let command = format!(
+            "node {}",
+            script("let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); process.stderr.write('diagnostic prefix\\n' + JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'failed',summary:'captured provider evidence',failure_classification:'provider',diagnostics:[{class:'codebox.empty_data_packet_returned',message:'empty data packet returned',data:{typed_artifacts:{}}}]}));")
+        );
+        let (request, provider) = request("task-stderr-outcome", command);
+
+        let outcome = run_provider_command(&request, &provider);
+
+        assert_eq!(outcome.status, AgentTaskOutcomeStatus::Failed);
+        assert_eq!(
+            outcome.summary.as_deref(),
+            Some("captured provider evidence")
+        );
+        assert_eq!(
+            outcome.diagnostics[0].class,
+            "codebox.empty_data_packet_returned"
+        );
+        assert_eq!(outcome.diagnostics[0].data["typed_artifacts"], json!({}));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Route agent-task status/logs/artifacts/review through runner-resident Lab offload when --runner is used.
- Read completed agent-task aggregates through lifecycle/mirrored observation state instead of blindly opening stored absolute aggregate paths.
- Preserve structured provider failure outcomes emitted on stderr when stdout is empty, instead of flattening them to provider_empty_stdout.

## Tests
- cargo test command_contract::lab::tests::test_supports_lab_runner
- cargo test command_contract::lab::tests::test_lab_command_contracts_cover_hot_commands
- cargo test commands::route::tests::agent_task_inspection_commands_support_runner_resident_recovery
- cargo test core::agent_task_lifecycle::tests::aggregate_source_loads_completed_run_without_path_spelunking
- cargo test core::agent_task_provider::tests::provider_preserves_structured_outcome_from_stderr_when_stdout_empty

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented runner-backed agent-task observability fixes and focused coverage; Chris remains responsible for review and testing.