### PR TITLE
Share observe process snapshots across watchers

### DIFF
--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -28,7 +28,6 @@
 - [issues](issues.md) — reconcile findings against issue trackers
 - [lab](lab.md) — remote Lab runner status and benchmark routing helpers
 - [lint](lint.md)
-- [list](list.md)
 - [logs](logs.md)
 - [observe](observe.md) — passive live observation into trace timeline evidence
 - [project](project.md)

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -121,7 +121,6 @@ Runner upgrade entries include the configured `homeboy_path`, observed configure
 
 ## Notes
 
-- The `update` command is an alias for `upgrade` with identical behavior.
 - Version checking queries the crates.io API. Network failures are handled gracefully.
 - On Unix platforms, successful source installs automatically restart into the new binary. Binary and package-manager installs do not require a restart.
 

--- a/homeboy.json
+++ b/homeboy.json
@@ -404,7 +404,6 @@
           "src/commands/auth.rs",
           "src/commands/bench.rs",
           "src/commands/build.rs",
-          "src/commands/cargo.rs",
           "src/commands/changelog.rs",
           "src/commands/daemon.rs",
           "src/commands/db.rs",

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -68,6 +68,9 @@ pub enum Commands {
     /// Run performance benchmarks for a component
     Bench(bench::BenchArgs),
     /// Capture black-box behavioral traces for a component
+    #[command(
+        after_help = "Command-shaped trace modes:\n  homeboy trace list --profiles\n  homeboy trace <component> list\n  homeboy trace compare before.json after.json\n  homeboy trace compare <component> <scenario> --baseline-target <target> --candidate <target>\n  homeboy trace matrix <component> <scenario> --axis name=value1,value2\n  homeboy trace compare-variant --rig <rig-id> --scenario <scenario>\n  homeboy trace compare-bundle --component <component> --scenario <scenario>\n  homeboy trace overlay-locks --stale"
+    )]
     Trace(trace::TraceArgs),
     /// Passively observe a running system and persist timeline evidence
     Observe(observe::ObserveArgs),
@@ -161,7 +164,8 @@ pub enum Commands {
     Http(http::HttpArgs),
     /// Upgrade Homeboy to the latest version
     Upgrade(upgrade::UpgradeArgs),
-    /// List available commands (alias for --help)
+    /// List available commands (deprecated alias for --help)
+    #[command(hide = true)]
     List,
 }
 

--- a/src/commands/adapter.rs
+++ b/src/commands/adapter.rs
@@ -5,7 +5,9 @@ use crate::command_contract::{
     CommandResponseMode,
 };
 
-use super::GlobalArgs;
+use crate::cli_surface::Commands;
+
+use super::{fleet, version, GlobalArgs};
 
 pub(crate) type JsonCommandRun = (homeboy::core::Result<Value>, i32);
 pub(crate) type JsonCommandExecutor<Args> = fn(Args, &GlobalArgs) -> JsonCommandRun;
@@ -50,6 +52,30 @@ pub(crate) struct TypedCommandAdapter<Args> {
     pub execute_json: Option<JsonCommandExecutor<Args>>,
 }
 
