### PR TITLE
refactor: extract core git intent helpers

### DIFF
--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -2,7 +2,6 @@
 //! lifecycle, spec defaults, and the CLI dispatch bridge.
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use serde_json::Value;
 
@@ -19,6 +18,7 @@ use homeboy::core::agent_tasks::controller_service::{
 use homeboy::core::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::core::agent_tasks::scheduler::AgentTaskExecutorAdapter;
 use homeboy::core::config;
+use homeboy::core::git;
 use homeboy::core::proof::validate_proof_value;
 
 use homeboy::core::agent_tasks::dispatch_service;
@@ -264,17 +264,7 @@ fn git_root_for_spec(spec_path: &Path) -> Option<PathBuf> {
 }
 
 fn git_root_for_path(path: &Path) -> Option<PathBuf> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(path)
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let root = String::from_utf8(output.stdout).ok()?.trim().to_string();
-    (!root.is_empty()).then(|| PathBuf::from(root))
+    git::repo_root(path)
 }
 
 /// Bridge controller spawn-task `"dispatch"` requests into the CLI dispatch path.

--- a/src/commands/refactor/autofix_commit.rs
+++ b/src/commands/refactor/autofix_commit.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 
 use homeboy::core::git::{
-    configure_identity, execute_git_for_release, parse_git_identity, run_git,
+    commit_staged_with_author, configure_identity, has_staged_changes, parse_git_identity,
+    stage_all,
 };
 
 const AUTOFIX_PREFIX: &str = "chore(ci): homeboy autofix";
@@ -12,12 +13,10 @@ pub(super) fn commit_refactor_sources(
     sources: &homeboy::core::refactor::plan::RefactorSourceRun,
     git_identity: Option<&str>,
 ) -> homeboy::core::Result<()> {
-    run_git(Path::new(path), &["add", "-A"], "git add -A")?;
+    stage_all(Path::new(path))?;
 
     // Check if there's anything staged (fixes may have been no-ops after formatting)
-    let diff_check = execute_git_for_release(path, &["diff", "--cached", "--quiet"])
-        .map_err(|e| homeboy::core::Error::git_command_failed(format!("git diff: {e}")))?;
-    if diff_check.status.success() {
+    if !has_staged_changes(Path::new(path))? {
         eprintln!("[refactor] No staged changes after git add — skipping commit");
         return Ok(());
     }
@@ -27,11 +26,7 @@ pub(super) fn commit_refactor_sources(
 
     let message = build_autofix_commit_message(sources);
     let author = format!("{} <{}>", identity.name, identity.email);
-    run_git(
-        Path::new(path),
-        &["commit", "-m", &message, "--author", &author],
-        "git commit",
-    )?;
+    commit_staged_with_author(Path::new(path), &message, &author)?;
 
     eprintln!(
         "[refactor] Committed autofix: {} files changed",

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -56,10 +56,12 @@ pub use pr_policy::{
     PrPolicyMergeOptions, PrPolicyMode, PrPolicyOpenOptions, PrPolicyRules,
 };
 pub use primitives::{
-    clone_repo, clone_repo_at_ref, current_branch, get_component_path_prefix, get_git_root,
-    head_sha, head_sha_short, is_workdir_clean_or_not_git, output_optional, output_optional_bytes,
-    pull_repo, remote_origin_url, remote_url, run_git, run_git_output, short_head_revision,
-    status_porcelain, status_porcelain_bytes, toplevel, update_to_remote_default_branch,
+    clone_repo, clone_repo_at_ref, commit_staged_with_author, current_branch,
+    get_component_path_prefix, get_git_root, has_staged_changes, head_sha, head_sha_short,
+    is_workdir_clean_or_not_git, output_optional, output_optional_bytes, pull_repo,
+    remote_origin_url, remote_url, repo_root, rev_parse, run_git, run_git_output,
+    short_head_revision, stage_all, status_porcelain, status_porcelain_bytes, toplevel,
+    update_to_remote_default_branch,
 };
 pub(crate) use primitives::{is_git_repo, list_tracked_markdown_files};
 

--- a/src/core/git/primitives.rs
+++ b/src/core/git/primitives.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::core::engine::command;
@@ -136,6 +136,12 @@ pub fn run_git_output(
         })
 }
 
+/// Resolve a git revision to its commit/object id, returning None when the ref
+/// cannot be resolved.
+pub fn rev_parse(git_root: &Path, git_ref: &str) -> Option<String> {
+    output_optional(git_root, &["rev-parse", git_ref])
+}
+
 /// Run a git command and return stdout bytes when the command succeeds.
 pub fn output_optional_bytes(git_root: &Path, args: &[&str]) -> Option<Vec<u8>> {
     let output = Command::new("git")
@@ -185,6 +191,33 @@ pub fn remote_url(git_root: &Path, remote: &str) -> Option<String> {
 /// Get the git repository root directory from any path within the repo.
 pub fn toplevel(git_root: &Path) -> Option<String> {
     output_optional(git_root, &["rev-parse", "--show-toplevel"])
+}
+
+/// Get the git repository root directory from any path within the repo.
+pub fn repo_root(path: &Path) -> Option<PathBuf> {
+    toplevel(path).map(PathBuf::from)
+}
+
+/// Stage all changes in a repository.
+pub fn stage_all(git_root: &Path) -> Result<()> {
+    run_git(git_root, &["add", "-A"], "git add -A")?;
+    Ok(())
+}
+
+/// Return true when the index contains staged changes.
+pub fn has_staged_changes(git_root: &Path) -> Result<bool> {
+    let output = run_git_output(git_root, &["diff", "--cached", "--quiet"], "git diff")?;
+    Ok(!output.status.success())
+}
+
+/// Commit staged changes with an explicit author string.
+pub fn commit_staged_with_author(git_root: &Path, message: &str, author: &str) -> Result<()> {
+    run_git(
+        git_root,
+        &["commit", "-m", message, "--author", author],
+        "git commit",
+    )?;
+    Ok(())
 }
 
 pub fn current_branch(git_root: &Path) -> Option<String> {

--- a/src/core/review.rs
+++ b/src/core/review.rs
@@ -3,7 +3,6 @@
 use chrono::Utc;
 use serde::Serialize;
 use serde_json::Value;
-use std::process::Command;
 
 use crate::core::ci_profile::CiRunOutput;
 use crate::core::code_audit::AuditCommandOutput;
@@ -325,15 +324,7 @@ pub fn artifact_status(commands: &[ReviewArtifactCommand]) -> &'static str {
 }
 
 pub fn git_ref(path: &str, git_ref: &str) -> Option<String> {
-    let output = Command::new("git")
-        .args(["rev-parse", git_ref])
-        .current_dir(path)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    crate::core::git::rev_parse(std::path::Path::new(path), git_ref)
 }
 
 fn generated_at_now() -> String {


### PR DESCRIPTION
## Summary
- Add small `core::git` intent helpers for repo root resolution, rev-parse, staging, staged-change checks, and commit-with-author.
- Replace repeated command/core direct git shell-outs in agent-task controller, review git ref capture, and refactor autofix commit staging/commit flow.
- Preserve existing identity and command behavior while centralizing the git contracts.

## Tests/verification
- `rustfmt src/core/git/primitives.rs src/core/git/mod.rs src/commands/refactor/autofix_commit.rs src/commands/agent_task/controller.rs src/core/review.rs`
- `git diff --check`
- No cargo commands or benchmarks run per instruction; CI should run Rust build/test coverage.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted core git helper extraction; Chris to review and CI to verify.