### PR TITLE
feat(upgrade): restart declared resident services after binary swap

### DIFF
--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -27,6 +27,11 @@ pub struct UpgradeArgs {
     #[arg(long)]
     pub skip_runners: bool,
 
+    /// Skip restarting declared binary-resident services after the binary swap.
+    /// They will be reported as pending with their recovery commands instead.
+    #[arg(long)]
+    pub no_restart_services: bool,
+
     /// Upgrade only the named configured runner. Repeat to target multiple runners.
     #[arg(long = "upgrade-runner", value_name = "RUNNER_ID")]
     pub runners: Vec<String>,
@@ -73,6 +78,7 @@ pub fn run(args: UpgradeArgs, _global: &GlobalArgs) -> CmdResult<Value> {
         method_override,
         args.skip_extensions,
         args.skip_runners,
+        args.no_restart_services,
         &args.runners,
         args.source_path.as_deref(),
     )?;
@@ -185,6 +191,8 @@ mod tests {
             runners_updated: Vec::new(),
             runners_skipped: Vec::new(),
             extensions_unrefreshed: Vec::new(),
+            services_restarted: Vec::new(),
+            services_pending_restart: Vec::new(),
         }
     }
 }

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -56,6 +56,42 @@ pub struct HomeboyConfig {
     /// or set HOMEBOY_NO_UPDATE_CHECK=1.
     #[serde(default = "default_true")]
     pub update_check: bool,
+
+    /// Long-running services that keep an in-memory copy of the Homeboy binary
+    /// resident and therefore must be restarted after `homeboy upgrade` swaps
+    /// the on-disk binary. These are declared per host/environment in config —
+    /// core ships none by default and hardcodes no service name, unit, or host.
+    ///
+    /// `homeboy upgrade` restarts each declared service after a successful
+    /// binary swap (unless `--no-restart-services` is passed) and reports the
+    /// outcome via `services_restarted` / `services_pending_restart`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resident_services: Vec<ResidentServiceConfig>,
+}
+
+/// A long-running, binary-resident service that must be restarted to pick up a
+/// newly-swapped Homeboy binary.
+///
+/// Intentionally generic and config-driven: a descriptor either names a
+/// `systemd_unit` (restarted with `systemctl restart <unit>`) or supplies an
+/// explicit `restart_command` shell line. No service name, unit, or host is
+/// hardcoded in core — every value comes from the host's own config, keeping
+/// the upgrade flow org/host-agnostic (see #5118).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResidentServiceConfig {
+    /// Stable identifier for the service, used in upgrade result reporting.
+    pub id: String,
+
+    /// systemd unit name (e.g. `homeboy-preview-ingress`). When set and no
+    /// `restart_command` is given, the service is restarted with
+    /// `systemctl restart <unit>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub systemd_unit: Option<String>,
+
+    /// Explicit restart command (shell line) overriding the systemd default.
+    /// Use this for non-systemd supervisors or custom restart logic.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub restart_command: Option<String>,
 }
 
 impl Default for HomeboyConfig {
@@ -70,6 +106,7 @@ impl Default for HomeboyConfig {
             release_gate: ReleaseGateConfig::default(),
             artifact_root: None,
             update_check: true,
+            resident_services: Vec::new(),
         }
     }
 }

--- a/src/core/upgrade/helpers.rs
+++ b/src/core/upgrade/helpers.rs
@@ -8,6 +8,7 @@ use super::constants::{CRATES_IO_API, GITHUB_RELEASES_API, VERSION};
 use super::execution::{execute_upgrade, resolve_source_workspace};
 use super::planning::resolve_binary_on_path;
 use super::runners;
+use super::services;
 use super::types::*;
 use super::validation::check_for_updates;
 
@@ -154,11 +155,13 @@ pub(crate) fn version_is_newer(latest: &str, current: &str) -> bool {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run_upgrade_with_method(
     force: bool,
     method_override: Option<InstallMethod>,
     skip_extensions: bool,
     skip_runners: bool,
+    skip_services: bool,
     runner_targets: &[String],
     source_path: Option<&Path>,
 ) -> Result<UpgradeResult> {
@@ -219,6 +222,10 @@ pub fn run_upgrade_with_method(
                 extensions_skipped,
                 runners_updated,
                 runners_skipped,
+                // No binary swap happened, so resident services already run the
+                // current binary and need no restart.
+                services_restarted: Vec::new(),
+                services_pending_restart: Vec::new(),
             });
         }
     }
@@ -253,6 +260,13 @@ pub fn run_upgrade_with_method(
         (vec![], vec![])
     };
 
