### PR TITLE
Bound reviewer-facing artifact evidence

### DIFF
--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -37,6 +37,8 @@ homeboy --output json runs refs --kind trace --component gutenberg --aggregate-a
 
 `homeboy runs resume-plan <run-id>` reads generic `validation_progress` metadata from a run and reports the last completed command, any active command, and the next pending command. Homeboy core records this ledger for Homeboy-managed validation command sets without understanding npm, smoke groups, benchmarks, or implementation-specific command names; command manifests come from project configuration or extension-provided runners.
 
+`homeboy runs evidence <run-id>` emits reviewer-facing evidence using generic artifact addresses. Local operator files are represented as non-reviewer-visible `homeboy://run/<run-id>/artifact/<artifact-id>` handles with a fetch command instead of absolute machine paths. Remote runner artifacts use `runner-artifact://...` refs, validated public HTTP(S) URLs are emitted as public evidence links, and metadata-only evidence remains non-public. Lab-specific publication or mirroring policy belongs in runner/extension enrichment, not in the generic evidence serializer.
+
 `homeboy runs artifact cleanup-downloads` plans cleanup for local runner artifact downloads under Homeboy's artifact root (`<artifact-root>/runner`). By default it is a dry run; pass `--apply` to remove the planned cache subtree. Use `--runner` and `--run-id` to narrow cleanup to a specific runner or run cache.
 
 `homeboy runs distribution` aggregates categorical values from dot-separated JSON metadata paths. Scalar string, number, and boolean values are counted directly; arrays are flattened and counted by scalar element. The output reports inspected runs, matched/missing runs per field, total and unique value counts, value percentages, and repeated values.

--- a/src/commands/runs/evidence.rs
+++ b/src/commands/runs/evidence.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 
+use homeboy::core::artifact_address::{ArtifactAddress, ArtifactAddressKind};
 use homeboy::core::artifact_ref::{ArtifactRef, EvidenceRef};
 use homeboy::core::evidence_manifest::{EvidenceManifest, EVIDENCE_MANIFEST_SCHEMA};
 use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore, RunRecord};
