### PR TITLE
Add core process path containment primitives

### DIFF
--- a/docs/developer-guide/architecture-overview.md
+++ b/docs/developer-guide/architecture-overview.md
@@ -102,6 +102,15 @@ Executes local, remote, and extension commands with:
 - Output capture
 - Exit code handling
 
+Core exposes generic local path helpers for process and runtime adapters:
+- `core::normalize_local_path` performs lexical normalization without requiring
+  paths to exist.
+- `core::local_path_is_contained` performs component-aware containment checks.
+- `core::resolve_contained_local_path` resolves relative paths below a root and
+  rejects absolute or parent-relative escapes.
+- `core::process::prepare_contained_process_step` applies the same containment
+  policy to a generic process step working directory.
+
 Supports:
 - Local commands such as builds, tests, benchmarks, and review gates
 - Remote commands via SSH for configured projects and fleets

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -148,3 +148,25 @@ pub fn artifact_root() -> Result<std::path::PathBuf> {
 pub fn join_remote_path(base_path: Option<&str>, path: &str) -> Result<String> {
     paths::join_remote_path(base_path, path)
 }
+
+/// Normalize a local path lexically without touching the filesystem.
+pub fn normalize_local_path(path: impl AsRef<std::path::Path>) -> std::path::PathBuf {
+    paths::normalize_local_path(path)
+}
+
+/// Return whether `path` is inside `root` after lexical normalization.
+pub fn local_path_is_contained(
+    root: impl AsRef<std::path::Path>,
+    path: impl AsRef<std::path::Path>,
+) -> bool {
+    paths::local_path_is_contained(root, path)
+}
+
+/// Resolve a local path against a root and reject paths that escape that root.
+pub fn resolve_contained_local_path(
+    root: impl AsRef<std::path::Path>,
+    candidate: impl AsRef<std::path::Path>,
+    field: &str,
+) -> Result<std::path::PathBuf> {
+    paths::resolve_contained_local_path(root, candidate, field)
+}

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -1,6 +1,7 @@
 use crate::core::error::{Error, Result};
 use std::env;
-use std::path::PathBuf;
+use std::ffi::OsString;
+use std::path::{Component, Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
 mod rigs;
@@ -144,6 +145,101 @@ pub(crate) fn sanitize_path_segment(segment: &str) -> String {
             }
         })
         .collect()
+}
+
+/// Normalize a local path lexically without touching the filesystem.
+///
+/// This removes `.` segments, collapses internal `..` segments, and preserves
+/// leading `..` segments for relative paths. Absolute paths do not escape above
+/// their root. Use this before containment checks when the target path may not
+/// exist yet.
+pub fn normalize_local_path(path: impl AsRef<Path>) -> PathBuf {
+    let path = path.as_ref();
+    let mut prefix: Option<OsString> = None;
+    let mut rooted = false;
+    let mut segments: Vec<OsString> = Vec::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(value) => {
+                prefix = Some(value.as_os_str().to_os_string());
+            }
+            Component::RootDir => {
+                rooted = true;
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if segments.last().is_some_and(|segment| segment != "..") {
+                    segments.pop();
+                } else if !rooted {
+                    segments.push(OsString::from(".."));
+                }
+            }
+            Component::Normal(value) => segments.push(value.to_os_string()),
+        }
+    }
+
+    let mut normalized = PathBuf::new();
+    if let Some(prefix) = prefix {
+        normalized.push(prefix);
+    }
+    if rooted {
+        normalized.push(std::path::MAIN_SEPARATOR.to_string());
+    }
+    for segment in segments {
+        normalized.push(segment);
+    }
+
+    if normalized.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        normalized
+    }
+}
+
+/// Return whether `path` is inside `root` after lexical normalization.
+pub fn local_path_is_contained(root: impl AsRef<Path>, path: impl AsRef<Path>) -> bool {
+    let root = normalize_local_path(root);
+    let path = normalize_local_path(path);
+
+    path == root || path.starts_with(root)
+}
+
+/// Resolve a local path against a root and reject paths that escape that root.
+///
+/// Relative candidates are resolved below `root`. Absolute candidates are
+/// accepted only when they already point inside `root` after lexical
+/// normalization.
+pub fn resolve_contained_local_path(
+    root: impl AsRef<Path>,
+    candidate: impl AsRef<Path>,
+    field: &str,
+) -> Result<PathBuf> {
+    let root = normalize_local_path(root);
+    let candidate = candidate.as_ref();
+    let resolved = if candidate.is_absolute() {
+        normalize_local_path(candidate)
+    } else {
+        normalize_local_path(root.join(candidate))
+    };
+
+    if local_path_is_contained(&root, &resolved) {
+        Ok(resolved)
+    } else {
+        Err(Error::validation_invalid_argument(
+            field,
+            format!(
+                "Path '{}' escapes root '{}'",
+                candidate.display(),
+                root.display()
+            ),
+            Some(candidate.to_string_lossy().to_string()),
+            Some(vec![
+                "Use a relative path inside the configured root".to_string(),
+                "Use an absolute path that starts inside the configured root".to_string(),
+            ]),
+        ))
+    }
 }
 
 /// Projects directory
