### PR TITLE
fix(cli): avoid extension loading for root help/version

### DIFF
--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -41,6 +41,25 @@ struct ExtensionCliDiscovery {
     health: ExtensionCliHealth,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StartupFastPath {
+    Help,
+    Version,
+}
+
+pub fn run_startup_fast_path(args: &[String]) -> Option<std::process::ExitCode> {
+    match startup_fast_path(args)? {
+        StartupFastPath::Help => {
+            let mut cmd = Cli::command();
+            cmd.print_help().expect("Failed to print help");
+            println!();
+        }
+        StartupFastPath::Version => println!("{}", upgrade::current_build_version()),
+    }
+
+    Some(std::process::ExitCode::SUCCESS)
+}
+
 impl CliRuntime {
     pub fn new() -> Self {
         let discovery = collect_extension_cli_info();
@@ -210,6 +229,14 @@ fn run_raw_agent_tool_dispatch(command: &Commands) -> Option<i32> {
 
 fn is_top_level_version_request(args: &[String]) -> bool {
     matches!(args, [_, flag] if flag == "--version" || flag == "-V")
+}
+
+fn startup_fast_path(args: &[String]) -> Option<StartupFastPath> {
+    match args {
+        [_, flag] if flag == "--help" || flag == "-h" => Some(StartupFastPath::Help),
+        [_, flag] if flag == "--version" || flag == "-V" => Some(StartupFastPath::Version),
+        _ => None,
+    }
 }
 
 impl Default for CliRuntime {
@@ -682,6 +709,38 @@ mod tests {
     #[test]
     fn normal_output_file_paths_are_allowed() {
         assert!(output_runtime::validate_output_file_path("./homeboy-output.json").is_none());
+    }
+
+    #[test]
+    fn startup_fast_path_only_matches_root_help_and_version_flags() {
+        let args = |values: &[&str]| {
+            values
+                .iter()
+                .map(|value| value.to_string())
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(
+            startup_fast_path(&args(&["homeboy", "--help"])),
+            Some(StartupFastPath::Help)
+        );
+        assert_eq!(
+            startup_fast_path(&args(&["homeboy", "-h"])),
+            Some(StartupFastPath::Help)
+        );
+        assert_eq!(
+            startup_fast_path(&args(&["homeboy", "--version"])),
+            Some(StartupFastPath::Version)
+        );
+        assert_eq!(
+            startup_fast_path(&args(&["homeboy", "-V"])),
+            Some(StartupFastPath::Version)
+        );
+        assert_eq!(
+            startup_fast_path(&args(&["homeboy", "status", "--help"])),
+            None
+        );
+        assert_eq!(startup_fast_path(&args(&["homeboy", "wp", "--help"])), None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,10 @@
 use homeboy::cli_runtime::CliRuntime;
 
 fn main() -> std::process::ExitCode {
-    CliRuntime::new().run_from_args(std::env::args().collect())
+    let args: Vec<String> = std::env::args().collect();
+    if let Some(exit_code) = homeboy::cli_runtime::run_startup_fast_path(&args) {
+        return exit_code;
+    }
+
+    CliRuntime::new().run_from_args(args)
 }


### PR DESCRIPTION
## Summary
- Add a pre-runtime startup fast path for exact root help/version invocations.
- Keep normal command parsing on `CliRuntime`, preserving dynamic extension command support outside the fast path.
- Cover the fast-path argument classifier so subcommand help still goes through the augmented parser.

## Tests / verification
- `git diff --check`
- `rustfmt --check src/main.rs src/cli_runtime.rs`
- Did not run cargo commands or benchmarks per instruction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the startup/help performance cleanup; Chris to review and CI to verify.