### PR TITLE
docs: clarify command surface helpers

### DIFF
--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -12,6 +12,11 @@ Manage project API secrets in the OS keychain.
 
 Secrets are scoped by project ID and variable name. `source: "keychain"` API variables use service `homeboy` and account `<project-id>:<variable-name>`.
 
+Generic HTTP auth profiles are separate reusable keychain entries for commands
+that accept `--auth-profile <profile>`. They are managed under `homeboy auth
+profile` and can store Basic auth credentials or Bearer tokens without embedding
+secrets in shell history.
+
 ## Subcommands
 
 ### `login`
@@ -70,6 +75,23 @@ homeboy auth status --project <project_id>
 
 Reports whether configured auth variables are available without printing secret values.
 
+### `profile`
+
+```sh
+homeboy auth profile set-basic <profile> [--username <username>] [--password <password>]
+homeboy auth profile set-bearer <profile> [--token <token>]
+homeboy auth profile status <profile>
+homeboy auth profile remove <profile>
+```
+
+Manages reusable auth profiles for generic HTTP requests. Omit secret values to
+prompt securely instead of passing them on the command line.
+
+- `set-basic`: store a username/password profile.
+- `set-bearer`: store a bearer token profile.
+- `status`: report whether the profile exists without printing the secret.
+- `remove`: delete the stored profile.
+
 ## Output
 
 JSON output is wrapped in the global envelope.
@@ -82,8 +104,12 @@ JSON output is wrapped in the global envelope.
 - `{ "command": "remove", "project_id": "...", "variable": "token", "removed": true }`
 - `{ "command": "logout", "project_id": "...", "removed": 1 }`
 - `{ "command": "status", "project_id": "...", "authenticated": true, "variables": [...] }`
+- `{ "profile": "...", "kind": "basic", "stored": true }`
+- `{ "profile": "...", "available": true, "kind": "bearer" }`
+- `{ "profile": "...", "removed": 3 }`
 
-Note: `command` is a tagged enum value, and fields use snake_case (`project_id`).
+Note: project-scoped auth outputs include a `command` field. Auth profile outputs
+use the profile result structs directly. Fields use snake_case (`project_id`).
 
 ## Related
 

--- a/docs/commands/lab.md
+++ b/docs/commands/lab.md
@@ -74,10 +74,10 @@ runner Homeboy command before remote execution starts. Legacy
 `lab.self_command_prefix` values in `homeboy.json` are ignored and are not
 preserved by portable config rewrites.
 
-`homeboy lab bench` delegates to the same benchmark path while making the Lab
-intent explicit at the command surface. Its output includes the same managed
-follow-up hints so the operator can keep a failed bench inside the Homeboy
-workflow.
+`homeboy lab bench` is a routing helper, not a benchmark executor. It prints the
+equivalent `homeboy bench ...` command plus the same managed follow-up hints so
+the operator can run the benchmark through the normal benchmark pipeline and keep
+failed follow-up work inside the Homeboy workflow.
 
 `homeboy lab extension-sync` updates a Lab runner's installed extension through
 the runner API. Use it to pin a runner-side runtime dependency, such as the
@@ -101,8 +101,8 @@ debugging.
 ## Commands
 
 - `status`: Show configured Lab runners and benchmark routing guidance.
-- `bench`: Run a benchmark through the standard benchmark pipeline with Lab
-  routing intent.
+- `bench`: Print the standard `homeboy bench ...` command for the provided
+  arguments with Lab routing guidance and managed follow-up commands.
 - `extension-sync`: Install or replace a Lab runner extension from a source and
   ref. Successful output returns the runner id, runner `homeboy_path`, install
   command, and remote execution output; failures surface the runner-side root

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -10,7 +10,9 @@ homeboy list
 
 `homeboy list` is a convenience command that prints the same help text as `homeboy --help`.
 
-This command exists as a convenience entrypoint (for example when you want a quick command list without remembering `--help`).
+This command is retained as a compatibility alias for existing operators and scripts. Prefer `homeboy --help` for new usage.
+
+`homeboy list` is intentionally raw help output rather than a structured command surface API.
 
 ## Output
 

--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -1,6 +1,6 @@
 # Runs Command
 
-Inspect persisted observation-store runs and artifacts.
+Inspect and maintain persisted observation-store runs and artifacts.
 
 ## Synopsis
 
