### PR TITLE
refactor(git): reuse central git helpers

### DIFF
--- a/src/commands/refactor/autofix_commit.rs
+++ b/src/commands/refactor/autofix_commit.rs
@@ -1,7 +1,9 @@
-use std::process::Command;
+use std::path::Path;
 
-const BOT_NAME: &str = "homeboy-ci[bot]";
-const BOT_EMAIL: &str = "266378653+homeboy-ci[bot]@users.noreply.github.com";
+use homeboy::core::git::{
+    configure_identity, execute_git_for_release, parse_git_identity, run_git,
+};
+
 const AUTOFIX_PREFIX: &str = "chore(ci): homeboy autofix";
 
 /// Stage all changes and create a commit after refactor --write.
@@ -10,85 +12,32 @@ pub(super) fn commit_refactor_sources(
     sources: &homeboy::core::refactor::plan::RefactorSourceRun,
     git_identity: Option<&str>,
 ) -> homeboy::core::Result<()> {
-    let add = Command::new("git")
-        .args(["add", "-A"])
-        .current_dir(path)
-        .output()
-        .map_err(|e| homeboy::core::Error::git_command_failed(format!("git add: {e}")))?;
-    if !add.status.success() {
-        let stderr = String::from_utf8_lossy(&add.stderr);
-        return Err(homeboy::core::Error::git_command_failed(format!(
-            "git add -A failed: {stderr}"
-        )));
-    }
+    run_git(Path::new(path), &["add", "-A"], "git add -A")?;
 
     // Check if there's anything staged (fixes may have been no-ops after formatting)
-    let diff_check = Command::new("git")
-        .args(["diff", "--cached", "--quiet"])
-        .current_dir(path)
-        .output()
+    let diff_check = execute_git_for_release(path, &["diff", "--cached", "--quiet"])
         .map_err(|e| homeboy::core::Error::git_command_failed(format!("git diff: {e}")))?;
     if diff_check.status.success() {
         eprintln!("[refactor] No staged changes after git add — skipping commit");
         return Ok(());
     }
 
-    let (name, email) = resolve_git_identity(git_identity);
-
-    for (key, value) in [("user.name", name.as_str()), ("user.email", email.as_str())] {
-        let config = Command::new("git")
-            .args(["config", key, value])
-            .current_dir(path)
-            .output()
-            .map_err(|e| homeboy::core::Error::git_command_failed(format!("git config: {e}")))?;
-        if !config.status.success() {
-            let stderr = String::from_utf8_lossy(&config.stderr);
-            return Err(homeboy::core::Error::git_command_failed(format!(
-                "git config {key} failed: {stderr}"
-            )));
-        }
-    }
+    let identity = parse_git_identity(git_identity);
+    configure_identity(path, &identity)?;
 
     let message = build_autofix_commit_message(sources);
-    let author = format!("{name} <{email}>");
-    let commit = Command::new("git")
-        .args(["commit", "-m", &message, "--author", &author])
-        .current_dir(path)
-        .output()
-        .map_err(|e| homeboy::core::Error::git_command_failed(format!("git commit: {e}")))?;
-    if !commit.status.success() {
-        let stderr = String::from_utf8_lossy(&commit.stderr);
-        return Err(homeboy::core::Error::git_command_failed(format!(
-            "git commit failed: {stderr}"
-        )));
-    }
+    let author = format!("{} <{}>", identity.name, identity.email);
+    run_git(
+        Path::new(path),
+        &["commit", "-m", &message, "--author", &author],
+        "git commit",
+    )?;
 
     eprintln!(
         "[refactor] Committed autofix: {} files changed",
         sources.files_modified
     );
     Ok(())
-}
-
-/// Resolve git identity from the --git-identity flag.
-/// "bot" -> default CI bot. "Name <email>" -> parsed. None -> default bot.
-fn resolve_git_identity(identity: Option<&str>) -> (String, String) {
-    match identity {
-        None | Some("bot") => (BOT_NAME.to_string(), BOT_EMAIL.to_string()),
-        Some(custom) => {
-            if let Some(angle_start) = custom.find('<') {
-                let name = custom[..angle_start].trim().to_string();
-                let email = custom[angle_start + 1..]
-                    .trim_end_matches('>')
-                    .trim()
-                    .to_string();
-                if !name.is_empty() && !email.is_empty() {
-                    return (name, email);
-                }
-            }
-            (custom.to_string(), BOT_EMAIL.to_string())
-        }
-    }
 }
 
 /// Build a structured commit message from refactor results.
@@ -142,38 +91,5 @@ fn build_autofix_commit_message(
         subject
     } else {
         format!("{subject}\n\n{}", body_lines.join("\n"))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn resolve_git_identity_bot_shorthand() {
-        let (name, email) = resolve_git_identity(Some("bot"));
-        assert_eq!(name, BOT_NAME);
-        assert_eq!(email, BOT_EMAIL);
-    }
-
-    #[test]
-    fn resolve_git_identity_none_defaults_to_bot() {
-        let (name, email) = resolve_git_identity(None);
-        assert_eq!(name, BOT_NAME);
-        assert_eq!(email, BOT_EMAIL);
-    }
-
-    #[test]
-    fn resolve_git_identity_custom_parsed() {
-        let (name, email) = resolve_git_identity(Some("My Bot <my-bot@example.com>"));
-        assert_eq!(name, "My Bot");
-        assert_eq!(email, "my-bot@example.com");
-    }
-
-    #[test]
-    fn resolve_git_identity_name_only_uses_bot_email() {
-        let (name, email) = resolve_git_identity(Some("Just A Name"));
-        assert_eq!(name, "Just A Name");
-        assert_eq!(email, BOT_EMAIL);
     }
 }

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -63,9 +63,8 @@ pub use primitives::{
 };
 pub(crate) use primitives::{is_git_repo, list_tracked_markdown_files};
 
