### PR TITLE
Wake agent-task scheduler on cancellation

### DIFF
--- a/src/core/agent_task_schedule.rs
+++ b/src/core/agent_task_schedule.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
@@ -665,19 +667,66 @@ pub struct AgentTaskResourceBudgetStatus {
     pub per_model_task_units: HashMap<String, u32>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone)]
 pub struct AgentTaskCancellationToken {
-    cancelled: Arc<std::sync::atomic::AtomicBool>,
+    inner: Arc<AgentTaskCancellationInner>,
+}
+
+struct AgentTaskCancellationInner {
+    cancelled: AtomicBool,
+    callbacks: Mutex<Vec<Arc<dyn Fn() + Send + Sync>>>,
+}
+
+impl Default for AgentTaskCancellationToken {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(AgentTaskCancellationInner {
+                cancelled: AtomicBool::new(false),
+                callbacks: Mutex::new(Vec::new()),
+            }),
+        }
+    }
+}
+
+impl fmt::Debug for AgentTaskCancellationToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AgentTaskCancellationToken")
+            .field("cancelled", &self.is_cancelled())
+            .finish_non_exhaustive()
+    }
 }
 
 impl AgentTaskCancellationToken {
     pub fn cancel(&self) {
-        self.cancelled
-            .store(true, std::sync::atomic::Ordering::SeqCst);
+        if self.inner.cancelled.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        let callbacks = self
+            .inner
+            .callbacks
+            .lock()
+            .expect("cancellation callbacks")
+            .clone();
+        for callback in callbacks {
+            callback();
+        }
     }
 
     pub(crate) fn is_cancelled(&self) -> bool {
-        self.cancelled.load(std::sync::atomic::Ordering::SeqCst)
+        self.inner.cancelled.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn on_cancel(&self, callback: Arc<dyn Fn() + Send + Sync>) {
+        let mut callbacks = self.inner.callbacks.lock().expect("cancellation callbacks");
+        if self.is_cancelled() {
+            drop(callbacks);
+            callback();
+            return;
+        }
+
+        callbacks.push(callback);
     }
 }
 

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -100,6 +100,10 @@ where
         let mut cancellation_notified = false;
         let max_attempts = plan.options.retry.max_attempts.max(1);
         let (tx, rx) = mpsc::channel();
+        let cancellation_tx = tx.clone();
+        cancellation.on_cancel(Arc::new(move || {
+            let _ = cancellation_tx.send(SchedulerEvent::Cancellation);
+        }));
         let mut adaptive_decisions = Vec::new();
         let mut last_effective_concurrency = None;
 
@@ -321,11 +325,11 @@ where
 
                 thread::spawn(move || {
                     let outcome = executor.execute(request, context);
-                    let _ = tx.send(TaskResult {
+                    let _ = tx.send(SchedulerEvent::TaskResult(TaskResult {
                         task_id,
                         attempt,
                         outcome,
-                    });
+                    }));
                 });
             }
 
@@ -341,7 +345,10 @@ where
             }
 
             match rx.recv_timeout(scheduler_result_wait_timeout(&running)) {
-                Ok(result) => {
+                Ok(SchedulerEvent::Cancellation) => {
+                    continue;
+                }
+                Ok(SchedulerEvent::TaskResult(result)) => {
                     if cancellation.is_cancelled() {
                         AgentTaskScheduleSupport::cancel_queued(
                             &mut queued,
@@ -447,6 +454,11 @@ struct TaskResult {
     task_id: String,
     attempt: u32,
     outcome: AgentTaskOutcome,
+}
+
+enum SchedulerEvent {
+    TaskResult(TaskResult),
+    Cancellation,
 }
 
 fn scheduler_result_wait_timeout(running: &[RunningTask]) -> Duration {
@@ -2105,6 +2117,29 @@ mod tests {
         ];
 
         assert_eq!(scheduler_result_wait_timeout(&running), Duration::ZERO);
+    }
+
+    #[test]
+    fn cancellation_token_callbacks_fire_once_and_after_existing_cancel() {
+        let token = AgentTaskCancellationToken::default();
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let callback_count_for_token = Arc::clone(&callback_count);
+        token.on_cancel(Arc::new(move || {
+            callback_count_for_token.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        token.cancel();
+        token.cancel();
+
+        assert_eq!(callback_count.load(Ordering::SeqCst), 1);
+
+        let immediate_count = Arc::new(AtomicUsize::new(0));
+        let immediate_count_for_token = Arc::clone(&immediate_count);
+        token.on_cancel(Arc::new(move || {
+            immediate_count_for_token.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        assert_eq!(immediate_count.load(Ordering::SeqCst), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add one-shot cancellation callbacks to `AgentTaskCancellationToken`
- wake the scheduler result channel immediately when cancellation fires
- preserve provider cancellation behavior while avoiding wait-window cancellation latency

## Tests
- `cargo fmt`
- `cargo test agent_task_scheduler`
- `cargo test cancellation_token_callbacks_fire_once_and_after_existing_cancel`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the wakeable cancellation implementation and tests; Chris directed the scheduler/resource cleanup wave.