### PR TITLE
Clear dead-code markers on test-only loop-controller and hygiene fns (Closes #5250)

### DIFF
--- a/src/core/agent_task_loop_controller.rs
+++ b/src/core/agent_task_loop_controller.rs
@@ -528,8 +528,8 @@ pub enum AgentTaskGateBundleCheckKind {
 }
 
 impl AgentTaskGateBundle {
-    // Part of the loop-controller API exercised by tests; production wiring is pending.
-    #[allow(dead_code)]
+    // Part of the loop-controller API exercised only by tests; production wiring is pending.
+    #[cfg(test)]
     pub(crate) fn from_verify_commands(
         bundle_id: impl Into<String>,
         commands: Vec<String>,
@@ -990,8 +990,8 @@ impl AgentTaskLoopControllerRecord {
         record
     }
 
-    // Part of the loop-controller API exercised by tests; production wiring is pending.
-    #[allow(dead_code)]
+    // Part of the loop-controller API exercised only by tests; production wiring is pending.
+    #[cfg(test)]
     pub(crate) fn block_action_for_runner_policy(
         &mut self,
         action_id: &str,
@@ -1164,8 +1164,8 @@ impl AgentTaskLoopControllerRecord {
         Ok(())
     }
 
-    // Part of the loop-controller API exercised by tests; production wiring is pending.
-    #[allow(dead_code)]
+    // Part of the loop-controller API exercised only by tests; production wiring is pending.
+    #[cfg(test)]
     pub(crate) fn route_finding_packet(
         &mut self,
         finding: AgentTaskLoopFindingPacket,
@@ -1229,8 +1229,8 @@ impl AgentTaskLoopControllerRecord {
         )
     }
 
-    // Part of the loop-controller API exercised by tests; production wiring is pending.
-    #[allow(dead_code)]
+    // Part of the loop-controller API exercised only by tests; production wiring is pending.
+    #[cfg(test)]
     pub(crate) fn record_candidate_patch_validation(
         &mut self,
         candidate: AgentTaskLoopCandidatePatch,

--- a/src/core/hygiene.rs
+++ b/src/core/hygiene.rs
@@ -109,8 +109,8 @@ pub struct DependencyHygieneOptions {
 }
 
 // Thin wrapper over `require_dependency_hygiene_for_source_with_settings`, kept for
-// callers that do not need settings; currently exercised by tests.
-#[allow(dead_code)]
+// callers that do not need settings; currently exercised only by tests.
+#[cfg(test)]
 pub(crate) fn require_dependency_hygiene_for_source(
     source_path: &Path,
     extension_path: Option<&Path>,


### PR DESCRIPTION
## Summary
Clears the 5 `dead_code_marker` audit findings from #5250 (the companion to #5234's `unreferenced_export` work, which narrowed these same functions to `pub(crate)` and added the now-flagged `#[allow(dead_code)]` markers).

All 5 functions are referenced **only** from their file's `#[cfg(test)] mod tests` blocks — there are no production callers. Rather than suppress the resulting non-test `dead_code` warning with `#[allow(dead_code)]`, this gates each function with `#[cfg(test)]`, which:
- removes the `allow_dead_code` marker the audit flags,
- keeps the test references compiling,
- excludes the functions from production builds entirely (no warning, no marker needed).

## Changes
- `src/core/agent_task_loop_controller.rs`: `from_verify_commands`, `block_action_for_runner_policy`, `route_finding_packet`, `record_candidate_patch_validation` — `#[allow(dead_code)]` → `#[cfg(test)]`.
- `src/core/hygiene.rs`: `require_dependency_hygiene_for_source` — `#[allow(dead_code)]` → `#[cfg(test)]`.

## Validation
- `cargo fmt` clean.
- `cargo build --lib` clean (confirms non-test build doesn't reference these fns).
- Full build/test left to CI.

Closes #5250