### PR TITLE
Add WordPress runtime orchestration plan

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -16,6 +16,7 @@ pub mod controller;
 pub mod review;
 pub mod run;
 pub mod status;
+pub mod wordpress_runtime;
 
 pub use args::{
     AgentTaskArgs, AgentTaskAuthArgs, AgentTaskAuthCommand, AgentTaskCommand,
@@ -25,6 +26,7 @@ pub use args::{
     AgentTaskControllerRunNextArgs, AgentTaskControllerStatusArgs, AgentTaskLoopArgs, CancelArgs,
     ContractArgs, ContractFormat, FinalizePrArgs, GateFeedbackArgs, PromoteArgs, ProvidersArgs,
     RetryArgs, ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
+    WordPressRuntimeArgs,
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 
@@ -38,6 +40,9 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
             super::agent_task_dispatch::run(dispatch_args, global)
         }
         AgentTaskCommand::RunPlan(run_args) => run::run_plan(run_args),
+        AgentTaskCommand::WordPressRuntime(runtime_args) => {
+            wordpress_runtime::wordpress_runtime(runtime_args)
+        }
         AgentTaskCommand::Run(status_args) => run::run_submitted(status_args),
         AgentTaskCommand::RunNext => run::run_next(),
         AgentTaskCommand::Submit(submit_args) => run::submit(submit_args),

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -41,6 +41,9 @@ pub enum AgentTaskCommand {
     Dispatch(DispatchArgs),
     /// Run an agent-task plan through extension-declared executor providers.
     RunPlan(RunPlanArgs),
+    /// Build, submit, or run a durable WordPress/Codebox runtime-task plan.
+    #[command(name = "wordpress-runtime")]
+    WordPressRuntime(WordPressRuntimeArgs),
     /// Execute a previously submitted durable agent-task run.
     Run(StatusArgs),
     /// Claim and execute the oldest queued durable agent-task run.
@@ -215,6 +218,97 @@ pub struct RunPlanArgs {
     /// Also persist the completed run lifecycle record under this id.
     #[arg(long, value_name = "ID")]
     pub record_run_id: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct WordPressRuntimeArgs {
+    /// Full WordPressRuntimePlanRequest JSON object, @file, or - for stdin.
+    #[arg(long = "spec", value_name = "JSON|@FILE|-")]
+    pub spec: Option<String>,
+
+    /// Runtime task JSON object to schedule. Repeatable for fanout.
+    #[arg(long = "runtime-task", value_name = "JSON|@FILE")]
+    pub runtime_task: Vec<String>,
+
+    /// Ability shorthand. Builds a runtime task like {"ability":"...","input":...}.
+    #[arg(long = "ability", value_name = "SLUG")]
+    pub ability: Option<String>,
+
+    /// JSON input object for --ability. Defaults to {}.
+    #[arg(long = "ability-input", value_name = "JSON|@FILE")]
+    pub ability_input: Option<String>,
+
+    /// Data Liberation Agent URL extraction shorthand. Repeatable for fanout.
+    #[arg(long = "dla-url", value_name = "URL")]
+    pub dla_url: Vec<String>,
+
+    /// Stable plan id. Generated when omitted.
+    #[arg(long = "plan-id", value_name = "ID")]
+    pub plan_id: Option<String>,
+
+    /// Group key shared by the scheduled tasks.
+    #[arg(long = "group-key", value_name = "KEY")]
+    pub group_key: Option<String>,
+
+    /// Durable run id used by --submit or --run --record.
+    #[arg(long = "run-id", value_name = "ID")]
+    pub run_id: Option<String>,
+
+    /// Executor backend. Defaults to codebox.
+    #[arg(long = "backend", default_value = "codebox", value_name = "BACKEND")]
+    pub backend: String,
+
+    /// Executor provider selector.
+    #[arg(long = "selector", value_name = "ID")]
+    pub selector: Option<String>,
+
+    /// Runtime package id. Defaults to wp-codebox.
+    #[arg(long = "runtime-id", default_value = "wp-codebox", value_name = "ID")]
+    pub runtime_id: String,
+
+    /// Provider id passed to the runtime selection.
+    #[arg(long = "provider", value_name = "ID")]
+    pub provider: Option<String>,
+
+    /// Model id passed to the runtime selection.
+    #[arg(long = "model", value_name = "ID")]
+    pub model: Option<String>,
+
+    /// Runtime substrate ref, such as a Codebox ref, selected by the executor provider.
+    #[arg(long = "substrate-ref", value_name = "REF")]
+    pub substrate_ref: Option<String>,
+
+    /// Required executor capability. Repeatable.
+    #[arg(long = "capability", value_name = "CAPABILITY")]
+    pub capability: Vec<String>,
+
+    /// Secret environment variable to expose through provider auth resolution. Repeatable.
+    #[arg(long = "secret-env", value_name = "ENV")]
+    pub secret_env: Vec<String>,
+
+    /// Expected artifact name. Repeatable.
+    #[arg(long = "expected-artifact", value_name = "NAME")]
+    pub expected_artifact: Vec<String>,
+
+    /// Max concurrent runtime tasks for fanout.
+    #[arg(long = "max-concurrency", default_value_t = 1, value_name = "N")]
+    pub max_concurrency: usize,
+
+    /// Per-task timeout in milliseconds.
+    #[arg(long = "timeout-ms", value_name = "MS")]
+    pub timeout_ms: Option<u64>,
+
+    /// Persist the plan as a queued durable run without executing.
+    #[arg(long = "submit")]
+    pub submit: bool,
+
+    /// Execute the plan immediately through the selected executor provider.
+    #[arg(long = "run")]
+    pub run: bool,
+
+    /// Persist --run lifecycle evidence under --run-id. Ignored without --run.
+    #[arg(long = "record")]
+    pub record: bool,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/agent_task/wordpress_runtime.rs
+++ b/src/commands/agent_task/wordpress_runtime.rs
@@ -1,0 +1,289 @@
+use std::io::Read;
+
+use serde_json::{json, Value};
+
+use homeboy::core::agent_tasks::lifecycle as agent_task_lifecycle;
+use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
+use homeboy::core::agent_tasks::scheduler::AgentTaskScheduleOptions;
+use homeboy::core::agent_tasks::{
+    build_wordpress_runtime_plan, dla_extraction_task, AgentTaskLimits,
+    WordPressRuntimeExecutorSpec, WordPressRuntimePlanRequest, WordPressRuntimeTaskSpec,
+    WORDPRESS_RUNTIME_PLAN_REQUEST_SCHEMA,
+};
+
+use super::args::WordPressRuntimeArgs;
+use super::run::run_loaded_plan;
+use crate::commands::CmdResult;
+
+pub(super) fn wordpress_runtime(args: WordPressRuntimeArgs) -> CmdResult<Value> {
+    if args.submit && args.run {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "submit",
+            "use either --submit or --run, not both",
+            None,
+            None,
+        ));
+    }
+
+    let plan_request = plan_request_from_args(&args)?;
+    let plan = build_wordpress_runtime_plan(plan_request);
+
+    if args.submit {
+        let record = agent_task_lifecycle::submit_plan(&plan, args.run_id.as_deref())?;
+        return Ok((serde_json::to_value(record).unwrap_or(Value::Null), 0));
+    }
+
+    if args.run {
+        let record_run_id = args.record.then_some(args.run_id.as_deref()).flatten();
+        return run_loaded_plan(
+            plan,
+            record_run_id,
+            ExtensionProviderAgentTaskExecutor::discover(),
+        );
+    }
+
+    Ok((serde_json::to_value(plan).unwrap_or(Value::Null), 0))
+}
+
+fn plan_request_from_args(
+    args: &WordPressRuntimeArgs,
+) -> homeboy::core::Result<WordPressRuntimePlanRequest> {
+    if let Some(spec) = &args.spec {
+        let mut request: WordPressRuntimePlanRequest =
+            serde_json::from_value(read_json_value(spec)?).map_err(|error| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "spec",
+                    format!("invalid WordPressRuntimePlanRequest JSON: {error}"),
+                    None,
+                    None,
+                )
+            })?;
+        apply_cli_overrides(args, &mut request);
+        return Ok(request);
+    }
+
+    let mut tasks: Vec<WordPressRuntimeTaskSpec> = Vec::new();
+    for runtime_task in &args.runtime_task {
+        tasks.push(task_from_runtime_value(
+            read_json_value(runtime_task)?,
+            args,
+        ));
+    }
+    if let Some(ability) = &args.ability {
+        let input = args
+            .ability_input
+            .as_ref()
+            .map(|value| read_json_value(value))
+            .transpose()?
+            .unwrap_or_else(|| json!({}));
+        tasks.push(task_from_runtime_value(
+            json!({
+                "ability": ability,
+                "input": input,
+            }),
+            args,
+        ));
+    }
+    for url in &args.dla_url {
+        let mut task = dla_extraction_task(url.clone());
+        merge_executor_overrides(args, &mut task.executor);
+        apply_task_overrides(args, &mut task);
+        tasks.push(task);
+    }
+
+    if tasks.is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "runtime-task",
+            "provide --spec, --runtime-task, --ability, or --dla-url",
+            None,
+            None,
+        ));
+    }
+
+    Ok(WordPressRuntimePlanRequest {
+        schema: WORDPRESS_RUNTIME_PLAN_REQUEST_SCHEMA.to_string(),
+        plan_id: args.plan_id.clone(),
+        group_key: args.group_key.clone(),
+        tasks,
+        options: AgentTaskScheduleOptions {
+            max_concurrency: args.max_concurrency.max(1),
+            ..AgentTaskScheduleOptions::default()
+        },
+        component_contracts: Vec::new(),
+        metadata: Value::Null,
+    })
+}
+
+fn task_from_runtime_value(
+    runtime_task: Value,
+    args: &WordPressRuntimeArgs,
+) -> WordPressRuntimeTaskSpec {
+    let mut task = WordPressRuntimeTaskSpec {
+        task_id: None,
+        kind: Some("runtime_task".to_string()),
+        instructions: None,
+        runtime_task,
+        executor: WordPressRuntimeExecutorSpec::default(),
+        source_refs: Vec::new(),
+        component_contracts: Vec::new(),
+        policy: Default::default(),
+        limits: AgentTaskLimits::default(),
+        expected_artifacts: Vec::new(),
+        artifact_declarations: Vec::new(),
+        metadata: Value::Null,
+    };
+    merge_executor_overrides(args, &mut task.executor);
+    apply_task_overrides(args, &mut task);
+    task
+}
+
+fn apply_cli_overrides(args: &WordPressRuntimeArgs, request: &mut WordPressRuntimePlanRequest) {
+    if args.plan_id.is_some() {
+        request.plan_id = args.plan_id.clone();
+    }
+    if args.group_key.is_some() {
+        request.group_key = args.group_key.clone();
+    }
+    if args.max_concurrency != 1 {
+        request.options.max_concurrency = args.max_concurrency;
+    }
+    for task in &mut request.tasks {
+        merge_executor_overrides(args, &mut task.executor);
+        apply_task_overrides(args, task);
+    }
+}
+
+fn apply_task_overrides(args: &WordPressRuntimeArgs, task: &mut WordPressRuntimeTaskSpec) {
+    if let Some(timeout_ms) = args.timeout_ms {
+        task.limits.timeout_ms = Some(timeout_ms);
+    }
+    for artifact in &args.expected_artifact {
+        if !task
+            .expected_artifacts
+            .iter()
+            .any(|existing| existing == artifact)
+        {
+            task.expected_artifacts.push(artifact.clone());
+        }
+    }
+}
+
+fn merge_executor_overrides(
+    args: &WordPressRuntimeArgs,
+    executor: &mut WordPressRuntimeExecutorSpec,
+) {
+    executor.backend = args.backend.clone();
+    executor.selector = args.selector.clone().or_else(|| executor.selector.clone());
+    executor.runtime_id = Some(args.runtime_id.clone());
+    executor.provider = args.provider.clone().or_else(|| executor.provider.clone());
+    executor.model = args.model.clone().or_else(|| executor.model.clone());
+    executor.substrate_ref = args
+        .substrate_ref
+        .clone()
+        .or_else(|| executor.substrate_ref.clone());
+    for capability in &args.capability {
+        if !executor
+            .required_capabilities
+            .iter()
+            .any(|existing| existing == capability)
+        {
+            executor.required_capabilities.push(capability.clone());
+        }
+    }
+    for secret_env in &args.secret_env {
+        if !executor
+            .secret_env
+            .iter()
+            .any(|existing| existing == secret_env)
+        {
+            executor.secret_env.push(secret_env.clone());
+        }
+    }
+}
+
+fn read_json_value(input: &str) -> homeboy::core::Result<Value> {
+    let raw = if input == "-" {
+        let mut buffer = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buffer)
+            .map_err(|error| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "json",
+                    format!("failed to read stdin: {error}"),
+                    None,
+                    None,
+                )
+            })?;
+        buffer
+    } else if let Some(path) = input.strip_prefix('@') {
+        std::fs::read_to_string(path).map_err(|error| {
+            homeboy::core::Error::validation_invalid_argument(
+                "json",
+                format!("failed to read {path}: {error}"),
+                None,
+                None,
+            )
+        })?
+    } else {
+        input.to_string()
+    };
+
+    serde_json::from_str(&raw).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "json",
+            format!("invalid JSON: {error}"),
+            None,
+            None,
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_build_dla_plan_without_local_execution() {
+        let args = WordPressRuntimeArgs {
+            spec: None,
+            runtime_task: Vec::new(),
+            ability: None,
+            ability_input: None,
+            dla_url: vec!["https://example.com".to_string()],
+            plan_id: Some("dla-run".to_string()),
+            group_key: None,
+            run_id: None,
+            backend: "codebox".to_string(),
+            selector: Some("lab-codebox".to_string()),
+            runtime_id: "wp-codebox".to_string(),
+            provider: None,
+            model: None,
+            substrate_ref: Some("main".to_string()),
+            capability: Vec::new(),
+            secret_env: Vec::new(),
+            expected_artifact: vec!["import-manifest".to_string()],
+            max_concurrency: 1,
+            timeout_ms: Some(120_000),
+            submit: false,
+            run: false,
+            record: false,
+        };
+
+        let request = plan_request_from_args(&args).expect("request");
+        let plan = build_wordpress_runtime_plan(request);
+        let task = &plan.tasks[0];
+
+        assert_eq!(task.executor.backend, "codebox");
+        assert_eq!(task.executor.executor_provider_id(), Some("lab-codebox"));
+        assert_eq!(task.executor.substrate_ref(), Some("main"));
+        assert_eq!(
+            task.inputs["runtime_task"]["source"]["url"],
+            "https://example.com"
+        );
+        assert_eq!(task.limits.timeout_ms, Some(120_000));
+        assert!(task
+            .artifact_declarations
+            .iter()
+            .any(|artifact| artifact.name == "import-manifest"));
+    }
+}

