### PR TITLE
fix(runner): enforce reverse claim leases

### DIFF
--- a/src/core/api_jobs.rs
+++ b/src/core/api_jobs.rs
@@ -1668,6 +1668,57 @@ mod tests {
     }
 
     #[test]
+    fn remote_runner_claim_heartbeat_extends_matching_unexpired_claim() {
+        let store = JobStore::default();
+        let job = store
+            .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+            .expect("remote runner job queues");
+        let claim = store
+            .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+            .expect("claim succeeds")
+            .expect("job is claimed");
+        let claim_id = claim.job.claim_id.expect("claim id");
+        let previous_expiry = claim.job.claim_expires_at_ms.expect("claim expiry");
+
+        let renewed = store
+            .renew_remote_runner_claim(job.id, "homeboy-lab", &claim_id, 60_000)
+            .expect("matching claim renews");
+
+        assert_eq!(renewed.id, job.id);
+        assert_eq!(renewed.claim_id.as_deref(), Some(claim_id.as_str()));
+        assert!(renewed.claim_expires_at_ms.expect("renewed expiry") > previous_expiry);
+    }
+
+    #[test]
+    fn remote_runner_claim_heartbeat_rejects_wrong_or_expired_claim() {
+        let store = JobStore::default();
+        let job = store
+            .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+            .expect("remote runner job queues");
+        let claim = store
+            .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+            .expect("claim succeeds")
+            .expect("job is claimed");
+        let claim_id = claim.job.claim_id.expect("claim id");
+
+        let wrong_claim = store.renew_remote_runner_claim(job.id, "homeboy-lab", "wrong", 30_000);
+        assert!(wrong_claim.is_err());
+
+        {
+            let mut inner = store.inner.lock().expect("job store mutex poisoned");
+            inner
+                .jobs
+                .get_mut(&job.id)
+                .expect("job exists")
+                .job
+                .claim_expires_at_ms = Some(timestamp_ms().saturating_sub(1));
+        }
+
+        let expired = store.renew_remote_runner_claim(job.id, "homeboy-lab", &claim_id, 30_000);
+        assert!(expired.is_err());
+    }
+
+    #[test]
     fn cancelled_remote_runner_job_cannot_be_claimed() {
         let store = JobStore::default();
         let job = store

--- a/src/core/api_jobs/remote_runner.rs
+++ b/src/core/api_jobs/remote_runner.rs
@@ -296,6 +296,28 @@ impl JobStore {
         )
     }
 
