### PR TITLE
test(core): neutralize rig fixture names

### DIFF
--- a/tests/core/rig/bench_resource_lease_test.rs
+++ b/tests/core/rig/bench_resource_lease_test.rs
@@ -31,7 +31,7 @@ fn run_single_rig_bench_fails_fast_on_active_resource_lease() {
             "exclusive": ["studio-runtime"],
             "paths": ["~/Developer/studio"],
             "ports": [9724],
-            "process_patterns": ["wordpress-server-child.mjs"]
+            "process_patterns": ["app-server-child.mjs"]
         });
         set_rig_resources(home, "studio", resources.clone());
         set_rig_resources(home, "studio-bfb", resources);

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -165,7 +165,7 @@ fn test_expand_resources_expands_string_entries() {
             "${components.studio.path}/apps/cli".to_string(),
         ];
         rig.resources.ports = vec![9724];
-        rig.resources.process_patterns = vec!["wordpress-server-child.mjs".to_string()];
+        rig.resources.process_patterns = vec!["app-server-child.mjs".to_string()];
 
         let resources = expand_resources(&rig);
         let expected_paths = vec![
@@ -193,10 +193,7 @@ fn test_expand_resources_expands_string_entries() {
             vec!["studio-runtime", "studio-runtime:bench-a"]
         );
         assert_eq!(resources.ports, vec![9724]);
-        assert_eq!(
-            resources.process_patterns,
-            vec!["wordpress-server-child.mjs"]
-        );
+        assert_eq!(resources.process_patterns, vec!["app-server-child.mjs"]);
         assert_eq!(resources.paths, expected_paths);
     });
 }
@@ -261,7 +258,7 @@ fn test_expand_resources_derives_paths_ports_and_process_patterns() {
                 env: HashMap::new(),
                 health: None,
                 discover: Some(DiscoverSpec {
-                    pattern: "wordpress-server-child.mjs".to_string(),
+                    pattern: "app-server-child.mjs".to_string(),
                     argv_contains: Vec::new(),
                 }),
             },
@@ -280,10 +277,7 @@ fn test_expand_resources_derives_paths_ports_and_process_patterns() {
             ]
         );
         assert_eq!(resources.ports, vec![9724]);
-        assert_eq!(
-            resources.process_patterns,
-            vec!["wordpress-server-child.mjs"]
-        );
+        assert_eq!(resources.process_patterns, vec!["app-server-child.mjs"]);
     });
 }
 
@@ -294,7 +288,7 @@ fn test_expand_resources_merges_explicit_resources_and_deduplicates() {
         rig.resources.paths = vec!["~/bin/studio".to_string(), "~/Developer/manual".to_string()];
         rig.resources.ports = vec![9724, 3000];
         rig.resources.process_patterns = vec![
-            "wordpress-server-child.mjs".to_string(),
+            "app-server-child.mjs".to_string(),
             "manual-process".to_string(),
         ];
         rig.symlinks = vec![SymlinkSpec {
@@ -323,7 +317,7 @@ fn test_expand_resources_merges_explicit_resources_and_deduplicates() {
                 env: HashMap::new(),
                 health: None,
                 discover: Some(DiscoverSpec {
-                    pattern: "wordpress-server-child.mjs".to_string(),
+                    pattern: "app-server-child.mjs".to_string(),
                     argv_contains: Vec::new(),
                 }),
             },
@@ -345,7 +339,7 @@ fn test_expand_resources_merges_explicit_resources_and_deduplicates() {
         assert_eq!(resources.ports, vec![9724, 3000]);
         assert_eq!(
             resources.process_patterns,
-            vec!["wordpress-server-child.mjs", "manual-process"]
+            vec!["app-server-child.mjs", "manual-process"]
         );
     });
 }

--- a/tests/core/rig/lease_test.rs
+++ b/tests/core/rig/lease_test.rs
@@ -56,7 +56,7 @@ fn resources() -> RigResourcesSpec {
         exclusive: vec!["studio-runtime".to_string()],
         paths: vec!["~/Developer/studio".to_string()],
         ports: vec![9724],
-        process_patterns: vec!["wordpress-server-child.mjs".to_string()],
+        process_patterns: vec!["app-server-child.mjs".to_string()],
     }
 }
 

