### PR TITLE
Expose generic controller events command

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -36,6 +36,27 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `auth` | Configure and inspect provider authentication secrets. |
 | `controller` | Create, inspect, and resume durable multi-agent loop controller state. |
 
+## Controller Events
+
+`agent-task controller events` is the stable generic primitive for applying an
+external event to a durable controller. It accepts the same provider-neutral event
+shape as `agent-task controller apply-event` and returns
+`homeboy/agent-task-loop-controller-event-result/v1` with the updated controller
+record and any actions created by event policy evaluation.
+
+```bash
+homeboy agent-task controller events "$loop_id" \
+  --event-type task.completed \
+  --event-id task-123-completed \
+  --event-key task#123 \
+  --entity-id entity-123 \
+  --payload @event.json
+```
+
+Use `events` for downstream integrations that need a stable generic controller
+event contract. `apply-event` remains the explicit event-application spelling and
+uses the same request and response contract.
+
 ## Loop Spec Compilation
 
 `agent-task compile-loop --definition <SPEC>` compiles a declarative loop spec into

--- a/src/commands/agent_task/args/controller.rs
+++ b/src/commands/agent_task/args/controller.rs
@@ -14,6 +14,8 @@ pub enum AgentTaskControllerCommand {
     Status(AgentTaskControllerStatusArgs),
     /// List durable loop controller records.
     List,
+    /// Apply a generic external controller event.
+    Events(AgentTaskControllerApplyEventArgs),
     /// Apply an external event and resume matching waits.
     ApplyEvent(AgentTaskControllerApplyEventArgs),
     /// Claim and execute the next pending controller action.

--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -49,6 +49,7 @@ pub(super) fn controller(args: AgentTaskControllerArgs) -> CmdResult<Value> {
             let report = agent_task_controller_service::list()?;
             Ok((command_json_value(report)?, 0))
         }
+        AgentTaskControllerCommand::Events(event_args) => apply_controller_event(event_args),
         AgentTaskControllerCommand::ApplyEvent(event_args) => apply_controller_event(event_args),
         AgentTaskControllerCommand::RunNext(run_args) => controller_run_next(run_args),
         AgentTaskControllerCommand::Run(run_args) => controller_run_action(run_args),
@@ -245,7 +246,7 @@ pub(super) fn dispatch_args_from_controller_request(
     })
 }
 
-fn apply_controller_event(args: AgentTaskControllerApplyEventArgs) -> CmdResult<Value> {
+pub(super) fn apply_controller_event(args: AgentTaskControllerApplyEventArgs) -> CmdResult<Value> {
     let payload = match args.payload {
         Some(spec) => {
             serde_json::from_str(&config::read_json_spec_to_string(&spec)?).map_err(|error| {

--- a/src/commands/agent_task/tests.rs
+++ b/src/commands/agent_task/tests.rs
@@ -4,13 +4,14 @@
 use std::process::Command;
 
 use super::super::agent_task_dispatch::DispatchArgs;
+use super::args::AgentTaskControllerApplyEventArgs;
 use super::args::{
     AgentTaskLoopArgs, CompileLoopArgs, ReviewArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
 };
 use super::controller::{
-    apply_from_spec_dispatch_defaults, apply_from_spec_dispatch_defaults_with_cwd,
-    controller_run_action_with_executor, controller_run_next_with_executor,
-    dispatch_args_from_controller_request,
+    apply_controller_event, apply_from_spec_dispatch_defaults,
+    apply_from_spec_dispatch_defaults_with_cwd, controller_run_action_with_executor,
+    controller_run_next_with_executor, dispatch_args_from_controller_request,
 };
 use super::run::{
     retry, run_loaded_plan, run_loop_with_executor, run_next_with_executor,
@@ -471,6 +472,42 @@ fn controller_dispatch_args_preserve_top_level_workspace_context_in_plan() {
         plan.metadata["workspace_root"].as_str(),
         Some(repo_path.as_str())
     );
+}
+
+#[test]
+fn controller_events_command_applies_generic_event() {
+    with_isolated_home(|_| {
+        agent_task_controller_service::init(
+            homeboy::core::agent_tasks::controller_service::ControllerInitRequest {
+                loop_id: "controller-events-cli".to_string(),
+                phase: "init".to_string(),
+                config_version: "v1".to_string(),
+            },
+        )
+        .expect("controller initialized");
+
+        let (value, status) = apply_controller_event(AgentTaskControllerApplyEventArgs {
+            loop_id: "controller-events-cli".to_string(),
+            event_type: "task.completed".to_string(),
+            event_id: Some("event-1".to_string()),
+            event_key: Some("task#1".to_string()),
+            entity_id: Some("entity-1".to_string()),
+            payload: Some(r#"{"status":"ok"}"#.to_string()),
+        })
+        .expect("event applied");
+
+        assert_eq!(status, 0);
+        assert_eq!(
+            value["schema"],
+            homeboy::core::agent_tasks::controller_service::APPLY_EVENT_RESULT_SCHEMA
+        );
+        assert_eq!(
+            value["controller"]["history"][0]["event_type"],
+            "task.completed"
+        );
+        assert_eq!(value["controller"]["history"][0]["entity_id"], "entity-1");
+        assert_eq!(value["controller"]["history"][0]["payload"]["status"], "ok");
+    });
 }
 
 #[test]

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -54,11 +54,34 @@ fn includes_second_level_subcommands() {
     let surface = current_command_surface();
 
     assert!(surface.contains_path(&["agent-task", "controller", "run-next"]));
+    assert!(surface.contains_path(&["agent-task", "controller", "events"]));
     assert!(surface.contains_path(&["agent-task", "auth", "status"]));
     assert!(surface.contains_path(&["runner", "job", "logs"]));
     assert!(surface.contains_path(&["tunnel", "preview-ingress", "route"]));
     assert!(surface.contains_path(&["tunnel", "preview-ingress", "list"]));
     assert!(surface.contains_path(&["tunnel", "preview-ingress", "status"]));
+}
+
+#[test]
+fn agent_task_controller_events_command_parses() {
+    Cli::try_parse_from([
+        "homeboy",
+        "agent-task",
+        "controller",
+        "events",
+        "loop-1",
+        "--event-type",
+        "task.completed",
+        "--event-id",
+        "event-1",
+        "--event-key",
+        "task#1",
+        "--entity-id",
+        "entity-1",
+        "--payload",
+        r#"{"status":"ok"}"#,
+    ])
+    .expect("agent-task controller events should parse as the generic event primitive");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds `homeboy agent-task controller events` as the generic event primitive backed by the existing typed controller event application path.
- Documents `events` as the stable downstream contract while keeping `apply-event` as the explicit spelling for the same request/response shape.
- Adds command-surface/parser coverage and a behavior test for applying a generic controller event.

## Verification
- `cargo fmt`
- `cargo test --test command_surface_test`
- `cargo test controller_events_command_applies_generic_event`
- `cargo run --quiet -- agent-task controller --help`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the controller events CLI surface, docs, and tests; Chris remains responsible for review and validation.