### PR TITLE
Share JSON envelope command descriptor

### DIFF
--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -177,6 +177,18 @@ pub struct CommandDescriptor {
 }
 
 impl CommandOutputDescriptor {
+    pub const fn json_envelope(
+        json_family: CommandJsonFamily,
+        output_file_mode: CommandOutputFileMode,
+    ) -> Self {
+        Self {
+            response_mode: CommandResponseMode::Json,
+            output_file_mode,
+            json_family,
+            output_contract: CommandOutputContractKind::JsonEnvelope,
+        }
+    }
+
     fn with_lab_contract(
         self,
         contract: Option<super::lab::LabCommandContract>,
@@ -400,12 +412,7 @@ fn json_envelope_descriptor(
     json_family: CommandJsonFamily,
     output_file_mode: CommandOutputFileMode,
 ) -> CommandOutputDescriptor {
-    CommandOutputDescriptor {
-        response_mode: CommandResponseMode::Json,
-        output_file_mode,
-        json_family,
-        output_contract: CommandOutputContractKind::JsonEnvelope,
-    }
+    CommandOutputDescriptor::json_envelope(json_family, output_file_mode)
 }
 
 fn registered_json_envelope_descriptor(
@@ -533,6 +540,21 @@ mod tests {
         assert!(aggregate_descriptor
             .lab_runner_unsupported_reason
             .is_some_and(|reason| reason.contains("Changed-scope lint")));
+    }
+
+    #[test]
+    fn json_envelope_descriptor_uses_shared_contract_shape() {
+        assert_eq!(
+            CommandOutputDescriptor::json_envelope(
+                CommandJsonFamily::Workspace,
+                CommandOutputFileMode::GenericEnvelope,
+            ),
+            workspace_descriptor(
+                CommandResponseMode::Json,
+                CommandOutputFileMode::GenericEnvelope,
+                CommandOutputContractKind::JsonEnvelope,
+            )
+        );
     }
 
     #[test]

--- a/src/commands/adapter.rs
+++ b/src/commands/adapter.rs
@@ -1,9 +1,6 @@
 use serde_json::Value;
 
-use crate::command_contract::{
-    CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode,
-    CommandResponseMode,
-};
+use crate::command_contract::{CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode};
 
 use crate::cli_surface::Commands;
 
@@ -79,17 +76,11 @@ impl<Args> TypedCommandAdapter<Args> {
     pub fn json_only(
         json_family: CommandJsonFamily,
         output_file_mode: CommandOutputFileMode,
-        output_contract: CommandOutputContractKind,
         execute_json: JsonCommandExecutor<Args>,
     ) -> Self {
         Self {
             contract: CommandAdapterContract {
-                output: CommandOutputDescriptor {
-                    response_mode: CommandResponseMode::Json,
-                    output_file_mode,
-                    json_family,
-                    output_contract,
-                },
+                output: CommandOutputDescriptor::json_envelope(json_family, output_file_mode),
                 lab_runner: CommandLabRunnerPolicy::LOCAL,
             },
             execute_json: Some(execute_json),
@@ -131,6 +122,7 @@ pub(crate) fn command_adapter(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::command_contract::{CommandOutputContractKind, CommandResponseMode};
     use clap::Parser;
 
     fn parsed_command(args: &[&str]) -> Commands {
@@ -144,7 +136,6 @@ mod tests {
         let adapter = TypedCommandAdapter::<()>::json_only(
             CommandJsonFamily::Workspace,
             CommandOutputFileMode::GenericEnvelope,
-            CommandOutputContractKind::JsonEnvelope,
             |_, _| (Ok(Value::Null), 0),
         );
 
@@ -156,6 +147,10 @@ mod tests {
             CommandOutputFileMode::GenericEnvelope
         );
         assert_eq!(descriptor.json_family, CommandJsonFamily::Workspace);
+        assert_eq!(
+            descriptor.output_contract,
+            CommandOutputContractKind::JsonEnvelope
+        );
         assert!(adapter.execute_json.is_some());
     }
     #[test]

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -19,7 +19,7 @@ use super::utils::observed_workflow::{
 };
 use super::{CmdResult, GlobalArgs};
 use crate::command_contract::{
-    CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode, LabCommandContract,
+    CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, LabCommandContract,
 };
 
 const AUDIT_CHANGED_SINCE_LAB_UNSUPPORTED_REASON: &str = "`audit --changed-since` is not Lab-portable yet because changed-since audit depends on git base refs that the current Lab workspace sync may not have fetched.";
@@ -66,12 +66,7 @@ impl AuditArgs {
         &self,
         output_file_mode: CommandOutputFileMode,
     ) -> CommandOutputDescriptor {
-        CommandOutputDescriptor {
-            response_mode: crate::command_contract::CommandResponseMode::Json,
-            output_file_mode,
-            json_family: crate::command_contract::CommandJsonFamily::Quality,
-            output_contract: CommandOutputContractKind::JsonEnvelope,
-        }
+        CommandOutputDescriptor::json_envelope(CommandJsonFamily::Quality, output_file_mode)
     }
 
     pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -21,8 +21,7 @@ use super::utils::args::{
 };
 use super::{runs, CmdResult, GlobalArgs};
 use crate::command_contract::{
-    CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode,
-    CommandResponseMode, LabCommandContract,
+    CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, LabCommandContract,
 };
 
 mod fanout;
@@ -44,12 +43,7 @@ impl BenchArgs {
         &self,
         output_file_mode: CommandOutputFileMode,
     ) -> CommandOutputDescriptor {
-        CommandOutputDescriptor {
-            response_mode: CommandResponseMode::Json,
-            output_file_mode,
-            json_family: CommandJsonFamily::Quality,
-            output_contract: CommandOutputContractKind::JsonEnvelope,
-        }
+        CommandOutputDescriptor::json_envelope(CommandJsonFamily::Quality, output_file_mode)
     }
 
     pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -8,9 +8,7 @@ use homeboy::core::project::Project;
 use homeboy::core::EntityCrudOutput;
 
 use super::{adapter, CmdResult, DynamicSetArgs};
-use crate::command_contract::{
-    CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode, LabCommandContract,
-};
+use crate::command_contract::{CommandJsonFamily, CommandOutputFileMode, LabCommandContract};
 
 const FLEET_EXEC_LAB_UNSUPPORTED_REASON: &str = "`fleet exec` stays local because it depends on local fleet, project, and server configuration before opening SSH sessions to each project; runner-side config parity is not guaranteed.";
 
@@ -191,12 +189,7 @@ pub fn run(args: FleetArgs, _global: &super::GlobalArgs) -> CmdResult<FleetOutpu
 pub(crate) fn adapter(
     output_file_mode: CommandOutputFileMode,
 ) -> adapter::TypedCommandAdapter<FleetArgs> {
-    adapter::TypedCommandAdapter::json_only(
-        CommandJsonFamily::Ops,
-        output_file_mode,
-        CommandOutputContractKind::JsonEnvelope,
-        run_json,
-    )
+    adapter::TypedCommandAdapter::json_only(CommandJsonFamily::Ops, output_file_mode, run_json)
 }
 
 fn run_json(args: FleetArgs, global: &super::GlobalArgs) -> adapter::JsonCommandRun {

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -23,8 +23,7 @@ use super::utils::args::{
 use super::utils::observed_workflow::{ObservedWorkflowRunner, WorkflowObservationAdapter};
 use super::{CmdResult, GlobalArgs};
 use crate::command_contract::{
-    CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode,
-    CommandResponseMode, LabCommandContract,
+    CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, LabCommandContract,
 };
 
 const LINT_CHANGED_SCOPE_LAB_UNSUPPORTED_REASON: &str = "Changed-scope lint runs stay local because changed-file scopes are not represented in the current Lab portability contract yet.";
@@ -101,12 +100,7 @@ impl LintArgs {
         &self,
         output_file_mode: CommandOutputFileMode,
     ) -> CommandOutputDescriptor {
-        CommandOutputDescriptor {
-            response_mode: CommandResponseMode::Json,
-            output_file_mode,
-            json_family: CommandJsonFamily::Quality,
-            output_contract: CommandOutputContractKind::JsonEnvelope,
-        }
+        CommandOutputDescriptor::json_envelope(CommandJsonFamily::Quality, output_file_mode)
     }
 
     pub(crate) fn lab_contract(&self) -> Option<LabCommandContract> {

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -23,8 +23,7 @@ use super::utils::args::{
 use super::utils::observed_workflow::ObservedWorkflowRunner;
 use super::{CmdResult, GlobalArgs};
 use crate::command_contract::{
-    CommandJsonFamily, CommandOutputContractKind, CommandOutputDescriptor, CommandOutputFileMode,
-    CommandResponseMode, LabCommandContract,
+    CommandJsonFamily, CommandOutputDescriptor, CommandOutputFileMode, LabCommandContract,
 };
 use homeboy::core::validation_progress::validation_progress_metadata;
 
@@ -94,12 +93,7 @@ impl TestArgs {
         &self,
         output_file_mode: CommandOutputFileMode,
     ) -> CommandOutputDescriptor {
-        CommandOutputDescriptor {
-            response_mode: CommandResponseMode::Json,
-            output_file_mode,
-            json_family: CommandJsonFamily::Quality,
-            output_contract: CommandOutputContractKind::JsonEnvelope,
-        }
+        CommandOutputDescriptor::json_envelope(CommandJsonFamily::Quality, output_file_mode)
     }
 
     pub(crate) fn lab_contract(&self) -> LabCommandContract {

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -5,9 +5,7 @@ use homeboy::core::component;
 use homeboy::core::release::version::{read_component_version, read_version, VersionTargetInfo};
 
 use super::{adapter, CmdResult};
-use crate::command_contract::{
-    CommandJsonFamily, CommandOutputContractKind, CommandOutputFileMode,
-};
+use crate::command_contract::{CommandJsonFamily, CommandOutputFileMode};
 
 #[derive(Serialize)]
 #[serde(untagged)]
@@ -62,7 +60,6 @@ pub(crate) fn adapter(
     adapter::TypedCommandAdapter::json_only(
         CommandJsonFamily::Workspace,
         output_file_mode,
-        CommandOutputContractKind::JsonEnvelope,
         run_json,
     )
 }


### PR DESCRIPTION
## Summary
- Add a shared `CommandOutputDescriptor::json_envelope` constructor for the common JSON-envelope command contract shape.
- Route registry-driven descriptors, typed adapters, and existing test/bench/lint/audit output descriptors through the shared constructor.
- Tighten `TypedCommandAdapter::json_only` so callers no longer redundantly pass the invariant `JsonEnvelope` contract kind.

## Verification
- `rustfmt src/command_contract/output.rs src/commands/adapter.rs src/commands/fleet.rs src/commands/version.rs src/commands/bench.rs src/commands/test.rs src/commands/lint.rs src/commands/audit.rs`
- `git diff --check`
- Targeted source searches for stale `TypedCommandAdapter::json_only` call sites and removed imports.
- Local cargo commands not run, per instruction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation/static verification