### PR TITLE
refactor(lab): add typed provider config envelope

### DIFF
--- a/src/core/runner/lab_args/envelope.rs
+++ b/src/core/runner/lab_args/envelope.rs
@@ -1,0 +1,165 @@
+//! Typed Lab execution input envelope.
+//!
+//! This is intentionally small for the first migration step: it captures the
+//! argv plus the Lab-relevant input refs discovered before `--`. Existing
+//! rewrite helpers can consume the typed refs one path at a time while preserving
+//! the exact argv output they already produced.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::core::runner) struct ExecutionEnvelope {
+    argv: Vec<String>,
+    pub inputs: LabCommandInputs,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(in crate::core::runner) struct LabCommandInputs {
+    pub provider_configs: Vec<ArgRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::core::runner) struct ArgRef {
+    pub flag: &'static str,
+    pub value: ArgValue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::core::runner) enum ArgValue {
+    InlineText(String),
+    PathRef(String),
+    Stdin,
+    Missing,
+}
+
+impl ExecutionEnvelope {
+    pub fn from_args(args: &[String]) -> Self {
+        let mut inputs = LabCommandInputs::default();
+        let mut iter = args.iter().peekable();
+        let mut passthrough = false;
+        while let Some(arg) = iter.next() {
+            if passthrough {
+                continue;
+            }
+            if arg == "--" {
+                passthrough = true;
+                continue;
+            }
+            if arg == "--provider-config" {
+                inputs.provider_configs.push(ArgRef {
+                    flag: "--provider-config",
+                    value: iter
+                        .next()
+                        .map_or(ArgValue::Missing, |spec| provider_config_value(spec)),
+                });
+                continue;
+            }
+            if let Some(spec) = arg.strip_prefix("--provider-config=") {
+                inputs.provider_configs.push(ArgRef {
+                    flag: "--provider-config",
+                    value: provider_config_value(spec),
+                });
+            }
+        }
+
+        Self {
+            argv: args.to_vec(),
+            inputs,
+        }
+    }
+
+    pub fn rewrite_provider_config_values(
+        &self,
+        mut rewrite: impl FnMut(&str) -> String,
+    ) -> Vec<String> {
+        let mut out = Vec::with_capacity(self.argv.len());
+        let mut iter = self.argv.iter().peekable();
+        let mut passthrough = false;
+        while let Some(arg) = iter.next() {
+            if passthrough {
+                out.push(arg.clone());
+                continue;
+            }
+            if arg == "--" {
+                passthrough = true;
+                out.push(arg.clone());
+                continue;
+            }
+            if arg == "--provider-config" {
+                out.push(arg.clone());
+                if let Some(spec) = iter.next() {
+                    out.push(rewrite(spec));
+                }
+                continue;
+            }
+            if let Some(spec) = arg.strip_prefix("--provider-config=") {
+                out.push(format!("--provider-config={}", rewrite(spec)));
+                continue;
+            }
+            out.push(arg.clone());
+        }
+        out
+    }
+}
+
+fn provider_config_value(spec: &str) -> ArgValue {
+    let trimmed = spec.trim();
+    if trimmed == "-" {
+        ArgValue::Stdin
+    } else if let Some(path) = trimmed.strip_prefix('@') {
+        ArgValue::PathRef(path.to_string())
+    } else {
+        ArgValue::InlineText(spec.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_captures_provider_config_refs_before_passthrough() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--provider-config".to_string(),
+            "@config.json".to_string(),
+            "--provider-config={\"provider\":\"codex\"}".to_string(),
+            "--provider-config=-".to_string(),
+            "--".to_string(),
+            "--provider-config".to_string(),
+            "ignored".to_string(),
+        ];
+
+        let envelope = ExecutionEnvelope::from_args(&args);
+
+        assert_eq!(envelope.inputs.provider_configs.len(), 3);
+        assert_eq!(
+            envelope.inputs.provider_configs[0].flag,
+            "--provider-config"
+        );
+        assert_eq!(
+            envelope.inputs.provider_configs[0].value,
+            ArgValue::PathRef("config.json".to_string())
+        );
+        assert_eq!(
+            envelope.inputs.provider_configs[1].value,
+            ArgValue::InlineText("{\"provider\":\"codex\"}".to_string())
+        );
+        assert_eq!(envelope.inputs.provider_configs[2].value, ArgValue::Stdin);
+    }
+
+    #[test]
+    fn envelope_captures_missing_provider_config_value() {
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--provider-config".to_string(),
+        ];
+
+        let envelope = ExecutionEnvelope::from_args(&args);
+
+        assert_eq!(envelope.inputs.provider_configs.len(), 1);
+        assert_eq!(envelope.inputs.provider_configs[0].value, ArgValue::Missing);
+    }
+}

