### PR TITLE
Add shared component target registry policy

### DIFF
--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -483,32 +483,15 @@ fn derive_component_id_for_create(
 }
 
 fn show(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
-    let component = match (id, path) {
-        // --path: discover from directory's homeboy.json
-        (_, Some(dir)) => {
-            let dir_path = std::path::Path::new(dir);
-            component::resolve_effective(id, Some(dir), None).map_err(|_| {
-                homeboy::core::Error::validation_invalid_argument(
-                    "path",
-                    format!(
-                        "No homeboy.json found at {} and no registered component matches",
-                        dir_path.display()
-                    ),
-                    None,
-                    Some(vec![
-                        format!("Create homeboy.json in {}", dir_path.display()),
-                        "Or provide a registered component ID".to_string(),
-                    ]),
-                )
-            })?
-        }
-        // ID only: load from registry
-        (Some(comp_id), None) => component::load(comp_id).map_err(|e| e.with_contextual_hint())?,
-        // Neither: try CWD discovery
-        (None, None) => component::resolve_effective(None, None, None).map_err(|_| {
-            homeboy::core::Error::validation_missing_argument(vec!["id or --path".to_string()])
-        })?,
-    };
+    let component = component::resolve_target(component::TargetSpec::new(id, path))
+        .map_err(|e| {
+            if id.is_none() && path.is_none() {
+                homeboy::core::Error::validation_missing_argument(vec!["id or --path".to_string()])
+            } else {
+                e.with_contextual_hint()
+            }
+        })?
+        .component;
 
     component.validate_supported_build_config()?;
 
@@ -543,33 +526,20 @@ struct ComponentRuntimeRequirement {
 }
 
 fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOutput> {
-    let component = match (id, path) {
-        // --path with explicit ID
-        (Some(comp_id), Some(dir)) => component::resolve_effective(Some(comp_id), Some(dir), None)
-            .map_err(|e| e.with_contextual_hint())?,
-        // --path without ID: discover from the directory's homeboy.json
-        (None, Some(dir)) => {
-            let dir_path = Path::new(dir);
-            component::portable::discover_from_portable(dir_path).ok_or_else(|| {
-                homeboy::core::Error::validation_invalid_argument(
-                    "path",
-                    format!("No homeboy.json found at {}", dir_path.display()),
-                    None,
-                    Some(vec![format!(
-                        "Create homeboy.json in {}",
-                        dir_path.display()
-                    )]),
-                )
-            })?
-        }
-        // ID only
-        (Some(comp_id), None) => component::resolve_effective(Some(comp_id), None, None)
-            .map_err(|e| e.with_contextual_hint())?,
-        // Neither: try CWD discovery
-        (None, None) => component::resolve_effective(None, None, None).map_err(|_| {
+    let component = component::resolve_target(component::TargetSpec {
+        component_id: id,
+        path_override: path,
+        allow_synthetic: id.is_some() || path.is_none(),
+        ..component::TargetSpec::new(id, path)
+    })
+    .map_err(|e| {
+        if id.is_none() && path.is_none() {
             homeboy::core::Error::validation_missing_argument(vec!["id or --path".to_string()])
-        })?,
-    };
+        } else {
+            e.with_contextual_hint()
+        }
+    })?
+    .component;
 
     let comp_id = component.id.clone();
     let local_path = Path::new(&component.local_path);
@@ -1294,6 +1264,27 @@ mod tests {
 
         assert!(err.message.contains("unsupported legacy build_command"));
         assert!(err.message.contains("Use scripts.build instead"));
+    }
+
+    #[test]
+    fn component_env_path_uses_shared_git_root_portable_discovery() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let subdir = repo.join("packages").join("plugin");
+        fs::create_dir_all(&subdir).expect("subdir");
+        fs::write(repo.join("homeboy.json"), r#"{"id":"portable-env"}"#).expect("homeboy.json");
+        let git_init = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&repo)
+            .output()
+            .expect("git init");
+        assert!(git_init.status.success());
+
+        let (output, code) = env(None, Some(&subdir.to_string_lossy())).expect("component env");
+
+        assert_eq!(code, 0);
+        assert_eq!(output.id.as_deref(), Some("portable-env"));
+        assert_eq!(output.command, "component.env");
     }
 
     #[test]

--- a/src/core/agent_task_config_materialization.rs
+++ b/src/core/agent_task_config_materialization.rs
@@ -176,6 +176,7 @@ fn resolve_repo_remote(repo: &str) -> Result<String> {
         capability: None,
         allow_synthetic: false,
         accept_bare_directory: false,
+        ..TargetSpec::default()
     }) {
         if let Some(git_root) = target.git_root {
             if let Ok(remote) = git_output(&git_root, &["config", "--get", "remote.origin.url"]) {

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -35,7 +35,7 @@ pub use portable::{
 pub use relationships::{associated_projects, projects_using, rename_component, shared_components};
 pub use resolution::{
     resolve, resolve_artifact, resolve_effective, resolve_target, resolve_target_from_component,
-    validate_local_path, ResolvedTarget, TargetSpec,
+    validate_local_path, RegistryLookupPolicy, ResolvedTarget, TargetSpec,
 };
 pub use scope::{resolve_component_scope, EffectiveScope, ScopeCommand};
 pub use versioning::{

--- a/src/core/component/resolution.rs
+++ b/src/core/component/resolution.rs
@@ -34,6 +34,10 @@ pub struct TargetSpec<'a> {
     /// Whether a positional component value that is a directory is accepted as
     /// an ad-hoc target.
     pub accept_bare_directory: bool,
+
+    /// Controls whether an ID-only target may fall back to the persisted
+    /// component registry after CWD/portable discovery fails.
+    pub registry_lookup: RegistryLookupPolicy,
 }
 
 impl<'a> TargetSpec<'a> {
@@ -45,8 +49,22 @@ impl<'a> TargetSpec<'a> {
             capability: None,
             allow_synthetic: true,
             accept_bare_directory: true,
+            registry_lookup: RegistryLookupPolicy::Allow,
         }
     }
+}
+
+/// Registry lookup policy for component target resolution.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RegistryLookupPolicy {
+    /// Allow ID-only targets to resolve through the standalone/project registry.
+    #[default]
+    Allow,
+
+    /// Resolve only from explicit paths, bare directories, or the current
+    /// checkout's portable config. Useful for commands that must not silently
+    /// operate on a globally registered checkout.
+    CwdOrPortableOnly,
 }
 
 /// Resolved target shared by git, audit, refactor, and execution context setup.
@@ -355,6 +373,7 @@ pub fn resolve_target(spec: TargetSpec<'_>) -> Result<ResolvedTarget> {
         spec.path_override,
         spec.project,
         spec.accept_bare_directory,
+        spec.registry_lookup,
     )?;
 
     let explicit_path = spec
@@ -477,7 +496,13 @@ pub fn resolve_effective(
     path_override: Option<&str>,
     project: Option<&crate::core::project::Project>,
 ) -> Result<Component> {
-    resolve_effective_inner(id, path_override, project, true)
+    resolve_effective_inner(
+        id,
+        path_override,
+        project,
+        true,
+        RegistryLookupPolicy::Allow,
+    )
 }
 
 fn resolve_effective_inner(
@@ -485,6 +510,7 @@ fn resolve_effective_inner(
     path_override: Option<&str>,
     project: Option<&crate::core::project::Project>,
     accept_bare_directory: bool,
+    registry_lookup: RegistryLookupPolicy,
 ) -> Result<Component> {
     if let (Some(project), Some(id)) = (project, id) {
         let mut component = crate::core::project::resolve_project_component(project, id)?;
@@ -538,6 +564,21 @@ fn resolve_effective_inner(
             // operates on the current checkout, not the registered local_path (#694).
             if let Some(cwd_component) = prefer_cwd_for_component(id) {
                 return Ok(cwd_component);
+            }
+
+            if registry_lookup == RegistryLookupPolicy::CwdOrPortableOnly {
+                return Err(Error::validation_invalid_argument(
+                    "component_id",
+                    format!(
+                        "Component '{}' was not found in the current checkout and registry lookup is disabled",
+                        id
+                    ),
+                    Some(id.to_string()),
+                    Some(vec![
+                        "Run from the component checkout or pass --path <checkout>".to_string(),
+                        "Allow registry lookup for commands that should use the registered local_path".to_string(),
+                    ]),
+                ));
             }
             load(id)
         }
@@ -772,6 +813,24 @@ mod tests {
             assert_eq!(target.component_id, "registered");
             assert_eq!(target.source_path, repo);
             assert!(!target.synthetic);
+        });
+    }
+
+    #[test]
+    fn target_spec_can_disable_registry_lookup_for_id_only_targets() {
+        crate::test_support::with_isolated_home(|home| {
+            let repo = home.path().join("registered-repo");
+            std::fs::create_dir_all(&repo).expect("repo dir");
+            write_standalone_registration(home.path(), "registered", &repo);
+
+            let err = resolve_target(TargetSpec {
+                component_id: Some("registered"),
+                registry_lookup: RegistryLookupPolicy::CwdOrPortableOnly,
+                ..TargetSpec::default()
+            })
+            .expect_err("registry lookup should be disabled");
+
+            assert!(err.to_string().contains("registry lookup is disabled"));
         });
     }
 

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -789,6 +789,7 @@ fn discovered_validation_dependency_workspaces(
         capability: None,
         allow_synthetic: true,
         accept_bare_directory: true,
+        ..TargetSpec::default()
     }) else {
         return Ok(Vec::new());
     };

--- a/src/core/worktree.rs
+++ b/src/core/worktree.rs
@@ -163,6 +163,7 @@ fn create_with_store(
         capability: None,
         allow_synthetic: false,
         accept_bare_directory: false,
+        ..TargetSpec::default()
     })?;
     let source_checkout = target
         .git_root


### PR DESCRIPTION
## Summary
- Add an explicit registry lookup policy to the shared component target resolver.
- Migrate `component show` and `component env` to resolve via `TargetSpec` instead of local branch logic.
- Cover registry-bypass behavior and `component env --path` portable discovery from a git-root `homeboy.json`.

## Tests
- `cargo test core::component::resolution::tests::target_spec_can_disable_registry_lookup_for_id_only_targets`
- `cargo test commands::component::tests::component_env_path_uses_shared_git_root_portable_discovery`
- `cargo test commands::component::tests::component_show_rejects_legacy_build_command`
- `cargo test core::component::resolution::tests`
- `cargo test commands::component::tests`
- `cargo test core::git::resolve_target_tests`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the resolver policy change, migrated the component command call sites, and drafted tests for Chris to review.