### PR TITLE
Record agent-task patch promotion status

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -130,6 +130,13 @@ The gate passes when:
 - `review` returns a `homeboy/agent-task-review/v1` envelope with `transport.chat_state_required: false`, aggregate reconciliation, and promotion candidates.
 - `promote <run-id> --dry-run` resolves the aggregate from the durable run id and reports the selected non-empty patch plus changed files without requiring the operator to look up `aggregate_path` manually.
 
+When `promote <run-id>` applies a patch, Homeboy records `metadata.latest_promotion`
+on the durable run. That status event includes the source run id, source task id,
+patch artifact id/path, target worktree, discovered target branch/head when
+available, changed files, and an operator notification. `agent-task status
+<run-id>` surfaces the latest promotion so callers can tell whether promotion
+completed or is blocked without spelunking Lab artifact paths.
+
 When promotion runs without `--dry-run`, each `--verify <command>` is treated as
 a visible deterministic gate in the promoted worktree. Promotion reports gate
 results as `deterministic_gates[]` using

--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -186,9 +186,13 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
 
 pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
     let to_worktree = args.to_worktree.clone();
+    let source_run_id = agent_task_lifecycle::status(&args.source)
+        .ok()
+        .map(|record| record.run_id);
     let (raw, source_path) = read_promotion_source(&args.source)?;
     let report = promote(AgentTaskPromotionOptions {
         source: raw,
+        source_run_id: source_run_id.clone(),
         source_path,
         to_worktree: args.to_worktree,
         task_id: args.task_id,
@@ -204,6 +208,15 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
     };
     let mut value = serde_json::to_value(&report).unwrap_or(Value::Null);
     value["handoff"] = promotion_handoff(&report, &to_worktree);
+    if let Some(run_id) = source_run_id.filter(|_| !args.dry_run) {
+        let record =
+            agent_task_lifecycle::record_promotion(&run_id, promotion_status_event(&report))?;
+        value["recorded_on_run"] = serde_json::json!({
+            "run_id": record.run_id,
+            "metadata_key": "latest_promotion",
+            "status_command": format!("homeboy agent-task status {} --full", run_id)
+        });
+    }
 
     Ok((value, exit_code))
 }
@@ -462,6 +475,21 @@ fn promotion_handoff(report: &AgentTaskPromotionReport, to_worktree: &str) -> Va
     })
 }
 
