### PR TITLE
refactor(test): centralize temp-dir and git fixture scaffolding

### DIFF
--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -7,12 +7,11 @@ use crate::core::rig::{
 use crate::test_support::HomeGuard;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 #[path = "support.rs"]
 mod support;
 
-use support::{minimal_rig, minimal_stack, run_git, write_rig, write_stack};
+use support::{minimal_rig, minimal_stack, write_rig, write_stack, GitFixture};
 
 fn write_single_rig(dir: &Path, id: &str, body: &str) -> std::path::PathBuf {
     fs::create_dir_all(dir).expect("single rig dir");
@@ -22,39 +21,10 @@ fn write_single_rig(dir: &Path, id: &str, body: &str) -> std::path::PathBuf {
     rig_path
 }
 
-fn commit_package(package: &Path) {
-    run_git(package, &["add", "."]);
-    run_git(
-        package,
-        &[
-            "-c",
-            "user.name=Test",
-            "-c",
-            "user.email=test@example.com",
-            "commit",
-            "-m",
-            "update rigs",
-        ],
-    );
-}
-
 fn bare_package(package: &Path) -> tempfile::TempDir {
-    run_git(package, &["init"]);
-    commit_package(package);
-
-    let bare = tempfile::tempdir().expect("bare parent");
-    let source_path = bare.path().join("rig-package.git");
-    let output = Command::new("git")
-        .args([
-            "clone",
-            "--bare",
-            package.to_str().unwrap(),
-            source_path.to_str().unwrap(),
-        ])
-        .output()
-        .expect("git clone --bare");
-    assert!(output.status.success());
-    bare
+    let git = GitFixture::init(package);
+    git.commit("update rigs");
+    git.clone_bare()
 }
 
 #[test]
@@ -535,44 +505,10 @@ fn git_url_installs_clone_package_and_config_link() {
     let package = tempfile::tempdir().expect("package");
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
-    std::process::Command::new("git")
-        .args(["init"])
-        .current_dir(package.path())
-        .output()
-        .expect("git init");
-    std::process::Command::new("git")
-        .args(["add", "."])
-        .current_dir(package.path())
-        .output()
-        .expect("git add");
-    std::process::Command::new("git")
-        .args([
-            "-c",
-            "user.name=Test",
-            "-c",
-            "user.email=test@example.com",
-            "commit",
-            "-m",
-            "init",
-        ])
-        .current_dir(package.path())
-        .output()
-        .expect("git commit");
-
-    let bare = tempfile::tempdir().expect("bare parent");
-    let source_path = bare.path().join("rig-package.git");
-    let clone_bare = std::process::Command::new("git")
-        .args([
-            "clone",
-            "--bare",
-            package.path().to_str().unwrap(),
-            source_path.to_str().unwrap(),
-        ])
-        .output()
-        .expect("git clone --bare");
-    assert!(clone_bare.status.success());
-
-    let source = source_path.to_string_lossy().to_string();
+    let bare = bare_package(package.path());
+    let source = support::bare_source_path(&bare)
+        .to_string_lossy()
+        .to_string();
     let result = install(&source, None, false).expect("install");
     assert!(!result.linked);
     assert_eq!(result.installed.len(), 1);

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -7,46 +7,20 @@ use crate::core::rig::{
 use crate::test_support::HomeGuard;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 #[path = "support.rs"]
 mod support;
 
-use support::{minimal_rig, minimal_stack, run_git, write_rig, write_stack};
+use support::{minimal_rig, minimal_stack, write_rig, write_stack, GitFixture};
 
 fn commit_package(package: &Path, message: &str) {
-    run_git(package, &["add", "."]);
-    run_git(
-        package,
-        &[
-            "-c",
-            "user.name=Test",
-            "-c",
-            "user.email=test@example.com",
-            "commit",
-            "-m",
-            message,
-        ],
-    );
+    GitFixture::attach(package).commit(message);
 }
 
 fn create_bare_source(package: &Path) -> tempfile::TempDir {
-    run_git(package, &["init", "-b", "main"]);
-    commit_package(package, "initial rigs");
-
-    let bare = tempfile::tempdir().expect("bare parent");
-    let source_path = bare.path().join("rig-package.git");
-    let output = Command::new("git")
-        .args([
-            "clone",
-            "--bare",
-            package.to_str().unwrap(),
-            source_path.to_str().unwrap(),
-        ])
-        .output()
-        .expect("git clone --bare");
-    assert!(output.status.success());
-    bare
+    let git = GitFixture::init(package);
+    git.commit("initial rigs");
+    git.clone_bare()
 }
 
 #[test]
@@ -299,9 +273,7 @@ fn update_git_source_fast_forwards_package_and_refreshes_metadata() {
     let package = tempfile::tempdir().expect("package");
     let source_rig = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     let bare = create_bare_source(package.path());
-    let source = bare
-        .path()
-        .join("rig-package.git")
+    let source = support::bare_source_path(&bare)
         .to_string_lossy()
         .to_string();
 
@@ -316,7 +288,7 @@ fn update_git_source_fast_forwards_package_and_refreshes_metadata() {
     )
     .expect("update rig");
     commit_package(package.path(), "update alpha");
-    run_git(package.path(), &["push", &source, "HEAD:main"]);
+    GitFixture::attach(package.path()).push_main(&source);
 
     let result = update_source_for_rig("alpha").expect("update rig source");
 
@@ -343,9 +315,7 @@ fn update_git_source_refreshes_owned_stack_specs() {
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     let source_stack = write_stack(package.path(), "alpha-combined", "alpha");
     let bare = create_bare_source(package.path());
-    let source = bare
-        .path()
-        .join("rig-package.git")
+    let source = support::bare_source_path(&bare)
         .to_string_lossy()
         .to_string();
 
@@ -360,7 +330,7 @@ fn update_git_source_refreshes_owned_stack_specs() {
     )
     .expect("update stack");
     commit_package(package.path(), "update alpha stack");
-    run_git(package.path(), &["push", &source, "HEAD:main"]);
+    GitFixture::attach(package.path()).push_main(&source);
 
     let result = update_source_for_rig("alpha").expect("update rig source");
 
@@ -379,9 +349,7 @@ fn update_all_reports_broken_sources_and_continues() {
     let broken_package = tempfile::tempdir().expect("broken package");
     write_rig(broken_package.path(), "broken", &minimal_rig("broken"));
     let broken_bare = create_bare_source(broken_package.path());
-    let broken_source = broken_bare
-        .path()
-        .join("rig-package.git")
+    let broken_source = support::bare_source_path(&broken_bare)
         .to_string_lossy()
         .to_string();
     install(&broken_source, None, false).expect("install broken source");
@@ -392,9 +360,7 @@ fn update_all_reports_broken_sources_and_continues() {
     let good_package = tempfile::tempdir().expect("good package");
     let good_rig = write_rig(good_package.path(), "good", &minimal_rig("good"));
     let good_bare = create_bare_source(good_package.path());
-    let good_source = good_bare
-        .path()
-        .join("rig-package.git")
+    let good_source = support::bare_source_path(&good_bare)
         .to_string_lossy()
         .to_string();
     install(&good_source, None, false).expect("install good source");
@@ -404,7 +370,7 @@ fn update_all_reports_broken_sources_and_continues() {
     )
     .expect("update good rig");
     commit_package(good_package.path(), "update good rig");
-    run_git(good_package.path(), &["push", &good_source, "HEAD:main"]);
+    GitFixture::attach(good_package.path()).push_main(&good_source);
 
     let result = update_all_sources().expect("update all continues after broken source");
 
@@ -424,9 +390,7 @@ fn refresh_source_selector_updates_recorded_package() {
     let package = tempfile::tempdir().expect("package");
     let source_rig = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     let bare = create_bare_source(package.path());
-    let source = bare
-        .path()
-        .join("rig-package.git")
+    let source = support::bare_source_path(&bare)
         .to_string_lossy()
         .to_string();
 
@@ -441,7 +405,7 @@ fn refresh_source_selector_updates_recorded_package() {
     )
     .expect("update rig");
     commit_package(package.path(), "refresh alpha");
-    run_git(package.path(), &["push", &source, "HEAD:main"]);
+    GitFixture::attach(package.path()).push_main(&source);
 
     let package_id = list_sources().expect("sources").sources[0]
         .package_id
@@ -472,9 +436,7 @@ fn refresh_without_selector_updates_all_sources() {
     let package = tempfile::tempdir().expect("package");
     let source_rig = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     let bare = create_bare_source(package.path());
-    let source = bare
-        .path()
-        .join("rig-package.git")
+    let source = support::bare_source_path(&bare)
         .to_string_lossy()
         .to_string();
 
@@ -485,7 +447,7 @@ fn refresh_without_selector_updates_all_sources() {
     )
     .expect("update rig");
     commit_package(package.path(), "refresh alpha");
-    run_git(package.path(), &["push", &source, "HEAD:main"]);
+    GitFixture::attach(package.path()).push_main(&source);
 
     let result = update_source(None).expect("refresh all sources");
 
@@ -502,9 +464,7 @@ fn update_git_source_skips_user_replaced_stack_specs() {
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     let source_stack = write_stack(package.path(), "alpha-combined", "alpha");
     let bare = create_bare_source(package.path());
-    let source = bare
-        .path()
-        .join("rig-package.git")
+    let source = support::bare_source_path(&bare)
         .to_string_lossy()
         .to_string();
 
@@ -518,7 +478,7 @@ fn update_git_source_skips_user_replaced_stack_specs() {
     )
     .expect("update source stack");
     commit_package(package.path(), "update alpha stack");
-    run_git(package.path(), &["push", &source, "HEAD:main"]);
+    GitFixture::attach(package.path()).push_main(&source);
 
     let result = update_source_for_rig("alpha").expect("update rig source");
 

--- a/tests/core/rig/support.rs
+++ b/tests/core/rig/support.rs
@@ -63,3 +63,82 @@ pub(crate) fn run_git(dir: &Path, args: &[&str]) {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+/// Test-only helper for the happy-path git flows shared across rig source and
+/// install tests: repository init, identity-stamped commits, bare clones used
+/// as remote sources, and pushes back to that source.
+///
+/// Tests that assert *failure* behavior or inspect raw git output should keep
+/// using [`run_git`] / explicit `Command::new("git")` calls instead.
+pub(crate) struct GitFixture<'a> {
+    dir: &'a Path,
+}
+
+impl<'a> GitFixture<'a> {
+    /// Initialize a git repository in `dir` on the `main` branch.
+    pub(crate) fn init(dir: &'a Path) -> Self {
+        run_git(dir, &["init", "-b", "main"]);
+        Self { dir }
+    }
+
+    /// Attach to an already-initialized repository in `dir` (e.g. one created
+    /// via a raw `git init` elsewhere) to reuse the commit/push helpers.
+    ///
+    /// `allow(dead_code)`: this shared support module is `#[path]`-included
+    /// separately into each rig test file, so helpers used by only one of them
+    /// (here, the source-update tests) appear unused from the other's view.
+    #[allow(dead_code)]
+    pub(crate) fn attach(dir: &'a Path) -> Self {
+        Self { dir }
+    }
+
+    /// Stage everything and create a commit with a stable test identity.
+    pub(crate) fn commit(&self, message: &str) {
+        run_git(self.dir, &["add", "."]);
+        run_git(
+            self.dir,
+            &[
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "-m",
+                message,
+            ],
+        );
+    }
+
+    /// Clone the repository as a bare `rig-package.git` source inside a fresh
+    /// temp dir, returning the parent [`tempfile::TempDir`] guard so the bare
+    /// clone is cleaned up automatically. Use [`bare_source_path`] to derive
+    /// the source string.
+    pub(crate) fn clone_bare(&self) -> tempfile::TempDir {
+        let bare = tempfile::tempdir().expect("bare parent");
+        let source_path = bare.path().join("rig-package.git");
+        run_git(
+            self.dir,
+            &[
+                "clone",
+                "--bare",
+                self.dir.to_str().expect("package path utf8"),
+                source_path.to_str().expect("bare path utf8"),
+            ],
+        );
+        bare
+    }
+
+    /// Push the current `HEAD` to the `main` branch of `source`.
+    ///
+    /// `allow(dead_code)`: only the source-update tests push; see `attach`.
+    #[allow(dead_code)]
+    pub(crate) fn push_main(&self, source: &str) {
+        run_git(self.dir, &["push", source, "HEAD:main"]);
+    }
+}
+
+/// Path to the bare `rig-package.git` clone produced by
+/// [`GitFixture::clone_bare`].
+pub(crate) fn bare_source_path(bare: &tempfile::TempDir) -> PathBuf {
+    bare.path().join("rig-package.git")
+}

--- a/tests/report_browser_evidence_compare_test.rs
+++ b/tests/report_browser_evidence_compare_test.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use homeboy::commands::report::{
     browser_evidence_compare_from_args, browser_evidence_compare_from_dirs,
@@ -11,24 +11,13 @@ use homeboy::core::extension::{
     TraceBrowserMetricAliasConfig, TraceBrowserSummaryAliasConfig,
 };
 
-fn tmp_dir(name: &str) -> PathBuf {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("clock should be after epoch")
-        .as_nanos();
-    std::env::temp_dir().join(format!("homeboy-browser-evidence-compare-{name}-{nanos}"))
-}
+#[path = "support/mod.rs"]
+mod support;
 
-fn write_fixture_file(dir: &Path, name: &str, body: &str) {
-    fs::create_dir_all(dir).expect("fixture dir should exist");
-    let path = dir.join(name);
-    fs::write(&path, body).unwrap_or_else(|err| {
-        panic!(
-            "failed to write browser evidence fixture {}: {}",
-            path.display(),
-            err
-        )
-    });
+use support::write_file as write_fixture_file;
+
+fn tmp_dir(name: &str) -> tempfile::TempDir {
+    support::temp_dir(&format!("browser-evidence-compare-{name}"))
 }
 
 fn browser_evidence_adapter() -> TraceBrowserEvidenceAdapterConfig {
@@ -76,7 +65,8 @@ fn args(root: &Path, include_local_paths: bool) -> BrowserEvidenceCompareArgs {
 
 #[test]
 fn compares_repeats_matrix_variants_and_browser_deltas() {
-    let root = tmp_dir("full");
+    let guard = tmp_dir("full");
+    let root = guard.path();
     write_fixture_file(
         &root.join("baseline"),
         "browser-evidence.json",
@@ -166,7 +156,7 @@ fn compares_repeats_matrix_variants_and_browser_deltas() {
         }"#,
     );
 
-    let report = browser_evidence_compare_from_args(&args(&root, false)).expect("report renders");
+    let report = browser_evidence_compare_from_args(&args(root, false)).expect("report renders");
 
     assert_eq!(report.totals.baseline_samples, 3);
     assert_eq!(report.totals.candidate_samples, 2);
@@ -206,13 +196,12 @@ fn compares_repeats_matrix_variants_and_browser_deltas() {
     assert!(report.markdown.contains("DOM Lifecycle Metrics"));
     assert!(report.markdown.contains("browser-evidence.json"));
     assert!(!report.markdown.contains(root.to_string_lossy().as_ref()));
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
 fn can_include_local_paths_when_requested() {
-    let root = tmp_dir("local-paths");
+    let guard = tmp_dir("local-paths");
+    let root = guard.path();
     write_fixture_file(
         &root.join("baseline"),
         "evidence.json",
@@ -224,16 +213,15 @@ fn can_include_local_paths_when_requested() {
         r#"{"scenario_id":"home","assertions":[],"request_count":2}"#,
     );
 
-    let report = browser_evidence_compare_from_args(&args(&root, true)).expect("report renders");
+    let report = browser_evidence_compare_from_args(&args(root, true)).expect("report renders");
 
     assert!(report.markdown.contains(root.to_string_lossy().as_ref()));
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
 fn compares_browser_evidence_across_multiple_run_dirs() {
-    let root = tmp_dir("multi-dirs");
+    let guard = tmp_dir("multi-dirs");
+    let root = guard.path();
     write_fixture_file(
         &root.join("baseline-run-1"),
         "browser.json",
@@ -274,13 +262,12 @@ fn compares_browser_evidence_across_multiple_run_dirs() {
     assert!(report.markdown.contains("throttled-mobile"));
     assert!(report.markdown.contains("baseline-ref"));
     assert!(report.markdown.contains("candidate-ref"));
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
 fn surfaces_failed_advisory_assertions_in_json_and_markdown() {
-    let root = tmp_dir("advisory-assertions");
+    let guard = tmp_dir("advisory-assertions");
+    let root = guard.path();
     write_fixture_file(
         &root.join("baseline"),
         "browser-evidence.json",
@@ -311,7 +298,7 @@ fn surfaces_failed_advisory_assertions_in_json_and_markdown() {
         }"##,
     );
 
-    let report = browser_evidence_compare_from_args(&args(&root, false)).expect("report renders");
+    let report = browser_evidence_compare_from_args(&args(root, false)).expect("report renders");
     let variant = report.variants.first().expect("variant should exist");
 
     assert_eq!(variant.assertions.baseline.advisory_failed, 0);
@@ -337,13 +324,12 @@ fn surfaces_failed_advisory_assertions_in_json_and_markdown() {
         report_json["variants"][0]["assertions"]["candidate"]["advisory_failed"],
         serde_json::json!(1)
     );
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
 fn promotes_declared_browser_summary_metrics() {
-    let root = tmp_dir("provider-summary");
+    let guard = tmp_dir("provider-summary");
+    let root = guard.path();
     write_fixture_file(
         &root.join("baseline"),
         "summary.json",
@@ -439,13 +425,12 @@ fn promotes_declared_browser_summary_metrics() {
         .candidate
         .iter()
         .any(|artifact| artifact.target == "files/browser/screenshot.png"));
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
 fn can_run_visual_compare_through_declared_provider() {
-    let root = tmp_dir("visual-compare");
+    let guard = tmp_dir("visual-compare");
+    let root = guard.path();
     let baseline_browser = root.join("baseline/files/browser");
     let candidate_browser = root.join("candidate/files/browser");
     fs::create_dir_all(&baseline_browser).expect("baseline browser dir");
@@ -558,12 +543,12 @@ process.stdout.write(JSON.stringify({
             std::env::remove_var("HOMEBOY_FAKE_VISUAL_INPUT");
         }
     }
-    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
 fn keeps_runtime_and_artifact_manifests_out_of_variant_matrix() {
-    let root = tmp_dir("artifact-manifests");
+    let guard = tmp_dir("artifact-manifests");
+    let root = guard.path();
     write_fixture_file(
         &root.join("baseline"),
         "browser-evidence.json",
@@ -611,7 +596,7 @@ fn keeps_runtime_and_artifact_manifests_out_of_variant_matrix() {
         );
     }
 
-    let report = browser_evidence_compare_from_args(&args(&root, false)).expect("report renders");
+    let report = browser_evidence_compare_from_args(&args(root, false)).expect("report renders");
 
     assert_eq!(report.totals.baseline_samples, 1);
     assert_eq!(report.totals.candidate_samples, 1);
@@ -637,6 +622,4 @@ fn keeps_runtime_and_artifact_manifests_out_of_variant_matrix() {
     assert!(!report
         .markdown
         .contains("`runtime-reference-manifest-sha256-cafebabe`"));
-
-    let _ = fs::remove_dir_all(&root);
 }

--- a/tests/report_failure_digest_test.rs
+++ b/tests/report_failure_digest_test.rs
@@ -1,23 +1,19 @@
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use homeboy::commands::report::{render_failure_digest_from_args, FailureDigestArgs};
+
+#[path = "support/mod.rs"]
+mod support;
+
+use support::write_file;
 
 const LINT_JSON: &str = include_str!("fixtures/failure_digest/lint.json");
 const TEST_JSON: &str = include_str!("fixtures/failure_digest/test.json");
 const AUDIT_JSON: &str = include_str!("fixtures/failure_digest/audit.json");
 const TOOLING_JSON: &str = include_str!("fixtures/failure_digest/tooling.json");
 
-fn tmp_dir(name: &str) -> PathBuf {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("clock should be after epoch")
-        .as_nanos();
-    std::env::temp_dir().join(format!("homeboy-failure-digest-{name}-{nanos}"))
-}
-
-fn write_file(dir: &Path, name: &str, body: &str) {
-    fs::write(dir.join(name), body).expect("fixture should be written");
+fn tmp_dir(name: &str) -> tempfile::TempDir {
+    support::temp_dir(&format!("failure-digest-{name}"))
 }
 
 fn render(dir: &Path, results: &str, autofix_enabled: bool, autofix_attempted: bool) -> String {
@@ -261,11 +257,11 @@ fn bench_json() -> &'static str {
 
 #[test]
 fn renders_lint_failure_digest_from_fixture() {
-    let dir = tmp_dir("lint");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
-    write_file(&dir, "lint.json", LINT_JSON);
+    let guard = tmp_dir("lint");
+    let dir = guard.path();
+    write_file(dir, "lint.json", LINT_JSON);
 
-    let markdown = render(&dir, r#"{"lint":"fail"}"#, false, false);
+    let markdown = render(dir, r#"{"lint":"fail"}"#, false, false);
 
     assert!(markdown.contains("## Failure Digest"));
     assert!(markdown.contains("### Lint Failure Digest"));
@@ -279,17 +275,15 @@ fn renders_lint_failure_digest_from_fixture() {
     assert!(markdown
         .contains("- Full lint log: https://github.com/Extra-Chill/homeboy/actions/runs/123"));
     assert!(!markdown.contains("### Test Failure Digest"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn caps_lint_findings_in_failure_digest() {
-    let dir = tmp_dir("lint-cap");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
-    write_file(&dir, "lint.json", &lint_json_with_findings(12));
+    let guard = tmp_dir("lint-cap");
+    let dir = guard.path();
+    write_file(dir, "lint.json", &lint_json_with_findings(12));
 
-    let markdown = render(&dir, r#"{"lint":"fail"}"#, false, false);
+    let markdown = render(dir, r#"{"lint":"fail"}"#, false, false);
 
     assert!(markdown.contains("- Actionable lint findings (10 shown):"));
     assert!(markdown.contains(
@@ -299,17 +293,15 @@ fn caps_lint_findings_in_failure_digest() {
         "- 2 more lint finding(s) omitted from this comment; see `lint.json` or the full lint log."
     ));
     assert!(!markdown.contains("src/file11.js"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn renders_test_failure_digest_from_fixture() {
-    let dir = tmp_dir("test");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
-    write_file(&dir, "test.json", TEST_JSON);
+    let guard = tmp_dir("test");
+    let dir = guard.path();
+    write_file(dir, "test.json", TEST_JSON);
 
-    let markdown = render(&dir, r#"{"test":"fail"}"#, false, false);
+    let markdown = render(dir, r#"{"test":"fail"}"#, false, false);
 
     assert!(markdown.contains("### Test Failure Digest"));
     assert!(markdown.contains("- Failed tests: **2**"));
@@ -318,17 +310,15 @@ fn renders_test_failure_digest_from_fixture() {
     assert!(markdown.contains(
         "2. test_widget_handles_empty_state — empty state missing — tests/widget_test.rs"
     ));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn renders_audit_failure_digest_from_fixture() {
-    let dir = tmp_dir("audit");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
-    write_file(&dir, "audit.json", AUDIT_JSON);
+    let guard = tmp_dir("audit");
+    let dir = guard.path();
+    write_file(dir, "audit.json", AUDIT_JSON);
 
-    let markdown = render(&dir, r#"{"audit":"fail"}"#, false, false);
+    let markdown = render(dir, r#"{"audit":"fail"}"#, false, false);
 
     assert!(markdown.contains("### Audit Failure Digest"));
     assert!(markdown.contains("- Alignment score: **0.812**"));
@@ -336,19 +326,17 @@ fn renders_audit_failure_digest_from_fixture() {
     assert!(markdown.contains("- New findings since baseline: **1**"));
     assert!(markdown.contains("1. **src/report.rs** — new report module lacks tests (`abc123`)"));
     assert!(markdown.contains("**src/render.rs** — god_file — file is too large"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn renders_mixed_failures_with_autofix_enabled_not_attempted() {
-    let dir = tmp_dir("mixed-autofix");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
-    write_file(&dir, "lint.json", LINT_JSON);
-    write_file(&dir, "test.json", TEST_JSON);
+    let guard = tmp_dir("mixed-autofix");
+    let dir = guard.path();
+    write_file(dir, "lint.json", LINT_JSON);
+    write_file(dir, "test.json", TEST_JSON);
 
     let markdown = render(
-        &dir,
+        dir,
         r#"{"lint":"fail","test":"fail","audit":"pass"}"#,
         true,
         false,
@@ -361,34 +349,30 @@ fn renders_mixed_failures_with_autofix_enabled_not_attempted() {
     assert!(markdown.contains("- Auto-fixable failed commands:"));
     assert!(markdown.contains("  - `lint`"));
     assert!(markdown.contains("  - `test`"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn renders_mixed_failures_after_autofix_attempted_as_human_needed() {
-    let dir = tmp_dir("attempted");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
-    write_file(&dir, "lint.json", LINT_JSON);
+    let guard = tmp_dir("attempted");
+    let dir = guard.path();
+    write_file(dir, "lint.json", LINT_JSON);
 
-    let markdown = render(&dir, r#"{"lint":"fail"}"#, true, true);
+    let markdown = render(dir, r#"{"lint":"fail"}"#, true, true);
 
     assert!(markdown.contains("- Overall: **human_needed**"));
     assert!(markdown.contains("- Autofix attempted this run: **yes**"));
     assert!(markdown.contains("- Human-needed failed commands:"));
     assert!(markdown.contains("  - `lint`"));
     assert!(markdown.contains("- Failed commands with available automated fixes:"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn missing_json_renders_explicit_structured_details_unavailable() {
-    let dir = tmp_dir("missing");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
+    let guard = tmp_dir("missing");
+    let dir = guard.path();
 
     let markdown = render(
-        &dir,
+        dir,
         r#"{"lint":"fail","test":"fail","audit":"fail"}"#,
         false,
         false,
@@ -399,17 +383,15 @@ fn missing_json_renders_explicit_structured_details_unavailable() {
     assert!(markdown.contains("- No structured audit findings available."));
     assert!(markdown
         .contains("- Full audit log: https://github.com/Extra-Chill/homeboy/actions/runs/123"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn error_statuses_render_command_sections_and_classify_as_failures() {
-    let dir = tmp_dir("error-statuses");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
+    let guard = tmp_dir("error-statuses");
+    let dir = guard.path();
 
     let markdown = render(
-        &dir,
+        dir,
         r#"{"lint":"error","test":"error","audit":"error"}"#,
         false,
         false,
@@ -432,16 +414,14 @@ fn error_statuses_render_command_sections_and_classify_as_failures() {
         .contains("- Full test log: https://github.com/Extra-Chill/homeboy/actions/runs/123"));
     assert!(markdown
         .contains("- Full audit log: https://github.com/Extra-Chill/homeboy/actions/runs/123"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn renders_tooling_metadata_from_json_file() {
-    let dir = tmp_dir("tooling");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
+    let guard = tmp_dir("tooling");
+    let dir = guard.path();
     let tooling_path = dir.join("tooling.json");
-    write_file(&dir, "tooling.json", TOOLING_JSON);
+    write_file(dir, "tooling.json", TOOLING_JSON);
 
     let markdown = render_failure_digest_from_args(&FailureDigestArgs {
         output_dir: dir.to_string_lossy().to_string(),
@@ -459,21 +439,19 @@ fn renders_tooling_metadata_from_json_file() {
     assert!(markdown.contains("### Tooling metadata"));
     assert!(markdown.contains("- action_repository: `Extra-Chill/homeboy-action`"));
     assert!(markdown.contains("- extension_id: `wordpress`"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn renders_trace_pass_status_and_artifact_paths() {
-    let dir = tmp_dir("trace-pass");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
+    let guard = tmp_dir("trace-pass");
+    let dir = guard.path();
     write_file(
-        &dir,
+        dir,
         "trace.json",
         &trace_json("pass", "Window stayed closed."),
     );
 
-    let markdown = render(&dir, r#"{"trace":"pass"}"#, false, false);
+    let markdown = render(dir, r#"{"trace":"pass"}"#, false, false);
 
     assert!(markdown.contains("### Trace: studio / close-window-running-site"));
     assert!(markdown.contains("**Status:** PASS"));
@@ -482,17 +460,15 @@ fn renders_trace_pass_status_and_artifact_paths() {
     assert!(markdown.contains("- process tree: artifacts/process-tree.txt"));
     assert!(!markdown.contains("**WP Codebox runtime diagnostics**"));
     assert!(!markdown.contains("raw log body that should never appear"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn renders_bench_status_and_artifact_paths() {
-    let dir = tmp_dir("bench-pass");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
-    write_file(&dir, "bench.json", bench_json());
+    let guard = tmp_dir("bench-pass");
+    let dir = guard.path();
+    write_file(dir, "bench.json", bench_json());
 
-    let markdown = render(&dir, r#"{"bench":"pass"}"#, false, false);
+    let markdown = render(dir, r#"{"bench":"pass"}"#, false, false);
 
     assert!(markdown.contains("### Bench: studio"));
     assert!(markdown.contains("**Status:** PASSED"));
@@ -507,52 +483,46 @@ fn renders_bench_status_and_artifact_paths() {
         "- scenario `wp-admin-load` — Final screenshot (screenshot): bench-artifacts/wp-admin-load/final.png"
     ));
     assert!(!markdown.contains("trace bytes should never appear"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn renders_trace_fail_status_without_inlining_artifact_content() {
-    let dir = tmp_dir("trace-fail");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
+    let guard = tmp_dir("trace-fail");
+    let dir = guard.path();
     write_file(
-        &dir,
+        dir,
         "trace.json",
         &trace_json("fail", "Window reopened after close."),
     );
 
-    let markdown = render(&dir, r#"{"trace":"fail"}"#, false, false);
+    let markdown = render(dir, r#"{"trace":"fail"}"#, false, false);
 
     assert!(markdown.contains("**Status:** FAIL"));
     assert!(markdown.contains("- Window reopened after close."));
     assert!(markdown.contains("- main log: artifacts/main.log"));
     assert!(!markdown.contains("raw log body that should never appear"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn renders_trace_span_summaries_with_metadata_and_missing_endpoints() {
-    let dir = tmp_dir("trace-span-summaries");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
-    write_file(&dir, "trace.json", trace_json_with_span_summaries());
+    let guard = tmp_dir("trace-span-summaries");
+    let dir = guard.path();
+    write_file(dir, "trace.json", trace_json_with_span_summaries());
 
-    let markdown = render(&dir, r#"{"trace":"fail"}"#, false, false);
+    let markdown = render(dir, r#"{"trace":"fail"}"#, false, false);
 
     assert!(markdown.contains("**Spans**"));
     assert!(markdown.contains("| `phase.boot_to_ready` | `runner.boot` | `runner.ready` | 125ms | ok | category=startup, critical, blocking, cacheable |"));
     assert!(markdown.contains("| `phase.ready_to_open` | `runner.ready` | `app.opened` | - | skipped: missing `app.opened`: span endpoint missing from timeline | category=ui, prewarmable |"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn renders_trace_toolchain_provenance() {
-    let dir = tmp_dir("trace-toolchain");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
-    write_file(&dir, "trace.json", trace_json_with_toolchain());
+    let guard = tmp_dir("trace-toolchain");
+    let dir = guard.path();
+    write_file(dir, "trace.json", trace_json_with_toolchain());
 
-    let markdown = render(&dir, r#"{"trace":"pass"}"#, false, false);
+    let markdown = render(dir, r#"{"trace":"pass"}"#, false, false);
 
     assert!(markdown.contains("**Toolchain provenance**"));
     assert!(markdown.contains("- Mode: `development`; canonical: **no**"));
@@ -565,21 +535,19 @@ fn renders_trace_toolchain_provenance() {
         markdown.contains("- Target: `/repo/studio` @ `789abc` (branch `trunk`, dirty `false`)")
     );
     assert!(markdown.contains("HOMEBOY_WP_CODEBOX_BIN selected a local WP Codebox runner path"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn renders_wp_codebox_partial_manifest_and_failure_phase() {
-    let dir = tmp_dir("trace-codebox-manifest");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
+    let guard = tmp_dir("trace-codebox-manifest");
+    let dir = guard.path();
     write_file(
-        &dir,
+        dir,
         "trace.json",
         trace_json_with_wp_codebox_partial_manifest(),
     );
 
-    let markdown = render(&dir, r#"{"trace":"error"}"#, false, false);
+    let markdown = render(dir, r#"{"trace":"error"}"#, false, false);
 
     assert!(markdown.contains("**Runtime diagnostics**"));
     assert!(markdown.contains("- Failure phase: **browser probe hang/failure**"));
@@ -594,16 +562,14 @@ fn renders_wp_codebox_partial_manifest_and_failure_phase() {
     assert!(markdown.contains("- Events log: wp-codebox-artifacts/runtime-123/events.jsonl"));
     assert!(markdown
         .contains("- Browser summary: wp-codebox-artifacts/runtime-123/browser-summary.json"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn renders_trace_error_status_from_failure_envelope() {
-    let dir = tmp_dir("trace-error");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
+    let guard = tmp_dir("trace-error");
+    let dir = guard.path();
     write_file(
-        &dir,
+        dir,
         "trace.json",
         r#"{
             "success": false,
@@ -622,12 +588,10 @@ fn renders_trace_error_status_from_failure_envelope() {
         }"#,
     );
 
-    let markdown = render(&dir, r#"{"trace":"error"}"#, false, false);
+    let markdown = render(dir, r#"{"trace":"error"}"#, false, false);
 
     assert!(markdown.contains("### Trace: studio / close-window-running-site"));
     assert!(markdown.contains("**Status:** ERROR"));
     assert!(markdown.contains("- runner failed before assertions"));
     assert!(markdown.contains("- No structured trace artifacts available."));
-
-    let _ = fs::remove_dir_all(&dir);
 }

--- a/tests/report_performance_digest_test.rs
+++ b/tests/report_performance_digest_test.rs
@@ -1,25 +1,14 @@
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use homeboy::commands::report::{performance_digest_from_args, PerformanceDigestArgs};
 
-fn tmp_dir(name: &str) -> PathBuf {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("clock should be after epoch")
-        .as_nanos();
-    std::env::temp_dir().join(format!("homeboy-performance-digest-{name}-{nanos}"))
-}
+#[path = "support/mod.rs"]
+mod support;
 
-fn write_fixture_file(dir: &Path, name: &str, body: &str) {
-    let path = dir.join(name);
-    fs::write(&path, body).unwrap_or_else(|err| {
-        panic!(
-            "failed to write performance digest fixture {}: {}",
-            path.display(),
-            err
-        )
-    });
+use support::write_file as write_fixture_file;
+
+fn tmp_dir(name: &str) -> tempfile::TempDir {
+    support::temp_dir(&format!("performance-digest-{name}"))
 }
 
 fn args(dir: &Path) -> PerformanceDigestArgs {
@@ -35,10 +24,10 @@ fn args(dir: &Path) -> PerformanceDigestArgs {
 
 #[test]
 fn renders_resource_summary_budget_findings_and_baseline_health() {
-    let dir = tmp_dir("full");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
+    let guard = tmp_dir("full");
+    let dir = guard.path();
     write_fixture_file(
-        &dir,
+        dir,
         "resource-summary.json",
         r#"{
             "label": "bench fixture",
@@ -60,7 +49,7 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
         }"#,
     );
     write_fixture_file(
-        &dir,
+        dir,
         "bench.json",
         r#"{
             "success": true,
@@ -108,7 +97,7 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
         }"#,
     );
     write_fixture_file(
-        &dir,
+        dir,
         "metadata.json",
         r#"{
             "warmup_iterations": 0,
@@ -170,7 +159,7 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
         }"#,
     );
 
-    let report = performance_digest_from_args(&args(&dir)).expect("digest should render");
+    let report = performance_digest_from_args(&args(dir)).expect("digest should render");
 
     assert!(report.resource_summary.is_some());
     assert_eq!(report.budget_findings.len(), 1);
@@ -258,18 +247,16 @@ fn renders_resource_summary_budget_findings_and_baseline_health() {
         .markdown
         .contains("`https://preview.example.test/?view=site`"));
     assert!(report.markdown.contains("| true | 1 |"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn renders_managed_service_preview_url_artifact_metadata() {
-    let dir = tmp_dir("managed-preview");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
-    write_fixture_file(&dir, "resource-summary.json", r#"{}"#);
-    write_fixture_file(&dir, "bench.json", r#"{}"#);
+    let guard = tmp_dir("managed-preview");
+    let dir = guard.path();
+    write_fixture_file(dir, "resource-summary.json", r#"{}"#);
+    write_fixture_file(dir, "bench.json", r#"{}"#);
     write_fixture_file(
-        &dir,
+        dir,
         "metadata.json",
         &format!(
             r#"{{"preview":{}}}"#,
@@ -277,7 +264,7 @@ fn renders_managed_service_preview_url_artifact_metadata() {
         ),
     );
 
-    let report = performance_digest_from_args(&args(&dir)).expect("digest should render");
+    let report = performance_digest_from_args(&args(dir)).expect("digest should render");
 
     assert_eq!(
         report.preview.get("schema"),
@@ -306,16 +293,14 @@ fn renders_managed_service_preview_url_artifact_metadata() {
         .markdown
         .contains("- cleanup.expires_at: `2026-06-07T13:00:00Z`"));
     assert!(report.markdown.contains("- source.run_id: `run-1`"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn reads_persisted_uuid_prefixed_artifacts() {
-    let dir = tmp_dir("persisted");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
+    let guard = tmp_dir("persisted");
+    let dir = guard.path();
     write_fixture_file(
-        &dir,
+        dir,
         "123-resource-summary.json",
         r#"{
             "label": "persisted bench",
@@ -326,7 +311,7 @@ fn reads_persisted_uuid_prefixed_artifacts() {
         }"#,
     );
     write_fixture_file(
-        &dir,
+        dir,
         "456-bench-results.json",
         r#"{
             "component_id": "homeboy",
@@ -354,7 +339,7 @@ fn reads_persisted_uuid_prefixed_artifacts() {
         }"#,
     );
 
-    let report = performance_digest_from_args(&args(&dir)).expect("digest should render");
+    let report = performance_digest_from_args(&args(dir)).expect("digest should render");
 
     assert!(report.gaps.is_empty());
     assert_eq!(
@@ -378,16 +363,14 @@ fn reads_persisted_uuid_prefixed_artifacts() {
         .any(|diagnostic| diagnostic.code == "baseline.missing_warmup"));
     assert!(report.markdown.contains("- Duration: **54321 ms**"));
     assert!(report.markdown.contains("persisted-subject"));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn missing_optional_artifacts_degrade_gracefully() {
-    let dir = tmp_dir("missing");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
+    let guard = tmp_dir("missing");
+    let dir = guard.path();
 
-    let report = performance_digest_from_args(&args(&dir)).expect("digest should render");
+    let report = performance_digest_from_args(&args(dir)).expect("digest should render");
 
     assert!(report.resource_summary.is_none());
     assert!(report.budget_findings.is_empty());
@@ -410,16 +393,14 @@ fn missing_optional_artifacts_degrade_gracefully() {
     assert!(report
         .markdown
         .contains("- No resource policy metadata available."));
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn renders_max_peak_rss_from_multi_run_memory() {
-    let dir = tmp_dir("multi-run-memory");
-    fs::create_dir_all(&dir).expect("temp dir should exist");
+    let guard = tmp_dir("multi-run-memory");
+    let dir = guard.path();
     write_fixture_file(
-        &dir,
+        dir,
         "bench-results.json",
         r#"{
             "component_id": "homeboy",
@@ -434,12 +415,10 @@ fn renders_max_peak_rss_from_multi_run_memory() {
         }"#,
     );
 
-    let report = performance_digest_from_args(&args(&dir)).expect("digest should render");
+    let report = performance_digest_from_args(&args(dir)).expect("digest should render");
 
     assert_eq!(report.benchmark_memory.len(), 1);
     assert_eq!(report.benchmark_memory[0].scenario, "audit-self");
     assert_eq!(report.benchmark_memory[0].peak_bytes, 33554432);
     assert!(report.markdown.contains("| `audit-self` | 32.0 MiB |"));
-
-    let _ = fs::remove_dir_all(&dir);
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,37 @@
+//! Shared scaffolding for integration tests.
+//!
+//! Centralizes temp-directory creation and fixture-file writes so individual
+//! test files do not re-implement manual temp-dir naming or remember to clean
+//! up after themselves. Backed by [`tempfile::TempDir`] for automatic removal
+//! when the returned guard is dropped.
+
+use std::path::Path;
+
+use tempfile::TempDir;
+
+/// Create an isolated, auto-cleaned temporary directory for a test.
+///
+/// The `prefix` keeps fixture directories human-recognizable on disk while a
+/// debug session is paused; the underlying [`TempDir`] is removed when the
+/// returned value is dropped, so tests no longer need an explicit
+/// `fs::remove_dir_all` at the end.
+pub fn temp_dir(prefix: &str) -> TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("homeboy-{prefix}-"))
+        .tempdir()
+        .expect("temp dir should be created")
+}
+
+/// Write a fixture file into `dir`, panicking with a descriptive message on
+/// failure. Parent directories are created as needed so callers can write into
+/// nested fixture layouts.
+pub fn write_file(dir: &Path, name: &str, body: &str) {
+    let path = dir.join(name);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap_or_else(|err| {
+            panic!("failed to create fixture dir {}: {err}", parent.display())
+        });
+    }
+    std::fs::write(&path, body)
+        .unwrap_or_else(|err| panic!("failed to write fixture {}: {err}", path.display()));
+}


### PR DESCRIPTION
Closes #4866

## Summary
Centralizes repeated test temp-dir naming, fixture-file writes, and happy-path git repo setup that was duplicated across report digest tests and rig source/install tests.

## Changes
- **New `tests/support/mod.rs`** — shared scaffolding for integration tests:
  - `temp_dir(prefix)` returns a `tempfile::TempDir` (via `tempfile::Builder`) so directories are cleaned up automatically on drop — no more manual nanos-based naming or `fs::remove_dir_all` at the end of each test.
  - `write_file(dir, name, body)` writes a fixture file (creating parent dirs as needed) with a descriptive panic message.
- **`report_failure_digest_test`, `report_performance_digest_test`, `report_browser_evidence_compare_test`** now use the shared helpers and rely on automatic cleanup, dropping their per-file `tmp_dir`/`write_file`/`write_fixture_file` copies and trailing `fs::remove_dir_all` calls.
- **`tests/core/rig/support.rs`** gains a small test-only `GitFixture` for the happy-path `init` / identity-stamped `commit` / bare `clone` / `push_main` flows, plus a `bare_source_path` helper.
- **`source_test.rs` / `install_test.rs`** use `GitFixture` for happy-path git setup. The previously inlined raw `Command::new("git")` init+commit+clone block in `git_url_installs_clone_package_and_config_link` now reuses `bare_package`.

## Preserved per the issue caveats
- Explicit `Command::new("git")` calls remain where they are incidental and not the test subject; malformed/inline fixture JSON used for parse/validation tests is left untouched.

## Validation
- `cargo build --lib --tests` — clean (only pre-existing unrelated warnings).
- `cargo fmt --check` — clean.
- `cargo test --lib core::rig::source` — 19 passed.
- `cargo test --lib core::rig::install` — 25 passed (incl. `git_url_installs_clone_package_and_config_link`).
- `cargo test --test report_failure_digest_test --test report_performance_digest_test --test report_browser_evidence_compare_test` — 28 passed.
- Full `cargo test --lib`: identical pass/fail counts to `origin/main` (4773 passed / 88 pre-existing env-dependent failures) — no regressions introduced.

> Note: the rig `source_test` / `install_test` files are lib-embedded via `#[path]` (they use `crate::` internals), so they run under `cargo test --lib`, not as standalone `--test` targets.