### PR TITLE
Add portable evidence manifest schema

### DIFF
--- a/src/commands/golden_contract_tests.rs
+++ b/src/commands/golden_contract_tests.rs
@@ -13,7 +13,8 @@ use super::deploy::{DeployCommandOutput, DeployOutput, MultiProjectDeployOutput}
 use super::release::{BatchReleaseOutput, ReleaseCommandOutput, ReleaseOutput};
 use super::runs::{
     DriftValue, QueryGroup, QueryRow, RunsDriftFilters, RunsDriftOutput, RunsQueryFilters,
-    SkippedArtifactRow, TestRunsQueryOutput as RunsQueryOutput,
+    RunsRefsArtifactRef, RunsRefsFilters, RunsRefsOutput, RunsRefsRunRef, SkippedArtifactRow,
+    TestRunsQueryOutput as RunsQueryOutput,
 };
 use super::runs::{
     RunDetail, RunSummary, RunsArtifactsOutput, RunsListOutput, RunsOutput, RunsShowOutput,
@@ -81,6 +82,37 @@ fn runs_command_json_contract_matches_golden_fixture() {
                 scenario("runs list", RunsOutput::List(RunsListOutput {
                     command: "runs.list",
                     runs: vec![run_summary()],
+                })),
+                scenario("runs refs json", RunsOutput::Refs(RunsRefsOutput {
+                    command: "runs.refs",
+                    filters: RunsRefsFilters {
+                        component_id: Some("homeboy".to_string()),
+                        kind: Some("bench".to_string()),
+                        rig: Some("contract-rig".to_string()),
+                        status: Some("pass".to_string()),
+                        since: None,
+                        limit: 50,
+                        artifact_kinds: Vec::new(),
+                        aggregate_artifact_kinds: Vec::new(),
+                    },
+                    run_count: 1,
+                    artifact_count: 1,
+                    aggregate_artifact_count: 1,
+                    runs: vec![RunsRefsRunRef {
+                        run_id: "run-contract-1".to_string(),
+                        ref_id: "homeboy://run/run-contract-1".to_string(),
+                        kind: "bench".to_string(),
+                        status: "pass".to_string(),
+                        started_at: "2026-05-24T00:00:00Z".to_string(),
+                        finished_at: Some("2026-05-24T00:01:00Z".to_string()),
+                        component_id: Some("homeboy".to_string()),
+                        rig_id: Some("contract-rig".to_string()),
+                        git_sha: Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string()),
+                        evidence_command: "homeboy runs evidence run-contract-1".to_string(),
+                        artifacts_command: "homeboy runs artifacts run-contract-1".to_string(),
+                    }],
+                    artifacts: vec![runs_refs_artifact_record()],
+                    aggregate_artifacts: vec![runs_refs_artifact_record()],
                 })),
                 scenario("runs show", RunsOutput::Show(RunsShowOutput {
                     command: "runs.show",
@@ -361,6 +393,24 @@ fn artifact_record() -> ArtifactRecord {
         mime: Some("application/json".to_string()),
         metadata_json: serde_json::json!({}),
         created_at: "2026-05-24T00:01:00Z".to_string(),
+    }
+}
+
+fn runs_refs_artifact_record() -> RunsRefsArtifactRef {
+    RunsRefsArtifactRef {
+        run_id: "run-contract-1".to_string(),
+        artifact_id: "artifact-aggregate".to_string(),
+        ref_id: "homeboy://run/run-contract-1/artifact/artifact-aggregate".to_string(),
+        kind: "trace_aggregate".to_string(),
+        artifact_type: "file".to_string(),
+        path: "artifacts/aggregate.json".to_string(),
+        url: None,
+        mime: Some("application/json".to_string()),
+        size_bytes: Some(1234),
+        sha256: Some(
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        ),
+        get_command: "homeboy runs artifact get run-contract-1 artifact-aggregate".to_string(),
     }
 }
 

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -51,7 +51,7 @@ use latest::{RunsLatestFindingOutput, RunsLatestRunArgs, RunsLatestRunOutput};
 use loop_sync::{loop_sync, RunsLoopSyncArgs, RunsLoopSyncOutput};
 use query::{runs_query, RunsQueryArgs, RunsQueryOutput};
 use reconcile::{reconcile_runs, RunsReconcileArgs, RunsReconcileOutput};
-use refs::{runs_refs, RunsRefsArgs, RunsRefsOutput};
+use refs::{runs_refs, RunsRefsArgs};
 
 #[cfg(test)]
 pub(crate) use common::SkippedArtifactRow;
@@ -61,6 +61,11 @@ pub(crate) use drift::{DriftValue, RunsDriftFilters};
 #[cfg(test)]
 pub(crate) use query::{
     QueryGroup, QueryRow, RunsQueryFilters, RunsQueryOutput as TestRunsQueryOutput,
+};
+pub(crate) use refs::RunsRefsOutput;
+#[cfg(test)]
+pub(crate) use refs::{
+    ArtifactRef as RunsRefsArtifactRef, RunRef as RunsRefsRunRef, RunsRefsFilters,
 };
 
 const DEFAULT_LIMIT: i64 = 20;

--- a/src/commands/runs/evidence.rs
+++ b/src/commands/runs/evidence.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use homeboy::core::artifact_ref::{ArtifactRef, EvidenceRef};
+use homeboy::core::evidence_manifest::{EvidenceManifest, EVIDENCE_MANIFEST_SCHEMA};
 use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore, RunRecord};
 use serde::Serialize;
 use serde_json::Value;
@@ -21,6 +22,10 @@ pub struct RunsEvidenceOutput {
     pub failure: RunsEvidenceFailureSummary,
     pub disk_budget: RunsEvidenceDiskBudget,
     pub evidence_links: Vec<RunsEvidenceLink>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_manifest: Option<EvidenceManifest>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub evidence_manifest_errors: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -117,6 +122,7 @@ pub fn evidence(run_id: &str) -> CmdResult<RunsOutput> {
     let metadata = evidence_metadata(&run.metadata_json);
     let failure = evidence_failure_summary(&run);
     let links = evidence_links(&artifacts);
+    let (evidence_manifest, evidence_manifest_errors) = evidence_manifest(&run, &artifacts);
 
     Ok((
         RunsOutput::Evidence(RunsEvidenceOutput {
@@ -147,6 +153,8 @@ pub fn evidence(run_id: &str) -> CmdResult<RunsOutput> {
             failure,
             disk_budget,
             evidence_links: links,
+            evidence_manifest,
+            evidence_manifest_errors,
         }),
         0,
     ))
@@ -380,6 +388,47 @@ fn evidence_links(artifacts: &[ArtifactRecord]) -> Vec<RunsEvidenceLink> {
         .collect()
 }
 
+fn evidence_manifest(
+    run: &RunRecord,
+    artifacts: &[ArtifactRecord],
+) -> (Option<EvidenceManifest>, Vec<String>) {
+    let mut errors = Vec::new();
+    if let Some(value) = run.metadata_json.get("evidence_manifest") {
+        match EvidenceManifest::parse_value(value.clone()) {
+            Ok(manifest) => return (Some(manifest), errors),
+            Err(err) => errors.push(format!("metadata.evidence_manifest: {err}")),
+        }
+    }
+
+    for artifact in artifacts {
+        if !is_evidence_manifest_artifact(artifact) {
+            continue;
+        }
+        let value = match fs::read_to_string(&artifact.path)
+            .map_err(|err| err.to_string())
+            .and_then(|body| serde_json::from_str::<Value>(&body).map_err(|err| err.to_string()))
+        {
+            Ok(value) => value,
+            Err(err) => {
+                errors.push(format!("artifact.{}: {err}", artifact.id));
+                continue;
+            }
+        };
+        match EvidenceManifest::parse_value(value) {
+            Ok(manifest) => return (Some(manifest), errors),
+            Err(err) => errors.push(format!("artifact.{}: {err}", artifact.id)),
+        }
+    }
+
+    (None, errors)
+}
+
+fn is_evidence_manifest_artifact(artifact: &ArtifactRecord) -> bool {
+    artifact.kind == "evidence_manifest"
+        || artifact.metadata_json.get("schema").and_then(Value::as_str)
+            == Some(EVIDENCE_MANIFEST_SCHEMA)
+}
+
 #[cfg(test)]
 mod tests {
     use homeboy::core::artifact_links::PUBLIC_ARTIFACT_BASE_URL_ENV;
@@ -460,6 +509,23 @@ mod tests {
                         "error": "boom",
                         "gate_failures": ["p95_ms exceeded"],
                         "hints": ["inspect artifacts"],
+                        "evidence_manifest": {
+                            "schema": "homeboy/evidence-manifest/v1",
+                            "status": { "state": "blocked" },
+                            "interpretation": {
+                                "summary": "Evidence is blocked on reviewer confirmation.",
+                                "confidence": "medium"
+                            },
+                            "tracker_refs": [{
+                                "kind": "github_issue",
+                                "id": "Extra-Chill/homeboy#123"
+                            }],
+                            "blocking_conditions": [{
+                                "kind": "review_needed",
+                                "summary": "Maintainer review is required.",
+                                "severity": "warning"
+                            }]
+                        },
                         "scenario_metrics": [{"scenario_id":"cold","metrics":{"p95_ms":42.0}}],
                         "resource_policy": {"hot_command":"bench"}
                     }),
@@ -543,6 +609,11 @@ mod tests {
             assert_eq!(output.failure.exit_code, Some(1));
             assert_eq!(output.failure.gate_failures, vec!["p95_ms exceeded"]);
             assert_eq!(output.failure.hints, vec!["inspect artifacts"]);
+            let manifest = output.evidence_manifest.expect("evidence manifest");
+            assert_eq!(manifest.schema, "homeboy/evidence-manifest/v1");
+            assert_eq!(manifest.tracker_refs[0].id, "Extra-Chill/homeboy#123");
+            assert_eq!(manifest.blocking_conditions[0].kind, "review_needed");
+            assert!(output.evidence_manifest_errors.is_empty());
             assert!(
                 output.disk_budget.available_bytes.is_some()
                     || output.disk_budget.warning.is_some()

--- a/src/core/evidence_manifest.rs
+++ b/src/core/evidence_manifest.rs
@@ -1,0 +1,257 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::core::artifact_ref::ArtifactRef;
+
+pub const EVIDENCE_MANIFEST_SCHEMA: &str = "homeboy/evidence-manifest/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvidenceManifest {
+    pub schema: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub status: EvidenceManifestStatus,
+    pub interpretation: EvidenceManifestInterpretation,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tracker_refs: Vec<TrackerRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pr_refs: Vec<PullRequestRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub run_refs: Vec<RunRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_refs: Vec<ArtifactRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blocking_conditions: Vec<BlockingCondition>,
+}
+
+impl EvidenceManifest {
+    pub fn parse_value(value: Value) -> Result<Self, String> {
+        let manifest: Self = serde_json::from_value(value).map_err(|err| err.to_string())?;
+        if manifest.schema != EVIDENCE_MANIFEST_SCHEMA {
+            return Err(format!(
+                "evidence manifest schema must be {EVIDENCE_MANIFEST_SCHEMA}"
+            ));
+        }
+        Ok(manifest)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvidenceManifestStatus {
+    pub state: EvidenceManifestState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceManifestState {
+    Pending,
+    Passed,
+    Failed,
+    Blocked,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvidenceManifestInterpretation {
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<EvidenceConfidence>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceConfidence {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrackerRef {
+    pub kind: String,
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PullRequestRef {
+    pub repo: String,
+    pub number: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunRef {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub component_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rig_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BlockingCondition {
+    pub kind: String,
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub severity: Option<BlockingSeverity>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockingSeverity {
+    Info,
+    Warning,
+    Critical,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn evidence_manifest_parses_portable_refs_status_and_blockers() {
+        let manifest = EvidenceManifest::parse_value(json!({
+            "schema": "homeboy/evidence-manifest/v1",
+            "id": "manifest-1",
+            "title": "Site editor preload proof",
+            "status": {
+                "state": "blocked",
+                "label": "Needs maintainer decision",
+                "updated_at": "2026-06-17T00:00:00Z"
+            },
+            "interpretation": {
+                "summary": "Candidate reduces REST preloads but one scenario regressed.",
+                "confidence": "medium",
+                "notes": ["Review full matrix before merge."]
+            },
+            "tracker_refs": [{
+                "kind": "github_issue",
+                "id": "Extra-Chill/homeboy#123",
+                "url": "https://github.com/Extra-Chill/homeboy/issues/123",
+                "state": "open"
+            }],
+            "pr_refs": [{
+                "repo": "Extra-Chill/homeboy",
+                "number": 456,
+                "url": "https://github.com/Extra-Chill/homeboy/pull/456",
+                "head_ref": "feature/proof",
+                "base_ref": "main"
+            }],
+            "run_refs": [{
+                "id": "run-1",
+                "kind": "bench",
+                "component_id": "homeboy",
+                "rig_id": "studio"
+            }],
+            "artifact_refs": [{
+                "schema": "homeboy/artifact-ref/v1",
+                "id": "artifact-1",
+                "run_id": "run-1",
+                "kind": "summary",
+                "type": "file",
+                "path": "summary.json"
+            }],
+            "blocking_conditions": [{
+                "kind": "coverage_gap",
+                "summary": "Missing mobile scenario.",
+                "severity": "warning",
+                "refs": ["run-1"]
+            }]
+        }))
+        .expect("manifest");
+
+        assert_eq!(manifest.schema, EVIDENCE_MANIFEST_SCHEMA);
+        assert_eq!(manifest.status.state, EvidenceManifestState::Blocked);
+        assert_eq!(
+            manifest.interpretation.confidence,
+            Some(EvidenceConfidence::Medium)
+        );
+        assert_eq!(manifest.tracker_refs[0].id, "Extra-Chill/homeboy#123");
+        assert_eq!(manifest.pr_refs[0].number, 456);
+        assert_eq!(manifest.run_refs[0].id, "run-1");
+        assert_eq!(manifest.artifact_refs[0].artifact_type, "file");
+        assert_eq!(
+            manifest.blocking_conditions[0].severity,
+            Some(BlockingSeverity::Warning)
+        );
+    }
+
+    #[test]
+    fn evidence_manifest_serializes_without_empty_optional_collections() {
+        let manifest = EvidenceManifest {
+            schema: EVIDENCE_MANIFEST_SCHEMA.to_string(),
+            id: None,
+            title: None,
+            status: EvidenceManifestStatus {
+                state: EvidenceManifestState::Passed,
+                label: None,
+                updated_at: None,
+            },
+            interpretation: EvidenceManifestInterpretation {
+                summary: "Evidence supports merge.".to_string(),
+                confidence: Some(EvidenceConfidence::High),
+                notes: Vec::new(),
+            },
+            tracker_refs: Vec::new(),
+            pr_refs: Vec::new(),
+            run_refs: Vec::new(),
+            artifact_refs: Vec::new(),
+            blocking_conditions: Vec::new(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(&manifest).expect("manifest json"),
+            json!({
+                "schema": "homeboy/evidence-manifest/v1",
+                "status": { "state": "passed" },
+                "interpretation": {
+                    "summary": "Evidence supports merge.",
+                    "confidence": "high"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn evidence_manifest_rejects_unknown_schema() {
+        let err = EvidenceManifest::parse_value(json!({
+            "schema": "example/manifest/v1",
+            "status": { "state": "unknown" },
+            "interpretation": { "summary": "Unknown schema." }
+        }))
+        .expect_err("schema error");
+
+        assert!(err.contains(EVIDENCE_MANIFEST_SCHEMA));
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -52,6 +52,7 @@ pub mod deploy;
 pub mod deps;
 pub mod engine;
 pub mod error;
+pub mod evidence_manifest;
 pub mod execution;
 pub mod execution_contract;
 pub(crate) mod expand;


### PR DESCRIPTION
## Summary
- Add `homeboy/evidence-manifest/v1` data types for tracker refs, PR refs, run refs, artifact refs, status, interpretation, and blocking conditions.
- Surface parsed evidence manifests from `runs evidence` when present in run metadata or an `evidence_manifest` artifact, keeping the output additive for runs without manifests.
- Restore the existing `runs refs json` golden contract scenario generator so the checked-in fixture is exercised.

## Verification
- `cargo fmt`
- `cargo test evidence_manifest`
- `cargo test evidence_command_reports_registry_artifacts_retention_and_failure_summary`
- `cargo test evidence_failure_summary_does_not_mark_running_run_failed`
- `cargo test runs_command_json_contract_matches_golden_fixture`
- `cargo test` currently reaches this branch's changes and then fails `tests/core_agnostic_test.rs::core_owned_source_stays_language_and_framework_agnostic` on pre-existing `src/core/runner/tool_registry.rs` ecosystem-term findings unrelated to this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the schema implementation, additive `runs evidence` hook, and tests; Chris remains responsible for review and validation.
