### PR TITLE
feat(status): detect merged-but-not-live code (merged → released gap)

### DIFF
--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -34,6 +34,37 @@ For the question *"what actually needs deploying right now?"*, run
 `homeboy status <project>` and look at the components reported as `outdated`
 (installed version != latest release tag). See issue #4588.
 
+## `unreleased_merges` — merged-but-not-live detection (read this)
+
+`ready_to_deploy` (and `--ready`) compare the **local checkout** against the
+latest tag, so they answer *"is my local git state ahead of the latest tag"*.
+There is a higher-stakes inverse question they cannot answer:
+
+> **"This PR is merged to `main` — is its code actually running on prod yet?"**
+
+A merged PR has three states and only the last is live:
+
+1. **merged-not-released** — merged on `origin/<default-branch>`, but no release
+   tag covers it → the new ability/CLI/code **does not exist on prod**.
+2. **released-not-deployed** — tagged, but the prod install runs an older
+   version.
+3. **live**.
+
+Reading a merged-PR list alone produces a false "✅ shipped" for
+merged-not-released code. The plain `homeboy status` summary now surfaces this as
+`unreleased_merges`: per component, the count of commits on
+`origin/<default-branch>` that are **past the latest release tag** (merge commits
+excluded). Because it measures `origin/<default-branch>` (refreshed by the same
+tag/branch fetch used for upstream drift), it is robust to a stale local checkout
+— unlike `ready_to_deploy`, which depends on a fresh local HEAD.
+
+When `unreleased_merges` is non-empty the JSON output includes an
+`unreleased_merges_note` repeating the caveat. To check the **released →
+deployed** axis (installed version vs latest tag), run `homeboy status <project>`
+and look at `outdated`. Together, `unreleased_merges` (tag-vs-merged),
+`ready_to_deploy` (local-vs-tag), and the project dashboard's `outdated`
+(installed-vs-tag) close the merged → released → deployed chain. See issue #4996.
+
 ## Common filters
 
 - `--full` — show the full workspace/context report
@@ -41,6 +72,7 @@ For the question *"what actually needs deploying right now?"*, run
 - `--needs-release` — show only components that need a release
 - `--ready` — show only components in a clean release state (git state only — not a target diff)
 - `--docs-only` — show only components with docs-only changes
