### PR TITLE
Closes #4606, Closes #4607, Closes #4608

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -194,6 +194,17 @@ impl Commands {
                 contract.workspace_mode_policy = LabWorkspaceModePolicy::RunnerResident;
                 contract
             }
+            Commands::Tunnel(args) if args.is_service_expose() => {
+                let mut contract = LabCommandContract::explicit_runner(
+                    "tunnel service expose",
+                    None,
+                    false,
+                    LAB_NO_EXTRA_TOOLS,
+                );
+                contract.source_path_mode = LabSourcePathMode::RunnerResident;
+                contract.workspace_mode_policy = LabWorkspaceModePolicy::RunnerResident;
+                contract
+            }
             _ => return None,
         };
 
@@ -521,6 +532,22 @@ mod tests {
         .supports_lab_runner());
         assert!(parsed_command(&[
             "homeboy",
+            "tunnel",
+            "service",
+            "expose",
+            "preview",
+            "--server",
+            "homeboy-lab",
+            "--remote-host",
+            "127.0.0.1",
+            "--remote-port",
+            "7331",
+            "--auth-mode",
+            "ssh-only",
+        ])
+        .supports_lab_runner());
+        assert!(parsed_command(&[
+            "homeboy",
             "agent-task",
             "auth",
             "status",
@@ -791,6 +818,34 @@ mod tests {
         );
         assert!(!tunnel_service_start.default_lab_offload);
         assert!(!tunnel_service_start.infer_source_path_tools);
+
+        let tunnel_service_expose = parsed_command(&[
+            "homeboy",
+            "tunnel",
+            "service",
+            "expose",
+            "preview",
+            "--server",
+            "homeboy-lab",
+            "--remote-host",
+            "127.0.0.1",
+            "--remote-port",
+            "7331",
+            "--auth-mode",
+            "ssh-only",
+        ])
+        .lab_contract()
+        .expect("tunnel service expose contract");
+        assert_eq!(
+            tunnel_service_expose.source_path_mode,
+            LabSourcePathMode::RunnerResident
+        );
+        assert_eq!(
+            tunnel_service_expose.workspace_mode_policy,
+            LabWorkspaceModePolicy::RunnerResident
+        );
+        assert!(!tunnel_service_expose.default_lab_offload);
+        assert!(!tunnel_service_expose.infer_source_path_tools);
 
         let rig = parsed_command(&["homeboy", "rig", "up", "studio"])
             .lab_contract()

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -151,6 +151,15 @@ impl TunnelArgs {
             }
         )
     }
+
+    pub(crate) fn is_service_expose(&self) -> bool {
+        matches!(
+            self.command,
+            TunnelCommand::Service {
+                command: TunnelServiceCommand::Expose { .. }
+            }
+        )
+    }
 }
 
 #[derive(Subcommand)]
