### PR TITLE
feat(agent-task): materialize loop specs

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -57,6 +57,29 @@ Use `events` for downstream integrations that need a stable generic controller
 event contract. `apply-event` remains the explicit event-application spelling and
 uses the same request and response contract.
 
+## Controller Spec Materialization
+
+`agent-task controller materialize <SPEC> --inputs <JSON>` is the generic seam for
+repos that have a loop spec plus per-run inputs, but should not carry repo-local
+`build-homeboy-controller-run-spec` scripts. It returns
+`homeboy/agent-task-loop-spec-materialization/v1` with a cloned materialized spec;
+it does not initialize durable controller state or mutate the source spec file.
+
+The inputs payload may contain `inputs` and `metadata` objects. `inputs` are
+merged into each workflow's `inputs`, and `metadata` is merged into top-level spec
+metadata. Explicit values override same-named workflow input or metadata keys.
+
+```bash
+homeboy agent-task controller materialize \
+  @.github/homeboy/controllers/site-loop.json \
+  --inputs @run-inputs.json
+```
+
+`agent-task controller from-spec` keeps its existing behavior: it reads a complete
+repo-authored controller spec, applies dispatch defaults for the spec checkout,
+and initializes or resumes durable controller state. Use `materialize` first when
+the spec needs deterministic run-input expansion before `from-spec`.
+
 ## Loop Spec Compilation
 
 `agent-task compile-loop --definition <SPEC>` compiles a declarative loop spec into

--- a/src/commands/agent_task.rs
+++ b/src/commands/agent_task.rs
@@ -23,10 +23,11 @@ pub use args::{
     AgentTaskArgs, AgentTaskAuthArgs, AgentTaskAuthCommand, AgentTaskCommand,
     AgentTaskControllerApplyEventArgs, AgentTaskControllerArgs, AgentTaskControllerCommand,
     AgentTaskControllerFromSpecArgs, AgentTaskControllerInitArgs,
-    AgentTaskControllerMarkHumanReadyArgs, AgentTaskControllerRunArgs,
-    AgentTaskControllerRunNextArgs, AgentTaskControllerStatusArgs, AgentTaskLoopArgs, CancelArgs,
-    CompileLoopArgs, ContractArgs, ContractFormat, FinalizePrArgs, GateFeedbackArgs, PromoteArgs,
-    ProvidersArgs, RetryArgs, ReviewArgs, RunPlanArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
+    AgentTaskControllerMarkHumanReadyArgs, AgentTaskControllerMaterializeArgs,
+    AgentTaskControllerRunArgs, AgentTaskControllerRunNextArgs, AgentTaskControllerStatusArgs,
+    AgentTaskLoopArgs, CancelArgs, CompileLoopArgs, ContractArgs, ContractFormat, FinalizePrArgs,
+    GateFeedbackArgs, PromoteArgs, ProvidersArgs, RetryArgs, ReviewArgs, RunPlanArgs, StatusArgs,
+    SubmitArgs, VerifyGateArgs,
 };
 pub(crate) use status::diagnostic_summary_from_aggregate;
 

