### PR TITLE
cook(runs): query artifact rows in sql

### DIFF
--- a/src/commands/runs/common.rs
+++ b/src/commands/runs/common.rs
@@ -40,7 +40,8 @@ pub fn run_summaries_with_artifact_indexes(
 ) -> homeboy::core::Result<Vec<RunSummary>> {
     let rig_run_ids = run_records
         .iter()
-        .filter_map(|run| (run.kind == "rig" && run.rig_id.is_some()).then(|| run.id.clone()))
+        .filter(|run| run.kind == "rig" && run.rig_id.is_some())
+        .map(|run| run.id.clone())
         .collect::<Vec<_>>();
     let mut artifacts_by_run = store.list_artifacts_for_runs(&rig_run_ids)?;
     Ok(run_records

--- a/src/commands/runs/common.rs
+++ b/src/commands/runs/common.rs
@@ -201,80 +201,69 @@ pub fn load_artifact_rows(
     filter: RunListFilter,
     since: Option<&str>,
 ) -> homeboy::core::Result<ArtifactJsonLoadResult> {
-    let runs = if let Some(raw) = since {
-        let threshold = since_threshold(raw)?;
-        store
-            .list_runs_started_since(&threshold)?
-            .into_iter()
-            .filter(|run| run_matches_filter(run, &filter))
-            .collect::<Vec<_>>()
-    } else {
-        store.list_runs(filter)?
-    };
+    let threshold = since.map(since_threshold).transpose()?;
+    let run_artifacts = store.list_run_artifacts(filter, threshold.as_deref())?;
 
     let mut rows = Vec::new();
     let mut skipped = Vec::new();
-    let run_ids = runs.iter().map(|run| run.id.clone()).collect::<Vec<_>>();
-    let mut artifacts_by_run = store.list_artifacts_for_runs(&run_ids)?;
-    for run in runs {
-        let artifacts = artifacts_by_run.remove(&run.id).unwrap_or_default();
-        for artifact in artifacts {
-            if artifact.artifact_type != "file" {
-                if artifact.artifact_type == "metadata-only" {
-                    skipped.push(skipped_artifact(
-                        &run,
-                        &artifact,
-                        "artifact bytes are not available in this imported metadata-only bundle",
-                    ));
-                }
-                continue;
-            }
-            if !is_reportable_artifact_evidence_path(&artifact.path) {
+    for run_artifact in run_artifacts {
+        let run = run_artifact.run;
+        let artifact = run_artifact.artifact;
+        if artifact.artifact_type != "file" {
+            if artifact.artifact_type == "metadata-only" {
                 skipped.push(skipped_artifact(
                     &run,
                     &artifact,
-                    "artifact path is not locally accessible or retrievable",
+                    "artifact bytes are not available in this imported metadata-only bundle",
+                ));
+            }
+            continue;
+        }
+        if !is_reportable_artifact_evidence_path(&artifact.path) {
+            skipped.push(skipped_artifact(
+                &run,
+                &artifact,
+                "artifact path is not locally accessible or retrievable",
+            ));
+            continue;
+        }
+        let path = Path::new(&artifact.path);
+        let file = match File::open(path) {
+            Ok(file) => file,
+            Err(_) => {
+                skipped.push(skipped_artifact(
+                    &run,
+                    &artifact,
+                    "artifact file is missing or unreadable",
                 ));
                 continue;
             }
-            let path = Path::new(&artifact.path);
-            let file = match File::open(path) {
-                Ok(file) => file,
-                Err(_) => {
-                    skipped.push(skipped_artifact(
-                        &run,
-                        &artifact,
-                        "artifact file is missing or unreadable",
-                    ));
-                    continue;
-                }
-            };
-            let json = match serde_json::from_reader::<_, Value>(file) {
-                Ok(json) => json,
-                Err(err) if err.is_io() => {
-                    skipped.push(skipped_artifact(
-                        &run,
-                        &artifact,
-                        "artifact file is missing or unreadable",
-                    ));
-                    continue;
-                }
-                Err(_) => {
-                    skipped.push(skipped_artifact(
-                        &run,
-                        &artifact,
-                        "artifact file is not valid JSON",
-                    ));
-                    continue;
-                }
-            };
-            rows.push(ArtifactJsonRow {
-                run: run.clone(),
-                artifact_kind: artifact.kind,
-                artifact_path: artifact.path,
-                json,
-            });
-        }
+        };
+        let json = match serde_json::from_reader::<_, Value>(file) {
+            Ok(json) => json,
+            Err(err) if err.is_io() => {
+                skipped.push(skipped_artifact(
+                    &run,
+                    &artifact,
+                    "artifact file is missing or unreadable",
+                ));
+                continue;
+            }
+            Err(_) => {
+                skipped.push(skipped_artifact(
+                    &run,
+                    &artifact,
+                    "artifact file is not valid JSON",
+                ));
+                continue;
+            }
+        };
+        rows.push(ArtifactJsonRow {
+            run,
+            artifact_kind: artifact.kind,
+            artifact_path: artifact.path,
+            json,
+        });
     }
     Ok(ArtifactJsonLoadResult { rows, skipped })
 }
@@ -292,33 +281,6 @@ fn skipped_artifact(
         path: artifact.path.clone(),
         reason: reason.into(),
     }
-}
-
-/// Apply the same filters `list_runs` applies, but client-side. Used to
-/// re-filter rows fetched via `list_runs_started_since` (which doesn't take
-/// a kind/component filter).
-fn run_matches_filter(run: &RunRecord, filter: &RunListFilter) -> bool {
-    if let Some(kind) = &filter.kind {
-        if &run.kind != kind {
-            return false;
-        }
-    }
-    if let Some(component) = &filter.component_id {
-        if run.component_id.as_deref() != Some(component.as_str()) {
-            return false;
-        }
-    }
-    if let Some(status) = &filter.status {
-        if &run.status != status {
-            return false;
-        }
-    }
-    if let Some(rig) = &filter.rig_id {
-        if run.rig_id.as_deref() != Some(rig.as_str()) {
-            return false;
-        }
-    }
-    true
 }
 
 /// Tally the share of each scalar value of `metric_path` across `rows`.

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -34,6 +34,12 @@ pub struct ObservationDbStatus {
     pub table_count: i64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunArtifactRecord {
+    pub run: RunRecord,
+    pub artifact: ArtifactRecord,
+}
+
 pub struct ObservationStore {
     connection: Connection,
     path: PathBuf,
@@ -751,6 +757,92 @@ impl ObservationStore {
         Ok(artifacts_by_run)
     }
 
+    pub fn list_run_artifacts(
+        &self,
+        filter: RunListFilter,
+        started_since: Option<&str>,
+    ) -> Result<Vec<RunArtifactRecord>> {
+        if let Some(started_since) = started_since {
+            validate_required("started_since", started_since)?;
+            let mut statement = self
+                .connection
+                .prepare(
+                    r#"
+                    SELECT r.id, r.kind, r.component_id, r.started_at, r.finished_at,
+                           r.status, r.command, r.cwd, r.homeboy_version, r.git_sha,
+                           r.rig_id, r.metadata_json,
+                           a.id, a.run_id, a.kind, a.artifact_type, a.path, a.sha256,
+                           a.size_bytes, a.mime, a.metadata_json, a.created_at
+                    FROM runs r
+                    INNER JOIN artifacts a ON a.run_id = r.id
+                    WHERE r.started_at >= ?1
+                      AND (?2 IS NULL OR r.kind = ?2)
+                      AND (?3 IS NULL OR r.component_id = ?3)
+                      AND (?4 IS NULL OR r.status = ?4)
+                      AND (?5 IS NULL OR r.rig_id = ?5)
+                    ORDER BY r.started_at DESC, a.created_at ASC
+                    "#,
+                )
+                .map_err(sqlite_error("prepare joined run artifact records"))?;
+            let rows = statement
+                .query_map(
+                    params![
+                        started_since,
+                        filter.kind.as_deref(),
+                        filter.component_id.as_deref(),
+                        filter.status.as_deref(),
+                        filter.rig_id.as_deref(),
+                    ],
+                    row_to_run_artifact_record,
+                )
+                .map_err(sqlite_error("list joined run artifact records"))?;
+
+            return collect_rows(rows, "collect joined run artifact records");
+        }
+
+        let limit = filter.limit.unwrap_or(100).clamp(1, 1000);
+        let mut statement = self
+            .connection
+            .prepare(
+                r#"
+                WITH selected_runs AS (
+                    SELECT rowid AS run_rowid, id, kind, component_id, started_at, finished_at,
+                           status, command, cwd, homeboy_version, git_sha, rig_id, metadata_json
+                    FROM runs
+                    WHERE (?1 IS NULL OR kind = ?1)
+                      AND (?2 IS NULL OR component_id = ?2)
+                      AND (?3 IS NULL OR status = ?3)
+                      AND (?4 IS NULL OR rig_id = ?4)
+                    ORDER BY started_at DESC, rowid DESC
+                    LIMIT ?5
+                )
+                SELECT r.id, r.kind, r.component_id, r.started_at, r.finished_at,
+                       r.status, r.command, r.cwd, r.homeboy_version, r.git_sha,
+                       r.rig_id, r.metadata_json,
+                       a.id, a.run_id, a.kind, a.artifact_type, a.path, a.sha256,
+                       a.size_bytes, a.mime, a.metadata_json, a.created_at
+                FROM selected_runs r
+                INNER JOIN artifacts a ON a.run_id = r.id
+                ORDER BY r.started_at DESC, r.run_rowid DESC, a.created_at ASC
+                "#,
+            )
+            .map_err(sqlite_error("prepare joined run artifact records"))?;
+        let rows = statement
+            .query_map(
+                params![
+                    filter.kind.as_deref(),
+                    filter.component_id.as_deref(),
+                    filter.status.as_deref(),
+                    filter.rig_id.as_deref(),
+                    limit,
+                ],
+                row_to_run_artifact_record,
+            )
+            .map_err(sqlite_error("list joined run artifact records"))?;
+
+        collect_rows(rows, "collect joined run artifact records")
+    }
+
     pub fn get_artifact(&self, artifact_id: &str) -> Result<Option<ArtifactRecord>> {
         validate_required("artifact_id", artifact_id)?;
         self.connection
@@ -1164,25 +1256,39 @@ fn row_to_run_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<RunRecord> {
 }
 
 fn row_to_artifact_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<ArtifactRecord> {
+    row_to_artifact_record_at(row, 0)
+}
+
+fn row_to_artifact_record_at(
+    row: &rusqlite::Row<'_>,
+    offset: usize,
+) -> rusqlite::Result<ArtifactRecord> {
     Ok(ArtifactRecord {
-        id: row.get(0)?,
-        run_id: row.get(1)?,
-        kind: row.get(2)?,
-        artifact_type: row.get(3)?,
-        path: row.get(4)?,
-        url: if row.get_ref(3)?.as_str()? == "url" {
-            Some(row.get(4)?)
+        id: row.get(offset)?,
+        run_id: row.get(offset + 1)?,
+        kind: row.get(offset + 2)?,
+        artifact_type: row.get(offset + 3)?,
+        path: row.get(offset + 4)?,
+        url: if row.get_ref(offset + 3)?.as_str()? == "url" {
+            Some(row.get(offset + 4)?)
         } else {
             None
         },
         public_url: None,
         viewer_url: None,
         viewer_links: Vec::new(),
-        sha256: row.get(5)?,
-        size_bytes: row.get(6)?,
-        mime: row.get(7)?,
-        metadata_json: parse_metadata(row.get(8)?)?,
-        created_at: row.get(9)?,
+        sha256: row.get(offset + 5)?,
+        size_bytes: row.get(offset + 6)?,
+        mime: row.get(offset + 7)?,
+        metadata_json: parse_metadata(row.get(offset + 8)?)?,
+        created_at: row.get(offset + 9)?,
+    })
+}
+
+fn row_to_run_artifact_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<RunArtifactRecord> {
+    Ok(RunArtifactRecord {
+        run: row_to_run_record(row)?,
+        artifact: row_to_artifact_record_at(row, 12)?,
     })
 }
 

--- a/src/core/observation/store.rs
+++ b/src/core/observation/store.rs
@@ -722,8 +722,7 @@ impl ObservationStore {
         }
 
         for chunk in run_ids.chunks(900) {
-            let placeholders = std::iter::repeat("?")
-                .take(chunk.len())
+            let placeholders = std::iter::repeat_n("?", chunk.len())
                 .collect::<Vec<_>>()
                 .join(", ");
             let sql = format!(


### PR DESCRIPTION
## Summary
- Query run artifact rows with SQL joins instead of loading runs and artifacts separately.
- Preserve run filters in the artifact JSON loading path, including `--since` handling.
- Add shared artifact row mapping with offsets for joined result sets.

## Verification
- `git diff --check`
- Not run: cargo commands or benchmarks, per instruction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Prepared the branch for review, inspected the diff/status/log, ran the requested verification, committed, pushed, and drafted this PR body.