### PR TITLE
fix(agent-task): resolve provider credential sources

### DIFF
--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -1960,6 +1960,46 @@ mod tests {
     }
 
     #[test]
+    fn provider_default_secret_sources_accept_keychain_bundle_sources() {
+        let (mut request, mut provider) = request("task-a", "node provider-a.js".to_string());
+        request.executor.config = json!({ "provider": "claude-code" });
+        provider.provider_defaults.insert(
+            "claude-code".to_string(),
+            json!({
+                "secret_env": [
+                    "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN",
+                    "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN",
+                    "AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT"
+                ],
+                "secret_env_sources": {
+                    "AI_PROVIDER_CLAUDE_CODE_ACCESS_TOKEN": {
+                        "source": "keychain-bundle",
+                        "scope": "agent-task",
+                        "name": "claude-code-oauth",
+                        "field": "access_token"
+                    },
+                    "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN": {
+                        "source": "keychain-bundle",
+                        "scope": "agent-task",
+                        "name": "claude-code-oauth",
+                        "field": "refresh_token"
+                    }
+                }
+            }),
+        );
+
+        let sources = provider_secret_sources(&provider, Some(&request));
+
+        let refresh = sources
+            .get("AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN")
+            .expect("refresh token source is declared");
+        assert_eq!(refresh.source, "keychain-bundle");
+        assert_eq!(refresh.scope.as_deref(), Some("agent-task"));
+        assert_eq!(refresh.name.as_deref(), Some("claude-code-oauth"));
+        assert_eq!(refresh.field.as_deref(), Some("refresh_token"));
+    }
+
+    #[test]
     fn provider_workspace_materialization_declares_requires_git_requirement() {
         let (_request, mut provider) = request("task-a", "node provider-a.js".to_string());
         provider.workspace_materialization = Some(AgentTaskProviderWorkspaceMaterialization {

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -14,7 +14,9 @@ use crate::core::agent_task::{
 use crate::core::agent_task_scheduler::{
     AgentTaskExecutionContext, AgentTaskExecutorAdapter, AgentTaskPlan,
 };
-use crate::core::agent_task_secrets::{resolve_secret_env, AgentTaskSecretResolutionError};
+use crate::core::agent_task_secrets::{
+    resolve_secret_env_with_fallbacks, AgentTaskSecretResolutionError,
+};
 use crate::core::agent_task_timeout::timeout_with_grace;
 use crate::core::{agent_runtime_manifest, component, defaults, extension, Error};
 
@@ -347,6 +349,13 @@ pub fn provider_runner_secret_env_for_plan(plan: &AgentTaskPlan) -> Vec<String> 
     provider_runner_secret_env_for_plan_with_providers(plan, &providers)
 }
 
+pub fn provider_secret_sources_for_plan(
+    plan: &AgentTaskPlan,
+) -> HashMap<String, defaults::AgentTaskSecretSource> {
+    let providers = discover_agent_task_executor_providers();
+    provider_secret_sources_for_plan_with_providers(plan, &providers)
+}
+
 pub(crate) fn role_aliases_for_executor(
     backend: &str,
     selector: Option<&str>,
@@ -416,6 +425,20 @@ fn provider_runner_secret_env_for_plan_with_providers(
     names
 }
 
+fn provider_secret_sources_for_plan_with_providers(
+    plan: &AgentTaskPlan,
+    providers: &[AgentTaskExecutorProvider],
+) -> HashMap<String, defaults::AgentTaskSecretSource> {
+    let mut sources = HashMap::new();
+    for request in &plan.tasks {
+        let Some(provider) = select_provider(providers, request) else {
+            continue;
+        };
+        sources.extend(provider_secret_sources(provider, Some(request)));
+    }
+    sources
+}
+
 fn provider_secret_env(
     provider: &AgentTaskExecutorProvider,
     request: Option<&AgentTaskRequest>,
@@ -453,6 +476,80 @@ fn provider_secret_env(
     names.sort();
     names.dedup();
     names
+}
+
+fn provider_secret_sources(
+    provider: &AgentTaskExecutorProvider,
+    request: Option<&AgentTaskRequest>,
+) -> HashMap<String, defaults::AgentTaskSecretSource> {
+    let mut sources = HashMap::new();
+    for requirement in &provider.secret_env_requirements {
+        if requirement_matches_request(requirement.when.as_ref(), request) {
+            sources.extend(secret_source_map_from_extra(&requirement.extra));
+        }
+    }
+    if let Some(request) = request {
+        if let Some(provider_name) = request
+            .executor
+            .config
+            .get("provider")
+            .and_then(Value::as_str)
+        {
+            if let Some(defaults) = provider.provider_defaults.get(provider_name) {
+                sources.extend(provider_config_secret_sources(defaults));
+            }
+        }
+    }
+    sources
+}
+
+fn secret_source_map_from_extra(
+    extra: &BTreeMap<String, Value>,
+) -> HashMap<String, defaults::AgentTaskSecretSource> {
+    for key in [
+        "secret_env_sources",
+        "secretEnvSources",
+        "credential_sources",
+        "credentialSources",
+    ] {
+        if let Some(value) = extra.get(key) {
+            return secret_source_map(value);
+        }
+    }
+    HashMap::new()
+}
+
+fn provider_config_secret_sources(
+    config: &Value,
+) -> HashMap<String, defaults::AgentTaskSecretSource> {
+    let Some(config) = config.as_object() else {
+        return HashMap::new();
+    };
+    for key in [
+        "secret_env_sources",
+        "secretEnvSources",
+        "credential_sources",
+        "credentialSources",
+    ] {
+        if let Some(value) = config.get(key) {
+            return secret_source_map(value);
+        }
+    }
+    HashMap::new()
+}
+
+fn secret_source_map(value: &Value) -> HashMap<String, defaults::AgentTaskSecretSource> {
+    let Some(entries) = value.as_object() else {
+        return HashMap::new();
+    };
+    entries
+        .iter()
+        .filter_map(|(name, source)| {
+            serde_json::from_value::<defaults::AgentTaskSecretSource>(source.clone())
+                .ok()
+                .map(|source| (name.clone(), source))
+        })
+        .collect()
 }
 
 fn provider_config_secret_env(config: &Value) -> Vec<String> {
@@ -1169,7 +1266,10 @@ fn provider_command_env(
                 .unwrap_or_default(),
         ),
     ];
-    env.extend(resolve_secret_env(&request.executor.secret_env)?);
+    env.extend(resolve_secret_env_with_fallbacks(
+        &request.executor.secret_env,
+        &provider_secret_sources(provider, Some(request)),
+    )?);
     Ok(env)
 }
 
@@ -1803,6 +1903,60 @@ mod tests {
             "test",
             None
         ));
+    }
+
+    #[test]
+    fn provider_default_secret_sources_resolve_required_env_without_duplicate_mapping() {
+        crate::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let auth_path = temp.path().join("codex-auth.json");
+            fs::write(
+                &auth_path,
+                json!({
+                    "tokens": {
+                        "access_token": "provider-owned-access-token",
+                        "refresh_token": "provider-owned-refresh-token"
+                    }
+                })
+                .to_string(),
+            )
+            .expect("write auth");
+            let (mut request, mut provider) = request("task-a", "node provider-a.js".to_string());
+            request.executor.config = json!({ "provider": "codex" });
+            request.executor.secret_env = vec![
+                "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN".to_string(),
+                "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN".to_string(),
+            ];
+            provider.provider_defaults.insert(
+                "codex".to_string(),
+                json!({
+                    "secret_env": request.executor.secret_env,
+                    "secret_env_sources": {
+                        "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN": {
+                            "source": "json-file",
+                            "path": auth_path,
+                            "field": "tokens.access_token"
+                        },
+                        "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN": {
+                            "source": "json-file",
+                            "path": auth_path,
+                            "field": "tokens.refresh_token"
+                        }
+                    }
+                }),
+            );
+
+            let env = provider_command_env(&request, &provider).expect("provider env resolves");
+
+            assert!(env.contains(&(
+                "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN".to_string(),
+                "provider-owned-access-token".to_string()
+            )));
+            let rendered =
+                serde_json::to_string(&provider_secret_sources(&provider, Some(&request)))
+                    .expect("sources json");
+            assert!(!rendered.contains("provider-owned-access-token"));
+        });
     }
 
     #[test]

