### PR TITLE
Clarify canonical apply change contract

### DIFF
--- a/src/core/change_artifact.rs
+++ b/src/core/change_artifact.rs
@@ -1,15 +1,30 @@
-//! Shared vocabulary for code-change artifacts and apply results.
+//! Runner apply/change wire payloads.
 //!
-//! This module intentionally stays small: producers can describe a patch or
-//! file delta with provenance, while apply surfaces can report a common result
-//! envelope without adopting a full runner/Lab/refactor rewrite at once.
+//! This module owns the serializable `homeboy/change-artifact/v1` and
+//! `homeboy/change-apply-result/v1` schemas used at runner/Lab apply
+//! boundaries. `core::execution` owns the higher-level lifecycle envelopes for
+//! execute/artifact/approve/apply/publish flows. Use [`ApplyChangeArtifact`] and
+//! [`ApplyChangeResult`] when the payload is consumed by an apply adapter; use
+//! `core::execution::ChangeArtifact` when describing a lifecycle artifact in an
+//! execution run.
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
+use crate::core::execution::ChangeArtifactProvenance as ExecutionChangeArtifactProvenance;
+use crate::core::execution::{ApprovalScope, ChangeArtifact as ExecutionChangeArtifact};
+use crate::core::execution_contract::EXECUTION_CONTRACT;
 use crate::core::source_snapshot::SourceSnapshot;
 
-pub const CHANGE_ARTIFACT_SCHEMA: &str = "homeboy/change-artifact/v1";
-pub const CHANGE_APPLY_RESULT_SCHEMA: &str = "homeboy/change-apply-result/v1";
+pub const CHANGE_ARTIFACT_SCHEMA: &str = EXECUTION_CONTRACT.apply.change_artifact_schema;
+pub const CHANGE_APPLY_RESULT_SCHEMA: &str = EXECUTION_CONTRACT.apply.change_apply_result_schema;
+pub const RUNNER_WORKSPACE_APPLY_ADAPTER: &str =
+    EXECUTION_CONTRACT.apply.runner_workspace_apply_adapter;
+pub const UNIFIED_DIFF_PATCH_FORMAT: &str = EXECUTION_CONTRACT.apply.unified_diff_patch_format;
+pub const DIGEST_ALGORITHM_SHA256: &str = EXECUTION_CONTRACT.apply.digest_algorithm_sha256;
+
+pub type ApplyChangeArtifact = ChangeArtifact;
+pub type ApplyChangeResult = ChangeApplyResult;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChangeArtifact {
@@ -101,6 +116,81 @@ impl ChangeArtifact {
             digest: self.digest.clone(),
         }
     }
