### PR TITLE
Add SecretEnvPlan primitive

### DIFF
--- a/src/core/agent_task_secrets.rs
+++ b/src/core/agent_task_secrets.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use crate::core::defaults::{self, AgentTaskSecretSource};
 use crate::core::keychain;
 use crate::core::paths;
+use crate::core::secret_env_plan::SecretEnvPlan;
 use crate::core::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -29,8 +30,18 @@ pub fn resolve_secret_env(
     resolve_secret_env_with_config(names, &AgentTaskSecretConfig::load())
 }
 
+pub fn resolve_secret_env_plan(
+    plan: &SecretEnvPlan,
+) -> Result<Vec<(String, String)>, AgentTaskSecretResolutionError> {
+    resolve_secret_env(&plan.secret_env_names())
+}
+
 pub fn secret_env_status(names: &[String]) -> Vec<AgentTaskSecretEnvStatus> {
     secret_env_status_with_config(names, &AgentTaskSecretConfig::load())
+}
+
+pub fn secret_env_plan_status(plan: &SecretEnvPlan) -> Vec<AgentTaskSecretEnvStatus> {
+    secret_env_status(&plan.secret_env_names())
 }
 
 pub fn map_secret_to_env(

--- a/src/core/agent_task_service.rs
+++ b/src/core/agent_task_service.rs
@@ -21,6 +21,7 @@ use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskScheduler, AgentTaskState,
 };
 use crate::core::agent_task_secrets::validate_secret_env;
+use crate::core::secret_env_plan::SecretEnvPlan;
 use crate::core::{config, Error, Result};
 
 #[derive(Debug, Clone)]
