### PR TITLE
fix: neutralize agent runtime package env

### DIFF
--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -1,0 +1,27 @@
+# `homeboy list`
+
+## Synopsis
+
+```sh
+homeboy list
+```
+
+## Description
+
+`homeboy list` is a convenience command that prints the same help text as `homeboy --help`.
+
+This command exists as a convenience entrypoint when you want a quick command list without remembering `--help`.
+
+## Output
+
+This command prints clap-generated `homeboy --help` output to stdout.
+
+- Output is help text, not a JSON envelope.
+
+## Exit Code
+
+- `0` on success.
+
+## Related
+
+- [Commands index](commands-index.md)

--- a/docs/commands/runtime.md
+++ b/docs/commands/runtime.md
@@ -2,6 +2,14 @@
 
 Inspect Homeboy core-owned runtime assets used by extension runners.
 
+## Runtime Packages
+
+Homeboy discovers installable runtime packages from `~/.config/homeboy/agent-runtimes/<runtime-id>/<runtime-id>.json`. Extension repositories can ship shared runtime packages in `agent-runtimes/`; `homeboy extension install` copies that directory into the Homeboy config area.
+
+Runtime package manifests declare generic executor providers through `agent_task_executors`. Core consumes provider identity, backend, command, capabilities, readiness, role aliases, workspace materialization, and secret requirement/default declarations for selection, listing, interpolation, and redacted execution setup. Backend-specific orchestration remains inside the runtime package command.
+
+Provider commands can use `{{runtime_path}}`, and Homeboy injects `HOMEBOY_RUNTIME_PATH`, `HOMEBOY_AGENT_RUNTIME_ID`, and `HOMEBOY_AGENT_RUNTIME_PATH` when executing runtime-package providers.
+
 ## Helper Paths
 
 Resolve the materialized path for a core runtime helper:

--- a/src/core/agent_task_provider.rs
+++ b/src/core/agent_task_provider.rs
@@ -2279,10 +2279,10 @@ fn provider_command_env(
         ),
         ("HOMEBOY_RUNTIME_PATH".to_string(), runtime_path.clone()),
         (
-            "HOMEBOY_AI_RUNTIME_ID".to_string(),
+            "HOMEBOY_AGENT_RUNTIME_ID".to_string(),
             provider.runtime_id.clone().unwrap_or_default(),
         ),
-        ("HOMEBOY_AI_RUNTIME_PATH".to_string(), runtime_path),
+        ("HOMEBOY_AGENT_RUNTIME_PATH".to_string(), runtime_path),
     ];
     env.extend(provider_executable_env(provider).map_err(ProviderCommandEnvError::Executable)?);
     env.extend(
@@ -3434,11 +3434,11 @@ process.stdout.write(JSON.stringify({
         let env = provider_command_env(&request, &provider).expect("provider env");
 
         assert!(env.contains(&(
-            "HOMEBOY_AI_RUNTIME_ID".to_string(),
+            "HOMEBOY_AGENT_RUNTIME_ID".to_string(),
             "custom-runtime".to_string()
         )));
         assert!(env.contains(&(
-            "HOMEBOY_AI_RUNTIME_PATH".to_string(),
+            "HOMEBOY_AGENT_RUNTIME_PATH".to_string(),
             "/tmp/custom-runtime".to_string()
         )));
         assert_eq!(

--- a/src/core/paths.rs
+++ b/src/core/paths.rs
@@ -272,7 +272,7 @@ pub fn extensions() -> Result<PathBuf> {
     Ok(homeboy()?.join("extensions"))
 }
 
-/// Agent runtimes directory
+/// Agent runtime package directory
 pub fn agent_runtimes() -> Result<PathBuf> {
     Ok(homeboy()?.join("agent-runtimes"))
 }


### PR DESCRIPTION
## Summary
- expose neutral HOMEBOY_AGENT_RUNTIME_* environment variables for runtime-package providers
- document agent-runtimes package discovery and provider execution env
- clarify the core path helper comment as agent runtime packages

## Tests/checks
- rustfmt src/core/agent_task_provider.rs src/core/paths.rs
- git diff --check

## CI-only
- Cargo build/test/checks were not run locally per task constraint.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused runtime package env/docs change and prepared the PR; Chris remains responsible for review and validation.