### PR TITLE
fix(runner): tolerate unreachable broker in status (Closes #5320)

### DIFF
--- a/src/core/runner/connection.rs
+++ b/src/core/runner/connection.rs
@@ -257,9 +257,12 @@ pub fn status(runner_id: &str) -> Result<RunnerStatusReport> {
     let state = session_state(session.as_ref());
     let connected = state == RunnerSessionState::Connected;
     let stale_daemon = stale_daemon_warning(&runner, session.as_ref(), connected);
+    // Active-job enrichment is best-effort: a status read must not hard-fail
+    // when the runner daemon or reverse broker is momentarily unreachable.
+    // Degrade to an empty job list so callers still receive session state.
     let active_jobs = if connected {
         match session.as_ref() {
-            Some(session) => active_runner_jobs(runner_id, session)?,
+            Some(session) => active_runner_jobs(runner_id, session).unwrap_or_default(),
             None => Vec::new(),
         }
     } else {


### PR DESCRIPTION
## Summary
- Repairs the RED main test gate (#5320). The failing test was `core::daemon::daemon_test::routes_remote_runner_session_registration`, which panicked at `tests/core/daemon_test.rs:571` with `list reverse runner broker jobs: error sending request for url (http://127.0.0.1:49152/jobs)`.
- Root cause: the reverse-broker job listing introduced by `8e65f9b7 feat(runner): surface reverse broker jobs` made `runner::status()` perform a **live HTTP request** to the daemon/broker and propagate any error via `?`. When the broker is unreachable, the whole `status()` call fails with `InternalUnexpected` instead of returning valid session state.
- Fix: active-job enrichment is now best-effort — `active_runner_jobs()` errors degrade to an empty job list (`unwrap_or_default()`), so a status read still returns connection/session info when the daemon or broker is momentarily unreachable. `active_jobs` already serializes as empty-by-default, so this is a safe, expected state.

## Why this surfaced now
A ~13-PR parallel cook merge storm (reverse-runner broker work: #5374, #5375, plus `8e65f9b7`) landed the network side-effect in a status read. CI's wrapped test output reported "test phase failed without structured counts (exit 101)" with no captured failure, so the failing test name had to be recovered from the test-gate observation's `test_scope.selected_files` (`tests/core/daemon_test.rs`, `tests/core/http_api_test.rs`) and reproduced locally.

## Validation
- `cargo test --lib daemon_test::` → **26 passed, 0 failed** (was 25 passed / 1 failed).
- `cargo test --lib runner::connection` → 14 passed.
- `cargo test --test core_agnostic_test` → 4 passed; `cargo test --test architecture_core_agnostic_test` → 11 passed (no baseline/agnostic drift).
- `cargo build --lib --tests` compiles clean; `cargo fmt --check` clean.

Closes #5320