### PR TITLE
Pass canonical secret env plans to agent-task providers

### DIFF
--- a/docs/architecture/secret-env-contract.md
+++ b/docs/architecture/secret-env-contract.md
@@ -9,7 +9,8 @@ The contract is intentionally small:
 - A resolver tries ordered value providers and returns materialized `(name, value)` pairs plus status metadata.
 - Status metadata records only `name`, `configured`, and `source`; it never includes resolved values.
 - Missing required names produce a structured error with normalized missing names and redacted status metadata.
+- Provider command execution receives `HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON`, a serialized `SecretEnvPlan` containing normalized env names, env-name mappings, and redacted configured/missing status metadata. It never contains resolved secret values.
 
 Value providers remain domain-owned. Core does not know where a secret comes from beyond the provider's source label. Current consumers can provide process env, config, keychain, remote runner, or extension-specific providers without adding domain semantics to the shared contract.
 
-Use this primitive when a workflow needs to declare or resolve required secret env names. Add command-specific storage, fallback order, and remediation text at the consumer boundary.
+Use this primitive when a workflow needs to declare or resolve required secret env names. Add command-specific storage, fallback order, and remediation text at the consumer boundary. Providers should consume the canonical plan instead of recomputing provider-default secret env merges.

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -15,9 +15,11 @@ use crate::core::agent_task_scheduler::{
     AgentTaskExecutionContext, AgentTaskExecutorAdapter, AgentTaskPlan,
 };
 use crate::core::agent_task_secrets::{
-    resolve_secret_env_with_fallbacks, AgentTaskSecretResolutionError,
+    resolve_secret_env_with_fallbacks, secret_env_status_with_fallbacks,
+    AgentTaskSecretResolutionError,
 };
 use crate::core::agent_task_timeout::timeout_with_grace;
+use crate::core::secret_env_plan::{SecretEnvPlan, SecretEnvStatus};
 use crate::core::{agent_runtime_manifest, component, defaults, extension, Error};
 
 pub const AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA: &str = "homeboy/agent-task-executor-provider/v1";
@@ -543,11 +545,8 @@ fn apply_provider_runner_secret_env_contracts_with_providers(
         let Some(provider) = select_provider(providers, request) else {
             continue;
         };
-        for name in provider_secret_env(provider, Some(request)) {
-            if !request.executor.secret_env.contains(&name) {
-                request.executor.secret_env.push(name);
-            }
-        }
+        request.executor.secret_env =
+            provider_secret_env_plan(provider, request).secret_env_names();
     }
 }
 
@@ -560,7 +559,7 @@ pub(crate) fn provider_runner_secret_env_for_plan_with_providers(
         let Some(provider) = select_provider(providers, request) else {
             continue;
         };
-        names.extend(provider_secret_env(provider, Some(request)));
+        names.extend(provider_secret_env_plan(provider, request).secret_env_names());
     }
     names.sort();
     names.dedup();
