### PR TITLE
Preserve agent-task provider manifest metadata

### DIFF
--- a/src/commands/runner/doctor/tests.rs
+++ b/src/commands/runner/doctor/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use homeboy::core::agent_tasks::provider::{
     AgentTaskProviderEnvPathReadiness, AgentTaskProviderRunnerReadiness,
 };
+use std::collections::BTreeMap;
 use types::{HomeboyProbe, RunnerDoctorStatus};
 
 #[test]
@@ -193,8 +194,10 @@ fn provider_readiness_renderer_uses_fake_provider_contract() {
             env: vec!["FAKE_RUNTIME_BIN".to_string()],
             revision: Some(true),
             canonical_path: None,
+            extra: BTreeMap::new(),
         }),
         remediation: Some("Refresh the fake runtime cache".to_string()),
+        extra: BTreeMap::new(),
     };
 
     let check = probes::provider_env_path_readiness_check_from_probe(
@@ -228,8 +231,10 @@ fn provider_readiness_warns_on_non_canonical_checkout() {
             env: vec!["FAKE_RUNTIME_BIN".to_string()],
             revision: Some(true),
             canonical_path: Some("/home/runner/.cache/homeboy/source".to_string()),
+            extra: BTreeMap::new(),
         }),
         remediation: Some("Refresh the managed source checkout".to_string()),
+        extra: BTreeMap::new(),
     };
 
     let check = probes::provider_env_path_readiness_check_from_probe(
@@ -262,8 +267,10 @@ fn provider_readiness_ok_when_path_within_canonical_root() {
             env: vec!["FAKE_RUNTIME_BIN".to_string()],
             revision: None,
             canonical_path: Some("/home/runner/.cache/homeboy/source".to_string()),
+            extra: BTreeMap::new(),
         }),
         remediation: None,
+        extra: BTreeMap::new(),
     };
 
     let check = probes::provider_env_path_readiness_check_from_probe(

--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use crate::core::agent_task_provider::AgentTaskExecutorProvider;
@@ -22,6 +23,8 @@ pub struct AgentRuntimeManifest {
     pub extension_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_path: Option<String>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
 }
 
 pub fn discover_agent_runtime_manifests() -> Vec<AgentRuntimeManifest> {
@@ -99,6 +102,7 @@ pub(crate) fn discover_agent_runtime_manifests_from_extensions(
                 extension_id: Some(extension.id.clone()),
                 extension_path: extension.extension_path.clone(),
                 runtime_path: extension.extension_path.clone(),
+                extra: runtime.extra.clone().into_iter().collect(),
             });
         }
     }
@@ -195,6 +199,7 @@ mod tests {
             serde_json::from_value(json!({
                 "id": "example-runtime",
                 "label": "Example Runtime",
+                "runtime_metadata": { "owner": "extension" },
                 "agent_task_executors": [provider_json("example.default", "example")]
             }))
             .expect("runtime manifest"),
@@ -214,6 +219,12 @@ mod tests {
             manifests[0].runtime_path.as_deref(),
             Some("/extensions/runtime-extension")
         );
+        assert_eq!(manifests[0].extra["runtime_metadata"]["owner"], "extension");
+        assert_eq!(
+            serde_json::to_value(&manifests[0]).expect("runtime export")["runtime_metadata"]
+                ["owner"],
+            "extension"
+        );
     }
 
     #[test]
