### PR TITLE
refactor(lab): reuse contract support copy

### DIFF
--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 use std::process::Stdio;
 use std::time::Duration;
 
-use crate::command_contract::lab::{lab_runner_unsupported_hint, lab_runner_unsupported_message};
+use crate::command_contract::{lab_runner_unsupported_hint, lab_runner_unsupported_message};
 use crate::core::{Error, Result};
 
 use super::{

--- a/src/core/runner/lab_selection.rs
+++ b/src/core/runner/lab_selection.rs
@@ -2,6 +2,7 @@ use std::io::Read;
 use std::process::Stdio;
 use std::time::Duration;
 
+use crate::command_contract::lab::{lab_runner_unsupported_hint, lab_runner_unsupported_message};
 use crate::core::{Error, Result};
 
 use super::{
@@ -352,15 +353,16 @@ pub(super) fn resolve_lab_runner_selection_from_default(
 ) -> Result<Option<LabRunnerSelection>> {
     if let Some(runner_id) = explicit_runner {
         if !command.portable {
-            let message = command.unsupported_reason.map_or_else(
-                || "--runner is only supported for hot Lab-offload commands: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, lint, test, audit, bench, trace, refactor source runs, and tunnel preview-consumer run".to_string(),
-                |reason| format!("--runner is unavailable for this hot command. {reason}"),
-            );
+            let message = command
+                .unsupported_reason
+                .map_or_else(lab_runner_unsupported_message, |reason| {
+                    format!("--runner is unavailable for this hot command. {reason}")
+                });
             return Err(Error::validation_invalid_argument(
                 "runner",
                 message,
                 Some(runner_id.to_string()),
-                Some(vec!["Current Lab offload support: agent-task dispatch/cook/loop/run-plan, agent-task retry --run, agent-task status/logs/artifacts/review/providers, agent-task auth status, audit, bench run, full lint, full test, trace, refactor source runs, and tunnel preview-consumer run.".to_string()]),
+                Some(vec![lab_runner_unsupported_hint()]),
             ));
         }
 


### PR DESCRIPTION
## Summary
- Reuse the command-contract Lab support message/hint in runner selection instead of duplicating stale hard-coded copy.
- Keeps unsupported command-specific reasons unchanged while centralizing the portable Lab support summary.

## Verification
- rustfmt --check src/core/runner/lab_selection.rs
- git diff --check
- grep for stale hard-coded Lab support copy in src/**/*.rs
- Did not run local cargo commands per instruction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation/static verification