### PR TITLE
fix(upgrade): repair runner-upgrade test regressions after #4956 (Closes #4961)

### DIFF
--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -248,17 +248,14 @@ fn upgrade_runner_with_executor(
     let mut new_version = runner_homeboy_version(runner, &upgrade_homeboy_path, exec)
         .ok()
         .flatten();
-    let configured_identity = runner_homeboy_identity(runner, &upgrade_homeboy_path, exec)
-        .ok()
-        .flatten();
     let mut source_path_realigned = false;
     if let Some(realignment) = source_upgrade_homeboy_path_realignment(
         runner,
         &original_homeboy_path,
         method_override,
         command_source_path.as_deref(),
+        &upgrade_homeboy_path,
         new_version.as_deref(),
-        configured_identity.as_deref(),
         exec,
     ) {
         match update_homeboy_path(&runner.id, &realignment.homeboy_path) {
@@ -638,16 +635,19 @@ fn source_upgrade_homeboy_path_realignment(
     original_homeboy_path: &str,
     method_override: Option<InstallMethod>,
     command_source_path: Option<&str>,
+    configured_homeboy_path: &str,
     configured_version: Option<&str>,
-    configured_identity: Option<&str>,
     exec: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
 ) -> Option<SourceUpgradeHomeboyPathRealignment> {
     if method_override != Some(InstallMethod::Source) {
         return None;
     }
     let current_identity = build_identity::current().display;
+    let configured_identity = runner_homeboy_identity(runner, configured_homeboy_path, exec)
+        .ok()
+        .flatten();
     if configured_version == Some(current_version())
-        && configured_identity == Some(current_identity.as_str())
+        && configured_identity.as_deref() == Some(current_identity.as_str())
     {
         return None;
     }


### PR DESCRIPTION
## P0 HOTFIX — main was RED

Closes #4961. 10 failing tests in `core::upgrade::runners::tests` were blocking every cook branched off main.

## Root cause (production regression, not stale tests)

#4956 ("realign source-built runner binaries by identity") added an **unconditional** `runner_homeboy_identity()` probe inside `upgrade_runner_with_executor`:

```rust
let configured_identity = runner_homeboy_identity(runner, &upgrade_homeboy_path, exec)...;
```

That probe fires an extra `homeboy --version` exec on **every** runner-upgrade path. But the resulting identity is only ever consumed by `source_upgrade_homeboy_path_realignment`, which returns early unless `method_override == Some(InstallMethod::Source)`.

So for all non-source upgrades the probe was a wasteful exec that shifted the mocked runner command sequence by one, breaking 10 tests (extension `show` vs `install`, bare-vs-versioned `--version` probe ordering, mock call-count expectations, `upgraded`/`updated` assertions).

## Fix

Move the identity probe **inside** `source_upgrade_homeboy_path_realignment`, after the `Source`-method guard, so it only runs when its result is actually used. Source-method realignment behavior and command ordering are fully preserved (verified by `source_runner_upgrade_realigns_to_materialized_source_build_when_path_shadows_old_homeboy`, still green); non-source paths no longer issue the spurious probe.

This is a real production-code fix — no test assertions were gutted.

## Validation

- `cargo test --lib core::upgrade::runners::tests` → **18 passed; 0 failed**
- `cargo test --lib core::upgrade` → **56 passed; 0 failed**
- `cargo build --lib --tests` clean (only pre-existing warnings in unrelated files)
- `cargo fmt` applied