### PR TITLE
Expose agent-task provider capability contract

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -70,6 +70,15 @@ This is the terminal/daemon-owned review surface for fleet cooking. Kimaki or an
 other chat UI should submit, poll, render, and call these commands rather than
 owning scheduling, state, artifacts, reconciliation, or promotion.
 
+## Provider Contracts
+
+`agent-task providers` returns `capability_contract` with Homeboy-owned schema ids
+for executor provider manifests, requests, and outcomes. Extensions should read
+that metadata, or import the matching `homeboy::core::agent_tasks::provider`
+constants, instead of copying schema strings into downstream code. Provider
+manifests may omit `schema`, `request_schema`, and `outcome_schema`; Homeboy
+defaults them to the current core contract ids.
+
 `agent-task status`, `logs`, `artifacts`, and `review` are read-only durable
 lifecycle inspection commands. They do not start workloads and are not gated by
 warm-machine resource policy; use `homeboy runner exec <runner> -- homeboy

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -287,6 +287,7 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
     Ok((
         serde_json::json!({
             "schema": "homeboy/agent-task-providers/v1",
+            "capability_contract": homeboy::core::agent_tasks::provider::provider_capability_contract(),
             "providers": providers,
             "secret_env": homeboy::core::agent_tasks::secrets::secret_env_status_with_fallbacks(&args.secret_env, &fallback_sources),
         }),

--- a/src/commands/agent_task/tests.rs
+++ b/src/commands/agent_task/tests.rs
@@ -15,12 +15,15 @@ use super::run::{
     run_resume_with_executor, run_submitted, submit,
 };
 use super::status::{cancel, logs, status};
-use super::{review, CancelArgs, RetryArgs};
+use super::{review, CancelArgs, ProvidersArgs, RetryArgs};
 use homeboy::core::agent_tasks::controller_service::{
     AgentTaskRepoLoopSpec, ControllerFromSpecRequest,
 };
 use homeboy::core::agent_tasks::gate::AgentTaskGateRevealPolicy;
 use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
+use homeboy::core::agent_tasks::provider::{
+    AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA, AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA,
+};
 use homeboy::core::agent_tasks::scheduler::{AgentTaskExecutorAdapter, AgentTaskPlan};
 
 use crate::test_support::with_isolated_home;
@@ -40,6 +43,34 @@ use homeboy::core::agent_tasks::{
 };
 use serde_json::{json, Value};
 use std::sync::{Arc, Mutex};
+
+#[test]
+fn providers_output_includes_core_capability_contract() {
+    with_isolated_home(|_| {
+        let (value, status) = review::providers(ProvidersArgs {
+            secret_env: Vec::new(),
+        })
+        .expect("providers output");
+
+        assert_eq!(status, 0);
+        assert_eq!(
+            value["capability_contract"]["schema"],
+            AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA
+        );
+        assert_eq!(
+            value["capability_contract"]["provider_schema"],
+            AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA
+        );
+        assert_eq!(
+            value["capability_contract"]["request_schema"],
+            AGENT_TASK_REQUEST_SCHEMA
+        );
+        assert_eq!(
+            value["capability_contract"]["outcome_schema"],
+            AGENT_TASK_OUTCOME_SCHEMA
+        );
+    });
+}
 
 #[test]
 fn from_spec_dispatch_defaults_use_spec_git_checkout() {

--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -134,6 +134,7 @@ mod tests {
 
     use super::*;
     use crate::core::agent_task::{AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA};
+    use crate::core::agent_task_provider::AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA;
 
     fn extension(id: &str) -> ExtensionManifest {
         ExtensionManifest {
@@ -178,7 +179,7 @@ mod tests {
 
     fn provider_json(id: &str, backend: &str) -> Value {
         json!({
-            "schema": "homeboy/agent-task-executor-provider/v1",
+            "schema": AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
             "id": id,
             "backend": backend,
             "command": "agent-task-provider",
@@ -233,7 +234,7 @@ mod tests {
                     "description": "Standalone runtime package fixture.",
                     "label": "Standalone Example",
                     "agent_task_executors": [{
-                        "schema": "homeboy/agent-task-executor-provider/v1",
+                        "schema": AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
                         "id": "standalone-example.default",
                         "backend": "example",
                         "command": "agent-task-provider",

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value};
 use crate::core::agent_task::{
     AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskFailureClassification,
     AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_ARTIFACT_SCHEMA,
-    AGENT_TASK_OUTCOME_SCHEMA,
+    AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
 };
 use crate::core::agent_task_scheduler::{
     AgentTaskExecutionContext, AgentTaskExecutorAdapter, AgentTaskPlan,
@@ -20,8 +20,30 @@ use crate::core::agent_task_secrets::{
 use crate::core::agent_task_timeout::timeout_with_grace;
 use crate::core::{agent_runtime_manifest, component, defaults, extension, Error};
 
+pub const AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA: &str = "homeboy/agent-task-executor-provider/v1";
+pub const AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA: &str =
+    "homeboy/agent-task-provider-capability-contract/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskProviderCapabilityContract {
+    pub schema: String,
+    pub provider_schema: String,
+    pub request_schema: String,
+    pub outcome_schema: String,
+}
+
+pub fn provider_capability_contract() -> AgentTaskProviderCapabilityContract {
+    AgentTaskProviderCapabilityContract {
+        schema: AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA.to_string(),
+        provider_schema: AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA.to_string(),
+        request_schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+        outcome_schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskExecutorProvider {
+    #[serde(default = "default_provider_schema")]
     pub schema: String,
     pub id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -30,7 +52,9 @@ pub struct AgentTaskExecutorProvider {
     #[serde(default, skip_serializing_if = "is_false")]
     pub default_backend: bool,
     pub command: String,
+    #[serde(default = "default_request_schema")]
     pub request_schema: String,
+    #[serde(default = "default_outcome_schema")]
     pub outcome_schema: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub capabilities: Vec<String>,
@@ -66,6 +90,18 @@ pub struct AgentTaskExecutorProvider {
     pub runtime_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_path: Option<String>,
+}
+
+fn default_provider_schema() -> String {
+    AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA.to_string()
+}
+
+fn default_request_schema() -> String {
+    AGENT_TASK_REQUEST_SCHEMA.to_string()
+}
+
+fn default_outcome_schema() -> String {
+    AGENT_TASK_OUTCOME_SCHEMA.to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -1390,10 +1426,39 @@ mod tests {
     use super::*;
     use crate::core::agent_task::{
         AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskWorkspace,
-        AGENT_TASK_REQUEST_SCHEMA,
     };
     use crate::core::agent_task_scheduler::{AgentTaskPlan, AgentTaskScheduler};
     use std::fs;
+
+    #[test]
+    fn provider_capability_contract_exports_core_owned_schema_ids() {
+        let contract = provider_capability_contract();
+
+        assert_eq!(
+            contract.schema,
+            AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA
+        );
+        assert_eq!(
+            contract.provider_schema,
+            AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA
+        );
+        assert_eq!(contract.request_schema, AGENT_TASK_REQUEST_SCHEMA);
+        assert_eq!(contract.outcome_schema, AGENT_TASK_OUTCOME_SCHEMA);
+    }
+
+    #[test]
+    fn provider_manifest_defaults_core_owned_schema_ids() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(json!({
+            "id": "minimal.provider",
+            "backend": "minimal",
+            "command": "minimal-provider"
+        }))
+        .expect("provider manifest");
+
+        assert_eq!(provider.schema, AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA);
+        assert_eq!(provider.request_schema, AGENT_TASK_REQUEST_SCHEMA);
+        assert_eq!(provider.outcome_schema, AGENT_TASK_OUTCOME_SCHEMA);
+    }
 
     fn script(body: &str) -> String {
         let path = std::env::temp_dir().join(format!(
@@ -1407,7 +1472,7 @@ mod tests {
 
     fn request(task_id: &str, command: String) -> (AgentTaskRequest, AgentTaskExecutorProvider) {
         let provider = AgentTaskExecutorProvider {
-            schema: "homeboy/agent-task-executor-provider/v1".to_string(),
+            schema: AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA.to_string(),
             id: "test.provider".to_string(),
             label: None,
             backend: "test".to_string(),

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -222,14 +222,16 @@ pub mod promotion {
 pub mod provider {
     pub use super::super::agent_task_provider::{
         default_backend, default_backend_for_component, dependency_failure_patterns,
-        provider_requires_cwd_git_checkout, provider_runner_readiness_contracts,
-        provider_runner_secret_env_for_plan, provider_runner_source_contracts,
-        provider_secret_sources_for_plan, provider_secret_sources_for_providers,
-        required_extension_ids_for_plan, AgentTaskExecutorProvider,
+        provider_capability_contract, provider_requires_cwd_git_checkout,
+        provider_runner_readiness_contracts, provider_runner_secret_env_for_plan,
+        provider_runner_source_contracts, provider_secret_sources_for_plan,
+        provider_secret_sources_for_providers, required_extension_ids_for_plan,
+        AgentTaskExecutorProvider, AgentTaskProviderCapabilityContract,
         AgentTaskProviderDependencyFailurePattern, AgentTaskProviderEnvPathReadiness,
         AgentTaskProviderRoleAliases, AgentTaskProviderRunnerReadiness,
         AgentTaskProviderRunnerSource, AgentTaskProviderWorkspaceMaterialization,
-        ExtensionProviderAgentTaskExecutor,
+        ExtensionProviderAgentTaskExecutor, AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
+        AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA,
     };
 }
 


### PR DESCRIPTION
## Summary
- Adds a core-owned agent-task provider capability contract metadata object and exported schema constants.
- Defaults provider manifest `schema`, `request_schema`, and `outcome_schema` to core contract ids so extensions can omit duplicated strings.
- Includes the contract in `agent-task providers` output and documents the extension consumption path.

## Tests
- `cargo fmt --check`
- `cargo test provider_capability_contract_exports_core_owned_schema_ids`
- `cargo test provider_manifest_defaults_core_owned_schema_ids`
- `cargo test providers_output_includes_core_capability_contract`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the provider contract metadata/defaults, focused tests, docs, and PR description; Chris remains responsible for review and validation.