### PR TITLE
feat(rig): materialize package template variants

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -30,6 +30,7 @@ For git sources, `repo.git//subpath` clones the repository root but discovers sp
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `id` | string | No | Rig ID. If absent, the filename stem is used. |
+| `extends` | string or array | No | Install-time template parents, resolved relative to the declaring `rig.json` and deep-merged before installation. |
 | `description` | string | No | Human-readable description shown in `rig list` / `rig show`. |
 | `components` | object | No | Map of component ID to `ComponentSpec`. |
 | `services` | object | No | Map of service ID to `ServiceSpec`. |
@@ -42,6 +43,46 @@ For git sources, `repo.git//subpath` clones the repository root but discovers sp
 | `trace_workloads` | object | No | Rig-owned out-of-tree trace workloads keyed by extension ID. |
 | `bench_profiles` | object | No | Named benchmark scenario profiles keyed by profile name. |
 | `app_launcher` | object | No | Optional desktop launcher wrapper config. |
+
+## Templates And Variants
+
+Rig package specs may declare `extends` to derive a concrete installed rig from one or more JSON templates in the same package source root. Homeboy resolves each parent relative to the declaring file, materializes the merged JSON during `homeboy rig install` / `rig sources update`, and writes the installed rig without the `extends` field. Runtime commands continue to load ordinary rig JSON.
+
+Merge rules are intentionally generic:
+
+- Parent files are applied in order; the declaring rig is applied last.
+- Objects merge recursively.
+- Arrays and scalar values replace the inherited value.
+- `extends` paths must be non-empty relative paths that stay inside the rig package source root.
+
+Example:
+
+```jsonc
+// templates/base.json
+{
+  "components": {
+    "app": { "path": "${env.DEV_ROOT}/app", "branch": "main" }
+  },
+  "pipeline": {
+    "check": [
+      { "kind": "check", "label": "app exists", "file": "${components.app.path}" }
+    ]
+  }
+}
+```
+
+```jsonc
+// rigs/app-branch/rig.json
+{
+  "extends": "../../templates/base.json",
+  "id": "app-branch",
+  "components": {
+    "app": { "path": "${env.DEV_ROOT}/app-branch" }
+  }
+}
+```
+
+The installed rig keeps the base `pipeline.check` and `components.app.branch`, while replacing `components.app.path`.
 
 ## `ComponentSpec`
 

--- a/src/core/rig/install.rs
+++ b/src/core/rig/install.rs
@@ -12,6 +12,8 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
+const EXTENDS_FIELD: &str = "extends";
+
 #[derive(Debug, Clone, Serialize)]
 pub struct DiscoveredRig {
     pub id: String,
@@ -74,6 +76,8 @@ pub struct RigSourceMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub discovery_path: Option<String>,
     pub linked: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub materialized: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_revision: Option<String>,
 }
@@ -116,12 +120,14 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
     let mut installed = Vec::new();
     for rig in selected {
         let target = paths::rig_config(&rig.id)?;
+        materialize_rig_spec(&rig.rig_path, &prepared.source_root)?;
         if target.exists() || fs::symlink_metadata(&target).is_ok() {
             ensure_rig_refreshable(&rig, &target)?;
             remove_existing_config(&target, "replace rig config link")?;
         }
 
-        link_or_copy_file(&rig.rig_path, &target)?;
+        let materialized =
+            write_rig_config_from_source(&rig.rig_path, &target, &prepared.source_root)?;
 
         let metadata = RigSourceMetadata {
             source: prepared.source.clone(),
@@ -130,6 +136,7 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
             rig_path: rig.rig_path.to_string_lossy().to_string(),
             discovery_path: Some(prepared.discovery_path.to_string_lossy().to_string()),
             linked: prepared.linked,
+            materialized,
             source_revision: prepared.source_revision.clone(),
         };
         write_source_metadata(&rig.id, &metadata)?;
@@ -179,6 +186,192 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
         installed,
         installed_stacks,
     })
