### PR TITLE
fix(runner): align job store tests with claim leases

### DIFF
--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -1430,6 +1430,7 @@ mod tests {
             .expect("claim succeeds")
             .expect("first job is claimed");
         assert_eq!(first_claim.job.id, first.id);
+        let first_claim_id = first_claim.job.claim_id.as_deref().expect("claim id");
 
         let saturated_claim = store
             .claim_remote_runner_job("homeboy-lab", None, 30_000, Some(1))
@@ -1444,6 +1445,7 @@ mod tests {
             .finish_remote_runner_job(
                 first.id,
                 "homeboy-lab",
+                first_claim_id,
                 RemoteRunnerJobResult {
                     exit_code: 0,
                     stdout: None,
@@ -1594,7 +1596,7 @@ mod tests {
             .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
             .expect("remote runner job queues");
         let claim = store
-            .claim_remote_runner_job("homeboy-lab", None, 30_000)
+            .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
             .expect("claim succeeds")
             .expect("job is claimed");
         let claim_id = claim.job.claim_id.expect("claim id");
@@ -1635,7 +1637,7 @@ mod tests {
             .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
             .expect("remote runner job queues");
         let claim = store
-            .claim_remote_runner_job("homeboy-lab", None, 30_000)
+            .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
             .expect("claim succeeds")
             .expect("job is claimed");
         let claim_id = claim.job.claim_id.expect("claim id");


### PR DESCRIPTION
## Summary
- Pass claim IDs when finishing claimed remote runner jobs in job store tests.
- Update remaining test claim calls to include the concurrency-limit argument.

## Testing
- Not run locally; local cargo commands are avoided on this machine.
- CI should cover lint/test compilation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the merged CI failure and prepared the minimal test compatibility fix; Chris remains responsible for review and merge.