### PR TITLE
cook(runner): add transport selector

### DIFF
--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -26,7 +26,8 @@ use super::resource_metrics::{
     measured_command_output, measured_command_output_until_cancelled, RunnerResourceMetrics,
 };
 use super::{
-    connect, load, status, Runner, RunnerCapabilityPreflight, RunnerKind, RunnerTunnelMode,
+    connect, load, select_runner_transport, status, Runner, RunnerCapabilityPreflight, RunnerKind,
+    RunnerTransport, RunnerTunnelMode,
 };
 use super::{normalize_runner_command_env, resolve_runner_secret_env};
 
@@ -216,45 +217,46 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
         }
         connected = status(runner_id)?;
     }
-    if connected.connected {
-        if let Some(session) = connected.session {
+    match select_runner_transport(&runner, Some(&connected), false) {
+        RunnerTransport::DirectDaemon(handle) => {
             run_capability_preflight(&runner)?;
-            if let Some(local_url) = session.local_url.as_deref() {
-                return exec_via_daemon(
-                    &runner,
-                    local_url,
-                    cwd,
-                    options.project_id,
-                    options.command,
-                    request_env,
-                    secret_env_names,
-                    options.capture_patch,
-                    Some(plan.source_snapshot),
-                    options.require_paths,
-                );
-            }
-            if session.mode == RunnerTunnelMode::Reverse {
-                if let Some(broker_url) = session.broker_url.as_deref() {
-                    return exec_via_reverse_broker(
-                        &runner,
-                        broker_url,
-                        cwd,
-                        options.project_id,
-                        options.command,
-                        request_env,
-                        secret_env_names,
-                        options.capture_patch,
-                        Some(plan.source_snapshot),
-                        options.require_paths,
-                    );
-                }
-            }
+            exec_via_daemon(
+                &runner,
+                handle.endpoint_url(),
+                cwd,
+                options.project_id,
+                options.command,
+                request_env,
+                secret_env_names,
+                options.capture_patch,
+                Some(plan.source_snapshot),
+                options.require_paths,
+            )
         }
-    }
-
-    match runner.kind {
-        RunnerKind::Local => exec_local(plan),
-        RunnerKind::Ssh => Err(Error::validation_invalid_argument(
+        RunnerTransport::ReverseBroker(handle) => {
+            run_capability_preflight(&runner)?;
+            exec_via_reverse_broker(
+                &runner,
+                handle.endpoint_url(),
+                cwd,
+                options.project_id,
+                options.command,
+                request_env,
+                secret_env_names,
+                options.capture_patch,
+                Some(plan.source_snapshot),
+                options.require_paths,
+            )
+        }
+        RunnerTransport::Local => exec_local(plan),
+        RunnerTransport::DiagnosticSsh => exec_diagnostic_ssh(
+            &runner,
+            cwd,
+            options.command,
+            request_env,
+            options.require_paths,
+        ),
+        RunnerTransport::Unavailable => Err(Error::validation_invalid_argument(
             "runner",
             "runner is not connected to a daemon; run `homeboy runner connect <runner-id>` or pass `--ssh` for explicit SSH diagnostics",
             Some(runner.id),
@@ -327,7 +329,8 @@ fn preflight_worker_local_capability_plan(
 }
 
 fn should_force_diagnostic_ssh(runner: &Runner, options: &RunnerExecOptions) -> bool {
-    runner.kind == RunnerKind::Ssh && options.allow_diagnostic_ssh
+    select_runner_transport(runner, None, options.allow_diagnostic_ssh)
+        == RunnerTransport::DiagnosticSsh
 }
 
 pub fn runner_exec_failure_error(output: &RunnerExecOutput) -> Option<Error> {

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -1414,7 +1414,7 @@ fn resolve_runner_secret_env_for_command_with_fallbacks(
         if fallback_sources.contains_key(name) {
             if let Ok(values) = agent_task_secrets::resolve_secret_env_with_fallbacks(
                 std::slice::from_ref(name),
-                &fallback_sources,
+                fallback_sources,
             ) {
                 for (name, value) in values {
                     resolved.insert(name, value);
@@ -1845,6 +1845,7 @@ fn command_output_until_cancelled(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn exec_output(
     runner: &Runner,
     mode: RunnerExecMode,

--- a/src/core/runner/mod.rs
+++ b/src/core/runner/mod.rs
@@ -40,6 +40,7 @@ mod rig_materialization;
 mod session;
 mod source_materialization;
 mod tool_registry;
+mod transport;
 mod validation_dependencies;
 pub(crate) use validation_dependencies::validation_dependency_ids;
 pub use validation_dependencies::RunnerValidationDependencySyncOutput;
@@ -101,6 +102,7 @@ pub use session::{
     RunnerStatusReport, RunnerTunnelMode,
 };
 pub use tool_registry::{RunnerToolRegistry, RunnerToolSpec};
+pub(crate) use transport::{select_runner_transport, RunnerTransport};
 pub use worker::{run_reverse_worker, ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput};
 pub use workspace::{
     sync_workspace, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,

--- a/src/core/runner/transport.rs
+++ b/src/core/runner/transport.rs
@@ -1,0 +1,156 @@
+use super::session::{RunnerSession, RunnerStatusReport, RunnerTunnelMode};
+use super::{Runner, RunnerKind};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RunnerSessionHandle {
+    pub(crate) session: RunnerSession,
+    endpoint_url: String,
+}
+
+impl RunnerSessionHandle {
+    fn new(session: RunnerSession, endpoint_url: String) -> Self {
+        Self {
+            session,
+            endpoint_url,
+        }
+    }
+
+    pub(crate) fn endpoint_url(&self) -> &str {
+        &self.endpoint_url
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RunnerTransport {
+    DirectDaemon(RunnerSessionHandle),
+    ReverseBroker(RunnerSessionHandle),
+    Local,
+    DiagnosticSsh,
+    Unavailable,
+}
+
+pub(crate) fn select_runner_transport(
+    runner: &Runner,
+    status: Option<&RunnerStatusReport>,
+    allow_diagnostic_ssh: bool,
+) -> RunnerTransport {
+    if runner.kind == RunnerKind::Ssh && allow_diagnostic_ssh {
+        return RunnerTransport::DiagnosticSsh;
+    }
+
+    if let Some(status) = status {
+        if status.connected {
+            if let Some(session) = status.session.as_ref() {
+                if let Some(local_url) = session.local_url.as_ref() {
+                    return RunnerTransport::DirectDaemon(RunnerSessionHandle::new(
+                        session.clone(),
+                        local_url.clone(),
+                    ));
+                }
+                if session.mode == RunnerTunnelMode::Reverse {
+                    if let Some(broker_url) = session.broker_url.as_ref() {
+                        return RunnerTransport::ReverseBroker(RunnerSessionHandle::new(
+                            session.clone(),
+                            broker_url.clone(),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    if runner.kind == RunnerKind::Local {
+        RunnerTransport::Local
+    } else {
+        RunnerTransport::Unavailable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::runner::session::{RunnerSessionRole, RunnerSessionState};
+
+    fn runner(kind: RunnerKind) -> Runner {
+        Runner {
+            id: "test-runner".to_string(),
+            kind,
+            server_id: None,
+            workspace_root: None,
+            settings: Default::default(),
+            env: Default::default(),
+            secret_env: Default::default(),
+            resources: Default::default(),
+            policy: Default::default(),
+        }
+    }
+
+    fn status(session: RunnerSession) -> RunnerStatusReport {
+        RunnerStatusReport {
+            runner_id: "test-runner".to_string(),
+            connected: true,
+            state: RunnerSessionState::Connected,
+            session: Some(session),
+            stale_daemon: None,
+            active_jobs: Vec::new(),
+            active_job_count: 0,
+            session_path: "/tmp/session.json".to_string(),
+        }
+    }
+
+    fn session(mode: RunnerTunnelMode) -> RunnerSession {
+        RunnerSession {
+            runner_id: "test-runner".to_string(),
+            mode,
+            role: RunnerSessionRole::Controller,
+            server_id: None,
+            controller_id: None,
+            broker_url: None,
+            remote_daemon_address: None,
+            local_port: None,
+            local_url: None,
+            tunnel_pid: None,
+            remote_daemon_pid: None,
+            homeboy_version: "test".to_string(),
+            homeboy_build_identity: None,
+            connected_at: "now".to_string(),
+            worker_identity: None,
+            worker_pid: None,
+            last_seen_at: None,
+        }
+    }
+
+    #[test]
+    fn selects_diagnostic_ssh_before_session_transport() {
+        assert_eq!(
+            select_runner_transport(&runner(RunnerKind::Ssh), None, true),
+            RunnerTransport::DiagnosticSsh
+        );
+    }
+
+    #[test]
+    fn selects_direct_daemon_from_connected_local_url() {
+        let mut session = session(RunnerTunnelMode::DirectSsh);
+        session.local_url = Some("http://127.0.0.1:1234".to_string());
+
+        match select_runner_transport(&runner(RunnerKind::Ssh), Some(&status(session)), false) {
+            RunnerTransport::DirectDaemon(handle) => {
+                assert_eq!(handle.endpoint_url(), "http://127.0.0.1:1234");
+            }
+            transport => panic!("expected direct daemon, got {transport:?}"),
+        }
+    }
+
+    #[test]
+    fn selects_reverse_broker_from_connected_reverse_session() {
+        let mut session = session(RunnerTunnelMode::Reverse);
+        session.broker_url = Some("https://broker.example".to_string());
+
+        match select_runner_transport(&runner(RunnerKind::Ssh), Some(&status(session)), false) {
+            RunnerTransport::ReverseBroker(handle) => {
+                assert_eq!(handle.endpoint_url(), "https://broker.example");
+            }
+            transport => panic!("expected reverse broker, got {transport:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a runner transport selection contract that resolves direct daemon, reverse broker, local, diagnostic SSH, and unavailable transports.
- Routes runner execution through the shared transport selector while preserving existing daemon, reverse broker, local, and explicit SSH diagnostic behavior.
- Adds focused unit coverage for transport selection cases.

## Verification
- `git status --short`
- `git diff --stat`
- `git diff`
- `git log --oneline -10`
- `git diff --check`
- Not run: cargo commands or benchmarks, per instruction.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Prepared the branch for review, inspected/staged the diff, committed, pushed, and drafted this PR description.