### PR TITLE
ci: reduce quality gate work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 # PR quality pipeline.
 #
 # Homeboy Action owns the CI DAG so command failures aggregate instead of
-# skipping later quality checks. Build remains the hard gate because this repo
-# validates the Homeboy binary produced from the PR source.
+# skipping later quality checks. Ordinary PR quality gates use the action-provided
+# Homeboy binary instead of compiling a release binary on every pull request.
 
 name: CI
 
@@ -32,6 +32,4 @@ jobs:
       # lands a bot commit mid-review and supersedes in-flight CI runs,
       # which reads as a spurious failure (see #3819). Require manual fixes.
       autofix: 'false'
-      build-command: cargo build --release
-      build-artifact-path: target/release/homeboy
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,7 @@ jobs:
           binary-path: .homeboy-bin/homeboy
           commands: lint
           expected-commands: audit,lint,test
+          args: ${{ github.event.before && format('--changed-since {0}', github.event.before) || '' }}
           autofix: 'false'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
@@ -296,6 +297,7 @@ jobs:
           binary-path: .homeboy-bin/homeboy
           commands: test
           expected-commands: audit,lint,test
+          args: ${{ github.event.before && format('--changed-since {0}', github.event.before) || '' }}
           autofix: 'false'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 


### PR DESCRIPTION
## Summary
- Stop compiling a release binary for ordinary PR quality gates.
- Pass the existing release changed-since scope to lint and test gates.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Checked workflow diffs and Homeboy Action usage before commit.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted workflow changes and PR text; Chris remains responsible for review and merge.