### PR TITLE
Route migrated JSON commands through typed adapters

### DIFF
--- a/src/commands/adapter.rs
+++ b/src/commands/adapter.rs
@@ -5,7 +5,9 @@ use crate::command_contract::{
     CommandResponseMode,
 };
 
-use super::GlobalArgs;
+use crate::cli_surface::Commands;
+
+use super::{fleet, version, GlobalArgs};
 
 pub(crate) type JsonCommandRun = (homeboy::core::Result<Value>, i32);
 pub(crate) type JsonCommandExecutor<Args> = fn(Args, &GlobalArgs) -> JsonCommandRun;
@@ -50,6 +52,30 @@ pub(crate) struct TypedCommandAdapter<Args> {
     pub execute_json: Option<JsonCommandExecutor<Args>>,
 }
 
+pub(crate) struct BoundCommandAdapter {
+    execution: BoundCommandExecution,
+}
+
+enum BoundCommandExecution {
+    Fleet {
+        args: fleet::FleetArgs,
+        execute_json: JsonCommandExecutor<fleet::FleetArgs>,
+    },
+    Version {
+        args: version::VersionArgs,
+        execute_json: JsonCommandExecutor<version::VersionArgs>,
+    },
+}
+
+impl BoundCommandAdapter {
+    pub fn execute_json(self, global: &GlobalArgs) -> JsonCommandRun {
+        match self.execution {
+            BoundCommandExecution::Fleet { args, execute_json } => execute_json(args, global),
+            BoundCommandExecution::Version { args, execute_json } => execute_json(args, global),
+        }
+    }
+}
+
 impl<Args> TypedCommandAdapter<Args> {
     pub fn output_descriptor(&self) -> CommandOutputDescriptor {
         self.contract.to_output_descriptor()
@@ -74,9 +100,47 @@ impl<Args> TypedCommandAdapter<Args> {
     }
 }
 
+pub(crate) fn command_adapter(
+    command: Commands,
+    output_file_mode: CommandOutputFileMode,
+) -> Result<BoundCommandAdapter, Commands> {
+    match command {
+        Commands::Fleet(args) => {
+            let adapter = fleet::adapter(output_file_mode);
+            Ok(BoundCommandAdapter {
+                execution: BoundCommandExecution::Fleet {
+                    args,
+                    execute_json: adapter
+                        .execute_json
+                        .expect("fleet adapter supports JSON execution"),
+                },
+            })
+        }
+        Commands::Version(args) => {
+            let adapter = version::adapter(output_file_mode);
+            Ok(BoundCommandAdapter {
+                execution: BoundCommandExecution::Version {
+                    args,
+                    execute_json: adapter
+                        .execute_json
+                        .expect("version adapter supports JSON execution"),
+                },
+            })
+        }
+        command => Err(command),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
+
+    fn parsed_command(args: &[&str]) -> Commands {
+        crate::cli_surface::Cli::try_parse_from(args)
+            .expect("CLI args should parse")
+            .command
+    }
 
     #[test]
     fn json_only_contract_maps_to_output_descriptor() {
@@ -96,5 +160,15 @@ mod tests {
         );
         assert_eq!(descriptor.json_family, CommandJsonFamily::Workspace);
         assert!(adapter.execute_json.is_some());
+    }
+    #[test]
+    fn command_adapter_recognizes_migrated_json_commands() {
+        assert!(command_adapter(
+            parsed_command(&["homeboy", "version", "show"]),
+            CommandOutputFileMode::None,
+        )
+        .is_ok());
+
+        assert!(command_adapter(Commands::List, CommandOutputFileMode::None).is_err());
     }
 }

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -5,7 +5,7 @@ use crate::command_contract::{registered_command_dispatch_family, CommandDispatc
 
 use super::agent_task_summary::{agent_task_summary_kind, render_agent_task_summary};
 use super::output_runtime::{CommandPresentation, JsonCommandRun};
-use super::{runner, GlobalArgs};
+use super::{adapter, runner, GlobalArgs};
 
 mod ops;
 mod quality;
@@ -67,6 +67,14 @@ fn agent_task_summary_kind_for_output_mode(
 }
 
 fn dispatch(command: Commands, global: &GlobalArgs) -> (homeboy::core::Result<Value>, i32) {
+    let command = match adapter::command_adapter(
+        command,
+        crate::command_contract::CommandOutputFileMode::None,
+    ) {
+        Ok(adapter) => return adapter.execute_json(global),
+        Err(command) => command,
+    };
+
     match dispatch_family(&command) {
         CommandDispatchFamily::Quality => quality::dispatch(command, global),
         CommandDispatchFamily::Workspace => workspace::dispatch(command, global),

--- a/src/commands/json_output/ops.rs
+++ b/src/commands/json_output/ops.rs
@@ -2,8 +2,8 @@ use crate::cli_surface::Commands;
 
 use super::{map, JsonRun};
 use crate::commands::{
-    api, auth, ci, daemon, db, deploy, deps, doctor, file, fleet, git, http, issues, logs,
-    self_cmd, server, ssh, status, triage, upgrade, GlobalArgs,
+    api, auth, ci, daemon, db, deploy, deps, doctor, file, git, http, issues, logs, self_cmd,
+    server, ssh, status, triage, upgrade, GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
@@ -16,11 +16,6 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Deps(args) => map(deps::run(args, global)),
         Commands::Doctor(args) => map(doctor::run(args, global)),
         Commands::File(args) => map(file::run(args, global)),
-        Commands::Fleet(args) => {
-            fleet::adapter(crate::command_contract::CommandOutputFileMode::None)
-                .execute_json
-                .expect("fleet adapter supports JSON execution")(args, global)
-        }
         Commands::Logs(args) => map(logs::run(args, global)),
         Commands::Triage(args) => map(triage::run(args, global)),
         Commands::Deploy(args) => map(deploy::run(args, global)),

--- a/src/commands/json_output/workspace.rs
+++ b/src/commands/json_output/workspace.rs
@@ -4,7 +4,7 @@ use super::{map, JsonRun};
 use crate::commands::{
     agent_task, build, changelog, changes, cleanup, component, config, docs, extension, lab,
     project, refactor, refs, release, report, rig, runner, runs, runtime, stack, tunnel, undo,
-    version, worktree, GlobalArgs,
+    worktree, GlobalArgs,
 };
 
 pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
@@ -17,11 +17,6 @@ pub(super) fn dispatch(command: Commands, global: &GlobalArgs) -> JsonRun {
         Commands::Docs(args) => map(docs::run(args, global)),
         Commands::Changelog(args) => map(changelog::run(args, global)),
         Commands::Cleanup(args) => map(cleanup::run(args, global)),
-        Commands::Version(args) => {
-            version::adapter(crate::command_contract::CommandOutputFileMode::None)
-                .execute_json
-                .expect("version adapter supports JSON execution")(args, global)
-        }
         Commands::Build(args) => map(build::run(args, global)),
         Commands::Changes(args) => map(changes::run(args, global)),
         Commands::Release(args) => map(release::run(args, global)),


### PR DESCRIPTION
## Summary
- add a central bound typed-command adapter path for migrated JSON commands
- route `fleet` and `version` JSON execution through the adapter before family dispatch
- remove duplicated adapter branches from JSON family dispatch modules

## Testing
- `cargo fmt`
- `cargo check`
- `cargo test commands::adapter`
- `cargo test commands::json_output`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the scoped refactor and tests; Chris/maintainers remain responsible for review and validation.