### PR TITLE
Compile repo loop specs into agent-task plans

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -36,6 +36,19 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `auth` | Configure and inspect provider authentication secrets. |
 | `controller` | Create, inspect, and resume durable multi-agent loop controller state. |
 
+## Loop Spec Compilation
+
+`agent-task compile-loop --definition <SPEC>` compiles a declarative loop spec into
+an executable `homeboy/agent-task-plan/v1` without submitting or running it. It
+accepts Homeboy's native `homeboy/agent-task-loop-definition/v1` shape and the
+repo-authored workflow-oriented loop spec shape used by WPSG-style controllers.
+
+Repo-style compilation is intentionally deterministic: workflow ids become task
+ids, artifact producers are wired to consumers through `output_dependencies`, and
+declared emitted artifacts become `artifact_outputs`. Controller-only sections
+such as transition policies, phases, arbitrary actions, initial events, and
+entity fan-out are rejected with explicit diagnostics instead of being ignored.
+
 ## Dispatch
 
 `agent-task dispatch` builds a durable task plan from common repo-cooking inputs

--- a/src/commands/agent_task/loop_definition.rs
+++ b/src/commands/agent_task/loop_definition.rs
@@ -8,14 +8,13 @@ use super::args::CompileLoopArgs;
 
 pub(super) fn compile_loop(args: CompileLoopArgs) -> CmdResult<Value> {
     let raw = config::read_json_spec_to_string(&args.definition)?;
-    let definition: loop_definition::AgentTaskLoopDefinition =
-        serde_json::from_str(&raw).map_err(|error| {
-            Error::validation_invalid_json(
-                error,
-                Some("agent-task loop definition".to_string()),
-                Some(raw.clone()),
-            )
-        })?;
-    let plan = loop_definition::compile_loop_definition(definition)?;
+    let value: Value = serde_json::from_str(&raw).map_err(|error| {
+        Error::validation_invalid_json(
+            error,
+            Some("agent-task loop definition".to_string()),
+            Some(raw.clone()),
+        )
+    })?;
+    let plan = loop_definition::compile_loop_spec_value(value)?;
     Ok((serde_json::to_value(plan).unwrap_or(Value::Null), 0))
 }

--- a/src/commands/agent_task/tests.rs
+++ b/src/commands/agent_task/tests.rs
@@ -175,6 +175,105 @@ fn compile_loop_command_emits_agent_task_plan() {
 }
 
 #[test]