@@ -419,8 +428,14 @@ enum TunnelServiceCommand {
         id: String,
 
         /// SSH server that can reach the private service
+        #[arg(long, required_unless_present = "runner_local")]
+        server: Option<String>,
+
+        /// Declare a runner-local service without a separate server declaration.
+        /// In a runner-local context the runner itself is the server, so a
+        /// duplicate server declaration is not required (#4606).
         #[arg(long)]
-        server: String,
+        runner_local: bool,
 
         /// Hostname or IP of the service as seen from the SSH server
         #[arg(long)]
@@ -1167,6 +1182,7 @@ fn run_service(command: TunnelServiceCommand) -> CmdResult<TunnelOutput> {
         TunnelServiceCommand::Expose {
             id,
             server,
+            runner_local,
             remote_host,
             remote_port,
             scheme,
@@ -1180,7 +1196,8 @@ fn run_service(command: TunnelServiceCommand) -> CmdResult<TunnelOutput> {
             preview_keep_alive_until,
         } => expose_service(ExposeServiceTunnelSpec {
             id,
-            server_id: server,
+            server_id: server.unwrap_or_default(),
+            runner_local,
             scheme,
             local_port,
             auth: ServiceTunnelAuth {
@@ -1510,7 +1527,8 @@ mod tests {
             create_server();
             let (output, exit_code) = run_service(TunnelServiceCommand::Expose {
                 id: "site-preview".to_string(),
-                server: "private-host".to_string(),
+                server: Some("private-host".to_string()),
+                runner_local: false,
                 remote_host: "127.0.0.1".to_string(),
                 remote_port: 7331,
                 scheme: "http".to_string(),
@@ -1528,6 +1546,33 @@ mod tests {
             assert_eq!(exit_code, 0);
             assert_eq!(output.command, "tunnel.service.expose");
             assert_eq!(output.entity.expect("entity").id, "site-preview");
+        });
+    }
+
+    #[test]
+    fn expose_service_command_supports_runner_local_without_server() {
+        test_support::with_isolated_home(|_| {
+            let (output, exit_code) = run_service(TunnelServiceCommand::Expose {
+                id: "runner-local-preview".to_string(),
+                server: None,
+                runner_local: true,
+                remote_host: "127.0.0.1".to_string(),
+                remote_port: 7331,
+                scheme: "http".to_string(),
+                local_port: Some(8831),
+                auth_mode: ServiceTunnelAuthModeArg::SshOnly,
+                auth_env: None,
+                auth_header: None,
+                allowed_clients: Vec::new(),
+                description: None,
+                preview_policy: ServiceTunnelPreviewPolicyArg::None,
+                preview_keep_alive_until: None,
+            })
+            .expect("runner-local expose succeeds without server declaration");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(output.command, "tunnel.service.expose");
+            assert_eq!(output.entity.expect("entity").id, "runner-local-preview");
         });
     }
 

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -298,7 +298,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if let Some(runner_id) = request.explicit_runner {
             return Err(unsupported_runner_error(
                 runner_id,
-                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, tunnel preview-consumer run, and tunnel service start".to_string(),
+                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, tunnel preview-consumer run, tunnel service expose, and tunnel service start".to_string(),
             ));
         }
         return Ok(LabOffloadOutcome::RunLocal {
@@ -311,7 +311,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.portable {
         if let Some(runner_id) = request.explicit_runner {
             let message = contract.unsupported_reason.map_or_else(
-                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, tunnel preview-consumer run, and tunnel service start".to_string(),
+                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, tunnel preview-consumer run, tunnel service expose, and tunnel service start".to_string(),
                 |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
             );
             return Err(unsupported_runner_error(runner_id, message));
@@ -477,7 +477,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
 }
 
 fn unsupported_runner_hints(runner_id: &str, normalized_args: &[String]) -> Vec<String> {
-    let mut hints = vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, refactor source runs, tunnel preview-consumer run, and tunnel service start.".to_string()];
+    let mut hints = vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, refactor source runs, tunnel preview-consumer run, tunnel service expose, and tunnel service start.".to_string()];
 
     if let Some(service_command) = tunnel_service_command(normalized_args) {
         hints.push(format!(
@@ -495,9 +495,7 @@ fn tunnel_service_command(normalized_args: &[String]) -> Option<&str> {
         };
         if first == "tunnel" && second == "service" {
             match third.as_str() {
-                "list" | "show" | "status" | "url" | "expose" | "set" | "remove" => {
-                    Some(third.as_str())
-                }
+                "list" | "show" | "status" | "url" | "set" | "remove" => Some(third.as_str()),
                 _ => None,
             }
         } else {

--- a/src/core/runner/lab_args.rs
+++ b/src/core/runner/lab_args.rs
@@ -698,6 +698,12 @@ pub(super) fn rewrite_lab_offload_args(
 }
 
 pub(super) fn rewrite_runner_resident_lab_offload_args(args: &[String]) -> Vec<String> {
+    // A runner-side `tunnel service expose` should not require a separate
+    // server declaration for the selected runner: in that context the runner
+    // itself is the server (#4606). Drop the controller-side `--server` value
+    // and mark the runner-side declaration as runner-local instead.
+    let is_service_expose = is_tunnel_service_command(args, "expose");
+    let already_runner_local = args.iter().any(|arg| arg == "--runner-local");
     let mut stripped = Vec::with_capacity(args.len());
     let mut iter = args.iter().peekable();
     let mut passthrough = false;
@@ -729,12 +735,33 @@ pub(super) fn rewrite_runner_resident_lab_offload_args(args: &[String]) -> Vec<S
         if arg.starts_with("--output=") {
             continue;
         }
+        if is_service_expose && arg == "--server" {
+            let _ = iter.next();
+            continue;
+        }
+        if is_service_expose && arg.starts_with("--server=") {
+            continue;
+        }
         stripped.push(arg.clone());
+    }
+    if is_service_expose && !already_runner_local {
+        stripped.push("--runner-local".to_string());
     }
     if !has_force_hot {
         stripped.insert(1, "--force-hot".to_string());
     }
     stripped
+}
+
+/// Returns true when `args` invoke `tunnel service <subcommand>`.
+fn is_tunnel_service_command(args: &[String], subcommand: &str) -> bool {
+    args.windows(3).any(|window| {
+        matches!(
+            window,
+            [first, second, third]
+                if first == "tunnel" && second == "service" && third == subcommand
+        )
+    })
 }
 
 #[cfg(test)]
@@ -791,6 +818,72 @@ mod tests {
                 "npm run dev".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn runner_resident_rewrite_expose_drops_server_and_marks_runner_local() {
+        // `tunnel service expose --runner homeboy-lab --server homeboy-lab`
+        // should not carry a server declaration to the runner: the runner is
+        // the server in that context, so the rewrite drops --server and marks
+        // the runner-side declaration runner-local (#4606/#4607).
+        let args = vec![
+            "homeboy".to_string(),
+            "--runner".to_string(),
+            "homeboy-lab".to_string(),
+            "tunnel".to_string(),
+            "service".to_string(),
+            "expose".to_string(),
+            "preview".to_string(),
+            "--server".to_string(),
+            "homeboy-lab".to_string(),
+            "--remote-host".to_string(),
+            "127.0.0.1".to_string(),
+            "--remote-port".to_string(),
+            "7331".to_string(),
+            "--auth-mode".to_string(),
+            "ssh-only".to_string(),
+        ];
+
+        let rewritten = rewrite_runner_resident_lab_offload_args(&args);
+        assert_eq!(
+            rewritten,
+            vec![
+                "homeboy".to_string(),
+                "--force-hot".to_string(),
+                "tunnel".to_string(),
+                "service".to_string(),
+                "expose".to_string(),
+                "preview".to_string(),
+                "--remote-host".to_string(),
+                "127.0.0.1".to_string(),
+                "--remote-port".to_string(),
+                "7331".to_string(),
+                "--auth-mode".to_string(),
+                "ssh-only".to_string(),
+                "--runner-local".to_string(),
+            ]
+        );
+        assert!(!rewritten.iter().any(|arg| arg == "--server"));
+        assert!(rewritten.iter().any(|arg| arg == "--runner-local"));
+    }
+
+    #[test]
+    fn runner_resident_rewrite_expose_handles_inline_server_value() {
+        let args = vec![
+            "homeboy".to_string(),
+            "--runner=homeboy-lab".to_string(),
+            "tunnel".to_string(),
+            "service".to_string(),
+            "expose".to_string(),
+            "preview".to_string(),
+            "--server=homeboy-lab".to_string(),
+            "--remote-host".to_string(),
+            "127.0.0.1".to_string(),
+        ];
+
+        let rewritten = rewrite_runner_resident_lab_offload_args(&args);
+        assert!(!rewritten.iter().any(|arg| arg.starts_with("--server")));
+        assert!(rewritten.iter().any(|arg| arg == "--runner-local"));
     }
 
     #[test]

--- a/src/core/tunnel.rs
+++ b/src/core/tunnel.rs
@@ -17,7 +17,17 @@ use crate::core::process::{pid_is_running, process_group_is_running};
 use crate::core::server;
 use crate::core::{CreateOutput, MergeOutput, RemoveResult};
 
-const RUNNER_LOCAL_SERVICE_SERVER_ID: &str = "__runner_local__";
+/// Sentinel server id used for runner-local service tunnels. A service tunnel
+/// carrying this server id is materialized/validated without requiring a
+/// separate `server` declaration: in a runner-local context the runner itself
+/// is the server, so demanding a duplicate server declaration is redundant
+/// (see #4606).
+pub const RUNNER_LOCAL_SERVICE_SERVER_ID: &str = "__runner_local__";
+
+/// Returns true when the given server id refers to the runner-local sentinel.
+pub fn is_runner_local_server_id(server_id: &str) -> bool {
+    server_id == RUNNER_LOCAL_SERVICE_SERVER_ID
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServiceTunnel {
@@ -423,6 +433,10 @@ pub struct ExposeServiceTunnelSpec {
     pub auth: ServiceTunnelAuth,
     pub policy: ServiceTunnelPolicy,
     pub description: Option<String>,
+    /// When true, the declaration is materialized against the runner-local
+    /// sentinel server instead of requiring a separate `server` declaration for
+    /// the selected runner (see #4606). The supplied `server_id` is ignored.
+    pub runner_local: bool,
 }
 
 fn default_scheme() -> String {
@@ -522,11 +536,16 @@ impl ConfigEntity for ServiceTunnel {
 entity_crud!(ServiceTunnel; list_ids, merge);
 
 pub fn expose(spec: ExposeServiceTunnelSpec) -> Result<ServiceTunnel> {
+    let server_id = if spec.runner_local || is_runner_local_server_id(&spec.server_id) {
+        RUNNER_LOCAL_SERVICE_SERVER_ID.to_string()
+    } else {
+        spec.server_id
+    };
     let tunnel = ServiceTunnel {
         id: spec.id,
         aliases: Vec::new(),
         description: spec.description,
-        server_id: spec.server_id,
+        server_id,
         target: spec.target,
         scheme: spec.scheme,
         local_host: default_local_host(),

--- a/src/core/tunnel_tests.rs
+++ b/src/core/tunnel_tests.rs
@@ -77,6 +77,7 @@ fn expose_records_private_loopback_declaration_without_running_tunnel() {
                 native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: Some("Private preview service".to_string()),
+            runner_local: false,
         })
         .expect("expose service");
 
@@ -85,6 +86,46 @@ fn expose_records_private_loopback_declaration_without_running_tunnel() {
         assert!(report.declared);
         assert!(!report.running);
         assert_eq!(report.local_url, "http://127.0.0.1:8831");
+    });
+}
+
+#[test]
+fn expose_runner_local_does_not_require_a_server_declaration() {
+    test_support::with_isolated_home(|_| {
+        // No server is declared on this (runner-local) host: in a runner-local
+        // context the runner itself is the server, so expose must not demand a
+        // duplicate server declaration (#4606).
+        let tunnel = expose(ExposeServiceTunnelSpec {
+            id: "runner-local-preview".to_string(),
+            server_id: "homeboy-lab".to_string(),
+            target: ServiceTunnelTarget {
+                host: "127.0.0.1".to_string(),
+                port: 7331,
+            },
+            scheme: "http".to_string(),
+            local_port: Some(8831),
+            auth: ServiceTunnelAuth {
+                mode: ServiceTunnelAuthMode::SshOnly,
+                env_var: None,
+                header: None,
+            },
+            policy: ServiceTunnelPolicy {
+                exposure: ServiceTunnelExposure::PrivateLoopback,
+                require_auth: true,
+                allowed_clients: Vec::new(),
+                preview: ServiceTunnelPreviewPolicy::default(),
+                native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
+            },
+            description: None,
+            runner_local: true,
+        })
+        .expect("runner-local expose without server declaration");
+
+        assert_eq!(tunnel.id, "runner-local-preview");
+        assert_eq!(tunnel.server_id, RUNNER_LOCAL_SERVICE_SERVER_ID);
+        assert!(is_runner_local_server_id(&tunnel.server_id));
+        let report = status("runner-local-preview").expect("status");
+        assert!(report.declared);
     });
 }
 
@@ -115,6 +156,7 @@ fn list_serializes_stable_service_ids() {
                 native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: Some("Copy-pasteable service".to_string()),
+            runner_local: false,
         })
         .expect("expose service");
 
@@ -152,6 +194,7 @@ fn validation_rejects_auth_mode_without_env_var() {
                 native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: None,
+            runner_local: false,
         })
         .expect_err("missing auth env should fail");
 
@@ -189,6 +232,7 @@ fn start_status_and_stop_manage_local_service_runtime_state() {
                 native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: None,
+            runner_local: false,
         })
         .expect("expose service");
 
@@ -266,6 +310,7 @@ fn start_cleans_runtime_state_when_readiness_fails() {
                 native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: None,
+            runner_local: false,
         })
         .expect("expose service");
 
@@ -325,6 +370,7 @@ fn proof_readiness_waits_for_stdout_signal_not_just_process_liveness() {
                 native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: None,
+            runner_local: false,
         })
         .expect("expose service");
 
@@ -389,6 +435,7 @@ fn preview_readiness_can_require_artifact_status() {
                 native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: None,
+            runner_local: false,
         })
         .expect("expose service");
 
@@ -457,6 +504,7 @@ fn preview_start_fails_when_listener_process_exits_after_readiness() {
                 native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: None,
+            runner_local: false,
         })
         .expect("expose service");
 
@@ -518,6 +566,7 @@ fn status_refresh_clears_exited_process_readiness() {
                 native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: None,
+            runner_local: false,
         })
         .expect("expose service");
 
@@ -581,6 +630,7 @@ fn command_backend_records_public_url_and_cleans_up_backend_process() {
                 native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: None,
+            runner_local: false,
         })
         .expect("expose service");
 
@@ -660,6 +710,7 @@ fn status_reports_degraded_when_backend_outlives_service_process() {
                 native_preview_auth: ServiceTunnelNativePreviewAuthPolicy::default(),
             },
             description: None,
+            runner_local: false,
         })
         .expect("expose service");
 


### PR DESCRIPTION
## Summary

Lets runner/Lab-offloaded preview workflows create + start a tunnel service declaration on the runner without a pre-existing runner-side declaration. These three issues are one cohesive feature for `--runner`/Lab offload of tunnel service declarations.

- **#4607** — `tunnel service expose --runner <runner>` no longer fails with `validation.invalid_argument: --runner is only supported for commands with portable Lab offload support`. Added a runner-resident Lab contract for `tunnel service expose` (mirrors `tunnel service start`), so the controller can offload declaration setup to the runner.
- **#4606** — Runner-local `service expose` no longer requires a duplicate `server` declaration for the selected runner. In a runner-local context the runner *is* the server, so a separate declaration is redundant. `ExposeServiceTunnelSpec` gains a `runner_local` flag (and a `--runner-local` CLI flag); when set, expose materializes against the `__runner_local__` sentinel and skips `server.not_found`. The runner-resident arg rewrite drops the controller-side `--server <runner>` and injects `--runner-local` automatically when offloading expose.
- **#4608** — `tunnel service start --runner <runner>` already materializes a complete runner-local declaration from the supplied spec (via #4646's `load_or_materialize_start_tunnel`) instead of refusing when no prior declaration exists; this PR keeps that path green and extends the help/contract surface to advertise it.

## Changes

- `core/tunnel.rs`: export `RUNNER_LOCAL_SERVICE_SERVER_ID` + `is_runner_local_server_id`; add `runner_local` to `ExposeServiceTunnelSpec`; `expose` honors the runner-local sentinel without a server declaration.
- `commands/tunnel.rs`: `--server` now optional (`required_unless_present = runner_local`), new `--runner-local` flag, new `is_service_expose()` accessor.
- `command_contract/lab.rs`: runner-resident Lab contract for `tunnel service expose`.
- `core/runner/lab_args.rs`: runner-resident rewrite drops `--server` and marks `--runner-local` for `tunnel service expose`.
- `core/runner/lab/offload.rs`: removed `expose` from the "not routed directly" hint list; updated support messages.

## Tests

Focused tests added and passing:
- expose `--runner` accepted (`supports_lab_runner` + runner-resident contract).
- runner-as-server not requiring a duplicate declaration (core + CLI).
- runner-resident rewrite drops `--server` and injects `--runner-local` (space and inline `=` forms).
- start materializing a full spec without a prior declaration (existing, kept green).

`cargo build --lib --tests`, `cargo test tunnel`, `cargo test service`, and the lab-contract module tests all pass; `cargo fmt --check` clean. (Did not touch `docs/changelog.md` — homeboy owns it.)

Closes #4606
Closes #4607
Closes #4608