+}
+
+pub(crate) fn write_rig_config_from_source(
+    source: &Path,
+    target: &Path,
+    source_root: &Path,
+) -> Result<bool> {
+    match materialize_rig_spec(source, source_root)? {
+        Some(value) => {
+            let content = serde_json::to_string_pretty(&value).map_err(|e| {
+                Error::internal_json(
+                    e.to_string(),
+                    Some("serialize materialized rig spec".into()),
+                )
+            })?;
+            fs::write(target, format!("{}\n", content)).map_err(|e| {
+                Error::internal_io(e.to_string(), Some("write materialized rig spec".into()))
+            })?;
+            Ok(true)
+        }
+        None => {
+            link_or_copy_file(source, target)?;
+            Ok(false)
+        }
+    }
+}
+
+pub(crate) fn materialize_rig_spec(
+    path: &Path,
+    source_root: &Path,
+) -> Result<Option<serde_json::Value>> {
+    let value = read_json_value(path)?;
+    if !value.get(EXTENDS_FIELD).is_some() {
+        return Ok(None);
+    }
+    materialize_rig_spec_value(path, source_root, value, &mut Vec::new()).map(Some)
+}
+
+fn materialize_rig_spec_value(
+    path: &Path,
+    source_root: &Path,
+    mut value: serde_json::Value,
+    stack: &mut Vec<PathBuf>,
+) -> Result<serde_json::Value> {
+    let canonical = path.canonicalize().map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("resolve rig spec {}", path.display())),
+        )
+    })?;
+    if stack.contains(&canonical) {
+        return Err(Error::validation_invalid_argument(
+            EXTENDS_FIELD,
+            format!("Rig template extends cycle includes {}", path.display()),
+            Some(path.to_string_lossy().to_string()),
+            None,
+        ));
+    }
+    stack.push(canonical);
+
+    let parents = extends_paths(&value, path, source_root)?;
+    remove_extends(&mut value);
+
+    let mut merged = serde_json::Value::Object(serde_json::Map::new());
+    for parent in parents {
+        let parent_value = read_json_value(&parent)?;
+        let parent_materialized =
+            materialize_rig_spec_value(&parent, source_root, parent_value, stack)?;
+        merge_json(&mut merged, parent_materialized);
+    }
+    merge_json(&mut merged, value);
+
+    stack.pop();
+    Ok(merged)
+}
+
+fn read_json_value(path: &Path) -> Result<serde_json::Value> {
+    let content = fs::read_to_string(path).map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!("read rig spec {}", path.display())),
+        )
+    })?;
+    serde_json::from_str(&content).map_err(|e| {
+        Error::validation_invalid_json(
+            e,
+            Some(format!("parse rig spec {}", path.display())),
+            Some(content.chars().take(200).collect()),
+        )
+    })
+}
+
+fn extends_paths(
+    value: &serde_json::Value,
+    path: &Path,
+    source_root: &Path,
+) -> Result<Vec<PathBuf>> {
+    let Some(extends) = value.get(EXTENDS_FIELD) else {
+        return Ok(Vec::new());
+    };
+
+    let raw_paths = match extends {
+        serde_json::Value::String(path) => vec![path.as_str()],
+        serde_json::Value::Array(paths) => paths
+            .iter()
+            .map(|entry| {
+                entry.as_str().ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        EXTENDS_FIELD,
+                        "Rig template extends entries must be strings",
+                        Some(entry.to_string()),
+                        None,
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>>>()?,
+        _ => {
+            return Err(Error::validation_invalid_argument(
+                EXTENDS_FIELD,
+                "Rig template extends must be a string or array of strings",
+                Some(extends.to_string()),
+                None,
+            ));
+        }
+    };
+
+    let source_root = source_root.canonicalize().map_err(|e| {
+        Error::internal_io(
+            e.to_string(),
+            Some(format!(
+                "resolve rig package root {}",
+                source_root.display()
+            )),
+        )
+    })?;
+    let base = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut paths = Vec::new();
+    for raw_path in raw_paths {
+        if raw_path.trim().is_empty() || Path::new(raw_path).is_absolute() {
+            return Err(Error::validation_invalid_argument(
+                EXTENDS_FIELD,
+                "Rig template extends paths must be non-empty relative paths",
+                Some(raw_path.to_string()),
+                None,
+            ));
+        }
+        let candidate = base.join(raw_path);
+        let canonical = candidate.canonicalize().map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("resolve rig template {}", candidate.display())),
+            )
+        })?;
+        if !canonical.starts_with(&source_root) {
+            return Err(Error::validation_invalid_argument(
+                EXTENDS_FIELD,
+                "Rig template extends paths must stay inside the rig package source root",
+                Some(raw_path.to_string()),
+                None,
+            ));
+        }
+        paths.push(canonical);
+    }
+    Ok(paths)
+}
+
+fn remove_extends(value: &mut serde_json::Value) {
+    if let Some(object) = value.as_object_mut() {
+        object.remove(EXTENDS_FIELD);
+    }
+}
+
+fn merge_json(target: &mut serde_json::Value, overlay: serde_json::Value) {
+    match (target, overlay) {
+        (serde_json::Value::Object(target), serde_json::Value::Object(overlay)) => {
+            for (key, value) in overlay {
+                match target.get_mut(&key) {
+                    Some(existing) => merge_json(existing, value),
+                    None => {
+                        target.insert(key, value);
+                    }
+                }
+            }
+        }
+        (target, overlay) => *target = overlay,
+    }
 }
 
 fn ensure_rig_refreshable(rig: &DiscoveredRig, target: &Path) -> Result<()> {

--- a/src/core/rig/lint.rs
+++ b/src/core/rig/lint.rs
@@ -28,6 +28,7 @@ pub fn run_package_lint(rig: &RigSpec) -> Result<PipelineOutcome> {
 
     let conflict_failures = conflict_marker_failures(&root, &files)?;
     let json_failures = json_parse_failures(&root, &files)?;
+    let template_failures = template_materialization_failures(&root, &files)?;
     let steps = vec![
         aggregate_step(
             "rig-package-lint",
@@ -38,6 +39,11 @@ pub fn run_package_lint(rig: &RigSpec) -> Result<PipelineOutcome> {
             "rig-package-lint",
             "rig package JSON specs parse",
             json_failures,
+        ),
+        aggregate_step(
+            "rig-package-lint",
+            "rig package template specs materialize",
+            template_failures,
         ),
     ];
 
@@ -139,6 +145,29 @@ fn json_parse_failures(root: &Path, files: &[PathBuf]) -> Result<Vec<String>> {
                 "{} invalid JSON: {}",
                 display_relative(root, file),
                 error
+            ));
+        }
+    }
+    Ok(failures)
+}
+
+fn template_materialization_failures(root: &Path, files: &[PathBuf]) -> Result<Vec<String>> {
+    let mut failures = Vec::new();
+    for file in files
+        .iter()
+        .filter(|path| path.file_name() == Some(OsStr::new("rig.json")))
+    {
+        let content = fs::read_to_string(file).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(format!("read {}", file.display())))
+        })?;
+        if !content.contains("\"extends\"") {
+            continue;
+        }
+        if let Err(error) = super::install::materialize_rig_spec(file, root) {
+            failures.push(format!(
+                "{} template materialization failed: {}",
+                display_relative(root, file),
+                error.message
             ));
         }
     }

