### PR TITLE
docs(deploy): clarify multi-project builds

### DIFF
--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -35,7 +35,7 @@ Options:
 - `--dry-run`: preview what would be deployed without executing (no build, no upload)
 - `--force`: deploy even with uncommitted changes
 - `--json`: JSON input spec for bulk operations (`{"component_ids": ["component-id", ...]}`)
-- `--projects`: deploy to multiple projects (comma-separated). When using this flag, all positional arguments are treated as component IDs. The build artifact is reused across projects.
+- `--projects`: deploy to multiple projects (comma-separated). When using this flag, all positional arguments are treated as component IDs. Each project deployment builds independently.
 - `-f`, `--fleet`: deploy to all projects in a fleet. Resolves fleet to project IDs, then runs multi-project deployment.
 - `-s`, `--shared`: deploy to all projects using the specified component(s). Auto-detects which projects have the component configured and deploys to all of them.
 - `--keep-deps`: keep build dependencies and skip post-deploy cleanup.
@@ -151,7 +151,7 @@ homeboy deploy --projects extra-chill,sarai-chinwag sample-plugin extrachill-api
 homeboy deploy --projects extra-chill,sarai-chinwag sample-plugin --dry-run
 ```
 
-The component is built once and the artifact is reused for all subsequent project deployments.
+Each project deployment builds independently; build artifacts are scoped to the individual project run.
 
 ### Multi-project JSON output
 


### PR DESCRIPTION
## Summary
- Update deploy docs so `--projects` says each project deployment builds independently.
- Remove the stale claim that one build artifact is reused across multi-project deploys.

## Verification
- Ran `git diff --check`.
- Local cargo verification was not run due site rule forbidding local cargo; this is a docs-only change verified with diff checks.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5
- **Used for:** Inspected the deploy implementation/docs mismatch, drafted the focused documentation correction, and prepared this PR body for Chris to review.