### PR TITLE
Batch rig artifact indexes in runs list

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -28,7 +28,6 @@
 - [issues](issues.md) — reconcile findings against issue trackers
 - [lab](lab.md) — remote Lab runner status and benchmark routing helpers
 - [lint](lint.md)
-- [list](list.md)
 - [logs](logs.md)
 - [observe](observe.md) — passive live observation into trace timeline evidence
 - [project](project.md)

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -121,7 +121,6 @@ Runner upgrade entries include the configured `homeboy_path`, observed configure
 
 ## Notes
 
-- The `update` command is an alias for `upgrade` with identical behavior.
 - Version checking queries the crates.io API. Network failures are handled gracefully.
 - On Unix platforms, successful source installs automatically restart into the new binary. Binary and package-manager installs do not require a restart.
 

--- a/homeboy.json
+++ b/homeboy.json
@@ -404,7 +404,6 @@
           "src/commands/auth.rs",
           "src/commands/bench.rs",
           "src/commands/build.rs",
-          "src/commands/cargo.rs",
           "src/commands/changelog.rs",
           "src/commands/daemon.rs",
           "src/commands/db.rs",

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -68,6 +68,9 @@ pub enum Commands {
     /// Run performance benchmarks for a component
     Bench(bench::BenchArgs),
     /// Capture black-box behavioral traces for a component
+    #[command(
+        after_help = "Command-shaped trace modes:\n  homeboy trace list --profiles\n  homeboy trace <component> list\n  homeboy trace compare before.json after.json\n  homeboy trace compare <component> <scenario> --baseline-target <target> --candidate <target>\n  homeboy trace matrix <component> <scenario> --axis name=value1,value2\n  homeboy trace compare-variant --rig <rig-id> --scenario <scenario>\n  homeboy trace compare-bundle --component <component> --scenario <scenario>\n  homeboy trace overlay-locks --stale"
+    )]
     Trace(trace::TraceArgs),
     /// Passively observe a running system and persist timeline evidence
     Observe(observe::ObserveArgs),
@@ -161,7 +164,8 @@ pub enum Commands {
     Http(http::HttpArgs),
     /// Upgrade Homeboy to the latest version
     Upgrade(upgrade::UpgradeArgs),
-    /// List available commands (alias for --help)
+    /// List available commands (deprecated alias for --help)
+    #[command(hide = true)]
     List,
 }
 

--- a/src/commands/adapter.rs
+++ b/src/commands/adapter.rs
@@ -5,7 +5,9 @@ use crate::command_contract::{
     CommandResponseMode,
 };
 
-use super::GlobalArgs;
+use crate::cli_surface::Commands;
+
+use super::{fleet, version, GlobalArgs};
 
 pub(crate) type JsonCommandRun = (homeboy::core::Result<Value>, i32);
 pub(crate) type JsonCommandExecutor<Args> = fn(Args, &GlobalArgs) -> JsonCommandRun;
@@ -50,6 +52,30 @@ pub(crate) struct TypedCommandAdapter<Args> {
     pub execute_json: Option<JsonCommandExecutor<Args>>,
 }
 
