### PR TITLE
Improve lab offload rig dependency recovery

### DIFF
--- a/src/core/runner/git_dependency_materialization.rs
+++ b/src/core/runner/git_dependency_materialization.rs
@@ -376,6 +376,27 @@ fn terminal_dependency_error(
             "Or make the dirty checkout the primary bench workspace with --path so its working tree is snapshotted directly instead of as a clean git-only rig dependency.".to_string(),
         );
     }
+    if freshness.status == DependencyUpdateStatus::DetachedUnpinned {
+        hints.push(format!(
+            "Use a branch-backed dependency checkout before Lab offload: git -C {} switch <branch>",
+            shell_arg(&local_path.display().to_string())
+        ));
+        hints.push(
+            "If this detached checkout is the component under test, create/select a branch-backed worktree and rerun the rig proof with --path <component-path>.".to_string(),
+        );
+        hints.push(
+            "If the detached commit is intentional and reviewable, pin the rig component dependency with an explicit ref.".to_string(),
+        );
+    }
+    if freshness.status == DependencyUpdateStatus::NoUpstream {
+        hints.push(format!(
+            "Set an upstream for the dependency branch before Lab offload: git -C {} branch --set-upstream-to=<remote>/<branch>",
+            shell_arg(&local_path.display().to_string())
+        ));
+        hints.push(
+            "Or use a branch-backed worktree with an upstream and pass it as the rig component --path when it is the component under test.".to_string(),
+        );
+    }
     if let Some(error) = &source_error {
         hints.push(format!("Fetch failure: {}", error.message));
     }
@@ -402,6 +423,16 @@ fn terminal_dependency_error(
         ),
         Some(hints),
     )
