### PR TITLE
Add agent task loop definition compiler

### DIFF
--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -13,6 +13,7 @@ pub mod args;
 pub mod auth;
 pub mod contract;
 pub mod controller;
+pub mod loop_definition;
 pub mod review;
 pub mod run;
 pub mod status;
@@ -23,8 +24,8 @@ pub use args::{
     AgentTaskControllerFromSpecArgs, AgentTaskControllerInitArgs,
     AgentTaskControllerMarkHumanReadyArgs, AgentTaskControllerRunArgs,
     AgentTaskControllerRunNextArgs, AgentTaskControllerStatusArgs, AgentTaskLoopArgs, CancelArgs,
-    ContractArgs, ContractFormat, FinalizePrArgs, GateFeedbackArgs, PromoteArgs, ProvidersArgs,
-    RetryArgs, ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
+    CompileLoopArgs, ContractArgs, ContractFormat, FinalizePrArgs, GateFeedbackArgs, PromoteArgs,
+    ProvidersArgs, RetryArgs, ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 
@@ -62,6 +63,7 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::GateFeedback(feedback_args) => review::gate_feedback(feedback_args),
         AgentTaskCommand::Providers(providers_args) => review::providers(providers_args),
         AgentTaskCommand::Contract(contract_args) => contract::contract(contract_args),
+        AgentTaskCommand::CompileLoop(compile_args) => loop_definition::compile_loop(compile_args),
         AgentTaskCommand::Auth(auth_args) => auth::auth(auth_args),
         AgentTaskCommand::Controller(controller_args) => controller::controller(controller_args),
     }

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -77,6 +77,8 @@ pub enum AgentTaskCommand {
     Providers(ProvidersArgs),
     /// Export Homeboy's machine-readable agent-task core contract metadata.
     Contract(ContractArgs),
+    /// Compile a declarative loop definition into an agent-task plan.
+    CompileLoop(CompileLoopArgs),
     /// Configure and inspect agent-task provider authentication secrets.
     Auth(AgentTaskAuthArgs),
     /// Create, inspect, and resume durable multi-agent loop controller state.
@@ -144,6 +146,13 @@ pub struct ContractArgs {
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum ContractFormat {
     Json,
+}
+
+#[derive(Args, Debug)]
+pub struct CompileLoopArgs {
+    /// AgentTaskLoopDefinition JSON file, @file, inline JSON, or - for stdin.
+    #[arg(long, value_name = "SPEC")]
+    pub definition: String,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/agent_task/loop_definition.rs
+++ b/src/commands/agent_task/loop_definition.rs
@@ -1,0 +1,21 @@
+use serde_json::Value;
+
+use homeboy::core::config;
+use homeboy::core::{agent_tasks::loop_definition, Error};
+
+use super::super::CmdResult;
+use super::args::CompileLoopArgs;
+
+pub(super) fn compile_loop(args: CompileLoopArgs) -> CmdResult<Value> {
+    let raw = config::read_json_spec_to_string(&args.definition)?;
+    let definition: loop_definition::AgentTaskLoopDefinition =
+        serde_json::from_str(&raw).map_err(|error| {
+            Error::validation_invalid_json(
+                error,
+                Some("agent-task loop definition".to_string()),
+                Some(raw.clone()),
+            )
+        })?;
+    let plan = loop_definition::compile_loop_definition(definition)?;
+    Ok((serde_json::to_value(plan).unwrap_or(Value::Null), 0))
+}

--- a/src/commands/agent_task/tests.rs
+++ b/src/commands/agent_task/tests.rs
@@ -4,7 +4,9 @@
 use std::process::Command;
 
 use super::super::agent_task_dispatch::DispatchArgs;
-use super::args::{AgentTaskLoopArgs, ReviewArgs, StatusArgs, SubmitArgs, VerifyGateArgs};
+use super::args::{
+    AgentTaskLoopArgs, CompileLoopArgs, ReviewArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
+};
 use super::controller::{
     apply_from_spec_dispatch_defaults, apply_from_spec_dispatch_defaults_with_cwd,
     controller_run_action_with_executor, controller_run_next_with_executor,
@@ -45,6 +47,7 @@ use serde_json::{json, Value};
 use std::sync::{Arc, Mutex};
 
 use super::contract;
+use super::loop_definition;
 use super::{ContractArgs, ContractFormat};
 
 #[test]
@@ -98,6 +101,10 @@ fn contract_output_exports_core_agent_task_metadata() {
         "homeboy/secret-env-requirement/v1"
     );
     assert_eq!(
+        value["schemas"]["loop_definition"],
+        "homeboy/agent-task-loop-definition/v1"
+    );
+    assert_eq!(
         value["schemas"]["provider"],
         AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA
     );
@@ -125,6 +132,46 @@ fn contract_output_exports_core_agent_task_metadata() {
         .as_array()
         .expect("sensitive keys")
         .contains(&json!("refresh_token")));
+}
+
+#[test]
+fn compile_loop_command_emits_agent_task_plan() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let definition_path = temp.path().join("loop-definition.json");
+    std::fs::write(
+        &definition_path,
+        serde_json::to_string(&json!({
+            "schema": "homeboy/agent-task-loop-definition/v1",
+            "loop_id": "cli/loop",
+            "tasks": [
+                { "task_id": "idea", "request": agent_task_request_json("idea") },
+                {
+                    "task_id": "design",
+                    "request": agent_task_request_json("design"),
+                    "depends_on": ["idea"],
+                    "bindings": {
+                        "concept_packet": { "task_id": "idea", "path": "/outputs/concept_packet" }
+                    }
+                }
+            ]
+        }))
+        .expect("definition json"),
+    )
+    .expect("write definition");
+
+    let (value, status) = loop_definition::compile_loop(CompileLoopArgs {
+        definition: format!("@{}", definition_path.display()),
+    })
+    .expect("compile loop");
+
+    assert_eq!(status, 0);
+    assert_eq!(value["schema"], "homeboy/agent-task-plan/v1");
+    assert_eq!(value["plan_id"], "cli/loop");
+    assert_eq!(value["tasks"].as_array().expect("tasks").len(), 2);
+    assert_eq!(
+        value["output_dependencies"]["design"]["bindings"]["concept_packet"]["task_id"],
+        "idea"
+    );
 }
 
 #[test]
@@ -1137,4 +1184,12 @@ fn test_plan() -> AgentTaskPlan {
             metadata: Value::Null,
         }],
     )
