### PR TITLE
Trim stale CLI surface docs

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -28,7 +28,6 @@
 - [issues](issues.md) — reconcile findings against issue trackers
 - [lab](lab.md) — remote Lab runner status and benchmark routing helpers
 - [lint](lint.md)
-- [list](list.md)
 - [logs](logs.md)
 - [observe](observe.md) — passive live observation into trace timeline evidence
 - [project](project.md)

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -121,7 +121,6 @@ Runner upgrade entries include the configured `homeboy_path`, observed configure
 
 ## Notes
 
-- The `update` command is an alias for `upgrade` with identical behavior.
 - Version checking queries the crates.io API. Network failures are handled gracefully.
 - On Unix platforms, successful source installs automatically restart into the new binary. Binary and package-manager installs do not require a restart.
 

--- a/homeboy.json
+++ b/homeboy.json
@@ -404,7 +404,6 @@
           "src/commands/auth.rs",
           "src/commands/bench.rs",
           "src/commands/build.rs",
-          "src/commands/cargo.rs",
           "src/commands/changelog.rs",
           "src/commands/daemon.rs",
           "src/commands/db.rs",

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -68,6 +68,9 @@ pub enum Commands {
     /// Run performance benchmarks for a component
     Bench(bench::BenchArgs),
     /// Capture black-box behavioral traces for a component
+    #[command(
+        after_help = "Command-shaped trace modes:\n  homeboy trace list --profiles\n  homeboy trace <component> list\n  homeboy trace compare before.json after.json\n  homeboy trace compare <component> <scenario> --baseline-target <target> --candidate <target>\n  homeboy trace matrix <component> <scenario> --axis name=value1,value2\n  homeboy trace compare-variant --rig <rig-id> --scenario <scenario>\n  homeboy trace compare-bundle --component <component> --scenario <scenario>\n  homeboy trace overlay-locks --stale"
+    )]
     Trace(trace::TraceArgs),
     /// Passively observe a running system and persist timeline evidence
     Observe(observe::ObserveArgs),
@@ -161,7 +164,8 @@ pub enum Commands {
     Http(http::HttpArgs),
     /// Upgrade Homeboy to the latest version
     Upgrade(upgrade::UpgradeArgs),
-    /// List available commands (alias for --help)
+    /// List available commands (deprecated alias for --help)
+    #[command(hide = true)]
     List,
 }
 


### PR DESCRIPTION
## Summary
- hide deprecated `homeboy list` from root help while keeping it parseable
- surface trace command-shaped modes in `trace --help`
- remove stale `update` alias docs and nonexistent command adapter allowlist entry

## Testing
- `cargo fmt`
- `cargo test cli_surface --lib`
- `cargo test --test command_surface_test`
- `cargo check --bin homeboy`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the command-surface cleanup and verification; Chris/maintainers remain responsible for review and validation.