### PR TITLE
Add declarative rig requirement steps

### DIFF
--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -104,7 +104,7 @@ fn run_ordered_steps(
         let label = step_label(rig, step, idx);
         crate::log_status!("rig", "{}: {}", name, label);
 
-        let result = run_step(rig, step);
+        let result = run_step(rig, name, step);
 
         let outcome = match &result {
             Ok(()) => PipelineStepOutcome {
@@ -151,7 +151,7 @@ fn step_matches_groups(step: &PipelineStep, wanted: &BTreeSet<&str>) -> bool {
     }
 }
 
-fn run_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {
+fn run_step(rig: &RigSpec, pipeline_name: &str, step: &PipelineStep) -> Result<()> {
     match step {
         PipelineStep::Service { id, op, .. } => run_service_step(rig, id, *op),
         PipelineStep::Build { component, .. } => run_build_step(rig, component),
@@ -171,6 +171,7 @@ fn run_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {
         PipelineStep::Command { .. } | PipelineStep::CommandIfMissing { .. } => {
             run_command_pipeline_step(rig, step)
         }
+        PipelineStep::Requirement { .. } => run_requirement_step(rig, pipeline_name, step),
         PipelineStep::Symlink { op, .. } => run_symlink_step(rig, *op),
         PipelineStep::SharedPath { op, .. } => run_shared_path_step(rig, *op),
         PipelineStep::Patch {
@@ -284,6 +285,7 @@ fn step_id(step: &PipelineStep) -> Option<&str> {
         | PipelineStep::Stack { step_id, .. }
         | PipelineStep::Command { step_id, .. }
         | PipelineStep::CommandIfMissing { step_id, .. }
+        | PipelineStep::Requirement { step_id, .. }
         | PipelineStep::Symlink { step_id, .. }
         | PipelineStep::SharedPath { step_id, .. }
         | PipelineStep::Patch { step_id, .. }
@@ -300,6 +302,7 @@ fn step_dependencies(step: &PipelineStep) -> &[String] {
         | PipelineStep::Stack { depends_on, .. }
         | PipelineStep::Command { depends_on, .. }
         | PipelineStep::CommandIfMissing { depends_on, .. }
+        | PipelineStep::Requirement { depends_on, .. }
         | PipelineStep::Symlink { depends_on, .. }
         | PipelineStep::SharedPath { depends_on, .. }
         | PipelineStep::Patch { depends_on, .. }
@@ -630,6 +633,149 @@ fn run_command_if_missing_step(
     }
 
     run_command_step(rig, cmd, cwd, env)
+}
+
+fn run_requirement_step(rig: &RigSpec, pipeline_name: &str, step: &PipelineStep) -> Result<()> {
+    let PipelineStep::Requirement {
+        path,
+        file,
+        dir,
+        component,
+        component_path_contains,
+        prepare_command,
+        prepare_phases,
+        cwd,
+        env,
+        remediation,
+        ..
+    } = step
+    else {
+        unreachable!("requirement helper only accepts requirement steps")
+    };
+
+    if component.is_some() != component_path_contains.is_some() {
+        return Err(Error::validation_invalid_argument(
+            "requirement.component_path_contains",
+            "Requirement must specify both `component` and `component_path_contains` or neither",
+            None,
+            None,
+        ));
+    }
+
+    if let (Some(component_id), Some(required)) = (component, component_path_contains) {
+        let (_, component_path) = resolve_component_path(rig, component_id)?;
+        if !component_path.contains(required) {
+            return Err(requirement_failed(
+                rig,
+                format!(
+                    "component `{}` path `{}` does not contain `{}`",
+                    component_id, component_path, required
+                ),
+                remediation.as_deref(),
+            ));
+        }
+    }
+
+    let mut path_specs = Vec::new();
+    if let Some(value) = path {
+        path_specs.push(("path", value));
+    }
+    if let Some(value) = file {
+        path_specs.push(("file", value));
+    }
+    if let Some(value) = dir {
+        path_specs.push(("dir", value));
+    }
+
+    if path_specs.is_empty() && component_path_contains.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "requirement",
+            "Requirement must specify at least one of `path`, `file`, `dir`, or `component_path_contains`",
+            None,
+            None,
+        ));
+    }
+
+    let missing_before_prepare = path_specs
+        .iter()
+        .filter_map(|(kind, declared)| {
+            requirement_path_failure(rig, cwd.as_deref(), kind, declared)
+        })
+        .collect::<Vec<_>>();
+
+    if !missing_before_prepare.is_empty()
+        && prepare_command.is_some()
+        && prepare_phases.iter().any(|phase| phase == pipeline_name)
+    {
+        run_command_step(
+            rig,
+            prepare_command.as_deref().unwrap(),
+            cwd.as_deref(),
+            env,
+        )?;
+    }
+
+    let missing = path_specs
+        .iter()
+        .filter_map(|(kind, declared)| {
+            requirement_path_failure(rig, cwd.as_deref(), kind, declared)
+        })
+        .collect::<Vec<_>>();
+
+    if !missing.is_empty() {
+        return Err(requirement_failed(
+            rig,
+            missing.join("; "),
+            remediation.as_deref(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn requirement_path_failure(
+    rig: &RigSpec,
+    cwd: Option<&str>,
+    kind: &str,
+    declared: &str,
+) -> Option<String> {
+    let resolved = resolve_requirement_path(rig, cwd, declared);
+    let ok = match kind {
+        "file" => resolved.is_file(),
+        "dir" => resolved.is_dir(),
+        _ => resolved.exists(),
+    };
+
+    (!ok).then(|| {
+        let display = resolved.display();
+        if declared == display.to_string() {
+            format!("{} does not exist: {}", kind, display)
+        } else {
+            format!(
+                "{} does not exist: {} (declared: {})",
+                kind, display, declared
+            )
+        }
+    })
+}
+
+fn resolve_requirement_path(rig: &RigSpec, cwd: Option<&str>, declared: &str) -> PathBuf {
+    let expanded = expand_vars(rig, declared);
+    let path = PathBuf::from(&expanded);
+    if path.is_absolute() {
+        path
+    } else if let Some(cwd) = cwd {
+        PathBuf::from(expand_vars(rig, cwd)).join(path)
+    } else {
+        path
+    }
+}
+
+fn requirement_failed(rig: &RigSpec, message: String, remediation: Option<&str>) -> Error {
+    let detail = remediation
+        .map(|text| format!("{}. Remediation: {}", message, expand_vars(rig, text)))
+        .unwrap_or(message);
+    Error::rig_pipeline_failed(&rig.id, "requirement", detail)
 }
 
 #[cfg(unix)]
@@ -1097,6 +1243,7 @@ fn step_kind(step: &PipelineStep) -> &'static str {
         PipelineStep::Stack { .. } => "stack",
         PipelineStep::Command { .. } => "command",
         PipelineStep::CommandIfMissing { .. } => "command-if-missing",
+        PipelineStep::Requirement { .. } => "requirement",
         PipelineStep::Symlink { .. } => "symlink",
         PipelineStep::SharedPath { .. } => "shared-path",
         PipelineStep::Patch { .. } => "patch",
@@ -1154,6 +1301,27 @@ fn step_label(rig: &RigSpec, step: &PipelineStep, idx: usize) -> String {
         PipelineStep::CommandIfMissing { cmd, label, .. } => label
             .clone()
             .unwrap_or_else(|| truncate(&expand_vars(rig, cmd), 80)),
+        PipelineStep::Requirement {
+            path,
+            file,
+            dir,
+            component,
+            component_path_contains,
+            label,
+            ..
+        } => label.clone().unwrap_or_else(|| {
+            if let Some(path) = file {
+                format!("require file {}", truncate(path, 60))
+            } else if let Some(path) = dir {
+                format!("require dir {}", truncate(path, 60))
+            } else if let Some(path) = path {
+                format!("require path {}", truncate(path, 60))
+            } else if let (Some(component), Some(required)) = (component, component_path_contains) {
+                format!("require {} path contains {}", component, required)
+            } else {
+                format!("requirement #{}", idx + 1)
+            }
+        }),
         PipelineStep::Symlink { op, .. } => format!("symlink {}", serialize_symlink_op(*op)),
         PipelineStep::SharedPath { op, .. } => {
             format!("shared-path {}", serialize_shared_path_op(*op))

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -1322,6 +1322,55 @@ pub enum PipelineStep {
         label: Option<String>,
     },
 
+    /// Declarative local requirement for common rig preflight checks.
+    ///
+    /// Use this for simple filesystem/component-path assertions instead of
+    /// inline shell. When `prepare_command` is set, it runs only in listed
+    /// `prepare_phases`; normal `check` remains read-only and reports the
+    /// declared remediation.
+    Requirement {
+        /// Optional stable node ID for dependency-aware pipeline ordering.
+        #[serde(default, rename = "id", skip_serializing_if = "Option::is_none")]
+        step_id: Option<String>,
+        /// Step IDs that must run before this step.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        depends_on: Vec<String>,
+        /// Existing path. Relative paths resolve against `cwd` when set.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<String>,
+        /// Existing regular file.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        file: Option<String>,
+        /// Existing directory.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        dir: Option<String>,
+        /// Component whose resolved path must contain `component_path_contains`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        component: Option<String>,
+        /// Required substring in the resolved component path.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        component_path_contains: Option<String>,
+        /// Command to run when the filesystem requirement is missing and the
+        /// current pipeline name appears in `prepare_phases`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        prepare_command: Option<String>,
+        /// Pipeline names allowed to run `prepare_command`.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        prepare_phases: Vec<String>,
+        /// Working directory for `prepare_command` and relative paths.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cwd: Option<String>,
+        /// Env vars (merged over inherited environment) for `prepare_command`.
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        env: HashMap<String, String>,
+        /// Human remediation shown when the requirement is not satisfied.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        remediation: Option<String>,
+        /// Human-readable label shown during execution.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+    },
+
     /// Ensure a declared symlink exists (or verify it in `check` pipelines).
     Symlink {
         /// Optional stable node ID for dependency-aware pipeline ordering.

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -152,6 +152,113 @@ fn test_command_if_missing_skips_when_path_exists() {
     assert!(!marker.exists(), "guarded command should not run");
 }
 
+#[test]
+fn test_requirement_passes_when_declared_file_exists() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let marker = tmp.path().join("marker.txt");
+    std::fs::write(&marker, "ok").expect("write marker");
+    let marker_arg = marker.to_string_lossy();
+    let rig: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "requirement-file",
+            "pipeline": {{
+                "check": [{{
+                    "kind": "requirement",
+                    "file": "{}"
+                }}]
+            }}
+        }}"#,
+        marker_arg
+    ))
+    .expect("parse rig");
+
+    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    assert!(out.is_success(), "outcomes: {:?}", out.steps);
+}
+
+#[test]
+fn test_requirement_prepare_command_runs_only_in_declared_phase() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let marker = tmp.path().join("prepared.txt");
+    let marker_arg = marker.to_string_lossy();
+    let rig: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "requirement-prepare",
+            "pipeline": {{
+                "bench_prepare": [{{
+                    "kind": "requirement",
+                    "file": "{}",
+                    "prepare_command": "printf prepared > {}",
+                    "prepare_phases": ["bench_prepare"]
+                }}]
+            }}
+        }}"#,
+        marker_arg, marker_arg
+    ))
+    .expect("parse rig");
+
+    let out = run_pipeline(&rig, "bench_prepare", true).expect("pipeline runs");
+    assert!(out.is_success(), "outcomes: {:?}", out.steps);
+    assert_eq!(std::fs::read_to_string(marker).expect("marker"), "prepared");
+}
+
+#[test]
+fn test_requirement_fails_with_remediation_without_prepare_phase() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let marker = tmp.path().join("missing.txt");
+    let marker_arg = marker.to_string_lossy();
+    let rig: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "requirement-remediation",
+            "pipeline": {{
+                "check": [{{
+                    "kind": "requirement",
+                    "file": "{}",
+                    "prepare_command": "printf prepared > {}",
+                    "prepare_phases": ["bench_prepare"],
+                    "remediation": "run bench_prepare"
+                }}]
+            }}
+        }}"#,
+        marker_arg, marker_arg
+    ))
+    .expect("parse rig");
+
+    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    assert!(!out.is_success());
+    let error = out.steps[0].error.as_deref().unwrap_or_default();
+    assert!(error.contains("run bench_prepare"), "error: {error}");
+    assert!(!marker.exists(), "check phase should not prepare");
+}
+
+#[test]
+fn test_requirement_validates_component_path_contains() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let component_path = tmp.path().join("plugins/example-plugin");
+    std::fs::create_dir_all(&component_path).expect("mkdir component");
+    let component_arg = component_path.to_string_lossy();
+    let rig: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "requirement-component-path",
+            "components": {{
+                "example": {{ "path": "{}" }}
+            }},
+            "pipeline": {{
+                "check": [{{
+                    "kind": "requirement",
+                    "component": "example",
+                    "component_path_contains": "plugins/example-plugin"
+                }}]
+            }}
+        }}"#,
+        component_arg
+    ))
+    .expect("parse rig");
+
+    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    assert!(out.is_success(), "outcomes: {:?}", out.steps);
+}
+
 // ---- Dependency-aware ordering ---------------------------------------------
 
 mod dag {


### PR DESCRIPTION
## Summary
- Add a generic rig pipeline `requirement` step for file/path/dir existence checks.
- Support component path substring assertions without embedding domain-specific semantics.
- Allow missing filesystem requirements to run an optional prepare command only in declared pipeline phases, with remediation text for read-only checks.
- Cover the new behavior in the rig pipeline test module.

## Verification
- `cargo test test_requirement`
- `cargo test core::rig::pipeline::pipeline_test`

## Coordinated follow-up
- Intended consumer PR: chubes4/homeboy-rigs branch `feat/declarative-rig-requirements`, migrating a WooCommerce rig slice away from inline shell preflight.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, verification commands, and PR description; Chris remains responsible for review and merge.