### PR TITLE
Route JSON dispatch through command registry

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -25,9 +25,9 @@ pub use lab::{
     LabSourcePathMode, LabWorkspaceModePolicy, LAB_TRACE_EXTRA_TOOLS,
 };
 pub use output::{
-    registered_command_json_family, CommandDescriptor, CommandJsonFamily,
-    CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode,
-    CommandRawOutputMode, CommandRegistryEntry, CommandResponseMode, CommandResponsePlan,
-    CommandStdoutMode, COMMAND_REGISTRY,
+    registered_command_dispatch_family, registered_command_json_family, CommandDescriptor,
+    CommandDispatchFamily, CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor,
+    CommandOutputFileMode, CommandRawOutputMode, CommandRegistryEntry, CommandResponseMode,
+    CommandResponsePlan, CommandStdoutMode, COMMAND_REGISTRY,
 };
 pub use public_variants::{PublicOutputVariantContract, PUBLIC_OUTPUT_VARIANT_CONTRACTS};

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -52,6 +52,25 @@ pub enum CommandJsonFamily {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandDispatchFamily {
+    Quality,
+    Workspace,
+    Ops,
+    RawOnly,
+}
+
+impl From<CommandJsonFamily> for CommandDispatchFamily {
+    fn from(json_family: CommandJsonFamily) -> Self {
+        match json_family {
+            CommandJsonFamily::Quality => CommandDispatchFamily::Quality,
+            CommandJsonFamily::Workspace => CommandDispatchFamily::Workspace,
+            CommandJsonFamily::Ops => CommandDispatchFamily::Ops,
+            CommandJsonFamily::RawOnly => CommandDispatchFamily::RawOnly,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandOutputContractKind {
     JsonEnvelope,
     RawOnly,
@@ -139,6 +158,10 @@ pub fn registered_command_json_family(name: &str) -> Option<CommandJsonFamily> {
         .iter()
         .find(|entry| entry.name == name)
         .map(|entry| entry.json_family)
+}
+
+pub fn registered_command_dispatch_family(name: &str) -> Option<CommandDispatchFamily> {
+    registered_command_json_family(name).map(Into::into)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 
 use crate::cli_surface::Commands;
-use crate::command_contract::CommandJsonFamily;
+use crate::command_contract::{registered_command_dispatch_family, CommandDispatchFamily};
 
 use super::agent_task_summary::{agent_task_summary_kind, render_agent_task_summary};
 use super::output_runtime::{CommandPresentation, JsonCommandRun};
@@ -67,12 +67,19 @@ fn agent_task_summary_kind_for_output_mode(
 }
 
 fn dispatch(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Value>, i32) {
-    match command.output_descriptor(false).json_family {
-        CommandJsonFamily::Quality => quality::dispatch(command, global),
-        CommandJsonFamily::Workspace => workspace::dispatch(command, global),
-        CommandJsonFamily::Ops => ops::dispatch(command, global),
-        CommandJsonFamily::RawOnly => unsupported_raw_command("List command uses raw output mode"),
+    match dispatch_family(&command) {
+        CommandDispatchFamily::Quality => quality::dispatch(command, global),
+        CommandDispatchFamily::Workspace => workspace::dispatch(command, global),
+        CommandDispatchFamily::Ops => ops::dispatch(command, global),
+        CommandDispatchFamily::RawOnly => {
+            unsupported_raw_command("List command uses raw output mode")
+        }
     }
+}
+
+fn dispatch_family(command: &Commands) -> CommandDispatchFamily {
+    registered_command_dispatch_family(command.top_level_name())
+        .expect("top-level command should be registered")
 }
 
 fn map<T: serde::Serialize>(result: super::CmdResult<T>) -> JsonRun {
@@ -87,9 +94,8 @@ fn unsupported_raw_command(message: &'static str) -> JsonRun {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::command_contract::{CommandJsonFamily, COMMAND_REGISTRY};
+    use crate::command_contract::CommandDispatchFamily;
     use crate::commands::agent_task::{AgentTaskArgs, AgentTaskCommand, StatusArgs};
-    use std::collections::BTreeMap;
 
     #[test]
     fn list_json_dispatch_reports_raw_output_mode() {
@@ -116,42 +122,10 @@ mod tests {
     }
 
     #[test]
-    fn json_dispatch_modules_match_command_registry_families() {
-        let mut registered: BTreeMap<&str, CommandJsonFamily> = COMMAND_REGISTRY
-            .iter()
-            .map(|entry| (entry.name, entry.json_family))
-            .collect();
-        assert_eq!(registered.remove("list"), Some(CommandJsonFamily::RawOnly));
-
-        assert_family_commands(
-            &mut registered,
-            CommandJsonFamily::Quality,
-            quality::COMMANDS,
+    fn json_dispatch_family_comes_from_command_registry() {
+        assert_eq!(
+            dispatch_family(&Commands::List),
+            CommandDispatchFamily::RawOnly
         );
-        assert_family_commands(
-            &mut registered,
-            CommandJsonFamily::Workspace,
-            workspace::COMMANDS,
-        );
-        assert_family_commands(&mut registered, CommandJsonFamily::Ops, ops::COMMANDS);
-
-        assert!(
-            registered.is_empty(),
-            "unclaimed JSON commands: {registered:?}"
-        );
-    }
-
-    fn assert_family_commands(
-        registered: &mut BTreeMap<&'static str, CommandJsonFamily>,
-        expected_family: CommandJsonFamily,
-        commands: &[&'static str],
-    ) {
-        for command in commands {
-            assert_eq!(
-                registered.remove(command),
-                Some(expected_family),
-                "{command} JSON dispatch family drifted from command registry"
-            );
-        }
     }
 }

--- a/src/commands/json_output/ops.rs
+++ b/src/commands/json_output/ops.rs
@@ -6,12 +6,6 @@ use crate::commands::{
     self_cmd, server, ssh, status, triage, upgrade, GlobalArgs,
 };
 
-#[cfg(test)]
-pub(super) const COMMANDS: &[&str] = &[
-    "api", "auth", "ci", "daemon", "db", "deploy", "deps", "doctor", "file", "fleet", "git",
-    "http", "issues", "logs", "self", "server", "ssh", "status", "triage", "upgrade",
-];
-
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
     match command {
         Commands::Status(args) => map(status::run(args, global)),

--- a/src/commands/json_output/quality.rs
+++ b/src/commands/json_output/quality.rs
@@ -5,18 +5,6 @@ use crate::commands::{
     audit, audit_baseline, bench, lint, observe, review, test, trace, GlobalArgs,
 };
 
-#[cfg(test)]
-pub(super) const COMMANDS: &[&str] = &[
-    "audit",
-    "audit-baseline",
-    "bench",
-    "lint",
-    "observe",
-    "review",
-    "test",
-    "trace",
-];
-
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
     match command {
         Commands::Test(args) => map(test::run(args, global)),

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -7,34 +7,6 @@ use crate::commands::{
     version, worktree, GlobalArgs,
 };
 
-#[cfg(test)]
-pub(super) const COMMANDS: &[&str] = &[
-    "agent-task",
-    "build",
-    "changelog",
-    "changes",
-    "cleanup",
-    "component",
-    "config",
-    "docs",
-    "extension",
-    "lab",
-    "project",
-    "refactor",
-    "refs",
-    "release",
-    "report",
-    "rig",
-    "runner",
-    "runs",
-    "runtime",
-    "stack",
-    "tunnel",
-    "undo",
-    "version",
-    "worktree",
-];
-
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
     match command {
         Commands::AgentTask(args) => map(agent_task::run(args, global)),


### PR DESCRIPTION
## Summary
- add a typed `CommandDispatchFamily` derived from the command registry
- route JSON dispatch family selection through the registry by top-level command name
- remove duplicated test-only per-family command lists from JSON dispatch modules

## Tests
- `cargo fmt`
- `cargo test command_contract`
- `cargo test json_output`
- `cargo test command_surface`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the registry-backed dispatch cleanup and focused tests; Chris directed the Homeboy refactor wave.