@@ -232,6 +243,7 @@ mod tests {
                     "name": "Standalone Example Package",
                     "version": "1.0.0",
                     "description": "Standalone runtime package fixture.",
+                    "runtime_metadata": { "owner": "standalone" },
                     "label": "Standalone Example",
                     "agent_task_executors": [{
                         "schema": AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
@@ -275,6 +287,16 @@ mod tests {
                 manifests[0].runtime_path.as_deref(),
                 Some(runtime_dir.to_str().expect("runtime dir utf-8"))
             );
+            assert_eq!(manifests[0].extra["name"], "Standalone Example Package");
+            assert_eq!(manifests[0].extra["version"], "1.0.0");
+            assert_eq!(
+                manifests[0].extra["runtime_metadata"]["owner"],
+                "standalone"
+            );
+            let exported = serde_json::to_value(&manifests[0]).expect("runtime export");
+            assert_eq!(exported["name"], "Standalone Example Package");
+            assert_eq!(exported["version"], "1.0.0");
+            assert_eq!(exported["runtime_metadata"]["owner"], "standalone");
             assert_eq!(manifests[0].agent_task_executors[0].backend, "example");
             let provider = &manifests[0].agent_task_executors[0];
             let materialization = provider

--- a/src/core/agent_task_contract.rs
+++ b/src/core/agent_task_contract.rs
@@ -142,6 +142,7 @@ pub fn agent_task_core_contract() -> AgentTaskCoreContract {
                 "extension_path",
                 "runtime_id",
                 "runtime_path",
+                "extra",
             ]),
         },
         enums: AgentTaskCoreContractEnums {

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -90,6 +90,8 @@ pub struct AgentTaskExecutorProvider {
     pub runtime_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_path: Option<String>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
 }
 
 fn default_provider_schema() -> String {
@@ -161,6 +163,8 @@ pub struct AgentTaskProviderRunnerReadiness {
     pub env_path: Option<AgentTaskProviderEnvPathReadiness>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remediation: Option<String>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -178,6 +182,8 @@ pub struct AgentTaskProviderEnvPathReadiness {
     /// entirely by the declaring extension.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub canonical_path: Option<String>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
 }
 
 /// A named, extension-declared source checkout that homeboy keeps synced on the
@@ -202,6 +208,8 @@ pub struct AgentTaskProviderRunnerSource {
     pub git_ref: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remediation: Option<String>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -213,6 +221,8 @@ pub struct AgentTaskProviderDependencyFailurePattern {
     pub error_contains_any: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remediation: Option<String>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -225,6 +235,8 @@ pub struct AgentTaskProviderTimeoutArtifactDiscovery {
     pub config_path_keys: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifact_patterns: Vec<AgentTaskProviderArtifactPattern>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
 }
 
 impl AgentTaskProviderTimeoutArtifactDiscovery {
@@ -233,6 +245,7 @@ impl AgentTaskProviderTimeoutArtifactDiscovery {
             && self.metadata_path_keys.is_empty()
             && self.config_path_keys.is_empty()
             && self.artifact_patterns.is_empty()
+            && self.extra.is_empty()
     }
 }
 
@@ -254,6 +267,8 @@ pub struct AgentTaskProviderArtifactPattern {
         skip_serializing_if = "is_empty_metadata"
     )]
     pub metadata: Value,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
 }
 
 fn default_metadata() -> Value {
@@ -274,6 +289,8 @@ pub struct AgentTaskProviderRoleAliases {
     pub outputs: BTreeMap<String, Vec<String>>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub metadata: BTreeMap<String, Vec<String>>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
 }
 
 impl AgentTaskProviderRoleAliases {
@@ -282,6 +299,7 @@ impl AgentTaskProviderRoleAliases {
             && self.artifact_filenames.is_empty()
             && self.outputs.is_empty()
             && self.metadata.is_empty()
+            && self.extra.is_empty()
     }
 
     pub fn artifact_kind_matches_role(&self, role: &str, kind: &str) -> bool {
@@ -357,6 +375,8 @@ pub struct AgentTaskProviderWorkspaceMaterialization {
     pub write_scope: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifact_paths: Vec<String>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1466,6 +1486,106 @@ mod tests {
         assert_eq!(provider.outcome_schema, AGENT_TASK_OUTCOME_SCHEMA);
     }
 
+    #[test]
+    fn provider_manifest_preserves_unknown_metadata_on_export() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(json!({
+            "id": "metadata.provider",
+            "backend": "metadata",
+            "command": "metadata-provider",
+            "provider_metadata": {
+                "runtime": "provider-owned"
+            },
+            "runner_readiness": [{
+                "id": "ready",
+                "label": "Ready",
+                "provider_hint": "preserve-me",
+                "env_path": {
+                    "env": ["PROVIDER_HOME"],
+                    "path_kind": "provider-cache"
+                }
+            }],
+            "timeout_artifact_discovery": {
+                "paths": ["artifacts"],
+                "provider_discovery": true,
+                "artifact_patterns": [{
+                    "kind": "log",
+                    "filename_contains": ["provider"],
+                    "provider_role": "diagnostic"
+                }]
+            },
+            "role_aliases": {
+                "outputs": { "patch": ["diff"] },
+                "provider_alias_policy": "strict"
+            },
+            "workspace_materialization": {
+                "cwd": "git_checkout",
+                "provider_workspace_mode": "linked"
+            }
+        }))
+        .expect("provider manifest");
+
+        assert_eq!(
+            provider.extra["provider_metadata"]["runtime"],
+            "provider-owned"
+        );
+        assert_eq!(
+            provider.runner_readiness[0].extra["provider_hint"],
+            "preserve-me"
+        );
+        assert_eq!(
+            provider.runner_readiness[0]
+                .env_path
+                .as_ref()
+                .expect("env path")
+                .extra["path_kind"],
+            "provider-cache"
+        );
+        assert_eq!(
+            provider.timeout_artifact_discovery.extra["provider_discovery"],
+            true
+        );
+        assert_eq!(
+            provider.timeout_artifact_discovery.artifact_patterns[0].extra["provider_role"],
+            "diagnostic"
+        );
+        assert_eq!(
+            provider.role_aliases.extra["provider_alias_policy"],
+            "strict"
+        );
+        assert_eq!(
+            provider
+                .workspace_materialization
+                .as_ref()
+                .expect("workspace materialization")
+                .extra["provider_workspace_mode"],
+            "linked"
+        );
+
+        let exported = serde_json::to_value(&provider).expect("provider export");
+        assert_eq!(exported["provider_metadata"]["runtime"], "provider-owned");
+        assert_eq!(
+            exported["runner_readiness"][0]["provider_hint"],
+            "preserve-me"
+        );
+        assert_eq!(
+            exported["runner_readiness"][0]["env_path"]["path_kind"],
+            "provider-cache"
+        );
+        assert_eq!(
+            exported["timeout_artifact_discovery"]["provider_discovery"],
+            true
+        );
+        assert_eq!(
+            exported["timeout_artifact_discovery"]["artifact_patterns"][0]["provider_role"],
+            "diagnostic"
+        );
+        assert_eq!(exported["role_aliases"]["provider_alias_policy"], "strict");
+        assert_eq!(
+            exported["workspace_materialization"]["provider_workspace_mode"],
+            "linked"
+        );
+    }
+
     fn script(body: &str) -> String {
         let path = std::env::temp_dir().join(format!(
             "homeboy-agent-task-provider-{}-{}.js",
@@ -1500,6 +1620,7 @@ mod tests {
             extension_path: None,
             runtime_id: None,
             runtime_path: None,
+            extra: BTreeMap::new(),
         };
         let request = AgentTaskRequest {
             schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
@@ -1917,6 +2038,7 @@ process.stdout.write(JSON.stringify({
             secret_env: vec!["PROVIDER_A_TOKEN".to_string()],
             env_path: None,
             remediation: Some("Configure provider A auth.".to_string()),
+            extra: BTreeMap::new(),
         }];
         let (mut request_b, mut provider_b) = request("task-b", "node provider-b.js".to_string());
         request_b.executor.backend = "provider-b".to_string();
@@ -1931,6 +2053,7 @@ process.stdout.write(JSON.stringify({
             ],
             env_path: None,
             remediation: None,
+            extra: BTreeMap::new(),
         }];
         let mut plan = AgentTaskPlan::new("plan-a", vec![request_a, request_b]);
 
@@ -2082,6 +2205,7 @@ process.stdout.write(JSON.stringify({
             requires_git: None,
             write_scope: None,
             artifact_paths: Vec::new(),
+            extra: BTreeMap::new(),
         });
 
         assert!(provider_requires_cwd_git_checkout_with_providers(
@@ -2287,6 +2411,7 @@ process.stdout.write(JSON.stringify({
             requires_git: Some(true),
             write_scope: Some("artifacts".to_string()),
             artifact_paths: vec![".homeboy/provider".to_string()],
+            extra: BTreeMap::new(),
         });
 
         assert!(provider_requires_cwd_git_checkout_with_providers(
@@ -2304,6 +2429,7 @@ process.stdout.write(JSON.stringify({
             requires_git: None,
             write_scope: None,
             artifact_paths: Vec::new(),
+            extra: BTreeMap::new(),
         });
 
         assert!(!provider_requires_cwd_git_checkout_with_providers(

--- a/src/core/extension/manifest.rs
+++ b/src/core/extension/manifest.rs
@@ -516,6 +516,8 @@ pub struct AgentRuntimeManifestConfig {
     pub label: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub agent_task_executors: Vec<serde_json::Value>,
+    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -783,6 +783,7 @@ trailing log"#;
             path_contains: "prepared-dependencies/".to_string(),
             error_contains_any: vec!["no such file or directory".to_string()],
             remediation: Some("refresh fixture dependencies".to_string()),
+            extra: Default::default(),
         }];
 
         let message =

--- a/src/core/runner/managed_source.rs
+++ b/src/core/runner/managed_source.rs
@@ -197,6 +197,7 @@ mod tests {
             remote_url: None,
             git_ref: None,
             remediation: None,
+            extra: Default::default(),
         }
     }
 


### PR DESCRIPTION
## Summary
- Preserve unknown provider/runtime manifest metadata with generic flattened extra JSON maps.
- Keep the existing Homeboy agent-task contract export authoritative and include the extra metadata field in the provider field list.
- Add tests proving unknown provider/runtime fields survive parse and export, and that the core contract exposes current agent-task enums.

## Tests
- cargo fmt --check
- cargo test agent_task_contract
- cargo test agent_runtime_manifest
- cargo test provider_manifest_preserves_unknown_metadata_on_export
- cargo check
- cargo run --quiet -- agent-task contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing the contract/metadata preservation slice and tests.