### PR TITLE
refactor(lab): centralize runner support labels

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -20,6 +20,7 @@ mod output;
 mod public_variants;
 
 pub use lab::{
+    lab_runner_supported_labels, lab_runner_unsupported_hint, lab_runner_unsupported_message,
     LabCommandContract, LabCommandPortability, LabCommandRequiredTool, LabSourcePathMode,
     LabWorkspaceModePolicy, LAB_TRACE_EXTRA_TOOLS,
 };

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -63,6 +63,63 @@ pub enum LabCommandRequiredTool {
 pub const LAB_TRACE_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[LabCommandRequiredTool::Playwright];
 const LAB_NO_EXTRA_TOOLS: &[LabCommandRequiredTool] = &[];
 const RIG_UP_LAB_UNSUPPORTED_REASON: &str = "`rig up` stays local because rig pipelines manage local services, leases, ports, and declared filesystem paths that the current single-workspace Lab snapshot cannot safely mirror.";
+const LAB_RUNNER_SUPPORTED_ERROR_LABELS: &[&str] = &[
+    "agent-task dispatch/cook/loop/run-plan",
+    "agent-task retry --run",
+    "agent-task status/logs/artifacts/review/providers",
+    "agent-task auth status",
+    "lint",
+    "test",
+    "audit",
+    "bench",
+    "trace",
+    "refactor source runs",
+    "tunnel preview-consumer run",
+    "tunnel service expose",
+    "tunnel service start",
+];
+const LAB_RUNNER_SUPPORTED_HINT_LABELS: &[&str] = &[
+    "agent-task dispatch/cook/loop/run-plan",
+    "agent-task retry --run",
+    "agent-task status/logs/artifacts/review/providers",
+    "agent-task auth status",
+    "audit",
+    "bench run",
+    "full lint",
+    "full test",
+    "trace",
+    "refactor source runs",
+    "tunnel preview-consumer run",
+    "tunnel service expose",
+    "tunnel service start",
+];
+
+pub fn lab_runner_supported_labels() -> &'static [&'static str] {
+    LAB_RUNNER_SUPPORTED_ERROR_LABELS
+}
+
+pub fn lab_runner_unsupported_message() -> String {
+    format!(
+        "--runner is only supported for commands with portable Lab offload support: {}",
+        human_join(lab_runner_supported_labels())
+    )
+}
+
+pub fn lab_runner_unsupported_hint() -> String {
+    format!(
+        "Current Lab offload support: {}.",
+        human_join(LAB_RUNNER_SUPPORTED_HINT_LABELS)
+    )
+}
+
+fn human_join(labels: &[&str]) -> String {
+    match labels {
+        [] => String::new(),
+        [label] => (*label).to_string(),
+        [first, second] => format!("{first} and {second}"),
+        [rest @ .., last] => format!("{}, and {last}", rest.join(", ")),
+    }
+}
 
 impl Commands {
     pub fn lab_contract(&self) -> Option<LabCommandContract> {
@@ -451,6 +508,36 @@ mod tests {
 
     fn parsed_cli(args: &[&str]) -> Cli {
         Cli::try_parse_from(args).expect("CLI args should parse")
+    }
+
+    #[test]
+    fn test_lab_runner_supported_labels_are_contract_owned() {
+        assert_eq!(
+            lab_runner_supported_labels(),
+            &[
+                "agent-task dispatch/cook/loop/run-plan",
+                "agent-task retry --run",
+                "agent-task status/logs/artifacts/review/providers",
+                "agent-task auth status",
+                "lint",
+                "test",
+                "audit",
+                "bench",
+                "trace",
+                "refactor source runs",
+                "tunnel preview-consumer run",
+                "tunnel service expose",
+                "tunnel service start",
+            ]
+        );
+        assert_eq!(
+            lab_runner_unsupported_message(),
+            "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, tunnel preview-consumer run, tunnel service expose, and tunnel service start"
+        );
+        assert_eq!(
+            lab_runner_unsupported_hint(),
+            "Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, refactor source runs, tunnel preview-consumer run, tunnel service expose, and tunnel service start."
+        );
     }
 
     #[test]

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -18,6 +18,7 @@
 
 use std::path::Path;
 
+use crate::command_contract::{lab_runner_unsupported_hint, lab_runner_unsupported_message};
 use crate::core::agent_task_lifecycle;
 use crate::core::agent_task_provider::provider_available_for_backend;
 use crate::core::agent_tasks::provider::{
@@ -298,7 +299,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if let Some(runner_id) = request.explicit_runner {
             return Err(unsupported_runner_error(
                 runner_id,
-                "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, tunnel preview-consumer run, tunnel service expose, and tunnel service start".to_string(),
+                lab_runner_unsupported_message(),
             ));
         }
         return Ok(LabOffloadOutcome::RunLocal {
@@ -311,7 +312,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.portable {
         if let Some(runner_id) = request.explicit_runner {
             let message = contract.unsupported_reason.map_or_else(
-                || "--runner is only supported for commands with portable Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, tunnel preview-consumer run, tunnel service expose, and tunnel service start".to_string(),
+                lab_runner_unsupported_message,
                 |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
             );
             return Err(unsupported_runner_error(runner_id, message));
@@ -477,7 +478,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
 }
 
 fn unsupported_runner_hints(runner_id: &str, normalized_args: &[String]) -> Vec<String> {
-    let mut hints = vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, refactor source runs, tunnel preview-consumer run, tunnel service expose, and tunnel service start.".to_string()];
+    let mut hints = vec![lab_runner_unsupported_hint()];
 
     if let Some(service_command) = tunnel_service_command(normalized_args) {
         hints.push(format!(


### PR DESCRIPTION
## Summary
- Moves Lab runner supported-command labels and unsupported runner diagnostic text into command_contract/lab.rs.
- Reuses contract helpers from runner Lab offload instead of duplicating hard-coded lists.
- Adds coverage for centralized labels/messages.

## Tests
- cargo fmt
- cargo test command_contract::lab
- cargo test core::runner::lab::offload
- cargo check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** refactoring Lab command support lookup to the contract registry.