### PR TITLE
Normalize agent-task artifact declarations

### DIFF
--- a/src/commands/bench/fanout.rs
+++ b/src/commands/bench/fanout.rs
@@ -182,7 +182,7 @@ fn matrix_template_request(
     executor_backend: &str,
     run_args: &BenchRunArgs,
 ) -> AgentTaskRequest {
-    AgentTaskRequest {
+    let mut request = AgentTaskRequest {
         schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
         task_id: format!("{plan_id}/template"),
         group_key: Some(plan_id.to_string()),
@@ -217,7 +217,9 @@ fn matrix_template_request(
         expected_artifacts: run_args.expected_artifact.clone(),
         artifact_declarations: Vec::new(),
         metadata: serde_json::json!({ "product_command": "bench.matrix" }),
-    }
+    };
+    request.normalize_artifact_declarations();
+    request
 }
 
 #[derive(Clone)]
@@ -358,5 +360,18 @@ mod tests {
         assert_eq!(err.details["field"], "matrix");
         assert!(err.message.contains("no-op cell"));
         assert!(err.message.contains("no benchmark workload ran"));
+    }
+
+    #[test]
+    fn matrix_template_canonicalizes_expected_artifacts() {
+        let mut args = run_args(Some("studio-web"));
+        args.expected_artifact = vec!["bench-results".to_string()];
+
+        let request = matrix_template_request("bench/studio-web", "studio-web", "codebox", &args);
+
+        assert_eq!(request.expected_artifacts, vec!["bench-results"]);
+        assert_eq!(request.artifact_declarations.len(), 1);
+        assert_eq!(request.artifact_declarations[0].name, "bench-results");
+        assert!(request.artifact_declarations[0].required);
     }
 }

--- a/src/core/agent_task.rs
+++ b/src/core/agent_task.rs
@@ -146,6 +146,44 @@ pub struct AgentTaskRequest {
     pub metadata: Value,
 }
 
