### PR TITLE
docs: align command surface references

### DIFF
--- a/docs/commands/extension.md
+++ b/docs/commands/extension.md
@@ -63,15 +63,26 @@ homeboy extension setup <extension_id>
 ### `install`
 
 ```sh
-homeboy extension install <source> [--id <extension_id>] [--ref <git-ref>] [--revision <git-ref>] [--replace]
+homeboy extension install <source> [--id <extension_id>] [--ref <git-ref>] [--replace]
 ```
 
 Installs an extension into Homeboy's extensions directory.
 
 - If `<source>` is a git URL, Homeboy clones it and writes `sourceUrl` into the installed extension's `<extension_id>.json` manifest.
-- For git URL installs, `--ref` (alias `--revision`) checks out a branch, tag, or commit after cloning. The installed metadata still records the resolved `source_revision` SHA.
+- For git URL installs, `--ref` checks out a branch, tag, or commit after cloning. The installed metadata still records the resolved `source_revision` SHA.
 - If `<source>` is a local path, Homeboy symlinks the directory into the extensions directory.
 - By default, install refuses to overwrite an existing extension. Use `--replace` to explicitly replace an existing install or link.
+
+### `install-for-component`
+
+```sh
+homeboy extension install-for-component --source <source> [--path <component_path>]
+```
+
+Installs every extension configured by a component.
+
+- `--source <source>`: git URL or local path to the extension repository or directory.
+- `--path <component_path>`: component path containing `homeboy.json` (defaults to the current directory).
 
 ### `relink`
 

--- a/docs/commands/project.md
+++ b/docs/commands/project.md
@@ -40,6 +40,14 @@ Arguments:
 
 - `<project_id>`: project ID
 
+### `resolve-path`
+
+```sh
+homeboy project resolve-path <path>
+```
+
+Resolves a filesystem path inside a configured project `base_path` to its Homeboy project.
+
 ### `create`
 
 ```sh

--- a/docs/commands/ssh.md
+++ b/docs/commands/ssh.md
@@ -22,9 +22,9 @@ homeboy ssh list
 
 ## Arguments and flags
 
-- `[ID]`: project ID or server ID (project wins when both exist). Optional when using `--project` or `--server`.
-- `--project <PROJECT>`: force project resolution
-- `--server <SERVER>`: force server resolution
+- `[ID]`: project ID or server ID (project wins when both exist).
+- `--as-server`: force interpretation as a server ID.
+- `--user <USER>`: override the SSH user instead of the server's configured user.
 - `[COMMAND...]` (optional): command to execute (omit for interactive shell).
   - Recommended form: `homeboy ssh <id> -- <command...>` (supports multiple args cleanly)
   - Put all Homeboy flags/options **before** `--` (everything after `--` is treated as part of the remote command)


### PR DESCRIPTION
## Summary
- Remove stale SSH force-resolution flags and document the live server/user flags.
- Document extension install-for-component and remove the stale install --revision alias.
- Document project resolve-path.

## Verification
- Verified docs against live help output for: homeboy ssh --help, homeboy auth --help, homeboy auth profile --help, homeboy extension --help, homeboy extension install --help, homeboy extension install-for-component --help, homeboy project --help, homeboy project resolve-path --help.
- Ran git diff --check.
- Local cargo verification was not run due site rule forbidding local cargo.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused documentation updates and PR description; Chris remains responsible for review and testing.