### PR TITLE
Closes #5184: keep rig pipeline settings-env fixture runtime-agnostic

### DIFF
--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -173,8 +173,8 @@ fn test_command_step_exposes_pipeline_settings_env() {
     .expect("parse rig");
 
     let settings = vec![(
-        "wp_sample-runtime_source_root".to_string(),
-        "/tmp/woocommerce".to_string(),
+        "sample_runtime_source_root".to_string(),
+        "/tmp/sample-runtime".to_string(),
     )];
     let out =
         run_pipeline_with_settings(&rig, "bench_prepare", true, &settings).expect("pipeline runs");
@@ -182,7 +182,7 @@ fn test_command_step_exposes_pipeline_settings_env() {
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
     assert_eq!(
         std::fs::read_to_string(marker).expect("marker"),
-        "/tmp/woocommerce"
+        "/tmp/sample-runtime"
     );
 }
 


### PR DESCRIPTION
## Summary
- Fixes the RED Test gate on `main` (#5184): `core::rig::pipeline::pipeline_test::test_command_step_exposes_pipeline_settings_env` was asserting an empty settings env value.

## Root cause
PR #5162 ("remove product-specific runtime fixtures") renamed the bench settings fixtures away from product-specific literals, but the edit to `tests/core/rig/pipeline_test.rs` was malformed: it left a residual `wp_` prefix and introduced a dash in the setting key (`wp_sample-runtime_source_root`) plus a `/tmp/woocommerce` value, while the command still expected `HOMEBOY_SETTINGS_SAMPLE_RUNTIME_SOURCE_ROOT`.

The production env-naming convention (shared with `lab_env::settings_env_diagnostics`) is the generic, runtime-agnostic `HOMEBOY_SETTINGS_<UPPERCASE(key)>`. Under that rule, `wp_sample-runtime_source_root` derives `HOMEBOY_SETTINGS_WP_SAMPLE-RUNTIME_SOURCE_ROOT` — not what the test asserts — so the value came through empty and the test failed.

## Fix
Correct the test fixture to match the established generic convention already used in `settings_matrix.rs` (`sample_runtime_*`):
- key: `sample_runtime_source_root`
- value: `/tmp/sample-runtime`

This is a test-fixture regression, not a production regression. **No WordPress/product literals and no prefix-stripping logic were added to core** — homeboy core stays fully runtime-agnostic (and unaware that WordPress exists), per the core agnosticism rule.

## Validation
- `cargo test --lib core::rig::pipeline::pipeline_test` → 43 passed, 0 failed (target test green).
- `cargo test --lib core::runner::lab_env` → settings-env diagnostics test still green (shared convention intact).
- `cargo build --lib --tests` clean; `cargo fmt --check` clean.
- The 25 `commands::bench`/`commands::trace` failures under the broad `rig` filter are pre-existing on clean `origin/main` (subprocess spawn exit 126 in this sandbox) and unrelated to this change.

Closes #5184