--- a/src/core/agent_task_secrets.rs
+++ b/src/core/agent_task_secrets.rs
@@ -54,6 +54,7 @@ pub fn map_secret_to_env(
         AgentTaskSecretSource {
             source: "env".to_string(),
             env_var: env_var.map(str::to_string),
+            path: None,
             scope: None,
             name: None,
             field: None,
@@ -74,6 +75,7 @@ pub fn set_config_secret(name: &str, value: &str) -> crate::core::Result<AgentTa
         AgentTaskSecretSource {
             source: "config".to_string(),
             env_var: None,
+            path: None,
             scope: None,
             name: None,
             field: None,
@@ -103,6 +105,7 @@ pub fn set_keychain_secret(
         AgentTaskSecretSource {
             source: "keychain".to_string(),
             env_var: None,
+            path: None,
             scope: Some(scope.to_string()),
             name: Some(keychain_name.to_string()),
             field: None,
@@ -149,6 +152,7 @@ pub fn map_secret_to_keychain_bundle(
         AgentTaskSecretSource {
             source: "keychain-bundle".to_string(),
             env_var: None,
+            path: None,
             scope: Some(scope.unwrap_or("agent-task").to_string()),
             name: Some(keychain_name.unwrap_or(bundle).to_string()),
             field: Some(field.to_string()),
@@ -190,6 +194,24 @@ pub fn validate_secret_env(names: &[String]) -> Result<(), AgentTaskSecretResolu
     resolve_secret_env(names).map(|_| ())
 }
 
+pub fn validate_secret_env_with_fallbacks(
+    names: &[String],
+    fallback_sources: &HashMap<String, AgentTaskSecretSource>,
+) -> Result<(), AgentTaskSecretResolutionError> {
+    resolve_secret_env_with_fallbacks(names, fallback_sources).map(|_| ())
+}
+
+pub fn resolve_secret_env_with_fallbacks(
+    names: &[String],
+    fallback_sources: &HashMap<String, AgentTaskSecretSource>,
+) -> Result<Vec<(String, String)>, AgentTaskSecretResolutionError> {
+    resolve_secret_env_with_config_and_fallbacks(
+        names,
+        &AgentTaskSecretConfig::load(),
+        fallback_sources,
+    )
+}
+
 fn secret_env_status_with_config(
     names: &[String],
     config: &AgentTaskSecretConfig,
@@ -224,6 +246,14 @@ fn resolve_secret_env_with_config(
     names: &[String],
     config: &AgentTaskSecretConfig,
 ) -> Result<Vec<(String, String)>, AgentTaskSecretResolutionError> {
+    resolve_secret_env_with_config_and_fallbacks(names, config, &HashMap::new())
+}
+
+fn resolve_secret_env_with_config_and_fallbacks(
+    names: &[String],
+    config: &AgentTaskSecretConfig,
+    fallback_sources: &HashMap<String, AgentTaskSecretSource>,
+) -> Result<Vec<(String, String)>, AgentTaskSecretResolutionError> {
     if names.is_empty() {
         return Ok(Vec::new());
     }
@@ -241,6 +271,7 @@ fn resolve_secret_env_with_config(
         match config
             .secrets
             .get(name)
+            .or_else(|| fallback_sources.get(name))
             .and_then(|source| source.resolve(name, &mut bundle_cache))
         {
             Some(value) => resolved.push((name.clone(), value)),
@@ -306,6 +337,7 @@ impl AgentTaskSecretSource {
         match self.source.as_str() {
             "config" => self.value.clone(),
             "env" => env::var(self.env_var.as_deref().unwrap_or(requested_name)).ok(),
+            "json-file" => self.resolve_json_file(requested_name, bundle_cache),
             "keychain" => keychain::get(
                 self.scope.as_deref().unwrap_or("agent-task"),
                 self.name.as_deref().unwrap_or(requested_name),
@@ -315,6 +347,25 @@ impl AgentTaskSecretSource {
             "keychain-bundle" => self.resolve_keychain_bundle(requested_name, bundle_cache),
             _ => None,
         }
+    }
+
+    fn resolve_json_file(
+        &self,
+        requested_name: &str,
+        bundle_cache: &mut HashMap<String, Option<Value>>,
+    ) -> Option<String> {
+        let raw_path = self.path.as_deref()?;
+        let path = shellexpand::tilde(raw_path).to_string();
+        let bundle = bundle_cache
+            .entry(format!("json-file\0{path}"))
+            .or_insert_with(|| {
+                fs::read_to_string(&path)
+                    .ok()
+                    .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+            })
+            .as_ref()?;
+        let field = self.field.as_deref().unwrap_or(requested_name);
+        bundle_field_value(bundle, field)
     }
 
     fn resolve_keychain_bundle(
@@ -416,6 +467,7 @@ mod tests {
             AgentTaskSecretSource {
                 source: "env".to_string(),
                 env_var: Some(source_name.clone()),
+                path: None,
                 scope: None,
                 name: None,
                 field: None,
@@ -504,6 +556,7 @@ mod tests {
         let source = AgentTaskSecretSource {
             source: "keychain-bundle".to_string(),
             env_var: None,
+            path: None,
             scope: Some("agent-task".to_string()),
             name: Some("provider-oauth".to_string()),
             field: Some("tokens.access".to_string()),
@@ -570,5 +623,48 @@ mod tests {
             assert_eq!(source.name.as_deref(), Some("provider-oauth"));
             assert_eq!(source.field.as_deref(), Some("tokens.access"));
         });
+    }
+
+    #[test]
+    fn resolves_provider_hint_from_json_file_without_exposing_value() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let auth_path = temp.path().join("auth.json");
+        fs::write(
+            &auth_path,
+            serde_json::json!({
+                "tokens": {
+                    "access_token": "json-file-access-token",
+                    "expires_at": 12345
+                }
+            })
+            .to_string(),
+        )
+        .expect("write auth file");
+        let name = "AI_PROVIDER_EXAMPLE_ACCESS_TOKEN".to_string();
+        std::env::remove_var(&name);
+        let mut fallbacks = HashMap::new();
+        fallbacks.insert(
+            name.clone(),
+            AgentTaskSecretSource {
+                source: "json-file".to_string(),
+                env_var: None,
+                path: Some(auth_path.to_string_lossy().to_string()),
+                scope: None,
+                name: None,
+                field: Some("tokens.access_token".to_string()),
+                value: None,
+            },
+        );
+
+        let resolved = resolve_secret_env_with_fallbacks(std::slice::from_ref(&name), &fallbacks)
+            .expect("json file fallback resolves");
+
+        assert_eq!(resolved, vec![(name, "json-file-access-token".to_string())]);
+        let status = secret_env_status(std::slice::from_ref(
+            &"AI_PROVIDER_EXAMPLE_ACCESS_TOKEN".to_string(),
+        ));
+        assert!(!serde_json::to_string(&status)
+            .unwrap()
+            .contains("json-file-access-token"));
     }
 }

--- a/src/core/agent_task_service.rs
+++ b/src/core/agent_task_service.rs
@@ -16,11 +16,13 @@ use crate::core::agent_task_lifecycle::{
 use crate::core::agent_task_promotion::{
     promote, AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionStatus,
 };
-use crate::core::agent_task_provider::apply_provider_runner_secret_env_contracts;
+use crate::core::agent_task_provider::{
+    apply_provider_runner_secret_env_contracts, provider_secret_sources_for_plan,
+};
 use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskScheduler, AgentTaskState,
 };
-use crate::core::agent_task_secrets::validate_secret_env;
+use crate::core::agent_task_secrets::validate_secret_env_with_fallbacks;
 use crate::core::secret_env_plan::SecretEnvPlan;
 use crate::core::{config, Error, Result};
 
@@ -627,7 +629,11 @@ fn preflight_plan_secret_env(plan: &AgentTaskPlan) -> Result<()> {
             .flat_map(|task| task.executor.secret_env.iter().cloned()),
     );
 
-    validate_secret_env(&secret_env_plan.secret_env_names()).map_err(|error| {
+    validate_secret_env_with_fallbacks(
+        &secret_env_plan.secret_env_names(),
+        &provider_secret_sources_for_plan(plan),
+    )
+    .map_err(|error| {
         Error::validation_invalid_argument(
             "secret_env",
             error.message,

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -222,11 +222,11 @@ pub mod provider {
         default_backend, default_backend_for_component, dependency_failure_patterns,
         provider_requires_cwd_git_checkout, provider_runner_readiness_contracts,
         provider_runner_secret_env_for_plan, provider_runner_source_contracts,
-        required_extension_ids_for_plan, AgentTaskExecutorProvider,
-        AgentTaskProviderDependencyFailurePattern, AgentTaskProviderEnvPathReadiness,
-        AgentTaskProviderRoleAliases, AgentTaskProviderRunnerReadiness,
-        AgentTaskProviderRunnerSource, AgentTaskProviderWorkspaceMaterialization,
-        ExtensionProviderAgentTaskExecutor,
+        provider_secret_sources_for_plan, required_extension_ids_for_plan,
+        AgentTaskExecutorProvider, AgentTaskProviderDependencyFailurePattern,
+        AgentTaskProviderEnvPathReadiness, AgentTaskProviderRoleAliases,
+        AgentTaskProviderRunnerReadiness, AgentTaskProviderRunnerSource,
+        AgentTaskProviderWorkspaceMaterialization, ExtensionProviderAgentTaskExecutor,
     };
 }
 

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -202,6 +202,8 @@ pub struct AgentTaskSecretSource {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub env_var: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scope: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -8,7 +8,9 @@
 
 use std::collections::HashMap;
 
-use crate::core::agent_tasks::provider::provider_runner_secret_env_for_plan;
+use crate::core::agent_tasks::provider::{
+    provider_runner_secret_env_for_plan, provider_secret_sources_for_plan,
+};
 use crate::core::agent_tasks::scheduler::AgentTaskPlan;
 use crate::core::agent_tasks::secrets as agent_task_secrets;
 use crate::core::{config, Error, Result};
@@ -120,8 +122,6 @@ pub(super) fn preflight_agent_task_runner_secret_env(
         return Ok(());
     }
 
-    let is_missing = |name: &str| !env.contains_key(name) && !runner.secret_env.contains_key(name);
-
     // Dedupe missing env names while preserving first-seen order so the
     // operator-facing message lists each name exactly once, even when several
     // plan tasks declare the same requirement.
@@ -129,7 +129,10 @@ pub(super) fn preflight_agent_task_runner_secret_env(
     let mut required_by_tasks: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
     for task in &tasks {
         for name in &task.secret_env {
-            if !is_missing(name) {
+            if env.contains_key(name)
+                || runner.secret_env.contains_key(name)
+                || task.secret_sources.contains(name)
+            {
                 continue;
             }
             if !missing.iter().any(|seen| seen == name) {
@@ -371,6 +374,7 @@ fn declared_agent_task_run_plan_secret_env(args: &[String]) -> Vec<String> {
 struct PlanTaskSecretEnv {
     task_id: String,
     secret_env: Vec<String>,
+    secret_sources: Vec<String>,
 }
 
 fn declared_agent_task_run_plan_secret_env_by_task(args: &[String]) -> Vec<PlanTaskSecretEnv> {
@@ -391,10 +395,14 @@ fn declared_agent_task_run_plan_secret_env_by_task(args: &[String]) -> Vec<PlanT
 
     let mut tasks = Vec::new();
     let provider_names = provider_runner_secret_env_for_plan(&plan);
+    let provider_secret_sources: Vec<String> = provider_secret_sources_for_plan(&plan)
+        .into_keys()
+        .collect();
     if !provider_names.is_empty() {
         tasks.push(PlanTaskSecretEnv {
             task_id: PLAN_PROVIDER_PROVENANCE.to_string(),
             secret_env: provider_names,
+            secret_sources: provider_secret_sources.clone(),
         });
     }
     for request in plan.tasks {
@@ -414,6 +422,7 @@ fn declared_agent_task_run_plan_secret_env_by_task(args: &[String]) -> Vec<PlanT
         tasks.push(PlanTaskSecretEnv {
             task_id: request.task_id,
             secret_env: names,
+            secret_sources: provider_secret_sources.clone(),
         });
     }
     tasks


### PR DESCRIPTION
## Summary
- add generic agent-task secret fallback sources for provider/runtime manifest hints
- support non-secret JSON file field sources for provider-owned credential bundles
- use provider sources during plan preflight, Lab runner preflight, and executor env injection

## Tests
- cargo test agent_task_secrets --lib
- cargo test provider_default_secret_sources_resolve_required_env_without_duplicate_mapping --lib
- cargo test hydrate_agent_task_secret_env_defers_run_plan_secrets_to_runner --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the Homeboy agent-task secret resolution path and drafted the provider credential source implementation and focused tests; Chris remains responsible for review and validation.