### PR TITLE
Persist agent task recovery plans

### DIFF
--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -146,7 +146,9 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
         })
         .unwrap_or_default();
     let next_actions = review_next_actions(
+        &record.run_id,
         &record.state,
+        &record.plan_path,
         aggregate_review.as_ref(),
         args.to_worktree.as_deref(),
     );
@@ -348,7 +350,9 @@ fn promotion_candidates(
 }
 
 fn review_next_actions(
+    run_id: &str,
     state: &agent_task_lifecycle::AgentTaskRunState,
+    plan_path: &str,
     aggregate_review: Option<&AgentTaskAggregateReport>,
     to_worktree: Option<&str>,
 ) -> Vec<String> {
@@ -373,10 +377,12 @@ fn review_next_actions(
         }
     }
     if review.summary.retry_candidates > 0 {
-        actions.push(
-            "retry provider-error or timeout candidates after fixing executor/preflight issues"
-                .to_string(),
-        );
+        actions.push(format!(
+            "retry provider-error or timeout candidates after fixing executor/preflight issues with `homeboy agent-task retry {run_id} --run`"
+        ));
+        actions.push(format!(
+            "rerun the persisted plan through Lab with `homeboy --runner <runner-id> agent-task run-plan --plan @{plan_path} --record-run-id <new-run-id>`"
+        ));
     }
     if review.summary.issue_report_candidates > 0 {
         actions.push(
@@ -504,6 +510,40 @@ mod tests {
     use homeboy::core::agent_tasks::promotion::{
         AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandReport, AgentTaskPromotionSource,
     };
+    use homeboy::core::agent_tasks::AgentTaskAggregateSummary;
+
+    #[test]
+    fn review_next_actions_include_retry_and_lab_run_plan_commands() {
+        let review = AgentTaskAggregateReport {
+            schema: "homeboy/agent-task-aggregate-report/v1".to_string(),
+            summary: AgentTaskAggregateSummary {
+                retry_candidates: 1,
+                ..AgentTaskAggregateSummary::default()
+            },
+            tasks: Vec::new(),
+            artifact_inventory: Vec::new(),
+            apply_candidates: Vec::new(),
+            issue_report_candidates: Vec::new(),
+            retry_plan: Vec::new(),
+            review_candidates: Vec::new(),
+            matrix: Vec::new(),
+        };
+
+        let actions = review_next_actions(
+            "agent-task-run-1",
+            &agent_task_lifecycle::AgentTaskRunState::Failed,
+            "/tmp/agent-task-run-1/plan.json",
+            Some(&review),
+            None,
+        );
+
+        assert!(actions
+            .iter()
+            .any(|action| action.contains("homeboy agent-task retry agent-task-run-1 --run")));
+        assert!(actions.iter().any(|action| action.contains(
+            "homeboy --runner <runner-id> agent-task run-plan --plan @/tmp/agent-task-run-1/plan.json --record-run-id <new-run-id>"
+        )));
+    }
 
     #[test]
     fn promotion_handoff_marks_promoted_patch_without_pr_claim() {

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -559,6 +559,7 @@ pub fn record_remote_dispatch_failure(
                 synthetic_remote_dispatch_plan(&run_id, &failure, envelope, &aggregate)
             });
             record.run_id = run_id.clone();
+            record.plan_path = store::write_plan(&run_id, &plan)?.display().to_string();
             apply_aggregate_to_record(
                 &mut record,
                 &plan,
@@ -1566,6 +1567,10 @@ mod tests {
                 "lab_offload_remote_dispatch_failure"
             );
             assert_eq!(loaded.metadata["runner_id"], "lab-a");
+            assert!(std::path::Path::new(&loaded.plan_path).is_file());
+            let loaded_plan = load_plan("local-run").expect("plan loaded");
+            assert_eq!(loaded_plan.plan_id, "plan-a");
+            assert_eq!(loaded_plan.tasks[0].task_id, "task-a");
             assert_eq!(
                 loaded.metadata["remote_workspace"],
                 "/runner/workspace/repo"

--- a/src/core/agent_task_service.rs
+++ b/src/core/agent_task_service.rs
@@ -81,6 +81,8 @@ pub struct AgentTaskDiscoveryCommands {
     pub logs: String,
     pub artifacts: String,
     pub review: String,
+    pub retry: String,
+    pub run_plan: String,
     pub promote: String,
 }
 
@@ -208,6 +210,11 @@ fn discovery_run(record: AgentTaskRunRecord) -> AgentTaskDiscoveryRun {
             logs: format!("homeboy agent-task logs {run_id}"),
             artifacts: format!("homeboy agent-task artifacts {run_id}"),
             review: format!("homeboy agent-task review {run_id}"),
+            retry: format!("homeboy agent-task retry {run_id} --run"),
+            run_plan: format!(
+                "homeboy --runner <runner-id> agent-task run-plan --plan @{} --record-run-id <new-run-id>",
+                record.plan_path
+            ),
             promote: aggregate_path
                 .map(|path| format!("homeboy agent-task promote {path} --to-worktree <handle>"))
                 .unwrap_or_else(|| format!("homeboy agent-task review {run_id}")),
@@ -916,6 +923,18 @@ mod tests {
                 run.commands.review,
                 "homeboy agent-task review run-discovery-list"
             );
+            assert_eq!(
+                run.commands.retry,
+                "homeboy agent-task retry run-discovery-list --run"
+            );
+            assert!(run
+                .commands
+                .run_plan
+                .contains("homeboy --runner <runner-id> agent-task run-plan --plan @"));
+            assert!(run
+                .commands
+                .run_plan
+                .contains("/agent-task-runs/run-discovery-list/plan.json"));
         });
     }
 


### PR DESCRIPTION
## Summary
- Persist the original agent-task plan into the local durable run directory when recording a failed remote/Lab dispatch record.
- Expose direct `retry` and Lab `run-plan` recovery commands in durable run discovery and review next actions.
- Add focused coverage for recovered plan loading and operator recovery commands.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test remote_dispatch_failure_preserves_structured_outcome_details --lib`
- `cargo test discovery_lists_durable_runs_with_operator_commands --lib`
- `cargo test review_next_actions_include_retry_and_lab_run_plan_commands`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused Homeboy core fix, tests, and PR description; Chris remains responsible for review and final validation.