### PR TITLE
Accept named refs after Lab extension sync

### DIFF
--- a/src/commands/lab.rs
+++ b/src/commands/lab.rs
@@ -478,7 +478,23 @@ fn parse_trailing_json(stdout: &str) -> Option<Value> {
 }
 
 fn revision_matches(requested: &str, installed: &str) -> bool {
-    requested == installed || requested.starts_with(installed) || installed.starts_with(requested)
+    if installed.trim().is_empty() {
+        return false;
+    }
+
+    if requested == installed
+        || requested.starts_with(installed)
+        || installed.starts_with(requested)
+    {
+        return true;
+    }
+
+    !looks_like_git_revision(requested)
+}
+
+fn looks_like_git_revision(value: &str) -> bool {
+    let trimmed = value.trim();
+    trimmed.len() >= 7 && trimmed.chars().all(|ch| ch.is_ascii_hexdigit())
 }
 
 fn extension_sync_revision_error(
@@ -785,6 +801,16 @@ Installing declared dependencies...
             "941bf8cff9f88758123db837ed12bb6f6de5d00f"
         ));
         assert!(!revision_matches("941bf8c", "f36543e"));
+    }
+
+    #[test]
+    fn lab_extension_sync_accepts_named_refs_resolved_by_install() {
+        assert!(revision_matches("main", "941bf8c"));
+        assert!(revision_matches(
+            "fix/codebox-bundled-agents-api",
+            "9d17a58a"
+        ));
+        assert!(!revision_matches("main", ""));
     }
 
     #[test]

--- a/src/core/runner/workspace.rs
+++ b/src/core/runner/workspace.rs
@@ -1725,6 +1725,7 @@ mod tests {
                 git_fetch_refs: Vec::new(),
                 snapshot_includes: Vec::new(),
                 allow_dirty_lab_workspace: false,
+                run_isolation_token: None,
             };
             let (first, _) = sync_workspace("lab-local", options.clone()).expect("first sync");
             let remote_path = Path::new(&first.remote_path);


### PR DESCRIPTION
## Summary
- Accept successful Lab extension installs for named refs like branches/tags when the runner reports a non-empty installed source revision.
- Keep SHA-like refs strict via prefix matching.
- Repair a stale RunnerWorkspaceSyncOptions test initializer after the run isolation token field was added.

## Verification
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@controller-materialize-main --runner homeboy-lab --allow-dirty-lab-workspace --skip-lint -- lab_extension_sync_accepts_named_refs_resolved_by_install`
- `homeboy test homeboy --path /Users/chubes/Developer/homeboy@controller-materialize-main --runner homeboy-lab --allow-dirty-lab-workspace --skip-lint -- snapshot_sync_uses_unique_clean_workspace_for_same_snapshot`
- `homeboy lint homeboy --path /Users/chubes/Developer/homeboy@controller-materialize-main --runner homeboy-lab --allow-dirty-lab-workspace`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the Lab extension-sync validation failure, drafted the minimal Rust fix and tests, and ran Lab verification; Chris remains responsible for review and merge.
