### PR TITLE
feat(db): tag output variants

### DIFF
--- a/src/command_contract/public_variants.rs
+++ b/src/command_contract/public_variants.rs
@@ -45,6 +45,27 @@ pub const PUBLIC_OUTPUT_VARIANT_CONTRACTS: &[PublicOutputVariantContract] = &[
         golden_fixture: Some("bench_contract.json"),
     },
     PublicOutputVariantContract {
+        command: "db",
+        variant: "status",
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("status"),
+        golden_fixture: None,
+    },
+    PublicOutputVariantContract {
+        command: "db",
+        variant: "query",
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("query"),
+        golden_fixture: None,
+    },
+    PublicOutputVariantContract {
+        command: "db",
+        variant: "tunnel",
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("tunnel"),
+        golden_fixture: None,
+    },
+    PublicOutputVariantContract {
         command: "runs",
         variant: "list",
         discriminator_field: Some("variant"),

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -1,5 +1,5 @@
 use clap::{Args, Subcommand};
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 use homeboy::core::db::{self, DbResult, DbTunnelResult};
 use homeboy::core::engine::text;
@@ -91,19 +91,48 @@ enum DbCommand {
 }
 
 #[derive(Serialize)]
-
 pub struct DbOutput {
     pub command: String,
     #[serde(flatten)]
     pub result: DbResultVariant,
 }
 
-#[derive(Serialize)]
-#[serde(untagged)]
 pub enum DbResultVariant {
     Status(ObservationDbStatus),
     Query(DbResult),
     Tunnel(DbTunnelResult),
+}
+
+#[derive(Serialize)]
+struct TaggedDbResult<'a, T: Serialize> {
+    variant: &'static str,
+    #[serde(flatten)]
+    result: &'a T,
+}
+
+impl Serialize for DbResultVariant {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            DbResultVariant::Status(result) => TaggedDbResult {
+                variant: "status",
+                result,
+            }
+            .serialize(serializer),
+            DbResultVariant::Query(result) => TaggedDbResult {
+                variant: "query",
+                result,
+            }
+            .serialize(serializer),
+            DbResultVariant::Tunnel(result) => TaggedDbResult {
+                variant: "tunnel",
+                result,
+            }
+            .serialize(serializer),
+        }
+    }
 }
 
 pub fn run(args: DbArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<DbOutput> {


### PR DESCRIPTION
## Summary
- Add explicit DB output variant tags for status, query, and tunnel payloads.
- Preserve the existing command field and flattened payload shape.
- Register DB variants in the public output variant contract list.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt/diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and PR text; Chris remains responsible for review and merge.