### PR TITLE
Isolate per-run cook/dispatch workspaces (Closes #4393)

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -377,6 +377,7 @@ fn materialize_lab_extension_source(
             git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),
             allow_dirty_lab_workspace: false,
+            run_isolation_token: None,
         },
     )?;
 

--- a/src/commands/runner/workspace/mod.rs
+++ b/src/commands/runner/workspace/mod.rs
@@ -92,6 +92,7 @@ fn sync(
             git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),
             allow_dirty_lab_workspace,
+            run_isolation_token: None,
         },
     )
 }

--- a/src/core/runner/lab/agent_task_bridge.rs
+++ b/src/core/runner/lab/agent_task_bridge.rs
@@ -170,6 +170,7 @@ fn sync_inline_agent_task_file(
             git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),
             allow_dirty_lab_workspace: false,
+            run_isolation_token: None,
         },
     )?
     .0;
@@ -337,6 +338,17 @@ pub(super) fn agent_task_dispatch_requested_run_id(args: &[String]) -> Option<St
 }
 
 pub(super) fn ensure_agent_task_dispatch_run_id(args: &[String]) -> Option<(Vec<String>, String)> {
+    ensure_agent_task_dispatch_run_id_with(args, None)
+}
+
+/// Like [`ensure_agent_task_dispatch_run_id`] but, when no `--run-id` is already
+/// present, uses `preferred` as the injected run id instead of generating a
+/// fresh UUID. This lets the offload orchestrator keep the workspace-isolation
+/// token and the dispatched `--run-id` identical for a given run (#4393).
+pub(super) fn ensure_agent_task_dispatch_run_id_with(
+    args: &[String],
+    preferred: Option<&str>,
+) -> Option<(Vec<String>, String)> {
     let invocation = CommandInvocation::for_subcommand(args, "agent-task")?;
     let action_index = invocation.child_index_matching(&["dispatch", "cook"])?;
 
@@ -344,11 +356,25 @@ pub(super) fn ensure_agent_task_dispatch_run_id(args: &[String]) -> Option<(Vec<
         return Some((args.to_vec(), run_id));
     }
 
-    let run_id = format!("agent-task-{}", uuid::Uuid::new_v4());
+    let run_id = preferred
+        .filter(|id| !id.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("agent-task-{}", uuid::Uuid::new_v4()));
     let out = ArgEditor::new(args)
         .insert_after(action_index, ["--run-id".to_string(), run_id.clone()])
         .into_args();
     Some((out, run_id))
+}
+
+/// Resolves the stable per-run isolation token for an agent-task `dispatch`/`cook`
+/// offload: the explicit `--run-id` when provided, otherwise a freshly generated
+/// run id. Returns `None` for non-dispatch/cook invocations (which already use
+/// unique snapshot workspaces and need no extra isolation).
+pub(super) fn agent_task_dispatch_run_isolation_token(args: &[String]) -> Option<String> {
+    if let Some(run_id) = agent_task_dispatch_requested_run_id(args) {
+        return Some(run_id);
+    }
+    ensure_agent_task_dispatch_run_id(args).map(|(_, run_id)| run_id)
 }
 
 pub(super) fn lab_pre_dispatch_failure_message(output: &str) -> Option<String> {
@@ -669,6 +695,84 @@ mod tests {
         assert_eq!(out[5], run_id);
         assert_eq!(out[6], "--repo");
         assert_eq!(out[7], "homeboy");
+    }
+
+    #[test]
+    fn ensure_agent_task_dispatch_run_id_with_uses_preferred_id_when_unset() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--repo".to_string(),
+            "homeboy".to_string(),
+        ];
+
+        let (out, run_id) = ensure_agent_task_dispatch_run_id_with(&args, Some("iso-token"))
+            .expect("agent task args");
+
+        assert_eq!(run_id, "iso-token");
+        assert!(out.contains(&"--run-id".to_string()));
+        assert!(out.contains(&"iso-token".to_string()));
+    }
+
+    #[test]
+    fn ensure_agent_task_dispatch_run_id_with_preserves_explicit_run_id() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--run-id".to_string(),
+            "explicit-run".to_string(),
+        ];
+
+        let (out, run_id) = ensure_agent_task_dispatch_run_id_with(&args, Some("iso-token"))
+            .expect("agent task args");
+
+        // An explicit --run-id always wins over the preferred isolation token.
+        assert_eq!(run_id, "explicit-run");
+        assert_eq!(out, args);
+    }
+
+    #[test]
+    fn dispatch_run_isolation_token_reuses_explicit_run_id() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "dispatch".to_string(),
+            "--run-id".to_string(),
+            "explicit-run".to_string(),
+        ];
+
+        assert_eq!(
+            agent_task_dispatch_run_isolation_token(&args),
+            Some("explicit-run".to_string())
+        );
+    }
+
+    #[test]
+    fn dispatch_run_isolation_token_generates_for_unset_run_id() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--repo".to_string(),
+            "homeboy".to_string(),
+        ];
+
+        let token = agent_task_dispatch_run_isolation_token(&args).expect("token");
+        assert!(token.starts_with("agent-task-"));
+    }
+
+    #[test]
+    fn dispatch_run_isolation_token_none_for_non_dispatch_commands() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "status".to_string(),
+            "run-1".to_string(),
+        ];
+
+        assert!(agent_task_dispatch_run_isolation_token(&args).is_none());
     }
 
     #[test]

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -68,9 +68,10 @@ use super::super::{
 };
 
 use super::agent_task_bridge::{
-    ensure_agent_task_dispatch_run_id, lab_pre_dispatch_failure_message,
-    materialize_inline_agent_task_plan_arg, materialize_inline_agent_task_tasks_arg,
-    mirror_agent_task_run_plan_lifecycle, parse_offloaded_dispatch_envelope_from_outputs,
+    agent_task_dispatch_run_isolation_token, ensure_agent_task_dispatch_run_id_with,
+    lab_pre_dispatch_failure_message, materialize_inline_agent_task_plan_arg,
+    materialize_inline_agent_task_tasks_arg, mirror_agent_task_run_plan_lifecycle,
+    parse_offloaded_dispatch_envelope_from_outputs,
 };
 use super::evidence::terminal_lab_run_evidence;
 use super::secrets::{
@@ -837,6 +838,13 @@ fn run_lab_offload_inner(
     )?);
     extra_workspaces.extend(path_setting_extra_workspaces(&offload_args, &source_path)?);
     extra_workspaces.extend(rig_component_path_env_extra_workspaces(&source_path)?);
