### PR TITLE
fix(tests): drop orphaned list.md reference in command surface test

### DIFF
--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -253,10 +253,6 @@ fn docs_cover_focused_command_surface_cleanup_targets() {
     assert!(runs.contains("artifact cleanup-persisted"));
     assert!(runs.contains("`reconcile`"));
 
-    let list = include_str!("../docs/commands/list.md");
-    assert!(list.contains("compatibility alias"));
-    assert!(list.contains("Prefer `homeboy --help`"));
-
     for args in [
         ["homeboy", "auth", "profile", "set-basic", "dev"].as_slice(),
         ["homeboy", "auth", "profile", "set-bearer", "dev"].as_slice(),


### PR DESCRIPTION
## Summary
- `tests/command_surface_test.rs` referenced `docs/commands/list.md` via `include_str!`, but that doc was intentionally deleted in #5258 ("chore: clean up command surface docs"). Since `include_str!` resolves at **compile time**, the missing file made the entire `command_surface_test` target fail to compile — so the Test phase died before running any tests ("test phase failed without structured counts", exit 1). This is the root cause behind #5266.
- Removed the orphaned `list.md` assertions to match the intentional doc removal. `docs/commands/commands-index.md` already no longer lists `list`, so this is consistent.

## Root cause timeline
- #5200 added both `docs/commands/list.md` and the `include_str!` test block.
- #5258 deleted `docs/commands/list.md` (and only renamed a string in the test) but left the `include_str!` reference — breaking the test build on main.
- #5294 (rustfmt unblock) fixed the *lint/format* blocker but not this compile error, which is why main's Test job kept failing after #5294 merged.

## Testing
- `cargo fmt --check` — clean
- `cargo test --test command_surface_test` — **19 passed, 0 failed** (target now compiles and runs)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** chubes-bot (Claude)
- **Used for:** Diagnosed #5266 from CI observation artifacts, traced root cause across #5200/#5258/#5294, and prepared the minimal test fix. Chris remains responsible for review.

Closes #5266