### PR TITLE
fix(status): cache upstream drift by git root

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -610,9 +610,10 @@ impl StatusGitCache {
     }
 
     fn fetch_upstream_drift_for(&mut self, path: &str, id: &str) -> Option<UpstreamDrift> {
+        let cache_key = upstream_drift_cache_key(path);
         let drift = self
             .upstream_drift
-            .entry(path.to_string())
+            .entry(cache_key)
             .or_insert_with(|| fetch_upstream_drift(path));
 
         drift.as_ref().map(|cached| {
@@ -621,6 +622,10 @@ impl StatusGitCache {
             drift
         })
     }
+}
+
+fn upstream_drift_cache_key(path: &str) -> String {
+    git::get_git_root(path).unwrap_or_else(|_| path.to_string())
 }
 
 /// Fetch from origin and compute upstream drift for a component.
@@ -1125,5 +1130,36 @@ mod tests {
             }
             _ => panic!("expected full output"),
         }
+    }
+
+    #[test]
+    fn upstream_drift_cache_reuses_git_root_and_preserves_component_id() {
+        let (_dir, repo) = make_git_repo("monorepo");
+        let component_dir = repo.join("components/demo");
+        fs::create_dir_all(&component_dir).expect("component dir");
+
+        let repo_key = upstream_drift_cache_key(&repo.to_string_lossy());
+        let component_key = upstream_drift_cache_key(&component_dir.to_string_lossy());
+        assert_eq!(component_key, repo_key);
+
+        let mut git_cache = StatusGitCache::default();
+        git_cache.upstream_drift.insert(
+            repo_key,
+            Some(UpstreamDrift {
+                component_id: "cached-component".to_string(),
+                ahead: Some(2),
+                behind: Some(1),
+                latest_origin_tag: Some("v1.2.3".to_string()),
+            }),
+        );
+
+        let drift = git_cache
+            .fetch_upstream_drift_for(&component_dir.to_string_lossy(), "actual-component")
+            .expect("cached drift");
+
+        assert_eq!(drift.component_id, "actual-component");
+        assert_eq!(drift.ahead, Some(2));
+        assert_eq!(drift.behind, Some(1));
+        assert_eq!(drift.latest_origin_tag.as_deref(), Some("v1.2.3"));
     }
 }


### PR DESCRIPTION
## Summary
- Cache \{
  "success": true,
  "data": {
    "clean": 0,
    "command": "status",
    "total": 1,
    "uncommitted": [
      "homeboy"
    ],
    "unreleased_merges": [
      {
        "commits_since_tag": 395,
        "component_id": "homeboy",
        "latest_tag": "v0.232.0"
      }
    ],
    "unreleased_merges_note": "unreleased_merges flags components with commits merged to origin/<default-branch> that are past the latest release tag (merged but NOT released — the code is not on prod yet). A merged PR here is NOT 'shipped'. Cut a release, then run `homeboy status <project>` to confirm installed-vs-tag (released-but-not-deployed).",
    "upstream_drift": [
      {
        "component_id": "homeboy",
        "latest_origin_tag": "v0.244.0"
      }
    ]
  }
} upstream drift lookups by git root within a status invocation.
- Preserve each caller's component ID when returning cached drift for shared checkouts/subpaths.
- Add a focused unit test covering git-root cache reuse and component ID preservation.

## Verification
- \
- Not run: local cargo verification, due site rule forbidding local cargo commands.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused cache-key change, unit test, and PR description; Chris remains responsible for review and testing.