### PR TITLE
refactor(agent-task,runner,lab): resolve audit findings — dedup, field patterns, preflight, thin adapters

### DIFF
--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -16,7 +16,9 @@ use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_tasks::scheduler::AgentTaskExecutorAdapter;
 use homeboy::core::config;
 
-use super::super::agent_task_dispatch::{dispatch_with_executor, DispatchArgs};
+use homeboy::core::agent_tasks::dispatch_service;
+
+use super::super::agent_task_dispatch::DispatchArgs;
 use super::super::CmdResult;
 use super::args::{
     AgentTaskControllerApplyEventArgs, AgentTaskControllerArgs, AgentTaskControllerCommand,
@@ -207,7 +209,7 @@ where
 {
     fn dispatch(&self, request: &Value) -> homeboy::core::Result<(Value, i32)> {
         let dispatch_args = dispatch_args_from_controller_request(request)?;
-        dispatch_with_executor(dispatch_args, self.executor.clone())
+        dispatch_service::run_dispatch_command(dispatch_args.into(), self.executor.clone())
     }
 }
 

--- a/src/commands/agent_task/run.rs
+++ b/src/commands/agent_task/run.rs
@@ -3,11 +3,11 @@
 
 use serde_json::Value;
 
+use homeboy::core::agent_tasks::dispatch_service;
 use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_tasks::scheduler::{AgentTaskExecutorAdapter, AgentTaskPlan};
 use homeboy::core::agent_tasks::service as agent_task_service;
 
-use super::super::agent_task_dispatch::dispatch_with_executor;
 use super::super::CmdResult;
 use super::args::{AgentTaskLoopArgs, RetryArgs, RunPlanArgs, StatusArgs, SubmitArgs};
 
@@ -33,7 +33,8 @@ where
         dispatch_args.prompt = args.goal.clone();
     }
     dispatch_args.queue_only = false;
-    let (dispatch_value, _dispatch_exit) = dispatch_with_executor(dispatch_args, executor.clone())?;
+    let (dispatch_value, _dispatch_exit) =
+        dispatch_service::run_dispatch_command(dispatch_args.into(), executor.clone())?;
     let run_id = dispatch_value["run_id"]
         .as_str()
         .ok_or_else(|| {

--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -1,13 +1,8 @@
 use clap::Args;
-use serde::Serialize;
 use serde_json::Value;
 
-use homeboy::core::agent_tasks::dispatch_service::{self, AgentTaskDispatchRequest};
-use homeboy::core::agent_tasks::provider::{
-    default_backend_for_component, ExtensionProviderAgentTaskExecutor,
-};
-use homeboy::core::agent_tasks::scheduler::{AgentTaskAggregate, AgentTaskExecutorAdapter};
-use homeboy::core::agent_tasks::AgentTaskAggregateReport;
+use homeboy::core::agent_tasks::dispatch_service::{self, AgentTaskDispatchCommand};
+use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
 
 use super::{CmdResult, GlobalArgs};
 
@@ -86,169 +81,40 @@ pub struct DispatchArgs {
     pub queue_only: bool,
 }
 
+impl From<DispatchArgs> for AgentTaskDispatchCommand {
+    fn from(args: DispatchArgs) -> Self {
+        AgentTaskDispatchCommand {
+            prompt: args.prompt,
+            tasks: args.tasks,
+            tasks_json: args.tasks_json,
+            cwd: args.cwd,
+            workspace: args.workspace,
+            repo: args.repo,
+            task_url: args.task_url,
+            backend: args.backend,
+            selector: args.selector,
+            model: args.model,
+            required_capabilities: args.required_capabilities,
+            secret_env: args.secret_env,
+            provider_config: args.provider_config,
+            client_context: args.client_context,
+            concurrency: args.concurrency,
+            attempts: args.attempts,
+            run_id: args.run_id,
+            queue_only: args.queue_only,
+        }
+    }
+}
+
 pub fn run(args: DispatchArgs, _global: &GlobalArgs) -> CmdResult<Value> {
-    dispatch_with_executor(args, ExtensionProviderAgentTaskExecutor::discover())
+    dispatch_service::run_dispatch_command(
+        args.into(),
+        ExtensionProviderAgentTaskExecutor::discover(),
+    )
 }
 
 pub(crate) fn cook(args: DispatchArgs, _global: &GlobalArgs) -> CmdResult<Value> {
-    cook_with_executor(args, ExtensionProviderAgentTaskExecutor::discover())
-}
-
-fn cook_with_executor<E>(args: DispatchArgs, executor: E) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter,
-{
-    let target_worktree = args.workspace.clone();
-    let (mut value, exit_code) = dispatch_with_executor(args, executor)?;
-    value["handoff"] = cook_handoff(&value, target_worktree.as_deref());
-    Ok((value, exit_code))
-}
-
-pub(crate) fn dispatch_with_executor<E>(args: DispatchArgs, executor: E) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter,
-{
-    let result = dispatch_service::dispatch(dispatch_request_from_args(args)?, executor)?;
-    Ok((command_json_value(result.value)?, result.exit_code))
-}
-
-pub(crate) fn dispatch_request_from_args(
-    args: DispatchArgs,
-) -> homeboy::core::Result<AgentTaskDispatchRequest> {
-    dispatch_request_from_args_with_default(args, default_backend_for_component)
-}
-
-fn dispatch_request_from_args_with_default(
-    args: DispatchArgs,
-    default_backend: impl FnOnce(Option<&str>) -> homeboy::core::Result<Option<String>>,
-) -> homeboy::core::Result<AgentTaskDispatchRequest> {
-    let backend = match args.backend {
-        Some(backend) => backend,
-        None => default_backend(args.repo.as_deref())?.ok_or_else(|| {
-            homeboy::core::Error::validation_invalid_argument(
-                "backend",
-                "agent-task dispatch requires --backend because no default backend policy is configured",
-                None,
-                Some(vec![
-                    "Set agent_task.default_backend in component, extension, or Homeboy config policy, or pass --backend explicitly.".to_string(),
-                ]),
-            )
-        })?,
-    };
-
-    Ok(AgentTaskDispatchRequest {
-        prompt: args.prompt,
-        tasks: args.tasks,
-        tasks_json: args.tasks_json,
-        cwd: args.cwd,
-        workspace: args.workspace,
-        repo: args.repo,
-        task_url: args.task_url,
-        backend,
-        selector: args.selector,
-        model: args.model,
-        required_capabilities: args.required_capabilities,
-        secret_env: args.secret_env,
-        provider_config: args.provider_config,
-        client_context: args.client_context,
-        concurrency: args.concurrency,
-        attempts: args.attempts,
-        run_id: args.run_id,
-        queue_only: args.queue_only,
-    })
-}
-
-fn command_json_value<T: Serialize>(value: T) -> homeboy::core::Result<Value> {
-    serde_json::to_value(value)
-        .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))
-}
-
-fn cook_handoff(value: &Value, to_worktree: Option<&str>) -> Value {
-    let run_id = value["run_id"].as_str().unwrap_or("<run-id>");
-    let aggregate_path = value["aggregate_path"].as_str().unwrap_or(run_id);
-    let aggregate_review = value
-        .get("aggregate")
-        .and_then(|aggregate| serde_json::from_value::<AgentTaskAggregate>(aggregate.clone()).ok())
-        .map(|aggregate| AgentTaskAggregateReport::from(aggregate.outcomes))
-        .unwrap_or_else(|| AgentTaskAggregateReport::from(Vec::new()));
-    let promotion_commands =
-        cook_promotion_commands(aggregate_path, to_worktree, &aggregate_review);
-    let patch_artifact_produced = !promotion_commands.is_empty();
-    let mut next_actions = Vec::new();
-
-    if patch_artifact_produced {
-        next_actions.push("patch artifact produced; promote one candidate before claiming worktree changes or PR completion".to_string());
-        if to_worktree.is_some() {
-            next_actions.push(
-                "run one `promote_commands` entry to apply the patch into the target worktree"
-                    .to_string(),
-            );
-        } else {
-            next_actions.push(format!(
-                "run `homeboy agent-task review {run_id} --to-worktree <handle>` to generate exact promote commands"
-            ));
-        }
-        next_actions.push(format!(
-            "after promotion and verification, run `homeboy agent-task finalize-pr --run-id {run_id} --path <promoted-worktree-path> --title <title> --commit-message <message>`"
-        ));
-    } else if value["queued"].as_bool().unwrap_or(false) {
-        next_actions.push(format!(
-            "queued only; run `homeboy agent-task run {run_id}` or let a daemon claim it with `homeboy agent-task run-next`"
-        ));
-    } else {
-        next_actions.push("no patch artifact was produced; inspect `aggregate` candidates before retrying or reporting".to_string());
-    }
-
-    serde_json::json!({
-        "schema": "homeboy/agent-task-cook-handoff/v1",
-        "states": {
-            "patch_artifact_produced": patch_artifact_produced,
-            "patch_promoted": false,
-            "pr_opened": false
-        },
-        "boundary": if value["queued"].as_bool().unwrap_or(false) {
-            "queued"
-        } else if patch_artifact_produced {
-            "patch_artifact_only"
-        } else {
-            "no_patch_artifact"
-        },
-        "promote_commands": promotion_commands,
-        "finalize_command": format!(
-            "homeboy agent-task finalize-pr --run-id {run_id} --path <promoted-worktree-path> --title <title> --commit-message <message>"
-        ),
-        "next_actions": next_actions
-    })
-}
-
-fn cook_promotion_commands(
-    source: &str,
-    to_worktree: Option<&str>,
-    review: &AgentTaskAggregateReport,
-) -> Vec<Vec<String>> {
-    review
-        .apply_candidates
-        .iter()
-        .flat_map(|candidate| {
-            candidate.artifact_ids.iter().map(move |artifact_id| {
-                let mut command = vec![
-                    "homeboy".to_string(),
-                    "agent-task".to_string(),
-                    "promote".to_string(),
-                    source.to_string(),
-                    "--task-id".to_string(),
-                    candidate.task_id.clone(),
-                    "--artifact-id".to_string(),
-                    artifact_id.clone(),
-                ];
-                if let Some(to_worktree) = to_worktree {
-                    command.push("--to-worktree".to_string());
-                    command.push(to_worktree.to_string());
-                }
-                command
-            })
-        })
-        .collect()
+    dispatch_service::run_cook_command(args.into(), ExtensionProviderAgentTaskExecutor::discover())
 }
 
 #[cfg(test)]