+fn promotion_status_event(report: &AgentTaskPromotionReport) -> Value {
+    serde_json::json!({
+        "schema": "homeboy/agent-task-promotion-status/v1",
+        "status": report.status,
+        "source_run_id": report.source.run_id,
+        "source_task_id": report.source.task_id,
+        "patch_artifact_id": report.patch_artifact.id,
+        "patch_artifact_path": report.patch_artifact.path,
+        "to_worktree": report.to_worktree,
+        "target": report.target,
+        "changed_files": report.changed_files,
+        "operator_notification": report.operator_notification,
+    })
+}
+
 fn finalization_handoff(status: &str, pr_url: Option<&str>) -> Value {
     let pr_opened = status == "review_ready" && pr_url.is_some();
     serde_json::json!({
@@ -524,7 +552,8 @@ pub(crate) fn read_promotion_source(
 mod tests {
     use super::*;
     use homeboy::core::agent_tasks::promotion::{
-        AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandReport, AgentTaskPromotionSource,
+        AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandReport,
+        AgentTaskPromotionNotification, AgentTaskPromotionSource, AgentTaskPromotionTarget,
     };
     use homeboy::core::agent_tasks::AgentTaskAggregateSummary;
 
@@ -569,9 +598,17 @@ mod tests {
             source: AgentTaskPromotionSource {
                 kind: "aggregate".to_string(),
                 task_id: "cook-homeboy".to_string(),
+                run_id: Some("agent-task-run-1".to_string()),
                 path: Some("/tmp/aggregate.json".to_string()),
             },
             to_worktree: "homeboy@fix-runtime".to_string(),
+            target: AgentTaskPromotionTarget {
+                worktree: "homeboy@fix-runtime".to_string(),
+                path: Some("/Users/chubes/Developer/homeboy@fix-runtime".to_string()),
+                branch: Some("fix/runtime".to_string()),
+                head: Some("abc123".to_string()),
+                dirty: Some(true),
+            },
             patch_artifact: AgentTaskPromotionArtifactRef {
                 id: "patch-1".to_string(),
                 kind: "patch".to_string(),
@@ -583,6 +620,12 @@ mod tests {
             deterministic_gates: Vec::new(),
             gate_results: Vec::new(),
             provenance: serde_json::json!({ "worktree_path": "/Users/chubes/Developer/homeboy@fix-runtime" }),
+            operator_notification: AgentTaskPromotionNotification {
+                status: "completed".to_string(),
+                message: "patch promoted".to_string(),
+                resumable_blocker: None,
+                next_command: None,
+            },
         };
 
         let handoff = promotion_handoff(&report, "homeboy@fix-runtime");

--- a/src/commands/agent_task/status.rs
+++ b/src/commands/agent_task/status.rs
@@ -120,6 +120,14 @@ fn compact_status_summary(record: &Value, run_id: &str) -> Value {
             summary["aggregate_path"] = aggregate_path.clone();
         }
     }
+    if let Some(latest_promotion) = record
+        .get("metadata")
+        .and_then(|metadata| metadata.get("latest_promotion"))
+    {
+        if !latest_promotion.is_null() {
+            summary["latest_promotion"] = latest_promotion.clone();
+        }
+    }
     summary
 }
 
@@ -343,4 +351,42 @@ fn evidence_is_test(kind: &str, uri: &str) -> bool {
         || kind.contains("gate")
         || uri.contains("test")
         || uri.contains("transcript")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_status_surfaces_latest_promotion() {
+        let record = json!({
+            "run_id": "agent-task-run-1",
+            "state": "succeeded",
+            "tasks": [],
+            "metadata": {
+                "latest_promotion": {
+                    "schema": "homeboy/agent-task-promotion-status/v1",
+                    "status": "applied",
+                    "source_run_id": "agent-task-run-1",
+                    "patch_artifact_id": "patch.diff",
+                    "to_worktree": "homeboy@fix-5055",
+                    "operator_notification": {
+                        "status": "completed",
+                        "message": "patch promoted"
+                    }
+                }
+            }
+        });
+
+        let summary = compact_status_summary(&record, "agent-task-run-1");
+
+        assert_eq!(
+            summary["latest_promotion"]["patch_artifact_id"],
+            "patch.diff"
+        );
+        assert_eq!(
+            summary["latest_promotion"]["operator_notification"]["status"],
+            "completed"
+        );
+    }
 }

--- a/src/core/agent_task_cook_loop.rs
+++ b/src/core/agent_task_cook_loop.rs
@@ -446,7 +446,8 @@ mod tests {
     };
     use crate::core::agent_task_gate::{AgentTaskGateEnvironment, AgentTaskGateFailureEvidence};
     use crate::core::agent_task_promotion::{
-        AgentTaskPromotionArtifactRef, AgentTaskPromotionSource, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
+        AgentTaskPromotionArtifactRef, AgentTaskPromotionNotification, AgentTaskPromotionSource,
+        AgentTaskPromotionTarget, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
     };
 
     #[test]
@@ -713,9 +714,17 @@ mod tests {
             source: AgentTaskPromotionSource {
                 kind: "aggregate".to_string(),
                 task_id: "cook-homeboy".to_string(),
+                run_id: Some("agent-task-run-1".to_string()),
                 path: Some("aggregate.json".to_string()),
             },
             to_worktree: "homeboy@fix-3676".to_string(),
+            target: AgentTaskPromotionTarget {
+                worktree: "homeboy@fix-3676".to_string(),
+                path: Some("/tmp/homeboy@fix-3676".to_string()),
+                branch: Some("fix/3676".to_string()),
+                head: Some("abc123".to_string()),
+                dirty: Some(true),
+            },
             patch_artifact: AgentTaskPromotionArtifactRef {
                 id: "patch".to_string(),
                 kind: "patch".to_string(),
@@ -727,6 +736,16 @@ mod tests {
             deterministic_gates,
             gate_results: Vec::new(),
             provenance: json!({ "worktree_path": "/tmp/homeboy@fix-3676" }),
+            operator_notification: AgentTaskPromotionNotification {
+                status: if status == AgentTaskPromotionStatus::Applied {
+                    "completed".to_string()
+                } else {
+                    "blocked".to_string()
+                },
+                message: "test promotion notification".to_string(),
+                resumable_blocker: None,
+                next_command: None,
+            },
         }
     }
 

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -1003,6 +1003,25 @@ pub fn aggregate_source(run_id: &str) -> Result<(String, PathBuf)> {
     Ok((raw, path))
 }
 
+pub fn record_promotion(run_id: &str, promotion: Value) -> Result<AgentTaskRunRecord> {
+    let mut record = store::read_record(&sanitize_run_id(run_id))?;
+    record.updated_at = Some(now_timestamp());
+    let metadata = record.ensure_metadata_object();
+    let promotions = metadata
+        .entry("promotions".to_string())
+        .or_insert_with(|| json!([]));
+    if !promotions.is_array() {
+        *promotions = json!([]);
+    }
+    promotions
+        .as_array_mut()
+        .expect("promotions array")
+        .push(promotion.clone());
+    metadata.insert("latest_promotion".to_string(), promotion);
+    store::write_record(&record)?;
+    Ok(record)
+}
+
 fn aggregate_artifacts(aggregate: Option<&AgentTaskAggregate>) -> Vec<AgentTaskArtifact> {
     aggregate
         .map(|aggregate| {
@@ -1541,6 +1560,48 @@ mod tests {
             assert_eq!(
                 loaded.tasks[0].provider_ref.as_deref(),
                 Some("test:fixture")
+            );
+        });
+    }
+
+    #[test]
+    fn record_promotion_persists_latest_event_on_run_metadata() {
+        with_isolated_home(|_| {
+            let plan = test_plan();
+            submit_plan(&plan, Some("run-promotion-status")).expect("submitted");
+
+            let promotion = json!({
+                "schema": "homeboy/agent-task-promotion-status/v1",
+                "status": "applied",
+                "source_run_id": "run-promotion-status",
+                "patch_artifact_id": "patch.diff",
+                "to_worktree": "homeboy@fix-5055",
+                "target": {
+                    "worktree": "homeboy@fix-5055",
+                    "branch": "fix/5055",
+                    "head": "abc123"
+                },
+                "operator_notification": {
+                    "status": "completed",
+                    "message": "patch promoted into homeboy@fix-5055"
+                }
+            });
+
+            let updated = record_promotion("run-promotion-status", promotion.clone())
+                .expect("promotion recorded");
+            let loaded = status("run-promotion-status").expect("status loaded");
+
+            assert_eq!(updated.metadata["latest_promotion"], promotion);
+            assert_eq!(
+                loaded.metadata["latest_promotion"]["patch_artifact_id"],
+                "patch.diff"
+            );
+            assert_eq!(
+                loaded.metadata["promotions"]
+                    .as_array()
+                    .expect("events")
+                    .len(),
+                1
             );
         });
     }

--- a/src/core/agent_task_promotion.rs
+++ b/src/core/agent_task_promotion.rs
@@ -26,6 +26,8 @@ const PROMOTION_PROVIDER_COMMAND_ENV: &str = "HOMEBOY_AGENT_TASK_PROMOTION_COMMA
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskPromotionOptions {
     pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_run_id: Option<String>,
     pub source_path: Option<PathBuf>,
     pub to_worktree: String,
     pub task_id: Option<String>,
@@ -48,6 +50,7 @@ pub struct AgentTaskPromotionReport {
     pub status: AgentTaskPromotionStatus,
     pub source: AgentTaskPromotionSource,
     pub to_worktree: String,
+    pub target: AgentTaskPromotionTarget,
     pub patch_artifact: AgentTaskPromotionArtifactRef,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub changed_files: Vec<String>,
@@ -59,6 +62,7 @@ pub struct AgentTaskPromotionReport {
     pub gate_results: Vec<HomeboyGateResult>,
     #[serde(default, skip_serializing_if = "Value::is_null")]
     pub provenance: Value,
+    pub operator_notification: AgentTaskPromotionNotification,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -74,7 +78,22 @@ pub struct AgentTaskPromotionSource {
     pub kind: String,
     pub task_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPromotionTarget {
+    pub worktree: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dirty: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -94,6 +113,43 @@ pub struct AgentTaskPromotionCommandReport {
     pub stdout: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub stderr: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPromotionNotification {
+    pub status: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resumable_blocker: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_command: Option<String>,
+}
+
+impl AgentTaskPromotionTarget {
+    fn from_worktree(worktree: String, path: Option<&Path>) -> Self {
+        Self {
+            worktree,
+            path: path.map(|path| path.display().to_string()),
+            branch: path.and_then(|path| git_output(path, &["rev-parse", "--abbrev-ref", "HEAD"])),
+            head: path.and_then(|path| git_output(path, &["rev-parse", "HEAD"])),
+            dirty: path.and_then(|path| {
+                git_output(path, &["status", "--porcelain"]).map(|status| !status.is_empty())
+            }),
+        }
+    }
+}
+
+fn git_output(cwd: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 pub fn promote(options: AgentTaskPromotionOptions) -> Result<AgentTaskPromotionReport> {
@@ -200,24 +256,27 @@ fn promote_with_provider(
         .map(HomeboyGateResult::from)
         .collect();
 
+    let status = status_for_report(options.dry_run, has_gate_failure);
+    let target = AgentTaskPromotionTarget::from_worktree(
+        options.to_worktree.clone(),
+        applied_worktree_path.as_deref(),
+    );
+    let operator_notification = promotion_notification(status, &target);
+
     Ok(AgentTaskPromotionReport {
         schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
-        status: if options.dry_run {
-            AgentTaskPromotionStatus::DryRun
-        } else if has_gate_failure {
-            AgentTaskPromotionStatus::GateFailed
-        } else {
-            AgentTaskPromotionStatus::Applied
-        },
+        status,
         source: AgentTaskPromotionSource {
             kind: source_kind,
             task_id: outcome.task_id.clone(),
+            run_id: options.source_run_id,
             path: options
                 .source_path
                 .as_ref()
                 .map(|path| path.display().to_string()),
         },
         to_worktree: options.to_worktree,
+        target,
         patch_artifact: AgentTaskPromotionArtifactRef {
             id: artifact.id,
             kind: artifact.kind,
@@ -233,7 +292,55 @@ fn promote_with_provider(
             "artifact_metadata": artifact.metadata,
             "worktree_path": applied_worktree_path,
         }),
+        operator_notification,
     })
+}
+
+fn status_for_report(dry_run: bool, has_gate_failure: bool) -> AgentTaskPromotionStatus {
+    if dry_run {
+        AgentTaskPromotionStatus::DryRun
+    } else if has_gate_failure {
+        AgentTaskPromotionStatus::GateFailed
+    } else {
+        AgentTaskPromotionStatus::Applied
+    }
+}
+
+fn promotion_notification(
+    status: AgentTaskPromotionStatus,
+    target: &AgentTaskPromotionTarget,
+) -> AgentTaskPromotionNotification {
+    let target_path = target.path.as_deref().unwrap_or(target.worktree.as_str());
+    match status {
+        AgentTaskPromotionStatus::Applied => AgentTaskPromotionNotification {
+            status: "completed".to_string(),
+            message: format!(
+                "patch promoted into {}; verify and finalize from {}",
+                target.worktree, target_path
+            ),
+            resumable_blocker: None,
+            next_command: Some(format!(
+                "homeboy agent-task finalize-pr --run-id <run-id> --path {target_path} --title <title> --commit-message <message>"
+            )),
+        },
+        AgentTaskPromotionStatus::GateFailed => AgentTaskPromotionNotification {
+            status: "blocked".to_string(),
+            message: "patch promoted, but deterministic gates failed".to_string(),
+            resumable_blocker: Some(
+                "run `homeboy agent-task gate-feedback` with the promotion report, then retry the follow-up request".to_string(),
+            ),
+            next_command: None,
+        },
+        AgentTaskPromotionStatus::DryRun => AgentTaskPromotionNotification {
+            status: "blocked".to_string(),
+            message: "dry run validated a patch artifact but did not apply it".to_string(),
+            resumable_blocker: Some("rerun promote without `--dry-run` to apply the patch".to_string()),
+            next_command: Some(format!(
+                "homeboy agent-task promote <run-id> --to-worktree {}",
+                target.worktree
+            )),
+        },
+    }
 }
 
 const AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA: &str =
@@ -1117,6 +1224,7 @@ mod tests {
 
         let report = promote(AgentTaskPromotionOptions {
             source,
+            source_run_id: None,
             source_path: Some(source_path),
             to_worktree: "repo@promoted-task".to_string(),
             task_id: None,
@@ -1152,6 +1260,7 @@ mod tests {
         let report = promote_with_provider(
             AgentTaskPromotionOptions {
                 source,
+                source_run_id: Some("run-1".to_string()),
                 source_path: Some(source_path),
                 to_worktree: "repo@controlled-worktree".to_string(),
                 task_id: None,
@@ -1243,6 +1352,7 @@ mod tests {
         let report = promote_with_provider(
             AgentTaskPromotionOptions {
                 source,
+                source_run_id: None,
                 source_path: Some(source_path),
                 to_worktree: "homeboy@promoted-task".to_string(),
                 task_id: None,
@@ -1277,6 +1387,7 @@ mod tests {
 
         let err = promote(AgentTaskPromotionOptions {
             source,
+            source_run_id: None,
             source_path: Some(source_path),
             to_worktree: "repo@controlled-worktree".to_string(),
             task_id: None,
@@ -1301,6 +1412,7 @@ mod tests {
         // keys must stay at the top level of the serialized options.
         let options = AgentTaskPromotionOptions {
             source: "source.json".to_string(),
+            source_run_id: Some("run-1".to_string()),
             source_path: None,
             to_worktree: "repo@flatten".to_string(),
             task_id: None,
@@ -1364,9 +1476,17 @@ mod tests {
             source: AgentTaskPromotionSource {
                 kind: "outcome".to_string(),
                 task_id: "task-1".to_string(),
+                run_id: Some("run-1".to_string()),
                 path: None,
             },
             to_worktree: "repo@controlled-worktree".to_string(),
+            target: AgentTaskPromotionTarget {
+                worktree: "repo@controlled-worktree".to_string(),
+                path: Some("/tmp/repo@controlled-worktree".to_string()),
+                branch: Some("fix/test".to_string()),
+                head: Some("abc123".to_string()),
+                dirty: Some(true),
+            },
             patch_artifact: AgentTaskPromotionArtifactRef {
                 id: "patch".to_string(),
                 kind: "patch".to_string(),
@@ -1381,6 +1501,12 @@ mod tests {
             deterministic_gates: Vec::new(),
             gate_results: Vec::new(),
             provenance: Value::Null,
+            operator_notification: AgentTaskPromotionNotification {
+                status: "completed".to_string(),
+                message: "patch promoted".to_string(),
+                resumable_blocker: None,
+                next_command: None,
+            },
         };
 
         let value = serde_json::to_value(report).expect("serialize report");

--- a/src/core/agent_task_service.rs
+++ b/src/core/agent_task_service.rs
@@ -680,6 +680,7 @@ fn promote_attempt(
     let (source, source_path) = promotion_source(run_id)?;
     promote(AgentTaskPromotionOptions {
         source,
+        source_run_id: Some(run_id.to_string()),
         source_path,
         to_worktree: options.to_worktree.clone(),
         task_id: None,

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -193,10 +193,11 @@ pub mod lifecycle {
     pub use super::super::agent_task_lifecycle::{
         aggregate_source, artifacts, cancel, cancel_run, claim_next_queued_run, list_records,
         load_plan, logs, mark_resuming, mark_running, record_completed_run,
-        record_pre_dispatch_failure, record_remote_dispatch_failure, record_run_aggregate, retry,
-        run_record_exists, status, submit_plan, AgentTaskArtifactRef, AgentTaskPreDispatchFailure,
-        AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts, AgentTaskRunLog,
-        AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState, AgentTaskRunTask,
+        record_pre_dispatch_failure, record_promotion, record_remote_dispatch_failure,
+        record_run_aggregate, retry, run_record_exists, status, submit_plan, AgentTaskArtifactRef,
+        AgentTaskPreDispatchFailure, AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts,
+        AgentTaskRunLog, AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState,
+        AgentTaskRunTask,
     };
 }
 
@@ -229,8 +230,9 @@ pub mod loop_controller {
 pub mod promotion {
     pub use super::super::agent_task_promotion::{
         promote, AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandReport,
-        AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionSource,
-        AgentTaskPromotionStatus, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
+        AgentTaskPromotionNotification, AgentTaskPromotionOptions, AgentTaskPromotionReport,
+        AgentTaskPromotionSource, AgentTaskPromotionStatus, AgentTaskPromotionTarget,
+        AGENT_TASK_PROMOTION_REPORT_SCHEMA,
     };
 }
 


### PR DESCRIPTION
## Summary
- records durable promotion metadata when `agent-task promote` applies a patch
- surfaces latest promotion status in compact `agent-task status` output
- includes source run, selected patch artifact, target worktree, git state, and operator notification details

Fixes #5055

## Verification
- `cargo test agent_task_promotion --lib`
- `cargo test record_promotion --lib`
- `cargo test compact_status_surfaces_latest_promotion --lib`
- `cargo test promotion_handoff --lib`
- `cargo test agent_task --lib`
- `git diff --check`

Note: `cargo fmt --check` currently reports an unrelated existing formatting diff in `src/core/runner/workspace.rs`; this PR does not touch that file.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the patch promotion status slice under Chris's direction.