+    pub(crate) fn renew_remote_runner_claim(
+        &self,
+        job_id: Uuid,
+        runner_id: &str,
+        claim_id: &str,
+        lease_ms: u64,
+    ) -> Result<Job> {
+        self.ensure_remote_runner_claim(job_id, runner_id, claim_id)?;
+        let now = timestamp_ms();
+        {
+            let mut inner = self.inner.lock().expect("job store mutex poisoned");
+            let stored = inner
+                .jobs
+                .get_mut(&job_id)
+                .ok_or_else(|| job_not_found(job_id))?;
+            stored.job.updated_at_ms = now;
+            stored.job.claim_expires_at_ms = Some(now.saturating_add(lease_ms.max(1)));
+        }
+        self.persist()?;
+        self.get(job_id)
+    }
+
     pub(crate) fn reconcile_expired_remote_runner_claims(&self, now_ms: u64) -> Result<Vec<Job>> {
         let expired_ids = {
             let inner = self.inner.lock().expect("job store mutex poisoned");

--- a/src/core/daemon/remote_runner.rs
+++ b/src/core/daemon/remote_runner.rs
@@ -40,6 +40,14 @@ struct FinishRequest {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+struct HeartbeatRequest {
+    runner_id: String,
+    claim_id: String,
+    #[serde(default)]
+    lease_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 struct SessionRequest {
     runner_id: String,
     controller_id: String,
@@ -84,7 +92,7 @@ pub(super) fn route(
                 "unknown remote runner broker path",
                 Some(path.to_string()),
                 Some(vec![
-                    "Use /runner/jobs, /runner/jobs/claim, /runner/jobs/<job-id>/events, or /runner/jobs/<job-id>/finish."
+                    "Use /runner/jobs, /runner/jobs/claim, /runner/jobs/<job-id>/events, /runner/jobs/<job-id>/finish, or /runner/jobs/<job-id>/heartbeat."
                         .to_string(),
                     "Use /runner/sessions to register reverse runner sessions.".to_string(),
                 ]),
@@ -187,7 +195,7 @@ fn update(path: &str, body: Option<Value>, job_store: &JobStore) -> HttpResponse
                 "unknown remote runner job path",
                 Some(path.to_string()),
                 Some(vec![
-                    "Use /runner/jobs/<job-id>/events or /runner/jobs/<job-id>/finish.".to_string(),
+                    "Use /runner/jobs/<job-id>/events, /runner/jobs/<job-id>/finish, or /runner/jobs/<job-id>/heartbeat.".to_string(),
                 ]),
             ),
         );
@@ -202,15 +210,17 @@ fn update(path: &str, body: Option<Value>, job_store: &JobStore) -> HttpResponse
             Ok(body) => daemon_endpoint_response("runner.jobs.finish", body),
             Err(err) => error_response(400, err),
         },
+        "heartbeat" => match heartbeat(job_id, body, job_store) {
+            Ok(body) => daemon_endpoint_response("runner.jobs.heartbeat", body),
+            Err(err) => error_response(400, err),
+        },
         _ => error_response(
             404,
             Error::validation_invalid_argument(
                 "path",
                 "unknown remote runner job operation",
                 Some(operation.to_string()),
-                Some(vec![
-                    "Supported operations are events and finish.".to_string()
-                ]),
+                Some(vec!["Supported operations are events, finish, and heartbeat.".to_string()]),
             ),
         ),
     }
@@ -251,6 +261,21 @@ fn finish(job_id: Uuid, body: Option<Value>, job_store: &JobStore) -> Result<Val
     )?;
     Ok(json!({
         "command": "api.runner.jobs.finish",
+        "job": job,
+    }))
+}
+
+fn heartbeat(job_id: Uuid, body: Option<Value>, job_store: &JobStore) -> Result<Value> {
+    let request: HeartbeatRequest = parse_body(body, "remote runner heartbeat request")?;
+    touch_reverse_session(&request.runner_id)?;
+    let job = job_store.renew_remote_runner_claim(
+        job_id,
+        &request.runner_id,
+        &request.claim_id,
+        request.lease_ms.unwrap_or(30_000),
+    )?;
+    Ok(json!({
+        "command": "api.runner.jobs.heartbeat",
         "job": job,
     }))
 }

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -341,14 +341,36 @@ fn routes_remote_runner_job_broker_lifecycle() {
     assert_eq!(claim.status_code, 200);
     assert_eq!(claim.body["endpoint"], "runner.jobs.claim");
     assert_eq!(claim.body["body"]["claim"]["job"]["id"], job_id);
-    let claim_id = claim.body["body"]["claim"]["claim_id"]
+    let claim_id = claim.body["body"]["claim"]["job"]["claim_id"]
         .as_str()
         .expect("claim id")
         .to_string();
+    let original_expiry = claim.body["body"]["claim"]["job"]["claim_expires_at_ms"]
+        .as_u64()
+        .expect("claim expiry");
     assert_eq!(
         claim.body["body"]["claim"]["request"]["command"],
         serde_json::json!(["homeboy", "test", "sample-plugin"])
     );
+
+    let heartbeat = route_with_job_store_and_body(
+        "POST",
+        &format!("/runner/jobs/{job_id}/heartbeat"),
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "claim_id": claim_id.clone(),
+            "lease_ms": 60000
+        })),
+        &store,
+    );
+
+    assert_eq!(heartbeat.status_code, 200);
+    assert_eq!(heartbeat.body["endpoint"], "runner.jobs.heartbeat");
+    assert_eq!(heartbeat.body["body"]["job"]["id"], job_id);
+    assert!(heartbeat.body["body"]["job"]["claim_expires_at_ms"]
+        .as_u64()
+        .expect("renewed expiry")
+        > original_expiry);
 
     let event = route_with_job_store_and_body(
         "POST",
@@ -384,6 +406,104 @@ fn routes_remote_runner_job_broker_lifecycle() {
     assert_eq!(finish.status_code, 200);
     assert_eq!(finish.body["endpoint"], "runner.jobs.finish");
     assert_eq!(finish.body["body"]["job"]["status"], "succeeded");
+}
+
+#[test]
+fn routes_remote_runner_job_updates_require_live_matching_claim_id() {
+    let store = JobStore::default();
+    let submit = route_with_job_store_and_body(
+        "POST",
+        "/runner/jobs",
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "command": ["homeboy", "test", "sample-plugin"]
+        })),
+        &store,
+    );
+    let job_id = submit.body["body"]["job"]["id"].as_str().expect("job id");
+    let claim = route_with_job_store_and_body(
+        "POST",
+        "/runner/jobs/claim",
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "lease_ms": 30000
+        })),
+        &store,
+    );
+    let claim_id = claim.body["body"]["claim"]["job"]["claim_id"]
+        .as_str()
+        .expect("claim id");
+
+    let missing_claim = route_with_job_store_and_body(
+        "POST",
+        &format!("/runner/jobs/{job_id}/events"),
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "kind": "progress"
+        })),
+        &store,
+    );
+    assert_eq!(missing_claim.status_code, 400);
+
+    let wrong_claim = route_with_job_store_and_body(
+        "POST",
+        &format!("/runner/jobs/{job_id}/finish"),
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "claim_id": "wrong-claim",
+            "result": { "exit_code": 0 }
+        })),
+        &store,
+    );
+    assert_eq!(wrong_claim.status_code, 400);
+
+    let expired_job = route_with_job_store_and_body(
+        "POST",
+        "/runner/jobs",
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "command": ["homeboy", "test", "sample-plugin"]
+        })),
+        &store,
+    );
+    let expired_job_id = expired_job.body["body"]["job"]["id"].as_str().expect("job id");
+    let expired_claim = route_with_job_store_and_body(
+        "POST",
+        "/runner/jobs/claim",
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "lease_ms": 1
+        })),
+        &store,
+    );
+    let expired_claim_id = expired_claim.body["body"]["claim"]["job"]["claim_id"]
+        .as_str()
+        .expect("claim id");
+    std::thread::sleep(std::time::Duration::from_millis(5));
+
+    let expired_event = route_with_job_store_and_body(
+        "POST",
+        &format!("/runner/jobs/{expired_job_id}/events"),
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "claim_id": expired_claim_id,
+            "kind": "progress"
+        })),
+        &store,
+    );
+    assert_eq!(expired_event.status_code, 400);
+
+    let valid_event = route_with_job_store_and_body(
+        "POST",
+        &format!("/runner/jobs/{job_id}/events"),
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "claim_id": claim_id,
+            "kind": "progress"
+        })),
+        &store,
+    );
+    assert_eq!(valid_event.status_code, 200);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Require matching reverse runner claim IDs for broker event and finish updates.
- Reject expired claims before accepting worker updates.
- Add broker heartbeat renewal support and focused tests.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran diff checks before commit; tests were added but not executed locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and tests; Chris remains responsible for review and merge.