### PR TITLE
feat(cli): add command safety manifest

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -195,6 +195,74 @@ pub struct CommandSurfaceEntry {
     pub subcommands: Vec<CommandSurfaceEntry>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandSafetyManifest {
+    pub commands: Vec<CommandSafetyEntry>,
+}
+
+impl CommandSafetyManifest {
+    pub fn find_path(&self, path: &[&str]) -> Option<&CommandSafetyEntry> {
+        let Some((first, rest)) = path.split_first() else {
+            return None;
+        };
+
+        self.commands
+            .iter()
+            .find(|entry| entry.name == *first)
+            .and_then(|entry| entry.find_rest(rest))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandSafetyEntry {
+    pub name: String,
+    pub path: Vec<String>,
+    pub mutates: bool,
+    pub operator: bool,
+    pub dry_run: CommandDryRunMetadata,
+    pub output: CommandOutputMetadata,
+    pub lab: CommandLabMetadata,
+    pub docs: CommandDocsMetadata,
+    pub dangerous_flags: Vec<String>,
+    pub subcommands: Vec<CommandSafetyEntry>,
+}
+
+impl CommandSafetyEntry {
+    fn find_rest(&self, path: &[&str]) -> Option<&CommandSafetyEntry> {
+        let Some((first, rest)) = path.split_first() else {
+            return Some(self);
+        };
+
+        self.subcommands
+            .iter()
+            .find(|entry| entry.name == *first)
+            .and_then(|entry| entry.find_rest(rest))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandDryRunMetadata {
+    pub supported: bool,
+    pub flag: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandOutputMetadata {
+    pub structured: bool,
+    pub notes: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandLabMetadata {
+    pub supported: bool,
+    pub notes: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandDocsMetadata {
+    pub path: Option<String>,
+}
+
 impl CommandSurfaceEntry {
     fn matches(&self, name: &str) -> bool {
         self.name == name || self.visible_aliases.iter().any(|alias| alias == name)
@@ -284,6 +352,151 @@ pub fn command_surface_from_with_depth(command: Command, depth: usize) -> Comman
     CommandSurface {
         commands: visible_subcommands(&command, depth),
     }
+}
+
+pub fn current_command_safety_manifest() -> CommandSafetyManifest {
+    command_safety_manifest_from(current_command_surface())
+}
+
+pub fn command_safety_manifest_from(surface: CommandSurface) -> CommandSafetyManifest {
+    CommandSafetyManifest {
+        commands: surface
+            .commands
+            .iter()
+            .map(|entry| command_safety_entry(entry, &[]))
+            .collect(),
+    }
+}
+
+fn command_safety_entry(entry: &CommandSurfaceEntry, parent_path: &[String]) -> CommandSafetyEntry {
+    let mut path = parent_path.to_vec();
+    path.push(entry.name.clone());
+    let safety = command_safety_metadata(&path);
+
+    CommandSafetyEntry {
+        name: entry.name.clone(),
+        path: path.clone(),
+        mutates: safety.mutates,
+        operator: safety.operator,
+        dry_run: CommandDryRunMetadata {
+            supported: safety.dry_run_flag.is_some(),
+            flag: safety.dry_run_flag.map(str::to_string),
+        },
+        output: CommandOutputMetadata {
+            structured: safety.structured_output,
+            notes: safety.output_notes.to_string(),
+        },
+        lab: CommandLabMetadata {
+            supported: safety.lab_supported,
+            notes: safety.lab_notes.to_string(),
+        },
+        docs: CommandDocsMetadata {
+            path: docs_path(&path),
+        },
+        dangerous_flags: safety
+            .dangerous_flags
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        subcommands: entry
+            .subcommands
+            .iter()
+            .map(|subcommand| command_safety_entry(subcommand, &path))
+            .collect(),
+    }
+}
+
+struct CommandSafetyMetadata {
+    mutates: bool,
+    operator: bool,
+    dry_run_flag: Option<&'static str>,
+    structured_output: bool,
+    output_notes: &'static str,
+    lab_supported: bool,
+    lab_notes: &'static str,
+    dangerous_flags: Vec<&'static str>,
+}
+
+impl Default for CommandSafetyMetadata {
+    fn default() -> Self {
+        Self {
+            mutates: false,
+            operator: false,
+            dry_run_flag: None,
+            structured_output: true,
+            output_notes: "standard CLI output contract",
+            lab_supported: false,
+            lab_notes: "not declared as Lab-routable in the safety manifest",
+            dangerous_flags: Vec::new(),
+        }
+    }
+}
+
+fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
+    let mut metadata = CommandSafetyMetadata::default();
+
+    match path
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .as_slice()
+    {
+        ["deploy"] => {
+            metadata.mutates = true;
+            metadata.operator = true;
+            metadata.dry_run_flag = Some("--dry-run");
+            metadata.dangerous_flags = vec!["--head", "--force"];
+        }
+        ["db", "delete-row"] | ["db", "drop-table"] => {
+            metadata.mutates = true;
+            metadata.operator = true;
+        }
+        ["file", "write"] | ["file", "delete"] => {
+            metadata.mutates = true;
+            metadata.operator = true;
+        }
+        ["file", "mkdir"] | ["file", "rename"] => {
+            metadata.mutates = true;
+        }
+        ["triage"] => {
+            metadata.mutates = true;
+            metadata.operator = true;
+            metadata.dangerous_flags = vec!["--auto-merge"];
+        }
+        ["fleet", "exec"] => {
+            metadata.mutates = true;
+            metadata.operator = true;
+            metadata.dry_run_flag = Some("--check");
+            metadata.lab_notes = "local-only: depends on local fleet/project/server configuration before SSH fan-out";
+        }
+        ["api", "post"] | ["api", "put"] | ["api", "patch"] | ["api", "delete"] => {
+            metadata.mutates = true;
+            metadata.operator = true;
+        }
+        ["http", "request"] => {
+            metadata.mutates = true;
+            metadata.operator = true;
+            metadata.dangerous_flags = vec!["METHOD!=GET", "METHOD!=HEAD", "METHOD!=OPTIONS"];
+        }
+        ["bench"] | ["test"] | ["lint"] | ["audit"] | ["trace"] => {
+            metadata.lab_supported = true;
+            metadata.lab_notes =
+                "portable Lab offload may be available for resource-heavy workflows";
+        }
+        ["list"] => {
+            metadata.structured_output = false;
+            metadata.output_notes = "hidden raw Markdown help alias";
+        }
+        _ => {}
+    }
+
+    metadata
+}
+
+fn docs_path(path: &[String]) -> Option<String> {
+    path.first()
+        .filter(|command| command.as_str() != "list")
+        .map(|command| format!("docs/commands/{command}.md"))
 }
 
 fn visible_subcommands(command: &Command, remaining_depth: usize) -> Vec<CommandSurfaceEntry> {
@@ -393,6 +606,57 @@ mod tests {
 
         assert!(surface.contains_path(&["self"]));
         assert!(!surface.contains_path(&["self", "missing"]));
+    }
+
+    #[test]
+    fn command_safety_manifest_covers_surface_paths() {
+        let manifest = current_command_safety_manifest();
+
+        assert!(manifest.find_path(&["db"]).is_some());
+        assert!(manifest.find_path(&["db", "delete-row"]).is_some());
+        assert!(manifest.find_path(&["file", "write"]).is_some());
+        assert!(manifest.find_path(&["api", "post"]).is_some());
+    }
+
+    #[test]
+    fn command_safety_manifest_classifies_known_dangerous_paths() {
+        let manifest = current_command_safety_manifest();
+
+        for path in [
+            ["db", "delete-row"].as_slice(),
+            ["db", "drop-table"].as_slice(),
+            ["file", "write"].as_slice(),
+            ["file", "delete"].as_slice(),
+            ["api", "post"].as_slice(),
+            ["api", "put"].as_slice(),
+            ["api", "patch"].as_slice(),
+            ["api", "delete"].as_slice(),
+            ["http", "request"].as_slice(),
+        ] {
+            let entry = manifest
+                .find_path(path)
+                .unwrap_or_else(|| panic!("missing safety entry for {path:?}"));
+
+            assert!(entry.mutates, "{path:?} should be marked mutating");
+            assert!(entry.operator, "{path:?} should be marked operator-gated");
+        }
+    }
+
+    #[test]
+    fn command_safety_manifest_records_guard_flags_and_dry_run_flags() {
+        let manifest = current_command_safety_manifest();
+
+        let deploy = manifest.find_path(&["deploy"]).unwrap();
+        assert!(deploy.operator);
+        assert_eq!(deploy.dry_run.flag.as_deref(), Some("--dry-run"));
+        assert_eq!(deploy.dangerous_flags, vec!["--head", "--force"]);
+
+        let triage = manifest.find_path(&["triage"]).unwrap();
+        assert_eq!(triage.dangerous_flags, vec!["--auto-merge"]);
+
+        let fleet_exec = manifest.find_path(&["fleet", "exec"]).unwrap();
+        assert_eq!(fleet_exec.dry_run.flag.as_deref(), Some("--check"));
+        assert!(fleet_exec.lab.notes.contains("local-only"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a recursive command safety manifest with mutation/operator/dry-run/lab/docs metadata.
- Classify known dangerous paths such as DB deletes, file writes, fleet exec, deploy force/head, and mutating API verbs.
- Add focused manifest coverage tests.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt/diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and PR text; Chris remains responsible for review and merge.