### PR TITLE
chore: format CI-blocking Rust files

### DIFF
--- a/src/core/defaults/builtins.rs
+++ b/src/core/defaults/builtins.rs
@@ -132,12 +132,8 @@ mod tests {
     fn source_upgrade_installs_active_binary() {
         let config = default_source_config();
 
-        assert!(config
-            .upgrade_command
-            .contains("cargo build --release"));
-        assert!(config
-            .upgrade_command
-            .contains("target/release/homeboy"));
+        assert!(config.upgrade_command.contains("cargo build --release"));
+        assert!(config.upgrade_command.contains("target/release/homeboy"));
         assert!(config.upgrade_command.contains("--version"));
         assert!(!config.upgrade_command.contains("cargo install --path"));
     }

--- a/src/core/extension/lifecycle.rs
+++ b/src/core/extension/lifecycle.rs
@@ -976,7 +976,8 @@ mod tests {
             .expect("runtime script dir");
         fs::write(&runtime_script, "console.log('sample runtime');\n").expect("runtime script");
 
-        let runtime_agent_ci_helper = root.join("runtime-agent-ci/lib/agent-task-provider-contract.js");
+        let runtime_agent_ci_helper =
+            root.join("runtime-agent-ci/lib/agent-task-provider-contract.js");
         fs::create_dir_all(
             runtime_agent_ci_helper
                 .parent()

--- a/src/core/extension/repair.rs
+++ b/src/core/extension/repair.rs
@@ -467,7 +467,8 @@ mod tests {
             .expect("runtime script dir");
         fs::write(&runtime_script, "console.log('sample runtime');\n").expect("runtime script");
 
-        let runtime_agent_ci_helper = root.join("runtime-agent-ci/lib/agent-task-provider-contract.js");
+        let runtime_agent_ci_helper =
+            root.join("runtime-agent-ci/lib/agent-task-provider-contract.js");
         fs::create_dir_all(
             runtime_agent_ci_helper
                 .parent()

--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -325,12 +325,16 @@ fn command_output_with_timeout(
     let start = Instant::now();
 
     loop {
-        if child.try_wait().map_err(|e| {
-            Error::internal_io(
-                e.to_string(),
-                Some("verify active binary version".to_string()),
-            )
-        })?.is_some() {
+        if child
+            .try_wait()
+            .map_err(|e| {
+                Error::internal_io(
+                    e.to_string(),
+                    Some("verify active binary version".to_string()),
+                )
+            })?
+            .is_some()
+        {
             return child.wait_with_output().map_err(|e| {
                 Error::internal_io(
                     e.to_string(),


### PR DESCRIPTION
## Summary
- Apply rustfmt to four files currently blocking Homeboy CI quality jobs.
- No behavior changes.

## Testing
- rustfmt src/core/defaults/builtins.rs src/core/extension/lifecycle.rs src/core/extension/repair.rs src/core/upgrade/execution.rs
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified CI formatting blocker and prepared the minimal rustfmt-only unblocker; Chris remains responsible for review and testing.