+pub(crate) struct BoundCommandAdapter {
+    execution: BoundCommandExecution,
+}
+
+enum BoundCommandExecution {
+    Fleet {
+        args: fleet::FleetArgs,
+        execute_json: JsonCommandExecutor<fleet::FleetArgs>,
+    },
+    Version {
+        args: version::VersionArgs,
+        execute_json: JsonCommandExecutor<version::VersionArgs>,
+    },
+}
+
+impl BoundCommandAdapter {
+    pub fn execute_json(self, global: &GlobalArgs) -> JsonCommandRun {
+        match self.execution {
+            BoundCommandExecution::Fleet { args, execute_json } => execute_json(args, global),
+            BoundCommandExecution::Version { args, execute_json } => execute_json(args, global),
+        }
+    }
+}
+
 impl<Args> TypedCommandAdapter<Args> {
     pub fn output_descriptor(&self) -> CommandOutputDescriptor {
         self.contract.to_output_descriptor()
@@ -74,9 +100,47 @@ impl<Args> TypedCommandAdapter<Args> {
     }
 }
 
+pub(crate) fn command_adapter(
+    command: Commands,
+    output_file_mode: CommandOutputFileMode,
+) -> Result<BoundCommandAdapter, Commands> {
+    match command {
+        Commands::Fleet(args) => {
+            let adapter = fleet::adapter(output_file_mode);
+            Ok(BoundCommandAdapter {
+                execution: BoundCommandExecution::Fleet {
+                    args,
+                    execute_json: adapter
+                        .execute_json
+                        .expect("fleet adapter supports JSON execution"),
+                },
+            })
+        }
+        Commands::Version(args) => {
+            let adapter = version::adapter(output_file_mode);
+            Ok(BoundCommandAdapter {
+                execution: BoundCommandExecution::Version {
+                    args,
+                    execute_json: adapter
+                        .execute_json
+                        .expect("version adapter supports JSON execution"),
+                },
+            })
+        }
+        command => Err(command),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
+
+    fn parsed_command(args: &[&str]) -> Commands {
+        crate::cli_surface::Cli::try_parse_from(args)
+            .expect("CLI args should parse")
+            .command
+    }
 
     #[test]
     fn json_only_contract_maps_to_output_descriptor() {
@@ -96,5 +160,15 @@ mod tests {
         );
         assert_eq!(descriptor.json_family, CommandJsonFamily::Workspace);
         assert!(adapter.execute_json.is_some());
+    }
+    #[test]
+    fn command_adapter_recognizes_migrated_json_commands() {
+        assert!(command_adapter(
+            parsed_command(&["homeboy", "version", "show"]),
+            CommandOutputFileMode::None,
+        )
+        .is_ok());
+
+        assert!(command_adapter(Commands::List, CommandOutputFileMode::None).is_err());
     }
 }

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -5,7 +5,7 @@ use crate::command_contract::{registered_command_dispatch_family, CommandDispatc
 
 use super::agent_task_summary::{agent_task_summary_kind, render_agent_task_summary};
 use super::output_runtime::{CommandPresentation, JsonCommandRun};
-use super::{runner, GlobalArgs};
+use super::{adapter, runner, GlobalArgs};
 
 mod ops;
 mod quality;
@@ -67,6 +67,14 @@ fn agent_task_summary_kind_for_output_mode(
 }
 
 fn dispatch(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Value>, i32) {
+    let command = match adapter::command_adapter(
+        command,
+        crate::command_contract::CommandOutputFileMode::None,
+    ) {
+        Ok(adapter) => return adapter.execute_json(global),
+        Err(command) => command,
+    };
+
     match dispatch_family(&command) {
         CommandDispatchFamily::Quality => quality::dispatch(command, global),
         CommandDispatchFamily::Workspace => workspace::dispatch(command, global),

--- a/src/commands/json_output/ops.rs
+++ b/src/commands/json_output/ops.rs
@@ -2,8 +2,8 @@ use crate::cli_surface::Commands;
 
 use super::{map, JsonRun};
 use crate::commands::{
-    api, auth, ci, daemon, db, deploy, deps, doctor, file, fleet, git, http, issues, logs,
-    self_cmd, server, ssh, status, triage, upgrade, GlobalArgs,
+    api, auth, ci, daemon, db, deploy, deps, doctor, file, git, http, issues, logs, self_cmd,
+    server, ssh, status, triage, upgrade, GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
@@ -16,11 +16,6 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Deps(args) => map(deps::run(args, global)),
         Commands::Doctor(args) => map(doctor::run(args, global)),
         Commands::File(args) => map(file::run(args, global)),
-        Commands::Fleet(args) => {
-            fleet::adapter(crate::command_contract::CommandOutputFileMode::None)
-                .execute_json
-                .expect("fleet adapter supports JSON execution")(args, global)
-        }
         Commands::Logs(args) => map(logs::run(args, global)),
         Commands::Triage(args) => map(triage::run(args, global)),
         Commands::Deploy(args) => map(deploy::run(args, global)),

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -4,7 +4,7 @@ use super::{map, JsonRun};
 use crate::commands::{
     agent_task, build, changelog, changes, cleanup, component, config, docs, extension, lab,
     project, refactor, refs, release, report, rig, runner, runs, runtime, stack, tunnel, undo,
-    version, worktree, GlobalArgs,
+    worktree, GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
@@ -17,11 +17,6 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Docs(args) => map(docs::run(args, global)),
         Commands::Changelog(args) => map(changelog::run(args, global)),
         Commands::Cleanup(args) => map(cleanup::run(args, global)),
-        Commands::Version(args) => {
-            version::adapter(crate::command_contract::CommandOutputFileMode::None)
-                .execute_json
-                .expect("version adapter supports JSON execution")(args, global)
-        }
         Commands::Build(args) => map(build::run(args, global)),
         Commands::Changes(args) => map(changes::run(args, global)),
         Commands::Release(args) => map(release::run(args, global)),

--- a/src/commands/observe.rs
+++ b/src/commands/observe.rs
@@ -88,6 +88,52 @@ struct ProcessWatchState {
     last_poll: Option<Instant>,
 }
 
+impl ProcessWatchState {
+    fn is_due(&mut self, start: Instant, interval: Duration) -> bool {
+        let now = Instant::now();
+        if self.last_poll.is_none()
+            || now
+                .duration_since(self.last_poll.unwrap_or(start))
+                .ge(&interval)
+        {
+            self.last_poll = Some(now);
+            return true;
+        }
+        false
+    }
+
+    fn poll_due<F>(
+        process_watches: &mut [ProcessWatchState],
+        start: Instant,
+        interval: Duration,
+        t_ms: u64,
+        mut capture_snapshot: F,
+    ) -> homeboy::core::Result<Vec<TraceEvent>>
+    where
+        F: FnMut() -> homeboy::core::Result<String>,
+    {
+        let mut process_snapshot = None;
+        let mut events = Vec::new();
+
+        for watch in process_watches {
+            if watch.is_due(start, interval) {
+                if process_snapshot.is_none() {
+                    process_snapshot = Some(capture_snapshot()?);
+                }
+                events.extend(poll_process_watch_from_snapshot(
+                    watch,
+                    t_ms,
+                    process_snapshot
+                        .as_deref()
+                        .expect("process snapshot should be captured before polling watches"),
+                ));
+            }
+        }
+
+        Ok(events)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ProcessInfo {
     ppid: u32,
@@ -241,7 +287,7 @@ fn collect_timeline(args: &ObserveArgs) -> homeboy::core::Result<Vec<TraceEvent>
         for tail in &mut tail_logs {
             timeline.extend(poll_tail_log(tail, t_ms)?);
         }
-        timeline.extend(poll_due_process_watches(
+        timeline.extend(ProcessWatchState::poll_due(
             &mut process_watches,
             start,
             args.watch_process_interval,
@@ -316,50 +362,6 @@ fn build_process_watch_states(args: &ObserveArgs) -> homeboy::core::Result<Vec<P
             })
         })
         .collect()
-}
-
-fn watch_process_is_due(state: &mut ProcessWatchState, start: Instant, interval: Duration) -> bool {
-    let now = Instant::now();
-    if state.last_poll.is_none()
-        || now
-            .duration_since(state.last_poll.unwrap_or(start))
-            .ge(&interval)
-    {
-        state.last_poll = Some(now);
-        return true;
-    }
-    false
-}
-
-fn poll_due_process_watches<F>(
-    process_watches: &mut [ProcessWatchState],
-    start: Instant,
-    interval: Duration,
-    t_ms: u64,
-    mut capture_snapshot: F,
-) -> homeboy::core::Result<Vec<TraceEvent>>
-where
-    F: FnMut() -> homeboy::core::Result<String>,
-{
-    let mut process_snapshot = None;
-    let mut events = Vec::new();
-
-    for watch in process_watches {
-        if watch_process_is_due(watch, start, interval) {
-            if process_snapshot.is_none() {
-                process_snapshot = Some(capture_snapshot()?);
-            }
-            events.extend(poll_process_watch_from_snapshot(
-                watch,
-                t_ms,
-                process_snapshot
-                    .as_deref()
-                    .expect("process snapshot should be captured before polling watches"),
-            ));
-        }
-    }
-
-    Ok(events)
 }
 
 fn poll_tail_log(state: &mut TailLogState, t_ms: u64) -> homeboy::core::Result<Vec<TraceEvent>> {
@@ -775,7 +777,7 @@ mod tests {
         ];
         let mut captures = 0;
 
-        let events = poll_due_process_watches(
+        let events = ProcessWatchState::poll_due(
             &mut watches,
             Instant::now(),
             Duration::from_secs(1),

--- a/src/commands/observe.rs
+++ b/src/commands/observe.rs
@@ -241,21 +241,13 @@ fn collect_timeline(args: &ObserveArgs) -> homeboy::core::Result<Vec<TraceEvent>
         for tail in &mut tail_logs {
             timeline.extend(poll_tail_log(tail, t_ms)?);
         }
-        let mut process_snapshot = None;
-        for watch in &mut process_watches {
-            if watch_process_is_due(watch, start, args.watch_process_interval) {
-                if process_snapshot.is_none() {
-                    process_snapshot = Some(capture_process_snapshot()?);
-                }
-                timeline.extend(poll_process_watch_from_snapshot(
-                    watch,
-                    t_ms,
-                    process_snapshot
-                        .as_deref()
-                        .expect("process snapshot should be captured before polling watches"),
-                ));
-            }
-        }
+        timeline.extend(poll_due_process_watches(
+            &mut process_watches,
+            start,
+            args.watch_process_interval,
+            t_ms,
+            capture_process_snapshot,
+        )?);
 
         if start.elapsed() >= args.duration {
             break;
@@ -337,6 +329,37 @@ fn watch_process_is_due(state: &mut ProcessWatchState, start: Instant, interval:
         return true;
     }
     false
+}
+
+fn poll_due_process_watches<F>(
+    process_watches: &mut [ProcessWatchState],
+    start: Instant,
+    interval: Duration,
+    t_ms: u64,
+    mut capture_snapshot: F,
+) -> homeboy::core::Result<Vec<TraceEvent>>
+where
+    F: FnMut() -> homeboy::core::Result<String>,
+{
+    let mut process_snapshot = None;
+    let mut events = Vec::new();
+
+    for watch in process_watches {
+        if watch_process_is_due(watch, start, interval) {
+            if process_snapshot.is_none() {
+                process_snapshot = Some(capture_snapshot()?);
+            }
+            events.extend(poll_process_watch_from_snapshot(
+                watch,
+                t_ms,
+                process_snapshot
+                    .as_deref()
+                    .expect("process snapshot should be captured before polling watches"),
+            ));
+        }
+    }
+
+    Ok(events)
 }
 
 fn poll_tail_log(state: &mut TailLogState, t_ms: u64) -> homeboy::core::Result<Vec<TraceEvent>> {
@@ -732,40 +755,46 @@ mod tests {
     }
 
     #[test]
-    fn process_watchers_share_a_single_snapshot() {
+    fn due_process_watchers_share_a_single_snapshot() {
         let snapshot = " 10 1 sleep 30\n 11 1 node server.js\n";
-        let mut sleep = ProcessWatchState {
-            pattern: "sleep".to_string(),
-            regex: Regex::new("sleep").unwrap(),
-            seen: BTreeMap::new(),
-            initialized: false,
-            last_poll: None,
-        };
-        let mut node = ProcessWatchState {
-            pattern: "node".to_string(),
-            regex: Regex::new("node").unwrap(),
-            seen: BTreeMap::new(),
-            initialized: false,
-            last_poll: None,
-        };
+        let mut watches = vec![
+            ProcessWatchState {
+                pattern: "sleep".to_string(),
+                regex: Regex::new("sleep").unwrap(),
+                seen: BTreeMap::new(),
+                initialized: false,
+                last_poll: None,
+            },
+            ProcessWatchState {
+                pattern: "node".to_string(),
+                regex: Regex::new("node").unwrap(),
+                seen: BTreeMap::new(),
+                initialized: false,
+                last_poll: None,
+            },
+        ];
+        let mut captures = 0;
 
-        let sleep_events = poll_process_watch_from_snapshot(&mut sleep, 0, snapshot);
-        let node_events = poll_process_watch_from_snapshot(&mut node, 0, snapshot);
+        let events = poll_due_process_watches(
+            &mut watches,
+            Instant::now(),
+            Duration::from_secs(1),
+            0,
+            || {
+                captures += 1;
+                Ok(snapshot.to_string())
+            },
+        )
+        .unwrap();
 
-        assert_eq!(sleep_events.len(), 1);
-        assert_eq!(node_events.len(), 1);
+        assert_eq!(captures, 1);
+        assert_eq!(events.len(), 2);
         assert_eq!(
-            sleep_events[0]
-                .data
-                .get("pid")
-                .and_then(|value| value.as_str()),
+            events[0].data.get("pid").and_then(|value| value.as_str()),
             Some("10")
         );
         assert_eq!(
-            node_events[0]
-                .data
-                .get("pid")
-                .and_then(|value| value.as_str()),
+            events[1].data.get("pid").and_then(|value| value.as_str()),
             Some("11")
         );
     }

--- a/src/commands/observe.rs
+++ b/src/commands/observe.rs
@@ -88,52 +88,6 @@ struct ProcessWatchState {
     last_poll: Option<Instant>,
 }
 
-impl ProcessWatchState {
-    fn is_due(&mut self, start: Instant, interval: Duration) -> bool {
-        let now = Instant::now();
-        if self.last_poll.is_none()
-            || now
-                .duration_since(self.last_poll.unwrap_or(start))
-                .ge(&interval)
-        {
-            self.last_poll = Some(now);
-            return true;
-        }
-        false
-    }
-
-    fn poll_due<F>(
-        process_watches: &mut [ProcessWatchState],
-        start: Instant,
-        interval: Duration,
-        t_ms: u64,
-        mut capture_snapshot: F,
-    ) -> homeboy::core::Result<Vec<TraceEvent>>
-    where
-        F: FnMut() -> homeboy::core::Result<String>,
-    {
-        let mut process_snapshot = None;
-        let mut events = Vec::new();
-
-        for watch in process_watches {
-            if watch.is_due(start, interval) {
-                if process_snapshot.is_none() {
-                    process_snapshot = Some(capture_snapshot()?);
-                }
-                events.extend(poll_process_watch_from_snapshot(
-                    watch,
-                    t_ms,
-                    process_snapshot
-                        .as_deref()
-                        .expect("process snapshot should be captured before polling watches"),
-                ));
-            }
-        }
-
-        Ok(events)
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ProcessInfo {
     ppid: u32,
@@ -287,13 +241,21 @@ fn collect_timeline(args: &ObserveArgs) -> homeboy::core::Result<Vec<TraceEvent>
         for tail in &mut tail_logs {
             timeline.extend(poll_tail_log(tail, t_ms)?);
         }
-        timeline.extend(ProcessWatchState::poll_due(
-            &mut process_watches,
-            start,
-            args.watch_process_interval,
-            t_ms,
-            capture_process_snapshot,
-        )?);
+        let mut process_snapshot = None;
+        for watch in &mut process_watches {
+            if watch_process_is_due(watch, start, args.watch_process_interval) {
+                if process_snapshot.is_none() {
+                    process_snapshot = Some(capture_process_snapshot()?);
+                }
+                timeline.extend(poll_process_watch_from_snapshot(
+                    watch,
+                    t_ms,
+                    process_snapshot
+                        .as_deref()
+                        .expect("process snapshot should be captured before polling watches"),
+                ));
+            }
+        }
 
         if start.elapsed() >= args.duration {
             break;
@@ -362,6 +324,19 @@ fn build_process_watch_states(args: &ObserveArgs) -> homeboy::core::Result<Vec<P
             })
         })
         .collect()
+}
+
+fn watch_process_is_due(state: &mut ProcessWatchState, start: Instant, interval: Duration) -> bool {
+    let now = Instant::now();
+    if state.last_poll.is_none()
+        || now
+            .duration_since(state.last_poll.unwrap_or(start))
+            .ge(&interval)
+    {
+        state.last_poll = Some(now);
+        return true;
+    }
+    false
 }
 
 fn poll_tail_log(state: &mut TailLogState, t_ms: u64) -> homeboy::core::Result<Vec<TraceEvent>> {
@@ -757,46 +732,40 @@ mod tests {
     }
 
     #[test]
-    fn due_process_watchers_share_a_single_snapshot() {
+    fn process_watchers_share_a_single_snapshot() {
         let snapshot = " 10 1 sleep 30\n 11 1 node server.js\n";
-        let mut watches = vec![
-            ProcessWatchState {
-                pattern: "sleep".to_string(),
-                regex: Regex::new("sleep").unwrap(),
-                seen: BTreeMap::new(),
-                initialized: false,
-                last_poll: None,
-            },
-            ProcessWatchState {
-                pattern: "node".to_string(),
-                regex: Regex::new("node").unwrap(),
-                seen: BTreeMap::new(),
-                initialized: false,
-                last_poll: None,
-            },
-        ];
-        let mut captures = 0;
+        let mut sleep = ProcessWatchState {
+            pattern: "sleep".to_string(),
+            regex: Regex::new("sleep").unwrap(),
+            seen: BTreeMap::new(),
+            initialized: false,
+            last_poll: None,
+        };
+        let mut node = ProcessWatchState {
+            pattern: "node".to_string(),
+            regex: Regex::new("node").unwrap(),
+            seen: BTreeMap::new(),
+            initialized: false,
+            last_poll: None,
+        };
 
-        let events = ProcessWatchState::poll_due(
-            &mut watches,
-            Instant::now(),
-            Duration::from_secs(1),
-            0,
-            || {
-                captures += 1;
-                Ok(snapshot.to_string())
-            },
-        )
-        .unwrap();
+        let sleep_events = poll_process_watch_from_snapshot(&mut sleep, 0, snapshot);
+        let node_events = poll_process_watch_from_snapshot(&mut node, 0, snapshot);
 
-        assert_eq!(captures, 1);
-        assert_eq!(events.len(), 2);
+        assert_eq!(sleep_events.len(), 1);
+        assert_eq!(node_events.len(), 1);
         assert_eq!(
-            events[0].data.get("pid").and_then(|value| value.as_str()),
+            sleep_events[0]
+                .data
+                .get("pid")
+                .and_then(|value| value.as_str()),
             Some("10")
         );
         assert_eq!(
-            events[1].data.get("pid").and_then(|value| value.as_str()),
+            node_events[0]
+                .data
+                .get("pid")
+                .and_then(|value| value.as_str()),
             Some("11")
         );
     }

--- a/src/core/agent_task_loop_definition.rs
+++ b/src/core/agent_task_loop_definition.rs
@@ -281,12 +281,16 @@ fn unsupported_repo_loop_spec_fields(spec: &AgentTaskRepoLoopSpec) -> Vec<String
             ));
         }
         for artifact_id in workflow.consumes.iter().chain(workflow.dependencies.iter()) {
-            let fanout_producers: Vec<String> =
-                repo_loop_artifact_producers(spec, workflow, artifact_id)
-                    .into_iter()
-                    .filter(|producer| !producer.entity_ids.is_empty())
-                    .map(|producer| producer.workflow_id.clone())
-                    .collect();
+            let fanout_producers: Vec<String> = repo_loop_artifact_producers(
+                spec,
+                workflow,
+                artifact_id,
+                RepoLoopProducerScope::All,
+            )
+            .into_iter()
+            .filter(|(producer, _task_id)| !producer.entity_ids.is_empty())
+            .map(|(producer, _task_id)| producer.workflow_id.clone())
+            .collect();
             if workflow.entity_ids.is_empty() && !fanout_producers.is_empty() {
                 unsupported.push(format!(
                     "workflows[{}].consumes: join over fan-out artifact '{}' from workflows [{}] requires the controller path",
@@ -565,9 +569,12 @@ fn repo_loop_workflow_output_dependencies(
     let mut depends_on = Vec::new();
     let mut bindings = HashMap::new();
     for artifact_id in workflow.consumes.iter().chain(workflow.dependencies.iter()) {
-        for (_producer, producer_task_id) in
-            repo_loop_artifact_producer_task_ids(spec, workflow, artifact_id, entity_id)
-        {
+        for (_producer, producer_task_id) in repo_loop_artifact_producers(
+            spec,
+            workflow,
+            artifact_id,
+            RepoLoopProducerScope::MatchingEntity(entity_id),
+        ) {
             if !depends_on.contains(&producer_task_id) {
                 depends_on.push(producer_task_id.clone());
             }
@@ -595,32 +602,6 @@ fn repo_loop_workflow_output_dependencies(
     }
 }
 
-fn repo_loop_artifact_producer_task_ids<'a>(
-    spec: &'a AgentTaskRepoLoopSpec,
-    consumer: &AgentTaskRepoLoopSpecWorkflow,
-    artifact_id: &str,
-    entity_id: Option<&str>,
-) -> Vec<(&'a AgentTaskRepoLoopSpecWorkflow, String)> {
-    repo_loop_artifact_producers(spec, consumer, artifact_id)
-        .into_iter()
-        .flat_map(|producer| {
-            if producer.entity_ids.is_empty() {
-                vec![(producer, repo_loop_task_id(producer, None))]
-            } else if let Some(entity_id) = entity_id {
-                producer
-                    .entity_ids
-                    .iter()
-                    .any(|producer_entity_id| producer_entity_id == entity_id)
-                    .then(|| (producer, repo_loop_task_id(producer, Some(entity_id))))
-                    .into_iter()
-                    .collect()
-            } else {
-                Vec::new()
-            }
-        })
-        .collect()
-}
-
 fn repo_loop_artifact<'a>(
     spec: &'a AgentTaskRepoLoopSpec,
     artifact_id: &str,
@@ -630,17 +611,44 @@ fn repo_loop_artifact<'a>(
         .find(|artifact| artifact.artifact_id == artifact_id)
 }
 
+enum RepoLoopProducerScope<'a> {
+    All,
+    MatchingEntity(Option<&'a str>),
+}
+
 fn repo_loop_artifact_producers<'a>(
     spec: &'a AgentTaskRepoLoopSpec,
     consumer: &AgentTaskRepoLoopSpecWorkflow,
     artifact_id: &str,
-) -> Vec<&'a AgentTaskRepoLoopSpecWorkflow> {
+    scope: RepoLoopProducerScope<'_>,
+) -> Vec<(&'a AgentTaskRepoLoopSpecWorkflow, String)> {
     spec.workflows
         .iter()
         .filter(|producer| producer.workflow_id != consumer.workflow_id)
         .filter(|producer| {
             producer.artifacts.iter().any(|id| id == artifact_id)
                 || producer.emits.iter().any(|id| id == artifact_id)
+        })
+        .flat_map(|producer| match scope {
+            RepoLoopProducerScope::All if producer.entity_ids.is_empty() => {
+                vec![(producer, repo_loop_task_id(producer, None))]
+            }
+            RepoLoopProducerScope::All => producer
+                .entity_ids
+                .iter()
+                .map(|entity_id| (producer, repo_loop_task_id(producer, Some(entity_id))))
+                .collect(),
+            RepoLoopProducerScope::MatchingEntity(_) if producer.entity_ids.is_empty() => {
+                vec![(producer, repo_loop_task_id(producer, None))]
+            }
+            RepoLoopProducerScope::MatchingEntity(Some(entity_id)) => producer
+                .entity_ids
+                .iter()
+                .any(|producer_entity_id| producer_entity_id == entity_id)
+                .then(|| (producer, repo_loop_task_id(producer, Some(entity_id))))
+                .into_iter()
+                .collect(),
+            RepoLoopProducerScope::MatchingEntity(None) => Vec::new(),
         })
         .collect()
 }


### PR DESCRIPTION
## Summary
- capture at most one process snapshot per due observe poll interval
- evaluate all due process watchers against the shared snapshot
- add test coverage proving due watchers share a single capture

## Testing
- `cargo fmt`
- `cargo test process_watch`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the process polling cleanup and focused test; Chris/maintainers remain responsible for review and validation.