### PR TITLE
refactor(status): extract dashboard-table rendering module (#4965)

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -9,6 +9,9 @@ use serde::Serialize;
 
 use super::CmdResult;
 
+mod dashboard_table;
+use dashboard_table::log_dashboard_table;
+
 #[derive(Args)]
 pub struct StatusArgs {
     /// Project ID — show version dashboard for a project's components
@@ -768,129 +771,6 @@ fn fetch_project_remote_versions(project_id: &str) -> std::collections::HashMap<
             );
             std::collections::HashMap::new()
         }
-    }
-}
-
-/// Log a human-readable table to stderr.
-fn log_dashboard_table(rows: &[ProjectStatusRow]) {
-    if rows.is_empty() || !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
-        return;
-    }
-
-    // Calculate column widths
-    let widths = DashboardColumnWidths {
-        id: rows
-            .iter()
-            .map(|r| r.component_id.len())
-            .max()
-            .unwrap_or(9)
-            .max(9),
-        local: rows
-            .iter()
-            .map(|r| r.local_version.as_deref().unwrap_or("-").len())
-            .max()
-            .unwrap_or(5)
-            .max(5),
-        remote: rows
-            .iter()
-            .map(|r| r.remote_version.as_deref().unwrap_or("-").len())
-            .max()
-            .unwrap_or(6)
-            .max(6),
-        origin: rows
-            .iter()
-            .map(|r| r.origin_version.as_deref().unwrap_or("-").len())
-            .max()
-            .unwrap_or(6)
-            .max(6),
-    };
-
-    log_dashboard_header(&widths);
-    log_dashboard_separator(&widths);
-
-    for row in rows {
-        let local = row.local_version.as_deref().unwrap_or("-");
-        let remote = row.remote_version.as_deref().unwrap_or("-");
-        let origin = row.origin_version.as_deref().unwrap_or("-");
-        let upstream = format_upstream(&row.ahead_upstream, &row.behind_upstream);
-        let status_icon = match &row.status {
-            ProjectComponentDashboardStatus::Current => "✅ current",
-            ProjectComponentDashboardStatus::PinnedCurrent => "📌 pinned current",
-            ProjectComponentDashboardStatus::Outdated => "⚠️  outdated",
-            ProjectComponentDashboardStatus::NeedsRelease => "🔶 needs release",
-            ProjectComponentDashboardStatus::DocsOnly => "📝 docs only",
-            ProjectComponentDashboardStatus::Uncommitted => "🔴 uncommitted",
-            ProjectComponentDashboardStatus::BehindUpstream => "⬇️  behind upstream",
-            ProjectComponentDashboardStatus::Unknown => "❓ unknown",
-        };
-
-        eprintln!(
-            "{:<id_w$}  {:<local_w$}  {:<remote_w$}  {:<origin_w$}  {:>10}  {:>8}  {}",
-            row.component_id,
-            local,
-            remote,
-            origin,
-            row.unreleased_commits,
-            upstream,
-            status_icon,
-            id_w = widths.id,
-            local_w = widths.local,
-            remote_w = widths.remote,
-            origin_w = widths.origin,
-        );
-    }
-}
-
-struct DashboardColumnWidths {
-    id: usize,
-    local: usize,
-    remote: usize,
-    origin: usize,
-}
-
-fn log_dashboard_header(widths: &DashboardColumnWidths) {
-    eprintln!(
-        "{:<id_w$}  {:<local_w$}  {:<remote_w$}  {:<origin_w$}  {:>10}  {:>8}  Status",
-        "Component",
-        "Local",
-        "Remote",
-        "Origin",
-        "Unreleased",
-        "Upstream",
-        id_w = widths.id,
-        local_w = widths.local,
-        remote_w = widths.remote,
-        origin_w = widths.origin,
-    );
-}
-
-fn log_dashboard_separator(widths: &DashboardColumnWidths) {
-    eprintln!(
-        "{:-<id_w$}  {:-<local_w$}  {:-<remote_w$}  {:-<origin_w$}  {:->10}  {:->8}  {:-<10}",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        id_w = widths.id,
-        local_w = widths.local,
-        remote_w = widths.remote,
-        origin_w = widths.origin,
-    );
-}
-
-/// Format upstream ahead/behind as a compact string like "↓3" or "↑1↓2" or "=".
-fn format_upstream(ahead: &Option<u32>, behind: &Option<u32>) -> String {
-    match (ahead, behind) {
-        (Some(a), Some(b)) if *a > 0 && *b > 0 => format!("↑{}↓{}", a, b),
-        (Some(a), Some(_)) if *a > 0 => format!("↑{}", a),
-        (Some(_), Some(b)) if *b > 0 => format!("↓{}", b),
-        (None, Some(b)) if *b > 0 => format!("↓{}", b),
-        (Some(a), None) if *a > 0 => format!("↑{}", a),
-        (Some(0), Some(0)) | (None, Some(0)) | (Some(0), None) => "=".to_string(),
-        _ => "-".to_string(),
     }
 }
 

