### PR TITLE
cook(runner): surface active jobs in status

### DIFF
--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -999,9 +999,7 @@ fn connect(
 
 fn status(id: Option<&str>) -> CmdResult<RunnerOutput> {
     if let Some(id) = id {
-        let mut report = runner::status(id)?;
-        report.active_jobs = active_runner_jobs(id);
-        report.active_job_count = report.active_jobs.len();
+        let report = runner::status(id)?;
         return Ok((
             RunnerOutput {
                 command: "runner.status".to_string(),
@@ -1020,36 +1018,13 @@ fn status(id: Option<&str>) -> CmdResult<RunnerOutput> {
         RunnerOutput {
             command: "runner.status".to_string(),
             extra: RunnerExtra {
-                sessions: runner::statuses()?
-                    .into_iter()
-                    .map(|mut report| {
-                        report.active_jobs = active_runner_jobs(&report.runner_id);
-                        report.active_job_count = report.active_jobs.len();
-                        report
-                    })
-                    .collect(),
+                sessions: runner::statuses()?,
                 ..Default::default()
             },
             ..Default::default()
         },
         0,
     ))
-}
-
-fn active_runner_jobs(runner_id: &str) -> Vec<homeboy::core::api_jobs::ActiveRunnerJobSummary> {
-    runner::daemon_api_get(runner_id, "/jobs")
-        .ok()
-        .and_then(|data| data.get("body").cloned())
-        .and_then(|body| body.get("active_runner_jobs").cloned())
-        .and_then(|jobs| serde_json::from_value(jobs).ok())
-        .map(
-            |jobs: Vec<homeboy::core::api_jobs::ActiveRunnerJobSummary>| {
-                jobs.into_iter()
-                    .filter(|job| job.runner_id == runner_id)
-                    .collect()
-            },
-        )
-        .unwrap_or_default()
 }
 
 fn disconnect(id: &str) -> CmdResult<RunnerOutput> {

--- a/src/commands/runs.rs
+++ b/src/commands/runs.rs
@@ -482,22 +482,13 @@ fn active_runner_job_summaries(status: Option<&str>) -> Vec<RunSummary> {
         .unwrap_or_default()
         .into_iter()
         .filter(|report| report.connected)
-        .flat_map(|report| active_runner_jobs(&report.runner_id))
+        .flat_map(|report| report.active_jobs)
         .filter(|job| match status {
             Some(status) => status == job.status.run_status_label(),
             None => true,
         })
         .map(active_runner_job_run_summary)
         .collect()
-}
-
-fn active_runner_jobs(runner_id: &str) -> Vec<ActiveRunnerJobSummary> {
-    runner::daemon_api_get(runner_id, "/jobs")
-        .ok()
-        .and_then(|data| data.get("body").cloned())
-        .and_then(|body| body.get("active_runner_jobs").cloned())
-        .and_then(|jobs| serde_json::from_value(jobs).ok())
-        .unwrap_or_default()
 }
 
 fn active_runner_job_run_summary(job: ActiveRunnerJobSummary) -> RunSummary {

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -8,6 +8,7 @@ use reqwest::blocking::Client;
 use serde::Deserialize;
 use serde_json::Value;
 
+use crate::core::api_jobs::ActiveRunnerJobSummary;
 use crate::core::engine::shell;
 use crate::core::error::{Error, Result};
 use crate::core::paths;
@@ -255,16 +256,36 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     let state = session_state(session.as_ref());
     let connected = state == RunnerSessionState::Connected;
     let stale_daemon = stale_daemon_warning(&runner, session.as_ref(), connected);
+    let active_jobs = if connected {
+        active_runner_jobs(runner_id)
+    } else {
+        Vec::new()
+    };
+    let active_job_count = active_jobs.len();
     Ok(RunnerStatusReport {
         runner_id: runner_id.to_string(),
         connected,
         state,
         session,
         stale_daemon,
-        active_jobs: Vec::new(),
-        active_job_count: 0,
+        active_jobs,
+        active_job_count,
         session_path: session_path.display().to_string(),
     })
+}
+
+fn active_runner_jobs(runner_id: &str) -> Vec<ActiveRunnerJobSummary> {
+    super::daemon_api_get(runner_id, "/jobs")
+        .ok()
+        .and_then(|data| data.get("body").cloned())
+        .and_then(|body| body.get("active_runner_jobs").cloned())
+        .and_then(|jobs| serde_json::from_value(jobs).ok())
+        .map(|jobs: Vec<ActiveRunnerJobSummary>| {
+            jobs.into_iter()
+                .filter(|job| job.runner_id == runner_id)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn stale_daemon_warning(


### PR DESCRIPTION
## Summary
- Populate active runner job details in runner status reports for connected runners.
- Reuse runner status active job data in `homeboy runs` instead of querying each runner separately.
- Keep inactive/disconnected runner status reports free of active job data.

## Verification
- `git status --short`
- `git diff --stat`
- `git diff`
- `git log --oneline -10`
- `git diff --check`
- Cargo and benchmarks were not run per instruction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Prepared the branch for review, inspected/staged intended changes, committed, pushed, and drafted this PR description.