### PR TITLE
core: add secret env contract resolver

### DIFF
--- a/docs/architecture/secret-env-contract.md
+++ b/docs/architecture/secret-env-contract.md
@@ -1,0 +1,15 @@
+# Secret Env Contract
+
+Homeboy core owns the generic contract for passing required secret environment variables across runners, agent tasks, trace workloads, lab offload, and extensions.
+
+The contract is intentionally small:
+
+- Secret env names are normalized by trimming whitespace, removing empty names, sorting, and deduplicating.
+- A `SecretEnvPlan` describes public env, required secret env names, provider credential mappings, and redaction policy without storing secret values.
+- A resolver tries ordered value providers and returns materialized `(name, value)` pairs plus status metadata.
+- Status metadata records only `name`, `configured`, and `source`; it never includes resolved values.
+- Missing required names produce a structured error with normalized missing names and redacted status metadata.
+
+Value providers remain domain-owned. Core does not know where a secret comes from beyond the provider's source label. Current consumers can provide process env, config, keychain, remote runner, or extension-specific providers without adding domain semantics to the shared contract.
+
+Use this primitive when a workflow needs to declare or resolve required secret env names. Add command-specific storage, fallback order, and remediation text at the consumer boundary.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ Internal system architecture and internals:
 - [Apply and publish contract](architecture/apply-publish-contract.md) - Local apply boundary and post-apply publish semantics
 - [Agent task executor adapter](architecture/agent-task-executor-adapter.md) - Provider-neutral adapter boundary for runtime providers, CLI sessions, and runner backends
 - [Provider fanout boundary](architecture/provider-fanout-boundary.md) - Ownership contract for durable orchestration versus provider runtime fanout
+- [Secret env contract](architecture/secret-env-contract.md) - Core-owned required secret env normalization, resolution, and redacted status metadata
 - [Preview metadata](architecture/preview-metadata.md) - Generic preview URL, hold, lifecycle, runtime, and cleanup metadata preserved across runs
 - [Scope model](architecture/scope-model.md) - Components, targets/projects, rigs, fleets, workspace, and paths
 - [Execution context](architecture/execution-context.md) - Runtime context for extensions

--- a/src/core/agent_task_secrets.rs
+++ b/src/core/agent_task_secrets.rs
@@ -6,7 +6,9 @@ use std::path::PathBuf;
 use crate::core::defaults::{self, AgentTaskSecretSource};
 use crate::core::keychain;
 use crate::core::paths;
