### PR TITLE
Closes #4382

### DIFF
--- a/src/commands/runs/disk.rs
+++ b/src/commands/runs/disk.rs
@@ -1,69 +1,8 @@
-use std::path::Path;
+//! Thin re-export of the core disk-budget probe.
+//!
+//! The probing logic moved to `core::observation::disk_budget` so the
+//! observation evidence report service can compute disk budgets without
+//! depending on a CLI command module. Command submodules keep referencing
+//! `disk::DiskBudget` / `disk::disk_budget` through this re-export.
 
-use serde::Serialize;
-
-#[derive(Clone, Serialize)]
-pub struct DiskBudget {
-    pub path: String,
-    pub available_bytes: Option<u64>,
-    pub total_bytes: Option<u64>,
-    pub used_percent: Option<f64>,
-    pub status: String,
-    pub warning: Option<String>,
-}
-
-#[cfg(unix)]
-pub fn disk_budget(path: &Path, subject: &str, _unavailable_message: &str) -> DiskBudget {
-    let c_path = match std::ffi::CString::new(path.to_string_lossy().as_bytes()) {
-        Ok(path) => path,
-        Err(_) => return unavailable_disk_budget(path, "path contains an interior NUL byte"),
-    };
-    let mut stat = std::mem::MaybeUninit::<libc::statvfs>::uninit();
-    let rc = unsafe { libc::statvfs(c_path.as_ptr(), stat.as_mut_ptr()) };
-    if rc != 0 {
-        return unavailable_disk_budget(path, "statvfs failed");
-    }
-    let stat = unsafe { stat.assume_init() };
-    let block_size = u128::from(stat.f_frsize.max(1));
-    let total = u64::try_from(u128::from(stat.f_blocks).saturating_mul(block_size)).ok();
-    let available = u64::try_from(u128::from(stat.f_bavail).saturating_mul(block_size)).ok();
-    let used_percent = match (total, available) {
-        (Some(total), Some(available)) if total > 0 => {
-            Some(((total.saturating_sub(available)) as f64 / total as f64) * 100.0)
-        }
-        _ => None,
-    };
-    let warning = match (available, total) {
-        (Some(available), Some(total)) if total > 0 && available < total / 10 => {
-            Some(format!("{subject} filesystem has less than 10% free space"))
-        }
-        (Some(available), _) if available < 5 * 1024 * 1024 * 1024 => Some(format!(
-            "{subject} filesystem has less than 5 GiB free space"
-        )),
-        _ => None,
-    };
-    DiskBudget {
-        path: path.display().to_string(),
-        available_bytes: available,
-        total_bytes: total,
-        used_percent,
-        status: if warning.is_some() { "warning" } else { "ok" }.to_string(),
-        warning,
-    }
-}
-
-#[cfg(not(unix))]
-pub fn disk_budget(path: &Path, _subject: &str, unavailable_message: &str) -> DiskBudget {
-    unavailable_disk_budget(path, unavailable_message)
-}
-
-fn unavailable_disk_budget(path: &Path, warning: &str) -> DiskBudget {
-    DiskBudget {
-        path: path.display().to_string(),
-        available_bytes: None,
-        total_bytes: None,
-        used_percent: None,
-        status: "unknown".to_string(),
-        warning: Some(warning.to_string()),
-    }
-}
+pub use homeboy::core::observation::disk_budget::{disk_budget, DiskBudget};

--- a/src/commands/runs/evidence.rs
+++ b/src/commands/runs/evidence.rs
@@ -1,130 +1,31 @@
-use std::fs;
-use std::path::Path;
-
-use homeboy::core::artifact_address::{ArtifactAddress, ArtifactAddressKind};
-use homeboy::core::artifact_ref::{ArtifactRef, EvidenceRef};
-use homeboy::core::evidence_manifest::{EvidenceManifest, EVIDENCE_MANIFEST_SCHEMA};
-use homeboy::core::observation::{runs_service, ArtifactRecord, ObservationStore, RunRecord};
-use serde::Serialize;
-use serde_json::Value;
+use homeboy::core::observation::evidence_report::{self, RunEvidenceReport};
+use homeboy::core::observation::{runs_service, ObservationStore};
 
 use super::{disk, reconcile, require_run, run_summary, CmdResult, RunSummary, RunsOutput};
 
