### PR TITLE
Export agent-task core contract metadata

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -79,6 +79,12 @@ constants, instead of copying schema strings into downstream code. Provider
 manifests may omit `schema`, `request_schema`, and `outcome_schema`; Homeboy
 defaults them to the current core contract ids.
 
+`agent-task contract --format=json` returns `homeboy/agent-task-core-contract/v1`,
+the machine-readable Homeboy-owned contract export for downstream integrations.
+It includes schema ids, provider capability metadata, status/failure enum values,
+and default redaction policy metadata without naming or depending on any specific
+executor provider.
+
 `agent-task status`, `logs`, `artifacts`, and `review` are read-only durable
 lifecycle inspection commands. They do not start workloads and are not gated by
 warm-machine resource policy; use `homeboy runner exec <runner> -- homeboy

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -11,6 +11,7 @@ use super::{CmdResult, GlobalArgs};
 
 pub mod args;
 pub mod auth;
+pub mod contract;
 pub mod controller;
 pub mod review;
 pub mod run;
@@ -22,8 +23,8 @@ pub use args::{
     AgentTaskControllerFromSpecArgs, AgentTaskControllerInitArgs,
     AgentTaskControllerMarkHumanReadyArgs, AgentTaskControllerRunArgs,
     AgentTaskControllerRunNextArgs, AgentTaskControllerStatusArgs, AgentTaskLoopArgs, CancelArgs,
-    FinalizePrArgs, GateFeedbackArgs, PromoteArgs, ProvidersArgs, RetryArgs, ReviewArgs,
-    RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
+    ContractArgs, ContractFormat, FinalizePrArgs, GateFeedbackArgs, PromoteArgs, ProvidersArgs,
+    RetryArgs, ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 
@@ -60,6 +61,7 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::FinalizePr(finalize_args) => review::finalize_pull_request(finalize_args),
         AgentTaskCommand::GateFeedback(feedback_args) => review::gate_feedback(feedback_args),
         AgentTaskCommand::Providers(providers_args) => review::providers(providers_args),
+        AgentTaskCommand::Contract(contract_args) => contract::contract(contract_args),
         AgentTaskCommand::Auth(auth_args) => auth::auth(auth_args),
         AgentTaskCommand::Controller(controller_args) => controller::controller(controller_args),
     }

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -4,7 +4,7 @@
 //! sibling module lets the `agent_task` root stay a thin dispatcher over the
 //! handler modules (`auth`, `controller`, `run`, `status`, `review`).
 
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use homeboy::core::agent_tasks::gate::{AgentTaskGateRevealPolicy, VerifyGateOptions};
 
 use super::super::agent_task_dispatch::DispatchArgs;
@@ -75,6 +75,8 @@ pub enum AgentTaskCommand {
     GateFeedback(GateFeedbackArgs),
     /// List extension-declared agent-task executor providers and optional secret readiness.
     Providers(ProvidersArgs),
+    /// Export Homeboy's machine-readable agent-task core contract metadata.
+    Contract(ContractArgs),
     /// Configure and inspect agent-task provider authentication secrets.
     Auth(AgentTaskAuthArgs),
     /// Create, inspect, and resume durable multi-agent loop controller state.
@@ -130,6 +132,18 @@ pub struct ProvidersArgs {
     /// Secret environment variable name to check without exposing its value. Repeatable.
     #[arg(long = "secret-env", value_name = "ENV")]
     pub secret_env: Vec<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct ContractArgs {
+    /// Output format for the contract export.
+    #[arg(long, default_value = "json", value_enum)]
+    pub format: ContractFormat,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ContractFormat {
+    Json,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/agent_task/contract.rs
+++ b/src/commands/agent_task/contract.rs
@@ -1,0 +1,12 @@
+use serde_json::Value;
+
+use homeboy::core::agent_tasks::agent_task_core_contract;
+
+use super::super::CmdResult;
+use super::{command_json_value, ContractArgs, ContractFormat};
+
+pub(crate) fn contract(args: ContractArgs) -> CmdResult<Value> {
+    match args.format {
+        ContractFormat::Json => Ok((command_json_value(agent_task_core_contract())?, 0)),
+    }
+}

--- a/src/commands/agent_task/tests.rs
+++ b/src/commands/agent_task/tests.rs
@@ -44,6 +44,9 @@ use homeboy::core::agent_tasks::{
 use serde_json::{json, Value};
 use std::sync::{Arc, Mutex};
 
+use super::contract;
+use super::{ContractArgs, ContractFormat};
+
 #[test]
 fn providers_output_includes_core_capability_contract() {
     with_isolated_home(|_| {
@@ -70,6 +73,38 @@ fn providers_output_includes_core_capability_contract() {
             AGENT_TASK_OUTCOME_SCHEMA
         );
     });
+}
+
+#[test]
+fn contract_output_exports_core_agent_task_metadata() {
+    let (value, status) = contract::contract(ContractArgs {
+        format: ContractFormat::Json,
+    })
+    .expect("contract output");
+
+    assert_eq!(status, 0);
+    assert_eq!(value["schema"], "homeboy/agent-task-core-contract/v1");
+    assert_eq!(value["schemas"]["request"], AGENT_TASK_REQUEST_SCHEMA);
+    assert_eq!(
+        value["schemas"]["provider"],
+        AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA
+    );
+    assert_eq!(
+        value["provider_capability"]["schema"],
+        AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA
+    );
+    assert!(value["enums"]["outcome_status"]
+        .as_array()
+        .expect("outcome statuses")
+        .contains(&json!("provider_error")));
+    assert!(value["enums"]["failure_classification"]
+        .as_array()
+        .expect("failure classifications")
+        .contains(&json!("capability_missing")));
+    assert!(value["redaction_defaults"]["sensitive_keys"]
+        .as_array()
+        .expect("sensitive keys")
+        .contains(&json!("refresh_token")));
 }
 
 #[test]

--- a/src/core/agent_task_contract.rs
+++ b/src/core/agent_task_contract.rs
@@ -1,0 +1,267 @@
+use serde::Serialize;
+
+use crate::core::agent_task::{
+    AgentTaskExecutionState, AgentTaskFailureClassification, AgentTaskOutcomeStatus,
+    AgentTaskWorkflowStepStatus, AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_MATRIX_AGGREGATE_SCHEMA,
+    AGENT_TASK_MATRIX_PLAN_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
+    AGENT_TASK_WORKFLOW_SCHEMA,
+};
+use crate::core::agent_task_aggregate::AGENT_TASK_AGGREGATE_SCHEMA;
+use crate::core::agent_task_cook_loop::AGENT_TASK_COOK_LOOP_REPORT_SCHEMA;
+use crate::core::agent_task_gate::AGENT_TASK_GATE_REPORT_SCHEMA;
+use crate::core::agent_task_lifecycle::AgentTaskRunState;
+use crate::core::agent_task_loop_controller::{
+    AGENT_TASK_LOOP_CONTROLLER_SCHEMA, AGENT_TASK_LOOP_CONTROLLER_STATUS_SCHEMA,
+};
+use crate::core::agent_task_promotion::AGENT_TASK_PROMOTION_REPORT_SCHEMA;
+use crate::core::agent_task_provider::{
+    provider_capability_contract, AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
+    AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA,
+};
+use crate::core::agent_task_schedule::{
+    AgentTaskAggregateStatus, AgentTaskState, AGENT_TASK_PLAN_SCHEMA,
+};
+use crate::core::redaction::RedactionPolicy;
+use crate::core::secret_env_plan::SECRET_ENV_PLAN_SCHEMA;
+
+pub const AGENT_TASK_CORE_CONTRACT_SCHEMA: &str = "homeboy/agent-task-core-contract/v1";
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentTaskCoreContract {
+    pub schema: String,
+    pub schemas: AgentTaskCoreContractSchemas,
+    pub provider_capability: AgentTaskCoreProviderCapabilityContract,
+    pub enums: AgentTaskCoreContractEnums,
+    pub redaction_defaults: AgentTaskCoreRedactionDefaults,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentTaskCoreContractSchemas {
+    pub request: String,
+    pub outcome: String,
+    pub artifact: String,
+    pub workflow: String,
+    pub plan: String,
+    pub aggregate: String,
+    pub matrix_plan: String,
+    pub matrix_aggregate: String,
+    pub provider: String,
+    pub provider_capability_contract: String,
+    pub gate_report: String,
+    pub promotion_report: String,
+    pub cook_loop_report: String,
+    pub loop_controller: String,
+    pub loop_controller_status: String,
+    pub secret_env_plan: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentTaskCoreProviderCapabilityContract {
+    pub schema: String,
+    pub provider_schema: String,
+    pub request_schema: String,
+    pub outcome_schema: String,
+    pub provider_capability_fields: Vec<String>,
+    pub executor_provider_fields: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentTaskCoreContractEnums {
+    pub execution_state: Vec<String>,
+    pub task_state: Vec<String>,
+    pub run_state: Vec<String>,
+    pub aggregate_status: Vec<String>,
+    pub outcome_status: Vec<String>,
+    pub failure_classification: Vec<String>,
+    pub workflow_step_status: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentTaskCoreRedactionDefaults {
+    pub replacement: String,
+    pub sensitive_keys: Vec<String>,
+    pub sensitive_headers: Vec<String>,
+}
+
+pub fn agent_task_core_contract() -> AgentTaskCoreContract {
+    let provider_capability = provider_capability_contract();
+    let redaction = RedactionPolicy::default();
+
+    AgentTaskCoreContract {
+        schema: AGENT_TASK_CORE_CONTRACT_SCHEMA.to_string(),
+        schemas: AgentTaskCoreContractSchemas {
+            request: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            outcome: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+            artifact: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            workflow: AGENT_TASK_WORKFLOW_SCHEMA.to_string(),
+            plan: AGENT_TASK_PLAN_SCHEMA.to_string(),
+            aggregate: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+            matrix_plan: AGENT_TASK_MATRIX_PLAN_SCHEMA.to_string(),
+            matrix_aggregate: AGENT_TASK_MATRIX_AGGREGATE_SCHEMA.to_string(),
+            provider: AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA.to_string(),
+            provider_capability_contract: AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA
+                .to_string(),
+            gate_report: AGENT_TASK_GATE_REPORT_SCHEMA.to_string(),
+            promotion_report: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
+            cook_loop_report: AGENT_TASK_COOK_LOOP_REPORT_SCHEMA.to_string(),
+            loop_controller: AGENT_TASK_LOOP_CONTROLLER_SCHEMA.to_string(),
+            loop_controller_status: AGENT_TASK_LOOP_CONTROLLER_STATUS_SCHEMA.to_string(),
+            secret_env_plan: SECRET_ENV_PLAN_SCHEMA.to_string(),
+        },
+        provider_capability: AgentTaskCoreProviderCapabilityContract {
+            schema: provider_capability.schema,
+            provider_schema: provider_capability.provider_schema,
+            request_schema: provider_capability.request_schema,
+            outcome_schema: provider_capability.outcome_schema,
+            provider_capability_fields: string_vec(&[
+                "schema",
+                "provider_schema",
+                "request_schema",
+                "outcome_schema",
+            ]),
+            executor_provider_fields: string_vec(&[
+                "schema",
+                "id",
+                "label",
+                "backend",
+                "default_backend",
+                "command",
+                "request_schema",
+                "outcome_schema",
+                "capabilities",
+                "secret_requirements",
+                "secret_env_requirements",
+                "workspace_materialization",
+                "provider_defaults",
+                "runner_readiness",
+                "runner_sources",
+                "dependency_failure_patterns",
+                "timeout_artifact_discovery",
+                "role_aliases",
+                "extension_id",
+                "extension_path",
+                "runtime_id",
+                "runtime_path",
+            ]),
+        },
+        enums: AgentTaskCoreContractEnums {
+            execution_state: enum_values(&[
+                AgentTaskExecutionState::Queued,
+                AgentTaskExecutionState::Running,
+                AgentTaskExecutionState::Waiting,
+                AgentTaskExecutionState::Succeeded,
+                AgentTaskExecutionState::Failed,
+                AgentTaskExecutionState::Cancelled,
+            ]),
+            task_state: enum_values(&[
+                AgentTaskState::Queued,
+                AgentTaskState::Blocked,
+                AgentTaskState::Skipped,
+                AgentTaskState::Running,
+                AgentTaskState::Succeeded,
+                AgentTaskState::Failed,
+                AgentTaskState::Cancelled,
+                AgentTaskState::TimedOut,
+            ]),
+            run_state: enum_values(&[
+                AgentTaskRunState::Queued,
+                AgentTaskRunState::Running,
+                AgentTaskRunState::Succeeded,
+                AgentTaskRunState::PartialFailure,
+                AgentTaskRunState::Failed,
+                AgentTaskRunState::Cancelled,
+            ]),
+            aggregate_status: enum_values(&[
+                AgentTaskAggregateStatus::Succeeded,
+                AgentTaskAggregateStatus::PartialFailure,
+                AgentTaskAggregateStatus::Failed,
+                AgentTaskAggregateStatus::Cancelled,
+            ]),
+            outcome_status: enum_values(&[
+                AgentTaskOutcomeStatus::Succeeded,
+                AgentTaskOutcomeStatus::NoOp,
+                AgentTaskOutcomeStatus::UnableToRemediate,
+                AgentTaskOutcomeStatus::ProviderError,
+                AgentTaskOutcomeStatus::Timeout,
+                AgentTaskOutcomeStatus::Failed,
+                AgentTaskOutcomeStatus::FollowUpIssue,
+                AgentTaskOutcomeStatus::Cancelled,
+            ]),
+            failure_classification: enum_values(&[
+                AgentTaskFailureClassification::Provider,
+                AgentTaskFailureClassification::Timeout,
+                AgentTaskFailureClassification::PolicyDenied,
+                AgentTaskFailureClassification::CapabilityMissing,
+                AgentTaskFailureClassification::InvalidInput,
+                AgentTaskFailureClassification::ExecutionFailed,
+                AgentTaskFailureClassification::Unknown,
+            ]),
+            workflow_step_status: enum_values(&[
+                AgentTaskWorkflowStepStatus::Pending,
+                AgentTaskWorkflowStepStatus::Running,
+                AgentTaskWorkflowStepStatus::Succeeded,
+                AgentTaskWorkflowStepStatus::Failed,
+                AgentTaskWorkflowStepStatus::Skipped,
+                AgentTaskWorkflowStepStatus::Cancelled,
+            ]),
+        },
+        redaction_defaults: AgentTaskCoreRedactionDefaults {
+            replacement: redaction.replacement().to_string(),
+            sensitive_keys: redaction.sensitive_keys().to_vec(),
+            sensitive_headers: redaction.sensitive_headers().to_vec(),
+        },
+    }
+}
+
+fn string_vec(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| value.to_string()).collect()
+}
+
+fn enum_values<T: Serialize>(variants: &[T]) -> Vec<String> {
+    variants
+        .iter()
+        .map(|variant| {
+            serde_json::to_value(variant)
+                .ok()
+                .and_then(|value| value.as_str().map(str::to_string))
+                .unwrap_or_default()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn core_contract_exports_authoritative_agent_task_metadata() {
+        let contract = agent_task_core_contract();
+
+        assert_eq!(contract.schema, AGENT_TASK_CORE_CONTRACT_SCHEMA);
+        assert_eq!(contract.schemas.request, AGENT_TASK_REQUEST_SCHEMA);
+        assert_eq!(
+            contract.schemas.provider,
+            AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA
+        );
+        assert_eq!(
+            contract.provider_capability.schema,
+            AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA
+        );
+        assert!(contract
+            .enums
+            .outcome_status
+            .contains(&"provider_error".to_string()));
+        assert!(contract
+            .enums
+            .failure_classification
+            .contains(&"capability_missing".to_string()));
+        assert!(contract
+            .redaction_defaults
+            .sensitive_keys
+            .contains(&"refresh_token".to_string()));
+        assert!(contract
+            .provider_capability
+            .executor_provider_fields
+            .contains(&"timeout_artifact_discovery".to_string()));
+    }
+}

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -55,6 +55,12 @@ pub use super::agent_task_aggregate::{
     AgentTaskReconciliationItem, AGENT_TASK_AGGREGATE_SCHEMA,
 };
 
+pub use super::agent_task_contract::{
+    agent_task_core_contract, AgentTaskCoreContract, AgentTaskCoreContractEnums,
+    AgentTaskCoreContractSchemas, AgentTaskCoreProviderCapabilityContract,
+    AgentTaskCoreRedactionDefaults, AGENT_TASK_CORE_CONTRACT_SCHEMA,
+};
+
 pub use super::agent_task_fanout::{
     AgentTaskFanoutAggregate, AgentTaskFanoutPlan, AgentTaskFanoutPlane, AgentTaskFanoutScheduler,
     AGENT_TASK_FANOUT_AGGREGATE_SCHEMA, AGENT_TASK_FANOUT_PLAN_SCHEMA,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -14,6 +14,7 @@ pub mod agent_runtime_manifest;
 pub mod agent_task;
 pub mod agent_task_aggregate;
 pub(crate) mod agent_task_config_materialization;
+pub mod agent_task_contract;
 pub mod agent_task_controller_service;
 pub mod agent_task_cook_loop;
 pub mod agent_task_dispatch_service;

--- a/src/core/redaction.rs
+++ b/src/core/redaction.rs
@@ -76,6 +76,14 @@ impl RedactionPolicy {
         &self.replacement
     }
 
+    pub fn sensitive_keys(&self) -> &[String] {
+        &self.sensitive_keys
+    }
+
+    pub fn sensitive_headers(&self) -> &[String] {
+        &self.sensitive_headers
+    }
+
     pub fn is_sensitive_key(&self, key: &str) -> bool {
         let key = normalize_key(key);
         self.sensitive_keys

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -41,6 +41,7 @@ fn includes_first_level_subcommands() {
     assert!(surface.contains_path(&["file", "sync"]));
     assert!(surface.contains_path(&["runner", "job"]));
     assert!(surface.contains_path(&["agent-task", "loop"]));
+    assert!(surface.contains_path(&["agent-task", "contract"]));
     assert!(surface.contains_path(&["version", "show"]));
     assert!(surface.contains_path(&["worktree", "create"]));
     assert!(surface.contains_path(&["worktree", "remove"]));


### PR DESCRIPTION
## Summary
- Add Homeboy-owned `homeboy/agent-task-core-contract/v1` metadata export for agent-task schemas, provider capability metadata, status/failure enums, and redaction defaults.
- Expose it via `homeboy agent-task contract --format=json` and the `homeboy::core::agent_tasks` facade.
- Document the command and cover the public CLI path plus core/command contract assertions.

## Tests
- `cargo fmt --check`
- `cargo test --lib agent_task_contract`
- `cargo test --lib contract_output_exports_core_agent_task_metadata`
- `cargo test --lib providers_output_includes_core_capability_contract`
- `cargo test --test command_surface_test includes_first_level_subcommands`
- `cargo run --quiet -- agent-task contract --format=json`

## Follow-up
- Update Homeboy Extensions/downstream agent-task provider discovery to read this core contract export instead of duplicating schema names, enum values, failure classifications, and redaction defaults.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted implementation, tests, docs, and command verification; Chris reviews and owns the change.