+- `--unreleased` — show only components carrying merged-but-unreleased work (commits on `origin/<default-branch>` past the latest release tag)
 - `--all` — show all components regardless of current directory context
 - `--outdated` — (project mode) show only components whose installed-on-target version is behind the latest release
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -707,7 +707,12 @@ fn default_origin_branch(path: &str) -> Option<String> {
     if let Some(symbolic) = homeboy::core::engine::command::run_in_optional(
         path,
         "git",
-        &["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        &[
+            "symbolic-ref",
+            "--quiet",
+            "--short",
+            "refs/remotes/origin/HEAD",
+        ],
     ) {
         let symbolic = symbolic.trim();
         if !symbolic.is_empty() {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -45,6 +45,11 @@ pub struct StatusArgs {
     /// Show only outdated components (local != remote)
     #[arg(long)]
     pub outdated: bool,
+
+    /// Show only components carrying merged-but-unreleased work (commits on
+    /// origin/<default-branch> that are past the latest release tag).
+    #[arg(long)]
+    pub unreleased: bool,
 }
 
 /// Per-component upstream drift info.
@@ -67,6 +72,29 @@ impl UpstreamDrift {
     }
 }
 
+/// A component carrying code that is merged to its default branch on origin but
+/// not yet in a release tag — the "merged-not-released" state.
+///
+/// This is the complement of `ready_to_deploy`/`UpstreamDrift`: instead of
+/// asking "is the local checkout ahead of the latest tag" (which depends on a
+/// fresh local checkout and a local-vs-tag diff), it asks the higher-stakes
+/// inverse — "is there work merged on `origin/<default-branch>` that no release
+/// tag covers yet, so the code does NOT exist on prod?"
+///
+/// The count is measured against `origin/<default-branch>` (refreshed by the
+/// tag/branch fetch that already runs for upstream drift), so it is robust to a
+/// stale local HEAD. See issue #4996.
+#[derive(Debug, Clone, Serialize)]
+pub struct UnreleasedMerge {
+    pub component_id: String,
+    /// The latest release tag the unreleased work is measured against.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_tag: Option<String>,
+    /// Count of commits on `origin/<default-branch>` past `latest_tag`
+    /// (merge commits excluded, matching release-state counting).
+    pub commits_since_tag: u32,
+}
+
 /// Clarifying note emitted alongside the git-state-only `ready_to_deploy` list.
 ///
 /// `ready_to_deploy` reflects local git/workspace state ("has a clean release
@@ -76,6 +104,15 @@ impl UpstreamDrift {
 /// `homeboy status <project>`, which reports `current` / `outdated` per
 /// component. See issue #4588.
 const READY_TO_DEPLOY_NOTE: &str = "ready_to_deploy is git-state-only (components with a clean release tag that *could* be deployed); it does NOT mean the deploy target is behind. Run `homeboy status <project>` for a target-accurate diff (installed version vs latest release tag).";
+
+/// Clarifying note emitted alongside `unreleased_merges`.
+///
+/// `unreleased_merges` flags components whose `origin/<default-branch>` carries
+/// commits past the latest release tag — i.e. work that is merged but not in any
+/// release, so the code does NOT exist on prod. This is the merged→released axis
+/// of the merged→released→deployed chain; for the released→deployed axis
+/// (installed version vs latest tag) run `homeboy status <project>`. See #4996.
+const UNRELEASED_MERGES_NOTE: &str = "unreleased_merges flags components with commits merged to origin/<default-branch> that are past the latest release tag (merged but NOT released — the code is not on prod yet). A merged PR here is NOT 'shipped'. Cut a release, then run `homeboy status <project>` to confirm installed-vs-tag (released-but-not-deployed).";
 
 #[derive(Debug, Serialize)]
 pub struct StatusOutput {
@@ -105,6 +142,15 @@ pub struct StatusOutput {
     pub behind_upstream: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub upstream_drift: Vec<UpstreamDrift>,
+    /// Components carrying code merged to `origin/<default-branch>` but not yet
+    /// covered by a release tag ("merged-not-released"). Closes the false
+    /// "shipped" read where a merged PR is mistaken for live code. Additive and
+    /// independent of `ready_to_deploy` (issue #4996).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub unreleased_merges: Vec<UnreleasedMerge>,
+    /// Clarifying note, emitted only when `unreleased_merges` is non-empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unreleased_merges_note: Option<&'static str>,
     pub clean: usize,
 }
 
@@ -243,6 +289,7 @@ fn summarize_components(
     let mut docs_only = Vec::new();
     let mut behind_upstream = Vec::new();
     let mut upstream_drift = Vec::new();
+    let mut unreleased_merges = Vec::new();
     let mut clean: usize = 0;
 
     // Fetch from origin and detect upstream drift for each component
@@ -252,6 +299,15 @@ fn summarize_components(
                 behind_upstream.push(comp.id.clone());
             }
             upstream_drift.push(drift);
+        }
+    }
+
+    // Detect merged-but-unreleased work per component (issue #4996). This is
+    // measured against origin/<default-branch> (refreshed by the fetch above),
+    // so a stale local checkout does not hide unreleased merges.
+    for comp in &components {
+        if let Some(merge) = detect_unreleased_merges_for(comp) {
+            unreleased_merges.push(merge);
         }
     }
 
@@ -270,7 +326,8 @@ fn summarize_components(
     }
 
     // Apply filters if any are set
-    let has_filter = args.uncommitted || args.needs_release || args.ready || args.docs_only;
+    let has_filter =
+        args.uncommitted || args.needs_release || args.ready || args.docs_only || args.unreleased;
 
     if has_filter {
         if !args.uncommitted {
@@ -285,6 +342,9 @@ fn summarize_components(
         if !args.docs_only {
             docs_only.clear();
         }
+        if !args.unreleased {
+            unreleased_merges.clear();
+        }
     }
 
     let ready_to_deploy_note = if ready_to_deploy.is_empty() {
@@ -292,6 +352,14 @@ fn summarize_components(
     } else {
         Some(READY_TO_DEPLOY_NOTE)
     };
+
+    let unreleased_merges_note = if unreleased_merges.is_empty() {
+        None
+    } else {
+        Some(UNRELEASED_MERGES_NOTE)
+    };
+
+    log_unreleased_merges(&unreleased_merges);
 
     Ok((
         StatusResult::Summary(StatusOutput {
@@ -304,6 +372,8 @@ fn summarize_components(
             docs_only,
             behind_upstream,
             upstream_drift,
+            unreleased_merges,
+            unreleased_merges_note,
             clean,
         }),
         0,
@@ -558,6 +628,106 @@ fn fetch_upstream_drift_for(path: &str, id: &str) -> Option<UpstreamDrift> {
     Some(drift)
 }
 
+/// Detect merged-but-unreleased work for a component (issue #4996).
+///
+/// Reuses existing primitives rather than introducing new ones:
+/// - `version::read_component_version` + `git::detect_baseline_with_version`
+///   resolve the same release baseline the local release-state uses (which also
+///   runs the best-effort tag fetch).
+/// - The default origin branch is resolved with the same precedence the deploy
+///   planner uses (`origin/HEAD` symbolic ref, then main/trunk/master).
+/// - Commits past the baseline are counted with `git rev-list --count
+///   --no-merges <baseline>..origin/<branch>`, mirroring the `--no-merges`
+///   counting in `get_commits_since_tag`.
+///
+/// Unlike `ready_to_deploy` (local HEAD vs tag), this measures
+/// `origin/<default-branch>` vs the latest tag, so a stale local checkout cannot
+/// mask unreleased merges. Returns `None` when there is no unreleased work, the
+/// path is not a git repo, or the origin branch cannot be resolved.
+fn detect_unreleased_merges_for(comp: &component::Component) -> Option<UnreleasedMerge> {
+    let path = &comp.local_path;
+
+    let origin_branch = default_origin_branch(path)?;
+
+    let current_version = version::read_component_version(comp)
+        .ok()
+        .map(|info| info.version);
+
+    let baseline = git::detect_baseline_with_version(path, current_version.as_deref()).ok()?;
+    let baseline_ref = baseline.reference.as_deref()?;
+
+    let range = format!("{}..{}", baseline_ref, origin_branch);
+    let count_output = homeboy::core::engine::command::run_in_optional(
+        path,
+        "git",
+        &["rev-list", "--count", "--no-merges", &range],
+    )?;
+
+    let commits_since_tag: u32 = count_output.trim().parse().ok()?;
+    if commits_since_tag == 0 {
+        return None;
+    }
+
+    Some(UnreleasedMerge {
+        component_id: comp.id.clone(),
+        latest_tag: baseline.latest_tag.clone(),
+        commits_since_tag,
+    })
+}
+
+/// Log merged-but-unreleased components to stderr for human-readable output.
+///
+/// Mirrors the dashboard table's terminal-only behavior so JSON consumers are
+/// unaffected. Keeps the merged-not-released signal visible in `homeboy status`
+/// without a project argument (issue #4996).
+fn log_unreleased_merges(merges: &[UnreleasedMerge]) {
+    if merges.is_empty() || !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+        return;
+    }
+
+    eprintln!(
+        "⚠️  {} component(s) carry merged-but-unreleased work (merged to origin, NOT in any release — code is not on prod yet):",
+        merges.len()
+    );
+    for merge in merges {
+        let tag = merge.latest_tag.as_deref().unwrap_or("(no tag)");
+        eprintln!(
+            "    {} — {} commit(s) past {}",
+            merge.component_id, merge.commits_since_tag, tag
+        );
+    }
+    eprintln!("    Cut a release, then `homeboy status <project>` to confirm installed-vs-tag.");
+}
+
+/// Resolve the default origin branch ref for a checkout.
+///
+/// Precedence matches the deploy planner: `origin/HEAD` symbolic ref first, then
+/// the conventional `origin/main` / `origin/trunk` / `origin/master` fallbacks.
+fn default_origin_branch(path: &str) -> Option<String> {
+    if let Some(symbolic) = homeboy::core::engine::command::run_in_optional(
+        path,
+        "git",
+        &["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+    ) {
+        let symbolic = symbolic.trim();
+        if !symbolic.is_empty() {
+            return Some(symbolic.to_string());
+        }
+    }
+
+    ["origin/main", "origin/trunk", "origin/master"]
+        .iter()
+        .find(|branch| {
+            homeboy::core::engine::command::run_in_optional(
+                path,
+                "git",
+                &["rev-parse", "--verify", "--quiet", branch],
+            )
+            .is_some()
+        })
+        .map(|branch| (*branch).to_string())
+}
+
 /// Fetch remote (deployed) versions for all components in a project.
 ///
 /// Uses deploy check mode internally, which handles SSH resolution.
@@ -740,6 +910,7 @@ mod tests {
             docs_only: false,
             all: false,
             outdated: false,
+            unreleased: false,
         }
     }
 
@@ -766,6 +937,8 @@ mod tests {
             docs_only: Vec::new(),
             behind_upstream: Vec::new(),
             upstream_drift: Vec::new(),
+            unreleased_merges: Vec::new(),
+            unreleased_merges_note: None,
             clean: 0,
         }
     }
@@ -887,6 +1060,119 @@ mod tests {
             }
             _ => panic!("expected summary output"),
         }
+    }
+
+    fn run_git(repo: &std::path::Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .status()
+            .expect("git command");
+        assert!(status.success(), "git {:?} failed", args);
+    }
+
+    fn commit_empty(repo: &std::path::Path, message: &str) {
+        run_git(repo, &["commit", "--allow-empty", "-q", "-m", message]);
+    }
+
+    #[test]
+    fn parser_accepts_unreleased_filter() {
+        let cli = Cli::try_parse_from(["homeboy", "status", "--unreleased"])
+            .expect("status --unreleased parses");
+
+        match cli.command {
+            Commands::Status(args) => assert!(args.unreleased),
+            _ => panic!("expected status command"),
+        }
+    }
+
+    #[test]
+    fn unreleased_merges_note_is_omitted_when_empty() {
+        let output = empty_status_output();
+        let json = serde_json::to_value(&output).expect("serialize status output");
+
+        assert!(
+            json.get("unreleased_merges").is_none(),
+            "empty unreleased_merges must not leak into the JSON contract"
+        );
+        assert!(
+            json.get("unreleased_merges_note").is_none(),
+            "note should be omitted when unreleased_merges is empty"
+        );
+    }
+
+    #[test]
+    fn unreleased_merges_note_present_when_merges_exist() {
+        let output = StatusOutput {
+            total: 1,
+            unreleased_merges: vec![UnreleasedMerge {
+                component_id: "extrachill-artist-platform".to_string(),
+                latest_tag: Some("v1.11.0".to_string()),
+                commits_since_tag: 3,
+            }],
+            unreleased_merges_note: Some(UNRELEASED_MERGES_NOTE),
+            ..empty_status_output()
+        };
+        let json = serde_json::to_value(&output).expect("serialize status output");
+
+        let note = json
+            .get("unreleased_merges_note")
+            .and_then(|v| v.as_str())
+            .expect("note present when unreleased_merges is non-empty");
+
+        // The note must steer operators away from reading a merged PR as shipped.
+        assert!(
+            note.contains("merged but NOT released"),
+            "note should flag merged-not-released"
+        );
+        assert!(
+            note.contains("not on prod yet"),
+            "note should clarify the code is not live"
+        );
+    }
+
+    #[test]
+    fn default_origin_branch_resolves_origin_head_symbolic_ref() {
+        let (_dir, repo) = make_git_repo("with-origin");
+        // Build a fake "origin" remote by cloning into a bare repo and wiring it up.
+        commit_empty(&repo, "feat: initial");
+        // Create the origin/main remote-tracking ref directly so the resolver
+        // has something to find without network access.
+        run_git(&repo, &["update-ref", "refs/remotes/origin/main", "HEAD"]);
+        run_git(
+            &repo,
+            &[
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/main",
+            ],
+        );
+
+        let resolved = default_origin_branch(&repo.to_string_lossy());
+        assert_eq!(resolved.as_deref(), Some("origin/main"));
+    }
+
+    #[test]
+    fn default_origin_branch_falls_back_to_conventional_branches() {
+        let (_dir, repo) = make_git_repo("fallback-origin");
+        commit_empty(&repo, "feat: initial");
+        // No origin/HEAD symbolic ref; only a conventional remote-tracking ref.
+        run_git(&repo, &["update-ref", "refs/remotes/origin/trunk", "HEAD"]);
+
+        let resolved = default_origin_branch(&repo.to_string_lossy());
+        assert_eq!(resolved.as_deref(), Some("origin/trunk"));
+    }
+
+    #[test]
+    fn default_origin_branch_none_without_remote_refs() {
+        let (_dir, repo) = make_git_repo("no-origin");
+        commit_empty(&repo, "feat: initial");
+
+        assert!(default_origin_branch(&repo.to_string_lossy()).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #4996.

Adds an `unreleased_merges` axis to the plain `homeboy status` summary (plus a `--unreleased` filter) that flags components carrying code **merged to `origin/<default-branch>` but not yet covered by a release tag** — the "merged-not-released" state. This closes the false-"✅ shipped" blind spot where a merged PR reads as live even though no release was cut and the code does not exist on prod.

## Primitives reused (no new infrastructure)

Per RULES.md, this reuses existing primitives rather than building a parallel system:

- `version::read_component_version` + `git::detect_baseline_with_version` — resolve the **same release baseline** the local release-state already uses (and which already runs the best-effort `git fetch --tags`).
- The deploy planner's origin-default-branch precedence (`origin/HEAD` symbolic ref → `origin/main`/`origin/trunk`/`origin/master`).
- `git rev-list --count --no-merges <baseline>..origin/<branch>` — mirrors the `--no-merges` counting in `get_commits_since_tag`.

The only new code is the small detector that wires these together and the additive output field.

## How it complements (not duplicates) `ready_to_deploy`

| Axis | Question | Source | Field |
|------|----------|--------|-------|
| local-vs-tag | "is my local checkout ahead of the latest tag?" | local HEAD | `ready_to_deploy` (#4588) |
| **tag-vs-merged** | **"is there work merged on origin past the latest tag?"** | **`origin/<default-branch>`** | **`unreleased_merges` (this PR)** |
| installed-vs-tag | "is the release deployed to prod?" | `homeboy status <project>` | `outdated` |

`ready_to_deploy` is **local-HEAD-vs-tag** and depends on a fresh checkout. This new detector measures **`origin/<default-branch>`-vs-tag** (the fetch that already runs for upstream drift refreshes `origin/main` + tags), so a stale local checkout cannot mask unreleased merges. The three axes together close the **merged → released → deployed** chain that the issue identifies.

Purely additive and gated behind an opt-in `--unreleased` filter, with `skip_serializing_if = "Vec::is_empty"` on the field — it cannot regress the #4588 phantom-backlog false-positive fix. When non-empty, the JSON includes an `unreleased_merges_note` repeating the "a merged PR here is NOT shipped" caveat, and a terminal-only stderr summary mirrors the dashboard table.

## Example output (real components, the Case A scenario from #4996)

`homeboy status --unreleased --all` (JSON `unreleased_merges`):

```json
[
  { "component_id": "data-machine",      "latest_tag": "v0.150.9",   "commits_since_tag": 20 },
  { "component_id": "data-machine-code", "latest_tag": "v0.48.0",    "commits_since_tag": 19 },
  { "component_id": "wp-coding-agents",  "latest_tag": "v1.5.0",     "commits_since_tag": 3  },
  { "component_id": "extrachill-tokens", "latest_tag": "v0.7.2",     "commits_since_tag": 1  }
]
```

```
unreleased_merges_note: "unreleased_merges flags components with commits merged to
origin/<default-branch> that are past the latest release tag (merged but NOT released —
the code is not on prod yet). A merged PR here is NOT 'shipped'. Cut a release, then run
`homeboy status <project>` to confirm installed-vs-tag (released-but-not-deployed)."
```

Each flagged component is exactly a merged-not-released case: code on `main`, no tag cut, not on prod — precisely what bit the 3 progress-report sessions in the issue.

## Tests

6 new unit tests (14 total in the status module, all green):
- `--unreleased` flag parses
- `unreleased_merges_note` omitted when empty / present + correct copy when non-empty
- `default_origin_branch` resolves `origin/HEAD` symbolic ref, falls back to conventional branches, and returns `None` without remote refs

`cargo build` and `cargo test --lib commands::status` both clean. (clippy/`homeboy lint` unavailable in this env per homeboy#4586 lint-preflight false-negative; verified via cargo directly.)

## Follow-ups (not in this PR)

- A deeper installed-vs-tag classification inside the non-project summary would require per-component target resolution; today that lives in the project dashboard (`homeboy status <project>` → `outdated`). Left as-is to keep this PR the smallest coherent detector.