### PR TITLE
Refactor output text presentation contract

### DIFF
--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -4,7 +4,7 @@ use crate::cli_surface::Commands;
 use crate::command_contract::CommandJsonFamily;
 
 use super::agent_task_summary::{agent_task_summary_kind, render_agent_task_summary};
-use super::output_runtime::JsonCommandRun;
+use super::output_runtime::{CommandPresentation, JsonCommandRun};
 use super::{runner, GlobalArgs};
 
 mod ops;
@@ -27,17 +27,16 @@ pub fn run_command_output(command: Commands, global: &GlobalArgs) -> JsonCommand
         Commands::AgentTask(args) => {
             let summary_kind = agent_task_summary_kind_for_output(&args);
             let (stdout_result, exit_code) = dispatch(Commands::AgentTask(args), global);
-            let human_stdout = stdout_result.as_ref().ok().and_then(|payload| {
+            let summary_stdout = stdout_result.as_ref().ok().and_then(|payload| {
                 summary_kind.and_then(|kind| render_agent_task_summary(kind, payload))
             });
 
-            JsonCommandRun {
-                stdout_result,
-                exit_code,
-                output_file_result: None,
-                human_stdout,
-                human_stderr: None,
-            }
+            JsonCommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+                CommandPresentation {
+                    stdout: summary_stdout,
+                    stderr: None,
+                },
+            )
         }
         Commands::Runner(args) => runner::run_command_output(args, global),
         command => {

--- a/src/commands/output_runtime.rs
+++ b/src/commands/output_runtime.rs
@@ -10,8 +10,13 @@ pub struct JsonCommandRun {
     pub stdout_result: homeboy::core::Result<Value>,
     pub exit_code: i32,
     pub output_file_result: Option<homeboy::core::Result<Value>>,
-    pub human_stdout: Option<String>,
-    pub human_stderr: Option<String>,
+    pub presentation: CommandPresentation,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CommandPresentation {
+    pub stdout: Option<String>,
+    pub stderr: Option<String>,
 }
 
 impl JsonCommandRun {
@@ -20,9 +25,13 @@ impl JsonCommandRun {
             stdout_result,
             exit_code,
             output_file_result: None,
-            human_stdout: None,
-            human_stderr: None,
+            presentation: CommandPresentation::default(),
         }
+    }
+
+    pub fn with_presentation(mut self, presentation: CommandPresentation) -> Self {
+        self.presentation = presentation;
+        self
     }
 
     pub fn from_raw(
@@ -43,8 +52,7 @@ impl JsonCommandRun {
                 stdout_result: output_file_result,
                 exit_code,
                 output_file_result: None,
-                human_stdout: None,
-                human_stderr: None,
+                presentation: CommandPresentation::default(),
             },
             raw_stdout,
         )
@@ -68,11 +76,11 @@ impl<'a> OutputService<'a> {
 
     pub fn emit_run(&self, run: JsonCommandRun, mode: CommandOutputFileMode) -> i32 {
         self.write_output_file(&run, mode);
-        if let Some(human_stderr) = run.human_stderr {
-            eprint!("{}", human_stderr);
+        if let Some(stderr) = run.presentation.stderr {
+            eprint!("{}", stderr);
         }
-        if let Some(human_stdout) = run.human_stdout {
-            print!("{}", human_stdout);
+        if let Some(stdout) = run.presentation.stdout {
+            print!("{}", stdout);
         } else {
             output::print_json_result(run.stdout_result, run.exit_code).ok();
         }
@@ -183,8 +191,7 @@ pub fn run_json(
                 stdout_result,
                 exit_code,
                 output_file_result,
-                human_stdout: None,
-                human_stderr: None,
+                presentation: CommandPresentation::default(),
             }
         }
         (_, command) => super::json_output::run_command_output(command, global),
@@ -239,8 +246,7 @@ mod tests {
             stdout_result: Ok(json!({ "kind": "stdout" })),
             exit_code: 0,
             output_file_result,
-            human_stdout: None,
-            human_stderr: None,
+            presentation: CommandPresentation::default(),
         }
     }
 
@@ -300,6 +306,23 @@ mod tests {
     fn generic_output_file_uses_stdout_result() {
         let run = run_with_output_file_result(Some(Ok(json!({ "kind": "summary" }))));
 
+        assert_eq!(
+            select_output_file_result(&run, CommandOutputFileMode::GenericEnvelope)
+                .as_ref()
+                .unwrap(),
+            &json!({ "kind": "stdout" })
+        );
+    }
+
+    #[test]
+    fn presentation_does_not_replace_structured_stdout_or_file_payload() {
+        let run = JsonCommandRun::from_stdout_result(Ok(json!({ "kind": "stdout" })), 0)
+            .with_presentation(CommandPresentation {
+                stdout: Some("short summary\n".to_string()),
+                stderr: Some("progress\n".to_string()),
+            });
+
+        assert_eq!(run.presentation.stdout.as_deref(), Some("short summary\n"));
         assert_eq!(
             select_output_file_result(&run, CommandOutputFileMode::GenericEnvelope)
                 .as_ref()

--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -17,7 +17,7 @@ use homeboy::core::runners::{
 use homeboy::core::server::{RunnerPolicy, RunnerSecretEnvRef, RunnerSettings};
 use homeboy::core::{EntityCrudOutput, MergeOutput};
 
-use super::output_runtime::JsonCommandRun;
+use super::output_runtime::{CommandPresentation, JsonCommandRun};
 use super::{CmdResult, DynamicSetArgs};
 
 pub mod doctor;
@@ -703,20 +703,19 @@ fn run_raw_exec(
 }
 
 fn raw_exec_command_run(output: RunnerExecOutput, exit_code: i32) -> JsonCommandRun {
-    let human_stdout = output.stdout.clone();
-    let human_stderr = output.stderr.clone();
+    let presentation_stdout = output.stdout.clone();
+    let presentation_stderr = output.stderr.clone();
     let (stdout_result, _) = crate::commands::utils::response::map_cmd_result_to_json(Ok((
         RunnerCommandOutput::Execution(output),
         exit_code,
     )));
 
-    JsonCommandRun {
-        stdout_result,
-        exit_code,
-        output_file_result: None,
-        human_stdout: Some(human_stdout),
-        human_stderr: Some(human_stderr),
-    }
+    JsonCommandRun::from_stdout_result(stdout_result, exit_code).with_presentation(
+        CommandPresentation {
+            stdout: Some(presentation_stdout),
+            stderr: Some(presentation_stderr),
+        },
+    )
 }
 
 fn map_registry(result: CmdResult<RunnerOutput>) -> CmdResult<RunnerCommandOutput> {
@@ -1460,7 +1459,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_exec_command_run_keeps_structured_output_and_human_streams() {
+    fn raw_exec_command_run_keeps_structured_output_and_presentation_streams() {
         let run = raw_exec_command_run(
             RunnerExecOutput {
                 command: "runner.exec",
@@ -1486,8 +1485,8 @@ mod tests {
         );
 
         assert_eq!(run.exit_code, 7);
-        assert_eq!(run.human_stdout.as_deref(), Some("hello\n"));
-        assert_eq!(run.human_stderr.as_deref(), Some("warn\n"));
+        assert_eq!(run.presentation.stdout.as_deref(), Some("hello\n"));
+        assert_eq!(run.presentation.stderr.as_deref(), Some("warn\n"));
 
         let value = run.stdout_result.expect("structured output");
         assert_eq!(value["command"], "runner.exec");


### PR DESCRIPTION
## Summary
- Introduce an explicit `CommandPresentation` primitive for text stdout/stderr emitted alongside structured command output.
- Route agent-task cook/status/logs/review summaries through the presentation primitive instead of ad hoc `human_stdout` fields.
- Keep output-file selection tied to structured stdout/artifact payloads, with tests proving presentation text does not replace file payloads.
- Migrate runner raw exec passthrough to the same presentation primitive.

## Tests
- `cargo fmt --check`
- `cargo test commands::output_runtime::tests`
- `cargo test commands::json_output::tests`
- `cargo test raw_exec_command_run_keeps_structured_output_and_presentation_streams`
- `cargo test --test output_contracts_test`

## Follow-ups
- Migrate remaining ad hoc `--json-summary`, `--format`, and `status-file` style command families onto the same primitive in focused PRs.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5
- **Used for:** Implementation and targeted tests for the output presentation primitive; Chris reviews and owns the change.