### PR TITLE
Refactor command JSON family registry

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -208,6 +208,66 @@ impl CommandSurfaceEntry {
     }
 }
 
+impl Commands {
+    pub fn top_level_name(&self) -> &'static str {
+        match self {
+            Commands::AgentTask(_) => "agent-task",
+            Commands::Project(_) => "project",
+            Commands::Ssh(_) => "ssh",
+            Commands::Server(_) => "server",
+            Commands::Test(_) => "test",
+            Commands::Bench(_) => "bench",
+            Commands::Trace(_) => "trace",
+            Commands::Observe(_) => "observe",
+            Commands::Lint(_) => "lint",
+            Commands::Db(_) => "db",
+            Commands::Deps(_) => "deps",
+            Commands::Ci(_) => "ci",
+            Commands::Doctor(_) => "doctor",
+            Commands::File(_) => "file",
+            Commands::Fleet(_) => "fleet",
+            Commands::Logs(_) => "logs",
+            Commands::Triage(_) => "triage",
+            Commands::Deploy(_) => "deploy",
+            Commands::Component(_) => "component",
+            Commands::Config(_) => "config",
+            Commands::Daemon(_) => "daemon",
+            Commands::Extension(_) => "extension",
+            Commands::Status(_) => "status",
+            Commands::Docs(_) => "docs",
+            Commands::Changelog(_) => "changelog",
+            Commands::Cleanup(_) => "cleanup",
+            Commands::Git(_) => "git",
+            Commands::Issues(_) => "issues",
+            Commands::Version(_) => "version",
+            Commands::Build(_) => "build",
+            Commands::Changes(_) => "changes",
+            Commands::Release(_) => "release",
+            Commands::Report(_) => "report",
+            Commands::Review(_) => "review",
+            Commands::Audit(_) => "audit",
+            Commands::AuditBaseline(_) => "audit-baseline",
+            Commands::Refactor(_) => "refactor",
+            Commands::Refs(_) => "refs",
+            Commands::Rig(_) => "rig",
+            Commands::Runner(_) => "runner",
+            Commands::Lab(_) => "lab",
+            Commands::Runtime(_) => "runtime",
+            Commands::Worktree(_) => "worktree",
+            Commands::Tunnel(_) => "tunnel",
+            Commands::Runs(_) => "runs",
+            Commands::SelfCmd(_) => "self",
+            Commands::Stack(_) => "stack",
+            Commands::Undo(_) => "undo",
+            Commands::Auth(_) => "auth",
+            Commands::Api(_) => "api",
+            Commands::Http(_) => "http",
+            Commands::Upgrade(_) => "upgrade",
+            Commands::List => "list",
+        }
+    }
+}
+
 pub fn current_command_surface() -> CommandSurface {
     command_surface_from(Cli::command())
 }

