### PR TITLE
refactor(commands): remove dead code + fix adapter naming (#5113, #5132)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -118,6 +118,7 @@
       ]
     },
     "convention_exception_globs": [
+      "src/commands/adapter.rs",
       "src/core/code_audit/detectors/test_coverage.rs",
       "src/core/code_audit/detectors/test_vacuity.rs",
       "src/core/code_audit/detectors/upstream_workaround.rs"

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -77,7 +77,7 @@ pub struct CommandDescriptor {
 }
 
 impl CommandOutputDescriptor {
-    pub fn with_lab_contract(
+    fn with_lab_contract(
         self,
         contract: Option<super::lab::LabCommandContract>,
     ) -> CommandDescriptor {

--- a/src/commands/adapter.rs
+++ b/src/commands/adapter.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 
 use crate::command_contract::{
     CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode,
-    CommandRawOutputMode, CommandResponseMode,
+    CommandResponseMode,
 };
 
 use super::GlobalArgs;
@@ -35,7 +35,7 @@ pub(crate) struct CommandAdapterContract {
 }
 
 impl CommandAdapterContract {
-    pub fn to_output_descriptor(self) -> CommandOutputDescriptor {
+    fn to_output_descriptor(self) -> CommandOutputDescriptor {
         CommandOutputDescriptor {
             response_mode: self.response_mode,
             output_file_mode: self.output_file_mode,
@@ -72,25 +72,6 @@ impl<Args> TypedCommandAdapter<Args> {
             execute_json: Some(execute_json),
         }
     }
-
-    #[allow(dead_code)]
-    pub fn raw_only(
-        raw_mode: CommandRawOutputMode,
-        json_family: CommandJsonFamily,
-        output_file_mode: CommandOutputFileMode,
-        output_contract: CommandOutputContractKind,
-    ) -> Self {
-        Self {
-            contract: CommandAdapterContract {
-                response_mode: CommandResponseMode::Raw(raw_mode),
-                output_file_mode,
-                json_family,
-                output_contract,
-                lab_runner: CommandLabRunnerPolicy::LOCAL,
-            },
-            execute_json: None,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -115,27 +96,5 @@ mod tests {
         );
         assert_eq!(descriptor.json_family, CommandJsonFamily::Workspace);
         assert!(adapter.execute_json.is_some());
-    }
-
-    #[test]
-    fn raw_contract_can_express_supported_raw_modes() {
-        for raw_mode in [
-            CommandRawOutputMode::Markdown,
-            CommandRawOutputMode::PlainText,
-            CommandRawOutputMode::InteractivePassthrough,
-        ] {
-            let adapter = TypedCommandAdapter::<()>::raw_only(
-                raw_mode,
-                CommandJsonFamily::RawOnly,
-                CommandOutputFileMode::None,
-                CommandOutputContractKind::RawOnly,
-            );
-
-            assert_eq!(
-                adapter.output_descriptor().response_mode,
-                CommandResponseMode::Raw(raw_mode)
-            );
-            assert!(adapter.execute_json.is_none());
-        }
     }
 }


### PR DESCRIPTION
## Summary
Clears two audit findings in the command-contract / adapter layer (both live in `src/commands/adapter.rs`, so handled as one cook).

### #5113 — dead code (4)
- **`CommandOutputDescriptor::with_lab_contract`** (`src/command_contract/output.rs`) — only referenced same-file by `Commands::descriptor`; narrowed `pub fn` → private `fn`.
- **`CommandAdapterContract::to_output_descriptor`** (`src/commands/adapter.rs`) — only referenced same-file by `TypedCommandAdapter::output_descriptor`; narrowed `pub fn` → private `fn`.
- **`TypedCommandAdapter::raw_only`** (`src/commands/adapter.rs`) — genuinely production-dead (carried `#[allow(dead_code)]`; only consumer was its own unit test). Removed the fn, its `#[allow(dead_code)]` marker, the test that only existed to exercise it, and the now-unused `CommandRawOutputMode` import.

### #5132 — naming mismatch (1) — false positive, fixed via convention config
- The directory-convention detector flags `src/commands/adapter.rs` because its types (`CommandLabRunnerPolicy`, `CommandAdapterContract`, `TypedCommandAdapter`, `JsonCommandRun`) don't match the `Args` suffix that dominates `src/commands/`. This file is adapter/contract **infrastructure**, not a command-args module — `CommandLabRunnerPolicy` is a *policy* type, and renaming it to an `Args` suffix would be semantically wrong (and wouldn't clear the finding, since `helper_like` requires *all* types in the file to miss the suffix).
- The detector's own suggestion offers "treat this as a utility/helper" as the first remedy. Added `src/commands/adapter.rs` to `convention_exception_globs` in `homeboy.json` — the established mechanism already used for similar infra files (test_coverage/test_vacuity/upstream_workaround detectors).

## Validation
- `cargo build --lib --tests` — clean (only 2 pre-existing warnings in unrelated files).
- `cargo test --lib command_contract::output::tests` / `commands::adapter::tests` — pass.
- Re-ran `homeboy audit`: target findings cleared (`CommandLabRunnerPolicy`, `with_lab_contract`, `to_output_descriptor`, `raw_only` → 0 remaining); `naming_mismatch` count dropped 9 → 7 (also cleared the sibling `JsonCommandRun` in the same exempted file). No new findings introduced.
- `cargo fmt` applied.

> Note: the 58 `bench`/`trace`/`component_env_detector` failures from `cargo test commands` are environmental — this VPS mounts `/tmp` `noexec`, so fixture `.sh` scripts fail with exit 126 (Permission denied). Pre-existing, unrelated to this change.

Closes #5113
Closes #5132