### PR TITLE
Resolve rig executable env aliases

### DIFF
--- a/src/core/rig/capabilities.rs
+++ b/src/core/rig/capabilities.rs
@@ -97,35 +97,57 @@ fn evaluate_executable(
     }
 
     let declared = expand_vars(rig, &requirement.executable);
-    let env_override = requirement
-        .env
-        .as_deref()
-        .and_then(|name| std::env::var(name).ok())
-        .filter(|value| !value.trim().is_empty())
-        .map(|value| expand_vars(rig, &value));
-    let candidate = env_override.as_deref().unwrap_or(&declared);
+    let mut attempts = Vec::new();
 
-    if find_executable(candidate).is_some() {
+    for name in executable_env_names(requirement) {
+        match std::env::var(name) {
+            Ok(value) if !value.trim().is_empty() => {
+                let candidate = expand_vars(rig, &value);
+                if find_executable(&candidate).is_some() {
+                    return Ok(());
+                }
+                attempts.push(format!("{}={} (not executable)", name, candidate));
+            }
+            _ => attempts.push(format!("{} is unset or empty", name)),
+        }
+    }
+
+    if find_executable(&declared).is_some() {
         return Ok(());
     }
 
-    let mut message = match (&requirement.env, env_override) {
-        (Some(name), Some(value)) => format!(
-            "executable `{}` does not exist or is not executable from {}={}",
-            declared, name, value
-        ),
-        (Some(name), None) => format!(
-            "executable `{}` not found on PATH ({} is unset or empty)",
-            declared, name
-        ),
-        (None, _) => format!("executable `{}` not found on PATH", declared),
-    };
+    attempts.push(declared_executable_attempt(&declared));
+
+    let mut message = format!(
+        "executable `{}` could not be resolved; tried {}",
+        declared,
+        attempts.join(", ")
+    );
 
     if let Some(remediation) = &requirement.remediation {
         message.push_str(&format!(". Remediation: {}", expand_vars(rig, remediation)));
     }
 
     Err(message)
+}
+
+fn executable_env_names(requirement: &ExecutableRequirementSpec) -> Vec<&str> {
+    requirement
+        .env
+        .iter()
+        .map(String::as_str)
+        .chain(requirement.env_aliases.iter().map(String::as_str))
+        .filter(|name| !name.trim().is_empty())
+        .collect()
+}
+
+fn declared_executable_attempt(declared: &str) -> String {
+    let path = Path::new(declared);
+    if declared.contains(std::path::MAIN_SEPARATOR) || path.is_absolute() {
+        format!("declared executable `{}`", declared)
+    } else {
+        format!("PATH lookup for `{}`", declared)
+    }
 }
 
 fn evaluate_filesystem_assertion(
@@ -309,4 +331,88 @@ mod tests {
             .unwrap()
             .contains("Remediation: install it"));
     }
