### PR TITLE
docs: refresh command surface docs

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -6,6 +6,36 @@ Homeboy owns durable orchestration and provider-neutral outcomes. Runtime
 providers own backend-specific execution. For the provider fanout ownership seam,
 see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-fanout-boundary.md).
 
+## Subcommands
+
+| Subcommand | Purpose |
+|---|---|
+| `cook` | Sync a workspace when `--runner` is supplied, dispatch a repo-cooking task, and return the durable run id. |
+| `loop` | Run a durable repo cook loop: dispatch, promote, verify, retry red gates, and finalize. |
+| `dispatch` | Build and dispatch common repo-cooking agent tasks without hand-authored provider JSON. |
+| `run-plan` | Run an `AgentTaskPlan` through extension-declared executor providers. |
+| `run <run-id>` | Execute a previously submitted durable run. |
+| `run-next` | Claim and execute the oldest queued durable run. |
+| `submit` | Persist an agent-task plan and return a durable run id without executing it. |
+| `status <run-id>` | Read durable run status. |
+| `list` | List durable runs, newest first. |
+| `active` | List queued and running durable runs, newest first. |
+| `latest` | Show the latest durable run. |
+| `logs <run-id>` | Read durable run scheduler events. |
+| `artifacts <run-id>` | List artifacts and evidence refs recorded for a completed run. |
+| `cancel <run-id>` | Mark a queued or stale-running durable run as cancelled. |
+| `resume <run-id>` | Resume a queued or stale-running durable run. |
+| `retry <run-id>` | Submit a fresh durable run from an existing run's plan. |
+| `review <run-id>` | Build a durable aggregate review envelope from run state, logs, artifacts, and promotion hints. |
+| `promote <source>` | Promote a completed generic patch artifact into a managed worktree. |
+| `finalize-pr` | Finalize a green cook run into a review-ready pull request. |
+| `gate-feedback` | Convert deterministic gate results into a cook-loop retry or stop decision. |
+| `providers` | List extension-declared executor providers and optional secret readiness. |
+| `contract` | Export Homeboy's machine-readable agent-task core contract metadata. |
+| `compile-loop` | Compile a declarative loop definition into an agent-task plan. |
+| `auth` | Configure and inspect provider authentication secrets. |
+| `controller` | Create, inspect, and resume durable multi-agent loop controller state. |
+
 ## Dispatch
 
 `agent-task dispatch` builds a durable task plan from common repo-cooking inputs

--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -3,8 +3,8 @@
 ## Synopsis
 
 ```sh
-homeboy deploy <project_id> [<component_ids...>] [-c|--component <id>]... [--all] [--outdated] [--check] [--dry-run] [--json '<spec>']
-# If no component IDs are provided, you must use --all, --outdated, or --check.
+homeboy deploy [<project_id>|<component_id>] [<component_ids...>] [-p|--project <id>] [-c|--component <id>]... [--all] [--outdated|--behind-upstream] [--check] [--dry-run] [--json '<spec>']
+# If no component IDs are provided, you must use --all, --outdated, --behind-upstream, or --check.
 
 # Multi-project deployment
 homeboy deploy --projects <project1>,<project2> <component_ids...>
@@ -24,17 +24,25 @@ homeboy deploy <component_id> --shared
 Options:
 
 - `-c`, `--component`: component ID to deploy (can be repeated, alternative to positional)
+- `-p`, `--project`: explicit project ID; takes precedence over positional project/component detection
 - `--all`: deploy all configured components
 - `--outdated`: deploy only outdated components
   - Determined from the first version target for each component.
+- `--behind-upstream`: deploy only components whose local checkout is behind upstream. Conflicts with `--outdated`.
 - `--check`: check component status without building or deploying
   - Shows all components for the project with version comparison status.
   - Combines with `--outdated` or component IDs to filter results.
 - `--dry-run`: preview what would be deployed without executing (no build, no upload)
+- `--force`: deploy even with uncommitted changes
 - `--json`: JSON input spec for bulk operations (`{"component_ids": ["component-id", ...]}`)
 - `--projects`: deploy to multiple projects (comma-separated). When using this flag, all positional arguments are treated as component IDs. The build artifact is reused across projects.
 - `-f`, `--fleet`: deploy to all projects in a fleet. Resolves fleet to project IDs, then runs multi-project deployment.
 - `-s`, `--shared`: deploy to all projects using the specified component(s). Auto-detects which projects have the component configured and deploys to all of them.
+- `--keep-deps`: keep build dependencies and skip post-deploy cleanup.
+- `--version <version>`: assert the expected local component version before deploying; aborts on mismatch.
+- `--no-pull`: skip the automatic pull before deploy.
+- `--head`: deploy the current branch `HEAD` instead of the latest tag.
+- `--tagged`: force tag-based deploy and ignore reusable build artifacts.
 
 Bulk JSON input uses `component_ids` (snake_case):
 
@@ -44,7 +52,7 @@ Bulk JSON input uses `component_ids` (snake_case):
 
 Positional and flag component IDs can be mixed; both are merged into the deployment list.
 
-If no component IDs are provided and neither `--all` nor `--outdated` is set, Homeboy returns an error. If `--outdated` finds no outdated components, Homeboy returns an error.
+If no component IDs are provided and none of `--all`, `--outdated`, `--behind-upstream`, or `--check` is set, Homeboy returns an error. If `--outdated` or `--behind-upstream` finds no matching components, Homeboy returns an error.
 
 ## JSON output
 
@@ -229,6 +237,8 @@ Use `--dry-run` to see what would be deployed without executing:
 
 ```sh
 homeboy deploy myproject --outdated --dry-run
