### PR TITLE
perf(runs): batch artifact lookup

### DIFF
--- a/src/commands/runs/common.rs
+++ b/src/commands/runs/common.rs
@@ -188,8 +188,10 @@ pub fn load_artifact_rows(
 
     let mut rows = Vec::new();
     let mut skipped = Vec::new();
+    let run_ids = runs.iter().map(|run| run.id.clone()).collect::<Vec<_>>();
+    let mut artifacts_by_run = store.list_artifacts_for_runs(&run_ids)?;
     for run in runs {
-        let artifacts = store.list_artifacts(&run.id)?;
+        let artifacts = artifacts_by_run.remove(&run.id).unwrap_or_default();
         for artifact in artifacts {
             if artifact.artifact_type != "file" {
                 if artifact.artifact_type == "metadata-only" {

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -707,6 +708,57 @@ impl ObservationStore {
             .map_err(sqlite_error("list artifact records"))?;
 
         collect_rows(rows, "collect artifact records")
+    }
+
+    pub fn list_artifacts_for_runs(
+        &self,
+        run_ids: &[String],
+    ) -> Result<BTreeMap<String, Vec<ArtifactRecord>>> {
+        let mut artifacts_by_run = run_ids
+            .iter()
+            .map(|run_id| {
+                validate_required("run_id", run_id)?;
+                Ok((run_id.clone(), Vec::new()))
+            })
+            .collect::<Result<BTreeMap<_, _>>>()?;
+        if run_ids.is_empty() {
+            return Ok(artifacts_by_run);
+        }
+
+        for chunk in run_ids.chunks(900) {
+            let placeholders = std::iter::repeat("?")
+                .take(chunk.len())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                r#"
+                SELECT id, run_id, kind, artifact_type, path, sha256, size_bytes, mime, metadata_json, created_at
+                FROM artifacts
+                WHERE run_id IN ({placeholders})
+                ORDER BY run_id ASC, created_at ASC
+                "#
+            );
+            let mut statement = self
+                .connection
+                .prepare(&sql)
+                .map_err(sqlite_error("prepare batch list artifact records"))?;
+            let rows = statement
+                .query_map(
+                    rusqlite::params_from_iter(chunk.iter().map(String::as_str)),
+                    row_to_artifact_record,
+                )
+                .map_err(sqlite_error("batch list artifact records"))?;
+
+            for row in rows {
+                let artifact = row.map_err(sqlite_error("collect batch artifact records"))?;
+                artifacts_by_run
+                    .entry(artifact.run_id.clone())
+                    .or_default()
+                    .push(artifact);
+            }
+        }
+
+        Ok(artifacts_by_run)
     }
 
     pub fn get_artifact(&self, artifact_id: &str) -> Result<Option<ArtifactRecord>> {

--- a/tests/core/observation/store_test.rs
+++ b/tests/core/observation/store_test.rs
@@ -860,6 +860,45 @@ fn test_list_artifacts() {
 }
 
 #[test]
+fn test_list_artifacts_for_runs() {
+    with_isolated_home(|home| {
+        let _xdg = XdgGuard::unset();
+        let store = ObservationStore::open_initialized().expect("init store");
+        let first_run = store
+            .start_run(sample_run("trace", "homeboy"))
+            .expect("start first run");
+        let second_run = store
+            .start_run(sample_run("bench", "homeboy"))
+            .expect("start second run");
+        let empty_run = store
+            .start_run(sample_run("lint", "homeboy"))
+            .expect("start empty run");
+        let first_path = home.path().join("first.json");
+        let second_path = home.path().join("second.log");
+        std::fs::write(&first_path, b"first").expect("write first");
+        std::fs::write(&second_path, b"second").expect("write second");
+
+        let first = store
+            .record_artifact(&first_run.id, "first", &first_path)
+            .expect("record first");
+        let second = store
+            .record_artifact(&second_run.id, "second", &second_path)
+            .expect("record second");
+
+        let artifacts = store
+            .list_artifacts_for_runs(&[
+                first_run.id.clone(),
+                second_run.id.clone(),
+                empty_run.id.clone(),
+            ])
+            .expect("list artifacts for runs");
+        assert_eq!(artifacts[&first_run.id], vec![first]);
+        assert_eq!(artifacts[&second_run.id], vec![second]);
+        assert!(artifacts[&empty_run.id].is_empty());
+    });
+}
+
+#[test]
 fn missing_artifact_file_returns_clear_error() {
     with_isolated_home(|home| {
         let _xdg = XdgGuard::unset();


### PR DESCRIPTION
## Summary
- Add `ObservationStore::list_artifacts_for_runs` for batch artifact lookup.
- Update runs artifact row loading to avoid one artifact query per run.
- Add store coverage for batch artifact listing across populated and empty runs.

## Testing
- `cargo fmt`
- `cargo test test_list_artifacts`
- `cargo test runs_query_projects_select_jsonpath_over_artifact_corpus`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified N+1 artifact lookup behavior, implemented the batch API and call-site change, and ran targeted tests. Chris remains responsible for review and final acceptance.