@@ -256,7 +122,9 @@ mod tests {
     use super::*;
     use crate::test_support::with_isolated_home;
     use homeboy::core::agent_task::AgentTaskRequest;
-    use homeboy::core::agent_tasks::scheduler::AgentTaskExecutionContext;
+    use homeboy::core::agent_tasks::scheduler::{
+        AgentTaskExecutionContext, AgentTaskExecutorAdapter,
+    };
     use homeboy::core::agent_tasks::{
         AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_ARTIFACT_SCHEMA,
         AGENT_TASK_OUTCOME_SCHEMA,
@@ -267,14 +135,15 @@ mod tests {
         with_isolated_home(|_| {
             let workspace = tempfile::tempdir().expect("workspace");
 
-            let (value, exit_code) = dispatch_with_executor(
+            let (value, exit_code) = dispatch_service::run_dispatch_command(
                 dispatch_args(DispatchArgOverrides {
                     prompt: Some("Queue this minion.".to_string()),
                     cwd: Some(workspace.path().display().to_string()),
                     queue_only: true,
                     run_id: Some("dispatch-queued".to_string()),
                     ..DispatchArgOverrides::default()
-                }),
+                })
+                .into(),
                 NoopExecutor,
             )
             .expect("dispatch queued");
@@ -301,13 +170,14 @@ mod tests {
                 .to_string();
             let patch_path = std::path::Path::new(&workspace).join("changes.patch");
             std::fs::write(&patch_path, "diff --git a/file b/file\n").expect("patch fixture");
-            let (value, exit_code) = cook_with_executor(
+            let (value, exit_code) = dispatch_service::run_cook_command(
                 dispatch_args(DispatchArgOverrides {
                     prompt: Some("Cook a patch.".to_string()),
                     workspace: Some(workspace.clone()),
                     run_id: Some("cook-handoff".to_string()),
                     ..DispatchArgOverrides::default()
-                }),
+                })
+                .into(),
                 PatchExecutor { patch_path },
             )
             .expect("cook run");
@@ -342,13 +212,14 @@ mod tests {
     #[test]
     fn queued_cook_handoff_surfaces_run_command_without_patch_claims() {
         with_isolated_home(|_| {
-            let (value, exit_code) = cook_with_executor(
+            let (value, exit_code) = dispatch_service::run_cook_command(
                 dispatch_args(DispatchArgOverrides {
                     prompt: Some("Queue this cook.".to_string()),
                     queue_only: true,
                     run_id: Some("cook-queued".to_string()),
                     ..DispatchArgOverrides::default()
-                }),
+                })
+                .into(),
                 PatchExecutor {
                     patch_path: std::path::PathBuf::new(),
                 },
@@ -368,7 +239,7 @@ mod tests {
 
     #[test]
     fn dispatch_request_uses_declared_default_backend_when_backend_is_absent() {
-        let request = dispatch_request_from_args_with_default(
+        let request = dispatch_service::resolve_dispatch_request_with_default(
             DispatchArgs {
                 prompt: Some("run with default".to_string()),
                 tasks: Vec::new(),
@@ -388,7 +259,8 @@ mod tests {
                 attempts: 1,
                 run_id: None,
                 queue_only: false,
-            },
+            }
+            .into(),
             |_| Ok(Some("fake-default".to_string())),
         )
         .expect("default backend request");
@@ -398,7 +270,7 @@ mod tests {
 
     #[test]
     fn dispatch_request_errors_when_backend_and_default_are_absent() {
-        let error = dispatch_request_from_args_with_default(
+        let error = dispatch_service::resolve_dispatch_request_with_default(
             DispatchArgs {
                 prompt: Some("run without default".to_string()),
                 tasks: Vec::new(),
@@ -418,7 +290,8 @@ mod tests {
                 attempts: 1,
                 run_id: None,
                 queue_only: false,
-            },
+            }
+            .into(),
             |_| Ok(None),
         )
         .expect_err("missing backend should fail");

--- a/src/commands/golden_contract_tests.rs
+++ b/src/commands/golden_contract_tests.rs
@@ -108,8 +108,10 @@ fn runs_command_json_contract_matches_golden_fixture() {
                         component_id: Some("homeboy".to_string()),
                         rig_id: Some("contract-rig".to_string()),
                         git_sha: Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string()),
-                        evidence_command: "homeboy runs evidence run-contract-1".to_string(),
-                        artifacts_command: "homeboy runs artifacts run-contract-1".to_string(),
+                        evidence_commands: homeboy::core::observation::RunEvidenceCommands {
+                            evidence_command: "homeboy runs evidence run-contract-1".to_string(),
+                            artifacts_command: "homeboy runs artifacts run-contract-1".to_string(),
+                        },
                     }],
                     artifacts: vec![runs_refs_artifact_record()],
                     aggregate_artifacts: vec![runs_refs_artifact_record()],

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -267,10 +267,10 @@ fn stdout_with_persisted_run_retrieval(
     ));
     rendered.push_str("- **ID scope:** runtime, temp, and artifact identifiers above are offload context; use the persisted Homeboy run ID for local retrieval.\n");
     rendered.push_str("- **Retrieve evidence:** `");
-    rendered.push_str(&retrieval.evidence_command);
+    rendered.push_str(&retrieval.commands.evidence_command);
     rendered.push_str("`\n");
     rendered.push_str("- **List artifacts:** `");
-    rendered.push_str(&retrieval.artifacts_command);
+    rendered.push_str(&retrieval.commands.artifacts_command);
     rendered.push_str("`\n");
     rendered.push_str("- **Export run bundle:** `");
     rendered.push_str(&retrieval.export_command);

--- a/src/commands/runs/artifact_index_tests.rs
+++ b/src/commands/runs/artifact_index_tests.rs
@@ -98,7 +98,7 @@ fn rig_runs_list_surfaces_compact_artifact_index() {
             .artifact_index_path
             .ends_with("rig-artifact-index.json"));
         assert_eq!(
-            artifact_index.artifacts_command,
+            artifact_index.evidence_commands.artifacts_command,
             format!("homeboy runs artifacts {}", run.id)
         );
         assert!(artifact_index

--- a/src/commands/runs/refs.rs
+++ b/src/commands/runs/refs.rs
@@ -1,7 +1,9 @@
 use clap::Args;
 use serde::Serialize;
 
-use homeboy::core::observation::{ArtifactRecord, ObservationStore, RunListFilter, RunRecord};
+use homeboy::core::observation::{
+    ArtifactRecord, ObservationStore, RunEvidenceCommands, RunListFilter, RunRecord,
+};
 
 use super::common::since_threshold;
 use super::{CmdResult, RunsOutput};
@@ -77,8 +79,8 @@ pub struct RunRef {
     pub component_id: Option<String>,
     pub rig_id: Option<String>,
     pub git_sha: Option<String>,
-    pub evidence_command: String,
-    pub artifacts_command: String,
+    #[serde(flatten)]
+    pub evidence_commands: RunEvidenceCommands,
 }
 
 #[derive(Serialize, Debug, Clone, PartialEq)]
@@ -185,8 +187,7 @@ fn run_ref(run: &RunRecord) -> RunRef {
         component_id: run.component_id.clone(),
         rig_id: run.rig_id.clone(),
         git_sha: run.git_sha.clone(),
-        evidence_command: format!("homeboy runs evidence {}", shell_arg(&run.id)),
-        artifacts_command: format!("homeboy runs artifacts {}", shell_arg(&run.id)),
+        evidence_commands: RunEvidenceCommands::for_run_id(&shell_arg(&run.id)),
     }
 }
 

--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -15,7 +15,8 @@ use homeboy::core::extension::trace::{
 };
 use homeboy::core::extension::ExtensionCapability;
 use homeboy::core::observation::{
-    NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord, ObservationStore, RunStatus,
+    NewRunRecord, NewTraceRunRecord, NewTraceSpanRecord, ObservationStore, RunEvidenceCommands,
+    RunStatus,
 };
 use homeboy::core::rig::{self, RigSpec};
 
@@ -1457,8 +1458,7 @@ pub(super) struct LabTraceDispatchObservation {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct PersistedRunRetrieval {
     pub run_id: String,
-    pub evidence_command: String,
-    pub artifacts_command: String,
+    pub commands: RunEvidenceCommands,
     pub export_command: String,
 }
 
@@ -1466,8 +1466,7 @@ impl PersistedRunRetrieval {
     pub(super) fn for_run(run_id: &str) -> Self {
         Self {
             run_id: run_id.to_string(),
-            evidence_command: format!("homeboy runs evidence {run_id}"),
-            artifacts_command: format!("homeboy runs artifacts {run_id}"),
+            commands: RunEvidenceCommands::for_run_id(run_id),
             export_command: format!(
                 "homeboy runs export --run {run_id} --output homeboy-run-{run_id}"
             ),
@@ -1479,8 +1478,8 @@ impl PersistedRunRetrieval {
             "persisted_run_id": self.run_id,
             "id_scope": "persisted_homeboy_run",
             "retrieval_commands": {
-                "evidence": self.evidence_command,
-                "artifacts": self.artifacts_command,
+                "evidence": self.commands.evidence_command,
+                "artifacts": self.commands.artifacts_command,
                 "export": self.export_command,
             }
         })
@@ -1512,6 +1511,13 @@ pub(super) fn start_lab_dispatch_observation(
     });
     let store = ObservationStore::open_initialized().ok()?;
     let cwd = std::env::current_dir().ok();
+    let lab_dispatch_metadata = || {
+        serde_json::json!({
+            "phase": "route_before_lab_dispatch",
+            "runner_id": runner_id,
+            "status": "running"
+        })
+    };
     let run =
         store
             .start_run(
@@ -1527,11 +1533,7 @@ pub(super) fn start_lab_dispatch_observation(
                     .metadata(serde_json::json!({
                         "scenario_id": scenario_id,
                         "component_path": component_path,
-                        "lab_dispatch": {
-                            "phase": "route_before_lab_dispatch",
-                            "runner_id": runner_id,
-                            "status": "running"
-                        }
+                        "lab_dispatch": lab_dispatch_metadata()
                     }))
                     .build(),
             )
@@ -1552,11 +1554,7 @@ pub(super) fn start_lab_dispatch_observation(
         )
         .trace_rig_id(observation.rig_id.as_deref())
         .metadata(serde_json::json!({
-            "lab_dispatch": {
-                "phase": "route_before_lab_dispatch",
-                "runner_id": runner_id,
-                "status": "running"
-            }
+            "lab_dispatch": lab_dispatch_metadata()
         }))
         .build(),
     );

--- a/src/core/agent_task_controller_service.rs
+++ b/src/core/agent_task_controller_service.rs
@@ -2833,6 +2833,22 @@ fn collect_required_artifacts_from_declarations(
     let Some(declarations) = value.as_array() else {
         return;
     };
+    // Resolve the first non-empty string field on a declaration from an ordered
+    // list of candidate paths. Each path is either a single top-level key or a
+    // `(parent, child)` pair resolving `declaration[parent][child]`.
+    let first_non_empty_str = |declaration: &Value, paths: &[&[&str]]| -> Option<String> {
+        paths
+            .iter()
+            .filter_map(|path| {
+                let mut node = declaration;
+                for segment in path.iter() {
+                    node = node.get(segment)?;
+                }
+                node.as_str()
+            })
+            .find(|value| !value.is_empty())
+            .map(str::to_string)
+    };
     for declaration in declarations {
         let required = declaration
             .get("required")
@@ -2847,21 +2863,14 @@ fn collect_required_artifacts_from_declarations(
         if !required {
             continue;
         }
-        let Some(artifact_id) = declaration
-            .get("artifact_id")
-            .or_else(|| declaration.get("id"))
-            .and_then(Value::as_str)
-            .filter(|value| !value.is_empty())
+        let Some(artifact_id) = first_non_empty_str(declaration, &[&["artifact_id"], &["id"]])
         else {
             continue;
         };
-        let Some(kind) = declaration
-            .get("kind")
-            .or_else(|| declaration.get("artifact_type"))
-            .or_else(|| declaration.get("data").and_then(|data| data.get("kind")))
-            .and_then(Value::as_str)
-            .filter(|value| !value.is_empty())
-        else {
+        let Some(kind) = first_non_empty_str(
+            declaration,
+            &[&["kind"], &["artifact_type"], &["data", "kind"]],
+        ) else {
             continue;
         };
         if artifacts

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -11,11 +11,13 @@ use crate::core::agent_task::{
     AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskSourceRef,
     AgentTaskWorkspace, AgentTaskWorkspaceMode, AGENT_TASK_REQUEST_SCHEMA,
 };
+use crate::core::agent_task_aggregate::AgentTaskAggregateReport;
 use crate::core::agent_task_config_materialization::materialize_provider_config_refs;
 use crate::core::agent_task_lifecycle as lifecycle;
 use crate::core::agent_task_lifecycle::{AgentTaskRunRecord, AgentTaskRunState};
 use crate::core::agent_task_provider::{
-    apply_provider_runner_secret_env_contracts, provider_requires_cwd_git_checkout,
+    apply_provider_runner_secret_env_contracts, default_backend_for_component,
+    provider_requires_cwd_git_checkout,
 };
 use crate::core::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskRetryPolicy,
@@ -738,6 +740,200 @@ fn sanitize_slug(value: &str) -> String {
     } else {
         slug
     }
+}
+
+/// Command-surface inputs for a dispatch/cook invocation. The CLI adapter maps
+/// its clap args into this plain data carrier; this service owns the orchestration
+/// (backend resolution, request construction, scheduler dispatch, and cook
+/// handoff rendering) so the command module stays a thin adapter (#5078).
+#[derive(Debug, Clone, Default)]
+pub struct AgentTaskDispatchCommand {
+    pub prompt: Option<String>,
+    pub tasks: Vec<String>,
+    pub tasks_json: Option<String>,
+    pub cwd: Option<String>,
+    pub workspace: Option<String>,
+    pub repo: Option<String>,
+    pub task_url: Option<String>,
+    pub backend: Option<String>,
+    pub selector: Option<String>,
+    pub model: Option<String>,
+    pub required_capabilities: Vec<String>,
+    pub secret_env: Vec<String>,
+    pub provider_config: Option<String>,
+    pub client_context: Option<String>,
+    pub concurrency: usize,
+    pub attempts: u32,
+    pub run_id: Option<String>,
+    pub queue_only: bool,
+}
+
+/// Resolve a typed dispatch request from command-surface inputs, applying the
+/// declared default-backend policy when `--backend` is absent.
+pub fn resolve_dispatch_request(
+    command: AgentTaskDispatchCommand,
+) -> Result<AgentTaskDispatchRequest> {
+    resolve_dispatch_request_with_default(command, default_backend_for_component)
+}
+
+/// Resolve a typed dispatch request, using the supplied default-backend resolver
+/// so tests can inject a deterministic policy.
+pub fn resolve_dispatch_request_with_default(
+    command: AgentTaskDispatchCommand,
+    default_backend: impl FnOnce(Option<&str>) -> Result<Option<String>>,
+) -> Result<AgentTaskDispatchRequest> {
+    let backend = match command.backend {
+        Some(backend) => backend,
+        None => default_backend(command.repo.as_deref())?.ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "backend",
+                "agent-task dispatch requires --backend because no default backend policy is configured",
+                None,
+                Some(vec![
+                    "Set agent_task.default_backend in component, extension, or Homeboy config policy, or pass --backend explicitly.".to_string(),
+                ]),
+            )
+        })?,
+    };
+
+    Ok(AgentTaskDispatchRequest {
+        prompt: command.prompt,
+        tasks: command.tasks,
+        tasks_json: command.tasks_json,
+        cwd: command.cwd,
+        workspace: command.workspace,
+        repo: command.repo,
+        task_url: command.task_url,
+        backend,
+        selector: command.selector,
+        model: command.model,
+        required_capabilities: command.required_capabilities,
+        secret_env: command.secret_env,
+        provider_config: command.provider_config,
+        client_context: command.client_context,
+        concurrency: command.concurrency,
+        attempts: command.attempts,
+        run_id: command.run_id,
+        queue_only: command.queue_only,
+    })
+}
+
+/// Run a dispatch invocation end to end: resolve the request, dispatch it through
+/// the scheduler, and adapt the report into a JSON value plus process exit code.
+pub fn run_dispatch_command<E>(
+    command: AgentTaskDispatchCommand,
+    executor: E,
+) -> Result<(Value, i32)>
+where
+    E: AgentTaskExecutorAdapter,
+{
+    let request = resolve_dispatch_request(command)?;
+    let result = dispatch(request, executor)?;
+    Ok((command_json_value(result.value)?, result.exit_code))
+}
+
+/// Run a cook invocation: dispatch the request and attach the cook handoff
+/// envelope describing the patch-artifact boundary and promotion next actions.
+pub fn run_cook_command<E>(command: AgentTaskDispatchCommand, executor: E) -> Result<(Value, i32)>
+where
+    E: AgentTaskExecutorAdapter,
+{
+    let target_worktree = command.workspace.clone();
+    let (mut value, exit_code) = run_dispatch_command(command, executor)?;
+    value["handoff"] = cook_handoff(&value, target_worktree.as_deref());
+    Ok((value, exit_code))
+}
+
+fn command_json_value<T: Serialize>(value: T) -> Result<Value> {
+    serde_json::to_value(value).map_err(|error| Error::internal_json(error.to_string(), None))
+}
+
+fn cook_handoff(value: &Value, to_worktree: Option<&str>) -> Value {
+    let run_id = value["run_id"].as_str().unwrap_or("<run-id>");
+    let aggregate_path = value["aggregate_path"].as_str().unwrap_or(run_id);
+    let aggregate_review = value
+        .get("aggregate")
+        .and_then(|aggregate| serde_json::from_value::<AgentTaskAggregate>(aggregate.clone()).ok())
+        .map(|aggregate| AgentTaskAggregateReport::from(aggregate.outcomes))
+        .unwrap_or_else(|| AgentTaskAggregateReport::from(Vec::new()));
+    let promotion_commands =
+        cook_promotion_commands(aggregate_path, to_worktree, &aggregate_review);
+    let patch_artifact_produced = !promotion_commands.is_empty();
+    let mut next_actions = Vec::new();
+
+    if patch_artifact_produced {
+        next_actions.push("patch artifact produced; promote one candidate before claiming worktree changes or PR completion".to_string());
+        if to_worktree.is_some() {
+            next_actions.push(
+                "run one `promote_commands` entry to apply the patch into the target worktree"
+                    .to_string(),
+            );
+        } else {
+            next_actions.push(format!(
+                "run `homeboy agent-task review {run_id} --to-worktree <handle>` to generate exact promote commands"
+            ));
+        }
+        next_actions.push(format!(
+            "after promotion and verification, run `homeboy agent-task finalize-pr --run-id {run_id} --path <promoted-worktree-path> --title <title> --commit-message <message>`"
+        ));
+    } else if value["queued"].as_bool().unwrap_or(false) {
+        next_actions.push(format!(
+            "queued only; run `homeboy agent-task run {run_id}` or let a daemon claim it with `homeboy agent-task run-next`"
+        ));
+    } else {
+        next_actions.push("no patch artifact was produced; inspect `aggregate` candidates before retrying or reporting".to_string());
+    }
+
+    serde_json::json!({
+        "schema": "homeboy/agent-task-cook-handoff/v1",
+        "states": {
+            "patch_artifact_produced": patch_artifact_produced,
+            "patch_promoted": false,
+            "pr_opened": false
+        },
+        "boundary": if value["queued"].as_bool().unwrap_or(false) {
+            "queued"
+        } else if patch_artifact_produced {
+            "patch_artifact_only"
+        } else {
+            "no_patch_artifact"
+        },
+        "promote_commands": promotion_commands,
+        "finalize_command": format!(
+            "homeboy agent-task finalize-pr --run-id {run_id} --path <promoted-worktree-path> --title <title> --commit-message <message>"
+        ),
+        "next_actions": next_actions
+    })
+}
+
+fn cook_promotion_commands(
+    source: &str,
+    to_worktree: Option<&str>,
+    review: &AgentTaskAggregateReport,
+) -> Vec<Vec<String>> {
+    review
+        .apply_candidates
+        .iter()
+        .flat_map(|candidate| {
+            candidate.artifact_ids.iter().map(move |artifact_id| {
+                let mut command = vec![
+                    "homeboy".to_string(),
+                    "agent-task".to_string(),
+                    "promote".to_string(),
+                    source.to_string(),
+                    "--task-id".to_string(),
+                    candidate.task_id.clone(),
+                    "--artifact-id".to_string(),
+                    artifact_id.clone(),
+                ];
+                if let Some(to_worktree) = to_worktree {
+                    command.push("--to-worktree".to_string());
+                    command.push(to_worktree.to_string());
+                }
+                command
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/core/agent_task_promotion.rs
+++ b/src/core/agent_task_promotion.rs
@@ -23,6 +23,39 @@ use crate::core::{Error, Result};
 pub const AGENT_TASK_PROMOTION_REPORT_SCHEMA: &str = "homeboy/agent-task-promotion-report/v1";
 const PROMOTION_PROVIDER_COMMAND_ENV: &str = "HOMEBOY_AGENT_TASK_PROMOTION_COMMAND";
 
+/// Maximum number of bytes retained per captured stream in a promotion command
+/// report. Mirrors the bounded-capture cap used by extension self-checks so the
+/// retained evidence cannot grow without bound (#5077).
+const PROMOTION_CAPTURE_LIMIT_BYTES: usize = 65_536;
+
+/// Truncation metadata describing how much of a captured stream was retained.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPromotionStreamCapture {
+    pub limit_bytes: usize,
+    pub seen_bytes: usize,
+    pub retained_bytes: usize,
+    pub truncated: bool,
+}
+
+/// Bound a captured stream to a retained-byte cap, keeping the trailing bytes
+/// (most relevant tail) and returning the retained text plus truncation
+/// metadata. Mirrors the `BoundedCapture` pattern in extension self-checks.
+fn bound_captured_stream(bytes: &[u8], limit: usize) -> (String, AgentTaskPromotionStreamCapture) {
+    let seen = bytes.len();
+    let retained: &[u8] = if seen > limit {
+        &bytes[seen - limit..]
+    } else {
+        bytes
+    };
+    let metadata = AgentTaskPromotionStreamCapture {
+        limit_bytes: limit,
+        seen_bytes: seen,
+        retained_bytes: retained.len(),
+        truncated: seen > retained.len(),
+    };
+    (String::from_utf8_lossy(retained).to_string(), metadata)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskPromotionOptions {
     pub source: String,
@@ -113,6 +146,32 @@ pub struct AgentTaskPromotionCommandReport {
     pub stdout: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub stderr: String,
+    /// Per-stream truncation metadata describing the retained-byte bound applied
+    /// to `stdout`/`stderr`. Skipped when both streams fit within the cap so the
+    /// historical serialized shape is preserved (#5077).
+    #[serde(
+        default,
+        skip_serializing_if = "AgentTaskPromotionCommandCapture::is_empty"
+    )]
+    pub capture: AgentTaskPromotionCommandCapture,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskPromotionCommandCapture {
+    #[serde(default, skip_serializing_if = "is_untruncated_stream")]
+    pub stdout: AgentTaskPromotionStreamCapture,
+    #[serde(default, skip_serializing_if = "is_untruncated_stream")]
+    pub stderr: AgentTaskPromotionStreamCapture,
+}
+
+impl AgentTaskPromotionCommandCapture {
+    fn is_empty(&self) -> bool {
+        is_untruncated_stream(&self.stdout) && is_untruncated_stream(&self.stderr)
+    }
+}
+
+fn is_untruncated_stream(stream: &AgentTaskPromotionStreamCapture) -> bool {
+    !stream.truncated
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -878,11 +937,23 @@ fn run_provider_command(
         )
     })?;
     let exit_code = output.status.code().unwrap_or(1);
+    // The full stdout is parsed for the provider response below, but the bytes
+    // retained in the evidence report are bounded with truncation metadata so
+    // a pathologically large stream cannot grow the report without bound.
+    let full_stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let (retained_stdout, stdout_capture) =
+        bound_captured_stream(&output.stdout, PROMOTION_CAPTURE_LIMIT_BYTES);
+    let (retained_stderr, stderr_capture) =
+        bound_captured_stream(&output.stderr, PROMOTION_CAPTURE_LIMIT_BYTES);
     let report = AgentTaskPromotionCommandReport {
         command: std::iter::once(program).chain(args).collect(),
         exit_code,
-        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        stdout: retained_stdout,
+        stderr: retained_stderr,
+        capture: AgentTaskPromotionCommandCapture {
+            stdout: stdout_capture,
+            stderr: stderr_capture,
+        },
     };
     if !output.status.success() {
         return Err(Error::validation_invalid_argument(
@@ -896,7 +967,7 @@ fn run_provider_command(
         ));
     }
     let response: AgentTaskPromotionApplyResponse =
-        serde_json::from_str(&report.stdout).map_err(|error| {
+        serde_json::from_str(&full_stdout).map_err(|error| {
             Error::validation_invalid_json(
                 error,
                 Some("agent-task promotion provider response".to_string()),
@@ -1018,6 +1089,7 @@ mod tests {
             exit_code: 0,
             stdout: String::new(),
             stderr: String::new(),
+            capture: AgentTaskPromotionCommandCapture::default(),
         }
     }
 

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -216,8 +216,11 @@ where
                                     &mut backpressure,
                                     &mut events,
                                 );
-                                completed_by_task.insert(outcome.task_id.clone(), outcome.clone());
-                                outcomes.push(outcome);
+                                record_completed_outcome(
+                                    &mut completed_by_task,
+                                    &mut outcomes,
+                                    outcome,
+                                );
                                 blocked_count += 1;
                                 continue;
                             }
@@ -284,8 +287,7 @@ where
                         scheduled.attempt,
                         outcome.summary.clone(),
                     ));
-                    completed_by_task.insert(outcome.task_id.clone(), outcome.clone());
-                    outcomes.push(outcome);
+                    record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
                     continue;
                 }
                 let task_id = request.task_id.clone();
@@ -383,8 +385,7 @@ where
                         });
                         continue;
                     }
-                    completed_by_task.insert(outcome.task_id.clone(), outcome.clone());
-                    outcomes.push(outcome);
+                    record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
                 }
                 Err(mpsc::RecvTimeoutError::Timeout) => {}
                 Err(mpsc::RecvTimeoutError::Disconnected) => break,
@@ -442,6 +443,18 @@ struct TaskResult {
     task_id: String,
     attempt: u32,
     outcome: AgentTaskOutcome,
+}
+
+/// Record a finalized outcome in the completed-by-task index and the ordered
+/// outcomes list. Shared by the scheduler's dependency-block, dependency-render,
+/// and task-completion paths to keep recording behavior identical.
+fn record_completed_outcome(
+    completed_by_task: &mut HashMap<String, AgentTaskOutcome>,
+    outcomes: &mut Vec<AgentTaskOutcome>,
+    outcome: AgentTaskOutcome,
+) {
+    completed_by_task.insert(outcome.task_id.clone(), outcome.clone());
+    outcomes.push(outcome);
 }
 
 struct AgentTaskScheduleSupport;
@@ -621,6 +634,18 @@ impl AgentTaskScheduleSupport {
             ));
         };
 
+        // Resolve the fallback for a missing binding value: default if set,
+        // a required-error if the binding is required, else an empty string.
+        let missing_binding_fallback = |required_error: String| -> Result<Value, String> {
+            if !binding.default.is_null() {
+                return Ok(binding.default.clone());
+            }
+            if binding.required {
+                return Err(required_error);
+            }
+            Ok(Value::String(String::new()))
+        };
+
         if let Some(artifact_binding) = &binding.artifact {
             let Some(artifact) = outcome.artifacts.iter().find(|artifact| {
                 artifact.kind == artifact_binding.kind
@@ -641,16 +666,10 @@ impl AgentTaskScheduleSupport {
                         })
                         .unwrap_or(true)
             }) else {
-                if !binding.default.is_null() {
-                    return Ok(binding.default.clone());
-                }
-                if binding.required {
-                    return Err(format!(
-                        "task '{}' skipped because required artifact binding '{}' with kind '{}' was missing from task '{}'",
-                        request.task_id, name, artifact_binding.kind, binding.task_id
-                    ));
-                }
-                return Ok(Value::String(String::new()));
+                return missing_binding_fallback(format!(
+                    "task '{}' skipped because required artifact binding '{}' with kind '{}' was missing from task '{}'",
+                    request.task_id, name, artifact_binding.kind, binding.task_id
+                ));
             };
 
             let artifact_value = serde_json::to_value(artifact).unwrap_or(Value::Null);
@@ -663,16 +682,10 @@ impl AgentTaskScheduleSupport {
                 {
                     return Ok(value.clone());
                 }
-                if !binding.default.is_null() {
-                    return Ok(binding.default.clone());
-                }
-                if binding.required {
-                    return Err(format!(
-                        "task '{}' skipped because required artifact binding '{}' payload was missing at '{}' from task '{}'",
-                        request.task_id, name, payload_path, binding.task_id
-                    ));
-                }
-                return Ok(Value::String(String::new()));
+                return missing_binding_fallback(format!(
+                    "task '{}' skipped because required artifact binding '{}' payload was missing at '{}' from task '{}'",
+                    request.task_id, name, payload_path, binding.task_id
+                ));
             }
 
             return Ok(artifact_value);
@@ -682,16 +695,10 @@ impl AgentTaskScheduleSupport {
         if let Some(value) = outcome_value.pointer(&binding.path) {
             return Ok(value.clone());
         }
-        if !binding.default.is_null() {
-            return Ok(binding.default.clone());
-        }
-        if binding.required {
-            return Err(format!(
-                "task '{}' skipped because required output binding '{}' was missing at '{}' from task '{}'",
-                request.task_id, name, binding.path, binding.task_id
-            ));
-        }
-        Ok(Value::String(String::new()))
+        missing_binding_fallback(format!(
+            "task '{}' skipped because required output binding '{}' was missing at '{}' from task '{}'",
+            request.task_id, name, binding.path, binding.task_id
+        ))
     }
 
     fn skipped_output_dependency_outcome(

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -163,7 +163,9 @@ pub mod cook_loop {
 pub mod dispatch_service {
     pub use super::super::agent_task_dispatch_service::{
         build_dispatch_plan, build_dispatch_plan_with_provider_requirements, dispatch,
-        dispatch_with_provider_requirements, AgentTaskDispatchReport, AgentTaskDispatchRequest,
+        dispatch_with_provider_requirements, resolve_dispatch_request,
+        resolve_dispatch_request_with_default, run_cook_command, run_dispatch_command,
+        AgentTaskDispatchCommand, AgentTaskDispatchReport, AgentTaskDispatchRequest,
         DISPATCH_RESULT_SCHEMA,
     };
 }

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -26,8 +26,8 @@ pub use records::{
     ArtifactCleanupCandidateRecord, ArtifactCleanupFilter, ArtifactRecord, ArtifactViewerLink,
     FindingListFilter, FindingRecord, NewFindingRecord, NewRunRecord, NewRunRecordBuilder,
     NewTraceRunRecord, NewTraceRunRecordBuilder, NewTraceSpanRecord, NewTraceSpanRecordBuilder,
-    NewTriageItemRecord, RecordedHomeboyFinding, RunListFilter, RunRecord, RunStatus,
-    TraceRunRecord, TraceSpanRecord, TriageItemRecord, TriagePullRequestSignals,
+    NewTriageItemRecord, RecordedHomeboyFinding, RunEvidenceCommands, RunListFilter, RunRecord,
+    RunStatus, TraceRunRecord, TraceSpanRecord, TriageItemRecord, TriagePullRequestSignals,
 };
 pub use store::{
     ObservationDbStatus, ObservationStore, CURRENT_SCHEMA_VERSION, LAB_OFFLOAD_METADATA_ENV,

--- a/src/core/observation/records.rs
+++ b/src/core/observation/records.rs
@@ -17,6 +17,28 @@ pub use trace_run_builder::NewTraceRunRecordBuilder;
 pub use trace_span_builder::NewTraceSpanRecordBuilder;
 pub use triage_items::{NewTriageItemRecord, TriageItemRecord, TriagePullRequestSignals};
 
+/// Shared CLI commands that retrieve a run's evidence and artifacts. Embedded
+/// via `#[serde(flatten)]` so the historical flat `evidence_command` /
+/// `artifacts_command` keys are preserved while the field group is defined once
+/// instead of being repeated across run-reference structs (#5068).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunEvidenceCommands {
+    pub evidence_command: String,
+    pub artifacts_command: String,
+}
+
+impl RunEvidenceCommands {
+    /// Build the standard `homeboy runs evidence/artifacts` retrieval commands
+    /// for a run id. `run_id` is interpolated verbatim; callers that need shell
+    /// quoting should pass an already-escaped value.
+    pub fn for_run_id(run_id: &str) -> Self {
+        Self {
+            evidence_command: format!("homeboy runs evidence {run_id}"),
+            artifacts_command: format!("homeboy runs artifacts {run_id}"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct NewRunRecord {
     pub kind: String,

--- a/src/core/rig/artifact_index.rs
+++ b/src/core/rig/artifact_index.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::pipeline::PipelineOutcome;
 use super::spec::RigSpec;
-use crate::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
+use crate::core::observation::{ArtifactRecord, ObservationStore, RunEvidenceCommands, RunRecord};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RigRunArtifactIndex {
@@ -14,8 +14,8 @@ pub struct RigRunArtifactIndex {
     pub artifact_root: String,
     pub artifact_index_path: String,
     pub artifact_index_command: String,
-    pub evidence_command: String,
-    pub artifacts_command: String,
+    #[serde(flatten)]
+    pub evidence_commands: RunEvidenceCommands,
     pub export_command: String,
     pub retrieval_commands: Vec<String>,
     pub key_report_refs: Vec<RigRunArtifactRef>,
@@ -118,8 +118,10 @@ fn build(
         artifact_root: artifact_root.display().to_string(),
         artifact_index_path: artifact_index_path.display().to_string(),
         artifact_index_command: artifacts_command.clone(),
-        evidence_command: evidence_command.clone(),
-        artifacts_command: artifacts_command.clone(),
+        evidence_commands: RunEvidenceCommands {
+            evidence_command: evidence_command.clone(),
+            artifacts_command: artifacts_command.clone(),
+        },
         export_command: export_command.clone(),
         retrieval_commands: vec![artifacts_command, evidence_command, export_command],
         key_report_refs,

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -178,12 +178,16 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
 
     validate_runner_extension_parity(runner_id, &runner, &cwd, &required_extensions)?;
 
-    if should_force_diagnostic_ssh(&runner, &options) {
+    let run_capability_preflight = |runner: &Runner| -> Result<()> {
         preflight_runner_capability_plan(
-            &runner,
+            runner,
             options.capability_preflight.as_ref(),
             &request_env,
-        )?;
+        )
+    };
+
+    if should_force_diagnostic_ssh(&runner, &options) {
+        run_capability_preflight(&runner)?;
         return exec_diagnostic_ssh(
             &runner,
             cwd,
@@ -214,11 +218,7 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
     }
     if connected.connected {
         if let Some(session) = connected.session {
-            preflight_runner_capability_plan(
-                &runner,
-                options.capability_preflight.as_ref(),
-                &request_env,
-            )?;
+            run_capability_preflight(&runner)?;
             if let Some(local_url) = session.local_url.as_deref() {
                 return exec_via_daemon(
                     &runner,
@@ -414,27 +414,18 @@ fn exec_via_reverse_broker(
         &redaction_secret_env_names,
     );
 
-    let result = result_event_data(&events).unwrap_or_else(|| json!({}));
-    let (stdout, stderr) = redact_runner_exec_streams(
-        string_field(&result, "stdout"),
-        string_field(&result, "stderr"),
+    let RunnerJobResultFields {
+        result: _,
+        stdout,
+        stderr,
+        metrics,
+        exit_code,
+    } = runner_job_result_fields(
+        &events,
+        job.status,
         &redaction_env,
         &redaction_secret_env_names,
     );
-    let metrics = result
-        .get("metrics")
-        .and_then(|value| serde_json::from_value(value.clone()).ok());
-    let exit_code = result
-        .get("exit_code")
-        .and_then(Value::as_i64)
-        .and_then(|code| i32::try_from(code).ok())
-        .unwrap_or_else(|| {
-            if job.status == JobStatus::Succeeded {
-                0
-            } else {
-                1
-            }
-        });
 
     print_lab_offload_handoff(
         &runner.id,
@@ -563,27 +554,13 @@ fn exec_via_daemon(
         &secret_env_names,
     );
 
-    let result = result_event_data(&events).unwrap_or_else(|| json!({}));
-    let (stdout, stderr) = redact_runner_exec_streams(
-        string_field(&result, "stdout"),
-        string_field(&result, "stderr"),
-        &env,
-        &secret_env_names,
-    );
-    let metrics = result
-        .get("metrics")
-        .and_then(|value| serde_json::from_value(value.clone()).ok());
-    let exit_code = result
-        .get("exit_code")
-        .and_then(Value::as_i64)
-        .and_then(|code| i32::try_from(code).ok())
-        .unwrap_or_else(|| {
-            if job.status == JobStatus::Succeeded {
-                0
-            } else {
-                1
-            }
-        });
+    let RunnerJobResultFields {
+        result,
+        stdout,
+        stderr,
+        metrics,
+        exit_code,
+    } = runner_job_result_fields(&events, job.status, &env, &secret_env_names);
 
     let mirror = mirror_daemon_evidence(runner, &cwd, &command, &job, &events, &result)?;
     let patch = mirror.as_ref().and_then(|evidence| evidence.patch.clone());
@@ -955,6 +932,54 @@ fn result_event_data(events: &[JobEvent]) -> Option<Value> {
         .rev()
         .find(|event| matches!(event.kind, crate::core::api_jobs::JobEventKind::Result))
         .and_then(|event| event.data.clone())
+}
+
+/// Stream + metric fields derived from a runner job's terminal result event.
+struct RunnerJobResultFields {
+    result: Value,
+    stdout: String,
+    stderr: String,
+    metrics: Option<RunnerResourceMetrics>,
+    exit_code: i32,
+}
+
+/// Extract the terminal result payload from a runner job's events and derive
+/// the redacted streams, metrics, and exit code. Shared by the reverse-broker
+/// and daemon execution paths to keep their result handling identical (#5067).
+fn runner_job_result_fields(
+    events: &[JobEvent],
+    job_status: JobStatus,
+    redaction_env: &HashMap<String, String>,
+    redaction_secret_env_names: &[String],
+) -> RunnerJobResultFields {
+    let result = result_event_data(events).unwrap_or_else(|| json!({}));
+    let (stdout, stderr) = redact_runner_exec_streams(
+        string_field(&result, "stdout"),
+        string_field(&result, "stderr"),
+        redaction_env,
+        redaction_secret_env_names,
+    );
+    let metrics = result
+        .get("metrics")
+        .and_then(|value| serde_json::from_value(value.clone()).ok());
+    let exit_code = result
+        .get("exit_code")
+        .and_then(Value::as_i64)
+        .and_then(|code| i32::try_from(code).ok())
+        .unwrap_or_else(|| {
+            if job_status == JobStatus::Succeeded {
+                0
+            } else {
+                1
+            }
+        });
+    RunnerJobResultFields {
+        result,
+        stdout,
+        stderr,
+        metrics,
+        exit_code,
+    }
 }
 
 fn exec_local(plan: PreparedRunnerProcess) -> Result<(RunnerExecOutput, i32)> {

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -620,6 +620,18 @@ fn run_runner_resident_lab_offload(
             .build(),
     );
 
+    // Refuse to dispatch caller-derived argv to the runner if any argument still
+    // embeds the controller-local source path instead of the runner-resident
+    // workspace. This mirrors the path-translation preflight used by the
+    // patch-provider offload path before its remote dispatch (#5071).
+    let source_path = lab_offload_source_path(request.normalized_args)?;
+    preflight_remote_argv_path_translation(
+        runner_id,
+        &command,
+        &source_path,
+        runner_workspace_root,
+    )?;
+
     eprintln!(
         "Lab offload: running runner-resident `{}` on runner `{}` in `{}`.",
         command.join(" "),

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -134,7 +134,7 @@ fn test_run_check_persists_failing_observation() {
             .ends_with("rig-artifact-index.json"));
         assert!(std::path::Path::new(&artifact_index.artifact_index_path).is_file());
         assert_eq!(
-            artifact_index.artifacts_command,
+            artifact_index.evidence_commands.artifacts_command,
             format!("homeboy runs artifacts {run_id}")
         );
         assert!(artifact_index


### PR DESCRIPTION
## Summary

Bundled resolution of six interconnected agent-task / runner / lab audit findings that share overlapping files, so one cook owns them together.

- **#5067 (duplication):** `src/core/runner/execution.rs` — extracted the duplicated result-event extraction (result payload → redacted streams, metrics, exit code) from `exec_via_reverse_broker` and `exec_via_daemon` into a single `runner_job_result_fields` helper (`RunnerJobResultFields`).
- **#5069 (intra-method duplication):** de-duplicated repeated blocks within five methods via small private helpers/closures, behavior-identical:
  - `trace.rs::start_lab_dispatch_observation` — shared `lab_dispatch` metadata builder
  - `agent_task_controller_service.rs::collect_required_artifacts_from_declarations` — shared `first_non_empty_str` candidate-path resolver (lookup order preserved exactly)
  - `agent_task_scheduler.rs::run_with_cancellation` — shared `record_completed_outcome` helper (3 call sites)
  - `agent_task_scheduler.rs::select_bound_output` — shared `missing_binding_fallback` closure (3 sites)
  - `runner/execution.rs::exec` — shared `run_capability_preflight` closure
- **#5077 (output capture):** `src/core/agent_task_promotion.rs` — bounded the retained stdout/stderr bytes of `AgentTaskPromotionCommandReport` with a `PROMOTION_CAPTURE_LIMIT_BYTES` cap + truncation metadata (`AgentTaskPromotionStreamCapture` with `limit_bytes`/`seen_bytes`/`retained_bytes`/`truncated`), mirroring the bounded-capture pattern used by extension self-checks. The full stdout is still used for JSON response parsing; only the retained evidence is bounded. Capture metadata is `skip_serializing_if` empty so the historical report shape is preserved.
- **#5071 (remote execution preflight):** `src/core/runner/lab/offload.rs` — added the existing `preflight_remote_argv_path_translation` check to the previously-unguarded runner-resident dispatch path (`run_runner_resident_lab_offload`) before remote `exec`, matching the patch-provider offload path.
- **#5078 (thin command adapters):** moved runner-execution orchestration out of `src/commands/agent_task_dispatch.rs` into the core service `src/core/agent_task_dispatch_service.rs` (new `AgentTaskDispatchCommand` carrier + `resolve_dispatch_request*`, `run_dispatch_command`, `run_cook_command`, and cook-handoff rendering). The command module is now a thin adapter: clap args → `AgentTaskDispatchCommand` → core service → JSON. Updated the two in-tree callers (`agent_task/run.rs`, `agent_task/controller.rs`).
- **#5068 (repeated field patterns):** factored the `[artifacts_command, evidence_command]` group into a shared `RunEvidenceCommands` struct (in `src/core/observation/records.rs`), embedded via `#[serde(flatten)]` so the flat JSON keys are preserved, across `RunRef`, `PersistedRunRetrieval`, and `RigRunArtifactIndex`.

## Deferred (noted per the cross-boundary CAUTION)

The remaining four #5068 field groups cross CLI/contract/plan boundaries (clap arg structs, serde-serialized contract types, and request structs with many call sites) where flattening risks changing public CLI flags or serialized JSON shapes. To keep this bundle safe and reviewable they are **deferred** for a focused follow-up:

- `[attempts, client_context, provider_config, queue_only, tasks_json]` (DispatchArgs / AgentTaskDispatchRequest / overrides) — clap `#[derive(Args)]` + serde + test-overrides mix.
- `[outcome_schema, request_schema]` (AgentTaskCoreProviderCapabilityContract / AgentTaskExecutorProvider / AgentTaskProviderCapabilityContract) — serde contract types with per-field `#[serde(default = ...)]`, exercised by golden-contract tests.
- `[allow_local_fallback, allow_local_hot]` (Cli / LabRoutingRequest / LabOffloadRequest).
- `[default_lab_offload, infer_source_path_tools, release_gate, requires_extension_parity]` (LabCommandContract / LabRoutePlan / LabOffloadCommand).

## Validation

- `cargo build --lib --tests` — clean (only 2 pre-existing unrelated warnings).
- `cargo fmt --check` — clean.
- `cargo test agent_task`, `cargo test lab`, `cargo test command_contract`, `cargo test golden_contract` — pass.
- `cargo test runner` — passes except 3 environmental failures in untouched files (`bench`, `extension/trace`) that exec fixture shell scripts from a `noexec`-mounted `/tmp` on this VPS (exit 126 `Permission denied`); unrelated to these changes.
- `docs/changelog.md` intentionally untouched.

Closes #5069
Closes #5068
Closes #5067
Closes #5071
Closes #5077
Closes #5078