### PR TITLE
Remove dead code flagged by audit (#4940)

### DIFF
--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -743,8 +743,7 @@ fn sanitize_slug(value: &str) -> String {
 mod tests {
     use super::*;
     use crate::core::agent_task::{
-        AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_ARTIFACT_SCHEMA,
-        AGENT_TASK_OUTCOME_SCHEMA,
+        AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_OUTCOME_SCHEMA,
     };
     use crate::core::agent_task_scheduler::AgentTaskExecutionContext;
     use crate::test_support::with_isolated_home;
@@ -1109,44 +1108,6 @@ mod tests {
                 summary: Some("ok".to_string()),
                 failure_classification: None,
                 artifacts: Vec::new(),
-                typed_artifacts: Vec::new(),
-                evidence_refs: Vec::new(),
-                diagnostics: Vec::new(),
-                outputs: Value::Null,
-                workflow: None,
-                follow_up: None,
-                metadata: Value::Null,
-            }
-        }
-    }
-
-    #[allow(dead_code)]
-    struct PatchExecutor;
-
-    impl AgentTaskExecutorAdapter for PatchExecutor {
-        fn execute(
-            &self,
-            _request: AgentTaskRequest,
-            _context: AgentTaskExecutionContext,
-        ) -> AgentTaskOutcome {
-            AgentTaskOutcome {
-                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
-                task_id: "cook-task".to_string(),
-                status: AgentTaskOutcomeStatus::Succeeded,
-                summary: Some("patch ready".to_string()),
-                failure_classification: None,
-                artifacts: vec![AgentTaskArtifact {
-                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-                    id: "patch-1".to_string(),
-                    kind: "patch".to_string(),
-                    name: Some("changes.patch".to_string()),
-                    path: Some("/tmp/changes.patch".to_string()),
-                    url: None,
-                    mime: None,
-                    size_bytes: None,
-                    sha256: None,
-                    metadata: Value::Null,
-                }],
                 typed_artifacts: Vec::new(),
                 evidence_refs: Vec::new(),
                 diagnostics: Vec::new(),

--- a/src/core/agent_task_fanout.rs
+++ b/src/core/agent_task_fanout.rs
@@ -72,7 +72,7 @@ impl AgentTaskFanoutPlan {
         }
     }
 
-    pub fn to_schedule_plan(&self) -> AgentTaskPlan {
+    pub(crate) fn to_schedule_plan(&self) -> AgentTaskPlan {
         let mut plan = AgentTaskPlan::new(
             self.fanout_id.clone(),
             self.tasks
@@ -235,7 +235,7 @@ fn fanout_dependency_step_ids(dependencies: &AgentTaskOutputDependencies) -> Vec
 }
 
 impl AgentTaskFanoutAggregate {
-    pub fn from_schedule(plan: &AgentTaskFanoutPlan, schedule: AgentTaskAggregate) -> Self {
+    pub(crate) fn from_schedule(plan: &AgentTaskFanoutPlan, schedule: AgentTaskAggregate) -> Self {
         let reconciliation = AgentTaskAggregateReport::from(schedule.outcomes.as_slice());
         Self {
             schema: AGENT_TASK_FANOUT_AGGREGATE_SCHEMA.to_string(),

--- a/src/core/observation/runs_service.rs
+++ b/src/core/observation/runs_service.rs
@@ -45,24 +45,6 @@ pub struct ArtifactFetchOutcome {
     pub sha256: Option<String>,
 }
 
-/// Pure artifact lookup input for callers that need records without refresh,
-/// indexing, or runner mirroring side effects.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct RunArtifactQuery {
-    pub run_id: String,
-    pub kind: Option<String>,
-    pub artifact_type: Option<String>,
-}
-
-impl RunArtifactQuery {
-    pub fn new(run_id: impl Into<String>) -> Self {
-        Self {
-            run_id: run_id.into(),
-            ..Default::default()
-        }
-    }
-}
-
 /// Look up a run and surface a stable validation error when it doesn't
 /// exist. Used by every observation command that takes a `run_id`.
 pub fn require_run(store: &ObservationStore, run_id: &str) -> Result<RunRecord> {
@@ -143,7 +125,7 @@ pub fn refresh_mirrored_daemon_evidence_best_effort(run_id: &str) {
 /// Mirrors the original CLI helper exactly: derive a public URL (from
 /// stored artifact metadata or by treating the artifact path as the URL
 /// for `url`-typed artifacts), then resolve any cached viewer links.
-pub fn enrich_artifact_link(mut artifact: ArtifactRecord) -> ArtifactRecord {
+pub(crate) fn enrich_artifact_link(mut artifact: ArtifactRecord) -> ArtifactRecord {
     let public_url =
         public_artifact_url(&artifact).or_else(|| public_url_for_url_artifact(&artifact));
     if let Some(url) = public_url.clone() {
@@ -215,33 +197,6 @@ pub fn list_artifacts_for_run(
     let mut artifacts = store.list_artifacts(run_id)?;
     artifacts.extend(related_lab_artifacts_for_runner_job(store, &run)?);
     Ok(enrich_artifact_links(artifacts))
-}
-
-/// List artifact records from the local store only, preserving the stored
-/// records exactly except for optional in-memory kind/type filtering.
-pub fn query_run_artifacts(
-    store: &ObservationStore,
-    query: &RunArtifactQuery,
-) -> Result<Vec<ArtifactRecord>> {
-    if store.get_run(&query.run_id)?.is_none() {
-        return Err(missing_run_error(&query.run_id));
-    }
-    let artifacts = store
-        .list_artifacts(&query.run_id)?
-        .into_iter()
-        .filter(|artifact| {
-            query
-                .kind
-                .as_ref()
-                .map_or(true, |kind| artifact.kind == *kind)
-        })
-        .filter(|artifact| {
-            query.artifact_type.as_ref().map_or(true, |artifact_type| {
-                artifact.artifact_type == *artifact_type
-            })
-        })
-        .collect();
-    Ok(artifacts)
 }
 
 /// Outcome of `get_artifact_bytes` describing where the bytes were written.
@@ -871,14 +826,6 @@ pub enum ArtifactStorage {
     Other,
 }
 
-/// Convenience accessor: returns the resolved local path used to display
-/// `homeboy runs artifacts` rows. Kept so other consumers don't need to
-/// reach into `ArtifactRecord` for path formatting.
-#[allow(dead_code)]
-pub fn artifact_display_path(artifact: &ArtifactRecord) -> &Path {
-    Path::new(&artifact.path)
-}
-
 #[cfg(test)]
 mod tests {
     //! Service-level coverage. The CLI adapter in `commands::runs` keeps the
@@ -1001,32 +948,6 @@ mod tests {
             assert_eq!(outcome.artifact_id, artifact.id);
             assert_eq!(outcome.output_path, dest);
             assert_eq!(std::fs::read(&dest).expect("downloaded"), br#"{"ok":true}"#);
-        });
-    }
-
-    #[test]
-    fn query_run_artifacts_filters_without_enrichment_side_effects() {
-        with_isolated_home(|home| {
-            let _xdg = XdgGuard::unset();
-            let store = ObservationStore::open_initialized().expect("store");
-            let run = store.start_run(sample_run("bench")).expect("run");
-            let source = home.path().join("bench-results.json");
-            std::fs::write(&source, br#"{"ok":true}"#).expect("source");
-            store
-                .record_artifact(&run.id, "bench_results", &source)
-                .expect("record");
-            store
-                .record_url_artifact(&run.id, "review", "https://example.test/evidence")
-                .expect("url");
-
-            let mut query = RunArtifactQuery::new(&run.id);
-            query.kind = Some("bench_results".to_string());
-            query.artifact_type = Some("file".to_string());
-
-            let artifacts = query_run_artifacts(&store, &query).expect("artifacts");
-            assert_eq!(artifacts.len(), 1);
-            assert_eq!(artifacts[0].kind, "bench_results");
-            assert_eq!(artifacts[0].public_url, None);
         });
     }
 


### PR DESCRIPTION
## Summary
Isolated dead-code cleanup for the 7 audit findings in #4940. Each item was investigated before acting; genuinely-unused items were removed, items used only within their own file had their visibility narrowed instead of deleted. Does **not** touch `src/core/upgrade/runners.rs` (the parallel P0 area).

## Findings addressed
1. `agent_task_dispatch_service.rs` — removed dead `PatchExecutor` test struct + impl + `#[allow(dead_code)]` (defined but never instantiated). Also dropped the now-orphaned `AgentTaskArtifact` / `AGENT_TASK_ARTIFACT_SCHEMA` test imports.
2. `agent_task_fanout.rs` — `from_schedule`: `pub` → `pub(crate)` (only called within the file by `run()`).
3. `agent_task_fanout.rs` — `to_schedule_plan`: `pub` → `pub(crate)` (only called within the file).
4–5. `observation/runs_service.rs` — deleted `artifact_display_path` (+ `#[allow(dead_code)]` + doc); zero callers anywhere including tests.
6. `observation/runs_service.rs` — `enrich_artifact_link`: `pub` → `pub(crate)` (only used internally by `enrich_artifact_links`; the plural stays `pub` for external callers).
7. `observation/runs_service.rs` — deleted `query_run_artifacts` plus its now-orphaned `RunArtifactQuery` struct/impl and the single test that only exercised it (no production callers).

## Validation
- `cargo build --lib --tests` — clean (no missed references; the 2 remaining warnings are pre-existing and in untouched files).
- `cargo test agent_task` — 355 passed, 0 failed.
- `cargo test observation` — all pass except 2 pre-existing, environment-dependent `commands::trace::tests` failures (exit 126 executing `.trace.mjs`), confirmed identical on clean `origin/main`.
- `cargo fmt` applied.

Closes #4940