### PR TITLE
Add generic agent tool control-plane contract

### DIFF
--- a/src/core/agent_task.rs
+++ b/src/core/agent_task.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
+use std::collections::BTreeMap;
 
-#[cfg(test)]
 use crate::core::redaction::RedactionPolicy;
+use serde_json::{Map, Value};
 
 pub use super::agent_task_aggregate::{
     AgentTaskAggregateReport, AgentTaskAggregateSummary, AgentTaskArtifactInventoryItem,
@@ -20,6 +20,9 @@ pub const AGENT_TASK_ARTIFACT_SCHEMA: &str = "homeboy/agent-task-artifact/v1";
 pub const AGENT_TASK_WORKFLOW_SCHEMA: &str = "homeboy/agent-task-workflow/v1";
 pub const AGENT_TASK_MATRIX_PLAN_SCHEMA: &str = "homeboy/agent-task-matrix-plan/v1";
 pub const AGENT_TASK_MATRIX_AGGREGATE_SCHEMA: &str = "homeboy/agent-task-matrix-aggregate/v1";
+pub const AGENT_TOOL_REQUEST_SCHEMA: &str = "homeboy/agent-tool-request/v1";
+pub const AGENT_TOOL_RESULT_SCHEMA: &str = "homeboy/agent-tool-result/v1";
+pub const AGENT_TOOL_POLICY_SCHEMA: &str = "homeboy/agent-tool-policy/v1";
 
 mod matrix;
 
@@ -396,6 +399,12 @@ pub struct AgentTaskPolicy {
     pub write: String,
     #[serde(default = "default_apply_policy")]
     pub apply: String,
+    #[serde(
+        default,
+        alias = "toolPolicy",
+        skip_serializing_if = "AgentToolPolicy::is_default"
+    )]
+    pub tools: AgentToolPolicy,
 }
 
 impl Default for AgentTaskPolicy {
@@ -404,8 +413,124 @@ impl Default for AgentTaskPolicy {
             read: default_read_policy(),
             write: default_write_policy(),
             apply: default_apply_policy(),
+            tools: AgentToolPolicy::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentToolRequest {
+    #[serde(default = "agent_tool_request_schema")]
+    pub schema: String,
+    pub request_id: String,
+    pub task_id: String,
+    pub tool: String,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub input: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+impl AgentToolRequest {
+    pub fn redacted(&self) -> Self {
+        let policy = RedactionPolicy::default();
+        let mut redacted = self.clone();
+        redacted.input = policy.redact_json(&redacted.input);
+        redacted.metadata = policy.redact_json(&redacted.metadata);
+        redacted
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentToolResult {
+    #[serde(default = "agent_tool_result_schema")]
+    pub schema: String,
+    pub request_id: String,
+    pub task_id: String,
+    pub tool: String,
+    pub status: AgentToolResultStatus,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub output: Value,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<AgentTaskDiagnostic>,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}
+
+impl AgentToolResult {
+    pub fn redacted(&self) -> Self {
+        let policy = RedactionPolicy::default();
+        let mut redacted = self.clone();
+        redacted.output = policy.redact_json(&redacted.output);
+        redacted.diagnostics = redacted
+            .diagnostics
+            .into_iter()
+            .map(|diagnostic| diagnostic.redacted_with(&policy))
+            .collect();
+        redacted.metadata = policy.redact_json(&redacted.metadata);
+        redacted
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentToolResultStatus {
+    Succeeded,
+    Failed,
+    Denied,
+    Timeout,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentToolPolicy {
+    #[serde(default = "agent_tool_policy_schema")]
+    pub schema: String,
+    #[serde(default = "default_agent_tool_execution_location")]
+    pub default_location: AgentToolExecutionLocation,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub tools: BTreeMap<String, AgentToolPolicyRule>,
+}
+
+impl AgentToolPolicy {
+    pub fn execution_location_for(&self, tool: &str) -> AgentToolExecutionLocation {
+        self.tools
+            .get(tool)
+            .map(|rule| rule.execution_location)
+            .unwrap_or(self.default_location)
+    }
+
+    fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
+impl Default for AgentToolPolicy {
+    fn default() -> Self {
+        Self {
+            schema: AGENT_TOOL_POLICY_SCHEMA.to_string(),
+            default_location: default_agent_tool_execution_location(),
+            tools: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentToolPolicyRule {
+    pub execution_location: AgentToolExecutionLocation,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentToolExecutionLocation {
+    Runner,
+    ControlPlane,
+    Disabled,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -648,7 +773,6 @@ pub struct AgentTaskDiagnostic {
     pub data: Value,
 }
 
-#[cfg(test)]
 impl AgentTaskDiagnostic {
     fn redacted_with(mut self, policy: &RedactionPolicy) -> Self {
         self.message = policy.redact_string(&self.message);
@@ -787,6 +911,22 @@ fn workflow_schema() -> String {
     AGENT_TASK_WORKFLOW_SCHEMA.to_string()
 }
 
+fn agent_tool_request_schema() -> String {
+    AGENT_TOOL_REQUEST_SCHEMA.to_string()
+}
+
+fn agent_tool_result_schema() -> String {
+    AGENT_TOOL_RESULT_SCHEMA.to_string()
+}
+
+fn agent_tool_policy_schema() -> String {
+    AGENT_TOOL_POLICY_SCHEMA.to_string()
+}
+
+fn default_agent_tool_execution_location() -> AgentToolExecutionLocation {
+    AgentToolExecutionLocation::Disabled
+}
+
 fn default_read_policy() -> String {
     "workspace".to_string()
 }
@@ -844,6 +984,7 @@ mod tests {
                 read: "workspace".to_string(),
                 write: "workspace".to_string(),
                 apply: "propose_only".to_string(),
+                tools: AgentToolPolicy::default(),
             },
             limits: AgentTaskLimits {
                 timeout_ms: Some(300_000),
@@ -868,6 +1009,109 @@ mod tests {
 
         assert_eq!(decoded, request);
         assert_eq!(decoded.schema, AGENT_TASK_REQUEST_SCHEMA);
+    }
+
+    #[test]
+    fn agent_tool_contract_round_trips_policy_request_and_result() {
+        let policy: AgentToolPolicy = serde_json::from_value(json!({
+            "schema": AGENT_TOOL_POLICY_SCHEMA,
+            "default_location": "disabled",
+            "tools": {
+                "repo.status": {
+                    "execution_location": "control_plane",
+                    "timeout_ms": 30_000,
+                    "reason": "controller owns this credential boundary"
+                },
+                "format.check": {
+                    "execution_location": "runner"
+                }
+            }
+        }))
+        .expect("decode tool policy");
+        let request = AgentToolRequest {
+            schema: AGENT_TOOL_REQUEST_SCHEMA.to_string(),
+            request_id: "tool-request-1".to_string(),
+            task_id: "task-1".to_string(),
+            tool: "repo.status".to_string(),
+            input: json!({ "path": "/workspace/repo" }),
+            timeout_ms: Some(30_000),
+            metadata: json!({ "attempt": 1 }),
+        };
+        let result = AgentToolResult {
+            schema: AGENT_TOOL_RESULT_SCHEMA.to_string(),
+            request_id: request.request_id.clone(),
+            task_id: request.task_id.clone(),
+            tool: request.tool.clone(),
+            status: AgentToolResultStatus::Succeeded,
+            output: json!({ "clean": true }),
+            diagnostics: Vec::new(),
+            metadata: json!({ "execution_location": "control_plane" }),
+        };
+
+        assert_eq!(
+            policy.execution_location_for("repo.status"),
+            AgentToolExecutionLocation::ControlPlane
+        );
+        assert_eq!(
+            policy.execution_location_for("format.check"),
+            AgentToolExecutionLocation::Runner
+        );
+        assert_eq!(
+            policy.execution_location_for("unknown.tool"),
+            AgentToolExecutionLocation::Disabled
+        );
+        assert_eq!(
+            serde_json::from_value::<AgentToolRequest>(
+                serde_json::to_value(&request).expect("serialize request")
+            )
+            .expect("decode request"),
+            request
+        );
+        assert_eq!(
+            serde_json::from_value::<AgentToolResult>(
+                serde_json::to_value(&result).expect("serialize result")
+            )
+            .expect("decode result"),
+            result
+        );
+    }
+
+    #[test]
+    fn agent_tool_evidence_redaction_removes_sensitive_values() {
+        let request = AgentToolRequest {
+            schema: AGENT_TOOL_REQUEST_SCHEMA.to_string(),
+            request_id: "tool-request-secret".to_string(),
+            task_id: "task-secret".to_string(),
+            tool: "repo.status".to_string(),
+            input: json!({ "authorization": "Bearer abc123", "safe": "value" }),
+            timeout_ms: None,
+            metadata: json!({ "refresh_token": "secret-refresh" }),
+        };
+        let result = AgentToolResult {
+            schema: AGENT_TOOL_RESULT_SCHEMA.to_string(),
+            request_id: request.request_id.clone(),
+            task_id: request.task_id.clone(),
+            tool: request.tool.clone(),
+            status: AgentToolResultStatus::Failed,
+            output: json!({ "api_key": "secret-value", "safe": "value" }),
+            diagnostics: vec![AgentTaskDiagnostic {
+                class: "tool".to_string(),
+                message: "Authorization: Bearer abc123".to_string(),
+                data: json!({ "password": "hunter2" }),
+            }],
+            metadata: json!({ "client_secret": "secret" }),
+        };
+
+        let redacted_request = serde_json::to_value(request.redacted()).expect("request json");
+        let redacted_result = serde_json::to_value(result.redacted()).expect("result json");
+
+        assert!(!redacted_request.to_string().contains("abc123"));
+        assert!(!redacted_request.to_string().contains("secret-refresh"));
+        assert_eq!(redacted_request["input"]["safe"], json!("value"));
+        assert!(!redacted_result.to_string().contains("secret-value"));
+        assert!(!redacted_result.to_string().contains("hunter2"));
+        assert!(!redacted_result.to_string().contains("abc123"));
+        assert_eq!(redacted_result["output"]["safe"], json!("value"));
     }
 
     #[test]

--- a/src/core/agent_task_contract.rs
+++ b/src/core/agent_task_contract.rs
@@ -4,7 +4,8 @@ use crate::core::agent_task::{
     AgentTaskExecutionState, AgentTaskFailureClassification, AgentTaskOutcomeStatus,
     AgentTaskWorkflowStepStatus, AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_MATRIX_AGGREGATE_SCHEMA,
     AGENT_TASK_MATRIX_PLAN_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
-    AGENT_TASK_WORKFLOW_SCHEMA,
+    AGENT_TASK_WORKFLOW_SCHEMA, AGENT_TOOL_POLICY_SCHEMA, AGENT_TOOL_REQUEST_SCHEMA,
+    AGENT_TOOL_RESULT_SCHEMA,
 };
 use crate::core::agent_task_aggregate::AGENT_TASK_AGGREGATE_SCHEMA;
 use crate::core::agent_task_cook_loop::AGENT_TASK_COOK_LOOP_REPORT_SCHEMA;
@@ -21,6 +22,7 @@ use crate::core::agent_task_provider::{
 use crate::core::agent_task_schedule::{
     AgentTaskAggregateStatus, AgentTaskState, AGENT_TASK_PLAN_SCHEMA,
 };
+use crate::core::agent_tool_control_plane::AGENT_TOOL_DISPATCH_EVIDENCE_SCHEMA;
 use crate::core::command_invocation::COMMAND_INVOCATION_SCHEMA;
 use crate::core::redaction::RedactionPolicy;
 use crate::core::secret_env_plan::SECRET_ENV_PLAN_SCHEMA;
@@ -54,6 +56,10 @@ pub struct AgentTaskCoreContractSchemas {
     pub matrix_aggregate: String,
     pub provider: String,
     pub provider_capability_contract: String,
+    pub tool_request: String,
+    pub tool_result: String,
+    pub tool_policy: String,
+    pub tool_dispatch_evidence: String,
     pub gate_report: String,
     pub promotion_report: String,
     pub cook_loop_report: String,
@@ -74,6 +80,9 @@ pub struct AgentTaskCoreProviderCapabilityContract {
     pub outcome_statuses: Vec<String>,
     pub failure_classifications: Vec<String>,
     pub redacted_metadata_keys: Vec<String>,
+    pub tool_request_schema: String,
+    pub tool_result_schema: String,
+    pub tool_policy_schema: String,
     pub provider_capability_fields: Vec<String>,
     pub executor_provider_fields: Vec<String>,
     pub workspace_materialization_fields: Vec<String>,
@@ -118,6 +127,10 @@ pub fn agent_task_core_contract() -> AgentTaskCoreContract {
             provider: AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA.to_string(),
             provider_capability_contract: AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA
                 .to_string(),
+            tool_request: AGENT_TOOL_REQUEST_SCHEMA.to_string(),
+            tool_result: AGENT_TOOL_RESULT_SCHEMA.to_string(),
+            tool_policy: AGENT_TOOL_POLICY_SCHEMA.to_string(),
+            tool_dispatch_evidence: AGENT_TOOL_DISPATCH_EVIDENCE_SCHEMA.to_string(),
             gate_report: AGENT_TASK_GATE_REPORT_SCHEMA.to_string(),
             promotion_report: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
             cook_loop_report: AGENT_TASK_COOK_LOOP_REPORT_SCHEMA.to_string(),
@@ -136,6 +149,9 @@ pub fn agent_task_core_contract() -> AgentTaskCoreContract {
             outcome_statuses: agent_task_outcome_statuses(),
             failure_classifications: agent_task_failure_classifications(),
             redacted_metadata_keys: agent_task_redacted_metadata_keys(),
+            tool_request_schema: provider_capability.tool_request_schema,
+            tool_result_schema: provider_capability.tool_result_schema,
+            tool_policy_schema: provider_capability.tool_policy_schema,
             provider_capability_fields: string_vec(&[
                 "schema",
                 "provider_schema",
@@ -145,6 +161,9 @@ pub fn agent_task_core_contract() -> AgentTaskCoreContract {
                 "outcome_statuses",
                 "failure_classifications",
                 "redacted_metadata_keys",
+                "tool_request_schema",
+                "tool_result_schema",
+                "tool_policy_schema",
             ]),
             executor_provider_fields: string_vec(&[
                 "schema",
@@ -365,6 +384,13 @@ mod tests {
             .provider_capability
             .executor_provider_fields
             .contains(&"invocation".to_string()));
+        assert_eq!(contract.schemas.tool_request, AGENT_TOOL_REQUEST_SCHEMA);
+        assert_eq!(contract.schemas.tool_result, AGENT_TOOL_RESULT_SCHEMA);
+        assert_eq!(contract.schemas.tool_policy, AGENT_TOOL_POLICY_SCHEMA);
+        assert_eq!(
+            contract.provider_capability.tool_request_schema,
+            AGENT_TOOL_REQUEST_SCHEMA
+        );
         assert!(contract
             .enums
             .outcome_status

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -251,6 +251,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
                 read: "workspace".to_string(),
                 write: "patch".to_string(),
                 apply: "manual".to_string(),
+                tools: Default::default(),
             },
             limits: AgentTaskLimits::default(),
             expected_artifacts: vec![

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -9,7 +9,8 @@ use serde_json::{json, Value};
 use crate::core::agent_task::{
     AgentTaskArtifact, AgentTaskDiagnostic, AgentTaskEvidenceRef, AgentTaskFailureClassification,
     AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskRequest, AGENT_TASK_ARTIFACT_SCHEMA,
-    AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
+    AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA, AGENT_TOOL_POLICY_SCHEMA,
+    AGENT_TOOL_REQUEST_SCHEMA, AGENT_TOOL_RESULT_SCHEMA,
 };
 use crate::core::agent_task_scheduler::{
     AgentTaskExecutionContext, AgentTaskExecutorAdapter, AgentTaskPlan,
@@ -33,6 +34,9 @@ pub struct AgentTaskProviderCapabilityContract {
     pub provider_schema: String,
     pub request_schema: String,
     pub outcome_schema: String,
+    pub tool_request_schema: String,
+    pub tool_result_schema: String,
+    pub tool_policy_schema: String,
 }
 
 pub fn provider_capability_contract() -> AgentTaskProviderCapabilityContract {
@@ -41,6 +45,9 @@ pub fn provider_capability_contract() -> AgentTaskProviderCapabilityContract {
         provider_schema: AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA.to_string(),
         request_schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
         outcome_schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+        tool_request_schema: AGENT_TOOL_REQUEST_SCHEMA.to_string(),
+        tool_result_schema: AGENT_TOOL_RESULT_SCHEMA.to_string(),
+        tool_policy_schema: AGENT_TOOL_POLICY_SCHEMA.to_string(),
     }
 }
 
@@ -1810,6 +1817,22 @@ fn provider_command_env(
                 .unwrap_or_else(|_| "null".to_string()),
         ),
         (
+            "HOMEBOY_AGENT_TOOL_POLICY_JSON".to_string(),
+            serde_json::to_string(&request.policy.tools).unwrap_or_else(|_| "null".to_string()),
+        ),
+        (
+            "HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA".to_string(),
+            AGENT_TOOL_REQUEST_SCHEMA.to_string(),
+        ),
+        (
+            "HOMEBOY_AGENT_TOOL_RESULT_SCHEMA".to_string(),
+            AGENT_TOOL_RESULT_SCHEMA.to_string(),
+        ),
+        (
+            "HOMEBOY_AGENT_TOOL_POLICY_SCHEMA".to_string(),
+            AGENT_TOOL_POLICY_SCHEMA.to_string(),
+        ),
+        (
             "HOMEBOY_EXTENSION_ID".to_string(),
             provider.extension_id.clone().unwrap_or_default(),
         ),
@@ -1887,6 +1910,7 @@ mod tests {
     use super::*;
     use crate::core::agent_task::{
         AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskWorkspace,
+        AgentToolExecutionLocation, AgentToolPolicyRule,
     };
     use crate::core::agent_task_scheduler::{AgentTaskPlan, AgentTaskScheduler};
     use std::fs;
@@ -1905,6 +1929,9 @@ mod tests {
         );
         assert_eq!(contract.request_schema, AGENT_TASK_REQUEST_SCHEMA);
         assert_eq!(contract.outcome_schema, AGENT_TASK_OUTCOME_SCHEMA);
+        assert_eq!(contract.tool_request_schema, AGENT_TOOL_REQUEST_SCHEMA);
+        assert_eq!(contract.tool_result_schema, AGENT_TOOL_RESULT_SCHEMA);
+        assert_eq!(contract.tool_policy_schema, AGENT_TOOL_POLICY_SCHEMA);
     }
 
     #[test]
@@ -2101,6 +2128,52 @@ mod tests {
         assert_eq!(
             exported["workspace_materialization"]["provider_workspace_mode"],
             "linked"
+        );
+    }
+
+    #[test]
+    fn provider_command_env_exposes_generic_agent_tool_contracts() {
+        let (mut request, provider) = request("task-1", "minimal-provider".to_string());
+        request.policy.tools.tools.insert(
+            "lookup".to_string(),
+            AgentToolPolicyRule {
+                execution_location: AgentToolExecutionLocation::ControlPlane,
+                timeout_ms: Some(500),
+                reason: Some("test policy".to_string()),
+            },
+        );
+
+        let env = provider_command_env(&request, &provider).expect("provider env");
+        let env: BTreeMap<String, String> = env.into_iter().collect();
+
+        assert_eq!(
+            env.get("HOMEBOY_AGENT_TOOL_REQUEST_SCHEMA")
+                .map(String::as_str),
+            Some(AGENT_TOOL_REQUEST_SCHEMA)
+        );
+        assert_eq!(
+            env.get("HOMEBOY_AGENT_TOOL_RESULT_SCHEMA")
+                .map(String::as_str),
+            Some(AGENT_TOOL_RESULT_SCHEMA)
+        );
+        assert_eq!(
+            env.get("HOMEBOY_AGENT_TOOL_POLICY_SCHEMA")
+                .map(String::as_str),
+            Some(AGENT_TOOL_POLICY_SCHEMA)
+        );
+
+        let policy: crate::core::agent_task::AgentToolPolicy = serde_json::from_str(
+            env.get("HOMEBOY_AGENT_TOOL_POLICY_JSON")
+                .expect("tool policy env"),
+        )
+        .expect("tool policy json");
+        assert_eq!(
+            policy.execution_location_for("lookup"),
+            AgentToolExecutionLocation::ControlPlane
+        );
+        assert_eq!(
+            policy.execution_location_for("unknown"),
+            AgentToolExecutionLocation::Disabled
         );
     }
 

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -44,9 +44,11 @@ pub use super::agent_task::{
     AgentTaskPreparedWorkspace, AgentTaskProgress, AgentTaskRequest, AgentTaskSourceRef,
     AgentTaskStart, AgentTaskWorkflowEvidence, AgentTaskWorkflowStepEvidence,
     AgentTaskWorkflowStepStatus, AgentTaskWorkflowStepSuggestion, AgentTaskWorkspace,
-    AgentTaskWorkspaceMode, AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_MATRIX_AGGREGATE_SCHEMA,
-    AGENT_TASK_MATRIX_PLAN_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
-    AGENT_TASK_WORKFLOW_SCHEMA,
+    AgentTaskWorkspaceMode, AgentToolExecutionLocation, AgentToolPolicy, AgentToolPolicyRule,
+    AgentToolRequest, AgentToolResult, AgentToolResultStatus, AGENT_TASK_ARTIFACT_SCHEMA,
+    AGENT_TASK_MATRIX_AGGREGATE_SCHEMA, AGENT_TASK_MATRIX_PLAN_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA,
+    AGENT_TASK_REQUEST_SCHEMA, AGENT_TASK_WORKFLOW_SCHEMA, AGENT_TOOL_POLICY_SCHEMA,
+    AGENT_TOOL_REQUEST_SCHEMA, AGENT_TOOL_RESULT_SCHEMA,
 };
 
 pub use super::agent_task_aggregate::{
@@ -87,6 +89,12 @@ pub use super::agent_task_schedule::{
 pub use super::agent_task_schedule::AgentTaskProgressEvent;
 
 pub use super::agent_task_scheduler::{AgentTaskExecutorAdapter, AgentTaskScheduler};
+
+pub use super::agent_tool_control_plane::{
+    dispatch_agent_tool_request, AgentToolControlPlaneDispatcher, AgentToolDispatchEvidence,
+    AgentToolDispatchOutcome, UnsupportedAgentToolControlPlaneDispatcher,
+    AGENT_TOOL_DISPATCH_EVIDENCE_SCHEMA,
+};
 
 // Matrix expansion is `pub(crate)` on the implementation module; expose it
 // through the facade for callers inside the crate that need to expand a plan

--- a/src/core/agent_tool_control_plane.rs
+++ b/src/core/agent_tool_control_plane.rs
@@ -1,0 +1,231 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::core::agent_task::{
+    AgentTaskDiagnostic, AgentToolExecutionLocation, AgentToolPolicy, AgentToolRequest,
+    AgentToolResult, AgentToolResultStatus, AGENT_TOOL_RESULT_SCHEMA,
+};
+
+pub const AGENT_TOOL_DISPATCH_EVIDENCE_SCHEMA: &str = "homeboy/agent-tool-dispatch-evidence/v1";
+
+pub trait AgentToolControlPlaneDispatcher {
+    fn dispatch(&self, request: &AgentToolRequest) -> AgentToolResult;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UnsupportedAgentToolControlPlaneDispatcher;
+
+impl AgentToolControlPlaneDispatcher for UnsupportedAgentToolControlPlaneDispatcher {
+    fn dispatch(&self, request: &AgentToolRequest) -> AgentToolResult {
+        unsupported_control_plane_result(request)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentToolDispatchOutcome {
+    pub location: AgentToolExecutionLocation,
+    pub result: AgentToolResult,
+    pub evidence: AgentToolDispatchEvidence,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentToolDispatchEvidence {
+    pub schema: String,
+    pub location: AgentToolExecutionLocation,
+    pub request: AgentToolRequest,
+    pub result: AgentToolResult,
+}
+
+pub fn dispatch_agent_tool_request(
+    policy: &AgentToolPolicy,
+    request: &AgentToolRequest,
+    dispatcher: &impl AgentToolControlPlaneDispatcher,
+) -> AgentToolDispatchOutcome {
+    let location = policy.execution_location_for(&request.tool);
+    let result = match location {
+        AgentToolExecutionLocation::Disabled => disabled_tool_result(request),
+        AgentToolExecutionLocation::ControlPlane => dispatcher.dispatch(request),
+        AgentToolExecutionLocation::Runner => runner_owned_tool_result(request),
+    };
+    let evidence = AgentToolDispatchEvidence {
+        schema: AGENT_TOOL_DISPATCH_EVIDENCE_SCHEMA.to_string(),
+        location,
+        request: request.redacted(),
+        result: result.redacted(),
+    };
+
+    AgentToolDispatchOutcome {
+        location,
+        result,
+        evidence,
+    }
+}
+
+fn disabled_tool_result(request: &AgentToolRequest) -> AgentToolResult {
+    AgentToolResult {
+        schema: AGENT_TOOL_RESULT_SCHEMA.to_string(),
+        request_id: request.request_id.clone(),
+        task_id: request.task_id.clone(),
+        tool: request.tool.clone(),
+        status: AgentToolResultStatus::Denied,
+        output: Value::Null,
+        diagnostics: vec![AgentTaskDiagnostic {
+            class: "agent_tool.disabled".to_string(),
+            message: format!("tool '{}' is disabled by agent tool policy", request.tool),
+            data: json!({ "tool": request.tool }),
+        }],
+        metadata: json!({ "execution_location": "disabled" }),
+    }
+}
+
+fn runner_owned_tool_result(request: &AgentToolRequest) -> AgentToolResult {
+    AgentToolResult {
+        schema: AGENT_TOOL_RESULT_SCHEMA.to_string(),
+        request_id: request.request_id.clone(),
+        task_id: request.task_id.clone(),
+        tool: request.tool.clone(),
+        status: AgentToolResultStatus::Failed,
+        output: Value::Null,
+        diagnostics: vec![AgentTaskDiagnostic {
+            class: "agent_tool.runner_dispatch_not_handled".to_string(),
+            message: "runner tool execution is owned by the provider runtime, not the control-plane dispatcher".to_string(),
+            data: json!({ "tool": request.tool }),
+        }],
+        metadata: json!({ "execution_location": "runner" }),
+    }
+}
+
+fn unsupported_control_plane_result(request: &AgentToolRequest) -> AgentToolResult {
+    AgentToolResult {
+        schema: AGENT_TOOL_RESULT_SCHEMA.to_string(),
+        request_id: request.request_id.clone(),
+        task_id: request.task_id.clone(),
+        tool: request.tool.clone(),
+        status: AgentToolResultStatus::Failed,
+        output: Value::Null,
+        diagnostics: vec![AgentTaskDiagnostic {
+            class: "agent_tool.control_plane_dispatch_unsupported".to_string(),
+            message: "control-plane tool dispatch is selected by policy, but no dispatcher is registered for this provider execution".to_string(),
+            data: json!({ "tool": request.tool }),
+        }],
+        metadata: json!({ "execution_location": "control_plane" }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    use crate::core::agent_task::{
+        AgentToolPolicyRule, AGENT_TOOL_POLICY_SCHEMA, AGENT_TOOL_REQUEST_SCHEMA,
+    };
+
+    #[derive(Debug, Clone, Copy)]
+    struct EchoDispatcher;
+
+    impl AgentToolControlPlaneDispatcher for EchoDispatcher {
+        fn dispatch(&self, request: &AgentToolRequest) -> AgentToolResult {
+            AgentToolResult {
+                schema: AGENT_TOOL_RESULT_SCHEMA.to_string(),
+                request_id: request.request_id.clone(),
+                task_id: request.task_id.clone(),
+                tool: request.tool.clone(),
+                status: AgentToolResultStatus::Succeeded,
+                output: json!({ "token": "secret-output", "safe": true }),
+                diagnostics: Vec::new(),
+                metadata: json!({ "authorization": "Bearer result-secret" }),
+            }
+        }
+    }
+
+    fn request(tool: &str) -> AgentToolRequest {
+        AgentToolRequest {
+            schema: AGENT_TOOL_REQUEST_SCHEMA.to_string(),
+            request_id: "request-1".to_string(),
+            task_id: "task-1".to_string(),
+            tool: tool.to_string(),
+            input: json!({ "token": "secret-input", "safe": true }),
+            timeout_ms: None,
+            metadata: json!({ "password": "secret-metadata" }),
+        }
+    }
+
+    fn policy(default_location: AgentToolExecutionLocation) -> AgentToolPolicy {
+        AgentToolPolicy {
+            schema: AGENT_TOOL_POLICY_SCHEMA.to_string(),
+            default_location,
+            tools: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn tool_policy_selects_explicit_route_over_default() {
+        let mut policy = policy(AgentToolExecutionLocation::Disabled);
+        policy.tools.insert(
+            "lookup".to_string(),
+            AgentToolPolicyRule {
+                execution_location: AgentToolExecutionLocation::ControlPlane,
+                timeout_ms: Some(250),
+                reason: Some("test route".to_string()),
+            },
+        );
+
+        let outcome = dispatch_agent_tool_request(&policy, &request("lookup"), &EchoDispatcher);
+
+        assert_eq!(outcome.location, AgentToolExecutionLocation::ControlPlane);
+        assert_eq!(outcome.result.status, AgentToolResultStatus::Succeeded);
+    }
+
+    #[test]
+    fn tool_policy_is_disabled_by_default() {
+        let outcome = dispatch_agent_tool_request(
+            &AgentToolPolicy::default(),
+            &request("lookup"),
+            &EchoDispatcher,
+        );
+
+        assert_eq!(outcome.location, AgentToolExecutionLocation::Disabled);
+        assert_eq!(outcome.result.status, AgentToolResultStatus::Denied);
+        assert_eq!(outcome.result.diagnostics[0].class, "agent_tool.disabled");
+    }
+
+    #[test]
+    fn tool_dispatch_evidence_redacts_request_and_result() {
+        let outcome = dispatch_agent_tool_request(
+            &policy(AgentToolExecutionLocation::ControlPlane),
+            &request("lookup"),
+            &EchoDispatcher,
+        );
+
+        assert_eq!(outcome.evidence.schema, AGENT_TOOL_DISPATCH_EVIDENCE_SCHEMA);
+        assert_eq!(outcome.evidence.request.input["token"], "[REDACTED]");
+        assert_eq!(outcome.evidence.request.input["safe"], true);
+        assert_eq!(outcome.evidence.request.metadata["password"], "[REDACTED]");
+        assert_eq!(outcome.evidence.result.output["token"], "[REDACTED]");
+        assert_eq!(
+            outcome.evidence.result.metadata["authorization"],
+            "[REDACTED]"
+        );
+    }
+
+    #[test]
+    fn unsupported_control_plane_dispatch_returns_explicit_diagnostic() {
+        let outcome = dispatch_agent_tool_request(
+            &policy(AgentToolExecutionLocation::ControlPlane),
+            &request("lookup"),
+            &UnsupportedAgentToolControlPlaneDispatcher,
+        );
+
+        assert_eq!(outcome.location, AgentToolExecutionLocation::ControlPlane);
+        assert_eq!(outcome.result.status, AgentToolResultStatus::Failed);
+        assert_eq!(
+            outcome.result.diagnostics[0].class,
+            "agent_tool.control_plane_dispatch_unsupported"
+        );
+        assert_eq!(
+            outcome.evidence.result.diagnostics[0].class,
+            "agent_tool.control_plane_dispatch_unsupported"
+        );
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -32,6 +32,7 @@ pub mod agent_task_secrets;
 pub mod agent_task_service;
 pub(crate) mod agent_task_timeout;
 pub(crate) mod agent_task_timeout_artifacts;
+pub mod agent_tool_control_plane;
 pub mod api_jobs;
 pub mod artifact_address;
 pub mod artifact_contract;


### PR DESCRIPTION
## Summary
- Adds generic agent tool request/result/policy contracts with disabled-by-default routing.
- Adds a control-plane dispatch seam with redacted evidence for controller-owned tool execution.
- Exposes the tool policy and schema IDs to provider runtimes through Homeboy agent-task environment variables.

Fixes #5017.

## Tests
- `cargo test provider_command_env_exposes_generic_agent_tool_contracts`
- `cargo test agent_tool_control_plane`
- `cargo test agent_tool`
- `cargo test core_contract_exports_authoritative_agent_task_metadata`
- `cargo fmt`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the generic Homeboy agent tool contract/control-plane seam and targeted tests; Chris remains responsible for review and verification.