### PR TITLE
refactor: clear audit dead-code + compiler-warning findings (#5322, #5358)

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -92,6 +92,7 @@ pub(crate) const TEST_LAB_LABEL: &str = "test";
 pub(crate) const AUDIT_LAB_LABEL: &str = "audit";
 pub(crate) const BENCH_LAB_LABEL: &str = "bench";
 const TRACE_LAB_LABEL: &str = "trace";
+#[cfg(test)]
 const REFACTOR_LAB_LABEL: &str = "refactor";
 const RIG_CHECK_LAB_LABEL: &str = "rig check";
 const TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL: &str = "tunnel preview-consumer run";
@@ -99,7 +100,7 @@ const TUNNEL_SERVICE_EXPOSE_LAB_LABEL: &str = "tunnel service expose";
 const TUNNEL_SERVICE_START_LAB_LABEL: &str = "tunnel service start";
 
 struct LabSupportedCommandSummary {
-    #[allow(dead_code)]
+    #[cfg(test)]
     contract_labels: &'static [&'static str],
     message_label: &'static str,
     hint_label: &'static str,
@@ -107,11 +108,13 @@ struct LabSupportedCommandSummary {
 
 const LAB_SUPPORTED_COMMAND_SUMMARIES: &[LabSupportedCommandSummary] = &[
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[AGENT_TASK_RUN_LAB_LABEL],
         message_label: "agent-task dispatch/cook/loop/run-plan",
         hint_label: "agent-task dispatch/cook/loop/run-plan",
     },
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[
             AGENT_TASK_CONTROLLER_FROM_SPEC_LAB_LABEL,
             AGENT_TASK_CONTROLLER_RESUME_LAB_LABEL,
@@ -120,66 +123,79 @@ const LAB_SUPPORTED_COMMAND_SUMMARIES: &[LabSupportedCommandSummary] = &[
         hint_label: "agent-task controller from-spec --resume/materialize/resume",
     },
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[AGENT_TASK_RUN_LAB_LABEL],
         message_label: "agent-task retry --run",
         hint_label: "agent-task retry --run",
     },
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[AGENT_TASK_STATUS_LAB_LABEL, AGENT_TASK_PROVIDERS_LAB_LABEL],
         message_label: "agent-task status/logs/artifacts/review/providers",
         hint_label: "agent-task status/logs/artifacts/review/providers",
     },
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[AGENT_TASK_AUTH_STATUS_LAB_LABEL],
         message_label: AGENT_TASK_AUTH_STATUS_LAB_LABEL,
         hint_label: AGENT_TASK_AUTH_STATUS_LAB_LABEL,
     },
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[LINT_LAB_LABEL],
         message_label: LINT_LAB_LABEL,
         hint_label: "full lint",
     },
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[TEST_LAB_LABEL],
         message_label: TEST_LAB_LABEL,
         hint_label: "full test",
     },
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[AUDIT_LAB_LABEL],
         message_label: AUDIT_LAB_LABEL,
         hint_label: AUDIT_LAB_LABEL,
     },
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[BENCH_LAB_LABEL],
         message_label: BENCH_LAB_LABEL,
         hint_label: "bench run",
     },
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[TRACE_LAB_LABEL],
         message_label: TRACE_LAB_LABEL,
         hint_label: TRACE_LAB_LABEL,
     },
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[REFACTOR_LAB_LABEL],
         message_label: "refactor source runs",
         hint_label: "refactor source runs",
     },
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[RIG_CHECK_LAB_LABEL],
         message_label: RIG_CHECK_LAB_LABEL,
         hint_label: RIG_CHECK_LAB_LABEL,
     },
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL],
         message_label: TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL,
         hint_label: TUNNEL_PREVIEW_CONSUMER_RUN_LAB_LABEL,
     },
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[TUNNEL_SERVICE_EXPOSE_LAB_LABEL],
         message_label: TUNNEL_SERVICE_EXPOSE_LAB_LABEL,
         hint_label: TUNNEL_SERVICE_EXPOSE_LAB_LABEL,
     },
     LabSupportedCommandSummary {
+        #[cfg(test)]
         contract_labels: &[TUNNEL_SERVICE_START_LAB_LABEL],
         message_label: TUNNEL_SERVICE_START_LAB_LABEL,
         hint_label: TUNNEL_SERVICE_START_LAB_LABEL,
@@ -214,7 +230,7 @@ fn lab_runner_supported_hint_labels() -> Vec<&'static str> {
         .collect()
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 fn lab_runner_summary_covers_contract_label(contract_label: &str) -> bool {
     LAB_SUPPORTED_COMMAND_SUMMARIES
         .iter()

--- a/src/core/agent_task.rs
+++ b/src/core/agent_task.rs
@@ -296,7 +296,8 @@ impl AgentTaskExecutor {
             .unwrap_or(&self.backend)
     }
 
-    pub fn executor_provider_id(&self) -> Option<&str> {
+    #[cfg(test)]
+    fn executor_provider_id(&self) -> Option<&str> {
         self.runtime_selection
             .as_ref()
             .and_then(|selection| selection.executor_provider_id.as_deref())
@@ -317,7 +318,8 @@ impl AgentTaskExecutor {
             .or(self.model.as_deref())
     }
 
-    pub fn substrate_ref(&self) -> Option<&str> {
+    #[cfg(test)]
+    fn substrate_ref(&self) -> Option<&str> {
         self.runtime_selection
             .as_ref()
             .and_then(|selection| selection.substrate_ref.as_deref())

--- a/src/core/deploy/planning.rs
+++ b/src/core/deploy/planning.rs
@@ -453,15 +453,6 @@ fn component_git_root(component: &Component) -> Option<String> {
     git::get_git_root(&component.local_path).ok()
 }
 
-/// Calculate component status based on local and remote versions.
-pub(super) fn calculate_component_status(
-    component: &Component,
-    remote_versions: &HashMap<String, String>,
-) -> ComponentStatus {
-    let mut git_probe_cache = GitProbeCache::default();
-    calculate_component_status_with_git_cache(component, remote_versions, &mut git_probe_cache)
-}
-
 pub(super) fn calculate_component_status_with_git_cache(
     component: &Component,
     remote_versions: &HashMap<String, String>,
@@ -862,6 +853,14 @@ mod tests {
             artifact_path: None,
         }]);
         component
+    }
+
+    fn calculate_component_status(
+        component: &Component,
+        remote_versions: &HashMap<String, String>,
+    ) -> ComponentStatus {
+        let mut git_probe_cache = GitProbeCache::default();
+        calculate_component_status_with_git_cache(component, remote_versions, &mut git_probe_cache)
     }
 
     fn deploy_config() -> DeployConfig {

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -18,7 +18,7 @@ use crate::core::observation::homeboy_findings_from_test_analysis_input;
 use crate::core::refactor::AppliedRefactor;
 use crate::core::validation_progress::{write_command_artifact, ValidationProgressRecorder};
 use serde::Serialize;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 #[derive(Debug, Clone)]
 pub struct TestRunWorkflowArgs {


### PR DESCRIPTION
## Summary
Clears the audit/compiler-warning findings tracked in #5322 (compiler warnings) and the lab.rs + agent_task.rs subset of #5358 (dead code). No behavior changes — every touched item was used only by same-file tests or genuinely dead.

## Changes
**#5322 — compiler warnings**
- `src/core/deploy/planning.rs`: removed the lib-dead `calculate_component_status` wrapper (only test callers used it). Replaced with a `#[cfg(test)]` test helper of the same name that delegates to `calculate_component_status_with_git_cache`, so the 4 test call sites stay unchanged.
- `src/core/extension/test/run.rs`: dropped the unused `PathBuf` import (`Path` is still used).

**#5358 — dead code**
- `src/command_contract/lab.rs`: removed the two `#[allow(dead_code)]` markers. `lab_runner_summary_covers_contract_label` and the `contract_labels` field are test-only, so they're now gated with `#[cfg(test)]` instead of suppressed. `REFACTOR_LAB_LABEL` (used only via `contract_labels`) is gated to match, avoiding a cascade warning.
- `src/core/agent_task.rs`: `executor_provider_id` and `substrate_ref` were `pub` accessors referenced only by same-file tests (flagged `unreferenced_export`). Gated both with `#[cfg(test)]` — drops the public export while keeping the fallback-resolution test coverage.

## Validation
- `cargo fmt`
- `cargo build --lib` passes (the only remaining warning, `daemon_api_post` in `src/core/runners.rs`, is pre-existing and out of scope). Full build/test left to CI per VPS build policy.

Closes #5322
Closes #5358