### PR TITLE
fix(api-jobs): add missing claim_id arg to finish_remote_runner_job test calls

### DIFF
--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -1430,6 +1430,7 @@ mod tests {
             .expect("claim succeeds")
             .expect("first job is claimed");
         assert_eq!(first_claim.job.id, first.id);
+        let first_claim_id = first_claim.job.claim_id.clone().expect("claim id");
 
         let saturated_claim = store
             .claim_remote_runner_job("homeboy-lab", None, 30_000, Some(1))
@@ -1444,6 +1445,7 @@ mod tests {
             .finish_remote_runner_job(
                 first.id,
                 "homeboy-lab",
+                &first_claim_id,
                 RemoteRunnerJobResult {
                     exit_code: 0,
                     stdout: None,
@@ -1594,7 +1596,7 @@ mod tests {
             .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
             .expect("remote runner job queues");
         let claim = store
-            .claim_remote_runner_job("homeboy-lab", None, 30_000)
+            .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
             .expect("claim succeeds")
             .expect("job is claimed");
         let claim_id = claim.job.claim_id.expect("claim id");
@@ -1635,7 +1637,7 @@ mod tests {
             .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
             .expect("remote runner job queues");
         let claim = store
-            .claim_remote_runner_job("homeboy-lab", None, 30_000)
+            .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
             .expect("claim succeeds")
             .expect("job is claimed");
         let claim_id = claim.job.claim_id.expect("claim id");


### PR DESCRIPTION
## Summary
Fixes the P0 compile error breaking the **Lint** and **Test** gates on `main` (so all PRs were stuck).

A recent merge added a `claim_id: &str` parameter to `finish_remote_runner_job` and updated the production call sites, but left three test-target call sites in `src/core/api_jobs.rs` out of sync. While fixing those, two `claim_remote_runner_job` calls in the same test module were also still missing the `max_concurrency` arg added by another merge.

## Changes
- Added `&first_claim_id` (3rd arg) to the `finish_remote_runner_job` call at the saturated-concurrency test (~L1445), deriving it from the job's claim.
- The other two `finish_remote_runner_job` test calls already passed `&claim_id` correctly.
- Added the missing `None` (max_concurrency) 4th arg to two 3-arg `claim_remote_runner_job` calls (~L1599, ~L1640).

## Validation
- `cargo build --lib --tests` compiles clean — no `E0061`.
- `cargo fmt` applied.
- Did NOT run the full test suite (RAM constraints on this host); leaving the rest to CI.
- `docs/changelog.md` untouched.

Closes #5320