### PR TITLE
Add executable rig requirements

### DIFF
--- a/docs/commands/rig-spec.md
+++ b/docs/commands/rig-spec.md
@@ -220,6 +220,31 @@ Runs git in the component checkout. Supported operations are `status`, `pull`, `
 
 Delegates to `homeboy stack sync <stack-id>` for the named component. The component must declare `stack`, and the rig component `path` must match the stack spec's `component_path`. `homeboy rig sync <id>` runs this for every stacked component without needing a pipeline step.
 
+### `requirement`
+
+```jsonc
+{
+  "kind": "requirement",
+  "executable": "wp",
+  "executable_env": "WP_CLI_BIN",
+  "remediation": "install WP-CLI or set WP_CLI_BIN to the executable path"
+}
+```
+
+Validates a declarative local preflight requirement. A step must declare at least one of `path`, `file`, `dir`, `component_path_contains`, or `executable`.
+
+Filesystem requirements resolve relative paths against `cwd` when set. Component path requirements require both `component` and `component_path_contains`.
+
+Executable requirements are provider-agnostic. If `executable_env` is set and that environment variable has a non-empty value, Homeboy resolves that value first. Otherwise Homeboy searches `PATH` for `executable`. The step `env` map participates in lookup and takes precedence over the process environment, so specs can provide a scoped `PATH` or env-var override without shell shims.
+
+```jsonc
+{
+  "kind": "requirement",
+  "executable": "node",
+  "env": { "PATH": "${components.node-toolchain.path}/bin:${env.PATH}" }
+}
+```
+
 ### `patch`
 
 ```jsonc

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -7,6 +7,7 @@
 //! a `PipelineOutcome` with overall success/failure.
 
 use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -642,6 +643,8 @@ fn run_requirement_step(rig: &RigSpec, pipeline_name: &str, step: &PipelineStep)
         dir,
         component,
         component_path_contains,
+        executable,
+        executable_env,
         prepare_command,
         prepare_phases,
         cwd,
@@ -687,10 +690,10 @@ fn run_requirement_step(rig: &RigSpec, pipeline_name: &str, step: &PipelineStep)
         path_specs.push(("dir", value));
     }
 
-    if path_specs.is_empty() && component_path_contains.is_none() {
+    if path_specs.is_empty() && component_path_contains.is_none() && executable.is_none() {
         return Err(Error::validation_invalid_argument(
             "requirement",
-            "Requirement must specify at least one of `path`, `file`, `dir`, or `component_path_contains`",
+            "Requirement must specify at least one of `path`, `file`, `dir`, `component_path_contains`, or `executable`",
             None,
             None,
         ));
@@ -701,6 +704,12 @@ fn run_requirement_step(rig: &RigSpec, pipeline_name: &str, step: &PipelineStep)
         .filter_map(|(kind, declared)| {
             requirement_path_failure(rig, cwd.as_deref(), kind, declared)
         })
+        .chain(requirement_executable_failure(
+            rig,
+            executable.as_deref(),
+            executable_env.as_deref(),
+            env,
+        ))
         .collect::<Vec<_>>();
 
     if !missing_before_prepare.is_empty()
@@ -720,6 +729,12 @@ fn run_requirement_step(rig: &RigSpec, pipeline_name: &str, step: &PipelineStep)
         .filter_map(|(kind, declared)| {
             requirement_path_failure(rig, cwd.as_deref(), kind, declared)
         })
+        .chain(requirement_executable_failure(
+            rig,
+            executable.as_deref(),
+            executable_env.as_deref(),
+            env,
+        ))
         .collect::<Vec<_>>();
 
     if !missing.is_empty() {
@@ -757,6 +772,75 @@ fn requirement_path_failure(
             )
         }
     })
