### PR TITLE
Repair core-agnostic-source test failure from god-file splits (#5217)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -173,7 +173,9 @@
           "src/core/product_identity.rs",
           "src/core/code_audit/conventions.rs",
           "src/core/runner/tool_registry.rs",
-          "src/core/cleanup.rs"
+          "src/core/cleanup.rs",
+          "src/core/cleanup/self_artifacts.rs",
+          "src/core/runner/lab_args/tests.rs"
         ],
         "id": "core-agnostic-source",
         "ignore_after_line_equals": [
@@ -275,10 +277,6 @@
           {
             "match_mode": "literal",
             "value": "Action Scheduler"
-          },
-          {
-            "match_mode": "literal",
-            "value": "runner-artifact://"
           }
         ],
         "type": "forbidden_terms"


### PR DESCRIPTION
Closes #5217

## Problem
main was RED: `core_owned_source_stays_language_and_framework_agnostic` (in `tests/core_agnostic_test.rs`) failed — 1 of 5234. CI logs for run 27802916305 had expired, so the failing test was unnamed in the issue. Recovered it via the run's `homeboy-observations-homeboy-test-gate-test-Linux` artifact, then reproduced locally with a single targeted test run.

## Root cause
Three recent god-file/refactor merges relocated literals that were already tolerated, surfacing them as **new, non-baselined** `core-agnostic-source` boundary leaks (the test asserts no new findings beyond baseline):

- **`src/core/cleanup/self_artifacts.rs`** (`cargo`, `Cargo.toml`) — #5110 split `src/core/cleanup.rs` into this sub-module. The old file was already in `exclude_path_contains`, but the new path is not. These literals are homeboy's own Cargo-manifest self-inspection, not an ecosystem leak.
- **`src/core/runner/lab_args/tests.rs`** (`npm`, `WooCommerce`) — #5192 extracted lab_args tests into a dedicated file. Previously these fixture literals sat below `#[cfg(test)]` and were skipped via `ignore_after_line_equals`; the extracted test file isn't gated by that line.
- **`src/core/proof.rs`** (`runner-artifact://`) — #5168 added `runner-artifact://` matching. This is homeboy's own evidence URI scheme (used right next to the unflagged `gh://`), not a third-party framework literal.

## Fix
Config-only change in `homeboy.json` — no production code, no new ecosystem literals baselined:
- Add the two relocated files to the `core-agnostic-source` `exclude_path_contains` (restoring prior scope intent for the split god files).
- Remove the homeboy-owned `runner-artifact://` scheme from the policy's forbidden terms.

## Validation
- `cargo test --test core_agnostic_test` → 4 passed (target test green)
- `cargo test --test architecture_core_agnostic_test` → 11 passed
- No Rust changes, so no `cargo fmt`/build impact. Full suite left to CI.

Did not touch `docs/changelog.md`.