+
+    #[test]
+    fn executable_requirement_uses_env_aliases_before_path() {
+        let temp = tempdir().expect("tempdir");
+        let alias_bin = temp.path().join("alias-tool");
+        fs::write(&alias_bin, "#!/bin/sh\nexit 0\n").expect("write executable");
+        make_executable(&alias_bin);
+
+        let primary_env = "HOMEBOY_TEST_PRIMARY_TOOL_BIN";
+        let alias_env = "HOMEBOY_TEST_ALIAS_TOOL_BIN";
+        std::env::set_var(primary_env, temp.path().join("missing-tool"));
+        std::env::set_var(alias_env, &alias_bin);
+
+        let rig = RigSpec {
+            requirements: RigRequirementsSpec {
+                executables: vec![ExecutableRequirementSpec {
+                    executable: "demo-tool".to_string(),
+                    env: Some(primary_env.to_string()),
+                    env_aliases: vec![alias_env.to_string()],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let outcome = evaluate_requirements(&rig);
+
+        std::env::remove_var(primary_env);
+        std::env::remove_var(alias_env);
+        assert_eq!(outcome.failed, 0, "outcome: {:?}", outcome.steps);
+    }
+
+    #[test]
+    fn executable_requirement_reports_resolution_sources() {
+        let primary_env = "HOMEBOY_TEST_MISSING_PRIMARY_TOOL_BIN";
+        let alias_env = "HOMEBOY_TEST_EMPTY_ALIAS_TOOL_BIN";
+        std::env::set_var(primary_env, "/nonexistent/primary-tool");
+        std::env::set_var(alias_env, "");
+
+        let rig = RigSpec {
+            requirements: RigRequirementsSpec {
+                executables: vec![ExecutableRequirementSpec {
+                    executable: "/nonexistent/missing-tool".to_string(),
+                    env: Some(primary_env.to_string()),
+                    env_aliases: vec![alias_env.to_string()],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let outcome = evaluate_requirements(&rig);
+
+        std::env::remove_var(primary_env);
+        std::env::remove_var(alias_env);
+        assert_eq!(outcome.failed, 1);
+        let error = outcome.steps[0].error.as_deref().unwrap_or_default();
+        assert!(
+            error.contains("HOMEBOY_TEST_MISSING_PRIMARY_TOOL_BIN=/nonexistent/primary-tool"),
+            "error: {error}"
+        );
+        assert!(
+            error.contains("HOMEBOY_TEST_EMPTY_ALIAS_TOOL_BIN is unset or empty"),
+            "error: {error}"
+        );
+        assert!(
+            error.contains("declared executable `/nonexistent/missing-tool`"),
+            "error: {error}"
+        );
+    }
+
+    #[cfg(unix)]
+    fn make_executable(path: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(path).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).expect("chmod");
+    }
+
+    #[cfg(not(unix))]
+    fn make_executable(_path: &std::path::Path) {}
 }

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -645,6 +645,7 @@ fn run_requirement_step(rig: &RigSpec, pipeline_name: &str, step: &PipelineStep)
         component_path_contains,
         executable,
         executable_env,
+        executable_env_aliases,
         prepare_command,
         prepare_phases,
         cwd,
@@ -708,6 +709,7 @@ fn run_requirement_step(rig: &RigSpec, pipeline_name: &str, step: &PipelineStep)
             rig,
             executable.as_deref(),
             executable_env.as_deref(),
+            executable_env_aliases,
             env,
         ))
         .collect::<Vec<_>>();
@@ -733,6 +735,7 @@ fn run_requirement_step(rig: &RigSpec, pipeline_name: &str, step: &PipelineStep)
             rig,
             executable.as_deref(),
             executable_env.as_deref(),
+            executable_env_aliases,
             env,
         ))
         .collect::<Vec<_>>();
@@ -778,32 +781,57 @@ fn requirement_executable_failure(
     rig: &RigSpec,
     executable: Option<&str>,
     executable_env: Option<&str>,
+    executable_env_aliases: &[String],
     env: &HashMap<String, String>,
 ) -> Option<String> {
     let executable = executable?;
     let executable = expand_vars(rig, executable);
-    let override_value = executable_env.and_then(|name| env_value(name, env));
-    let candidate = override_value
-        .as_deref()
-        .filter(|value| !value.trim().is_empty())
-        .map(|value| expand_vars(rig, value))
-        .unwrap_or_else(|| executable.clone());
+    let mut attempts = Vec::new();
 
-    if find_executable(&candidate, env).is_some() {
+    for name in executable_env_names(executable_env, executable_env_aliases) {
+        match env_value(name, env) {
+            Some(value) if !value.trim().is_empty() => {
+                let candidate = expand_vars(rig, &value);
+                if find_executable(&candidate, env).is_some() {
+                    return None;
+                }
+                attempts.push(format!("{}={} (not executable)", name, candidate));
+            }
+            _ => attempts.push(format!("{} is unset or empty", name)),
+        }
+    }
+
+    if find_executable(&executable, env).is_some() {
         return None;
     }
 
-    Some(match (executable_env, override_value) {
-        (Some(name), Some(value)) if !value.trim().is_empty() => format!(
-            "executable `{}` does not exist or is not executable from {}={}",
-            executable, name, value
-        ),
-        (Some(name), _) => format!(
-            "executable `{}` not found on PATH ({} is unset or empty)",
-            executable, name
-        ),
-        _ => format!("executable `{}` not found on PATH", executable),
-    })
+    attempts.push(declared_executable_attempt(&executable));
+
+    Some(format!(
+        "executable `{}` could not be resolved; tried {}",
+        executable,
+        attempts.join(", ")
+    ))
+}
+
+fn executable_env_names<'a>(
+    executable_env: Option<&'a str>,
+    executable_env_aliases: &'a [String],
+) -> Vec<&'a str> {
+    executable_env
+        .into_iter()
+        .chain(executable_env_aliases.iter().map(String::as_str))
+        .filter(|name| !name.trim().is_empty())
+        .collect()
+}
+
+fn declared_executable_attempt(declared: &str) -> String {
+    let path = Path::new(declared);
+    if declared.contains(std::path::MAIN_SEPARATOR) || path.is_absolute() {
+        format!("declared executable `{}`", declared)
+    } else {
+        format!("PATH lookup for `{}`", declared)
+    }
 }
 
 fn env_value(name: &str, env: &HashMap<String, String>) -> Option<String> {

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -196,6 +196,10 @@ pub struct ExecutableRequirementSpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub env: Option<String>,
 
+    /// Additional environment variables to try, in order, before PATH lookup.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env_aliases: Vec<String>,
+
     /// Human-readable label shown in `rig check` output.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
@@ -1496,6 +1500,9 @@ pub enum PipelineStep {
         /// Environment variable whose value overrides `executable` lookup.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         executable_env: Option<String>,
+        /// Additional environment variables to try, in order, before PATH lookup.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        executable_env_aliases: Vec<String>,
         /// Command to run when the filesystem requirement is missing and the
         /// current pipeline name appears in `prepare_phases`.
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -260,7 +260,7 @@ fn test_requirement_validates_component_path_contains() {
 }
 
 #[test]
-fn test_requirement_executable_uses_env_override_before_path() {
+fn test_requirement_executable_falls_back_to_path_when_env_override_missing() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let path_bin_dir = tmp.path().join("path-bin");
     std::fs::create_dir_all(&path_bin_dir).expect("mkdir path bin");
@@ -288,14 +288,44 @@ fn test_requirement_executable_uses_env_override_before_path() {
     .expect("parse rig");
 
     let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
-    assert!(!out.is_success(), "outcomes: {:?}", out.steps);
-    let error = out.steps[0].error.as_deref().unwrap_or_default();
-    assert!(error.contains("DEMO_TOOL_BIN"), "error: {error}");
-    assert!(error.contains("missing-override-tool"), "error: {error}");
+    assert!(out.is_success(), "outcomes: {:?}", out.steps);
 }
 
 #[test]
-fn test_requirement_executable_falls_back_to_path_when_env_override_is_empty() {
+fn test_requirement_executable_uses_ordered_env_aliases_before_path() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let alias_bin = tmp.path().join("alias-tool");
+    write_executable(&alias_bin);
+    let missing_override = tmp.path().join("missing-override-tool");
+
+    let rig: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "requirement-executable-env-aliases",
+            "pipeline": {{
+                "check": [{{
+                    "kind": "requirement",
+                    "executable": "demo-tool",
+                    "executable_env": "DEMO_TOOL_BIN",
+                    "executable_env_aliases": ["DEMO_TOOL_ALIAS_BIN"],
+                    "env": {{
+                        "DEMO_TOOL_BIN": "{}",
+                        "DEMO_TOOL_ALIAS_BIN": "{}",
+                        "PATH": "/nonexistent"
+                    }}
+                }}]
+            }}
+        }}"#,
+        missing_override.to_string_lossy(),
+        alias_bin.to_string_lossy()
+    ))
+    .expect("parse rig");
+
+    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    assert!(out.is_success(), "outcomes: {:?}", out.steps);
+}
+
+#[test]
+fn test_requirement_executable_falls_back_to_path_when_env_override_is_unusable() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let path_bin_dir = tmp.path().join("path-bin");
     std::fs::create_dir_all(&path_bin_dir).expect("mkdir path bin");
