### PR TITLE
Refactor stack git handling onto core primitives

### DIFF
--- a/src/core/git/github.rs
+++ b/src/core/git/github.rs
@@ -436,6 +436,60 @@ pub fn pr_find(component_id: Option<&str>, options: PrFindOptions) -> Result<Git
     })
 }
 
+/// Find PRs that contain a commit SHA.
+///
+/// GitHub indexes commit SHAs in PR search, which makes this the shared helper
+/// for read-only stack/branch inspection flows that need to decorate commits.
+pub fn pr_find_by_commit(
+    repo_path: &Path,
+    sha: &str,
+    repo: Option<&str>,
+    limit: usize,
+) -> Result<Vec<GithubFindItem>> {
+    ensure_gh_ready()?;
+
+    let mut args: Vec<String> = vec![
+        "pr".into(),
+        "list".into(),
+        "--search".into(),
+        sha.to_string(),
+        "--state".into(),
+        "all".into(),
+        "--json".into(),
+        "number,state,title,url".into(),
+        "--limit".into(),
+        limit.to_string(),
+    ];
+    if let Some(repo) = repo {
+        args.push("-R".into());
+        args.push(repo.to_string());
+    }
+
+    let output = Command::new("gh")
+        .args(&args)
+        .current_dir(repo_path)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .map_err(|e| {
+            Error::git_command_failed(format!(
+                "gh pr list --search: {} (is `gh` installed and authenticated?)",
+                e
+            ))
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::git_command_failed(format!(
+            "gh pr list --search {}: {}",
+            sha,
+            stderr.trim()
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_pr_list_json(&stdout)
+}
+
 /// Fetch metadata for one PR.
 pub fn pr_view(
     component_id: Option<&str>,

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -28,8 +28,8 @@ pub use commits::{
 };
 pub use github::{
     gh_probe_succeeds, github_token_from_env_or_gh, issue_close, issue_comment, issue_create,
-    issue_edit, issue_find, pr_create, pr_edit, pr_files, pr_find, pr_merge, pr_view,
-    GithubFindItem, GithubFindOutput, GithubIssueOutput, GithubPrOutput, GithubPrView,
+    issue_edit, issue_find, pr_create, pr_edit, pr_files, pr_find, pr_find_by_commit, pr_merge,
+    pr_view, GithubFindItem, GithubFindOutput, GithubIssueOutput, GithubPrOutput, GithubPrView,
     IssueCloseOptions, IssueCloseReason, IssueCommentOptions, IssueCreateOptions, IssueEditOptions,
     IssueFindOptions, IssueState, PrCreateOptions, PrEditOptions, PrFindOptions, PrMergeOptions,
     PrState,
@@ -58,8 +58,8 @@ pub use pr_policy::{
 pub use primitives::{
     clone_repo, clone_repo_at_ref, current_branch, get_component_path_prefix, get_git_root,
     head_sha, head_sha_short, is_workdir_clean_or_not_git, output_optional, output_optional_bytes,
-    pull_repo, remote_origin_url, remote_url, run_git, short_head_revision, status_porcelain,
-    status_porcelain_bytes, toplevel, update_to_remote_default_branch,
+    pull_repo, remote_origin_url, remote_url, run_git, run_git_output, short_head_revision,
+    status_porcelain, status_porcelain_bytes, toplevel, update_to_remote_default_branch,
 };
 pub(crate) use primitives::{is_git_repo, list_tracked_markdown_files};
 

--- a/src/core/git/primitives.rs
+++ b/src/core/git/primitives.rs
@@ -87,24 +87,7 @@ pub fn is_workdir_clean_or_not_git(path: &Path) -> bool {
 
 /// Run a git command in a repository and return stdout.
 pub fn run_git(git_root: &Path, args: &[&str], context: &str) -> Result<String> {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(git_root)
-        .stdin(std::process::Stdio::null())
-        .output()
-        .map_err(|e| {
-            Error::git_command_failed_with_details(
-                git_failure_message(context, &e.to_string()),
-                GitCommandFailedDetails {
-                    command: git_command_display(args),
-                    cwd: git_cwd_display(git_root),
-                    exit_code: None,
-                    stdout: String::new(),
-                    stderr: String::new(),
-                    io_error: Some(e.to_string()),
-                },
-            )
-        })?;
+    let output = run_git_output(git_root, args, context)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -124,6 +107,33 @@ pub fn run_git(git_root: &Path, args: &[&str], context: &str) -> Result<String> 
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Run a git command in a repository and return raw output without treating
+/// non-zero exit status as an error.
+pub fn run_git_output(
+    git_root: &Path,
+    args: &[&str],
+    context: &str,
+) -> Result<std::process::Output> {
+    Command::new("git")
+        .args(args)
+        .current_dir(git_root)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .map_err(|e| {
+            Error::git_command_failed_with_details(
+                git_failure_message(context, &e.to_string()),
+                GitCommandFailedDetails {
+                    command: git_command_display(args),
+                    cwd: git_cwd_display(git_root),
+                    exit_code: None,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                    io_error: Some(e.to_string()),
+                },
+            )
+        })
 }
 
 /// Run a git command and return stdout bytes when the command succeeds.

--- a/src/core/stack/git.rs
+++ b/src/core/stack/git.rs
@@ -1,15 +1,12 @@
 //! Shared git command helpers for stack verbs.
 
-use std::process::Command;
+use std::path::Path;
 
-use crate::core::error::{Error, Result};
+use crate::core::error::Result;
+use crate::core::git;
 
 pub(crate) fn run_git(path: &str, args: &[&str]) -> Result<std::process::Output> {
-    Command::new("git")
-        .args(args)
-        .current_dir(path)
-        .output()
-        .map_err(|e| Error::git_command_failed(format!("git {}: {}", args.join(" "), e)))
+    git::run_git_output(Path::new(path), args, &format!("git {}", args.join(" ")))
 }
 
 #[cfg(test)]

--- a/src/core/stack/inspect.rs
+++ b/src/core/stack/inspect.rs
@@ -16,10 +16,10 @@
 //! that would warrant a single `gh api` GraphQL query.
 
 use serde::{Deserialize, Serialize};
-use std::process::Command;
+use std::path::Path;
 
 use crate::core::error::{Error, Result};
-use crate::core::git::resolve_target;
+use crate::core::git::{self, resolve_target};
 
 /// Per-commit detail row for the inspect output.
 #[derive(Debug, Clone, Serialize)]
@@ -160,11 +160,11 @@ fn resolve_base(path: &str, override_base: Option<&str>) -> Result<(String, bool
 
     // Try @{upstream} of HEAD. If unset, return a clear error pointing the
     // user at --base.
-    let output = Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "@{upstream}"])
-        .current_dir(path)
-        .output()
-        .map_err(|e| Error::git_command_failed(format!("git rev-parse @{{upstream}}: {}", e)))?;
+    let output = git::run_git_output(
+        Path::new(path),
+        &["rev-parse", "--abbrev-ref", "@{upstream}"],
+        "git rev-parse @{upstream}",
+    )?;
 
     if !output.status.success() {
         return Err(Error::validation_invalid_argument(
@@ -194,11 +194,11 @@ fn resolve_base(path: &str, override_base: Option<&str>) -> Result<(String, bool
 
 /// Get the current branch name (or `HEAD` for detached HEAD).
 fn current_branch(path: &str) -> Result<String> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(path)
-        .output()
-        .map_err(|e| Error::git_command_failed(format!("git rev-parse HEAD: {}", e)))?;
+    let output = git::run_git_output(
+        Path::new(path),
+        &["rev-parse", "--abbrev-ref", "HEAD"],
+        "git rev-parse HEAD",
+    )?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -216,16 +216,16 @@ fn list_commits_over_base(path: &str, base: &str) -> Result<Vec<InspectCommitDet
     let range = format!("{}..HEAD", base);
     // Reverse so output is oldest-first (rebase order). Tab-separated
     // columns: full SHA, subject, author name, ISO date.
-    let output = Command::new("git")
-        .args([
+    let output = git::run_git_output(
+        Path::new(path),
+        &[
             "log",
             "--reverse",
             "--format=%H%x09%s%x09%an%x09%aI",
             &range,
-        ])
-        .current_dir(path)
-        .output()
-        .map_err(|e| Error::git_command_failed(format!("git log {}: {}", range, e)))?;
+        ],
+        &format!("git log {}", range),
+    )?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -293,52 +293,15 @@ enum PrLookup {
 /// free-text search for the SHA reliably returns the PR(s) containing
 /// that commit.
 fn find_pr_for_commit(path: &str, sha: &str, repo: Option<&str>) -> Result<PrLookup> {
-    let mut args: Vec<String> = vec![
-        "pr".into(),
-        "list".into(),
-        "--search".into(),
-        sha.to_string(),
-        "--state".into(),
-        "all".into(),
-        "--json".into(),
-        "number,state,title,url".into(),
-        "--limit".into(),
-        "5".into(),
-    ];
-    if let Some(repo) = repo {
-        args.push("--repo".into());
-        args.push(repo.to_string());
-    }
-    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-
-    let output = Command::new("gh")
-        .args(&arg_refs)
-        .current_dir(path)
-        .output()
-        .map_err(|e| {
-            Error::git_command_failed(format!(
-                "gh pr list --search: {} (is `gh` installed and authenticated?)",
-                e
-            ))
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(Error::git_command_failed(format!(
-            "gh pr list --search {}: {}",
-            sha,
-            stderr.trim()
-        )));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let parsed: Vec<InspectPr> = serde_json::from_str(&stdout).map_err(|e| {
-        Error::validation_invalid_json(
-            e,
-            Some(format!("parse `gh pr list --search {}`", sha)),
-            Some(stdout.chars().take(200).collect()),
-        )
-    })?;
+    let parsed = git::pr_find_by_commit(Path::new(path), sha, repo, 5)?
+        .into_iter()
+        .map(|item| InspectPr {
+            number: item.number,
+            state: item.state,
+            title: item.title,
+            url: item.url,
+        })
+        .collect::<Vec<_>>();
 
     match parsed.len() {
         0 => Ok(PrLookup::None),


### PR DESCRIPTION
## Summary
- Add a core git raw-output primitive for callers that need to inspect non-zero git statuses.
- Route stack git command execution through the core primitive instead of a stack-local Command wrapper.
- Add a core GitHub PR-by-commit search helper and use it from stack inspect instead of invoking gh directly in stack code.

## Verification
- `cargo fmt --check`
- `cargo test core::stack`
- `cargo test core::git::github`
- `cargo test --test architecture_core_agnostic_test --test core_agnostic_test` *(fails in `core_owned_source_stays_language_and_framework_agnostic` on pre-existing `src/core/runner/tool_registry.rs` cargo/composer/npm/php/rust/wordpress findings; this PR does not touch that file)*

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** audited and drafted the refactor; Chris remains responsible.