### PR TITLE
Refresh command surface documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ servers, fleets, rigs, stacks, and extensions.
 | **Release** | `release`, `version`, `changelog`, `changes` | Turn commit history into versions, tags, and release notes. |
 | **Attention** | `deps`, `triage`, `issues` | Find dependency drift, failing work, and tracked findings. |
 | **Remote ops** | `deploy`, `ssh`, `file`, `db`, `logs`, `server`, `project`, `component`, `fleet` | Operate configured projects, servers, and fleets. |
-| **Platforms** | `extension`, `wp`, `cargo` | Route platform-specific behavior through extensions. |
+| **Platforms** | `extension`, extension-provided verbs such as `wp` and `cargo` | Route platform-specific behavior through extensions. |
 | **Meta** | `config`, `docs`, `daemon`, `self`, `undo`, `auth`, `api`, `upgrade` | Manage Homeboy itself and its API surfaces. |
 
 For exhaustive command docs, see

--- a/docs/commands/cargo.md
+++ b/docs/commands/cargo.md
@@ -1,6 +1,6 @@
 # `homeboy cargo`
 
-Run Cargo commands through Homeboy's Rust extension routing.
+Run Cargo commands through an extension-provided top-level CLI verb.
 
 ## Synopsis
 
@@ -10,7 +10,14 @@ homeboy cargo <project_id> [args]...
 
 ## Usage
 
-Use this command when a project is configured for Rust-aware command execution and you want Homeboy to route the Cargo invocation through the project/extension layer.
+`cargo` is not a core subcommand compiled into Homeboy. It is registered at
+runtime by an installed extension with CLI tool metadata, typically the Rust
+extension. Use this command when a component or project is configured for
+Rust-aware command execution and you want Homeboy to route the Cargo invocation
+through the project/extension layer.
+
+If `homeboy cargo ...` is unavailable, install or link the extension that
+provides the Cargo CLI tool, then confirm it appears in `homeboy docs list`.
 
 ## Related
 

--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -11,8 +11,27 @@ homeboy report <COMMAND>
 ## Subcommands
 
 - `failure-digest` — render a markdown failure digest from Homeboy command output JSON files
+- `performance-digest` — render resource, budget, baseline-health, preview, and Lab offload details from Homeboy run artifacts
 - `bench-coverage` — report list-only benchmark coverage for hot command paths
 - `browser-evidence-compare` — compare baseline/candidate browser evidence artifact bundles, optionally including visual screenshot diffs through a declared provider
+
+## Performance Digest
+
+```sh
+homeboy report performance-digest \
+  --output-dir <DIR> \
+  [--metadata-json <JSON_OR_FILE>] \
+  [--run-url <URL>] \
+  [--min-samples 3] \
+  [--max-cv-pct 20] \
+  [--format markdown]
+```
+
+`performance-digest` reads run artifacts such as `resource-summary.json` and
+`bench.json`, then renders a Markdown summary of host pressure, extension child
+process usage, budget findings, benchmark memory peaks, baseline health, preview
+metadata, browser-origin evidence, and missing-artifact gaps. It is a report
+renderer only; it does not run benchmarks.
 
 ## Browser Evidence Compare
 

--- a/docs/commands/runs.md
+++ b/docs/commands/runs.md
@@ -7,19 +7,27 @@ Inspect and maintain persisted observation-store runs and artifacts.
 ```bash
 homeboy runs list [--runner <runner-id>] [--kind bench|rig|trace] [--component <id>] [--rig <id>] [--status <status>] [--limit 20] [--include-active-runner-jobs]
 homeboy runs distribution --field <metadata.path> [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--status <status>] [--limit 20]
+homeboy runs latest-run [--kind bench|rig|trace] [--component <id>] [--rig <id>] [--status <status>]
 homeboy runs compare [--kind bench] [--component <id>] [--rig <id>] [--scenario <id>] [--metric <name>] [--limit 20] [--format table|json]
 homeboy runs show <run-id>
 homeboy runs resume-plan <run-id>
+homeboy runs evidence <run-id>
 homeboy runs artifacts <run-id>
 homeboy runs refs [--kind bench] [--component <id>] [--rig <id>] [--status <status>] [--since 24h] [--artifact-kind <kind>] [--aggregate-artifact-kind <kind>]
 homeboy runs artifact get <run-id> <artifact-id> [--output <path>]
 homeboy runs artifact cleanup-downloads [--runner <runner-id>] [--run-id <run-id>] [--apply]
 homeboy runs artifact cleanup-persisted [--older-than-days <days>] [--run-id <run-id>] [--apply]
+homeboy runs findings <run-id> [--tool <tool>] [--file <path>] [--fingerprint <fingerprint>] [--limit 100]
+homeboy runs finding <finding-id>
+homeboy runs latest-finding [--kind bench|rig|trace] [--component <id>] [--rig <id>] [--status <status>] [--tool <tool>] [--file <path>]
 homeboy runs export --run <run-id> --output <dir>
 homeboy runs export --since <duration> --output <dir>
 homeboy runs import <dir>
 homeboy runs import --from-gh-actions --component <id> --repo <owner/repo> --workflow <workflow.yml> --artifact-glob <glob>
 homeboy runs import --from-gh-actions --component <id> --repo <owner/repo> --run-id <gh-run-id> --artifact-glob <glob>
+homeboy runs query --select <jsonpath>[,<jsonpath>...] [--group-by <jsonpath>] [--count] [--format json|table|csv]
+homeboy runs drift --metric <jsonpath> [--window 7d] [--threshold 0.0] [--baseline <duration>] [--format json|table]
+homeboy runs loop-sync <archive-root> [--component <id>] [--rig <id>] [--label <label>] [--dry-run]
 ```
 
 ## Description