+impl AgentTaskRequest {
+    pub fn canonical_artifact_declarations(&self) -> Vec<AgentTaskArtifactDeclaration> {
+        let mut declarations = Vec::new();
+        for declaration in &self.artifact_declarations {
+            if let Some(declaration) = declaration.canonical() {
+                push_artifact_declaration_once(&mut declarations, declaration);
+            }
+        }
+
+        for expected in &self.expected_artifacts {
+            if let Some(declaration) =
+                AgentTaskArtifactDeclaration::from_expected_artifact(expected)
+            {
+                push_artifact_declaration_once(&mut declarations, declaration);
+            }
+        }
+
+        declarations
+    }
+
+    pub fn normalize_artifact_declarations(&mut self) {
+        self.artifact_declarations = self.canonical_artifact_declarations();
+    }
+}
+
+fn push_artifact_declaration_once(
+    declarations: &mut Vec<AgentTaskArtifactDeclaration>,
+    declaration: AgentTaskArtifactDeclaration,
+) {
+    if declarations
+        .iter()
+        .any(|existing| existing.name == declaration.name)
+    {
+        return;
+    }
+    declarations.push(declaration);
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskComponentContract {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -466,9 +504,22 @@ pub enum AgentTaskFailureClassification {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskArtifactDeclaration {
     pub name: String,
-    #[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "type",
+        alias = "artifact_type",
+        alias = "artifactType",
+        alias = "kind",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub artifact_type: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        alias = "artifactSchema",
+        alias = "content_schema",
+        alias = "contentSchema",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub artifact_schema: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
@@ -478,6 +529,39 @@ pub struct AgentTaskArtifactDeclaration {
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub metadata: Value,
+}
+
+impl AgentTaskArtifactDeclaration {
+    fn canonical(&self) -> Option<Self> {
+        let name = non_empty_trimmed(&self.name)?;
+        Some(Self {
+            name,
+            artifact_type: self.artifact_type.as_deref().and_then(non_empty_trimmed),
+            artifact_schema: self.artifact_schema.as_deref().and_then(non_empty_trimmed),
+            path: self.path.as_deref().and_then(non_empty_trimmed),
+            required: self.required,
+            description: self.description.as_deref().and_then(non_empty_trimmed),
+            metadata: self.metadata.clone(),
+        })
+    }
+
+    fn from_expected_artifact(expected: &str) -> Option<Self> {
+        let name = non_empty_trimmed(expected)?;
+        Some(Self {
+            name,
+            artifact_type: None,
+            artifact_schema: None,
+            path: None,
+            required: true,
+            description: None,
+            metadata: Value::Null,
+        })
+    }
+}
+
+fn non_empty_trimmed(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -885,6 +969,40 @@ mod tests {
             Some("AnalysisReport")
         );
         assert!(request.artifact_declarations[0].required);
+    }
+
+    #[test]
+    fn request_canonicalizes_artifact_declarations_from_expected_artifacts() {
+        let mut request: AgentTaskRequest = serde_json::from_value(json!({
+            "schema": AGENT_TASK_REQUEST_SCHEMA,
+            "task_id": "task-artifact-normalization",
+            "executor": { "backend": "codebox" },
+            "instructions": "Return artifacts.",
+            "expected_artifacts": [" patch ", "analysis_report", ""],
+            "artifact_declarations": [{
+                "name": " analysis_report ",
+                "kind": "AnalysisReport",
+                "contentSchema": "example/analysis-report/v1",
+                "required": false
+            }]
+        }))
+        .expect("decode request with artifact aliases");
+
+        request.normalize_artifact_declarations();
+
+        assert_eq!(request.artifact_declarations.len(), 2);
+        assert_eq!(request.artifact_declarations[0].name, "analysis_report");
+        assert_eq!(
+            request.artifact_declarations[0].artifact_type.as_deref(),
+            Some("AnalysisReport")
+        );
+        assert_eq!(
+            request.artifact_declarations[0].artifact_schema.as_deref(),
+            Some("example/analysis-report/v1")
+        );
+        assert!(!request.artifact_declarations[0].required);
+        assert_eq!(request.artifact_declarations[1].name, "patch");
+        assert!(request.artifact_declarations[1].required);
     }
 
     #[test]

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -997,7 +997,9 @@ fn run_provider_command(
         .timeout_ms
         .or(request.limits.max_runtime_ms)
         .map(|timeout_ms| (timeout_ms, timeout_with_grace(timeout_ms)));
-    let input = match serde_json::to_vec(request) {
+    let mut provider_request = request.clone();
+    provider_request.normalize_artifact_declarations();
+    let input = match serde_json::to_vec(&provider_request) {
         Ok(input) => input,
         Err(error) => {
             return failure_outcome(
@@ -1505,6 +1507,41 @@ mod tests {
                 .role_aliases
                 .output_aliases_for_role("provider_run_result"),
             vec!["custom_run_result"]
+        );
+    }
+
+    #[test]
+    fn provider_command_receives_canonical_artifact_declarations() {
+        let command = format!(
+            "node {}",
+            script(
+                r#"
+const fs = require('fs');
+const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+process.stdout.write(JSON.stringify({
+  schema: 'homeboy/agent-task-outcome/v1',
+  task_id: input.task_id,
+  status: 'succeeded',
+  artifacts: [],
+  typed_artifacts: [],
+  evidence_refs: [],
+  diagnostics: [],
+  outputs: { artifact_declarations: input.artifact_declarations },
+  metadata: null
+}));
+"#
+            )
+        );
+        let (mut request, provider) = request("task-artifact-normalization", command);
+        request.expected_artifacts = vec!["patch".to_string()];
+
+        let outcome = run_provider_command(&request, &provider);
+
+        assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
+        assert_eq!(outcome.outputs["artifact_declarations"][0]["name"], "patch");
+        assert_eq!(
+            outcome.outputs["artifact_declarations"][0]["required"],
+            true
         );
     }
 


### PR DESCRIPTION
## Summary
- Add a canonical Homeboy core artifact declaration normalization path on `AgentTaskRequest`.
- Canonicalize legacy `expected_artifacts` into `artifact_declarations` while preserving explicit declarations and common field aliases.
- Send normalized declarations to provider commands and bench matrix fan-out templates.

## Verification
- `cargo fmt`
- `cargo test canonical`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and focused tests; Chris remains responsible for review and validation.
