### PR TITLE
feat(agent-task): declare timeout artifact contracts

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -243,6 +243,71 @@ without `origin` fail on the controller before offload with a supported-path
 diagnostic; use a Homeboy worktree or another clean checkout
 for write-capable agent tasks.
 
+## Provider Runtime Contracts
+
+Agent runtime manifests may declare portable provider contracts that Homeboy uses
+before and after execution without learning provider-specific APIs. These fields
+belong on each `agent_task_executors[]` entry:
+
+```json
+{
+  "schema": "homeboy/agent-task-executor-provider/v1",
+  "id": "example.default",
+  "backend": "example",
+  "command": "example-provider",
+  "request_schema": "homeboy/agent-task-request/v1",
+  "outcome_schema": "homeboy/agent-task-outcome/v1",
+  "secret_env_requirements": [
+    {
+      "env": ["EXAMPLE_API_TOKEN"],
+      "secret_env_sources": {
+        "EXAMPLE_API_TOKEN": { "kind": "env", "name": "EXAMPLE_API_TOKEN" }
+      }
+    }
+  ],
+  "runner_readiness": [
+    {
+      "id": "example-auth",
+      "label": "Example provider auth",
+      "secret_env": ["EXAMPLE_API_TOKEN"],
+      "remediation": "Configure EXAMPLE_API_TOKEN with homeboy agent-task auth."
+    }
+  ],
+  "workspace_materialization": {
+    "cwd": "git_checkout",
+    "requires_git": true,
+    "write_scope": "workspace",
+    "artifact_paths": ["artifacts"]
+  },
+  "timeout_artifact_discovery": {
+    "config_path_keys": ["provider_artifact_root"],
+    "paths": ["/var/tmp/example-provider/latest"],
+    "artifact_patterns": [
+      {
+        "kind": "metrics",
+        "filename_patterns": ["*-metrics.ndjson"],
+        "mime": "application/x-ndjson",
+        "metadata": { "role": "telemetry" }
+      }
+    ]
+  }
+}
+```
+
+Homeboy treats these declarations as generic contracts:
+
+- `secret_env_requirements` and `runner_readiness` describe required secret env
+  names and redacted readiness probes without exposing values.
+- `workspace_materialization` describes the checkout shape a provider needs; it
+  does not name any workspace manager or product runtime.
+- `timeout_artifact_discovery` extends timeout evidence recovery with declared
+  paths, request metadata/config path keys, and typed filename/extension patterns.
+  Discovered files are normalized into `AgentTaskArtifact` entries with generic
+  `kind`, `mime`, and opaque metadata.
+- Provider-specific sessions, APIs, artifact namespaces, and backend payloads stay
+  outside Homeboy core and are represented only as artifacts, evidence refs,
+  diagnostics, workflow steps, or opaque metadata.
+
 ## Durable Loop Controllers
 
 `agent-task controller` stores domain-agnostic controller state for multi-day

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -50,6 +50,11 @@ pub struct AgentTaskExecutorProvider {
     pub dependency_failure_patterns: Vec<AgentTaskProviderDependencyFailurePattern>,
     #[serde(
         default,
+        skip_serializing_if = "AgentTaskProviderTimeoutArtifactDiscovery::is_empty"
+    )]
+    pub timeout_artifact_discovery: AgentTaskProviderTimeoutArtifactDiscovery,
+    #[serde(
+        default,
         skip_serializing_if = "AgentTaskProviderRoleAliases::is_empty"
     )]
     pub role_aliases: AgentTaskProviderRoleAliases,
