### PR TITLE
Split agent task runner policy module

### DIFF
--- a/src/core/agent_task_loop_controller.rs
+++ b/src/core/agent_task_loop_controller.rs
@@ -1323,13 +1323,17 @@ impl AgentTaskLoopControllerRecord {
             return;
         }
         match action {
-            AgentTaskLoopPolicyAction::RouteFinding { entity_id, .. } => {
-                if let Some(entity_id) = entity_id {
-                    if let Some(entity) = self.entities.get_mut(entity_id) {
-                        entity.state = Some("routed".to_string());
-                    }
+            AgentTaskLoopPolicyAction::RouteFinding {
+                entity_id: Some(entity_id),
+                ..
+            } => {
+                if let Some(entity) = self.entities.get_mut(entity_id) {
+                    entity.state = Some("routed".to_string());
                 }
             }
+            AgentTaskLoopPolicyAction::RouteFinding {
+                entity_id: None, ..
+            } => {}
             AgentTaskLoopPolicyAction::ValidateCandidatePatch {
                 candidate,
                 validation,
@@ -1477,6 +1481,7 @@ impl AgentTaskLoopControllerRecord {
         self.updated_at = now_timestamp();
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn record_subcontroller_ref(
         &mut self,
         loop_id: &str,

--- a/src/core/agent_task_loop_controller.rs
+++ b/src/core/agent_task_loop_controller.rs
@@ -7,6 +7,14 @@ use std::io::ErrorKind;
 use std::path::PathBuf;
 
 use crate::core::agent_task_lifecycle::AgentTaskRunState;
+use crate::core::agent_task_loop_runner_policy::{
+    blocked_runner_decision, runner_policy_for_action,
+};
+pub use crate::core::agent_task_loop_runner_policy::{
+    AgentTaskLoopLocalFallbackPolicy, AgentTaskLoopRunnerAvailability,
+    AgentTaskLoopRunnerExecutionTarget, AgentTaskLoopRunnerPolicy,
+    AgentTaskLoopRunnerPolicyDecision,
+};
 use crate::core::{agent_task_lifecycle, paths, Error, Result};
 
 pub const AGENT_TASK_LOOP_CONTROLLER_SCHEMA: &str = "homeboy/agent-task-loop-controller/v1";
@@ -462,41 +470,6 @@ pub enum AgentTaskLoopActionStatus {
     BlockedRunnerUnavailable,
     BlockedRemoteMaterialization,
     BlockedLocalFallbackDenied,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AgentTaskLoopRunnerPolicy {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub runner: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub local_fallback: Option<AgentTaskLoopLocalFallbackPolicy>,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum AgentTaskLoopLocalFallbackPolicy {
-    Allowed,
-    Denied,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AgentTaskLoopRunnerAvailability {
-    Available,
-    Unavailable { reason: String },
-    MaterializationBlocked { reason: String },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AgentTaskLoopRunnerExecutionTarget {
-    Local,
-    Runner(String),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AgentTaskLoopRunnerPolicyDecision {
-    pub target: Option<AgentTaskLoopRunnerExecutionTarget>,
-    pub blocked_status: Option<AgentTaskLoopActionStatus>,
-    pub diagnostic: Option<AgentTaskLoopActionDiagnostic>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1042,27 +1015,6 @@ impl AgentTaskLoopControllerRecord {
         Ok(())
     }
 
-    fn runner_policy_for_action(
-        &self,
-        action: &AgentTaskLoopPolicyAction,
-    ) -> AgentTaskLoopRunnerPolicy {
-        let request = action_runner_request(action);
-        let runner = request
-            .and_then(|value| value.get("runner"))
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|runner| !runner.is_empty())
-            .map(ToString::to_string);
-        let local_fallback = request
-            .and_then(|value| value.get("local_fallback"))
-            .and_then(parse_local_fallback_policy);
-
-        AgentTaskLoopRunnerPolicy {
-            runner,
-            local_fallback,
-        }
-    }
-
     pub fn resolve_action_runner_policy<F>(
         &self,
         action: &AgentTaskLoopPolicyAction,
@@ -1071,7 +1023,7 @@ impl AgentTaskLoopControllerRecord {
     where
         F: FnMut(&str) -> AgentTaskLoopRunnerAvailability,
     {
-        let policy = self.runner_policy_for_action(action);
+        let policy = runner_policy_for_action(action);
         let fallback = policy.local_fallback.unwrap_or_else(|| {
             if policy.runner.is_some() {
                 AgentTaskLoopLocalFallbackPolicy::Denied
@@ -1802,60 +1754,6 @@ fn action_dedupe_key(action: &AgentTaskLoopPolicyAction) -> Option<String> {
             feedback_id.as_deref().unwrap_or("latest")
         )),
         _ => None,
-    }
-}
-
-fn action_runner_request(action: &AgentTaskLoopPolicyAction) -> Option<&Value> {
-    match action {
-        AgentTaskLoopPolicyAction::SpawnTask { request, .. } => Some(request),
-        AgentTaskLoopPolicyAction::FanOut {
-            request_template, ..
-        }
-        | AgentTaskLoopPolicyAction::RouteFinding {
-            request_template, ..
-        } => Some(request_template),
-        _ => None,
-    }
-}
-
-fn parse_local_fallback_policy(value: &Value) -> Option<AgentTaskLoopLocalFallbackPolicy> {
-    match value {
-        Value::Bool(true) => Some(AgentTaskLoopLocalFallbackPolicy::Allowed),
-        Value::Bool(false) => Some(AgentTaskLoopLocalFallbackPolicy::Denied),
-        Value::String(value) if value == "allowed" || value == "allow" || value == "true" => {
-            Some(AgentTaskLoopLocalFallbackPolicy::Allowed)
-        }
-        Value::String(value) if value == "denied" || value == "deny" || value == "false" => {
-            Some(AgentTaskLoopLocalFallbackPolicy::Denied)
-        }
-        _ => None,
-    }
-}
-
-fn blocked_runner_decision(
-    status: AgentTaskLoopActionStatus,
-    runner: Option<String>,
-    message: impl Into<String>,
-    details: Value,
-) -> AgentTaskLoopRunnerPolicyDecision {
-    AgentTaskLoopRunnerPolicyDecision {
-        target: None,
-        blocked_status: Some(status),
-        diagnostic: Some(AgentTaskLoopActionDiagnostic {
-            code: blocked_runner_status_code(status).to_string(),
-            message: message.into(),
-            runner,
-            details,
-        }),
-    }
-}
-
-fn blocked_runner_status_code(status: AgentTaskLoopActionStatus) -> &'static str {
-    match status {
-        AgentTaskLoopActionStatus::BlockedRunnerUnavailable => "blocked_runner_unavailable",
-        AgentTaskLoopActionStatus::BlockedRemoteMaterialization => "blocked_remote_materialization",
-        AgentTaskLoopActionStatus::BlockedLocalFallbackDenied => "blocked_local_fallback_denied",
-        _ => "runner_policy_not_blocked",
     }
 }
 

--- a/src/core/agent_task_loop_runner_policy.rs
+++ b/src/core/agent_task_loop_runner_policy.rs
@@ -1,0 +1,115 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::core::agent_task_loop_controller::{
+    AgentTaskLoopActionDiagnostic, AgentTaskLoopActionStatus, AgentTaskLoopPolicyAction,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskLoopRunnerPolicy {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_fallback: Option<AgentTaskLoopLocalFallbackPolicy>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskLoopLocalFallbackPolicy {
+    Allowed,
+    Denied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentTaskLoopRunnerAvailability {
+    Available,
+    Unavailable { reason: String },
+    MaterializationBlocked { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentTaskLoopRunnerExecutionTarget {
+    Local,
+    Runner(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentTaskLoopRunnerPolicyDecision {
+    pub target: Option<AgentTaskLoopRunnerExecutionTarget>,
+    pub blocked_status: Option<AgentTaskLoopActionStatus>,
+    pub diagnostic: Option<AgentTaskLoopActionDiagnostic>,
+}
+
+pub(crate) fn runner_policy_for_action(
+    action: &AgentTaskLoopPolicyAction,
+) -> AgentTaskLoopRunnerPolicy {
+    let request = action_runner_request(action);
+    let runner = request
+        .and_then(|value| value.get("runner"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|runner| !runner.is_empty())
+        .map(ToString::to_string);
+    let local_fallback = request
+        .and_then(|value| value.get("local_fallback"))
+        .and_then(parse_local_fallback_policy);
+
+    AgentTaskLoopRunnerPolicy {
+        runner,
+        local_fallback,
+    }
+}
+
+pub(crate) fn blocked_runner_decision(
+    status: AgentTaskLoopActionStatus,
+    runner: Option<String>,
+    message: impl Into<String>,
+    details: Value,
+) -> AgentTaskLoopRunnerPolicyDecision {
+    AgentTaskLoopRunnerPolicyDecision {
+        target: None,
+        blocked_status: Some(status),
+        diagnostic: Some(AgentTaskLoopActionDiagnostic {
+            code: blocked_runner_status_code(status).to_string(),
+            message: message.into(),
+            runner,
+            details,
+        }),
+    }
+}
+
+fn action_runner_request(action: &AgentTaskLoopPolicyAction) -> Option<&Value> {
+    match action {
+        AgentTaskLoopPolicyAction::SpawnTask { request, .. } => Some(request),
+        AgentTaskLoopPolicyAction::FanOut {
+            request_template, ..
+        }
+        | AgentTaskLoopPolicyAction::RouteFinding {
+            request_template, ..
+        } => Some(request_template),
+        _ => None,
+    }
+}
+
+fn parse_local_fallback_policy(value: &Value) -> Option<AgentTaskLoopLocalFallbackPolicy> {
+    match value {
+        Value::Bool(true) => Some(AgentTaskLoopLocalFallbackPolicy::Allowed),
+        Value::Bool(false) => Some(AgentTaskLoopLocalFallbackPolicy::Denied),
+        Value::String(value) if value == "allowed" || value == "allow" || value == "true" => {
+            Some(AgentTaskLoopLocalFallbackPolicy::Allowed)
+        }
+        Value::String(value) if value == "denied" || value == "deny" || value == "false" => {
+            Some(AgentTaskLoopLocalFallbackPolicy::Denied)
+        }
+        _ => None,
+    }
+}
+
+fn blocked_runner_status_code(status: AgentTaskLoopActionStatus) -> &'static str {
+    match status {
+        AgentTaskLoopActionStatus::BlockedRunnerUnavailable => "blocked_runner_unavailable",
+        AgentTaskLoopActionStatus::BlockedRemoteMaterialization => "blocked_remote_materialization",
+        AgentTaskLoopActionStatus::BlockedLocalFallbackDenied => "blocked_local_fallback_denied",
+        _ => "runner_policy_not_blocked",
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -26,6 +26,7 @@ pub mod agent_task_gate_executor;
 pub mod agent_task_lifecycle;
 pub mod agent_task_loop_controller;
 pub mod agent_task_loop_definition;
+pub mod agent_task_loop_runner_policy;
 mod agent_task_pr_body;
 pub mod agent_task_promotion;
 pub mod agent_task_provider;


### PR DESCRIPTION
## Summary
- Extract agent task loop runner policy types and helper functions into a dedicated core module.
- Re-export the runner policy API from the controller to preserve existing call sites.
- Register the new module in core.

## Verification
- Inspected git status, diff stat, full diff, and recent commit log before staging.
- Ran `git diff --check`.
- Did not run cargo or benchmarks per instruction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Reviewed the branch diff, staged the intended files, committed the refactor, pushed the branch, and drafted this PR body.