### PR TITLE
refactor(commands): expose adapter output descriptors

### DIFF
--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -201,9 +201,7 @@ impl Commands {
                 output_file_mode,
                 CommandOutputContractKind::JsonEnvelope,
             ),
-            Commands::Version(_) => version::adapter(output_file_mode)
-                .contract
-                .to_output_descriptor(),
+            Commands::Version(_) => version::adapter(output_file_mode).output_descriptor(),
             Commands::AgentTask(_)
             | Commands::Project(_)
             | Commands::Component(_)
@@ -245,9 +243,7 @@ impl Commands {
             | Commands::Http(_)
             | Commands::Upgrade(_)
             | Commands::Ssh(_) => ops_json_descriptor(output_file_mode),
-            Commands::Fleet(_) => fleet::adapter(output_file_mode)
-                .contract
-                .to_output_descriptor(),
+            Commands::Fleet(_) => fleet::adapter(output_file_mode).output_descriptor(),
             Commands::Triage(_) => ops_json_descriptor(output_file_mode),
         }
     }

--- a/src/commands/adapter.rs
+++ b/src/commands/adapter.rs
@@ -51,6 +51,10 @@ pub(crate) struct TypedCommandAdapter<Args> {
 }
 
 impl<Args> TypedCommandAdapter<Args> {
+    pub fn output_descriptor(&self) -> CommandOutputDescriptor {
+        self.contract.to_output_descriptor()
+    }
+
     pub fn json_only(
         json_family: CommandJsonFamily,
         output_file_mode: CommandOutputFileMode,
@@ -102,7 +106,7 @@ mod tests {
             |_, _| (Ok(Value::Null), 0),
         );
 
-        let descriptor = adapter.contract.to_output_descriptor();
+        let descriptor = adapter.output_descriptor();
 
         assert_eq!(descriptor.response_mode, CommandResponseMode::Json);
         assert_eq!(
@@ -128,7 +132,7 @@ mod tests {
             );
 
             assert_eq!(
-                adapter.contract.to_output_descriptor().response_mode,
+                adapter.output_descriptor().response_mode,
                 CommandResponseMode::Raw(raw_mode)
             );
             assert!(adapter.execute_json.is_none());


### PR DESCRIPTION
## Summary
- Add `TypedCommandAdapter::output_descriptor()`.
- Migrate the existing adapter-backed `Version` and `Fleet` descriptor call sites to use it.
- Keep this as a small proof toward converged command contracts.

## Testing
- `cargo test commands::adapter`
- `cargo test command_contract::output`
- `cargo fmt`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified a narrow command adapter consolidation path, implemented the proof, and ran targeted tests. Chris remains responsible for review and final acceptance.