### PR TITLE
Repair core-agnostic-source test after dependency-materialization comments (#5227)

### DIFF
--- a/src/core/agent_task_promotion.rs
+++ b/src/core/agent_task_promotion.rs
@@ -287,11 +287,11 @@ fn promote_with_provider(
                 None,
             )
         })?;
-        // Materialize dependencies (composer install / npm install / component
-        // deps script) in the freshly created worktree before running the
-        // verify gates. Without this, a fresh worktree has no vendor/ or
-        // node_modules/ and PHP/JS gates fatal on missing autoloaded deps,
-        // masking the real pass/fail signal (#3771).
+        // Materialize dependencies via the component's resolved dependency
+        // providers (install + build steps) in the freshly created worktree
+        // before running the verify gates. Without this, a fresh worktree has
+        // no installed dependency artifacts and gates fatal on missing
+        // dependencies, masking the real pass/fail signal (#3771).
         dependencies_materialized =
             crate::core::hygiene::materialize_worktree_dependencies(Path::new(worktree_path))?;
         for (index, command) in options.gates.verify.iter().enumerate() {

--- a/src/core/hygiene.rs
+++ b/src/core/hygiene.rs
@@ -514,15 +514,15 @@ pub(crate) fn run_validation_dependency_lifecycle(
     run_dependency_build_lifecycle(component, path)
 }
 
-/// Materialize dependencies (e.g. `composer install`, `npm install`) for the
-/// component rooted at `path` so that downstream gates/tests run against a
-/// dependency-ready worktree rather than fataling on missing autoloaded deps.
+/// Materialize a component's declared dependencies for the component rooted at
+/// `path` so that downstream gates/tests run against a dependency-ready
+/// worktree rather than fataling on missing dependency artifacts.
 ///
 /// This is generic and config-driven: it resolves the component's dependency
-/// providers (composer/npm/component-script/extension) and runs each provider's
-/// install step. When no component or dependency provider can be resolved for
-/// the path (nothing to install), it is a no-op and returns `Ok(false)`.
-/// Returns `Ok(true)` when at least one install step ran.
+/// providers (component-script / extension-declared providers) and runs each
+/// provider's install step. When no component or dependency provider can be
+/// resolved for the path (nothing to install), it is a no-op and returns
+/// `Ok(false)`. Returns `Ok(true)` when at least one install step ran.
 ///
 /// A provider install failure is propagated as an error so callers can
 /// distinguish a genuine setup failure from a real gate result.


### PR DESCRIPTION
Closes #5227

## Problem
main was RED on the **Test** gate (#5227). The Test gate builds tests + runs clippy + runs the suite, so two independent defects were stacking on it. Both are fixed here.

## Defect 1 — `core_owned_source_stays_language_and_framework_agnostic` (the named #5227 failure)
The #3771 worktree dependency-materialization work (merged in #5229) introduced **doc/inline comments** naming concrete ecosystem tooling. The `core-agnostic-source` source policy scans comment lines, so these surfaced as new, non-baselined `core_boundary_leak` findings:
- `src/core/agent_task_promotion.rs` (`promote_with_provider`) — `composer install / npm install ... PHP/JS gates`.
- `src/core/hygiene.rs` (`materialize_worktree_dependencies`) — `composer install`, `npm install`, `composer/npm/...`.

The behavior is already generic and config-driven (resolves a component's *declared* dependency providers). Only the comments leaked literals. **Fix: reword the comments** to describe the generic provider mechanism — removes the leak at the source, no baseline change, no policy weakening.

## Defect 2 — lib-test compile error (E0063) blocking the same gate
#5231 added `run_isolation_token` to `RunnerWorkspaceSyncOptions` but left one **test-module initializer** in `src/core/runner/workspace.rs` unupdated → `error[E0063]: missing field run_isolation_token`. This compiles under `cargo build --lib` but fails the Test gate (tests + clippy), so the gate stayed RED even after Defect 1 was fixed. **Fix: add `run_isolation_token: None`** to the test initializer.

## Validation
- `cargo test --test core_agnostic_test` → **4 passed** (was 3/1).
- `cargo test --test architecture_core_agnostic_test` → **11 passed**.
- `cargo check --lib --tests` → clean (E0063 gone, no other compile errors).
- `cargo build --lib` clean; `cargo fmt` no-op on logic.
- Full suite left to CI per VPS build policy.

Did **not** touch `docs/changelog.md`.