### PR TITLE
docs(agent-task): clarify command boundaries

### DIFF
--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -6,13 +6,22 @@ Homeboy owns durable orchestration and provider-neutral outcomes. Runtime
 providers own backend-specific execution. For the provider fanout ownership seam,
 see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-fanout-boundary.md).
 
+## Boundaries
+
+`agent-task` is split into four operator-facing seams:
+
+- **Lifecycle:** durable run submission, execution, inspection, cancellation, and retry.
+- **Cook/review:** repo-cooking conveniences that compose lifecycle runs with promotion, gates, and PR finalization.
+- **Provider:** executor discovery, machine-readable contracts, and redacted auth readiness.
+- **Controller:** durable multi-agent loop state that can create or observe lifecycle runs over time.
+
 ## Subcommands
+
+### Lifecycle
 
 | Subcommand | Purpose |
 |---|---|
-| `cook` | Sync a workspace when `--runner` is supplied, dispatch a repo-cooking task, and return the durable run id. |
-| `loop` | Run a durable repo cook loop: dispatch, promote, verify, retry red gates, and finalize. |
-| `dispatch` | Build and dispatch common repo-cooking agent tasks without hand-authored provider JSON. |
+| `dispatch` | Build and queue common repo-cooking agent tasks without hand-authored provider JSON. |
 | `run-plan` | Run an `AgentTaskPlan` through extension-declared executor providers. |
 | `run <run-id>` | Execute a previously submitted durable run. |
 | `run-next` | Claim and execute the oldest queued durable run. |
@@ -26,14 +35,31 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 | `cancel <run-id>` | Mark a queued or stale-running durable run as cancelled. |
 | `resume <run-id>` | Resume a queued or stale-running durable run. |
 | `retry <run-id>` | Submit a fresh durable run from an existing run's plan. |
+
+### Cook/Review
+
+| Subcommand | Purpose |
+|---|---|
+| `cook` | Sync a workspace when `--runner` is supplied, dispatch a repo-cooking task, and return the durable run id. |
+| `loop` | Run a durable repo cook loop: dispatch, promote, verify, retry red gates, and finalize. |
 | `review <run-id>` | Build a durable aggregate review envelope from run state, logs, artifacts, and promotion hints. |
 | `promote <source>` | Promote a completed generic patch artifact into a managed worktree. |
 | `finalize-pr` | Finalize a green cook run into a review-ready pull request. |
 | `gate-feedback` | Convert deterministic gate results into a cook-loop retry or stop decision. |
+
+### Provider
+
+| Subcommand | Purpose |
+|---|---|
 | `providers` | List extension-declared executor providers and optional secret readiness. |
 | `contract` | Export Homeboy's machine-readable agent-task core contract metadata. |
-| `compile-loop` | Compile a declarative loop definition into an agent-task plan. |
 | `auth` | Configure and inspect provider authentication secrets. |
+
+### Controller
+
+| Subcommand | Purpose |
+|---|---|
+| `compile-loop` | Compile a declarative loop definition into an agent-task plan. |
 | `controller` | Create, inspect, and resume durable multi-agent loop controller state. |
 
 ## Controller Events

--- a/src/commands/agent_task/args/mod.rs
+++ b/src/commands/agent_task/args/mod.rs
@@ -2,7 +2,11 @@
 //!
 //! These types are the durable CLI contract surface. Keeping them in one
 //! sibling module lets the `agent_task` root stay a thin dispatcher over the
-//! handler modules (`auth`, `controller`, `run`, `status`, `review`).
+//! handler modules (`auth`, `controller`, `run`, `status`, `review`). The
+//! command tree is grouped by boundary: lifecycle commands own durable run
+//! records, cook-loop commands compose lifecycle primitives into reviewer
+//! workflows, provider commands expose executor contracts/auth, and controller
+//! commands own long-running loop state.
 
 use clap::{Args, Subcommand, ValueEnum};
 use homeboy::core::agent_tasks::gate::{AgentTaskGateRevealPolicy, VerifyGateOptions};
