### PR TITLE
Allow controller workflow dependencies outside artifacts

### DIFF
--- a/src/core/agent_task_loop_definition.rs
+++ b/src/core/agent_task_loop_definition.rs
@@ -1079,12 +1079,6 @@ fn validate_repo_loop_artifact_references(spec: &AgentTaskRepoLoopSpec) -> Resul
                     .iter()
                     .map(|artifact_id| ("consumes", artifact_id)),
             )
-            .chain(
-                workflow
-                    .dependencies
-                    .iter()
-                    .map(|artifact_id| ("dependencies", artifact_id)),
-            )
         {
             if !declared.contains(artifact_id.as_str()) {
                 diagnostics.push(format!(


### PR DESCRIPTION
## Summary
- stop validating repo-loop workflow dependencies as artifact references
- preserve artifact validation for workflow artifacts, emits, and consumes

## Verification
- cargo test agent_task_loop_definition --locked
- cargo test agent_task_controller --locked

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the WPSG controller materialization failure and drafted the focused validator fix.
