### PR TITLE
Formalize argv command invocations

### DIFF
--- a/src/core/agent_task_contract.rs
+++ b/src/core/agent_task_contract.rs
@@ -21,6 +21,7 @@ use crate::core::agent_task_provider::{
 use crate::core::agent_task_schedule::{
     AgentTaskAggregateStatus, AgentTaskState, AGENT_TASK_PLAN_SCHEMA,
 };
+use crate::core::command_invocation::COMMAND_INVOCATION_SCHEMA;
 use crate::core::redaction::RedactionPolicy;
 use crate::core::secret_env_plan::SECRET_ENV_PLAN_SCHEMA;
 
@@ -60,6 +61,7 @@ pub struct AgentTaskCoreContractSchemas {
     pub loop_controller_status: String,
     pub secret_env_plan: String,
     pub secret_env_requirement: String,
+    pub command_invocation: String,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -123,6 +125,7 @@ pub fn agent_task_core_contract() -> AgentTaskCoreContract {
             loop_controller_status: AGENT_TASK_LOOP_CONTROLLER_STATUS_SCHEMA.to_string(),
             secret_env_plan: SECRET_ENV_PLAN_SCHEMA.to_string(),
             secret_env_requirement: SECRET_ENV_REQUIREMENT_SCHEMA.to_string(),
+            command_invocation: COMMAND_INVOCATION_SCHEMA.to_string(),
         },
         provider_capability: AgentTaskCoreProviderCapabilityContract {
             schema: provider_capability.schema,
@@ -150,6 +153,8 @@ pub fn agent_task_core_contract() -> AgentTaskCoreContract {
                 "backend",
                 "default_backend",
                 "command",
+                "command_argv",
+                "invocation",
                 "request_schema",
                 "outcome_schema",
                 "capabilities",
@@ -337,6 +342,10 @@ mod tests {
             SECRET_ENV_REQUIREMENT_SCHEMA
         );
         assert_eq!(
+            contract.schemas.command_invocation,
+            COMMAND_INVOCATION_SCHEMA
+        );
+        assert_eq!(
             contract.provider_capability.request_required_fields,
             agent_task_request_required_fields()
         );
@@ -352,6 +361,10 @@ mod tests {
             contract.provider_capability.redacted_metadata_keys,
             agent_task_redacted_metadata_keys()
         );
+        assert!(contract
+            .provider_capability
+            .executor_provider_fields
+            .contains(&"invocation".to_string()));
         assert!(contract
             .enums
             .outcome_status

--- a/src/core/agent_task_promotion.rs
+++ b/src/core/agent_task_promotion.rs
@@ -16,6 +16,7 @@ use crate::core::agent_task_gate::{
 };
 use crate::core::agent_task_scheduler::{AgentTaskAggregate, AGENT_TASK_AGGREGATE_SCHEMA};
 use crate::core::agent_task_timeout_artifacts::is_actionable_patch_artifact;
+use crate::core::command_invocation::CommandInvocation;
 use crate::core::gate::HomeboyGateResult;
 use crate::core::{Error, Result};
 
@@ -279,18 +280,34 @@ trait AgentTaskPromotionWorkspaceProvider {
 }
 
 struct ExternalPromotionWorkspaceProvider {
-    command: Option<String>,
+    invocation: Option<CommandInvocation>,
 }
 
 impl ExternalPromotionWorkspaceProvider {
     fn from_options(options: &AgentTaskPromotionOptions) -> Self {
         Self {
-            command: options
+            invocation: options
                 .provider_command
                 .clone()
-                .or_else(|| std::env::var(PROMOTION_PROVIDER_COMMAND_ENV).ok()),
+                .or_else(|| std::env::var(PROMOTION_PROVIDER_COMMAND_ENV).ok())
+                .map(|command| {
+                    eprintln!(
+                        "Warning: agent-task promotion provider string command is deprecated; use argv-capable provider invocation instead"
+                    );
+                    CommandInvocation {
+                        argv: command.split_whitespace().map(str::to_string).collect(),
+                        display: Some(command),
+                        ..Default::default()
+                    }
+                }),
         }
     }
+}
+
+fn invocation_program_and_args(invocation: &CommandInvocation) -> Option<(String, Vec<String>)> {
+    let mut argv = invocation.argv.clone().into_iter();
+    let program = argv.next()?;
+    Some((program, argv.collect()))
 }
 
 impl AgentTaskPromotionWorkspaceProvider for ExternalPromotionWorkspaceProvider {
@@ -298,7 +315,7 @@ impl AgentTaskPromotionWorkspaceProvider for ExternalPromotionWorkspaceProvider 
         &mut self,
         request: AgentTaskPromotionApplyRequest,
     ) -> Result<AgentTaskPromotionWorkspace> {
-        let command = self.command.as_deref().ok_or_else(|| {
+        let invocation = self.invocation.as_ref().ok_or_else(|| {
             Error::validation_invalid_argument(
                 "promotion_provider",
                 format!(
@@ -308,7 +325,7 @@ impl AgentTaskPromotionWorkspaceProvider for ExternalPromotionWorkspaceProvider 
                 None,
             )
         })?;
-        run_provider_command(command, &request)
+        run_provider_command(invocation, &request)
     }
 
     fn verify(
@@ -690,9 +707,23 @@ fn validate_workspace_handle(handle: &str) -> Result<()> {
 }
 
 fn run_provider_command(
-    command: &str,
+    invocation: &CommandInvocation,
     request: &AgentTaskPromotionApplyRequest,
 ) -> Result<AgentTaskPromotionWorkspace> {
+    let (program, args) = invocation_program_and_args(invocation).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "promotion_provider.argv",
+            "promotion provider invocation argv must not be empty",
+            None,
+            None,
+        )
+    })?;
+    let display = invocation.display.clone().unwrap_or_else(|| {
+        std::iter::once(program.clone())
+            .chain(args.clone())
+            .collect::<Vec<_>>()
+            .join(" ")
+    });
     let request_json = serde_json::to_vec(request).map_err(|error| {
         Error::validation_invalid_json(
             error,
@@ -700,9 +731,13 @@ fn run_provider_command(
             None,
         )
     })?;
-    let mut process = Command::new("sh")
-        .arg("-lc")
-        .arg(command)
+    let mut command_builder = Command::new(&program);
+    command_builder.args(&args);
+    if let Some(cwd) = invocation.cwd.as_deref() {
+        command_builder.current_dir(cwd);
+    }
+
+    let mut process = command_builder
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -737,7 +772,7 @@ fn run_provider_command(
     })?;
     let exit_code = output.status.code().unwrap_or(1);
     let report = AgentTaskPromotionCommandReport {
-        command: vec!["sh".to_string(), "-lc".to_string(), command.to_string()],
+        command: std::iter::once(program).chain(args).collect(),
         exit_code,
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),
         stderr: String::from_utf8_lossy(&output.stderr).to_string(),
@@ -747,8 +782,7 @@ fn run_provider_command(
             "command",
             format!(
                 "promotion provider command failed with exit code {}: {}",
-                exit_code,
-                report.command.join(" ")
+                exit_code, display
             ),
             None,
             Some(vec![report.stderr.clone()]),
@@ -1381,8 +1415,14 @@ mod tests {
             patch_path: temp.path().join("changes.patch").display().to_string(),
             changed_files: vec!["src/lib.rs".to_string()],
         };
-        let workspace = run_provider_command(&format!("cat {}", response_path.display()), &request)
-            .expect("provider response");
+        let workspace = run_provider_command(
+            &CommandInvocation {
+                argv: vec!["cat".to_string(), response_path.display().to_string()],
+                ..Default::default()
+            },
+            &request,
+        )
+        .expect("provider response");
 
         assert!(workspace.path.ends_with("workspace"));
         assert_eq!(

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -20,6 +20,7 @@ use crate::core::agent_task_secrets::{
 };
 use crate::core::agent_task_timeout::timeout_with_grace;
 use crate::core::secret_env_plan::{SecretEnvPlan, SecretEnvStatus};
+use crate::core::command_invocation::CommandInvocation;
 use crate::core::{agent_runtime_manifest, component, defaults, extension, Error};
 
 pub const AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA: &str = "homeboy/agent-task-executor-provider/v1";
@@ -57,6 +58,8 @@ pub struct AgentTaskExecutorProvider {
     pub command: String,
     #[serde(default, alias = "argv", skip_serializing_if = "Vec::is_empty")]
     pub command_argv: Vec<String>,
+    #[serde(default, skip_serializing_if = "CommandInvocation::is_empty")]
+    pub invocation: CommandInvocation,
     #[serde(default = "default_request_schema")]
     pub request_schema: String,
     #[serde(default = "default_outcome_schema")]
@@ -1310,7 +1313,7 @@ fn run_provider_command(
     provider: &AgentTaskExecutorProvider,
 ) -> AgentTaskOutcome {
     let command = render_provider_command_display(provider);
-    let Some((program, args)) = provider_command_parts(provider) else {
+    let Some((program, args, cwd)) = provider_command_parts(provider) else {
         return failure_outcome(
             request,
             AgentTaskOutcomeStatus::ProviderError,
@@ -1354,12 +1357,16 @@ fn run_provider_command(
         }
     };
 
-    let mut child = match Command::new(&program)
-        .args(&args)
-        .envs(
-            env.iter()
-                .map(|(key, value)| (key.as_str(), value.as_str())),
-        )
+    let mut command_builder = Command::new(&program);
+    command_builder.args(&args).envs(
+        env.iter()
+            .map(|(key, value)| (key.as_str(), value.as_str())),
+    );
+    if let Some(cwd) = cwd {
+        command_builder.current_dir(cwd);
+    }
+
+    let mut child = match command_builder
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -1540,6 +1547,12 @@ fn output_value<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
 }
 
 fn render_provider_command_display(provider: &AgentTaskExecutorProvider) -> String {
+    if let Some(display) = provider.invocation.display.as_deref() {
+        return render_provider_command_template(display, provider);
+    }
+    if !provider.invocation.argv.is_empty() {
+        return render_provider_invocation_argv(provider).join(" ");
+    }
     if !provider.command_argv.is_empty() {
         return render_provider_command_argv(provider).join(" ");
     }
@@ -1548,41 +1561,66 @@ fn render_provider_command_display(provider: &AgentTaskExecutorProvider) -> Stri
 }
 
 fn render_provider_command_string(provider: &AgentTaskExecutorProvider) -> String {
+    render_provider_command_template(&provider.command, provider)
+}
+
+fn render_provider_command_template(value: &str, provider: &AgentTaskExecutorProvider) -> String {
     let extension_path = provider.extension_path.as_deref().unwrap_or_default();
     let runtime_path = provider.runtime_path.as_deref().unwrap_or(extension_path);
-    provider
-        .command
+    value
         .replace("{{extension_path}}", extension_path)
         .replace("{{runtime_path}}", runtime_path)
 }
 
 fn render_provider_command_argv(provider: &AgentTaskExecutorProvider) -> Vec<String> {
-    let extension_path = provider.extension_path.as_deref().unwrap_or_default();
-    let runtime_path = provider.runtime_path.as_deref().unwrap_or(extension_path);
     provider
         .command_argv
         .iter()
-        .map(|arg| {
-            arg.replace("{{extension_path}}", extension_path)
-                .replace("{{runtime_path}}", runtime_path)
-        })
+        .map(|arg| render_provider_command_template(arg, provider))
         .collect()
 }
 
-fn provider_command_parts(provider: &AgentTaskExecutorProvider) -> Option<(String, Vec<String>)> {
-    let argv = if provider.command_argv.is_empty() {
+fn render_provider_invocation_argv(provider: &AgentTaskExecutorProvider) -> Vec<String> {
+    provider
+        .invocation
+        .argv
+        .iter()
+        .map(|arg| render_provider_command_template(arg, provider))
+        .collect()
+}
+
+fn provider_command_parts(
+    provider: &AgentTaskExecutorProvider,
+) -> Option<(String, Vec<String>, Option<PathBuf>)> {
+    let (argv, cwd) = if !provider.invocation.argv.is_empty() {
+        (
+            render_provider_invocation_argv(provider),
+            provider
+                .invocation
+                .cwd
+                .as_deref()
+                .map(|cwd| PathBuf::from(render_provider_command_template(cwd, provider))),
+        )
+    } else if provider.command_argv.is_empty() {
         // Legacy string commands retain their historical split behavior for
         // compatibility. New provider manifests should use command_argv/argv.
-        render_provider_command_string(provider)
-            .split_whitespace()
-            .map(str::to_string)
-            .collect()
+        eprintln!(
+            "Warning: agent task provider '{}' uses deprecated string command; use invocation.argv or argv instead",
+            provider.id
+        );
+        (
+            render_provider_command_string(provider)
+                .split_whitespace()
+                .map(str::to_string)
+                .collect(),
+            None,
+        )
     } else {
-        render_provider_command_argv(provider)
+        (render_provider_command_argv(provider), None)
     };
     let mut parts = argv.into_iter();
     let program = parts.next()?;
-    Some((program, parts.collect()))
+    Some((program, parts.collect(), cwd))
 }
 
 fn provider_command_env(
@@ -1733,6 +1771,45 @@ mod tests {
     }
 
     #[test]
+    fn provider_manifest_accepts_command_invocation_contract() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(json!({
+            "id": "invocation.provider",
+            "backend": "invocation",
+            "command": "legacy-provider --legacy",
+            "invocation": {
+                "schema": "homeboy/command-invocation/v1",
+                "argv": ["{{runtime_path}}/bin/provider", "--json"],
+                "cwd": "{{runtime_path}}",
+                "env": [{ "name": "TOKEN", "source": "secret_env", "redacted": true }],
+                "display": "provider --json",
+                "redaction": { "env": ["TOKEN"] }
+            }
+        }))
+        .expect("provider manifest");
+
+        assert_eq!(provider.invocation.argv[0], "{{runtime_path}}/bin/provider");
+        assert_eq!(provider.invocation.cwd.as_deref(), Some("{{runtime_path}}"));
+        assert_eq!(provider.invocation.env[0].name, "TOKEN");
+        assert_eq!(
+            provider.invocation.display.as_deref(),
+            Some("provider --json")
+        );
+        assert_eq!(provider.invocation.redaction.env, vec!["TOKEN"]);
+    }
+
+    #[test]
+    fn provider_command_parts_warns_for_legacy_string_command() {
+        let (_request, provider) =
+            request("task-legacy-command", "legacy-provider --flag".to_string());
+
+        let (program, args, cwd) = provider_command_parts(&provider).expect("command parts");
+
+        assert_eq!(program, "legacy-provider");
+        assert_eq!(args, vec!["--flag"]);
+        assert_eq!(cwd, None);
+    }
+
+    #[test]
     fn provider_manifest_preserves_unknown_metadata_on_export() {
         let provider: AgentTaskExecutorProvider = serde_json::from_value(json!({
             "id": "metadata.provider",
@@ -1851,6 +1928,7 @@ mod tests {
             default_backend: false,
             command,
             command_argv: Vec::new(),
+            invocation: CommandInvocation::default(),
             request_schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
             outcome_schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
             capabilities: vec!["structured_outcome".to_string()],
@@ -2101,6 +2179,40 @@ process.stdout.write(JSON.stringify({
             .as_deref()
             .unwrap_or_default()
             .contains("extension path with spaces"));
+    }
+
+    #[test]
+    fn provider_invocation_argv_and_cwd_preserve_paths_with_spaces() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = temp.path().join("runtime path with spaces");
+        fs::create_dir_all(&runtime_dir).expect("runtime dir");
+        fs::write(
+            runtime_dir.join("provider.js"),
+            r#"
+const fs = require('fs');
+const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+process.stdout.write(JSON.stringify({
+  schema: 'homeboy/agent-task-outcome/v1',
+  task_id: input.task_id,
+  status: process.cwd().includes('runtime path with spaces') ? 'succeeded' : 'failed',
+  summary: process.cwd()
+}));
+"#,
+        )
+        .expect("provider script");
+        let (request, mut provider) = request("task-invocation-cwd", "legacy unused".to_string());
+        provider.runtime_path = Some(runtime_dir.to_string_lossy().to_string());
+        provider.invocation.argv = vec!["node".to_string(), "provider.js".to_string()];
+        provider.invocation.cwd = Some("{{runtime_path}}".to_string());
+
+        let outcome = run_provider_command(&request, &provider);
+
+        assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
+        assert!(outcome
+            .summary
+            .as_deref()
+            .unwrap_or_default()
+            .contains("runtime path with spaces"));
     }
 
     #[test]

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -19,8 +19,8 @@ use crate::core::agent_task_secrets::{
     AgentTaskSecretResolutionError,
 };
 use crate::core::agent_task_timeout::timeout_with_grace;
-use crate::core::secret_env_plan::{SecretEnvPlan, SecretEnvStatus};
 use crate::core::command_invocation::CommandInvocation;
+use crate::core::secret_env_plan::{SecretEnvPlan, SecretEnvStatus};
 use crate::core::{agent_runtime_manifest, component, defaults, extension, Error};
 
 pub const AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA: &str = "homeboy/agent-task-executor-provider/v1";

--- a/src/core/command_invocation.rs
+++ b/src/core/command_invocation.rs
@@ -1,0 +1,106 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const COMMAND_INVOCATION_SCHEMA: &str = "homeboy/command-invocation/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct CommandInvocation {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub argv: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<CommandEnvRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display: Option<String>,
+    #[serde(default, skip_serializing_if = "CommandRedaction::is_empty")]
+    pub redaction: CommandRedaction,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+impl CommandInvocation {
+    pub fn is_empty(&self) -> bool {
+        self.schema.is_none()
+            && self.argv.is_empty()
+            && self.cwd.is_none()
+            && self.env.is_empty()
+            && self.display.is_none()
+            && self.redaction.is_empty()
+            && self.extra.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct CommandEnvRef {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redacted: Option<bool>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct CommandRedaction {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub argv_indices: Vec<usize>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replacement: Option<String>,
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, Value>,
+}
+
+impl CommandRedaction {
+    pub fn is_empty(&self) -> bool {
+        self.argv_indices.is_empty()
+            && self.env.is_empty()
+            && self.replacement.is_none()
+            && self.extra.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn command_invocation_contract_accepts_argv_cwd_env_display_and_redaction() {
+        let invocation: CommandInvocation = serde_json::from_value(json!({
+            "schema": COMMAND_INVOCATION_SCHEMA,
+            "argv": ["provider", "--token", "secret-ref"],
+            "cwd": "{{runtime_path}}",
+            "env": [{ "name": "TOKEN", "source": "secret_env", "redacted": true }],
+            "display": "provider --token [redacted]",
+            "redaction": { "argv_indices": [2], "env": ["TOKEN"] },
+            "provider_note": "preserved"
+        }))
+        .expect("command invocation parses");
+
+        assert_eq!(
+            invocation.schema.as_deref(),
+            Some(COMMAND_INVOCATION_SCHEMA)
+        );
+        assert_eq!(invocation.argv, vec!["provider", "--token", "secret-ref"]);
+        assert_eq!(invocation.cwd.as_deref(), Some("{{runtime_path}}"));
+        assert_eq!(invocation.env[0].name, "TOKEN");
+        assert_eq!(
+            invocation.display.as_deref(),
+            Some("provider --token [redacted]")
+        );
+        assert_eq!(invocation.redaction.argv_indices, vec![2]);
+        assert_eq!(invocation.extra["provider_note"], "preserved");
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -48,6 +48,7 @@ pub mod ci_profile;
 pub mod cleanup;
 pub mod code_audit;
 pub mod command_execution_plan;
+pub mod command_invocation;
 pub mod component;
 pub mod context;
 pub mod daemon;

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -19,6 +19,7 @@ use crate::core::agent_tasks::secrets as agent_task_secrets;
 use crate::core::agent_tasks::{
     AgentTaskExecutor, AgentTaskRequest, AgentTaskWorkspace, AGENT_TASK_REQUEST_SCHEMA,
 };
+use crate::core::command_invocation::CommandInvocation;
 use crate::core::{config, Error, Result};
 
 use super::super::Runner;
@@ -1294,6 +1295,7 @@ HOMEBOY_SHARED_MISSING_SECRET_TEST, HOMEBOY_OTHER_MISSING_SECRET_TEST"
             default_backend: true,
             command: "wp-codebox agent".to_string(),
             command_argv: Vec::new(),
+            invocation: CommandInvocation::default(),
             request_schema: "homeboy/agent-task-request/v1".to_string(),
             outcome_schema: "homeboy/agent-task-outcome/v1".to_string(),
             capabilities: Vec::new(),


### PR DESCRIPTION
## Summary
- Add a generic command invocation contract with argv, cwd, env refs, display, and redaction metadata.
- Teach agent task provider dispatch to prefer invocation.argv, preserve argv fallback, and warn on legacy string command fallback.
- Run promotion provider commands via argv instead of sh -lc while preserving the legacy string option as a deprecated compatibility input.

## Tests
- cargo test agent_task_provider --lib
- cargo test agent_task_promotion --lib
- cargo test agent_task_contract --lib
- cargo test command_invocation --lib

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5
- **Used for:** Drafted the command invocation contract, provider/promotion migration, and focused tests; Chris remains responsible for review and validation.