--- a/src/core/agent_task_wordpress_runtime.rs
+++ b/src/core/agent_task_wordpress_runtime.rs
@@ -1,0 +1,350 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+
+use crate::core::agent_task::{
+    AgentTaskArtifactDeclaration, AgentTaskComponentContract, AgentTaskExecutor, AgentTaskLimits,
+    AgentTaskPolicy, AgentTaskRequest, AgentTaskRuntimeSelection, AgentTaskSourceRef,
+    AgentTaskWorkspace, AgentTaskWorkspaceMode,
+};
+use crate::core::agent_task_schedule::{AgentTaskPlan, AgentTaskScheduleOptions};
+
+pub const WORDPRESS_RUNTIME_PLAN_REQUEST_SCHEMA: &str = "homeboy/wordpress-runtime-plan-request/v1";
+pub const WORDPRESS_RUNTIME_TASK_SCHEMA: &str = "homeboy/wordpress-runtime-task/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WordPressRuntimePlanRequest {
+    #[serde(default = "default_plan_request_schema")]
+    pub schema: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group_key: Option<String>,
+    pub tasks: Vec<WordPressRuntimeTaskSpec>,
+    #[serde(default)]
+    pub options: AgentTaskScheduleOptions,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub component_contracts: Vec<AgentTaskComponentContract>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WordPressRuntimeTaskSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+    pub runtime_task: Value,
+    #[serde(default)]
+    pub executor: WordPressRuntimeExecutorSpec,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_refs: Vec<AgentTaskSourceRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub component_contracts: Vec<AgentTaskComponentContract>,
+    #[serde(default)]
+    pub policy: AgentTaskPolicy,
+    #[serde(default)]
+    pub limits: AgentTaskLimits,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expected_artifacts: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_declarations: Vec<AgentTaskArtifactDeclaration>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WordPressRuntimeExecutorSpec {
+    #[serde(default = "default_executor_backend")]
+    pub backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub substrate_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_capabilities: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secret_env: Vec<String>,
+}
+
+impl Default for WordPressRuntimeExecutorSpec {
+    fn default() -> Self {
+        Self {
+            backend: default_executor_backend(),
+            selector: None,
+            runtime_id: Some(default_runtime_id()),
+            provider: None,
+            model: None,
+            substrate_ref: None,
+            required_capabilities: Vec::new(),
+            secret_env: Vec::new(),
+        }
+    }
+}
+
+pub fn build_wordpress_runtime_plan(mut request: WordPressRuntimePlanRequest) -> AgentTaskPlan {
+    let plan_id = request
+        .plan_id
+        .clone()
+        .unwrap_or_else(|| format!("wordpress-runtime-{}", uuid::Uuid::new_v4()));
+    let tasks = request
+        .tasks
+        .drain(..)
+        .enumerate()
+        .map(|(index, task)| task.into_agent_task_request(&plan_id, index))
+        .collect();
+    let mut plan = AgentTaskPlan::new(plan_id, tasks);
+    plan.group_key = request.group_key;
+    plan.options = request.options;
+    plan.component_contracts = request.component_contracts;
+    plan.metadata = metadata_with_schema(request.metadata, WORDPRESS_RUNTIME_PLAN_REQUEST_SCHEMA);
+    plan.rebuild_homeboy_plan();
+    plan
+}
+
+pub fn dla_extraction_task(url: impl Into<String>) -> WordPressRuntimeTaskSpec {
+    let url = url.into();
+    WordPressRuntimeTaskSpec {
+        task_id: None,
+        kind: Some("dla_extraction".to_string()),
+        instructions: Some("Run the declared WordPress runtime task and return normalized artifacts, diagnostics, metrics, logs, and status evidence.".to_string()),
+        runtime_task: json!({
+            "schema": "datamachine/runtime-task-request/v1",
+            "operation": "extract",
+            "engine": {
+                "id": "data-liberation-agent"
+            },
+            "source": {
+                "url": url
+            }
+        }),
+        executor: WordPressRuntimeExecutorSpec {
+            required_capabilities: vec![
+                "wordpress.runtime".to_string(),
+                "wordpress.abilities".to_string(),
+                "data-liberation-agent".to_string(),
+            ],
+            ..WordPressRuntimeExecutorSpec::default()
+        },
+        source_refs: vec![AgentTaskSourceRef {
+            kind: "url".to_string(),
+            uri: url,
+            revision: None,
+        }],
+        component_contracts: Vec::new(),
+        policy: AgentTaskPolicy::default(),
+        limits: AgentTaskLimits::default(),
+        expected_artifacts: vec!["runtime-task-result".to_string(), "artifact-bundle".to_string()],
+        artifact_declarations: Vec::new(),
+        metadata: Value::Null,
+    }
+}
+
+impl WordPressRuntimeTaskSpec {
+    fn into_agent_task_request(self, plan_id: &str, index: usize) -> AgentTaskRequest {
+        let task_id = self
+            .task_id
+            .clone()
+            .unwrap_or_else(|| format!("{plan_id}-task-{}", index + 1));
+        let kind = self
+            .kind
+            .clone()
+            .unwrap_or_else(|| "runtime_task".to_string());
+        let runtime_task = metadata_with_schema(self.runtime_task, WORDPRESS_RUNTIME_TASK_SCHEMA);
+        let instructions = self.instructions.unwrap_or_else(|| {
+            "Run the declared WordPress runtime task and return normalized artifacts, diagnostics, metrics, logs, and status evidence.".to_string()
+        });
+        let executor = self.executor.into_agent_task_executor(&runtime_task);
+        let mut request = AgentTaskRequest {
+            schema: crate::core::agent_task::AGENT_TASK_REQUEST_SCHEMA.to_string(),
+            task_id,
+            group_key: None,
+            parent_plan_id: Some(plan_id.to_string()),
+            executor,
+            instructions,
+            inputs: json!({
+                "schema": WORDPRESS_RUNTIME_TASK_SCHEMA,
+                "kind": kind,
+                "runtime_task": runtime_task,
+            }),
+            source_refs: self.source_refs,
+            workspace: AgentTaskWorkspace {
+                kind: Some("wordpress-runtime".to_string()),
+                mode: AgentTaskWorkspaceMode::Ephemeral,
+                ..AgentTaskWorkspace::default()
+            },
+            component_contracts: self.component_contracts,
+            policy: self.policy,
+            limits: self.limits,
+            expected_artifacts: self.expected_artifacts,
+            artifact_declarations: self.artifact_declarations,
+            metadata: metadata_with_schema(self.metadata, WORDPRESS_RUNTIME_TASK_SCHEMA),
+        };
+        request.normalize_artifact_declarations();
+        request
+    }
+}
+
+impl WordPressRuntimeExecutorSpec {
+    fn into_agent_task_executor(self, runtime_task: &Value) -> AgentTaskExecutor {
+        let mut required_capabilities = vec!["wordpress.runtime".to_string()];
+        if runtime_task.get("ability").is_some() || runtime_task.get("operation").is_some() {
+            push_unique(&mut required_capabilities, "wordpress.abilities");
+        }
+        if runtime_task
+            .get("engine")
+            .and_then(|engine| engine.get("id"))
+            .and_then(Value::as_str)
+            == Some("data-liberation-agent")
+        {
+            push_unique(&mut required_capabilities, "data-liberation-agent");
+        }
+        for capability in self.required_capabilities {
+            push_unique(&mut required_capabilities, &capability);
+        }
+
+        let mut config = Map::new();
+        if let Some(provider) = &self.provider {
+            config.insert("provider".to_string(), Value::String(provider.clone()));
+        }
+
+        AgentTaskExecutor {
+            backend: self.backend.clone(),
+            selector: self.selector.clone(),
+            runtime_selection: Some(AgentTaskRuntimeSelection {
+                runtime_id: self.runtime_id,
+                executor_backend: Some(self.backend),
+                executor_provider_id: self.selector,
+                provider: self.provider.clone(),
+                model: self.model.clone(),
+                substrate_ref: self.substrate_ref,
+            }),
+            required_capabilities,
+            secret_env: self.secret_env,
+            model: self.model,
+            config: Value::Object(config),
+        }
+    }
+}
+
+fn metadata_with_schema(value: Value, schema: &str) -> Value {
+    let mut object = match value {
+        Value::Object(object) => object,
+        Value::Null => Map::new(),
+        other => Map::from_iter([("payload".to_string(), other)]),
+    };
+    object
+        .entry("schema".to_string())
+        .or_insert_with(|| Value::String(schema.to_string()));
+    Value::Object(object)
+}
+
+fn push_unique(values: &mut Vec<String>, value: &str) {
+    if !value.is_empty() && !values.iter().any(|existing| existing == value) {
+        values.push(value.to_string());
+    }
+}
+
+fn default_plan_request_schema() -> String {
+    WORDPRESS_RUNTIME_PLAN_REQUEST_SCHEMA.to_string()
+}
+
+fn default_executor_backend() -> String {
+    "codebox".to_string()
+}
+
+fn default_runtime_id() -> String {
+    "wp-codebox".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_codebox_runtime_task_plan() {
+        let plan = build_wordpress_runtime_plan(WordPressRuntimePlanRequest {
+            schema: WORDPRESS_RUNTIME_PLAN_REQUEST_SCHEMA.to_string(),
+            plan_id: Some("wp-runtime-plan".to_string()),
+            group_key: Some("imports".to_string()),
+            tasks: vec![WordPressRuntimeTaskSpec {
+                task_id: Some("extract".to_string()),
+                kind: Some("runtime_task".to_string()),
+                instructions: None,
+                runtime_task: json!({
+                    "ability": "datamachine/run-runtime-task",
+                    "input": { "operation": "extract" }
+                }),
+                executor: WordPressRuntimeExecutorSpec::default(),
+                source_refs: Vec::new(),
+                component_contracts: Vec::new(),
+                policy: AgentTaskPolicy::default(),
+                limits: AgentTaskLimits {
+                    timeout_ms: Some(30_000),
+                    ..AgentTaskLimits::default()
+                },
+                expected_artifacts: vec!["runtime-task-result".to_string()],
+                artifact_declarations: Vec::new(),
+                metadata: Value::Null,
+            }],
+            options: AgentTaskScheduleOptions {
+                max_concurrency: 2,
+                ..AgentTaskScheduleOptions::default()
+            },
+            component_contracts: Vec::new(),
+            metadata: Value::Null,
+        });
+
+        assert_eq!(plan.plan_id, "wp-runtime-plan");
+        assert_eq!(plan.group_key.as_deref(), Some("imports"));
+        assert_eq!(plan.options.max_concurrency, 2);
+        assert_eq!(plan.tasks[0].executor.backend, "codebox");
+        assert_eq!(plan.tasks[0].executor.runtime_id(), Some("wp-codebox"));
+        assert!(plan.tasks[0]
+            .executor
+            .required_capabilities
+            .contains(&"wordpress.runtime".to_string()));
+        assert_eq!(
+            plan.tasks[0].inputs["runtime_task"]["ability"],
+            "datamachine/run-runtime-task"
+        );
+        assert_eq!(plan.tasks[0].limits.timeout_ms, Some(30_000));
+    }
+
+    #[test]
+    fn dla_extraction_shorthand_records_source_and_capability() {
+        let plan = build_wordpress_runtime_plan(WordPressRuntimePlanRequest {
+            schema: WORDPRESS_RUNTIME_PLAN_REQUEST_SCHEMA.to_string(),
+            plan_id: Some("dla-plan".to_string()),
+            group_key: None,
+            tasks: vec![dla_extraction_task("https://example.com")],
+            options: AgentTaskScheduleOptions::default(),
+            component_contracts: Vec::new(),
+            metadata: Value::Null,
+        });
+
+        let task = &plan.tasks[0];
+        assert_eq!(task.inputs["kind"], "dla_extraction");
+        assert_eq!(
+            task.inputs["runtime_task"]["engine"]["id"],
+            "data-liberation-agent"
+        );
+        assert_eq!(task.source_refs[0].uri, "https://example.com");
+        assert!(task
+            .executor
+            .required_capabilities
+            .contains(&"data-liberation-agent".to_string()));
+        assert!(task
+            .artifact_declarations
+            .iter()
+            .any(|artifact| artifact.name == "artifact-bundle"));
+    }
+}

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -88,6 +88,12 @@ pub use super::agent_task_schedule::AgentTaskProgressEvent;
 
 pub use super::agent_task_scheduler::{AgentTaskExecutorAdapter, AgentTaskScheduler};
 
