### PR TITLE
feat(runner): mirror reverse broker evidence

### DIFF
--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use base64::Engine;
 use serde_json::{json, Value};
 
-use crate::core::api_jobs::{Job, JobEvent, JobStatus};
+use crate::core::api_jobs::{Job, JobArtifactMetadata, JobEvent, JobStatus};
 use crate::core::error::{Error, Result};
 use crate::core::execution_contract::{
     decode_uri_component, encode_uri_component, EXECUTION_CONTRACT,
@@ -204,6 +204,40 @@ pub fn mirror_daemon_evidence(
         run: local_job_run,
         patch,
     }))
+}
+
+pub fn mirror_reverse_broker_evidence(
+    runner: &Runner,
+    broker_url: &str,
+    cwd: &str,
+    command: &[String],
+    job: &Job,
+    events: &[JobEvent],
+    result: &Value,
+) -> Result<Option<MirroredDaemonEvidence>> {
+    let store = ObservationStore::open_initialized()?;
+    let mut run = mirror_job_run(&store, runner, cwd, command, job, events, result)?;
+    let artifacts = mirror_reverse_broker_artifacts(&store, runner, broker_url, &run.id, job)?;
+
+    let mut metadata = run.metadata_json.clone();
+    metadata["lab"]["reverse_broker"] = json!({
+        "runner_id": runner.id.clone(),
+        "job_id": job.id.to_string(),
+        "broker_url": broker_url,
+        "status": job.status,
+        "events": events,
+        "stdout": result.get("stdout").cloned().unwrap_or(Value::Null),
+        "stderr": result.get("stderr").cloned().unwrap_or(Value::Null),
+        "artifacts": artifacts,
+    });
+    run = store.update_run_metadata(&run.id, metadata)?;
+
+    let patch = mirrored_reverse_patch_result(
+        &store,
+        &run.id,
+        result.get("patch").or_else(|| result.pointer("/data/patch")),
+    )?;
+    Ok(Some(MirroredDaemonEvidence { run, patch }))
 }
 
 pub fn mirror_daemon_job_progress(
@@ -434,6 +468,91 @@ fn import_artifact_if_absent(store: &ObservationStore, artifact: &ArtifactRecord
         return Ok(());
     }
     store.import_artifact(artifact)
+}
+
+fn mirror_reverse_broker_artifacts(
+    store: &ObservationStore,
+    runner: &Runner,
+    broker_url: &str,
+    run_id: &str,
+    job: &Job,
+) -> Result<Vec<ArtifactRecord>> {
+    let mut mirrored = Vec::new();
+    for artifact in &job.artifacts {
+        let record = reverse_broker_artifact_record(runner, broker_url, run_id, job, artifact);
+        import_artifact_if_absent(store, &record)?;
+        mirrored.push(record);
+    }
+    Ok(mirrored)
+}
+
+fn reverse_broker_artifact_record(
+    runner: &Runner,
+    broker_url: &str,
+    run_id: &str,
+    job: &Job,
+    artifact: &JobArtifactMetadata,
+) -> ArtifactRecord {
+    ArtifactRecord {
+        id: artifact.id.clone(),
+        run_id: run_id.to_string(),
+        kind: artifact
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("kind"))
+            .and_then(Value::as_str)
+            .unwrap_or("reverse_broker_artifact")
+            .to_string(),
+        artifact_type: "metadata".to_string(),
+        path: EXECUTION_CONTRACT.artifacts.metadata_only_ref(&artifact.id),
+        url: artifact.url.clone(),
+        public_url: None,
+        viewer_url: None,
+        viewer_links: Vec::new(),
+        sha256: artifact.sha256.clone(),
+        size_bytes: artifact.size_bytes.and_then(|size| i64::try_from(size).ok()),
+        mime: artifact.mime.clone(),
+        metadata_json: json!({
+            "runner_id": runner.id.clone(),
+            "job_id": job.id.to_string(),
+            "broker_url": broker_url,
+            "name": artifact.name.clone(),
+            "remote_path": artifact.path.clone(),
+            "url": artifact.url.clone(),
+            "metadata": artifact.metadata.clone(),
+        }),
+        created_at: ms_to_rfc3339(job.finished_at_ms.unwrap_or(job.updated_at_ms)),
+    }
+}
+
+fn mirrored_reverse_patch_result(
+    store: &ObservationStore,
+    run_id: &str,
+    patch: Option<&Value>,
+) -> Result<Option<Value>> {
+    let Some(patch) = patch.filter(|patch| !patch.is_null()) else {
+        return Ok(None);
+    };
+    let Some(artifact_id) = patch.get("patch_artifact_id").and_then(Value::as_str) else {
+        return Ok(Some(patch.clone()));
+    };
+    if artifact_id.is_empty() {
+        return Ok(Some(patch.clone()));
+    }
+    let Some(artifact) = store
+        .get_artifact(artifact_id)?
+        .filter(|artifact| artifact.run_id == run_id)
+    else {
+        return Ok(Some(patch.clone()));
+    };
+    let mut patched = patch.clone();
+    if let Some(object) = patched.as_object_mut() {
+        object.insert(
+            "patch_artifact_path".to_string(),
+            Value::String(artifact.path),
+        );
+    }
+    Ok(Some(patched))
 }
 
 fn remote_detail_to_run_record(

--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -21,7 +21,9 @@ use super::broker_http;
 use super::capabilities::{
     runner_capability_snapshot_for_preflight, validate_runner_capability_preflight,
 };
-use super::evidence::{mirror_daemon_evidence, mirror_daemon_job_progress};
+use super::evidence::{
+    mirror_daemon_evidence, mirror_daemon_job_progress, mirror_reverse_broker_evidence,
+};
 use super::resource_metrics::{
     measured_command_output, measured_command_output_until_cancelled, RunnerResourceMetrics,
 };
@@ -479,7 +481,7 @@ fn exec_via_reverse_broker(
     );
 
     let RunnerJobResultFields {
-        result: _,
+        result,
         stdout,
         stderr,
         metrics,
@@ -491,11 +493,23 @@ fn exec_via_reverse_broker(
         &redaction_secret_env_names,
     );
 
+    let mirror = mirror_reverse_broker_evidence(
+        runner,
+        broker_url,
+        &cwd,
+        &command,
+        &job,
+        &events,
+        &result,
+    )?;
+    let patch = mirror.as_ref().and_then(|evidence| evidence.patch.clone());
+    let mirror_run_id = mirror.as_ref().map(|evidence| evidence.run.id.as_str());
+
     print_lab_offload_handoff(
         &runner.id,
         Some(&cwd),
         &job.id.to_string(),
-        None,
+        mirror_run_id,
         DaemonJobHandoffState::Terminal(job.status),
     );
 
@@ -514,8 +528,8 @@ fn exec_via_reverse_broker(
             job_id: Some(job.id.to_string()),
             job: Some(job),
             job_events: Some(events),
-            mirror_run_id: None,
-            patch: None,
+            mirror_run_id: mirror.map(|evidence| evidence.run.id),
+            patch,
             metrics,
             capture: None,
             diagnostics: runner_exec_diagnostics(runner, Some(&source_snapshot), &require_paths),
@@ -3759,7 +3773,21 @@ mod tests {
                         "result": {
                             "exit_code": 0,
                             "stdout": "reverse ok",
-                            "stderr": ""
+                            "stderr": "",
+                            "data": {
+                                "patch": {
+                                    "patch_artifact_id": "reverse-patch"
+                                }
+                            },
+                            "artifacts": [{
+                                "id": "reverse-patch",
+                                "name": "reverse.patch",
+                                "path": "/srv/homeboy/.homeboy/artifacts/reverse.patch",
+                                "mime": "text/x-diff",
+                                "size_bytes": 12,
+                                "sha256": "abc123",
+                                "metadata": { "kind": "lab_fix_patch" }
+                            }]
                         }
                     }))
                     .send()
@@ -3786,11 +3814,45 @@ mod tests {
             assert_eq!(output.stdout, "reverse ok");
             assert_eq!(output.runner_id, "lab");
             assert!(output.job_id.is_some());
+            let mirror_run_id = output.mirror_run_id.as_deref().expect("mirror run id");
+            assert!(mirror_run_id.starts_with("runner-exec-lab-"));
+            assert_eq!(
+                output
+                    .patch
+                    .as_ref()
+                    .and_then(|patch| patch.get("patch_artifact_path").and_then(Value::as_str)),
+                Some("metadata-only:reverse-patch")
+            );
             assert!(output
                 .job_events
                 .expect("events")
                 .iter()
                 .any(|event| { event.kind == crate::core::api_jobs::JobEventKind::Progress }));
+
+            let store = crate::core::observation::ObservationStore::open_initialized()
+                .expect("observation store");
+            let run = store
+                .get_run(mirror_run_id)
+                .expect("read mirror run")
+                .expect("mirror run");
+            assert_eq!(
+                run.metadata_json["lab"]["reverse_broker"]["runner_id"].as_str(),
+                Some("lab")
+            );
+            assert_eq!(
+                run.metadata_json["lab"]["reverse_broker"]["broker_url"].as_str(),
+                Some(broker_url.as_str())
+            );
+            assert_eq!(
+                run.metadata_json["lab"]["reverse_broker"]["stdout"].as_str(),
+                Some("reverse ok")
+            );
+            let artifact = store
+                .get_artifact("reverse-patch")
+                .expect("read reverse artifact")
+                .expect("reverse artifact");
+            assert_eq!(artifact.run_id, mirror_run_id);
+            assert_eq!(artifact.path, "metadata-only:reverse-patch");
         });
     }
 


### PR DESCRIPTION
## Summary
- Mirror terminal reverse broker jobs into local observation evidence.
- Preserve reverse broker metadata, events, stdout/stderr, artifacts, and patch metadata.
- Add mirror_run_id to reverse broker execution output when evidence is mirrored.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and tests; Chris remains responsible for review and merge.