### PR TITLE
Add control-plane agent tool dispatch

### DIFF
--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -154,6 +154,10 @@ impl CliRuntime {
             return std::process::ExitCode::from(exit_code_to_u8(exit_code));
         }
 
+        if let Some(exit_code) = run_raw_agent_tool_dispatch(&cli.command) {
+            return std::process::ExitCode::from(exit_code_to_u8(exit_code));
+        }
+
         run_startup_update_checks(&cli.command);
 
         if matches!(cli.command, Commands::List) {
@@ -185,6 +189,22 @@ impl CliRuntime {
 
     fn try_parse_extension_cli_command(&self, matches: &ArgMatches) -> Option<ExtensionCliCommand> {
         try_parse_extension_cli_command(matches, &self.extension_info)
+    }
+}
+
+fn run_raw_agent_tool_dispatch(command: &Commands) -> Option<i32> {
+    let Commands::AgentTask(args) = command else {
+        return None;
+    };
+    let crate::commands::agent_task::AgentTaskCommand::Tool(tool_args) = &args.command else {
+        return None;
+    };
+    match &tool_args.command {
+        crate::commands::agent_task::tool::AgentTaskToolCommand::Dispatch(_args) => {
+            Some(crate::commands::agent_task::tool::dispatch_raw(
+                crate::commands::agent_task::tool::AgentTaskToolDispatchArgs {},
+            ))
+        }
     }
 }
 

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -17,6 +17,7 @@ pub mod loop_definition;
 pub mod review;
 pub mod run;
 pub mod status;
+pub mod tool;
 
 pub use args::{
     AgentTaskArgs, AgentTaskAuthArgs, AgentTaskAuthCommand, AgentTaskCommand,
@@ -66,6 +67,16 @@ pub fn run(args: AgentTaskArgs, global: &GlobalArgs) -> CmdResult<Value> {
         AgentTaskCommand::CompileLoop(compile_args) => loop_definition::compile_loop(compile_args),
         AgentTaskCommand::Auth(auth_args) => auth::auth(auth_args),
         AgentTaskCommand::Controller(controller_args) => controller::controller(controller_args),
+        AgentTaskCommand::Tool(tool_args) => match tool_args.command {
+            tool::AgentTaskToolCommand::Dispatch(_) => {
+                Err(homeboy::core::Error::validation_invalid_argument(
+                    "agent-task tool dispatch",
+                    "this internal bridge command is handled by the raw CLI runtime",
+                    None,
+                    None,
+                ))
+            }
+        },
     }
 }
 

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -9,6 +9,7 @@ use homeboy::core::agent_tasks::gate::{AgentTaskGateRevealPolicy, VerifyGateOpti
 
 use super::super::agent_task_dispatch::DispatchArgs;
 use super::review;
+use super::tool::AgentTaskToolArgs;
 
 mod auth;
 mod controller;
@@ -83,6 +84,9 @@ pub enum AgentTaskCommand {
     Auth(AgentTaskAuthArgs),
     /// Create, inspect, and resume durable multi-agent loop controller state.
     Controller(AgentTaskControllerArgs),
+    /// Internal bridge for provider-runtime agent tool requests.
+    #[command(hide = true)]
+    Tool(AgentTaskToolArgs),
 }
 
 /// Shared deterministic verification gate flags. Flattened into every

--- a/src/commands/agent_task/tool.rs
+++ b/src/commands/agent_task/tool.rs
@@ -1,0 +1,129 @@
+use std::io::Read;
+
+use clap::{Args, Subcommand};
+use homeboy::core::agent_tasks::{
+    dispatch_agent_tool_request, AgentToolPolicy, AgentToolRequest,
+    HomeboyAgentToolControlPlaneDispatcher,
+};
+use serde_json::Value;
+
+#[derive(Args, Debug)]
+pub struct AgentTaskToolArgs {
+    #[command(subcommand)]
+    pub command: AgentTaskToolCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AgentTaskToolCommand {
+    /// Dispatch one agent tool request from stdin and emit a raw agent-tool-result JSON object.
+    Dispatch(AgentTaskToolDispatchArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskToolDispatchArgs {}
+
+pub fn dispatch_raw(_args: AgentTaskToolDispatchArgs) -> i32 {
+    match dispatch_raw_result() {
+        Ok(result) => {
+            println!("{}", result);
+            0
+        }
+        Err(message) => {
+            eprintln!("{message}");
+            2
+        }
+    }
+}
+
+fn dispatch_raw_result() -> Result<String, String> {
+    let mut stdin = String::new();
+    std::io::stdin()
+        .read_to_string(&mut stdin)
+        .map_err(|error| format!("failed to read agent tool request from stdin: {error}"))?;
+
+    let request: AgentToolRequest = serde_json::from_str(&stdin)
+        .map_err(|error| format!("invalid agent tool request JSON: {error}"))?;
+    let policy = policy_from_env()?;
+    let outcome =
+        dispatch_agent_tool_request(&policy, &request, &HomeboyAgentToolControlPlaneDispatcher);
+
+    serde_json::to_string(&outcome.result)
+        .map_err(|error| format!("failed to serialize agent tool result JSON: {error}"))
+}
+
+fn policy_from_env() -> Result<AgentToolPolicy, String> {
+    match std::env::var("HOMEBOY_AGENT_TOOL_POLICY_JSON") {
+        Ok(raw) if raw.trim().is_empty() => Ok(AgentToolPolicy::default()),
+        Ok(raw) => serde_json::from_str(&raw)
+            .map_err(|error| format!("invalid HOMEBOY_AGENT_TOOL_POLICY_JSON: {error}")),
+        Err(std::env::VarError::NotPresent) => Ok(AgentToolPolicy::default()),
+        Err(std::env::VarError::NotUnicode(value)) => Err(format!(
+            "HOMEBOY_AGENT_TOOL_POLICY_JSON is not valid unicode: {:?}",
+            Value::String(value.to_string_lossy().to_string())
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy::core::agent_tasks::{
+        AgentToolExecutionLocation, AgentToolResultStatus, AGENT_TOOL_POLICY_SCHEMA,
+        AGENT_TOOL_REQUEST_SCHEMA,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn missing_policy_env_defaults_to_disabled() {
+        std::env::remove_var("HOMEBOY_AGENT_TOOL_POLICY_JSON");
+
+        assert_eq!(
+            policy_from_env().expect("policy").default_location,
+            AgentToolExecutionLocation::Disabled
+        );
+    }
+
+    #[test]
+    fn dispatch_result_is_denied_when_policy_disabled() {
+        let policy: AgentToolPolicy = serde_json::from_value(json!({
+            "schema": AGENT_TOOL_POLICY_SCHEMA,
+            "default_location": "disabled"
+        }))
+        .expect("policy");
+        let request: AgentToolRequest =
+            serde_json::from_value(request_json("create_github_issue")).expect("request");
+
+        let outcome =
+            dispatch_agent_tool_request(&policy, &request, &HomeboyAgentToolControlPlaneDispatcher);
+
+        assert_eq!(outcome.result.status, AgentToolResultStatus::Denied);
+        assert_eq!(outcome.result.diagnostics[0].class, "agent_tool.disabled");
+    }
+
+    #[test]
+    fn dispatch_result_validates_control_plane_tools() {
+        let policy: AgentToolPolicy = serde_json::from_value(json!({
+            "schema": AGENT_TOOL_POLICY_SCHEMA,
+            "default_location": "control_plane"
+        }))
+        .expect("policy");
+        let request: AgentToolRequest =
+            serde_json::from_value(request_json("create_github_issue")).expect("request");
+
+        let outcome =
+            dispatch_agent_tool_request(&policy, &request, &HomeboyAgentToolControlPlaneDispatcher);
+
+        assert_eq!(outcome.result.status, AgentToolResultStatus::Failed);
+        assert_eq!(outcome.result.diagnostics[0].class, "agent_tool.validation");
+    }
+
+    fn request_json(tool: &str) -> Value {
+        json!({
+            "schema": AGENT_TOOL_REQUEST_SCHEMA,
+            "request_id": "request-1",
+            "task_id": "task-1",
+            "tool": tool,
+            "input": {}
+        })
+    }
+}

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -23,6 +23,7 @@ use crate::core::agent_task_secrets::{
 };
 use crate::core::agent_task_timeout::timeout_with_grace;
 use crate::core::command_invocation::CommandInvocation;
+use crate::core::engine::shell;
 use crate::core::secret_env_plan::{SecretEnvPlan, SecretEnvStatus};
 use crate::core::{agent_runtime_manifest, component, defaults, extension, Error};
 
@@ -2191,6 +2192,10 @@ fn provider_command_env(
             AGENT_TOOL_POLICY_SCHEMA.to_string(),
         ),
         (
+            "HOMEBOY_AGENT_TOOL_DISPATCH_COMMAND".to_string(),
+            agent_tool_dispatch_command(),
+        ),
+        (
             "HOMEBOY_EXTENSION_ID".to_string(),
             provider.extension_id.clone().unwrap_or_default(),
         ),
@@ -2214,6 +2219,16 @@ fn provider_command_env(
         .map_err(ProviderCommandEnvError::Secret)?,
     );
     Ok(env)
+}
+
+fn agent_tool_dispatch_command() -> String {
+    let current_exe = std::env::current_exe()
+        .map(|path| path.to_string_lossy().to_string())
+        .expect("current executable path is required for agent tool dispatch command");
+    format!(
+        "{} agent-task tool dispatch",
+        shell::quote_arg(&current_exe)
+    )
 }
 
 fn failure_outcome(
@@ -2654,6 +2669,17 @@ mod tests {
             env.get("HOMEBOY_AGENT_TOOL_POLICY_SCHEMA")
                 .map(String::as_str),
             Some(AGENT_TOOL_POLICY_SCHEMA)
+        );
+        let dispatch_command = env
+            .get("HOMEBOY_AGENT_TOOL_DISPATCH_COMMAND")
+            .expect("tool dispatch command env");
+        assert!(
+            dispatch_command.ends_with(" agent-task tool dispatch"),
+            "dispatch command should invoke hidden tool dispatch command: {dispatch_command}"
+        );
+        assert!(
+            dispatch_command.starts_with('/') || dispatch_command.starts_with('\''),
+            "dispatch command should start with an absolute executable path, shell quoted when needed: {dispatch_command}"
         );
 
         let policy: crate::core::agent_task::AgentToolPolicy = serde_json::from_str(

--- a/src/core/agent_tasks.rs
+++ b/src/core/agent_tasks.rs
@@ -92,8 +92,8 @@ pub use super::agent_task_scheduler::{AgentTaskExecutorAdapter, AgentTaskSchedul
 
 pub use super::agent_tool_control_plane::{
     dispatch_agent_tool_request, AgentToolControlPlaneDispatcher, AgentToolDispatchEvidence,
-    AgentToolDispatchOutcome, UnsupportedAgentToolControlPlaneDispatcher,
-    AGENT_TOOL_DISPATCH_EVIDENCE_SCHEMA,
+    AgentToolDispatchOutcome, HomeboyAgentToolControlPlaneDispatcher,
+    UnsupportedAgentToolControlPlaneDispatcher, AGENT_TOOL_DISPATCH_EVIDENCE_SCHEMA,
 };
 
 // Matrix expansion is `pub(crate)` on the implementation module; expose it

--- a/src/core/agent_tool_control_plane.rs
+++ b/src/core/agent_tool_control_plane.rs
@@ -1,3 +1,8 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
@@ -5,6 +10,7 @@ use crate::core::agent_task::{
     AgentTaskDiagnostic, AgentToolExecutionLocation, AgentToolPolicy, AgentToolRequest,
     AgentToolResult, AgentToolResultStatus, AGENT_TOOL_RESULT_SCHEMA,
 };
+use crate::core::{git, worktree};
 
 pub const AGENT_TOOL_DISPATCH_EVIDENCE_SCHEMA: &str = "homeboy/agent-tool-dispatch-evidence/v1";
 
@@ -18,6 +24,18 @@ pub struct UnsupportedAgentToolControlPlaneDispatcher;
 impl AgentToolControlPlaneDispatcher for UnsupportedAgentToolControlPlaneDispatcher {
     fn dispatch(&self, request: &AgentToolRequest) -> AgentToolResult {
         unsupported_control_plane_result(request)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct HomeboyAgentToolControlPlaneDispatcher;
+
+impl AgentToolControlPlaneDispatcher for HomeboyAgentToolControlPlaneDispatcher {
+    fn dispatch(&self, request: &AgentToolRequest) -> AgentToolResult {
+        match dispatch_homeboy_control_plane_tool(request) {
+            Ok(output) => succeeded_tool_result(request, output),
+            Err(diagnostic) => failed_tool_result(request, diagnostic),
+        }
     }
 }
 
@@ -109,6 +127,577 @@ fn unsupported_control_plane_result(request: &AgentToolRequest) -> AgentToolResu
             data: json!({ "tool": request.tool }),
         }],
         metadata: json!({ "execution_location": "control_plane" }),
+    }
+}
+
+fn succeeded_tool_result(request: &AgentToolRequest, output: Value) -> AgentToolResult {
+    AgentToolResult {
+        schema: AGENT_TOOL_RESULT_SCHEMA.to_string(),
+        request_id: request.request_id.clone(),
+        task_id: request.task_id.clone(),
+        tool: request.tool.clone(),
+        status: AgentToolResultStatus::Succeeded,
+        output,
+        diagnostics: Vec::new(),
+        metadata: json!({ "execution_location": "control_plane" }),
+    }
+}
+
+fn failed_tool_result(
+    request: &AgentToolRequest,
+    diagnostic: AgentTaskDiagnostic,
+) -> AgentToolResult {
+    AgentToolResult {
+        schema: AGENT_TOOL_RESULT_SCHEMA.to_string(),
+        request_id: request.request_id.clone(),
+        task_id: request.task_id.clone(),
+        tool: request.tool.clone(),
+        status: AgentToolResultStatus::Failed,
+        output: Value::Null,
+        diagnostics: vec![diagnostic],
+        metadata: json!({ "execution_location": "control_plane" }),
+    }
+}
+
+fn dispatch_homeboy_control_plane_tool(
+    request: &AgentToolRequest,
+) -> Result<Value, AgentTaskDiagnostic> {
+    let input = request.input.as_object().ok_or_else(|| {
+        validation_error(
+            "input",
+            "tool input must be a JSON object",
+            json!({ "tool": request.tool }),
+        )
+    })?;
+
+    match request.tool.as_str() {
+        "workspace_read" => workspace_read(input),
+        "workspace_grep" => workspace_grep(input),
+        "workspace_write" => workspace_write(input),
+        "workspace_edit" => workspace_edit(input),
+        "workspace_apply_patch" | "apply_patch" => workspace_apply_patch(input),
+        "workspace_git_status" => workspace_git_status(input),
+        "workspace_git_diff" => workspace_git_diff(input),
+        "workspace_git_add" => workspace_git_add(input),
+        "workspace_git_commit" => workspace_git_commit(input),
+        "workspace_git_push" => workspace_git_push(input),
+        "workspace_worktree_add" => workspace_worktree_add(input),
+        "get_github_issue" => github_issue_get(input),
+        "create_github_issue" => github_issue_create(input),
+        "list_github_pulls" => github_pulls_list(input),
+        "create_github_pull_request" => github_pull_create(input),
+        "comment_github_pull_request" => github_pull_comment(input),
+        _ => Err(AgentTaskDiagnostic {
+            class: "agent_tool.control_plane_tool_unknown".to_string(),
+            message: format!("unsupported control-plane tool '{}'", request.tool),
+            data: json!({ "tool": request.tool }),
+        }),
+    }
+}
+
+fn workspace_read(input: &serde_json::Map<String, Value>) -> Result<Value, AgentTaskDiagnostic> {
+    let root = workspace_root(input)?;
+    let file = workspace_file_path(&root, required_string(input, &["path", "file_path"])?)?;
+    let content =
+        fs::read_to_string(&file).map_err(|error| io_error("workspace_read", &file, error))?;
+    Ok(
+        json!({ "path": file.strip_prefix(&root).unwrap_or(&file).to_string_lossy(), "content": content, "bytes": content.len() }),
+    )
+}
+
+fn workspace_write(input: &serde_json::Map<String, Value>) -> Result<Value, AgentTaskDiagnostic> {
+    let root = workspace_root_for(input, true)?;
+    let file = workspace_file_path(&root, required_string(input, &["path", "file_path"])?)?;
+    let content = required_string(input, &["content"])?;
+    if let Some(parent) = file.parent() {
+        fs::create_dir_all(parent).map_err(|error| io_error("workspace_write", parent, error))?;
+    }
+    fs::write(&file, content).map_err(|error| io_error("workspace_write", &file, error))?;
+    Ok(
+        json!({ "path": file.strip_prefix(&root).unwrap_or(&file).to_string_lossy(), "bytes_written": content.len() }),
+    )
+}
+
+fn workspace_edit(input: &serde_json::Map<String, Value>) -> Result<Value, AgentTaskDiagnostic> {
+    let root = workspace_root_for(input, true)?;
+    let file = workspace_file_path(&root, required_string(input, &["path", "file_path"])?)?;
+    let old = required_string(input, &["old_string", "old", "search"])?;
+    let new = required_string(input, &["new_string", "new", "replace"])?;
+    let content =
+        fs::read_to_string(&file).map_err(|error| io_error("workspace_edit", &file, error))?;
+    let count = content.matches(old).count();
+    if count != 1 {
+        return Err(validation_error(
+            "old_string",
+            "workspace_edit requires old_string to match exactly once",
+            json!({ "matches": count }),
+        ));
+    }
+    let updated = content.replacen(old, new, 1);
+    fs::write(&file, updated).map_err(|error| io_error("workspace_edit", &file, error))?;
+    Ok(
+        json!({ "path": file.strip_prefix(&root).unwrap_or(&file).to_string_lossy(), "replacements": 1 }),
+    )
+}
+
+fn workspace_grep(input: &serde_json::Map<String, Value>) -> Result<Value, AgentTaskDiagnostic> {
+    let root = workspace_root(input)?;
+    let pattern = required_string(input, &["pattern", "query"])?;
+    let include = optional_string(input, &["include", "file_pattern"]);
+    let path = optional_string(input, &["path", "directory"]).unwrap_or(".");
+    let search_path = workspace_file_path(&root, path)?;
+    let mut args = vec!["-n".to_string(), "--color=never".to_string()];
+    if let Some(include) = include {
+        args.push("--glob".to_string());
+        args.push(include.to_string());
+    }
+    args.push(pattern.to_string());
+    args.push(search_path.to_string_lossy().to_string());
+    let output = Command::new("rg")
+        .args(&args)
+        .current_dir(&root)
+        .output()
+        .map_err(|error| command_spawn_error("workspace_grep", error))?;
+    if !output.status.success() && output.status.code() != Some(1) {
+        return Err(command_error("workspace_grep", output));
+    }
+    let matches = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|line| json!({ "line": line }))
+        .collect::<Vec<_>>();
+    Ok(json!({ "matches": matches }))
+}
+
+fn workspace_apply_patch(
+    input: &serde_json::Map<String, Value>,
+) -> Result<Value, AgentTaskDiagnostic> {
+    let root = workspace_root(input)?;
+    let patch = required_string(input, &["patch", "diff"])?;
+    let mut child = Command::new("git")
+        .args(["apply", "--whitespace=nowarn", "-"])
+        .current_dir(&root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| command_spawn_error("workspace_apply_patch", error))?;
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(patch.as_bytes())
+        .map_err(|error| AgentTaskDiagnostic {
+            class: "agent_tool.io".to_string(),
+            message: error.to_string(),
+            data: json!({ "operation": "workspace_apply_patch" }),
+        })?;
+    let output = child
+        .wait_with_output()
+        .map_err(|error| command_spawn_error("workspace_apply_patch", error))?;
+    if !output.status.success() {
+        return Err(command_error("workspace_apply_patch", output));
+    }
+    Ok(json!({ "applied": true }))
+}
+
+fn workspace_git_status(
+    input: &serde_json::Map<String, Value>,
+) -> Result<Value, AgentTaskDiagnostic> {
+    to_value(git::status_at(
+        component_id(input),
+        workspace_path_for(input, true).as_deref(),
+    ))
+}
+
+fn workspace_git_commit(
+    input: &serde_json::Map<String, Value>,
+) -> Result<Value, AgentTaskDiagnostic> {
+    let message = required_string(input, &["message"])?;
+    let files =
+        optional_string_array(input, "paths").or_else(|| optional_string_array(input, "files"));
+    to_value(git::commit_at(
+        component_id(input),
+        Some(message),
+        git::CommitOptions {
+            staged_only: bool_input(input, "staged_only"),
+            files,
+            exclude: None,
+            amend: false,
+        },
+        workspace_path_for(input, true).as_deref(),
+    ))
+}
+
+fn workspace_git_push(
+    input: &serde_json::Map<String, Value>,
+) -> Result<Value, AgentTaskDiagnostic> {
+    to_value(git::push_at(
+        component_id(input),
+        git::PushOptions {
+            tags: bool_input(input, "tags"),
+            force_with_lease: bool_input(input, "force_with_lease"),
+            remote_url: optional_string(input, &["remote_url"]).map(str::to_string),
+            token: None,
+            refspec: optional_string(input, &["refspec"]).map(str::to_string),
+            strip_extraheader: bool_input(input, "strip_extraheader"),
+        },
+        workspace_path_for(input, true).as_deref(),
+    ))
+}
+
+fn workspace_git_diff(
+    input: &serde_json::Map<String, Value>,
+) -> Result<Value, AgentTaskDiagnostic> {
+    let root = workspace_root_for(input, true)?;
+    let output = Command::new("git")
+        .args(["diff"])
+        .current_dir(&root)
+        .output()
+        .map_err(|error| command_spawn_error("workspace_git_diff", error))?;
+    if !output.status.success() {
+        return Err(command_error("workspace_git_diff", output));
+    }
+    Ok(json!({ "diff": String::from_utf8_lossy(&output.stdout).to_string() }))
+}
+
+fn workspace_git_add(input: &serde_json::Map<String, Value>) -> Result<Value, AgentTaskDiagnostic> {
+    let root = workspace_root_for(input, true)?;
+    let paths = optional_string_array(input, "paths").unwrap_or_else(|| vec![".".to_string()]);
+    let mut args = vec!["add".to_string(), "--".to_string()];
+    args.extend(paths.clone());
+    let output = Command::new("git")
+        .args(&args)
+        .current_dir(&root)
+        .output()
+        .map_err(|error| command_spawn_error("workspace_git_add", error))?;
+    if !output.status.success() {
+        return Err(command_error("workspace_git_add", output));
+    }
+    Ok(json!({ "paths": paths }))
+}
+
+fn workspace_worktree_add(
+    input: &serde_json::Map<String, Value>,
+) -> Result<Value, AgentTaskDiagnostic> {
+    let repo = required_string(input, &["repo", "component_id", "name"])?;
+    let branch = required_string(input, &["branch"])?;
+    to_value(worktree::create(worktree::WorktreeCreateOptions {
+        component_id: component_slug(repo).to_string(),
+        branch: branch.to_string(),
+        from: optional_string(input, &["from", "base_ref"]).map(str::to_string),
+        task_url: optional_string(input, &["task_url"]).map(str::to_string),
+        run_id: optional_string(input, &["run_id", "task_ref"]).map(str::to_string),
+        cleanup_policy: None,
+    }))
+}
+
+fn github_issue_get(input: &serde_json::Map<String, Value>) -> Result<Value, AgentTaskDiagnostic> {
+    let repo = required_string(input, &["repo"])?;
+    let number = required_u64(input, &["number", "issue_number"])?;
+    run_gh_json(&[
+        "issue",
+        "view",
+        &number.to_string(),
+        "-R",
+        repo,
+        "--json",
+        "number,title,body,url,state,labels",
+    ])
+}
+
+fn github_issue_create(
+    input: &serde_json::Map<String, Value>,
+) -> Result<Value, AgentTaskDiagnostic> {
+    let repo = required_string(input, &["repo"])?;
+    let title = required_string(input, &["title"])?;
+    let body = required_string(input, &["body"])?;
+    let mut args = vec![
+        "issue".to_string(),
+        "create".to_string(),
+        "-R".to_string(),
+        repo.to_string(),
+        "--title".to_string(),
+        title.to_string(),
+        "--body".to_string(),
+        body.to_string(),
+    ];
+    for label in optional_string_array(input, "labels").unwrap_or_default() {
+        args.push("--label".to_string());
+        args.push(label);
+    }
+    run_gh_url(&args, "issue.create")
+}
+
+fn github_pulls_list(input: &serde_json::Map<String, Value>) -> Result<Value, AgentTaskDiagnostic> {
+    let repo = required_string(input, &["repo"])?;
+    let limit = optional_u64(input, &["limit"]).unwrap_or(30).to_string();
+    run_gh_json(&[
+        "pr",
+        "list",
+        "-R",
+        repo,
+        "--limit",
+        &limit,
+        "--json",
+        "number,title,url,state,baseRefName,headRefName",
+    ])
+}
+
+fn github_pull_create(
+    input: &serde_json::Map<String, Value>,
+) -> Result<Value, AgentTaskDiagnostic> {
+    let repo = required_string(input, &["repo"])?;
+    let title = required_string(input, &["title"])?;
+    let body = required_string(input, &["body"])?;
+    let base = required_string(input, &["base"])?;
+    let head = required_string(input, &["head", "branch"])?;
+    let mut args = vec![
+        "pr".to_string(),
+        "create".to_string(),
+        "-R".to_string(),
+        repo.to_string(),
+        "--base".to_string(),
+        base.to_string(),
+        "--head".to_string(),
+        head.to_string(),
+        "--title".to_string(),
+        title.to_string(),
+        "--body".to_string(),
+        body.to_string(),
+    ];
+    if bool_input(input, "draft") {
+        args.push("--draft".to_string());
+    }
+    run_gh_url(&args, "pr.create")
+}
+
+fn github_pull_comment(
+    input: &serde_json::Map<String, Value>,
+) -> Result<Value, AgentTaskDiagnostic> {
+    let repo = required_string(input, &["repo"])?;
+    let number = required_u64(input, &["number", "pr", "pull_number"])?;
+    let body = required_string(input, &["body", "comment"])?;
+    run_gh_url(
+        &[
+            "pr".to_string(),
+            "comment".to_string(),
+            number.to_string(),
+            "-R".to_string(),
+            repo.to_string(),
+            "--body".to_string(),
+            body.to_string(),
+        ],
+        "pr.comment",
+    )
+}
+
+fn run_gh_json(args: &[&str]) -> Result<Value, AgentTaskDiagnostic> {
+    let output = Command::new("gh")
+        .args(args)
+        .output()
+        .map_err(|error| command_spawn_error("github", error))?;
+    if !output.status.success() {
+        return Err(command_error("github", output));
+    }
+    serde_json::from_slice(&output.stdout)
+        .map_err(|error| validation_error("github_json", &error.to_string(), Value::Null))
+}
+
+fn run_gh_url(args: &[String], action: &str) -> Result<Value, AgentTaskDiagnostic> {
+    let output = Command::new("gh")
+        .args(args)
+        .output()
+        .map_err(|error| command_spawn_error(action, error))?;
+    if !output.status.success() {
+        return Err(command_error(action, output));
+    }
+    Ok(json!({ "action": action, "url": String::from_utf8_lossy(&output.stdout).trim() }))
+}
+
+fn workspace_root(input: &serde_json::Map<String, Value>) -> Result<PathBuf, AgentTaskDiagnostic> {
+    workspace_root_for(input, false)
+}
+
+fn workspace_root_for(
+    input: &serde_json::Map<String, Value>,
+    prefer_worktree: bool,
+) -> Result<PathBuf, AgentTaskDiagnostic> {
+    let path = workspace_path_for(input, prefer_worktree).ok_or_else(|| validation_error(
+        "path",
+        "workspace tool requires path/workspace_path/root, or a repo/name/component_id resolvable by Homeboy",
+        Value::Null,
+    ))?;
+    fs::canonicalize(&path).map_err(|error| io_error("workspace_root", Path::new(&path), error))
+}
+
+fn workspace_path_for(
+    input: &serde_json::Map<String, Value>,
+    prefer_worktree: bool,
+) -> Option<String> {
+    optional_string(input, &["workspace_path", "root"])
+        .map(str::to_string)
+        .or_else(|| {
+            component_id(input).and_then(|id| {
+                if prefer_worktree {
+                    if let Some(path) = latest_active_worktree_path(id) {
+                        return Some(path);
+                    }
+                }
+                git::status_at(Some(id), None)
+                    .ok()
+                    .map(|output| output.path)
+            })
+        })
+}
+
+fn latest_active_worktree_path(component_id: &str) -> Option<String> {
+    worktree::list()
+        .ok()?
+        .worktrees
+        .into_iter()
+        .filter(|record| {
+            record.component_id == component_id
+                && record.state == worktree::TaskWorktreeState::Active
+        })
+        .max_by(|left, right| left.created_at.cmp(&right.created_at))
+        .map(|record| record.worktree_path)
+}
+
+fn workspace_file_path(root: &Path, path: &str) -> Result<PathBuf, AgentTaskDiagnostic> {
+    let joined = root.join(path);
+    let normalized = normalize_path(&joined);
+    if !normalized.starts_with(root) {
+        return Err(validation_error(
+            "path",
+            "path must stay inside workspace root",
+            json!({ "path": path }),
+        ));
+    }
+    Ok(normalized)
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            std::path::Component::CurDir => {}
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn component_id(input: &serde_json::Map<String, Value>) -> Option<&str> {
+    optional_string(input, &["component_id", "name", "repo"]).map(component_slug)
+}
+
+fn component_slug(value: &str) -> &str {
+    value.rsplit('/').next().unwrap_or(value)
+}
+
+fn required_string<'a>(
+    input: &'a serde_json::Map<String, Value>,
+    keys: &[&str],
+) -> Result<&'a str, AgentTaskDiagnostic> {
+    optional_string(input, keys).ok_or_else(|| {
+        validation_error(
+            keys[0],
+            "missing required string field",
+            json!({ "accepted_keys": keys }),
+        )
+    })
+}
+
+fn optional_string<'a>(
+    input: &'a serde_json::Map<String, Value>,
+    keys: &[&str],
+) -> Option<&'a str> {
+    keys.iter()
+        .find_map(|key| input.get(*key).and_then(Value::as_str))
+}
+
+fn required_u64(
+    input: &serde_json::Map<String, Value>,
+    keys: &[&str],
+) -> Result<u64, AgentTaskDiagnostic> {
+    optional_u64(input, keys).ok_or_else(|| {
+        validation_error(
+            keys[0],
+            "missing required integer field",
+            json!({ "accepted_keys": keys }),
+        )
+    })
+}
+
+fn optional_u64(input: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<u64> {
+    keys.iter()
+        .find_map(|key| input.get(*key).and_then(Value::as_u64))
+}
+
+fn optional_string_array(input: &serde_json::Map<String, Value>, key: &str) -> Option<Vec<String>> {
+    input.get(key).and_then(Value::as_array).map(|items| {
+        items
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect()
+    })
+}
+
+fn bool_input(input: &serde_json::Map<String, Value>, key: &str) -> bool {
+    input.get(key).and_then(Value::as_bool).unwrap_or(false)
+}
+
+fn to_value<T: Serialize>(result: crate::core::Result<T>) -> Result<Value, AgentTaskDiagnostic> {
+    result
+        .map_err(|error| AgentTaskDiagnostic {
+            class: "agent_tool.homeboy_error".to_string(),
+            message: error.to_string(),
+            data: Value::Null,
+        })
+        .and_then(|output| {
+            serde_json::to_value(output)
+                .map_err(|error| validation_error("serialization", &error.to_string(), Value::Null))
+        })
+}
+
+fn validation_error(field: &str, message: &str, data: Value) -> AgentTaskDiagnostic {
+    AgentTaskDiagnostic {
+        class: "agent_tool.validation".to_string(),
+        message: message.to_string(),
+        data: json!({ "field": field, "details": data }),
+    }
+}
+
+fn io_error(operation: &str, path: &Path, error: std::io::Error) -> AgentTaskDiagnostic {
+    AgentTaskDiagnostic {
+        class: "agent_tool.io".to_string(),
+        message: error.to_string(),
+        data: json!({ "operation": operation, "path": path.to_string_lossy() }),
+    }
+}
+
+fn command_spawn_error(operation: &str, error: std::io::Error) -> AgentTaskDiagnostic {
+    AgentTaskDiagnostic {
+        class: "agent_tool.command_spawn".to_string(),
+        message: error.to_string(),
+        data: json!({ "operation": operation }),
+    }
+}
+
+fn command_error(operation: &str, output: std::process::Output) -> AgentTaskDiagnostic {
+    AgentTaskDiagnostic {
+        class: "agent_tool.command_failed".to_string(),
+        message: format!("{} failed", operation),
+        data: json!({
+            "operation": operation,
+            "exit_code": output.status.code(),
+            "stdout": String::from_utf8_lossy(&output.stdout),
+            "stderr": String::from_utf8_lossy(&output.stderr),
+        }),
     }
 }
 

--- a/tests/agent_tool_dispatch.rs
+++ b/tests/agent_tool_dispatch.rs
@@ -1,0 +1,133 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use serde_json::{json, Value};
+
+#[test]
+fn agent_tool_dispatch_outputs_raw_denied_result_without_wrapper() {
+    let output = run_tool_dispatch(
+        json!({
+            "schema": "homeboy/agent-tool-policy/v1",
+            "default_location": "disabled"
+        }),
+        request_json("create_github_issue"),
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        output.stderr.is_empty(),
+        "stderr should be empty: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("raw result json");
+    assert_eq!(stdout["schema"], "homeboy/agent-tool-result/v1");
+    assert_eq!(stdout["status"], "denied");
+    assert_eq!(stdout["diagnostics"][0]["class"], "agent_tool.disabled");
+    assert!(
+        stdout.get("success").is_none(),
+        "must not emit command wrapper"
+    );
+    assert!(
+        stdout.get("data").is_none(),
+        "must not emit command wrapper"
+    );
+}
+
+#[test]
+fn agent_tool_dispatch_handles_workspace_write_and_read() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let policy = json!({
+        "schema": "homeboy/agent-tool-policy/v1",
+        "default_location": "control_plane"
+    });
+
+    let write_output = run_tool_dispatch(
+        policy.clone(),
+        json!({
+            "schema": "homeboy/agent-tool-request/v1",
+            "request_id": "request-write",
+            "task_id": "task-1",
+            "tool": "workspace_write",
+            "input": {
+                "workspace_path": dir.path(),
+                "path": "notes/result.txt",
+                "content": "hello dispatcher\n"
+            }
+        }),
+    );
+    assert_eq!(write_output.status.code(), Some(0));
+    let write_stdout: Value = serde_json::from_slice(&write_output.stdout).expect("write json");
+    assert_eq!(write_stdout["status"], "succeeded");
+
+    let read_output = run_tool_dispatch(
+        policy,
+        json!({
+            "schema": "homeboy/agent-tool-request/v1",
+            "request_id": "request-read",
+            "task_id": "task-1",
+            "tool": "workspace_read",
+            "input": {
+                "workspace_path": dir.path(),
+                "path": "notes/result.txt"
+            }
+        }),
+    );
+    assert_eq!(read_output.status.code(), Some(0));
+    let read_stdout: Value = serde_json::from_slice(&read_output.stdout).expect("read json");
+    assert_eq!(read_stdout["status"], "succeeded");
+    assert_eq!(read_stdout["output"]["content"], "hello dispatcher\n");
+}
+
+#[test]
+fn agent_tool_dispatch_outputs_raw_control_plane_validation_result() {
+    let output = run_tool_dispatch(
+        json!({
+            "schema": "homeboy/agent-tool-policy/v1",
+            "default_location": "control_plane"
+        }),
+        request_json("create_github_issue"),
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("raw result json");
+    assert_eq!(stdout["schema"], "homeboy/agent-tool-result/v1");
+    assert_eq!(stdout["status"], "failed");
+    assert_eq!(stdout["diagnostics"][0]["class"], "agent_tool.validation");
+    assert!(
+        stdout.get("success").is_none(),
+        "must not emit command wrapper"
+    );
+}
+
+fn run_tool_dispatch(policy: Value, request: Value) -> std::process::Output {
+    let mut child = Command::new(homeboy_bin())
+        .args(["agent-task", "tool", "dispatch"])
+        .env("HOMEBOY_AGENT_TOOL_POLICY_JSON", policy.to_string())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn homeboy");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(request.to_string().as_bytes())
+        .expect("write request");
+    child.wait_with_output().expect("homeboy output")
+}
+
+fn request_json(tool: &str) -> Value {
+    json!({
+        "schema": "homeboy/agent-tool-request/v1",
+        "request_id": "request-1",
+        "task_id": "task-1",
+        "tool": tool,
+        "input": {}
+    })
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}


### PR DESCRIPTION
## Summary
- add hidden `homeboy agent-task tool dispatch` command for provider runtime agent-tool requests
- emit raw `homeboy/agent-tool-result/v1` JSON without the normal command wrapper
- export `HOMEBOY_AGENT_TOOL_DISPATCH_COMMAND` to provider runtimes alongside the generic agent-tool schemas/policy
- add concrete control-plane handlers for the WPSG iterator workspace and GitHub tool names
- cover raw output, disabled policy, validation failure, provider env export, and workspace read/write dispatch

## Tests
- `cargo test agent_tool_dispatch --test agent_tool_dispatch`
- `cargo test provider_command_env_exposes_generic_agent_tool_contracts`
- `cargo test dispatch_result`

Note: focused tests pass with existing warnings for `src/core/release/executor.rs:1660` unused variable `log` and `src/core/agent_task_lifecycle.rs:851` unused `write_run_record_for_test`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the control-plane agent-tool dispatch command plumbing, provider env export, concrete workspace/GitHub handlers, and focused tests; Chris remains responsible for review and validation.