+homeboy deploy myproject --behind-upstream --dry-run
+homeboy deploy myproject my-plugin --version 1.2.3 --tagged --dry-run
 ```
 
 ## Check Component Status

--- a/docs/commands/file.md
+++ b/docs/commands/file.md
@@ -20,6 +20,7 @@ homeboy file <COMMAND>
 - `upload <server> <local_path> <remote_path> [-c|--compress] [--dry-run]`
 - `copy <source> <destination> [-r|--recursive] [-c|--compress] [--dry-run] [--exclude <pattern>]`
 - `sync <source> <destination> [-c|--compress] [--dry-run] [--exclude <pattern>]`
+- `edit <project_id> <file_path> [operations] [-n|--dry-run] [-f|--force]`
 
 `copy` and `sync` targets use `local/path` or `server_id:/path` syntax. `sync` is recursive and non-deleting by default; it does not expose a delete mode.
 
@@ -88,6 +89,41 @@ Notes:
 - `upload` is the ergonomic mirror of `download` for local-to-server uploads.
 - `copy` preserves the old local↔remote and remote↔remote transfer target syntax.
 - `sync` is directory-oriented and recursive, but does not delete files from the destination.
+
+### `edit`
+
+```sh
+homeboy file edit <project_id> <file_path> [operations]
+```
+
+Operations:
+
+- `--replace-line <n> --replace-line-content <content>`: replace one line by number.
+- `--insert-after <n> --insert-after-content <content>`: insert content after a line.
+- `--insert-before <n> --insert-before-content <content>`: insert content before a line.
+- `--delete-line <n>`: delete one line by number.
+- `--delete-lines <start> <end>`: delete an inclusive line range.
+- `--replace-pattern <pattern> --replace-pattern-content <content>`: replace a unique pattern match.
+- `--replace-all-pattern <pattern> --replace-all-content <content>`: replace all pattern matches.
+- `--delete-pattern <pattern>`: delete the line or content matched by a pattern operation.
+- `--append <content>`: append content to the file.
+- `--prepend <content>`: prepend content to the file.
+
+Flags:
+
+- `-n`, `--dry-run`: show changes without applying them.
+- `-f`, `--force`: apply even when a pattern operation has multiple matches.
+
+Examples:
+
+```sh
+homeboy file edit mysite /var/www/wp-config.php \
+  --replace-pattern "WP_DEBUG', false" \
+  --replace-pattern-content "WP_DEBUG', true" \
+  --dry-run
+
+homeboy file edit mysite /var/www/.maintenance --append "enabled"
+```
 
 ## JSON output
 
@@ -159,6 +195,19 @@ Match objects (`matches[]`):
 - `file`: file path
 - `line`: line number
 - `content`: matching line content
+
+### Edit output
+
+Fields:
+
+- `command`: `file.edit`
+- `project_id`
+- `base_path`: project base path if configured
+- `path`: edited file path
+- `changes_made`: array of line change records
+- `change_count`: number of changes made or planned
+- `success`
+- `error`: error string when editing failed
 
 ## Exit code
 

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -268,13 +268,19 @@ non-zero after `--broker-retry-limit` consecutive failures. `SIGINT` and
 ### `job`
 
 ```sh
-homeboy runner job logs <job-id>
-homeboy runner job logs <job-id> --follow
+homeboy runner job logs <runner-id> <job-id>
+homeboy runner job logs <runner-id> <job-id> --follow --poll-ms 1000
+homeboy runner job cancel <runner-id> <job-id>
 ```
 
-Inspects durable runner daemon job events. Use `logs` to read the persisted event
-stream for a brokered or daemon-backed runner job without connecting directly to
-the runner process.
+Inspects or cancels durable runner daemon jobs after `runner exec` or Lab offload
+has submitted work to a connected runner. `logs` fetches the persisted job plus
+its event stream; `--follow` keeps polling until the job reaches a terminal state
+and prints newly observed events as they arrive. Use this when a controller exits
+after dispatching runner work and you need to inspect the already-started job.
+
+`cancel` requests cancellation for a queued or running durable runner daemon job
+through the connected runner daemon.
 
 Minimal Homeboy Lab systemd unit:
 
@@ -300,19 +306,6 @@ WantedBy=multi-user.target
 The unit intentionally leaves authentication out until the broker auth contract
 lands; configure the broker URL and any future auth material using the production
 mechanism for issue #2990 rather than embedding secrets in the unit file.
-
-### `job`
-
-```sh
-homeboy runner job logs <runner-id> <job-id>
-homeboy runner job logs <runner-id> <job-id> --follow --poll-ms 1000
-```
-
-Inspects durable runner daemon jobs after `runner exec` or Lab offload has
-submitted work to a connected runner. `logs` fetches the persisted job plus its
-event stream; `--follow` keeps polling until the job reaches a terminal state and
-prints newly observed events as they arrive. Use this when a controller exits
-after dispatching runner work and you need to inspect the already-started job.
 
 ### `status`
 


### PR DESCRIPTION
## Summary
- Document `homeboy file edit` operations and output shape.
- Document deploy provenance/safety flags including `--behind-upstream`, `--version`, `--head`, and `--tagged`.
- Correct `runner job` syntax, add `runner job cancel`, and add an `agent-task` subcommand reference table.

## Testing
- `cargo test command_surface --test command_surface_test`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated command documentation drift, drafted the documentation updates, and ran targeted verification. Chris remains responsible for review and final acceptance.