@@ -310,7 +340,7 @@ fn test_requirement_executable_falls_back_to_path_when_env_override_is_empty() {
                     "executable": "demo-tool",
                     "executable_env": "DEMO_TOOL_BIN",
                     "env": {{
-                        "DEMO_TOOL_BIN": "",
+                        "DEMO_TOOL_BIN": "/nonexistent/demo-tool",
                         "PATH": "{}"
                     }}
                 }}]
@@ -322,6 +352,45 @@ fn test_requirement_executable_falls_back_to_path_when_env_override_is_empty() {
 
     let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
+}
+
+#[test]
+fn test_requirement_executable_reports_resolution_sources() {
+    let rig: RigSpec = serde_json::from_str(
+        r#"{
+            "id": "requirement-executable-missing-aliases",
+            "pipeline": {
+                "check": [{
+                    "kind": "requirement",
+                    "executable": "missing-homeboy-test-tool",
+                    "executable_env": "PRIMARY_TOOL_BIN",
+                    "executable_env_aliases": ["SECONDARY_TOOL_BIN"],
+                    "env": {
+                        "PATH": "/nonexistent",
+                        "PRIMARY_TOOL_BIN": "/nonexistent/primary-tool",
+                        "SECONDARY_TOOL_BIN": ""
+                    }
+                }]
+            }
+        }"#,
+    )
+    .expect("parse rig");
+
+    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    assert!(!out.is_success());
+    let error = out.steps[0].error.as_deref().unwrap_or_default();
+    assert!(
+        error.contains("PRIMARY_TOOL_BIN=/nonexistent/primary-tool"),
+        "error: {error}"
+    );
+    assert!(
+        error.contains("SECONDARY_TOOL_BIN is unset or empty"),
+        "error: {error}"
+    );
+    assert!(
+        error.contains("PATH lookup for `missing-homeboy-test-tool`"),
+        "error: {error}"
+    );
 }
 
 #[test]

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -251,6 +251,7 @@ fn test_spec_requirements_parse_generic_executables_and_filesystem_assertions() 
                 {
                     "executable": "node",
                     "env": "NODE_BIN",
+                    "env_aliases": ["ASDF_NODE_BIN", "VOLTA_NODE_BIN"],
                     "remediation": "install Node.js"
                 }
             ],
@@ -273,6 +274,10 @@ fn test_spec_requirements_parse_generic_executables_and_filesystem_assertions() 
     assert_eq!(
         spec.requirements.executables[0].env.as_deref(),
         Some("NODE_BIN")
+    );
+    assert_eq!(
+        spec.requirements.executables[0].env_aliases,
+        vec!["ASDF_NODE_BIN", "VOLTA_NODE_BIN"]
     );
     assert_eq!(
         spec.requirements.filesystem_assertions[0].kind,


### PR DESCRIPTION
## Summary
- Add ordered env alias resolution for rig executable requirements while preserving existing env/executable_env fields as the first lookup source.
- Fall back to declared executable/PATH lookup after env candidates instead of requiring shell preflight shims.
- Report each attempted env/PATH source in requirement failures and cover declarative plus pipeline requirement paths.

## Tests
- cargo fmt --check
- cargo test core::rig::capabilities
- cargo test test_requirement_executable
- cargo test test_spec_requirements_parse_generic_executables_and_filesystem_assertions
- cargo check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing executable requirement env alias support and tests