### PR TITLE
refactor(agent-task,lab): resolve audit-finding bundle (dedup, dead code, field patterns, preflight)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -157,7 +157,8 @@
         "extension_selector"
       ],
       "path_translation_markers": [
-        "rewrite_component_remote_args"
+        "rewrite_component_remote_args",
+        "preflight_remote_argv_path_translation"
       ]
     },
     "source_policies": [
@@ -909,7 +910,6 @@
         "dead_code::src/core/agent_task_dispatch_service.rs::DeadCodeMarker",
         "dead_code::src/core/agent_task_fanout.rs::UnreferencedExport",
         "dead_code::src/core/agent_task_loop_controller.rs::UnreferencedExport",
-        "dead_code::src/core/agent_task_provider.rs::UnreferencedExport",
         "dead_code::src/core/artifact_links.rs::UnreferencedExport",
         "dead_code::src/core/extension/bench/parsing.rs::UnreferencedExport",
         "dead_code::src/core/fleet/exec.rs::UnreferencedExport",
@@ -933,14 +933,12 @@
         "field_patterns::src/core/agent_task_controller_service.rs::RepeatedFieldPattern",
         "field_patterns::src/core/agent_task_dispatch_service.rs::RepeatedFieldPattern",
         "field_patterns::src/core/agent_task_fanout.rs::RepeatedFieldPattern",
-        "field_patterns::src/core/agent_task_lifecycle.rs::RepeatedFieldPattern",
         "field_patterns::src/core/agent_task_loop_controller.rs::RepeatedFieldPattern",
         "field_patterns::src/core/agent_task_promotion.rs::RepeatedFieldPattern",
         "field_patterns::src/core/agent_task_schedule.rs::RepeatedFieldPattern",
         "field_patterns::src/core/agent_task_service.rs::RepeatedFieldPattern",
         "field_patterns::src/core/context/report.rs::RepeatedFieldPattern",
         "field_patterns::src/core/daemon/broker_config.rs::RepeatedFieldPattern",
-        "field_patterns::src/core/daemon/patch_capture.rs::RepeatedFieldPattern",
         "field_patterns::src/core/engine/resource.rs::RepeatedFieldPattern",
         "field_patterns::src/core/engine/temp.rs::RepeatedFieldPattern",
         "field_patterns::src/core/extension/bench/artifact.rs::RepeatedFieldPattern",
@@ -984,7 +982,6 @@
         "intra-method-duplication::src/core/runner/execution.rs::IntraMethodDuplicate",
         "intra-method-duplication::src/core/runner/execution/extension_parity.rs::IntraMethodDuplicate",
         "intra-method-duplication::src/core/runner/git_dependency_materialization.rs::IntraMethodDuplicate",
-        "intra-method-duplication::src/core/runner/lab/offload.rs::IntraMethodDuplicate",
         "intra-method-duplication::src/core/runner/rig_materialization.rs::IntraMethodDuplicate",
         "intra-method-duplication::src/core/runner/validation_dependencies.rs::IntraMethodDuplicate",
         "intra-method-duplication::src/core/runner/worker.rs::IntraMethodDuplicate",
@@ -1005,7 +1002,6 @@
         "parallel-implementation::src/core/release/executor/publish.rs::ParallelImplementation",
         "remote_execution_preflight::src/commands/route.rs::RemoteExecutionPreflight",
         "remote_execution_preflight::src/core/runner/execution/policy.rs::RemoteExecutionPreflight",
-        "remote_execution_preflight::src/core/runner/lab/offload.rs::RemoteExecutionPreflight",
         "remote_execution_preflight::src/core/runner/lab_workspaces.rs::RemoteExecutionPreflight",
         "remote_execution_preflight::src/core/runner/rig_materialization.rs::RemoteExecutionPreflight",
         "remote_execution_preflight::src/core/runner/worker.rs::RemoteExecutionPreflight",

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -374,12 +374,21 @@ pub fn record_run_aggregate(
     record_aggregate(&mut record, plan, aggregate)
 }
 
+/// Shared `(run_id, runner_id)` identity borrowed by the Lab offload dispatch
+/// failure/record builders. Embedded as a named field so each builder stops
+/// repeating the same two borrows without changing any serialized shape (these
+/// builders are internal and not serialized).
+#[derive(Debug, Clone, Copy)]
+pub struct RunDispatchIdentity<'a> {
+    pub run_id: &'a str,
+    pub runner_id: &'a str,
+}
+
 #[derive(Debug, Clone)]
 pub struct AgentTaskPreDispatchFailure<'a> {
-    pub run_id: &'a str,
+    pub identity: RunDispatchIdentity<'a>,
     pub local_command: Vec<String>,
     pub remote_command: Vec<String>,
-    pub runner_id: &'a str,
     pub remote_workspace: &'a str,
     pub failure_message: &'a str,
     pub stdout: &'a str,