--- a/src/commands/status/dashboard_table.rs
+++ b/src/commands/status/dashboard_table.rs
@@ -1,0 +1,133 @@
+//! Human-readable dashboard table rendering for `homeboy status <project>`.
+//!
+//! Extracted from the `status` command entry to keep that file a thin command
+//! surface. This module owns the terminal-only table layout (column widths,
+//! header, separator, rows) and the compact upstream ahead/behind formatter.
+//! All output goes to stderr and is gated on an interactive terminal, so JSON
+//! consumers are unaffected.
+
+use super::ProjectComponentDashboardStatus;
+use super::ProjectStatusRow;
+
+/// Log a human-readable table to stderr.
+pub(super) fn log_dashboard_table(rows: &[ProjectStatusRow]) {
+    if rows.is_empty() || !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+        return;
+    }
+
+    // Calculate column widths
+    let widths = DashboardColumnWidths {
+        id: rows
+            .iter()
+            .map(|r| r.component_id.len())
+            .max()
+            .unwrap_or(9)
+            .max(9),
+        local: rows
+            .iter()
+            .map(|r| r.local_version.as_deref().unwrap_or("-").len())
+            .max()
+            .unwrap_or(5)
+            .max(5),
+        remote: rows
+            .iter()
+            .map(|r| r.remote_version.as_deref().unwrap_or("-").len())
+            .max()
+            .unwrap_or(6)
+            .max(6),
+        origin: rows
+            .iter()
+            .map(|r| r.origin_version.as_deref().unwrap_or("-").len())
+            .max()
+            .unwrap_or(6)
+            .max(6),
+    };
+
+    log_dashboard_header(&widths);
+    log_dashboard_separator(&widths);
+
+    for row in rows {
+        let local = row.local_version.as_deref().unwrap_or("-");
+        let remote = row.remote_version.as_deref().unwrap_or("-");
+        let origin = row.origin_version.as_deref().unwrap_or("-");
+        let upstream = format_upstream(&row.ahead_upstream, &row.behind_upstream);
+        let status_icon = match &row.status {
+            ProjectComponentDashboardStatus::Current => "✅ current",
+            ProjectComponentDashboardStatus::PinnedCurrent => "📌 pinned current",
+            ProjectComponentDashboardStatus::Outdated => "⚠️  outdated",
+            ProjectComponentDashboardStatus::NeedsRelease => "🔶 needs release",
+            ProjectComponentDashboardStatus::DocsOnly => "📝 docs only",
+            ProjectComponentDashboardStatus::Uncommitted => "🔴 uncommitted",
+            ProjectComponentDashboardStatus::BehindUpstream => "⬇️  behind upstream",
+            ProjectComponentDashboardStatus::Unknown => "❓ unknown",
+        };
+
+        eprintln!(
+            "{:<id_w$}  {:<local_w$}  {:<remote_w$}  {:<origin_w$}  {:>10}  {:>8}  {}",
+            row.component_id,
+            local,
+            remote,
+            origin,
+            row.unreleased_commits,
+            upstream,
+            status_icon,
+            id_w = widths.id,
+            local_w = widths.local,
+            remote_w = widths.remote,
+            origin_w = widths.origin,
+        );
+    }
+}
+
+struct DashboardColumnWidths {
+    id: usize,
+    local: usize,
+    remote: usize,
+    origin: usize,
+}
+
+fn log_dashboard_header(widths: &DashboardColumnWidths) {
+    eprintln!(
+        "{:<id_w$}  {:<local_w$}  {:<remote_w$}  {:<origin_w$}  {:>10}  {:>8}  Status",
+        "Component",
+        "Local",
+        "Remote",
+        "Origin",
+        "Unreleased",
+        "Upstream",
+        id_w = widths.id,
+        local_w = widths.local,
+        remote_w = widths.remote,
+        origin_w = widths.origin,
+    );
+}
+
+fn log_dashboard_separator(widths: &DashboardColumnWidths) {
+    eprintln!(
+        "{:-<id_w$}  {:-<local_w$}  {:-<remote_w$}  {:-<origin_w$}  {:->10}  {:->8}  {:-<10}",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        id_w = widths.id,
+        local_w = widths.local,
+        remote_w = widths.remote,
+        origin_w = widths.origin,
+    );
+}
+
+/// Format upstream ahead/behind as a compact string like "↓3" or "↑1↓2" or "=".
+fn format_upstream(ahead: &Option<u32>, behind: &Option<u32>) -> String {
+    match (ahead, behind) {
+        (Some(a), Some(b)) if *a > 0 && *b > 0 => format!("↑{}↓{}", a, b),
+        (Some(a), Some(_)) if *a > 0 => format!("↑{}", a),
+        (Some(_), Some(b)) if *b > 0 => format!("↓{}", b),
+        (None, Some(b)) if *b > 0 => format!("↓{}", b),
+        (Some(a), None) if *a > 0 => format!("↑{}", a),
+        (Some(0), Some(0)) | (None, Some(0)) | (Some(0), None) => "=".to_string(),
+        _ => "-".to_string(),
+    }
+}


### PR DESCRIPTION
Closes #4965.

## Summary
`src/commands/status.rs` had 31 top-level items, one over the structural threshold of 30 (`high_item_count`). This extracts the cohesive dashboard-table rendering cluster into a sibling module so `status.rs` stays a thin command surface.

## Change
- New `src/commands/status/dashboard_table.rs` owns the terminal-only project-dashboard table rendering:
  - `log_dashboard_table` (now `pub(super)`, called from `run_project_dashboard`)
  - `DashboardColumnWidths`, `log_dashboard_header`, `log_dashboard_separator`, `format_upstream`
- `status.rs` declares `mod dashboard_table;` and imports `log_dashboard_table`.
- Net: 5 items moved out, 1 `mod` item added → top-level item count drops from 31 to 26, clearing the `high_item_count` finding.

## Behavior
No public behavior or command-contract output changes. All extracted code is stderr-only, terminal-gated presentation logic; JSON output is untouched.

## Validation
- `cargo build --lib --tests` — clean (only pre-existing unrelated warnings)
- `cargo test status` — all pass (0 failed)
- `cargo test command_contract` — 17 pass
- `cargo test golden_contract` — 5 pass
- `cargo fmt` clean
- `homeboy audit homeboy --only high_item_count --ignore-baseline` confirms `src/commands/status.rs` no longer trips the detector.

Did not touch `docs/changelog.md` (homeboy owns it).