@@ -12,7 +12,9 @@ homeboy runs show <run-id>
 homeboy runs resume-plan <run-id>
 homeboy runs artifacts <run-id>
 homeboy runs refs [--kind bench] [--component <id>] [--rig <id>] [--status <status>] [--since 24h] [--artifact-kind <kind>] [--aggregate-artifact-kind <kind>]
+homeboy runs artifact get <run-id> <artifact-id> [--output <path>]
 homeboy runs artifact cleanup-downloads [--runner <runner-id>] [--run-id <run-id>] [--apply]
+homeboy runs artifact cleanup-persisted [--older-than-days <days>] [--run-id <run-id>] [--apply]
 homeboy runs export --run <run-id> --output <dir>
 homeboy runs export --since <duration> --output <dir>
 homeboy runs import <dir>
@@ -22,7 +24,7 @@ homeboy runs import --from-gh-actions --component <id> --repo <owner/repo> --run
 
 ## Description
 
-`homeboy runs` is a read-only query surface over Homeboy's local observation store. Producers such as `bench`, `rig`, and `trace` write run and artifact records; this command lets humans and agents inspect that evidence without opening SQLite directly.
+`homeboy runs` is the inspection and maintenance surface for Homeboy's local observation store. Producers such as `bench`, `rig`, and `trace` write run and artifact records; this command lets humans and agents inspect that evidence without opening SQLite directly, export/import portable bundles, and run explicit cleanup or reconciliation tasks.
 
 `homeboy runs list --runner <runner-id>` queries a connected runner daemon instead of the local observation store, preserving the normal `runs.list` JSON payload while returning evidence from the runner machine.
 
@@ -40,6 +42,10 @@ homeboy --output json runs refs --kind trace --component gutenberg --aggregate-a
 `homeboy runs evidence <run-id>` emits reviewer-facing evidence using generic artifact addresses. Local operator files are represented as non-reviewer-visible `homeboy://run/<run-id>/artifact/<artifact-id>` handles with a fetch command instead of absolute machine paths. Remote runner artifacts use `runner-artifact://...` refs, validated public HTTP(S) URLs are emitted as public evidence links, and metadata-only evidence remains non-public. Lab-specific publication or mirroring policy belongs in runner/extension enrichment, not in the generic evidence serializer.
 
 `homeboy runs artifact cleanup-downloads` plans cleanup for local runner artifact downloads under Homeboy's artifact root (`<artifact-root>/runner`). By default it is a dry run; pass `--apply` to remove the planned cache subtree. Use `--runner` and `--run-id` to narrow cleanup to a specific runner or run cache.
+
+`homeboy runs artifact cleanup-persisted` plans cleanup for persisted local run artifacts and their database records. By default it is a dry run; pass `--apply` to delete planned artifact files/directories and remove their database rows.
+
+`homeboy runs reconcile` marks orphaned `running` observation records stale. Treat it as a mutating maintenance command, not a reader.
 
 `homeboy runs distribution` aggregates categorical values from dot-separated JSON metadata paths. Scalar string, number, and boolean values are counted directly; arrays are flattened and counted by scalar element. The output reports inspected runs, matched/missing runs per field, total and unique value counts, value percentages, and repeated values.
 
@@ -89,11 +95,26 @@ The v1 bundle is metadata-only: artifact records are exported, but artifact file
 
 `homeboy runs import` is idempotent. Existing identical records are accepted, while conflicting records with the same primary key fail clearly.
 
+`homeboy runs export` writes a directory bundle. `homeboy runs import` mutates the local observation store by inserting the bundle's records when they are new or identical.
+
 ## GitHub Actions Artifacts
 
 `homeboy runs import --from-gh-actions` imports JSON files from matching GitHub Actions artifacts into the local observation store. Use `--workflow` to scan recent workflow runs, or `--run-id` when triage starts from an exact GitHub Actions run URL or ID and the workflow filename is irrelevant.
 
 The structured output includes stable Homeboy run/artifact IDs and persisted local artifact paths under `artifacts[]`, so agents can read the copied JSON directly without searching temporary download directories.