+use std::path::Path;
 use std::process::Command;
-
-use crate::core::error::Error;
 
 fn execute_git(path: &str, args: &[&str]) -> std::io::Result<std::process::Output> {
     Command::new("git").args(args).current_dir(path).output()
@@ -118,14 +117,11 @@ pub fn configure_identity(path: &str, identity: &GitIdentity) -> crate::core::er
         ("user.name", identity.name.as_str()),
         ("user.email", identity.email.as_str()),
     ] {
-        let output = execute_git(path, &["config", key, value])
-            .map_err(|e| Error::git_command_failed(format!("git config {key}: {e}")))?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(Error::git_command_failed(format!(
-                "git config {key} failed: {stderr}"
-            )));
-        }
+        run_git(
+            Path::new(path),
+            &["config", key, value],
+            &format!("git config {key}"),
+        )?;
     }
     Ok(())
 }

--- a/src/core/git/operations.rs
+++ b/src/core/git/operations.rs
@@ -1,13 +1,12 @@
 use serde::{Deserialize, Serialize};
 use std::path::Path;
-use std::process::Command;
 
 use crate::core::config::read_json_spec_to_string;
 use crate::core::error::{Error, Result};
 use crate::core::output::BulkResult;
 
 use super::operation_output::{run_bulk_ids, GitOutput};
-use super::primitives::is_git_repo;
+use super::primitives::{is_git_repo, run_git, short_head_revision};
 use super::{execute_git, resolve_target};
 
 #[derive(Debug, Clone, Serialize)]
@@ -43,15 +42,13 @@ pub fn get_repo_snapshot(path: &str) -> Result<RepoSnapshot> {
         "git branch",
     )?;
 
-    // Use direct Command to properly handle empty output (clean repo).
-    // run_in_optional returns None for empty stdout, which would incorrectly
-    // indicate a dirty repo when used with .unwrap_or(false).
-    let clean = Command::new("git")
-        .args(["status", "--porcelain=v1"])
-        .current_dir(path)
-        .output()
-        .map(|o| o.status.success() && o.stdout.is_empty())
-        .unwrap_or(false);
+    let clean = run_git(
+        Path::new(path),
+        &["status", "--porcelain=v1"],
+        "git status --porcelain",
+    )
+    .map(|output| output.is_empty())
+    .unwrap_or(false);
 
     let (ahead, behind) = crate::core::engine::command::run_in_optional(
         path,
@@ -488,18 +485,7 @@ pub fn delete_remote_tag(path: &str, tag_name: &str) -> Result<GitOutput> {
 
 /// Get the current HEAD short commit SHA, returning `None` outside git checkouts.
 pub fn short_head_revision_at(path: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .current_dir(path)
-        .stdin(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let revision = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    (!revision.is_empty()).then_some(revision)
+    short_head_revision(path)
 }
 
 /// Fetch from remote and return count of commits behind upstream.
@@ -572,6 +558,7 @@ pub fn fetch_and_fast_forward(path: &str) -> Result<Option<u32>> {
 #[cfg(test)]
 mod is_ancestor_tests {
     use super::*;
+    use std::process::Command;
 
     fn run_in(dir: &std::path::Path, args: &[&str]) {
         let output = Command::new(args[0])

--- a/src/core/runner/origin_refs.rs
+++ b/src/core/runner/origin_refs.rs
@@ -1,7 +1,6 @@
-use std::path::Path;
-use std::process::Command;
-
 use crate::core::error::{Error, Result};
+use crate::core::git::run_git;
+use std::path::Path;
 
 pub(super) fn advertised_origin_refs_for_commit(
     path: &Path,
@@ -11,25 +10,25 @@ pub(super) fn advertised_origin_refs_for_commit(
     error_id: String,
     error_hints: Vec<String>,
 ) -> Result<Vec<String>> {
-    let output = Command::new("git")
-        .args(["ls-remote", "origin"])
-        .current_dir(path)
-        .output()
-        .map_err(|err| {
-            Error::internal_io(err.to_string(), Some("run git ls-remote".to_string()))
+    let stdout =
+        run_git(path, &["ls-remote", "origin"], "git ls-remote origin").map_err(|err| {
+            let mut hints = err
+                .details
+                .get("stderr")
+                .and_then(|value| value.as_str())
+                .filter(|value| !value.is_empty())
+                .map(|value| vec![value.to_string()])
+                .unwrap_or_default();
+            hints.extend(error_hints);
+            Error::validation_invalid_argument(
+                error_field,
+                error_message,
+                Some(error_id),
+                Some(hints),
+            )
         })?;
-    if !output.status.success() {
-        let mut hints = vec![String::from_utf8_lossy(&output.stderr).trim().to_string()];
-        hints.extend(error_hints);
-        return Err(Error::validation_invalid_argument(
-            error_field,
-            error_message,
-            Some(error_id),
-            Some(hints),
-        ));
-    }
 
-    Ok(String::from_utf8_lossy(&output.stdout)
+    Ok(stdout
         .lines()
         .filter_map(|line| {
             let (sha, git_ref) = line.split_once('\t')?;


### PR DESCRIPTION
## Summary
- Route refactor autofix git staging/config/commit through existing git helpers.
- Reuse central git identity parsing/configuration.
- Route selected direct git query call sites through existing primitives.

## Verification
- `cargo fmt --check`
- `cargo test core::git`
- `cargo test origin_refs`
- `cargo check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the helper reuse cleanup and ran targeted verification; Chris remains responsible for review and merge.