### PR TITLE
Add shared artifact and evidence refs

### DIFF
--- a/src/commands/runs/evidence.rs
+++ b/src/commands/runs/evidence.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 
+use homeboy::core::artifact_ref::{ArtifactRef, EvidenceRef};
 use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore, RunRecord};
 use serde::Serialize;
 use serde_json::Value;
@@ -53,6 +54,8 @@ pub struct RunsEvidenceArtifactIndex {
 
 #[derive(Serialize)]
 pub struct RunsEvidenceArtifact {
+    #[serde(rename = "ref")]
+    pub reference: ArtifactRef,
     pub id: String,
     pub kind: String,
     #[serde(rename = "type")]
@@ -92,6 +95,8 @@ pub type RunsEvidenceDiskBudget = disk::DiskBudget;
 
 #[derive(Serialize)]
 pub struct RunsEvidenceLink {
+    #[serde(rename = "ref")]
+    pub reference: EvidenceRef,
     pub kind: String,
     pub target: String,
     pub label: String,
@@ -190,6 +195,7 @@ fn evidence_artifact_index(artifacts: &[ArtifactRecord]) -> RunsEvidenceArtifact
     let artifacts = artifacts
         .iter()
         .map(|artifact| {
+            let reference = artifact_ref(artifact);
             let public_url = artifact_public_url(artifact);
             let exists = artifact_exists(artifact);
             if !exists {
@@ -204,10 +210,10 @@ fn evidence_artifact_index(artifacts: &[ArtifactRecord]) -> RunsEvidenceArtifact
             let size = artifact_size_bytes(artifact);
             total_size_bytes = total_size_bytes.saturating_add(size);
             RunsEvidenceArtifact {
-                id: artifact.id.clone(),
-                kind: artifact.kind.clone(),
-                artifact_type: artifact.artifact_type.clone(),
-                path: artifact.path.clone(),
+                id: reference.id.clone(),
+                kind: reference.kind.clone(),
+                artifact_type: reference.artifact_type.clone(),
+                path: reference.path.clone(),
                 url: artifact
                     .url
                     .clone()
@@ -221,6 +227,7 @@ fn evidence_artifact_index(artifacts: &[ArtifactRecord]) -> RunsEvidenceArtifact
                 created_at: artifact.created_at.clone(),
                 exists,
                 retention_candidate: artifact.artifact_type != "url",
+                reference,
             }
         })
         .collect::<Vec<_>>();
@@ -238,7 +245,7 @@ fn evidence_artifact_index(artifacts: &[ArtifactRecord]) -> RunsEvidenceArtifact
 
 fn artifact_public_url(artifact: &ArtifactRecord) -> Option<String> {
     if artifact.artifact_type == "url" {
-        return artifact.url.clone().or_else(|| Some(artifact.path.clone()));
+        return artifact_ref(artifact).public_target();
     }
     artifact.public_url.clone().or_else(|| {
         artifact
@@ -247,6 +254,18 @@ fn artifact_public_url(artifact: &ArtifactRecord) -> Option<String> {
             .and_then(Value::as_str)
             .map(str::to_string)
     })
+}
+
+fn artifact_ref(artifact: &ArtifactRecord) -> ArtifactRef {
+    let mut reference = ArtifactRef::from_record(artifact);
+    if reference.public_url.is_none() {
+        reference.public_url = artifact
+            .metadata_json
+            .get("public_url")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+    }
+    reference
 }
 
 fn artifact_relative_to(artifact: &ArtifactRecord) -> Option<String> {
@@ -348,10 +367,14 @@ fn evidence_links(artifacts: &[ArtifactRecord]) -> Vec<RunsEvidenceLink> {
     artifacts
         .iter()
         .filter_map(|artifact| {
-            artifact_public_url(artifact).map(|target| RunsEvidenceLink {
-                kind: artifact.kind.clone(),
-                target,
-                label: artifact.kind.clone(),
+            let target = artifact_public_url(artifact)?;
+            let mut reference = EvidenceRef::new(&artifact.kind, &target, &artifact.kind);
+            reference.artifact = Some(artifact_ref(artifact));
+            Some(RunsEvidenceLink {
+                kind: reference.kind.clone(),
+                target: reference.target.clone(),
+                label: reference.label.clone(),
+                reference,
             })
         })
         .collect()
@@ -485,6 +508,8 @@ mod tests {
                 bench_results.fetch_command.as_deref(),
                 Some(expected_fetch_command.as_str())
             );
+            assert_eq!(bench_results.reference.schema, "homeboy/artifact-ref/v1");
+            assert_eq!(bench_results.reference.id, bench_results.id);
             let review = output
                 .artifact_index
                 .artifacts
@@ -497,6 +522,10 @@ mod tests {
                 Some("https://example.test/evidence")
             );
             assert_eq!(output.evidence_links.len(), 1);
+            assert_eq!(
+                output.evidence_links[0].reference.schema,
+                "homeboy/evidence-ref/v1"
+            );
             assert_eq!(
                 output.evidence_links[0].target,
                 "https://example.test/evidence"

--- a/src/core/artifact_ref.rs
+++ b/src/core/artifact_ref.rs
@@ -1,0 +1,136 @@
+use serde::{Deserialize, Serialize};
+
+use crate::core::observation::ArtifactRecord;
+
+pub const ARTIFACT_REF_SCHEMA: &str = "homeboy/artifact-ref/v1";
+pub const EVIDENCE_REF_SCHEMA: &str = "homeboy/evidence-ref/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactRef {
+    pub schema: String,
+    pub id: String,
+    pub run_id: String,
+    pub kind: String,
+    #[serde(rename = "type")]
+    pub artifact_type: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
+}
+
+impl ArtifactRef {
+    pub fn from_record(artifact: &ArtifactRecord) -> Self {
+        Self {
+            schema: ARTIFACT_REF_SCHEMA.to_string(),
+            id: artifact.id.clone(),
+            run_id: artifact.run_id.clone(),
+            kind: artifact.kind.clone(),
+            artifact_type: artifact.artifact_type.clone(),
+            path: artifact.path.clone(),
+            url: artifact.url.clone(),
+            public_url: artifact.public_url.clone(),
+        }
+    }
+
+    pub fn public_target(&self) -> Option<String> {
+        self.public_url
+            .clone()
+            .or_else(|| self.url.clone())
+            .or_else(|| (self.artifact_type == "url").then(|| self.path.clone()))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvidenceRef {
+    pub schema: String,
+    pub kind: String,
+    pub target: String,
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact: Option<ArtifactRef>,
+}
+
+impl EvidenceRef {
+    pub fn new(
+        kind: impl Into<String>,
+        target: impl Into<String>,
+        label: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema: EVIDENCE_REF_SCHEMA.to_string(),
+            kind: kind.into(),
+            target: target.into(),
+            label: label.into(),
+            artifact: None,
+        }
+    }
+
+    pub fn from_artifact(artifact: ArtifactRef) -> Option<Self> {
+        let target = artifact.public_target()?;
+        Some(Self {
+            schema: EVIDENCE_REF_SCHEMA.to_string(),
+            kind: artifact.kind.clone(),
+            target,
+            label: artifact.kind.clone(),
+            artifact: Some(artifact),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn artifact_ref_serializes_stable_schema_and_type_field() {
+        let artifact = ArtifactRef {
+            schema: ARTIFACT_REF_SCHEMA.to_string(),
+            id: "artifact-1".to_string(),
+            run_id: "run-1".to_string(),
+            kind: "summary".to_string(),
+            artifact_type: "file".to_string(),
+            path: "summary.json".to_string(),
+            url: None,
+            public_url: Some("https://example.test/summary.json".to_string()),
+        };
+
+        assert_eq!(
+            serde_json::to_value(&artifact).expect("artifact ref json"),
+            json!({
+                "schema": "homeboy/artifact-ref/v1",
+                "id": "artifact-1",
+                "run_id": "run-1",
+                "kind": "summary",
+                "type": "file",
+                "path": "summary.json",
+                "public_url": "https://example.test/summary.json"
+            })
+        );
+    }
+
+    #[test]
+    fn evidence_ref_can_wrap_public_artifact_ref() {
+        let artifact = ArtifactRef {
+            schema: ARTIFACT_REF_SCHEMA.to_string(),
+            id: "artifact-1".to_string(),
+            run_id: "run-1".to_string(),
+            kind: "review".to_string(),
+            artifact_type: "url".to_string(),
+            path: "https://example.test/review".to_string(),
+            url: None,
+            public_url: None,
+        };
+
+        let evidence = EvidenceRef::from_artifact(artifact).expect("evidence ref");
+        assert_eq!(evidence.schema, EVIDENCE_REF_SCHEMA);
+        assert_eq!(evidence.target, "https://example.test/review");
+        assert_eq!(
+            evidence.artifact.expect("artifact").schema,
+            ARTIFACT_REF_SCHEMA
+        );
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -37,6 +37,7 @@ pub mod artifact_links;
 pub mod artifact_manifest;
 pub(crate) mod artifact_metadata;
 pub mod artifact_origin;
+pub mod artifact_ref;
 pub mod browser_evidence;
 pub mod build_identity;
 pub mod change_artifact;


### PR DESCRIPTION
## Summary
- Add shared homeboy/artifact-ref/v1 and homeboy/evidence-ref/v1 Rust reference types in core.
- Wire homeboy runs evidence artifacts and evidence links to emit additive ref objects while preserving existing compatibility fields.
- Add unit coverage for stable reference serialization and the wired runs evidence output.

## Verification
- cargo fmt
- cargo test artifact_ref
- cargo test evidence_command_reports_registry_artifacts_retention_and_failure_summary
- cargo test (fails in existing tests/core_agnostic_test.rs::core_owned_source_stays_language_and_framework_agnostic because src/core/runner/tool_registry.rs has pre-existing unbaselined ecosystem terms: cargo, composer, npm, php, rust, wordpress; unrelated to this diff.)

## Follow-up
- Normalize additional artifact/evidence-producing surfaces onto these shared refs, especially agent-task artifact normalization.
- Resolve or baseline the existing core-agnostic tool_registry.rs findings separately.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the core reference module, wired runs evidence, added tests, and ran local verification; Chris remains responsible for review and acceptance.