### PR TITLE
Route fleet output through typed adapter

### DIFF
--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -12,7 +12,7 @@
 //! returned from [`Commands::descriptor`].
 
 use crate::cli_surface::Commands;
-use crate::commands::{changelog, file, logs, report, review, runtime, trace, version};
+use crate::commands::{changelog, file, fleet, logs, report, review, runtime, trace, version};
 
 use super::lab::apply_lab_contract_to_descriptor;
 
@@ -245,7 +245,9 @@ impl Commands {
             | Commands::Http(_)
             | Commands::Upgrade(_)
             | Commands::Ssh(_) => ops_json_descriptor(output_file_mode),
-            Commands::Fleet(args) => args.output_descriptor(output_file_mode),
+            Commands::Fleet(_) => fleet::adapter(output_file_mode)
+                .contract
+                .to_output_descriptor(),
             Commands::Triage(_) => ops_json_descriptor(output_file_mode),
         }
     }
@@ -376,6 +378,14 @@ mod tests {
         assert_eq!(runs_descriptor.response_mode, CommandResponseMode::Json);
         assert_eq!(
             runs_descriptor.output_contract,
+            CommandOutputContractKind::JsonEnvelope
+        );
+
+        let fleet_descriptor = parsed_command(&["homeboy", "fleet", "list"]).descriptor(false);
+        assert_eq!(fleet_descriptor.json_family, CommandJsonFamily::Ops);
+        assert_eq!(fleet_descriptor.response_mode, CommandResponseMode::Json);
+        assert_eq!(
+            fleet_descriptor.output_contract,
             CommandOutputContractKind::JsonEnvelope
         );
 

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -7,8 +7,10 @@ use homeboy::core::plan::HomeboyPlan;
 use homeboy::core::project::Project;
 use homeboy::core::EntityCrudOutput;
 
-use super::{CmdResult, DynamicSetArgs};
-use crate::command_contract::{CommandOutputDescriptor, CommandOutputFileMode, LabCommandContract};
+use super::{adapter, CmdResult, DynamicSetArgs};
+use crate::command_contract::{
+    CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode, LabCommandContract,
+};
 
 const FLEET_EXEC_LAB_UNSUPPORTED_REASON: &str = "`fleet exec` stays local because it depends on local fleet, project, and server configuration before opening SSH sessions to each project; runner-side config parity is not guaranteed.";
 
@@ -19,18 +21,6 @@ pub struct FleetArgs {
 }
 
 impl FleetArgs {
-    pub(crate) fn output_descriptor(
-        &self,
-        output_file_mode: CommandOutputFileMode,
-    ) -> CommandOutputDescriptor {
-        CommandOutputDescriptor {
-            response_mode: crate::command_contract::CommandResponseMode::Json,
-            output_file_mode,
-            json_family: crate::command_contract::CommandJsonFamily::Ops,
-            output_contract: crate::command_contract::CommandOutputContractKind::JsonEnvelope,
-        }
-    }
-
     pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {
         self.is_hot_resource_command().then(|| {
             LabCommandContract::local_only("fleet exec", FLEET_EXEC_LAB_UNSUPPORTED_REASON)
@@ -196,6 +186,21 @@ pub fn run(args: FleetArgs, _global: &super::GlobalArgs) -> CmdResult<FleetOutpu
             user,
         } => exec(&id, command, check, user),
     }
+}
+
+pub(crate) fn adapter(
+    output_file_mode: CommandOutputFileMode,
+) -> adapter::TypedCommandAdapter<FleetArgs> {
+    adapter::TypedCommandAdapter::json_only(
+        CommandJsonFamily::Ops,
+        output_file_mode,
+        CommandOutputContractKind::JsonEnvelope,
+        run_json,
+    )
+}
+
+fn run_json(args: FleetArgs, global: &super::GlobalArgs) -> adapter::JsonCommandRun {
+    crate::commands::utils::response::map_cmd_result_to_json(run(args, global))
 }
 
 fn create(

--- a/src/commands/json_output/ops.rs
+++ b/src/commands/json_output/ops.rs
@@ -16,7 +16,11 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Deps(args) => map(deps::run(args, global)),
         Commands::Doctor(args) => map(doctor::run(args, global)),
         Commands::File(args) => map(file::run(args, global)),
-        Commands::Fleet(args) => map(fleet::run(args, global)),
+        Commands::Fleet(args) => {
+            fleet::adapter(crate::command_contract::CommandOutputFileMode::None)
+                .execute_json
+                .expect("fleet adapter supports JSON execution")(args, global)
+        }
         Commands::Logs(args) => map(logs::run(args, global)),
         Commands::Triage(args) => map(triage::run(args, global)),
         Commands::Deploy(args) => map(deploy::run(args, global)),


### PR DESCRIPTION
## Summary
- Move the fleet command family onto the typed command adapter contract for output descriptor lookup.
- Route fleet JSON dispatch through the adapter executor.
- Add descriptor coverage confirming fleet remains an ops JSON-envelope command.

## Tests
- cargo test --lib command_contract::output::tests::test_command_descriptor_drives_behavioral_routing
- cargo test --test command_surface_test
- cargo test --test output_contracts_test

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small Rust refactor, focused descriptor assertion, and test/PR workflow; Chris remains responsible for review and merge.