--- a/src/commands/agent_task/args/controller.rs
+++ b/src/commands/agent_task/args/controller.rs
@@ -8,6 +8,8 @@ pub enum AgentTaskControllerCommand {
     Init(AgentTaskControllerInitArgs),
     /// Initialize or resume a durable loop controller from a repo-authored JSON spec.
     FromSpec(AgentTaskControllerFromSpecArgs),
+    /// Materialize a repo-authored loop spec with explicit run inputs.
+    Materialize(AgentTaskControllerMaterializeArgs),
     /// Compile a controller spec into a dry Homeboy plan without writing state.
     Plan(AgentTaskControllerPlanArgs),
     /// Read a durable loop controller record.
@@ -51,6 +53,17 @@ pub struct AgentTaskControllerFromSpecArgs {
     /// Execute pending actions after applying the spec.
     #[arg(long)]
     pub resume: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct AgentTaskControllerMaterializeArgs {
+    /// Repo loop spec JSON, @file, or - for stdin.
+    #[arg(value_name = "SPEC")]
+    pub spec: String,
+
+    /// Explicit run inputs JSON, @file, or - for stdin. Supports `inputs` and `metadata` objects.
+    #[arg(long, value_name = "JSON")]
+    pub inputs: Option<String>,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -22,8 +22,8 @@ pub use auth::{
 pub use controller::{
     AgentTaskControllerApplyEventArgs, AgentTaskControllerCommand, AgentTaskControllerFromSpecArgs,
     AgentTaskControllerInitArgs, AgentTaskControllerMarkHumanReadyArgs,
-    AgentTaskControllerPlanArgs, AgentTaskControllerRunArgs, AgentTaskControllerRunNextArgs,
-    AgentTaskControllerStatusArgs,
+    AgentTaskControllerMaterializeArgs, AgentTaskControllerPlanArgs, AgentTaskControllerRunArgs,
+    AgentTaskControllerRunNextArgs, AgentTaskControllerStatusArgs,
 };
 
 #[derive(Args, Debug)]

--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -6,6 +6,9 @@ use std::process::Command;
 
 use serde_json::Value;
 
+use homeboy::core::agent_task_loop_definition::{
+    materialize_repo_loop_spec, AgentTaskLoopSpecMaterializationRequest,
+};
 use homeboy::core::agent_tasks::controller_service as agent_task_controller_service;
 use homeboy::core::agent_tasks::controller_service::{
     AgentTaskRepoLoopSpec, ControllerApplyEventRequest, ControllerDispatchHook,
@@ -22,8 +25,8 @@ use super::super::agent_task_dispatch::DispatchArgs;
 use super::super::CmdResult;
 use super::args::{
     AgentTaskControllerApplyEventArgs, AgentTaskControllerArgs, AgentTaskControllerCommand,
-    AgentTaskControllerFromSpecArgs, AgentTaskControllerPlanArgs, AgentTaskControllerRunArgs,
-    AgentTaskControllerRunNextArgs,
+    AgentTaskControllerFromSpecArgs, AgentTaskControllerMaterializeArgs,
+    AgentTaskControllerPlanArgs, AgentTaskControllerRunArgs, AgentTaskControllerRunNextArgs,
 };
 use super::command_json_value;
 
@@ -38,6 +41,9 @@ pub(super) fn controller(args: AgentTaskControllerArgs) -> CmdResult<Value> {
             Ok((command_json_value(record)?, 0))
         }
         AgentTaskControllerCommand::FromSpec(spec_args) => controller_from_spec(spec_args),
+        AgentTaskControllerCommand::Materialize(materialize_args) => {
+            controller_materialize(materialize_args)
+        }
         AgentTaskControllerCommand::Plan(plan_args) => controller_plan(plan_args),
         AgentTaskControllerCommand::Status(status_args) => {
             let report = homeboy::core::agent_tasks::loop_controller::controller_status_report(
@@ -64,6 +70,37 @@ pub(super) fn controller(args: AgentTaskControllerArgs) -> CmdResult<Value> {
             Ok((command_json_value(record)?, 0))
         }
     }
+}
+
+pub(super) fn controller_materialize(args: AgentTaskControllerMaterializeArgs) -> CmdResult<Value> {
+    let raw = config::read_json_spec_to_string(&args.spec)?;
+    let mut spec: AgentTaskRepoLoopSpec = serde_json::from_str(&raw).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "spec",
+            error.to_string(),
+            Some(args.spec.clone()),
+            None,
+        )
+    })?;
+    apply_from_spec_dispatch_defaults(&mut spec, &args.spec);
+    let run_inputs = match args.inputs {
+        Some(inputs) => {
+            serde_json::from_str(&config::read_json_spec_to_string(&inputs)?).map_err(|error| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "inputs",
+                    error.to_string(),
+                    Some(inputs),
+                    None,
+                )
+            })?
+        }
+        None => Value::Null,
+    };
+    let report = materialize_repo_loop_spec(AgentTaskLoopSpecMaterializationRequest {
+        spec: &spec,
+        run_inputs: &run_inputs,
+    })?;
+    Ok((command_json_value(report)?, 0))
 }
 
 fn controller_plan(args: AgentTaskControllerPlanArgs) -> CmdResult<Value> {

--- a/src/commands/agent_task/tests.rs
+++ b/src/commands/agent_task/tests.rs
@@ -4,14 +4,15 @@
 use std::process::Command;
 
 use super::super::agent_task_dispatch::DispatchArgs;
-use super::args::AgentTaskControllerApplyEventArgs;
+use super::args::{AgentTaskControllerApplyEventArgs, AgentTaskControllerMaterializeArgs};
 use super::args::{
     AgentTaskLoopArgs, CompileLoopArgs, ReviewArgs, StatusArgs, SubmitArgs, VerifyGateArgs,
 };
 use super::controller::{
     apply_controller_event, apply_from_spec_dispatch_defaults,
-    apply_from_spec_dispatch_defaults_with_cwd, controller_run_action_with_executor,
-    controller_run_next_with_executor, dispatch_args_from_controller_request,
+    apply_from_spec_dispatch_defaults_with_cwd, controller_materialize,
+    controller_run_action_with_executor, controller_run_next_with_executor,
+    dispatch_args_from_controller_request,
 };
 use super::run::{
     retry, run_loaded_plan, run_loop_with_executor, run_next_with_executor,
@@ -272,6 +273,95 @@ fn compile_loop_command_rejects_controller_only_sections() {
         .expect("diagnostics")
         .iter()
         .any(|diagnostic| diagnostic.as_str().unwrap_or_default().contains("policy")));
+}
+
+#[test]
+fn controller_materialize_merges_inputs_and_metadata_without_mutating_source() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let spec_path = temp.path().join("repo-loop.json");
+    let inputs_path = temp.path().join("inputs.json");
+    std::fs::write(
+        &spec_path,
+        serde_json::to_string(&json!({
+            "loop_id": "materialize-loop",
+            "metadata": { "source": "fixture" },
+            "artifacts": {
+                "brief": { "kind": "example/Brief/v1" }
+            },
+            "workflows": [
+                {
+                    "workflow_id": "brief",
+                    "prompt": "Draft the brief.",
+                    "inputs": { "topic": "existing" },
+                    "emits": ["brief"]
+                }
+            ]
+        }))
+        .expect("spec json"),
+    )
+    .expect("write spec");
+    std::fs::write(
+        &inputs_path,
+        serde_json::to_string(&json!({
+            "inputs": { "topic": "explicit", "audience": "operators" },
+            "metadata": { "run_id": "run-123" }
+        }))
+        .expect("inputs json"),
+    )
+    .expect("write inputs");
+
+    let (value, status) = controller_materialize(AgentTaskControllerMaterializeArgs {
+        spec: format!("@{}", spec_path.display()),
+        inputs: Some(format!("@{}", inputs_path.display())),
+    })
+    .expect("materialize spec");
+
+    assert_eq!(status, 0);
+    assert_eq!(
+        value["schema"],
+        "homeboy/agent-task-loop-spec-materialization/v1"
+    );
+    assert_eq!(value["spec"]["workflows"][0]["inputs"]["topic"], "explicit");
+    assert_eq!(
+        value["spec"]["workflows"][0]["inputs"]["audience"],
+        "operators"
+    );
+    assert_eq!(value["spec"]["metadata"]["source"], "fixture");
+    assert_eq!(value["spec"]["metadata"]["run_id"], "run-123");
+
+    let source_after: Value = serde_json::from_str(
+        &std::fs::read_to_string(&spec_path).expect("source spec remains readable"),
+    )
+    .expect("source spec json");
+    assert_eq!(source_after["workflows"][0]["inputs"]["topic"], "existing");
+    assert!(source_after["metadata"].get("run_id").is_none());
+}
+
+#[test]
+fn compile_loop_command_rejects_undeclared_workflow_artifacts() {
+    let error = loop_definition::compile_loop(CompileLoopArgs {
+        definition: serde_json::to_string(&json!({
+            "loop_id": "repo-loop-with-missing-artifact",
+            "artifacts": {
+                "brief": { "kind": "example/Brief/v1" }
+            },
+            "workflows": [
+                { "workflow_id": "brief", "prompt": "Draft.", "emits": ["missing"] }
+            ]
+        }))
+        .expect("definition json"),
+    })
+    .expect_err("undeclared artifact is rejected");
+
+    assert!(error.message.contains("artifacts"));
+    assert!(error.details["tried"]
+        .as_array()
+        .expect("diagnostics")
+        .iter()
+        .any(|diagnostic| diagnostic
+            .as_str()
+            .unwrap_or_default()
+            .contains("references undeclared artifact 'missing'")));
 }
 
 #[test]

