### PR TITLE
Simplify command output descriptors (#4869)

### DIFF
--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -188,17 +188,14 @@ impl Commands {
             Commands::Lint(args) => args.output_descriptor(output_file_mode),
             Commands::Audit(args) => args.output_descriptor(output_file_mode),
             Commands::Observe(_) => {
-                quality_json_descriptor(output_file_mode, CommandOutputContractKind::JsonEnvelope)
+                json_envelope_descriptor(CommandJsonFamily::Quality, output_file_mode)
             }
             Commands::AuditBaseline(_) => {
-                quality_json_descriptor(output_file_mode, CommandOutputContractKind::JsonEnvelope)
+                json_envelope_descriptor(CommandJsonFamily::Quality, output_file_mode)
             }
-            Commands::Refactor(_) => CommandOutputDescriptor {
-                response_mode: CommandResponseMode::Json,
-                output_file_mode,
-                json_family: CommandJsonFamily::Workspace,
-                output_contract: CommandOutputContractKind::JsonEnvelope,
-            },
+            Commands::Refactor(_) => {
+                json_envelope_descriptor(CommandJsonFamily::Workspace, output_file_mode)
+            }
             Commands::Refs(_) => workspace_descriptor(
                 CommandResponseMode::Json,
                 output_file_mode,
@@ -224,18 +221,12 @@ impl Commands {
             | Commands::Worktree(_)
             | Commands::Tunnel(_)
             | Commands::Stack(_)
-            | Commands::Undo(_) => CommandOutputDescriptor {
-                response_mode: CommandResponseMode::Json,
-                output_file_mode,
-                json_family: CommandJsonFamily::Workspace,
-                output_contract: CommandOutputContractKind::JsonEnvelope,
-            },
-            Commands::Rig(_) => CommandOutputDescriptor {
-                response_mode: CommandResponseMode::Json,
-                output_file_mode,
-                json_family: CommandJsonFamily::Workspace,
-                output_contract: CommandOutputContractKind::JsonEnvelope,
-            },
+            | Commands::Undo(_) => {
+                json_envelope_descriptor(CommandJsonFamily::Workspace, output_file_mode)
+            }
+            Commands::Rig(_) => {
+                json_envelope_descriptor(CommandJsonFamily::Workspace, output_file_mode)
+            }
             Commands::Status(_)
             | Commands::Ci(_)
             | Commands::Server(_)
@@ -253,9 +244,9 @@ impl Commands {
             | Commands::Api(_)
             | Commands::Http(_)
             | Commands::Upgrade(_)
-            | Commands::Ssh(_) => ops_json_descriptor(output_file_mode, None),
+            | Commands::Ssh(_) => ops_json_descriptor(output_file_mode),
             Commands::Fleet(args) => args.output_descriptor(output_file_mode),
-            Commands::Triage(_) => ops_json_descriptor(output_file_mode, None),
+            Commands::Triage(_) => ops_json_descriptor(output_file_mode),
         }
     }
 
@@ -317,28 +308,23 @@ fn markdown_or_json_response(markdown: bool) -> CommandResponseMode {
     }
 }
 
-fn quality_json_descriptor(
+/// Builds the common JSON-envelope descriptor: a JSON response mode paired with
+/// the [`CommandOutputContractKind::JsonEnvelope`] contract, varying only by
+/// [`CommandJsonFamily`] and output-file mode.
+fn json_envelope_descriptor(
+    json_family: CommandJsonFamily,
     output_file_mode: CommandOutputFileMode,
-    output_contract: CommandOutputContractKind,
 ) -> CommandOutputDescriptor {
     CommandOutputDescriptor {
         response_mode: CommandResponseMode::Json,
         output_file_mode,
-        json_family: CommandJsonFamily::Quality,
-        output_contract,
+        json_family,
+        output_contract: CommandOutputContractKind::JsonEnvelope,
     }
 }
 
-fn ops_json_descriptor(
-    output_file_mode: CommandOutputFileMode,
-    _lab_runner_unsupported_reason: Option<&'static str>,
-) -> CommandOutputDescriptor {
-    CommandOutputDescriptor {
-        response_mode: CommandResponseMode::Json,
-        output_file_mode,
-        json_family: CommandJsonFamily::Ops,
-        output_contract: CommandOutputContractKind::JsonEnvelope,
-    }
+fn ops_json_descriptor(output_file_mode: CommandOutputFileMode) -> CommandOutputDescriptor {
+    json_envelope_descriptor(CommandJsonFamily::Ops, output_file_mode)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
Closes #4869.

Audit-finding cleanup in `src/command_contract/output.rs`:

- Removed the unused `_lab_runner_unsupported_reason` parameter from `ops_json_descriptor` and updated both call sites (`Status`/`Ssh` group and `Triage`).
- Added a small `json_envelope_descriptor(json_family, output_file_mode)` helper for the common JSON-envelope descriptor (JSON response + `JsonEnvelope` contract, varying only by family). Deduped the `Observe`, `AuditBaseline`, `Refactor`, the large Workspace group, `Rig`, and `Ops` arms onto it.

## Notes
- Raw-mode descriptors (docs / changelog / review / trace / runs) are intentionally left untouched.
- Lab routing policy stays owned by the lab contract path (`with_lab_contract` / `apply_lab_contract_to_descriptor`); output descriptors carry no lab fields.

## Validation
- `cargo test command_contract` — 16 passed
- `cargo test golden_contract` — 5 passed
- `cargo test output_contracts` — 1 passed
- `cargo build --lib --tests` — clean (2 pre-existing unrelated warnings)
- `cargo fmt --check` — clean