+}
+
+fn requirement_executable_failure(
+    rig: &RigSpec,
+    executable: Option<&str>,
+    executable_env: Option<&str>,
+    env: &HashMap<String, String>,
+) -> Option<String> {
+    let executable = executable?;
+    let executable = expand_vars(rig, executable);
+    let override_value = executable_env.and_then(|name| env_value(name, env));
+    let candidate = override_value
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| expand_vars(rig, value))
+        .unwrap_or_else(|| executable.clone());
+
+    if find_executable(&candidate, env).is_some() {
+        return None;
+    }
+
+    Some(match (executable_env, override_value) {
+        (Some(name), Some(value)) if !value.trim().is_empty() => format!(
+            "executable `{}` does not exist or is not executable from {}={}",
+            executable, name, value
+        ),
+        (Some(name), _) => format!(
+            "executable `{}` not found on PATH ({} is unset or empty)",
+            executable, name
+        ),
+        _ => format!("executable `{}` not found on PATH", executable),
+    })
+}
+
+fn env_value(name: &str, env: &HashMap<String, String>) -> Option<String> {
+    env.get(name).cloned().or_else(|| std::env::var(name).ok())
+}
+
+fn find_executable(candidate: &str, env: &HashMap<String, String>) -> Option<PathBuf> {
+    let path = Path::new(candidate);
+    if candidate.contains(std::path::MAIN_SEPARATOR) || path.is_absolute() {
+        return is_executable_file(path).then(|| path.to_path_buf());
+    }
+
+    let path_var = env
+        .get("PATH")
+        .map(OsString::from)
+        .or_else(|| std::env::var_os("PATH"));
+    let path_var = path_var?;
+
+    std::env::split_paths(&path_var)
+        .map(|dir| dir.join(candidate))
+        .find(|path| is_executable_file(path))
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    path.is_file()
+        && path
+            .metadata()
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
 }
 
 fn resolve_requirement_path(rig: &RigSpec, cwd: Option<&str>, declared: &str) -> PathBuf {
@@ -1307,6 +1391,7 @@ fn step_label(rig: &RigSpec, step: &PipelineStep, idx: usize) -> String {
             dir,
             component,
             component_path_contains,
+            executable,
             label,
             ..
         } => label.clone().unwrap_or_else(|| {
@@ -1318,6 +1403,8 @@ fn step_label(rig: &RigSpec, step: &PipelineStep, idx: usize) -> String {
                 format!("require path {}", truncate(path, 60))
             } else if let (Some(component), Some(required)) = (component, component_path_contains) {
                 format!("require {} path contains {}", component, required)
+            } else if let Some(executable) = executable {
+                format!("require executable {}", executable)
             } else {
                 format!("requirement #{}", idx + 1)
             }

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -1324,10 +1324,10 @@ pub enum PipelineStep {
 
     /// Declarative local requirement for common rig preflight checks.
     ///
-    /// Use this for simple filesystem/component-path assertions instead of
-    /// inline shell. When `prepare_command` is set, it runs only in listed
-    /// `prepare_phases`; normal `check` remains read-only and reports the
-    /// declared remediation.
+    /// Use this for simple filesystem/component-path/executable assertions
+    /// instead of inline shell. When `prepare_command` is set, it runs only in
+    /// listed `prepare_phases`; normal `check` remains read-only and reports
+    /// the declared remediation.
     Requirement {
         /// Optional stable node ID for dependency-aware pipeline ordering.
         #[serde(default, rename = "id", skip_serializing_if = "Option::is_none")]
@@ -1350,6 +1350,12 @@ pub enum PipelineStep {
         /// Required substring in the resolved component path.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         component_path_contains: Option<String>,
+        /// Executable name or path. Bare names are resolved from PATH.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        executable: Option<String>,
+        /// Environment variable whose value overrides `executable` lookup.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        executable_env: Option<String>,
         /// Command to run when the filesystem requirement is missing and the
         /// current pipeline name appears in `prepare_phases`.
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -259,6 +259,115 @@ fn test_requirement_validates_component_path_contains() {
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
 }
 
+#[test]
+fn test_requirement_executable_uses_env_override_before_path() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let path_bin_dir = tmp.path().join("path-bin");
+    std::fs::create_dir_all(&path_bin_dir).expect("mkdir path bin");
+    write_executable(&path_bin_dir.join("demo-tool"));
+    let missing_override = tmp.path().join("missing-override-tool");
+
+    let rig: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "requirement-executable-env",
+            "pipeline": {{
+                "check": [{{
+                    "kind": "requirement",
+                    "executable": "demo-tool",
+                    "executable_env": "DEMO_TOOL_BIN",
+                    "env": {{
+                        "DEMO_TOOL_BIN": "{}",
+                        "PATH": "{}"
+                    }}
+                }}]
+            }}
+        }}"#,
+        missing_override.to_string_lossy(),
+        path_bin_dir.to_string_lossy()
+    ))
+    .expect("parse rig");
+
+    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    assert!(!out.is_success(), "outcomes: {:?}", out.steps);
+    let error = out.steps[0].error.as_deref().unwrap_or_default();
+    assert!(error.contains("DEMO_TOOL_BIN"), "error: {error}");
+    assert!(error.contains("missing-override-tool"), "error: {error}");
+}
+
+#[test]
+fn test_requirement_executable_falls_back_to_path_when_env_override_is_empty() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let path_bin_dir = tmp.path().join("path-bin");
+    std::fs::create_dir_all(&path_bin_dir).expect("mkdir path bin");
+    write_executable(&path_bin_dir.join("demo-tool"));
+
+    let rig: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "requirement-executable-path",
+            "pipeline": {{
+                "check": [{{
+                    "kind": "requirement",
+                    "executable": "demo-tool",
+                    "executable_env": "DEMO_TOOL_BIN",
+                    "env": {{
+                        "DEMO_TOOL_BIN": "",
+                        "PATH": "{}"
+                    }}
+                }}]
+            }}
+        }}"#,
+        path_bin_dir.to_string_lossy()
+    ))
+    .expect("parse rig");
+
+    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    assert!(out.is_success(), "outcomes: {:?}", out.steps);
+}
+
+#[test]
+fn test_requirement_executable_reports_missing_tool() {
+    let rig: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "requirement-executable-missing",
+            "pipeline": {
+                "check": [{
+                    "kind": "requirement",
+                    "executable": "missing-homeboy-test-tool",
+                    "env": { "PATH": "/nonexistent" },
+                    "remediation": "install the tool"
+                }]
+            }
+        }"#,
+    )
+    .expect("parse rig");
+
+    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    assert!(!out.is_success());
+    let error = out.steps[0].error.as_deref().unwrap_or_default();
+    assert!(
+        error.contains("missing-homeboy-test-tool"),
+        "error: {error}"
+    );
+    assert!(error.contains("install the tool"), "error: {error}");
+}
+
+fn write_executable(path: &std::path::Path) {
+    std::fs::write(path, "#!/bin/sh\nexit 0\n").expect("write executable");
+    make_executable(path);
+}
+
+#[cfg(unix)]
+fn make_executable(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = std::fs::metadata(path).expect("metadata").permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).expect("chmod");
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &std::path::Path) {}
+
 // ---- Dependency-aware ordering ---------------------------------------------
 
 mod dag {


### PR DESCRIPTION
## Summary
- Add provider-agnostic `executable` requirements to rig pipeline `kind: "requirement"` steps.
- Support `executable_env` override precedence before PATH lookup, with step `env` values taking precedence over the process environment.
- Document the new rig spec fields and cover env override, PATH fallback, and missing-tool remediation behavior.

## Tests
- `cargo test core::rig::pipeline::pipeline_test`
- `cargo test core::rig`
- `cargo test` was also run; it failed in pre-existing/unrelated areas: `core::upgrade::runners::*` expectation failures plus `core::extension::runner::tests::with_run_dir_tracks_resource_artifact_path` tempdir setup (`Invalid argument (os error 22)`).

## Downstream follow-up
- Replace rig-local `check-cli.sh` shims with declarative `kind: "requirement"` steps using `executable` and optional `executable_env`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the rig requirement primitive, tests, docs, and local verification; Chris remains responsible for review and merge.