@@ -620,16 +621,13 @@ fn prepare_plan_for_execution(plan: &mut AgentTaskPlan) -> Result<()> {
 }
 
 fn preflight_plan_secret_env(plan: &AgentTaskPlan) -> Result<()> {
-    let mut names = Vec::new();
-    for task in &plan.tasks {
-        for name in &task.executor.secret_env {
-            if !names.contains(name) {
-                names.push(name.clone());
-            }
-        }
-    }
+    let secret_env_plan = SecretEnvPlan::from_secret_env_names(
+        plan.tasks
+            .iter()
+            .flat_map(|task| task.executor.secret_env.iter().cloned()),
+    );
 
-    validate_secret_env(&names).map_err(|error| {
+    validate_secret_env(&secret_env_plan.secret_env_names()).map_err(|error| {
         Error::validation_invalid_argument(
             "secret_env",
             error.message,

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -94,7 +94,13 @@ pub use super::agent_task_loop_controller::{
 };
 
 // Secret-env status type is referenced from review/dispatch commands.
-pub use super::agent_task_secrets::{secret_env_status, AgentTaskSecretEnvStatus};
+pub use super::agent_task_secrets::{
+    resolve_secret_env_plan, secret_env_plan_status, secret_env_status, AgentTaskSecretEnvStatus,
+};
+pub use super::secret_env_plan::{
+    SecretEnvCredentialSource, SecretEnvPlan, SecretEnvProviderCredentialMapping,
+    SecretEnvRedactionPolicy, SECRET_ENV_PLAN_SCHEMA,
+};
 
 // Provider helpers used directly from the facade root for common callers.
 pub use super::agent_task_provider::required_extension_ids_for_plan;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -88,6 +88,7 @@ pub mod release;
 pub mod rig;
 pub mod runner;
 pub mod scope;
+pub mod secret_env_plan;
 pub mod self_status;
 pub mod server;
 pub mod source_snapshot;

--- a/src/core/secret_env_plan.rs
+++ b/src/core/secret_env_plan.rs
@@ -1,0 +1,250 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::redaction::RedactionPolicy;
+
+pub const SECRET_ENV_PLAN_SCHEMA: &str = "homeboy/secret-env-plan/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecretEnvPlan {
+    #[serde(default = "secret_env_plan_schema")]
+    pub schema: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub public_env: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secret_env_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub provider_credentials: BTreeMap<String, SecretEnvProviderCredentialMapping>,
+    #[serde(default, skip_serializing_if = "SecretEnvRedactionPolicy::is_default")]
+    pub redaction: SecretEnvRedactionPolicy,
+}
+
+impl Default for SecretEnvPlan {
+    fn default() -> Self {
+        Self {
+            schema: SECRET_ENV_PLAN_SCHEMA.to_string(),
+            public_env: BTreeMap::new(),
+            secret_env_names: Vec::new(),
+            provider_credentials: BTreeMap::new(),
+            redaction: SecretEnvRedactionPolicy::default(),
+        }
+    }
+}
+
+impl SecretEnvPlan {
+    pub fn from_secret_env_names(names: impl IntoIterator<Item = String>) -> Self {
+        let mut plan = Self::default();
+        plan.secret_env_names = normalize_names(names);
+        plan
+    }
+
+    pub fn secret_env_names(&self) -> Vec<String> {
+        let mapped_names = self
+            .provider_credentials
+            .values()
+            .flat_map(|mapping| mapping.secret_env.iter().cloned());
+        normalize_names(self.secret_env_names.iter().cloned().chain(mapped_names))
+    }
+
+    pub fn materialize(
+        &self,
+        secret_values: impl IntoIterator<Item = (String, String)>,
+    ) -> BTreeMap<String, String> {
+        let mut env = self.public_env.clone();
+        for (name, value) in secret_values {
+            env.insert(name, value);
+        }
+        env
+    }
+
+    pub fn redacted_env(&self) -> BTreeMap<String, String> {
+        let policy = self.redaction.to_policy();
+        let mut env = self
+            .public_env
+            .iter()
+            .map(|(name, value)| (name.clone(), redact_env_value(&policy, value)))
+            .collect::<BTreeMap<_, _>>();
+        for name in self.secret_env_names() {
+            env.insert(name, self.redaction.replacement.clone());
+        }
+        env
+    }
+
+    pub fn redacted(&self) -> Self {
+        let policy = self.redaction.to_policy();
+        let mut redacted = self.clone();
+        redacted.public_env = self
+            .public_env
+            .iter()
+            .map(|(name, value)| (name.clone(), redact_env_value(&policy, value)))
+            .collect();
+        redacted
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecretEnvProviderCredentialMapping {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secret_env: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub sources: BTreeMap<String, SecretEnvCredentialSource>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecretEnvCredentialSource {
+    #[serde(default = "default_secret_env_source")]
+    pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env_var: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecretEnvRedactionPolicy {
+    #[serde(default = "default_replacement")]
+    pub replacement: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sensitive_env_names: Vec<String>,
+}
+
+impl Default for SecretEnvRedactionPolicy {
+    fn default() -> Self {
+        Self {
+            replacement: default_replacement(),
+            sensitive_env_names: Vec::new(),
+        }
+    }
+}
+
+impl SecretEnvRedactionPolicy {
+    fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
+    fn to_policy(&self) -> RedactionPolicy {
+        self.sensitive_env_names.iter().fold(
+            RedactionPolicy::default().with_replacement(self.replacement.clone()),
+            |policy, name| policy.with_sensitive_key(name),
+        )
+    }
+}
+
+fn normalize_names(names: impl IntoIterator<Item = String>) -> Vec<String> {
+    names
+        .into_iter()
+        .filter(|name| !name.is_empty())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn redact_env_value(policy: &RedactionPolicy, value: &str) -> String {
+    if value.contains("://") || value.starts_with('/') && value.contains('?') {
+        policy.redact_url(value)
+    } else {
+        policy.redact_string(value)
+    }
+}
+
+fn secret_env_plan_schema() -> String {
+    SECRET_ENV_PLAN_SCHEMA.to_string()
+}
+
+fn default_secret_env_source() -> String {
+    "env".to_string()
+}
+
+fn default_replacement() -> String {
+    "[REDACTED]".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secret_env_plan_materializes_public_and_secret_values() {
+        let plan = SecretEnvPlan {
+            public_env: BTreeMap::from([("PUBLIC_FLAG".to_string(), "1".to_string())]),
+            secret_env_names: vec!["API_TOKEN".to_string()],
+            ..SecretEnvPlan::default()
+        };
+
+        let env = plan.materialize([("API_TOKEN".to_string(), "secret-value".to_string())]);
+
+        assert_eq!(env.get("PUBLIC_FLAG"), Some(&"1".to_string()));
+        assert_eq!(env.get("API_TOKEN"), Some(&"secret-value".to_string()));
+    }
+
+    #[test]
+    fn secret_env_plan_redacts_secret_values_without_storing_them() {
+        let mut provider_credentials = BTreeMap::new();
+        provider_credentials.insert(
+            "codex".to_string(),
+            SecretEnvProviderCredentialMapping {
+                secret_env: vec!["CODEX_REFRESH_TOKEN".to_string()],
+                sources: BTreeMap::from([(
+                    "CODEX_REFRESH_TOKEN".to_string(),
+                    SecretEnvCredentialSource {
+                        source: "keychain-bundle".to_string(),
+                        scope: Some("agent-task".to_string()),
+                        name: Some("codex-oauth".to_string()),
+                        field: Some("refresh_token".to_string()),
+                        env_var: None,
+                    },
+                )]),
+            },
+        );
+        let plan = SecretEnvPlan {
+            public_env: BTreeMap::from([(
+                "PUBLIC_ENDPOINT".to_string(),
+                "https://example.test/?token=abc&ok=1".to_string(),
+            )]),
+            provider_credentials,
+            ..SecretEnvPlan::default()
+        };
+
+        let serialized = serde_json::to_string(&plan).expect("plan json");
+        let redacted = plan.redacted_env();
+
+        assert!(!serialized.contains("secret-value"));
+        assert_eq!(
+            redacted.get("PUBLIC_ENDPOINT"),
+            Some(&"https://example.test/?token=[REDACTED]&ok=1".to_string())
+        );
+        assert_eq!(
+            redacted.get("CODEX_REFRESH_TOKEN"),
+            Some(&"[REDACTED]".to_string())
+        );
+    }
+
+    #[test]
+    fn secret_env_plan_deduplicates_direct_and_provider_secret_names() {
+        let plan = SecretEnvPlan {
+            secret_env_names: vec!["B_SECRET".to_string(), "A_SECRET".to_string()],
+            provider_credentials: BTreeMap::from([(
+                "provider".to_string(),
+                SecretEnvProviderCredentialMapping {
+                    secret_env: vec!["A_SECRET".to_string(), "C_SECRET".to_string()],
+                    sources: BTreeMap::new(),
+                },
+            )]),
+            ..SecretEnvPlan::default()
+        };
+
+        assert_eq!(
+            plan.secret_env_names(),
+            vec![
+                "A_SECRET".to_string(),
+                "B_SECRET".to_string(),
+                "C_SECRET".to_string()
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add a core SecretEnvPlan type for public env, secret env names, provider credential mappings, and redaction policy without storing secret values.
- Add plan-aware secret resolver/status helpers and export the primitive through the agent task facade.
- Use SecretEnvPlan in agent-task secret preflight to preserve existing behavior while deduplicating through the primitive.

## Verification
- cargo fmt
- cargo test secret_env_plan
- cargo test agent_task_secrets
- cargo test --lib (fails in unrelated existing tests: commands::golden_contract_tests::runs_command_json_contract_matches_golden_fixture, core::extension::bench::run::tests::attach_memory_timeline_adds_metrics_and_artifacts)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the SecretEnvPlan primitive, low-risk agent-task integration, tests, and verification notes for Chris to review.