+}
+
+fn shell_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn run_git(local_path: &Path, args: &[&str]) -> Result<()> {
@@ -496,6 +527,16 @@ mod tests {
             ensure_git_dependency_fresh(checkout.path(), None, false).expect_err("detached fails");
 
         assert!(err.message.contains("detached_unpinned"));
+        let hints = err.details["tried"]
+            .as_array()
+            .expect("tried hints")
+            .iter()
+            .filter_map(|hint| hint.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(hints.contains("git -C"));
+        assert!(hints.contains("switch <branch>"));
+        assert!(hints.contains("--path <component-path>"));
         assert_eq!(git_output(checkout.path(), &["rev-parse", "HEAD"]), head);
     }
 

--- a/src/core/runner/rig_materialization.rs
+++ b/src/core/runner/rig_materialization.rs
@@ -1,8 +1,10 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+use crate::core::component::Component;
 use crate::core::rig;
 use crate::core::{Error, Result};
+use crate::extensions::deps_provider;
 
 use super::{
     exec, load, materialize_git_dependency, sync_workspace,
@@ -78,6 +80,7 @@ pub(super) fn sync_lab_offload_rigs(
                 .source_root
                 .clone()
                 .unwrap_or_else(|| metadata.package_path.clone());
+            validate_installed_rig_source(rig_id, &source_root, &metadata.package_path)?;
             let synced = sync_workspace(
                 runner_id,
                 RunnerWorkspaceSyncOptions {
@@ -399,6 +402,7 @@ pub(super) fn sync_lab_offload_rig_component_dependencies(
         if !seen.insert(dependency.remote_checkout_root.clone()) {
             continue;
         }
+        prepare_rig_component_dependency(&dependency)?;
         synced.push(materialize_git_dependency(
             &runner,
             RunnerGitDependencyMaterializationOptions {
@@ -416,6 +420,65 @@ pub(super) fn sync_lab_offload_rig_component_dependencies(
         materializations: synced,
         component_path_env,
     })
+}
+
+fn validate_installed_rig_source(
+    rig_id: &str,
+    source_root: &str,
+    package_path: &str,
+) -> Result<()> {
+    if Path::new(source_root).is_dir() {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "rig",
+        format!(
+            "runner dispatch cannot materialize rig `{rig_id}` because its installed source metadata points at a missing path"
+        ),
+        Some(source_root.to_string()),
+        Some(vec![
+            format!(
+                "Repair the rig source metadata with: homeboy rig install {} --id {} --reinstall",
+                shell_arg(package_path),
+                shell_arg(rig_id)
+            ),
+            format!(
+                "Or remove the stale source metadata with: homeboy rig sources remove {}",
+                shell_arg(package_path)
+            ),
+            "Run `homeboy rig sources list` to inspect installed rig sources.".to_string(),
+        ]),
+    ))
+}
+
+fn prepare_rig_component_dependency(dependency: &RigComponentDependency) -> Result<()> {
+    let path = Path::new(&dependency.local_checkout_root);
+    let component = Component {
+        id: dependency.component_id.clone(),
+        local_path: dependency.local_checkout_root.clone(),
+        remote_url: dependency.remote_url.clone(),
+        ..Component::default()
+    };
+    let providers = match deps_provider::resolve_dependency_providers(&component, path) {
+        Ok(providers) => providers,
+        Err(_) => return Ok(()),
+    };
+
+    for provider in providers {
+        provider.install(&component, path)?;
+    }
+    Ok(())
+}
+
+fn shell_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 /// Join a runner-side checkout root with the component's required subpath.
@@ -794,6 +857,29 @@ mod tests {
             installed_source_selector_for_rig(&stdout, "target-rig").unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn stale_installed_rig_source_metadata_suggests_reinstall() {
+        let err = validate_installed_rig_source(
+            "woocommerce-performance",
+            "/missing/homeboy-rigs/woocommerce/woocommerce",
+            "/Users/chubes/Developer/homeboy-rigs@issue-323-codebox-fresh/woocommerce/woocommerce",
+        )
+        .expect_err("missing source should fail");
+
+        assert!(err.message.contains("installed source metadata"));
+        assert_eq!(err.details["field"], "rig");
+        let hints = err.details["tried"]
+            .as_array()
+            .expect("tried hints")
+            .iter()
+            .filter_map(|hint| hint.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(hints.contains("homeboy rig install"));
+        assert!(hints.contains("--id woocommerce-performance --reinstall"));
+        assert!(hints.contains("homeboy rig sources list"));
     }
 
     #[test]

--- a/src/extensions/deps_provider.rs
+++ b/src/extensions/deps_provider.rs
@@ -287,9 +287,48 @@ impl ComposerDependencyProvider {
     fn install(
         &self,
         _component: &Component,
-        _path: &Path,
+        path: &Path,
     ) -> Result<Option<DependencyCommandResult>> {
-        Ok(None)
+        let args = vec!["install".to_string(), "--no-interaction".to_string()];
+        let output = Command::new("composer")
+            .args(&args)
+            .current_dir(path)
+            .output()
+            .map_err(|e| {
+                Error::internal_io(e.to_string(), Some("run dependency provider".to_string()))
+            })?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let status = output.status.code();
+        if !output.status.success() {
+            return Err(Error::validation_invalid_argument(
+                "dependency_provider",
+                format!(
+                    "Dependency provider install failed with status {}: {}",
+                    output.status,
+                    first_non_empty_line(&stderr)
+                        .or_else(|| first_non_empty_line(&stdout))
+                        .unwrap_or("no output")
+                ),
+                None,
+                Some(vec![format!(
+                    "Run manually in {}: composer {}",
+                    path.display(),
+                    args.join(" ")
+                )]),
+            ));
+        }
+
+        Ok(Some(DependencyCommandResult {
+            command: std::iter::once("composer".to_string())
+                .chain(args)
+                .collect(),
+            skipped: false,
+            status,
+            stdout,
+            stderr,
+        }))
     }
 }
 
@@ -634,4 +673,50 @@ fn read_optional_json_file(path: &Path) -> Result<Option<Value>> {
 
 fn first_non_empty_line(output: &str) -> Option<&str> {
     output.lines().find(|line| !line.trim().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn composer_install_runs_full_dependency_install_lifecycle() {
+        let _guard = crate::test_support::home_env_guard();
+        let old_path = std::env::var("PATH").unwrap_or_default();
+        let bin = tempfile::tempdir().expect("bin tempdir");
+        let project = tempfile::tempdir().expect("project tempdir");
+        let composer = bin.path().join("composer");
+        std::fs::write(
+            &composer,
+            "#!/bin/sh\nprintf '%s\n' \"$@\" > composer-args.txt\n",
+        )
+        .expect("fake composer");
+        let mode = std::fs::metadata(&composer)
+            .expect("fake composer metadata")
+            .permissions();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut mode = mode;
+            mode.set_mode(0o755);
+            std::fs::set_permissions(&composer, mode).expect("chmod fake composer");
+        }
+        std::env::set_var("PATH", format!("{}:{old_path}", bin.path().display()));
+        std::fs::write(project.path().join("composer.json"), "{}").expect("composer json");
+
+        let result = ComposerDependencyProvider
+            .install(&Component::default(), project.path())
+            .expect("composer install");
+
+        std::env::set_var("PATH", old_path);
+        let result = result.expect("install result");
+        assert_eq!(
+            result.command,
+            vec!["composer", "install", "--no-interaction"]
+        );
+        assert_eq!(
+            std::fs::read_to_string(project.path().join("composer-args.txt")).unwrap(),
+            "install\n--no-interaction\n"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- validates stale installed rig source metadata before runner sync and emits direct recovery suggestions
- improves detached/unpinned dependency guidance with branch-backed checkout and `--path` recovery hints
- adds generic Composer dependency installation to the Homeboy dependency provider lifecycle before lab staging

Fixes #5057

## Verification
- `cargo test stale_installed_rig_source_metadata_suggests_reinstall`
- `cargo test detached_dependency_without_pinned_ref_fails`
- `cargo test composer_install_runs_full_dependency_install_lifecycle`
- `git diff --check`

Note: `cargo fmt --check` currently reports an unrelated existing formatting diff in `src/core/runner/workspace.rs`; this PR does not touch that file.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the lab offload ergonomics fixes under Chris's direction.