### PR TITLE
Add typed workspace materialization specs

### DIFF
--- a/src/core/agent_task_contract.rs
+++ b/src/core/agent_task_contract.rs
@@ -63,6 +63,8 @@ pub struct AgentTaskCoreProviderCapabilityContract {
     pub outcome_schema: String,
     pub provider_capability_fields: Vec<String>,
     pub executor_provider_fields: Vec<String>,
+    pub workspace_materialization_fields: Vec<String>,
+    pub workspace_mount_spec_fields: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -142,6 +144,25 @@ pub fn agent_task_core_contract() -> AgentTaskCoreContract {
                 "extension_path",
                 "runtime_id",
                 "runtime_path",
+                "extra",
+            ]),
+            workspace_materialization_fields: string_vec(&[
+                "cwd",
+                "requires_git",
+                "write_scope",
+                "artifact_paths",
+                "spec",
+                "mounts",
+                "extra",
+            ]),
+            workspace_mount_spec_fields: string_vec(&[
+                "handle",
+                "repo",
+                "host_path",
+                "target_path",
+                "mode",
+                "materialization",
+                "metadata",
                 "extra",
             ]),
         },
@@ -264,5 +285,13 @@ mod tests {
             .provider_capability
             .executor_provider_fields
             .contains(&"timeout_artifact_discovery".to_string()));