+    // Isolate the primary workspace per cook/dispatch run. Without a per-run
+    // token the git-mode remote path is keyed only on (source path, HEAD), so a
+    // later unrelated run at the same HEAD reuses the earlier run's checkout and
+    // can observe its leftover untracked artifacts (#4393). Resolve the
+    // agent-task run id (existing or freshly generated) up front and fold it
+    // into the workspace identity so each run gets a clean, isolated directory.
+    let run_isolation_token = agent_task_dispatch_run_isolation_token(request.normalized_args);
     let synced = sync_workspace(
         runner_id,
         RunnerWorkspaceSyncOptions {
@@ -847,6 +855,7 @@ fn run_lab_offload_inner(
             git_fetch_refs: git_fetch_refs.clone(),
             snapshot_includes: Vec::new(),
             allow_dirty_lab_workspace: request.allow_dirty_lab_workspace,
+            run_isolation_token: run_isolation_token.clone(),
         },
     )?
     .0;
@@ -1003,8 +1012,9 @@ fn run_lab_offload_inner(
         synced_remapped_plan,
         "lab.sync_remapped_agent_task_plan",
     );
-    let (remapped_args, agent_task_run_id) = ensure_agent_task_dispatch_run_id(&remapped_args)
-        .map_or((remapped_args, None), |(args, run_id)| (args, Some(run_id)));
+    let (remapped_args, agent_task_run_id) =
+        ensure_agent_task_dispatch_run_id_with(&remapped_args, run_isolation_token.as_deref())
+            .map_or((remapped_args, None), |(args, run_id)| (args, Some(run_id)));
 
     let mut command = command_prefix.argv.clone();
     command.extend(

--- a/src/core/runner/lab/secrets.rs
+++ b/src/core/runner/lab/secrets.rs
@@ -1107,10 +1107,14 @@ mod tests {
             .expect("provider default source should resolve on controller");
 
             assert!(matches!(
-                env.get("AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN").map(String::as_str),
+                env.get("AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN")
+                    .map(String::as_str),
                 Some("controller-access-token")
             ));
-            assert_eq!(diagnostics["runner_deferred_secret_env"], serde_json::json!([]));
+            assert_eq!(
+                diagnostics["runner_deferred_secret_env"],
+                serde_json::json!([])
+            );
             assert_eq!(
                 diagnostics["secret_env"],
                 serde_json::json!([

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -71,6 +71,7 @@ pub(super) fn sync_extra_lab_workspaces(
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: extra.snapshot_includes.clone(),
                 allow_dirty_lab_workspace: false,
+                run_isolation_token: None,
             },
         )?
         .0;

--- a/src/core/runner/rig_materialization.rs
+++ b/src/core/runner/rig_materialization.rs
@@ -91,6 +91,7 @@ pub(super) fn sync_lab_offload_rigs(
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    run_isolation_token: None,
                 },
             )?
             .0;

--- a/src/core/runner/validation_dependencies.rs
+++ b/src/core/runner/validation_dependencies.rs
@@ -507,6 +507,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    run_isolation_token: None,
                 },
             )
             .expect("sync workspace");
@@ -616,6 +617,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    run_isolation_token: None,
                 },
             )
             .expect("sync workspace");
