### PR TITLE
test(core-agnostic): neutralize wordpress-plugin fixture to keep baseline at 81 (#5075)

### DIFF
--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -438,7 +438,7 @@ fn test_trace_variants() {
             "dependencies": [
                 {
                     "id": "woocommerce",
-                    "kind": "wordpress-plugin",
+                    "kind": "component-plugin",
                     "source": "release-package-or-build-artifact",
                     "path": "/tmp/packages/woocommerce",
                     "plugin_file": "woocommerce/woocommerce.php",
@@ -461,7 +461,7 @@ fn test_trace_variants() {
     assert_eq!(workload.trace_dependencies().len(), 1);
     let dependency = &workload.trace_dependencies()[0];
     assert_eq!(dependency.id, "woocommerce");
-    assert_eq!(dependency.kind, "wordpress-plugin");
+    assert_eq!(dependency.kind, "component-plugin");
     assert_eq!(
         dependency.plugin_file.as_deref(),
         Some("woocommerce/woocommerce.php")


### PR DESCRIPTION
## Summary
Closes #5075.

The Release pipeline went RED on `core_owned_test_content_stays_language_and_framework_agnostic` (tests/core_agnostic_test.rs):

```
core-owned test content ecosystem baseline occurrence count changed.
  left: 83   right: 81
```

`left` is the live scan, `right` is `TEST_CONTENT_BASELINE_OCCURRENCES`. The recent "neutralize rig fixture names" cleanup (6b1108bb) set the constant to 81 but left **two** `wordpress-plugin` literals in `tests/core/rig/spec_test.rs` (lines 441 + 464), so the live scan still found 83. The `(path, term)` baseline pairs were unchanged — only the total occurrence count was off by 2.

## Fix
Rather than baseline-in the debt (the whole point of the #3034 guard is to keep ecosystem literals **out** of core-owned test content), the two literals are neutralized. The dependency `kind` field is a free-form `String` (spec.rs:576), so renaming the fixture value `wordpress-plugin` → `component-plugin` keeps full serde round-trip coverage while removing the ecosystem debt. Baseline stays at 81; no rows added.

## Validation
- `cargo test --test core_agnostic_test` — green under simulated Release CI env (`GITHUB_ACTIONS=true`, audit not release-blocking): all 4 tests pass.
- `cargo fmt` clean (no-op).

Note: the separate `core_owned_source_stays_language_and_framework_agnostic` (re: `src/core/runner/tool_registry.rs`) fails on clean origin/main too, but it returns early in the Release pipeline via `release_ci_tracks_audit_without_blocking()` — out of scope for this Release-unblock.