+        assert!(contract
+            .provider_capability
+            .workspace_materialization_fields
+            .contains(&"mounts".to_string()));
+        assert!(contract
+            .provider_capability
+            .workspace_mount_spec_fields
+            .contains(&"target_path".to_string()));
     }
 }

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -378,8 +378,166 @@ pub struct AgentTaskProviderWorkspaceMaterialization {
     pub write_scope: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifact_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spec: Option<WorkspaceMaterializationSpec>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mounts: Vec<WorkspaceMountSpec>,
     #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, Value>,
+}
+
+impl AgentTaskProviderWorkspaceMaterialization {
+    pub fn validate(&self) -> Result<(), Vec<String>> {
+        let mut errors = Vec::new();
+        if let Some(spec) = &self.spec {
+            errors.extend(
+                spec.validation_errors()
+                    .into_iter()
+                    .map(|error| format!("spec.{error}")),
+            );
+        }
+        for (index, mount) in self.mounts.iter().enumerate() {
+            errors.extend(
+                mount
+                    .validation_errors()
+                    .into_iter()
+                    .map(|error| format!("mounts[{index}].{error}")),
+            );
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct WorkspaceMaterializationSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handle: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub materialization: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mounts: Vec<WorkspaceMountSpec>,
+    #[serde(
+        default = "default_metadata",
+        skip_serializing_if = "is_empty_metadata"
+    )]
+    pub metadata: Value,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+impl WorkspaceMaterializationSpec {
+    pub fn validate(&self) -> Result<(), Vec<String>> {
+        let errors = self.validation_errors();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+
+    fn validation_errors(&self) -> Vec<String> {
+        let mut errors = workspace_mount_like_validation_errors(
+            self.handle.as_deref(),
+            self.repo.as_deref(),
+            self.host_path.as_deref(),
+            self.target_path.as_deref(),
+            self.mode.as_deref(),
+            self.materialization.as_deref(),
+        );
+        for (index, mount) in self.mounts.iter().enumerate() {
+            errors.extend(
+                mount
+                    .validation_errors()
+                    .into_iter()
+                    .map(|error| format!("mounts[{index}].{error}")),
+            );
+        }
+        errors
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct WorkspaceMountSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handle: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub materialization: Option<String>,
+    #[serde(
+        default = "default_metadata",
+        skip_serializing_if = "is_empty_metadata"
+    )]
+    pub metadata: Value,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+impl WorkspaceMountSpec {
+    pub fn validate(&self) -> Result<(), Vec<String>> {
+        let errors = self.validation_errors();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+
+    fn validation_errors(&self) -> Vec<String> {
+        workspace_mount_like_validation_errors(
+            self.handle.as_deref(),
+            self.repo.as_deref(),
+            self.host_path.as_deref(),
+            self.target_path.as_deref(),
+            self.mode.as_deref(),
+            self.materialization.as_deref(),
+        )
+    }
+}
+
+fn workspace_mount_like_validation_errors(
+    handle: Option<&str>,
+    repo: Option<&str>,
+    host_path: Option<&str>,
+    target_path: Option<&str>,
+    mode: Option<&str>,
+    materialization: Option<&str>,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+    validate_non_blank_optional("handle", handle, &mut errors);
+    validate_non_blank_optional("repo", repo, &mut errors);
+    validate_non_blank_optional("host_path", host_path, &mut errors);
+    validate_non_blank_optional("target_path", target_path, &mut errors);
+    validate_non_blank_optional("mode", mode, &mut errors);
+    validate_non_blank_optional("materialization", materialization, &mut errors);
+    if host_path.is_some() && target_path.is_none() {
+        errors.push("target_path is required when host_path is set".to_string());
+    }
+    errors
+}
+
+fn validate_non_blank_optional(field: &str, value: Option<&str>, errors: &mut Vec<String>) {
+    if value.is_some_and(|value| value.trim().is_empty()) {
+        errors.push(format!("{field} must not be blank"));
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -2304,6 +2462,8 @@ process.stdout.write(JSON.stringify({
             requires_git: None,
             write_scope: None,
             artifact_paths: Vec::new(),
+            spec: None,
+            mounts: Vec::new(),
             extra: BTreeMap::new(),
         });
 
@@ -2510,6 +2670,8 @@ process.stdout.write(JSON.stringify({
             requires_git: Some(true),
             write_scope: Some("artifacts".to_string()),
             artifact_paths: vec![".homeboy/provider".to_string()],
+            spec: None,
+            mounts: Vec::new(),
             extra: BTreeMap::new(),
         });
 
@@ -2528,6 +2690,8 @@ process.stdout.write(JSON.stringify({
             requires_git: None,
             write_scope: None,
             artifact_paths: Vec::new(),
+            spec: None,
+            mounts: Vec::new(),
             extra: BTreeMap::new(),
         });
 
@@ -2536,6 +2700,70 @@ process.stdout.write(JSON.stringify({
             "other",
             None
         ));
+    }
+
+    #[test]
+    fn provider_workspace_materialization_exports_typed_mount_specs() {
+        let (_request, mut provider) = request("task-a", "node provider-a.js".to_string());
+        provider.workspace_materialization = Some(AgentTaskProviderWorkspaceMaterialization {
+            cwd: Some("workspace".to_string()),
+            mounts: vec![WorkspaceMountSpec {
+                handle: Some("homeboy@fix-workspace-materialization-spec".to_string()),
+                repo: Some("homeboy".to_string()),
+                host_path: Some("/host/workspaces/homeboy@fix".to_string()),
+                target_path: Some("/workspace/homeboy".to_string()),
+                mode: Some("read_write".to_string()),
+                materialization: Some("bind_mount".to_string()),
+                metadata: json!({ "source": "fixture" }),
+                extra: BTreeMap::new(),
+            }],
+            ..AgentTaskProviderWorkspaceMaterialization::default()
+        });
+
+        let exported = serde_json::to_value(&provider).expect("provider json");
+
+        assert_eq!(
+            exported["workspace_materialization"]["mounts"][0]["handle"],
+            "homeboy@fix-workspace-materialization-spec"
+        );
+        assert_eq!(
+            exported["workspace_materialization"]["mounts"][0]["target_path"],
+            "/workspace/homeboy"
+        );
+        assert_eq!(
+            exported["workspace_materialization"]["mounts"][0]["materialization"],
+            "bind_mount"
+        );
+    }
+
+    #[test]
+    fn workspace_materialization_spec_validates_nested_mounts() {
+        let materialization = AgentTaskProviderWorkspaceMaterialization {
+            spec: Some(WorkspaceMaterializationSpec {
+                materialization: Some("bind_mount".to_string()),
+                mounts: vec![WorkspaceMountSpec {
+                    host_path: Some("/tmp/homeboy".to_string()),
+                    target_path: Some(" ".to_string()),
+                    ..WorkspaceMountSpec::default()
+                }],
+                ..WorkspaceMaterializationSpec::default()
+            }),
+            mounts: vec![WorkspaceMountSpec {
+                host_path: Some("/tmp/homeboy".to_string()),
+                ..WorkspaceMountSpec::default()
+            }],
+            ..AgentTaskProviderWorkspaceMaterialization::default()
+        };
+
+        let errors = materialization.validate().expect_err("validation errors");
+
+        assert_eq!(
+            errors,
+            vec![
+                "spec.mounts[0].target_path must not be blank".to_string(),
+                "mounts[0].target_path is required when host_path is set".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -238,8 +238,8 @@ pub mod provider {
         AgentTaskProviderDependencyFailurePattern, AgentTaskProviderEnvPathReadiness,
         AgentTaskProviderRoleAliases, AgentTaskProviderRunnerReadiness,
         AgentTaskProviderRunnerSource, AgentTaskProviderWorkspaceMaterialization,
-        ExtensionProviderAgentTaskExecutor, AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
-        AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA,
+        ExtensionProviderAgentTaskExecutor, WorkspaceMaterializationSpec, WorkspaceMountSpec,
+        AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA, AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA,
     };
     pub(crate) use super::super::agent_task_provider::{
         provider_runner_secret_env_for_plan_with_providers,


### PR DESCRIPTION
## Summary
- Add generic `WorkspaceMaterializationSpec` and `WorkspaceMountSpec` core provider primitives.
- Extend `workspace_materialization` provider export with typed `spec` and `mounts` while preserving existing fields.
- Advertise the new materialization/mount fields through the core provider capability contract.
- Add focused serialization and validation coverage.

## Tests
- `cargo test workspace_materialization --lib`
- `cargo test core_contract_exports_authoritative_agent_task_metadata --lib`
- `cargo test discovers_standalone_agent_runtime_manifests --lib`
- `cargo test --lib` reached 5000 passed / 1 failed / 18 ignored; failure was `core::runner::workspace::tests::git_sync_for_private_remote_materializes_controller_bundle_checkout` because local SSH auth to `proxy.automattic.com` was denied while cloning a private remote.

## Notes
- Kept this PR core-only. No homeboy-extensions adapter wiring is included because the new contract can be exported without changing executor behavior.
- No deploy performed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the core provider structs, contract exports, tests, and PR description for Chris to review and validate.
