### PR TITLE
refactor: dedupe Lab routing-policy fields + fix runs corpus test (#5090, #5088)

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -21,8 +21,8 @@ mod public_variants;
 
 pub use lab::{
     lab_runner_supported_labels, lab_runner_unsupported_hint, lab_runner_unsupported_message,
-    LabCommandContract, LabCommandPortability, LabCommandRequiredTool, LabSourcePathMode,
-    LabWorkspaceModePolicy, LAB_TRACE_EXTRA_TOOLS,
+    LabCommandContract, LabCommandPortability, LabCommandRequiredTool, LabRoutingPolicy,
+    LabSourcePathMode, LabWorkspaceModePolicy, LAB_TRACE_EXTRA_TOOLS,
 };
 pub use output::{
     CommandDescriptor, CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor,

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -16,16 +16,18 @@ use crate::core::engine::execution_context::{self, ResolveOptions};
 use crate::core::extension::ExtensionCapability;
 use std::collections::BTreeSet;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct LabCommandContract {
-    pub hot_label: &'static str,
-    pub portability: LabCommandPortability,
+/// Routing-policy flags shared by every Lab command representation
+/// (`LabCommandContract`, `LabRoutePlan`, `LabOffloadCommand`). These four
+/// booleans travel together as one cohesive policy as a command is resolved
+/// from its contract into a route plan and finally an offload command, so they
+/// live in a single embedded struct rather than being duplicated field-by-field
+/// across the three layers.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LabRoutingPolicy {
+    /// Whether the command offloads to a default Lab runner without an explicit
+    /// `--runner` selection.
     pub default_lab_offload: bool,
-    pub source_path_mode: LabSourcePathMode,
-    pub workspace_mode_policy: LabWorkspaceModePolicy,
-    pub mutation_flag: Option<&'static str>,
-    pub requires_extension_parity: bool,
-    pub extra_required_tools: &'static [LabCommandRequiredTool],
+    /// Whether source-path tool inference applies to this command.
     pub infer_source_path_tools: bool,
     /// Whether this command is a release gate whose routing fidelity matters
     /// for validating a release (lint/test/audit). When true, force-local
@@ -33,6 +35,21 @@ pub struct LabCommandContract {
     /// `/release_gate/local_hot` policy if a default Lab runner is configured.
     /// See issues #4603 / #4605.
     pub release_gate: bool,
+    /// Whether the command requires extension parity between controller and
+    /// runner before offloading.
+    pub requires_extension_parity: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LabCommandContract {
+    pub hot_label: &'static str,
+    pub portability: LabCommandPortability,
+    pub source_path_mode: LabSourcePathMode,
+    pub workspace_mode_policy: LabWorkspaceModePolicy,
+    pub mutation_flag: Option<&'static str>,
+    pub extra_required_tools: &'static [LabCommandRequiredTool],
+    /// Routing-policy flags shared across the Lab command layers.
+    pub routing_policy: LabRoutingPolicy,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -325,14 +342,16 @@ impl LabCommandContract {
         Self {
             hot_label,
             portability: LabCommandPortability::Portable,
-            default_lab_offload: true,
             source_path_mode: LabSourcePathMode::CwdOrPathFlag,
             workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
             mutation_flag,
-            requires_extension_parity,
             extra_required_tools,
-            infer_source_path_tools: true,
-            release_gate: false,
+            routing_policy: LabRoutingPolicy {
+                default_lab_offload: true,
+                infer_source_path_tools: true,
+                release_gate: false,
+                requires_extension_parity,
+            },
         }
     }
 
@@ -342,14 +361,18 @@ impl LabCommandContract {
         requires_extension_parity: bool,
         extra_required_tools: &'static [LabCommandRequiredTool],
     ) -> Self {
+        let base = Self::portable(
+            hot_label,
+            mutation_flag,
+            requires_extension_parity,
+            extra_required_tools,
+        );
         Self {
-            infer_source_path_tools: false,
-            ..Self::portable(
-                hot_label,
-                mutation_flag,
-                requires_extension_parity,
-                extra_required_tools,
-            )
+            routing_policy: LabRoutingPolicy {
+                infer_source_path_tools: false,
+                ..base.routing_policy
+            },
+            ..base
         }
     }
 
@@ -359,14 +382,18 @@ impl LabCommandContract {
         requires_extension_parity: bool,
         extra_required_tools: &'static [LabCommandRequiredTool],
     ) -> Self {
+        let base = Self::portable_workload(
+            hot_label,
+            mutation_flag,
+            requires_extension_parity,
+            extra_required_tools,
+        );
         Self {
-            default_lab_offload: false,
-            ..Self::portable_workload(
-                hot_label,
-                mutation_flag,
-                requires_extension_parity,
-                extra_required_tools,
-            )
+            routing_policy: LabRoutingPolicy {
+                default_lab_offload: false,
+                ..base.routing_policy
+            },
+            ..base
         }
     }
 
@@ -374,14 +401,16 @@ impl LabCommandContract {
         Self {
             hot_label,
             portability: LabCommandPortability::LocalOnly(reason),
-            default_lab_offload: false,
             source_path_mode: LabSourcePathMode::CwdOrPathFlag,
             workspace_mode_policy: LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
             mutation_flag: None,
-            requires_extension_parity: false,
             extra_required_tools: LAB_NO_EXTRA_TOOLS,
-            infer_source_path_tools: false,
-            release_gate: false,
+            routing_policy: LabRoutingPolicy {
+                default_lab_offload: false,
+                infer_source_path_tools: false,
+                release_gate: false,
+                requires_extension_parity: false,
+            },
         }
     }
 
@@ -389,7 +418,7 @@ impl LabCommandContract {
     /// `/release_gate/local_hot` policy applies to force-local bypass and
     /// stale-runner local fallback when a default Lab runner is configured.
     pub(crate) const fn release_gate(mut self) -> Self {
-        self.release_gate = true;
+        self.routing_policy.release_gate = true;
         self
     }
 }
@@ -417,7 +446,7 @@ impl Commands {
         let Some(contract) = self.lab_contract() else {
             return Ok(Vec::new());
         };
-        if !contract.requires_extension_parity {
+        if !contract.routing_policy.requires_extension_parity {
             return Ok(Vec::new());
         }
 
@@ -782,8 +811,8 @@ mod tests {
             .lab_contract()
             .expect("trace contract");
         assert_eq!(trace.extra_required_tools, LAB_TRACE_EXTRA_TOOLS);
-        assert!(!trace.requires_extension_parity);
-        assert!(!trace.infer_source_path_tools);
+        assert!(!trace.routing_policy.requires_extension_parity);
+        assert!(!trace.routing_policy.infer_source_path_tools);
         assert_eq!(
             trace.workspace_mode_policy,
             LabWorkspaceModePolicy::ChangedSinceGitElseSnapshot
@@ -810,19 +839,19 @@ mod tests {
         let lint = parsed_command(&["homeboy", "lint"])
             .lab_contract()
             .expect("lint contract");
-        assert!(lint.requires_extension_parity);
-        assert!(lint.infer_source_path_tools);
-        assert!(lint.release_gate);
+        assert!(lint.routing_policy.requires_extension_parity);
+        assert!(lint.routing_policy.infer_source_path_tools);
+        assert!(lint.routing_policy.release_gate);
 
         let test_full = parsed_command(&["homeboy", "test"])
             .lab_contract()
             .expect("test contract");
-        assert!(test_full.release_gate);
+        assert!(test_full.routing_policy.release_gate);
 
         let audit_full = parsed_command(&["homeboy", "audit"])
             .lab_contract()
             .expect("audit contract");
-        assert!(audit_full.release_gate);
+        assert!(audit_full.routing_policy.release_gate);
 
         // Changed-scope/local-only variants and non-gate commands are NOT
         // release gates.
@@ -830,24 +859,28 @@ mod tests {
             !parsed_command(&["homeboy", "lint", "--changed-since", "origin/main"])
                 .lab_contract()
                 .expect("changed-scope lint contract")
+                .routing_policy
                 .release_gate
         );
         assert!(
             !parsed_command(&["homeboy", "bench"])
                 .lab_contract()
                 .expect("bench contract")
+                .routing_policy
                 .release_gate
         );
         assert!(
             !parsed_command(&["homeboy", "trace"])
                 .lab_contract()
                 .expect("trace contract")
+                .routing_policy
                 .release_gate
         );
         assert!(
             !parsed_command(&["homeboy", "agent-task", "dispatch", "--prompt", "cook"])
                 .lab_contract()
                 .expect("agent-task contract")
+                .routing_policy
                 .release_gate
         );
 
@@ -865,7 +898,7 @@ mod tests {
                 contract.workspace_mode_policy,
                 LabWorkspaceModePolicy::RunnerResident
             );
-            assert!(!contract.default_lab_offload);
+            assert!(!contract.routing_policy.default_lab_offload);
         }
 
         let auth_status = parsed_command(&[
@@ -878,9 +911,9 @@ mod tests {
         ])
         .lab_contract()
         .expect("agent-task auth status contract");
-        assert!(!auth_status.default_lab_offload);
-        assert!(!auth_status.requires_extension_parity);
-        assert!(!auth_status.infer_source_path_tools);
+        assert!(!auth_status.routing_policy.default_lab_offload);
+        assert!(!auth_status.routing_policy.requires_extension_parity);
+        assert!(!auth_status.routing_policy.infer_source_path_tools);
 
         let tunnel_service_start = parsed_command(&[
             "homeboy",
@@ -903,8 +936,8 @@ mod tests {
             tunnel_service_start.workspace_mode_policy,
             LabWorkspaceModePolicy::RunnerResident
         );
-        assert!(!tunnel_service_start.default_lab_offload);
-        assert!(!tunnel_service_start.infer_source_path_tools);
+        assert!(!tunnel_service_start.routing_policy.default_lab_offload);
+        assert!(!tunnel_service_start.routing_policy.infer_source_path_tools);
 
         let tunnel_service_expose = parsed_command(&[
             "homeboy",
@@ -931,8 +964,8 @@ mod tests {
             tunnel_service_expose.workspace_mode_policy,
             LabWorkspaceModePolicy::RunnerResident
         );
-        assert!(!tunnel_service_expose.default_lab_offload);
-        assert!(!tunnel_service_expose.infer_source_path_tools);
+        assert!(!tunnel_service_expose.routing_policy.default_lab_offload);
+        assert!(!tunnel_service_expose.routing_policy.infer_source_path_tools);
 
         let rig = parsed_command(&["homeboy", "rig", "up", "studio"])
             .lab_contract()

--- a/src/commands/route.rs
+++ b/src/commands/route.rs
@@ -641,7 +641,7 @@ mod tests {
         assert_eq!(command.hot_label, "lint");
         assert!(command.portable);
         assert!(command.unsupported_reason.is_none());
-        assert!(command.requires_extension_parity);
+        assert!(command.routing_policy.requires_extension_parity);
     }
 
     #[test]
@@ -659,11 +659,11 @@ mod tests {
 
         assert_eq!(command.hot_label, "extension update");
         assert!(command.portable);
-        assert!(!command.default_lab_offload);
+        assert!(!command.routing_policy.default_lab_offload);
         assert!(command.unsupported_reason.is_none());
-        assert!(!command.requires_extension_parity);
+        assert!(!command.routing_policy.requires_extension_parity);
         assert!(command.required_extensions.is_empty());
-        assert!(!command.infer_source_path_tools);
+        assert!(!command.routing_policy.infer_source_path_tools);
         assert!(cli.command.supports_lab_runner());
     }
 
@@ -807,7 +807,7 @@ mod tests {
                 command.workspace_mode_policy,
                 runners::LabOffloadWorkspaceModePolicy::RunnerResident
             );
-            assert!(!command.default_lab_offload);
+            assert!(!command.routing_policy.default_lab_offload);
         }
     }
 
@@ -843,7 +843,7 @@ mod tests {
                 "agent-task dispatch/cook/loop/run-plan/retry --run"
             );
             assert!(command.portable);
-            assert!(command.default_lab_offload);
+            assert!(command.routing_policy.default_lab_offload);
         }
     }
 
@@ -862,10 +862,10 @@ mod tests {
         assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
         assert_eq!(command.hot_label, "agent-task providers");
         assert!(command.portable);
-        assert!(!command.default_lab_offload);
-        assert!(!command.requires_extension_parity);
+        assert!(!command.routing_policy.default_lab_offload);
+        assert!(!command.routing_policy.requires_extension_parity);
         assert!(command.required_extensions.is_empty());
-        assert!(!command.infer_source_path_tools);
+        assert!(!command.routing_policy.infer_source_path_tools);
     }
 
     #[test]
@@ -889,7 +889,7 @@ mod tests {
         assert_eq!(cli.runner.as_deref(), Some("homeboy-lab"));
         assert_eq!(command.hot_label, "tunnel service start");
         assert!(command.portable);
-        assert!(!command.default_lab_offload);
+        assert!(!command.routing_policy.default_lab_offload);
         assert_eq!(
             command.source_path_mode,
             runners::LabOffloadSourcePathMode::RunnerResident
@@ -898,9 +898,9 @@ mod tests {
             command.workspace_mode_policy,
             runners::LabOffloadWorkspaceModePolicy::RunnerResident
         );
-        assert!(!command.requires_extension_parity);
+        assert!(!command.routing_policy.requires_extension_parity);
         assert!(command.required_extensions.is_empty());
-        assert!(!command.infer_source_path_tools);
+        assert!(!command.routing_policy.infer_source_path_tools);
     }
 
     #[test]
@@ -922,7 +922,7 @@ mod tests {
 
         assert_eq!(command.hot_label, "tunnel preview-consumer run");
         assert!(command.portable);
-        assert!(!command.default_lab_offload);
+        assert!(!command.routing_policy.default_lab_offload);
     }
 
     #[test]
@@ -934,7 +934,7 @@ mod tests {
         assert_eq!(command.hot_label, "audit");
         assert!(command.portable);
         assert_eq!(command.unsupported_reason, None);
-        assert!(command.requires_extension_parity);
+        assert!(command.routing_policy.requires_extension_parity);
     }
 
     #[test]
@@ -946,7 +946,7 @@ mod tests {
         assert_eq!(command.hot_label, "audit");
         assert!(command.portable);
         assert_eq!(command.unsupported_reason, None);
-        assert!(command.requires_extension_parity);
+        assert!(command.routing_policy.requires_extension_parity);
     }
 
     #[test]
@@ -958,6 +958,6 @@ mod tests {
         assert_eq!(command.hot_label, "rig up");
         assert!(!command.portable);
         assert!(command.unsupported_reason.is_some());
-        assert!(!command.requires_extension_parity);
+        assert!(!command.routing_policy.requires_extension_parity);
     }
 }

--- a/src/commands/runs/corpus_tests.rs
+++ b/src/commands/runs/corpus_tests.rs
@@ -9,6 +9,7 @@
 
 use homeboy::core::observation::{NewRunRecord, ObservationStore, RunRecord, RunStatus};
 use homeboy::test_support::with_isolated_home;
+use serde_json::Value;
 
 use super::bundle::{RunsExportArgs, RunsImportArgs};
 use super::{bundle::import_runs, drift, query, RunsOutput};
@@ -34,20 +35,24 @@ impl Drop for XdgGuard {
     }
 }
 
+fn sample_run(kind: &str, component_id: &str, rig_id: &str, metadata: Value) -> NewRunRecord {
+    NewRunRecord::builder(kind)
+        .component_id(component_id)
+        .rig_id(rig_id)
+        .metadata(metadata)
+        .build()
+}
+
 fn install_artifact(
     store: &ObservationStore,
     home: &std::path::Path,
     run_kind: &str,
     component: &str,
-    body: serde_json::Value,
+    body: Value,
     artifact_kind: &str,
 ) -> RunRecord {
     let run = store
-        .start_run(
-            NewRunRecord::builder(run_kind)
-                .component_id(component)
-                .build(),
-        )
+        .start_run(sample_run(run_kind, component, "corpus", Value::Null))
         .expect("start run");
     store
         .finish_run(&run.id, RunStatus::Pass, None)

--- a/src/core/command_execution_plan.rs
+++ b/src/core/command_execution_plan.rs
@@ -2,6 +2,8 @@
 
 use serde::Serialize;
 
+use crate::command_contract::LabRoutingPolicy;
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct CommandExecutionPlan {
     pub label: String,
@@ -117,15 +119,16 @@ pub enum CommandOutputFormat {
 pub struct LabRoutePlan {
     pub label: String,
     pub portability: CommandPortability,
-    pub default_lab_offload: bool,
     pub source_policy: CommandSourcePolicy,
     pub workspace_policy: CommandWorkspacePolicy,
     pub output_contract: CommandOutputContract,
-    pub requires_extension_parity: bool,
     pub required_extensions: Vec<String>,
     pub requires_playwright: bool,
-    pub infer_source_path_tools: bool,
-    pub release_gate: bool,
+    /// Routing-policy flags shared across the Lab command layers. Flattened so
+    /// the serialized shape keeps `default_lab_offload`, `infer_source_path_tools`,
+    /// `release_gate`, and `requires_extension_parity` as top-level keys.
+    #[serde(flatten)]
+    pub routing_policy: LabRoutingPolicy,
 }
 
 impl LabRoutePlan {
@@ -133,15 +136,12 @@ impl LabRoutePlan {
         Self {
             label: label.into(),
             portability: CommandPortability::Portable,
-            default_lab_offload: false,
             source_policy: CommandSourcePolicy::ControllerCwdOrExplicitPath,
             workspace_policy: CommandWorkspacePolicy::ChangedSinceGitElseSnapshot,
             output_contract: CommandOutputContract::inherit(),
-            requires_extension_parity: false,
             required_extensions: Vec::new(),
             requires_playwright: false,
-            infer_source_path_tools: false,
-            release_gate: false,
+            routing_policy: LabRoutingPolicy::default(),
         }
     }
 

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -56,7 +56,6 @@ pub fn lab_offload_command_from_contract(
     runners::LabOffloadCommand {
         hot_label: contract.hot_label,
         portable: matches!(plan.portability, CommandPortability::Portable),
-        default_lab_offload: plan.default_lab_offload,
         unsupported_reason: match contract.portability {
             LabCommandPortability::Portable => None,
             LabCommandPortability::LocalOnly(reason) => Some(reason),
@@ -85,11 +84,9 @@ pub fn lab_offload_command_from_contract(
                 runners::LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot
             }
         },
-        requires_extension_parity: plan.requires_extension_parity,
         required_extensions: plan.required_extensions,
         requires_playwright: plan.requires_playwright,
-        infer_source_path_tools: plan.infer_source_path_tools,
-        release_gate: plan.release_gate,
+        routing_policy: plan.routing_policy,
     }
 }
 
@@ -103,7 +100,7 @@ pub fn lab_route_plan_from_contract(
             LabRoutePlan::local_only(contract.hot_label, reason)
         }
     };
-    plan.default_lab_offload = contract.default_lab_offload;
+    plan.routing_policy = contract.routing_policy;
     plan.source_policy = match contract.source_path_mode {
         LabSourcePathMode::CwdOrPathFlag => CommandSourcePolicy::ControllerCwdOrExplicitPath,
         LabSourcePathMode::RunnerResident => CommandSourcePolicy::RunnerResident,
@@ -116,14 +113,11 @@ pub fn lab_route_plan_from_contract(
         LabWorkspaceModePolicy::GitCheckoutRequired => CommandWorkspacePolicy::GitCheckoutRequired,
         LabWorkspaceModePolicy::RunnerResident => CommandWorkspacePolicy::RunnerResident,
     };
-    plan.requires_extension_parity = contract.requires_extension_parity;
     plan.required_extensions = required_extensions;
     plan.requires_playwright = contract
         .extra_required_tools
         .iter()
         .any(|tool| matches!(tool, LabCommandRequiredTool::Playwright));
-    plan.infer_source_path_tools = contract.infer_source_path_tools;
-    plan.release_gate = contract.release_gate;
     plan
 }
 
@@ -199,7 +193,8 @@ fn execute_lab_offload_with_timeout(
 mod tests {
     use super::*;
     use crate::command_contract::{
-        LabCommandContract, LabCommandPortability, LabSourcePathMode, LAB_TRACE_EXTRA_TOOLS,
+        LabCommandContract, LabCommandPortability, LabRoutingPolicy, LabSourcePathMode,
+        LAB_TRACE_EXTRA_TOOLS,
     };
     use crate::core::command_execution_plan::{
         CommandPortability, CommandSourcePolicy, CommandWorkspacePolicy,
@@ -241,14 +236,16 @@ mod tests {
         LabCommandContract {
             hot_label: "trace",
             portability: LabCommandPortability::Portable,
-            default_lab_offload: true,
             source_path_mode: LabSourcePathMode::CwdOrPathFlag,
             workspace_mode_policy: LabWorkspaceModePolicy::GitCheckoutRequired,
             mutation_flag: Some("--keep-overlay"),
-            requires_extension_parity: true,
             extra_required_tools: LAB_TRACE_EXTRA_TOOLS,
-            infer_source_path_tools: false,
-            release_gate: false,
+            routing_policy: LabRoutingPolicy {
+                default_lab_offload: true,
+                infer_source_path_tools: false,
+                release_gate: false,
+                requires_extension_parity: true,
+            },
         }
     }
 
@@ -261,16 +258,16 @@ mod tests {
 
         assert_eq!(command.hot_label, "trace");
         assert!(command.portable);
-        assert!(command.default_lab_offload);
+        assert!(command.routing_policy.default_lab_offload);
         assert_eq!(command.unsupported_reason, None);
         assert_eq!(
             command.workspace_mode_policy,
             runners::LabOffloadWorkspaceModePolicy::GitCheckoutRequired
         );
-        assert!(command.requires_extension_parity);
+        assert!(command.routing_policy.requires_extension_parity);
         assert_eq!(command.required_extensions, vec!["wordpress", "playwright"]);
         assert!(command.requires_playwright);
-        assert!(!command.infer_source_path_tools);
+        assert!(!command.routing_policy.infer_source_path_tools);
     }
 
     #[test]
@@ -291,8 +288,8 @@ mod tests {
             plan.workspace_policy,
             CommandWorkspacePolicy::GitCheckoutRequired
         );
-        assert!(plan.default_lab_offload);
-        assert!(plan.requires_extension_parity);
+        assert!(plan.routing_policy.default_lab_offload);
+        assert!(plan.routing_policy.requires_extension_parity);
         assert_eq!(plan.required_extensions, vec!["wordpress", "playwright"]);
         assert!(plan.requires_playwright);
     }

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -98,17 +98,15 @@ pub struct LabOffloadRequest<'a> {
 pub struct LabOffloadCommand {
     pub hot_label: &'static str,
     pub portable: bool,
-    pub default_lab_offload: bool,
     pub unsupported_reason: Option<&'static str>,
     pub source_path_mode: LabOffloadSourcePathMode,
     pub workspace_mode_policy: LabOffloadWorkspaceModePolicy,
-    pub requires_extension_parity: bool,
     pub required_extensions: Vec<String>,
     pub requires_playwright: bool,
-    pub infer_source_path_tools: bool,
-    /// Whether this is a release-gate command (lint/test/audit) subject to the
-    /// `/release_gate/local_hot` fail-closed routing policy.
-    pub release_gate: bool,
+    /// Routing-policy flags shared across the Lab command layers
+    /// (`default_lab_offload`, `infer_source_path_tools`, `release_gate`,
+    /// `requires_extension_parity`).
+    pub routing_policy: crate::command_contract::LabRoutingPolicy,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -434,7 +432,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         return Ok(skipped_automatic_run_local(plan, reason));
     }
 
-    if request.explicit_runner.is_none() && !contract.default_lab_offload {
+    if request.explicit_runner.is_none() && !contract.routing_policy.default_lab_offload {
         return Ok(LabOffloadOutcome::RunLocal {
             plan: disabled_select_runner_plan(plan, "automatic Lab offload disabled"),
             metadata: None,
@@ -521,7 +519,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             // diagnostic that surfaces the underlying runner reason, rather
             // than letting a stale launcher route the gate to the controller.
             // The operator-only override is `/release_gate/local_hot: allowed`.
-            if contract.release_gate
+            if contract.routing_policy.release_gate
                 && matches!(selection.source, LabRunnerSelectionSource::Default)
                 && !crate::core::defaults::resolve_release_gate_local_hot_policy().is_allowed()
             {
@@ -1103,7 +1101,7 @@ fn run_lab_offload_inner(
         Some(&remote_cwd),
         "lab_offload",
     );
-    if contract.requires_extension_parity {
+    if contract.routing_policy.requires_extension_parity {
         plan = with_step(
             plan,
             PlanStep::ready("lab.extension_parity", "lab.extension_parity").build(),
@@ -2363,15 +2361,17 @@ mod tests {
         LabOffloadCommand {
             hot_label: label,
             portable: true,
-            default_lab_offload: true,
             unsupported_reason: None,
             source_path_mode: LabOffloadSourcePathMode::CwdOrPathFlag,
             workspace_mode_policy: LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
-            requires_extension_parity: true,
             required_extensions: Vec::new(),
             requires_playwright: false,
-            infer_source_path_tools: true,
-            release_gate: false,
+            routing_policy: crate::command_contract::LabRoutingPolicy {
+                default_lab_offload: true,
+                infer_source_path_tools: true,
+                release_gate: false,
+                requires_extension_parity: true,
+            },
         }
     }
 
@@ -2379,15 +2379,12 @@ mod tests {
         LabOffloadCommand {
             hot_label: "rig up",
             portable: false,
-            default_lab_offload: false,
             unsupported_reason: Some(reason),
             source_path_mode: LabOffloadSourcePathMode::CwdOrPathFlag,
             workspace_mode_policy: LabOffloadWorkspaceModePolicy::ChangedSinceGitElseSnapshot,
-            requires_extension_parity: false,
             required_extensions: Vec::new(),
             requires_playwright: false,
-            infer_source_path_tools: false,
-            release_gate: false,
+            routing_policy: crate::command_contract::LabRoutingPolicy::default(),
         }
     }
 
@@ -2767,7 +2764,7 @@ mod tests {
         std::fs::write(dir.path().join("docker-compose.yml"), "services: {}")
             .expect("docker signal");
         let mut command = portable_lab_command("trace");
-        command.infer_source_path_tools = false;
+        command.routing_policy.infer_source_path_tools = false;
 
         let contract =
             lab_runner_capability_contract(&command, dir.path(), &[RunnerRequiredTool::Homeboy])
@@ -3214,7 +3211,7 @@ mod tests {
     #[test]
     fn lab_runner_selection_ignores_default_when_auto_offload_is_disabled() {
         let mut command = portable_lab_command("extension update");
-        command.default_lab_offload = false;
+        command.routing_policy.default_lab_offload = false;
 
         let selection = resolve_lab_runner_selection_from_default(
             &command,
@@ -3233,7 +3230,7 @@ mod tests {
     #[test]
     fn lab_runner_selection_honors_explicit_runner_when_auto_offload_is_disabled() {
         let mut command = portable_lab_command("extension update");
-        command.default_lab_offload = false;
+        command.routing_policy.default_lab_offload = false;
 
         let selection = resolve_lab_runner_selection_from_default(
             &command,
@@ -3378,7 +3375,7 @@ mod tests {
 
     fn release_gate_lab_command(label: &'static str) -> LabOffloadCommand {
         let mut command = portable_lab_command(label);
-        command.release_gate = true;
+        command.routing_policy.release_gate = true;
         command
     }
 

--- a/src/core/runner/lab_capabilities.rs
+++ b/src/core/runner/lab_capabilities.rs
@@ -17,7 +17,7 @@ pub(super) fn lab_runner_capability_contract(
         push_unique(&mut required_tools, *tool);
     }
 
-    if command.infer_source_path_tools {
+    if command.routing_policy.infer_source_path_tools {
         if source_path.join(concat!("package", ".json")).is_file() {
             push_node_package_tool(&mut required_tools, RunnerRequiredTool::Npm);
         }

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -320,12 +320,14 @@ pub(super) fn resolve_lab_runner_selection(
     let deny_local_bench = config.bench.local_execution.is_denied();
     let release_gate_local_hot_allowed =
         crate::core::defaults::resolve_release_gate_local_hot_policy_from(&config).is_allowed();
-    let default_runner =
-        if explicit_runner.is_none() && command.portable && command.default_lab_offload {
-            super::resolve_default_lab_runner()?
-        } else {
-            None
-        };
+    let default_runner = if explicit_runner.is_none()
+        && command.portable
+        && command.routing_policy.default_lab_offload
+    {
+        super::resolve_default_lab_runner()?
+    } else {
+        None
+    };
 
     resolve_lab_runner_selection_from_default(
         command,
@@ -385,7 +387,7 @@ pub(super) fn resolve_lab_runner_selection_from_default(
         ));
     }
 
-    if !command.default_lab_offload {
+    if !command.routing_policy.default_lab_offload {
         fail_if_local_bench_denied(command, deny_local_bench)?;
         return Ok(None);
     }
@@ -416,7 +418,7 @@ pub(super) fn resolve_lab_runner_selection_from_default(
     // closed with a clear diagnostic unless the operator explicitly opts back
     // into local-hot via config/env, in which case the override is recorded by
     // the offload metadata (`force_hot_local_override`).
-    if command.release_gate && force_hot && allow_local_hot {
+    if command.routing_policy.release_gate && force_hot && allow_local_hot {
         if let Some(runner_id) = default_runner.as_ref() {
             if !release_gate_local_hot_allowed {
                 return Err(release_gate_local_hot_denied_error(


### PR DESCRIPTION
## Summary
- **#5088 (Runs/Tests, 2 findings):** `src/commands/runs/corpus_tests.rs` was missing the `serde_json::Value` import and a `sample_run` test helper that all its sibling runs test files declare. Added `use serde_json::Value;` and a `sample_run` helper, and routed `install_artifact` through it so the helper is genuinely used (not dead scaffolding). The file now matches the established runs-test shape and the 2 findings clear.
- **#5090 (field patterns):** Extracted the cohesive Lab routing-policy 4-tuple `[default_lab_offload, infer_source_path_tools, release_gate, requires_extension_parity]` into a shared `LabRoutingPolicy` struct, embedded in `LabCommandContract`, `LabRoutePlan`, and `LabOffloadCommand`. This is a genuine concept these three layers share as a command is resolved contract → plan → offload-command. Clears that repeated-field finding (3 → 0).

## Why LabRoutingPolicy
These four booleans always travel together. Before, every contract→plan→command conversion in `lab_routing.rs` copied them field-by-field; now those collapse into single `policy: other.routing_policy` moves. Shapes are kept **stable**:
- `LabRoutePlan` is `Serialize` → the embedded field uses `#[serde(flatten)]`, so the JSON keys remain top-level and identical.
- `LabCommandContract` and `LabOffloadCommand` are **not** serialized, so embedding as a named field is shape-neutral.
- No CLI flags touched (none of these structs are clap surfaces).

Verified empirically with `homeboy audit --only repeated_field_pattern --ignore-baseline`: total field-pattern findings dropped **47 → 44**, the lab-policy group went **3 → 0**, and **no new** field-pattern findings were introduced.

## Deferred groups (with rationale)
Per the safe-subset guidance, the other 4 groups in #5090 are intentionally deferred — forcing extraction would add artificial indirection or risk serialized shapes:
- **`[max, min]`** and **`[queued, running]`** — generic numeric pairs scattered among structs with different surrounding semantics and differing serde attrs (`#[serde(default)]` vs `skip_serializing_if`). These are the kind of coincidental overlap the detector's own `is_low_value_generic_group` heuristic already suppresses for pairs like `from/to`, `host/port`; better handled by extending suppression than by inventing a shared type.
- **`[viewer_links, viewer_url]`** — `BenchArtifact` carries `#[serde(deny_unknown_fields)]`, which conflicts with `#[serde(flatten)]`, so a flattened shared struct can't keep the JSON identical here.
- **`[attempts, client_context, provider_config, queue_only, tasks_json]`** — a *partial* overlap of the larger `DispatchArgs`/`AgentTaskDispatchCommand`/`AgentTaskDispatchRequest`/`DispatchRequestOverrides` family (they share many more fields too). The honest fix is unifying the whole dispatch DTO family, which crosses the `DispatchArgs` CLI boundary and is a larger, riskier change best done on its own.

## Validation
- `cargo build --lib --tests` — clean.
- `cargo fmt` — applied.
- Tests for every touched area pass: `corpus_tests`, `lab_routing`, `command_contract::lab` (and full `command_contract`), `runner::lab` (161), `commands::route` (27), `golden_contract`.
- The 11 substring-matched `*runs*` failures from `cargo test runs` are **pre-existing on clean `origin/main`** (env/external-script dependent: bench/trace rig-workload expansion, composer install, shebang execution) — confirmed by `git stash` + re-run on base.

Closes #5090
Closes #5088