### PR TITLE
refactor(lab): centralize support summary

### DIFF
--- a/src/command_contract.rs
+++ b/src/command_contract.rs
@@ -20,9 +20,10 @@ mod output;
 mod public_variants;
 
 pub use lab::{
-    lab_runner_supported_labels, lab_runner_unsupported_hint, lab_runner_unsupported_message,
-    LabCommandContract, LabCommandPortability, LabCommandRequiredTool, LabRoutingPolicy,
-    LabSourcePathMode, LabWorkspaceModePolicy, LAB_TRACE_EXTRA_TOOLS,
+    lab_runner_support_summary, lab_runner_supported_labels, lab_runner_unsupported_hint,
+    lab_runner_unsupported_message, LabCommandContract, LabCommandPortability,
+    LabCommandRequiredTool, LabRoutingPolicy, LabRunnerSupportSummary, LabSourcePathMode,
+    LabWorkspaceModePolicy, LAB_TRACE_EXTRA_TOOLS,
 };
 pub(crate) use lab::{AUDIT_LAB_LABEL, BENCH_LAB_LABEL, LINT_LAB_LABEL, TEST_LAB_LABEL};
 pub use output::{

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -106,6 +106,13 @@ struct LabSupportedCommandSummary {
     hint_label: &'static str,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabRunnerSupportSummary {
+    pub supported_labels: Vec<&'static str>,
+    pub unsupported_message: String,
+    pub hint: String,
+}
+
 const LAB_SUPPORTED_COMMAND_SUMMARIES: &[LabSupportedCommandSummary] = &[
     LabSupportedCommandSummary {
         #[cfg(test)]
@@ -209,18 +216,29 @@ pub fn lab_runner_supported_labels() -> Vec<&'static str> {
         .collect()
 }
 
+pub fn lab_runner_support_summary() -> LabRunnerSupportSummary {
+    let supported_labels = lab_runner_supported_labels();
+    let hint_labels = lab_runner_supported_hint_labels();
+
+    LabRunnerSupportSummary {
+        unsupported_message: format!(
+            "--runner is only supported for commands with portable Lab offload support: {}",
+            human_join(&supported_labels)
+        ),
+        hint: format!(
+            "Current Lab offload support: {}.",
+            human_join(&hint_labels)
+        ),
+        supported_labels,
+    }
+}
+
 pub fn lab_runner_unsupported_message() -> String {
-    format!(
-        "--runner is only supported for commands with portable Lab offload support: {}",
-        human_join(&lab_runner_supported_labels())
-    )
+    lab_runner_support_summary().unsupported_message
 }
 
 pub fn lab_runner_unsupported_hint() -> String {
-    format!(
-        "Current Lab offload support: {}.",
-        human_join(&lab_runner_supported_hint_labels())
-    )
+    lab_runner_support_summary().hint
 }
 
 fn lab_runner_supported_hint_labels() -> Vec<&'static str> {

--- a/src/core/runner/lab/offload.rs
+++ b/src/core/runner/lab/offload.rs
@@ -18,7 +18,7 @@
 
 use std::path::Path;
 
-use crate::command_contract::{lab_runner_unsupported_hint, lab_runner_unsupported_message};
+use crate::command_contract::lab_runner_support_summary;
 use crate::core::agent_task_lifecycle;
 use crate::core::agent_task_provider::{resolve_provider_for_backend, ProviderResolution};
 use crate::core::agent_tasks::provider::{
@@ -202,7 +202,11 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
             "runner",
             message,
             Some(runner_id.to_string()),
-            Some(unsupported_runner_hints(runner_id, request.normalized_args)),
+            Some(unsupported_runner_hints(
+                runner_id,
+                request.normalized_args,
+                lab_runner_support_summary().hint,
+            )),
         )
     };
     let mut plan = base_lab_plan(request.command.as_ref());
@@ -210,7 +214,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
         if let Some(runner_id) = request.explicit_runner {
             return Err(unsupported_runner_error(
                 runner_id,
-                lab_runner_unsupported_message(),
+                lab_runner_support_summary().unsupported_message,
             ));
         }
         return Ok(LabOffloadOutcome::RunLocal {
@@ -223,7 +227,7 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     if !contract.portable {
         if let Some(runner_id) = request.explicit_runner {
             let message = contract.unsupported_reason.map_or_else(
-                lab_runner_unsupported_message,
+                || lab_runner_support_summary().unsupported_message,
                 |reason| format!("--runner is unavailable for this local-only resource-pressure command. {reason}"),
             );
             return Err(unsupported_runner_error(runner_id, message));
@@ -372,8 +376,12 @@ pub fn execute_lab_offload(request: LabOffloadRequest<'_>) -> Result<LabOffloadO
     run_lab_offload_inner(request, selection, contract, plan, messages)
 }
 
-fn unsupported_runner_hints(runner_id: &str, normalized_args: &[String]) -> Vec<String> {
-    let mut hints = vec![lab_runner_unsupported_hint()];
+fn unsupported_runner_hints(
+    runner_id: &str,
+    normalized_args: &[String],
+    support_hint: String,
+) -> Vec<String> {
+    let mut hints = vec![support_hint];
 
     if let Some(service_command) = tunnel_service_command(normalized_args) {
         hints.push(format!(


### PR DESCRIPTION
## Summary
- Centralize Lab runner support summary rendering in the command contract layer.
- Remove duplicated supported-command strings from Lab offload.
- Preserve existing unsupported-runner behavior and messages.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran diff checks and targeted string search in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and PR text; Chris remains responsible for review and merge.