--- a/src/core/rig/source.rs
+++ b/src/core/rig/source.rs
@@ -8,8 +8,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::install::{
-    discover_stacks, link_or_copy_file, write_source_metadata, write_stack_source_metadata,
-    RigSourceMetadata, StackSourceMetadata,
+    discover_stacks, link_or_copy_file, write_rig_config_from_source, write_source_metadata,
+    write_stack_source_metadata, RigSourceMetadata, StackSourceMetadata,
 };
 
 mod types;
@@ -319,12 +319,14 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
         }
 
         let config_path = PathBuf::from(&rig.config_path);
+        super::install::materialize_rig_spec(&rig_path, Path::new(&source.source_root))?;
         if config_path.exists() || fs::symlink_metadata(&config_path).is_ok() {
             fs::remove_file(&config_path).map_err(|e| {
                 Error::internal_io(e.to_string(), Some("replace rig config link".into()))
             })?;
         }
-        link_or_copy_file(&rig_path, &config_path)?;
+        let materialized =
+            write_rig_config_from_source(&rig_path, &config_path, Path::new(&source.source_root))?;
 
         let metadata = RigSourceMetadata {
             source: source.source.clone(),
@@ -333,6 +335,7 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
             rig_path: rig.rig_path.clone(),
             discovery_path: Some(source.discovery_path.clone()),
             linked: false,
+            materialized,
             source_revision: source_revision.clone(),
         };
         write_source_metadata(&rig.id, &metadata)?;