--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -25,8 +25,9 @@ pub use lab::{
     LabSourcePathMode, LabWorkspaceModePolicy, LAB_TRACE_EXTRA_TOOLS,
 };
 pub use output::{
-    CommandDescriptor, CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor,
-    CommandOutputFileMode, CommandRawOutputMode, CommandResponseMode, CommandResponsePlan,
-    CommandStdoutMode,
+    registered_command_json_family, CommandDescriptor, CommandJsonFamily,
+    CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode,
+    CommandRawOutputMode, CommandRegistryEntry, CommandResponseMode, CommandResponsePlan,
+    CommandStdoutMode, COMMAND_REGISTRY,
 };
 pub use public_variants::{PublicOutputVariantContract, PUBLIC_OUTPUT_VARIANT_CONTRACTS};

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -66,6 +66,82 @@ pub struct CommandOutputDescriptor {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandRegistryEntry {
+    pub name: &'static str,
+    pub json_family: CommandJsonFamily,
+}
+
+const fn command_registry_entry(
+    name: &'static str,
+    json_family: CommandJsonFamily,
+) -> CommandRegistryEntry {
+    CommandRegistryEntry { name, json_family }
+}
+
+pub const COMMAND_REGISTRY: &[CommandRegistryEntry] = &[
+    command_registry_entry("agent-task", CommandJsonFamily::Workspace),
+    command_registry_entry("project", CommandJsonFamily::Workspace),
+    command_registry_entry("ssh", CommandJsonFamily::Ops),
+    command_registry_entry("server", CommandJsonFamily::Ops),
+    command_registry_entry("test", CommandJsonFamily::Quality),
+    command_registry_entry("bench", CommandJsonFamily::Quality),
+    command_registry_entry("trace", CommandJsonFamily::Quality),
+    command_registry_entry("observe", CommandJsonFamily::Quality),
+    command_registry_entry("lint", CommandJsonFamily::Quality),
+    command_registry_entry("db", CommandJsonFamily::Ops),
+    command_registry_entry("deps", CommandJsonFamily::Ops),
+    command_registry_entry("ci", CommandJsonFamily::Ops),
+    command_registry_entry("doctor", CommandJsonFamily::Ops),
+    command_registry_entry("file", CommandJsonFamily::Ops),
+    command_registry_entry("fleet", CommandJsonFamily::Ops),
+    command_registry_entry("logs", CommandJsonFamily::Ops),
+    command_registry_entry("triage", CommandJsonFamily::Ops),
+    command_registry_entry("deploy", CommandJsonFamily::Ops),
+    command_registry_entry("component", CommandJsonFamily::Workspace),
+    command_registry_entry("config", CommandJsonFamily::Workspace),
+    command_registry_entry("daemon", CommandJsonFamily::Ops),
+    command_registry_entry("extension", CommandJsonFamily::Workspace),
+    command_registry_entry("status", CommandJsonFamily::Ops),
+    command_registry_entry("docs", CommandJsonFamily::Workspace),
+    command_registry_entry("changelog", CommandJsonFamily::Workspace),
+    command_registry_entry("cleanup", CommandJsonFamily::Workspace),
+    command_registry_entry("git", CommandJsonFamily::Ops),
+    command_registry_entry("issues", CommandJsonFamily::Ops),
+    command_registry_entry("version", CommandJsonFamily::Workspace),
+    command_registry_entry("build", CommandJsonFamily::Workspace),
+    command_registry_entry("changes", CommandJsonFamily::Workspace),
+    command_registry_entry("release", CommandJsonFamily::Workspace),
+    command_registry_entry("report", CommandJsonFamily::Workspace),
+    command_registry_entry("review", CommandJsonFamily::Quality),
+    command_registry_entry("audit", CommandJsonFamily::Quality),
+    command_registry_entry("audit-baseline", CommandJsonFamily::Quality),
+    command_registry_entry("refactor", CommandJsonFamily::Workspace),
+    command_registry_entry("refs", CommandJsonFamily::Workspace),
+    command_registry_entry("rig", CommandJsonFamily::Workspace),
+    command_registry_entry("runner", CommandJsonFamily::Workspace),
+    command_registry_entry("lab", CommandJsonFamily::Workspace),
+    command_registry_entry("runtime", CommandJsonFamily::Workspace),
+    command_registry_entry("worktree", CommandJsonFamily::Workspace),
+    command_registry_entry("tunnel", CommandJsonFamily::Workspace),
+    command_registry_entry("runs", CommandJsonFamily::Workspace),
+    command_registry_entry("self", CommandJsonFamily::Ops),
+    command_registry_entry("stack", CommandJsonFamily::Workspace),
+    command_registry_entry("undo", CommandJsonFamily::Workspace),
+    command_registry_entry("auth", CommandJsonFamily::Ops),
+    command_registry_entry("api", CommandJsonFamily::Ops),
+    command_registry_entry("http", CommandJsonFamily::Ops),
+    command_registry_entry("upgrade", CommandJsonFamily::Ops),
+    command_registry_entry("list", CommandJsonFamily::RawOnly),
+];
+
+pub fn registered_command_json_family(name: &str) -> Option<CommandJsonFamily> {
+    COMMAND_REGISTRY
+        .iter()
+        .find(|entry| entry.name == name)
+        .map(|entry| entry.json_family)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CommandDescriptor {
     pub response_mode: CommandResponseMode,
     pub output_file_mode: CommandOutputFileMode,
@@ -187,14 +263,8 @@ impl Commands {
             Commands::Bench(args) => args.output_descriptor(output_file_mode),
             Commands::Lint(args) => args.output_descriptor(output_file_mode),
             Commands::Audit(args) => args.output_descriptor(output_file_mode),
-            Commands::Observe(_) => {
-                json_envelope_descriptor(CommandJsonFamily::Quality, output_file_mode)
-            }
-            Commands::AuditBaseline(_) => {
-                json_envelope_descriptor(CommandJsonFamily::Quality, output_file_mode)
-            }
-            Commands::Refactor(_) => {
-                json_envelope_descriptor(CommandJsonFamily::Workspace, output_file_mode)
+            Commands::Observe(_) | Commands::AuditBaseline(_) | Commands::Refactor(_) => {
+                registered_json_envelope_descriptor(self, output_file_mode)
             }
             Commands::Refs(_) => workspace_descriptor(
                 CommandResponseMode::Json,
@@ -219,12 +289,8 @@ impl Commands {
             | Commands::Worktree(_)
             | Commands::Tunnel(_)
             | Commands::Stack(_)
-            | Commands::Undo(_) => {
-                json_envelope_descriptor(CommandJsonFamily::Workspace, output_file_mode)
-            }
-            Commands::Rig(_) => {
-                json_envelope_descriptor(CommandJsonFamily::Workspace, output_file_mode)
-            }
+            | Commands::Undo(_) => registered_json_envelope_descriptor(self, output_file_mode),
+            Commands::Rig(_) => registered_json_envelope_descriptor(self, output_file_mode),
             Commands::Status(_)
             | Commands::Ci(_)
             | Commands::Server(_)
@@ -242,9 +308,9 @@ impl Commands {
             | Commands::Api(_)
             | Commands::Http(_)
             | Commands::Upgrade(_)
-            | Commands::Ssh(_) => ops_json_descriptor(output_file_mode),
+            | Commands::Ssh(_) => registered_json_envelope_descriptor(self, output_file_mode),
             Commands::Fleet(_) => fleet::adapter(output_file_mode).output_descriptor(),
-            Commands::Triage(_) => ops_json_descriptor(output_file_mode),
+            Commands::Triage(_) => registered_json_envelope_descriptor(self, output_file_mode),
         }
     }
 
@@ -321,15 +387,21 @@ fn json_envelope_descriptor(
     }
 }
 
-fn ops_json_descriptor(output_file_mode: CommandOutputFileMode) -> CommandOutputDescriptor {
-    json_envelope_descriptor(CommandJsonFamily::Ops, output_file_mode)
+fn registered_json_envelope_descriptor(
+    command: &Commands,
+    output_file_mode: CommandOutputFileMode,
+) -> CommandOutputDescriptor {
+    let json_family = registered_command_json_family(command.top_level_name())
+        .expect("top-level command should be registered");
+    json_envelope_descriptor(json_family, output_file_mode)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli_surface::{Cli, Commands};
+    use crate::cli_surface::{current_command_surface, Cli, Commands};
     use clap::Parser;
+    use std::collections::BTreeSet;
 
     fn parsed_command(args: &[&str]) -> Commands {
         Cli::try_parse_from(args)
@@ -391,6 +463,21 @@ mod tests {
             list_descriptor.response_mode,
             CommandResponseMode::Raw(CommandRawOutputMode::Markdown)
         );
+    }
+
+    #[test]
+    fn command_registry_covers_visible_top_level_surface() {
+        let surface_names = current_command_surface()
+            .commands
+            .into_iter()
+            .map(|entry| entry.name)
+            .collect::<BTreeSet<_>>();
+        let registry_names = COMMAND_REGISTRY
+            .iter()
+            .map(|entry| entry.name.to_string())
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(registry_names, surface_names);
     }
 
     #[test]

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -87,7 +87,9 @@ fn unsupported_raw_command(message: &'static str) -> JsonRun {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::command_contract::{CommandJsonFamily, COMMAND_REGISTRY};
     use crate::commands::agent_task::{AgentTaskArgs, AgentTaskCommand, StatusArgs};
+    use std::collections::BTreeMap;
 
     #[test]
     fn list_json_dispatch_reports_raw_output_mode() {
@@ -111,5 +113,45 @@ mod tests {
 
         assert!(agent_task_summary_kind_for_output_mode(&args, false).is_some());
         assert!(agent_task_summary_kind_for_output_mode(&args, true).is_none());
+    }
+
+    #[test]
+    fn json_dispatch_modules_match_command_registry_families() {
+        let mut registered: BTreeMap<&str, CommandJsonFamily> = COMMAND_REGISTRY
+            .iter()
+            .map(|entry| (entry.name, entry.json_family))
+            .collect();
+        assert_eq!(registered.remove("list"), Some(CommandJsonFamily::RawOnly));
+
+        assert_family_commands(
+            &mut registered,
+            CommandJsonFamily::Quality,
+            quality::COMMANDS,
+        );
+        assert_family_commands(
+            &mut registered,
+            CommandJsonFamily::Workspace,
+            workspace::COMMANDS,
+        );
+        assert_family_commands(&mut registered, CommandJsonFamily::Ops, ops::COMMANDS);
+
+        assert!(
+            registered.is_empty(),
+            "unclaimed JSON commands: {registered:?}"
+        );
+    }
+
+    fn assert_family_commands(
+        registered: &mut BTreeMap<&'static str, CommandJsonFamily>,
+        expected_family: CommandJsonFamily,
+        commands: &[&'static str],
+    ) {
+        for command in commands {
+            assert_eq!(
+                registered.remove(command),
+                Some(expected_family),
+                "{command} JSON dispatch family drifted from command registry"
+            );
+        }
     }
 }

--- a/src/commands/json_output/ops.rs
+++ b/src/commands/json_output/ops.rs
@@ -6,6 +6,12 @@ use crate::commands::{
     self_cmd, server, ssh, status, triage, upgrade, GlobalArgs,
 };
 
+#[cfg(test)]
+pub(super) const COMMANDS: &[&str] = &[
+    "api", "auth", "ci", "daemon", "db", "deploy", "deps", "doctor", "file", "fleet", "git",
+    "http", "issues", "logs", "self", "server", "ssh", "status", "triage", "upgrade",
+];
+
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
     match command {
         Commands::Status(args) => map(status::run(args, global)),

--- a/src/commands/json_output/quality.rs
+++ b/src/commands/json_output/quality.rs
@@ -5,6 +5,18 @@ use crate::commands::{
     audit, audit_baseline, bench, lint, observe, review, test, trace, GlobalArgs,
 };
 
+#[cfg(test)]
+pub(super) const COMMANDS: &[&str] = &[
+    "audit",
+    "audit-baseline",
+    "bench",
+    "lint",
+    "observe",
+    "review",
+    "test",
+    "trace",
+];
+
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
     match command {
         Commands::Test(args) => map(test::run(args, global)),

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -7,6 +7,34 @@ use crate::commands::{
     version, worktree, GlobalArgs,
 };
 
+#[cfg(test)]
+pub(super) const COMMANDS: &[&str] = &[
+    "agent-task",
+    "build",
+    "changelog",
+    "changes",
+    "cleanup",
+    "component",
+    "config",
+    "docs",
+    "extension",
+    "lab",
+    "project",
+    "refactor",
+    "refs",
+    "release",
+    "report",
+    "rig",
+    "runner",
+    "runs",
+    "runtime",
+    "stack",
+    "tunnel",
+    "undo",
+    "version",
+    "worktree",
+];
+
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
     match command {
         Commands::AgentTask(args) => map(agent_task::run(args, global)),


### PR DESCRIPTION
## Summary
- add a shared command registry for top-level JSON output families
- reuse registry-backed descriptor helpers for common JSON envelope commands
- add drift coverage between the visible command surface, registry, and JSON dispatch modules

## Tests
- `cargo test command_contract`
- `cargo test json_output`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused refactor and tests; Chris reviewed and directed the investigation scope.