-use crate::core::secret_env_plan::SecretEnvPlan;
+use crate::core::secret_env_plan::{
+    resolve_secret_env_names, SecretEnvPlan, SecretEnvValueProvider,
+};
 use crate::core::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -254,42 +256,26 @@ fn resolve_secret_env_with_config_and_fallbacks(
     config: &AgentTaskSecretConfig,
     fallback_sources: &HashMap<String, AgentTaskSecretSource>,
 ) -> Result<Vec<(String, String)>, AgentTaskSecretResolutionError> {
-    if names.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let mut resolved = Vec::new();
-    let mut missing = Vec::new();
     let mut bundle_cache = HashMap::new();
-
-    for name in names {
-        if let Ok(value) = env::var(name) {
-            resolved.push((name.clone(), value));
-            continue;
-        }
-
-        match config
-            .secrets
-            .get(name)
-            .or_else(|| fallback_sources.get(name))
-            .and_then(|source| source.resolve(name, &mut bundle_cache))
-        {
-            Some(value) => resolved.push((name.clone(), value)),
-            None => missing.push(name.clone()),
-        }
-    }
-
-    if missing.is_empty() {
-        Ok(resolved)
-    } else {
-        Err(AgentTaskSecretResolutionError {
-            message: format!(
-                "missing required agent-task secret env: {}",
-                missing.join(", ")
-            ),
-            missing_secret_env: missing,
-        })
-    }
+    resolve_secret_env_names(
+        names.iter().cloned(),
+        vec![
+            SecretEnvValueProvider::new("env", |name| env::var(name).ok()),
+            SecretEnvValueProvider::new("agent-task", move |name| {
+                config
+                    .secrets
+                    .get(name)
+                    .or_else(|| fallback_sources.get(name))
+                    .and_then(|source| source.resolve(name, &mut bundle_cache))
+            }),
+        ],
+        "missing required agent-task secret env",
+    )
+    .map(|resolution| resolution.env)
+    .map_err(|error| AgentTaskSecretResolutionError {
+        missing_secret_env: error.missing_secret_env,
+        message: error.message,
+    })
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/core/secret_env_plan.rs
+++ b/src/core/secret_env_plan.rs
@@ -20,6 +20,103 @@ pub struct SecretEnvPlan {
     pub redaction: SecretEnvRedactionPolicy,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecretEnvStatus {
+    pub name: String,
+    pub configured: bool,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecretEnvResolution {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<(String, String)>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub status: Vec<SecretEnvStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecretEnvResolutionError {
+    pub missing_secret_env: Vec<String>,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub status: Vec<SecretEnvStatus>,
+}
+
+pub struct SecretEnvValueProvider<'a> {
+    source: String,
+    resolve: Box<dyn FnMut(&str) -> Option<String> + 'a>,
+}
+
+impl<'a> SecretEnvValueProvider<'a> {
+    pub fn new(
+        source: impl Into<String>,
+        resolve: impl FnMut(&str) -> Option<String> + 'a,
+    ) -> Self {
+        Self {
+            source: source.into(),
+            resolve: Box::new(resolve),
+        }
+    }
+}
+
+pub fn resolve_secret_env_names(
+    names: impl IntoIterator<Item = String>,
+    providers: Vec<SecretEnvValueProvider<'_>>,
+    missing_message_prefix: &str,
+) -> Result<SecretEnvResolution, SecretEnvResolutionError> {
+    SecretEnvResolver::new(providers).resolve_required(names, missing_message_prefix)
+}
+
+pub struct SecretEnvResolver<'a> {
+    providers: Vec<SecretEnvValueProvider<'a>>,
+}
+
+impl<'a> SecretEnvResolver<'a> {
+    pub fn new(providers: Vec<SecretEnvValueProvider<'a>>) -> Self {
+        Self { providers }
+    }
+
+    pub fn resolve_required(
+        mut self,
+        names: impl IntoIterator<Item = String>,
+        missing_message_prefix: &str,
+    ) -> Result<SecretEnvResolution, SecretEnvResolutionError> {
+        let names = normalize_names(names);
+        let mut env = Vec::new();
+        let mut status = Vec::new();
+        let mut missing = Vec::new();
+
+        for name in names {
+            let mut resolved = None;
+            for provider in self.providers.iter_mut() {
+                if let Some(value) = (provider.resolve)(&name) {
+                    resolved = Some((provider.source.clone(), value));
+                    break;
+                }
+            }
+
+            if let Some((source, value)) = resolved {
+                env.push((name.clone(), value));
+                status.push(secret_env_status(name, true, source));
+            } else {
+                status.push(secret_env_status(name.clone(), false, "missing"));
+                missing.push(name);
+            }
+        }
+
+        if missing.is_empty() {
+            Ok(SecretEnvResolution { env, status })
+        } else {
+            Err(SecretEnvResolutionError {
+                message: format!("{missing_message_prefix}: {}", missing.join(", ")),
+                missing_secret_env: missing,
+                status,
+            })
+        }
+    }
+}
+
 impl Default for SecretEnvPlan {
     fn default() -> Self {
         Self {
@@ -135,13 +232,22 @@ impl SecretEnvRedactionPolicy {
     }
 }
 
-fn normalize_names(names: impl IntoIterator<Item = String>) -> Vec<String> {
+pub fn normalize_names(names: impl IntoIterator<Item = String>) -> Vec<String> {
     names
         .into_iter()
+        .map(|name| name.trim().to_string())
         .filter(|name| !name.is_empty())
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect()
+}
+
+fn secret_env_status(name: String, configured: bool, source: impl Into<String>) -> SecretEnvStatus {
+    SecretEnvStatus {
+        name,
+        configured,
+        source: source.into(),
+    }
 }
 
 fn redact_env_value(policy: &RedactionPolicy, value: &str) -> String {
@@ -246,5 +352,73 @@ mod tests {
                 "C_SECRET".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn normalizes_secret_env_names_by_trimming_sorting_and_deduplicating() {
+        assert_eq!(
+            normalize_names([
+                " B_SECRET ".to_string(),
+                "".to_string(),
+                "A_SECRET".to_string(),
+                "B_SECRET".to_string(),
+            ]),
+            vec!["A_SECRET".to_string(), "B_SECRET".to_string()]
+        );
+    }
+
+    #[test]
+    fn resolver_returns_values_and_redacted_status_contract() {
+        let resolver = SecretEnvResolver::new(vec![
+            SecretEnvValueProvider::new("missing-source", |_| None),
+            SecretEnvValueProvider::new("test-source", |name| {
+                (name == "API_TOKEN").then(|| "secret-value".to_string())
+            }),
+        ]);
+
+        let resolved = resolver
+            .resolve_required(vec!["API_TOKEN".to_string()], "missing required secret env")
+            .expect("secret resolves");
+
+        assert_eq!(
+            resolved.env,
+            vec![("API_TOKEN".to_string(), "secret-value".to_string())]
+        );
+        assert_eq!(
+            resolved.status,
+            vec![SecretEnvStatus {
+                name: "API_TOKEN".to_string(),
+                configured: true,
+                source: "test-source".to_string(),
+            }]
+        );
+        assert!(!serde_json::to_string(&resolved.status)
+            .expect("status json")
+            .contains("secret-value"));
+    }
+
+    #[test]
+    fn resolver_reports_missing_names_without_values() {
+        let resolver =
+            SecretEnvResolver::new(vec![SecretEnvValueProvider::new("test-source", |_| None)]);
+
+        let error = resolver
+            .resolve_required(
+                vec!["B_SECRET".to_string(), "A_SECRET".to_string()],
+                "missing required secret env",
+            )
+            .expect_err("secrets are missing");
+
+        assert_eq!(
+            error.missing_secret_env,
+            vec!["A_SECRET".to_string(), "B_SECRET".to_string()]
+        );
+        assert_eq!(
+            error.message,
+            "missing required secret env: A_SECRET, B_SECRET"
+        );
+        assert!(!serde_json::to_string(&error)
+            .expect("error json")
+            .contains("secret-value"));
     }
 }


### PR DESCRIPTION
## Summary
- Add a core-owned secret env normalization/resolution/status primitive.
- Keep source-specific lookup at consumer boundaries via ordered value providers.
- Wire agent-task secret resolution through the shared primitive as the first narrow consumer.
- Document the generic contract for later agent-task, lab, trace, and extension adoption.

## Tests
- `cargo test secret_env_plan --lib`
- `cargo test agent_task_secrets --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the minimal core contract/resolver, focused tests/docs, and agent-task integration; Chris remains responsible for review and validation.