@@ -618,6 +617,35 @@ fn provider_secret_env(
     names.sort();
     names.dedup();
     names
+}
+
+fn provider_secret_env_plan(
+    provider: &AgentTaskExecutorProvider,
+    request: &AgentTaskRequest,
+) -> SecretEnvPlan {
+    let provider_names = provider_secret_env(provider, Some(request));
+    let mut plan = SecretEnvPlan::from_secret_env_names(request.executor.secret_env.clone());
+    plan.extend_secret_env_names(provider_names.clone());
+    plan.map_env_names(provider.id.clone(), provider_names);
+    plan
+}
+
+fn provider_secret_env_plan_with_status(
+    provider: &AgentTaskExecutorProvider,
+    request: &AgentTaskRequest,
+) -> SecretEnvPlan {
+    let plan = provider_secret_env_plan(provider, request);
+    let status = secret_env_status_with_fallbacks(
+        &plan.secret_env_names(),
+        &provider_secret_sources(provider, Some(request)),
+    )
+    .into_iter()
+    .map(|status| SecretEnvStatus {
+        name: status.name,
+        configured: status.configured,
+        source: status.source,
+    });
+    plan.with_status(status).redacted()
 }
 
 fn provider_secret_sources(
@@ -1411,6 +1439,11 @@ fn provider_command_env(
         (
             "HOMEBOY_AGENT_TASK_EXECUTOR_CONFIG_JSON".to_string(),
             serde_json::to_string(&request.executor.config).unwrap_or_else(|_| "null".to_string()),
+        ),
+        (
+            "HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON".to_string(),
+            serde_json::to_string(&provider_secret_env_plan_with_status(provider, request))
+                .unwrap_or_else(|_| "null".to_string()),
         ),
         (
             "HOMEBOY_EXTENSION_ID".to_string(),
@@ -2779,6 +2812,42 @@ process.stdout.write(JSON.stringify({
         let aggregate = scheduler.run(AgentTaskPlan::new("plan-secret-env", vec![request]));
 
         assert_eq!(aggregate.totals.succeeded, 1);
+        std::env::remove_var(secret_name);
+    }
+
+    #[test]
+    fn provider_command_receives_canonical_secret_env_plan_without_values() {
+        let secret_name = format!("HOMEBOY_TEST_AGENT_TASK_PLAN_SECRET_{}", std::process::id());
+        std::env::set_var(&secret_name, "hydrated-secret");
+        let command = format!(
+            "node {}",
+            script(&format!(
+                "let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); let plan=JSON.parse(process.env.HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON); let mapped=(plan.env_name_mapping['test.provider']||[]).includes('{secret_name}'); let configured=(plan.status||[]).some((item)=>item.name==='{secret_name}'&&item.configured===true&&item.source==='env'); let leaked=JSON.stringify(plan).includes('hydrated-secret'); process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:mapped&&configured&&!leaked?'succeeded':'failed',summary:JSON.stringify(plan)}}));"
+            ))
+        );
+        let (mut request, mut provider) = request("task-secret-env-plan", command);
+        provider.runner_readiness = vec![AgentTaskProviderRunnerReadiness {
+            id: "test.provider.auth".to_string(),
+            label: "Test provider auth".to_string(),
+            secret_env: vec![secret_name.clone()],
+            env_path: None,
+            remediation: None,
+            extra: BTreeMap::new(),
+        }];
+        request.executor.secret_env = vec![secret_name.clone()];
+        let scheduler =
+            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
+                provider,
+            ]));
+
+        let aggregate = scheduler.run(AgentTaskPlan::new("plan-secret-env-plan", vec![request]));
+
+        assert_eq!(aggregate.totals.succeeded, 1);
+        assert!(!aggregate.outcomes[0]
+            .summary
+            .as_deref()
+            .unwrap_or_default()
+            .contains("hydrated-secret"));
         std::env::remove_var(secret_name);
     }
 

--- a/src/core/secret_env_plan.rs
+++ b/src/core/secret_env_plan.rs
@@ -16,6 +16,10 @@ pub struct SecretEnvPlan {
     pub secret_env_names: Vec<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub provider_credentials: BTreeMap<String, SecretEnvProviderCredentialMapping>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env_name_mapping: BTreeMap<String, Vec<String>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub status: Vec<SecretEnvStatus>,
     #[serde(default, skip_serializing_if = "SecretEnvRedactionPolicy::is_default")]
     pub redaction: SecretEnvRedactionPolicy,
 }
@@ -124,6 +128,8 @@ impl Default for SecretEnvPlan {
             public_env: BTreeMap::new(),
             secret_env_names: Vec::new(),
             provider_credentials: BTreeMap::new(),
+            env_name_mapping: BTreeMap::new(),
+            status: Vec::new(),
             redaction: SecretEnvRedactionPolicy::default(),
         }
     }
@@ -141,7 +147,37 @@ impl SecretEnvPlan {
             .provider_credentials
             .values()
             .flat_map(|mapping| mapping.secret_env.iter().cloned());
-        normalize_names(self.secret_env_names.iter().cloned().chain(mapped_names))
+        let env_name_mapping_names = self
+            .env_name_mapping
+            .values()
+            .flat_map(|names| names.iter().cloned());
+        normalize_names(
+            self.secret_env_names
+                .iter()
+                .cloned()
+                .chain(mapped_names)
+                .chain(env_name_mapping_names),
+        )
+    }
+
+    pub fn extend_secret_env_names(&mut self, names: impl IntoIterator<Item = String>) {
+        self.secret_env_names = normalize_names(self.secret_env_names.iter().cloned().chain(names));
+    }
+
+    pub fn map_env_names(
+        &mut self,
+        key: impl Into<String>,
+        names: impl IntoIterator<Item = String>,
+    ) {
+        let names = normalize_names(names);
+        if !names.is_empty() {
+            self.env_name_mapping.insert(key.into(), names);
+        }
+    }
+
+    pub fn with_status(mut self, status: impl IntoIterator<Item = SecretEnvStatus>) -> Self {
+        self.status = status.into_iter().collect();
+        self
     }
 
     pub fn materialize(
@@ -351,6 +387,27 @@ mod tests {
                 "B_SECRET".to_string(),
                 "C_SECRET".to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn secret_env_plan_includes_mapped_env_names() {
+        let mut plan = SecretEnvPlan::from_secret_env_names(["DIRECT_SECRET".to_string()]);
+        plan.map_env_names(
+            "provider.example",
+            ["MAPPED_SECRET".to_string(), "DIRECT_SECRET".to_string()],
+        );
+
+        assert_eq!(
+            plan.secret_env_names(),
+            vec!["DIRECT_SECRET".to_string(), "MAPPED_SECRET".to_string()]
+        );
+        assert_eq!(
+            plan.env_name_mapping.get("provider.example"),
+            Some(&vec![
+                "DIRECT_SECRET".to_string(),
+                "MAPPED_SECRET".to_string()
+            ])
         );
     }
 


### PR DESCRIPTION
## Summary
- extend core `SecretEnvPlan` with env-name mappings and redacted status metadata
- build provider-selected secret env plans in Homeboy instead of directly mutating provider secret names ad hoc
- pass the canonical plan to provider processes via `HOMEBOY_AGENT_TASK_SECRET_ENV_PLAN_JSON` without resolved secret values
- document the provider-facing plan contract

## Tests
- `cargo fmt --check`
- `cargo test secret_env_plan`
- `cargo test provider_command_receives_canonical_secret_env_plan_without_values`
- `cargo test provider_runner_secret_env_contracts_are_applied_to_selected_plan_tasks`
- `cargo test provider_secret_contracts_are_applied_generically`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the core secret env plan contract changes, tests, docs, and PR preparation; Chris remains responsible for review and merge.