+pub use super::agent_task_wordpress_runtime::{
+    build_wordpress_runtime_plan, dla_extraction_task, WordPressRuntimeExecutorSpec,
+    WordPressRuntimePlanRequest, WordPressRuntimeTaskSpec, WORDPRESS_RUNTIME_PLAN_REQUEST_SCHEMA,
+    WORDPRESS_RUNTIME_TASK_SCHEMA,
+};
+
 // Matrix expansion is `pub(crate)` on the implementation module; expose it
 // through the facade for callers inside the crate that need to expand a plan
 // matrix without depending on the implementation path.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -32,6 +32,7 @@ pub mod agent_task_secrets;
 pub mod agent_task_service;
 pub(crate) mod agent_task_timeout;
 pub(crate) mod agent_task_timeout_artifacts;
+pub mod agent_task_wordpress_runtime;
 pub mod api_jobs;
 pub mod artifact_address;
 pub mod artifact_contract;

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -1309,6 +1309,7 @@ HOMEBOY_SHARED_MISSING_SECRET_TEST, HOMEBOY_OTHER_MISSING_SECRET_TEST"
             extension_path: None,
             runtime_id: None,
             runtime_path: None,
+            extra: Default::default(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a generic WordPress runtime task planner that projects Codebox/WordPress/DLA requests into existing durable `agent-task` plans.
- Add `homeboy agent-task wordpress-runtime` to emit plans, queue durable runs, or execute immediately through extension-declared executor providers.
- Keep execution out of product web requests: Homeboy owns fanout, runner/provider selection, timeouts, durable status/log/artifact evidence, and lifecycle records.
- Fix a stale test fixture initializer for the provider `extra` field so focused tests compile.

## Testing
- `cargo test wordpress_runtime --lib`
- `cargo check`
- `cargo run -- agent-task wordpress-runtime --help`
- `cargo run --quiet -- agent-task wordpress-runtime --plan-id smoke --ability datamachine/run-runtime-task --ability-input '{"operation":"extract"}' --expected-artifact runtime-task-result`

## Dependency order
1. WP Codebox runtime primitives: Automattic/wp-codebox#1127, Automattic/wp-codebox#1129, Automattic/wp-codebox#1133, Automattic/wp-codebox#1134.
2. Data Machine runtime-task ability contract: Extra-Chill/data-machine#2712.
3. This Homeboy PR, which submits/builds durable orchestration plans against those runtime/provider contracts.
4. Product callers can then replace direct web-request process execution or hand-managed fanout with `homeboy agent-task wordpress-runtime --submit` / existing `agent-task run-next` workers.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the generic WordPress runtime orchestration planner, CLI wiring, tests, and PR description; Chris remains responsible for review and testing.
