### PR TITLE
Surface Lab run evidence followups

### DIFF
--- a/docs/commands/lab.md
+++ b/docs/commands/lab.md
@@ -32,6 +32,10 @@ routine lifecycle work:
 - `homeboy runs latest-run --kind bench` resolves the latest benchmark run id.
 - `homeboy runs artifacts <run-id>` lists recorded run artifacts through
   Homeboy.
+- `homeboy runs evidence <run-id>` shows the stable evidence summary and
+  reviewer-facing commands for one persisted run.
+- `homeboy runs refs --kind bench --limit 10` lists recent benchmark run and
+  artifact refs when you need shareable evidence handles.
 - `homeboy runner doctor <runner>` probes runner tools, workspace writability,
   artifact storage, and browser readiness.
 - `homeboy runner env <runner>` prints the redacted runner job environment.

--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -521,6 +521,16 @@ fn lab_followups(runner_id: Option<&str>, current_workspace: Option<&str>) -> Ve
             command: "homeboy runs artifacts <run-id>".to_string(),
             purpose: "List recorded artifacts for a run through Homeboy instead of spelunking runner paths.",
         },
+        LabFollowup {
+            label: "run_evidence",
+            command: "homeboy runs evidence <run-id>".to_string(),
+            purpose: "Show the stable evidence summary and reviewer-facing commands for one persisted run.",
+        },
+        LabFollowup {
+            label: "bench_refs",
+            command: "homeboy runs refs --kind bench --limit 10".to_string(),
+            purpose: "List recent benchmark run and artifact refs when you need shareable evidence handles.",
+        },
     ];
 
     let Some(runner_id) = runner_id else {
@@ -784,6 +794,8 @@ Installing declared dependencies...
         assert!(commands.contains(&"homeboy runs list --limit 5"));
         assert!(commands.contains(&"homeboy runs latest-run --kind bench"));
         assert!(commands.contains(&"homeboy runs artifacts <run-id>"));
+        assert!(commands.contains(&"homeboy runs evidence <run-id>"));
+        assert!(commands.contains(&"homeboy runs refs --kind bench --limit 10"));
         assert!(commands.contains(&"homeboy runner doctor homeboy-lab"));
         assert!(commands.contains(&"homeboy runner env homeboy-lab"));
         assert!(commands.contains(
@@ -804,6 +816,8 @@ Installing declared dependencies...
         assert!(commands.contains(&"homeboy runs list --limit 5"));
         assert!(commands.contains(&"homeboy runs latest-run --kind bench"));
         assert!(commands.contains(&"homeboy runs artifacts <run-id>"));
+        assert!(commands.contains(&"homeboy runs evidence <run-id>"));
+        assert!(commands.contains(&"homeboy runs refs --kind bench --limit 10"));
         assert!(!commands
             .iter()
             .any(|command| command.starts_with("homeboy runner ")));


### PR DESCRIPTION
## Summary
- add `runs evidence` and `runs refs` to Lab managed followups
- document the evidence followups in the Lab command docs
- preserve existing JSON shape by only adding followup list entries

## Tests
- `cargo test lab_followups`
- `cargo test --test command_surface_test`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Lab followup UX change and tests; Chris directed the operator-surfacing investigation.