### PR TITLE
refactor(git): reuse bot identity constant

### DIFF
--- a/src/core/refactor/auto/guard.rs
+++ b/src/core/refactor/auto/guard.rs
@@ -14,14 +14,13 @@
 use serde::Serialize;
 use std::process::Command;
 
+use crate::core::git::BOT_NAME;
+
 /// Prefix used for all autofix commits. Must match the action's prefix.
 const AUTOFIX_COMMIT_PREFIX: &str = "chore(ci): homeboy autofix";
 
 /// Label that permanently disables autofix on a PR.
 const AUTOFIX_DISABLED_LABEL: &str = "autofix-disabled";
-
-/// Bot identity for authored commits.
-const BOT_NAME: &str = "homeboy-ci[bot]";
 
 /// Why autofix was blocked.
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Summary
- Reuse the core git bot identity constant in the refactor autofix guard.
- Remove a duplicated local bot identity constant.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt/diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and PR text; Chris remains responsible for review and merge.