+    // After a verified binary swap, long-running services still hold the old
+    // binary in memory until restarted. Restart each declared resident service
+    // (config-driven; nothing is hardcoded in core) unless restarts were
+    // skipped, in which case report each as pending with its recovery command.
+    let (services_restarted, services_pending_restart) =
+        restart_resident_services_after_swap(success, skip_services);
+
     Ok(UpgradeResult {
         command: "upgrade".to_string(),
         install_method,
@@ -285,7 +299,74 @@ pub fn run_upgrade_with_method(
         extensions_skipped,
         runners_updated,
         runners_skipped,
+        services_restarted,
+        services_pending_restart,
     })
+}
+
+/// Restart declared binary-resident services after a successful binary swap.
+///
+/// Returns `(restarted, pending)`. When the swap did not succeed there is no
+/// new binary to load, so nothing is restarted. When `skip_services` is set,
+/// every declared service is reported as pending with its recovery command.
+fn restart_resident_services_after_swap(
+    swap_succeeded: bool,
+    skip_services: bool,
+) -> (Vec<ServiceRestartEntry>, Vec<ServiceRestartEntry>) {
+    if !swap_succeeded {
+        return (Vec::new(), Vec::new());
+    }
+
+    let resident_services = defaults::load_config().resident_services;
+    if resident_services.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+
+    if skip_services {
+        let pending = services::pending_when_skipped(&resident_services);
+        warn_pending_resident_services(&pending);
+        return (Vec::new(), pending);
+    }
+
+    log_status!(
+        "upgrade",
+        "Restarting {} binary-resident service(s) to load the new binary...",
+        resident_services.len()
+    );
+
+    let (restarted, pending) =
+        services::restart_resident_services(&resident_services, services::run_restart_command);
+
+    for entry in &restarted {
+        log_status!("upgrade", "  {} restarted", entry.service_id);
+    }
+    warn_pending_resident_services(&pending);
+
+    (restarted, pending)
+}
+
+/// Surface declared resident services that still hold the old binary, with the
+/// exact recovery command, instead of failing the upgrade silently.
+fn warn_pending_resident_services(pending: &[ServiceRestartEntry]) {
+    for entry in pending {
+        let detail = entry.detail.as_deref().unwrap_or("restart required");
+        if entry.restart_command.is_empty() {
+            log_status!(
+                "upgrade",
+                "  WARNING: {} not restarted ({})",
+                entry.service_id,
+                detail,
+            );
+        } else {
+            log_status!(
+                "upgrade",
+                "  WARNING: {} not restarted ({}). Run: {}",
+                entry.service_id,
+                detail,
+                entry.restart_command,
+            );
+        }
+    }
 }
 
 fn source_upgrade_path_for_method(

--- a/src/core/upgrade/mod.rs
+++ b/src/core/upgrade/mod.rs
@@ -3,6 +3,7 @@ mod execution;
 mod helpers;
 mod planning;
 mod runners;
+mod services;
 mod types;
 pub mod update_check;
 mod validation;
@@ -14,7 +15,8 @@ pub use helpers::{
 };
 pub use planning::resolve_binary_on_path;
 pub use types::{
-    ExtensionUpgradeEntry, InstallMethod, RunnerUpgradeEntry, UpgradeResult, VersionCheck,
+    ExtensionUpgradeEntry, InstallMethod, RunnerUpgradeEntry, ServiceRestartEntry, UpgradeResult,
+    VersionCheck,
 };
 pub use validation::check_for_updates;
 

--- a/src/core/upgrade/services.rs
+++ b/src/core/upgrade/services.rs
@@ -1,0 +1,255 @@
+//! Restart of long-running, binary-resident services after an upgrade.
+//!
+//! When `homeboy upgrade` swaps the on-disk binary, the CLI process can simply
+//! re-exec itself, but any long-running service (e.g. a systemd unit) keeps the
+//! *old* binary resident in memory until it is restarted. The set of such
+//! services is host/environment-specific, so it is declared entirely in config
+//! (`resident_services`) — core hardcodes no service name, unit, or host. See
+//! issues #5197 and #5118.
+
+use std::process::Command;
+
+use crate::core::defaults::ResidentServiceConfig;
+
+use super::types::ServiceRestartEntry;
+
+/// Resolve the restart command for a declared service.
+///
+/// Precedence: an explicit `restart_command` overrides everything; otherwise a
+/// `systemd_unit` yields `systemctl restart <unit>`. Returns `None` when the
+/// descriptor declares neither — such a descriptor is unrunnable and is
+/// surfaced to the operator as pending rather than silently dropped.
+pub(super) fn restart_command_for(service: &ResidentServiceConfig) -> Option<String> {
+    if let Some(cmd) = service
+        .restart_command
+        .as_deref()
+        .map(str::trim)
+        .filter(|c| !c.is_empty())
+    {
+        return Some(cmd.to_string());
+    }
+
+    service
+        .systemd_unit
+        .as_deref()
+        .map(str::trim)
+        .filter(|u| !u.is_empty())
+        .map(|unit| format!("systemctl restart {}", unit))
+}
+
+/// Restart every declared resident service after a successful binary swap.
+///
+/// Returns `(restarted, pending)`:
+/// - `restarted`: services that came back successfully.
+/// - `pending`: services that still hold the old binary — either the restart
+///   failed, or the descriptor was unrunnable (no unit/command). Failures are
+///   surfaced clearly rather than failing the whole upgrade silently.
+///
+/// `run` executes a restart command and returns `Ok(())` on success or an
+/// `Err(detail)` describing the failure. It is injected so the logic can be
+/// exercised without spawning processes.
+pub(super) fn restart_resident_services<R>(
+    services: &[ResidentServiceConfig],
+    mut run: R,
+) -> (Vec<ServiceRestartEntry>, Vec<ServiceRestartEntry>)
+where
+    R: FnMut(&str) -> Result<(), String>,
+{
+    let mut restarted = Vec::new();
+    let mut pending = Vec::new();
+
+    for service in services {
+        let Some(command) = restart_command_for(service) else {
+            pending.push(ServiceRestartEntry {
+                service_id: service.id.clone(),
+                restart_command: String::new(),
+                restarted: false,
+                detail: Some(
+                    "no systemd_unit or restart_command declared; cannot restart".to_string(),
+                ),
+            });
+            continue;
+        };
+
+        match run(&command) {
+            Ok(()) => restarted.push(ServiceRestartEntry {
+                service_id: service.id.clone(),
+                restart_command: command,
+                restarted: true,
+                detail: None,
+            }),
+            Err(detail) => pending.push(ServiceRestartEntry {
+                service_id: service.id.clone(),
+                restart_command: command,
+                restarted: false,
+                detail: Some(detail),
+            }),
+        }
+    }
+
+    (restarted, pending)
+}
+
+/// Build the pending-restart entries for declared services when restarts are
+/// skipped entirely (e.g. `--no-restart-services`). Every declared service is
+/// reported as pending with its recovery command so the operator knows exactly
+/// what still needs restarting.
+pub(super) fn pending_when_skipped(services: &[ResidentServiceConfig]) -> Vec<ServiceRestartEntry> {
+    services
+        .iter()
+        .map(|service| {
+            let command = restart_command_for(service).unwrap_or_default();
+            let detail = if command.is_empty() {
+                "no systemd_unit or restart_command declared; cannot restart".to_string()
+            } else {
+                "restart skipped (--no-restart-services); restart manually".to_string()
+            };
+            ServiceRestartEntry {
+                service_id: service.id.clone(),
+                restart_command: command,
+                restarted: false,
+                detail: Some(detail),
+            }
+        })
+        .collect()
+}
+
+/// Run a restart command via `sh -c`, returning `Err(detail)` on a non-zero
+/// exit or spawn failure. This is the production runner injected into
+/// [`restart_resident_services`].
+pub(super) fn run_restart_command(command: &str) -> Result<(), String> {
+    let output = Command::new("sh")
+        .args(["-c", command])
+        .output()
+        .map_err(|e| e.to_string())?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let detail = if !stderr.trim().is_empty() {
+        stderr.trim().to_string()
+    } else if !stdout.trim().is_empty() {
+        stdout.trim().to_string()
+    } else {
+        format!("exit code {}", output.status.code().unwrap_or(1))
+    };
+    Err(detail)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn service(id: &str, unit: Option<&str>, cmd: Option<&str>) -> ResidentServiceConfig {
+        ResidentServiceConfig {
+            id: id.to_string(),
+            systemd_unit: unit.map(str::to_string),
+            restart_command: cmd.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn restart_command_prefers_explicit_command_over_systemd_unit() {
+        let svc = service("ingress", Some("homeboy-ingress"), Some("custom restart"));
+        assert_eq!(restart_command_for(&svc).as_deref(), Some("custom restart"));
+    }
+
+    #[test]
+    fn restart_command_falls_back_to_systemctl_for_unit() {
+        let svc = service("ingress", Some("homeboy-ingress"), None);
+        assert_eq!(
+            restart_command_for(&svc).as_deref(),
+            Some("systemctl restart homeboy-ingress")
+        );
+    }
+
+    #[test]
+    fn restart_command_is_none_without_unit_or_command() {
+        let svc = service("ingress", None, None);
+        assert!(restart_command_for(&svc).is_none());
+    }
+
+    #[test]
+    fn restart_command_ignores_blank_command_and_unit() {
+        let svc = service("ingress", Some("   "), Some("  "));
+        assert!(restart_command_for(&svc).is_none());
+    }
+
+    #[test]
+    fn restart_resident_services_records_successes_and_failures() {
+        // Service list provided via fixture, not hardcoded in production code.
+        let services = vec![
+            service("ingress", Some("homeboy-ingress"), None),
+            service("broker", Some("homeboy-broker"), None),
+            service("custom", None, Some("supervisorctl restart custom")),
+        ];
+
+        let (restarted, pending) = restart_resident_services(&services, |cmd| {
+            if cmd.contains("homeboy-broker") {
+                Err("Unit homeboy-broker not found".to_string())
+            } else {
+                Ok(())
+            }
+        });
+
+        assert_eq!(restarted.len(), 2);
+        assert!(restarted.iter().all(|e| e.restarted));
+        assert!(restarted.iter().any(|e| e.service_id == "ingress"));
+        assert!(restarted.iter().any(|e| e.service_id == "custom"));
+
+        assert_eq!(pending.len(), 1);
+        let failed = &pending[0];
+        assert_eq!(failed.service_id, "broker");
+        assert!(!failed.restarted);
+        assert_eq!(failed.restart_command, "systemctl restart homeboy-broker");
+        assert_eq!(
+            failed.detail.as_deref(),
+            Some("Unit homeboy-broker not found")
+        );
+    }
+
+    #[test]
+    fn restart_resident_services_marks_unrunnable_descriptor_pending() {
+        let services = vec![service("orphan", None, None)];
+
+        let (restarted, pending) = restart_resident_services(&services, |_| Ok(()));
+
+        assert!(restarted.is_empty());
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].service_id, "orphan");
+        assert!(pending[0]
+            .detail
+            .as_deref()
+            .unwrap()
+            .contains("cannot restart"));
+    }
+
+    #[test]
+    fn restart_resident_services_empty_list_is_noop() {
+        let (restarted, pending) = restart_resident_services(&[], |_| Ok(()));
+        assert!(restarted.is_empty());
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn pending_when_skipped_reports_all_declared_services() {
+        let services = vec![
+            service("ingress", Some("homeboy-ingress"), None),
+            service("orphan", None, None),
+        ];
+
+        let pending = pending_when_skipped(&services);
+
+        assert_eq!(pending.len(), 2);
+        let ingress = pending.iter().find(|e| e.service_id == "ingress").unwrap();
+        assert_eq!(ingress.restart_command, "systemctl restart homeboy-ingress");
+        assert!(ingress.detail.as_deref().unwrap().contains("skipped"));
+
+        let orphan = pending.iter().find(|e| e.service_id == "orphan").unwrap();
+        assert!(orphan.restart_command.is_empty());
+        assert!(orphan.detail.as_deref().unwrap().contains("cannot restart"));
+    }
+}

--- a/src/core/upgrade/types.rs
+++ b/src/core/upgrade/types.rs
@@ -79,6 +79,33 @@ pub struct UpgradeResult {
     /// Each entry carries the exact recovery command to bring the clone current.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extensions_unrefreshed: Vec<UnrefreshedExtensionWarning>,
+    /// Long-running, binary-resident services (declared in config) that were
+    /// successfully restarted to pick up the newly-swapped binary. Distinct
+    /// from `restart_required`, which only describes the CLI process itself.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub services_restarted: Vec<ServiceRestartEntry>,
+    /// Declared resident services that still hold the old binary and need a
+    /// restart: either because a restart attempt failed, or because the
+    /// upgrade was run with `--no-restart-services`. Each entry carries the
+    /// exact recovery command so the operator can restart it manually.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub services_pending_restart: Vec<ServiceRestartEntry>,
+}
+
+/// Outcome of attempting to restart one declared binary-resident service after
+/// an upgrade. Used both for successful restarts (`services_restarted`) and for
+/// services that still need attention (`services_pending_restart`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceRestartEntry {
+    /// Configured service id.
+    pub service_id: String,
+    /// The restart command that was run (or would need to be run).
+    pub restart_command: String,
+    /// Whether the restart succeeded.
+    pub restarted: bool,
+    /// Failure or skip detail when `restarted` is false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 /// A symlinked extension in the invoking user's config dir that a privileged


### PR DESCRIPTION
Closes #5197

Adds a config-driven `resident_services` surface so `homeboy upgrade` restarts long-running binary-resident services (e.g. a systemd unit) after a successful binary swap, with a `--no-restart-services` opt-out and `services_restarted`/`services_pending_restart` in the result. Core ships none by default and hardcodes no service name/unit/host (org-agnostic, per #5118). 

(Hand-landed: the cook's kimaki session was killed by a bridge auto-restart before it could push. Validated via cargo fmt + rebase; CI runs the full build/test.)