--- a/src/core/runner/lab_args/mod.rs
+++ b/src/core/runner/lab_args/mod.rs
@@ -12,6 +12,7 @@
 //! the surface the rest of the `runner` module consumes.
 
 mod agent_task_specs;
+mod envelope;
 mod offload;
 mod path_remap;
 mod provider_config;

--- a/src/core/runner/lab_args/provider_config.rs
+++ b/src/core/runner/lab_args/provider_config.rs
@@ -11,6 +11,7 @@ use crate::core::config::read_json_spec_to_string;
 use crate::core::defaults;
 use crate::core::{Error, Result};
 
+use super::envelope::ExecutionEnvelope;
 use super::path_remap::{remap_paths_in_value, LabPathRemap};
 
 /// Rewrite controller-local absolute paths inside a `--provider-config` value to
@@ -28,6 +29,7 @@ pub(in crate::core::runner) fn remap_provider_config_in_args(
     args: &[String],
     mappings: &[LabPathRemap],
 ) -> Vec<String> {
+    let envelope = ExecutionEnvelope::from_args(args);
     // NOTE: do not early-return on empty mappings. A `--provider-config @file`
     // (or `-` stdin) spec must always be inlined to JSON before offload, because
     // the controller-local file path is meaningless on the remote runner and the
@@ -45,42 +47,14 @@ pub(in crate::core::runner) fn remap_provider_config_in_args(
         )
     });
 
-    let mut out = Vec::with_capacity(args.len());
-    let mut iter = args.iter().peekable();
-    let mut passthrough = false;
-    while let Some(arg) = iter.next() {
-        if passthrough {
-            out.push(arg.clone());
-            continue;
-        }
-        if arg == "--" {
-            passthrough = true;
-            out.push(arg.clone());
-            continue;
-        }
-        if arg == "--provider-config" {
-            out.push(arg.clone());
-            if let Some(spec) = iter.next() {
-                out.push(remap_provider_config_spec(spec, &ordered));
-            }
-            continue;
-        }
-        if let Some(spec) = arg.strip_prefix("--provider-config=") {
-            out.push(format!(
-                "--provider-config={}",
-                remap_provider_config_spec(spec, &ordered)
-            ));
-            continue;
-        }
-        out.push(arg.clone());
-    }
-    out
+    envelope.rewrite_provider_config_values(|spec| remap_provider_config_spec(spec, &ordered))
 }
 
 pub(in crate::core::runner) fn inject_agent_task_default_provider_config_in_args(
     args: &[String],
 ) -> Result<Vec<String>> {
-    if !is_agent_task_dispatch_or_cook(args) || args_have_provider_config(args) {
+    let envelope = ExecutionEnvelope::from_args(args);
+    if !is_agent_task_dispatch_or_cook(args) || !envelope.inputs.provider_configs.is_empty() {
         return Ok(args.to_vec());
     }
 
@@ -128,23 +102,6 @@ fn is_agent_task_dispatch_or_cook(args: &[String]) -> bool {
         .skip(agent_task_index + 1)
         .find(|arg| !arg.starts_with('-'))
         .is_some_and(|command| matches!(command.as_str(), "dispatch" | "cook"))
-}
-
-fn args_have_provider_config(args: &[String]) -> bool {
-    let mut passthrough = false;
-    for arg in args {
-        if passthrough {
-            continue;
-        }
-        if arg == "--" {
-            passthrough = true;
-            continue;
-        }
-        if arg == "--provider-config" || arg.starts_with("--provider-config=") {
-            return true;
-        }
-    }
-    false
 }
 
 /// Resolve a provider-config spec (inline JSON / `@file` / `-`), remap its


### PR DESCRIPTION
## Summary
- Add a small typed Lab execution envelope for command input refs.
- Convert provider-config arg handling to use the envelope while preserving argv output.
- Remove duplicated provider-config presence scanning.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt and diff checks before commit.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and tests; Chris remains responsible for review and merge.