### PR TITLE
Make source snapshot policy configurable

### DIFF
--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -164,6 +164,17 @@ fn lab_workspace_sync_mode(
     args: &[String],
     source_path: &Path,
 ) -> Result<RunnerWorkspaceSyncMode> {
+    let source_policy =
+        super::super::source_materialization::SourceMaterializationPolicy::from_env();
+    lab_workspace_sync_mode_with_source_policy(policy, args, source_path, &source_policy)
+}
+
+fn lab_workspace_sync_mode_with_source_policy(
+    policy: LabOffloadWorkspaceModePolicy,
+    args: &[String],
+    source_path: &Path,
+    source_policy: &super::super::source_materialization::SourceMaterializationPolicy,
+) -> Result<RunnerWorkspaceSyncMode> {
     let requested = requested_lab_workspace_sync_mode(policy, args);
     if requested != RunnerWorkspaceSyncMode::Git {
         return Ok(requested);
@@ -177,8 +188,10 @@ fn lab_workspace_sync_mode(
         source_path,
         &["config", "--get", "remote.origin.url"],
     )?;
-    if super::super::source_materialization::requires_controller_routed_workspace_sync(&remote_url)
-    {
+    if super::super::source_materialization::requires_controller_routed_workspace_sync_with_policy(
+        &remote_url,
+        source_policy,
+    ) {
         return Ok(RunnerWorkspaceSyncMode::Snapshot);
     }
 
@@ -2314,6 +2327,10 @@ mod tests {
 
     #[test]
     fn lab_git_workspace_sync_uses_snapshot_for_private_proxied_sources() {
+        let source_policy =
+            crate::core::runner::source_materialization::SourceMaterializationPolicy {
+                private_proxied_source_hosts: vec!["github.a8c.com".to_string()],
+            };
         let dir = tempfile::tempdir().expect("temp dir");
         std::process::Command::new("git")
             .args(["init"])
@@ -2336,8 +2353,13 @@ mod tests {
             "agent-task".to_string(),
             "cook".to_string(),
         ];
-        let mode = lab_workspace_sync_mode(LabOffloadWorkspaceModePolicy::Git, &args, dir.path())
-            .expect("sync mode");
+        let mode = lab_workspace_sync_mode_with_source_policy(
+            LabOffloadWorkspaceModePolicy::Git,
+            &args,
+            dir.path(),
+            &source_policy,
+        )
+        .expect("sync mode");
 
         assert_eq!(mode, RunnerWorkspaceSyncMode::Snapshot);
     }

--- a/src/core/runner/source_materialization.rs
+++ b/src/core/runner/source_materialization.rs
@@ -1,10 +1,34 @@
 use crate::core::error::{Error, Result};
 
 const PRIVATE_PROXIED_SOURCE_HOSTS_ENV: &str = "HOMEBOY_PRIVATE_PROXIED_SOURCE_HOSTS";
-const DEFAULT_PRIVATE_PROXIED_SOURCE_HOSTS: &[&str] = &["github.a8c.com"];
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct SourceMaterializationPolicy {
+    pub private_proxied_source_hosts: Vec<String>,
+}
+
+impl SourceMaterializationPolicy {
+    pub(super) fn from_env() -> Self {
+        Self {
+            private_proxied_source_hosts: split_env_list(PRIVATE_PROXIED_SOURCE_HOSTS_ENV)
+                .into_iter()
+                .map(|host| host.to_ascii_lowercase())
+                .collect(),
+        }
+    }
+}
 
 pub(super) fn validate_runner_git_materialization(remote_url: &str, runner_id: &str) -> Result<()> {
-    if let Some(host) = private_proxied_source_host(remote_url) {
+    let policy = SourceMaterializationPolicy::from_env();
+    validate_runner_git_materialization_with_policy(remote_url, runner_id, &policy)
+}
+
+fn validate_runner_git_materialization_with_policy(
+    remote_url: &str,
+    runner_id: &str,
+    policy: &SourceMaterializationPolicy,
+) -> Result<()> {
+    if let Some(host) = private_proxied_source_host(remote_url, policy) {
         return Err(private_proxied_source_error(
             "mode",
             &host,
@@ -17,17 +41,34 @@ pub(super) fn validate_runner_git_materialization(remote_url: &str, runner_id: &
 }
 
 pub(super) fn requires_controller_routed_workspace_sync(remote_url: &str) -> bool {
-    private_proxied_source_host(remote_url).is_some()
+    let policy = SourceMaterializationPolicy::from_env();
+    requires_controller_routed_workspace_sync_with_policy(remote_url, &policy)
+}
+
+pub(super) fn requires_controller_routed_workspace_sync_with_policy(
+    remote_url: &str,
+    policy: &SourceMaterializationPolicy,
+) -> bool {
+    private_proxied_source_host(remote_url, policy).is_some()
 }
 
 pub(super) fn validate_runner_exec_source_fetch(command: &[String], runner_id: &str) -> Result<()> {
+    let policy = SourceMaterializationPolicy::from_env();
+    validate_runner_exec_source_fetch_with_policy(command, runner_id, &policy)
+}
+
+fn validate_runner_exec_source_fetch_with_policy(
+    command: &[String],
+    runner_id: &str,
+    policy: &SourceMaterializationPolicy,
+) -> Result<()> {
     if !looks_like_git_fetch_command(command) {
         return Ok(());
     }
 
     if let Some(host) = command
         .iter()
-        .find_map(|arg| private_proxied_source_host(arg))
+        .find_map(|arg| private_proxied_source_host(arg, policy))
     {
         return Err(private_proxied_source_error(
             "command",
@@ -67,21 +108,29 @@ fn looks_like_git_fetch_command(command: &[String]) -> bool {
         || lower.contains("git ls-remote")
 }
 
-fn private_proxied_source_host(value: &str) -> Option<String> {
+fn private_proxied_source_host(
+    value: &str,
+    policy: &SourceMaterializationPolicy,
+) -> Option<String> {
     let value = value.trim();
-    private_proxied_source_hosts()
-        .into_iter()
+    policy
+        .private_proxied_source_hosts
+        .iter()
         .find(|host| remote_matches_host(value, host))
+        .cloned()
 }
 
-fn private_proxied_source_hosts() -> Vec<String> {
-    let raw = std::env::var(PRIVATE_PROXIED_SOURCE_HOSTS_ENV)
-        .unwrap_or_else(|_| DEFAULT_PRIVATE_PROXIED_SOURCE_HOSTS.to_vec().join(","));
-
-    raw.split(',')
-        .map(str::trim)
-        .filter(|host| !host.is_empty())
-        .map(|host| host.to_ascii_lowercase())
+fn split_env_list(name: &str) -> Vec<String> {
+    std::env::var(name)
+        .ok()
+        .into_iter()
+        .flat_map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
         .collect()
 }
 
@@ -101,26 +150,44 @@ mod tests {
     use super::*;
 
     #[test]
-    fn detects_default_private_proxied_source_hosts() {
+    fn defaults_are_product_neutral() {
+        let policy = SourceMaterializationPolicy::default();
+
         assert_eq!(
-            private_proxied_source_host("git@github.a8c.com:Automattic/example.git"),
+            private_proxied_source_host("git@github.a8c.com:Automattic/example.git", &policy),
+            None
+        );
+    }
+
+    #[test]
+    fn detects_configured_private_proxied_source_hosts() {
+        let policy = SourceMaterializationPolicy {
+            private_proxied_source_hosts: vec!["github.a8c.com".to_string()],
+        };
+
+        assert_eq!(
+            private_proxied_source_host("git@github.a8c.com:Automattic/example.git", &policy),
             Some("github.a8c.com".to_string())
         );
         assert_eq!(
-            private_proxied_source_host("https://github.a8c.com/Automattic/example.git"),
+            private_proxied_source_host("https://github.a8c.com/Automattic/example.git", &policy),
             Some("github.a8c.com".to_string())
         );
         assert_eq!(
-            private_proxied_source_host("https://github.com/Extra-Chill/homeboy.git"),
+            private_proxied_source_host("https://github.com/Extra-Chill/homeboy.git", &policy),
             None
         );
     }
 
     #[test]
     fn rejects_runner_side_private_proxied_git_materialization() {
-        let err = validate_runner_git_materialization(
+        let policy = SourceMaterializationPolicy {
+            private_proxied_source_hosts: vec!["github.a8c.com".to_string()],
+        };
+        let err = validate_runner_git_materialization_with_policy(
             "git@github.a8c.com:Automattic/example.git",
             "homeboy-lab",
+            &policy,
         )
         .expect_err("private/proxied runner-side git materialization should fail");
 
@@ -131,23 +198,32 @@ mod tests {
 
     #[test]
     fn identifies_sources_that_need_controller_routed_workspace_sync() {
-        assert!(requires_controller_routed_workspace_sync(
-            "git@github.a8c.com:Automattic/example.git"
+        let policy = SourceMaterializationPolicy {
+            private_proxied_source_hosts: vec!["github.a8c.com".to_string()],
+        };
+        assert!(requires_controller_routed_workspace_sync_with_policy(
+            "git@github.a8c.com:Automattic/example.git",
+            &policy
         ));
-        assert!(!requires_controller_routed_workspace_sync(
-            "https://github.com/Extra-Chill/homeboy.git"
+        assert!(!requires_controller_routed_workspace_sync_with_policy(
+            "https://github.com/Extra-Chill/homeboy.git",
+            &policy
         ));
     }
 
     #[test]
     fn rejects_runner_exec_private_proxied_git_fetches() {
-        let err = validate_runner_exec_source_fetch(
+        let policy = SourceMaterializationPolicy {
+            private_proxied_source_hosts: vec!["github.a8c.com".to_string()],
+        };
+        let err = validate_runner_exec_source_fetch_with_policy(
             &[
                 "sh".to_string(),
                 "-c".to_string(),
                 "git clone git@github.a8c.com:Automattic/example.git".to_string(),
             ],
             "homeboy-lab",
+            &policy,
         )
         .expect_err("private/proxied runner-side git clone should fail");
 

--- a/src/core/source_snapshot.rs
+++ b/src/core/source_snapshot.rs
@@ -6,6 +6,8 @@ use sha2::{Digest, Sha256};
 
 use crate::core::git;
 
+const SOURCE_SYNC_EXCLUDES_ENV: &str = "HOMEBOY_SOURCE_SYNC_EXCLUDES";
+
 const DEFAULT_SYNC_EXCLUDES: &[&str] = &[
     ".git/",
     "node_modules/",
@@ -14,13 +16,45 @@ const DEFAULT_SYNC_EXCLUDES: &[&str] = &[
     ".homeboy-build/",
     ".homeboy-bin/",
     ".homeboy/",
-    ".datamachine/",
     ".DS_Store",
     "._*",
     "**/._*",
     ".env",
     ".env.*",
 ];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceSnapshotPolicy {
+    pub sync_excludes: Vec<String>,
+}
+
+impl SourceSnapshotPolicy {
+    pub fn from_env() -> Self {
+        let mut policy = Self::default();
+        policy
+            .sync_excludes
+            .extend(split_env_list(SOURCE_SYNC_EXCLUDES_ENV));
+        policy
+    }
+
+    pub fn with_sync_excludes<I, S>(mut self, excludes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.sync_excludes
+            .extend(excludes.into_iter().map(Into::into));
+        self
+    }
+}
+
+impl Default for SourceSnapshotPolicy {
+    fn default() -> Self {
+        Self {
+            sync_excludes: default_sync_excludes(),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SourceSnapshot {
@@ -49,6 +83,17 @@ impl SourceSnapshot {
         remote_path: Option<&str>,
         sync_mode: &str,
     ) -> Self {
+        let policy = SourceSnapshotPolicy::from_env();
+        Self::collect_local_with_policy(runner_id, path, remote_path, sync_mode, &policy)
+    }
+
+    pub fn collect_local_with_policy(
+        runner_id: &str,
+        path: &Path,
+        remote_path: Option<&str>,
+        sync_mode: &str,
+        policy: &SourceSnapshotPolicy,
+    ) -> Self {
         let local_path = path.display().to_string();
         let git_root = git::toplevel(path);
         let git_branch = git::current_branch(path)
@@ -74,7 +119,7 @@ impl SourceSnapshot {
             sync_mode: sync_mode.to_string(),
             snapshot_hash,
             synced_at: chrono::Utc::now().to_rfc3339(),
-            sync_excludes: default_sync_excludes(),
+            sync_excludes: policy.sync_excludes.clone(),
         }
     }
 
@@ -82,6 +127,16 @@ impl SourceSnapshot {
         runner_id: &str,
         remote_path: &str,
         workspace_root: Option<&str>,
+    ) -> Self {
+        let policy = SourceSnapshotPolicy::from_env();
+        Self::existing_remote_with_policy(runner_id, remote_path, workspace_root, &policy)
+    }
+
+    pub fn existing_remote_with_policy(
+        runner_id: &str,
+        remote_path: &str,
+        workspace_root: Option<&str>,
+        policy: &SourceSnapshotPolicy,
     ) -> Self {
         let mut hasher = Sha256::new();
         hasher.update(b"existing_remote\0");
@@ -104,7 +159,7 @@ impl SourceSnapshot {
             sync_mode: "existing_remote".to_string(),
             snapshot_hash: format!("sha256:{:x}", hasher.finalize()),
             synced_at: chrono::Utc::now().to_rfc3339(),
-            sync_excludes: default_sync_excludes(),
+            sync_excludes: policy.sync_excludes.clone(),
         }
     }
 }
@@ -113,6 +168,20 @@ pub fn default_sync_excludes() -> Vec<String> {
     DEFAULT_SYNC_EXCLUDES
         .iter()
         .map(|value| value.to_string())
+        .collect()
+}
+
+fn split_env_list(name: &str) -> Vec<String> {
+    std::env::var(name)
+        .ok()
+        .into_iter()
+        .flat_map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
         .collect()
 }
 
@@ -179,6 +248,23 @@ mod tests {
         assert!(excludes.contains(&"node_modules/".to_string()));
         assert!(excludes.contains(&".homeboy-build/".to_string()));
         assert!(excludes.contains(&".env".to_string()));
+        assert!(!excludes.contains(&".datamachine/".to_string()));
+    }
+
+    #[test]
+    fn source_snapshot_policy_allows_product_specific_excludes() {
+        let policy = SourceSnapshotPolicy::default().with_sync_excludes([".datamachine/"]);
+        let snapshot = SourceSnapshot::existing_remote_with_policy(
+            "lab",
+            "/srv/homeboy/repo",
+            Some("/srv/homeboy"),
+            &policy,
+        );
+
+        assert!(snapshot.sync_excludes.contains(&".git/".to_string()));
+        assert!(snapshot
+            .sync_excludes
+            .contains(&".datamachine/".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add explicit source snapshot policy primitives with neutral core defaults.
- Remove .datamachine/ from generic source snapshot excludes and keep product-specific excludes configurable.
- Add source materialization policy primitives so private/proxied Git hosts are configured instead of hard-coded in generic core.

## Tests
- cargo fmt
- cargo check
- cargo test source_snapshot
- cargo test source_materialization
- cargo test lab_git_workspace_sync_uses_snapshot_for_private_proxied_sources

## Notes
- Full cargo test was attempted, but timed out after 5 minutes while unrelated release tests were failing: core::release::planning_changelog::tests::test_generate_changelog_entries, core::release::executor::tests::tag_availability_preflight_refuses_existing_release_tags_before_mutation, core::release::executor::tests::git_tag_step_refuses_invalid_release_tags, core::release::executor::publish::tests::run_publish_passes_github_host_config_to_action_payload.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing generic source/snapshot policy cleanup and tests