+fn compile_loop_command_emits_plan_from_repo_loop_spec() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let definition_path = temp.path().join("repo-loop.json");
+    std::fs::write(
+        &definition_path,
+        serde_json::to_string(&json!({
+            "schema": "wpsg/loop-spec/v1",
+            "loop_id": "wpsg/site-loop",
+            "metadata": {
+                "group_key": "wpsg-site",
+                "dispatch_defaults": {
+                    "backend": "fixture",
+                    "selector": "local",
+                    "cwd": temp.path().display().to_string(),
+                    "repo": "wp-site-generator@fixture"
+                }
+            },
+            "agents": [
+                { "agent_id": "builder", "tools": ["write-file"], "abilities": ["render-blocks"] }
+            ],
+            "artifacts": [
+                { "artifact_id": "site_brief", "kind": "wpsg/SiteBrief/v1", "required": true },
+                { "artifact_id": "theme_patch", "kind": "homeboy/Patch/v1", "required": true }
+            ],
+            "workflows": [
+                {
+                    "workflow_id": "brief",
+                    "agent_id": "builder",
+                    "prompt": "Draft the site brief.",
+                    "emits": ["site_brief"]
+                },
+                {
+                    "workflow_id": "build",
+                    "prompt": "Build from the site brief.",
+                    "consumes": ["site_brief"],
+                    "emits": ["theme_patch"]
+                }
+            ]
+        }))
+        .expect("definition json"),
+    )
+    .expect("write definition");
+
+    let (value, status) = loop_definition::compile_loop(CompileLoopArgs {
+        definition: format!("@{}", definition_path.display()),
+    })
+    .expect("compile loop");
+
+    assert_eq!(status, 0);
+    assert_eq!(value["schema"], "homeboy/agent-task-plan/v1");
+    assert_eq!(value["plan_id"], "wpsg/site-loop");
+    assert_eq!(value["group_key"], "wpsg-site");
+    assert_eq!(value["tasks"][0]["task_id"], "brief");
+    assert_eq!(value["tasks"][0]["executor"]["backend"], "fixture");
+    assert_eq!(
+        value["tasks"][0]["executor"]["required_capabilities"],
+        json!(["tool:write-file", "ability:render-blocks"])
+    );
+    assert_eq!(
+        value["tasks"][0]["workspace"]["slug"],
+        "wp-site-generator@fixture"
+    );
+    assert_eq!(
+        value["output_dependencies"]["build"]["depends_on"],
+        json!(["brief"])
+    );
+    assert_eq!(
+        value["output_dependencies"]["build"]["bindings"]["site_brief"]["task_id"],
+        "brief"
+    );
+    assert_eq!(
+        value["artifact_outputs"]["brief"][0]["kind"],
+        "wpsg/SiteBrief/v1"
+    );
+}
+
+#[test]
+fn compile_loop_command_rejects_controller_only_sections() {
+    let error = loop_definition::compile_loop(CompileLoopArgs {
+        definition: serde_json::to_string(&json!({
+            "loop_id": "repo-loop-with-controller-policy",
+            "workflows": [
+                { "workflow_id": "brief", "prompt": "Draft the site brief." }
+            ],
+            "policy": { "policy_id": "runtime-policy", "transitions": [] }
+        }))
+        .expect("definition json"),
+    })
+    .expect_err("controller-only section is rejected");
+
+    assert!(error.message.contains("controller-only sections"));
+    assert!(error.details["tried"]
+        .as_array()
+        .expect("diagnostics")
+        .iter()
+        .any(|diagnostic| diagnostic.as_str().unwrap_or_default().contains("policy")));
+}
+
+#[test]
 fn from_spec_dispatch_defaults_use_spec_git_checkout() {
     let repo = tempfile::tempdir().expect("repo dir");
     let git_status = Command::new("git")

--- a/src/core/agent_task_loop_definition.rs
+++ b/src/core/agent_task_loop_definition.rs
@@ -3,7 +3,14 @@ use std::collections::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::core::agent_task::{AgentTaskComponentContract, AgentTaskRequest};
+use crate::core::agent_task::{
+    AgentTaskArtifactDeclaration, AgentTaskComponentContract, AgentTaskExecutor, AgentTaskLimits,
+    AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace, AgentTaskWorkspaceMode,
+    AGENT_TASK_REQUEST_SCHEMA,
+};
+use crate::core::agent_task_controller_service::{
+    AgentTaskRepoLoopSpec, AgentTaskRepoLoopSpecArtifact, AgentTaskRepoLoopSpecWorkflow,
+};
 use crate::core::agent_task_schedule::{
     AgentTaskArtifactOutputDeclaration, AgentTaskOutputBinding, AgentTaskOutputDependencies,
     AgentTaskPlan, AgentTaskScheduleOptions,
@@ -81,6 +88,416 @@ pub fn compile_loop_definition(definition: AgentTaskLoopDefinition) -> Result<Ag
 
     plan.rebuild_homeboy_plan();
     Ok(plan)
+}
+
+pub fn compile_loop_spec_value(value: Value) -> Result<AgentTaskPlan> {
+    if value.get("tasks").is_some_and(|tasks| tasks.is_array())
+        && value
+            .get("tasks")
+            .and_then(Value::as_array)
+            .is_some_and(|tasks| tasks.iter().any(|task| task.get("request").is_some()))
+    {
+        let definition: AgentTaskLoopDefinition =
+            serde_json::from_value(value).map_err(|error| {
+                Error::validation_invalid_argument(
+                    "definition",
+                    error.to_string(),
+                    Some("agent-task loop definition".to_string()),
+                    None,
+                )
+            })?;
+        return compile_loop_definition(definition);
+    }
+
+    let spec: AgentTaskRepoLoopSpec = serde_json::from_value(value).map_err(|error| {
+        Error::validation_invalid_argument(
+            "definition",
+            error.to_string(),
+            Some("repo loop spec".to_string()),
+            None,
+        )
+    })?;
+    compile_repo_loop_spec(spec)
+}
+
+fn compile_repo_loop_spec(spec: AgentTaskRepoLoopSpec) -> Result<AgentTaskPlan> {
+    validate_repo_loop_spec_for_agent_task_plan(&spec)?;
+
+    let mut tasks = Vec::new();
+    let mut output_dependencies: HashMap<String, AgentTaskOutputDependencies> = HashMap::new();
+    let mut artifact_outputs: HashMap<String, Vec<AgentTaskArtifactOutputDeclaration>> =
+        HashMap::new();
+
+    for workflow in &spec.workflows {
+        let request = repo_loop_workflow_request(&spec, workflow)?;
+        let dependencies = repo_loop_workflow_output_dependencies(&spec, workflow);
+        if !dependencies.depends_on.is_empty() || !dependencies.bindings.is_empty() {
+            output_dependencies.insert(workflow.workflow_id.clone(), dependencies);
+        }
+        let outputs = repo_loop_workflow_artifact_outputs(&spec, workflow);
+        if !outputs.is_empty() {
+            artifact_outputs.insert(workflow.workflow_id.clone(), outputs);
+        }
+        tasks.push(request);
+    }
+
+    let mut plan = AgentTaskPlan::new(spec.loop_id.clone(), tasks);
+    plan.group_key = optional_metadata_string(&spec.metadata, "group_key");
+    plan.output_dependencies = output_dependencies;
+    plan.artifact_outputs = artifact_outputs;
+    plan.metadata = serde_json::json!({
+        "source_schema": spec.schema,
+        "loop_id": spec.loop_id,
+        "config_version": spec.config_version,
+        "source": "repo_loop_spec",
+    });
+    plan.rebuild_homeboy_plan();
+    Ok(plan)
+}
+
+fn validate_repo_loop_spec_for_agent_task_plan(spec: &AgentTaskRepoLoopSpec) -> Result<()> {
+    if spec.loop_id.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "loop_id",
+            "repo loop spec requires a non-empty loop_id",
+            None,
+            None,
+        ));
+    }
+    if spec.workflows.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "workflows",
+            "repo loop spec must include at least one workflow to compile an agent-task plan",
+            Some(spec.loop_id.clone()),
+            None,
+        ));
+    }
+
+    let unsupported = unsupported_repo_loop_spec_fields(spec);
+    if !unsupported.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "definition",
+            "repo loop spec contains controller-only sections that cannot be compiled into a deterministic agent-task plan",
+            Some(spec.loop_id.clone()),
+            Some(unsupported),
+        ));
+    }
+
+    let mut workflow_ids = HashSet::new();
+    for workflow in &spec.workflows {
+        if workflow.workflow_id.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "workflows[].workflow_id",
+                "repo loop spec workflow requires a non-empty workflow_id",
+                Some(spec.loop_id.clone()),
+                None,
+            ));
+        }
+        if !workflow_ids.insert(workflow.workflow_id.clone()) {
+            return Err(Error::validation_invalid_argument(
+                "workflows[].workflow_id",
+                format!("duplicate workflow_id {}", workflow.workflow_id),
+                Some(spec.loop_id.clone()),
+                None,
+            ));
+        }
+        if workflow
+            .prompt
+            .as_deref()
+            .unwrap_or_default()
+            .trim()
+            .is_empty()
+            && workflow.tasks.is_empty()
+        {
+            return Err(Error::validation_invalid_argument(
+                "workflows[]",
+                "repo loop spec workflow requires prompt or tasks",
+                Some(workflow.workflow_id.clone()),
+                None,
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn unsupported_repo_loop_spec_fields(spec: &AgentTaskRepoLoopSpec) -> Vec<String> {
+    let mut unsupported = Vec::new();
+    if spec.policy.is_some() {
+        unsupported.push(
+            "policy: controller transition policies are not executable task records".to_string(),
+        );
+    }
+    if !spec.phases.is_empty() {
+        unsupported.push(
+            "phases: controller phase transitions are not executable task records".to_string(),
+        );
+    }
+    if !spec.actions.is_empty() {
+        unsupported.push(
+            "actions: arbitrary controller actions are not executable task records".to_string(),
+        );
+    }
+    if spec.initial_event.is_some() {
+        unsupported
+            .push("initial_event: event evaluation belongs to agent-task controller".to_string());
+    }
+    for workflow in &spec.workflows {
+        if !workflow.entity_ids.is_empty() {
+            unsupported.push(format!(
+                "workflows[{}].entity_ids: fan-out expansion needs explicit entity materialization before compile-loop",
+                workflow.workflow_id
+            ));
+        }
+    }
+    unsupported
+}
+
+fn repo_loop_workflow_request(
+    spec: &AgentTaskRepoLoopSpec,
+    workflow: &AgentTaskRepoLoopSpecWorkflow,
+) -> Result<AgentTaskRequest> {
+    let defaults = spec
+        .metadata
+        .get("dispatch_defaults")
+        .and_then(Value::as_object);
+    let backend = defaults
+        .and_then(|defaults| defaults.get("backend"))
+        .and_then(Value::as_str)
+        .unwrap_or("agent-task")
+        .to_string();
+    let selector = defaults
+        .and_then(|defaults| defaults.get("selector"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let model = defaults
+        .and_then(|defaults| defaults.get("model"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let secret_env = defaults
+        .and_then(|defaults| defaults.get("secret_env"))
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    let config = defaults
+        .and_then(|defaults| defaults.get("provider_config"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    Ok(AgentTaskRequest {
+        schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+        task_id: workflow.workflow_id.clone(),
+        group_key: optional_metadata_string(&spec.metadata, "group_key"),
+        parent_plan_id: Some(spec.loop_id.clone()),
+        executor: AgentTaskExecutor {
+            backend,
+            selector,
+            runtime_selection: None,
+            required_capabilities: repo_loop_required_capabilities(spec, workflow),
+            secret_env,
+            model,
+            config,
+        },
+        instructions: repo_loop_workflow_instructions(workflow),
+        inputs: workflow.inputs.clone(),
+        source_refs: Vec::new(),
+        workspace: repo_loop_workspace(spec),
+        component_contracts: Vec::new(),
+        policy: AgentTaskPolicy::default(),
+        limits: AgentTaskLimits::default(),
+        expected_artifacts: Vec::new(),
+        artifact_declarations: repo_loop_workflow_artifact_declarations(spec, workflow),
+        metadata: serde_json::json!({
+            "source": "repo_loop_spec",
+            "loop_id": spec.loop_id,
+            "workflow_id": workflow.workflow_id,
+            "agent_id": workflow.agent_id,
+            "tools": workflow.tools,
+            "abilities": workflow.abilities,
+            "consumes": workflow.consumes,
+            "emits": workflow.emits,
+        }),
+    })
+}
+
+fn repo_loop_workspace(spec: &AgentTaskRepoLoopSpec) -> AgentTaskWorkspace {
+    let defaults = spec
+        .metadata
+        .get("dispatch_defaults")
+        .and_then(Value::as_object);
+    AgentTaskWorkspace {
+        mode: if defaults.is_some() {
+            AgentTaskWorkspaceMode::Existing
+        } else {
+            AgentTaskWorkspaceMode::Ephemeral
+        },
+        root: defaults
+            .and_then(|defaults| defaults.get("cwd"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        slug: defaults
+            .and_then(|defaults| defaults.get("repo"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        cleanup: Some("preserve".to_string()),
+        ..AgentTaskWorkspace::default()
+    }
+}
+
+fn repo_loop_workflow_instructions(workflow: &AgentTaskRepoLoopSpecWorkflow) -> String {
+    if let Some(prompt) = workflow.prompt.as_ref().filter(|prompt| !prompt.is_empty()) {
+        return prompt.clone();
+    }
+    workflow
+        .tasks
+        .iter()
+        .map(|task| format!("- {task}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn repo_loop_required_capabilities(
+    spec: &AgentTaskRepoLoopSpec,
+    workflow: &AgentTaskRepoLoopSpecWorkflow,
+) -> Vec<String> {
+    let mut capabilities = Vec::new();
+    if let Some(agent_id) = &workflow.agent_id {
+        if let Some(agent) = spec.agents.iter().find(|agent| &agent.agent_id == agent_id) {
+            for tool_id in &agent.tools {
+                push_capability(&mut capabilities, "tool", tool_id);
+            }
+            for ability_id in &agent.abilities {
+                push_capability(&mut capabilities, "ability", ability_id);
+            }
+        }
+    }
+    for tool_id in &workflow.tools {
+        push_capability(&mut capabilities, "tool", tool_id);
+    }
+    for ability_id in &workflow.abilities {
+        push_capability(&mut capabilities, "ability", ability_id);
+    }
+    capabilities
+}
+
+fn push_capability(capabilities: &mut Vec<String>, kind: &str, id: &str) {
+    let capability = format!("{kind}:{id}");
+    if !capabilities.contains(&capability) {
+        capabilities.push(capability);
+    }
+}
+
+fn repo_loop_workflow_artifact_declarations(
+    spec: &AgentTaskRepoLoopSpec,
+    workflow: &AgentTaskRepoLoopSpecWorkflow,
+) -> Vec<AgentTaskArtifactDeclaration> {
+    workflow
+        .artifacts
+        .iter()
+        .chain(workflow.emits.iter())
+        .filter_map(|artifact_id| repo_loop_artifact(spec, artifact_id))
+        .map(|artifact| AgentTaskArtifactDeclaration {
+            name: artifact.artifact_id.clone(),
+            artifact_type: Some(artifact.kind.clone()),
+            artifact_schema: None,
+            path: None,
+            required: artifact.required,
+            description: artifact.description.clone(),
+            metadata: Value::Null,
+        })
+        .collect()
+}
+
+fn repo_loop_workflow_artifact_outputs(
+    spec: &AgentTaskRepoLoopSpec,
+    workflow: &AgentTaskRepoLoopSpecWorkflow,
+) -> Vec<AgentTaskArtifactOutputDeclaration> {
+    workflow
+        .artifacts
+        .iter()
+        .chain(workflow.emits.iter())
+        .filter_map(|artifact_id| repo_loop_artifact(spec, artifact_id))
+        .map(|artifact| AgentTaskArtifactOutputDeclaration {
+            name: artifact.artifact_id.clone(),
+            kind: artifact.kind.clone(),
+            schema: None,
+            artifact_id: Some(artifact.artifact_id.clone()),
+            payload_path: None,
+        })
+        .collect()
+}
+
+fn repo_loop_workflow_output_dependencies(
+    spec: &AgentTaskRepoLoopSpec,
+    workflow: &AgentTaskRepoLoopSpecWorkflow,
+) -> AgentTaskOutputDependencies {
+    let mut depends_on = Vec::new();
+    let mut bindings = HashMap::new();
+    for artifact_id in workflow.consumes.iter().chain(workflow.dependencies.iter()) {
+        for producer in repo_loop_artifact_producers(spec, workflow, artifact_id) {
+            if !depends_on.contains(&producer.workflow_id) {
+                depends_on.push(producer.workflow_id.clone());
+            }
+            bindings
+                .entry(artifact_id.clone())
+                .or_insert(AgentTaskOutputBinding {
+                    task_id: producer.workflow_id.clone(),
+                    path: format!("/typed_artifacts/{artifact_id}"),
+                    artifact: repo_loop_artifact(spec, artifact_id).map(|artifact| {
+                        crate::core::agent_task_schedule::AgentTaskArtifactBinding {
+                            kind: artifact.kind.clone(),
+                            schema: None,
+                            artifact_id: Some(artifact.artifact_id.clone()),
+                            payload_path: None,
+                        }
+                    }),
+                    required: true,
+                    default: Value::Null,
+                });
+        }
+    }
+    AgentTaskOutputDependencies {
+        depends_on,
+        bindings,
+    }
+}
+
+fn repo_loop_artifact<'a>(
+    spec: &'a AgentTaskRepoLoopSpec,
+    artifact_id: &str,
+) -> Option<&'a AgentTaskRepoLoopSpecArtifact> {
+    spec.artifacts
+        .iter()
+        .find(|artifact| artifact.artifact_id == artifact_id)
+}
+
+fn repo_loop_artifact_producers<'a>(
+    spec: &'a AgentTaskRepoLoopSpec,
+    consumer: &AgentTaskRepoLoopSpecWorkflow,
+    artifact_id: &str,
+) -> Vec<&'a AgentTaskRepoLoopSpecWorkflow> {
+    spec.workflows
+        .iter()
+        .filter(|producer| producer.workflow_id != consumer.workflow_id)
+        .filter(|producer| {
+            producer.artifacts.iter().any(|id| id == artifact_id)
+                || producer.emits.iter().any(|id| id == artifact_id)
+        })
+        .collect()
+}
+
+fn optional_metadata_string(metadata: &Value, key: &str) -> Option<String> {
+    metadata
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
 }
 
 fn validate_loop_definition(definition: &AgentTaskLoopDefinition) -> Result<()> {

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -107,8 +107,8 @@ pub use super::agent_task_loop_controller::{
     AgentTaskLoopControllerState, AgentTaskLoopTaskLineage,
 };
 pub use super::agent_task_loop_definition::{
-    compile_loop_definition, AgentTaskLoopDefinition, AgentTaskLoopDefinitionTask,
-    AGENT_TASK_LOOP_DEFINITION_SCHEMA,
+    compile_loop_definition, compile_loop_spec_value, AgentTaskLoopDefinition,
+    AgentTaskLoopDefinitionTask, AGENT_TASK_LOOP_DEFINITION_SCHEMA,
 };
 
 // Secret-env status type is referenced from review/dispatch commands.
@@ -235,8 +235,8 @@ pub mod loop_controller {
 /// Declarative loop definitions compiled into scheduler plans.
 pub mod loop_definition {
     pub use super::super::agent_task_loop_definition::{
-        compile_loop_definition, AgentTaskLoopDefinition, AgentTaskLoopDefinitionTask,
-        AGENT_TASK_LOOP_DEFINITION_SCHEMA,
+        compile_loop_definition, compile_loop_spec_value, AgentTaskLoopDefinition,
+        AgentTaskLoopDefinitionTask, AGENT_TASK_LOOP_DEFINITION_SCHEMA,
     };
 }
 


### PR DESCRIPTION
## Summary
- Extend agent-task compile-loop to accept repo/WPSG-style workflow loop specs as well as native loop definitions.
- Compile workflow ids into deterministic task ids, emitted artifacts into artifact_outputs, and artifact consumers into output_dependencies.
- Reject controller-only sections such as policy, phases, actions, initial_event, and entity fan-out with explicit diagnostics.
- Document the expanded compile-loop contract.

## Tests
- cargo test compile_loop --lib
- cargo test agent_task_loop_definition --lib
- cargo clippy --lib (passes with existing warning baseline)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested generic agent-task loop spec compiler primitive.