### PR TITLE
feat(agent-task): materialize policy result inputs

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -75,6 +75,33 @@ homeboy agent-task controller materialize \
   --inputs @run-inputs.json
 ```
 
+Domains that evaluate their own policies can pass deterministic policy decisions
+without teaching Homeboy the policy semantics:
+
+```bash
+homeboy agent-task controller materialize \
+  @.github/homeboy/controllers/site-loop.json \
+  --policy-result @policy-result.json
+```
+
+The generic policy result envelope is:
+
+```json
+{
+  "policy_id": "example-policy",
+  "policy_inputs": { "requested_tier": "foundation" },
+  "policy_results": { "selected_tier": "foundation", "decision": "hold" },
+  "provenance": { "source": "policy-evaluator", "sha256": "..." }
+}
+```
+
+`policy_id` is required and must be unique per materialization. The other fields
+are optional JSON objects. Homeboy projects `policy_inputs` and `policy_results`
+under the same keys in every workflow's `inputs`, keyed by `policy_id`, and records
+the full envelope under top-level `metadata.policy_materialization`. Homeboy does
+not evaluate expressions, choose tiers, generate random seeds, or interpret the
+policy result; repo-owned evaluators supply the envelope.
+
 `agent-task controller from-spec` keeps its existing behavior: it reads a complete
 repo-authored controller spec, applies dispatch defaults for the spec checkout,
 and initializes or resumes durable controller state. Use `materialize` first when

--- a/src/commands/agent_task/args/controller.rs
+++ b/src/commands/agent_task/args/controller.rs
@@ -64,6 +64,10 @@ pub struct AgentTaskControllerMaterializeArgs {
     /// Explicit run inputs JSON, @file, or - for stdin. Supports `inputs` and `metadata` objects.
     #[arg(long, value_name = "JSON")]
     pub inputs: Option<String>,
+
+    /// Declarative policy result JSON, @file, or - for stdin. Repeatable.
+    #[arg(long = "policy-result", value_name = "JSON")]
+    pub policy_results: Vec<String>,
 }
 
 #[derive(Args, Debug)]

--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -7,7 +7,8 @@ use std::process::Command;
 use serde_json::Value;
 
 use homeboy::core::agent_task_loop_definition::{
-    materialize_repo_loop_spec, AgentTaskLoopSpecMaterializationRequest,
+    materialize_repo_loop_spec, AgentTaskLoopPolicyResultMaterialization,
+    AgentTaskLoopSpecMaterializationRequest,
 };
 use homeboy::core::agent_tasks::controller_service as agent_task_controller_service;
 use homeboy::core::agent_tasks::controller_service::{
@@ -96,11 +97,32 @@ pub(super) fn controller_materialize(args: AgentTaskControllerMaterializeArgs) -
         }
         None => Value::Null,
     };
+    let policy_results = args
+        .policy_results
+        .iter()
+        .map(|policy_result| parse_policy_result(policy_result))
+        .collect::<homeboy::core::Result<Vec<_>>>()?;
     let report = materialize_repo_loop_spec(AgentTaskLoopSpecMaterializationRequest {
         spec: &spec,
         run_inputs: &run_inputs,
+        policy_results: &policy_results,
     })?;
     Ok((command_json_value(report)?, 0))
+}
+
+fn parse_policy_result(
+    source: &str,
+) -> homeboy::core::Result<AgentTaskLoopPolicyResultMaterialization> {
+    let raw = config::read_json_spec_to_string(source)?;
+    let value: Value = serde_json::from_str(&raw).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "policy-result",
+            error.to_string(),
+            Some(source.to_string()),
+            None,
+        )
+    })?;
+    AgentTaskLoopPolicyResultMaterialization::from_value(value, source)
 }
 
 fn controller_plan(args: AgentTaskControllerPlanArgs) -> CmdResult<Value> {

--- a/src/commands/agent_task/tests.rs
+++ b/src/commands/agent_task/tests.rs
@@ -313,6 +313,7 @@ fn controller_materialize_merges_inputs_and_metadata_without_mutating_source() {
     let (value, status) = controller_materialize(AgentTaskControllerMaterializeArgs {
         spec: format!("@{}", spec_path.display()),
         inputs: Some(format!("@{}", inputs_path.display())),
+        policy_results: Vec::new(),
     })
     .expect("materialize spec");
 
@@ -335,6 +336,123 @@ fn controller_materialize_merges_inputs_and_metadata_without_mutating_source() {
     .expect("source spec json");
     assert_eq!(source_after["workflows"][0]["inputs"]["topic"], "existing");
     assert!(source_after["metadata"].get("run_id").is_none());
+}
+
+#[test]
+fn controller_materialize_projects_policy_results_with_provenance() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let spec_path = temp.path().join("repo-loop.json");
+    let policy_path = temp.path().join("policy-result.json");
+    let second_policy_path = temp.path().join("second-policy-result.json");
+    std::fs::write(
+        &spec_path,
+        serde_json::to_string(&json!({
+            "loop_id": "materialize-policy-loop",
+            "workflows": [
+                {
+                    "workflow_id": "brief",
+                    "prompt": "Draft the brief.",
+                    "inputs": { "topic": "existing" }
+                },
+                {
+                    "workflow_id": "build",
+                    "prompt": "Build the site."
+                }
+            ]
+        }))
+        .expect("spec json"),
+    )
+    .expect("write spec");
+    std::fs::write(
+        &policy_path,
+        serde_json::to_string(&json!({
+            "policy_id": "example-policy",
+            "policy_inputs": { "requested_tier": "foundation" },
+            "policy_results": { "selected_tier": "foundation", "decision": "hold" },
+            "provenance": { "source": "fixture", "sha256": "abc123" }
+        }))
+        .expect("policy result json"),
+    )
+    .expect("write policy result");
+    std::fs::write(
+        &second_policy_path,
+        serde_json::to_string(&json!({
+            "policy_id": "second-policy",
+            "policy_results": { "enabled": true },
+            "provenance": { "source": "second-fixture" }
+        }))
+        .expect("policy result json"),
+    )
+    .expect("write second policy result");
+
+    let (value, status) = controller_materialize(AgentTaskControllerMaterializeArgs {
+        spec: format!("@{}", spec_path.display()),
+        inputs: None,
+        policy_results: vec![
+            format!("@{}", policy_path.display()),
+            format!("@{}", second_policy_path.display()),
+        ],
+    })
+    .expect("materialize spec");
+
+    assert_eq!(status, 0);
+    assert_eq!(
+        value["spec"]["workflows"][0]["inputs"]["policy_inputs"]["example-policy"]
+            ["requested_tier"],
+        "foundation"
+    );
+    assert_eq!(
+        value["spec"]["workflows"][1]["inputs"]["policy_results"]["example-policy"]["decision"],
+        "hold"
+    );
+    assert_eq!(
+        value["spec"]["workflows"][1]["inputs"]["policy_results"]["second-policy"]["enabled"],
+        true
+    );
+    assert_eq!(
+        value["spec"]["metadata"]["policy_materialization"]["example-policy"]["provenance"]
+            ["source"],
+        "fixture"
+    );
+    assert_eq!(
+        value["spec"]["metadata"]["policy_materialization"]["second-policy"]["provenance"]
+            ["source"],
+        "second-fixture"
+    );
+}
+
+#[test]
+fn controller_materialize_rejects_non_object_policy_result_fields() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let spec_path = temp.path().join("repo-loop.json");
+    let policy_path = temp.path().join("policy-result.json");
+    std::fs::write(
+        &spec_path,
+        serde_json::to_string(&json!({
+            "loop_id": "materialize-policy-validation-loop",
+            "workflows": [{ "workflow_id": "brief", "prompt": "Draft." }]
+        }))
+        .expect("spec json"),
+    )
+    .expect("write spec");
+    std::fs::write(
+        &policy_path,
+        serde_json::to_string(&json!({
+            "policy_id": "example-policy",
+            "policy_results": "hold"
+        }))
+        .expect("policy result json"),
+    )
+    .expect("write policy result");
+
+    let error = controller_materialize(AgentTaskControllerMaterializeArgs {
+        spec: format!("@{}", spec_path.display()),
+        inputs: None,
+        policy_results: vec![format!("@{}", policy_path.display())],
+    })
+    .expect_err("policy result fields are validated");
+
+    assert!(error.message.contains("policy materialization fields"));
 }
 
 #[test]

--- a/src/core/agent_task_loop_definition.rs
+++ b/src/core/agent_task_loop_definition.rs
@@ -57,6 +57,69 @@ pub struct AgentTaskLoopDefinitionTask {
 pub struct AgentTaskLoopSpecMaterializationRequest<'a> {
     pub spec: &'a AgentTaskRepoLoopSpec,
     pub run_inputs: &'a Value,
+    pub policy_results: &'a [AgentTaskLoopPolicyResultMaterialization],
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskLoopPolicyResultMaterialization {
+    pub policy_id: String,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub policy_inputs: Value,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub policy_results: Value,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub provenance: Value,
+}
+
+impl AgentTaskLoopPolicyResultMaterialization {
+    pub fn from_value(value: Value, source: impl Into<String>) -> Result<Self> {
+        let source = source.into();
+        if !value.is_object() {
+            return Err(Error::validation_invalid_argument(
+                "policy-result",
+                "policy result must be a JSON object",
+                Some(source),
+                None,
+            ));
+        }
+        let result: Self = serde_json::from_value(value).map_err(|error| {
+            Error::validation_invalid_argument(
+                "policy-result",
+                error.to_string(),
+                Some(source.clone()),
+                None,
+            )
+        })?;
+        result.validate(source)?;
+        Ok(result)
+    }
+
+    fn validate(&self, source: String) -> Result<()> {
+        if self.policy_id.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "policy-result.policy_id",
+                "policy_id must not be empty",
+                Some(source),
+                None,
+            ));
+        }
+        validate_optional_policy_object(
+            &self.policy_inputs,
+            "policy-result.policy_inputs",
+            &self.policy_id,
+        )?;
+        validate_optional_policy_object(
+            &self.policy_results,
+            "policy-result.policy_results",
+            &self.policy_id,
+        )?;
+        validate_optional_policy_object(
+            &self.provenance,
+            "policy-result.provenance",
+            &self.policy_id,
+        )?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -93,10 +156,110 @@ pub fn materialize_repo_loop_spec(
         merge_json_objects(&mut spec.metadata, metadata);
     }
 
+    materialize_policy_results(&mut spec, request.policy_results)?;
+
     Ok(AgentTaskLoopSpecMaterialization {
         schema: AGENT_TASK_LOOP_SPEC_MATERIALIZATION_SCHEMA.to_string(),
         spec,
     })
+}
+
+fn materialize_policy_results(
+    spec: &mut AgentTaskRepoLoopSpec,
+    policy_results: &[AgentTaskLoopPolicyResultMaterialization],
+) -> Result<()> {
+    let mut seen = HashSet::new();
+    let mut policy_inputs = serde_json::Map::new();
+    let mut policy_result_values = serde_json::Map::new();
+    let mut policy_materialization = serde_json::Map::new();
+
+    for policy_result in policy_results {
+        if !seen.insert(policy_result.policy_id.clone()) {
+            return Err(Error::validation_invalid_argument(
+                "policy-result.policy_id",
+                format!("duplicate policy_id {}", policy_result.policy_id),
+                Some(spec.loop_id.clone()),
+                None,
+            ));
+        }
+        if !policy_result.policy_inputs.is_null() {
+            policy_inputs.insert(
+                policy_result.policy_id.clone(),
+                policy_result.policy_inputs.clone(),
+            );
+        }
+        if !policy_result.policy_results.is_null() {
+            policy_result_values.insert(
+                policy_result.policy_id.clone(),
+                policy_result.policy_results.clone(),
+            );
+        }
+        policy_materialization.insert(
+            policy_result.policy_id.clone(),
+            policy_result_metadata(policy_result),
+        );
+    }
+
+    let mut workflow_inputs = serde_json::Map::new();
+    if !policy_inputs.is_empty() {
+        workflow_inputs.insert("policy_inputs".to_string(), Value::Object(policy_inputs));
+    }
+    if !policy_result_values.is_empty() {
+        workflow_inputs.insert(
+            "policy_results".to_string(),
+            Value::Object(policy_result_values),
+        );
+    }
+    let workflow_inputs = Value::Object(workflow_inputs);
+    for workflow in &mut spec.workflows {
+        merge_workflow_inputs(&mut workflow.inputs, &workflow_inputs);
+    }
+
+    if !policy_materialization.is_empty() {
+        let mut metadata = serde_json::Map::new();
+        metadata.insert(
+            "policy_materialization".to_string(),
+            Value::Object(policy_materialization),
+        );
+        merge_json_objects(&mut spec.metadata, &Value::Object(metadata));
+    }
+    Ok(())
+}
+
+fn policy_result_metadata(policy_result: &AgentTaskLoopPolicyResultMaterialization) -> Value {
+    let mut envelope = serde_json::Map::new();
+    envelope.insert(
+        "policy_id".to_string(),
+        Value::String(policy_result.policy_id.clone()),
+    );
+    if !policy_result.policy_inputs.is_null() {
+        envelope.insert(
+            "policy_inputs".to_string(),
+            policy_result.policy_inputs.clone(),
+        );
+    }
+    if !policy_result.policy_results.is_null() {
+        envelope.insert(
+            "policy_results".to_string(),
+            policy_result.policy_results.clone(),
+        );
+    }
+    if !policy_result.provenance.is_null() {
+        envelope.insert("provenance".to_string(), policy_result.provenance.clone());
+    }
+    Value::Object(envelope)
+}
+
+fn validate_optional_policy_object(value: &Value, field: &str, policy_id: &str) -> Result<()> {
+    if value.is_null() || value.is_object() {
+        return Ok(());
+    }
+    Err(Error::validation_invalid_argument(
+        field,
+        "policy materialization fields must be JSON objects when present",
+        Some(policy_id.to_string()),
+        None,
+    ))
 }
 
 pub fn compile_loop_definition(definition: AgentTaskLoopDefinition) -> Result<AgentTaskPlan> {


### PR DESCRIPTION
## Summary
- Add repeatable `agent-task controller materialize --policy-result @file` support for generic policy result envelopes.
- Validate `policy_id`, object-shaped `policy_inputs`, `policy_results`, and `provenance`, then project keyed policy inputs/results into every workflow input and preserve the full envelope in metadata.
- Document the generic policy-result contract without adding Homeboy-owned expression, complexity, or randomness semantics.

## WPSG consumption
WPSG can keep evaluating its own complexity/randomness policy in repo code, emit a policy result envelope with a stable `policy_id`, `policy_inputs`, `policy_results`, and `provenance`, then pass it to Homeboy materialization with `--policy-result @policy-result.json`. The materialized loop spec will expose that decision at `workflow.inputs.policy_results.<policy_id>` and retain provenance at `metadata.policy_materialization.<policy_id>`.

## Tests
- `cargo check`
- `cargo test commands::agent_task::tests::controller_materialize`
- `cargo test core::extension::bench::run::tests::attach_memory_timeline_adds_metrics_and_artifacts -- --nocapture`
- `cargo test core::refactor::plan::generate::module_surface::tests::build_uses_snapshot_content_for_module_surfaces -- --nocapture`
- `cargo test` completed with 5100 passed, 2 unrelated failures; both failures passed in isolation.
- `cargo test -- --test-threads=1` passed lib tests, then failed `tests/core_agnostic_test.rs::core_owned_source_stays_language_and_framework_agnostic` on pre-existing `src/core/cleanup/self_artifacts.rs` Cargo-term baseline findings outside this branch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted implementation, tests, documentation updates, and verification notes; Chris reviews and owns the change.