### PR TITLE
perf(runs): make active runner jobs opt-in

### DIFF
--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -5,7 +5,7 @@ Inspect and maintain persisted observation-store runs and artifacts.
 ## Synopsis
 
 ```bash
-homeboy runs list [--runner <runner-id>] [--kind bench|rig|trace] [--component <id>] [--rig <id>] [--status <status>] [--limit 20]
+homeboy runs list [--runner <runner-id>] [--kind bench|rig|trace] [--component <id>] [--rig <id>] [--status <status>] [--limit 20] [--include-active-runner-jobs]
 homeboy runs distribution --field <metadata.path> [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--status <status>] [--limit 20]
 homeboy runs compare [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--metric <name>] [--limit 20] [--format table|json]
 homeboy runs show <run-id>
@@ -26,7 +26,7 @@ homeboy runs import --from-gh-actions --component <id> --repo <owner/repo> --run
 
 `homeboy runs` is the inspection and maintenance surface for Homeboy's local observation store. Producers such as `bench`, `rig`, and `trace` write run and artifact records; this command lets humans and agents inspect that evidence without opening SQLite directly, export/import portable bundles, and run explicit cleanup or reconciliation tasks.
 
-`homeboy runs list --runner <runner-id>` queries a connected runner daemon instead of the local observation store, preserving the normal `runs.list` JSON payload while returning evidence from the runner machine.
+`homeboy runs list` reads only the local observation store by default. Pass `--include-active-runner-jobs` to also append active jobs from connected runner daemons, which may inspect runner sessions. `homeboy runs list --runner <runner-id>` queries a connected runner daemon instead of the local observation store, preserving the normal `runs.list` JSON payload while returning evidence from the runner machine.
 
 The JSON output includes stable run fields: run id, kind, status, timestamps, component id, rig id, git SHA, command, cwd, metadata, and artifact records where relevant.
 

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -140,6 +140,9 @@ pub struct RunsListArgs {
     /// Maximum runs to return
     #[arg(long, default_value_t = DEFAULT_LIMIT)]
     pub limit: i64,
+    /// Include active runner jobs from connected runner daemons
+    #[arg(long)]
+    pub include_active_runner_jobs: bool,
 }
 
 #[derive(Serialize)]
@@ -467,7 +470,9 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
     })?;
     let mut runs = run_summaries_with_artifact_indexes(&store, run_records)?;
 
-    runs.extend(active_runner_job_summaries(status_filter.as_deref()));
+    if args.include_active_runner_jobs {
+        runs.extend(active_runner_job_summaries(status_filter.as_deref()));
+    }
 
     Ok((RunsOutput::List(RunsListOutput { command, runs }), 0))
 }
@@ -840,6 +845,7 @@ mod tests {
                     rig: Some("studio".to_string()),
                     status: Some("pass".to_string()),
                     limit: 20,
+                    include_active_runner_jobs: false,
                 },
                 "runs.list",
             )
@@ -870,6 +876,7 @@ mod tests {
                     rig: Some("studio".to_string()),
                     status: None,
                     limit: 20,
+                    include_active_runner_jobs: false,
                 },
                 "runs.list",
             )

--- a/src/commands/runs/artifact_index_tests.rs
+++ b/src/commands/runs/artifact_index_tests.rs
@@ -77,6 +77,7 @@ fn rig_runs_list_surfaces_compact_artifact_index() {
                 rig: Some("proof-rig".to_string()),
                 status: None,
                 limit: 20,
+                include_active_runner_jobs: false,
             },
             "rig.runs",
         )


### PR DESCRIPTION
## Summary
- Make local `homeboy runs list` read only persisted observation-store runs by default.
- Add `--include-active-runner-jobs` to opt into appending active connected runner daemon jobs.
- Document the new opt-in behavior and keep explicit `runs list --runner <id>` behavior unchanged.

## Verification
- `rustfmt src/commands/runs.rs src/commands/runs/artifact_index_tests.rs`
- `git diff --check`
- Not run: local Cargo tests/builds, per task constraint.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused code, docs, and test fixture updates for Chris to review.