### PR TITLE
feat(bench): add --run-id and warn on unknown setting keys

### DIFF
--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -202,13 +202,24 @@ pub struct BenchRunArgs {
     #[arg(long, value_name = "N", allow_hyphen_values = true)]
     warmup: Option<u64>,
 
-    /// Number of independent substrate spawns. Default 1 preserves today's
-    /// exact behaviour. When > 1, the bench dispatcher is invoked N times in
-    /// sequence and per-scenario metrics carry both the cross-run p50
-    /// (top-level, unchanged shape) and a runs array with each run's raw
-    /// metrics, plus a runs_summary object with n/min/max/mean/stdev/cv_pct/p50/p95.
-    #[arg(long, default_value_t = 1)]
+    /// Number of repetitions (independent substrate spawns). Default 1
+    /// preserves today's exact behaviour. This is a numeric COUNT, not a
+    /// proof label — use --run-id to tag a run with a stable identifier.
+    /// When > 1, the bench dispatcher is invoked N times in sequence and
+    /// per-scenario metrics carry both the cross-run p50 (top-level,
+    /// unchanged shape) and a runs array with each run's raw metrics, plus
+    /// a runs_summary object with n/min/max/mean/stdev/cv_pct/p50/p95.
+    #[arg(long, default_value_t = 1, value_name = "COUNT", value_parser = crate::commands::parse_runs_count)]
     runs: u64,
+
+    /// Caller-supplied stable proof label for this run. Forwarded to
+    /// component bench scripts via HOMEBOY_BENCH_RUN_ID so a run can be
+    /// correlated across systems (CI logs, dashboards, proof archives).
+    /// This is NOT a repetition count — use --runs for that. Components
+    /// whose bench runner does not consume HOMEBOY_BENCH_RUN_ID simply
+    /// ignore it; homeboy emits a notice rather than a hard error.
+    #[arg(long = "run-id", value_name = "ID")]
+    run_id: Option<String>,
 
     /// Directory shared across bench runner instances.
     #[arg(long, value_name = "DIR")]
@@ -342,6 +353,59 @@ pub enum BenchRigOrder {
 #[serde(rename_all = "kebab-case")]
 pub enum BenchReportFormat {
     SideBySide,
+}
+
+/// Warn — before a (potentially long) bench run starts — when a
+/// `--setting` / `--setting-json` key is not declared by the resolved
+/// extension's manifest `settings` block.
+///
+/// Silently accepting a key the component bench script never consumes
+/// (e.g. `bench_env` typo vs the correct `workflow_bench_env`) wastes
+/// long proof runs: the operator believes they configured the run, but
+/// the value was dropped on the floor. A warning is the safe default —
+/// it surfaces the typo without failing runs whose extension legitimately
+/// declares no settings (where validation can't be performed).
+fn warn_unknown_setting_keys(
+    ctx: &execution_context::ExecutionContext,
+    setting_args: &SettingArgs,
+) {
+    if let Some(message) = unknown_setting_keys_warning(ctx, setting_args) {
+        eprintln!("{message}");
+    }
+}
+
+/// Build the unknown-setting-key warning message, or `None` when every
+/// provided override is declared (or the extension declares no settings,
+/// in which case validation is skipped). Split out from
+/// [`warn_unknown_setting_keys`] so the message content is unit-testable
+/// without capturing stderr.
+fn unknown_setting_keys_warning(
+    ctx: &execution_context::ExecutionContext,
+    setting_args: &SettingArgs,
+) -> Option<String> {
+    let unknown = ctx.unknown_setting_overrides(
+        setting_args.setting.iter().map(|(k, _)| k.as_str()),
+        setting_args.setting_json.iter().map(|(k, _)| k.as_str()),
+    );
+    if unknown.is_empty() {
+        return None;
+    }
+
+    let mut accepted = ctx.accepted_setting_keys.clone();
+    accepted.sort();
+    let extension = ctx.extension_id.as_deref().unwrap_or("<unknown>");
+    Some(format!(
+        "warning: bench ignored {} unknown setting key(s) not declared by extension '{}': {}. \
+         Accepted settings: {}. Check for a typo before relying on this run.",
+        unknown.len(),
+        extension,
+        unknown.join(", "),
+        if accepted.is_empty() {
+            "<none declared>".to_string()
+        } else {
+            accepted.join(", ")
+        },
+    ))
 }
 
 /// Filter out homeboy-owned flags from trailing args before passing to
@@ -700,6 +764,7 @@ fn run_list(args: &BenchListArgs) -> CmdResult<BenchOutput> {
     resolve_options.extension_overrides = args.extension_override.extensions.clone();
 
     let ctx = execution_context::resolve_with_component(&resolve_options, component_override)?;
+    warn_unknown_setting_keys(&ctx, &args.setting_args);
     let extra_workloads = rig_spec
         .as_ref()
         .and_then(|spec| {

--- a/src/commands/bench/fanout.rs
+++ b/src/commands/bench/fanout.rs
@@ -277,6 +277,7 @@ mod tests {
             iterations: 1,
             warmup: None,
             runs: 1,
+            run_id: None,
             shared_state: None,
             concurrency: 1,
             matrix: Vec::new(),

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -500,6 +500,7 @@ fn run_component_with_rig_context(
     resolve_options.extension_overrides = args.extension_override.extensions.clone();
 
     let ctx = execution_context::resolve_with_component(&resolve_options, component_override)?;
+    super::warn_unknown_setting_keys(&ctx, &args.setting_args);
     homeboy::core::hygiene::require_dependency_hygiene_for_source_with_settings(
         &ctx.source_path,
         ctx.extension_path.as_deref(),
@@ -552,6 +553,7 @@ fn run_component_with_rig_context(
             settings_json: ctx.resolved_settings().json_overrides(),
             iterations: args.iterations,
             warmup_iterations: effective_warmup_iterations(args, rig_spec),
+            run_id: args.run_id.clone(),
             execution: BenchRunExecution {
                 runs: args.runs,
                 concurrency: args.concurrency,
@@ -719,6 +721,7 @@ mod tests {
             iterations: 1,
             warmup: None,
             runs: 1,
+            run_id: None,
             shared_state: None,
             concurrency: 1,
             matrix: Vec::new(),

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -913,6 +913,7 @@ mod tests {
             iterations: 10,
             warmup: None,
             runs: 1,
+            run_id: None,
             shared_state: None,
             concurrency: 1,
             matrix: Vec::new(),

--- a/src/commands/bench/parse_tests.rs
+++ b/src/commands/bench/parse_tests.rs
@@ -74,6 +74,32 @@ fn scenario_and_profile_conflict() {
 }
 
 #[test]
+fn parses_run_id_proof_label() {
+    let cli = TestCli::try_parse_from(["bench", "homeboy", "--run-id", "proof-2026-06"])
+        .expect("bench --run-id should parse");
+
+    assert_eq!(cli.bench.run.run_id.as_deref(), Some("proof-2026-06"));
+}
+
+#[test]
+fn non_integer_runs_hints_at_run_id() {
+    let err = match TestCli::try_parse_from(["bench", "homeboy", "--runs", "proof-label"]) {
+        Ok(_) => panic!("--runs with a non-integer should fail to parse"),
+        Err(err) => err,
+    };
+
+    let message = err.to_string();
+    assert!(
+        message.contains("--runs is a numeric repetition count"),
+        "expected repetition-count guidance, got: {message}"
+    );
+    assert!(
+        message.contains("--run-id"),
+        "expected pointer to --run-id for proof labels, got: {message}"
+    );
+}
+
+#[test]
 fn parses_dotted_setting_override_for_nested_bench_env() {
     let cli = TestCli::try_parse_from([
         "bench",

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -271,6 +271,7 @@ pub(super) fn run_args(
             iterations: 1,
             warmup: None,
             runs: 1,
+            run_id: None,
             shared_state: None,
             concurrency: 1,
             matrix: Vec::new(),
@@ -1435,6 +1436,59 @@ fn bench_output_comparison_serializes_with_tagged_payload() {
         Some(&serde_json::Value::String("cross_rig".to_string()))
     );
 }
+
+fn ctx_with_accepted_setting_keys(
+    accepted: &[&str],
+) -> homeboy::core::engine::execution_context::ExecutionContext {
+    use homeboy::core::engine::execution_context::ExecutionContext;
+    ExecutionContext {
+        component: Default::default(),
+        component_id: "studio".to_string(),
+        source_path: std::path::PathBuf::from("/tmp/studio"),
+        git_root: None,
+        extension_id: Some("rust".to_string()),
+        extension_path: None,
+        settings: Vec::new(),
+        accepted_setting_keys: accepted.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+#[test]
+fn unknown_setting_key_warns_before_run() {
+    let ctx = ctx_with_accepted_setting_keys(&["workflow_bench_env", "iterations"]);
+    let setting_args = SettingArgs {
+        // `bench_env` is a typo for the declared `workflow_bench_env`.
+        setting: vec![("bench_env.CORPUS".to_string(), "1000".to_string())],
+        setting_json: Vec::new(),
+    };
+
+    let warning =
+        unknown_setting_keys_warning(&ctx, &setting_args).expect("unknown key should warn");
+    assert!(
+        warning.contains("bench_env"),
+        "warning names the typo: {warning}"
+    );
+    assert!(
+        warning.contains("workflow_bench_env"),
+        "warning lists accepted settings: {warning}"
+    );
+    assert!(
+        warning.contains("extension 'rust'"),
+        "warning names the resolved extension: {warning}"
+    );
+}
+
+#[test]
+fn declared_setting_key_does_not_warn() {
+    let ctx = ctx_with_accepted_setting_keys(&["workflow_bench_env"]);
+    let setting_args = SettingArgs {
+        setting: vec![("workflow_bench_env.CORPUS".to_string(), "1000".to_string())],
+        setting_json: Vec::new(),
+    };
+
+    assert!(unknown_setting_keys_warning(&ctx, &setting_args).is_none());
+}
+
 #[cfg(test)]
 #[path = "../../../tests/core/rig/bench_default_baseline_dispatch_test.rs"]
 mod bench_default_baseline_dispatch_test;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -46,6 +46,24 @@ pub fn parse_key_json(s: &str) -> Result<(String, serde_json::Value), String> {
     Ok((key, value))
 }
 
+/// Parse the `--runs` repetition count, surfacing a helpful hint when the
+/// operator passes a non-integer.
+///
+/// `--runs` is a numeric repetition count, but operators frequently confuse
+/// it with wanting a stable proof label (e.g. `--runs proof-2026-06`). Clap's
+/// default `u64` parser would emit a raw `invalid digit found in string`
+/// error that gives no guidance. This parser points them at `--run-id`
+/// instead.
+pub fn parse_runs_count(s: &str) -> Result<u64, String> {
+    s.parse::<u64>().map_err(|_| {
+        format!(
+            "`{s}` is not a valid number. --runs is a numeric repetition count \
+             (how many independent substrate spawns to run); use --run-id for a \
+             custom proof label."
+        )
+    })
+}
+
 pub struct GlobalArgs {}
 
 /// Shared arguments for dynamic set commands.

--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -49,6 +49,13 @@ pub struct ExecutionContext {
 
     /// Merged settings (manifest defaults → component → overrides).
     pub settings: Vec<(String, serde_json::Value)>,
+
+    /// Setting keys the resolved extension declares it understands (from
+    /// the manifest `settings` block). Empty when no extension capability
+    /// was requested or the extension declares no settings. Used to warn
+    /// on `--setting` / `--setting-json` keys the runner never consumes.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub accepted_setting_keys: Vec<String>,
 }
 
 /// What to resolve when building an execution context.
@@ -240,44 +247,47 @@ pub fn resolve_with_component(
     apply_extension_overrides(&mut component, &options.extension_overrides);
 
     // 2. Optionally resolve extension context
-    let (extension_id, extension_path, settings) = if let Some(capability) = options.capability {
-        let ext_context =
-            extension::resolve_execution_context(&component, capability).map_err(|err| {
-                add_extension_override_hints(
-                    err,
-                    &options.extension_overrides,
-                    &declared_extension_ids,
-                )
-            })?;
-        let mut settings = ext_context.settings.clone();
-        // Merge CLI string overrides on top (CLI string values stay strings).
-        for (key, value) in &options.settings_overrides {
-            // Remove existing key if present (override semantics)
-            settings.retain(|(k, _)| k != key);
-            settings.push((key.clone(), serde_json::Value::String(value.clone())));
-        }
-        // Then merge typed-JSON overrides — these win against both
-        // manifest defaults / component settings AND --setting string
-        // overrides. Strictly more expressive: an --setting-json on the
-        // same key represents intentional type preservation that string
-        // coercion can't represent.
-        for (key, value) in &options.settings_json_overrides {
-            settings.retain(|(k, _)| k != key);
-            settings.push((key.clone(), value.clone()));
-        }
-        (
-            Some(ext_context.extension_id.clone()),
-            Some(ext_context.extension_path.clone()),
-            settings,
-        )
-    } else {
-        // No extension context — only CLI overrides, wrapped as JSON strings.
-        let mut settings = Vec::new();
-        for (key, value) in &options.settings_overrides {
-            merge_string_setting_override(&mut settings, key, value);
-        }
-        (None, None, settings)
-    };
+    let (extension_id, extension_path, settings, accepted_setting_keys) =
+        if let Some(capability) = options.capability {
+            let ext_context = extension::resolve_execution_context(&component, capability)
+                .map_err(|err| {
+                    add_extension_override_hints(
+                        err,
+                        &options.extension_overrides,
+                        &declared_extension_ids,
+                    )
+                })?;
+            let accepted_setting_keys = ext_context.accepted_setting_keys.clone();
+            let mut settings = ext_context.settings.clone();
+            // Merge CLI string overrides on top (CLI string values stay strings).
+            for (key, value) in &options.settings_overrides {
+                // Remove existing key if present (override semantics)
+                settings.retain(|(k, _)| k != key);
+                settings.push((key.clone(), serde_json::Value::String(value.clone())));
+            }
+            // Then merge typed-JSON overrides — these win against both
+            // manifest defaults / component settings AND --setting string
+            // overrides. Strictly more expressive: an --setting-json on the
+            // same key represents intentional type preservation that string
+            // coercion can't represent.
+            for (key, value) in &options.settings_json_overrides {
+                settings.retain(|(k, _)| k != key);
+                settings.push((key.clone(), value.clone()));
+            }
+            (
+                Some(ext_context.extension_id.clone()),
+                Some(ext_context.extension_path.clone()),
+                settings,
+                accepted_setting_keys,
+            )
+        } else {
+            // No extension context — only CLI overrides, wrapped as JSON strings.
+            let mut settings = Vec::new();
+            for (key, value) in &options.settings_overrides {
+                merge_string_setting_override(&mut settings, key, value);
+            }
+            (None, None, settings, Vec::new())
+        };
 
     Ok(ExecutionContext {
         component_id: component.id.clone(),
@@ -287,6 +297,7 @@ pub fn resolve_with_component(
         extension_id,
         extension_path,
         settings,
+        accepted_setting_keys,
     })
 }
 
@@ -350,6 +361,53 @@ impl ExecutionContext {
     /// Return an explicit view over resolved extension settings.
     pub fn resolved_settings(&self) -> ResolvedSettings<'_> {
         ResolvedSettings::new(&self.settings)
+    }
+
+    /// Identify caller-supplied setting override keys the resolved
+    /// extension does not declare it understands.
+    ///
+    /// A `--setting`/`--setting-json` key the extension never consumes
+    /// (a typo like `bench_env` vs `workflow_bench_env`) silently does
+    /// nothing today and can waste a long proof run. This compares the
+    /// *root* of each provided key (so `bench_env.FOO` validates against
+    /// the `bench_env` declaration) against
+    /// [`Self::accepted_setting_keys`]. Provided keys are deduplicated and
+    /// returned in input order.
+    ///
+    /// Returns an empty `Vec` when the extension declares no accepted
+    /// setting keys: with nothing to validate against, every key is
+    /// treated as potentially valid rather than universally unknown.
+    pub fn unknown_setting_overrides<'a, S, J>(
+        &self,
+        string_overrides: S,
+        json_overrides: J,
+    ) -> Vec<String>
+    where
+        S: IntoIterator<Item = &'a str>,
+        J: IntoIterator<Item = &'a str>,
+    {
+        if self.accepted_setting_keys.is_empty() {
+            return Vec::new();
+        }
+
+        let accepted: std::collections::HashSet<&str> = self
+            .accepted_setting_keys
+            .iter()
+            .map(String::as_str)
+            .collect();
+
+        let mut unknown = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for key in string_overrides.into_iter().chain(json_overrides) {
+            let root = key.split_once('.').map(|(root, _)| root).unwrap_or(key);
+            if root.is_empty() || accepted.contains(root) {
+                continue;
+            }
+            if seen.insert(root.to_string()) {
+                unknown.push(root.to_string());
+            }
+        }
+        unknown
     }
 
     /// Get the effective working directory for command execution.
@@ -885,9 +943,60 @@ mod tests {
             extension_id: None,
             extension_path: None,
             settings: Vec::new(),
+            accepted_setting_keys: Vec::new(),
         };
 
         assert_eq!(ctx.working_dir(), dir.path().to_str().unwrap());
+    }
+
+    fn ctx_with_accepted_keys(accepted: &[&str]) -> ExecutionContext {
+        ExecutionContext {
+            component: Component::default(),
+            component_id: "component".to_string(),
+            source_path: PathBuf::from("/tmp/component"),
+            git_root: None,
+            extension_id: Some("rust".to_string()),
+            extension_path: None,
+            settings: Vec::new(),
+            accepted_setting_keys: accepted.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn unknown_setting_overrides_flags_undeclared_keys() {
+        let ctx = ctx_with_accepted_keys(&["workflow_bench_env", "iterations"]);
+
+        let unknown =
+            ctx.unknown_setting_overrides(["bench_env"].into_iter(), ["iterations"].into_iter());
+
+        assert_eq!(unknown, vec!["bench_env".to_string()]);
+    }
+
+    #[test]
+    fn unknown_setting_overrides_validates_dotted_key_root() {
+        let ctx = ctx_with_accepted_keys(&["workflow_bench_env"]);
+
+        // Dotted child of an accepted root is fine; dotted child of an
+        // unknown root surfaces the root once.
+        let unknown = ctx.unknown_setting_overrides(
+            ["workflow_bench_env.FOO", "bench_env.BAR", "bench_env.BAZ"].into_iter(),
+            std::iter::empty(),
+        );
+
+        assert_eq!(unknown, vec!["bench_env".to_string()]);
+    }
+
+    #[test]
+    fn unknown_setting_overrides_skips_validation_without_declaration() {
+        // No declared settings → cannot validate → treat all as valid.
+        let ctx = ctx_with_accepted_keys(&[]);
+
+        let unknown = ctx.unknown_setting_overrides(
+            ["anything", "at_all"].into_iter(),
+            ["json_key"].into_iter(),
+        );
+
+        assert!(unknown.is_empty());
     }
 
     fn resolved_settings_entries() -> Vec<(String, serde_json::Value)> {
@@ -979,6 +1088,7 @@ mod tests {
             extension_id: None,
             extension_path: None,
             settings: vec![("mode".to_string(), serde_json::json!("test"))],
+            accepted_setting_keys: Vec::new(),
         };
 
         ctx.log_debug();

--- a/src/core/extension/bench/failure_diagnostic.rs
+++ b/src/core/extension/bench/failure_diagnostic.rs
@@ -129,6 +129,7 @@ mod tests {
             settings_json: Vec::new(),
             iterations: 1,
             warmup_iterations: Some(1),
+            run_id: None,
             execution: BenchRunExecution {
                 runs: 1,
                 concurrency: 1,

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -48,6 +48,11 @@ pub struct BenchRunWorkflowArgs {
     pub settings_json: Vec<(String, serde_json::Value)>,
     pub iterations: u64,
     pub warmup_iterations: Option<u64>,
+    /// Caller-supplied stable proof label from `--run-id`. Forwarded to
+    /// component bench scripts via `$HOMEBOY_BENCH_RUN_ID` so a run can be
+    /// correlated across CI logs, dashboards, and proof archives. `None`
+    /// leaves the env var unset, preserving prior behaviour exactly.
+    pub run_id: Option<String>,
     pub execution: BenchRunExecution,
     pub baseline_flags: BaselineFlags,
     pub regression_threshold_percent: f64,
@@ -182,6 +187,7 @@ pub fn run_bench_list_workflow(
             settings_json: args.settings_json,
             iterations: 0,
             warmup_iterations: None,
+            run_id: None,
             execution: BenchRunExecution {
                 runs: 1,
                 concurrency: 1,
@@ -980,6 +986,14 @@ fn bench_component_script_env(
             )?,
         ),
     ];
+    if let Some(run_id) = args
+        .run_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        env.push(("HOMEBOY_BENCH_RUN_ID".to_string(), run_id.to_string()));
+    }
     env.extend(args.ci_env.iter().cloned());
     Ok(env)
 }
@@ -1932,6 +1946,7 @@ mod tests {
                 )],
                 iterations: 10,
                 warmup_iterations: None,
+                run_id: None,
                 execution: BenchRunExecution {
                     runs: 1,
                     concurrency: 1,
@@ -1976,6 +1991,76 @@ mod tests {
         );
         assert!(parsed["workflow_bench_env"]["FOO"].is_null());
         run_dir.cleanup();
+    }
+
+    #[test]
+    fn component_script_bench_env_forwards_run_id_proof_label() {
+        let run_dir = RunDir::create().expect("run dir");
+        let mut args = bench_run_workflow_args_fixture();
+        args.run_id = Some("proof-2026-06".to_string());
+
+        let env = bench_component_script_env(&args, &run_dir).expect("component-script env");
+
+        assert_eq!(
+            env.iter()
+                .find_map(|(key, value)| (key == "HOMEBOY_BENCH_RUN_ID").then_some(value)),
+            Some(&"proof-2026-06".to_string()),
+            "run-id proof label should forward to HOMEBOY_BENCH_RUN_ID"
+        );
+        run_dir.cleanup();
+    }
+
+    #[test]
+    fn component_script_bench_env_omits_run_id_when_absent_or_blank() {
+        let run_dir = RunDir::create().expect("run dir");
+
+        let mut absent = bench_run_workflow_args_fixture();
+        absent.run_id = None;
+        let env = bench_component_script_env(&absent, &run_dir).expect("component-script env");
+        assert!(
+            !env.iter().any(|(key, _)| key == "HOMEBOY_BENCH_RUN_ID"),
+            "no --run-id should leave HOMEBOY_BENCH_RUN_ID unset"
+        );
+
+        let mut blank = bench_run_workflow_args_fixture();
+        blank.run_id = Some("   ".to_string());
+        let env = bench_component_script_env(&blank, &run_dir).expect("component-script env");
+        assert!(
+            !env.iter().any(|(key, _)| key == "HOMEBOY_BENCH_RUN_ID"),
+            "whitespace-only --run-id should be ignored, not forwarded blank"
+        );
+        run_dir.cleanup();
+    }
+
+    fn bench_run_workflow_args_fixture() -> BenchRunWorkflowArgs {
+        BenchRunWorkflowArgs {
+            component_label: "studio-web".to_string(),
+            component_id: "studio-web".to_string(),
+            path_override: None,
+            settings: Vec::new(),
+            settings_json: Vec::new(),
+            iterations: 10,
+            warmup_iterations: None,
+            run_id: None,
+            execution: BenchRunExecution {
+                runs: 1,
+                concurrency: 1,
+            },
+            baseline_flags: BaselineFlags {
+                baseline: false,
+                ignore_baseline: true,
+                ratchet: false,
+            },
+            regression_threshold_percent: 5.0,
+            json_summary: false,
+            ci_env: Vec::new(),
+            passthrough_args: Vec::new(),
+            scenario_ids: Vec::new(),
+            rig_id: None,
+            shared_state: None,
+            extra_workloads: Vec::new(),
+            invocation_requirements: InvocationRequirements::default(),
+        }
     }
 
     #[test]
@@ -2227,6 +2312,7 @@ printf '{}' > "$(dirname "$HOMEBOY_BENCH_RESULTS_FILE")/bench-report.json"
                     settings_json: Vec::new(),
                     iterations: 1,
                     warmup_iterations: None,
+                    run_id: None,
                     execution: BenchRunExecution {
                         runs: 1,
                         concurrency: 1,
@@ -2468,6 +2554,7 @@ printf '{}' > "$(dirname "$HOMEBOY_BENCH_RESULTS_FILE")/bench-report.json"
                 settings_json: Vec::new(),
                 iterations: 1,
                 warmup_iterations: None,
+                run_id: None,
                 execution: BenchRunExecution {
                     runs: 1,
                     concurrency: 0,

--- a/src/core/extension/bench/run_metadata.rs
+++ b/src/core/extension/bench/run_metadata.rs
@@ -190,6 +190,7 @@ mod tests {
             extension_path: extension_dir.path().to_path_buf(),
             script_path: "bench-runner.sh".to_string(),
             settings: Vec::new(),
+            accepted_setting_keys: Vec::new(),
         };
         let args = BenchRunWorkflowArgs {
             component_label: "homeboy".to_string(),
@@ -199,6 +200,7 @@ mod tests {
             settings_json: Vec::new(),
             iterations: 7,
             warmup_iterations: None,
+            run_id: None,
             execution: BenchRunExecution {
                 runs: 3,
                 concurrency: 2,

--- a/src/core/extension/capability.rs
+++ b/src/core/extension/capability.rs
@@ -98,6 +98,11 @@ pub struct ExtensionExecutionContext {
     pub extension_path: PathBuf,
     pub script_path: String,
     pub settings: Vec<(String, serde_json::Value)>,
+    /// Setting keys the resolved extension declares it understands (from
+    /// the manifest `settings` block). Used to validate `--setting` /
+    /// `--setting-json` overrides before a run. Empty means the extension
+    /// declares no settings, in which case validation is skipped.
+    pub accepted_setting_keys: Vec<String>,
 }
 
 pub struct ScenarioRunnerOptions<'a> {
@@ -353,5 +358,6 @@ pub fn resolve_execution_context(
         extension_path,
         script_path,
         settings: extract_component_extension_settings(component, &extension_id),
+        accepted_setting_keys: manifest.accepted_setting_keys(),
     })
 }

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -645,6 +645,22 @@ impl ExtensionManifest {
         self.cli.is_some()
     }
 
+    /// Setting keys this extension declares it understands.
+    ///
+    /// Used to validate `--setting` / `--setting-json` overrides before a
+    /// run: a key the extension never consumes (a typo like `bench_env`
+    /// vs `workflow_bench_env`) silently does nothing today and can waste
+    /// a long proof run. Returns the declared `id`s from the manifest's
+    /// `settings` block. An empty result means the extension declares no
+    /// settings — callers should treat that as "cannot validate" rather
+    /// than "rejects everything".
+    pub fn accepted_setting_keys(&self) -> Vec<String> {
+        self.settings
+            .iter()
+            .map(|setting| setting.id.clone())
+            .collect()
+    }
+
     pub fn has_build(&self) -> bool {
         self.build.is_some()
     }

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -374,6 +374,7 @@ mod tests {
             extension_path: PathBuf::from("/tmp/fixture-extension"),
             script_path: "lint.sh".to_string(),
             settings: Vec::new(),
+            accepted_setting_keys: Vec::new(),
         }
     }
 

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -1003,6 +1003,7 @@ printf '{"total":%s,"passed":%s,"failed":%s,"skipped":%s}\n' "$total" "$passed" 
                 extension_path: extension_dir,
                 script_path: "test.sh".to_string(),
                 settings: Vec::new(),
+                accepted_setting_keys: Vec::new(),
             };
             let spec = ParseSpec {
                 extension_script: Some("parse-results.sh".to_string()),
@@ -1062,6 +1063,7 @@ printf '{"total":%s,"passed":%s,"failed":%s,"skipped":%s}\n' "$total" "$passed" 
             extension_path: extension_dir.clone(),
             script_path: "test.sh".to_string(),
             settings: Vec::new(),
+            accepted_setting_keys: Vec::new(),
         };
         let spec = ParseSpec {
             extension_script: Some("missing-parser.sh".to_string()),
@@ -1128,6 +1130,7 @@ exit 23
             extension_path: extension_dir,
             script_path: "test.sh".to_string(),
             settings: Vec::new(),
+            accepted_setting_keys: Vec::new(),
         };
         let spec = ParseSpec {
             extension_script: Some("parse-results.sh".to_string()),
@@ -1195,6 +1198,7 @@ printf '{"total":5,"passed":3,"failed":1,"skipped":1}\n'
                 extension_path: extension_dir,
                 script_path: "test.sh".to_string(),
                 settings: Vec::new(),
+                accepted_setting_keys: Vec::new(),
             };
             let spec = ParseSpec {
                 extension_script: Some("parse-results.sh".to_string()),
@@ -1257,6 +1261,7 @@ printf 'not json\n'
             extension_path: extension_dir,
             script_path: "test.sh".to_string(),
             settings: Vec::new(),
+            accepted_setting_keys: Vec::new(),
         };
         let spec = ParseSpec {
             extension_script: Some("parse-results.sh".to_string()),

--- a/src/core/extension/trace/canonicality.rs
+++ b/src/core/extension/trace/canonicality.rs
@@ -877,6 +877,7 @@ mod tests {
             extension_path: extension_dir.path().to_path_buf(),
             script_path: "trace.js".to_string(),
             settings: Vec::new(),
+            accepted_setting_keys: Vec::new(),
         };
 
         let report = evaluate_trace_canonicality(Some(&context), &component, &args).unwrap();
@@ -902,6 +903,7 @@ mod tests {
             extension_path: extension_dir.path().to_path_buf(),
             script_path: "trace.js".to_string(),
             settings: Vec::new(),
+            accepted_setting_keys: Vec::new(),
         };
 
         let report = evaluate_trace_canonicality(Some(&context), &component, &args).unwrap();
@@ -975,6 +977,7 @@ mod tests {
             extension_path: extension_dir,
             script_path: "trace.js".to_string(),
             settings: Vec::new(),
+            accepted_setting_keys: Vec::new(),
         }
     }
 

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -1653,6 +1653,7 @@ mod tests {
             extension_path: extension_dir,
             script_path: "trace.js".to_string(),
             settings: Vec::new(),
+            accepted_setting_keys: Vec::new(),
         }
     }
 

--- a/src/core/extension/trace/run_tests.inc
+++ b/src/core/extension/trace/run_tests.inc
@@ -827,6 +827,7 @@ exit 7
             extension_path: extension_dir.to_path_buf(),
             script_path: "trace-runner.sh".to_string(),
             settings: Vec::new(),
+            accepted_setting_keys: Vec::new(),
         }
     }
 

--- a/tests/core/rig/bench_default_baseline_dispatch_test.rs
+++ b/tests/core/rig/bench_default_baseline_dispatch_test.rs
@@ -43,6 +43,7 @@ fn make_args(
             iterations: 1,
             warmup: None,
             runs: 1,
+            run_id: None,
             shared_state: None,
             concurrency: 1,
             matrix: Vec::new(),


### PR DESCRIPTION
Closes #4477
Closes #4478

## Summary

Two bench-CLI papercuts that bite during long proof runs, both confined to `src/commands/bench.rs`, `src/commands/bench/`, and the settings/manifest plumbing they depend on.

### #4477 — run id vs run count clarity
Operators confused `--runs` (a numeric repetition count) with wanting a stable proof label, and `--runs <non-integer>` gave a raw clap parse error.

- **Clearer `--runs` help**: now reads "Number of repetitions (independent substrate spawns)… This is a numeric COUNT, not a proof label — use `--run-id`…" and the value name is `<COUNT>`.
- **First-class `--run-id <ID>`**: a caller-supplied stable proof label, forwarded to component bench scripts via `HOMEBOY_BENCH_RUN_ID`. Whitespace-only / empty labels are dropped rather than forwarded blank. Components that don't consume the env var simply ignore it — no hard error.
- **Helpful non-integer hint**: a custom `--runs` value parser now emits `` `proof-label` is not a valid number. --runs is a numeric repetition count … use --run-id for a custom proof label.`` instead of `invalid digit found in string`.

### #4478 — warn on unknown setting keys
`--setting-json <key>=…` silently accepted keys the component script never consumes (e.g. `bench_env` typo vs the correct `workflow_bench_env`), wasting long proof runs.

- Extensions already DECLARE accepted setting keys via the manifest `settings` block. Added `ExtensionManifest::accepted_setting_keys()` and threaded the declared keys through `ExtensionExecutionContext` → `ExecutionContext`.
- Added `ExecutionContext::unknown_setting_overrides()` which validates each provided `--setting` / `--setting-json` key (by its dotted root, so `bench_env.FOO` checks against the `bench_env` declaration) against the declaration.
- `homeboy bench` now emits a **pre-run warning** listing the unknown key(s) and the accepted settings, before the (potentially long) run starts. When an extension declares no settings, validation is skipped rather than flagging everything.

## Tests
Focused tests added (all passing):
- `non_integer_runs_hints_at_run_id`, `parses_run_id_proof_label`
- `component_script_bench_env_forwards_run_id_proof_label`, `component_script_bench_env_omits_run_id_when_absent_or_blank`
- `unknown_setting_overrides_*` (flags undeclared, validates dotted root, skips without declaration)
- `unknown_setting_key_warns_before_run`, `declared_setting_key_does_not_warn`

`cargo build --lib --tests`, `cargo test command_contract` (16 passed), and `cargo fmt --check` are clean. The 32 failing `cargo test bench` cases are pre-existing and environment-only (fixture `bench-runner.sh` runs from a `noexec` tmp mount → exit 126); the failure count is identical to `origin/main`, and all 6 net-new tests pass.

> Note: `docs/changelog.md` intentionally untouched — homeboy owns it.