### PR TITLE
docs: document hidden agent-task tool bridge

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -36,6 +36,13 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `auth` | Configure and inspect provider authentication secrets. |
 | `controller` | Create, inspect, and resume durable multi-agent loop controller state. |
 
+## Internal Bridge
+
+`agent-task tool` is a hidden provider-runtime bridge. It remains parseable for
+runtime adapters that dispatch tool requests through Homeboy, but it is omitted
+from `homeboy agent-task --help` and the visible command surface because it is
+not an operator-facing workflow.
+
 ## Controller Events
 
 `agent-task controller events` is the stable generic primitive for applying an

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -50,6 +50,19 @@ fn includes_first_level_subcommands() {
 }
 
 #[test]
+fn agent_task_tool_bridge_stays_hidden_but_parseable() {
+    let surface = current_command_surface();
+
+    assert!(!surface.contains_path(&["agent-task", "tool"]));
+    Cli::try_parse_from(["homeboy", "agent-task", "tool", "dispatch"])
+        .expect("hidden agent-task tool bridge should stay parseable for runtimes");
+
+    let docs = include_str!("../docs/commands/agent-task.md");
+    assert!(docs.contains("## Internal Bridge"));
+    assert!(docs.contains("hidden provider-runtime bridge"));
+}
+
+#[test]
 fn includes_second_level_subcommands() {
     let surface = current_command_surface();
 


### PR DESCRIPTION
## Summary
- Document the hidden `agent-task tool` provider-runtime bridge near the public agent-task command surface.
- Add a command-surface test proving the bridge remains parseable for runtimes while staying absent from the visible command surface.

## Verification
- `git diff --check`
- `git diff --check origin/main...HEAD`
- Static diff/log/status inspection only; local Cargo commands were intentionally not run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation/static verification