@@ -48,6 +56,24 @@ homeboy --output json runs refs --kind trace --component gutenberg --aggregate-a
 `homeboy runs reconcile` marks orphaned `running` observation records stale. Treat it as a mutating maintenance command, not a reader.
 
 `homeboy runs distribution` aggregates categorical values from dot-separated JSON metadata paths. Scalar string, number, and boolean values are counted directly; arrays are flattened and counted by scalar element. The output reports inspected runs, matched/missing runs per field, total and unique value counts, value percentages, and repeated values.
+
+`homeboy runs latest-run` and `homeboy runs latest-finding` select the newest run
+or finding that matches the provided filters. They are useful when automation
+starts from component/kind/status context instead of a known run id.
+
+`homeboy runs findings` lists recorded findings for a run, while `homeboy runs
+finding` reads one finding by id.
+
+`homeboy runs query` projects JSONPath expressions over imported run artifact
+rows. It can return raw JSON rows, grouped counts, Markdown-friendly tables, or
+CSV without baking domain-specific artifact schemas into Homeboy core.
+
+`homeboy runs drift` calculates window-based distribution drift for one JSONPath
+metric across imported artifact rows. It reports value shares for the selected
+window and can compare them against a longer baseline window.
+
+`homeboy runs loop-sync` inventories continuous-loop archive directories and,
+unless `--dry-run` is passed, records the triage summary as observation evidence.
 
 ## Compare Metrics Across History
 

--- a/docs/commands/wp.md
+++ b/docs/commands/wp.md
@@ -1,6 +1,6 @@
 # `homeboy wp`
 
-Run WP-CLI commands through Homeboy's WordPress extension routing.
+Run WP-CLI commands through an extension-provided top-level CLI verb.
 
 ## Synopsis
 