@@ -691,6 +693,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    run_isolation_token: None,
                 },
             )
             .expect("sync workspace");
@@ -763,6 +766,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    run_isolation_token: None,
                 },
             )
             .expect_err("failed dependency build should fail sync");
@@ -843,6 +847,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    run_isolation_token: None,
                 },
             )
             .expect("sync workspace");

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -43,9 +43,10 @@ pub(super) const DEFAULT_EXCLUDES: &[&str] = &[
     "*.tsbuildinfo",
 ];
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum RunnerWorkspaceSyncMode {
+    #[default]
     Snapshot,
     Git,
 }
@@ -59,7 +60,7 @@ impl RunnerWorkspaceSyncMode {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RunnerWorkspaceSyncOptions {
     pub path: String,
     pub mode: RunnerWorkspaceSyncMode,
@@ -68,6 +69,16 @@ pub struct RunnerWorkspaceSyncOptions {
     pub git_fetch_refs: Vec<String>,
     pub snapshot_includes: Vec<String>,
     pub allow_dirty_lab_workspace: bool,
+    /// Opaque per-run token (e.g. an agent-task run id) folded into the
+    /// deterministic remote workspace path so two distinct cook/dispatch runs
+    /// at the same source HEAD never share a long-lived remote checkout.
+    ///
+    /// Without this, the git-mode remote path is keyed only on
+    /// `(source path, HEAD)`, so a later unrelated run reuses the earlier run's
+    /// workspace directory and can observe leftover untracked artifacts from it
+    /// (cross-run contamination, see #4393). When set, each run gets an
+    /// isolated `_lab_workspaces/<name>-<digest>` directory.
+    pub run_isolation_token: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -125,7 +136,12 @@ pub fn sync_workspace(
         RunnerWorkspaceSyncMode::Snapshot => {
             let snapshot = snapshot_identity(&local_path, &excludes, &includes)?;
             let remote_path = temp::unique_name(
-                &deterministic_remote_path(workspace_root, &local_path, &snapshot),
+                &deterministic_remote_path(
+                    workspace_root,
+                    &local_path,
+                    &snapshot,
+                    options.run_isolation_token.as_deref(),
+                ),
                 "",
             );
             let stats = local_snapshot_stats(&local_path, &excludes, &includes)?;
@@ -161,7 +177,12 @@ pub fn sync_workspace(
                 options.changed_since_base.as_deref(),
                 options.git_fetch_refs,
             )?;
-            let remote_path = deterministic_remote_path(workspace_root, &local_path, &git.head);
+            let remote_path = deterministic_remote_path(
+                workspace_root,
+                &local_path,
+                &git.head,
+                options.run_isolation_token.as_deref(),
+            );
             if options.controller_routed_git
                 || git.branch.is_none()
                 || super::source_materialization::requires_controller_routed_workspace_sync(
@@ -269,7 +290,12 @@ fn validate_absolute_path(field: &str, path: &str) -> Result<()> {
     ))
 }
 
-fn deterministic_remote_path(workspace_root: &str, local_path: &Path, snapshot: &str) -> String {
+fn deterministic_remote_path(
+    workspace_root: &str,
+    local_path: &Path,
+    snapshot: &str,
+    run_isolation_token: Option<&str>,
+) -> String {
     let name = local_path
         .file_name()
         .and_then(|value| value.to_str())
@@ -277,6 +303,14 @@ fn deterministic_remote_path(workspace_root: &str, local_path: &Path, snapshot: 
     let mut hasher = Sha256::new();
     hasher.update(local_path.display().to_string().as_bytes());
     hasher.update(snapshot.as_bytes());
+    // Fold a per-run isolation token (when present) into the digest so two
+    // distinct runs at the same source HEAD never resolve to the same remote
+    // workspace directory. This prevents cross-run contamination where a later
+    // run observes an earlier run's leftover untracked artifacts (#4393).
+    if let Some(token) = run_isolation_token.filter(|token| !token.trim().is_empty()) {
+        hasher.update(b"\0run-isolation\0");
+        hasher.update(token.as_bytes());
+    }
     let digest = hex_prefix(&hasher.finalize(), 12);
     format!(
         "{}/_lab_workspaces/{}-{}",
@@ -1005,11 +1039,50 @@ mod tests {
     #[test]
     fn deterministic_path_stays_under_workspace_root() {
         let path = Path::new("/Users/user/Developer/homeboy@fix-runner-workspace-sync");
-        let remote = deterministic_remote_path("/srv/homeboy", path, "snapshot:abc");
+        let remote = deterministic_remote_path("/srv/homeboy", path, "snapshot:abc", None);
 
         assert!(
             remote.starts_with("/srv/homeboy/_lab_workspaces/homeboy-fix-runner-workspace-sync-")
         );
+    }
+
+    #[test]
+    fn run_isolation_token_yields_distinct_remote_paths_for_same_head() {
+        let path = Path::new("/Users/user/Developer/homeboy");
+        let base = deterministic_remote_path("/srv/homeboy", path, "abc123", None);
+        let run_a = deterministic_remote_path("/srv/homeboy", path, "abc123", Some("run-a"));
+        let run_b = deterministic_remote_path("/srv/homeboy", path, "abc123", Some("run-b"));
+
+        // Two different runs at the same HEAD must not share a remote workspace
+        // directory, otherwise leftover untracked artifacts from one run can
+        // contaminate the other (#4393).
+        assert_ne!(run_a, run_b);
+        assert_ne!(run_a, base);
+        assert_ne!(run_b, base);
+        // All paths still stay under the deterministic workspace root.
+        for remote in [&base, &run_a, &run_b] {
+            assert!(remote.starts_with("/srv/homeboy/_lab_workspaces/homeboy-"));
+        }
+    }
+
+    #[test]
+    fn run_isolation_token_is_stable_for_same_run() {
+        let path = Path::new("/Users/user/Developer/homeboy");
+        let first = deterministic_remote_path("/srv/homeboy", path, "abc123", Some("run-a"));
+        let second = deterministic_remote_path("/srv/homeboy", path, "abc123", Some("run-a"));
+
+        // The same run id must deterministically resolve to the same workspace
+        // so retries/streaming of one run reuse its own isolated checkout.
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn blank_run_isolation_token_does_not_change_remote_path() {
+        let path = Path::new("/Users/user/Developer/homeboy");
+        let base = deterministic_remote_path("/srv/homeboy", path, "abc123", None);
+        let blank = deterministic_remote_path("/srv/homeboy", path, "abc123", Some("   "));
+
+        assert_eq!(base, blank);
     }
 
     #[test]
@@ -1089,6 +1162,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    run_isolation_token: None,
                 },
             )
             .expect("sync workspace");
@@ -1135,6 +1209,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    run_isolation_token: None,
                 },
             )
             .expect("sync workspace");
@@ -1203,6 +1278,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    run_isolation_token: None,
                 },
             )
             .expect("sync workspace");
@@ -1284,6 +1360,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    run_isolation_token: None,
                 },
             );
 
@@ -1358,6 +1435,7 @@ mod tests {
                         git_fetch_refs: Vec::new(),
                         snapshot_includes: Vec::new(),
                         allow_dirty_lab_workspace: false,
+                        run_isolation_token: None,
                     },
                 )
             };
