### PR TITLE
Signal Lab auto-offload target and clarify remote failures

### DIFF
--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -275,11 +275,19 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
 
     let mut messages = Vec::new();
     if matches!(selection.source, LabRunnerSelectionSource::Default) {
-        messages.push(format!(
-            "Lab offload: auto-selected default {} runner `{}`.",
+        // Make the auto-offload visible up front (#3815): the operator did not
+        // ask for a runner explicitly, so spell out that this command is about
+        // to leave the local machine and run remotely, on which runner, and how
+        // to keep it local. Without this the first sign of remote execution is
+        // a confusing remote-specific failure (e.g. a local `@file` that does
+        // not exist on the runner).
+        let auto_offload_signal = format!(
+            "Lab offload: auto-selected default {} runner `{}`; this command will run REMOTELY on that runner, not on this machine. Pass `--force-hot --allow-local-hot` to run it locally instead.",
             selection.mode.label(),
             selection.runner_id
-        ));
+        );
+        eprintln!("{auto_offload_signal}");
+        messages.push(auto_offload_signal);
     }
 
     plan = with_step(
@@ -1229,6 +1237,17 @@ fn run_lab_offload_inner(
     }
     stderr.push_str(&exec_output.stderr);
     if exit_code != 0 {
+        // Remote-failure clarity (#3815): a non-zero offloaded exit can be
+        // confusing because the failure surfaces controller-side as if it ran
+        // locally. Lead with an explicit banner that names the runner and
+        // remote workspace so a controller-vs-runner mismatch (a path/file that
+        // exists locally but not on the runner, a missing remote dependency,
+        // etc.) is obviously a remote failure, not a bug in the command itself.
+        // This runs for every offloaded failure, including plain cooks that
+        // have no agent-task run id.
+        stderr.push_str(&format!(
+            "Lab offload FAILED REMOTELY: command exited {exit_code} on runner `{runner_id}` (remote workspace `{remote_cwd}`), NOT on this machine. If the error references a path or file, check that it exists on runner `{runner_id}`, not just locally.\n"
+        ));
         if let Some(run_id) = agent_task_run_id.as_deref() {
             if let Some(envelope) = parse_offloaded_dispatch_envelope_from_outputs(
                 &exec_output.stdout,


### PR DESCRIPTION
## Summary
Closes #3815.

`homeboy agent-task cook` silently auto-offloads to a connected default Lab runner with no obvious signal that execution jumped to a remote machine. The first sign was usually a confusing remote-specific failure (e.g. a local `--provider-config @file` that can't be read on the runner), making it unclear whether the failure was in the cook itself or an artifact of remote execution.

This makes the auto-offload **visible up front** and makes the **remote failure mode explicit**:

- **Up-front offload signal:** When a command auto-offloads to a default Lab runner, emit a clear early line — which runner, that execution is REMOTE (not local), and how to force local (`--force-hot --allow-local-hot`). Printed via `eprintln!` immediately and also threaded into the result messages.
- **Remote-failure clarity:** On any non-zero offloaded exit, lead with an explicit banner naming the runner and remote workspace, so a controller-vs-runner mismatch (path/file that exists locally but not on the runner, missing remote dependency) reads as a remote failure rather than a bug in the command. This now fires for every offloaded failure, including plain cooks with no agent-task run id (previously the extra context only appeared when an agent-task run id was present).

Scoped strictly to offload signaling/output in `src/core/runner/lab/offload.rs`. No changes to routing behavior, the local-override flag surface (the `--local` alias suggestion in the issue is left for a separate change), or `docs/changelog.md`.

## Validation
- `cargo fmt`
- `cargo build --lib` (passes locally; full build/test left to CI)