### PR TITLE
Remove product-specific runtime fixtures from core

### DIFF
--- a/docs/architecture/agent-task-executor-adapter.md
+++ b/docs/architecture/agent-task-executor-adapter.md
@@ -140,8 +140,8 @@ mechanics and native payload vocabulary.
 
 ```json
 {
-  "id": "wp-codebox.codex",
-  "backend": "codebox",
+  "id": "sample-runtime.codex",
+  "backend": "sample-runtime",
   "capabilities": ["structured_outcome"],
   "runtime_contract": {
     "capabilities": ["sandbox", "artifacts", "agent_result"],
@@ -160,14 +160,14 @@ mechanics and native payload vocabulary.
       }
     },
     "normalization": {
-      "status_path": "outputs.codebox.state",
-      "summary_path": "outputs.codebox.summary",
+      "status_path": "outputs.sample-runtime.state",
+      "summary_path": "outputs.sample-runtime.summary",
       "output_artifacts": [
         {
           "name": "patch",
           "type": "patch",
           "artifact_schema": "text/x-patch",
-          "path": "outputs.codebox.artifacts.patch",
+          "path": "outputs.sample-runtime.artifacts.patch",
           "kind": "patch",
           "mime": "text/x-patch"
         },
@@ -175,7 +175,7 @@ mechanics and native payload vocabulary.
           "name": "agent-report",
           "type": "agent_report",
           "artifact_schema": "application/json",
-          "path": "outputs.codebox.artifacts.report",
+          "path": "outputs.sample-runtime.artifacts.report",
           "kind": "report",
           "mime": "application/json"
         }
@@ -199,10 +199,10 @@ The normalization hook is intentionally manifest-driven and small:
   `AgentTaskArtifact` records and, when `type` or `artifact_schema` is present,
   matching `AgentTaskTypedArtifact` records.
 
-For Codebox, the adapter should expose the native Codebox result under a stable
-`outputs.codebox` object and declare the mapping above. Homeboy then treats
-Codebox like any other runtime adapter: it records the run, evaluates canonical
-artifacts, promotes patches, reports status, and leaves Codebox-specific session
+For Sample Runtime, the adapter should expose the native Sample Runtime result under a stable
+`outputs.sample-runtime` object and declare the mapping above. Homeboy then treats
+Sample Runtime like any other runtime adapter: it records the run, evaluates canonical
+artifacts, promotes patches, reports status, and leaves Sample Runtime-specific session
 details inside the runtime payload.
 
 For the fanout boundary, see

--- a/docs/architecture/apply-publish-contract.md
+++ b/docs/architecture/apply-publish-contract.md
@@ -75,13 +75,13 @@ current JSON input can project into the shared contract without changing behavio
 This issue only defines the shared contract. Existing Lab CLI behavior can keep
 its current input and output shape while adapters migrate.
 
-## WP Codebox Migration Path
+## Sample Runtime Migration Path
 
-The existing `homeboy/wp-codebox-apply-adapter/v1` extension adapter can migrate
+The existing `homeboy/sample-runtime-apply-adapter/v1` extension adapter can migrate
 to the core contract in two steps:
 
 1. Return or accept `ApplyAdapterContract` with artifact types such as
-   `wp_codebox.bundle` and `wp_codebox.file`, plus an `ApplyPreflightPolicy`.
+   `wp_sample-runtime.bundle` and `wp_sample-runtime.file`, plus an `ApplyPreflightPolicy`.
 2. Map its current verify/apply/stage/commit/push/PR flow so verify and file
    mutation return `ApplyResult`, while commit, push, and PR creation move to
    `PublishRequest`/`PublishResult` or compatibility CLI flags that call publish

--- a/docs/architecture/ci-results-contract.md
+++ b/docs/architecture/ci-results-contract.md
@@ -84,7 +84,7 @@ only fetch logs when they need extra debugging context.
     "summary": {
       "passed": false,
       "status": "failed",
-      "component": "data-machine",
+      "component": "sample-plugin",
       "scope": "changed-since",
       "changed_since": "origin/main",
       "total_findings": 3,
@@ -97,7 +97,7 @@ only fetch logs when they need extra debugging context.
       "passed": false,
       "exit_code": 1,
       "finding_count": 2,
-      "hint": "Deep dive: homeboy audit data-machine --changed-since=origin/main",
+      "hint": "Deep dive: homeboy audit sample-plugin --changed-since=origin/main",
       "output": { "...": "AuditCommandOutput" }
     },
     "lint": { "...": "ReviewStage<LintCommandOutput>" },
@@ -172,12 +172,12 @@ Recommended manifest:
 {
   "schema": "homeboy.ci-results.v1",
   "producer": "homeboy-action",
-  "repo": "Extra-Chill/data-machine",
+  "repo": "Extra-Chill/sample-plugin",
   "head_sha": "abc123",
   "run_id": "1234567890",
   "run_attempt": "1",
   "artifact_name": "homeboy-ci-results",
-  "check_url": "https://github.com/Extra-Chill/data-machine/actions/runs/1234567890"
+  "check_url": "https://github.com/Extra-Chill/sample-plugin/actions/runs/1234567890"
 }
 ```
 

--- a/docs/architecture/planned-change-execution.md
+++ b/docs/architecture/planned-change-execution.md
@@ -53,7 +53,7 @@ the call site when they adopt the contract.
   `ChangeArtifact`; local mutation belongs in `ApplyResult`.
 - Refactor write paths can treat `--write` as `ExecutionMode::Apply` while
   preserving their existing command outputs.
-- WP Codebox-style adapters should split local file mutation from publish steps:
+- Sample Runtime-style adapters should split local file mutation from publish steps:
   apply verifies and writes files, while publish commits, pushes, opens pull
   requests, releases, or deploys.
 

--- a/docs/architecture/preview-metadata.md
+++ b/docs/architecture/preview-metadata.md
@@ -152,7 +152,7 @@ fields in the same report so reviewer artifacts can distinguish browser/client
 errors from tunnel ingress or origin delivery gaps.
 
 Use this core gate for generic HTTP asset fanout proof. Product-specific proofs,
-such as WP Codebox or WooCommerce asset lists for Extra-Chill/homeboy#4062,
+such as Sample Runtime or WooCommerce asset lists for Extra-Chill/homeboy#4062,
 should live in the owning rig or extension and consume this generic
 `asset_fanout` contract.
 

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -77,7 +77,7 @@ without requiring hand-authored provider JSON:
 
 ```bash
 homeboy agent-task dispatch \
-  --repo data-machine \
+  --repo sample-plugin \
   --cwd /path/to/worktree \
   --provider-config @provider-config.json \
   --client-context @client-context.json \

--- a/docs/commands/audit-rules.md
+++ b/docs/commands/audit-rules.md
@@ -18,7 +18,7 @@ Use one of:
       "name": "engine-owns-terminal-status",
       "forbid": {
         "glob": "inc/Core/Steps/**/*.php",
-        "patterns": ["JobStatus::", "datamachine_fail_job"]
+        "patterns": ["JobStatus::", "sampleplugin_fail_job"]
       },
       "allow": {
         "glob": "inc/Abilities/Engine/**/*.php"

--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -96,7 +96,7 @@ homeboy refactor my-component --from all --write
 
 ```sh
 # Audit a registered component
-homeboy audit data-machine
+homeboy audit sample-plugin
 
 # Audit a raw filesystem path
 homeboy audit /path/to/project
@@ -118,7 +118,7 @@ homeboy audit my-plugin --ratchet
 homeboy audit-baseline refresh my-plugin --changed-since origin/main
 
 # Audit a workspace clone instead of local_path
-homeboy audit my-plugin --path /var/lib/datamachine/workspace/my-plugin
+homeboy audit my-plugin --path /var/lib/sampleplugin/workspace/my-plugin
 
 # Force a one-shot extension when the checkout has no registered component
 homeboy audit --path /path/to/worktree --extension rust

--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -86,7 +86,7 @@ the other capabilities.
   normal child bench per cell, and aggregates child statuses, run IDs, and
   numeric metric samples.
 - `--runner-pool <BACKEND>`: Executor backend string for matrix cells. Core keeps
-  this as data so concrete backends such as Codebox remain extension-owned.
+  this as data so concrete backends such as Sample Runtime remain extension-owned.
   Omit to use the local no-op executor for plan/scheduler smoke checks.
 - `--max-tasks <N>` / `--max-queue-depth <N>`: Scheduler backpressure limits for
   matrix cells.
@@ -140,7 +140,7 @@ homeboy bench studio-web \
   --rig studio-web-evals \
   --matrix model=gpt-5.5,kimi,claude \
   --matrix prompt=site-a,site-b,site-c \
-  --runner-pool codebox \
+  --runner-pool sample-runtime \
   --concurrency 8 \
   --max-queue-depth 16 \
   --expect-artifact bench-results \
@@ -304,7 +304,7 @@ The common shape is:
   "actual": 4378195,
   "expected": 250000,
   "unit": "bytes",
-  "subject": "/wp-json/datamachine/v1/pipelines?per_page=100",
+  "subject": "/wp-json/sampleplugin/v1/pipelines?per_page=100",
   "passed": false
 }
 ```

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -21,7 +21,7 @@ Builds are extension-owned. A component links to one build-capable extension, an
 Use `--path` to run the build against a different directory than the configured `local_path`:
 
 ```sh
-homeboy build data-machine --path /var/lib/datamachine/workspace/data-machine
+homeboy build sample-plugin --path /var/lib/sampleplugin/workspace/sample-plugin
 ```
 
 This is useful for:
@@ -38,7 +38,7 @@ Build resolution checks component-owned `scripts.build` first. If absent, it req
 Use `--changed-since <ref>` to ask the build provider whether the changed files require a build:
 
 ```sh
-homeboy build data-machine --changed-since origin/main
+homeboy build sample-plugin --changed-since origin/main
 homeboy build intelligence-example --all --changed-since origin/main
 ```
 

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -43,7 +43,7 @@ homeboy config set /defaults/permissions/local/file_mode '"g+r"'
 homeboy config set /artifact_root '"~/Developer/.homeboy-artifacts"'
 
 # Set an extension string setting without JSON quoting
-homeboy config set /settings/wp_codebox_provider codex --string
+homeboy config set /settings/wp_sample-runtime_provider codex --string
 ```
 
 ### `homeboy config remove`

--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -141,14 +141,14 @@ Exit code is `0` when `summary.failed == 0`, otherwise `1`.
 When a component belongs to multiple projects, use `--projects` to deploy to all of them in a single command:
 
 ```sh
-# Deploy data-machine to both extra-chill and sarai-chinwag projects
-homeboy deploy --projects extra-chill,sarai-chinwag data-machine
+# Deploy sample-plugin to both extra-chill and sarai-chinwag projects
+homeboy deploy --projects extra-chill,sarai-chinwag sample-plugin
 
 # Deploy multiple components to multiple projects
-homeboy deploy --projects extra-chill,sarai-chinwag data-machine extrachill-api
+homeboy deploy --projects extra-chill,sarai-chinwag sample-plugin extrachill-api
 
 # Preview multi-project deployment
-homeboy deploy --projects extra-chill,sarai-chinwag data-machine --dry-run
+homeboy deploy --projects extra-chill,sarai-chinwag sample-plugin --dry-run
 ```
 
 The component is built once and the artifact is reused for all subsequent project deployments.
@@ -160,7 +160,7 @@ When using `--projects`, the output structure differs:
 ```json
 {
   "command": "deploy.run_multi",
-  "component_ids": ["data-machine"],
+  "component_ids": ["sample-plugin"],
   "dry_run": false,
   "check": false,
   "force": false,

--- a/docs/commands/git.md
+++ b/docs/commands/git.md
@@ -47,7 +47,7 @@ Shows git status for one checkout. `component_id` is optional when Homeboy can d
 Bulk status is available through `--json`:
 
 ```sh
-homeboy git status --json '{"component_ids":["homeboy","data-machine"]}'
+homeboy git status --json '{"component_ids":["homeboy","sample-plugin"]}'
 ```
 
 ### Commit
@@ -88,7 +88,7 @@ homeboy git push --force-with-lease
 Bulk push is available through `--json`:
 
 ```sh
-homeboy git push --json '{"component_ids":["homeboy","data-machine"],"tags":true}'
+homeboy git push --json '{"component_ids":["homeboy","sample-plugin"],"tags":true}'
 ```
 
 ### Pull
@@ -225,7 +225,7 @@ Notes:
 {
   "components": [
     { "id": "homeboy", "message": "Update git docs" },
-    { "id": "data-machine", "message": "Update workflow docs" }
+    { "id": "sample-plugin", "message": "Update workflow docs" }
   ]
 }
 ```
@@ -234,7 +234,7 @@ Notes:
 
 ```json
 {
-  "component_ids": ["homeboy", "data-machine"],
+  "component_ids": ["homeboy", "sample-plugin"],
   "tags": true,
   "force_with_lease": false
 }

--- a/docs/commands/refactor.md
+++ b/docs/commands/refactor.md
@@ -109,13 +109,13 @@ This is useful for compound renames where inserting characters breaks boundary r
 
 ```sh
 # Rename a hyphenated slug
-homeboy refactor rename --literal --from datamachine-events --to data-machine-events --path . --write
+homeboy refactor rename --literal --from sampleplugin-events --to sample-plugin-events --path . --write
 
 # Rename an underscored prefix
-homeboy refactor rename --literal --from datamachine_events --to data_machine_events --path . --write
+homeboy refactor rename --literal --from sampleplugin_events --to sample_plugin_events --path . --write
 
 # Rename constants
-homeboy refactor rename --literal --from DATAMACHINE_EVENTS --to DATA_MACHINE_EVENTS --path . --write
+homeboy refactor rename --literal --from SAMPLEPLUGIN_EVENTS --to SAMPLE_PLUGIN_EVENTS --path . --write
 ```
 
 Since literal mode has no case-variant generation, run multiple passes for different casings (UPPER, snake, hyphen).

--- a/docs/commands/refs.md
+++ b/docs/commands/refs.md
@@ -24,8 +24,8 @@ homeboy refs <symbol> [--scope code|config|all] [--context key|variable|paramete
 
 ```sh
 homeboy refs DependencyStackEdge --path /tmp/homeboy
-homeboy refs package_name --component data-machine --component homeboy --scope code
-homeboy refs old_config_key --components data-machine,homeboy --context key
+homeboy refs package_name --component sample-plugin --component homeboy --scope code
+homeboy refs old_config_key --components sample-plugin,homeboy --context key
 ```
 
 The command exits with status `1` when no references are found, so scripts can treat an empty result as a failed lookup.

--- a/docs/commands/runner.md
+++ b/docs/commands/runner.md
@@ -111,14 +111,14 @@ and the configured workspace root are usable on the target machine.
 
 Use `--scope lab-offload` before serious Lab evidence runs. It adds checks for
 the configured runner Homeboy command, bare `homeboy` PATH resolution, preferred
-runner binaries, connected daemon exec readiness, and WP Codebox runner-path
+runner binaries, connected daemon exec readiness, and Sample Runtime runner-path
 freshness signals. When Homeboy can identify a safe exact recovery command, the
 check includes that remediation instead of leaving the operator to infer it from
 logs.
 
 Use `--scope lab-offload --repair` for the narrow self-healing path. Today this
 reconnects a failing direct Lab runner daemon and reruns the daemon exec probe.
-It does not upgrade binaries, rewrite runner paths, or refresh WP Codebox caches;
+It does not upgrade binaries, rewrite runner paths, or refresh Sample Runtime caches;
 those remain explicit operator actions because they can be expensive or depend
 on environment-specific paths.
 

--- a/docs/commands/trace.md
+++ b/docs/commands/trace.md
@@ -138,7 +138,7 @@ homeboy/preview-asset-fanout/v1`, expected/client request totals, status counts,
 failure buckets, and request rows. Native tunnel integrations may also fill
 ingress and local-origin request counts when those counters are available.
 
-Keep core fanout proof generic. WP Codebox, WooCommerce, or other product-specific
+Keep core fanout proof generic. Sample Runtime, WooCommerce, or other product-specific
 asset lists should live in their owning rig or extension and consume this
 contract.
 

--- a/docs/commands/tunnel.md
+++ b/docs/commands/tunnel.md
@@ -35,7 +35,7 @@ Check one published Workflow Bench path locally before sharing a public URL:
 ```sh
 HOMEBOY_PUBLIC_ARTIFACT_BASE_URL=https://homeboy-artifacts-tunnel.dev.example.com \
   homeboy tunnel artifact-origin inspect \
-  workflow-bench/studio-web-plain-site-data-machine-live-20260615-r15-pr995-replay-export/report.html \
+  workflow-bench/studio-web-plain-site-sample-plugin-live-20260615-r15-pr995-replay-export/report.html \
   --fail-on-missing
 ```
 
@@ -56,19 +56,19 @@ export HOMEBOY_PUBLIC_ARTIFACT_BASE_URL=https://homeboy-artifacts-tunnel.dev.exa
 # 2. Publish/copy the Lab-generated replay bundle preserving its workflow-bench path.
 mkdir -p "$HOMEBOY_ARTIFACT_ROOT/workflow-bench"
 cp -R \
-  /home/user/Developer/studio-web-eval-runs/studio-web-plain-site-data-machine-live-20260615-r15-pr995-replay-export \
+  /home/user/Developer/studio-web-eval-runs/studio-web-plain-site-sample-plugin-live-20260615-r15-pr995-replay-export \
   "$HOMEBOY_ARTIFACT_ROOT/workflow-bench/"
 
 # 3. Smoke-check the exact public path before handing it to reviewers.
 homeboy tunnel artifact-origin inspect \
-  workflow-bench/studio-web-plain-site-data-machine-live-20260615-r15-pr995-replay-export/report.html \
+  workflow-bench/studio-web-plain-site-sample-plugin-live-20260615-r15-pr995-replay-export/report.html \
   --fail-on-missing
 
 # 4. Serve the root through the long-running artifact origin process.
 homeboy tunnel artifact-origin serve --bind 127.0.0.1:7351
 ```
 
-The same path convention covers `report.html`, `report.md`, `evidence.json`, compact WP Codebox replay files such as `blueprint.after.json`, and external bundle files such as `files/runtime-snapshot.json`.
+The same path convention covers `report.html`, `report.md`, `evidence.json`, compact Sample Runtime replay files such as `blueprint.after.json`, and external bundle files such as `files/runtime-snapshot.json`.
 
 ## Service Tunnels
 

--- a/docs/commands/wp.md
+++ b/docs/commands/wp.md
@@ -15,7 +15,7 @@ For multisite projects, use `project:subtarget` as the project ID.
 ```sh
 homeboy wp my-site plugin list
 homeboy wp my-site option get blogname
-homeboy wp extra-chill:events datamachine pipelines list
+homeboy wp extra-chill:events sampleplugin pipelines list
 ```
 
 ## Related

--- a/docs/schemas/portable-config.md
+++ b/docs/schemas/portable-config.md
@@ -30,11 +30,11 @@ The component `id` field is required and must be a non-empty string. All other f
 
 ```json
 {
-  "id": "data-machine",
-  "remote_path": "wp-content/plugins/data-machine",
+  "id": "sample-plugin",
+  "remote_path": "wp-content/plugins/sample-plugin",
   "version_targets": [
     {
-      "file": "data-machine.php",
+      "file": "sample-plugin.php",
       "pattern": "Version:\\s*([0-9.]+)"
     }
   ],

--- a/src/commands/agent_task/tests.rs
+++ b/src/commands/agent_task/tests.rs
@@ -423,7 +423,7 @@ fn controller_dispatch_args_preserve_top_level_workspace_context_in_plan() {
         "repo": "wp-site-generator@canonical-loop-main-20260616",
         "dispatch": {
             "prompt": "cook the next workflow",
-            "backend": "codebox"
+            "backend": "sample-runtime"
         }
     });
 
@@ -792,13 +792,13 @@ fn run_plan_maps_resolved_component_worktree_before_provider_dispatch() {
     let mut plan = test_plan();
     plan.tasks[0].workspace.kind = Some("component-worktree".to_string());
     plan.tasks[0].workspace.component_id = Some("wp-coding-agents".to_string());
-    plan.tasks[0].workspace.branch = Some("fix/179-homeboy-codebox-guidance".to_string());
+    plan.tasks[0].workspace.branch = Some("fix/179-runtime-guidance".to_string());
     plan.tasks[0].workspace.base_ref = Some("origin/main".to_string());
     plan.tasks[0].workspace.task_url =
         Some("https://github.com/Extra-Chill/wp-coding-agents/issues/179".to_string());
     plan.tasks[0].workspace.cleanup = Some("preserve".to_string());
     plan.tasks[0].workspace.materialization = json!({
-        "root": "/tmp/homeboy-worktrees/wp-coding-agents@fix-179-homeboy-codebox-guidance"
+        "root": "/tmp/homeboy-worktrees/sample-component@fix-179-runtime-guidance"
     });
 
     let (_value, exit_code) = run_loaded_plan(plan, None, executor).expect("run-plan completed");
@@ -815,7 +815,7 @@ fn run_plan_maps_resolved_component_worktree_before_provider_dispatch() {
     );
     assert_eq!(
         observed.workspace.root.as_deref(),
-        Some("/tmp/homeboy-worktrees/wp-coding-agents@fix-179-homeboy-codebox-guidance")
+        Some("/tmp/homeboy-worktrees/sample-component@fix-179-runtime-guidance")
     );
     assert_eq!(observed.workspace.slug.as_deref(), Some("wp-coding-agents"));
     assert!(observed.workspace.kind.is_none());

--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -28,7 +28,7 @@ pub struct DispatchArgs {
     #[arg(long, value_name = "ID_OR_PATH")]
     pub workspace: Option<String>,
 
-    /// Repo/component slug for metadata and task grouping, e.g. data-machine.
+    /// Repo/component slug for metadata and task grouping, e.g. sample-plugin.
     #[arg(long, value_name = "REPO")]
     pub repo: Option<String>,
 

--- a/src/commands/agent_task_summary.rs
+++ b/src/commands/agent_task_summary.rs
@@ -716,19 +716,19 @@ mod tests {
                     "failed": 0
                 },
                 "apply_candidates": [
-                    { "task_id": "cell-1", "decision": "apply_candidate", "reason": "succeeded with reviewable patch/artifact output", "artifact_ids": ["codebox-patch-1"] },
-                    { "task_id": "cell-2", "decision": "apply_candidate", "reason": "succeeded with reviewable patch/artifact output", "artifact_ids": ["codebox-patch-2"] },
-                    { "task_id": "cell-3", "decision": "apply_candidate", "reason": "succeeded with reviewable patch/artifact output", "artifact_ids": ["codebox-patch-3"] }
+                    { "task_id": "cell-1", "decision": "apply_candidate", "reason": "succeeded with reviewable patch/artifact output", "artifact_ids": ["sample-patch-1"] },
+                    { "task_id": "cell-2", "decision": "apply_candidate", "reason": "succeeded with reviewable patch/artifact output", "artifact_ids": ["sample-patch-2"] },
+                    { "task_id": "cell-3", "decision": "apply_candidate", "reason": "succeeded with reviewable patch/artifact output", "artifact_ids": ["sample-patch-3"] }
                 ],
                 "artifact_inventory": [
-                    { "task_id": "cell-1", "artifact_id": "codebox-patch-1", "kind": "patch", "path": "/tmp/patch-1.diff", "size_bytes": 0 },
-                    { "task_id": "cell-2", "artifact_id": "codebox-patch-2", "kind": "patch", "path": "/tmp/patch-2.diff", "size_bytes": 0 },
-                    { "task_id": "cell-3", "artifact_id": "codebox-patch-3", "kind": "patch", "path": "/tmp/patch-3.diff", "size_bytes": 0 }
+                    { "task_id": "cell-1", "artifact_id": "sample-patch-1", "kind": "patch", "path": "/tmp/patch-1.diff", "size_bytes": 0 },
+                    { "task_id": "cell-2", "artifact_id": "sample-patch-2", "kind": "patch", "path": "/tmp/patch-2.diff", "size_bytes": 0 },
+                    { "task_id": "cell-3", "artifact_id": "sample-patch-3", "kind": "patch", "path": "/tmp/patch-3.diff", "size_bytes": 0 }
                 ]
             },
             "promotion_candidates": [{
-                "artifact_id": "codebox-patch-1",
-                "command": ["homeboy", "agent-task", "promote", "homeboy-4345", "--artifact-id", "codebox-patch-1"]
+                "artifact_id": "sample-patch-1",
+                "command": ["homeboy", "agent-task", "promote", "homeboy-4345", "--artifact-id", "sample-patch-1"]
             }],
             "next_actions": ["inspect task summaries before retrying or reporting"]
         });