@@ -1426,6 +1504,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    run_isolation_token: None,
                 },
             )
             .expect("sync workspace");
@@ -1507,6 +1586,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    run_isolation_token: None,
                 },
             )
             .expect_err("shallow source checkout should fail before bundle creation");
@@ -1585,6 +1665,7 @@ mod tests {
                     git_fetch_refs: Vec::new(),
                     snapshot_includes: Vec::new(),
                     allow_dirty_lab_workspace: false,
+                    run_isolation_token: None,
                 },
             )
             .expect("sync workspace");

--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -926,6 +926,7 @@ fn materialize_runner_source_path(runner: &Runner, source_path: &Path) -> Result
             git_fetch_refs: Vec::new(),
             snapshot_includes: Vec::new(),
             allow_dirty_lab_workspace: false,
+            run_isolation_token: None,
         },
     )?;
 


### PR DESCRIPTION
## Summary

Closes #4393.

Two separate Lab cook fanouts at the same source HEAD reused the **same** remote workspace directory, so a leftover untracked file from the first run (`src/core/agent_task_dispatch_service.rs`) was still present and got picked up in a later, unrelated papercut run — cross-run contamination.

## Root cause

In git-mode workspace sync (`src/core/runner/workspace.rs`), the remote checkout path is computed by `deterministic_remote_path()` keyed **only** on `(source path, HEAD)`. Two distinct cook/dispatch runs at the same HEAD therefore resolve to the identical `_lab_workspaces/<name>-<digest>` directory and share state across runs. (Snapshot mode already gets a unique dir via `temp::unique_name`, so the leak was specific to git mode.)

