### PR TITLE
fix(agent-task): use provider sources for readiness

### DIFF
--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -283,11 +283,14 @@ pub(crate) fn gate_feedback(args: GateFeedbackArgs) -> CmdResult<Value> {
 
 pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
     let executor = ExtensionProviderAgentTaskExecutor::discover();
+    let providers = executor.providers();
+    let fallback_sources =
+        homeboy::core::agent_tasks::provider::provider_secret_sources_for_providers(providers);
     Ok((
         serde_json::json!({
             "schema": "homeboy/agent-task-providers/v1",
-            "providers": executor.providers(),
-            "secret_env": homeboy::core::agent_tasks::secret_env_status(&args.secret_env),
+            "providers": providers,
+            "secret_env": homeboy::core::agent_tasks::secrets::secret_env_status_with_fallbacks(&args.secret_env, &fallback_sources),
         }),
         0,
     ))

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -356,6 +356,19 @@ pub fn provider_secret_sources_for_plan(
     provider_secret_sources_for_plan_with_providers(plan, &providers)
 }
 
+pub fn provider_secret_sources_for_providers(
+    providers: &[AgentTaskExecutorProvider],
+) -> HashMap<String, defaults::AgentTaskSecretSource> {
+    let mut sources = HashMap::new();
+    for provider in providers {
+        sources.extend(provider_secret_sources(provider, None));
+        for defaults in provider.provider_defaults.values() {
+            sources.extend(provider_config_secret_sources(defaults));
+        }
+    }
+    sources
+}
+
 pub(crate) fn role_aliases_for_executor(
     backend: &str,
     selector: Option<&str>,
@@ -2059,6 +2072,47 @@ process.stdout.write(JSON.stringify({
                 "EXAMPLE_PROVIDER_EXPIRES_AT".to_string(),
                 "12345".to_string()
             )));
+        });
+    }
+
+    #[test]
+    fn provider_default_secret_sources_feed_secret_readiness_status() {
+        crate::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let auth_path = temp.path().join("codex-auth.json");
+            fs::write(
+                &auth_path,
+                json!({
+                    "tokens": {
+                        "access_token": "provider-owned-access-token"
+                    }
+                })
+                .to_string(),
+            )
+            .expect("write auth");
+            let (_request, mut provider) = request("task-a", "node provider-a.js".to_string());
+            provider.provider_defaults.insert(
+                "codex".to_string(),
+                json!({
+                    "secret_env_sources": {
+                        "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN": {
+                            "source": "json-file",
+                            "path": auth_path,
+                            "field": "tokens.access_token"
+                        }
+                    }
+                }),
+            );
+            let fallback_sources = provider_secret_sources_for_providers(&[provider]);
+
+            let status = crate::core::agent_task_secrets::secret_env_status_with_fallbacks(
+                &["AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN".to_string()],
+                &fallback_sources,
+            );
+
+            assert_eq!(status.len(), 1);
+            assert!(status[0].configured);
+            assert_eq!(status[0].source, "json-file");
         });
     }
 

