### PR TITLE
Build refactor module surfaces from snapshots

### DIFF
--- a/src/core/code_audit/walker.rs
+++ b/src/core/code_audit/walker.rs
@@ -38,11 +38,7 @@ pub(crate) fn extension_provided_file_extensions() -> Vec<String> {
         .collect()
 }
 
-/// `ScanConfig` matching `walk_source_files` — extension-provided file types only.
-///
-/// Extracted so [`walk_source_files`] and [`walk_source_files_snapshot`] stay
-/// in lockstep. Both consumers walk the same set of files; only the return
-/// shape (paths vs in-memory snapshot) differs.
+/// `ScanConfig` matching source snapshots — extension-provided file types only.
 fn source_scan_config() -> ScanConfig {
     let dynamic_extensions = extension_provided_file_extensions();
     ScanConfig {
@@ -83,30 +79,16 @@ pub(crate) fn walk_shared_audit_files_snapshot(
     )
 }
 
-/// Walk source files under a root, skipping common non-source directories
-/// and extension index files.
-///
-/// Delegates to `codebase_scan::walk_files` with extension-provided file types.
-pub(crate) fn walk_source_files(root: &Path) -> std::io::Result<Vec<std::path::PathBuf>> {
-    let mut files = codebase_scan::walk_files(root, &source_scan_config());
-
-    // Exclude extension index files from convention sibling detection
-    files.retain(|f| !is_index_file(f));
-
-    Ok(files)
-}
-
 /// Build a [`CodebaseSnapshot`] of source files under a root.
 ///
-/// Same selection rules as [`walk_source_files`] — extension-provided file
-/// types, post-filter on extension index files — but reads each file once
-/// during the walk and returns owned `(path, content)` pairs ready for
+/// Uses extension-provided file types, post-filters extension index files, and
+/// reads each file once during the walk and returns owned `(path, content)` pairs ready for
 /// downstream consumers (`fingerprint_content`, `FingerprintIndex`, etc.).
 ///
 /// This is the entry point audit consumers should use. Slice 2 of #1492
 /// migrates `discovery::auto_discover_groups` and `fingerprint_reference_paths`
-/// onto this helper; further slices migrate refactor's `ModuleSurfaceIndex`
-/// and the symbol graph.
+/// onto this helper; a later slice moved refactor's `ModuleSurfaceIndex` fallback
+/// build path here as well.
 pub(crate) fn walk_source_files_snapshot(root: &Path) -> CodebaseSnapshot {
     let mut snapshot = CodebaseSnapshot::build(root, &source_scan_config());
     snapshot.retain(|path| !is_index_file(path));

--- a/src/core/engine/codebase_scan.rs
+++ b/src/core/engine/codebase_scan.rs
@@ -577,8 +577,8 @@ pub fn discover_casing(root: &Path, term: &str, config: &ScanConfig) -> Vec<(Str
 /// audit pipeline (`code_audit::discovery::auto_discover_groups` and
 /// `fingerprint_reference_paths`) consumes snapshots directly, replacing the
 /// per-detector `walk_source_files` + `fingerprint_file` loops. Subsequent
-/// slices migrate the remaining consumers (refactor's `ModuleSurfaceIndex`,
-/// the symbol graph) onto the same shared state.
+/// slices migrate remaining consumers such as the symbol graph onto the same
+/// shared state.
 #[derive(Debug, Clone)]
 pub struct CodebaseSnapshot {
     root: PathBuf,

--- a/src/core/refactor/plan/generate/module_surface.rs
+++ b/src/core/refactor/plan/generate/module_surface.rs
@@ -61,11 +61,11 @@ pub struct ModuleSurfaceIndex {
 
 impl ModuleSurfaceIndex {
     pub fn build(root: &Path) -> Self {
-        let files = walker::walk_source_files(root).unwrap_or_default();
+        let snapshot = walker::walk_source_files_snapshot(root);
         let mut fingerprints = Vec::new();
 
-        for file_path in files {
-            let Some(fp) = fingerprint::fingerprint_file(&file_path, root) else {
+        for (file_path, content) in snapshot.iter() {
+            let Some(fp) = fingerprint::fingerprint_content(file_path, root, content) else {
                 continue;
             };
             fingerprints.push(fp);
@@ -252,5 +252,34 @@ mod tests {
         assert!(has_pub_use_of(content, "foo"));
         assert!(has_pub_use_of(content, "bar"));
         assert!(!has_pub_use_of(content, "baz"));
+    }
+
+    #[test]
+    fn build_uses_snapshot_content_for_module_surfaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src/core/example");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(
+            src.join("producer.rs"),
+            "pub fn make_value() -> usize { 1 }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            src.join("consumer.rs"),
+            "use crate::core::example::producer::make_value;\n\npub fn consume() -> usize { make_value() }\n",
+        )
+        .unwrap();
+
+        let index = ModuleSurfaceIndex::build(dir.path());
+        let producer = index.get("src/core/example/producer.rs").unwrap();
+        let surface = producer.symbol_surface("make_value").unwrap();
+
+        assert!(producer.owns_public_symbol("make_value"));
+        assert!(surface
+            .incoming_callers
+            .contains(&"src/core/example/consumer.rs".to_string()));
+        assert!(surface
+            .incoming_importers
+            .contains(&"src/core/example/consumer.rs".to_string()));
     }
 }


### PR DESCRIPTION
## Summary
- migrate `ModuleSurfaceIndex::build()` to `CodebaseSnapshot` and `fingerprint_content()`
- remove the now-unused path-only audit walker helper
- update snapshot docs to reflect the migrated refactor path

## Tests
- `cargo fmt && git diff --check`
- `cargo test module_surface --lib`
- `cargo test codebase_scan --lib`
- `cargo test core::code_audit::walker --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the snapshot migration and focused regression test; Chris directed the scan-efficiency cleanup wave.