--- a/tests/core/rig/service_test.rs
+++ b/tests/core/rig/service_test.rs
@@ -168,17 +168,17 @@ mod lifecycle {
     fn test_discover_newest_from_ps_requires_all_argv_selectors() {
         let now = 1_000;
         let ps_output = r#"
-101  00:00:50  node /Applications/Studio.app/wordpress-server-child.mjs
-202  00:00:40  node /Users/chubes/Developer/studio@bfb-mu-plugin/playground-server-child.mjs wordpress-server-child.mjs
-303  00:00:30  node /Users/chubes/Developer/studio@other/playground-server-child.mjs wordpress-server-child.mjs
+101  00:00:50  node /Applications/Sample.app/app-server-child.mjs
+202  00:00:40  node /Users/chubes/Developer/sample-app@feature-a/preview-server-child.mjs app-server-child.mjs
+303  00:00:30  node /Users/chubes/Developer/sample-app@other/preview-server-child.mjs app-server-child.mjs
 "#;
         let selectors = vec![
-            "studio@bfb-mu-plugin".to_string(),
-            "playground-server-child.mjs".to_string(),
+            "sample-app@feature-a".to_string(),
+            "preview-server-child.mjs".to_string(),
         ];
 
         let found = super::super::platform::discover_newest_from_ps(
-            "wordpress-server-child.mjs",
+            "app-server-child.mjs",
             &selectors,
             now,
             999,
@@ -192,13 +192,13 @@ mod lifecycle {
 
     #[test]
     fn test_discover_newest_from_ps_returns_none_when_argv_selector_misses() {
-        let selectors = vec!["studio@bfb-mu-plugin".to_string()];
+        let selectors = vec!["sample-app@feature-a".to_string()];
         let found = super::super::platform::discover_newest_from_ps(
-            "wordpress-server-child.mjs",
+            "app-server-child.mjs",
             &selectors,
             1_000,
             999,
-            "101  00:00:50  node /Applications/Studio.app/wordpress-server-child.mjs",
+            "101  00:00:50  node /Applications/Sample.app/app-server-child.mjs",
         );
 
         assert_eq!(found, None);

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -36,7 +36,7 @@ const STUDIO_PLAYGROUND_SPEC: &str = r#"{
         "exclusive": ["studio-runtime"],
         "paths": ["~/Developer/studio@bfb-mu-plugin-agent-output"],
         "ports": [9724],
-        "process_patterns": ["wordpress-server-child.mjs"]
+        "process_patterns": ["app-server-child.mjs"]
     },
     "pipeline": {
         "up": [
@@ -216,7 +216,7 @@ fn test_spec_resources_block_parses_full_shape() {
             "exclusive": ["studio-runtime"],
             "paths": ["~/Developer/studio@bfb-mu-plugin-agent-output"],
             "ports": [9724],
-            "process_patterns": ["wordpress-server-child.mjs"]
+            "process_patterns": ["app-server-child.mjs"]
         }
     }"#;
     let spec: RigSpec = serde_json::from_str(json).expect("parse");
@@ -228,7 +228,7 @@ fn test_spec_resources_block_parses_full_shape() {
     assert_eq!(spec.resources.ports, vec![9724]);
     assert_eq!(
         spec.resources.process_patterns,
-        vec!["wordpress-server-child.mjs"]
+        vec!["app-server-child.mjs"]
     );
 }
 
@@ -736,8 +736,8 @@ fn test_spec_external_service_kind_with_discover() {
             "studio-daemon": {
                 "kind": "external",
                 "discover": {
-                    "pattern": "wordpress-server-child.mjs",
-                    "argv_contains": ["studio@bfb-mu-plugin", "playground-server-child.mjs"]
+                    "pattern": "app-server-child.mjs",
+                    "argv_contains": ["sample-app@feature-a", "preview-server-child.mjs"]
                 }
             }
         }
@@ -747,13 +747,13 @@ fn test_spec_external_service_kind_with_discover() {
     assert_eq!(svc.kind, ServiceKind::External);
     assert_eq!(
         svc.discover.as_ref().unwrap().pattern,
-        "wordpress-server-child.mjs"
+        "app-server-child.mjs"
     );
     assert_eq!(
         svc.discover.as_ref().unwrap().argv_contains,
         vec![
-            "studio@bfb-mu-plugin".to_string(),
-            "playground-server-child.mjs".to_string()
+            "sample-app@feature-a".to_string(),
+            "preview-server-child.mjs".to_string()
         ]
     );
 }
@@ -769,7 +769,7 @@ fn test_spec_newer_than_check_parses() {
                     "kind": "check",
                     "label": "Daemon newer than bundle",
                     "newer_than": {
-                        "left":  { "process_start": { "pattern": "wordpress-server-child.mjs" } },
+                        "left":  { "process_start": { "pattern": "app-server-child.mjs" } },
                         "right": { "file_mtime": "${components.studio.path}/apps/cli/dist/cli/main.mjs" }
                     }
                 }
@@ -782,7 +782,7 @@ fn test_spec_newer_than_check_parses() {
             let nt = spec.newer_than.as_ref().expect("newer_than present");
             assert_eq!(
                 nt.left.process_start.as_ref().unwrap().pattern,
-                "wordpress-server-child.mjs"
+                "app-server-child.mjs"
             );
             assert!(nt
                 .right

--- a/tests/core/rig/state_test.rs
+++ b/tests/core/rig/state_test.rs
@@ -81,7 +81,7 @@ fn test_state_round_trips_with_materialized_ownership() {
                 exclusive: vec!["studio-dev".to_string()],
                 paths: vec!["/tmp/studio".to_string()],
                 ports: vec![9724],
-                process_patterns: vec!["wordpress-server-child".to_string()],
+                process_patterns: vec!["app-server-child".to_string()],
             },
             components: Default::default(),
         }),
@@ -95,7 +95,7 @@ fn test_state_round_trips_with_materialized_ownership() {
     assert_eq!(materialized.resources.ports, vec![9724]);
     assert_eq!(
         materialized.resources.process_patterns,
-        vec!["wordpress-server-child"]
+        vec!["app-server-child"]
     );
 }
 

--- a/tests/core_agnostic_test.rs
+++ b/tests/core_agnostic_test.rs
@@ -288,31 +288,11 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
         term: "rust",
     },
     ViolationKey {
-        path: "tests/core/rig/bench_resource_lease_test.rs",
-        term: "wordpress",
-    },
-    ViolationKey {
-        path: "tests/core/rig/expand_test.rs",
-        term: "wordpress",
-    },
-    ViolationKey {
-        path: "tests/core/rig/lease_test.rs",
-        term: "wordpress",
-    },
-    ViolationKey {
-        path: "tests/core/rig/service_test.rs",
-        term: "wordpress",
-    },
-    ViolationKey {
         path: "tests/core/rig/spec_test.rs",
         term: "php",
     },
     ViolationKey {
         path: "tests/core/rig/spec_test.rs",
-        term: "wordpress",
-    },
-    ViolationKey {
-        path: "tests/core/rig/state_test.rs",
         term: "wordpress",
     },
     ViolationKey {
@@ -325,7 +305,7 @@ const TEST_CONTENT_BASELINE: &[ViolationKey] = &[
     },
 ];
 
-const TEST_CONTENT_BASELINE_OCCURRENCES: usize = 102;
+const TEST_CONTENT_BASELINE_OCCURRENCES: usize = 81;
 const CORE_AGNOSTIC_REPAIR_DIRECTIVE: &str = "This is a boundary violation, not a baseline chore. Do not add these findings to the baseline unless explicitly approved by a maintainer. Move platform-specific behavior into the owning extension or replace it with a generic core contract that extensions can populate.";
 
 #[test]

--- a/tests/output_contracts_test.rs
+++ b/tests/output_contracts_test.rs
@@ -538,8 +538,8 @@ fn normalize_provider_fanout_fixture(task_id: &str, provider_payload: &Value) ->
 fn extension_show_output_contracts_use_top_level_structured_sidecars() {
     let output = typed_output_value(ExtensionOutput::Show {
         extension: ExtensionDetail {
-            id: "wordpress".to_string(),
-            name: "WordPress".to_string(),
+            id: "sample-extension".to_string(),
+            name: "Sample Extension".to_string(),
             version: "1.0.0".to_string(),
             description: None,
             author: None,
@@ -553,7 +553,7 @@ fn extension_show_output_contracts_use_top_level_structured_sidecars() {
             ready_reason: None,
             ready_detail: None,
             linked: false,
-            path: "/extensions/wordpress".to_string(),
+            path: "/extensions/sample-extension".to_string(),
             source_revision: None,
             cli: None,
             actions: Vec::new(),


### PR DESCRIPTION
## Summary
- Replaces WordPress-shaped rig process fixture names with neutral app-server examples in core tests.
- Uses a neutral extension fixture in the output contract test.
- Ratchets the core-owned test-content boundary baseline after removing those WordPress-shaped fixture rows.

## Tests
- `cargo fmt --check`
- `cargo test core_owned_test_content_stays_language_and_framework_agnostic --test core_agnostic_test`
- `cargo test --test output_contracts_test extension_show_output_contracts_use_top_level_structured_sidecars`
- `cargo test test_state_round_trips_with_materialized_ownership`
- `cargo test test_spec_resources_block_parses_full_shape`
- `cargo test test_discover_newest_from_ps_requires_all_argv_selectors`
- `cargo test test_expand_resources_derives_paths_ports_and_process_patterns`
- `cargo test run_single_rig_bench_fails_fast_on_active_resource_lease`
- `cargo test test_acquire_active_run_lease_blocks_overlapping_resources_until_drop`

## Notes
- Full `cargo test --test core_agnostic_test` still fails on unrelated existing source-boundary findings in `src/core/runner/tool_registry.rs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the fixture cleanup, baseline ratchet, focused verification, and PR text for Chris to review.