--- a/src/core/agent_task_secrets.rs
+++ b/src/core/agent_task_secrets.rs
@@ -37,7 +37,22 @@ pub fn resolve_secret_env_plan(
 }
 
 pub fn secret_env_status(names: &[String]) -> Vec<AgentTaskSecretEnvStatus> {
-    secret_env_status_with_config(names, &AgentTaskSecretConfig::load())
+    secret_env_status_with_config_and_fallbacks(
+        names,
+        &AgentTaskSecretConfig::load(),
+        &HashMap::new(),
+    )
+}
+
+pub fn secret_env_status_with_fallbacks(
+    names: &[String],
+    fallback_sources: &HashMap<String, AgentTaskSecretSource>,
+) -> Vec<AgentTaskSecretEnvStatus> {
+    secret_env_status_with_config_and_fallbacks(
+        names,
+        &AgentTaskSecretConfig::load(),
+        fallback_sources,
+    )
 }
 
 pub fn secret_env_plan_status(plan: &SecretEnvPlan) -> Vec<AgentTaskSecretEnvStatus> {
@@ -216,6 +231,14 @@ fn secret_env_status_with_config(
     names: &[String],
     config: &AgentTaskSecretConfig,
 ) -> Vec<AgentTaskSecretEnvStatus> {
+    secret_env_status_with_config_and_fallbacks(names, config, &HashMap::new())
+}
+
+fn secret_env_status_with_config_and_fallbacks(
+    names: &[String],
+    config: &AgentTaskSecretConfig,
+    fallback_sources: &HashMap<String, AgentTaskSecretSource>,
+) -> Vec<AgentTaskSecretEnvStatus> {
     let mut bundle_cache = HashMap::new();
     names
         .iter()
@@ -228,7 +251,10 @@ fn secret_env_status_with_config(
                 };
             }
 
-            let source = config.secrets.get(name);
+            let source = config
+                .secrets
+                .get(name)
+                .or_else(|| fallback_sources.get(name));
             AgentTaskSecretEnvStatus {
                 name: name.clone(),
                 configured: source

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -95,7 +95,8 @@ pub use super::agent_task_loop_controller::{
 
 // Secret-env status type is referenced from review/dispatch commands.
 pub use super::agent_task_secrets::{
-    resolve_secret_env_plan, secret_env_plan_status, secret_env_status, AgentTaskSecretEnvStatus,
+    resolve_secret_env_plan, secret_env_plan_status, secret_env_status,
+    secret_env_status_with_fallbacks, AgentTaskSecretEnvStatus,
 };
 pub use super::secret_env_plan::{
     SecretEnvCredentialSource, SecretEnvPlan, SecretEnvProviderCredentialMapping,
@@ -222,11 +223,12 @@ pub mod provider {
         default_backend, default_backend_for_component, dependency_failure_patterns,
         provider_requires_cwd_git_checkout, provider_runner_readiness_contracts,
         provider_runner_secret_env_for_plan, provider_runner_source_contracts,
-        provider_secret_sources_for_plan, required_extension_ids_for_plan,
-        AgentTaskExecutorProvider, AgentTaskProviderDependencyFailurePattern,
-        AgentTaskProviderEnvPathReadiness, AgentTaskProviderRoleAliases,
-        AgentTaskProviderRunnerReadiness, AgentTaskProviderRunnerSource,
-        AgentTaskProviderWorkspaceMaterialization, ExtensionProviderAgentTaskExecutor,
+        provider_secret_sources_for_plan, provider_secret_sources_for_providers,
+        required_extension_ids_for_plan, AgentTaskExecutorProvider,
+        AgentTaskProviderDependencyFailurePattern, AgentTaskProviderEnvPathReadiness,
+        AgentTaskProviderRoleAliases, AgentTaskProviderRunnerReadiness,
+        AgentTaskProviderRunnerSource, AgentTaskProviderWorkspaceMaterialization,
+        ExtensionProviderAgentTaskExecutor,
     };
 }
 
@@ -254,7 +256,8 @@ pub mod scheduler {
 pub mod secrets {
     pub use super::super::agent_task_secrets::{
         map_secret_to_env, map_secret_to_keychain_bundle, remove_secret_mapping,
-        resolve_secret_env, secret_env_status, set_config_secret, set_keychain_bundle,
+        resolve_secret_env, resolve_secret_env_with_fallbacks, secret_env_status,
+        secret_env_status_with_fallbacks, set_config_secret, set_keychain_bundle,
         set_keychain_secret, validate_secret_env, AgentTaskSecretEnvStatus,
         AgentTaskSecretResolutionError,
     };

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 
 use crate::core::agent_tasks::provider::{
     provider_runner_secret_env_for_plan, provider_secret_sources_for_plan,
+    provider_secret_sources_for_providers, ExtensionProviderAgentTaskExecutor,
 };
 use crate::core::agent_tasks::scheduler::AgentTaskPlan;
 use crate::core::agent_tasks::secrets as agent_task_secrets;
@@ -39,7 +40,8 @@ pub(super) fn hydrate_agent_task_secret_env(
     }
 
     if !names.is_empty() {
-        let resolved = agent_task_secrets::resolve_secret_env(&names).map_err(|error| {
+        let fallback_sources = declared_agent_task_controller_secret_sources(args);
+        let resolved = agent_task_secrets::resolve_secret_env_with_fallbacks(&names, &fallback_sources).map_err(|error| {
             Error::validation_invalid_argument(
                 "secret-env",
                 error.message,
@@ -209,6 +211,20 @@ fn declared_agent_task_controller_secret_env(args: &[String]) -> Vec<String> {
     names.sort();
     names.dedup();
     names
+}
+
+fn declared_agent_task_controller_secret_sources(
+    args: &[String],
+) -> HashMap<String, crate::core::defaults::AgentTaskSecretSource> {
+    let Some(agent_task_index) = subcommand_index(args, "agent-task") else {
+        return HashMap::new();
+    };
+    if args.get(agent_task_index + 1).map(String::as_str) != Some("providers") {
+        return HashMap::new();
+    }
+
+    let executor = ExtensionProviderAgentTaskExecutor::discover();
+    provider_secret_sources_for_providers(executor.providers())
 }
 
 pub(crate) fn declared_trace_secret_env(args: &[String]) -> Vec<String> {


### PR DESCRIPTION
## Summary
- Use provider-declared secret sources when rendering `agent-task providers --secret-env` readiness.
- Hydrate Lab-offloaded `agent-task providers --secret-env` from provider manifest fallback sources before dispatching to the runner.
- Adds regression coverage for provider default JSON-file sources feeding readiness without global secret mappings.

## Tests
- `cargo test provider_default_secret_sources_feed_secret_readiness_status --lib`
- `cargo test provider_default_secret_sources_resolve_required_env_without_duplicate_mapping --lib`
- `cargo test hydrate_agent_task_secret_env_defers_run_plan_secrets_to_runner --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the provider-readiness fallback gap, drafted the minimal code and regression test, and ran focused verification.
