### PR TITLE
feat(runs): emit machine-readable run refs

### DIFF
--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -11,6 +11,7 @@ homeboy runs compare [--kind bench] [--component <id>] [--rig <id>] [--scenario 
 homeboy runs show <run-id>
 homeboy runs resume-plan <run-id>
 homeboy runs artifacts <run-id>
+homeboy runs refs [--kind bench] [--component <id>] [--rig <id>] [--status <status>] [--since 24h] [--artifact-kind <kind>] [--aggregate-artifact-kind <kind>]
 homeboy runs artifact cleanup-downloads [--runner <runner-id>] [--run-id <run-id>] [--apply]
 homeboy runs export --run <run-id> --output <dir>
 homeboy runs export --since <duration> --output <dir>
@@ -26,6 +27,13 @@ homeboy runs import --from-gh-actions --component <id> --repo <owner/repo> --run
 `homeboy runs list --runner <runner-id>` queries a connected runner daemon instead of the local observation store, preserving the normal `runs.list` JSON payload while returning evidence from the runner machine.
 
 The JSON output includes stable run fields: run id, kind, status, timestamps, component id, rig id, git SHA, command, cwd, metadata, and artifact records where relevant.
+
+`homeboy runs refs` emits a compact machine-readable ref index for matching runs. It is intended for matrix orchestration scripts and agents that need stable run refs and aggregate artifact refs without scraping human stdout. The output includes `homeboy://run/<id>` refs, `homeboy://run/<id>/artifact/<artifact-id>` refs, evidence/artifact follow-up commands, and detected aggregate artifact refs. Aggregate detection is schema-blind by default (`aggregate` in artifact id/kind/path); pass `--aggregate-artifact-kind <kind>` to mark additional artifact kinds as aggregate outputs.
+
+```bash
+homeboy --output json runs refs --kind bench --component studio --rig studio-bfb --since 24h
+homeboy --output json runs refs --kind trace --component gutenberg --aggregate-artifact-kind trace_summary
+```
 
 `homeboy runs resume-plan <run-id>` reads generic `validation_progress` metadata from a run and reports the last completed command, any active command, and the next pending command. Homeboy core records this ledger for Homeboy-managed validation command sets without understanding npm, smoke groups, benchmarks, or implementation-specific command names; command manifests come from project configuration or extension-provided runners.
 

--- a/src/command_contract/public_variants.rs
+++ b/src/command_contract/public_variants.rs
@@ -74,6 +74,13 @@ pub const PUBLIC_OUTPUT_VARIANT_CONTRACTS: &[PublicOutputVariantContract] = &[
     },
     PublicOutputVariantContract {
         command: "runs",
+        variant: "refs",
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("refs"),
+        golden_fixture: Some("runs_contract.json"),
+    },
+    PublicOutputVariantContract {
+        command: "runs",
         variant: "drift",
         discriminator_field: Some("variant"),
         discriminator_value: Some("drift"),

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -18,6 +18,7 @@ mod latest;
 mod loop_sync;
 mod query;
 mod reconcile;
+mod refs;
 mod remote;
 mod remote_artifact;
 
@@ -50,6 +51,7 @@ use latest::{RunsLatestFindingOutput, RunsLatestRunArgs, RunsLatestRunOutput};
 use loop_sync::{loop_sync, RunsLoopSyncArgs, RunsLoopSyncOutput};
 use query::{runs_query, RunsQueryArgs, RunsQueryOutput};
 use reconcile::{reconcile_runs, RunsReconcileArgs, RunsReconcileOutput};
+use refs::{runs_refs, RunsRefsArgs, RunsRefsOutput};
 
 #[cfg(test)]
 pub(crate) use common::SkippedArtifactRow;
@@ -104,6 +106,8 @@ enum RunsCommand {
     Import(RunsImportArgs),
     /// Project JSONPath expressions over imported run artifact rows.
     Query(RunsQueryArgs),
+    /// Emit stable run/artifact refs for matching runs.
+    Refs(RunsRefsArgs),
     /// Window-based distribution drift over a JSONPath metric.
     Drift(RunsDriftArgs),
     /// Sync continuous-loop archive directories into observation artifacts.
@@ -156,6 +160,7 @@ pub enum RunsOutput {
     Import(RunsImportOutput),
     ImportFromGhActions(GhActionsImportOutput),
     Query(RunsQueryOutput),
+    Refs(RunsRefsOutput),
     Drift(RunsDriftOutput),
     LoopSync(RunsLoopSyncOutput),
 }
@@ -334,6 +339,7 @@ pub fn run(args: RunsArgs, _global: &GlobalArgs) -> CmdResult<RunsOutput> {
         RunsCommand::Export(args) => export_runs(args),
         RunsCommand::Import(args) => import_runs(args),
         RunsCommand::Query(args) => runs_query(args),
+        RunsCommand::Refs(args) => runs_refs(args),
         RunsCommand::Drift(args) => runs_drift(args),
         RunsCommand::LoopSync(args) => loop_sync(args),
     }

--- a/src/commands/runs/refs.rs
+++ b/src/commands/runs/refs.rs
@@ -1,0 +1,294 @@
+use clap::Args;
+use serde::Serialize;
+
+use homeboy::core::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
+
+use super::common::since_threshold;
+use super::{CmdResult, RunsOutput};
+
+#[derive(Args, Clone, Debug)]
+pub struct RunsRefsArgs {
+    /// Component ID.
+    #[arg(long = "component")]
+    pub component_id: Option<String>,
+    /// Run kind: bench, rig, trace, gh-actions, etc.
+    #[arg(long)]
+    pub kind: Option<String>,
+    /// Rig ID.
+    #[arg(long)]
+    pub rig: Option<String>,
+    /// Run status.
+    #[arg(long)]
+    pub status: Option<String>,
+    /// Restrict to runs started within this duration (e.g. 24h, 7d).
+    #[arg(long)]
+    pub since: Option<String>,
+    /// Maximum runs to inspect.
+    #[arg(long, default_value_t = 50)]
+    pub limit: i64,
+    /// Restrict artifact refs to these artifact kinds. Repeatable.
+    #[arg(long = "artifact-kind")]
+    pub artifact_kinds: Vec<String>,
+    /// Treat these artifact kinds as aggregate refs in addition to the default
+    /// schema-blind aggregate detector. Repeatable.
+    #[arg(long = "aggregate-artifact-kind")]
+    pub aggregate_artifact_kinds: Vec<String>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct RunsRefsOutput {
+    pub command: &'static str,
+    pub filters: RunsRefsFilters,
+    pub run_count: usize,
+    pub artifact_count: usize,
+    pub aggregate_artifact_count: usize,
+    pub runs: Vec<RunRef>,
+    pub artifacts: Vec<ArtifactRef>,
+    pub aggregate_artifacts: Vec<ArtifactRef>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct RunsRefsFilters {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rig: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub since: Option<String>,
+    pub limit: i64,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub artifact_kinds: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub aggregate_artifact_kinds: Vec<String>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct RunRef {
+    pub run_id: String,
+    pub ref_id: String,
+    pub kind: String,
+    pub status: String,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    pub component_id: Option<String>,
+    pub rig_id: Option<String>,
+    pub git_sha: Option<String>,
+    pub evidence_command: String,
+    pub artifacts_command: String,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct ArtifactRef {
+    pub run_id: String,
+    pub artifact_id: String,
+    pub ref_id: String,
+    pub kind: String,
+    #[serde(rename = "type")]
+    pub artifact_type: String,
+    pub path: String,
+    pub url: Option<String>,
+    pub mime: Option<String>,
+    pub size_bytes: Option<i64>,
+    pub sha256: Option<String>,
+    pub get_command: String,
+}
+
+pub fn runs_refs(args: RunsRefsArgs) -> CmdResult<RunsOutput> {
+    let store = ObservationStore::open_initialized()?;
+    let filter = RunListFilter {
+        kind: args.kind.clone(),
+        component_id: args.component_id.clone(),
+        status: args.status.clone(),
+        rig_id: args.rig.clone(),
+        limit: Some(args.limit.clamp(1, 5000)),
+    };
+    let runs = if let Some(raw_since) = args.since.as_deref() {
+        let threshold = since_threshold(raw_since)?;
+        store
+            .list_runs_started_since(&threshold)?
+            .into_iter()
+            .filter(|run| run_matches_filter(run, &filter))
+            .take(args.limit.clamp(1, 5000) as usize)
+            .collect::<Vec<_>>()
+    } else {
+        store.list_runs(filter.clone())?
+    };
+
+    let mut run_refs = Vec::with_capacity(runs.len());
+    let mut artifact_refs = Vec::new();
+    let mut aggregate_refs = Vec::new();
+    for run in runs {
+        run_refs.push(run_ref(&run));
+        for artifact in store.list_artifacts(&run.id)? {
+            if !args.artifact_kinds.is_empty() && !args.artifact_kinds.contains(&artifact.kind) {
+                continue;
+            }
+            let artifact_ref = artifact_ref(&artifact);
+            if is_aggregate_artifact(&artifact, &args.aggregate_artifact_kinds) {
+                aggregate_refs.push(artifact_ref.clone());
+            }
+            artifact_refs.push(artifact_ref);
+        }
+    }
+
+    Ok((
+        RunsOutput::Refs(RunsRefsOutput {
+            command: "runs.refs",
+            filters: RunsRefsFilters {
+                component_id: args.component_id,
+                kind: args.kind,
+                rig: args.rig,
+                status: args.status,
+                since: args.since,
+                limit: args.limit,
+                artifact_kinds: args.artifact_kinds,
+                aggregate_artifact_kinds: args.aggregate_artifact_kinds,
+            },
+            run_count: run_refs.len(),
+            artifact_count: artifact_refs.len(),
+            aggregate_artifact_count: aggregate_refs.len(),
+            runs: run_refs,
+            artifacts: artifact_refs,
+            aggregate_artifacts: aggregate_refs,
+        }),
+        0,
+    ))
+}
+
+fn run_matches_filter(run: &RunRecord, filter: &RunListFilter) -> bool {
+    filter.kind.as_deref().map_or(true, |kind| run.kind == kind)
+        && filter.component_id.as_deref().map_or(true, |component| {
+            run.component_id.as_deref() == Some(component)
+        })
+        && filter
+            .status
+            .as_deref()
+            .map_or(true, |status| run.status == status)
+        && filter
+            .rig_id
+            .as_deref()
+            .map_or(true, |rig| run.rig_id.as_deref() == Some(rig))
+}
+
+fn run_ref(run: &RunRecord) -> RunRef {
+    RunRef {
+        run_id: run.id.clone(),
+        ref_id: format!("homeboy://run/{}", run.id),
+        kind: run.kind.clone(),
+        status: run.status.clone(),
+        started_at: run.started_at.clone(),
+        finished_at: run.finished_at.clone(),
+        component_id: run.component_id.clone(),
+        rig_id: run.rig_id.clone(),
+        git_sha: run.git_sha.clone(),
+        evidence_command: format!("homeboy runs evidence {}", shell_arg(&run.id)),
+        artifacts_command: format!("homeboy runs artifacts {}", shell_arg(&run.id)),
+    }
+}
+
+fn artifact_ref(artifact: &ArtifactRecord) -> ArtifactRef {
+    ArtifactRef {
+        run_id: artifact.run_id.clone(),
+        artifact_id: artifact.id.clone(),
+        ref_id: format!("homeboy://run/{}/artifact/{}", artifact.run_id, artifact.id),
+        kind: artifact.kind.clone(),
+        artifact_type: artifact.artifact_type.clone(),
+        path: artifact.path.clone(),
+        url: artifact
+            .url
+            .clone()
+            .or_else(|| (artifact.artifact_type == "url").then(|| artifact.path.clone())),
+        mime: artifact.mime.clone(),
+        size_bytes: artifact.size_bytes,
+        sha256: artifact.sha256.clone(),
+        get_command: format!(
+            "homeboy runs artifact get {} {}",
+            shell_arg(&artifact.run_id),
+            shell_arg(&artifact.id)
+        ),
+    }
+}
+
+fn is_aggregate_artifact(artifact: &ArtifactRecord, extra_kinds: &[String]) -> bool {
+    extra_kinds.contains(&artifact.kind)
+        || contains_aggregate_token(&artifact.kind)
+        || contains_aggregate_token(&artifact.id)
+        || contains_aggregate_token(&artifact.path)
+}
+
+fn contains_aggregate_token(value: &str) -> bool {
+    value
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .any(|part| part.eq_ignore_ascii_case("aggregate"))
+}
+
+fn shell_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':'))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy::core::observation::{NewRunRecord, RunStatus};
+    use homeboy::test_support::with_isolated_home;
+
+    #[test]
+    fn refs_emit_run_artifact_and_aggregate_refs() {
+        with_isolated_home(|home| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(
+                    NewRunRecord::builder("bench")
+                        .component_id("homeboy")
+                        .rig_id("matrix-rig")
+                        .metadata(serde_json::json!({ "matrix": { "php": "8.3" } }))
+                        .build(),
+                )
+                .expect("run");
+            store
+                .finish_run(&run.id, RunStatus::Pass, None)
+                .expect("finish");
+            let aggregate_path = home.path().join("matrix.aggregate.json");
+            std::fs::write(&aggregate_path, b"{}").expect("artifact");
+            store
+                .record_artifact(&run.id, "trace_aggregate", &aggregate_path)
+                .expect("record artifact");
+
+            let (output, _) = runs_refs(RunsRefsArgs {
+                component_id: Some("homeboy".to_string()),
+                kind: Some("bench".to_string()),
+                rig: Some("matrix-rig".to_string()),
+                status: Some("pass".to_string()),
+                since: None,
+                limit: 20,
+                artifact_kinds: Vec::new(),
+                aggregate_artifact_kinds: Vec::new(),
+            })
+            .expect("refs");
+
+            let RunsOutput::Refs(output) = output else {
+                panic!("expected refs output");
+            };
+            assert_eq!(output.run_count, 1);
+            assert_eq!(output.artifact_count, 1);
+            assert_eq!(output.aggregate_artifact_count, 1);
+            assert_eq!(output.runs[0].ref_id, format!("homeboy://run/{}", run.id));
+            assert_eq!(output.artifacts[0].run_id, run.id);
+            assert_eq!(
+                output.aggregate_artifacts[0].artifact_id,
+                output.artifacts[0].artifact_id
+            );
+        });
+    }
+}

--- a/tests/fixtures/golden_json_contracts/runs_contract.json
+++ b/tests/fixtures/golden_json_contracts/runs_contract.json
@@ -31,6 +31,73 @@
       "payload": {
         "data": {
           "payload": {
+            "aggregate_artifact_count": 1,
+            "aggregate_artifacts": [
+              {
+                "artifact_id": "artifact-aggregate",
+                "get_command": "homeboy runs artifact get run-contract-1 artifact-aggregate",
+                "kind": "trace_aggregate",
+                "mime": "application/json",
+                "path": "artifacts/aggregate.json",
+                "ref_id": "homeboy://run/run-contract-1/artifact/artifact-aggregate",
+                "run_id": "run-contract-1",
+                "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "size_bytes": 1234,
+                "type": "file",
+                "url": null
+              }
+            ],
+            "artifact_count": 1,
+            "artifacts": [
+              {
+                "artifact_id": "artifact-aggregate",
+                "get_command": "homeboy runs artifact get run-contract-1 artifact-aggregate",
+                "kind": "trace_aggregate",
+                "mime": "application/json",
+                "path": "artifacts/aggregate.json",
+                "ref_id": "homeboy://run/run-contract-1/artifact/artifact-aggregate",
+                "run_id": "run-contract-1",
+                "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "size_bytes": 1234,
+                "type": "file",
+                "url": null
+              }
+            ],
+            "command": "runs.refs",
+            "filters": {
+              "component_id": "homeboy",
+              "kind": "bench",
+              "limit": 50,
+              "rig": "contract-rig",
+              "status": "pass"
+            },
+            "run_count": 1,
+            "runs": [
+              {
+                "artifacts_command": "homeboy runs artifacts run-contract-1",
+                "component_id": "homeboy",
+                "evidence_command": "homeboy runs evidence run-contract-1",
+                "finished_at": "2026-05-24T00:01:00Z",
+                "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "kind": "bench",
+                "ref_id": "homeboy://run/run-contract-1",
+                "rig_id": "contract-rig",
+                "run_id": "run-contract-1",
+                "started_at": "2026-05-24T00:00:00Z",
+                "status": "pass"
+              }
+            ]
+          },
+          "variant": "refs"
+        },
+        "success": true
+      },
+      "scenario": "runs refs json"
+    },
+    {
+      "payload": {
+        "data": {
+          "payload": {
             "command": "runs.show",
             "run": {
               "artifacts": [


### PR DESCRIPTION
## Summary
- Add `homeboy runs refs` to emit compact machine-readable run refs, artifact refs, and aggregate artifact refs from the observation store.
- Support generic filters for kind/component/rig/status/since plus artifact-kind and aggregate-artifact-kind refinement.
- Document the command and anchor its JSON shape in the public runs contract fixture.

## Verification
- `cargo test commands::runs::refs::tests::refs_emit_run_artifact_and_aggregate_refs`
- `cargo test --test output_contracts_test`
- `cargo test --test command_surface_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the implementation, tests, docs, and PR description for Chris to review.