@@ -493,9 +496,9 @@ fn group_source_entries(entries: SourceEntries) -> RigSourceListResult {
         let key = format!("{}\0{}", entry.metadata.source, entry.metadata.package_path);
         let config_path = paths::rig_config(&entry.id).ok();
         let config_present = config_path.as_ref().is_some_and(|path| path.exists());
-        let config_owned = config_path
-            .as_ref()
-            .is_some_and(|path| rig_config_matches_source(path, &entry.metadata.rig_path));
+        let config_owned = config_path.as_ref().is_some_and(|path| {
+            entry.metadata.materialized || rig_config_matches_source(path, &entry.metadata.rig_path)
+        });
 
         groups
             .entry(key)

--- a/src/core/runner/rig_materialization.rs
+++ b/src/core/runner/rig_materialization.rs
@@ -1028,6 +1028,7 @@ mod tests {
                     discovery_path: Some(checkout.display().to_string()),
                     source_revision: None,
                     linked: true,
+                    materialized: false,
                 },
             )
             .expect("source metadata");

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -206,6 +206,80 @@ fn installed_rig_check_reports_package_lint_failures() {
 }
 
 #[test]
+fn install_materializes_rig_template_extends() {
+    let _home = HomeGuard::new();
+    let package = tempfile::tempdir().expect("package");
+    fs::create_dir_all(package.path().join("templates")).expect("templates dir");
+    fs::write(
+        package.path().join("templates/base.json"),
+        r#"{
+            "description": "base rig",
+            "components": {
+                "app": { "path": "${env.DEV_ROOT}/base", "branch": "main" }
+            },
+            "pipeline": {
+                "check": [
+                    { "kind": "check", "label": "app exists", "file": "${components.app.path}" }
+                ]
+            }
+        }"#,
+    )
+    .expect("base template");
+    write_rig(
+        package.path(),
+        "alpha",
+        r#"{
+            "extends": "../../templates/base.json",
+            "id": "alpha",
+            "description": "alpha rig",
+            "components": {
+                "app": { "path": "${env.DEV_ROOT}/alpha" }
+            }
+        }"#,
+    );
+
+    let result = install(package.path().to_str().unwrap(), None, false).expect("install");
+
+    assert_eq!(result.installed.len(), 1);
+    let installed_path = crate::core::paths::rig_config("alpha").expect("rig config");
+    #[cfg(unix)]
+    assert!(fs::read_link(&installed_path).is_err());
+    let installed = fs::read_to_string(&installed_path).expect("installed rig");
+    assert!(!installed.contains("extends"));
+    let rig = load("alpha").expect("load rig");
+    assert_eq!(rig.description, "alpha rig");
+    assert_eq!(rig.components["app"].path, "${env.DEV_ROOT}/alpha");
+    assert_eq!(rig.components["app"].branch.as_deref(), Some("main"));
+    assert_eq!(rig.pipeline["check"].len(), 1);
+    assert!(
+        read_source_metadata("alpha")
+            .expect("metadata")
+            .materialized
+    );
+}
+
+#[test]
+fn install_rejects_rig_template_extends_outside_source_root() {
+    let _home = HomeGuard::new();
+    let root = tempfile::tempdir().expect("root");
+    let package = root.path().join("package");
+    let outside = root.path().join("outside");
+    fs::create_dir_all(&package).expect("package dir");
+    fs::create_dir_all(&outside).expect("outside dir");
+    fs::write(outside.join("base.json"), minimal_rig("base")).expect("outside base");
+    fs::write(
+        package.join("rig.json"),
+        r#"{"id":"alpha","extends":"../outside/base.json"}"#,
+    )
+    .expect("rig json");
+
+    let err = install(package.to_str().unwrap(), None, false).expect_err("outside extends");
+
+    assert_eq!(err.details["field"], "extends");
+    assert!(err.message.contains("inside the rig package source root"));
+}
+
+#[test]
 fn installed_rig_load_applies_trace_workload_defaults() {
     let _home = HomeGuard::new();
     let package = tempfile::tempdir().expect("package");

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -303,6 +303,7 @@ fn write_rig_source_metadata(rig_id: &str) {
             rig_path: "/tmp/rigs/rig.json".to_string(),
             discovery_path: Some("/tmp/rigs".to_string()),
             linked: false,
+            materialized: false,
             source_revision: Some("abc123".to_string()),
         })
         .expect("serialize source metadata"),


### PR DESCRIPTION
## Summary
- Add install/update-time rig package template materialization via generic `extends` JSON parents.
- Preserve existing symlink/copy installs for plain rig specs while writing concrete installed JSON for templated specs.
- Add package lint validation for templated `rig.json` files and document merge rules.

## Tests
- `cargo test core::rig::install::install_test --lib`
- `cargo test core::rig::lint --lib`
- `cargo test core::rig --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, and documentation; Chris remains responsible for review and validation.