@@ -66,6 +67,7 @@ pub struct RunsEvidenceArtifact {
     #[serde(rename = "type")]
     pub artifact_type: String,
     pub path: String,
+    pub address: ArtifactAddress,
     pub url: Option<String>,
     pub public: bool,
     pub public_url: Option<String>,
@@ -203,8 +205,9 @@ fn evidence_artifact_index(artifacts: &[ArtifactRecord]) -> RunsEvidenceArtifact
     let artifacts = artifacts
         .iter()
         .map(|artifact| {
-            let reference = artifact_ref(artifact);
-            let public_url = artifact_public_url(artifact);
+            let address = ArtifactAddress::from_record(artifact);
+            let reference = artifact_ref(artifact, &address);
+            let public_url = public_url_from_address(&address);
             let exists = artifact_exists(artifact);
             if !exists {
                 missing_count += 1;
@@ -221,12 +224,10 @@ fn evidence_artifact_index(artifacts: &[ArtifactRecord]) -> RunsEvidenceArtifact
                 id: reference.id.clone(),
                 kind: reference.kind.clone(),
                 artifact_type: reference.artifact_type.clone(),
-                path: reference.path.clone(),
-                url: artifact
-                    .url
-                    .clone()
-                    .or_else(|| (artifact.artifact_type == "url").then(|| artifact.path.clone())),
-                public: public_url.is_some() || artifact.artifact_type == "url",
+                path: address.value.clone(),
+                address,
+                url: public_url.clone(),
+                public: public_url.is_some(),
                 public_url,
                 relative_to: artifact_relative_to(artifact),
                 fetch_command: artifact_fetch_command(artifact),
@@ -251,33 +252,21 @@ fn evidence_artifact_index(artifacts: &[ArtifactRecord]) -> RunsEvidenceArtifact
     }
 }
 
-fn artifact_public_url(artifact: &ArtifactRecord) -> Option<String> {
-    if artifact.artifact_type == "url" {
-        return artifact_ref(artifact).public_target();
-    }
-    artifact.public_url.clone().or_else(|| {
-        artifact
-            .metadata_json
-            .get("public_url")
-            .and_then(Value::as_str)
-            .map(str::to_string)
-    })
-}
-
-fn artifact_ref(artifact: &ArtifactRecord) -> ArtifactRef {
+fn artifact_ref(artifact: &ArtifactRecord, address: &ArtifactAddress) -> ArtifactRef {
     let mut reference = ArtifactRef::from_record(artifact);
-    if reference.public_url.is_none() {
-        reference.public_url = artifact
-            .metadata_json
-            .get("public_url")
-            .and_then(Value::as_str)
-            .map(str::to_string);
-    }
+    reference.path = address.value.clone();
+    reference.url = public_url_from_address(address);
+    reference.public_url = reference.url.clone();
     reference
 }
 
+fn public_url_from_address(address: &ArtifactAddress) -> Option<String> {
+    (address.kind == ArtifactAddressKind::PublicUrl).then(|| address.value.clone())
+}
+
 fn artifact_relative_to(artifact: &ArtifactRecord) -> Option<String> {
-    if artifact.artifact_type == "url" || artifact_public_url(artifact).is_some() {
+    let address = ArtifactAddress::from_record(artifact);
+    if address.reviewer_visible {
         return None;
     }
     if artifact.artifact_type == "file" || artifact.artifact_type == "remote_file" {
@@ -302,6 +291,11 @@ fn artifact_fetch_command(artifact: &ArtifactRecord) -> Option<String> {
 
 fn artifact_exists(artifact: &ArtifactRecord) -> bool {
     if artifact.artifact_type == "url" {
+        return true;
+    }
+    if artifact.artifact_type == "remote_file"
+        || homeboy::core::runners::is_remote_runner_artifact_path(&artifact.path)
+    {
         return true;
     }
     Path::new(&artifact.path).exists()
@@ -375,9 +369,10 @@ fn evidence_links(artifacts: &[ArtifactRecord]) -> Vec<RunsEvidenceLink> {
     artifacts
         .iter()
         .filter_map(|artifact| {
-            let target = artifact_public_url(artifact)?;
-            let mut reference = EvidenceRef::new(&artifact.kind, &target, &artifact.kind);
-            reference.artifact = Some(artifact_ref(artifact));
+            let address = ArtifactAddress::from_record(artifact);
+            let target = address.reviewer_target()?;
+            let mut reference = EvidenceRef::new(&artifact.kind, target, &artifact.kind);
+            reference.artifact = Some(artifact_ref(artifact, &address));
             Some(RunsEvidenceLink {
                 kind: reference.kind.clone(),
                 target: reference.target.clone(),
@@ -563,6 +558,16 @@ mod tests {
                 .expect("bench results artifact");
             assert!(!bench_results.public);
             assert_eq!(
+                bench_results.path,
+                format!("homeboy://run/{}/artifact/{}", run.id, bench_results.id)
+            );
+            assert!(!Path::new(&bench_results.path).is_absolute());
+            assert_eq!(
+                bench_results.address.kind,
+                ArtifactAddressKind::LocalOperatorPath
+            );
+            assert!(!bench_results.address.reviewer_visible);
+            assert_eq!(
                 bench_results.relative_to.as_deref(),
                 Some("homeboy observation artifact store")
             );
@@ -587,6 +592,8 @@ mod tests {
                 review.public_url.as_deref(),
                 Some("https://example.test/evidence")
             );
+            assert_eq!(review.address.kind, ArtifactAddressKind::PublicUrl);
+            assert!(review.address.reviewer_visible);
             assert_eq!(output.evidence_links.len(), 1);
             assert_eq!(
                 output.evidence_links[0].reference.schema,
@@ -619,6 +626,42 @@ mod tests {
                     || output.disk_budget.warning.is_some()
             );
             homeboy::core::set_artifact_root_override(None);
+        });
+    }
+
+    #[test]
+    fn evidence_links_reject_unvalidated_local_urls() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store
+                .start_run(sample_run(
+                    "trace",
+                    "homeboy",
+                    "studio",
+                    serde_json::json!({}),
+                ))
+                .expect("run");
+            store
+                .record_url_artifact(&run.id, "review", "http://localhost:8888/evidence")
+                .expect("record url");
+
+            let (output, _) = evidence(&run.id).expect("evidence");
+            let RunsOutput::Evidence(output) = output else {
+                panic!("expected evidence output");
+            };
+
+            let review = output
+                .artifact_index
+                .artifacts
+                .iter()
+                .find(|artifact| artifact.kind == "review")
+                .expect("review artifact");
+            assert!(!review.public);
+            assert_eq!(review.url, None);
+            assert_eq!(review.public_url, None);
+            assert_eq!(review.address.kind, ArtifactAddressKind::MetadataOnly);
+            assert!(output.evidence_links.is_empty());
         });
     }
 

--- a/src/core/artifact_address.rs
+++ b/src/core/artifact_address.rs
@@ -1,0 +1,234 @@
+use serde::{Deserialize, Serialize};
+
+use crate::core::execution_contract::encode_uri_component;
+use crate::core::observation::ArtifactRecord;
+
+pub const ARTIFACT_ADDRESS_SCHEMA: &str = "homeboy/artifact-address/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactAddress {
+    pub schema: String,
+    pub kind: ArtifactAddressKind,
+    pub value: String,
+    pub reviewer_visible: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation: Option<ArtifactAddressValidation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactAddressKind {
+    LocalOperatorPath,
+    RemoteRunnerRef,
+    PublicUrl,
+    MetadataOnly,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactAddressValidation {
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl ArtifactAddress {
+    pub fn from_record(artifact: &ArtifactRecord) -> Self {
+        if let Some(public_url) = public_url_for_record(artifact) {
+            return Self::public_url(public_url);
+        }
+
+        if crate::core::runners::is_remote_runner_artifact_path(&artifact.path) {
+            return Self::remote_runner_ref(artifact.path.clone());
+        }
+
+        if artifact.artifact_type == "remote_file" {
+            return Self::metadata_only(format!("remote-artifact:{}", artifact.id));
+        }
+
+        if artifact.artifact_type == "metadata-only" {
+            let value = if std::path::Path::new(&artifact.path).is_absolute() {
+                format!("metadata-only:{}", artifact.id)
+            } else {
+                artifact.path.clone()
+            };
+            return Self::metadata_only(value);
+        }
+
+        if artifact.artifact_type == "url" {
+            return Self::metadata_only(format!("unvalidated-url:{}", artifact.id));
+        }
+
+        Self::local_operator_path(format!(
+            "homeboy://run/{}/artifact/{}",
+            encode_uri_component(&artifact.run_id),
+            encode_uri_component(&artifact.id)
+        ))
+    }
+
+    pub fn reviewer_target(&self) -> Option<&str> {
+        self.reviewer_visible.then_some(self.value.as_str())
+    }
+
+    fn public_url(url: String) -> Self {
+        Self {
+            schema: ARTIFACT_ADDRESS_SCHEMA.to_string(),
+            kind: ArtifactAddressKind::PublicUrl,
+            value: url,
+            reviewer_visible: true,
+            validation: Some(ArtifactAddressValidation {
+                status: "validated".to_string(),
+                reason: None,
+            }),
+        }
+    }
+
+    fn remote_runner_ref(value: String) -> Self {
+        Self {
+            schema: ARTIFACT_ADDRESS_SCHEMA.to_string(),
+            kind: ArtifactAddressKind::RemoteRunnerRef,
+            value,
+            reviewer_visible: true,
+            validation: None,
+        }
+    }
+
+    fn metadata_only(value: String) -> Self {
+        Self {
+            schema: ARTIFACT_ADDRESS_SCHEMA.to_string(),
+            kind: ArtifactAddressKind::MetadataOnly,
+            value,
+            reviewer_visible: false,
+            validation: None,
+        }
+    }
+
+    fn local_operator_path(value: String) -> Self {
+        Self {
+            schema: ARTIFACT_ADDRESS_SCHEMA.to_string(),
+            kind: ArtifactAddressKind::LocalOperatorPath,
+            value,
+            reviewer_visible: false,
+            validation: Some(ArtifactAddressValidation {
+                status: "local_only".to_string(),
+                reason: Some(
+                    "local operator paths are not reviewer-facing evidence targets".to_string(),
+                ),
+            }),
+        }
+    }
+}
+
+pub fn validated_public_url(value: &str) -> Option<String> {
+    let url = reqwest::Url::parse(value).ok()?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return None;
+    }
+    let host = url.host_str()?.to_ascii_lowercase();
+    let local_host =
+        host == "localhost" || host == "127.0.0.1" || host == "::1" || host.ends_with(".local");
+    (!local_host).then(|| value.to_string())
+}
+
+fn public_url_for_record(artifact: &ArtifactRecord) -> Option<String> {
+    artifact
+        .public_url
+        .as_deref()
+        .or(artifact.url.as_deref())
+        .or_else(|| {
+            artifact
+                .metadata_json
+                .get("public_url")
+                .and_then(|value| value.as_str())
+        })
+        .or_else(|| (artifact.artifact_type == "url").then_some(artifact.path.as_str()))
+        .and_then(validated_public_url)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::*;
+
+    fn artifact(artifact_type: &str, path: &str) -> ArtifactRecord {
+        ArtifactRecord {
+            id: "artifact-1".to_string(),
+            run_id: "run-1".to_string(),
+            kind: "trace".to_string(),
+            artifact_type: artifact_type.to_string(),
+            path: path.to_string(),
+            url: None,
+            public_url: None,
+            viewer_url: None,
+            viewer_links: Vec::new(),
+            sha256: None,
+            size_bytes: None,
+            mime: None,
+            metadata_json: Value::Null,
+            created_at: "2026-06-12T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn local_paths_become_non_reviewer_visible_artifact_refs() {
+        let address = ArtifactAddress::from_record(&artifact("file", "/tmp/private.json"));
+
+        assert_eq!(address.kind, ArtifactAddressKind::LocalOperatorPath);
+        assert_eq!(address.value, "homeboy://run/run-1/artifact/artifact-1");
+        assert!(!address.reviewer_visible);
+        assert_eq!(address.reviewer_target(), None);
+    }
+
+    #[test]
+    fn public_urls_are_reviewer_visible_after_validation() {
+        let address =
+            ArtifactAddress::from_record(&artifact("url", "https://example.test/evidence"));
+
+        assert_eq!(address.kind, ArtifactAddressKind::PublicUrl);
+        assert_eq!(
+            address.reviewer_target(),
+            Some("https://example.test/evidence")
+        );
+    }
+
+    #[test]
+    fn localhost_urls_are_not_reviewer_visible_public_urls() {
+        let address =
+            ArtifactAddress::from_record(&artifact("url", "http://localhost:8888/evidence"));
+
+        assert_eq!(address.kind, ArtifactAddressKind::MetadataOnly);
+        assert!(!address.reviewer_visible);
+    }
+
+    #[test]
+    fn remote_runner_refs_are_reviewer_visible_tokens() {
+        let address = ArtifactAddress::from_record(&artifact(
+            "remote_file",
+            "runner-artifact://lab/run-1/artifact-1",
+        ));
+
+        assert_eq!(address.kind, ArtifactAddressKind::RemoteRunnerRef);
+        assert_eq!(
+            address.reviewer_target(),
+            Some("runner-artifact://lab/run-1/artifact-1")
+        );
+    }
+
+    #[test]
+    fn malformed_remote_file_paths_are_metadata_only() {
+        let address = ArtifactAddress::from_record(&artifact("remote_file", "/srv/private.zip"));
+
+        assert_eq!(address.kind, ArtifactAddressKind::MetadataOnly);
+        assert_eq!(address.value, "remote-artifact:artifact-1");
+        assert!(!address.reviewer_visible);
+    }
+
+    #[test]
+    fn absolute_metadata_only_paths_are_redacted_to_labels() {
+        let address = ArtifactAddress::from_record(&artifact("metadata-only", "/tmp/private.zip"));
+
+        assert_eq!(address.kind, ArtifactAddressKind::MetadataOnly);
+        assert_eq!(address.value, "metadata-only:artifact-1");
+        assert!(!address.reviewer_visible);
+    }
+}

--- a/src/core/artifacts.rs
+++ b/src/core/artifacts.rs
@@ -3,6 +3,10 @@
 //! New command/core code should import artifact APIs from this module instead of
 //! reaching into individual artifact implementation modules.
 
+pub use super::artifact_address::{
+    validated_public_url, ArtifactAddress, ArtifactAddressKind, ArtifactAddressValidation,
+    ARTIFACT_ADDRESS_SCHEMA,
+};
 pub use super::artifact_inputs::ResolvedArtifactInput;
 pub use super::artifact_links::{
     annotate_public_artifact_url_validation, cached_validated_viewer_links,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -32,6 +32,7 @@ pub mod agent_task_service;
 pub(crate) mod agent_task_timeout;
 pub(crate) mod agent_task_timeout_artifacts;
 pub mod api_jobs;
+pub mod artifact_address;
 pub mod artifact_inputs;
 pub mod artifact_links;
 pub mod artifact_manifest;

--- a/src/core/observation/runs_service.rs
+++ b/src/core/observation/runs_service.rs
@@ -45,6 +45,24 @@ pub struct ArtifactFetchOutcome {
     pub sha256: Option<String>,
 }
 
+/// Pure artifact lookup input for callers that need records without refresh,
+/// indexing, or runner mirroring side effects.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RunArtifactQuery {
+    pub run_id: String,
+    pub kind: Option<String>,
+    pub artifact_type: Option<String>,
+}
+
+impl RunArtifactQuery {
+    pub fn new(run_id: impl Into<String>) -> Self {
+        Self {
+            run_id: run_id.into(),
+            ..Default::default()
+        }
+    }
+}
+
 /// Look up a run and surface a stable validation error when it doesn't
 /// exist. Used by every observation command that takes a `run_id`.
 pub fn require_run(store: &ObservationStore, run_id: &str) -> Result<RunRecord> {
@@ -197,6 +215,33 @@ pub fn list_artifacts_for_run(
     let mut artifacts = store.list_artifacts(run_id)?;
     artifacts.extend(related_lab_artifacts_for_runner_job(store, &run)?);
     Ok(enrich_artifact_links(artifacts))
+}
+
+/// List artifact records from the local store only, preserving the stored
+/// records exactly except for optional in-memory kind/type filtering.
+pub fn query_run_artifacts(
+    store: &ObservationStore,
+    query: &RunArtifactQuery,
+) -> Result<Vec<ArtifactRecord>> {
+    if store.get_run(&query.run_id)?.is_none() {
+        return Err(missing_run_error(&query.run_id));
+    }
+    let artifacts = store
+        .list_artifacts(&query.run_id)?
+        .into_iter()
+        .filter(|artifact| {
+            query
+                .kind
+                .as_ref()
+                .map_or(true, |kind| artifact.kind == *kind)
+        })
+        .filter(|artifact| {
+            query.artifact_type.as_ref().map_or(true, |artifact_type| {
+                artifact.artifact_type == *artifact_type
+            })
+        })
+        .collect();
+    Ok(artifacts)
 }
 
 /// Outcome of `get_artifact_bytes` describing where the bytes were written.
@@ -956,6 +1001,32 @@ mod tests {
             assert_eq!(outcome.artifact_id, artifact.id);
             assert_eq!(outcome.output_path, dest);
             assert_eq!(std::fs::read(&dest).expect("downloaded"), br#"{"ok":true}"#);
+        });
+    }
+
+    #[test]
+    fn query_run_artifacts_filters_without_enrichment_side_effects() {
+        with_isolated_home(|home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let run = store.start_run(sample_run("bench")).expect("run");
+            let source = home.path().join("bench-results.json");
+            std::fs::write(&source, br#"{"ok":true}"#).expect("source");
+            store
+                .record_artifact(&run.id, "bench_results", &source)
+                .expect("record");
+            store
+                .record_url_artifact(&run.id, "review", "https://example.test/evidence")
+                .expect("url");
+
+            let mut query = RunArtifactQuery::new(&run.id);
+            query.kind = Some("bench_results".to_string());
+            query.artifact_type = Some("file".to_string());
+
+            let artifacts = query_run_artifacts(&store, &query).expect("artifacts");
+            assert_eq!(artifacts.len(), 1);
+            assert_eq!(artifacts[0].kind, "bench_results");
+            assert_eq!(artifacts[0].public_url, None);
         });
     }
 


### PR DESCRIPTION
## Summary
- Add a generic ArtifactAddress model for local operator paths, remote runner refs, validated public URLs, and metadata-only evidence.
- Update runs evidence output to avoid reviewer-facing absolute/local paths and to emit evidence links only for reviewer-visible artifact addresses.
- Add pure RunArtifactQuery for local artifact reads without refresh/enrichment side effects.
- Document evidence address boundaries for runs evidence.

## Tests
- cargo fmt
- cargo test core::artifact_address
- cargo test commands::runs::evidence
- cargo test core::observation::runs_service
- cargo test --test output_contracts_test
- cargo test --test command_surface_test
- cargo test --test architecture_core_agnostic_test

## Blockers / known failures
- cargo test --test core_agnostic_test fails on pre-existing, unrelated core boundary audit findings in src/core/runner/tool_registry.rs; this branch does not modify that file.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, tests, docs, and PR description for Chris to review and validate.