### PR TITLE
docs: clarify triage watch mutability

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,8 +332,9 @@ jobs:
 ### Dependencies And Attention
 
 `homeboy deps` inspects and updates component dependencies. `homeboy triage`
-gathers read-only attention reports across components, projects, fleets, rigs,
-or the whole workspace.
+gathers attention reports across components, projects, fleets, rigs, or the
+whole workspace. Snapshot report mode is read-only; watch mode only mutates
+GitHub when `--auto-merge` is explicitly passed.
 
 ```bash
 homeboy deps status my-project

--- a/docs/cli/homeboy-root-command.md
+++ b/docs/cli/homeboy-root-command.md
@@ -49,3 +49,8 @@ explain why `--runner` is unavailable.
 ## Subcommands
 
 See the full list of supported subcommands in the [Commands index](../commands/commands-index.md).
+
+## Hidden Compatibility Aliases
+
+`homeboy list` remains accepted as a hidden, deprecated alias for top-level help.
+It is omitted from normal help and the commands index; prefer `homeboy --help`.

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -47,7 +47,7 @@
 - [status](status.md) — actionable component overview
 - [test](test.md)
 - [trace](trace.md) — black-box behavioral trace and evidence capture
-- [triage](triage.md) — read-only attention report across components, projects, fleets, and rigs
+- [triage](triage.md) — attention reports and watch utilities across components, projects, fleets, and rigs
 - [tunnel](tunnel.md) — private service tunnel declarations
 - [undo](undo.md) — restore or manage write-operation snapshots
 - [upgrade](upgrade.md)

--- a/docs/commands/triage.md
+++ b/docs/commands/triage.md
@@ -1,9 +1,10 @@
 # `homeboy triage`
 
 Produce an attention report for components, projects, fleets, rigs, or the full configured workspace.
-GitHub access is read-only; each run also records a local observation in the
+Snapshot report mode reads GitHub state and records a local observation in the
 Homeboy SQLite database so later runs can compare against the previous
-observation for the same target.
+observation for the same target. Watch mode is also read-only unless
+`--auto-merge` is explicitly passed.
 
 `triage` is the reference consumer of Homeboy's shared scope model: it accepts
 component, project/target, fleet, rig, workspace, and direct path scopes, then

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -90,7 +90,7 @@ pub enum Commands {
     Fleet(fleet::FleetArgs),
     /// Remote log viewing
     Logs(logs::LogsArgs),
-    /// Read-only attention report for components, projects, fleets, and rigs
+    /// Attention reports and watch utilities for components, projects, fleets, and rigs
     Triage(triage::TriageArgs),
     /// Deploy components to remote server
     Deploy(deploy::DeployArgs),


### PR DESCRIPTION
## Summary
- Clarify that triage snapshot report mode is read-only, while watch mode only mutates GitHub when --auto-merge is explicitly passed.
- Update the command index and CLI help description so triage is not advertised as purely read-only.
- Document the hidden deprecated homeboy list compatibility alias in root command docs without adding it to the normal command index.

## Verification
- git diff --check
- Static review of the focused diff
- Local cargo commands intentionally not run per request.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation/static verification