### PR TITLE
perf(audit): add PR profile

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -45,6 +45,11 @@ pub struct AuditArgs {
     #[arg(long = "exclude", value_name = "kind")]
     pub exclude: Vec<String>,
 
+    /// Detector profile to run. `full` preserves the default full audit;
+    /// `pr` runs cheap root-level blockers for changed-file review.
+    #[arg(long, value_name = "PROFILE", default_value = "full", value_parser = ["full", "pr", "architecture"])]
+    pub profile: String,
+
     #[command(flatten)]
     pub baseline_args: BaselineArgs,
 
@@ -112,9 +117,16 @@ fn parse_finding_kinds(
         .collect()
 }
 
+fn parse_audit_profile(value: &str) -> homeboy::core::Result<code_audit::AuditProfile> {
+    value.parse().map_err(|msg| {
+        homeboy::core::Error::validation_invalid_argument("profile", msg, None, None)
+    })
+}
+
 pub fn run(args: AuditArgs, _global: &GlobalArgs) -> CmdResult<AuditCommandOutput> {
     let only_kinds = parse_finding_kinds(&args.only, "only")?;
     let exclude_kinds = parse_finding_kinds(&args.exclude, "exclude")?;
+    let profile = parse_audit_profile(&args.profile)?;
 
     let source_ctx = resolve_source_context(
         &args.comp,
@@ -136,6 +148,7 @@ pub fn run(args: AuditArgs, _global: &GlobalArgs) -> CmdResult<AuditCommandOutpu
         exclude_kinds,
         only_labels: args.only,
         exclude_labels: args.exclude,
+        profile,
         extension_overrides: args.extension_override.extensions,
         baseline_flags: homeboy::core::engine::baseline::BaselineFlags {
             baseline: args.baseline_args.baseline,
@@ -239,6 +252,9 @@ fn audit_observation_command(component_id: &str, args: &AuditArgs) -> String {
     for kind in &args.exclude {
         parts.push(format!("--exclude={kind}"));
     }
+    if args.profile != "full" {
+        parts.push(format!("--profile={}", args.profile));
+    }
     for extension in &args.extension_override.extensions {
         parts.push(format!("--extension={extension}"));
     }
@@ -258,6 +274,7 @@ fn audit_observation_initial_metadata(source_path: &str, args: &AuditArgs) -> se
     serde_json::json!({
         "source_path": source_path,
         "mode": if args.conventions { "conventions" } else { "audit" },
+        "profile": args.profile,
         "only": args.only,
         "exclude": args.exclude,
         "extensions": args.extension_override.extensions,
@@ -488,6 +505,7 @@ mod tests {
             conventions: false,
             only: vec![],
             exclude: vec![],
+            profile: "full".to_string(),
             baseline_args: BaselineArgs {
                 baseline: false,
                 ignore_baseline: false,
@@ -645,11 +663,14 @@ mod tests {
             "rust",
             "--changed-since",
             "origin/main",
+            "--profile",
+            "pr",
         ])
         .expect("audit should parse --extension override");
 
         assert_eq!(cli.audit.extension_override.extensions, vec!["rust"]);
         assert_eq!(cli.audit.changed_since.as_deref(), Some("origin/main"));
+        assert_eq!(cli.audit.profile, "pr");
     }
 
     #[test]
@@ -902,6 +923,7 @@ mod tests {
                 conventions: false,
                 only: vec![],
                 exclude: vec![],
+                profile: "full".to_string(),
                 baseline_args: BaselineArgs {
                     baseline: false,
                     ignore_baseline: true,

--- a/src/commands/audit_baseline.rs
+++ b/src/commands/audit_baseline.rs
@@ -86,6 +86,7 @@ fn refresh(
         exclude_kinds: Vec::new(),
         only_labels: Vec::new(),
         exclude_labels: Vec::new(),
+        profile: homeboy::core::code_audit::AuditProfile::Full,
         extension_overrides: args.extension_override.extensions,
         baseline_flags: homeboy::core::engine::baseline::BaselineFlags {
             baseline: true,

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -125,6 +125,19 @@ impl<Args, Output: Serialize + ReviewArtifactFindings> ReviewStageDescriptor<Arg
             (self.run)((self.build_args)(review_args, review_context), global)?;
         let finding_count = (self.finding_count)(&output);
 
+        let mut hint = format!(
+            "Deep dive: homeboy {} {}{}",
+            self.name,
+            component_label,
+            scope_flag_suffix(review_args, self.include_changed_only_scope),
+        );
+        if self.name == "audit"
+            && (review_args.changed_since.is_some()
+                || review_context.precomputed_changed_files().is_some())
+        {
+            hint.push_str(" --profile=pr");
+        }
+
         Ok((
             ReviewStage {
                 stage: self.name.to_string(),
@@ -132,12 +145,7 @@ impl<Args, Output: Serialize + ReviewArtifactFindings> ReviewStageDescriptor<Arg
                 passed: exit_code == 0,
                 exit_code,
                 finding_count,
-                hint: format!(
-                    "Deep dive: homeboy {} {}{}",
-                    self.name,
-                    component_label,
-                    scope_flag_suffix(review_args, self.include_changed_only_scope),
-                ),
+                hint,
                 skipped_reason: None,
                 output: Some(output),
             },
@@ -470,6 +478,13 @@ fn build_audit_args(
         conventions: false,
         only: Vec::new(),
         exclude: Vec::new(),
+        profile: if args.changed_since.is_some()
+            || review_context.precomputed_changed_files().is_some()
+        {
+            "pr".to_string()
+        } else {
+            "full".to_string()
+        },
         baseline_args: args.baseline_args.clone(),
         changed_since: args.changed_since.clone(),
         precomputed_changed_files: review_context
@@ -905,6 +920,31 @@ mod tests {
         };
         assert_eq!(scope_flag_suffix(&args, true), "");
         assert_eq!(scope_flag_suffix(&args, false), "");
+    }
+
+    #[test]
+    fn changed_since_review_uses_pr_audit_profile() {
+        let mut args = review_args_fixture();
+        args.changed_since = Some("origin/main".to_string());
+        let review_context = ReviewExecutionContext {
+            scope: "changed since origin/main".to_string(),
+            changed_file_count: Some(1),
+            precomputed_changed_files: None,
+        };
+
+        assert_eq!(build_audit_args(&args, &review_context).profile, "pr");
+    }
+
+    #[test]
+    fn full_review_uses_full_audit_profile() {
+        let args = review_args_fixture();
+        let review_context = ReviewExecutionContext {
+            scope: "full".to_string(),
+            changed_file_count: None,
+            precomputed_changed_files: None,
+        };
+
+        assert_eq!(build_audit_args(&args, &review_context).profile, "full");
     }
 
     fn review_args_fixture() -> ReviewArgs {

--- a/src/core/code_audit/execution_plan.rs
+++ b/src/core/code_audit/execution_plan.rs
@@ -9,6 +9,62 @@ pub(crate) struct AuditExecutionPlan {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuditProfile {
+    Full,
+    Pr,
+    Architecture,
+}
+
+impl AuditProfile {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Pr => "pr",
+            Self::Architecture => "architecture",
+        }
+    }
+
+    fn includes_detector(self, family: &DetectorDescriptor) -> bool {
+        match self {
+            Self::Full => true,
+            Self::Pr => matches!(
+                family.id,
+                "structural"
+                    | "layer_ownership"
+                    | "test_topology"
+                    | "test_wiring"
+                    | "docs"
+                    | "command_status_contracts"
+                    | "thin_command_adapter"
+            ),
+            Self::Architecture => matches!(
+                family.id,
+                "structural"
+                    | "layer_ownership"
+                    | "docs"
+                    | "command_status_contracts"
+                    | "thin_command_adapter"
+            ),
+        }
+    }
+}
+
+impl std::str::FromStr for AuditProfile {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "full" => Ok(Self::Full),
+            "pr" => Ok(Self::Pr),
+            "architecture" => Ok(Self::Architecture),
+            _ => Err(format!(
+                "unknown audit profile '{value}' (expected full, pr, or architecture)"
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DetectorAccess {
     Discovery,
     RootOnly,
@@ -417,16 +473,26 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
 
 impl AuditExecutionPlan {
     pub(crate) fn full() -> Self {
-        Self::from_enabled_families("full", |family| family_enabled(&[], &[], family.findings))
+        Self::from_profile_and_filters(AuditProfile::Full, &[], &[])
     }
 
     pub(crate) fn from_filters(only: &[AuditFinding], exclude: &[AuditFinding]) -> Self {
-        if only.is_empty() && exclude.is_empty() {
-            return Self::full();
-        }
+        Self::from_profile_and_filters(AuditProfile::Full, only, exclude)
+    }
 
-        Self::from_enabled_families("filtered", |family| {
-            family_enabled(only, exclude, family.findings)
+    pub(crate) fn from_profile_and_filters(
+        profile: AuditProfile,
+        only: &[AuditFinding],
+        exclude: &[AuditFinding],
+    ) -> Self {
+        let mode = if profile == AuditProfile::Full && (!only.is_empty() || !exclude.is_empty()) {
+            "filtered"
+        } else {
+            profile.as_str()
+        };
+
+        Self::from_enabled_families(mode, |family| {
+            profile.includes_detector(family) && family_enabled(only, exclude, family.findings)
         })
     }
 
@@ -627,5 +693,33 @@ mod tests {
                 DetectorRuntime::Root(RootDetectorRunner::TestWiring),
             ]
         );
+    }
+
+    #[test]
+    fn pr_profile_uses_root_only_detector_families() {
+        let plan = AuditExecutionPlan::from_profile_and_filters(AuditProfile::Pr, &[], &[]);
+
+        assert!(!plan.requires_discovery());
+        assert!(plan.run_structural());
+        assert!(plan.detector_enabled("test_topology"));
+        assert!(plan.detector_enabled("command_status_contracts"));
+        assert!(plan.run_thin_command_adapter());
+        assert!(!plan.run_duplication());
+        assert!(!plan.run_dead_code());
+        assert!(!plan.run_source_policy());
+        assert!(!plan.run_compiler_warnings());
+    }
+
+    #[test]
+    fn profile_filters_are_applied_within_profile_scope() {
+        let plan = AuditExecutionPlan::from_profile_and_filters(
+            AuditProfile::Pr,
+            &[AuditFinding::DuplicateFunction],
+            &[],
+        );
+
+        assert!(!plan.run_structural());
+        assert!(!plan.run_duplication());
+        assert!(!plan.requires_discovery());
     }
 }

--- a/src/core/code_audit/mod.rs
+++ b/src/core/code_audit/mod.rs
@@ -67,6 +67,7 @@ pub use compare::{
 };
 pub use conventions::{AuditFinding, Convention, Deviation, Language, Outlier};
 pub use duplication::DuplicateGroup;
+pub use execution_plan::AuditProfile;
 pub(crate) use execution_plan::{
     AuditExecutionPlan, DetectorDescriptor, DetectorRuntime, FingerprintDetectorRunner,
     RootDetectorRunner,
@@ -512,6 +513,7 @@ fn audit_internal(
             root,
             plan,
             extension_overrides,
+            scoped_execution.file_filter,
             &mut timing,
         );
         timing.push_ok("detectors", detector_started.elapsed());
@@ -1433,6 +1435,7 @@ fn audit_root_only(
     root: &Path,
     plan: &AuditExecutionPlan,
     extension_overrides: &[String],
+    file_filter: Option<&[String]>,
     timing: &mut AuditTiming,
 ) -> CodeAuditResult {
     let audit_config = audit_config_for(component_id, root, extension_overrides);
@@ -1567,6 +1570,22 @@ fn audit_root_only(
         findings.extend(artifact_portability_findings);
     }
 
+    let command_status_findings = time_audit_detector(
+        timing,
+        "detector.command_status_contracts",
+        plan.run_command_status_contracts(),
+        || command_status_contracts::run(root, &audit_config.command_status_contracts),
+        Vec::new,
+    );
+    if !command_status_findings.is_empty() {
+        log_status!(
+            "audit",
+            "Command status contracts: {} finding(s) (inconsistent no-op/dry-run status fields)",
+            command_status_findings.len()
+        );
+        findings.extend(command_status_findings);
+    }
+
     let thin_command_adapter_findings = time_audit_detector(
         timing,
         "detector.thin_command_adapter",
@@ -1581,6 +1600,22 @@ fn audit_root_only(
             thin_command_adapter_findings.len()
         );
         findings.extend(thin_command_adapter_findings);
+    }
+
+    if let Some(filter) = file_filter {
+        let scope_started = std::time::Instant::now();
+        let before = findings.len();
+        findings.retain(|finding| filter.iter().any(|scope| finding.file.contains(scope)));
+        let filtered_out = before - findings.len();
+        if filtered_out > 0 {
+            log_status!(
+                "audit",
+                "Scoped: filtered {} root-only finding(s) from out-of-scope files ({} remaining)",
+                filtered_out,
+                findings.len()
+            );
+        }
+        timing.push_ok("scope.filter", scope_started.elapsed());
     }
 
     let outliers_found = findings.len();

--- a/src/core/code_audit/run.rs
+++ b/src/core/code_audit/run.rs
@@ -24,6 +24,7 @@ pub struct AuditRunWorkflowArgs {
     pub exclude_kinds: Vec<code_audit::AuditFinding>,
     pub only_labels: Vec<String>,
     pub exclude_labels: Vec<String>,
+    pub profile: code_audit::AuditProfile,
     pub extension_overrides: Vec<String>,
     pub baseline_flags: crate::core::engine::baseline::BaselineFlags,
     pub changed_since: Option<String>,
@@ -200,10 +201,14 @@ fn scope_convention_outliers_to_findings(result: &mut CodeAuditResult) {
 
 /// Run the audit scan (scoped or full). Returns None if changed-since found no files.
 fn run_audit(args: &AuditRunWorkflowArgs) -> crate::core::Result<Option<AuditWithAnalysis>> {
-    let plan = if args.baseline_flags.baseline {
+    let plan = if args.baseline_flags.baseline || args.conventions {
         code_audit::AuditExecutionPlan::full()
     } else {
-        code_audit::AuditExecutionPlan::from_filters(&args.only_kinds, &args.exclude_kinds)
+        code_audit::AuditExecutionPlan::from_profile_and_filters(
+            args.profile,
+            &args.only_kinds,
+            &args.exclude_kinds,
+        )
     };
 
     if let Some(ref git_ref) = args.changed_since {


### PR DESCRIPTION
## Summary
- Add audit profiles: full, pr, and architecture.
- Use the PR profile for changed-since review audit stages.
- Keep full audit as the default and force full mode for conventions/baseline flows.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt/diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and PR text; Chris remains responsible for review and merge.