@@ -9,6 +9,11 @@ homeboy wp <project_id> [args]...
 ```
 
 For multisite projects, use `project:subtarget` as the project ID.
+
+`wp` is not a core subcommand compiled into Homeboy. It is registered at runtime
+by an installed extension with CLI tool metadata, typically the WordPress
+extension. Use `homeboy docs list` to confirm the command is available in the
+current installation.
 
 ## Examples
 

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -279,9 +279,7 @@ fn docs_cover_focused_command_surface_cleanup_targets() {
     assert!(lab.contains("routing helper, not a benchmark executor"));
 
     let extension = include_str!("../docs/commands/extension.md");
-    assert!(
-        extension.contains("install-for-component --source <source> [--path <component_path>]")
-    );
+    assert!(extension.contains("install-for-component --source <source> [--path <component_path>]"));
     assert!(!extension.contains("install-for-component") || !extension.contains("--revision"));
 
     let report = include_str!("../docs/commands/report.md");

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -1,6 +1,7 @@
 use clap::{CommandFactory, Parser};
 use homeboy::cli_surface::{command_surface_from_with_depth, current_command_surface, Cli};
 use std::collections::BTreeSet;
+use std::fs;
 
 #[test]
 fn includes_current_top_level_commands() {
@@ -169,6 +170,35 @@ fn command_index_matches_top_level_command_surface() {
         stale.is_empty(),
         "docs/commands/commands-index.md lists stale top-level commands: {stale:?}"
     );
+
+    for command in &expected {
+        assert!(
+            command_doc_path(command).is_file(),
+            "docs/commands/commands-index.md lists `{command}` but docs/commands/{command}.md is missing"
+        );
+    }
+}
+
+#[test]
+fn command_docs_files_match_command_index_snapshot() {
+    let documented = documented_command_index_entries();
+    let companion_topics = BTreeSet::from([
+        "audit-rules".to_string(),
+        "commands-index".to_string(),
+        "rig-spec".to_string(),
+    ]);
+    let docs_files = documented_command_doc_files();
+
+    let missing_from_index: Vec<_> = docs_files
+        .difference(&documented)
+        .filter(|entry| !companion_topics.contains(*entry))
+        .cloned()
+        .collect();
+
+    assert!(
+        missing_from_index.is_empty(),
+        "docs/commands/*.md contains command docs that are not listed in commands-index.md: {missing_from_index:?}"
+    );
 }
 
 #[test]
@@ -248,10 +278,28 @@ fn docs_cover_focused_command_surface_cleanup_targets() {
     let lab = include_str!("../docs/commands/lab.md");
     assert!(lab.contains("routing helper, not a benchmark executor"));
 
+    let extension = include_str!("../docs/commands/extension.md");
+    assert!(
+        extension.contains("install-for-component --source <source> [--path <component_path>]")
+    );
+    assert!(!extension.contains("install-for-component") || !extension.contains("--revision"));
+
+    let report = include_str!("../docs/commands/report.md");
+    assert!(report.contains("`performance-digest`"));
+
     let runs = include_str!("../docs/commands/runs.md");
     assert!(runs.contains("## Mutating Subcommands"));
     assert!(runs.contains("artifact cleanup-persisted"));
     assert!(runs.contains("`reconcile`"));
+    assert!(runs.contains("`latest-run`"));
+    assert!(runs.contains("`query`"));
+    assert!(runs.contains("`drift`"));
+    assert!(runs.contains("`loop-sync`"));
+
+    let cargo = include_str!("../docs/commands/cargo.md");
+    assert!(cargo.contains("extension-provided"));
+    let wp = include_str!("../docs/commands/wp.md");
+    assert!(wp.contains("extension-provided"));
 
     for args in [
         ["homeboy", "auth", "profile", "set-basic", "dev"].as_slice(),
@@ -265,7 +313,21 @@ fn docs_cover_focused_command_surface_cleanup_targets() {
             "14",
         ]
         .as_slice(),
+        [
+            "homeboy",
+            "report",
+            "performance-digest",
+            "--output-dir",
+            ".",
+        ]
+        .as_slice(),
         ["homeboy", "runs", "artifact", "get", "run-1", "artifact-1"].as_slice(),
+        ["homeboy", "runs", "latest-run"].as_slice(),
+        ["homeboy", "runs", "evidence", "run-1"].as_slice(),
+        ["homeboy", "runs", "findings", "run-1"].as_slice(),
+        ["homeboy", "runs", "query", "--select", "$.status"].as_slice(),
+        ["homeboy", "runs", "drift", "--metric", "$.status"].as_slice(),
+        ["homeboy", "runs", "loop-sync", ".", "--dry-run"].as_slice(),
         [
             "homeboy",
             "runs",
@@ -280,6 +342,20 @@ fn docs_cover_focused_command_surface_cleanup_targets() {
             panic!("documented cleanup target failed to parse: {args:?}\n{error}")
         });
     }
+
+    assert!(
+        Cli::try_parse_from([
+            "homeboy",
+            "extension",
+            "install-for-component",
+            "--source",
+            "https://example.com/extensions.git",
+            "--revision",
+            "main",
+        ])
+        .is_err(),
+        "extension install-for-component should not advertise or accept stale --revision/--ref flags"
+    );
 }
 
 #[test]
@@ -351,4 +427,28 @@ fn documented_command_index_entries() -> BTreeSet<String> {
         .filter_map(|rest| rest.split(']').next())
         .map(str::to_string)
         .collect()
+}
+
+fn documented_command_doc_files() -> BTreeSet<String> {
+    let commands_dir = command_doc_path("");
+    fs::read_dir(&commands_dir)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", commands_dir.display()))
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            entry
+                .path()
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .map(str::to_string)
+        })
+        .collect()
+}
+
+fn command_doc_path(command: &str) -> std::path::PathBuf {
+    let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("docs/commands");
+    if !command.is_empty() {
+        path.push(format!("{command}.md"));
+    }
+    path
 }


### PR DESCRIPTION
## Summary
- Clarify that `wp` and `cargo` are extension-provided Homeboy verbs rather than core subcommands.
- Document additional `runs` and `report performance-digest` command surfaces.
- Add command-surface tests that keep command docs and the command index aligned.

## Verification
- Inspected `git status --short`, `git diff --stat`, `git diff`, and `git log --oneline -10` before committing.
- Ran `git diff --check`.
- Did not run cargo commands or benchmarks.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Reviewed the branch diff, prepared the commit, pushed the branch, and drafted this PR description.