+
+## Mutating Subcommands
+
+Most `homeboy runs` subcommands are readers. These subcommands write files,
+delete files, or update the local observation store:
+
+- `artifact get`: copies a recorded file artifact to a local destination.
+- `artifact cleanup-downloads --apply`: deletes locally cached runner artifact downloads.
+- `artifact cleanup-persisted --apply`: deletes persisted local artifact files/directories and their database records.
+- `export`: writes an observation bundle directory.
+- `import`: inserts observation bundle or GitHub Actions artifact records into the local observation store.
+- `loop-sync`: syncs continuous-loop archive directories into observation artifacts.
+- `reconcile`: marks orphaned running records stale.
 
 ```bash
 homeboy runs import --from-gh-actions \

--- a/docs/commands/self.md
+++ b/docs/commands/self.md
@@ -11,6 +11,41 @@ homeboy self <COMMAND>
 ## Subcommands
 
 - `status` — report the active binary, version, and install/update signals
+- `identity` — report the active binary build identity without external probes
+- `cleanup-runtime-tmp` — plan or delete orphaned Homeboy runtime temp entries
+
+### `status`
+
+```sh
+homeboy self status
+```
+
+Reports active binary location, version, build identity, and nearby install or
+update signals.
+
+### `identity`
+
+```sh
+homeboy self identity
+```
+
+Returns the current binary build identity directly from the running executable.
+Use this when a runner or daemon freshness check needs a cheap local identity
+without probing surrounding install state.
+
+### `cleanup-runtime-tmp`
+
+```sh
+homeboy self cleanup-runtime-tmp [--older-than-days <days>] [--prefix <prefix>] [--limit <n>] [--apply]
+```
+
+Plans cleanup for orphaned Homeboy runtime temp entries. Without `--apply`, this
+is a dry run. Pass `--apply` to delete the planned entries.
+
+- `--older-than-days <days>`: only include entries older than this many days; defaults to `7`.
+- `--prefix <prefix>`: only include entries whose file or directory name starts with the prefix.
+- `--limit <n>`: maximum temp entries to inspect; defaults to `1000`.
+- `--apply`: delete planned entries instead of only reporting the plan.
 
 ## Related
 

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -202,6 +202,60 @@ fn runner_env_rejects_legacy_show_values_flag() {
 }
 
 #[test]
+fn docs_cover_focused_command_surface_cleanup_targets() {
+    let auth = include_str!("../docs/commands/auth.md");
+    assert!(auth.contains("`profile`"));
+    assert!(auth.contains("set-basic"));
+    assert!(auth.contains("set-bearer"));
+
+    let self_docs = include_str!("../docs/commands/self.md");
+    assert!(self_docs.contains("`identity`"));
+    assert!(self_docs.contains("`cleanup-runtime-tmp`"));
+    assert!(self_docs.contains("--older-than-days"));
+    assert!(self_docs.contains("--apply"));
+
+    let lab = include_str!("../docs/commands/lab.md");
+    assert!(lab.contains("routing helper, not a benchmark executor"));
+
+    let runs = include_str!("../docs/commands/runs.md");
+    assert!(runs.contains("## Mutating Subcommands"));
+    assert!(runs.contains("artifact cleanup-persisted"));
+    assert!(runs.contains("`reconcile`"));
+
+    let list = include_str!("../docs/commands/list.md");
+    assert!(list.contains("compatibility alias"));
+    assert!(list.contains("Prefer `homeboy --help`"));
+
+    for args in [
+        ["homeboy", "auth", "profile", "set-basic", "dev"].as_slice(),
+        ["homeboy", "auth", "profile", "set-bearer", "dev"].as_slice(),
+        ["homeboy", "self", "identity"].as_slice(),
+        [
+            "homeboy",
+            "self",
+            "cleanup-runtime-tmp",
+            "--older-than-days",
+            "14",
+        ]
+        .as_slice(),
+        ["homeboy", "runs", "artifact", "get", "run-1", "artifact-1"].as_slice(),
+        [
+            "homeboy",
+            "runs",
+            "artifact",
+            "cleanup-persisted",
+            "--older-than-days",
+            "30",
+        ]
+        .as_slice(),
+    ] {
+        Cli::try_parse_from(args).unwrap_or_else(|error| {
+            panic!("documented cleanup target failed to parse: {args:?}\n{error}")
+        });
+    }
+}
+
+#[test]
 fn agent_task_auth_status_accepts_global_runner_and_secret_env() {
     Cli::try_parse_from([
         "homeboy",


### PR DESCRIPTION
## Summary
- Document `auth profile`, `self identity`, and `self cleanup-runtime-tmp`.
- Clarify that `lab bench` prints a routed benchmark command rather than executing the benchmark.
- Clarify mutating `runs` subcommands and compatibility status of `homeboy list`.
- Add targeted docs/parse parity coverage for these surfaces.

## Verification
- `cargo fmt --check`
- `cargo test --test command_surface_test`
- `cargo test cli_surface::tests --lib`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the documentation/test updates, resolved current-main conflicts, and ran targeted verification; Chris remains responsible for review and merge.