@@ -172,6 +177,55 @@ pub struct AgentTaskProviderDependencyFailurePattern {
     pub error_contains_any: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remediation: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentTaskProviderTimeoutArtifactDiscovery {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub metadata_path_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub config_path_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_patterns: Vec<AgentTaskProviderArtifactPattern>,
+}
+
+impl AgentTaskProviderTimeoutArtifactDiscovery {
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+            && self.metadata_path_keys.is_empty()
+            && self.config_path_keys.is_empty()
+            && self.artifact_patterns.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentTaskProviderArtifactPattern {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub filename_patterns: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub filename_contains: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extensions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime: Option<String>,
+    #[serde(
+        default = "default_metadata",
+        skip_serializing_if = "is_empty_metadata"
+    )]
+    pub metadata: Value,
+}
+
+fn default_metadata() -> Value {
+    Value::Object(Default::default())
+}
+
+fn is_empty_metadata(value: &Value) -> bool {
+    value.as_object().is_none_or(|object| object.is_empty())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -363,6 +417,16 @@ pub(crate) fn role_aliases_for_executor(
     let providers = discover_agent_task_executor_providers();
     select_provider_by_backend(&providers, backend, selector)
         .map(|provider| provider.role_aliases.clone())
+        .unwrap_or_default()
+}
+
+pub(crate) fn timeout_artifact_discovery_for_executor(
+    backend: &str,
+    selector: Option<&str>,
+) -> AgentTaskProviderTimeoutArtifactDiscovery {
+    let providers = discover_agent_task_executor_providers();
+    select_provider_by_backend(&providers, backend, selector)
+        .map(|provider| provider.timeout_artifact_discovery.clone())
         .unwrap_or_default()
 }
 
@@ -1346,6 +1410,7 @@ mod tests {
             runner_readiness: Vec::new(),
             runner_sources: Vec::new(),
             dependency_failure_patterns: Vec::new(),
+            timeout_artifact_discovery: AgentTaskProviderTimeoutArtifactDiscovery::default(),
             role_aliases: AgentTaskProviderRoleAliases::default(),
             extension_id: None,
             extension_path: None,

--- a/src/core/agent_task_timeout_artifacts.rs
+++ b/src/core/agent_task_timeout_artifacts.rs
@@ -9,7 +9,11 @@ use crate::core::agent_task::{
     AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_ARTIFACT_SCHEMA,
     AGENT_TASK_OUTCOME_SCHEMA,
 };
-use crate::core::agent_task_provider::{role_aliases_for_executor, AgentTaskProviderRoleAliases};
+use crate::core::agent_task_provider::{
+    role_aliases_for_executor, timeout_artifact_discovery_for_executor,
+    AgentTaskProviderArtifactPattern, AgentTaskProviderRoleAliases,
+    AgentTaskProviderTimeoutArtifactDiscovery,
+};
 
 const EXPECTED_RUNTIME_EVIDENCE_FILES: &[&str] = &[
     "transcript.json",
@@ -36,18 +40,35 @@ impl TimeoutArtifactDiscovery {
             &request.executor.backend,
             request.executor.selector.as_deref(),
         );
-        Self::discover_with_role_aliases(request, &role_aliases)
+        let timeout_discovery = timeout_artifact_discovery_for_executor(
+            &request.executor.backend,
+            request.executor.selector.as_deref(),
+        );
+        Self::discover_with_contract(request, &role_aliases, &timeout_discovery)
     }
 
+    fn discover_with_contract(
+        request: &AgentTaskRequest,
+        role_aliases: &AgentTaskProviderRoleAliases,
+        timeout_discovery: &AgentTaskProviderTimeoutArtifactDiscovery,
+    ) -> Self {
+        let mut discovery = Self::default();
+        for path in artifact_discovery_paths(request, timeout_discovery) {
+            discovery.scan_path(&path, request, role_aliases, timeout_discovery);
+        }
+        discovery
+    }
+
+    #[cfg(test)]
     fn discover_with_role_aliases(
         request: &AgentTaskRequest,
         role_aliases: &AgentTaskProviderRoleAliases,
     ) -> Self {
-        let mut discovery = Self::default();
-        for path in artifact_discovery_paths(request) {
-            discovery.scan_path(&path, request, role_aliases);
-        }
-        discovery
+        Self::discover_with_contract(
+            request,
+            role_aliases,
+            &AgentTaskProviderTimeoutArtifactDiscovery::default(),
+        )
     }
 
     pub(crate) fn has_runtime_evidence(&self) -> bool {
@@ -59,13 +80,14 @@ impl TimeoutArtifactDiscovery {
         path: &Path,
         request: &AgentTaskRequest,
         role_aliases: &AgentTaskProviderRoleAliases,
+        timeout_discovery: &AgentTaskProviderTimeoutArtifactDiscovery,
     ) {
         let Ok(metadata) = fs::metadata(path) else {
             return;
         };
 
         if metadata.is_file() {
-            self.record_file(path, request, role_aliases);
+            self.record_file(path, request, role_aliases, timeout_discovery);
             return;
         }
 
@@ -74,7 +96,7 @@ impl TimeoutArtifactDiscovery {
         }
 
         let runtime_evidence_count_before = self.runtime_evidence_count();
-        self.scan_directory_files(path, request, role_aliases, 0, &mut 0);
+        self.scan_directory_files(path, request, role_aliases, timeout_discovery, 0, &mut 0);
         self.record_directory_if_useful(
             path,
             self.runtime_evidence_count() > runtime_evidence_count_before,
@@ -134,6 +156,7 @@ impl TimeoutArtifactDiscovery {
         path: &Path,
         request: &AgentTaskRequest,
         role_aliases: &AgentTaskProviderRoleAliases,
+        timeout_discovery: &AgentTaskProviderTimeoutArtifactDiscovery,
     ) {
         if let Some(outcome) = read_discovered_outcome(path, request) {
             append_unique_artifacts(&mut self.artifacts, outcome.artifacts.clone());
@@ -147,7 +170,9 @@ impl TimeoutArtifactDiscovery {
             return;
         }
 
-        let Some(kind) = artifact_kind_from_path(path, role_aliases) else {
+        let Some((kind, mime, metadata)) =
+            artifact_shape_from_path(path, role_aliases, timeout_discovery)
+        else {
             return;
         };
         let Some(id) = artifact_id_from_path(path) else {
@@ -163,10 +188,10 @@ impl TimeoutArtifactDiscovery {
                 .map(|name| name.to_string_lossy().to_string()),
             path: Some(path.display().to_string()),
             url: None,
-            mime: mime_from_path(path),
+            mime,
             size_bytes,
             sha256,
-            metadata: serde_json::json!({ "discovered_from": "timeout_artifact_scan" }),
+            metadata,
         });
     }
 
@@ -175,6 +200,7 @@ impl TimeoutArtifactDiscovery {
         path: &Path,
         request: &AgentTaskRequest,
         role_aliases: &AgentTaskProviderRoleAliases,
+        timeout_discovery: &AgentTaskProviderTimeoutArtifactDiscovery,
         depth: usize,
         visited: &mut usize,
     ) {
@@ -195,10 +221,17 @@ impl TimeoutArtifactDiscovery {
                 continue;
             };
             if child_metadata.is_file() {
-                self.record_file(&child, request, role_aliases);
+                self.record_file(&child, request, role_aliases, timeout_discovery);
             } else if child_metadata.is_dir() {
                 let runtime_evidence_count_before = self.runtime_evidence_count();
-                self.scan_directory_files(&child, request, role_aliases, depth + 1, visited);
+                self.scan_directory_files(
+                    &child,
+                    request,
+                    role_aliases,
+                    timeout_discovery,
+                    depth + 1,
+                    visited,
+                );
                 self.record_directory_if_useful(
                     &child,
                     self.runtime_evidence_count() > runtime_evidence_count_before,
@@ -298,10 +331,24 @@ fn artifact_has_content(artifact: &AgentTaskArtifact) -> bool {
         .unwrap_or(true)
 }
 
-fn artifact_discovery_paths(request: &AgentTaskRequest) -> Vec<PathBuf> {
+fn artifact_discovery_paths(
+    request: &AgentTaskRequest,
+    timeout_discovery: &AgentTaskProviderTimeoutArtifactDiscovery,
+) -> Vec<PathBuf> {
     let mut paths = Vec::new();
-    collect_artifact_paths_from_value(&request.metadata, &mut paths);
-    collect_artifact_paths_from_value(&request.executor.config, &mut paths);
+    collect_artifact_paths_from_value(&request.metadata, default_path_keys(), &mut paths);
+    collect_artifact_paths_from_value(&request.executor.config, default_path_keys(), &mut paths);
+    collect_artifact_paths_from_value(
+        &request.metadata,
+        &timeout_discovery.metadata_path_keys,
+        &mut paths,
+    );
+    collect_artifact_paths_from_value(
+        &request.executor.config,
+        &timeout_discovery.config_path_keys,
+        &mut paths,
+    );
+    paths.extend(timeout_discovery.paths.iter().map(PathBuf::from));
     for expected in &request.expected_artifacts {
         paths.push(PathBuf::from(expected));
     }
@@ -313,24 +360,29 @@ fn artifact_discovery_paths(request: &AgentTaskRequest) -> Vec<PathBuf> {
     paths
 }
 
-fn collect_artifact_paths_from_value(value: &Value, paths: &mut Vec<PathBuf>) {
-    for key in [
+fn default_path_keys() -> &'static [&'static str] {
+    &[
         "artifact_root",
         "artifact_path",
         "outcome_path",
         "agent_result_path",
-    ] {
-        if let Some(path) = value.get(key).and_then(Value::as_str) {
-            paths.push(PathBuf::from(path));
-        }
-    }
-
-    for key in [
         "artifact_roots",
         "artifact_paths",
         "outcome_paths",
         "agent_result_paths",
-    ] {
+    ]
+}
+
+fn collect_artifact_paths_from_value(
+    value: &Value,
+    keys: &[impl AsRef<str>],
+    paths: &mut Vec<PathBuf>,
+) {
+    for key in keys {
+        let key = key.as_ref();
+        if let Some(path) = value.get(key).and_then(Value::as_str) {
+            paths.push(PathBuf::from(path));
+        }
         if let Some(values) = value.get(key).and_then(Value::as_array) {
             paths.extend(values.iter().filter_map(Value::as_str).map(PathBuf::from));
         }
@@ -366,6 +418,32 @@ fn merge_outcome_metadata_actionable(metadata: Value, actionable: bool) -> Value
         }
         _ => serde_json::json!({ "actionable": actionable }),
     }
+}
+
+fn artifact_shape_from_path(
+    path: &Path,
+    role_aliases: &AgentTaskProviderRoleAliases,
+    timeout_discovery: &AgentTaskProviderTimeoutArtifactDiscovery,
+) -> Option<(String, Option<String>, Value)> {
+    if let Some(pattern) = timeout_discovery
+        .artifact_patterns
+        .iter()
+        .find(|pattern| artifact_pattern_matches(pattern, path))
+    {
+        return Some((
+            pattern.kind.clone(),
+            pattern.mime.clone().or_else(|| mime_from_path(path)),
+            merge_artifact_metadata(pattern.metadata.clone()),
+        ));
+    }
+
+    artifact_kind_from_path(path, role_aliases).map(|kind| {
+        (
+            kind,
+            mime_from_path(path),
+            serde_json::json!({ "discovered_from": "timeout_artifact_scan" }),
+        )
+    })
 }
 
 fn artifact_kind_from_path(
@@ -406,6 +484,71 @@ fn artifact_kind_from_path(
     }
 
     None
+}
+
+fn artifact_pattern_matches(pattern: &AgentTaskProviderArtifactPattern, path: &Path) -> bool {
+    let Some(file_name) = path
+        .file_name()
+        .map(|file_name| file_name.to_string_lossy().to_ascii_lowercase())
+    else {
+        return false;
+    };
+    let extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    pattern
+        .filename_patterns
+        .iter()
+        .any(|candidate| wildcard_match(&candidate.to_ascii_lowercase(), &file_name))
+        || pattern
+            .filename_contains
+            .iter()
+            .any(|candidate| file_name.contains(&candidate.to_ascii_lowercase()))
+        || pattern
+            .extensions
+            .iter()
+            .map(|candidate| candidate.trim_start_matches('.').to_ascii_lowercase())
+            .any(|candidate| candidate == extension)
+}
+
+fn wildcard_match(pattern: &str, value: &str) -> bool {
+    if !pattern.contains('*') {
+        return pattern == value;
+    }
+
+    let mut remainder = value;
+    let anchored_start = !pattern.starts_with('*');
+    let anchored_end = !pattern.ends_with('*');
+    let parts: Vec<&str> = pattern.split('*').filter(|part| !part.is_empty()).collect();
+    if parts.is_empty() {
+        return true;
+    }
+    if anchored_start && !value.starts_with(parts[0]) {
+        return false;
+    }
+    for part in &parts {
+        let Some(index) = remainder.find(part) else {
+            return false;
+        };
+        remainder = &remainder[index + part.len()..];
+    }
+    !anchored_end || value.ends_with(parts[parts.len() - 1])
+}
+
+fn merge_artifact_metadata(metadata: Value) -> Value {
+    match metadata {
+        Value::Object(mut object) => {
+            object.insert(
+                "discovered_from".to_string(),
+                Value::String("timeout_artifact_scan".to_string()),
+            );
+            Value::Object(object)
+        }
+        _ => serde_json::json!({ "discovered_from": "timeout_artifact_scan" }),
+    }
 }
 
 fn artifact_id_from_path(path: &Path) -> Option<String> {
@@ -519,6 +662,59 @@ mod tests {
             artifact.kind == "preflight_evidence"
                 && artifact.path.as_deref() == Some(&evidence_path.to_string_lossy())
         }));
+    }
+
+    #[test]
+    fn provider_timeout_contract_adds_discovery_paths_and_typed_artifact_patterns() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let provider_root = temp.path().join("provider-artifacts");
+        fs::create_dir_all(&provider_root).expect("provider artifact root");
+        let metrics_path = provider_root.join("worker-metrics.ndjson");
+        fs::write(&metrics_path, r#"{"tokens":12}"#).expect("metrics artifact");
+
+        let timeout_discovery: AgentTaskProviderTimeoutArtifactDiscovery =
+            serde_json::from_value(json!({
+                "config_path_keys": ["provider_artifact_root"],
+                "artifact_patterns": [
+                    {
+                        "kind": "metrics",
+                        "filename_patterns": ["*-metrics.ndjson"],
+                        "mime": "application/x-ndjson",
+                        "metadata": { "role": "telemetry" }
+                    }
+                ]
+            }))
+            .expect("timeout discovery contract");
+
+        let mut request = test_request(json!({}));
+        request.executor.config = json!({
+            "provider_artifact_root": provider_root,
+        });
+
+        let discovery = TimeoutArtifactDiscovery::discover_with_contract(
+            &request,
+            &AgentTaskProviderRoleAliases::default(),
+            &timeout_discovery,
+        );
+
+        let artifact = discovery
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.path.as_deref() == Some(&metrics_path.to_string_lossy()))
+            .expect("typed metrics artifact");
+        assert_eq!(artifact.kind, "metrics");
+        assert_eq!(artifact.mime.as_deref(), Some("application/x-ndjson"));
+        assert_eq!(
+            artifact.metadata.get("role").and_then(Value::as_str),
+            Some("telemetry")
+        );
+        assert_eq!(
+            artifact
+                .metadata
+                .get("discovered_from")
+                .and_then(Value::as_str),
+            Some("timeout_artifact_scan")
+        );
     }
 
     fn test_request(metadata: Value) -> AgentTaskRequest {


### PR DESCRIPTION
## Summary
- add generic provider manifest support for timeout artifact discovery contracts
- let providers declare additional timeout evidence paths, request path keys, and typed artifact filename/extension patterns
- document the portable provider runtime contract surface alongside existing secret, readiness, and workspace materialization primitives

## Tests
- `cargo fmt --check`
- `cargo test core::agent_task_timeout_artifacts`
- `cargo test core::agent_runtime_manifest`
- `cargo test --test architecture_core_agnostic_test`
- `cargo test core::agent_task_provider`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the generic manifest fields, timeout artifact discovery wiring, tests, and docs; Chris remains responsible for review and validation.
