### PR TITLE
test(cli): cover nested command surface

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -10,6 +10,7 @@ use crate::commands::{
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+const DEFAULT_COMMAND_SURFACE_DEPTH: usize = 2;
 
 #[derive(Parser)]
 #[command(name = "homeboy")]
@@ -179,11 +180,7 @@ impl CommandSurface {
             return false;
         };
 
-        match rest {
-            [] => true,
-            [second] => entry.subcommands.iter().any(|sub| sub.matches(second)),
-            _ => false,
-        }
+        entry.contains_rest(rest)
     }
 }
 
@@ -198,6 +195,17 @@ impl CommandSurfaceEntry {
     fn matches(&self, name: &str) -> bool {
         self.name == name || self.visible_aliases.iter().any(|alias| alias == name)
     }
+
+    fn contains_rest(&self, path: &[&str]) -> bool {
+        let Some((first, rest)) = path.split_first() else {
+            return true;
+        };
+
+        self.subcommands
+            .iter()
+            .find(|entry| entry.matches(first))
+            .is_some_and(|entry| entry.contains_rest(rest))
+    }
 }
 
 pub fn current_command_surface() -> CommandSurface {
@@ -205,8 +213,12 @@ pub fn current_command_surface() -> CommandSurface {
 }
 
 pub fn command_surface_from(command: Command) -> CommandSurface {
+    command_surface_from_with_depth(command, DEFAULT_COMMAND_SURFACE_DEPTH)
+}
+
+pub fn command_surface_from_with_depth(command: Command, depth: usize) -> CommandSurface {
     CommandSurface {
-        commands: visible_subcommands(&command, 1),
+        commands: visible_subcommands(&command, depth),
     }
 }
 

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -1,5 +1,5 @@
 use clap::{CommandFactory, Parser};
-use homeboy::cli_surface::{current_command_surface, Cli};
+use homeboy::cli_surface::{command_surface_from_with_depth, current_command_surface, Cli};
 use std::collections::BTreeSet;
 
 #[test]
@@ -50,6 +50,26 @@ fn includes_first_level_subcommands() {
 }
 
 #[test]
+fn includes_second_level_subcommands() {
+    let surface = current_command_surface();
+
+    assert!(surface.contains_path(&["agent-task", "controller", "run-next"]));
+    assert!(surface.contains_path(&["agent-task", "auth", "status"]));
+    assert!(surface.contains_path(&["runner", "job", "logs"]));
+    assert!(surface.contains_path(&["tunnel", "preview-ingress", "route"]));
+    assert!(surface.contains_path(&["tunnel", "preview-ingress", "list"]));
+    assert!(surface.contains_path(&["tunnel", "preview-ingress", "status"]));
+}
+
+#[test]
+fn command_surface_depth_is_configurable() {
+    let surface = command_surface_from_with_depth(Cli::command(), 1);
+
+    assert!(surface.contains_path(&["runner", "job"]));
+    assert!(!surface.contains_path(&["runner", "job", "logs"]));
+}
+
+#[test]
 fn excludes_removed_cli_aliases() {
     let surface = current_command_surface();
 
@@ -60,7 +80,7 @@ fn excludes_removed_cli_aliases() {
 }
 
 #[test]
-fn rejects_stale_or_deeper_paths() {
+fn rejects_stale_or_unrepresented_paths() {
     let surface = current_command_surface();
 
     assert!(!surface.contains_path(&["supports"]));
@@ -68,6 +88,7 @@ fn rejects_stale_or_deeper_paths() {
     assert!(!surface.contains_path(&["audit", "docs"]));
     assert!(!surface.contains_path(&["audit", "structure"]));
     assert!(!surface.contains_path(&["stack", "inspect", "extra"]));
+    assert!(!surface.contains_path(&["runner", "job", "logs", "extra"]));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Extend command surface discovery to include second-level nested subcommands by default.
- Add configurable command surface depth for focused assertions.
- Cover nested `agent-task`, `runner job`, and `tunnel preview-ingress` paths.

## Testing
- `cargo fmt`
- `cargo test --test command_surface_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified first-level-only command surface coverage, implemented nested coverage, and ran targeted tests. Chris remains responsible for review and final acceptance.