### PR TITLE
fix(rig): expose bench settings to prepare commands

### DIFF
--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -35,7 +35,8 @@ fn prepare_rig_bench_context(
     let declared_spec = spec.clone();
     apply_bench_path_override(&mut spec, args);
     let lease = rig::lease::acquire_active_run_lease(&spec, "bench")?;
-    if let Some(prepare) = rig::run_bench_prepare(&spec)? {
+    let prepare_settings = bench_prepare_settings(args);
+    if let Some(prepare) = rig::run_bench_prepare(&spec, &prepare_settings)? {
         if !prepare.success {
             return Err(homeboy::core::Error::rig_pipeline_failed(
                 &spec.id,
@@ -54,6 +55,20 @@ fn prepare_rig_bench_context(
         snapshot,
         _lease: lease,
     })
+}
+
+fn bench_prepare_settings(args: &BenchRunArgs) -> Vec<(String, String)> {
+    args.setting_args
+        .setting
+        .iter()
+        .cloned()
+        .chain(
+            args.setting_args
+                .setting_json
+                .iter()
+                .map(|(key, value)| (key.clone(), value.to_string())),
+        )
+        .collect()
 }
 
 fn apply_bench_path_override(spec: &mut RigSpec, args: &BenchRunArgs) {

--- a/src/core/rig/pipeline.rs
+++ b/src/core/rig/pipeline.rs
@@ -55,9 +55,18 @@ impl PipelineOutcome {
 }
 
 pub fn run_pipeline(rig: &RigSpec, name: &str, fail_fast: bool) -> Result<PipelineOutcome> {
+    run_pipeline_with_settings(rig, name, fail_fast, &[])
+}
+
+pub fn run_pipeline_with_settings(
+    rig: &RigSpec,
+    name: &str,
+    fail_fast: bool,
+    settings: &[(String, String)],
+) -> Result<PipelineOutcome> {
     let steps = rig.pipeline.get(name).cloned().unwrap_or_default();
     let ordered_indices = order_pipeline_steps(rig, name, &steps)?;
-    run_ordered_steps(rig, name, &steps, ordered_indices, fail_fast)
+    run_ordered_steps(rig, name, &steps, ordered_indices, fail_fast, settings)
 }
 
 pub fn run_pipeline_check_groups(
@@ -75,7 +84,7 @@ pub fn run_pipeline_check_groups(
         .filter(|step| step_matches_groups(step, &wanted))
         .collect::<Vec<_>>();
     let ordered_indices = order_pipeline_steps(rig, "check", &steps)?;
-    run_ordered_steps(rig, "check", &steps, ordered_indices, fail_fast)
+    run_ordered_steps(rig, "check", &steps, ordered_indices, fail_fast, &[])
 }
 
 fn run_ordered_steps(
@@ -84,6 +93,7 @@ fn run_ordered_steps(
     steps: &[PipelineStep],
     ordered_indices: Vec<usize>,
     fail_fast: bool,
+    settings: &[(String, String)],
 ) -> Result<PipelineOutcome> {
     let mut outcomes = Vec::with_capacity(ordered_indices.len());
     let mut failed = 0;
@@ -105,7 +115,7 @@ fn run_ordered_steps(
         let label = step_label(rig, step, idx);
         crate::log_status!("rig", "{}: {}", name, label);
 
-        let result = run_step(rig, name, step);
+        let result = run_step(rig, name, step, settings);
 
         let outcome = match &result {
             Ok(()) => PipelineStepOutcome {
@@ -152,7 +162,12 @@ fn step_matches_groups(step: &PipelineStep, wanted: &BTreeSet<&str>) -> bool {
     }
 }
 
-fn run_step(rig: &RigSpec, pipeline_name: &str, step: &PipelineStep) -> Result<()> {
+fn run_step(
+    rig: &RigSpec,
+    pipeline_name: &str,
+    step: &PipelineStep,
+    settings: &[(String, String)],
+) -> Result<()> {
     match step {
         PipelineStep::Service { id, op, .. } => run_service_step(rig, id, *op),
         PipelineStep::Build { component, .. } => run_build_step(rig, component),
@@ -170,9 +185,11 @@ fn run_step(rig: &RigSpec, pipeline_name: &str, step: &PipelineStep) -> Result<(
             ..
         } => run_stack_step(rig, component, *op, *dry_run),
         PipelineStep::Command { .. } | PipelineStep::CommandIfMissing { .. } => {
-            run_command_pipeline_step(rig, step)
+            run_command_pipeline_step(rig, step, settings)
         }
-        PipelineStep::Requirement { .. } => run_requirement_step(rig, pipeline_name, step),
+        PipelineStep::Requirement { .. } => {
+            run_requirement_step(rig, pipeline_name, step, settings)
+        }
         PipelineStep::Symlink { op, .. } => run_symlink_step(rig, *op),
         PipelineStep::SharedPath { op, .. } => run_shared_path_step(rig, *op),
         PipelineStep::Patch {
@@ -552,6 +569,7 @@ fn run_command_step(
     cmd: &str,
     cwd: Option<&str>,
     env: &HashMap<String, String>,
+    settings: &[(String, String)],
 ) -> Result<()> {
     let expanded = expand_vars(rig, cmd);
     let mut command = Command::new(command_step_shell());
@@ -570,6 +588,10 @@ fn run_command_step(
 
     for (k, v) in env {
         command.env(k, expand_vars(rig, v));
+    }
+
+    for (k, v) in settings_env(settings) {
+        command.env(k, v);
     }
 
     let status = command.status().map_err(|e| {
@@ -596,10 +618,26 @@ fn run_command_step(
     Ok(())
 }
 
-fn run_command_pipeline_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {
+fn settings_env(settings: &[(String, String)]) -> Vec<(String, String)> {
+    settings
+        .iter()
+        .map(|(key, value)| {
+            (
+                format!("HOMEBOY_SETTINGS_{}", key.to_uppercase()),
+                value.clone(),
+            )
+        })
+        .collect()
+}
+
+fn run_command_pipeline_step(
+    rig: &RigSpec,
+    step: &PipelineStep,
+    settings: &[(String, String)],
+) -> Result<()> {
     match step {
         PipelineStep::Command { cmd, cwd, env, .. } => {
-            run_command_step(rig, cmd, cwd.as_deref(), env)
+            run_command_step(rig, cmd, cwd.as_deref(), env, settings)
         }
         PipelineStep::CommandIfMissing {
             missing,
@@ -607,7 +645,7 @@ fn run_command_pipeline_step(rig: &RigSpec, step: &PipelineStep) -> Result<()> {
             cwd,
             env,
             ..
-        } => run_command_if_missing_step(rig, missing, cmd, cwd.as_deref(), env),
+        } => run_command_if_missing_step(rig, missing, cmd, cwd.as_deref(), env, settings),
         _ => unreachable!("command pipeline helper only accepts command steps"),
     }
 }
@@ -618,6 +656,7 @@ fn run_command_if_missing_step(
     cmd: &str,
     cwd: Option<&str>,
     env: &HashMap<String, String>,
+    settings: &[(String, String)],
 ) -> Result<()> {
     let expanded_missing = expand_vars(rig, missing);
     let missing_path = PathBuf::from(&expanded_missing);
@@ -633,10 +672,15 @@ fn run_command_if_missing_step(
         return Ok(());
     }
 
-    run_command_step(rig, cmd, cwd, env)
+    run_command_step(rig, cmd, cwd, env, settings)
 }
 
-fn run_requirement_step(rig: &RigSpec, pipeline_name: &str, step: &PipelineStep) -> Result<()> {
+fn run_requirement_step(
+    rig: &RigSpec,
+    pipeline_name: &str,
+    step: &PipelineStep,
+    settings: &[(String, String)],
+) -> Result<()> {
     let PipelineStep::Requirement {
         path,
         file,
@@ -723,6 +767,7 @@ fn run_requirement_step(rig: &RigSpec, pipeline_name: &str, step: &PipelineStep)
             prepare_command.as_deref().unwrap(),
             cwd.as_deref(),
             env,
+            settings,
         )?;
     }
 

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -16,7 +16,8 @@ use super::expand::{expand_resources, expand_vars};
 use super::lease::acquire_active_run_lease;
 use super::lint::run_package_lint;
 use super::pipeline::{
-    cleanup_shared_paths, run_pipeline, run_pipeline_check_groups, PipelineOutcome,
+    cleanup_shared_paths, run_pipeline, run_pipeline_check_groups, run_pipeline_with_settings,
+    PipelineOutcome,
 };
 use super::service::{self, ServiceStatus};
 use super::spec::{RigSpec, ServiceKind, SymlinkSpec};
@@ -259,12 +260,15 @@ pub fn run_check_groups(rig: &RigSpec, groups: &[String]) -> Result<CheckReport>
 /// Missing `bench_prepare` pipelines are a no-op so existing rigs keep their
 /// previous bench behavior. Declared steps fail fast because workload timing
 /// must not start when dependency/bootstrap preparation is incomplete.
-pub fn run_bench_prepare(rig: &RigSpec) -> Result<Option<BenchPrepareReport>> {
+pub fn run_bench_prepare(
+    rig: &RigSpec,
+    settings: &[(String, String)],
+) -> Result<Option<BenchPrepareReport>> {
     if !rig.pipeline.contains_key("bench_prepare") {
         return Ok(None);
     }
 
-    let outcome = run_pipeline(rig, "bench_prepare", true)?;
+    let outcome = run_pipeline_with_settings(rig, "bench_prepare", true, settings)?;
     Ok(Some(BenchPrepareReport {
         rig_id: rig.id.clone(),
         success: outcome.is_success(),

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -5,7 +5,8 @@
 //! the public outcome types — shape, serialization, `is_success` contract.
 
 use crate::core::rig::pipeline::{
-    run_pipeline, run_pipeline_check_groups, PipelineOutcome, PipelineStepOutcome,
+    run_pipeline, run_pipeline_check_groups, run_pipeline_with_settings, PipelineOutcome,
+    PipelineStepOutcome,
 };
 use crate::core::rig::spec::RigSpec;
 
@@ -150,6 +151,39 @@ fn test_command_if_missing_skips_when_path_exists() {
     let out = run_pipeline(&rig, "bench_prepare", true).expect("pipeline runs");
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
     assert!(!marker.exists(), "guarded command should not run");
+}
+
+#[test]
+fn test_command_step_exposes_pipeline_settings_env() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let marker = tmp.path().join("setting.txt");
+    let marker_arg = marker.to_string_lossy();
+    let rig: RigSpec = serde_json::from_str(&format!(
+        r#"{{
+            "id": "command-settings-env",
+            "pipeline": {{
+                "bench_prepare": [{{
+                    "kind": "command",
+                    "command": "printf '%s' \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\" > {}"
+                }}]
+            }}
+        }}"#,
+        marker_arg
+    ))
+    .expect("parse rig");
+
+    let settings = vec![(
+        "wp_codebox_source_root".to_string(),
+        "/tmp/woocommerce".to_string(),
+    )];
+    let out =
+        run_pipeline_with_settings(&rig, "bench_prepare", true, &settings).expect("pipeline runs");
+
+    assert!(out.is_success(), "outcomes: {:?}", out.steps);
+    assert_eq!(
+        std::fs::read_to_string(marker).expect("marker"),
+        "/tmp/woocommerce"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Exposes bench CLI settings to rig pipeline command steps as HOMEBOY_SETTINGS_* env vars.
- Threads those settings into rig bench_prepare without changing normal rig pipeline behavior.
- Adds coverage proving prepare commands can read a forwarded setting env var.

## Testing
- cargo test core::rig::pipeline::pipeline_test::test_command_step_exposes_pipeline_settings_env
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Homeboy core patch and focused regression test; Chris remains responsible for review and validation.