+}
+
+fn agent_task_request_json(task_id: &str) -> Value {
+    let mut plan = test_plan();
+    let mut request = plan.tasks.pop().expect("test task");
+    request.task_id = task_id.to_string();
+    request.instructions = format!("run {task_id}");
+    serde_json::to_value(request).expect("request json")
 }

--- a/src/core/agent_task_contract.rs
+++ b/src/core/agent_task_contract.rs
@@ -14,6 +14,7 @@ use crate::core::agent_task_lifecycle::AgentTaskRunState;
 use crate::core::agent_task_loop_controller::{
     AGENT_TASK_LOOP_CONTROLLER_SCHEMA, AGENT_TASK_LOOP_CONTROLLER_STATUS_SCHEMA,
 };
+use crate::core::agent_task_loop_definition::AGENT_TASK_LOOP_DEFINITION_SCHEMA;
 use crate::core::agent_task_promotion::AGENT_TASK_PROMOTION_REPORT_SCHEMA;
 use crate::core::agent_task_provider::{
     provider_capability_contract, AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA,
@@ -65,6 +66,7 @@ pub struct AgentTaskCoreContractSchemas {
     pub cook_loop_report: String,
     pub loop_controller: String,
     pub loop_controller_status: String,
+    pub loop_definition: String,
     pub secret_env_plan: String,
     pub secret_env_requirement: String,
     pub command_invocation: String,
@@ -136,6 +138,7 @@ pub fn agent_task_core_contract() -> AgentTaskCoreContract {
             cook_loop_report: AGENT_TASK_COOK_LOOP_REPORT_SCHEMA.to_string(),
             loop_controller: AGENT_TASK_LOOP_CONTROLLER_SCHEMA.to_string(),
             loop_controller_status: AGENT_TASK_LOOP_CONTROLLER_STATUS_SCHEMA.to_string(),
+            loop_definition: AGENT_TASK_LOOP_DEFINITION_SCHEMA.to_string(),
             secret_env_plan: SECRET_ENV_PLAN_SCHEMA.to_string(),
             secret_env_requirement: SECRET_ENV_REQUIREMENT_SCHEMA.to_string(),
             command_invocation: COMMAND_INVOCATION_SCHEMA.to_string(),

--- a/src/core/agent_task_loop_definition.rs
+++ b/src/core/agent_task_loop_definition.rs
@@ -1,0 +1,273 @@
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::core::agent_task::{AgentTaskComponentContract, AgentTaskRequest};
+use crate::core::agent_task_schedule::{
+    AgentTaskArtifactOutputDeclaration, AgentTaskOutputBinding, AgentTaskOutputDependencies,
+    AgentTaskPlan, AgentTaskScheduleOptions,
+};
+use crate::core::{Error, Result};
+
+pub const AGENT_TASK_LOOP_DEFINITION_SCHEMA: &str = "homeboy/agent-task-loop-definition/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskLoopDefinition {
+    #[serde(default = "loop_definition_schema")]
+    pub schema: String,
+    pub loop_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub component_contracts: Vec<AgentTaskComponentContract>,
+    #[serde(default)]
+    pub options: AgentTaskScheduleOptions,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tasks: Vec<AgentTaskLoopDefinitionTask>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskLoopDefinitionTask {
+    pub task_id: String,
+    pub request: AgentTaskRequest,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub bindings: HashMap<String, AgentTaskOutputBinding>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_outputs: Vec<AgentTaskArtifactOutputDeclaration>,
+}
+
+pub fn compile_loop_definition(definition: AgentTaskLoopDefinition) -> Result<AgentTaskPlan> {
+    validate_loop_definition(&definition)?;
+
+    let plan_id = definition
+        .plan_id
+        .clone()
+        .unwrap_or_else(|| definition.loop_id.clone());
+    let mut plan = AgentTaskPlan::new(
+        plan_id,
+        definition
+            .tasks
+            .iter()
+            .map(|task| task.request.clone())
+            .collect(),
+    );
+    plan.group_key = definition.group_key.clone();
+    plan.component_contracts = definition.component_contracts.clone();
+    plan.options = definition.options.clone();
+    plan.metadata = compile_metadata(&definition);
+
+    for task in &definition.tasks {
+        if !task.depends_on.is_empty() || !task.bindings.is_empty() {
+            plan.output_dependencies.insert(
+                task.task_id.clone(),
+                AgentTaskOutputDependencies {
+                    depends_on: task.depends_on.clone(),
+                    bindings: task.bindings.clone(),
+                },
+            );
+        }
+        if !task.artifact_outputs.is_empty() {
+            plan.artifact_outputs
+                .insert(task.task_id.clone(), task.artifact_outputs.clone());
+        }
+    }
+
+    plan.rebuild_homeboy_plan();
+    Ok(plan)
+}
+
+fn validate_loop_definition(definition: &AgentTaskLoopDefinition) -> Result<()> {
+    if definition.schema != AGENT_TASK_LOOP_DEFINITION_SCHEMA {
+        return Err(Error::validation_invalid_argument(
+            "schema",
+            format!(
+                "expected {AGENT_TASK_LOOP_DEFINITION_SCHEMA}, got {}",
+                definition.schema
+            ),
+            Some(definition.loop_id.clone()),
+            None,
+        ));
+    }
+    if definition.loop_id.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "loop_id",
+            "loop_id must not be empty",
+            None,
+            None,
+        ));
+    }
+    if definition.tasks.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "tasks",
+            "loop definition must include at least one task",
+            Some(definition.loop_id.clone()),
+            None,
+        ));
+    }
+
+    let mut task_ids = HashSet::new();
+    for task in &definition.tasks {
+        if task.task_id != task.request.task_id {
+            return Err(Error::validation_invalid_argument(
+                "tasks[].task_id",
+                format!(
+                    "task_id {} must match request.task_id {}",
+                    task.task_id, task.request.task_id
+                ),
+                Some(definition.loop_id.clone()),
+                None,
+            ));
+        }
+        if !task_ids.insert(task.task_id.clone()) {
+            return Err(Error::validation_invalid_argument(
+                "tasks[].task_id",
+                format!("duplicate task_id {}", task.task_id),
+                Some(definition.loop_id.clone()),
+                None,
+            ));
+        }
+    }
+
+    for task in &definition.tasks {
+        for dependency in &task.depends_on {
+            if !task_ids.contains(dependency) {
+                return Err(Error::validation_invalid_argument(
+                    "tasks[].depends_on",
+                    format!("{} depends on unknown task {}", task.task_id, dependency),
+                    Some(definition.loop_id.clone()),
+                    None,
+                ));
+            }
+        }
+        for binding in task.bindings.values() {
+            if !task_ids.contains(&binding.task_id) {
+                return Err(Error::validation_invalid_argument(
+                    "tasks[].bindings",
+                    format!(
+                        "{} binds output from unknown task {}",
+                        task.task_id, binding.task_id
+                    ),
+                    Some(definition.loop_id.clone()),
+                    None,
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn compile_metadata(definition: &AgentTaskLoopDefinition) -> Value {
+    let mut metadata = match definition.metadata.clone() {
+        Value::Object(map) => map,
+        Value::Null => serde_json::Map::new(),
+        other => {
+            let mut map = serde_json::Map::new();
+            map.insert("definition_metadata".to_string(), other);
+            map
+        }
+    };
+    metadata.insert(
+        "source_schema".to_string(),
+        Value::String(definition.schema.clone()),
+    );
+    metadata.insert(
+        "loop_id".to_string(),
+        Value::String(definition.loop_id.clone()),
+    );
+    Value::Object(metadata)
+}
+
+fn loop_definition_schema() -> String {
+    AGENT_TASK_LOOP_DEFINITION_SCHEMA.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn compiles_definition_into_agent_task_plan() {
+        let definition: AgentTaskLoopDefinition = serde_json::from_value(json!({
+            "schema": AGENT_TASK_LOOP_DEFINITION_SCHEMA,
+            "loop_id": "example/loop",
+            "plan_id": "example-plan",
+            "group_key": "example",
+            "metadata": { "owner": "tests" },
+            "options": { "max_concurrency": 2, "retry": { "max_attempts": 1 } },
+            "tasks": [
+                {
+                    "task_id": "idea",
+                    "request": request("idea"),
+                    "artifact_outputs": [
+                        { "name": "concept_packet", "kind": "example/ConceptPacket/v1", "payload_path": "/artifacts/ConceptPacket.json" }
+                    ]
+                },
+                {
+                    "task_id": "design",
+                    "request": request("design"),
+                    "depends_on": ["idea"],
+                    "bindings": {
+                        "concept_packet": { "task_id": "idea", "path": "/outputs/concept_packet" }
+                    }
+                }
+            ]
+        }))
+        .expect("definition parses");
+
+        let plan = compile_loop_definition(definition).expect("definition compiles");
+
+        assert_eq!(plan.schema, "homeboy/agent-task-plan/v1");
+        assert_eq!(plan.plan_id, "example-plan");
+        assert_eq!(plan.group_key.as_deref(), Some("example"));
+        assert_eq!(plan.tasks.len(), 2);
+        assert_eq!(plan.options.max_concurrency, 2);
+        assert_eq!(
+            plan.metadata["source_schema"],
+            AGENT_TASK_LOOP_DEFINITION_SCHEMA
+        );
+        assert_eq!(plan.metadata["loop_id"], "example/loop");
+        assert_eq!(plan.metadata["owner"], "tests");
+        assert_eq!(
+            plan.output_dependencies["design"].bindings["concept_packet"].task_id,
+            "idea"
+        );
+        assert_eq!(
+            plan.artifact_outputs["idea"][0].kind,
+            "example/ConceptPacket/v1"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_dependencies() {
+        let definition: AgentTaskLoopDefinition = serde_json::from_value(json!({
+            "schema": AGENT_TASK_LOOP_DEFINITION_SCHEMA,
+            "loop_id": "example/loop",
+            "tasks": [
+                { "task_id": "design", "request": request("design"), "depends_on": ["missing"] }
+            ]
+        }))
+        .expect("definition parses");
+
+        let error = compile_loop_definition(definition).expect_err("dependency is rejected");
+        assert!(error.message.contains("unknown task missing"));
+    }
+
+    fn request(task_id: &str) -> Value {
+        json!({
+            "schema": "homeboy/agent-task-request/v1",
+            "task_id": task_id,
+            "executor": { "backend": "noop", "config": {} },
+            "instructions": format!("Run {task_id}")
+        })
+    }
+}

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -106,6 +106,10 @@ pub(crate) use super::agent_task::expand_agent_task_matrix;
 pub use super::agent_task_loop_controller::{
     AgentTaskLoopControllerState, AgentTaskLoopTaskLineage,
 };
+pub use super::agent_task_loop_definition::{
+    compile_loop_definition, AgentTaskLoopDefinition, AgentTaskLoopDefinitionTask,
+    AGENT_TASK_LOOP_DEFINITION_SCHEMA,
+};
 
 // Secret-env status type is referenced from review/dispatch commands.
 pub use super::agent_task_secrets::{
@@ -225,6 +229,14 @@ pub mod loop_controller {
         AgentTaskLoopSubcontrollerRef, AgentTaskLoopTaskLineage, AgentTaskLoopTransition,
         AgentTaskLoopWait, AgentTaskLoopWaitStatus, AGENT_TASK_LOOP_CONTROLLER_SCHEMA,
         AGENT_TASK_LOOP_CONTROLLER_STATUS_SCHEMA,
+    };
+}
+
+/// Declarative loop definitions compiled into scheduler plans.
+pub mod loop_definition {
+    pub use super::super::agent_task_loop_definition::{
+        compile_loop_definition, AgentTaskLoopDefinition, AgentTaskLoopDefinitionTask,
+        AGENT_TASK_LOOP_DEFINITION_SCHEMA,
     };
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -23,6 +23,7 @@ pub mod agent_task_finalization;
 pub mod agent_task_gate;
 pub mod agent_task_lifecycle;
 pub mod agent_task_loop_controller;
+pub mod agent_task_loop_definition;
 mod agent_task_pr_body;
 pub mod agent_task_promotion;
 pub mod agent_task_provider;


### PR DESCRIPTION
## Summary
- Add `homeboy/agent-task-loop-definition/v1` as a declarative loop-definition contract.
- Compile loop definitions into existing `homeboy/agent-task-plan/v1` scheduler plans with task dependencies, output bindings, artifact outputs, metadata, and schedule options.
- Add `homeboy agent-task compile-loop --definition <SPEC>` and export the schema through the agent-task core contract.

## Testing
- `cargo fmt --check`
- `cargo test loop_definition`
- `cargo test compile_loop_command_emits_agent_task_plan`
- `cargo test contract_output_exports_core_agent_task_metadata`
- `cargo test command_surface`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation and tests; Chris reviews and owns the change.