@@ -390,7 +399,7 @@ pub struct AgentTaskPreDispatchFailure<'a> {
 pub fn record_pre_dispatch_failure(
     failure: AgentTaskPreDispatchFailure<'_>,
 ) -> Result<AgentTaskRunRecord> {
-    let run_id = sanitize_run_id(failure.run_id);
+    let run_id = sanitize_run_id(failure.identity.run_id);
     if let Ok(record) = status(&run_id) {
         return Ok(record);
     }
@@ -398,7 +407,7 @@ pub fn record_pre_dispatch_failure(
     let task_id = "agent-task-predispatch".to_string();
     let metadata = json!({
         "kind": "lab_offload_pre_dispatch_failure",
-        "runner_id": failure.runner_id,
+        "runner_id": failure.identity.runner_id,
         "remote_workspace": failure.remote_workspace,
         "local_command": failure.local_command,
         "remote_command": failure.remote_command,
@@ -426,7 +435,7 @@ pub fn record_pre_dispatch_failure(
             inputs: json!({
                 "local_command": failure.local_command,
                 "remote_command": failure.remote_command,
-                "runner_id": failure.runner_id,
+                "runner_id": failure.identity.runner_id,
                 "remote_workspace": failure.remote_workspace,
                 "failure": {
                     "message": failure.failure_message,
@@ -485,7 +494,7 @@ pub fn record_pre_dispatch_failure(
             diagnostics: Vec::new(),
             outputs: json!({
                 "schema": "homeboy/agent-task-predispatch-failure/v1",
-                "runner_id": failure.runner_id,
+                "runner_id": failure.identity.runner_id,
                 "remote_workspace": failure.remote_workspace,
                 "local_command": failure.local_command,
                 "remote_command": failure.remote_command,
@@ -523,10 +532,9 @@ pub fn record_pre_dispatch_failure(
 
 #[derive(Debug, Clone)]
 pub struct AgentTaskRemoteDispatchFailure<'a> {
-    pub run_id: &'a str,
+    pub identity: RunDispatchIdentity<'a>,
     pub local_command: Vec<String>,
     pub remote_command: Vec<String>,
-    pub runner_id: &'a str,
     pub remote_workspace: &'a str,
     pub stdout: &'a str,
     pub stderr: &'a str,
@@ -545,7 +553,7 @@ pub fn record_remote_dispatch_failure(
         return Ok(None);
     };
 
-    let run_id = sanitize_run_id(failure.run_id);
+    let run_id = sanitize_run_id(failure.identity.run_id);
     let mut aggregate: AgentTaskAggregate = serde_json::from_value(aggregate_value.clone())
         .map_err(|error| {
             Error::internal_json(
@@ -593,7 +601,7 @@ pub fn record_remote_dispatch_failure(
             let remote_run_id = envelope
                 .get("run_id")
                 .and_then(Value::as_str)
-                .unwrap_or(failure.run_id)
+                .unwrap_or(failure.identity.run_id)
                 .to_string();
             let remote_plan_path = envelope
                 .get("plan_path")
@@ -631,7 +639,7 @@ pub fn record_remote_dispatch_failure(
         "kind".to_string(),
         json!("lab_offload_remote_dispatch_failure"),
     );
-    metadata.insert("runner_id".to_string(), json!(failure.runner_id));
+    metadata.insert("runner_id".to_string(), json!(failure.identity.runner_id));
     metadata.insert(
         "remote_workspace".to_string(),
         json!(failure.remote_workspace),
@@ -743,7 +751,7 @@ fn synthetic_remote_dispatch_plan(
                     task_url: None,
                     cleanup: Some("preserve".to_string()),
                     materialization: json!({
-                        "runner_id": failure.runner_id,
+                        "runner_id": failure.identity.runner_id,
                         "remote_workspace": failure.remote_workspace,
                     }),
                 },
@@ -767,7 +775,7 @@ fn synthetic_remote_dispatch_plan(
     plan.group_key = Some("lab-offload".to_string());
     plan.metadata = json!({
         "kind": "lab_offload_remote_dispatch_failure",
-        "runner_id": failure.runner_id,
+        "runner_id": failure.identity.runner_id,
         "remote_workspace": failure.remote_workspace,
         "remote_run_id": envelope.get("run_id").and_then(Value::as_str),
     });
@@ -1549,7 +1557,10 @@ mod tests {
     fn pre_dispatch_failure_persists_failed_run_without_provider_handle() {
         with_isolated_home(|_| {
             let record = record_pre_dispatch_failure(AgentTaskPreDispatchFailure {
-                run_id: "cook-lab-predispatch",
+                identity: RunDispatchIdentity {
+                    run_id: "cook-lab-predispatch",
+                    runner_id: "lab-a",
+                },
                 local_command: vec![
                     "homeboy".to_string(),
                     "agent-task".to_string(),
@@ -1564,7 +1575,6 @@ mod tests {
                     "--cwd".to_string(),
                     "/runner/workspace/repo".to_string(),
                 ],
-                runner_id: "lab-a",
                 remote_workspace: "/runner/workspace/repo",
                 failure_message: "Invalid argument 'cwd': agent-task Codebox dispatch requires --cwd to be a git checkout",
                 stdout: "",
@@ -1687,7 +1697,10 @@ mod tests {
 
             let record = record_remote_dispatch_failure(
                 AgentTaskRemoteDispatchFailure {
-                    run_id: "local-run",
+                    identity: RunDispatchIdentity {
+                        run_id: "local-run",
+                        runner_id: "lab-a",
+                    },
                     local_command: vec![
                         "homeboy".to_string(),
                         "agent-task".to_string(),
@@ -1698,7 +1711,6 @@ mod tests {
                         "agent-task".to_string(),
                         "cook".to_string(),
                     ],
-                    runner_id: "lab-a",
                     remote_workspace: "/runner/workspace/repo",
                     stdout: &envelope.to_string(),
                     stderr: "",
@@ -1803,7 +1815,10 @@ mod tests {
 
             let record = record_remote_dispatch_failure(
                 AgentTaskRemoteDispatchFailure {
-                    run_id: "conductor-full-loop-proof-retry2-20260611",
+                    identity: RunDispatchIdentity {
+                        run_id: "conductor-full-loop-proof-retry2-20260611",
+                        runner_id: "lab-a",
+                    },
                     local_command: vec![
                         "homeboy".to_string(),
                         "agent-task".to_string(),
@@ -1814,7 +1829,6 @@ mod tests {
                         "agent-task".to_string(),
                         "cook".to_string(),
                     ],
-                    runner_id: "lab-a",
                     remote_workspace: "/runner/workspace/conductor",
                     stdout: &envelope.to_string(),
                     stderr: "",
@@ -1904,7 +1918,10 @@ mod tests {
 
             record_remote_dispatch_failure(
                 AgentTaskRemoteDispatchFailure {
-                    run_id: "local-sparse-run",
+                    identity: RunDispatchIdentity {
+                        run_id: "local-sparse-run",
+                        runner_id: "lab-a",
+                    },
                     local_command: vec![
                         "homeboy".to_string(),
                         "agent-task".to_string(),
@@ -1915,7 +1932,6 @@ mod tests {
                         "agent-task".to_string(),
                         "cook".to_string(),
                     ],
-                    runner_id: "lab-a",
                     remote_workspace: "/runner/workspace/conductor",
                     stdout: "",
                     stderr: &envelope.to_string(),

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -382,7 +382,7 @@ impl AgentTaskProviderRoleAliases {
         alias_matches(self.artifact_filenames.get(role), filename)
     }
 
-    pub fn role_for_artifact_kind(&self, kind: &str) -> Option<&str> {
+    fn role_for_artifact_kind(&self, kind: &str) -> Option<&str> {
         self.artifact_kinds
             .iter()
             .find_map(|(role, aliases)| alias_matches(Some(aliases), kind).then_some(role.as_str()))
@@ -413,7 +413,10 @@ fn alias_matches(aliases: Option<&Vec<String>>, value: &str) -> bool {
     })
 }
 
-fn wildcard_match(pattern: &str, value: &str) -> bool {
+/// Shared glob-style matcher used by provider role-alias resolution and the
+/// timeout artifact discovery scanner. Supports `*` wildcards with optional
+/// start/end anchoring.
+pub(crate) fn wildcard_match(pattern: &str, value: &str) -> bool {
     if !pattern.contains('*') {
         return pattern == value;
     }
@@ -1802,6 +1805,13 @@ fn provider_command_env(
     request: &AgentTaskRequest,
     provider: &AgentTaskExecutorProvider,
 ) -> Result<Vec<(String, String)>, ProviderCommandEnvError> {
+    // Both runtime path env vars resolve to the provider runtime_path, falling
+    // back to the extension_path when the runtime is not separately declared.
+    let runtime_path = provider
+        .runtime_path
+        .clone()
+        .or_else(|| provider.extension_path.clone())
+        .unwrap_or_default();
     let mut env = vec![
         (
             "HOMEBOY_AGENT_TASK_PROVIDER_ID".to_string(),
@@ -1840,26 +1850,12 @@ fn provider_command_env(
             "HOMEBOY_EXTENSION_PATH".to_string(),
             provider.extension_path.clone().unwrap_or_default(),
         ),
-        (
-            "HOMEBOY_RUNTIME_PATH".to_string(),
-            provider
-                .runtime_path
-                .clone()
-                .or_else(|| provider.extension_path.clone())
-                .unwrap_or_default(),
-        ),
+        ("HOMEBOY_RUNTIME_PATH".to_string(), runtime_path.clone()),
         (
             "HOMEBOY_AI_RUNTIME_ID".to_string(),
             provider.runtime_id.clone().unwrap_or_default(),
         ),
-        (
-            "HOMEBOY_AI_RUNTIME_PATH".to_string(),
-            provider
-                .runtime_path
-                .clone()
-                .or_else(|| provider.extension_path.clone())
-                .unwrap_or_default(),
-        ),
+        ("HOMEBOY_AI_RUNTIME_PATH".to_string(), runtime_path),
     ];
     env.extend(provider_executable_env(provider).map_err(ProviderCommandEnvError::Executable)?);
     env.extend(

--- a/src/core/agent_task_timeout_artifacts.rs
+++ b/src/core/agent_task_timeout_artifacts.rs
@@ -10,7 +10,7 @@ use crate::core::agent_task::{
     AGENT_TASK_OUTCOME_SCHEMA,
 };
 use crate::core::agent_task_provider::{
-    role_aliases_for_executor, timeout_artifact_discovery_for_executor,
+    role_aliases_for_executor, timeout_artifact_discovery_for_executor, wildcard_match,
     AgentTaskProviderArtifactPattern, AgentTaskProviderRoleAliases,
     AgentTaskProviderTimeoutArtifactDiscovery,
 };
@@ -512,30 +512,6 @@ fn artifact_pattern_matches(pattern: &AgentTaskProviderArtifactPattern, path: &P
             .iter()
             .map(|candidate| candidate.trim_start_matches('.').to_ascii_lowercase())
             .any(|candidate| candidate == extension)
-}
-
-fn wildcard_match(pattern: &str, value: &str) -> bool {
-    if !pattern.contains('*') {
-        return pattern == value;
-    }
-
-    let mut remainder = value;
-    let anchored_start = !pattern.starts_with('*');
-    let anchored_end = !pattern.ends_with('*');
-    let parts: Vec<&str> = pattern.split('*').filter(|part| !part.is_empty()).collect();
-    if parts.is_empty() {
-        return true;
-    }
-    if anchored_start && !value.starts_with(parts[0]) {
-        return false;
-    }
-    for part in &parts {
-        let Some(index) = remainder.find(part) else {
-            return false;
-        };
-        remainder = &remainder[index + part.len()..];
-    }
-    !anchored_end || value.ends_with(parts[parts.len() - 1])
 }
 
 fn merge_artifact_metadata(metadata: Value) -> Value {

--- a/src/core/daemon/patch_capture.rs
+++ b/src/core/daemon/patch_capture.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::core::agent_task_lifecycle::RunDispatchIdentity;
 use crate::core::error::{Error, Result};
 use crate::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
 use crate::core::paths;
@@ -52,8 +53,7 @@ pub(super) struct PatchCaptureReport {
 }
 
 struct PatchRunInput<'a> {
-    run_id: &'a str,
-    runner_id: &'a str,
+    identity: RunDispatchIdentity<'a>,
     cwd: &'a str,
     command: &'a [String],
     source_snapshot: Option<&'a SourceSnapshot>,
@@ -121,8 +121,10 @@ pub(super) fn capture_patch_report(
         baseline_missing: false,
     };
     persist_patch_run(PatchRunInput {
-        run_id: &run_id,
-        runner_id,
+        identity: RunDispatchIdentity {
+            run_id: &run_id,
+            runner_id,
+        },
         cwd,
         command,
         source_snapshot,
@@ -172,7 +174,7 @@ fn persist_patch_run(input: PatchRunInput<'_>) -> Result<()> {
     let store = ObservationStore::open_initialized()?;
     let now = chrono::Utc::now().to_rfc3339();
     let run = RunRecord {
-        id: input.run_id.to_string(),
+        id: input.identity.run_id.to_string(),
         kind: "runner-exec".to_string(),
         component_id: None,
         started_at: now.clone(),
@@ -187,13 +189,13 @@ fn persist_patch_run(input: PatchRunInput<'_>) -> Result<()> {
         rig_id: None,
         metadata_json: json!({
             "lab": {
-                "runner_id": input.runner_id,
+                "runner_id": input.identity.runner_id,
                 "source_snapshot": input.source_snapshot,
                 "patch": input.report,
             }
         }),
     };
-    if store.get_run(input.run_id)?.is_none() {
+    if store.get_run(input.identity.run_id)?.is_none() {
         store.import_run(&run)?;
     }
     if let Some(path) = input.patch_artifact_path {
@@ -202,7 +204,7 @@ fn persist_patch_run(input: PatchRunInput<'_>) -> Result<()> {
         })?;
         let artifact = ArtifactRecord {
             id: input.artifact_id.to_string(),
-            run_id: input.run_id.to_string(),
+            run_id: input.identity.run_id.to_string(),
             kind: "lab_fix_patch".to_string(),
             artifact_type: "file".to_string(),
             path: path.display().to_string(),

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -25,7 +25,6 @@ use crate::core::agent_tasks::provider::{
     default_backend_for_component, AgentTaskExecutorProvider, ExtensionProviderAgentTaskExecutor,
 };
 use crate::core::engine::shell;
-use crate::core::observation::{PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV};
 use crate::core::plan::{HomeboyPlan, PlanStep, PlanStepStatus, PlanValues};
 use crate::core::source_snapshot::SourceSnapshot;
 use crate::core::{Error, ErrorCode, Result};
@@ -42,9 +41,8 @@ use super::super::lab_args::{
 use super::super::lab_capabilities::lab_runner_capability_contract;
 use super::super::lab_command::lab_offload_command_prefix;
 use super::super::lab_env::{
-    build_lab_offload_env, forward_env_if_present, forward_release_ci_env,
-    forward_rig_component_path_env, misplaced_runner_exec_wait_timeout_warning,
-    settings_env_diagnostics,
+    build_lab_offload_env_with_passthroughs, forward_rig_component_path_env,
+    misplaced_runner_exec_wait_timeout_warning, settings_env_diagnostics,
 };
 use super::super::lab_plan::{base_lab_plan, disabled_select_runner_plan, with_step};
 use super::super::lab_selection::{
@@ -298,6 +296,105 @@ fn dirty_patch_provider_checkout_hints(source_path: &Path, status: &str) -> Vec<
     hints
 }
 
+/// Explicit path-translation preflight for the remote dispatch argv.
+///
+/// By the time this runs the argv has already passed through the Lab offload
+/// remap pipeline (`remap_path_settings_in_args`, `remap_provider_config_in_args`,
+/// `rewrite_lab_offload_args`, ...), which rewrites controller-local paths to
+/// their synced remote locations. This is the final gate before
+/// [`exec`]: it rejects any argument that still embeds the controller-local
+/// source-checkout root, so a missed remap fails loudly on the controller
+/// instead of handing a non-existent local path to the remote runner.
+fn preflight_remote_argv_path_translation(
+    runner_id: &str,
+    command: &[String],
+    source_path: &Path,
+    remote_cwd: &str,
+) -> Result<()> {
+    let local_root = source_path.display().to_string();
+    let local_root = local_root.trim_end_matches('/');
+    if local_root.is_empty() {
+        return Ok(());
+    }
+
+    let leaked: Vec<String> = command
+        .iter()
+        .filter(|arg| arg_embeds_untranslated_local_path(arg, local_root, remote_cwd))
+        .cloned()
+        .collect();
+    if leaked.is_empty() {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "command",
+        format!(
+            "Lab offload refused to dispatch to runner `{runner_id}`: {} remote argv argument(s) still reference the controller-local source path `{local_root}` instead of the remote workspace `{remote_cwd}`",
+            leaked.len()
+        ),
+        Some(runner_id.to_string()),
+        Some(vec![
+            format!("Untranslated argument(s): {}", leaked.join(", ")),
+            "This is a path-translation defect in the Lab offload remap pipeline; the argument must be remapped to the remote workspace path before dispatch.".to_string(),
+        ]),
+    ))
+}
+
+/// True when `arg` embeds the controller-local source root but has not been
+/// translated to the remote workspace path. Arguments that already point at the
+/// remote workspace (or do not reference the local root at all) are accepted.
+fn arg_embeds_untranslated_local_path(arg: &str, local_root: &str, remote_cwd: &str) -> bool {
+    if !arg.contains(local_root) {
+        return false;
+    }
+    // A correctly translated argument addresses the remote workspace root; if it
+    // happens to share a prefix string with the local root that is fine.
+    if !remote_cwd.is_empty() && arg.contains(remote_cwd) {
+        return false;
+    }
+    true
+}
+
+/// Record a freshly synced, remapped agent-task workspace entry: append it to
+/// the workspace mapping and emit the matching Lab plan step. Shared by the
+/// inline tasks-arg and plan-arg materialization in `run_lab_offload_inner`.
+fn record_synced_remapped_workspace_entry(
+    plan: HomeboyPlan,
+    workspace_mapping: &mut Vec<super::super::lab_workspaces::LabWorkspaceMappingEntry>,
+    entry: Option<super::super::lab_workspaces::LabWorkspaceMappingEntry>,
+    step_id: &str,
+) -> HomeboyPlan {
+    let Some(entry) = entry else {
+        return plan;
+    };
+    workspace_mapping.push(entry.clone());
+    with_step(
+        plan,
+        PlanStep::ready(step_id, step_id)
+            .inputs(PlanValues::new().json("workspace", &entry))
+            .build(),
+    )
+}
+
+/// Build the `RunLocal` outcome used whenever automatic Lab offload is skipped
+/// for a portability/default-runner reason. Centralizes the repeated
+/// "automatic / skipped" metadata shape used by `execute_lab_offload`.
+fn skipped_automatic_run_local(plan: HomeboyPlan, reason: &str) -> LabOffloadOutcome {
+    LabOffloadOutcome::RunLocal {
+        metadata: Some(lab_offload_metadata(
+            &plan,
+            "automatic",
+            None,
+            None,
+            "skipped",
+            None,
+            Some(reason),
+        )),
+        plan,
+        messages: Vec::new(),
+    }
+}
+
 pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadOutcome> {
     let unsupported_runner_error = |runner_id: &str, message: String| {
         Error::validation_invalid_argument(
@@ -334,19 +431,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             .unsupported_reason
             .unwrap_or("command is local-only");
         plan = disabled_select_runner_plan(plan, reason);
-        return Ok(LabOffloadOutcome::RunLocal {
-            metadata: Some(lab_offload_metadata(
-                &plan,
-                "automatic",
-                None,
-                None,
-                "skipped",
-                None,
-                Some(reason),
-            )),
-            plan,
-            messages: Vec::new(),
-        });
+        return Ok(skipped_automatic_run_local(plan, reason));
     }
 
     if request.explicit_runner.is_none() && !contract.default_lab_offload {
@@ -386,19 +471,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             .skip_reason(reason)
             .build(),
         );
-        return Ok(LabOffloadOutcome::RunLocal {
-            metadata: Some(lab_offload_metadata(
-                &plan,
-                "automatic",
-                None,
-                None,
-                "skipped",
-                None,
-                Some(reason),
-            )),
-            plan,
-            messages: Vec::new(),
-        });
+        return Ok(skipped_automatic_run_local(plan, reason));
     };
 
     let mut messages = Vec::new();
@@ -569,16 +642,10 @@ fn run_runner_resident_lab_offload(
         "runner_cwd": runner_workspace_root,
         "command_paths": "runner_side",
     });
-    let mut env = build_lab_offload_env(&lab_metadata);
-    forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
-    forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
-    forward_release_ci_env(&mut env);
+    let mut env = build_lab_offload_env_with_passthroughs(&lab_metadata);
     let tunnel_secret_env = hydrate_tunnel_secret_env(&remapped_args, &mut env)?;
     lab_metadata["tunnel_secret_env"] = tunnel_secret_env;
-    env = build_lab_offload_env(&lab_metadata);
-    forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
-    forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
-    forward_release_ci_env(&mut env);
+    env = build_lab_offload_env_with_passthroughs(&lab_metadata);
     hydrate_tunnel_secret_env(&remapped_args, &mut env)?;
 
     let (exec_output, exit_code) = exec(
@@ -1110,32 +1177,20 @@ fn run_lab_offload_inner(
     let remapped_args = remap_path_settings_in_args(&remapped_args, &path_remaps);
     let (remapped_args, synced_remapped_tasks) =
         materialize_inline_agent_task_tasks_arg(runner_id, &remapped_args)?;
-    if let Some(entry) = synced_remapped_tasks {
-        workspace_mapping.push(entry.clone());
-        plan = with_step(
-            plan,
-            PlanStep::ready(
-                "lab.sync_remapped_agent_task_tasks",
-                "lab.sync_remapped_agent_task_tasks",
-            )
-            .inputs(PlanValues::new().json("workspace", &entry))
-            .build(),
-        );
-    }
+    plan = record_synced_remapped_workspace_entry(
+        plan,
+        &mut workspace_mapping,
+        synced_remapped_tasks,
+        "lab.sync_remapped_agent_task_tasks",
+    );
     let (remapped_args, synced_remapped_plan) =
         materialize_inline_agent_task_plan_arg(runner_id, &remapped_args)?;
-    if let Some(entry) = synced_remapped_plan {
-        workspace_mapping.push(entry.clone());
-        plan = with_step(
-            plan,
-            PlanStep::ready(
-                "lab.sync_remapped_agent_task_plan",
-                "lab.sync_remapped_agent_task_plan",
-            )
-            .inputs(PlanValues::new().json("workspace", &entry))
-            .build(),
-        );
-    }
+    plan = record_synced_remapped_workspace_entry(
+        plan,
+        &mut workspace_mapping,
+        synced_remapped_plan,
+        "lab.sync_remapped_agent_task_plan",
+    );
     let (remapped_args, agent_task_run_id) = ensure_agent_task_dispatch_run_id(&remapped_args)
         .map_or((remapped_args, None), |(args, run_id)| (args, Some(run_id)));
 
@@ -1178,10 +1233,7 @@ fn run_lab_offload_inner(
         None,
         Some(&workspace_mapping_metadata),
     );
-    let mut env = build_lab_offload_env(&lab_metadata);
-    forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
-    forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
-    forward_release_ci_env(&mut env);
+    let mut env = build_lab_offload_env_with_passthroughs(&lab_metadata);
     let rig_component_path_env = forward_rig_component_path_env(&mut env, &workspace_mapping)?;
     apply_rig_component_path_overrides(&mut env, &rig_component_path_overrides);
     let agent_task_secret_env =
@@ -1211,10 +1263,7 @@ fn run_lab_offload_inner(
         "status": synced.workspace_cleanliness,
         "allow_dirty_lab_workspace": request.allow_dirty_lab_workspace,
     });
-    env = build_lab_offload_env(&lab_metadata);
-    forward_env_if_present(&mut env, PREVIEW_METADATA_ENV);
-    forward_env_if_present(&mut env, PREVIEW_PUBLIC_URL_ENV);
-    forward_release_ci_env(&mut env);
+    env = build_lab_offload_env_with_passthroughs(&lab_metadata);
     forward_rig_component_path_env(&mut env, &workspace_mapping)?;
     apply_rig_component_path_overrides(&mut env, &rig_component_path_overrides);
     hydrate_agent_task_secret_env(&changed_since_preflight.args, &mut env)?;
@@ -1238,6 +1287,12 @@ fn run_lab_offload_inner(
         &runner_homeboy,
         &runner_status,
     )?;
+    // Path-translation preflight: the argv has already been routed through the
+    // `rewrite_lab_offload_args` / `remap_*` translation pipeline above. Assert
+    // that no controller-local source-checkout path survived un-translated
+    // before we dispatch the command to the remote runner, so a missed remap
+    // fails loudly here instead of corrupting the remote run.
+    preflight_remote_argv_path_translation(runner_id, &command, &source_path, &remote_cwd)?;
     let exec_result = exec(
         runner_id,
         RunnerExecOptions {
@@ -1363,10 +1418,9 @@ fn run_lab_offload_inner(
             )? {
                 if let Some(record) = agent_task_lifecycle::record_remote_dispatch_failure(
                     agent_task_lifecycle::AgentTaskRemoteDispatchFailure {
-                        run_id,
+                        identity: agent_task_lifecycle::RunDispatchIdentity { run_id, runner_id },
                         local_command: request.normalized_args.to_vec(),
                         remote_command: remote_command.clone(),
-                        runner_id,
                         remote_workspace: &remote_cwd,
                         stdout: &exec_output.stdout,
                         stderr: &exec_output.stderr,
@@ -1392,10 +1446,9 @@ fn run_lab_offload_inner(
             stderr.push_str(&format!("Lab pre-dispatch failure: {failure_message}\n"));
             let record = agent_task_lifecycle::record_pre_dispatch_failure(
                 agent_task_lifecycle::AgentTaskPreDispatchFailure {
-                    run_id,
+                    identity: agent_task_lifecycle::RunDispatchIdentity { run_id, runner_id },
                     local_command: request.normalized_args.to_vec(),
                     remote_command: remote_command.clone(),
-                    runner_id,
                     remote_workspace: &remote_cwd,
                     failure_message: &failure_message,
                     stdout: &exec_output.stdout,

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -19,7 +19,6 @@ use crate::core::agent_tasks::secrets as agent_task_secrets;
 use crate::core::agent_tasks::{
     AgentTaskExecutor, AgentTaskRequest, AgentTaskWorkspace, AGENT_TASK_REQUEST_SCHEMA,
 };
-use crate::core::command_invocation::CommandInvocation;
 use crate::core::{config, Error, Result};
 
 use super::super::Runner;
@@ -566,6 +565,7 @@ fn agent_task_run_plan_plan_spec(args: &[String]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::command_invocation::CommandInvocation;
     use crate::core::runner::RunnerKind;
     use crate::core::server::{RunnerPolicy, RunnerSecretEnvRef, RunnerSettings};
 

--- a/src/core/runner/lab_env.rs
+++ b/src/core/runner/lab_env.rs
@@ -4,7 +4,9 @@ use crate::core::{Error, Result};
 
 use super::execution::RUNNER_EXEC_WAIT_TIMEOUT_ENV;
 use super::lab_workspaces::{is_rig_component_path_env_name, LabWorkspaceMappingEntry};
-use crate::core::observation::LAB_OFFLOAD_METADATA_ENV;
+use crate::core::observation::{
+    LAB_OFFLOAD_METADATA_ENV, PREVIEW_METADATA_ENV, PREVIEW_PUBLIC_URL_ENV,
+};
 
 const SETTINGS_DIAGNOSTICS_SCHEMA: &str = "homeboy/lab-offload-settings-env/v1";
 
@@ -27,6 +29,25 @@ pub(super) fn build_lab_offload_env(lab_metadata: &serde_json::Value) -> HashMap
         LAB_OFFLOAD_METADATA_ENV.to_string(),
         serde_json::to_string(lab_metadata).unwrap_or_default(),
     )])
+}
+
+/// Forward the preview metadata/public-url passthroughs plus release CI context
+/// into a Lab offload env. Centralizes the repeated forward sequence shared by
+/// the offload dispatch paths so they stay in lock-step.
+pub(super) fn forward_preview_and_release_ci_env(env: &mut HashMap<String, String>) {
+    forward_env_if_present(env, PREVIEW_METADATA_ENV);
+    forward_env_if_present(env, PREVIEW_PUBLIC_URL_ENV);
+    forward_release_ci_env(env);
+}
+
+/// Build a fresh Lab offload env from `lab_metadata` and forward the preview and
+/// release CI passthroughs in one step.
+pub(super) fn build_lab_offload_env_with_passthroughs(
+    lab_metadata: &serde_json::Value,
+) -> HashMap<String, String> {
+    let mut env = build_lab_offload_env(lab_metadata);
+    forward_preview_and_release_ci_env(&mut env);
+    env
 }
 
 pub(super) fn forward_rig_component_path_env(

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -566,7 +566,11 @@ fn materialize_snapshot_piped(
     run_shell_command(&command, action)
 }
 
-fn snapshot_archive_command(local_path: &Path, target_command: &str, excludes: &[String]) -> String {
+fn snapshot_archive_command(
+    local_path: &Path,
+    target_command: &str,
+    excludes: &[String],
+) -> String {
     format!(
         "COPYFILE_DISABLE=1 tar --no-xattrs -C {src} {exclude} -cf - . | {target_command}",
         src = shell::quote_arg(&local_path.display().to_string()),


### PR DESCRIPTION
## Summary

One cook owning six interrelated audit findings that all touch overlapping files in the agent-task + lab area (`agent_task_provider.rs`, `runner/lab/offload.rs`, `agent_task_lifecycle.rs`, etc.), bundled together to avoid cross-PR conflicts.

- **#5048** (compiler): removed the unused `CommandInvocation` import from `lab/secrets.rs` (it is only used by the test module, so it moved there).
- **#5040** (dead code): `role_for_artifact_kind` is referenced only same-file, so its visibility was narrowed from `pub` to private.
- **#5049** (duplication): the byte-identical `wildcard_match` is now defined once in `agent_task_provider.rs` (`pub(crate)`) and reused by `agent_task_timeout_artifacts.rs`.
- **#5050** (intra-method duplication): extracted helpers to remove repeated blocks —
  - `agent_task_provider::provider_command_env`: shared `runtime_path` resolution
  - `runner/lab/lab_env`: `build_lab_offload_env_with_passthroughs` / `forward_preview_and_release_ci_env`
  - `runner/lab/offload`: `skipped_automatic_run_local` and `record_synced_remapped_workspace_entry`
- **#5052** (remote execution preflight): added an explicit `preflight_remote_argv_path_translation` gate that runs on the final argv right before remote dispatch in `run_lab_offload_inner`. It rejects any argument still embedding the controller-local source-checkout root instead of the remote workspace, so a missed remap fails loudly on the controller. Its function name is registered as a `path_translation_marker` in `remote_execution_safety`.
- **#5011** (repeated field patterns): factored the shared `(run_id, runner_id)` borrow into a new `RunDispatchIdentity<'a>` embedded as a named field across `AgentTaskPreDispatchFailure`, `AgentTaskRemoteDispatchFailure`, and `PatchRunInput` (group 1).

## Deferred (noted per task guidance)

Three of the #5011 field groups cross a serialized-contract or CLI boundary where factoring would risk changing a public/serialized shape, so they were intentionally left for a dedicated, careful change:

- `[outcome_schema, request_schema]` — the owning structs derive `Serialize` and back golden contracts; nesting would change JSON shape.
- `[allow_local_fallback, allow_local_hot]` — these are `global = true` clap flags on the top-level `Cli`, interleaved with other globals; flattening risks the CLI surface.
- `[default_lab_offload, infer_source_path_tools, release_gate, requires_extension_parity]` — `LabRoutePlan` derives `Serialize`, so factoring would change its route-plan JSON shape.

## Baseline

Surgically cleared only the `homeboy.json` baseline entries the changes genuinely resolved (verified via `homeboy audit`): the offload remote-execution-preflight + intra-method entries, the `agent_task_provider` unreferenced-export, and the `agent_task_lifecycle` / `patch_capture` repeated-field-pattern entries.

## Validation

- `cargo build --lib --tests` clean
- `cargo test agent_task` / `lab` / `command_contract` / `golden_contract` all pass
- `cargo fmt --check` clean (includes one incidental pre-existing one-line fmt fix in `runner/workspace.rs` so fmt-check stays green)
- `homeboy audit` confirms the six targeted findings clear with no new regressions in the touched files

Closes #5050
Closes #5040
Closes #5048
Closes #5049
Closes #5052
Closes #5011