### PR TITLE
fix(cook): materialize worktree dependencies before verify gate

### DIFF
--- a/src/core/agent_task_promotion.rs
+++ b/src/core/agent_task_promotion.rs
@@ -275,6 +275,7 @@ fn promote_with_provider(
     }
 
     let mut deterministic_gates = Vec::new();
+    let mut dependencies_materialized = false;
     if !options.dry_run
         && (!options.gates.verify.is_empty() || !options.gates.private_verify.is_empty())
     {
@@ -286,6 +287,13 @@ fn promote_with_provider(
                 None,
             )
         })?;
+        // Materialize dependencies (composer install / npm install / component
+        // deps script) in the freshly created worktree before running the
+        // verify gates. Without this, a fresh worktree has no vendor/ or
+        // node_modules/ and PHP/JS gates fatal on missing autoloaded deps,
+        // masking the real pass/fail signal (#3771).
+        dependencies_materialized =
+            crate::core::hygiene::materialize_worktree_dependencies(Path::new(worktree_path))?;
         for (index, command) in options.gates.verify.iter().enumerate() {
             deterministic_gates.push(provider.verify(
                 worktree_path,
@@ -350,6 +358,7 @@ fn promote_with_provider(
             "source_schema": outcome.schema,
             "artifact_metadata": artifact.metadata,
             "worktree_path": applied_worktree_path,
+            "dependencies_materialized": dependencies_materialized,
         }),
         operator_notification,
     })
@@ -1392,6 +1401,72 @@ mod tests {
             report.deterministic_gates[1].visibility,
             AgentTaskGateVisibility::Private
         );
+    }
+
+    #[test]
+    fn promote_materializes_worktree_dependencies_before_verify_gate() {
+        // #3771: a freshly created worktree has no installed dependencies, so a
+        // verify gate that touches autoloaded deps fatals on missing deps
+        // instead of reporting a real pass/fail. Promotion must run the
+        // component's dependency install step against the worktree before the
+        // verify gate executes. This uses a runtime-agnostic component `deps`
+        // script (no composer/npm binary required) to prove the install ran.
+        crate::test_support::with_isolated_home(|_| {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let (source_path, source) = write_patch_source(&temp);
+
+            let worktree_path = temp.path().join("worktree");
+            std::fs::create_dir_all(&worktree_path).expect("worktree dir");
+            let deps_marker = worktree_path.join("deps-installed.txt");
+            std::fs::write(
+                worktree_path.join("homeboy.json"),
+                serde_json::json!({
+                    "id": "deps-worktree",
+                    "scripts": {
+                        "deps": ["sh -c 'printf installed > deps-installed.txt'"]
+                    }
+                })
+                .to_string(),
+            )
+            .expect("worktree manifest");
+
+            let mut provider = FakePromotionWorkspaceProvider {
+                workspace_path: Some(worktree_path.clone()),
+                ..Default::default()
+            };
+
+            let report = promote_with_provider(
+                AgentTaskPromotionOptions {
+                    source,
+                    source_run_id: Some("run-3771".to_string()),
+                    source_path: Some(source_path),
+                    to_worktree: "repo@worktree".to_string(),
+                    task_id: None,
+                    artifact_id: None,
+                    dry_run: false,
+                    gates: VerifyGateOptions {
+                        verify: vec!["true".to_string()],
+                        private_verify: Vec::new(),
+                        private_gate_reveal: AgentTaskGateRevealPolicy::FullEvidence,
+                    },
+                    provider_command: None,
+                },
+                &mut provider,
+            )
+            .expect("promotion materializes deps then verifies");
+
+            assert!(
+                deps_marker.exists(),
+                "dependency install step should run against the worktree before the verify gate"
+            );
+            assert_eq!(
+                report.provenance["dependencies_materialized"].as_bool(),
+                Some(true),
+                "promotion report should record that dependencies were materialized"
+            );
+            assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+            assert_eq!(provider.verify_calls.len(), 1);
+        });
     }
 
     #[test]

--- a/src/core/hygiene.rs
+++ b/src/core/hygiene.rs
@@ -514,6 +514,45 @@ pub(crate) fn run_validation_dependency_lifecycle(
     run_dependency_build_lifecycle(component, path)
 }
 
+/// Materialize dependencies (e.g. `composer install`, `npm install`) for the
+/// component rooted at `path` so that downstream gates/tests run against a
+/// dependency-ready worktree rather than fataling on missing autoloaded deps.
+///
+/// This is generic and config-driven: it resolves the component's dependency
+/// providers (composer/npm/component-script/extension) and runs each provider's
+/// install step. When no component or dependency provider can be resolved for
+/// the path (nothing to install), it is a no-op and returns `Ok(false)`.
+/// Returns `Ok(true)` when at least one install step ran.
+///
+/// A provider install failure is propagated as an error so callers can
+/// distinguish a genuine setup failure from a real gate result.
+pub fn materialize_worktree_dependencies(path: &Path) -> Result<bool> {
+    let Some(component) = resolve_component_for_dependency_materialization(path) else {
+        return Ok(false);
+    };
+
+    let providers = match deps_provider::resolve_dependency_providers(&component, path) {
+        Ok(providers) => providers,
+        // No dependency provider resolved for this worktree -> nothing to do.
+        Err(_) => return Ok(false),
+    };
+
+    let mut ran = false;
+    for provider in providers {
+        if provider.install(&component, path)?.is_some() {
+            ran = true;
+        }
+    }
+    Ok(ran)
+}
+
+fn resolve_component_for_dependency_materialization(path: &Path) -> Option<Component> {
+    let path_arg = path.display().to_string();
+    let mut component = component::resolve_effective(None, Some(&path_arg), None).ok()?;
+    component.local_path = path_arg;
+    Some(component)
+}
+
 fn run_validation_dependency_lifecycle_isolated(component: &Component, path: &Path) -> Result<()> {
     let tempdir = tempfile::tempdir().map_err(|err| {
         Error::internal_io(


### PR DESCRIPTION
## Summary
Closes #3771.

A freshly created cook worktree has no installed dependencies (no composer `vendor/` or npm `node_modules/`), so a verify/test gate that touches autoloaded deps **fatals on missing dependencies** instead of reporting a real pass/fail:

```
PHP Fatal error: Uncaught RuntimeException: Agents API dependency is missing. Run composer install before this smoke.
```

The cook loop correctly classifies this as a red gate, but the failure is **environmental** (deps not installed), not a code defect — so unattended fleet cooking against fresh worktrees spuriously fails gates.

## Fix
Wire dependency materialization into the promotion verify-gate setup (`agent_task_promotion::promote_with_provider`): after the candidate patch is applied to the worktree and **before** the deterministic verify gates run, resolve the component's dependency providers and run each provider's install step against the worktree.

- Reuses the existing generic, **config-driven deps-provider lifecycle** (composer / npm / component `scripts.deps` / extension) — not hardcoded to PHP/composer.
- New `hygiene::materialize_worktree_dependencies(path)` resolves the component at the worktree root and runs the install lifecycle; no-ops when no component/provider resolves.
- Promotion report records `dependencies_materialized` in `provenance`.

## Test
Added `promote_materializes_worktree_dependencies_before_verify_gate`, which uses a runtime-agnostic component `deps` script (no composer/npm binary required) to prove the install step runs against the worktree before the verify gate, and asserts the provenance flag.

## Validation
- `cargo build --lib` passes locally.
- `cargo fmt` clean on changed files.
- Full build/test deferred to CI per this VPS's build policy.