### PR TITLE
feat(runner): surface reverse broker jobs

### DIFF
--- a/src/commands/runner.rs
+++ b/src/commands/runner.rs
@@ -12,7 +12,8 @@ use homeboy::core::redaction::RedactionPolicy;
 use homeboy::core::runners::{
     self as runner, runner_job_log_snapshot, ReverseRunnerConnectOptions,
     ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput, Runner, RunnerConnectReport,
-    RunnerDisconnectReport, RunnerExecOutput, RunnerKind, RunnerStatusReport,
+    RunnerDisconnectReport, RunnerExecOutput, RunnerKind, RunnerSession, RunnerStatusReport,
+    RunnerTunnelMode,
 };
 use homeboy::core::server::{RunnerPolicy, RunnerSecretEnvRef, RunnerSettings};
 use homeboy::core::{EntityCrudOutput, MergeOutput};
@@ -30,6 +31,8 @@ pub struct RunnerExtra {
     pub connection: Option<RunnerConnectionOutput>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub sessions: Vec<RunnerStatusReport>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub operator_hints: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1000,12 +1003,14 @@ fn connect(
 fn status(id: Option<&str>) -> CmdResult<RunnerOutput> {
     if let Some(id) = id {
         let report = runner::status(id)?;
+        let operator_hints = runner_status_operator_hints(&report);
         return Ok((
             RunnerOutput {
                 command: "runner.status".to_string(),
                 id: Some(id.to_string()),
                 extra: RunnerExtra {
                     connection: Some(RunnerConnectionOutput::Status(report)),
+                    operator_hints,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -1014,17 +1019,66 @@ fn status(id: Option<&str>) -> CmdResult<RunnerOutput> {
         ));
     }
 
+    let sessions = runner::statuses()?;
+    let operator_hints = sessions
+        .iter()
+        .flat_map(runner_status_operator_hints)
+        .collect();
     Ok((
         RunnerOutput {
             command: "runner.status".to_string(),
             extra: RunnerExtra {
-                sessions: runner::statuses()?,
+                sessions,
+                operator_hints,
                 ..Default::default()
             },
             ..Default::default()
         },
         0,
     ))
+}
+
+fn runner_status_operator_hints(report: &RunnerStatusReport) -> Vec<String> {
+    let Some(session) = report.session.as_ref().filter(|_| report.connected) else {
+        return Vec::new();
+    };
+    let mut hints = Vec::new();
+    match session.mode {
+        RunnerTunnelMode::DirectSsh => {
+            if report.active_job_count > 0 {
+                hints.push(format!(
+                    "Active daemon jobs for `{}` are listed from the direct daemon; inspect with `homeboy runner job logs {} <job-id> --follow` and cancel known jobs with `homeboy runner job cancel {} <job-id>`.",
+                    report.runner_id, report.runner_id, report.runner_id
+                ));
+            }
+        }
+        RunnerTunnelMode::Reverse => reverse_runner_status_hints(report, session, &mut hints),
+    }
+    hints
+}
+
+fn reverse_runner_status_hints(
+    report: &RunnerStatusReport,
+    session: &RunnerSession,
+    hints: &mut Vec<String>,
+) {
+    if session.broker_url.is_none() {
+        hints.push(format!(
+            "Reverse runner `{}` has no broker URL; active-job listing, logs, and cancel require reconnecting with `homeboy runner connect <controller-id> --reverse --reverse-runner {} --broker-url <url>`.",
+            report.runner_id, report.runner_id
+        ));
+        return;
+    }
+    hints.push(format!(
+        "Reverse runner `{}` active jobs are listed through the broker; inspect with `homeboy runner job logs {} <job-id> --follow`.",
+        report.runner_id, report.runner_id
+    ));
+    if report.active_job_count > 0 {
+        hints.push(format!(
+            "Cancel known reverse broker jobs with `homeboy runner job cancel {} <job-id>`; if the broker rejects an already-claimed job, runner-side interrupt-on-cancel needs claim/heartbeat support rather than a local workaround.",
+            report.runner_id
+        ));
+    }
 }
 
 fn disconnect(id: &str) -> CmdResult<RunnerOutput> {

--- a/src/core/runner/broker_http.rs
+++ b/src/core/runner/broker_http.rs
@@ -39,6 +39,27 @@ pub(crate) fn post_json(
     canonical_broker_body(&data)
 }
 
+pub(crate) fn get_json(client: &Client, base_url: &str, path: &str, action: &str) -> Result<Value> {
+    let response = client
+        .get(format!("{}{}", base_url.trim_end_matches('/'), path))
+        .send()
+        .map_err(|err| Error::internal_unexpected(format!("{action}: {err}")))?;
+    let status_code = response.status().as_u16();
+    let envelope: BrokerEnvelope = response.json().map_err(|err| {
+        Error::internal_json(err.to_string(), Some("parse broker response".to_string()))
+    })?;
+    if status_code >= 400 || !envelope.success {
+        return Err(Error::internal_unexpected(format!(
+            "broker request failed: {}",
+            envelope.error.unwrap_or(Value::Null)
+        )));
+    }
+    let data = envelope
+        .data
+        .ok_or_else(|| Error::internal_unexpected("broker response missing data"))?;
+    canonical_broker_body(&data)
+}
+
 fn canonical_broker_body(data: &Value) -> Result<Value> {
     data.get("body")
         .cloned()

--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -14,6 +14,7 @@ use crate::core::error::{Error, Result};
 use crate::core::paths;
 use crate::core::server::{self, Server, ServerAuthMode, SshClient};
 
+use super::broker_http;
 use super::session::{
     ReverseRunnerConnectOptions, RunnerConnectReport, RunnerDisconnectReport, RunnerFailureKind,
     RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerStaleDaemonWarning,
@@ -257,7 +258,10 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     let connected = state == RunnerSessionState::Connected;
     let stale_daemon = stale_daemon_warning(&runner, session.as_ref(), connected);
     let active_jobs = if connected {
-        active_runner_jobs(runner_id)
+        match session.as_ref() {
+            Some(session) => active_runner_jobs(runner_id, session)?,
+            None => Vec::new(),
+        }
     } else {
         Vec::new()
     };
@@ -274,18 +278,66 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     })
 }
 
-fn active_runner_jobs(runner_id: &str) -> Vec<ActiveRunnerJobSummary> {
-    super::daemon_api_get(runner_id, "/jobs")
-        .ok()
-        .and_then(|data| data.get("body").cloned())
-        .and_then(|body| body.get("active_runner_jobs").cloned())
-        .and_then(|jobs| serde_json::from_value(jobs).ok())
-        .map(|jobs: Vec<ActiveRunnerJobSummary>| {
-            jobs.into_iter()
-                .filter(|job| job.runner_id == runner_id)
-                .collect()
-        })
-        .unwrap_or_default()
+fn active_runner_jobs(
+    runner_id: &str,
+    session: &RunnerSession,
+) -> Result<Vec<ActiveRunnerJobSummary>> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|err| Error::internal_unexpected(format!("build active job client: {err}")))?;
+    let body = if let Some(local_url) = session.local_url.as_deref() {
+        let data = daemon_get(&client, local_url, "/jobs")?;
+        data.get("body")
+            .cloned()
+            .ok_or_else(|| Error::internal_unexpected("daemon jobs response missing data.body"))?
+    } else if session.mode == RunnerTunnelMode::Reverse {
+        let Some(broker_url) = session.broker_url.as_deref() else {
+            return Ok(Vec::new());
+        };
+        broker_http::get_json(
+            &client,
+            broker_url,
+            "/jobs",
+            "list reverse runner broker jobs",
+        )?
+    } else {
+        return Ok(Vec::new());
+    };
+    let jobs: Vec<ActiveRunnerJobSummary> = serde_json::from_value(
+        body.get("active_runner_jobs")
+            .cloned()
+            .unwrap_or_else(|| Value::Array(Vec::new())),
+    )
+    .map_err(|err| {
+        Error::internal_json(
+            err.to_string(),
+            Some("parse active runner jobs".to_string()),
+        )
+    })?;
+    Ok(jobs
+        .into_iter()
+        .filter(|job| job.runner_id == runner_id)
+        .collect())
+}
+
+fn daemon_get(client: &Client, local_url: &str, path: &str) -> Result<Value> {
+    let response = client
+        .get(format!("{}{}", local_url.trim_end_matches('/'), path))
+        .send()
+        .map_err(|err| Error::internal_unexpected(format!("query runner daemon: {err}")))?;
+    let envelope: CliEnvelope = response.json().map_err(|err| {
+        Error::internal_json(err.to_string(), Some("parse daemon response".to_string()))
+    })?;
+    if !envelope.success {
+        return Err(Error::internal_unexpected(format!(
+            "daemon request failed: {}",
+            envelope.error.unwrap_or(Value::Null)
+        )));
+    }
+    envelope
+        .data
+        .ok_or_else(|| Error::internal_unexpected("daemon response missing data"))
 }
 
 fn stale_daemon_warning(

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -1039,23 +1039,50 @@ fn daemon_api_request(runner_id: &str, path: &str, method: &str) -> Result<Value
         .timeout(Duration::from_secs(10))
         .build()
         .map_err(|err| Error::internal_unexpected(format!("build daemon HTTP client: {err}")))?;
-    let Some(local_url) = session.local_url.as_deref() else {
-        return Err(Error::validation_invalid_argument(
-            "runner",
-            "runner session does not expose a local daemon URL yet",
-            Some(runner.id),
-            Some(vec![
-                "Reverse tunnel daemon routing is tracked in #2946 and #2948.".to_string(),
-            ]),
-        ));
-    };
-    match method {
-        "GET" => daemon_get(&client, local_url, path),
-        "POST" => daemon_post(&client, local_url, path),
-        _ => Err(Error::internal_unexpected(format!(
-            "unsupported daemon API method {method}"
-        ))),
+    if let Some(local_url) = session.local_url.as_deref() {
+        return match method {
+            "GET" => daemon_get(&client, local_url, path),
+            "POST" => daemon_post(&client, local_url, path),
+            _ => Err(Error::internal_unexpected(format!(
+                "unsupported daemon API method {method}"
+            ))),
+        };
     }
+    if session.mode == RunnerTunnelMode::Reverse {
+        let Some(broker_url) = session.broker_url.as_deref() else {
+            return Err(Error::validation_invalid_argument(
+                "runner",
+                "reverse runner session does not expose a broker URL",
+                Some(runner.id),
+                Some(vec![
+                    "Reconnect the reverse runner with `homeboy runner connect <controller-id> --reverse --reverse-runner <runner-id> --broker-url <url>`.".to_string(),
+                ]),
+            ));
+        };
+        return match method {
+            "GET" => {
+                broker_http::get_json(&client, broker_url, path, "query reverse runner broker")
+            }
+            "POST" => broker_http::post_json(
+                &client,
+                broker_url,
+                path,
+                json!({}),
+                "query reverse runner broker",
+            ),
+            _ => Err(Error::internal_unexpected(format!(
+                "unsupported daemon API method {method}"
+            ))),
+        };
+    }
+    Err(Error::validation_invalid_argument(
+        "runner",
+        "runner session does not expose a local daemon URL or reverse broker URL",
+        Some(runner.id),
+        Some(vec![
+            "Use a direct daemon connection or a reverse runner session registered with a broker before querying runner jobs.".to_string(),
+        ]),
+    ))
 }
 
 fn daemon_post(client: &Client, local_url: &str, path: &str) -> Result<Value> {


### PR DESCRIPTION
## Summary
- Surface active jobs for reverse runner sessions through broker-backed job listing.
- Route runner job API helpers by direct daemon vs reverse broker mode.
- Add operator hints for reverse runner inspection and cancellation follow-up.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt and diff checks before commit.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and PR text; Chris remains responsible for review and merge.