@@ -427,6 +523,47 @@ mod tests {
         );
         assert_eq!(resolve_optional_base_path(Some("   ")), None);
         assert_eq!(resolve_optional_base_path(None), None);
+    }
+
+    #[test]
+    fn normalize_local_path_collapses_dot_and_parent_segments() {
+        assert_eq!(
+            normalize_local_path("/repo/./packages/../src"),
+            PathBuf::from("/repo/src")
+        );
+        assert_eq!(
+            normalize_local_path("packages/../src/./lib"),
+            PathBuf::from("src/lib")
+        );
+        assert_eq!(
+            normalize_local_path("../../src"),
+            PathBuf::from("../../src")
+        );
+        assert_eq!(normalize_local_path("/../../src"), PathBuf::from("/src"));
+    }
+
+    #[test]
+    fn local_path_containment_is_component_aware() {
+        assert!(local_path_is_contained("/repo", "/repo/src/lib.rs"));
+        assert!(local_path_is_contained("/repo", "/repo/src/../Cargo.toml"));
+        assert!(!local_path_is_contained("/repo", "/repo-other/file"));
+        assert!(!local_path_is_contained("/repo", "/repo/../etc/passwd"));
+    }
+
+    #[test]
+    fn resolve_contained_local_path_resolves_relative_paths_under_root() {
+        assert_eq!(
+            resolve_contained_local_path("/repo", "src/../Cargo.toml", "cwd").unwrap(),
+            PathBuf::from("/repo/Cargo.toml")
+        );
+    }
+
+    #[test]
+    fn resolve_contained_local_path_rejects_parent_escape() {
+        let err = resolve_contained_local_path("/repo/worktree", "../secrets", "cwd")
+            .expect_err("parent escape should fail");
+
+        assert!(err.to_string().contains("escapes root '/repo/worktree'"));
     }
 
     #[test]

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -1,3 +1,57 @@
+use crate::core::error::Result;
+use std::path::{Path, PathBuf};
+
+/// Generic process step shape shared by command/runner adapters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessStep {
+    pub program: String,
+    pub args: Vec<String>,
+    pub working_dir: Option<PathBuf>,
+}
+
+impl ProcessStep {
+    pub fn new(program: impl Into<String>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+            working_dir: None,
+        }
+    }
+
+    pub fn args(mut self, args: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.args = args.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn working_dir(mut self, working_dir: impl Into<PathBuf>) -> Self {
+        self.working_dir = Some(working_dir.into());
+        self
+    }
+}
+
+/// Resolve a process step's working directory inside a containment root.
+///
+/// When a step omits a working directory, the normalized root becomes the
+/// effective working directory. This gives local commands, extensions, and rigs
+/// one reusable path policy without requiring filesystem canonicalization.
+pub fn prepare_contained_process_step(
+    root: impl AsRef<Path>,
+    step: ProcessStep,
+) -> Result<ProcessStep> {
+    let root = crate::core::paths::normalize_local_path(root);
+    let working_dir = match step.working_dir.as_deref() {
+        Some(working_dir) => {
+            crate::core::paths::resolve_contained_local_path(&root, working_dir, "working_dir")?
+        }
+        None => root,
+    };
+
+    Ok(ProcessStep {
+        working_dir: Some(working_dir),
+        ..step
+    })
+}
+
 pub fn pid_is_running(pid: u32) -> bool {
     if pid > i32::MAX as u32 {
         return false;
@@ -16,6 +70,48 @@ pub fn pid_is_running(pid: u32) -> bool {
     #[cfg(not(unix))]
     {
         pid == std::process::id()
+    }
+}
+
+#[cfg(test)]
+mod containment_tests {
+    use super::*;
+
+    #[test]
+    fn process_step_defaults_to_root_working_dir() {
+        let step = prepare_contained_process_step("/repo/./worktree", ProcessStep::new("cargo"))
+            .expect("prepared step");
+
+        assert_eq!(step.working_dir, Some(PathBuf::from("/repo/worktree")));
+    }
+
+    #[test]
+    fn process_step_accepts_relative_working_dir_inside_root() {
+        let step = prepare_contained_process_step(
+            "/repo/worktree",
+            ProcessStep::new("cargo")
+                .args(["test"])
+                .working_dir("crates/core/.."),
+        )
+        .expect("prepared step");
+
+        assert_eq!(step.program, "cargo");
+        assert_eq!(step.args, vec!["test".to_string()]);
+        assert_eq!(
+            step.working_dir,
+            Some(PathBuf::from("/repo/worktree/crates"))
+        );
+    }
+
+    #[test]
+    fn process_step_rejects_working_dir_escape() {
+        let err = prepare_contained_process_step(
+            "/repo/worktree",
+            ProcessStep::new("cargo").working_dir("../outside"),
+        )
+        .expect_err("cwd escape should fail");
+
+        assert!(err.to_string().contains("escapes root '/repo/worktree'"));
     }
 }
 


### PR DESCRIPTION
## Summary
- Add lexical local path normalization and component-aware containment helpers in Homeboy core.
- Add a generic process step shape plus contained working-directory preparation helper.
- Document the new process/runtime path policy surface.

## Tests
- cargo test core::paths::tests --lib
- cargo test core::process::containment_tests --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the core helper implementation, tests, documentation update, and PR text for Chris to review.