@@ -35,55 +39,55 @@ pub struct AgentTaskArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum AgentTaskCommand {
-    /// Sync a workspace if --runner is supplied, dispatch a repo-cooking task, and return the durable run id.
+    /// Cook loop: sync a workspace when needed, dispatch a repo-cooking task, and return the durable run id.
     Cook(DispatchArgs),
-    /// Run a durable repo cook loop: dispatch, promote, verify, retry red gates, and finalize.
+    /// Cook loop: dispatch, promote, verify, retry red gates, and finalize.
     Loop(AgentTaskLoopArgs),
-    /// Build and dispatch common repo-cooking agent tasks without hand-authored provider JSON.
+    /// Lifecycle: build and queue common repo-cooking agent tasks without hand-authored provider JSON.
     Dispatch(DispatchArgs),
-    /// Run an agent-task plan through extension-declared executor providers.
+    /// Lifecycle: run an agent-task plan through extension-declared executor providers.
     RunPlan(RunPlanArgs),
-    /// Execute a previously submitted durable agent-task run.
+    /// Lifecycle: execute a previously submitted durable agent-task run.
     Run(StatusArgs),
-    /// Claim and execute the oldest queued durable agent-task run.
+    /// Lifecycle: claim and execute the oldest queued durable agent-task run.
     RunNext,
-    /// Persist an agent-task plan and return a durable run id without executing it.
+    /// Lifecycle: persist an agent-task plan and return a durable run id without executing it.
     Submit(SubmitArgs),
-    /// Read durable agent-task run status.
+    /// Lifecycle: read durable agent-task run status.
     Status(StatusArgs),
-    /// List durable agent-task runs, newest first.
+    /// Lifecycle: list durable agent-task runs, newest first.
     List,
-    /// List queued and running durable agent-task runs, newest first.
+    /// Lifecycle: list queued and running durable agent-task runs, newest first.
     Active,
-    /// Show the latest durable agent-task run.
+    /// Lifecycle: show the latest durable agent-task run.
     Latest,
-    /// Read durable agent-task run scheduler events.
+    /// Lifecycle: read durable agent-task run scheduler events.
     Logs(StatusArgs),
-    /// List artifacts and evidence refs recorded for a completed run.
+    /// Lifecycle: list artifacts and evidence refs recorded for a completed run.
     Artifacts(StatusArgs),
-    /// Mark a queued or stale-running durable agent-task run as cancelled.
+    /// Lifecycle: mark a queued or stale-running durable agent-task run as cancelled.
     Cancel(CancelArgs),
-    /// Resume a queued or stale-running durable run.
+    /// Lifecycle: resume a queued or stale-running durable run.
     Resume(StatusArgs),
-    /// Submit a fresh durable run from an existing run's plan.
+    /// Lifecycle: submit a fresh durable run from an existing run's plan.
     Retry(RetryArgs),
-    /// Build a durable aggregate review envelope from run state, logs, artifacts, and promotion hints.
+    /// Review: build a durable aggregate envelope from run state, logs, artifacts, and promotion hints.
     Review(ReviewArgs),
-    /// Promote a completed generic patch artifact into a managed worktree.
+    /// Review: promote a completed generic patch artifact into a managed worktree.
     Promote(PromoteArgs),
-    /// Finalize a green cook run into a review-ready pull request.
+    /// Review: finalize a green cook run into a review-ready pull request.
     FinalizePr(FinalizePrArgs),
-    /// Convert deterministic gate results into a cook-loop retry or stop decision.
+    /// Review: convert deterministic gate results into a cook-loop retry or stop decision.
     GateFeedback(GateFeedbackArgs),
-    /// List extension-declared agent-task executor providers and optional secret readiness.
+    /// Provider: list extension-declared agent-task executor providers and optional secret readiness.
     Providers(ProvidersArgs),
-    /// Export Homeboy's machine-readable agent-task core contract metadata.
+    /// Provider: export Homeboy's machine-readable agent-task core contract metadata.
     Contract(ContractArgs),
-    /// Compile a declarative loop definition into an agent-task plan.
+    /// Controller: compile a declarative loop definition into an agent-task plan.
     CompileLoop(CompileLoopArgs),
-    /// Configure and inspect agent-task provider authentication secrets.
+    /// Provider: configure and inspect agent-task provider authentication secrets.
     Auth(AgentTaskAuthArgs),
-    /// Create, inspect, and resume durable multi-agent loop controller state.
+    /// Controller: create, inspect, and resume durable multi-agent loop controller state.
     Controller(AgentTaskControllerArgs),
     /// Internal bridge for provider-runtime agent tool requests.
     #[command(hide = true)]


### PR DESCRIPTION
## Summary
- Group `agent-task` command docs by lifecycle, cook/review, provider, and controller boundaries.
- Add matching boundary language to the clap args module docs and command help summaries.
- Keep command paths and runtime behavior unchanged.

## Verification
- `git diff --check`
- `git diff --check origin/main...HEAD`
- Not run: local cargo, per operator instruction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused docs/help wording changes and ran non-cargo git verification; Chris remains responsible for review and merge.