--- a/src/commands/bench/fanout.rs
+++ b/src/commands/bench/fanout.rs
@@ -321,7 +321,7 @@ mod tests {
             "--matrix",
             "prompt=site-a,site-b",
             "--runner-pool",
-            "codebox",
+            "sample-runtime",
             "--concurrency",
             "8",
             "--max-queue-depth",
@@ -334,7 +334,7 @@ mod tests {
         .expect("bench matrix fan-out should parse");
 
         assert_eq!(cli.bench.run.matrix.len(), 2);
-        assert_eq!(cli.bench.run.runner_pool.as_deref(), Some("codebox"));
+        assert_eq!(cli.bench.run.runner_pool.as_deref(), Some("sample-runtime"));
         assert_eq!(cli.bench.run.concurrency, 8);
         assert_eq!(cli.bench.run.matrix_max_queue_depth, Some(3));
         assert_eq!(cli.bench.run.expected_artifact, vec!["bench-results"]);
@@ -368,7 +368,8 @@ mod tests {
         let mut args = run_args(Some("studio-web"));
         args.expected_artifact = vec!["bench-results".to_string()];
 
-        let request = matrix_template_request("bench/studio-web", "studio-web", "codebox", &args);
+        let request =
+            matrix_template_request("bench/studio-web", "studio-web", "sample-runtime", &args);
 
         assert_eq!(request.expected_artifacts, vec!["bench-results"]);
         assert_eq!(request.artifact_declarations.len(), 1);

--- a/src/commands/bench/settings_matrix.rs
+++ b/src/commands/bench/settings_matrix.rs
@@ -379,7 +379,10 @@ mod tests {
             "bench_env.GUTENBERG_RTC_BATCH_SIZE".to_string(),
             "25".to_string(),
         );
-        settings.insert("wp_codebox_bin".to_string(), "/tmp/wp-codebox".to_string());
+        settings.insert(
+            "sample_runtime_bin".to_string(),
+            "/tmp/sample-runtime".to_string(),
+        );
 
         apply_matrix_settings(&mut args, &settings);
 
@@ -394,7 +397,10 @@ mod tests {
                     "bench_env.GUTENBERG_RTC_CLIENTS".to_string(),
                     "100".to_string()
                 ),
-                ("wp_codebox_bin".to_string(), "/tmp/wp-codebox".to_string())
+                (
+                    "sample_runtime_bin".to_string(),
+                    "/tmp/sample-runtime".to_string()
+                )
             ]
         );
         assert!(args.setting_args.setting_json.is_empty());

--- a/src/commands/component.rs
+++ b/src/commands/component.rs
@@ -1252,8 +1252,8 @@ mod tests {
         fs::write(
             temp.path().join("homeboy.json"),
             r#"{
-                "id": "sample-codebox",
-                "build_artifact": "packages/browser-extension/dist/sample-codebox.zip",
+                "id": "sample-extension",
+                "build_artifact": "packages/browser-extension/dist/sample-extension.zip",
                 "build_command": "npm run package:browser-extension"
             }"#,
         )

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -845,7 +845,7 @@ mod tests {
     fn ready_to_deploy_note_clarifies_git_state_only_when_components_are_clean() {
         let output = StatusOutput {
             total: 1,
-            ready_to_deploy: vec!["data-machine".to_string()],
+            ready_to_deploy: vec!["sample-plugin".to_string()],
             ready_to_deploy_note: Some(READY_TO_DEPLOY_NOTE),
             ..empty_status_output()
         };

--- a/src/core/agent_runtime_manifest.rs
+++ b/src/core/agent_runtime_manifest.rs
@@ -523,35 +523,35 @@ mod tests {
     }
 
     #[test]
-    fn wp_codebox_runtime_materialization_fixture_is_plain_data() {
+    fn sample_runtime_materialization_fixture_is_plain_data() {
         let manifest: AgentRuntimeManifest = serde_json::from_str(include_str!(
-            "../../tests/fixtures/wp_codebox_runtime_materialization_manifest.json"
+            "../../tests/fixtures/sample_runtime_materialization_manifest.json"
         ))
-        .expect("wp-codebox fixture parses");
+        .expect("sample runtime fixture parses");
 
         let materialization_plan = runtime_materialization_plan(&manifest);
 
-        assert_eq!(manifest.id, "wp-codebox");
-        assert_eq!(materialization_plan.runtime_id, "wp-codebox");
-        assert_eq!(materialization_plan.source_roots[0].id, "wp-codebox");
+        assert_eq!(manifest.id, "sample-runtime");
+        assert_eq!(materialization_plan.runtime_id, "sample-runtime");
+        assert_eq!(materialization_plan.source_roots[0].id, "sample-runtime");
         assert_eq!(
             materialization_plan.source_roots[0].remote_url.as_deref(),
-            Some("https://github.com/example-org/wp-codebox.git")
+            Some("https://github.com/example-org/sample-runtime.git")
         );
         assert_eq!(
             materialization_plan.executable_requirements[0].env,
-            vec!["WP_CODEBOX_BIN".to_string()]
+            vec!["SAMPLE_RUNTIME_BIN".to_string()]
         );
         assert_eq!(
             materialization_plan.readiness_checks[0].label,
-            "WP Codebox runtime available"
+            "Sample Runtime available"
         );
         assert_eq!(
             materialization_plan.env_passthrough,
             vec![
                 "AI_PROVIDER_OPENAI_CODEX_API_KEY".to_string(),
-                "WP_CODEBOX_BIN".to_string(),
-                "WP_CODEBOX_HOME".to_string()
+                "SAMPLE_RUNTIME_BIN".to_string(),
+                "SAMPLE_RUNTIME_HOME".to_string()
             ]
         );
     }

--- a/src/core/agent_task.rs
+++ b/src/core/agent_task.rs
@@ -1121,7 +1121,7 @@ mod tests {
     #[test]
     fn executor_runtime_selection_synthesizes_legacy_fields() {
         let executor = AgentTaskExecutor {
-            backend: "codebox".to_string(),
+            backend: "sample-runtime".to_string(),
             selector: Some("claude-code".to_string()),
             runtime_selection: None,
             required_capabilities: Vec::new(),
@@ -1133,7 +1133,10 @@ mod tests {
         let selection = executor.runtime_selection();
 
         assert_eq!(selection.runtime_id, None);
-        assert_eq!(selection.executor_backend.as_deref(), Some("codebox"));
+        assert_eq!(
+            selection.executor_backend.as_deref(),
+            Some("sample-runtime")
+        );
         assert_eq!(
             selection.executor_provider_id.as_deref(),
             Some("claude-code")
@@ -1141,7 +1144,7 @@ mod tests {
         assert_eq!(selection.provider.as_deref(), Some("claude-code"));
         assert_eq!(selection.model.as_deref(), Some("opus-4.7"));
         assert_eq!(selection.substrate_ref, None);
-        assert_eq!(executor.executor_backend(), "codebox");
+        assert_eq!(executor.executor_backend(), "sample-runtime");
         assert_eq!(executor.executor_provider_id(), Some("claude-code"));
         assert_eq!(executor.provider(), Some("claude-code"));
         assert_eq!(executor.model(), Some("opus-4.7"));
@@ -1158,7 +1161,7 @@ mod tests {
                 "selector": "runtime-selector",
                 "provider": "codex",
                 "model": "gpt-5.5",
-                "substrate_ref": "wp-codebox://sandbox/123"
+                "substrate_ref": "sample-runtime://sandbox/123"
             }
         });
 
@@ -1171,7 +1174,10 @@ mod tests {
         assert_eq!(executor.executor_provider_id(), Some("runtime-selector"));
         assert_eq!(executor.provider(), Some("codex"));
         assert_eq!(executor.model(), Some("gpt-5.5"));
-        assert_eq!(executor.substrate_ref(), Some("wp-codebox://sandbox/123"));
+        assert_eq!(
+            executor.substrate_ref(),
+            Some("sample-runtime://sandbox/123")
+        );
         assert_eq!(
             selection.executor_backend.as_deref(),
             Some("runtime-backend")
@@ -1196,7 +1202,7 @@ mod tests {
         let request: AgentTaskRequest = serde_json::from_value(json!({
             "schema": AGENT_TASK_REQUEST_SCHEMA,
             "task_id": "task-typed-artifacts",
-            "executor": { "backend": "codebox" },
+            "executor": { "backend": "sample-runtime" },
             "instructions": "Return the declared typed report.",
             "expected_artifacts": ["legacy-report.json"],
             "artifactDeclarations": [{
@@ -1224,7 +1230,7 @@ mod tests {
         let mut request: AgentTaskRequest = serde_json::from_value(json!({
             "schema": AGENT_TASK_REQUEST_SCHEMA,
             "task_id": "task-artifact-normalization",
-            "executor": { "backend": "codebox" },
+            "executor": { "backend": "sample-runtime" },
             "instructions": "Return artifacts.",
             "expected_artifacts": [" patch ", "analysis_report", ""],
             "artifact_declarations": [{

--- a/src/core/agent_task_aggregate.rs
+++ b/src/core/agent_task_aggregate.rs
@@ -581,7 +581,7 @@ mod tests {
 
     #[test]
     fn aggregate_outcomes_does_not_apply_empty_patch_artifacts() {
-        let mut empty_patch = artifact("codebox-patch", "patch", json!({}));
+        let mut empty_patch = artifact("sample-patch", "patch", json!({}));
         empty_patch.size_bytes = Some(0);
 
         let report = aggregate_agent_task_outcomes(&[outcome(
@@ -602,7 +602,7 @@ mod tests {
 
     #[test]
     fn aggregate_outcomes_keeps_non_empty_patch_apply_candidate() {
-        let mut non_empty_patch = artifact("codebox-patch", "patch", json!({}));
+        let mut non_empty_patch = artifact("sample-patch", "patch", json!({}));
         non_empty_patch.size_bytes = Some(128);
 
         let report = aggregate_agent_task_outcomes(&[outcome(
@@ -615,7 +615,7 @@ mod tests {
         assert_eq!(report.apply_candidates[0].task_id, "non-empty-patch");
         assert_eq!(
             report.apply_candidates[0].artifact_ids,
-            vec!["codebox-patch"]
+            vec!["sample-patch"]
         );
     }
 

--- a/src/core/agent_task_dispatch_service.rs
+++ b/src/core/agent_task_dispatch_service.rs
@@ -145,7 +145,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
             "agent-task dispatch requires --prompt, --prompt @file, --prompt -, repeated --task inputs, or --tasks @tasks.json",
             None,
             Some(vec![
-                "Example: homeboy agent-task dispatch --repo data-machine --cwd /path/to/worktree --prompt @task.txt".to_string(),
+                "Example: homeboy agent-task dispatch --repo sample-plugin --cwd /path/to/worktree --prompt @task.txt".to_string(),
                 "Wave input: homeboy agent-task dispatch --tasks @tasks.json --concurrency 8".to_string(),
             ]),
         ));
@@ -958,7 +958,7 @@ mod tests {
         let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
             prompt: Some(format!("@{}", prompt.path().display())),
             cwd: Some(workspace.path().display().to_string()),
-            repo: Some("data-machine".to_string()),
+            repo: Some("sample-plugin".to_string()),
             client_context: Some(
                 r#"{"surface":"chat","conversation_id":"opaque-123"}"#.to_string(),
             ),
@@ -967,8 +967,8 @@ mod tests {
         .expect("dispatch plan");
 
         assert_eq!(plan.tasks.len(), 1);
-        assert_eq!(plan.group_key.as_deref(), Some("data-machine"));
-        assert_eq!(plan.tasks[0].task_id, "cook-data-machine");
+        assert_eq!(plan.group_key.as_deref(), Some("sample-plugin"));
+        assert_eq!(plan.tasks[0].task_id, "cook-sample-plugin");
         assert_eq!(plan.tasks[0].instructions, "Cook the issue cleanly.");
         assert_eq!(
             plan.tasks[0].workspace.mode,

--- a/src/core/agent_task_finalization.rs
+++ b/src/core/agent_task_finalization.rs
@@ -773,13 +773,13 @@ mod tests {
             },
             provider_runtime: vec![ProviderRuntimeLifecycle {
                 task_id: "task-a".to_string(),
-                backend: "codebox".to_string(),
+                backend: "sample-runtime".to_string(),
                 state: ProviderRuntimeState::Succeeded,
                 stream_uri: None,
                 external_runtime_ids: vec![ExternalRuntimeId {
                     kind: "provider_run_id".to_string(),
                     value: "provider-run-123".to_string(),
-                    provider: Some("codebox".to_string()),
+                    provider: Some("sample-runtime".to_string()),
                     url: None,
                 }],
                 metadata: serde_json::Value::Null,
@@ -787,7 +787,7 @@ mod tests {
             external_runtime_ids: vec![ExternalRuntimeId {
                 kind: "provider_run_id".to_string(),
                 value: "provider-run-123".to_string(),
-                provider: Some("codebox".to_string()),
+                provider: Some("sample-runtime".to_string()),
                 url: None,
             }],
             cleanup: CleanupLifecycle {

--- a/src/core/agent_task_lifecycle.rs
+++ b/src/core/agent_task_lifecycle.rs
@@ -1637,9 +1637,9 @@ mod tests {
                     "/runner/workspace/repo".to_string(),
                 ],
                 remote_workspace: "/runner/workspace/repo",
-                failure_message: "Invalid argument 'cwd': agent-task Codebox dispatch requires --cwd to be a git checkout",
+                failure_message: "Invalid argument 'cwd': agent-task runtime dispatch requires --cwd to be a git checkout",
                 stdout: "",
-                stderr: "Invalid argument 'cwd': agent-task Codebox dispatch requires --cwd to be a git checkout\n",
+                stderr: "Invalid argument 'cwd': agent-task runtime dispatch requires --cwd to be a git checkout\n",
                 exit_code: 1,
             })
             .expect("pre-dispatch failure recorded");
@@ -2133,7 +2133,7 @@ mod tests {
             aggregate.outcomes[0].metadata = json!({
                 "provider_handle": AgentTaskExecutionHandle {
                     task_id: "task-a".to_string(),
-                    backend: "codebox".to_string(),
+                    backend: "sample-runtime".to_string(),
                     run_id: "provider-run-123".to_string(),
                     stream_uri: Some("provider://runs/provider-run-123/events".to_string()),
                     metadata: json!({ "opaque": { "provider_owned": true } }),
@@ -2145,7 +2145,7 @@ mod tests {
 
             assert_eq!(record.provider_handles.len(), 1);
             assert_eq!(record.provider_handles[0].task_id, "task-a");
-            assert_eq!(record.provider_handles[0].backend, "codebox");
+            assert_eq!(record.provider_handles[0].backend, "sample-runtime");
             assert_eq!(
                 record.provider_handles[0].provider_run_id,
                 "provider-run-123"
@@ -2540,12 +2540,12 @@ mod tests {
             Vec::new(),
             vec![
                 AgentTaskEvidenceRef {
-                    kind: "codebox-command-log".to_string(),
+                    kind: "sample-runtime-command-log".to_string(),
                     uri: "".to_string(),
                     label: Some("command log".to_string()),
                 },
                 AgentTaskEvidenceRef {
-                    kind: "codebox-command-evidence".to_string(),
+                    kind: "sample-runtime-command-evidence".to_string(),
                     uri: "   ".to_string(),
                     label: None,
                 },
@@ -2571,11 +2571,11 @@ mod tests {
             vec![
                 artifact_ref_artifact(
                     "dir-empty",
-                    "codebox-artifact-directory",
+                    "sample-runtime-artifact-directory",
                     Some(""),
                     Some(""),
                 ),
-                artifact_ref_artifact("dir-none", "codebox-agent-task-input", None, None),
+                artifact_ref_artifact("dir-none", "sample-runtime-agent-task-input", None, None),
                 artifact_ref_artifact("patch", "patch", None, Some("/tmp/patch.diff")),
             ],
             Vec::new(),
@@ -2594,7 +2594,7 @@ mod tests {
             "task-a",
             vec![artifact_ref_artifact(
                 "dir",
-                "codebox-artifact-directory",
+                "sample-runtime-artifact-directory",
                 Some("   "),
                 Some("/tmp/artifacts/dir"),
             )],
@@ -2651,7 +2651,7 @@ mod tests {
                     vec![
                         artifact_ref_artifact(
                             "dir-empty",
-                            "codebox-artifact-directory",
+                            "sample-runtime-artifact-directory",
                             Some(""),
                             None,
                         ),
@@ -2659,7 +2659,7 @@ mod tests {
                     ],
                     vec![
                         AgentTaskEvidenceRef {
-                            kind: "codebox-command-log".to_string(),
+                            kind: "sample-runtime-command-log".to_string(),
                             uri: "".to_string(),
                             label: Some("command log".to_string()),
                         },

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -2603,18 +2603,18 @@ mod tests {
             "schema": AGENT_TASK_OUTCOME_SCHEMA,
             "task_id": "task-runtime-failed",
             "status": "succeeded",
-            "outputs": { "codebox": { "state": "failed" } }
+            "outputs": { "sample_runtime": { "state": "failed" } }
         });
         let script = script(&format!(
             "process.stdout.write(JSON.stringify({}));",
             provider_output
         ));
         let (request, mut provider) = request("task-runtime-failed", format!("node {script}"));
-        provider.backend = "codebox".to_string();
+        provider.backend = "sample-runtime".to_string();
         provider.runtime_contract.lifecycle_states.outcome_statuses =
             BTreeMap::from([("failed".to_string(), AgentTaskOutcomeStatus::Failed)]);
         provider.runtime_contract.normalization.status_path =
-            Some("outputs.codebox.state".to_string());
+            Some("outputs.sample_runtime.state".to_string());
 
         let outcome = run_provider_command(&request, &provider);
 
@@ -3922,7 +3922,7 @@ process.stdout.write(JSON.stringify({
     fn provider_preserves_structured_outcome_from_stderr_when_stdout_empty() {
         let command = format!(
             "node {}",
-            script("let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); process.stderr.write('diagnostic prefix\\n' + JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'failed',summary:'captured provider evidence',failure_classification:'provider',diagnostics:[{class:'codebox.empty_data_packet_returned',message:'empty data packet returned',data:{typed_artifacts:{}}}]}));")
+            script("let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); process.stderr.write('diagnostic prefix\\n' + JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'failed',summary:'captured provider evidence',failure_classification:'provider',diagnostics:[{class:'sample_runtime.empty_data_packet_returned',message:'empty data packet returned',data:{typed_artifacts:{}}}]}));")
         );
         let (request, provider) = request("task-stderr-outcome", command);
 
@@ -3935,7 +3935,7 @@ process.stdout.write(JSON.stringify({
         );
         assert_eq!(
             outcome.diagnostics[0].class,
-            "codebox.empty_data_packet_returned"
+            "sample_runtime.empty_data_packet_returned"
         );
         assert_eq!(outcome.diagnostics[0].data["typed_artifacts"], json!({}));
     }

--- a/src/core/agent_task_scheduler.rs
+++ b/src/core/agent_task_scheduler.rs
@@ -1834,7 +1834,7 @@ fn runtime_result_is_materializable(outcome: &AgentTaskOutcome) -> bool {
 
 fn provider_run_result_is_empty_incomplete(result: &Value) -> bool {
     // The provider run state may live at the top level of the result object or
-    // nested under an `outputs` key (the shape Codebox reports today, e.g.
+    // nested under an `outputs` key (a common provider-wrapper shape, e.g.
     // `{ "success": true, "status": "completed", "outputs": { "completed": false, ... } }`).
     // Detect an incomplete, no-output run at either level so cook does not treat
     // a cell that never produced an assistant/tool interaction as successful.
@@ -2934,7 +2934,7 @@ mod tests {
 
     #[test]
     fn incomplete_nested_outputs_provider_result_is_detected() {
-        // Mirrors the Codebox wrapper shape reported in #4613: the provider claims
+        // Mirrors a provider wrapper shape: the provider claims
         // top-level success/completed, but `outputs.completed` is false, the reply
         // is empty, and `messages` only contains the initial user prompt.
         let result = json!({
@@ -3553,14 +3553,14 @@ mod tests {
                 task_id: request.task_id,
                 status: AgentTaskOutcomeStatus::Failed,
                 summary: Some(
-                    "WP Codebox agent task did not produce required typed artifacts: patch, agent_result, transcript."
+                    "Sample runtime agent task did not produce required typed artifacts: patch, agent_result, transcript."
                         .to_string(),
                 ),
                 failure_classification: Some(AgentTaskFailureClassification::Provider),
                 artifacts: vec![
                     AgentTaskArtifact {
                         schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-                        id: "codebox-patch".to_string(),
+                        id: "sample-runtime-patch".to_string(),
                         kind: "patch".to_string(),
                         name: Some("patch.diff".to_string()),
                         path: Some(self.patch_path.display().to_string()),
@@ -3570,14 +3570,14 @@ mod tests {
                         sha256: Some("sha256:patch".to_string()),
                         metadata: json!({
                             "artifact": "files/patch.diff",
-                            "provider_kind": "codebox-patch",
+                            "provider_kind": "sample-runtime-patch",
                             "role": "patch"
                         }),
                     },
                     AgentTaskArtifact {
                         schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-                        id: "codebox-transcript".to_string(),
-                        kind: "codebox-transcript".to_string(),
+                        id: "sample-runtime-transcript".to_string(),
+                        kind: "sample-runtime-transcript".to_string(),
                         name: Some("transcript.json".to_string()),
                         path: Some(self.transcript_path.display().to_string()),
                         url: None,
@@ -3589,7 +3589,7 @@ mod tests {
                 ],
                 typed_artifacts: Vec::new(),
                 evidence_refs: vec![AgentTaskEvidenceRef {
-                    kind: "codebox-artifact-bundle".to_string(),
+                    kind: "sample-runtime-artifact-bundle".to_string(),
                     uri: self
                         .patch_path
                         .parent()
@@ -3597,11 +3597,11 @@ mod tests {
                         .unwrap_or_else(|| self.patch_path.as_path())
                         .display()
                         .to_string(),
-                    label: Some("WP Codebox artifact bundle".to_string()),
+                    label: Some("Sample runtime artifact bundle".to_string()),
                 }],
                 diagnostics: vec![AgentTaskDiagnostic {
                     class: "agent_task.required_typed_artifacts_missing".to_string(),
-                    message: "WP Codebox agent task did not produce required typed artifacts: patch, agent_result, transcript."
+                    message: "Sample runtime agent task did not produce required typed artifacts: patch, agent_result, transcript."
                         .to_string(),
                     data: Value::Null,
                 }],

--- a/src/core/agent_task_timeout_artifacts.rs
+++ b/src/core/agent_task_timeout_artifacts.rs
@@ -589,8 +589,8 @@ mod tests {
         let artifact_root = temp.path().join("task-1-artifacts");
         let empty_runtime = artifact_root.join("runtime-mpxgndju-f4v9yn");
         fs::create_dir_all(&empty_runtime).expect("empty runtime bundle");
-        let preflight_path = artifact_root.join("homeboy-codebox-task-runner.json");
-        fs::write(&preflight_path, r#"{"runner":"codebox"}"#).expect("preflight evidence");
+        let preflight_path = artifact_root.join("sample-runtime-preflight.json");
+        fs::write(&preflight_path, r#"{"runner":"sample-runtime"}"#).expect("preflight evidence");
 
         let discovery = TimeoutArtifactDiscovery::discover_with_role_aliases(
             &test_request(json!({
@@ -598,7 +598,7 @@ mod tests {
             })),
             &role_aliases(json!({
                 "artifact_filenames": {
-                    "preflight_evidence": ["homeboy-codebox-task-runner.json"]
+                    "preflight_evidence": ["sample-runtime-preflight.json"]
                 }
             })),
         );

--- a/src/core/code_audit/conventions.rs
+++ b/src/core/code_audit/conventions.rs
@@ -2037,7 +2037,7 @@ mod tests {
                 language: Language::Php,
                 methods: vec!["execute".to_string()],
                 type_name: Some("CreateFlow".to_string()),
-                namespace: Some("DataMachine\\Abilities\\Flow".to_string()),
+                namespace: Some("SamplePlugin\\Abilities\\Flow".to_string()),
                 ..Default::default()
             },
             FileFingerprint {
@@ -2045,7 +2045,7 @@ mod tests {
                 language: Language::Php,
                 methods: vec!["execute".to_string()],
                 type_name: Some("UpdateFlow".to_string()),
-                namespace: Some("DataMachine\\Abilities\\Flow".to_string()),
+                namespace: Some("SamplePlugin\\Abilities\\Flow".to_string()),
                 ..Default::default()
             },
             FileFingerprint {
@@ -2053,7 +2053,7 @@ mod tests {
                 language: Language::Php,
                 methods: vec!["execute".to_string()],
                 type_name: Some("DeleteFlow".to_string()),
-                namespace: Some("DataMachine\\Flow".to_string()), // WRONG namespace
+                namespace: Some("SamplePlugin\\Flow".to_string()), // WRONG namespace
                 ..Default::default()
             },
         ];
@@ -2062,7 +2062,7 @@ mod tests {
 
         assert_eq!(
             convention.expected_namespace,
-            Some("DataMachine\\Abilities\\Flow".to_string())
+            Some("SamplePlugin\\Abilities\\Flow".to_string())
         );
         assert_eq!(convention.conforming.len(), 2);
         assert_eq!(convention.outliers.len(), 1);
@@ -2086,11 +2086,11 @@ mod tests {
                 language: Language::Php,
                 methods: vec!["register".to_string()],
                 type_name: Some("AgentTokenAbilities".to_string()),
-                namespace: Some("DataMachine\\Abilities".to_string()),
+                namespace: Some("SamplePlugin\\Abilities".to_string()),
                 // Imports PermissionHelper via fully-qualified name in the import list
                 // in most files, but THIS file relies on same-namespace resolution.
                 imports: vec![],
-                content: "namespace DataMachine\\Abilities;\n\nclass AgentTokenAbilities {\n    public function register() { PermissionHelper::can_manage(); }\n}".to_string(),
+                content: "namespace SamplePlugin\\Abilities;\n\nclass AgentTokenAbilities {\n    public function register() { PermissionHelper::can_manage(); }\n}".to_string(),
                 ..Default::default()
             },
             FileFingerprint {
@@ -2098,8 +2098,8 @@ mod tests {
                 language: Language::Php,
                 methods: vec!["register".to_string()],
                 type_name: Some("FlowAbilities".to_string()),
-                namespace: Some("DataMachine\\Abilities".to_string()),
-                imports: vec!["DataMachine\\Abilities\\PermissionHelper".to_string()],
+                namespace: Some("SamplePlugin\\Abilities".to_string()),
+                imports: vec!["SamplePlugin\\Abilities\\PermissionHelper".to_string()],
                 ..Default::default()
             },
             FileFingerprint {
@@ -2107,8 +2107,8 @@ mod tests {
                 language: Language::Php,
                 methods: vec!["register".to_string()],
                 type_name: Some("JobAbilities".to_string()),
-                namespace: Some("DataMachine\\Abilities".to_string()),
-                imports: vec!["DataMachine\\Abilities\\PermissionHelper".to_string()],
+                namespace: Some("SamplePlugin\\Abilities".to_string()),
+                imports: vec!["SamplePlugin\\Abilities\\PermissionHelper".to_string()],
                 ..Default::default()
             },
         ];
@@ -2117,7 +2117,7 @@ mod tests {
 
         assert!(convention
             .expected_imports
-            .contains(&"DataMachine\\Abilities\\PermissionHelper".to_string()));
+            .contains(&"SamplePlugin\\Abilities\\PermissionHelper".to_string()));
 
         // AgentTokenAbilities references PermissionHelper (same namespace) —
         // it should NOT be flagged as a missing import.
@@ -2151,11 +2151,11 @@ mod tests {
                 methods: vec!["can_manage".to_string()],
                 type_name: Some("PermissionHelper".to_string()),
                 type_names: vec!["PermissionHelper".to_string()],
-                namespace: Some("DataMachine\\Abilities".to_string()),
+                namespace: Some("SamplePlugin\\Abilities".to_string()),
                 // File defines the class; its convention peers might import it,
                 // but self-import is nonsensical.
                 imports: vec![],
-                content: "namespace DataMachine\\Abilities;\n\nclass PermissionHelper { public function can_manage() {} }".to_string(),
+                content: "namespace SamplePlugin\\Abilities;\n\nclass PermissionHelper { public function can_manage() {} }".to_string(),
                 ..Default::default()
             },
             FileFingerprint {
@@ -2163,9 +2163,9 @@ mod tests {
                 language: Language::Php,
                 methods: vec!["can_manage".to_string()],
                 type_name: Some("FlowAbilities".to_string()),
-                namespace: Some("DataMachine\\Abilities".to_string()),
-                imports: vec!["DataMachine\\Abilities\\PermissionHelper".to_string()],
-                content: "use DataMachine\\Abilities\\PermissionHelper;".to_string(),
+                namespace: Some("SamplePlugin\\Abilities".to_string()),
+                imports: vec!["SamplePlugin\\Abilities\\PermissionHelper".to_string()],
+                content: "use SamplePlugin\\Abilities\\PermissionHelper;".to_string(),
                 ..Default::default()
             },
             FileFingerprint {
@@ -2173,9 +2173,9 @@ mod tests {
                 language: Language::Php,
                 methods: vec!["can_manage".to_string()],
                 type_name: Some("JobAbilities".to_string()),
-                namespace: Some("DataMachine\\Abilities".to_string()),
-                imports: vec!["DataMachine\\Abilities\\PermissionHelper".to_string()],
-                content: "use DataMachine\\Abilities\\PermissionHelper;".to_string(),
+                namespace: Some("SamplePlugin\\Abilities".to_string()),
+                imports: vec!["SamplePlugin\\Abilities\\PermissionHelper".to_string()],
+                content: "use SamplePlugin\\Abilities\\PermissionHelper;".to_string(),
                 ..Default::default()
             },
         ];
@@ -2207,9 +2207,9 @@ mod tests {
                 language: Language::Php,
                 methods: vec!["__construct".to_string()],
                 type_name: Some("AgentBundler".to_string()),
-                namespace: Some("DataMachine\\Core\\Agents".to_string()),
-                imports: vec!["DataMachine\\Core\\Database\\Agents\\Agents".to_string()],
-                content: "namespace DataMachine\\Core\\Agents;\nuse DataMachine\\Core\\Database\\Agents\\Agents;\nclass AgentBundler { public function __construct() { new Agents(); } }".to_string(),
+                namespace: Some("SamplePlugin\\Core\\Agents".to_string()),
+                imports: vec!["SamplePlugin\\Core\\Database\\Agents\\Agents".to_string()],
+                content: "namespace SamplePlugin\\Core\\Agents;\nuse SamplePlugin\\Core\\Database\\Agents\\Agents;\nclass AgentBundler { public function __construct() { new Agents(); } }".to_string(),
                 ..Default::default()
             },
             FileFingerprint {
@@ -2217,9 +2217,9 @@ mod tests {
                 language: Language::Php,
                 methods: vec!["__construct".to_string()],
                 type_name: Some("AgentIdentityResolver".to_string()),
-                namespace: Some("DataMachine\\Core\\Agents".to_string()),
-                imports: vec!["DataMachine\\Core\\Database\\Agents\\Agents".to_string()],
-                content: "namespace DataMachine\\Core\\Agents;\nuse DataMachine\\Core\\Database\\Agents\\Agents;\nclass AgentIdentityResolver { public function __construct() { new Agents(); } }".to_string(),
+                namespace: Some("SamplePlugin\\Core\\Agents".to_string()),
+                imports: vec!["SamplePlugin\\Core\\Database\\Agents\\Agents".to_string()],
+                content: "namespace SamplePlugin\\Core\\Agents;\nuse SamplePlugin\\Core\\Database\\Agents\\Agents;\nclass AgentIdentityResolver { public function __construct() { new Agents(); } }".to_string(),
                 ..Default::default()
             },
             FileFingerprint {
@@ -2227,9 +2227,9 @@ mod tests {
                 language: Language::Php,
                 methods: vec!["__construct".to_string()],
                 type_name: Some("AgentIdentity".to_string()),
-                namespace: Some("DataMachine\\Core\\Agents".to_string()),
+                namespace: Some("SamplePlugin\\Core\\Agents".to_string()),
                 imports: vec![],
-                content: "namespace DataMachine\\Core\\Agents;\nclass AgentIdentity { public function __construct() {} }".to_string(),
+                content: "namespace SamplePlugin\\Core\\Agents;\nclass AgentIdentity { public function __construct() {} }".to_string(),
                 ..Default::default()
             },
         ];
@@ -2238,7 +2238,7 @@ mod tests {
 
         assert!(convention
             .expected_imports
-            .contains(&"DataMachine\\Core\\Database\\Agents\\Agents".to_string()));
+            .contains(&"SamplePlugin\\Core\\Database\\Agents\\Agents".to_string()));
 
         let identity_outlier = convention
             .outliers
@@ -2263,14 +2263,14 @@ mod tests {
                 relative_path: "abilities/A.php".to_string(),
                 language: Language::Php,
                 methods: vec!["execute".to_string()],
-                imports: vec!["DataMachine\\Core\\Base".to_string()],
+                imports: vec!["SamplePlugin\\Core\\Base".to_string()],
                 ..Default::default()
             },
             FileFingerprint {
                 relative_path: "abilities/B.php".to_string(),
                 language: Language::Php,
                 methods: vec!["execute".to_string()],
-                imports: vec!["DataMachine\\Core\\Base".to_string()],
+                imports: vec!["SamplePlugin\\Core\\Base".to_string()],
                 ..Default::default()
             },
             FileFingerprint {
@@ -2287,7 +2287,7 @@ mod tests {
 
         assert!(convention
             .expected_imports
-            .contains(&"DataMachine\\Core\\Base".to_string()));
+            .contains(&"SamplePlugin\\Core\\Base".to_string()));
         assert_eq!(convention.outliers.len(), 1);
         assert!(convention.outliers[0]
             .deviations

--- a/src/core/code_audit/core_fingerprint.rs
+++ b/src/core/code_audit/core_fingerprint.rs
@@ -566,7 +566,7 @@ fn extract_types(symbols: &[Symbol]) -> (Option<String>, Vec<String>) {
 
 /// Extract namespace from symbols or derive from grammar-owned path metadata.
 fn extract_namespace(symbols: &[Symbol], relative_path: &str, grammar: &Grammar) -> Option<String> {
-    // Direct namespace symbol (PHP: namespace DataMachine\Abilities;)
+    // Direct namespace symbol (PHP: namespace SamplePlugin\Abilities;)
     for s in symbols.iter().filter(|s| s.concept == "namespace") {
         if let Some(name) = s.name() {
             return Some(name.to_string());
@@ -1064,7 +1064,7 @@ mod tests {
 
     fn rust_grammar() -> Grammar {
         let grammar_path = std::path::Path::new(
-            "/var/lib/datamachine/workspace/homeboy-extensions/rust/grammar.toml",
+            "/var/lib/sampleplugin/workspace/homeboy-extensions/rust/grammar.toml",
         );
         if grammar_path.exists() {
             grammar::load_grammar(grammar_path).expect("Failed to load Rust grammar")
@@ -1688,7 +1688,7 @@ fn helper() {}
     /// alongside this repo via the standard workspace layout.
     fn php_grammar() -> Option<Grammar> {
         let grammar_path = std::path::Path::new(
-            "/var/lib/datamachine/workspace/homeboy-extensions/wordpress/grammar.toml",
+            "/var/lib/sampleplugin/workspace/homeboy-extensions/wordpress/grammar.toml",
         );
         if !grammar_path.exists() {
             return None;
@@ -1708,7 +1708,7 @@ fn helper() {}
             return;
         };
 
-        let content = "<?php\nnamespace DataMachine\\Engine\\AI\\Tools\\Global;\n\nclass WebFetch {\n    public function handle() {}\n}\n";
+        let content = "<?php\nnamespace SamplePlugin\\Engine\\AI\\Tools\\Global;\n\nclass WebFetch {\n    public function handle() {}\n}\n";
 
         let fp =
             fingerprint_from_grammar(content, &grammar, "inc/Engine/AI/Tools/Global/WebFetch.php")
@@ -1716,7 +1716,7 @@ fn helper() {}
 
         assert_eq!(
             fp.namespace.as_deref(),
-            Some("DataMachine\\Engine\\AI\\Tools\\Global"),
+            Some("SamplePlugin\\Engine\\AI\\Tools\\Global"),
             "Namespace with reserved word segment 'Global' should be extracted. Got: {:?}",
             fp.namespace
         );
@@ -1726,7 +1726,7 @@ fn helper() {}
     fn namespace_with_leading_whitespace_is_extracted() {
         // Regression test for #1134 (real-world case).
         //
-        // data-machine has files like Engine/AI/Tools/Global/AgentMemory.php
+        // sample-plugin has files like Engine/AI/Tools/Global/AgentMemory.php
         // where the namespace line has a leading tab/indent (stylistic choice
         // after a docblock). The grammar regex is anchored to `^namespace`,
         // which fails when the line has leading whitespace.
@@ -1739,7 +1739,7 @@ fn helper() {}
             return;
         };
 
-        let content = "<?php\n/**\n * Docblock.\n */\n\n\tnamespace DataMachine\\Engine\\AI\\Tools\\Global;\n\nclass AgentMemory {}\n";
+        let content = "<?php\n/**\n * Docblock.\n */\n\n\tnamespace SamplePlugin\\Engine\\AI\\Tools\\Global;\n\nclass AgentMemory {}\n";
 
         let fp = fingerprint_from_grammar(
             content,
@@ -1750,7 +1750,7 @@ fn helper() {}
 
         assert_eq!(
             fp.namespace.as_deref(),
-            Some("DataMachine\\Engine\\AI\\Tools\\Global"),
+            Some("SamplePlugin\\Engine\\AI\\Tools\\Global"),
             "Namespace with leading whitespace (valid PHP) should be extracted. Got: {:?}",
             fp.namespace
         );

--- a/src/core/code_audit/dead_code.rs
+++ b/src/core/code_audit/dead_code.rs
@@ -1085,7 +1085,7 @@ class EmailCommand extends RuntimeCommand {
             vec![],
         );
         command_fp.language = Language::Php;
-        command_fp.namespace = Some("DataMachine\\Cli\\Commands".to_string());
+        command_fp.namespace = Some("SamplePlugin\\Cli\\Commands".to_string());
         command_fp.type_name = Some("EmailCommand".to_string());
 
         let findings = analyze_dead_code(&[&bootstrap_fp, &command_fp], &[]);
@@ -1155,7 +1155,7 @@ class EmailCommand extends WP_CLI_Command {
     /**
      * ## EXAMPLES
      *
-     *     wp datamachine email test-connection
+     *     wp sampleplugin email test-connection
      *
      * @subcommand test-connection
      */

--- a/src/core/code_audit/detectors/deprecation_age.rs
+++ b/src/core/code_audit/detectors/deprecation_age.rs
@@ -572,9 +572,9 @@ function legacy_api() {}
  * @deprecated 0.48.0 Context has moved.
  */
 
-namespace DataMachine\Core\WordPress;
+namespace SamplePlugin\Core\WordPress;
 
-use DataMachine\Core\Baz;
+use SamplePlugin\Core\Baz;
 
 class SiteContext {}
 "#;

--- a/src/core/code_audit/detectors/field_patterns.rs
+++ b/src/core/code_audit/detectors/field_patterns.rs
@@ -895,7 +895,7 @@ class AIStep {
             class_name: self::class,
             label: 'AI',
         );
-        add_filter('datamachine_handlers', [self::class, 'register']);
+        add_filter('sampleplugin_handlers', [self::class, 'register']);
     }
 }
 "#;

--- a/src/core/code_audit/detectors/layer_ownership.rs
+++ b/src/core/code_audit/detectors/layer_ownership.rs
@@ -162,7 +162,7 @@ mod tests {
                     "name": "engine-owns-terminal-status",
                     "forbid": {
                       "glob": "inc/Core/Steps/**/*.php",
-                      "patterns": ["JobStatus::", "datamachine_fail_job"]
+                      "patterns": ["JobStatus::", "sampleplugin_fail_job"]
                     },
                     "allow": {"glob": "inc/Abilities/Engine/**/*.php"}
                   }
@@ -199,7 +199,7 @@ mod tests {
                     "name": "engine-owns-terminal-status",
                     "forbid": {
                       "glob": "inc/Core/Steps/**/*.php",
-                      "patterns": ["datamachine_fail_job"]
+                      "patterns": ["sampleplugin_fail_job"]
                     }
                   }
                 ]
@@ -210,7 +210,7 @@ mod tests {
 
         std::fs::write(
             steps_dir.join("agent_ping.php"),
-            "<?php\ndatamachine_fail_job($job_id);\n",
+            "<?php\nsampleplugin_fail_job($job_id);\n",
         )
         .unwrap();
 

--- a/src/core/code_audit/detectors/shared_scaffolding.rs
+++ b/src/core/code_audit/detectors/shared_scaffolding.rs
@@ -6,7 +6,7 @@
 //! candidates for extraction into a shared base class.
 //!
 //! Where existing detectors compare pairs of functions, this detector compares
-//! whole class shapes. It catches cases like data-machine's ~90 ability classes
+//! whole class shapes. It catches cases like sample-plugin's ~90 ability classes
 //! all following `__construct → registerAbility → execute → checkPermission`.
 //!
 //! Algorithm:

--- a/src/core/code_audit/detectors/upstream_workaround.rs
+++ b/src/core/code_audit/detectors/upstream_workaround.rs
@@ -484,7 +484,7 @@ mod tests {
         let fp = make_fp(
             "src/Api/WebhookSignatureVerifier.php",
             Language::Php,
-            "<?php\n/**\n * Kept only as a transitional shim for older callers.\n *\n * @see https://github.com/Extra-Chill/data-machine/issues/1179\n * @deprecated\n */\nclass Verifier {}\n",
+            "<?php\n/**\n * Kept only as a transitional shim for older callers.\n *\n * @see https://github.com/Extra-Chill/sample-plugin/issues/1179\n * @deprecated\n */\nclass Verifier {}\n",
         );
         let findings = run(&[&fp], &default_config());
         assert_eq!(findings.len(), 1);
@@ -492,7 +492,7 @@ mod tests {
         assert_eq!(findings[0].severity, Severity::Warning);
         assert!(findings[0]
             .suggestion
-            .contains("github.com/Extra-Chill/data-machine/issues/1179"));
+            .contains("github.com/Extra-Chill/sample-plugin/issues/1179"));
     }
 
     #[test]
@@ -500,7 +500,7 @@ mod tests {
         let fp = make_fp(
             "src/Api/WebhookAuthResolver.php",
             Language::Php,
-            "<?php\n/**\n * Webhook auth config resolver.\n *\n * Produces a canonical verifier config for an HMAC flow.\n *\n * @see https://github.com/Extra-Chill/data-machine/issues/1179\n */\nclass WebhookAuthResolver {}\n",
+            "<?php\n/**\n * Webhook auth config resolver.\n *\n * Produces a canonical verifier config for an HMAC flow.\n *\n * @see https://github.com/Extra-Chill/sample-plugin/issues/1179\n */\nclass WebhookAuthResolver {}\n",
         );
 
         let findings = run(&[&fp], &default_config());

--- a/src/core/code_audit/detectors/wrapper_inference.rs
+++ b/src/core/code_audit/detectors/wrapper_inference.rs
@@ -264,7 +264,7 @@ mod tests {
     #[test]
     fn test_trace_calls_basic() {
         let content = r#"
-            $result = wp_get_ability('datamachine/create-pipeline');
+            $result = wp_get_ability('sampleplugin/create-pipeline');
             $other = doSomething();
         "#;
         let regex = Regex::new(r"wp_get_ability\('([^']+)'\)").unwrap();
@@ -272,7 +272,7 @@ mod tests {
 
         let matches = trace_calls(content, &patterns);
         assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].captured, "datamachine/create-pipeline");
+        assert_eq!(matches[0].captured, "sampleplugin/create-pipeline");
     }
 
     #[test]
@@ -303,16 +303,16 @@ mod tests {
     #[test]
     fn test_build_suggestion_single_target() {
         let rule = make_rule("test", "*", "ability", &[]);
-        let suggestion = build_suggestion(&rule, &["datamachine/search".to_string()]);
-        assert_eq!(suggestion, "Add 'ability' => 'datamachine/search'");
+        let suggestion = build_suggestion(&rule, &["sampleplugin/search".to_string()]);
+        assert_eq!(suggestion, "Add 'ability' => 'sampleplugin/search'");
     }
 
     #[test]
     fn test_build_suggestion_with_format() {
         let mut rule = make_rule("test", "*", "ability", &[]);
         rule.field_format = Some("'ability' => '{inferred}'".to_string());
-        let suggestion = build_suggestion(&rule, &["datamachine/search".to_string()]);
-        assert_eq!(suggestion, "'ability' => 'datamachine/search'");
+        let suggestion = build_suggestion(&rule, &["sampleplugin/search".to_string()]);
+        assert_eq!(suggestion, "'ability' => 'sampleplugin/search'");
     }
 
     #[test]
@@ -321,18 +321,18 @@ mod tests {
         let suggestion = build_suggestion(
             &rule,
             &[
-                "datamachine/search".to_string(),
-                "datamachine/fetch".to_string(),
+                "sampleplugin/search".to_string(),
+                "sampleplugin/fetch".to_string(),
             ],
         );
         assert!(suggestion.contains("Multiple implementations"));
-        assert!(suggestion.contains("datamachine/search"));
-        assert!(suggestion.contains("datamachine/fetch"));
+        assert!(suggestion.contains("sampleplugin/search"));
+        assert!(suggestion.contains("sampleplugin/fetch"));
     }
 
     #[test]
     fn test_analyze_wrappers_skips_files_with_field() {
-        let content_with_field = "'ability' => 'datamachine/search'\nSearchAbilities::run();";
+        let content_with_field = "'ability' => 'sampleplugin/search'\nSearchAbilities::run();";
         let fp = make_fingerprint("tools/Search.php", content_with_field);
         let _fps: Vec<&FileFingerprint> = vec![&fp];
 

--- a/src/core/code_audit/docs_audit/claims.rs
+++ b/src/core/code_audit/docs_audit/claims.rs
@@ -19,7 +19,7 @@ pub enum ClaimType {
     DirectoryPath,
     /// Code example in a fenced block
     CodeExample,
-    /// Namespaced class reference (e.g., `DataMachine\Services\CacheManager`)
+    /// Namespaced class reference (e.g., `SamplePlugin\Services\CacheManager`)
     ClassName,
 }
 
@@ -67,8 +67,8 @@ static CODE_BLOCK_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 static CLASS_NAME_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    // Matches namespaced class references like DataMachine\Services\CacheManager
-    // or DataMachine\\Services\\CacheManager (escaped backslashes in markdown)
+    // Matches namespaced class references like SamplePlugin\Services\CacheManager
+    // or SamplePlugin\\Services\\CacheManager (escaped backslashes in markdown)
     // Requires at least two segments (Namespace\Class)
     Regex::new(r"(?:`)?([A-Z][a-zA-Z0-9]*(?:\\{1,2}[A-Z][a-zA-Z0-9]*)+)(?:`)?").unwrap()
 });
@@ -489,7 +489,7 @@ Supported types: `text/plain`, `image/png`, `audio/mpeg`, `video/mp4`.
 
     #[test]
     fn test_ignore_patterns_filter_rest_api() {
-        let content = "The endpoint is at `/wp-json/datamachine/v1/events`.";
+        let content = "The endpoint is at `/wp-json/sampleplugin/v1/events`.";
         // Use ** to match multiple path segments
         let patterns = vec!["/wp-json/**".to_string()];
         let claims = extract_claims(content, "test.md", &patterns);
@@ -509,7 +509,7 @@ Supported types: `text/plain`, `image/png`, `audio/mpeg`, `video/mp4`.
 
     #[test]
     fn test_ignore_patterns_filter_oauth_callback() {
-        let content = "OAuth redirects to `/datamachine-auth/twitter/` callback.";
+        let content = "OAuth redirects to `/sampleplugin-auth/twitter/` callback.";
         // Use ** to match any path starting with segment ending in -auth
         let patterns = vec!["/*-auth/**".to_string()];
         let claims = extract_claims(content, "test.md", &patterns);
@@ -529,7 +529,7 @@ Supported types: `text/plain`, `image/png`, `audio/mpeg`, `video/mp4`.
     #[test]
     fn test_no_ignore_patterns_extracts_api_paths() {
         // Without ignore patterns, API-like paths ARE extracted
-        let content = "The endpoint is at `/wp-json/datamachine/v1/events.json`.";
+        let content = "The endpoint is at `/wp-json/sampleplugin/v1/events.json`.";
         let claims = extract_claims(content, "test.md", &[]);
 
         // With no patterns, this should be extracted as a file path
@@ -579,7 +579,7 @@ Supported types: `text/plain`, `image/png`, `audio/mpeg`, `video/mp4`.
 
     #[test]
     fn test_real_class_in_prose_is_real_confidence() {
-        let content = "The DataMachine\\Services\\CacheManager handles caching.";
+        let content = "The AcmeProduct\\Services\\CacheManager handles caching.";
         let claims = extract_claims(content, "test.md", &[]);
 
         let claim = claims
@@ -617,7 +617,7 @@ Supported types: `text/plain`, `image/png`, `audio/mpeg`, `video/mp4`.
 
     #[test]
     fn test_annotation_context_is_real() {
-        let content = "@see DataMachine\\Core\\Engine for the main engine class.";
+        let content = "@see AcmeProduct\\Core\\Engine for the main engine class.";
         let claims = extract_claims(content, "test.md", &[]);
 
         let claim = claims
@@ -634,7 +634,7 @@ Supported types: `text/plain`, `image/png`, `audio/mpeg`, `video/mp4`.
         assert!(is_placeholder_class("Example\\Namespace\\Class"));
         assert!(is_placeholder_class("Foo\\Bar\\Baz"));
         assert!(is_placeholder_class("Test\\Mock\\Handler"));
-        assert!(!is_placeholder_class("DataMachine\\Services\\Cache"));
+        assert!(!is_placeholder_class("AcmeProduct\\Services\\Cache"));
         assert!(!is_placeholder_class("WordPress\\Plugin\\Activator"));
     }
 
@@ -658,7 +658,7 @@ Supported types: `text/plain`, `image/png`, `audio/mpeg`, `video/mp4`.
         ));
         assert!(is_os_path_context("Path is C:/Users/admin/AppData", 20));
         assert!(!is_os_path_context(
-            "The DataMachine\\Services\\Cache class",
+            "The AcmeProduct\\Services\\Cache class",
             4
         ));
     }

--- a/src/core/code_audit/docs_audit/verify.rs
+++ b/src/core/code_audit/docs_audit/verify.rs
@@ -172,12 +172,12 @@ fn verify_directory_path(
 
 /// Verify a namespaced class reference by searching for the class definition in source files.
 ///
-/// Converts namespace path to directory structure (e.g., `DataMachine\Services\CacheManager`
+/// Converts namespace path to directory structure (e.g., `SamplePlugin\Services\CacheManager`
 /// becomes a search for `class CacheManager` in files under a path matching the namespace).
 fn verify_class_name(claim: &Claim, source_path: &Path) -> VerifyResult {
     let class_ref = &claim.value;
 
-    // Split into segments: DataMachine\Services\CacheManager -> ["DataMachine", "Services", "CacheManager"]
+    // Split into segments: SamplePlugin\Services\CacheManager -> ["SamplePlugin", "Services", "CacheManager"]
     let segments: Vec<&str> = class_ref.split('\\').collect();
     if segments.len() < 2 {
         return VerifyResult::NeedsVerification {

--- a/src/core/code_audit/import_matching.rs
+++ b/src/core/code_audit/import_matching.rs
@@ -454,7 +454,7 @@ fn is_only_in_attribute_string(line: &str, name: &str) -> bool {
 /// (e.g., global-namespace `ClassName`).
 ///
 /// Examples:
-/// - `DataMachine\Abilities\PermissionHelper` → `DataMachine\Abilities`
+/// - `SamplePlugin\Abilities\PermissionHelper` → `SamplePlugin\Abilities`
 /// - `crate::commands::CmdResult` → `crate::commands`
 /// - `PermissionHelper` → `` (no namespace)
 pub(crate) fn namespace_of(path: &str) -> String {
@@ -702,7 +702,7 @@ fn production(values: BTreeMap<String, f64>) {}
     #[test]
     fn content_references_name_skips_php_namespace_declarations() {
         assert!(!content_references_name(
-            "namespace DataMachine\\Core\\Agents;\n\nclass AgentIdentity { public function __construct() {} }",
+            "namespace SamplePlugin\\Core\\Agents;\n\nclass AgentIdentity { public function __construct() {} }",
             "Agents"
         ));
     }
@@ -710,7 +710,7 @@ fn production(values: BTreeMap<String, f64>) {}
     #[test]
     fn content_references_name_skips_comment_only_references() {
         assert!(!content_references_name(
-            "<?php\n/**\n * @package DataMachine\\Core\\Agents\n */\nnamespace DataMachine\\Core;\nclass AgentIdentity {}",
+            "<?php\n/**\n * @package SamplePlugin\\Core\\Agents\n */\nnamespace SamplePlugin\\Core;\nclass AgentIdentity {}",
             "Agents"
         ));
     }
@@ -793,8 +793,8 @@ type AgentIdentity {}
     #[test]
     fn namespace_of_splits_php_style() {
         assert_eq!(
-            namespace_of("DataMachine\\Abilities\\PermissionHelper"),
-            "DataMachine\\Abilities"
+            namespace_of("SamplePlugin\\Abilities\\PermissionHelper"),
+            "SamplePlugin\\Abilities"
         );
     }
 
@@ -817,10 +817,10 @@ type AgentIdentity {}
         let imports = vec![];
         let content = "class PermissionHelper {}";
         assert!(has_import_with_context(
-            "DataMachine\\Abilities\\PermissionHelper",
+            "SamplePlugin\\Abilities\\PermissionHelper",
             &imports,
             content,
-            Some("DataMachine\\Abilities"),
+            Some("SamplePlugin\\Abilities"),
             Some("PermissionHelper"),
             &["PermissionHelper".to_string()],
         ));
@@ -828,15 +828,15 @@ type AgentIdentity {}
 
     #[test]
     fn has_import_same_namespace_satisfied() {
-        // A class in DataMachine\Abilities can reference another class in
-        // DataMachine\Abilities without a `use` statement.
+        // A class in SamplePlugin\Abilities can reference another class in
+        // SamplePlugin\Abilities without a `use` statement.
         let imports = vec![];
         let content = "class AgentTokenAbilities { function r() { PermissionHelper::x(); } }";
         assert!(has_import_with_context(
-            "DataMachine\\Abilities\\PermissionHelper",
+            "SamplePlugin\\Abilities\\PermissionHelper",
             &imports,
             content,
-            Some("DataMachine\\Abilities"),
+            Some("SamplePlugin\\Abilities"),
             Some("AgentTokenAbilities"),
             &["AgentTokenAbilities".to_string()],
         ));
@@ -844,15 +844,15 @@ type AgentIdentity {}
 
     #[test]
     fn has_import_cross_namespace_still_flagged() {
-        // A class in DataMachine\Core that uses DataMachine\Abilities\Foo
+        // A class in SamplePlugin\Core that uses SamplePlugin\Abilities\Foo
         // still needs an import.
         let imports = vec![];
         let content = "class Something { function r() { Foo::x(); } }";
         assert!(!has_import_with_context(
-            "DataMachine\\Abilities\\Foo",
+            "SamplePlugin\\Abilities\\Foo",
             &imports,
             content,
-            Some("DataMachine\\Core"),
+            Some("SamplePlugin\\Core"),
             Some("Something"),
             &["Something".to_string()],
         ));

--- a/src/core/component/inventory.rs
+++ b/src/core/component/inventory.rs
@@ -134,7 +134,7 @@ fn load_standalone_components() -> Result<Vec<Component>> {
             continue;
         }
 
-        // Derive component ID from filename (e.g., "data-machine.json" -> "data-machine")
+        // Derive component ID from filename (e.g., "sample-plugin.json" -> "sample-plugin")
         let id = match path.file_stem().and_then(|s| s.to_str()) {
             Some(stem) => stem.to_string(),
             None => continue,

--- a/src/core/component/mod.rs
+++ b/src/core/component/mod.rs
@@ -742,9 +742,9 @@ mod tests {
     #[test]
     fn component_priority_labels_serialization_roundtrip() {
         let mut component = Component::new(
-            "data-machine".to_string(),
-            "/tmp/data-machine".to_string(),
-            "wp-content/plugins/data-machine".to_string(),
+            "sample-plugin".to_string(),
+            "/tmp/sample-plugin".to_string(),
+            "wp-content/plugins/sample-plugin".to_string(),
             None,
         );
         component.priority_labels = Some(vec!["urgent".to_string()]);
@@ -852,7 +852,7 @@ mod tests {
     #[test]
     fn validate_supported_build_config_rejects_legacy_build_command() {
         let component = Component {
-            id: "sample-codebox".to_string(),
+            id: "sample-extension".to_string(),
             build_command: Some("npm run package:browser-extension".to_string()),
             ..Default::default()
         };
@@ -1162,7 +1162,7 @@ mod tests {
 
     #[test]
     fn discover_from_portable_with_baselines_and_extensions() {
-        // Mirrors data-machine's real homeboy.json — includes subsystem-owned
+        // Mirrors a real homeboy.json — includes subsystem-owned
         // baselines and component-owned extensions. This must not silently fail.
         let tmp = tempfile::TempDir::new().unwrap();
         let dir = tmp.path().to_path_buf();
@@ -1171,7 +1171,7 @@ mod tests {
             "auto_cleanup": false,
             "baselines": {
                 "lint": {
-                    "context_id": "data-machine",
+                    "context_id": "sample-plugin",
                     "created_at": "2026-03-06T04:47:29Z",
                     "item_count": 0,
                     "known_fingerprints": [],
@@ -1184,9 +1184,9 @@ mod tests {
             "extensions": {
                 "wordpress": {}
             },
-            "id": "data-machine",
+            "id": "sample-plugin",
             "version_targets": [
-                {"file": "data-machine.php", "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"}
+                {"file": "sample-plugin.php", "pattern": "(?m)^\\s*\\*?\\s*Version:\\s*([0-9.]+)"}
             ]
         });
         std::fs::write(dir.join("homeboy.json"), config.to_string()).unwrap();
@@ -1199,7 +1199,7 @@ mod tests {
 
         let comp = result.unwrap();
         // id comes from portable JSON
-        assert_eq!(comp.id, "data-machine");
+        assert_eq!(comp.id, "sample-plugin");
         assert_eq!(comp.local_path, dir.to_string_lossy());
         // extensions must be present
         assert!(

--- a/src/core/component/mutations.rs
+++ b/src/core/component/mutations.rs
@@ -239,15 +239,15 @@ mod tests {
     #[test]
     fn merge_writes_registry_without_rewriting_portable_config() {
         crate::test_support::with_isolated_home(|home| {
-            let repo = home.path().join("codebox");
+            let repo = home.path().join("sample-plugin");
             fs::create_dir_all(&repo).expect("repo dir");
-            let portable = r#"{"id":"codebox","remote_path":"deploy/codebox"}"#;
+            let portable = r#"{"id":"sample-plugin","remote_path":"deploy/sample-plugin"}"#;
             fs::write(repo.join("homeboy.json"), portable).expect("homeboy.json");
 
             let component = Component::new(
-                "codebox".to_string(),
+                "sample-plugin".to_string(),
                 repo.to_string_lossy().to_string(),
-                "deploy/codebox".to_string(),
+                "deploy/sample-plugin".to_string(),
                 None,
             );
             inventory::write_standalone_registration(&component)
@@ -259,7 +259,7 @@ mod tests {
                 }
             })
             .to_string();
-            let result = merge(Some("codebox"), &patch, &[]).expect("component merge");
+            let result = merge(Some("sample-plugin"), &patch, &[]).expect("component merge");
             let MergeOutput::Single(result) = result else {
                 panic!("expected single merge result");
             };
@@ -271,13 +271,15 @@ mod tests {
                 "component set must not rewrite repo-owned homeboy.json by default"
             );
 
-            let loaded = crate::core::component::load("codebox").expect("load component");
+            let loaded = crate::core::component::load("sample-plugin").expect("load component");
             assert_eq!(
                 loaded.scripts.expect("scripts should be registered").build,
                 vec!["npm run package".to_string()]
             );
 
-            let registration_path = home.path().join(".config/homeboy/components/codebox.json");
+            let registration_path = home
+                .path()
+                .join(".config/homeboy/components/sample-plugin.json");
             let registration: serde_json::Value = serde_json::from_str(
                 &fs::read_to_string(registration_path).expect("read registration"),
             )

--- a/src/core/deploy/effect.rs
+++ b/src/core/deploy/effect.rs
@@ -154,15 +154,15 @@ mod tests {
         // component declares no version_targets, so Homeboy cannot confirm the
         // files actually landed. It must refuse to fabricate a success.
         let component = Component {
-            id: "data-machine-socials".to_string(),
-            remote_path: "wp-content/plugins/data-machine-socials".to_string(),
+            id: "sample-plugin-socials".to_string(),
+            remote_path: "wp-content/plugins/sample-plugin-socials".to_string(),
             version_targets: None,
             ..Component::default()
         };
         let effect = DeployEffect {
-            remote_path: "wp-content/plugins/data-machine-socials".to_string(),
+            remote_path: "wp-content/plugins/sample-plugin-socials".to_string(),
             artifact_path: Some(
-                "wp-content/plugins/data-machine-socials/.homeboy-data-machine-socials.zip"
+                "wp-content/plugins/sample-plugin-socials/.homeboy-sample-plugin-socials.zip"
                     .to_string(),
             ),
             verified: false,
@@ -190,14 +190,14 @@ mod tests {
         // When an extension verifier already confirmed the deploy (`verified`),
         // the absence of version_targets is acceptable and we report local_version.
         let component = Component {
-            id: "data-machine-socials".to_string(),
-            remote_path: "wp-content/plugins/data-machine-socials".to_string(),
+            id: "sample-plugin-socials".to_string(),
+            remote_path: "wp-content/plugins/sample-plugin-socials".to_string(),
             version_targets: None,
             ..Component::default()
         };
         let effect = DeployEffect {
-            remote_path: "wp-content/plugins/data-machine-socials".to_string(),
-            artifact_path: Some("/srv/staging/.homeboy-data-machine-socials.zip".to_string()),
+            remote_path: "wp-content/plugins/sample-plugin-socials".to_string(),
+            artifact_path: Some("/srv/staging/.homeboy-sample-plugin-socials.zip".to_string()),
             verified: true,
         };
         let expected_version = "0.14.0".to_string();

--- a/src/core/deploy/generated_artifacts.rs
+++ b/src/core/deploy/generated_artifacts.rs
@@ -190,14 +190,14 @@ mod tests {
     #[test]
     fn deploy_target_debris_matches_relative_remote_path_and_collapsed_untracked_dir() {
         let component = Component {
-            remote_path: "wp-content/plugins/data-machine".to_string(),
-            build_artifact: Some("dist/data-machine.zip".to_string()),
+            remote_path: "wp-content/plugins/sample-plugin".to_string(),
+            build_artifact: Some("dist/sample-plugin.zip".to_string()),
             ..Component::default()
         };
 
         assert!(is_deploy_target_debris_path(
             &component,
-            "wp-content/plugins/data-machine/data-machine"
+            "wp-content/plugins/sample-plugin/sample-plugin"
         ));
         assert!(is_deploy_target_debris_path(&component, "wp-content/"));
         assert!(!is_deploy_target_debris_path(&component, "src/lib.rs"));

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -1048,7 +1048,7 @@ mod tests {
 
     #[test]
     fn deploy_tag_for_version_formats_regular_release_tag() {
-        let component = make_component("data-machine", "/tmp/not-a-git-repo");
+        let component = make_component("sample-plugin", "/tmp/not-a-git-repo");
 
         assert_eq!(deploy_tag_for_version(&component, "0.139.18"), "v0.139.18");
         assert_eq!(deploy_tag_for_version(&component, "v0.139.18"), "v0.139.18");
@@ -1088,9 +1088,9 @@ mod tests {
     #[test]
     fn deploy_validation_rejects_legacy_build_command_before_artifact_checks() {
         let dir = TempDir::new().expect("temp dir");
-        let mut component = make_component("sample-codebox", &dir.path().to_string_lossy());
+        let mut component = make_component("sample-extension", &dir.path().to_string_lossy());
         component.build_artifact =
-            Some("packages/browser-extension/dist/sample-codebox.zip".to_string());
+            Some("packages/browser-extension/dist/sample-extension.zip".to_string());
         component.build_command = Some("npm run package:browser-extension".to_string());
 
         let err = validate_supported_build_configs(&[component])
@@ -1322,17 +1322,17 @@ mod tests {
         let path = dir.path();
 
         init_clean_repo(path);
-        std::fs::create_dir_all(path.join("wp-content/plugins/data-machine/data-machine"))
+        std::fs::create_dir_all(path.join("wp-content/plugins/sample-plugin/sample-plugin"))
             .expect("deploy debris dir");
         std::fs::write(
-            path.join("wp-content/plugins/data-machine/data-machine/plugin.php"),
+            path.join("wp-content/plugins/sample-plugin/sample-plugin/plugin.php"),
             "<?php",
         )
         .expect("deploy debris file");
 
-        let mut component = make_component("data-machine", &path.to_string_lossy());
-        component.remote_path = "wp-content/plugins/data-machine".to_string();
-        component.build_artifact = Some("dist/data-machine.zip".to_string());
+        let mut component = make_component("sample-plugin", &path.to_string_lossy());
+        component.remote_path = "wp-content/plugins/sample-plugin".to_string();
+        component.build_artifact = Some("dist/sample-plugin.zip".to_string());
 
         check_uncommitted_changes(&[component])
             .expect("untracked deploy-target debris should not block deploy");
@@ -1371,20 +1371,20 @@ mod tests {
 
     #[test]
     fn auto_pull_version_drift_message_reports_changed_version() {
-        let component = make_component("data-machine", "/tmp/data-machine");
+        let component = make_component("sample-plugin", "/tmp/sample-plugin");
 
         let message =
             auto_pull_version_drift_message(&component, Some("0.139.12"), Some("0.139.13"))
                 .expect("version drift message");
 
-        assert!(message.contains("data-machine"));
+        assert!(message.contains("sample-plugin"));
         assert!(message.contains("0.139.12"));
         assert!(message.contains("0.139.13"));
     }
 
     #[test]
     fn auto_pull_version_drift_message_skips_unchanged_version() {
-        let component = make_component("data-machine", "/tmp/data-machine");
+        let component = make_component("sample-plugin", "/tmp/sample-plugin");
 
         assert!(
             auto_pull_version_drift_message(&component, Some("0.139.12"), Some("0.139.12"))

--- a/src/core/deploy/release_download.rs
+++ b/src/core/deploy/release_download.rs
@@ -402,12 +402,12 @@ mod tests {
         let repo = GitHubRepo {
             host: "github.com".to_string(),
             owner: "Extra-Chill".to_string(),
-            repo: "data-machine".to_string(),
+            repo: "sample-plugin".to_string(),
         };
-        let url = repo.release_artifact_url("v0.36.1", "data-machine.zip");
+        let url = repo.release_artifact_url("v0.36.1", "sample-plugin.zip");
         assert_eq!(
             url,
-            "https://github.com/Extra-Chill/data-machine/releases/download/v0.36.1/data-machine.zip"
+            "https://github.com/Extra-Chill/sample-plugin/releases/download/v0.36.1/sample-plugin.zip"
         );
     }
 

--- a/src/core/deploy/safety_and_artifact.rs
+++ b/src/core/deploy/safety_and_artifact.rs
@@ -514,17 +514,17 @@ mod tests {
         let vars = std::collections::HashMap::from([
             (
                 "artifact".to_string(),
-                ".homeboy-data-machine-events.zip".to_string(),
+                ".homeboy-sample-plugin-events.zip".to_string(),
             ),
             (
                 "targetDir".to_string(),
-                "/srv/site/wp-content/plugins/data-machine-events".to_string(),
+                "/srv/site/wp-content/plugins/sample-plugin-events".to_string(),
             ),
         ]);
 
         assert_eq!(
             render_extract_command("unzip -o {{artifact}} && rm {{artifact}}", &vars),
-            "unzip -o .homeboy-data-machine-events.zip && rm .homeboy-data-machine-events.zip"
+            "unzip -o .homeboy-sample-plugin-events.zip && rm .homeboy-sample-plugin-events.zip"
         );
     }
 
@@ -823,11 +823,11 @@ mod tests {
             .prefix("homeboy-relative-flatten-")
             .tempdir_in(&current_dir)
             .expect("temp dir in cwd");
-        let plugin = "data-machine";
+        let plugin = "sample-plugin";
         let target = temp.path().join("wp-content/plugins").join(plugin);
         let nested = target.join(plugin);
         fs::create_dir_all(&nested).expect("nested dir");
-        fs::write(nested.join("data-machine.php"), "<?php").expect("plugin main");
+        fs::write(nested.join("sample-plugin.php"), "<?php").expect("plugin main");
 
         let relative_target = target
             .strip_prefix(&current_dir)
@@ -838,7 +838,7 @@ mod tests {
         let result = flatten_double_nested_dir(&local_client(), relative_target).expect("ok");
 
         assert!(result.is_none(), "flatten should not fail");
-        assert!(target.join("data-machine.php").is_file());
+        assert!(target.join("sample-plugin.php").is_file());
         assert!(!target.join(plugin).exists());
         assert!(!target.join(".artifact-flatten-staging").exists());
     }

--- a/src/core/deploy/version_overrides.rs
+++ b/src/core/deploy/version_overrides.rs
@@ -1191,7 +1191,7 @@ mod tests {
         let vars = deploy_override_template_vars(
             "artifact.zip",
             "/tmp/homeboy-staging/artifact.zip",
-            "/srv/htdocs/wp-content/plugins/wp-codebox",
+            "/srv/htdocs/wp-content/plugins/sample-plugin",
             Some("/srv/htdocs"),
             "wp",
             Some("example.com"),
@@ -1209,14 +1209,14 @@ mod tests {
         );
         assert_eq!(
             vars.get(TemplateVars::TARGET_BASENAME).map(String::as_str),
-            Some("wp-codebox")
+            Some("sample-plugin")
         );
         assert_eq!(
             render_map(
                 "mktemp -d {{targetAdjacentTempPattern}} && cp {{stagingArtifact}} {{targetDir}}/installed.zip",
                 &vars,
             ),
-            "mktemp -d /srv/htdocs/wp-content/plugins/.homeboy-install.XXXXXX && cp /tmp/homeboy-staging/artifact.zip /srv/htdocs/wp-content/plugins/wp-codebox/installed.zip"
+            "mktemp -d /srv/htdocs/wp-content/plugins/.homeboy-install.XXXXXX && cp /tmp/homeboy-staging/artifact.zip /srv/htdocs/wp-content/plugins/sample-plugin/installed.zip"
         );
     }
 }

--- a/src/core/engine/cli_tool.rs
+++ b/src/core/engine/cli_tool.rs
@@ -30,8 +30,8 @@ pub struct CliToolResult {
 pub fn run(tool: &str, identifier: &str, args: &[String]) -> Result<CliToolResult> {
     // Normalize args: split quoted strings containing spaces.
     // This ensures both syntaxes work identically:
-    //   homeboy wp extra-chill:events datamachine pipelines list
-    //   homeboy wp extra-chill:events "datamachine pipelines list"
+    //   homeboy wp extra-chill:events sampleplugin pipelines list
+    //   homeboy wp extra-chill:events "sampleplugin pipelines list"
     let args = shell::normalize_args(args);
 
     // Parse project:subtarget syntax

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -2072,7 +2072,7 @@ mod tests {
             settings: Vec::new(),
             settings_json: vec![(
                 "workflow_bench_env".to_string(),
-                serde_json::json!({ "WORKFLOW_BENCH_SCENARIO": "plain-site-data-machine" }),
+                serde_json::json!({ "WORKFLOW_BENCH_SCENARIO": "plain-site-sample-plugin" }),
             )],
             passthrough_args: Vec::new(),
             scenario_ids: Vec::new(),
@@ -2090,7 +2090,7 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(settings).expect("settings json");
         assert_eq!(
             parsed["workflow_bench_env"]["WORKFLOW_BENCH_SCENARIO"],
-            "plain-site-data-machine"
+            "plain-site-sample-plugin"
         );
     }
 

--- a/src/core/extension/execution.rs
+++ b/src/core/extension/execution.rs
@@ -949,7 +949,7 @@ mod tests {
         let extension_settings: Vec<(String, serde_json::Value)> = vec![
             (
                 "validation_dependencies".to_string(),
-                serde_json::json!(["data-machine"]),
+                serde_json::json!(["sample-plugin"]),
             ),
             (
                 "plain_string".to_string(),
@@ -972,7 +972,7 @@ mod tests {
         // Array from extension settings is preserved
         assert_eq!(
             parsed["validation_dependencies"],
-            serde_json::json!(["data-machine"]),
+            serde_json::json!(["sample-plugin"]),
             "Array setting should be preserved, not flattened to empty string"
         );
 

--- a/src/core/extension/grammar.rs
+++ b/src/core/extension/grammar.rs
@@ -1572,7 +1572,7 @@ mod integration_tests {
     fn load_and_use_rust_grammar() {
         // Try to find the Rust grammar in the extensions workspace
         let grammar_path = std::path::Path::new(
-            "/var/lib/datamachine/workspace/homeboy-modules/rust/grammar.toml",
+            "/var/lib/sampleplugin/workspace/homeboy-modules/rust/grammar.toml",
         );
         if !grammar_path.exists() {
             // Skip if not in development environment
@@ -1663,7 +1663,7 @@ mod tests {
     #[test]
     fn load_and_use_php_grammar() {
         let grammar_path = std::path::Path::new(
-            "/var/lib/datamachine/workspace/homeboy-modules/wordpress/grammar.toml",
+            "/var/lib/sampleplugin/workspace/homeboy-modules/wordpress/grammar.toml",
         );
         if !grammar_path.exists() {
             eprintln!("Skipping: PHP grammar not found at {:?}", grammar_path);
@@ -1677,10 +1677,10 @@ mod tests {
         assert!(grammar.patterns.contains_key("namespace"));
 
         let sample = r#"<?php
-namespace DataMachine\Abilities;
+namespace SamplePlugin\Abilities;
 
 use WP_UnitTestCase;
-use DataMachine\Core\Pipeline;
+use SamplePlugin\Core\Pipeline;
 
 class PipelineAbilities extends BaseAbilities {
     public function register() {
@@ -1707,7 +1707,7 @@ class PipelineAbilities extends BaseAbilities {
 
         // Should find namespace
         let ns = namespace(&symbols);
-        assert_eq!(ns, Some("DataMachine\\Abilities".to_string()));
+        assert_eq!(ns, Some("SamplePlugin\\Abilities".to_string()));
 
         // Should find class
         let classes: Vec<_> = symbols.iter().filter(|s| s.concept == "class").collect();

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -958,11 +958,11 @@ mod tests {
 
     fn write_shared_runtime_fixture(root: &Path) {
         let runtime_script = root.join(
-            "agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs",
+            "agent-runtimes/sample-runtime/scripts/agent/sample-runtime-agent-task-executor.cjs",
         );
         fs::create_dir_all(runtime_script.parent().expect("runtime script parent"))
             .expect("runtime script dir");
-        fs::write(&runtime_script, "console.log('wp-codebox runtime');\n").expect("runtime script");
+        fs::write(&runtime_script, "console.log('sample runtime');\n").expect("runtime script");
     }
 
     fn run_git(dir: &Path, args: &[&str]) -> bool {
@@ -1341,7 +1341,7 @@ exec '{}' "$@"
                 .join(".config/homeboy/extensions/wordpress/wordpress.json")
                 .exists());
             assert!(home
-                .join(".config/homeboy/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs")
+                .join(".config/homeboy/agent-runtimes/sample-runtime/scripts/agent/sample-runtime-agent-task-executor.cjs")
                 .exists());
         });
     }
@@ -1361,7 +1361,7 @@ exec '{}' "$@"
             install(&remote_url.to_string_lossy(), Some("wordpress"))
                 .expect("install cloned extension");
             assert!(!home
-                .join(".config/homeboy/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs")
+                .join(".config/homeboy/agent-runtimes/sample-runtime/scripts/agent/sample-runtime-agent-task-executor.cjs")
                 .exists());
 
             write_shared_runtime_fixture(&source);
@@ -1371,7 +1371,7 @@ exec '{}' "$@"
             update("wordpress", false).expect("update cloned extension");
 
             assert!(home
-                .join(".config/homeboy/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs")
+                .join(".config/homeboy/agent-runtimes/sample-runtime/scripts/agent/sample-runtime-agent-task-executor.cjs")
                 .exists());
         });
     }
@@ -1426,7 +1426,7 @@ exec '{}' "$@"
                 .join(".config/homeboy/extensions/wordpress/wordpress.json")
                 .exists());
             assert!(home
-                .join(".config/homeboy/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs")
+                .join(".config/homeboy/agent-runtimes/sample-runtime/scripts/agent/sample-runtime-agent-task-executor.cjs")
                 .exists());
         });
     }

--- a/src/core/extension/lint/run.rs
+++ b/src/core/extension/lint/run.rs
@@ -1320,16 +1320,16 @@ mod tests {
         let component = component("/repo");
         let runs = build_changed_lint_runs_with_routes(
             &component,
-            &["data-machine.php".to_string(), "inc/Foo.php".to_string()],
+            &["sample-plugin.php".to_string(), "inc/Foo.php".to_string()],
             &split_lint_routes(),
         );
 
         assert_eq!(
             runs,
             vec![ScopedLintRun {
-                glob: "{/repo/data-machine.php,/repo/inc/Foo.php}".to_string(),
+                glob: "{/repo/sample-plugin.php,/repo/inc/Foo.php}".to_string(),
                 step: Some("phpcs,phpstan".to_string()),
-                changed_files: vec!["data-machine.php".to_string(), "inc/Foo.php".to_string()],
+                changed_files: vec!["sample-plugin.php".to_string(), "inc/Foo.php".to_string()],
             }]
         );
     }

--- a/src/core/extension/repair.rs
+++ b/src/core/extension/repair.rs
@@ -436,11 +436,11 @@ mod tests {
 
     fn write_shared_runtime_fixture(root: &Path) {
         let runtime_script = root.join(
-            "agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs",
+            "agent-runtimes/sample-runtime/scripts/agent/sample-runtime-agent-task-executor.cjs",
         );
         fs::create_dir_all(runtime_script.parent().expect("runtime script parent"))
             .expect("runtime script dir");
-        fs::write(&runtime_script, "console.log('wp-codebox runtime');\n").expect("runtime script");
+        fs::write(&runtime_script, "console.log('sample runtime');\n").expect("runtime script");
     }
 
     fn run_git(dir: &Path, args: &[&str]) -> bool {
@@ -629,7 +629,7 @@ mod tests {
                 .expect("relink should materialize shared runtime");
 
             assert!(home
-                .join(".config/homeboy/agent-runtimes/wp-codebox/scripts/agent/homeboy-codebox-agent-task-executor.cjs")
+                .join(".config/homeboy/agent-runtimes/sample-runtime/scripts/agent/sample-runtime-agent-task-executor.cjs")
                 .exists());
         });
     }

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -464,18 +464,18 @@ mod tests {
 
     #[test]
     fn detects_stale_validation_dependency_warning() {
-        let stderr = "Resolved validation dependency 'data-machine' to local checkout '/tmp/data-machine', but it is behind origin/main by 3 commit(s). Update the checkout or pass an explicit dependency path.";
+        let stderr = "Resolved validation dependency 'sample-plugin' to local checkout '/tmp/sample-plugin', but it is behind origin/main by 3 commit(s). Update the checkout or pass an explicit dependency path.";
 
         let message = stale_validation_dependency_message("", stderr).expect("stale dependency");
 
-        assert!(message.contains("data-machine"));
+        assert!(message.contains("sample-plugin"));
         assert!(message.contains("behind origin/main by 3 commit(s)"));
     }
 
     #[test]
     fn ignores_non_stale_validation_dependency_output() {
         let stderr =
-            "Resolved validation dependency 'data-machine' to local checkout '/tmp/data-machine'.";
+            "Resolved validation dependency 'sample-plugin' to local checkout '/tmp/sample-plugin'.";
 
         assert!(stale_validation_dependency_message("", stderr).is_none());
     }

--- a/src/core/extension/test/analyze.rs
+++ b/src/core/extension/test/analyze.rs
@@ -635,13 +635,13 @@ mod tests {
                 "FooTest::testA",
                 "tests/FooTest.php",
                 "Fatal",
-                "Cannot redeclare datamachine_get_monolog_instance()",
+                "Cannot redeclare sampleplugin_get_monolog_instance()",
             ),
             failure(
                 "BarTest::testB",
                 "tests/BarTest.php",
                 "Fatal",
-                "Cannot redeclare datamachine_get_monolog_instance()",
+                "Cannot redeclare sampleplugin_get_monolog_instance()",
             ),
         ];
 

--- a/src/core/extension/test/baseline.rs
+++ b/src/core/extension/test/baseline.rs
@@ -124,10 +124,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let counts = counts(100, 80, 15, 5);
 
-        save_baseline(dir.path(), "data-machine", &counts).unwrap();
+        save_baseline(dir.path(), "sample-plugin", &counts).unwrap();
         let loaded = load_baseline(dir.path()).unwrap();
 
-        assert_eq!(loaded.context_id, "data-machine");
+        assert_eq!(loaded.context_id, "sample-plugin");
         assert_eq!(loaded.metadata, counts);
     }
 

--- a/src/core/issues/reconcile.rs
+++ b/src/core/issues/reconcile.rs
@@ -450,7 +450,7 @@ mod tests {
     fn group(category: &str, count: usize) -> IssueGroup {
         IssueGroup {
             command: "audit".into(),
-            component_id: "data-machine".into(),
+            component_id: "sample-plugin".into(),
             category: category.into(),
             count,
             label: String::new(),
@@ -467,7 +467,7 @@ mod tests {
     ) -> TrackedIssue {
         TrackedIssue {
             number,
-            title: format!("audit: {} in data-machine ({})", category_label, count),
+            title: format!("audit: {} in sample-plugin ({})", category_label, count),
             body: String::new(),
             url: format!("https://github.com/o/r/issues/{}", number),
             state,
@@ -508,7 +508,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(*count, 12);
-                assert_eq!(title, "audit: unreferenced export in data-machine (12)");
+                assert_eq!(title, "audit: unreferenced export in sample-plugin (12)");
                 assert_eq!(labels, &vec!["audit".to_string()]);
             }
             other => panic!("expected FileNew, got {:?}", other),
@@ -532,7 +532,7 @@ mod tests {
             } => {
                 assert_eq!(*number, 675);
                 assert_eq!(*count, 23);
-                assert_eq!(title, "audit: god file in data-machine (23)");
+                assert_eq!(title, "audit: god file in sample-plugin (23)");
             }
             other => panic!("expected Update, got {:?}", other),
         }
@@ -816,10 +816,10 @@ mod tests {
 
     #[test]
     fn parse_category_key_round_trips() {
-        let title = "audit: unreferenced export in data-machine (57)";
+        let title = "audit: unreferenced export in sample-plugin (57)";
         let (cmd, comp, cat) = parse_category_key(title).unwrap();
         assert_eq!(cmd, "audit");
-        assert_eq!(comp, "data-machine");
+        assert_eq!(comp, "sample-plugin");
         assert_eq!(cat, "unreferenced_export");
     }
 
@@ -952,7 +952,7 @@ mod tests {
             issue(30, "closed thing", TrackedIssueState::ClosedCompleted, 0),
         ];
 
-        let plan = reconcile_scoped(&[], &existing, &cfg(), "audit", "data-machine");
+        let plan = reconcile_scoped(&[], &existing, &cfg(), "audit", "sample-plugin");
 
         assert_eq!(plan.actions.len(), 2);
         assert!(matches!(
@@ -981,7 +981,7 @@ mod tests {
             issue(20, "unreferenced export", TrackedIssueState::Open, 9),
         ];
 
-        let plan = reconcile_scoped(&groups, &existing, &cfg(), "audit", "data-machine");
+        let plan = reconcile_scoped(&groups, &existing, &cfg(), "audit", "sample-plugin");
 
         assert_eq!(plan.actions.len(), 2);
         assert!(matches!(
@@ -1005,7 +1005,7 @@ mod tests {
             issue(10, "dead guard", TrackedIssueState::Open, 4),
         ];
 
-        let plan = reconcile_scoped(&[], &existing, &cfg(), "audit", "data-machine");
+        let plan = reconcile_scoped(&[], &existing, &cfg(), "audit", "sample-plugin");
 
         assert_eq!(plan.actions.len(), 2);
         assert!(matches!(
@@ -1031,7 +1031,7 @@ mod tests {
             issue(20, "god file", TrackedIssueState::Open, 9),
             issue(30, "unreferenced export", TrackedIssueState::Open, 2),
         ];
-        let plan = reconcile_scoped(&[], &existing, &cfg(), "audit", "data-machine");
+        let plan = reconcile_scoped(&[], &existing, &cfg(), "audit", "sample-plugin");
 
         assert_eq!(plan.actions.len(), 2);
         assert!(matches!(

--- a/src/core/observation/budget_findings.rs
+++ b/src/core/observation/budget_findings.rs
@@ -53,7 +53,7 @@ mod tests {
             4378195.0,
             250000.0,
             "bytes",
-            Some("/wp-json/datamachine/v1/pipelines?per_page=100".to_string()),
+            Some("/wp-json/sampleplugin/v1/pipelines?per_page=100".to_string()),
         );
 
         let record = finding_record_from_budget("run-1", &finding);
@@ -64,7 +64,7 @@ mod tests {
         assert_eq!(record.metadata_json["actual"], 4378195.0);
         assert_eq!(
             record.fingerprint.as_deref(),
-            Some("rest.max_response_bytes:/wp-json/datamachine/v1/pipelines?per_page=100")
+            Some("rest.max_response_bytes:/wp-json/sampleplugin/v1/pipelines?per_page=100")
         );
     }
 

--- a/src/core/preview_ingress_tests.rs
+++ b/src/core/preview_ingress_tests.rs
@@ -247,7 +247,7 @@ fn reverse_channel_client_forwards_bootstrap_redirect_and_repeated_cookies() {
         let browser = thread::spawn(move || {
             raw_http_request(
                 port,
-                "GET /__wp-codebox/reviewer-auth-bootstrap?token=fake HTTP/1.1\r\nHost: run-1-tunnel.example.com\r\n\r\n",
+                "GET /__runtime/reviewer-auth-bootstrap?token=fake HTTP/1.1\r\nHost: run-1-tunnel.example.com\r\n\r\n",
             )
         });
         thread::sleep(Duration::from_millis(100));
@@ -261,7 +261,7 @@ fn reverse_channel_client_forwards_bootstrap_redirect_and_repeated_cookies() {
             json!({ "public_host": "run-1-tunnel.example.com", "timeout_secs": 2 }).to_string(),
         );
         assert!(
-            next.contains("/__wp-codebox/reviewer-auth-bootstrap?token=fake"),
+            next.contains("/__runtime/reviewer-auth-bootstrap?token=fake"),
             "{next}"
         );
         let request_id = response_json(&next)["request"]["request_id"]

--- a/src/core/project/component/attachments.rs
+++ b/src/core/project/component/attachments.rs
@@ -182,7 +182,7 @@ pub fn attach_discovered_component_path(project_id: &str, local_path: &Path) -> 
 
     // When the inferred ID doesn't match any existing project component, check
     // whether a directory-name fallback produced a version-stamped ID (e.g.
-    // "data-machine-v0402-clean" from a clone path). If an existing component
+    // "sample-plugin-v0402-clean" from a clone path). If an existing component
     // whose ID is a prefix of the inferred ID exists, prefer the existing ID.
     // This prevents component identity mutation from clone directory names. (#932)
     let project = load(project_id)?;
@@ -198,8 +198,8 @@ pub fn attach_discovered_component_path(project_id: &str, local_path: &Path) -> 
 
 /// Find an existing project component whose ID is a prefix of the inferred ID.
 ///
-/// When a clean clone directory name like "data-machine-v0.40.2-clean" gets slugified
-/// to "data-machine-v0402-clean", the real component ID "data-machine" is a prefix.
+/// When a clean clone directory name like "sample-plugin-v0.40.2-clean" gets slugified
+/// to "sample-plugin-v0402-clean", the real component ID "sample-plugin" is a prefix.
 /// This function detects that pattern and returns the existing component's ID.
 ///
 /// Only matches if:
@@ -259,45 +259,45 @@ mod tests {
 
     #[test]
     fn find_prefix_match_version_suffix() {
-        let project = project_with_components(&["data-machine", "example-theme"]);
-        // Clone dir "data-machine-v0402-clean" → slugified inferred ID
+        let project = project_with_components(&["sample-plugin", "example-theme"]);
+        // Clone dir "sample-plugin-v0402-clean" → slugified inferred ID
         assert_eq!(
-            find_prefix_match(&project, "data-machine-v0402-clean"),
-            Some("data-machine".to_string()),
+            find_prefix_match(&project, "sample-plugin-v0402-clean"),
+            Some("sample-plugin".to_string()),
         );
     }
 
     #[test]
     fn find_prefix_match_numeric_suffix() {
-        let project = project_with_components(&["data-machine"]);
-        // Clone dir "data-machine-0402" → numeric version suffix
+        let project = project_with_components(&["sample-plugin"]);
+        // Clone dir "sample-plugin-0402" → numeric version suffix
         assert_eq!(
-            find_prefix_match(&project, "data-machine-0402"),
-            Some("data-machine".to_string()),
+            find_prefix_match(&project, "sample-plugin-0402"),
+            Some("sample-plugin".to_string()),
         );
     }
 
     #[test]
     fn find_prefix_match_no_match_non_version_suffix() {
-        let project = project_with_components(&["data-machine"]);
-        // "data-machine-socials" is NOT a version suffix, it's a different component
-        assert_eq!(find_prefix_match(&project, "data-machine-socials"), None);
+        let project = project_with_components(&["sample-plugin"]);
+        // "sample-plugin-socials" is NOT a version suffix, it's a different component
+        assert_eq!(find_prefix_match(&project, "sample-plugin-socials"), None);
     }
 
     #[test]
     fn find_prefix_match_exact_match_not_prefix() {
-        let project = project_with_components(&["data-machine"]);
+        let project = project_with_components(&["sample-plugin"]);
         // Exact match — not a prefix scenario
-        assert_eq!(find_prefix_match(&project, "data-machine"), None);
+        assert_eq!(find_prefix_match(&project, "sample-plugin"), None);
     }
 
     #[test]
     fn find_prefix_match_prefers_longest() {
-        let project = project_with_components(&["data", "data-machine"]);
-        // Both "data" and "data-machine" are prefixes, but "data-machine" is longer
+        let project = project_with_components(&["data", "sample-plugin"]);
+        // Both "data" and "sample-plugin" are prefixes, but "sample-plugin" is longer
         assert_eq!(
-            find_prefix_match(&project, "data-machine-v1"),
-            Some("data-machine".to_string()),
+            find_prefix_match(&project, "sample-plugin-v1"),
+            Some("sample-plugin".to_string()),
         );
     }
 

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -106,7 +106,7 @@ pub struct Project {
     pub components: Vec<ProjectComponentAttachment>,
     /// Per-component field overrides applied when a component runs in this project.
     ///
-    /// Example: `{"data-machine": {"extract_command": "...", "remote_owner": "opencode:opencode"}}`
+    /// Example: `{"sample-plugin": {"extract_command": "...", "remote_owner": "opencode:opencode"}}`
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub component_overrides: HashMap<String, ProjectComponentOverrides>,
 

--- a/src/core/refactor/plan/generate/convention_fixes.rs
+++ b/src/core/refactor/plan/generate/convention_fixes.rs
@@ -54,7 +54,7 @@ pub(crate) fn generate_type_conformance_declaration(
 pub(crate) fn generate_registration_stub(hook_name: &str) -> String {
     let callback = hook_name
         .strip_prefix("wp_")
-        .or_else(|| hook_name.strip_prefix("datamachine_"))
+        .or_else(|| hook_name.strip_prefix("sampleplugin_"))
         .unwrap_or(hook_name);
 
     format!(

--- a/src/core/refactor/plan/generate/duplicate_fixes.rs
+++ b/src/core/refactor/plan/generate/duplicate_fixes.rs
@@ -829,19 +829,19 @@ mod tests {
     #[test]
     fn test_extract_php_fqcn_with_namespace() {
         let content =
-            "<?php\nnamespace DataMachine\\Abilities\\Fetch;\n\nclass FetchRssAbility {\n";
+            "<?php\nnamespace SamplePlugin\\Abilities\\Fetch;\n\nclass FetchRssAbility {\n";
         assert_eq!(
             extract_php_fqcn(content),
-            Some("DataMachine\\Abilities\\Fetch\\FetchRssAbility".to_string())
+            Some("SamplePlugin\\Abilities\\Fetch\\FetchRssAbility".to_string())
         );
     }
 
     #[test]
     fn test_extract_php_fqcn_abstract_class() {
-        let content = "<?php\nnamespace DataMachine\\Core;\n\nabstract class BaseHandler {\n";
+        let content = "<?php\nnamespace SamplePlugin\\Core;\n\nabstract class BaseHandler {\n";
         assert_eq!(
             extract_php_fqcn(content),
-            Some("DataMachine\\Core\\BaseHandler".to_string())
+            Some("SamplePlugin\\Core\\BaseHandler".to_string())
         );
     }
 
@@ -853,7 +853,7 @@ mod tests {
 
     #[test]
     fn test_extract_php_fqcn_no_class() {
-        let content = "<?php\nnamespace DataMachine;\n\nfunction helper() {}\n";
+        let content = "<?php\nnamespace SamplePlugin;\n\nfunction helper() {}\n";
         assert_eq!(extract_php_fqcn(content), None);
     }
 
@@ -881,7 +881,7 @@ mod tests {
         fs::create_dir_all(&php_dir).unwrap();
         fs::write(
             php_dir.join("FetchRssAbility.php"),
-            "<?php\nnamespace DataMachine\\Abilities\\Fetch;\n\nclass FetchRssAbility {\n    public function httpGet() {}\n}\n",
+            "<?php\nnamespace SamplePlugin\\Abilities\\Fetch;\n\nclass FetchRssAbility {\n    public function httpGet() {}\n}\n",
         ).unwrap();
 
         let import = generate_duplicate_import(
@@ -892,7 +892,7 @@ mod tests {
         );
         assert_eq!(
             import,
-            "use DataMachine\\Abilities\\Fetch\\FetchRssAbility;"
+            "use SamplePlugin\\Abilities\\Fetch\\FetchRssAbility;"
         );
     }
 

--- a/src/core/refactor/rename/mod.rs
+++ b/src/core/refactor/rename/mod.rs
@@ -258,15 +258,15 @@ impl RenameSpec {
     /// Splits the `from` and `to` terms into constituent words, then generates
     /// all standard naming convention variants:
     ///
-    /// - `kebab-case` (e.g., `data-machine-agent`)
-    /// - `snake_case` (e.g., `data_machine_agent`)
-    /// - `UPPER_SNAKE` (e.g., `DATA_MACHINE_AGENT`)
-    /// - `PascalCase` (e.g., `DataMachineAgent`)
-    /// - `camelCase` (e.g., `dataMachineAgent`)
-    /// - `Display Name` (e.g., `Data Machine Agent`)
+    /// - `kebab-case` (e.g., `sample-plugin-agent`)
+    /// - `snake_case` (e.g., `sample_plugin_agent`)
+    /// - `UPPER_SNAKE` (e.g., `SAMPLE_PLUGIN_AGENT`)
+    /// - `PascalCase` (e.g., `SamplePluginAgent`)
+    /// - `camelCase` (e.g., `samplePluginAgent`)
+    /// - `Display Name` (e.g., `Sample Plugin Agent`)
     /// - Plus plural forms of each
     ///
-    /// This means a single `--from wp-agent --to data-machine-agent` will also
+    /// This means a single `--from wp-agent --to sample-plugin-agent` will also
     /// match and replace `wp_agent`, `WP_AGENT`, `WPAgent`, `wpAgent`, `WP Agent`,
     /// and all their plurals.
     pub fn new(from: &str, to: &str, scope: RenameScope) -> Self {
@@ -498,7 +498,7 @@ fn pluralize(s: &str) -> String {
 /// - `UPPER_SNAKE` → `["upper", "snake"]`
 /// - `WPAgent` → `["wp", "agent"]` (consecutive uppercase → separate word)
 /// - `XMLParser` → `["xml", "parser"]`
-/// - `data-machine-agent` → `["data", "machine", "agent"]`
+/// - `sample-plugin-agent` → `["sample", "plugin", "agent"]`
 /// - Mixed: `my_WPAgent-thing` → `["my", "wp", "agent", "thing"]`
 ///
 /// All returned words are lowercase.
@@ -549,17 +549,17 @@ fn split_words(term: &str) -> Vec<String> {
 // Cross-separator join functions
 // ============================================================================
 
-/// Join words as kebab-case: `["data", "machine", "agent"]` → `"data-machine-agent"`
+/// Join words as kebab-case: `["sample", "plugin", "agent"]` → `"sample-plugin-agent"`
 fn join_kebab(words: &[String]) -> String {
     words.join("-")
 }
 
-/// Join words as snake_case: `["data", "machine", "agent"]` → `"data_machine_agent"`
+/// Join words as snake_case: `["sample", "plugin", "agent"]` → `"sample_plugin_agent"`
 fn join_snake(words: &[String]) -> String {
     words.join("_")
 }
 
-/// Join words as UPPER_SNAKE: `["data", "machine", "agent"]` → `"DATA_MACHINE_AGENT"`
+/// Join words as UPPER_SNAKE: `["sample", "plugin", "agent"]` → `"SAMPLE_PLUGIN_AGENT"`
 fn join_upper_snake(words: &[String]) -> String {
     words
         .iter()
@@ -568,7 +568,7 @@ fn join_upper_snake(words: &[String]) -> String {
         .join("_")
 }
 
-/// Join words as PascalCase: `["data", "machine", "agent"]` → `"DataMachineAgent"`
+/// Join words as PascalCase: `["sample", "plugin", "agent"]` → `"SamplePluginAgent"`
 fn join_pascal(words: &[String]) -> String {
     words
         .iter()
@@ -577,7 +577,7 @@ fn join_pascal(words: &[String]) -> String {
         .join("")
 }
 
-/// Join words as camelCase: `["data", "machine", "agent"]` → `"dataMachineAgent"`
+/// Join words as camelCase: `["sample", "plugin", "agent"]` → `"samplePluginAgent"`
 fn join_camel(words: &[String]) -> String {
     let mut parts: Vec<String> = Vec::new();
     for (i, w) in words.iter().enumerate() {
@@ -590,7 +590,7 @@ fn join_camel(words: &[String]) -> String {
     parts.join("")
 }
 
-/// Join words as display name: `["data", "machine", "agent"]` → `"Data Machine Agent"`
+/// Join words as display name: `["sample", "plugin", "agent"]` → `"Sample Plugin Agent"`
 fn join_display(words: &[String]) -> String {
     words
         .iter()
@@ -1464,36 +1464,36 @@ mod tests {
     #[test]
     fn literal_spec_has_single_variant() {
         let spec = RenameSpec::literal(
-            "datamachine-events",
-            "data-machine-events",
+            "sampleplugin-events",
+            "sample-plugin-events",
             RenameScope::All,
         );
         assert!(spec.literal);
         assert_eq!(spec.variants.len(), 1);
-        assert_eq!(spec.variants[0].from, "datamachine-events");
-        assert_eq!(spec.variants[0].to, "data-machine-events");
+        assert_eq!(spec.variants[0].from, "sampleplugin-events");
+        assert_eq!(spec.variants[0].to, "sample-plugin-events");
         assert_eq!(spec.variants[0].label, "literal");
     }
 
     #[test]
     fn find_literal_matches_exact() {
         // Should find exact substring — no boundary detection
-        let matches = find_literal_matches("datamachine-events is great", "datamachine-events");
+        let matches = find_literal_matches("sampleplugin-events is great", "sampleplugin-events");
         assert_eq!(matches, vec![0]);
 
         // Should match inside larger strings (no boundary filtering)
-        let matches = find_literal_matches("the-datamachine-events-plugin", "datamachine-events");
+        let matches = find_literal_matches("the-sampleplugin-events-plugin", "sampleplugin-events");
         assert_eq!(matches, vec![4]);
 
         // Multiple occurrences
         let matches = find_literal_matches(
-            "datamachine-events and datamachine-events",
-            "datamachine-events",
+            "sampleplugin-events and sampleplugin-events",
+            "sampleplugin-events",
         );
-        assert_eq!(matches, vec![0, 23]);
+        assert_eq!(matches, vec![0, 24]);
 
         // No match
-        let matches = find_literal_matches("data-machine-events", "datamachine-events");
+        let matches = find_literal_matches("sample-plugin-events", "sampleplugin-events");
         assert!(matches.is_empty());
     }
 
@@ -1504,26 +1504,26 @@ mod tests {
 
         std::fs::write(
             dir.join("plugin.php"),
-            "// Plugin: datamachine-events\ndefine('DATAMACHINE_EVENTS_VERSION', '1.0');\nfunction datamachine_events_init() {}\n",
+            "// Plugin: sampleplugin-events\ndefine('SAMPLEPLUGIN_EVENTS_VERSION', '1.0');\nfunction sampleplugin_events_init() {}\n",
         )
         .unwrap();
 
         // Literal mode: only exact match, no case variants
         let spec = RenameSpec::literal(
-            "datamachine-events",
-            "data-machine-events",
+            "sampleplugin-events",
+            "sample-plugin-events",
             RenameScope::All,
         );
         let refs = find_references(&spec, &dir);
 
-        // Should find only the hyphenated form, not DATAMACHINE_EVENTS or datamachine_events
+        // Should find only the hyphenated form, not SAMPLEPLUGIN_EVENTS or sampleplugin_events
         assert_eq!(
             refs.len(),
             1,
             "Should find exactly 1 literal match, got: {:?}",
             refs.iter().map(|r| &r.matched).collect::<Vec<_>>()
         );
-        assert_eq!(refs[0].matched, "datamachine-events");
+        assert_eq!(refs[0].matched, "sampleplugin-events");
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1535,13 +1535,13 @@ mod tests {
 
         std::fs::write(
             dir.join("plugin.php"),
-            "Text Domain: datamachine-events\nSlug: datamachine-events\n",
+            "Text Domain: sampleplugin-events\nSlug: sampleplugin-events\n",
         )
         .unwrap();
 
         let spec = RenameSpec::literal(
-            "datamachine-events",
-            "data-machine-events",
+            "sampleplugin-events",
+            "sample-plugin-events",
             RenameScope::All,
         );
         let result = generate_renames(&spec, &dir);
@@ -1550,7 +1550,7 @@ mod tests {
         assert_eq!(result.edits[0].replacements, 2);
         assert_eq!(
             result.edits[0].new_content,
-            "Text Domain: data-machine-events\nSlug: data-machine-events\n"
+            "Text Domain: sample-plugin-events\nSlug: sample-plugin-events\n"
         );
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -1561,22 +1561,22 @@ mod tests {
         let dir = std::env::temp_dir().join("homeboy_refactor_literal_file_rename_test");
         let _ = std::fs::create_dir_all(&dir);
 
-        std::fs::write(dir.join("datamachine-events.php"), "// main file\n").unwrap();
+        std::fs::write(dir.join("sampleplugin-events.php"), "// main file\n").unwrap();
 
         let spec = RenameSpec::literal(
-            "datamachine-events",
-            "data-machine-events",
+            "sampleplugin-events",
+            "sample-plugin-events",
             RenameScope::All,
         );
         let result = generate_renames(&spec, &dir);
 
         assert!(
             !result.file_renames.is_empty(),
-            "Should rename datamachine-events.php"
+            "Should rename sampleplugin-events.php"
         );
         let rename = &result.file_renames[0];
-        assert_eq!(rename.from, "datamachine-events.php");
-        assert_eq!(rename.to, "data-machine-events.php");
+        assert_eq!(rename.from, "sampleplugin-events.php");
+        assert_eq!(rename.to, "sample-plugin-events.php");
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1586,11 +1586,11 @@ mod tests {
         let dir = std::env::temp_dir().join("homeboy_refactor_literal_apply_test");
         let _ = std::fs::create_dir_all(&dir);
 
-        std::fs::write(dir.join("test.php"), "slug: datamachine-events\n").unwrap();
+        std::fs::write(dir.join("test.php"), "slug: sampleplugin-events\n").unwrap();
 
         let spec = RenameSpec::literal(
-            "datamachine-events",
-            "data-machine-events",
+            "sampleplugin-events",
+            "sample-plugin-events",
             RenameScope::All,
         );
         let mut result = generate_renames(&spec, &dir);
@@ -1599,7 +1599,7 @@ mod tests {
         assert!(result.applied);
 
         let content = std::fs::read_to_string(dir.join("test.php")).unwrap();
-        assert_eq!(content, "slug: data-machine-events\n");
+        assert_eq!(content, "slug: sample-plugin-events\n");
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1630,8 +1630,8 @@ mod tests {
     fn split_words_kebab() {
         assert_eq!(split_words("wp-agent"), vec!["wp", "agent"]);
         assert_eq!(
-            split_words("data-machine-agent"),
-            vec!["data", "machine", "agent"]
+            split_words("sample-plugin-agent"),
+            vec!["sample", "plugin", "agent"]
         );
     }
 
@@ -1639,8 +1639,8 @@ mod tests {
     fn split_words_snake() {
         assert_eq!(split_words("wp_agent"), vec!["wp", "agent"]);
         assert_eq!(
-            split_words("data_machine_agent"),
-            vec!["data", "machine", "agent"]
+            split_words("sample_plugin_agent"),
+            vec!["sample", "plugin", "agent"]
         );
     }
 
@@ -1648,8 +1648,8 @@ mod tests {
     fn split_words_upper_snake() {
         assert_eq!(split_words("WP_AGENT"), vec!["wp", "agent"]);
         assert_eq!(
-            split_words("DATA_MACHINE_AGENT"),
-            vec!["data", "machine", "agent"]
+            split_words("SAMPLE_PLUGIN_AGENT"),
+            vec!["sample", "plugin", "agent"]
         );
     }
 
@@ -1657,8 +1657,8 @@ mod tests {
     fn split_words_pascal() {
         assert_eq!(split_words("WpAgent"), vec!["wp", "agent"]);
         assert_eq!(
-            split_words("DataMachineAgent"),
-            vec!["data", "machine", "agent"]
+            split_words("SamplePluginAgent"),
+            vec!["sample", "plugin", "agent"]
         );
     }
 
@@ -1676,8 +1676,8 @@ mod tests {
     fn split_words_camel() {
         assert_eq!(split_words("wpAgent"), vec!["wp", "agent"]);
         assert_eq!(
-            split_words("dataMachineAgent"),
-            vec!["data", "machine", "agent"]
+            split_words("samplePluginAgent"),
+            vec!["sample", "plugin", "agent"]
         );
     }
 
@@ -1685,8 +1685,8 @@ mod tests {
     fn split_words_display() {
         assert_eq!(split_words("WP Agent"), vec!["wp", "agent"]);
         assert_eq!(
-            split_words("Data Machine Agent"),
-            vec!["data", "machine", "agent"]
+            split_words("Sample Plugin Agent"),
+            vec!["sample", "plugin", "agent"]
         );
     }
 
@@ -1703,7 +1703,7 @@ mod tests {
 
     #[test]
     fn cross_separator_variants_from_kebab() {
-        let spec = RenameSpec::new("wp-agent", "data-machine-agent", RenameScope::All);
+        let spec = RenameSpec::new("wp-agent", "sample-plugin-agent", RenameScope::All);
         let from_values: Vec<&str> = spec.variants.iter().map(|v| v.from.as_str()).collect();
         let to_values: Vec<&str> = spec.variants.iter().map(|v| v.to.as_str()).collect();
 
@@ -1719,27 +1719,27 @@ mod tests {
         assert!(from_values.contains(&"Wp Agent"), "Missing display from");
 
         assert!(
-            to_values.contains(&"data-machine-agent"),
+            to_values.contains(&"sample-plugin-agent"),
             "Missing kebab to"
         );
         assert!(
-            to_values.contains(&"data_machine_agent"),
+            to_values.contains(&"sample_plugin_agent"),
             "Missing snake to"
         );
         assert!(
-            to_values.contains(&"DATA_MACHINE_AGENT"),
+            to_values.contains(&"SAMPLE_PLUGIN_AGENT"),
             "Missing UPPER_SNAKE to"
         );
         assert!(
-            to_values.contains(&"DataMachineAgent"),
+            to_values.contains(&"SamplePluginAgent"),
             "Missing PascalCase to"
         );
         assert!(
-            to_values.contains(&"dataMachineAgent"),
+            to_values.contains(&"samplePluginAgent"),
             "Missing camelCase to"
         );
         assert!(
-            to_values.contains(&"Data Machine Agent"),
+            to_values.contains(&"Sample Plugin Agent"),
             "Missing display to"
         );
 
@@ -1765,7 +1765,7 @@ mod tests {
     #[test]
     fn cross_separator_variants_from_pascal() {
         // Providing PascalCase input should produce the same cross-separator variants
-        let spec = RenameSpec::new("WpAgent", "DataMachineAgent", RenameScope::All);
+        let spec = RenameSpec::new("WpAgent", "SamplePluginAgent", RenameScope::All);
         let from_values: Vec<&str> = spec.variants.iter().map(|v| v.from.as_str()).collect();
 
         assert!(from_values.contains(&"wp-agent"), "Missing kebab from");
@@ -1781,7 +1781,7 @@ mod tests {
     #[test]
     fn cross_separator_variants_from_snake() {
         // Providing snake_case input should produce the same cross-separator variants
-        let spec = RenameSpec::new("wp_agent", "data_machine_agent", RenameScope::All);
+        let spec = RenameSpec::new("wp_agent", "sample_plugin_agent", RenameScope::All);
         let from_values: Vec<&str> = spec.variants.iter().map(|v| v.from.as_str()).collect();
 
         assert!(from_values.contains(&"wp-agent"), "Missing kebab from");
@@ -1857,7 +1857,7 @@ mod tests {
 
     #[test]
     fn cross_separator_end_to_end_rename() {
-        // The real use case: rename wp-agent → data-machine-agent across all conventions
+        // The real use case: rename wp-agent → sample-plugin-agent across all conventions
         let dir = std::env::temp_dir().join("homeboy_cross_sep_e2e_test");
         let _ = std::fs::create_dir_all(&dir);
 
@@ -1873,34 +1873,34 @@ mod tests {
         )
         .unwrap();
 
-        let spec = RenameSpec::new("wp-agent", "data-machine-agent", RenameScope::All);
+        let spec = RenameSpec::new("wp-agent", "sample-plugin-agent", RenameScope::All);
         let result = generate_renames(&spec, &dir);
 
         assert!(!result.edits.is_empty(), "Should have edits");
         let content = &result.edits[0].new_content;
 
         assert!(
-            content.contains("data-machine-agent"),
+            content.contains("sample-plugin-agent"),
             "Should rename kebab: {}",
             content
         );
         assert!(
-            content.contains("DataMachineAgent"),
+            content.contains("SamplePluginAgent"),
             "Should rename PascalCase: {}",
             content
         );
         assert!(
-            content.contains("DATA_MACHINE_AGENT_VERSION"),
+            content.contains("SAMPLE_PLUGIN_AGENT_VERSION"),
             "Should rename UPPER_SNAKE: {}",
             content
         );
         assert!(
-            content.contains("data_machine_agent_init"),
+            content.contains("sample_plugin_agent_init"),
             "Should rename snake_case: {}",
             content
         );
         assert!(
-            content.contains("data-machine-agents"),
+            content.contains("sample-plugin-agents"),
             "Should rename plural kebab: {}",
             content
         );

--- a/src/core/refactor/transform.rs
+++ b/src/core/refactor/transform.rs
@@ -1144,19 +1144,19 @@ mod tests {
         let content = "let x = new BlueskyDeleteAbility();\nlet y = new FacebookPostAbility();\n";
         let (new, matches, _) = apply_line_context(
             &regex,
-            "wp_get_ability('datamachine/$1:kebab')",
+            "wp_get_ability('sampleplugin/$1:kebab')",
             content,
             "test.rs",
             None,
         );
         assert_eq!(matches.len(), 2);
         assert!(
-            new.contains("wp_get_ability('datamachine/bluesky-delete')"),
+            new.contains("wp_get_ability('sampleplugin/bluesky-delete')"),
             "got: {}",
             new
         );
         assert!(
-            new.contains("wp_get_ability('datamachine/facebook-post')"),
+            new.contains("wp_get_ability('sampleplugin/facebook-post')"),
             "got: {}",
             new
         );
@@ -1168,13 +1168,13 @@ mod tests {
         let content = "$ability = new BlueskyDeleteAbility();\n";
         let (new, _, _) = apply_line_context(
             &regex,
-            "$$ability = wp_get_ability('datamachine/$1:kebab')",
+            "$$ability = wp_get_ability('sampleplugin/$1:kebab')",
             content,
             "test.php",
             None,
         );
         assert!(
-            new.contains("$ability = wp_get_ability('datamachine/bluesky-delete')"),
+            new.contains("$ability = wp_get_ability('sampleplugin/bluesky-delete')"),
             "got: {}",
             new
         );

--- a/src/core/release/pipeline_summary.rs
+++ b/src/core/release/pipeline_summary.rs
@@ -253,15 +253,15 @@ mod tests {
             },
         ];
         let status = derive_overall_status(&results);
-        let summary = build_summary("wp-codebox", &results, &status);
+        let summary = build_summary("sample-plugin", &results, &status);
 
         assert_eq!(status, ReleaseStepStatus::Success);
         assert!(summary.next_actions.iter().any(|action| action.contains(
-            "homeboy release wp-codebox --head --skip-publish --from-artifacts <artifact-dir>"
+            "homeboy release sample-plugin --head --skip-publish --from-artifacts <artifact-dir>"
         )));
         assert!(summary
             .next_actions
             .iter()
-            .any(|action| action.contains("homeboy release wp-codebox --head")));
+            .any(|action| action.contains("homeboy release sample-plugin --head")));
     }
 }

--- a/src/core/release/planning_policy.rs
+++ b/src/core/release/planning_policy.rs
@@ -179,7 +179,7 @@ mod tests {
             ..Default::default()
         };
 
-        let plan = release_skip_plan("data-machine-code", &options, None, None)
+        let plan = release_skip_plan("sample-plugin-code", &options, None, None)
             .expect("docs-only invocation should still skip");
 
         let hint = plan
@@ -197,7 +197,7 @@ mod tests {
             "skip hint should echo --path: {hint}"
         );
         assert!(
-            hint.contains("homeboy release data-machine-code --bump patch"),
+            hint.contains("homeboy release sample-plugin-code --bump patch"),
             "skip hint should provide a fully-qualified force command: {hint}"
         );
     }
@@ -290,7 +290,7 @@ mod tests {
             ..Default::default()
         };
 
-        let plan = release_skip_plan("data-machine-code", &options, None, Some("v0.47.121"))
+        let plan = release_skip_plan("sample-plugin-code", &options, None, Some("v0.47.121"))
             .expect("tag-already-at-HEAD should produce a skip plan");
 
         assert!(!plan.enabled());
@@ -317,7 +317,7 @@ mod tests {
             "hint should point operator at --head finalization: {hint}"
         );
         assert!(
-            hint.contains("homeboy release data-machine-code --head"),
+            hint.contains("homeboy release sample-plugin-code --head"),
             "hint should provide an actionable command: {hint}"
         );
     }

--- a/src/core/release/planning_worktree.rs
+++ b/src/core/release/planning_worktree.rs
@@ -376,7 +376,7 @@ mod tests {
 
     #[test]
     fn unexpected_files_skip_homeboy_build_dir() {
-        let changes = uncommitted(&[], &[], &[".homeboy-build/data-machine-0.70.1.zip"]);
+        let changes = uncommitted(&[], &[], &[".homeboy-build/sample-plugin-0.70.1.zip"]);
         let unexpected = get_unexpected_uncommitted_files(&changes, &[]);
         assert!(
             unexpected.is_empty(),

--- a/src/core/rig/lint.rs
+++ b/src/core/rig/lint.rs
@@ -12,7 +12,7 @@ use crate::core::error::{Error, Result};
 const IGNORED_DIRECTORIES: &[&str] = &[
     ".git",
     ".claude",
-    ".datamachine",
+    ".sampleplugin",
     ".opencode",
     "node_modules",
     "vendor",

--- a/src/core/run_lifecycle_record.rs
+++ b/src/core/run_lifecycle_record.rs
@@ -251,13 +251,13 @@ mod tests {
             },
             provider_runtime: vec![ProviderRuntimeLifecycle {
                 task_id: "task-a".to_string(),
-                backend: "codebox".to_string(),
+                backend: "sample-runtime".to_string(),
                 state: ProviderRuntimeState::Running,
                 stream_uri: Some("provider://runs/provider-run-123/events".to_string()),
                 external_runtime_ids: vec![ExternalRuntimeId {
                     kind: "provider_run_id".to_string(),
                     value: "provider-run-123".to_string(),
-                    provider: Some("codebox".to_string()),
+                    provider: Some("sample-runtime".to_string()),
                     url: None,
                 }],
                 metadata: Value::Null,

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -3509,9 +3509,9 @@ mod tests {
                 "--from".to_string(),
                 "lint".to_string(),
                 "--write".to_string(),
-                "data-machine-code".to_string(),
+                "sample-plugin-code".to_string(),
             ],
-            remote_cwd: "/srv/homeboy/_lab_workspaces/data-machine-code".to_string(),
+            remote_cwd: "/srv/homeboy/_lab_workspaces/sample-plugin-code".to_string(),
             exit_code: 0,
             stdout: String::new(),
             stderr: String::new(),
@@ -3533,7 +3533,7 @@ mod tests {
                 "--from".to_string(),
                 "lint".to_string(),
                 "--write".to_string(),
-                "data-machine-code".to_string(),
+                "sample-plugin-code".to_string(),
             ],
             Some("--write"),
             &exec_output,
@@ -3560,7 +3560,7 @@ mod tests {
             .any(|hint| hint.contains("homeboy runs artifacts runner-exec-lab-default-job-123")));
         assert!(hints
             .iter()
-            .any(|hint| hint.contains("homeboy refactor --from lint --write data-machine-code")));
+            .any(|hint| hint.contains("homeboy refactor --from lint --write sample-plugin-code")));
     }
 
     #[test]

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -836,7 +836,7 @@ mod tests {
             "agent-task".to_string(),
             "cook".to_string(),
             "--backend".to_string(),
-            "codebox".to_string(),
+            "sample-runtime".to_string(),
             "--provider-config".to_string(),
             serde_json::json!({ "provider": "codex" }).to_string(),
         ];
@@ -894,7 +894,7 @@ mod tests {
                         "schema": "homeboy/agent-task-request/v1",
                         "task_id": "idea",
                         "executor": {
-                            "backend": "codebox",
+                            "backend": "sample-runtime",
                             "secret_env": ["OPENAI_API_KEY"],
                             "config": {
                                 "secret_env": ["GITHUB_TOKEN"]
@@ -906,7 +906,7 @@ mod tests {
                         "schema": "homeboy/agent-task-request/v1",
                         "task_id": "design",
                         "executor": {
-                            "backend": "codebox",
+                            "backend": "sample-runtime",
                             "secret_env": ["OPENAI_API_KEY"]
                         },
                         "instructions": "Design the idea."
@@ -947,7 +947,7 @@ mod tests {
                         "schema": "homeboy/agent-task-request/v1",
                         "task_id": "idea",
                         "executor": {
-                            "backend": "codebox",
+                            "backend": "sample-runtime",
                             "secret_env": ["GITHUB_TOKEN"]
                         },
                         "instructions": "Generate an idea."
@@ -1289,11 +1289,11 @@ HOMEBOY_SHARED_MISSING_SECRET_TEST, HOMEBOY_OTHER_MISSING_SECRET_TEST"
 
         AgentTaskExecutorProvider {
             schema: "homeboy/agent-task-executor-provider/v1".to_string(),
-            id: "wp-codebox.codex".to_string(),
+            id: "sample-runtime.codex".to_string(),
             label: None,
-            backend: "codebox".to_string(),
+            backend: "sample-runtime".to_string(),
             default_backend: true,
-            command: "wp-codebox agent".to_string(),
+            command: "sample-runtime agent".to_string(),
             command_argv: Vec::new(),
             invocation: CommandInvocation::default(),
             request_schema: "homeboy/agent-task-request/v1".to_string(),

--- a/src/core/runner/lab_arg_tests.rs
+++ b/src/core/runner/lab_arg_tests.rs
@@ -66,23 +66,23 @@ fn strips_internal_passthrough_sentinel_from_lab_offload_command() {
     let input = args(&[
         "homeboy",
         "test",
-        "data-machine",
+        "sample-plugin",
         "--path",
-        "/Users/user/Developer/data-machine@fix",
+        "/Users/user/Developer/sample-plugin@fix",
         "--",
         EXPLICIT_PASSTHROUGH_SENTINEL,
         filter,
     ]);
 
     assert_eq!(
-        rewrite_lab_offload_args(&input, "/home/user/Developer/data-machine@fix", &[]),
+        rewrite_lab_offload_args(&input, "/home/user/Developer/sample-plugin@fix", &[]),
         args(&[
             "homeboy",
             "--force-hot",
             "test",
-            "data-machine",
+            "sample-plugin",
             "--path",
-            "/home/user/Developer/data-machine@fix",
+            "/home/user/Developer/sample-plugin@fix",
             "--",
             filter,
         ])

--- a/src/core/runner/lab_args.rs
+++ b/src/core/runner/lab_args.rs
@@ -973,19 +973,19 @@ mod tests {
     fn remap_inlines_and_rewrites_provider_config_local_paths() {
         let mappings = vec![
             LabPathRemap {
-                local: "/Users/user/Developer/data-machine@cook".to_string(),
-                remote: "/home/user/_lab_workspaces/data-machine@cook-abc".to_string(),
+                local: "/Users/user/Developer/sample-plugin@cook".to_string(),
+                remote: "/home/user/_lab_workspaces/sample-plugin@cook-abc".to_string(),
             },
             LabPathRemap {
-                local: "/Users/user/Developer/data-machine-code".to_string(),
-                remote: "/home/user/_lab_workspaces/data-machine-code-def".to_string(),
+                local: "/Users/user/Developer/sample-plugin-code".to_string(),
+                remote: "/home/user/_lab_workspaces/sample-plugin-code-def".to_string(),
             },
         ];
         let config = serde_json::json!({
-            "workspace_root": "/Users/user/Developer/data-machine@cook",
-            "mounts": [{ "source": "/Users/user/Developer/data-machine@cook", "target": "/workspace/data-machine" }],
-            "runtime_component_paths": { "agent_runtime_tools": "/Users/user/Developer/data-machine-code" },
-            "provider_plugin_paths": ["/Users/user/Developer/data-machine@cook/vendor/provider"],
+            "workspace_root": "/Users/user/Developer/sample-plugin@cook",
+            "mounts": [{ "source": "/Users/user/Developer/sample-plugin@cook", "target": "/workspace/sample-plugin" }],
+            "runtime_component_paths": { "agent_runtime_tools": "/Users/user/Developer/sample-plugin-code" },
+            "provider_plugin_paths": ["/Users/user/Developer/sample-plugin@cook/vendor/provider"],
             "model": "claude-opus-4-8"
         })
         .to_string();
@@ -1005,20 +1005,20 @@ mod tests {
 
         assert_eq!(
             remapped["workspace_root"],
-            "/home/user/_lab_workspaces/data-machine@cook-abc"
+            "/home/user/_lab_workspaces/sample-plugin@cook-abc"
         );
         assert_eq!(
             remapped["mounts"][0]["source"],
-            "/home/user/_lab_workspaces/data-machine@cook-abc"
+            "/home/user/_lab_workspaces/sample-plugin@cook-abc"
         );
-        assert_eq!(remapped["mounts"][0]["target"], "/workspace/data-machine");
+        assert_eq!(remapped["mounts"][0]["target"], "/workspace/sample-plugin");
         assert_eq!(
             remapped["runtime_component_paths"]["agent_runtime_tools"],
-            "/home/user/_lab_workspaces/data-machine-code-def"
+            "/home/user/_lab_workspaces/sample-plugin-code-def"
         );
         assert_eq!(
             remapped["provider_plugin_paths"][0],
-            "/home/user/_lab_workspaces/data-machine@cook-abc/vendor/provider"
+            "/home/user/_lab_workspaces/sample-plugin@cook-abc/vendor/provider"
         );
         assert_eq!(remapped["model"], "claude-opus-4-8");
         // unrelated args preserved
@@ -1168,8 +1168,11 @@ mod tests {
         // "failed to read agent-task dispatch provider-config input: IO error".
         let temp = tempfile::tempdir().expect("tempdir");
         let cfg = temp.path().join("cfg.json");
-        std::fs::write(&cfg, r#"{"model":"claude-opus-4-8","backend":"codebox"}"#)
-            .expect("write provider config");
+        std::fs::write(
+            &cfg,
+            r#"{"model":"claude-opus-4-8","backend":"sample-runtime"}"#,
+        )
+        .expect("write provider config");
 
         let args = vec![
             "homeboy".to_string(),
@@ -1193,7 +1196,7 @@ mod tests {
         );
         let inlined: serde_json::Value = serde_json::from_str(spec).expect("inline json");
         assert_eq!(inlined["model"], "claude-opus-4-8");
-        assert_eq!(inlined["backend"], "codebox");
+        assert_eq!(inlined["backend"], "sample-runtime");
         // Unrelated args preserved.
         assert!(out.iter().any(|a| a == "--prompt"));
         assert!(out.iter().any(|a| a == "fix it"));
@@ -1513,7 +1516,7 @@ mod tests {
             "cook".to_string(),
             "--prompt".to_string(),
             format!("@{}", prompt.display()),
-            "--backend=codebox".to_string(),
+            "--backend=sample-runtime".to_string(),
         ];
 
         let out =
@@ -1521,7 +1524,7 @@ mod tests {
 
         assert_eq!(out[4], "Cook this repo\nwith care");
         assert!(out.iter().all(|arg| !arg.starts_with('@')));
-        assert_eq!(out[5], "--backend=codebox");
+        assert_eq!(out[5], "--backend=sample-runtime");
     }
 
     #[test]

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -956,11 +956,11 @@ mod provider_config_candidate_paths_tests {
     #[test]
     fn extracts_all_local_path_sources_including_runtime_overlays() {
         let value = serde_json::json!({
-            "workspace_root": "/local/data-machine@cook",
-            "mounts": [{ "source": "/local/data-machine@cook", "target": "/workspace/data-machine" }],
+            "workspace_root": "/local/sample-plugin@cook",
+            "mounts": [{ "source": "/local/sample-plugin@cook", "target": "/workspace/sample-plugin" }],
             "runtime_component_paths": {
-                "agent_runtime": "/local/data-machine",
-                "agent_runtime_tools": "/local/data-machine-code"
+                "agent_runtime": "/local/sample-plugin",
+                "agent_runtime_tools": "/local/sample-plugin-code"
             },
             "provider_plugin_paths": ["/local/ai-provider-for-claude-code"],
             "runtime_overlays": [
@@ -974,9 +974,9 @@ mod provider_config_candidate_paths_tests {
         let paths = provider_config_candidate_paths(&value);
 
         for expected in [
-            "/local/data-machine@cook",
-            "/local/data-machine",
-            "/local/data-machine-code",
+            "/local/sample-plugin@cook",
+            "/local/sample-plugin",
+            "/local/sample-plugin-code",
             "/local/ai-provider-for-claude-code",
             "/local/portable-ai-client@custom-provider-auth",
             "/local/agents-api",

--- a/src/core/runner/managed_source.rs
+++ b/src/core/runner/managed_source.rs
@@ -11,7 +11,7 @@
 //! This module lets homeboy keep such a checkout synced automatically. Core
 //! treats the source generically: it is a *named* checkout with an optional
 //! canonical remote URL and an optional intended ref. Core has **no knowledge**
-//! of what the source actually is (wp-codebox, a CLI, a toolchain, ...). The
+//! of what the source actually is (a runtime, a CLI, a toolchain, ...). The
 //! declaring extension supplies the path/remote/ref via the
 //! [`AgentTaskProviderRunnerSource`] manifest contract; this keeps homeboy core
 //! runtime-agnostic.
@@ -285,12 +285,12 @@ mod tests {
     }
 
     #[test]
-    fn script_is_runtime_agnostic_no_codebox_literals() {
+    fn script_is_runtime_agnostic_no_product_literals() {
         let mut decl = source("src", "/home/r/.cache/homeboy/source");
         decl.remote_url = Some("https://example.test/repo.git".to_string());
         let plan = plan_managed_runner_source_sync(&decl).expect("plan");
         let lower = plan.script.to_ascii_lowercase();
-        assert!(!lower.contains("codebox"));
+        assert!(!lower.contains("sample-runtime"));
         assert!(!lower.contains("wordpress"));
         assert!(!lower.contains("wp-"));
     }

--- a/src/core/runner/rig_materialization.rs
+++ b/src/core/runner/rig_materialization.rs
@@ -864,7 +864,7 @@ mod tests {
         let err = validate_installed_rig_source(
             "woocommerce-performance",
             "/missing/homeboy-rigs/woocommerce/woocommerce",
-            "/Users/user/Developer/homeboy-rigs@issue-323-codebox-fresh/woocommerce/woocommerce",
+            "/Users/user/Developer/sample-rigs@issue-323-runtime-fresh/sample-plugin/sample-plugin",
         )
         .expect_err("missing source should fail");
 

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -1683,7 +1683,7 @@ mod tests {
     #[test]
     fn git_materialization_restores_workspace_owner_after_root_run() {
         let command = materialize_git_command(
-            "/var/lib/datamachine/workspace/_lab_workspaces/homeboy-abc",
+            "/var/lib/sampleplugin/workspace/_lab_workspaces/homeboy-abc",
             "https://github.com/Extra-Chill/homeboy.git",
             "abc123",
             None,
@@ -1703,7 +1703,7 @@ mod tests {
     #[test]
     fn snapshot_install_restores_workspace_owner_after_root_run() {
         let command =
-            snapshot_install_command("/var/lib/datamachine/workspace/_lab_workspaces/homeboy-abc");
+            snapshot_install_command("/var/lib/sampleplugin/workspace/_lab_workspaces/homeboy-abc");
 
         assert!(command.contains("owner_path=$parent"));
         assert!(command.contains("mkdir -p \"$parent\""));

--- a/src/core/source_snapshot.rs
+++ b/src/core/source_snapshot.rs
@@ -248,12 +248,12 @@ mod tests {
         assert!(excludes.contains(&"node_modules/".to_string()));
         assert!(excludes.contains(&".homeboy-build/".to_string()));
         assert!(excludes.contains(&".env".to_string()));
-        assert!(!excludes.contains(&".datamachine/".to_string()));
+        assert!(!excludes.contains(&".sampleplugin/".to_string()));
     }
 
     #[test]
     fn source_snapshot_policy_allows_product_specific_excludes() {
-        let policy = SourceSnapshotPolicy::default().with_sync_excludes([".datamachine/"]);
+        let policy = SourceSnapshotPolicy::default().with_sync_excludes([".sampleplugin/"]);
         let snapshot = SourceSnapshot::existing_remote_with_policy(
             "lab",
             "/srv/homeboy/repo",
@@ -264,7 +264,7 @@ mod tests {
         assert!(snapshot.sync_excludes.contains(&".git/".to_string()));
         assert!(snapshot
             .sync_excludes
-            .contains(&".datamachine/".to_string()));
+            .contains(&".sampleplugin/".to_string()));
     }
 
     #[test]

--- a/src/core/triage/tests.rs
+++ b/src/core/triage/tests.rs
@@ -64,11 +64,11 @@ mod parsing {
     #[test]
     fn dedupe_refs_by_repo_keeps_unresolved_entries_separate() {
         let resolved = ComponentRef::new(
-            "data-machine".to_string(),
-            "/tmp/data-machine".to_string(),
-            Some("https://github.com/Extra-Chill/data-machine.git".to_string()),
+            "sample-plugin".to_string(),
+            "/tmp/sample-plugin".to_string(),
+            Some("https://github.com/Extra-Chill/sample-plugin.git".to_string()),
             None,
-            "component:data-machine".to_string(),
+            "component:sample-plugin".to_string(),
         );
         let unresolved = ComponentRef::new(
             "local-only".to_string(),
@@ -81,7 +81,7 @@ mod parsing {
         let refs = dedupe_refs_by_repo(vec![unresolved, resolved]);
 
         assert_eq!(refs.len(), 2);
-        assert!(refs.iter().any(|r| r.component_id == "data-machine"));
+        assert!(refs.iter().any(|r| r.component_id == "sample-plugin"));
         assert!(refs.iter().any(|r| r.component_id == "local-only"));
     }
 
@@ -573,11 +573,11 @@ mod priority_and_summary {
     #[test]
     fn priority_actions_use_default_labels_when_unconfigured() {
         let component_ref = ComponentRef::new(
-            "data-machine".to_string(),
-            "/tmp/data-machine".to_string(),
+            "sample-plugin".to_string(),
+            "/tmp/sample-plugin".to_string(),
             None,
-            Some("https://github.com/Extra-Chill/data-machine.git".to_string()),
-            "component:data-machine".to_string(),
+            Some("https://github.com/Extra-Chill/sample-plugin.git".to_string()),
+            "component:sample-plugin".to_string(),
         );
         let labels = resolve_priority_labels(&component_ref, None);
         let issues = issues_with_labels(vec![vec!["bug"], vec!["polish"]]);
@@ -592,11 +592,11 @@ mod priority_and_summary {
     #[test]
     fn component_priority_labels_override_global_labels() {
         let component_ref = ComponentRef::new(
-            "data-machine".to_string(),
-            "/tmp/data-machine".to_string(),
+            "sample-plugin".to_string(),
+            "/tmp/sample-plugin".to_string(),
             None,
-            Some("https://github.com/Extra-Chill/data-machine.git".to_string()),
-            "component:data-machine".to_string(),
+            Some("https://github.com/Extra-Chill/sample-plugin.git".to_string()),
+            "component:sample-plugin".to_string(),
         )
         .with_priority_labels(Some(vec!["urgent".to_string()]));
         let global = vec!["bug".to_string()];
@@ -613,11 +613,11 @@ mod priority_and_summary {
     #[test]
     fn global_priority_labels_apply_when_component_and_fleet_unset() {
         let component_ref = ComponentRef::new(
-            "data-machine".to_string(),
-            "/tmp/data-machine".to_string(),
+            "sample-plugin".to_string(),
+            "/tmp/sample-plugin".to_string(),
             None,
-            Some("https://github.com/Extra-Chill/data-machine.git".to_string()),
-            "component:data-machine".to_string(),
+            Some("https://github.com/Extra-Chill/sample-plugin.git".to_string()),
+            "component:sample-plugin".to_string(),
         );
         let global = vec!["critical".to_string()];
         let labels = resolve_priority_labels(&component_ref, Some(&global));
@@ -640,10 +640,10 @@ mod priority_and_summary {
             std::fs::create_dir_all(&project_dir).unwrap();
             std::fs::create_dir_all(&fleet_dir).unwrap();
             std::fs::write(
-                component_dir.join("data-machine.json"),
+                component_dir.join("sample-plugin.json"),
                 r#"{
-                    "local_path": "/tmp/data-machine",
-                    "remote_url": "https://github.com/Extra-Chill/data-machine.git"
+                    "local_path": "/tmp/sample-plugin",
+                    "remote_url": "https://github.com/Extra-Chill/sample-plugin.git"
                 }"#,
             )
             .unwrap();
@@ -651,7 +651,7 @@ mod priority_and_summary {
                 project_dir.join("site.json"),
                 r#"{
                     "components": [
-                        {"id": "data-machine", "local_path": "/tmp/data-machine"}
+                        {"id": "sample-plugin", "local_path": "/tmp/sample-plugin"}
                     ]
                 }"#,
             )
@@ -678,15 +678,15 @@ mod priority_and_summary {
     #[test]
     fn summarize_counts_component_actions() {
         let component = TriageComponentReport {
-            component_id: "data-machine".to_string(),
-            local_path: "/tmp/data-machine".to_string(),
-            sources: vec!["component:data-machine".to_string()],
+            component_id: "sample-plugin".to_string(),
+            local_path: "/tmp/sample-plugin".to_string(),
+            sources: vec!["component:sample-plugin".to_string()],
             usage: vec![],
             repo: TriageRepo {
                 provider: "github",
                 owner: "Extra-Chill".to_string(),
-                name: "data-machine".to_string(),
-                url: "https://github.com/Extra-Chill/data-machine".to_string(),
+                name: "sample-plugin".to_string(),
+                url: "https://github.com/Extra-Chill/sample-plugin".to_string(),
                 source_repo: None,
                 triage_remote_url: None,
             },

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -313,8 +313,8 @@ fn routes_remote_runner_job_broker_lifecycle() {
         Some(serde_json::json!({
             "runner_id": "homeboy-lab",
             "project_id": "extrachill",
-            "command": ["homeboy", "test", "data-machine"],
-            "cwd": "/home/user/Developer/data-machine"
+            "command": ["homeboy", "test", "sample-plugin"],
+            "cwd": "/home/user/Developer/sample-plugin"
         })),
         &store,
     );
@@ -343,7 +343,7 @@ fn routes_remote_runner_job_broker_lifecycle() {
     assert_eq!(claim.body["body"]["claim"]["job"]["id"], job_id);
     assert_eq!(
         claim.body["body"]["claim"]["request"]["command"],
-        serde_json::json!(["homeboy", "test", "data-machine"])
+        serde_json::json!(["homeboy", "test", "sample-plugin"])
     );
 
     let event = route_with_job_store_and_body(

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -164,7 +164,7 @@ fn test_command_step_exposes_pipeline_settings_env() {
             "pipeline": {{
                 "bench_prepare": [{{
                     "kind": "command",
-                    "command": "printf '%s' \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\" > {}"
+                    "command": "printf '%s' \"$HOMEBOY_SETTINGS_SAMPLE_RUNTIME_SOURCE_ROOT\" > {}"
                 }}]
             }}
         }}"#,
@@ -173,7 +173,7 @@ fn test_command_step_exposes_pipeline_settings_env() {
     .expect("parse rig");
 
     let settings = vec![(
-        "wp_codebox_source_root".to_string(),
+        "wp_sample-runtime_source_root".to_string(),
         "/tmp/woocommerce".to_string(),
     )];
     let out =

--- a/tests/core/rig/spec_test.rs
+++ b/tests/core/rig/spec_test.rs
@@ -451,7 +451,7 @@ fn test_trace_variants() {
                 }
             ],
             "runner_capabilities": [
-                "wp-codebox.recipe-run",
+                "sample-runtime.recipe-run",
                 "wordpress.browser-probe.capture.network"
             ]
         }"#,
@@ -471,7 +471,7 @@ fn test_trace_variants() {
     assert_eq!(
         workload.runner_capabilities(),
         &[
-            "wp-codebox.recipe-run".to_string(),
+            "sample-runtime.recipe-run".to_string(),
             "wordpress.browser-probe.capture.network".to_string()
         ]
     );

--- a/tests/core/rig/workloads_test.rs
+++ b/tests/core/rig/workloads_test.rs
@@ -337,13 +337,13 @@ fn test_trace_workload_dependencies_expand_paths_and_capabilities_dedupe() {
                             }
                         ],
                         "runner_capabilities": [
-                            "wp-codebox.recipe-run",
+                            "sample-runtime.recipe-run",
                             "browser-probe.assertions"
                         ]
                     },
                     {
                         "path": "/tmp/ece-second.trace.mjs",
-                        "runner_capabilities": ["wp-codebox.recipe-run"]
+                        "runner_capabilities": ["sample-runtime.recipe-run"]
                     }
                 ]
             }
@@ -361,7 +361,7 @@ fn test_trace_workload_dependencies_expand_paths_and_capabilities_dedupe() {
         runner_capabilities_for_extension(&rig_spec, "extension-a"),
         vec![
             "browser-probe.assertions".to_string(),
-            "wp-codebox.recipe-run".to_string()
+            "sample-runtime.recipe-run".to_string()
         ]
     );
 }

--- a/tests/fixtures/sample_runtime_materialization_manifest.json
+++ b/tests/fixtures/sample_runtime_materialization_manifest.json
@@ -1,14 +1,14 @@
 {
   "schema": "homeboy/agent-runtime-manifest/v1",
-  "id": "wp-codebox",
-  "label": "WP Codebox",
+  "id": "sample-runtime",
+  "label": "Sample Runtime",
   "materialization": {
     "source_roots": [
       {
-        "id": "wp-codebox",
-        "label": "WP Codebox source",
-        "path": "~/.cache/homeboy/runtimes/wp-codebox",
-        "remote_url": "https://github.com/example-org/wp-codebox.git",
+        "id": "sample-runtime",
+        "label": "Sample Runtime source",
+        "path": "~/.cache/homeboy/runtimes/sample-runtime",
+        "remote_url": "https://github.com/example-org/sample-runtime.git",
         "git_ref": "main"
       }
     ],
@@ -16,55 +16,55 @@
       {
         "id": "runtime-package",
         "label": "Runtime package",
-        "source_root": "wp-codebox",
+        "source_root": "sample-runtime",
         "requirement": "runtime source checkout"
       }
     ],
     "executable_requirements": [
       {
-        "id": "wp-codebox-cli",
-        "label": "WP Codebox CLI",
-        "env": ["WP_CODEBOX_BIN"],
-        "candidates": ["wp-codebox", "codebox"],
+        "id": "sample-runtime-cli",
+        "label": "Sample Runtime CLI",
+        "env": ["SAMPLE_RUNTIME_BIN"],
+        "candidates": ["sample-runtime", "sample-runtime-cli"],
         "version_command": ["--version"],
         "install_hint": "Install the runtime CLI before dispatching tasks."
       }
     ],
     "readiness_checks": [
       {
-        "id": "wp-codebox.ready",
-        "label": "WP Codebox runtime available",
+        "id": "sample-runtime.ready",
+        "label": "Sample Runtime available",
         "secret_env": ["AI_PROVIDER_OPENAI_CODEX_API_KEY"],
         "env_path": {
-          "env": ["WP_CODEBOX_HOME"],
+          "env": ["SAMPLE_RUNTIME_HOME"],
           "revision": true,
-          "canonical_path": "~/.cache/homeboy/runtimes/wp-codebox"
+          "canonical_path": "~/.cache/homeboy/runtimes/sample-runtime"
         },
         "executable": {
-          "env": ["WP_CODEBOX_BIN"],
-          "candidates": ["wp-codebox", "codebox"],
+          "env": ["SAMPLE_RUNTIME_BIN"],
+          "candidates": ["sample-runtime", "sample-runtime-cli"],
           "version_command": ["--version"]
         }
       }
     ],
     "env_passthrough": [
-      "WP_CODEBOX_HOME",
-      "WP_CODEBOX_BIN",
+      "SAMPLE_RUNTIME_HOME",
+      "SAMPLE_RUNTIME_BIN",
       "AI_PROVIDER_OPENAI_CODEX_API_KEY"
     ],
     "workspace": {
       "cwd": "git_checkout",
       "requires_git": true,
       "write_scope": "artifacts",
-      "artifact_paths": [".homeboy/codebox"]
+      "artifact_paths": [".homeboy/sample-runtime"]
     }
   },
   "agent_task_executors": [
     {
       "schema": "homeboy/agent-task-executor-provider/v1",
-      "id": "wp-codebox.default",
-      "backend": "codebox",
-      "command": "wp-codebox-agent-task-provider",
+      "id": "sample-runtime.default",
+      "backend": "sample-runtime",
+      "command": "sample-runtime-agent-task-provider",
       "request_schema": "homeboy/agent-task-request/v1",
       "outcome_schema": "homeboy/agent-task-outcome/v1"
     }

--- a/tests/report_failure_digest_test.rs
+++ b/tests/report_failure_digest_test.rs
@@ -146,10 +146,10 @@ fn trace_json_with_toolchain() -> &'static str {
             "toolchain": {
                 "canonical": false,
                 "mode": "development",
-                "reasons": ["HOMEBOY_WP_CODEBOX_BIN selected a local WP Codebox runner path"],
+                "reasons": ["HOMEBOY_SAMPLE_RUNTIME_BIN selected a local sample runtime path"],
                 "homeboy": {"path":"/repo/homeboy","sha":"abc123","branch":"main","dirty":false},
                 "toolchains": {
-                    "WP Codebox": {"path":"/repo/wp-codebox","sha":"def456","branch":"main","dirty":true}
+                    "Sample Runtime": {"path":"/repo/sample-runtime","sha":"def456","branch":"main","dirty":true}
                 },
                 "node": "v24.0.0"
             },
@@ -170,7 +170,7 @@ fn trace_json_with_toolchain() -> &'static str {
     }"#
 }
 
-fn trace_json_with_wp_codebox_partial_manifest() -> &'static str {
+fn trace_json_with_sample_runtime_partial_manifest() -> &'static str {
     r#"{
         "success": false,
         "data": {
@@ -179,11 +179,11 @@ fn trace_json_with_wp_codebox_partial_manifest() -> &'static str {
             "component": "studio",
             "exit_code": 2,
             "runtime_diagnostics": {
-                "manifest_path": "wp-codebox-artifacts/runtime-123/manifest.json",
-                "runtime_metadata_path": "wp-codebox-artifacts/runtime-123/runtime.json",
-                "commands_log_path": "wp-codebox-artifacts/runtime-123/commands.jsonl",
-                "events_log_path": "wp-codebox-artifacts/runtime-123/events.jsonl",
-                "browser_summary_path": "wp-codebox-artifacts/runtime-123/browser-summary.json",
+                "manifest_path": "sample-runtime-artifacts/runtime-123/manifest.json",
+                "runtime_metadata_path": "sample-runtime-artifacts/runtime-123/runtime.json",
+                "commands_log_path": "sample-runtime-artifacts/runtime-123/commands.jsonl",
+                "events_log_path": "sample-runtime-artifacts/runtime-123/events.jsonl",
+                "browser_summary_path": "sample-runtime-artifacts/runtime-123/browser-summary.json",
                 "current_phase": "browser.probe.wait_for_ready",
                 "current_command": "browser probe /wp-admin/",
                 "last_command": "runtime setup"
@@ -214,7 +214,7 @@ fn bench_json() -> &'static str {
                     "category": "budget",
                     "severity": "error",
                     "message": "REST response exceeded 250 KB budget",
-                    "fingerprint": "rest.max_response_bytes:/wp-json/datamachine/v1/pipelines?per_page=100",
+                    "fingerprint": "rest.max_response_bytes:/wp-json/sample/v1/items?per_page=100",
                     "source": { "kind": "budget", "label": "profile:wordpress-rest" },
                     "metadata": {
                         "code": "rest.max_response_bytes",
@@ -222,7 +222,7 @@ fn bench_json() -> &'static str {
                         "actual": 4378195,
                         "expected": 250000,
                         "unit": "bytes",
-                        "subject": "/wp-json/datamachine/v1/pipelines?per_page=100",
+                        "subject": "/wp-json/sample/v1/items?per_page=100",
                         "passed": false
                     },
                     "raw": { "category": "budget" }
@@ -458,7 +458,7 @@ fn renders_trace_pass_status_and_artifact_paths() {
     assert!(markdown.contains("- Window stayed closed."));
     assert!(markdown.contains("- main log: artifacts/main.log"));
     assert!(markdown.contains("- process tree: artifacts/process-tree.txt"));
-    assert!(!markdown.contains("**WP Codebox runtime diagnostics**"));
+    assert!(!markdown.contains("**Sample Runtime runtime diagnostics**"));
     assert!(!markdown.contains("raw log body that should never appear"));
 }
 
@@ -474,7 +474,7 @@ fn renders_bench_status_and_artifact_paths() {
     assert!(markdown.contains("**Status:** PASSED"));
     assert!(markdown.contains("**Budget findings**"));
     assert!(markdown.contains(
-        "| `rest.max_response_bytes` | /wp-json/datamachine/v1/pipelines?per_page=100 | 4378195 | 250000 | bytes | REST response exceeded 250 KB budget |"
+        "| `rest.max_response_bytes` | /wp-json/sample/v1/items?per_page=100 | 4378195 | 250000 | bytes | REST response exceeded 250 KB budget |"
     ));
     assert!(markdown.contains(
         "- scenario `wp-admin-load` / run 0 — Playwright trace (playwright-trace): bench-artifacts/wp-admin-load/trace.zip"
@@ -529,22 +529,23 @@ fn renders_trace_toolchain_provenance() {
     assert!(
         markdown.contains("- Homeboy: `/repo/homeboy` @ `abc123` (branch `main`, dirty `false`)")
     );
-    assert!(markdown
-        .contains("- WP Codebox: `/repo/wp-codebox` @ `def456` (branch `main`, dirty `true`)"));
+    assert!(markdown.contains(
+        "- Sample Runtime: `/repo/sample-runtime` @ `def456` (branch `main`, dirty `true`)"
+    ));
     assert!(
         markdown.contains("- Target: `/repo/studio` @ `789abc` (branch `trunk`, dirty `false`)")
     );
-    assert!(markdown.contains("HOMEBOY_WP_CODEBOX_BIN selected a local WP Codebox runner path"));
+    assert!(markdown.contains("HOMEBOY_SAMPLE_RUNTIME_BIN selected a local sample runtime path"));
 }
 
 #[test]
-fn renders_wp_codebox_partial_manifest_and_failure_phase() {
-    let guard = tmp_dir("trace-codebox-manifest");
+fn renders_sample_runtime_partial_manifest_and_failure_phase() {
+    let guard = tmp_dir("trace-runtime-manifest");
     let dir = guard.path();
     write_file(
         dir,
         "trace.json",
-        trace_json_with_wp_codebox_partial_manifest(),
+        trace_json_with_sample_runtime_partial_manifest(),
     );
 
     let markdown = render(dir, r#"{"trace":"error"}"#, false, false);
@@ -554,14 +555,17 @@ fn renders_wp_codebox_partial_manifest_and_failure_phase() {
     assert!(markdown.contains("- Current/last phase: `browser.probe.wait_for_ready`"));
     assert!(markdown.contains("- Current command: `browser probe /wp-admin/`"));
     assert!(markdown.contains("- Last command: `runtime setup`"));
-    assert!(
-        markdown.contains("- Artifact manifest: wp-codebox-artifacts/runtime-123/manifest.json")
-    );
-    assert!(markdown.contains("- Runtime metadata: wp-codebox-artifacts/runtime-123/runtime.json"));
-    assert!(markdown.contains("- Commands log: wp-codebox-artifacts/runtime-123/commands.jsonl"));
-    assert!(markdown.contains("- Events log: wp-codebox-artifacts/runtime-123/events.jsonl"));
     assert!(markdown
-        .contains("- Browser summary: wp-codebox-artifacts/runtime-123/browser-summary.json"));
+        .contains("- Artifact manifest: sample-runtime-artifacts/runtime-123/manifest.json"));
+    assert!(
+        markdown.contains("- Runtime metadata: sample-runtime-artifacts/runtime-123/runtime.json")
+    );
+    assert!(
+        markdown.contains("- Commands log: sample-runtime-artifacts/runtime-123/commands.jsonl")
+    );
+    assert!(markdown.contains("- Events log: sample-runtime-artifacts/runtime-123/events.jsonl"));
+    assert!(markdown
+        .contains("- Browser summary: sample-runtime-artifacts/runtime-123/browser-summary.json"));
 }
 
 #[test]

--- a/tests/runtime_product_boundary_test.rs
+++ b/tests/runtime_product_boundary_test.rs
@@ -1,0 +1,65 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn core_files_do_not_name_extension_owned_runtime_products() {
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let needles = [
+        format!("{}box", "code"),
+        format!("wp-{}box", "code"),
+        format!("{}machine", "data"),
+        format!("{}-machine", "data"),
+        format!("{} Machine", "Data"),
+        format!("{}Machine", "Data"),
+    ];
+    let mut violations = Vec::new();
+
+    for root in ["src", "tests", "docs"] {
+        collect_violations(&repo.join(root), &repo, &needles, &mut violations);
+    }
+
+    assert!(
+        violations.is_empty(),
+        "Homeboy core must keep extension-owned runtime product knowledge in extensions/adapters:\n{}",
+        violations.join("\n")
+    );
+}
+
+fn collect_violations(path: &Path, repo: &Path, needles: &[String], violations: &mut Vec<String>) {
+    let entries = match fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_violations(&path, repo, needles, violations);
+            continue;
+        }
+        if should_skip(&path, repo) {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let lower = content.to_lowercase();
+        if needles
+            .iter()
+            .any(|needle| lower.contains(&needle.to_lowercase()))
+        {
+            violations.push(
+                path.strip_prefix(repo)
+                    .unwrap_or(&path)
+                    .display()
+                    .to_string(),
+            );
+        }
+    }
+}
+
+fn should_skip(path: &Path, repo: &Path) -> bool {
+    let relative = path.strip_prefix(repo).unwrap_or(path);
+    relative == Path::new("docs/changelog.md")
+        || relative == Path::new("tests/runtime_product_boundary_test.rs")
+}


### PR DESCRIPTION
## Summary
- replaces WP Codebox/Data Machine-shaped core fixtures, docs examples, and test data with neutral sample runtime/provider/component names
- renames the runtime materialization fixture to `sample_runtime_materialization_manifest.json`
- adds a boundary regression test that scans core source/tests/docs for extension-owned runtime product names while leaving changelog history untouched

## Tests
- `cargo fmt`
- `cargo test --test runtime_product_boundary_test`
- `cargo test --test report_failure_digest_test`
- `cargo test agent_runtime_manifest`
- `cargo test agent_task_timeout_artifacts`
- `cargo test deploy::orchestration`
- `cargo test code_audit`
- `cargo test refactor -- --test-threads=1`
- `cargo clippy --all-targets`
- `cargo run -- --force-hot --allow-local-hot audit --path . --changed-since origin/main --json-summary` (runs, exits 1 on existing/structural unbaselined audit findings unrelated to this cleanup)

## Caveats
- `docs/changelog.md` still contains historical product names; it is intentionally excluded from the boundary test because changelog files are generated/release history and should not be edited manually.
- `cargo test refactor` has parallel shared-state sensitivity in this worktree; the same filter passes with `-- --test-threads=1`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** removed product-specific runtime fixtures from Homeboy core.