### PR TITLE
refactor(trace): dedupe git_probe_path and path-resolution helpers (#5237, #5239)

### DIFF
--- a/src/core/extension/trace/canonicality.rs
+++ b/src/core/extension/trace/canonicality.rs
@@ -241,7 +241,7 @@ fn check_declared_toolchain_provenance(
         match value {
             Some(path) if !path.trim().is_empty() => checks.push(check_git_checkout(
                 &format!("toolchain:{} ({key}, {source})", requirement.id),
-                &git_probe_path(Path::new(path)),
+                &crate::core::git::git_probe_path(Path::new(path)),
                 None,
                 reasons,
             )),
@@ -250,16 +250,6 @@ fn check_declared_toolchain_provenance(
                 requirement.label, key, source
             )),
         }
-    }
-}
-
-fn git_probe_path(path: &Path) -> std::path::PathBuf {
-    if path.is_file() {
-        path.parent()
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| path.to_path_buf())
-    } else {
-        path.to_path_buf()
     }
 }
 

--- a/src/core/extension/trace/run.rs
+++ b/src/core/extension/trace/run.rs
@@ -644,7 +644,7 @@ fn mark_non_canonical(toolchain: &mut TraceToolchainProvenance, reason: &str) {
 }
 
 fn git_provenance(path: &Path, source: Option<&str>) -> TraceGitProvenance {
-    let probe_path = git_probe_path(path);
+    let probe_path = crate::core::git::git_probe_path(path);
     let git_root = crate::core::git::get_git_root(&probe_path.to_string_lossy())
         .ok()
         .map(PathBuf::from)
@@ -655,16 +655,6 @@ fn git_provenance(path: &Path, source: Option<&str>) -> TraceGitProvenance {
         branch: crate::core::git::current_branch(&git_root),
         dirty: git_dirty_state(&git_root),
         source: source.map(ToString::to_string),
-    }
-}
-
-fn git_probe_path(path: &Path) -> PathBuf {
-    if path.is_file() {
-        path.parent()
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| path.to_path_buf())
-    } else {
-        path.to_path_buf()
     }
 }
 

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -57,9 +57,10 @@ pub use pr_policy::{
 };
 pub use primitives::{
     clone_repo, clone_repo_at_ref, current_branch, get_component_path_prefix, get_git_root,
-    head_sha, head_sha_short, is_workdir_clean_or_not_git, output_optional, output_optional_bytes,
-    pull_repo, remote_origin_url, remote_url, run_git, run_git_output, short_head_revision,
-    status_porcelain, status_porcelain_bytes, toplevel, update_to_remote_default_branch,
+    git_probe_path, head_sha, head_sha_short, is_workdir_clean_or_not_git, output_optional,
+    output_optional_bytes, pull_repo, remote_origin_url, remote_url, run_git, run_git_output,
+    short_head_revision, status_porcelain, status_porcelain_bytes, toplevel,
+    update_to_remote_default_branch,
 };
 pub(crate) use primitives::{is_git_repo, list_tracked_markdown_files};
 

--- a/src/core/git/primitives.rs
+++ b/src/core/git/primitives.rs
@@ -295,6 +295,22 @@ pub fn get_git_root(path: &str) -> Result<String> {
     .map(|s| s.trim().to_string())
 }
 
+/// Normalize a path into a directory suitable for probing git provenance.
+///
+/// Git commands need a directory to run inside; when the caller hands us a file
+/// path (e.g. a toolchain binary or component artifact), probe its parent
+/// directory instead. Directories (and files with no parent) are returned
+/// unchanged.
+pub fn git_probe_path(path: &Path) -> std::path::PathBuf {
+    if path.is_file() {
+        path.parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| path.to_path_buf())
+    } else {
+        path.to_path_buf()
+    }
+}
+
 /// Compute the relative path prefix of a component within a monorepo.
 ///
 /// If `local_path` is a subdirectory of the git root, returns the relative path


### PR DESCRIPTION
## Summary
Clears two trace-area audit findings, both touching `src/core/extension/trace/run.rs`.

### #5237 — near-duplication (`git_probe_path`)
`git_probe_path` was byte-for-byte identical in `trace/run.rs` and `trace/canonicality.rs`. Both call it immediately before/around `crate::core::git::get_git_root`, so the shared logic now lives next to that primitive as `crate::core::git::git_probe_path` (in `src/core/git/primitives.rs`, re-exported from `core::git`). Both trace sites now call the single shared helper.

### #5239 — parallel implementation (`recipe_path_from_args` vs `screenshot_path`)
Reviewed and judged a **coincidental/soft signal**, not real duplication — left as-is with justification:
- `recipe_path_from_args` (trace/run.rs): scans `(String, serde_json::Value)` JSON settings for a key containing `"recipe"`, falling back to the first workload `PathBuf`.
- `screenshot_path` (report/browser_evidence_compare.rs): scans `&[ArtifactRef]` for a `"source"` artifact to establish a parent dir, then for a `"screenshot"`-labelled artifact, resolving relative paths against that parent.

They share only the superficial shape "find an item by a label/key substring and produce a path." Input types, fallback strategy, and relative-path resolution all differ. A forced shared helper would require generic closures that obscure both call sites rather than reduce real duplication, so no change was made here.

## Validation
- `cargo fmt`
- single `cargo build --lib` — clean (per VPS build policy; full build/test left to CI)
- Single canonical `git_probe_path` definition, two call sites; no behavior change.

Closes #5237
Closes #5239