### PR TITLE
Add generic run lifecycle record

### DIFF
--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -120,6 +120,7 @@ impl From<FinalizePrEvidenceArgs> for AgentTaskPrEvidence {
                 evidence_discriminators: args.evidence_discriminators,
                 nearby_contracts_preserved: args.nearby_contracts_preserved,
             },
+            lifecycle: None,
         }
     }
 }

--- a/src/core/agent_task_finalization.rs
+++ b/src/core/agent_task_finalization.rs
@@ -12,6 +12,7 @@ use crate::core::proof::{
     HomeboyProof, HomeboyProofArtifactRef, HomeboyProofEnvironmentDisposition,
     HomeboyProofEnvironmentVariable, HomeboyProofProvenance,
 };
+use crate::core::run_lifecycle_record::RunLifecycleRecord;
 
 pub const AGENT_TASK_PR_FINALIZATION_SCHEMA: &str = "homeboy/agent-task-pr-finalization/v1";
 
@@ -65,6 +66,8 @@ pub struct AgentTaskPrEvidence {
         skip_serializing_if = "AgentTaskPrRuntimeGuardrails::is_empty"
     )]
     pub runtime_guardrails: AgentTaskPrRuntimeGuardrails,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lifecycle: Option<RunLifecycleRecord>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -567,6 +570,11 @@ fn proof_environment_variables(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::run_lifecycle_record::{
+        ArtifactRetentionLifecycle, ArtifactRetentionStatus, CleanupLifecycle, CleanupState,
+        ExternalRuntimeId, FinalizationLifecycle, FinalizationState, ProviderRuntimeLifecycle,
+        ProviderRuntimeState, RunExecutionLifecycle, RunExecutionState,
+    };
 
     #[derive(Default)]
     struct MockBackend {
@@ -750,6 +758,67 @@ mod tests {
     }
 
     #[test]
+    fn pr_body_reports_run_lifecycle_evidence() {
+        let mut backend = MockBackend {
+            changed_files: vec!["src/lib.rs".to_string()],
+            ..Default::default()
+        };
+        let mut options = options();
+        options.evidence.lifecycle = Some(RunLifecycleRecord {
+            execution: RunExecutionLifecycle {
+                state: RunExecutionState::Succeeded,
+                started_at: None,
+                finished_at: Some("2026-06-16T00:00:05Z".to_string()),
+                updated_at: Some("2026-06-16T00:00:05Z".to_string()),
+            },
+            provider_runtime: vec![ProviderRuntimeLifecycle {
+                task_id: "task-a".to_string(),
+                backend: "codebox".to_string(),
+                state: ProviderRuntimeState::Succeeded,
+                stream_uri: None,
+                external_runtime_ids: vec![ExternalRuntimeId {
+                    kind: "provider_run_id".to_string(),
+                    value: "provider-run-123".to_string(),
+                    provider: Some("codebox".to_string()),
+                    url: None,
+                }],
+                metadata: serde_json::Value::Null,
+            }],
+            external_runtime_ids: vec![ExternalRuntimeId {
+                kind: "provider_run_id".to_string(),
+                value: "provider-run-123".to_string(),
+                provider: Some("codebox".to_string()),
+                url: None,
+            }],
+            cleanup: CleanupLifecycle {
+                state: CleanupState::Preserved,
+                policy: Some("preserve".to_string()),
+                updated_at: None,
+            },
+            finalization: FinalizationLifecycle {
+                state: FinalizationState::Pending,
+                updated_at: None,
+            },
+            artifact_retention: ArtifactRetentionLifecycle {
+                status: ArtifactRetentionStatus::Retained,
+                policy: Some("retain".to_string()),
+                updated_at: None,
+            },
+            ..RunLifecycleRecord::default()
+        });
+
+        finalize_pr_with_backend(options, &mut backend).expect("finalized");
+
+        assert!(backend.last_body.contains("## Run lifecycle"));
+        assert!(backend
+            .last_body
+            .contains("provider_run_id:provider-run-123"));
+        assert!(backend
+            .last_body
+            .contains("Artifact retention:** `Retained`"));
+    }
+
+    #[test]
     fn updates_existing_pr_for_same_branch() {
         let mut backend = MockBackend {
             changed_files: vec!["src/lib.rs".to_string()],
@@ -859,6 +928,7 @@ mod tests {
                 source_relationship: AgentTaskPrSourceRelationship::default(),
                 verification: AgentTaskPrVerification::default(),
                 runtime_guardrails: AgentTaskPrRuntimeGuardrails::default(),
+                lifecycle: None,
             },
             ai_used_for: "Drafted implementation and tests; Chris reviews and owns the change."
                 .to_string(),

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -16,6 +16,11 @@ use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals, AgentTaskPlan,
     AgentTaskProgressEvent, AgentTaskQueueStatus, AgentTaskState, AGENT_TASK_AGGREGATE_SCHEMA,
 };
+use crate::core::run_lifecycle_record::{
+    ArtifactRetentionLifecycle, ArtifactRetentionStatus, CleanupLifecycle, CleanupState,
+    ExternalRuntimeId, ProviderRuntimeLifecycle, ProviderRuntimeState, RunExecutionState,
+    RunHeartbeat, RunLifecycleRecord, RUN_LIFECYCLE_RECORD_SCHEMA,
+};
 use crate::core::{paths, Error, ErrorCode, Result};
 
 #[path = "lifecycle_store.rs"]
@@ -49,6 +54,8 @@ pub struct AgentTaskRunRecord {
     pub artifact_refs: Vec<AgentTaskArtifactRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub provider_handles: Vec<AgentTaskRunProviderHandle>,
+    #[serde(default)]
+    pub lifecycle: RunLifecycleRecord,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
 }
@@ -187,10 +194,12 @@ pub fn submit_plan(
         tasks: plan.tasks.iter().map(queued_task).collect(),
         artifact_refs: Vec::new(),
         provider_handles: Vec::new(),
+        lifecycle: lifecycle_for_submitted_plan(plan),
         metadata: json!({
             "task_count": plan.tasks.len(),
             "max_concurrency": plan.options.max_concurrency,
             "provider_run_ids": [],
+            "lifecycle_schema": RUN_LIFECYCLE_RECORD_SCHEMA,
             "note": "submitted tasks are durable; provider run ids are recorded after an executor returns them as generic artifacts or evidence refs"
         }),
     };
@@ -247,6 +256,8 @@ pub fn mark_running(run_id: &str) -> Result<AgentTaskRunRecord> {
     let reclaimed_stale = record.state == AgentTaskRunState::Running;
     record.state = AgentTaskRunState::Running;
     record.updated_at = Some(now_timestamp());
+    update_lifecycle_execution(&mut record, AgentTaskRunState::Running);
+    update_lifecycle_heartbeat(&mut record);
     for task in &mut record.tasks {
         if task.state == AgentTaskState::Queued {
             task.state = AgentTaskState::Running;
@@ -330,6 +341,7 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
     let was_stale_running = record.state == AgentTaskRunState::Running;
     record.state = AgentTaskRunState::Cancelled;
     record.updated_at = Some(cancelled_at.clone());
+    update_lifecycle_execution(&mut record, AgentTaskRunState::Cancelled);
     for task in &mut record.tasks {
         if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
             task.state = AgentTaskState::Cancelled;
@@ -786,6 +798,7 @@ fn apply_aggregate_to_record(
     record.tasks = tasks_for_aggregate(plan, aggregate);
     record.artifact_refs = artifact_refs_for_outcomes(&aggregate.outcomes);
     record.provider_handles = provider_handles_for_outcomes(&aggregate.outcomes);
+    update_lifecycle_from_record(record, plan);
     let provider_run_ids: Vec<String> = record
         .provider_handles
         .iter()
@@ -875,6 +888,7 @@ pub fn cancel(run_id: &str) -> Result<AgentTaskRunRecord> {
 
     record.state = AgentTaskRunState::Cancelled;
     record.updated_at = Some(now_timestamp());
+    update_lifecycle_execution(&mut record, AgentTaskRunState::Cancelled);
     for task in &mut record.tasks {
         if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
             task.state = AgentTaskState::Cancelled;
@@ -1307,6 +1321,136 @@ fn run_state_for_aggregate(aggregate: &AgentTaskAggregate) -> AgentTaskRunState 
         crate::core::agent_task_scheduler::AgentTaskAggregateStatus::Cancelled => {
             AgentTaskRunState::Cancelled
         }
+    }
+}
+
+fn lifecycle_for_submitted_plan(plan: &AgentTaskPlan) -> RunLifecycleRecord {
+    let timestamp = now_timestamp();
+    let mut lifecycle = RunLifecycleRecord::with_execution_state(RunExecutionState::Queued);
+    lifecycle.updated_at = Some(timestamp.clone());
+    lifecycle.execution.updated_at = Some(timestamp.clone());
+    lifecycle.cleanup = cleanup_lifecycle_for_plan(plan, Some(timestamp.clone()));
+    lifecycle.artifact_retention = ArtifactRetentionLifecycle {
+        status: ArtifactRetentionStatus::Pending,
+        policy: Some("retain".to_string()),
+        updated_at: Some(timestamp),
+    };
+    lifecycle
+}
+
+fn update_lifecycle_execution(record: &mut AgentTaskRunRecord, state: AgentTaskRunState) {
+    let timestamp = record.updated_at.clone().unwrap_or_else(now_timestamp);
+    record.lifecycle.execution.state = execution_state_for_run_state(state);
+    record.lifecycle.execution.updated_at = Some(timestamp.clone());
+    if state == AgentTaskRunState::Running && record.lifecycle.execution.started_at.is_none() {
+        record.lifecycle.execution.started_at = Some(timestamp.clone());
+    }
+    if matches!(
+        state,
+        AgentTaskRunState::Succeeded
+            | AgentTaskRunState::PartialFailure
+            | AgentTaskRunState::Failed
+            | AgentTaskRunState::Cancelled
+    ) {
+        record.lifecycle.execution.finished_at = Some(timestamp.clone());
+    }
+    record.lifecycle.updated_at = Some(timestamp);
+}
+
+fn update_lifecycle_heartbeat(record: &mut AgentTaskRunRecord) {
+    let timestamp = record.updated_at.clone().unwrap_or_else(now_timestamp);
+    record.lifecycle.heartbeat = Some(RunHeartbeat {
+        last_seen_at: timestamp,
+        owner_pid: record.owner_pid().or_else(|| Some(std::process::id())),
+        stale_after_seconds: None,
+    });
+}
+
+fn update_lifecycle_from_record(record: &mut AgentTaskRunRecord, plan: &AgentTaskPlan) {
+    update_lifecycle_execution(record, record.state);
+    record.lifecycle.cleanup = cleanup_lifecycle_for_plan(plan, record.updated_at.clone());
+    record.lifecycle.provider_runtime = record
+        .provider_handles
+        .iter()
+        .map(provider_runtime_for_handle)
+        .collect();
+    record.lifecycle.external_runtime_ids = record
+        .lifecycle
+        .provider_runtime
+        .iter()
+        .flat_map(|runtime| runtime.external_runtime_ids.clone())
+        .collect();
+    record.lifecycle.artifact_retention = ArtifactRetentionLifecycle {
+        status: if record.artifact_refs.is_empty() {
+            ArtifactRetentionStatus::NotApplicable
+        } else {
+            ArtifactRetentionStatus::Retained
+        },
+        policy: Some("retain".to_string()),
+        updated_at: record.updated_at.clone(),
+    };
+}
+
+fn cleanup_lifecycle_for_plan(
+    plan: &AgentTaskPlan,
+    updated_at: Option<String>,
+) -> CleanupLifecycle {
+    let policies: Vec<String> = plan
+        .tasks
+        .iter()
+        .filter_map(|task| task.workspace.cleanup.clone())
+        .collect();
+    let preserved = policies.iter().any(|policy| policy == "preserve");
+    CleanupLifecycle {
+        state: if preserved {
+            CleanupState::Preserved
+        } else if policies.is_empty() {
+            CleanupState::Unknown
+        } else {
+            CleanupState::Pending
+        },
+        policy: (!policies.is_empty()).then(|| policies.join(",")),
+        updated_at,
+    }
+}
+
+fn provider_runtime_for_handle(handle: &AgentTaskRunProviderHandle) -> ProviderRuntimeLifecycle {
+    ProviderRuntimeLifecycle {
+        task_id: handle.task_id.clone(),
+        backend: handle.backend.clone(),
+        state: provider_runtime_state_for_task_state(handle.state),
+        stream_uri: handle.stream_uri.clone(),
+        external_runtime_ids: vec![ExternalRuntimeId {
+            kind: "provider_run_id".to_string(),
+            value: handle.provider_run_id.clone(),
+            provider: Some(handle.backend.clone()),
+            url: handle.stream_uri.clone(),
+        }],
+        metadata: handle.metadata.clone(),
+    }
+}
+
+fn execution_state_for_run_state(state: AgentTaskRunState) -> RunExecutionState {
+    match state {
+        AgentTaskRunState::Queued => RunExecutionState::Queued,
+        AgentTaskRunState::Running => RunExecutionState::Running,
+        AgentTaskRunState::Succeeded => RunExecutionState::Succeeded,
+        AgentTaskRunState::PartialFailure => RunExecutionState::PartialFailure,
+        AgentTaskRunState::Failed => RunExecutionState::Failed,
+        AgentTaskRunState::Cancelled => RunExecutionState::Cancelled,
+    }
+}
+
+fn provider_runtime_state_for_task_state(state: Option<AgentTaskState>) -> ProviderRuntimeState {
+    match state {
+        None | Some(AgentTaskState::Queued | AgentTaskState::Blocked | AgentTaskState::Skipped) => {
+            ProviderRuntimeState::NotStarted
+        }
+        Some(AgentTaskState::Running) => ProviderRuntimeState::Running,
+        Some(AgentTaskState::Succeeded) => ProviderRuntimeState::Succeeded,
+        Some(AgentTaskState::Failed) => ProviderRuntimeState::Failed,
+        Some(AgentTaskState::Cancelled) => ProviderRuntimeState::Cancelled,
+        Some(AgentTaskState::TimedOut) => ProviderRuntimeState::TimedOut,
     }
 }
 
@@ -1875,8 +2019,17 @@ mod tests {
             assert_eq!(loaded_plan.plan_id, "plan-a");
             assert_eq!(running.state, AgentTaskRunState::Running);
             assert_eq!(running.tasks[0].state, AgentTaskState::Running);
+            assert_eq!(
+                running.lifecycle.execution.state,
+                RunExecutionState::Running
+            );
+            assert!(running.lifecycle.heartbeat.is_some());
             assert_eq!(completed.state, AgentTaskRunState::Succeeded);
             assert_eq!(completed.tasks[0].state, AgentTaskState::Succeeded);
+            assert_eq!(
+                completed.lifecycle.execution.state,
+                RunExecutionState::Succeeded
+            );
             assert_eq!(completed.totals, Some(aggregate.totals.clone()));
             assert_eq!(durable_status.state, AgentTaskRunState::Succeeded);
             assert_eq!(durable_status.tasks[0].state, AgentTaskState::Succeeded);
@@ -1925,6 +2078,18 @@ mod tests {
             assert_eq!(
                 record.metadata["provider_run_ids"],
                 json!(["provider-run-123"])
+            );
+            assert_eq!(
+                record.lifecycle.provider_runtime[0].state,
+                ProviderRuntimeState::Succeeded
+            );
+            assert_eq!(
+                record.lifecycle.external_runtime_ids[0].value,
+                "provider-run-123"
+            );
+            assert_eq!(
+                record.lifecycle.artifact_retention.status,
+                ArtifactRetentionStatus::NotApplicable
             );
         });
     }

--- a/src/core/agent_task_pr_body.rs
+++ b/src/core/agent_task_pr_body.rs
@@ -20,13 +20,14 @@ pub(crate) fn render_pr_body(
     changed_files: &[String],
 ) -> String {
     format!(
-        "## Summary\n- Finalized Homeboy agent-task cook run `{}` into review-ready branch `{}`.\n\n## Proof provenance\n{}\n\n## Source refs\n{}\n\n{}{}## Attempt summary\n{}\n\n## Gate results\n{}\n\n## Verification capability\n{}\n\n## CI-equivalent coverage\n{}\n\n## Changed files\n{}\n\n## Artifact refs\n{}\n\n{}## Final status\n- **Status:** review-ready\n- **Base:** `{}`\n- **Head:** `{}`\n- **Merge/deploy:** not performed\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** {}\n- **Model:** {}\n- **Used for:** {}\n",
+        "## Summary\n- Finalized Homeboy agent-task cook run `{}` into review-ready branch `{}`.\n\n## Proof provenance\n{}\n\n## Source refs\n{}\n\n{}{}{}## Attempt summary\n{}\n\n## Gate results\n{}\n\n## Verification capability\n{}\n\n## CI-equivalent coverage\n{}\n\n## Changed files\n{}\n\n## Artifact refs\n{}\n\n{}## Final status\n- **Status:** review-ready\n- **Base:** `{}`\n- **Head:** `{}`\n- **Merge/deploy:** not performed\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** {}\n- **Model:** {}\n- **Used for:** {}\n",
         options.run_id,
         head,
         proof_provenance(proof),
         bullets(&options.evidence.source_refs),
         source_relationship_section(options),
         runtime_guardrails_section(options),
+        lifecycle_section(options),
         options.evidence.attempt_summary,
         gate_bullets(&proof.gates),
         verification_bullets(options),
@@ -44,6 +45,37 @@ pub(crate) fn render_pr_body(
             .unwrap_or(AI_MODEL_NOT_RECORDED),
         options.ai_used_for
     )
+}
+
+fn lifecycle_section(options: &AgentTaskPrFinalizationOptions) -> String {
+    let Some(lifecycle) = options.evidence.lifecycle.as_ref() else {
+        return String::new();
+    };
+
+    format!(
+        "## Run lifecycle\n- **Execution state:** `{:?}`\n- **Provider runtime state:** `{:?}`\n- **External runtime IDs:** {}\n- **Artifact retention:** `{:?}`\n- **Cleanup:** `{:?}`\n- **Finalization:** `{:?}`\n\n",
+        lifecycle.execution.state,
+        lifecycle.provider_runtime_state(),
+        lifecycle_runtime_ids(lifecycle),
+        lifecycle.artifact_retention.status,
+        lifecycle.cleanup.state,
+        lifecycle.finalization.state,
+    )
+}
+
+fn lifecycle_runtime_ids(
+    lifecycle: &crate::core::run_lifecycle_record::RunLifecycleRecord,
+) -> String {
+    if lifecycle.external_runtime_ids.is_empty() {
+        return NONE_RECORDED.to_string();
+    }
+
+    lifecycle
+        .external_runtime_ids
+        .iter()
+        .map(|id| format!("{}:{}", id.kind, id.value))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn proof_provenance(proof: &HomeboyProof) -> String {

--- a/src/core/agent_task_service.rs
+++ b/src/core/agent_task_service.rs
@@ -742,6 +742,9 @@ fn finalize_loop_pr(
                 manual_reviewer_check: None,
             },
             runtime_guardrails: AgentTaskPrRuntimeGuardrails::default(),
+            lifecycle: crate::core::agent_task_lifecycle::status(loop_id)
+                .ok()
+                .map(|record| record.lifecycle),
         },
         ai_used_for: options.ai_used_for.clone(),
         protected_branches: options.protected_branches.clone(),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -86,6 +86,7 @@ pub mod redaction;
 pub mod refactor;
 pub mod release;
 pub mod rig;
+pub mod run_lifecycle_record;
 pub mod runner;
 pub mod scope;
 pub mod self_status;

--- a/src/core/run_lifecycle_record.rs
+++ b/src/core/run_lifecycle_record.rs
@@ -1,0 +1,294 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const RUN_LIFECYCLE_RECORD_SCHEMA: &str = "homeboy/run-lifecycle-record/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunLifecycleRecord {
+    #[serde(default = "record_schema")]
+    pub schema: String,
+    pub execution: RunExecutionLifecycle,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provider_runtime: Vec<ProviderRuntimeLifecycle>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub heartbeat: Option<RunHeartbeat>,
+    #[serde(default)]
+    pub cleanup: CleanupLifecycle,
+    #[serde(default)]
+    pub finalization: FinalizationLifecycle,
+    #[serde(default)]
+    pub artifact_retention: ArtifactRetentionLifecycle,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub external_runtime_ids: Vec<ExternalRuntimeId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+impl Default for RunLifecycleRecord {
+    fn default() -> Self {
+        Self {
+            schema: record_schema(),
+            execution: RunExecutionLifecycle::default(),
+            provider_runtime: Vec::new(),
+            heartbeat: None,
+            cleanup: CleanupLifecycle::default(),
+            finalization: FinalizationLifecycle::default(),
+            artifact_retention: ArtifactRetentionLifecycle::default(),
+            external_runtime_ids: Vec::new(),
+            updated_at: None,
+        }
+    }
+}
+
+impl RunLifecycleRecord {
+    pub fn with_execution_state(state: RunExecutionState) -> Self {
+        Self {
+            execution: RunExecutionLifecycle {
+                state,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    pub fn provider_runtime_state(&self) -> ProviderRuntimeState {
+        let mut states = self.provider_runtime.iter().map(|runtime| runtime.state);
+        let Some(first) = states.next() else {
+            return ProviderRuntimeState::NotStarted;
+        };
+        if states.all(|state| state == first) {
+            first
+        } else {
+            ProviderRuntimeState::Mixed
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunExecutionLifecycle {
+    pub state: RunExecutionState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+impl Default for RunExecutionLifecycle {
+    fn default() -> Self {
+        Self {
+            state: RunExecutionState::Unknown,
+            started_at: None,
+            finished_at: None,
+            updated_at: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunExecutionState {
+    Unknown,
+    Queued,
+    Running,
+    Succeeded,
+    PartialFailure,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderRuntimeLifecycle {
+    pub task_id: String,
+    pub backend: String,
+    pub state: ProviderRuntimeState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_uri: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub external_runtime_ids: Vec<ExternalRuntimeId>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderRuntimeState {
+    Unknown,
+    NotStarted,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+    TimedOut,
+    Mixed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExternalRuntimeId {
+    pub kind: String,
+    pub value: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunHeartbeat {
+    pub last_seen_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stale_after_seconds: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CleanupLifecycle {
+    pub state: CleanupState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+impl Default for CleanupLifecycle {
+    fn default() -> Self {
+        Self {
+            state: CleanupState::Unknown,
+            policy: None,
+            updated_at: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CleanupState {
+    Unknown,
+    NotRequired,
+    Pending,
+    Running,
+    Succeeded,
+    Failed,
+    Preserved,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FinalizationLifecycle {
+    pub state: FinalizationState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+impl Default for FinalizationLifecycle {
+    fn default() -> Self {
+        Self {
+            state: FinalizationState::NotRequested,
+            updated_at: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FinalizationState {
+    NotRequested,
+    Pending,
+    Running,
+    Succeeded,
+    Failed,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactRetentionLifecycle {
+    pub status: ArtifactRetentionStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+impl Default for ArtifactRetentionLifecycle {
+    fn default() -> Self {
+        Self {
+            status: ArtifactRetentionStatus::Unknown,
+            policy: None,
+            updated_at: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactRetentionStatus {
+    Unknown,
+    NotApplicable,
+    Pending,
+    Retained,
+    Expired,
+    Deleted,
+    Failed,
+}
+
+fn record_schema() -> String {
+    RUN_LIFECYCLE_RECORD_SCHEMA.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_record_serializes_typed_runtime_state() {
+        let record = RunLifecycleRecord {
+            execution: RunExecutionLifecycle {
+                state: RunExecutionState::Running,
+                started_at: Some("2026-06-16T00:00:00Z".to_string()),
+                finished_at: None,
+                updated_at: Some("2026-06-16T00:00:05Z".to_string()),
+            },
+            provider_runtime: vec![ProviderRuntimeLifecycle {
+                task_id: "task-a".to_string(),
+                backend: "codebox".to_string(),
+                state: ProviderRuntimeState::Running,
+                stream_uri: Some("provider://runs/provider-run-123/events".to_string()),
+                external_runtime_ids: vec![ExternalRuntimeId {
+                    kind: "provider_run_id".to_string(),
+                    value: "provider-run-123".to_string(),
+                    provider: Some("codebox".to_string()),
+                    url: None,
+                }],
+                metadata: Value::Null,
+            }],
+            heartbeat: Some(RunHeartbeat {
+                last_seen_at: "2026-06-16T00:00:05Z".to_string(),
+                owner_pid: Some(42),
+                stale_after_seconds: Some(300),
+            }),
+            artifact_retention: ArtifactRetentionLifecycle {
+                status: ArtifactRetentionStatus::Pending,
+                policy: Some("retain".to_string()),
+                updated_at: Some("2026-06-16T00:00:05Z".to_string()),
+            },
+            ..RunLifecycleRecord::default()
+        };
+
+        let json = serde_json::to_value(&record).expect("serialize lifecycle record");
+
+        assert_eq!(json["schema"], RUN_LIFECYCLE_RECORD_SCHEMA);
+        assert_eq!(json["execution"]["state"], "running");
+        assert_eq!(json["provider_runtime"][0]["state"], "running");
+        assert_eq!(
+            json["provider_runtime"][0]["external_runtime_ids"][0]["value"],
+            "provider-run-123"
+        );
+        assert_eq!(json["heartbeat"]["owner_pid"], 42);
+        assert_eq!(json["artifact_retention"]["status"], "pending");
+
+        let round_trip: RunLifecycleRecord =
+            serde_json::from_value(json).expect("deserialize lifecycle record");
+        assert_eq!(round_trip, record);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a generic typed `RunLifecycleRecord` primitive for execution state, provider runtime state, heartbeat, cleanup/finalization state, artifact retention, and external runtime IDs.
- Populate the lifecycle record additively from agent-task durable run records, provider handles, cancellations, and aggregate reconciliation.
- Surface lifecycle evidence in agent-task PR body rendering when available.

## Verification
- `cargo test lifecycle --lib`
- `cargo check`

## Follow-ups
- Wire provider-specific live heartbeat intervals/staleness thresholds when async providers expose that contract.
- Extend cleanup/finalization transitions as those workflows emit first-class lifecycle events.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Model:** GPT-5.5
- **Used for:** Drafted implementation, tests, verification, and PR description; Chris reviews and owns the change.