+pub(crate) struct BoundCommandAdapter {
+    execution: BoundCommandExecution,
+}
+
+enum BoundCommandExecution {
+    Fleet {
+        args: fleet::FleetArgs,
+        execute_json: JsonCommandExecutor<fleet::FleetArgs>,
+    },
+    Version {
+        args: version::VersionArgs,
+        execute_json: JsonCommandExecutor<version::VersionArgs>,
+    },
+}
+
+impl BoundCommandAdapter {
+    pub fn execute_json(self, global: &GlobalArgs) -> JsonCommandRun {
+        match self.execution {
+            BoundCommandExecution::Fleet { args, execute_json } => execute_json(args, global),
+            BoundCommandExecution::Version { args, execute_json } => execute_json(args, global),
+        }
+    }
+}
+
 impl<Args> TypedCommandAdapter<Args> {
     pub fn output_descriptor(&self) -> CommandOutputDescriptor {
         self.contract.to_output_descriptor()
@@ -74,9 +100,47 @@ impl<Args> TypedCommandAdapter<Args> {
     }
 }
 
+pub(crate) fn command_adapter(
+    command: Commands,
+    output_file_mode: CommandOutputFileMode,
+) -> Result<BoundCommandAdapter, Commands> {
+    match command {
+        Commands::Fleet(args) => {
+            let adapter = fleet::adapter(output_file_mode);
+            Ok(BoundCommandAdapter {
+                execution: BoundCommandExecution::Fleet {
+                    args,
+                    execute_json: adapter
+                        .execute_json
+                        .expect("fleet adapter supports JSON execution"),
+                },
+            })
+        }
+        Commands::Version(args) => {
+            let adapter = version::adapter(output_file_mode);
+            Ok(BoundCommandAdapter {
+                execution: BoundCommandExecution::Version {
+                    args,
+                    execute_json: adapter
+                        .execute_json
+                        .expect("version adapter supports JSON execution"),
+                },
+            })
+        }
+        command => Err(command),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
+
+    fn parsed_command(args: &[&str]) -> Commands {
+        crate::cli_surface::Cli::try_parse_from(args)
+            .expect("CLI args should parse")
+            .command
+    }
 
     #[test]
     fn json_only_contract_maps_to_output_descriptor() {
@@ -96,5 +160,15 @@ mod tests {
         );
         assert_eq!(descriptor.json_family, CommandJsonFamily::Workspace);
         assert!(adapter.execute_json.is_some());
+    }
+    #[test]
+    fn command_adapter_recognizes_migrated_json_commands() {
+        assert!(command_adapter(
+            parsed_command(&["homeboy", "version", "show"]),
+            CommandOutputFileMode::None,
+        )
+        .is_ok());
+
+        assert!(command_adapter(Commands::List, CommandOutputFileMode::None).is_err());
     }
 }

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -5,7 +5,7 @@ use crate::command_contract::{registered_command_dispatch_family, CommandDispatc
 
 use super::agent_task_summary::{agent_task_summary_kind, render_agent_task_summary};
 use super::output_runtime::{CommandPresentation, JsonCommandRun};
-use super::{runner, GlobalArgs};
+use super::{adapter, runner, GlobalArgs};
 
 mod ops;
 mod quality;
@@ -67,6 +67,14 @@ fn agent_task_summary_kind_for_output_mode(
 }
 
 fn dispatch(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Value>, i32) {
+    let command = match adapter::command_adapter(
+        command,
+        crate::command_contract::CommandOutputFileMode::None,
+    ) {
+        Ok(adapter) => return adapter.execute_json(global),
+        Err(command) => command,
+    };
+
     match dispatch_family(&command) {
         CommandDispatchFamily::Quality => quality::dispatch(command, global),
         CommandDispatchFamily::Workspace => workspace::dispatch(command, global),

--- a/src/commands/json_output/ops.rs
+++ b/src/commands/json_output/ops.rs
@@ -2,8 +2,8 @@ use crate::cli_surface::Commands;
 
 use super::{map, JsonRun};
 use crate::commands::{
-    api, auth, ci, daemon, db, deploy, deps, doctor, file, fleet, git, http, issues, logs,
-    self_cmd, server, ssh, status, triage, upgrade, GlobalArgs,
+    api, auth, ci, daemon, db, deploy, deps, doctor, file, git, http, issues, logs, self_cmd,
+    server, ssh, status, triage, upgrade, GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
@@ -16,11 +16,6 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Deps(args) => map(deps::run(args, global)),
         Commands::Doctor(args) => map(doctor::run(args, global)),
         Commands::File(args) => map(file::run(args, global)),
-        Commands::Fleet(args) => {
-            fleet::adapter(crate::command_contract::CommandOutputFileMode::None)
-                .execute_json
-                .expect("fleet adapter supports JSON execution")(args, global)
-        }
         Commands::Logs(args) => map(logs::run(args, global)),
         Commands::Triage(args) => map(triage::run(args, global)),
         Commands::Deploy(args) => map(deploy::run(args, global)),

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -4,7 +4,7 @@ use super::{map, JsonRun};
 use crate::commands::{
     agent_task, build, changelog, changes, cleanup, component, config, docs, extension, lab,
     project, refactor, refs, release, report, rig, runner, runs, runtime, stack, tunnel, undo,
-    version, worktree, GlobalArgs,
+    worktree, GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
@@ -17,11 +17,6 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Docs(args) => map(docs::run(args, global)),
         Commands::Changelog(args) => map(changelog::run(args, global)),
         Commands::Cleanup(args) => map(cleanup::run(args, global)),
-        Commands::Version(args) => {
-            version::adapter(crate::command_contract::CommandOutputFileMode::None)
-                .execute_json
-                .expect("version adapter supports JSON execution")(args, global)
-        }
         Commands::Build(args) => map(build::run(args, global)),
         Commands::Changes(args) => map(changes::run(args, global)),
         Commands::Release(args) => map(release::run(args, global)),

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -457,16 +457,25 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
     let store = ObservationStore::open_initialized()?;
     reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
     let status_filter = args.status.clone();
-    let mut runs: Vec<RunSummary> = store
-        .list_runs(RunListFilter {
-            kind: args.kind,
-            component_id: args.component_id,
-            status: args.status,
-            rig_id: args.rig,
-            limit: Some(args.limit),
-        })?
+    let run_records = store.list_runs(RunListFilter {
+        kind: args.kind,
+        component_id: args.component_id,
+        status: args.status,
+        rig_id: args.rig,
+        limit: Some(args.limit),
+    })?;
+    let rig_run_ids = run_records
+        .iter()
+        .filter(|run| run.kind == "rig" && run.rig_id.is_some())
+        .map(|run| run.id.clone())
+        .collect::<Vec<_>>();
+    let mut artifacts_by_run = store.list_artifacts_for_runs(&rig_run_ids)?;
+    let mut runs: Vec<RunSummary> = run_records
         .into_iter()
-        .map(|run| run_summary_with_artifact_index(&store, run))
+        .map(|run| {
+            let artifacts = artifacts_by_run.remove(&run.id).unwrap_or_default();
+            run_summary_with_artifact_index(run, &artifacts)
+        })
         .collect();
 
     runs.extend(active_runner_job_summaries(status_filter.as_deref()));
@@ -711,8 +720,8 @@ pub(crate) fn run_summary(run: RunRecord) -> RunSummary {
     }
 }
 
-fn run_summary_with_artifact_index(store: &ObservationStore, run: RunRecord) -> RunSummary {
-    let artifact_index = homeboy::core::rig::artifact_index_for_run(store, &run);
+fn run_summary_with_artifact_index(run: RunRecord, artifacts: &[ArtifactRecord]) -> RunSummary {
+    let artifact_index = homeboy::core::rig::artifact_index_for_run_with_artifacts(&run, artifacts);
     RunSummary {
         artifact_index,
         ..run_summary(run)

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -40,6 +40,7 @@ pub(super) use bench::{bench_numeric_metrics, run_contains_scenario};
 use bundle::{
     export_runs, import_runs, RunsExportArgs, RunsExportOutput, RunsImportArgs, RunsImportOutput,
 };
+use common::run_summaries_with_artifact_indexes;
 pub use common::RunSummary;
 use compare::{compare_runs, RunsCompareArgs, RunsCompareOutput};
 pub use distribution::{runs_distribution, RunsDistributionArgs, RunsDistributionOutput};
@@ -464,19 +465,7 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
         rig_id: args.rig,
         limit: Some(args.limit),
     })?;
-    let rig_run_ids = run_records
-        .iter()
-        .filter(|run| run.kind == "rig" && run.rig_id.is_some())
-        .map(|run| run.id.clone())
-        .collect::<Vec<_>>();
-    let mut artifacts_by_run = store.list_artifacts_for_runs(&rig_run_ids)?;
-    let mut runs: Vec<RunSummary> = run_records
-        .into_iter()
-        .map(|run| {
-            let artifacts = artifacts_by_run.remove(&run.id).unwrap_or_default();
-            run_summary_with_artifact_index(run, &artifacts)
-        })
-        .collect();
+    let mut runs = run_summaries_with_artifact_indexes(&store, run_records)?;
 
     runs.extend(active_runner_job_summaries(status_filter.as_deref()));
 
@@ -717,14 +706,6 @@ pub(crate) fn run_summary(run: RunRecord) -> RunSummary {
         cwd: run.cwd,
         status_note,
         artifact_index: None,
-    }
-}
-
-fn run_summary_with_artifact_index(run: RunRecord, artifacts: &[ArtifactRecord]) -> RunSummary {
-    let artifact_index = homeboy::core::rig::artifact_index_for_run_with_artifacts(&run, artifacts);
-    RunSummary {
-        artifact_index,
-        ..run_summary(run)
     }
 }
 

--- a/src/commands/runs/common.rs
+++ b/src/commands/runs/common.rs
@@ -34,6 +34,32 @@ pub struct RunSummary {
     pub artifact_index: Option<RigRunArtifactIndex>,
 }
 
+pub fn run_summaries_with_artifact_indexes(
+    store: &ObservationStore,
+    run_records: Vec<RunRecord>,
+) -> homeboy::core::Result<Vec<RunSummary>> {
+    let rig_run_ids = run_records
+        .iter()
+        .filter_map(|run| (run.kind == "rig" && run.rig_id.is_some()).then(|| run.id.clone()))
+        .collect::<Vec<_>>();
+    let mut artifacts_by_run = store.list_artifacts_for_runs(&rig_run_ids)?;
+    Ok(run_records
+        .into_iter()
+        .map(|run| {
+            let artifacts = artifacts_by_run.remove(&run.id).unwrap_or_default();
+            run_summary_with_artifact_index(run, &artifacts)
+        })
+        .collect())
+}
+
+fn run_summary_with_artifact_index(run: RunRecord, artifacts: &[ArtifactRecord]) -> RunSummary {
+    let artifact_index = homeboy::core::rig::artifact_index_for_run_with_artifacts(&run, artifacts);
+    RunSummary {
+        artifact_index,
+        ..super::run_summary(run)
+    }
+}
+
 /// Convert a `--since <duration>` flag value into an RFC-3339 timestamp.
 ///
 /// Accepts the same forms as elsewhere in the runs surface (s, m, h, d).

--- a/src/core/agent_task_loop_definition.rs
+++ b/src/core/agent_task_loop_definition.rs
@@ -281,12 +281,16 @@ fn unsupported_repo_loop_spec_fields(spec: &AgentTaskRepoLoopSpec) -> Vec<String
             ));
         }
         for artifact_id in workflow.consumes.iter().chain(workflow.dependencies.iter()) {
-            let fanout_producers: Vec<String> =
-                repo_loop_artifact_producers(spec, workflow, artifact_id)
-                    .into_iter()
-                    .filter(|producer| !producer.entity_ids.is_empty())
-                    .map(|producer| producer.workflow_id.clone())
-                    .collect();
+            let fanout_producers: Vec<String> = repo_loop_artifact_producers(
+                spec,
+                workflow,
+                artifact_id,
+                RepoLoopProducerScope::All,
+            )
+            .into_iter()
+            .filter(|(producer, _task_id)| !producer.entity_ids.is_empty())
+            .map(|(producer, _task_id)| producer.workflow_id.clone())
+            .collect();
             if workflow.entity_ids.is_empty() && !fanout_producers.is_empty() {
                 unsupported.push(format!(
                     "workflows[{}].consumes: join over fan-out artifact '{}' from workflows [{}] requires the controller path",
@@ -565,9 +569,12 @@ fn repo_loop_workflow_output_dependencies(
     let mut depends_on = Vec::new();
     let mut bindings = HashMap::new();
     for artifact_id in workflow.consumes.iter().chain(workflow.dependencies.iter()) {
-        for (_producer, producer_task_id) in
-            repo_loop_artifact_producer_task_ids(spec, workflow, artifact_id, entity_id)
-        {
+        for (_producer, producer_task_id) in repo_loop_artifact_producers(
+            spec,
+            workflow,
+            artifact_id,
+            RepoLoopProducerScope::MatchingEntity(entity_id),
+        ) {
             if !depends_on.contains(&producer_task_id) {
                 depends_on.push(producer_task_id.clone());
             }
@@ -595,32 +602,6 @@ fn repo_loop_workflow_output_dependencies(
     }
 }
 
-fn repo_loop_artifact_producer_task_ids<'a>(
-    spec: &'a AgentTaskRepoLoopSpec,
-    consumer: &AgentTaskRepoLoopSpecWorkflow,
-    artifact_id: &str,
-    entity_id: Option<&str>,
-) -> Vec<(&'a AgentTaskRepoLoopSpecWorkflow, String)> {
-    repo_loop_artifact_producers(spec, consumer, artifact_id)
-        .into_iter()
-        .flat_map(|producer| {
-            if producer.entity_ids.is_empty() {
-                vec![(producer, repo_loop_task_id(producer, None))]
-            } else if let Some(entity_id) = entity_id {
-                producer
-                    .entity_ids
-                    .iter()
-                    .any(|producer_entity_id| producer_entity_id == entity_id)
-                    .then(|| (producer, repo_loop_task_id(producer, Some(entity_id))))
-                    .into_iter()
-                    .collect()
-            } else {
-                Vec::new()
-            }
-        })
-        .collect()
-}
-
 fn repo_loop_artifact<'a>(
     spec: &'a AgentTaskRepoLoopSpec,
     artifact_id: &str,
@@ -630,17 +611,44 @@ fn repo_loop_artifact<'a>(
         .find(|artifact| artifact.artifact_id == artifact_id)
 }
 
+enum RepoLoopProducerScope<'a> {
+    All,
+    MatchingEntity(Option<&'a str>),
+}
+
 fn repo_loop_artifact_producers<'a>(
     spec: &'a AgentTaskRepoLoopSpec,
     consumer: &AgentTaskRepoLoopSpecWorkflow,
     artifact_id: &str,
-) -> Vec<&'a AgentTaskRepoLoopSpecWorkflow> {
+    scope: RepoLoopProducerScope<'_>,
+) -> Vec<(&'a AgentTaskRepoLoopSpecWorkflow, String)> {
     spec.workflows
         .iter()
         .filter(|producer| producer.workflow_id != consumer.workflow_id)
         .filter(|producer| {
             producer.artifacts.iter().any(|id| id == artifact_id)
                 || producer.emits.iter().any(|id| id == artifact_id)
+        })
+        .flat_map(|producer| match scope {
+            RepoLoopProducerScope::All if producer.entity_ids.is_empty() => {
+                vec![(producer, repo_loop_task_id(producer, None))]
+            }
+            RepoLoopProducerScope::All => producer
+                .entity_ids
+                .iter()
+                .map(|entity_id| (producer, repo_loop_task_id(producer, Some(entity_id))))
+                .collect(),
+            RepoLoopProducerScope::MatchingEntity(_) if producer.entity_ids.is_empty() => {
+                vec![(producer, repo_loop_task_id(producer, None))]
+            }
+            RepoLoopProducerScope::MatchingEntity(Some(entity_id)) => producer
+                .entity_ids
+                .iter()
+                .any(|producer_entity_id| producer_entity_id == entity_id)
+                .then(|| (producer, repo_loop_task_id(producer, Some(entity_id))))
+                .into_iter()
+                .collect(),
+            RepoLoopProducerScope::MatchingEntity(None) => Vec::new(),
         })
         .collect()
 }

--- a/src/core/rig/artifact_index.rs
+++ b/src/core/rig/artifact_index.rs
@@ -74,20 +74,30 @@ pub fn for_completed_rig_run(
 }
 
 pub fn for_run(store: &ObservationStore, run: &RunRecord) -> Option<RigRunArtifactIndex> {
+    if run.rig_id.is_none() || run.kind != "rig" {
+        return None;
+    }
+    let artifacts = store.list_artifacts(&run.id).unwrap_or_default();
+    for_run_with_artifacts(run, &artifacts)
+}
+
+pub fn for_run_with_artifacts(
+    run: &RunRecord,
+    artifacts: &[ArtifactRecord],
+) -> Option<RigRunArtifactIndex> {
     let rig_id = run.rig_id.as_ref()?;
     if run.kind != "rig" {
         return None;
     }
     let artifact_root = crate::core::artifact_root().ok()?;
     let artifact_index_path = artifact_root.join(&run.id).join("rig-artifact-index.json");
-    let artifacts = store.list_artifacts(&run.id).unwrap_or_default();
     Some(build(
         rig_id,
         &run.id,
         &run.status,
         &artifact_root,
         &artifact_index_path,
-        &artifacts,
+        artifacts,
         failed_step_refs_from_metadata(&run.metadata_json),
     ))
 }

--- a/src/core/rig/mod.rs
+++ b/src/core/rig/mod.rs
@@ -38,7 +38,9 @@ pub mod workloads;
 
 pub use app::{AppLauncherAction, AppLauncherOptions, AppLauncherReport};
 pub use artifact_index::{
-    for_run as artifact_index_for_run, RigRunArtifactIndex, RigRunArtifactRef, RigRunFailedStepRef,
+    for_run as artifact_index_for_run,
+    for_run_with_artifacts as artifact_index_for_run_with_artifacts, RigRunArtifactIndex,
+    RigRunArtifactRef, RigRunFailedStepRef,
 };
 pub use capabilities::{evaluate_requirements, plan_requirement_checks, RigRequirementCheckPlan};
 pub use install::{


### PR DESCRIPTION
## Summary
- batch-load artifact records for listed rig runs
- avoid per-run artifact queries when building `runs list` summaries
- keep existing artifact index behavior for individual run lookups

## Testing
- `cargo fmt`
- `cargo test commands::runs::artifact_index_tests`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the N+1 query cleanup and verification; Chris/maintainers remain responsible for review and validation.