### PR TITLE
perf(project): cache standalone config fallbacks

### DIFF
--- a/src/core/component/inventory.rs
+++ b/src/core/component/inventory.rs
@@ -68,9 +68,14 @@ pub fn inventory() -> Result<Vec<Component>> {
     };
 
     // 1. Project-attached components (highest priority)
+    let standalone_snapshot = project::StandaloneComponentConfigSnapshot::load();
     for project in &projects {
         for attachment in &project.components {
-            if let Ok(component) = project::resolve_project_component(project, &attachment.id) {
+            if let Ok(component) = project::resolve_project_component_with_standalone_snapshot(
+                project,
+                &attachment.id,
+                Some(&standalone_snapshot),
+            ) {
                 add_component(component);
             }
         }

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -587,6 +587,7 @@ pub(super) fn load_project_components(
     let mut deployable = Vec::new();
     let mut skipped = Vec::new();
     let mut extension_skipped = Vec::new();
+    let standalone_snapshot = project::StandaloneComponentConfigSnapshot::load();
 
     for attachment in project
         .components
@@ -598,7 +599,11 @@ pub(super) fn load_project_components(
         // should not block deploying the ones you asked for.
         let is_requested = requested_ids.is_empty() || requested_ids.contains(&attachment.id);
 
-        let mut loaded = project::resolve_project_component(project, &attachment.id)?;
+        let mut loaded = project::resolve_project_component_with_standalone_snapshot(
+            project,
+            &attachment.id,
+            Some(&standalone_snapshot),
+        )?;
 
         // Validate required extensions are installed before attempting artifact resolution.
         // Without this check, missing extensions cause resolve_artifact() to silently

--- a/src/core/project/component/mod.rs
+++ b/src/core/project/component/mod.rs
@@ -13,4 +13,7 @@ pub use report::{
     attach_component_path_report, clear_components, list_components, remove_components_report,
     set_components, ProjectComponentsOutput,
 };
-pub use resolution::{resolve_project_component, resolve_project_components};
+pub use resolution::{
+    resolve_project_component, resolve_project_component_with_standalone_snapshot,
+    resolve_project_components, StandaloneComponentConfigSnapshot,
+};

--- a/src/core/project/component/resolution.rs
+++ b/src/core/project/component/resolution.rs
@@ -1,5 +1,6 @@
 use crate::core::error::{Error, Result};
 use crate::core::project::Project;
+use std::collections::HashMap;
 use std::path::Path;
 
 use super::discovery::discover_attached_component;
@@ -8,6 +9,14 @@ use super::overrides::apply_component_overrides;
 pub fn resolve_project_component(
     project: &Project,
     component_id: &str,
+) -> Result<crate::core::component::Component> {
+    resolve_project_component_with_standalone_snapshot(project, component_id, None)
+}
+
+pub fn resolve_project_component_with_standalone_snapshot(
+    project: &Project,
+    component_id: &str,
+    standalone_snapshot: Option<&StandaloneComponentConfigSnapshot>,
 ) -> Result<crate::core::component::Component> {
     let (mut component, attachment_local_path, attachment_remote_path) = if let Some(attachment) =
         project
@@ -48,7 +57,7 @@ pub fn resolve_project_component(
         }
     }
 
-    apply_standalone_component_fallbacks(&mut component);
+    apply_standalone_component_fallbacks(&mut component, standalone_snapshot);
 
     let mut resolved = apply_component_overrides(&component, project);
     resolved.local_path = attachment_local_path;
@@ -72,8 +81,15 @@ pub fn resolve_project_component(
     Ok(resolved)
 }
 
-fn apply_standalone_component_fallbacks(component: &mut crate::core::component::Component) {
-    let Some(standalone) = load_standalone_component_config(&component.id) else {
+fn apply_standalone_component_fallbacks(
+    component: &mut crate::core::component::Component,
+    standalone_snapshot: Option<&StandaloneComponentConfigSnapshot>,
+) {
+    let standalone = match standalone_snapshot {
+        Some(snapshot) => snapshot.get(&component.id).cloned(),
+        None => load_standalone_component_config(&component.id),
+    };
+    let Some(standalone) = standalone else {
         return;
     };
 
@@ -90,11 +106,60 @@ fn apply_standalone_component_fallbacks(component: &mut crate::core::component::
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct StandaloneComponentConfigSnapshot {
+    components: HashMap<String, crate::core::component::Component>,
+}
+
+impl StandaloneComponentConfigSnapshot {
+    pub fn load() -> Self {
+        let mut snapshot = Self::default();
+        let Ok(dir) = crate::core::paths::components() else {
+            return snapshot;
+        };
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return snapshot;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+
+            let Some(component_id) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let Some(component) = load_standalone_component_config_from_path(component_id, &path)
+            else {
+                continue;
+            };
+
+            snapshot
+                .components
+                .insert(component_id.to_string(), component);
+        }
+
+        snapshot
+    }
+
+    fn get(&self, component_id: &str) -> Option<&crate::core::component::Component> {
+        self.components.get(component_id)
+    }
+}
+
 fn load_standalone_component_config(
     component_id: &str,
 ) -> Option<crate::core::component::Component> {
     let dir = crate::core::paths::components().ok()?;
     let path = dir.join(format!("{component_id}.json"));
+    load_standalone_component_config_from_path(component_id, &path)
+}
+
+fn load_standalone_component_config_from_path(
+    component_id: &str,
+    path: &Path,
+) -> Option<crate::core::component::Component> {
     let content = std::fs::read_to_string(path).ok()?;
     let mut json: serde_json::Value = serde_json::from_str(&content).ok()?;
 
@@ -111,10 +176,17 @@ fn load_standalone_component_config(
 pub fn resolve_project_components(
     project: &Project,
 ) -> Result<Vec<crate::core::component::Component>> {
+    let standalone_snapshot = StandaloneComponentConfigSnapshot::load();
     project
         .components
         .iter()
-        .map(|component| resolve_project_component(project, &component.id))
+        .map(|component| {
+            resolve_project_component_with_standalone_snapshot(
+                project,
+                &component.id,
+                Some(&standalone_snapshot),
+            )
+        })
         .collect()
 }
 

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -22,8 +22,9 @@ pub use component::{
     apply_component_overrides, attach_component_path, attach_component_path_report,
     attach_discovered_component_path, clear_component_attachments, clear_components, has_component,
     list_components, project_component_ids, remove_components, remove_components_report,
-    resolve_project_component, resolve_project_components, set_component_attachments,
-    set_components, ProjectComponentsOutput,
+    resolve_project_component, resolve_project_component_with_standalone_snapshot,
+    resolve_project_components, set_component_attachments, set_components, ProjectComponentsOutput,
+    StandaloneComponentConfigSnapshot,
 };
 pub use files::{FileEntry, GrepMatch, LineChange};
 pub use logs::{LogContent, LogEntry, LogSearchResult, PinnedLogsContent};

--- a/src/core/project/readiness.rs
+++ b/src/core/project/readiness.rs
@@ -40,8 +40,13 @@ pub fn calculate_deploy_readiness(project: &Project) -> (bool, Vec<String>) {
             project.id
         ));
     } else {
+        let standalone_snapshot = super::StandaloneComponentConfigSnapshot::load();
         let has_deployable = project.components.iter().any(|attachment| {
-            if let Ok(comp) = super::resolve_project_component(project, &attachment.id) {
+            if let Ok(comp) = super::resolve_project_component_with_standalone_snapshot(
+                project,
+                &attachment.id,
+                Some(&standalone_snapshot),
+            ) {
                 let is_git = comp.deploy_strategy.as_deref() == Some("git");
                 let has_artifact = component::resolve_artifact(&comp).is_some();
                 is_git || has_artifact


### PR DESCRIPTION
## Summary
- Add a command-scoped standalone component config snapshot for project component resolution.
- Reuse the snapshot in bulk project resolution, component inventory, deploy planning, and readiness loops.
- Preserve the existing single-component resolver behavior by keeping its direct standalone config read path.

## Verification
- Ran `rustfmt` directly on touched Rust files.
- Ran `git diff --check`.
- Did not run local Cargo commands per instruction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the focused implementation; Chris remains responsible for review and testing.