### PR TITLE
perf(runs): reduce artifact IO overhead

### DIFF
--- a/src/commands/runs/common.rs
+++ b/src/commands/runs/common.rs
@@ -5,7 +5,7 @@
 //! `query`/`drift` to project JSON over imported run artifacts).
 
 use std::collections::BTreeMap;
-use std::fs;
+use std::fs::File;
 use std::path::Path;
 use std::time::Duration;
 
@@ -238,8 +238,8 @@ pub fn load_artifact_rows(
                 continue;
             }
             let path = Path::new(&artifact.path);
-            let raw = match fs::read_to_string(path) {
-                Ok(raw) => raw,
+            let file = match File::open(path) {
+                Ok(file) => file,
                 Err(_) => {
                     skipped.push(skipped_artifact(
                         &run,
@@ -249,13 +249,24 @@ pub fn load_artifact_rows(
                     continue;
                 }
             };
-            let Ok(json) = serde_json::from_str::<Value>(&raw) else {
-                skipped.push(skipped_artifact(
-                    &run,
-                    &artifact,
-                    "artifact file is not valid JSON",
-                ));
-                continue;
+            let json = match serde_json::from_reader::<_, Value>(file) {
+                Ok(json) => json,
+                Err(err) if err.is_io() => {
+                    skipped.push(skipped_artifact(
+                        &run,
+                        &artifact,
+                        "artifact file is missing or unreadable",
+                    ));
+                    continue;
+                }
+                Err(_) => {
+                    skipped.push(skipped_artifact(
+                        &run,
+                        &artifact,
+                        "artifact file is not valid JSON",
+                    ));
+                    continue;
+                }
             };
             rows.push(ArtifactJsonRow {
                 run: run.clone(),

--- a/src/core/artifact_metadata.rs
+++ b/src/core/artifact_metadata.rs
@@ -1,15 +1,30 @@
 use crate::core::error::{Error, Result};
 use sha2::{Digest, Sha256};
+use std::io::Read;
 use std::path::Path;
 
 pub(crate) fn sha256_file(path: &Path) -> Result<String> {
-    let bytes = std::fs::read(path).map_err(|e| {
+    let mut file = std::fs::File::open(path).map_err(|e| {
         Error::internal_io(
             e.to_string(),
-            Some(format!("read artifact bytes {}", path.display())),
+            Some(format!("open artifact bytes {}", path.display())),
         )
     })?;
-    Ok(format!("{:x}", Sha256::digest(&bytes)))
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer).map_err(|e| {
+            Error::internal_io(
+                e.to_string(),
+                Some(format!("read artifact bytes {}", path.display())),
+            )
+        })?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 pub(crate) fn content_type_from_path(path: &Path) -> Option<String> {

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -518,15 +518,11 @@ impl ObservationStore {
             )
         })?;
 
-        let artifact = self
-            .list_artifacts(run_id)?
-            .into_iter()
-            .find(|artifact| artifact.id == id)
-            .ok_or_else(|| {
-                Error::internal_unexpected(format!(
-                    "Inserted artifact record {id} but could not read it back"
-                ))
-            })?;
+        let artifact = self.get_artifact(&id)?.ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "Inserted artifact record {id} but could not read it back"
+            ))
+        })?;
         crate::core::publication_artifacts::index_published_artifact_refs(
             self,
             &artifact,
@@ -617,14 +613,11 @@ impl ObservationStore {
             )
         })?;
 
-        self.list_artifacts(run_id)?
-            .into_iter()
-            .find(|artifact| artifact.id == id)
-            .ok_or_else(|| {
-                Error::internal_unexpected(format!(
-                    "Inserted directory artifact record {id} but could not read it back"
-                ))
-            })
+        self.get_artifact(&id)?.ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "Inserted directory artifact record {id} but could not read it back"
+            ))
+        })
     }
 
     pub fn record_url_artifact(
@@ -680,14 +673,11 @@ impl ObservationStore {
             )
         })?;
 
-        self.list_artifacts(run_id)?
-            .into_iter()
-            .find(|artifact| artifact.id == id)
-            .ok_or_else(|| {
-                Error::internal_unexpected(format!(
-                    "Inserted artifact record {id} but could not read it back"
-                ))
-            })
+        self.get_artifact(&id)?.ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "Inserted artifact record {id} but could not read it back"
+            ))
+        })
     }
 
     pub fn list_artifacts(&self, run_id: &str) -> Result<Vec<ArtifactRecord>> {
@@ -784,24 +774,26 @@ impl ObservationStore {
     ) -> Result<Option<ArtifactRecord>> {
         validate_required("run_id", run_id)?;
         validate_required("artifact_token", artifact_token)?;
-        for artifact in self.list_artifacts(run_id)? {
-            if artifact.id == artifact_token
-                || artifact.kind == artifact_token
-                || artifact
-                    .metadata_json
-                    .get("name")
-                    .and_then(serde_json::Value::as_str)
-                    .is_some_and(|value| value == artifact_token)
-                || artifact
-                    .metadata_json
-                    .get("original_manifest_id")
-                    .and_then(serde_json::Value::as_str)
-                    .is_some_and(|value| value == artifact_token)
-            {
-                return Ok(Some(artifact));
-            }
-        }
-        Ok(None)
+        self.connection
+            .query_row(
+                r#"
+                SELECT id, run_id, kind, artifact_type, path, sha256, size_bytes, mime, metadata_json, created_at
+                FROM artifacts
+                WHERE run_id = ?1
+                  AND (
+                    id = ?2
+                    OR kind = ?2
+                    OR json_extract(metadata_json, '$.name') = ?2
+                    OR json_extract(metadata_json, '$.original_manifest_id') = ?2
+                  )
+                ORDER BY created_at ASC
+                LIMIT 1
+                "#,
+                params![run_id, artifact_token],
+                row_to_artifact_record,
+            )
+            .optional()
+            .map_err(sqlite_error("read artifact record for run token"))
     }
 
     pub fn list_artifact_cleanup_candidates(


### PR DESCRIPTION
## Summary
- Replace post-insert artifact list scans with direct artifact lookups.
- Resolve run artifact tokens with a targeted SQL query instead of loading every artifact for the run.
- Stream artifact hashing and JSON loading to avoid buffering full artifact files in memory.

## Verification
- git status --short --branch
- git diff --stat origin/main...HEAD
- git diff --check origin/main...HEAD
- Static source inspection of the touched observation artifact-store paths.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation/static verification.