-#[derive(Serialize)]
-pub struct RunsEvidenceOutput {
-    pub command: &'static str,
-    pub run_id: String,
-    pub run: RunSummary,
-    pub homeboy_version: Option<String>,
-    pub metadata: RunsEvidenceMetadata,
-    pub heartbeat: RunsEvidenceHeartbeat,
-    pub artifact_index: RunsEvidenceArtifactIndex,
-    pub retention: RunsEvidenceRetention,
-    pub failure: RunsEvidenceFailureSummary,
-    pub disk_budget: RunsEvidenceDiskBudget,
-    pub evidence_links: Vec<RunsEvidenceLink>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub evidence_manifest: Option<EvidenceManifest>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub evidence_manifest_errors: Vec<String>,
-}
-
-#[derive(Serialize)]
-pub struct RunsEvidenceMetadata {
-    pub cost: Value,
-    pub timing: Value,
-    pub version: Value,
-    pub host: Value,
-    pub runtime: Value,
-}
-
-#[derive(Serialize)]
-pub struct RunsEvidenceHeartbeat {
-    pub status: String,
-    pub stale: bool,
-    pub stale_reason: Option<String>,
-    pub owner_pid: Option<u32>,
-    pub updated_at: String,
-}
-
-#[derive(Serialize)]
-pub struct RunsEvidenceArtifactIndex {
-    pub count: usize,
-    pub file_count: usize,
-    pub directory_count: usize,
-    pub url_count: usize,
-    pub missing_count: usize,
-    pub total_size_bytes: u64,
-    pub artifacts: Vec<RunsEvidenceArtifact>,
-}
-
-#[derive(Serialize)]
-pub struct RunsEvidenceArtifact {
-    #[serde(rename = "ref")]
-    pub reference: ArtifactRef,
-    pub id: String,
-    pub kind: String,
-    #[serde(rename = "type")]
-    pub artifact_type: String,
-    pub path: String,
-    pub address: ArtifactAddress,
-    pub url: Option<String>,
-    pub public: bool,
-    pub public_url: Option<String>,
-    pub relative_to: Option<String>,
-    pub fetch_command: Option<String>,
-    pub size_bytes: Option<i64>,
-    pub sha256: Option<String>,
-    pub created_at: String,
-    pub exists: bool,
-    pub retention_candidate: bool,
-}
-
-#[derive(Serialize)]
-pub struct RunsEvidenceRetention {
-    pub artifact_root: String,
-    pub default_retention_days: i64,
-    pub cleanup_command: String,
-}
-
-#[derive(Serialize)]
-pub struct RunsEvidenceFailureSummary {
-    pub failed: bool,
-    pub status: String,
-    pub exit_code: Option<i64>,
-    pub error: Option<String>,
-    pub failure: Value,
-    pub gate_failures: Vec<String>,
-    pub hints: Vec<String>,
-}
-
-pub type RunsEvidenceDiskBudget = disk::DiskBudget;
-
-#[derive(Serialize)]
-pub struct RunsEvidenceLink {
-    #[serde(rename = "ref")]
-    pub reference: EvidenceRef,
-    pub kind: String,
-    pub target: String,
-    pub label: String,
-}
+/// `runs evidence` output. The report shaping lives in
+/// [`homeboy::core::observation::evidence_report`]; this adapter only embeds
+/// the command-local [`RunSummary`] as the report's `run` field.
+pub type RunsEvidenceOutput = RunEvidenceReport<RunSummary>;
 
 pub fn evidence(run_id: &str) -> CmdResult<RunsOutput> {
     let store = ObservationStore::open_initialized()?;
     let run = require_run(&store, run_id)?;
     let artifacts = runs_service::enrich_artifact_links(store.list_artifacts(run_id)?);
     let artifact_root = homeboy::core::artifacts::root()?;
-    let artifact_index = evidence_artifact_index(&artifacts);
     let disk_budget = disk::disk_budget(
         &artifact_root,
         "artifact",
         "disk budget probing is not implemented for this platform",
     );
     let stale_reason = reconcile::running_status_note(&run);
-    let metadata = evidence_metadata(&run.metadata_json);
-    let failure = evidence_failure_summary(&run);
-    let links = evidence_links(&artifacts);
-    let (evidence_manifest, evidence_manifest_errors) = evidence_manifest(&run, &artifacts);
+    let metadata = evidence_report::evidence_metadata(&run.metadata_json);
+    let artifact_index = evidence_report::evidence_artifact_index(&artifacts);
+    let failure = evidence_report::evidence_failure_summary(&run);
+    let retention = evidence_report::evidence_retention(&artifact_root, &run.id);
+    let evidence_links = evidence_report::evidence_links(&artifacts);
+    let (evidence_manifest, evidence_manifest_errors) =
+        evidence_report::evidence_manifest(&run, &artifacts);
 
     Ok((
         RunsOutput::Evidence(RunsEvidenceOutput {
@@ -133,7 +34,7 @@ pub fn evidence(run_id: &str) -> CmdResult<RunsOutput> {
             run: run_summary(run.clone()),
             homeboy_version: run.homeboy_version.clone(),
             metadata,
-            heartbeat: RunsEvidenceHeartbeat {
+            heartbeat: evidence_report::EvidenceHeartbeat {
                 status: run.status.clone(),
                 stale: stale_reason.is_some(),
                 stale_reason,
@@ -144,17 +45,10 @@ pub fn evidence(run_id: &str) -> CmdResult<RunsOutput> {
                     .unwrap_or_else(|| run.started_at.clone()),
             },
             artifact_index,
-            retention: RunsEvidenceRetention {
-                artifact_root: artifact_root.display().to_string(),
-                default_retention_days: 30,
-                cleanup_command: format!(
-                    "homeboy runs artifact cleanup-persisted --run-id {} --older-than-days 30",
-                    run.id
-                ),
-            },
+            retention,
             failure,
             disk_budget,
-            evidence_links: links,
+            evidence_links,
             evidence_manifest,
             evidence_manifest_errors,
         }),
@@ -162,274 +56,14 @@ pub fn evidence(run_id: &str) -> CmdResult<RunsOutput> {
     ))
 }
 
-fn evidence_metadata(metadata: &Value) -> RunsEvidenceMetadata {
-    RunsEvidenceMetadata {
-        cost: pick_metadata(metadata, &["cost", "costs", "usage", "token_usage"]),
-        timing: pick_metadata(
-            metadata,
-            &[
-                "timing",
-                "timings",
-                "duration",
-                "scenario_metrics",
-                "phase_events",
-                "phase_summaries",
-                "failure_classification",
-            ],
-        ),
-        version: pick_metadata(metadata, &["version", "versions", "homeboy_version"]),
-        host: pick_metadata(
-            metadata,
-            &["host", "hostname", "machine", "resource_policy"],
-        ),
-        runtime: pick_metadata(metadata, &["runtime", "runner", "ci_context", "rig_state"]),
-    }
-}
-
-fn pick_metadata(metadata: &Value, keys: &[&str]) -> Value {
-    let mut out = serde_json::Map::new();
-    for key in keys {
-        if let Some(value) = metadata.get(*key) {
-            out.insert((*key).to_string(), value.clone());
-        }
-    }
-    Value::Object(out)
-}
-
-fn evidence_artifact_index(artifacts: &[ArtifactRecord]) -> RunsEvidenceArtifactIndex {
-    let mut file_count = 0;
-    let mut directory_count = 0;
-    let mut url_count = 0;
-    let mut missing_count = 0;
-    let mut total_size_bytes = 0u64;
-    let artifacts = artifacts
-        .iter()
-        .map(|artifact| {
-            let address = ArtifactAddress::from_record(artifact);
-            let reference = artifact_ref(artifact, &address);
-            let public_url = public_url_from_address(&address);
-            let exists = artifact_exists(artifact);
-            if !exists {
-                missing_count += 1;
-            }
-            match artifact.artifact_type.as_str() {
-                "file" => file_count += 1,
-                "directory" => directory_count += 1,
-                "url" => url_count += 1,
-                _ => {}
-            }
-            let size = artifact_size_bytes(artifact);
-            total_size_bytes = total_size_bytes.saturating_add(size);
-            RunsEvidenceArtifact {
-                id: reference.id.clone(),
-                kind: reference.kind.clone(),
-                artifact_type: reference.artifact_type.clone(),
-                path: address.value.clone(),
-                address,
-                url: public_url.clone(),
-                public: public_url.is_some(),
-                public_url,
-                relative_to: artifact_relative_to(artifact),
-                fetch_command: artifact_fetch_command(artifact),
-                size_bytes: artifact.size_bytes,
-                sha256: artifact.sha256.clone(),
-                created_at: artifact.created_at.clone(),
-                exists,
-                retention_candidate: artifact.artifact_type != "url",
-                reference,
-            }
-        })
-        .collect::<Vec<_>>();
-
-    RunsEvidenceArtifactIndex {
-        count: artifacts.len(),
-        file_count,
-        directory_count,
-        url_count,
-        missing_count,
-        total_size_bytes,
-        artifacts,
-    }
-}
-
-fn artifact_ref(artifact: &ArtifactRecord, address: &ArtifactAddress) -> ArtifactRef {
-    let mut reference = ArtifactRef::from_record(artifact);
-    reference.path = address.value.clone();
-    reference.url = public_url_from_address(address);
-    reference.public_url = reference.url.clone();
-    reference
-}
-
-fn public_url_from_address(address: &ArtifactAddress) -> Option<String> {
-    (address.kind == ArtifactAddressKind::PublicUrl).then(|| address.value.clone())
-}
-
-fn artifact_relative_to(artifact: &ArtifactRecord) -> Option<String> {
-    let address = ArtifactAddress::from_record(artifact);
-    if address.reviewer_visible {
-        return None;
-    }
-    if artifact.artifact_type == "file" || artifact.artifact_type == "remote_file" {
-        return Some("homeboy observation artifact store".to_string());
-    }
-    artifact
-        .metadata_json
-        .get("source")
-        .and_then(Value::as_str)
-        .map(|source| format!("{source} metadata"))
-}
-
-fn artifact_fetch_command(artifact: &ArtifactRecord) -> Option<String> {
-    if artifact.artifact_type == "file" || artifact.artifact_type == "remote_file" {
-        return Some(format!(
-            "homeboy runs artifact get {} {} -o <path>",
-            artifact.run_id, artifact.id
-        ));
-    }
-    None
-}
-
-fn artifact_exists(artifact: &ArtifactRecord) -> bool {
-    if artifact.artifact_type == "url" {
-        return true;
-    }
-    if artifact.artifact_type == "remote_file"
-        || homeboy::core::runners::is_remote_runner_artifact_path(&artifact.path)
-    {
-        return true;
-    }
-    Path::new(&artifact.path).exists()
-}
-
-fn artifact_size_bytes(artifact: &ArtifactRecord) -> u64 {
-    if let Some(size) = artifact
-        .size_bytes
-        .and_then(|size| u64::try_from(size).ok())
-    {
-        return size;
-    }
-    let path = Path::new(&artifact.path);
-    if path.is_file() {
-        return fs::metadata(path).map(|meta| meta.len()).unwrap_or(0);
-    }
-    if path.is_dir() {
-        return directory_size_bytes(path);
-    }
-    0
-}
-
-fn directory_size_bytes(path: &Path) -> u64 {
-    let Ok(entries) = fs::read_dir(path) else {
-        return 0;
-    };
-    entries
-        .flatten()
-        .map(|entry| {
-            let path = entry.path();
-            if path.is_dir() {
-                directory_size_bytes(&path)
-            } else {
-                fs::metadata(&path).map(|meta| meta.len()).unwrap_or(0)
-            }
-        })
-        .sum()
-}
-
-fn evidence_failure_summary(run: &RunRecord) -> RunsEvidenceFailureSummary {
-    let metadata = &run.metadata_json;
-    let exit_code = metadata.get("exit_code").and_then(|value| value.as_i64());
-    let error = metadata
-        .get("error")
-        .and_then(|value| value.as_str())
-        .map(str::to_string);
-    RunsEvidenceFailureSummary {
-        failed: matches!(run.status.as_str(), "fail" | "failed" | "error" | "stale"),
-        status: run.status.clone(),
-        exit_code,
-        error,
-        failure: metadata.get("failure").cloned().unwrap_or(Value::Null),
-        gate_failures: string_array(metadata.get("gate_failures")),
-        hints: string_array(metadata.get("hints")),
-    }
-}
-
-fn string_array(value: Option<&Value>) -> Vec<String> {
-    value
-        .and_then(|value| value.as_array())
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(|item| item.as_str().map(str::to_string))
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn evidence_links(artifacts: &[ArtifactRecord]) -> Vec<RunsEvidenceLink> {
-    artifacts
-        .iter()
-        .filter_map(|artifact| {
-            let address = ArtifactAddress::from_record(artifact);
-            let target = address.reviewer_target()?;
-            let mut reference = EvidenceRef::new(&artifact.kind, target, &artifact.kind);
-            reference.artifact = Some(artifact_ref(artifact, &address));
-            Some(RunsEvidenceLink {
-                kind: reference.kind.clone(),
-                target: reference.target.clone(),
-                label: reference.label.clone(),
-                reference,
-            })
-        })
-        .collect()
-}
-
-fn evidence_manifest(
-    run: &RunRecord,
-    artifacts: &[ArtifactRecord],
-) -> (Option<EvidenceManifest>, Vec<String>) {
-    let mut errors = Vec::new();
-    if let Some(value) = run.metadata_json.get("evidence_manifest") {
-        match EvidenceManifest::parse_value(value.clone()) {
-            Ok(manifest) => return (Some(manifest), errors),
-            Err(err) => errors.push(format!("metadata.evidence_manifest: {err}")),
-        }
-    }
-
-    for artifact in artifacts {
-        if !is_evidence_manifest_artifact(artifact) {
-            continue;
-        }
-        let value = match fs::read_to_string(&artifact.path)
-            .map_err(|err| err.to_string())
-            .and_then(|body| serde_json::from_str::<Value>(&body).map_err(|err| err.to_string()))
-        {
-            Ok(value) => value,
-            Err(err) => {
-                errors.push(format!("artifact.{}: {err}", artifact.id));
-                continue;
-            }
-        };
-        match EvidenceManifest::parse_value(value) {
-            Ok(manifest) => return (Some(manifest), errors),
-            Err(err) => errors.push(format!("artifact.{}: {err}", artifact.id)),
-        }
-    }
-
-    (None, errors)
-}
-
-fn is_evidence_manifest_artifact(artifact: &ArtifactRecord) -> bool {
-    artifact.kind == "evidence_manifest"
-        || artifact.metadata_json.get("schema").and_then(Value::as_str)
-            == Some(EVIDENCE_MANIFEST_SCHEMA)
-}
-
 #[cfg(test)]
 mod tests {
+    use homeboy::core::artifact_address::ArtifactAddressKind;
     use homeboy::core::artifact_links::PUBLIC_ARTIFACT_BASE_URL_ENV;
     use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
     use homeboy::test_support::with_isolated_home;
     use serde_json::Value;
+    use std::path::Path;
 
     use super::*;
 

--- a/src/core/observation/disk_budget.rs
+++ b/src/core/observation/disk_budget.rs
@@ -1,0 +1,75 @@
+//! Filesystem disk-budget probing for observation evidence reports.
+//!
+//! Extracted from the `commands::runs::disk` adapter so the evidence report
+//! service and other observation consumers can compute the same disk budget
+//! without depending on a CLI command module. Output shape is unchanged.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+#[derive(Clone, Serialize)]
+pub struct DiskBudget {
+    pub path: String,
+    pub available_bytes: Option<u64>,
+    pub total_bytes: Option<u64>,
+    pub used_percent: Option<f64>,
+    pub status: String,
+    pub warning: Option<String>,
+}
+
+#[cfg(unix)]
+pub fn disk_budget(path: &Path, subject: &str, _unavailable_message: &str) -> DiskBudget {
+    let c_path = match std::ffi::CString::new(path.to_string_lossy().as_bytes()) {
+        Ok(path) => path,
+        Err(_) => return unavailable_disk_budget(path, "path contains an interior NUL byte"),
+    };
+    let mut stat = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+    let rc = unsafe { libc::statvfs(c_path.as_ptr(), stat.as_mut_ptr()) };
+    if rc != 0 {
+        return unavailable_disk_budget(path, "statvfs failed");
+    }
+    let stat = unsafe { stat.assume_init() };
+    let block_size = u128::from(stat.f_frsize.max(1));
+    let total = u64::try_from(u128::from(stat.f_blocks).saturating_mul(block_size)).ok();
+    let available = u64::try_from(u128::from(stat.f_bavail).saturating_mul(block_size)).ok();
+    let used_percent = match (total, available) {
+        (Some(total), Some(available)) if total > 0 => {
+            Some(((total.saturating_sub(available)) as f64 / total as f64) * 100.0)
+        }
+        _ => None,
+    };
+    let warning = match (available, total) {
+        (Some(available), Some(total)) if total > 0 && available < total / 10 => {
+            Some(format!("{subject} filesystem has less than 10% free space"))
+        }
+        (Some(available), _) if available < 5 * 1024 * 1024 * 1024 => Some(format!(
+            "{subject} filesystem has less than 5 GiB free space"
+        )),
+        _ => None,
+    };
+    DiskBudget {
+        path: path.display().to_string(),
+        available_bytes: available,
+        total_bytes: total,
+        used_percent,
+        status: if warning.is_some() { "warning" } else { "ok" }.to_string(),
+        warning,
+    }
+}
+
+#[cfg(not(unix))]
+pub fn disk_budget(path: &Path, _subject: &str, unavailable_message: &str) -> DiskBudget {
+    unavailable_disk_budget(path, unavailable_message)
+}
+
+fn unavailable_disk_budget(path: &Path, warning: &str) -> DiskBudget {
+    DiskBudget {
+        path: path.display().to_string(),
+        available_bytes: None,
+        total_bytes: None,
+        used_percent: None,
+        status: "unknown".to_string(),
+        warning: Some(warning.to_string()),
+    }
+}

--- a/src/core/observation/evidence_report.rs
+++ b/src/core/observation/evidence_report.rs
@@ -1,0 +1,415 @@
+//! Run evidence report shaping.
+//!
+//! Extracted from the `commands::runs::evidence` adapter so the stable
+//! `runs evidence` report (metadata buckets, artifact index, heartbeat,
+//! retention guidance, failure summary, evidence links, and embedded
+//! evidence manifest) is owned by a reusable core service rather than the
+//! CLI command module.
+//!
+//! The command adapter now only:
+//!   * opens the store and resolves the run,
+//!   * builds its `RunSummary` and disk-budget inputs, and
+//!   * maps [`RunEvidenceReport`] into its `RunsOutput` enum.
+//!
+//! All artifact indexing, metadata bucketing, failure classification,
+//! evidence-link derivation, and manifest resolution lives here. Output is
+//! byte-for-byte equivalent to the previous inline command implementation.
+
+use std::fs;
+use std::path::Path;
+
+use serde::Serialize;
+use serde_json::Value;
+
+use super::{ArtifactRecord, RunRecord};
+use crate::core::artifact_address::{ArtifactAddress, ArtifactAddressKind};
+use crate::core::artifact_ref::{ArtifactRef, EvidenceRef};
+use crate::core::evidence_manifest::{EvidenceManifest, EVIDENCE_MANIFEST_SCHEMA};
+use crate::core::observation::disk_budget::DiskBudget;
+
+/// Default retention window (days) surfaced in evidence retention guidance.
+pub const DEFAULT_RETENTION_DAYS: i64 = 30;
+
+/// Fully shaped `runs evidence` report.
+///
+/// Generic over the run-summary type `S` so the command adapter can embed
+/// its own `RunSummary` (which carries CLI-only enrichment) without leaking
+/// that type into core. Serialization is identical regardless of `S`.
+#[derive(Serialize)]
+pub struct RunEvidenceReport<S: Serialize> {
+    pub command: &'static str,
+    pub run_id: String,
+    pub run: S,
+    pub homeboy_version: Option<String>,
+    pub metadata: EvidenceMetadata,
+    pub heartbeat: EvidenceHeartbeat,
+    pub artifact_index: EvidenceArtifactIndex,
+    pub retention: EvidenceRetention,
+    pub failure: EvidenceFailureSummary,
+    pub disk_budget: DiskBudget,
+    pub evidence_links: Vec<EvidenceLink>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_manifest: Option<EvidenceManifest>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub evidence_manifest_errors: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct EvidenceMetadata {
+    pub cost: Value,
+    pub timing: Value,
+    pub version: Value,
+    pub host: Value,
+    pub runtime: Value,
+}
+
+#[derive(Serialize)]
+pub struct EvidenceHeartbeat {
+    pub status: String,
+    pub stale: bool,
+    pub stale_reason: Option<String>,
+    pub owner_pid: Option<u32>,
+    pub updated_at: String,
+}
+
+#[derive(Serialize)]
+pub struct EvidenceArtifactIndex {
+    pub count: usize,
+    pub file_count: usize,
+    pub directory_count: usize,
+    pub url_count: usize,
+    pub missing_count: usize,
+    pub total_size_bytes: u64,
+    pub artifacts: Vec<EvidenceArtifact>,
+}
+
+#[derive(Serialize)]
+pub struct EvidenceArtifact {
+    #[serde(rename = "ref")]
+    pub reference: ArtifactRef,
+    pub id: String,
+    pub kind: String,
+    #[serde(rename = "type")]
+    pub artifact_type: String,
+    pub path: String,
+    pub address: ArtifactAddress,
+    pub url: Option<String>,
+    pub public: bool,
+    pub public_url: Option<String>,
+    pub relative_to: Option<String>,
+    pub fetch_command: Option<String>,
+    pub size_bytes: Option<i64>,
+    pub sha256: Option<String>,
+    pub created_at: String,
+    pub exists: bool,
+    pub retention_candidate: bool,
+}
+
+#[derive(Serialize)]
+pub struct EvidenceRetention {
+    pub artifact_root: String,
+    pub default_retention_days: i64,
+    pub cleanup_command: String,
+}
+
+#[derive(Serialize)]
+pub struct EvidenceFailureSummary {
+    pub failed: bool,
+    pub status: String,
+    pub exit_code: Option<i64>,
+    pub error: Option<String>,
+    pub failure: Value,
+    pub gate_failures: Vec<String>,
+    pub hints: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct EvidenceLink {
+    #[serde(rename = "ref")]
+    pub reference: EvidenceRef,
+    pub kind: String,
+    pub target: String,
+    pub label: String,
+}
+
+/// Build the metadata buckets surfaced by `runs evidence`.
+pub fn evidence_metadata(metadata: &Value) -> EvidenceMetadata {
+    EvidenceMetadata {
+        cost: pick_metadata(metadata, &["cost", "costs", "usage", "token_usage"]),
+        timing: pick_metadata(
+            metadata,
+            &[
+                "timing",
+                "timings",
+                "duration",
+                "scenario_metrics",
+                "phase_events",
+                "phase_summaries",
+                "failure_classification",
+            ],
+        ),
+        version: pick_metadata(metadata, &["version", "versions", "homeboy_version"]),
+        host: pick_metadata(
+            metadata,
+            &["host", "hostname", "machine", "resource_policy"],
+        ),
+        runtime: pick_metadata(metadata, &["runtime", "runner", "ci_context", "rig_state"]),
+    }
+}
+
+fn pick_metadata(metadata: &Value, keys: &[&str]) -> Value {
+    let mut out = serde_json::Map::new();
+    for key in keys {
+        if let Some(value) = metadata.get(*key) {
+            out.insert((*key).to_string(), value.clone());
+        }
+    }
+    Value::Object(out)
+}
+
+/// Build the stable artifact index for `runs evidence`.
+pub fn evidence_artifact_index(artifacts: &[ArtifactRecord]) -> EvidenceArtifactIndex {
+    let mut file_count = 0;
+    let mut directory_count = 0;
+    let mut url_count = 0;
+    let mut missing_count = 0;
+    let mut total_size_bytes = 0u64;
+    let artifacts = artifacts
+        .iter()
+        .map(|artifact| {
+            let address = ArtifactAddress::from_record(artifact);
+            let reference = artifact_ref(artifact, &address);
+            let public_url = public_url_from_address(&address);
+            let exists = artifact_exists(artifact);
+            if !exists {
+                missing_count += 1;
+            }
+            match artifact.artifact_type.as_str() {
+                "file" => file_count += 1,
+                "directory" => directory_count += 1,
+                "url" => url_count += 1,
+                _ => {}
+            }
+            let size = artifact_size_bytes(artifact);
+            total_size_bytes = total_size_bytes.saturating_add(size);
+            EvidenceArtifact {
+                id: reference.id.clone(),
+                kind: reference.kind.clone(),
+                artifact_type: reference.artifact_type.clone(),
+                path: address.value.clone(),
+                address,
+                url: public_url.clone(),
+                public: public_url.is_some(),
+                public_url,
+                relative_to: artifact_relative_to(artifact),
+                fetch_command: artifact_fetch_command(artifact),
+                size_bytes: artifact.size_bytes,
+                sha256: artifact.sha256.clone(),
+                created_at: artifact.created_at.clone(),
+                exists,
+                retention_candidate: artifact.artifact_type != "url",
+                reference,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    EvidenceArtifactIndex {
+        count: artifacts.len(),
+        file_count,
+        directory_count,
+        url_count,
+        missing_count,
+        total_size_bytes,
+        artifacts,
+    }
+}
+
+fn artifact_ref(artifact: &ArtifactRecord, address: &ArtifactAddress) -> ArtifactRef {
+    let mut reference = ArtifactRef::from_record(artifact);
+    reference.path = address.value.clone();
+    reference.url = public_url_from_address(address);
+    reference.public_url = reference.url.clone();
+    reference
+}
+
+fn public_url_from_address(address: &ArtifactAddress) -> Option<String> {
+    (address.kind == ArtifactAddressKind::PublicUrl).then(|| address.value.clone())
+}
+
+fn artifact_relative_to(artifact: &ArtifactRecord) -> Option<String> {
+    let address = ArtifactAddress::from_record(artifact);
+    if address.reviewer_visible {
+        return None;
+    }
+    if artifact.artifact_type == "file" || artifact.artifact_type == "remote_file" {
+        return Some("homeboy observation artifact store".to_string());
+    }
+    artifact
+        .metadata_json
+        .get("source")
+        .and_then(Value::as_str)
+        .map(|source| format!("{source} metadata"))
+}
+
+fn artifact_fetch_command(artifact: &ArtifactRecord) -> Option<String> {
+    if artifact.artifact_type == "file" || artifact.artifact_type == "remote_file" {
+        return Some(format!(
+            "homeboy runs artifact get {} {} -o <path>",
+            artifact.run_id, artifact.id
+        ));
+    }
+    None
+}
+
+fn artifact_exists(artifact: &ArtifactRecord) -> bool {
+    if artifact.artifact_type == "url" {
+        return true;
+    }
+    if artifact.artifact_type == "remote_file"
+        || crate::core::runners::is_remote_runner_artifact_path(&artifact.path)
+    {
+        return true;
+    }
+    Path::new(&artifact.path).exists()
+}
+
+fn artifact_size_bytes(artifact: &ArtifactRecord) -> u64 {
+    if let Some(size) = artifact
+        .size_bytes
+        .and_then(|size| u64::try_from(size).ok())
+    {
+        return size;
+    }
+    let path = Path::new(&artifact.path);
+    if path.is_file() {
+        return fs::metadata(path).map(|meta| meta.len()).unwrap_or(0);
+    }
+    if path.is_dir() {
+        return directory_size_bytes(path);
+    }
+    0
+}
+
+fn directory_size_bytes(path: &Path) -> u64 {
+    let Ok(entries) = fs::read_dir(path) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .map(|entry| {
+            let path = entry.path();
+            if path.is_dir() {
+                directory_size_bytes(&path)
+            } else {
+                fs::metadata(&path).map(|meta| meta.len()).unwrap_or(0)
+            }
+        })
+        .sum()
+}
+
+/// Build the failure summary surfaced by `runs evidence`.
+pub fn evidence_failure_summary(run: &RunRecord) -> EvidenceFailureSummary {
+    let metadata = &run.metadata_json;
+    let exit_code = metadata.get("exit_code").and_then(|value| value.as_i64());
+    let error = metadata
+        .get("error")
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    EvidenceFailureSummary {
+        failed: matches!(run.status.as_str(), "fail" | "failed" | "error" | "stale"),
+        status: run.status.clone(),
+        exit_code,
+        error,
+        failure: metadata.get("failure").cloned().unwrap_or(Value::Null),
+        gate_failures: string_array(metadata.get("gate_failures")),
+        hints: string_array(metadata.get("hints")),
+    }
+}
+
+fn string_array(value: Option<&Value>) -> Vec<String> {
+    value
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Build the retention guidance block for `runs evidence`.
+pub fn evidence_retention(artifact_root: &Path, run_id: &str) -> EvidenceRetention {
+    EvidenceRetention {
+        artifact_root: artifact_root.display().to_string(),
+        default_retention_days: DEFAULT_RETENTION_DAYS,
+        cleanup_command: format!(
+            "homeboy runs artifact cleanup-persisted --run-id {run_id} --older-than-days {DEFAULT_RETENTION_DAYS}"
+        ),
+    }
+}
+
+/// Build the evidence-link list (reviewer-visible artifact targets).
+pub fn evidence_links(artifacts: &[ArtifactRecord]) -> Vec<EvidenceLink> {
+    artifacts
+        .iter()
+        .filter_map(|artifact| {
+            let address = ArtifactAddress::from_record(artifact);
+            let target = address.reviewer_target()?;
+            let mut reference = EvidenceRef::new(&artifact.kind, target, &artifact.kind);
+            reference.artifact = Some(artifact_ref(artifact, &address));
+            Some(EvidenceLink {
+                kind: reference.kind.clone(),
+                target: reference.target.clone(),
+                label: reference.label.clone(),
+                reference,
+            })
+        })
+        .collect()
+}
+
+/// Resolve an embedded evidence manifest from run metadata or artifacts.
+///
+/// Returns the parsed manifest (if any) plus any non-fatal parse errors
+/// encountered while resolving candidates, preserving the original error
+/// message format.
+pub fn evidence_manifest(
+    run: &RunRecord,
+    artifacts: &[ArtifactRecord],
+) -> (Option<EvidenceManifest>, Vec<String>) {
+    let mut errors = Vec::new();
+    if let Some(value) = run.metadata_json.get("evidence_manifest") {
+        match EvidenceManifest::parse_value(value.clone()) {
+            Ok(manifest) => return (Some(manifest), errors),
+            Err(err) => errors.push(format!("metadata.evidence_manifest: {err}")),
+        }
+    }
+
+    for artifact in artifacts {
+        if !is_evidence_manifest_artifact(artifact) {
+            continue;
+        }
+        let value = match fs::read_to_string(&artifact.path)
+            .map_err(|err| err.to_string())
+            .and_then(|body| serde_json::from_str::<Value>(&body).map_err(|err| err.to_string()))
+        {
+            Ok(value) => value,
+            Err(err) => {
+                errors.push(format!("artifact.{}: {err}", artifact.id));
+                continue;
+            }
+        };
+        match EvidenceManifest::parse_value(value) {
+            Ok(manifest) => return (Some(manifest), errors),
+            Err(err) => errors.push(format!("artifact.{}: {err}", artifact.id)),
+        }
+    }
+
+    (None, errors)
+}
+
+fn is_evidence_manifest_artifact(artifact: &ArtifactRecord) -> bool {
+    artifact.kind == "evidence_manifest"
+        || artifact.metadata_json.get("schema").and_then(Value::as_str)
+            == Some(EVIDENCE_MANIFEST_SCHEMA)
+}

--- a/src/core/observation/mod.rs
+++ b/src/core/observation/mod.rs
@@ -6,6 +6,8 @@
 
 mod budget_findings;
 pub mod context;
+pub mod disk_budget;
+pub mod evidence_report;
 mod lifecycle;
 pub mod records;
 pub mod runs_service;


### PR DESCRIPTION
## Summary

Finishes extracting run/artifact observation behavior out of `src/commands/runs/evidence.rs` into reusable core services. The `runs evidence` command module is now a thin adapter that owns only clap args + `RunsOutput` mapping; all report semantics live in core.

## What moved to core

- **New `core::observation::evidence_report`** — owns the full `runs evidence` report shaping: metadata buckets, artifact index (incl. size/exists/public-url derivation), failure summary classification, retention guidance, evidence-link derivation, and embedded evidence-manifest resolution. Exposes `RunEvidenceReport<S>` (generic over the run-summary type so core stays decoupled from the CLI's `RunSummary`) plus the per-section structs and pure builder functions.
- **New `core::observation::disk_budget`** — the filesystem disk-budget probe moved out of the `commands::runs::disk` adapter so the evidence report service can compute budgets without depending on a command module. `commands::runs::disk` is now a thin re-export (keeps `loop_sync` working).

## Adapter shape

`commands/runs/evidence.rs` shrank from ~695 to ~365 lines (mostly tests). The command now: opens the store, resolves the run, builds its `RunSummary` + disk-budget inputs, calls the core builders, and maps the result into `RunsOutput::Evidence`. `RunsEvidenceOutput` is a type alias for `RunEvidenceReport<RunSummary>`.

> Note: artifact cleanup planning/execution and artifact retrieval/indexing were already extracted to `core::observation::runs_service` in prior work (`remote_artifact.rs` is already a thin adapter). This PR completes the remaining inline service behavior — the evidence report shaping — which was the last large chunk of run/report semantics living in the command module.

## Output contract stability

This is a pure structural move. The serialized `runs evidence` JSON is byte-for-byte equivalent — confirmed by the passing **command_contract** (17) and **golden_contract** (5) suites.

## Validation

- `cargo build --lib --tests` — clean
- `cargo test command_contract` — 17 passed
- `cargo test golden_contract` — 5 passed
- `commands::runs::evidence` unit tests — 3 passed; `commands::runs` — 27 passed; `remote_artifact` — 4 passed
- `cargo fmt --check` — clean; `cargo clippy --lib` — no warnings in changed modules

Pre-existing env-dependent failures on this host (`commands::trace::tests::*`, `commands::bench::tests::*`, `composer_install_*` — exit 126/127 / missing external executables) were verified to fail identically on clean `main` and are unrelated to this change.

Closes #4382