### PR TITLE
Omit xattrs from runner snapshots

### DIFF
--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -562,13 +562,17 @@ fn materialize_snapshot_piped(
     excludes: &[String],
     action: &str,
 ) -> Result<()> {
-    let command = format!(
-        "COPYFILE_DISABLE=1 tar -C {src} {exclude} -cf - . | {target_command}",
+    let command = snapshot_archive_command(local_path, target_command, excludes);
+    run_shell_command(&command, action)
+}
+
+fn snapshot_archive_command(local_path: &Path, target_command: &str, excludes: &[String]) -> String {
+    format!(
+        "COPYFILE_DISABLE=1 tar --no-xattrs -C {src} {exclude} -cf - . | {target_command}",
         src = shell::quote_arg(&local_path.display().to_string()),
         exclude = tar_exclude_args(excludes),
         target_command = target_command,
-    );
-    run_shell_command(&command, action)
+    )
 }
 
 pub(super) fn effective_snapshot_excludes(
@@ -1676,6 +1680,18 @@ mod tests {
         assert!(command.contains("mkdir -p \"$parent\""));
         assert!(command.contains("mv \"$tmp\" \"$dest\" && if"));
         assert!(command.contains("chown -R \"$owner\" $dest"));
+    }
+
+    #[test]
+    fn snapshot_archive_command_disables_extended_attributes() {
+        let command = snapshot_archive_command(
+            Path::new("/Users/chubes/Developer/wp-site-generator"),
+            "ssh runner 'tar -xf -'",
+            &[],
+        );
+
+        assert!(command.contains("COPYFILE_DISABLE=1"));
+        assert!(command.contains("tar --no-xattrs"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `--no-xattrs` to Homeboy runner snapshot archive creation.
- Prevent macOS/libarchive extended attribute warnings like `LIBARCHIVE.xattr.com.apple.provenance` from breaking SSH snapshot materialization on Linux runners.
- Add command-shape coverage for the snapshot archive command.

## Evidence
WPSG Lab run failed before agent execution while materializing a snapshot with:
`materialize SSH workspace snapshot failed: tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.com.apple.provenance'`.

## Testing
- `cargo test -p homeboy snapshot_archive_command_disables_extended_attributes`
- `cargo test -p homeboy runner::workspace` ran; 20 passed and 1 existing private-SSH clone test failed due `github.a8c.com` SSH permission in this environment.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runner snapshot xattr failure, drafted the tar command fix and regression test, and ran local verification. Chris remains responsible for review and final validation.