+
+    /// Project this apply-wire artifact into the lifecycle artifact envelope.
+    ///
+    /// The projection is intentionally lossy: source snapshot, schema, and
+    /// digest remain in metadata while the lifecycle artifact carries the
+    /// review-facing id/type/files/diff/provenance fields.
+    pub fn to_execution_change_artifact(
+        &self,
+        fallback_id: impl Into<String>,
+        artifact_type: impl Into<String>,
+    ) -> ExecutionChangeArtifact {
+        let artifact_id = self
+            .provenance
+            .as_ref()
+            .and_then(|provenance| provenance.artifact_id.clone())
+            .unwrap_or_else(|| fallback_id.into());
+        let artifact_type = artifact_type.into();
+        let mut metadata = HashMap::new();
+        metadata.insert("schema".to_string(), serde_json::json!(self.schema.clone()));
+        metadata.insert(
+            "source_snapshot".to_string(),
+            serde_json::to_value(&self.source_snapshot).unwrap_or(serde_json::Value::Null),
+        );
+        if let Some(digest) = &self.digest {
+            metadata.insert(
+                "digest".to_string(),
+                serde_json::to_value(digest).unwrap_or(serde_json::Value::Null),
+            );
+        }
+
+        ExecutionChangeArtifact {
+            id: artifact_id.clone(),
+            artifact_type,
+            provenance: self.provenance.as_ref().map_or_else(
+                || ExecutionChangeArtifactProvenance {
+                    source: "apply_change_artifact".to_string(),
+                    run_id: None,
+                    step_id: None,
+                    command: None,
+                    captured_at: None,
+                },
+                |provenance| ExecutionChangeArtifactProvenance {
+                    source: provenance.producer.clone(),
+                    run_id: provenance.run_id.clone(),
+                    step_id: None,
+                    command: provenance.command.as_ref().map(|command| command.join(" ")),
+                    captured_at: None,
+                },
+            ),
+            title: None,
+            summary: None,
+            path: None,
+            files: self.files(),
+            diff: self.patch.as_ref().map(|patch| patch.content.clone()),
+            approval_scope: Some(ApprovalScope::Artifact { artifact_id }),
+            metadata,
+        }
+    }
+
+    pub fn files(&self) -> Vec<String> {
+        let mut files = self
+            .delta
+            .as_ref()
+            .map(|delta| {
+                delta
+                    .files
+                    .iter()
+                    .map(|file| file.path.clone())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        files.sort();
+        files.dedup();
+        files
+    }
 }
 
 impl ChangeApplyResult {
@@ -132,11 +222,11 @@ fn default_change_apply_result_schema() -> String {
 }
 
 fn default_patch_format() -> String {
-    "unified_diff".to_string()
+    UNIFIED_DIFF_PATCH_FORMAT.to_string()
 }
 
 fn default_digest_algorithm() -> String {
-    "sha256".to_string()
+    DIGEST_ALGORITHM_SHA256.to_string()
 }
 
 fn is_false(value: &bool) -> bool {
@@ -212,6 +302,73 @@ mod tests {
             "refactor.transform"
         );
         assert_eq!(json["artifact"]["digest"]["value"], "def456");
+    }
+
+    #[test]
+    fn constants_are_sourced_from_canonical_execution_contract() {
+        assert_eq!(
+            CHANGE_ARTIFACT_SCHEMA,
+            crate::core::execution_contract::EXECUTION_CONTRACT
+                .apply
+                .change_artifact_schema
+        );
+        assert_eq!(
+            CHANGE_APPLY_RESULT_SCHEMA,
+            crate::core::execution_contract::EXECUTION_CONTRACT
+                .apply
+                .change_apply_result_schema
+        );
+        assert_eq!(UNIFIED_DIFF_PATCH_FORMAT, "unified_diff");
+        assert_eq!(DIGEST_ALGORITHM_SHA256, "sha256");
+    }
+
+    #[test]
+    fn apply_artifact_projects_to_execution_lifecycle_artifact() {
+        let artifact = ChangeArtifact {
+            schema: CHANGE_ARTIFACT_SCHEMA.to_string(),
+            source_snapshot: source_snapshot(),
+            patch: None,
+            delta: Some(ChangeDelta {
+                files: vec![ChangeDeltaFile {
+                    path: "src/lib.rs".to_string(),
+                    content_base64: Some("Zm9vCg==".to_string()),
+                    delete: false,
+                }],
+            }),
+            provenance: Some(ChangeArtifactProvenance {
+                producer: "runner.capture_patch".to_string(),
+                run_id: Some("run-1".to_string()),
+                artifact_id: Some("patch.diff".to_string()),
+                command: Some(vec!["homeboy".to_string(), "lab".to_string()]),
+            }),
+            digest: Some(ChangeArtifactDigest {
+                algorithm: DIGEST_ALGORITHM_SHA256.to_string(),
+                value: "abc123".to_string(),
+            }),
+        };
+
+        let execution_artifact =
+            artifact.to_execution_change_artifact("fallback.patch", "runner.apply.change_artifact");
+
+        assert_eq!(execution_artifact.id, "patch.diff");
+        assert_eq!(
+            execution_artifact.artifact_type,
+            "runner.apply.change_artifact"
+        );
+        assert_eq!(execution_artifact.provenance.source, "runner.capture_patch");
+        assert_eq!(
+            execution_artifact.provenance.command.as_deref(),
+            Some("homeboy lab")
+        );
+        assert_eq!(execution_artifact.files, vec!["src/lib.rs"]);
+        assert_eq!(
+            execution_artifact.metadata["schema"],
+            serde_json::json!(CHANGE_ARTIFACT_SCHEMA)
+        );
+        assert_eq!(
+            execution_artifact.metadata["digest"]["algorithm"],
+            DIGEST_ALGORITHM_SHA256
+        );
     }
 
     fn source_snapshot() -> SourceSnapshot {

--- a/src/core/execution_contract.rs
+++ b/src/core/execution_contract.rs
@@ -7,6 +7,7 @@
 pub struct ExecutionContract {
     pub artifacts: ArtifactUriContract,
     pub lab_offload: LabOffloadExecutionContract,
+    pub apply: ApplyChangeContract,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,6 +49,20 @@ pub struct LabOffloadExecutionContract {
     pub metadata_schema: &'static str,
 }
 
+/// Canonical apply/change wire contract shared by Lab, runners, and adapters.
+///
+/// `core::change_artifact` owns this schema's serializable payload structs.
+/// `core::execution` owns higher-level lifecycle envelopes that may reference
+/// these artifacts when describing execute/artifact/approve/apply/publish flows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ApplyChangeContract {
+    pub change_artifact_schema: &'static str,
+    pub change_apply_result_schema: &'static str,
+    pub runner_workspace_apply_adapter: &'static str,
+    pub unified_diff_patch_format: &'static str,
+    pub digest_algorithm_sha256: &'static str,
+}
+
 pub const EXECUTION_CONTRACT: ExecutionContract = ExecutionContract {
     artifacts: ArtifactUriContract {
         runner_artifact_scheme: "runner-artifact://",
@@ -55,6 +70,13 @@ pub const EXECUTION_CONTRACT: ExecutionContract = ExecutionContract {
     },
     lab_offload: LabOffloadExecutionContract {
         metadata_schema: "homeboy/lab-offload/v1",
+    },
+    apply: ApplyChangeContract {
+        change_artifact_schema: "homeboy/change-artifact/v1",
+        change_apply_result_schema: "homeboy/change-apply-result/v1",
+        runner_workspace_apply_adapter: "homeboy/runner-workspace-apply/v1",
+        unified_diff_patch_format: "unified_diff",
+        digest_algorithm_sha256: "sha256",
     },
 };
 
@@ -107,5 +129,22 @@ mod tests {
             "metadata-only:trace.zip"
         );
         assert_eq!(decode_uri_component("runner%2Fa"), "runner/a");
+    }
+
+    #[test]
+    fn apply_contract_names_canonical_wire_schemas() {
+        let apply = EXECUTION_CONTRACT.apply;
+
+        assert_eq!(apply.change_artifact_schema, "homeboy/change-artifact/v1");
+        assert_eq!(
+            apply.change_apply_result_schema,
+            "homeboy/change-apply-result/v1"
+        );
+        assert_eq!(
+            apply.runner_workspace_apply_adapter,
+            "homeboy/runner-workspace-apply/v1"
+        );
+        assert_eq!(apply.unified_diff_patch_format, "unified_diff");
+        assert_eq!(apply.digest_algorithm_sha256, "sha256");
     }
 }

--- a/src/core/runner/apply.rs
+++ b/src/core/runner/apply.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::core::change_artifact::{
     ChangeApplyResult, ChangeApplyStatus, ChangeArtifact, ChangeDelta, ChangePatch,
+    UNIFIED_DIFF_PATCH_FORMAT,
 };
 use crate::core::engine::command::{wait_with_bounded_output, DEFAULT_CAPTURE_LIMIT_BYTES};
 use crate::core::error::{Error, Result};
@@ -168,7 +169,7 @@ fn local_source_path(snapshot: &SourceSnapshot) -> Result<PathBuf> {
 }
 
 fn apply_unified_patch(local_path: &Path, patch: ChangePatch) -> Result<Vec<String>> {
-    if patch.format != "unified_diff" {
+    if patch.format != UNIFIED_DIFF_PATCH_FORMAT {
         return Err(Error::validation_invalid_argument(
             "patch.format",
             "only unified_diff Lab patches are supported",
@@ -315,7 +316,7 @@ mod tests {
             serde_json::json!({
                 "source_snapshot": snapshot,
                 "patch": {
-                    "format": "unified_diff",
+                    "format": UNIFIED_DIFF_PATCH_FORMAT,
                     "content": "diff --git a/file.txt b/file.txt\nindex 5626abf..f719efd 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-before\n+after\n"
                 }
             })
@@ -354,7 +355,7 @@ mod tests {
             serde_json::json!({
                 "source_snapshot": snapshot,
                 "patch": {
-                    "format": "unified_diff",
+                    "format": UNIFIED_DIFF_PATCH_FORMAT,
                     "content": "diff --git a/file.txt b/file.txt\nindex 5626abf..f719efd 100644\n--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-before\n+after\n"
                 }
             })

--- a/src/core/runner/lab_apply.rs
+++ b/src/core/runner/lab_apply.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
-use crate::core::change_artifact::{ChangeArtifact, ChangePatch, CHANGE_ARTIFACT_SCHEMA};
+use crate::core::change_artifact::{
+    ChangeArtifact, ChangePatch, CHANGE_ARTIFACT_SCHEMA, UNIFIED_DIFF_PATCH_FORMAT,
+};
 use crate::core::{Error, Result};
 
 use super::{
@@ -47,7 +49,7 @@ pub(super) fn apply_lab_offload_patch(
         schema: CHANGE_ARTIFACT_SCHEMA.to_string(),
         source_snapshot,
         patch: Some(ChangePatch {
-            format: "unified_diff".to_string(),
+            format: UNIFIED_DIFF_PATCH_FORMAT.to_string(),
             content: patch_content,
         }),
         delta: None,


### PR DESCRIPTION
## Summary
- Adds a canonical apply/change contract section to `EXECUTION_CONTRACT` for schema ids, adapter id, patch format, and digest algorithm.
- Clarifies that `core::change_artifact` owns runner/Lab apply wire payloads while `core::execution` owns lifecycle envelopes.
- Adds aliases and a projection helper from apply-wire artifacts into lifecycle artifacts, then migrates runner/Lab apply code to the canonical constants.

## Tests
- `cargo test core::execution_contract && cargo test core::change_artifact && cargo test core::runner::apply && cargo test core::runner::lab_apply`
- `cargo test --lib` was also run; it reached 4,937 passing tests but failed in unrelated extension/upgrade runner tests already outside this scoped contract change.

## Remaining extension migration
- Extension-owned apply producers can keep their existing payloads for now.
- Follow-up migration should import `EXECUTION_CONTRACT.apply` / `core::change_artifact::{ApplyChangeArtifact, ApplyChangeResult}` instead of hard-coded schema strings.
- Any extension lifecycle summaries can use `to_execution_change_artifact` when they need to report an apply-wire artifact through `core::execution`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the scoped Rust contract constants, helper methods, tests, and PR description; Chris remains responsible for review and acceptance.