## Fix

Fold a per-run isolation token into the deterministic workspace identity so each cook/dispatch run gets its own isolated remote checkout:

- Add `run_isolation_token: Option<String>` to `RunnerWorkspaceSyncOptions`; when set (and non-blank) it is hashed into `deterministic_remote_path()` for both git and snapshot modes.
- In the Lab offload orchestrator (`offload.rs`), resolve the agent-task run id up front (explicit `--run-id`, else a freshly generated one) and pass it as the isolation token for the primary workspace sync.
- Keep the isolation token and the dispatched `--run-id` identical via `ensure_agent_task_dispatch_run_id_with(preferred)`, so retries/streaming of one run reuse that run's own isolated checkout while different runs never collide.
- Non-dispatch/cook commands and inline-plan snapshots are unchanged (they already use unique snapshot dirs).

## Tests

- `run_isolation_token_yields_distinct_remote_paths_for_same_head` — different run ids at the same HEAD never share a dir.
- `run_isolation_token_is_stable_for_same_run` — same run id is deterministic (retry-safe).
- `blank_run_isolation_token_does_not_change_remote_path` — backward-compatible default.
- agent_task_bridge: preferred-id injection, explicit-id precedence, and isolation-token resolution coverage.

`cargo build --lib` + `cargo fmt` pass locally; full build/test left to CI per VPS resource limits.

Did not touch `docs/changelog.md` (homeboy owns it).