--- a/src/core/agent_task_loop_definition.rs
+++ b/src/core/agent_task_loop_definition.rs
@@ -18,6 +18,8 @@ use crate::core::agent_task_schedule::{
 use crate::core::{Error, Result};
 
 pub const AGENT_TASK_LOOP_DEFINITION_SCHEMA: &str = "homeboy/agent-task-loop-definition/v1";
+pub const AGENT_TASK_LOOP_SPEC_MATERIALIZATION_SCHEMA: &str =
+    "homeboy/agent-task-loop-spec-materialization/v1";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskLoopDefinition {
@@ -48,6 +50,52 @@ pub struct AgentTaskLoopDefinitionTask {
     pub bindings: HashMap<String, AgentTaskOutputBinding>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub artifact_outputs: Vec<AgentTaskArtifactOutputDeclaration>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentTaskLoopSpecMaterializationRequest<'a> {
+    pub spec: &'a AgentTaskRepoLoopSpec,
+    pub run_inputs: &'a Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskLoopSpecMaterialization {
+    #[serde(default = "loop_spec_materialization_schema")]
+    pub schema: String,
+    pub spec: AgentTaskRepoLoopSpec,
+}
+
+pub fn materialize_repo_loop_spec(
+    request: AgentTaskLoopSpecMaterializationRequest<'_>,
+) -> Result<AgentTaskLoopSpecMaterialization> {
+    validate_repo_loop_artifact_references(request.spec)?;
+
+    let mut spec = request.spec.clone();
+    let explicit_inputs = request.run_inputs.get("inputs").or_else(|| {
+        request
+            .run_inputs
+            .get("metadata")
+            .is_none()
+            .then_some(request.run_inputs)
+    });
+    if let Some(explicit_inputs) = explicit_inputs.filter(|value| !value.is_null()) {
+        for workflow in &mut spec.workflows {
+            merge_workflow_inputs(&mut workflow.inputs, explicit_inputs);
+        }
+    }
+
+    if let Some(metadata) = request
+        .run_inputs
+        .get("metadata")
+        .filter(|value| value.is_object())
+    {
+        merge_json_objects(&mut spec.metadata, metadata);
+    }
+
+    Ok(AgentTaskLoopSpecMaterialization {
+        schema: AGENT_TASK_LOOP_SPEC_MATERIALIZATION_SCHEMA.to_string(),
+        spec,
+    })
 }
 
 pub fn compile_loop_definition(definition: AgentTaskLoopDefinition) -> Result<AgentTaskPlan> {
@@ -159,6 +207,8 @@ fn compile_repo_loop_spec(spec: AgentTaskRepoLoopSpec) -> Result<AgentTaskPlan> 
 }
 
 fn validate_repo_loop_spec_for_agent_task_plan(spec: &AgentTaskRepoLoopSpec) -> Result<()> {
+    validate_repo_loop_artifact_references(spec)?;
+
     if spec.loop_id.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
             "loop_id",
@@ -765,6 +815,93 @@ fn compile_metadata(definition: &AgentTaskLoopDefinition) -> Value {
 
 fn loop_definition_schema() -> String {
     AGENT_TASK_LOOP_DEFINITION_SCHEMA.to_string()
+}
+
+fn loop_spec_materialization_schema() -> String {
+    AGENT_TASK_LOOP_SPEC_MATERIALIZATION_SCHEMA.to_string()
+}
+
+fn merge_workflow_inputs(target: &mut Value, explicit_inputs: &Value) {
+    if !explicit_inputs.is_object() {
+        return;
+    }
+    if !target.is_object() {
+        let mut wrapped = serde_json::Map::new();
+        if !target.is_null() {
+            wrapped.insert("workflow_inputs".to_string(), target.clone());
+        }
+        *target = Value::Object(wrapped);
+    }
+    merge_json_objects(target, explicit_inputs);
+}
+
+fn merge_json_objects(target: &mut Value, source: &Value) {
+    let Some(source) = source.as_object() else {
+        return;
+    };
+    if !target.is_object() {
+        *target = Value::Object(serde_json::Map::new());
+    }
+    let target = target.as_object_mut().expect("target object");
+    for (key, value) in source {
+        target.insert(key.clone(), value.clone());
+    }
+}
+
+fn validate_repo_loop_artifact_references(spec: &AgentTaskRepoLoopSpec) -> Result<()> {
+    let declared = spec
+        .artifacts
+        .iter()
+        .map(|artifact| artifact.artifact_id.as_str())
+        .collect::<HashSet<_>>();
+    if declared.is_empty() {
+        return Ok(());
+    }
+
+    let mut diagnostics = Vec::new();
+    for workflow in &spec.workflows {
+        for (field, artifact_id) in workflow
+            .artifacts
+            .iter()
+            .map(|artifact_id| ("artifacts", artifact_id))
+            .chain(
+                workflow
+                    .emits
+                    .iter()
+                    .map(|artifact_id| ("emits", artifact_id)),
+            )
+            .chain(
+                workflow
+                    .consumes
+                    .iter()
+                    .map(|artifact_id| ("consumes", artifact_id)),
+            )
+            .chain(
+                workflow
+                    .dependencies
+                    .iter()
+                    .map(|artifact_id| ("dependencies", artifact_id)),
+            )
+        {
+            if !declared.contains(artifact_id.as_str()) {
+                diagnostics.push(format!(
+                    "workflows[{}].{} references undeclared artifact '{}'",
+                    workflow.workflow_id, field, artifact_id
+                ));
+            }
+        }
+    }
+
+    if diagnostics.is_empty() {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "artifacts",
+        "repo loop spec workflows reference artifacts that are not declared in artifacts",
+        Some(spec.loop_id.clone()),
+        Some(diagnostics),
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add a first-class `agent-task controller materialize` seam for repo loop specs plus explicit run inputs.
- Add a reusable core materialization helper that clones specs, merges run inputs into workflow inputs, merges run metadata into top-level metadata, and preserves source spec behavior.
- Validate declared workflow artifact references and keep unsupported graph/controller shapes on deterministic diagnostics instead of implementing retry/join/gate execution.
- Document controller materialize/from-spec usage.

## Tests
- `cargo test controller_materialize_merges_inputs_and_metadata_without_mutating_source`
- `cargo test compile_loop_command_rejects_undeclared_workflow_artifacts`
- `cargo test compile_loop_command_emits_plan_from_repo_loop_spec`
- `cargo test compiles_repo_loop_entity_fanout_into_concrete_agent_tasks`
- `cargo test rejects_repo_loop_join_over_fanout_with_controller_diagnostic`
- `cargo test rejects_repo_loop_gates_with_controller_diagnostic`
- `cargo test command_surface`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, and documentation; Chris reviews and owns the change.