### PR TITLE
feat(cli): require apply for destructive commands

### DIFF
--- a/docs/commands/db.md
+++ b/docs/commands/db.md
@@ -60,18 +60,25 @@ homeboy db search mysite wp_posts --column post_status --exact --pattern publish
 ### `delete-row`
 
 ```sh
-homeboy db delete-row <project_id> [<subtarget>] <table> <row_id>
+homeboy db delete-row <project_id> [--apply] [<subtarget>] <table> <row_id>
 ```
 
 Notes:
 
+- Without `--apply`, this command returns a non-mutating plan with the SQL that would run.
+- Pass `--apply` before the trailing table arguments to delete the row.
 - `<row_id>` must be numeric.
 
 ### `drop-table`
 
 ```sh
-homeboy db drop-table <project_id> [<subtarget>] <table>
+homeboy db drop-table <project_id> [--apply] [<subtarget>] <table>
 ```
+
+Notes:
+
+- Without `--apply`, this command returns a non-mutating plan with the SQL that would run.
+- Pass `--apply` before the trailing table argument to drop the table.
 
 ### `tunnel`
 
@@ -89,6 +96,7 @@ Common fields:
 - `project_id`
 - `exit_code`, `success`
 - `stdout`, `stderr` (for remote command execution)
+- `dry_run`, `action_required` (for guarded destructive commands)
 
 Action-specific fields:
 

--- a/docs/commands/file.md
+++ b/docs/commands/file.md
@@ -10,9 +10,9 @@ homeboy file <COMMAND>
 
 - `list <project_id> <path>`
 - `read <project_id> <path>`
-- `write <project_id> <path>` (reads content from stdin)
+- `write <project_id> <path> [--apply]` (reads content from stdin)
 - `mkdir <project_id> <path>` (create a directory)
-- `delete <project_id> <path> [-r|--recursive]` (delete directories recursively)
+- `delete <project_id> <path> [-r|--recursive] [--apply]` (delete files or directories)
 - `rename <project_id> <old_path> <new_path>`
 - `find <project_id> <path> [options]` (search for files by name)
 - `grep <project_id> <path> <pattern> [options]` (search file contents)
@@ -23,6 +23,17 @@ homeboy file <COMMAND>
 - `edit <project_id> <file_path> [operations] [-n|--dry-run] [-f|--force]`
 
 `copy` and `sync` targets use `local/path` or `server_id:/path` syntax. `sync` is recursive and non-deleting by default; it does not expose a delete mode.
+
+### `write` and `delete`
+
+`write` and `delete` default to non-mutating plan output. Pass `--apply` to perform the remote mutation.
+
+```sh
+printf 'content' | homeboy file write mysite /tmp/example.txt
+printf 'content' | homeboy file write mysite /tmp/example.txt --apply
+homeboy file delete mysite /tmp/example.txt
+homeboy file delete mysite /tmp/example.txt --apply
+```
 
 ### `find`
 
@@ -141,6 +152,7 @@ Fields:
 - `entries`: for `list` (parsed from `ls -la`)
 - `content`: for `read`
 - `bytes_written`: for `write` (number of bytes written after stripping one trailing `\n` if present)
+- `dry_run`, `action_required`: for guarded `write` and `delete` plans
 - `stdout`, `stderr`: included for error context when applicable
 - `exit_code`, `success`
 

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -450,10 +450,12 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         ["db", "delete-row"] | ["db", "drop-table"] => {
             metadata.mutates = true;
             metadata.operator = true;
+            metadata.output_notes = "default output is a non-mutating plan; pass --apply to mutate";
         }
         ["file", "write"] | ["file", "delete"] => {
             metadata.mutates = true;
             metadata.operator = true;
+            metadata.output_notes = "default output is a non-mutating plan; pass --apply to mutate";
         }
         ["file", "mkdir"] | ["file", "rename"] => {
             metadata.mutates = true;
@@ -657,6 +659,12 @@ mod tests {
         let fleet_exec = manifest.find_path(&["fleet", "exec"]).unwrap();
         assert_eq!(fleet_exec.dry_run.flag.as_deref(), Some("--check"));
         assert!(fleet_exec.lab.notes.contains("local-only"));
+
+        let db_delete_row = manifest.find_path(&["db", "delete-row"]).unwrap();
+        assert!(db_delete_row.output.notes.contains("--apply"));
+
+        let file_write = manifest.find_path(&["file", "write"]).unwrap();
+        assert!(file_write.output.notes.contains("--apply"));
     }
 
     #[test]
@@ -702,6 +710,19 @@ mod tests {
             ["homeboy", "runner", "connect", "homeboy-lab"].as_slice(),
             ["homeboy", "runner", "status", "homeboy-lab"].as_slice(),
             ["homeboy", "runner", "disconnect", "homeboy-lab"].as_slice(),
+            [
+                "homeboy",
+                "db",
+                "delete-row",
+                "mysite",
+                "--apply",
+                "wp_posts",
+                "1",
+            ]
+            .as_slice(),
+            ["homeboy", "db", "drop-table", "mysite", "--apply", "wp_tmp"].as_slice(),
+            ["homeboy", "file", "delete", "mysite", "tmp.txt", "--apply"].as_slice(),
+            ["homeboy", "file", "write", "mysite", "tmp.txt", "--apply"].as_slice(),
         ] {
             Cli::try_parse_from(args).unwrap_or_else(|error| {
                 panic!("documented command form failed to parse: {args:?}\n{error}")

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -68,6 +68,9 @@ enum DbCommand {
     DeleteRow {
         /// Project ID
         project_id: String,
+        /// Apply the destructive mutation. Without this flag, prints a plan only.
+        #[arg(long)]
+        apply: bool,
         /// Table name and row ID
         #[arg(trailing_var_arg = true)]
         args: Vec<String>,
@@ -76,6 +79,9 @@ enum DbCommand {
     DropTable {
         /// Project ID
         project_id: String,
+        /// Apply the destructive mutation. Without this flag, prints a plan only.
+        #[arg(long)]
+        apply: bool,
         /// Table name
         #[arg(trailing_var_arg = true)]
         args: Vec<String>,
@@ -93,8 +99,16 @@ enum DbCommand {
 #[derive(Serialize)]
 pub struct DbOutput {
     pub command: String,
+    #[serde(skip_serializing_if = "is_false")]
+    pub dry_run: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action_required: Option<String>,
     #[serde(flatten)]
     pub result: DbResultVariant,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 pub enum DbResultVariant {
@@ -158,8 +172,16 @@ pub fn run(args: DbArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<DbO
             limit,
             subtarget.as_deref(),
         ),
-        DbCommand::DeleteRow { project_id, args } => delete_row(&project_id, &args),
-        DbCommand::DropTable { project_id, args } => drop_table(&project_id, &args),
+        DbCommand::DeleteRow {
+            project_id,
+            apply,
+            args,
+        } => delete_row(&project_id, &args, apply),
+        DbCommand::DropTable {
+            project_id,
+            apply,
+            args,
+        } => drop_table(&project_id, &args, apply),
         DbCommand::Tunnel {
             project_id,
             local_port,
@@ -171,6 +193,8 @@ fn status() -> CmdResult<DbOutput> {
     Ok((
         DbOutput {
             command: "db.status".to_string(),
+            dry_run: false,
+            action_required: None,
             result: DbResultVariant::Status(store::status()?),
         },
         0,
@@ -207,6 +231,8 @@ fn tables(project_id: &str, args: &[String]) -> CmdResult<DbOutput> {
     Ok((
         DbOutput {
             command: "db.tables".to_string(),
+            dry_run: false,
+            action_required: None,
             result: DbResultVariant::Query(result),
         },
         exit_code,
@@ -224,6 +250,8 @@ fn describe(project_id: &str, args: &[String]) -> CmdResult<DbOutput> {
     Ok((
         DbOutput {
             command: "db.describe".to_string(),
+            dry_run: false,
+            action_required: None,
             result: DbResultVariant::Query(result),
         },
         exit_code,
@@ -240,6 +268,8 @@ fn query(project_id: &str, args: &[String]) -> CmdResult<DbOutput> {
     Ok((
         DbOutput {
             command: "db.query".to_string(),
+            dry_run: false,
+            action_required: None,
             result: DbResultVariant::Query(result),
         },
         exit_code,
@@ -261,41 +291,111 @@ fn search(
     Ok((
         DbOutput {
             command: "db.search".to_string(),
+            dry_run: false,
+            action_required: None,
             result: DbResultVariant::Query(result),
         },
         exit_code,
     ))
 }
 
-fn delete_row(project_id: &str, args: &[String]) -> CmdResult<DbOutput> {
+fn delete_row(project_id: &str, args: &[String], apply: bool) -> CmdResult<DbOutput> {
     let (subtarget, remaining) = parse_subtarget(project_id, args)?;
 
     // Core validates table_name and row_id
     let table_name = remaining.first().map(|s| s.as_str());
     let row_id = remaining.get(1).map(|s| s.as_str());
+    if !apply {
+        let table = table_name
+            .ok_or_else(|| homeboy::core::Error::config("Table name required".to_string()))?;
+        let row_id: i64 = row_id
+            .ok_or_else(|| homeboy::core::Error::config("Row ID required".to_string()))?
+            .parse()
+            .map_err(|_| homeboy::core::Error::config("Row ID must be numeric".to_string()))?;
+        let sql = format!("DELETE FROM {} WHERE ID = {} LIMIT 1", table, row_id);
+
+        return Ok((
+            DbOutput {
+                command: "db.deleteRow".to_string(),
+                dry_run: true,
+                action_required: Some(
+                    "Re-run with --apply before the trailing table arguments to delete the row."
+                        .to_string(),
+                ),
+                result: DbResultVariant::Query(db::DbResult {
+                    project_id: project_id.to_string(),
+                    base_path: None,
+                    domain: None,
+                    cli_path: None,
+                    stdout: None,
+                    stderr: None,
+                    exit_code: 0,
+                    success: true,
+                    tables: None,
+                    table: Some(table.to_string()),
+                    sql: Some(sql),
+                }),
+            },
+            0,
+        ));
+    }
     let result = db::delete_row(project_id, table_name, row_id, subtarget.as_deref())?;
     let exit_code = result.exit_code;
 
     Ok((
         DbOutput {
             command: "db.deleteRow".to_string(),
+            dry_run: false,
+            action_required: None,
             result: DbResultVariant::Query(result),
         },
         exit_code,
     ))
 }
 
-fn drop_table(project_id: &str, args: &[String]) -> CmdResult<DbOutput> {
+fn drop_table(project_id: &str, args: &[String], apply: bool) -> CmdResult<DbOutput> {
     let (subtarget, remaining) = parse_subtarget(project_id, args)?;
 
     // Core validates table_name
     let table_name = remaining.first().map(|s| s.as_str());
+    if !apply {
+        let table = table_name
+            .ok_or_else(|| homeboy::core::Error::config("Table name required".to_string()))?;
+        let sql = format!("DROP TABLE {}", table);
+
+        return Ok((
+            DbOutput {
+                command: "db.dropTable".to_string(),
+                dry_run: true,
+                action_required: Some(
+                    "Re-run with --apply before the trailing table argument to drop the table."
+                        .to_string(),
+                ),
+                result: DbResultVariant::Query(db::DbResult {
+                    project_id: project_id.to_string(),
+                    base_path: None,
+                    domain: None,
+                    cli_path: None,
+                    stdout: None,
+                    stderr: None,
+                    exit_code: 0,
+                    success: true,
+                    tables: None,
+                    table: Some(table.to_string()),
+                    sql: Some(sql),
+                }),
+            },
+            0,
+        ));
+    }
     let result = db::drop_table(project_id, table_name, subtarget.as_deref())?;
     let exit_code = result.exit_code;
 
     Ok((
         DbOutput {
             command: "db.dropTable".to_string(),
+            dry_run: false,
+            action_required: None,
             result: DbResultVariant::Query(result),
         },
         exit_code,
@@ -309,6 +409,8 @@ fn tunnel(project_id: &str, local_port: Option<u16>) -> CmdResult<DbOutput> {
     Ok((
         DbOutput {
             command: "db.tunnel".to_string(),
+            dry_run: false,
+            action_required: None,
             result: DbResultVariant::Tunnel(result),
         },
         exit_code,

--- a/src/commands/file.rs
+++ b/src/commands/file.rs
@@ -41,6 +41,9 @@ enum FileCommand {
         project_id: String,
         /// Remote file path
         path: String,
+        /// Apply the destructive write. Without this flag, prints a plan only.
+        #[arg(long)]
+        apply: bool,
     },
     /// Create a directory
     Mkdir {
@@ -58,6 +61,9 @@ enum FileCommand {
         /// Delete directories recursively
         #[arg(short, long)]
         recursive: bool,
+        /// Apply the destructive delete. Without this flag, prints a plan only.
+        #[arg(long)]
+        apply: bool,
     },
     /// Rename or move a file
     Rename {
@@ -278,10 +284,18 @@ pub struct FileOutput {
     content: Option<String>,
     size: Option<i64>,
     bytes_written: Option<usize>,
+    #[serde(skip_serializing_if = "is_false")]
+    dry_run: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    action_required: Option<String>,
     stdout: Option<String>,
     stderr: Option<String>,
     exit_code: i32,
     success: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Serialize)]
@@ -368,8 +382,12 @@ pub fn run(args: FileArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<F
                 Ok((FileCommandOutput::Standard(out), code))
             }
         }
-        FileCommand::Write { project_id, path } => {
-            let (out, code) = write(&project_id, &path)?;
+        FileCommand::Write {
+            project_id,
+            path,
+            apply,
+        } => {
+            let (out, code) = write(&project_id, &path, apply)?;
             Ok((FileCommandOutput::Standard(out), code))
         }
         FileCommand::Mkdir { project_id, path } => {
@@ -395,6 +413,8 @@ pub fn run(args: FileArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<F
                     content: None,
                     size: None,
                     bytes_written: None,
+                    dry_run: false,
+                    action_required: None,
                     stdout: None,
                     stderr: None,
                     exit_code: 0,
@@ -407,8 +427,9 @@ pub fn run(args: FileArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<F
             project_id,
             path,
             recursive,
+            apply,
         } => {
-            let (out, code) = delete(&project_id, &path, recursive)?;
+            let (out, code) = delete(&project_id, &path, recursive, apply)?;
             Ok((FileCommandOutput::Standard(out), code))
         }
         FileCommand::Rename {
@@ -521,6 +542,8 @@ fn list(project_id: &str, path: &str) -> CmdResult<FileOutput> {
             content: None,
             size: None,
             bytes_written: None,
+            dry_run: false,
+            action_required: None,
             stdout: None,
             stderr: None,
             exit_code: 0,
@@ -546,6 +569,8 @@ fn read(project_id: &str, path: &str) -> CmdResult<FileOutput> {
             content: Some(result.content),
             size: result.size,
             bytes_written: None,
+            dry_run: false,
+            action_required: None,
             stdout: None,
             stderr: None,
             exit_code: 0,
@@ -555,8 +580,38 @@ fn read(project_id: &str, path: &str) -> CmdResult<FileOutput> {
     ))
 }
 
-fn write(project_id: &str, path: &str) -> CmdResult<FileOutput> {
+fn write(project_id: &str, path: &str, apply: bool) -> CmdResult<FileOutput> {
     let content = files::read_stdin()?;
+    if !apply {
+        let project = project::load(project_id)?;
+        let project_base_path = require_project_base_path(project_id, &project)?;
+        let full_path = join_remote_path(Some(&project_base_path), path)?;
+
+        return Ok((
+            FileOutput {
+                command: "file.write".to_string(),
+                project_id: project_id.to_string(),
+                base_path: Some(project_base_path),
+                path: Some(full_path),
+                old_path: None,
+                new_path: None,
+                recursive: None,
+                entries: None,
+                content: None,
+                size: None,
+                bytes_written: Some(content.len()),
+                dry_run: true,
+                action_required: Some(
+                    "Re-run with --apply to write stdin to the remote file.".to_string(),
+                ),
+                stdout: None,
+                stderr: None,
+                exit_code: 0,
+                success: true,
+            },
+            0,
+        ));
+    }
     let result = files::write(project_id, path, &content)?;
 
     Ok((
@@ -572,6 +627,8 @@ fn write(project_id: &str, path: &str) -> CmdResult<FileOutput> {
             content: None,
             size: None,
             bytes_written: Some(result.bytes_written),
+            dry_run: false,
+            action_required: None,
             stdout: None,
             stderr: None,
             exit_code: 0,
@@ -581,7 +638,35 @@ fn write(project_id: &str, path: &str) -> CmdResult<FileOutput> {
     ))
 }
 
-fn delete(project_id: &str, path: &str, recursive: bool) -> CmdResult<FileOutput> {
+fn delete(project_id: &str, path: &str, recursive: bool, apply: bool) -> CmdResult<FileOutput> {
+    if !apply {
+        let project = project::load(project_id)?;
+        let project_base_path = require_project_base_path(project_id, &project)?;
+        let full_path = join_remote_path(Some(&project_base_path), path)?;
+
+        return Ok((
+            FileOutput {
+                command: "file.delete".to_string(),
+                project_id: project_id.to_string(),
+                base_path: Some(project_base_path),
+                path: Some(full_path),
+                old_path: None,
+                new_path: None,
+                recursive: Some(recursive),
+                entries: None,
+                content: None,
+                size: None,
+                bytes_written: None,
+                dry_run: true,
+                action_required: Some("Re-run with --apply to delete the remote path.".to_string()),
+                stdout: None,
+                stderr: None,
+                exit_code: 0,
+                success: true,
+            },
+            0,
+        ));
+    }
     let result = files::delete(project_id, path, recursive)?;
 
     Ok((
@@ -597,6 +682,8 @@ fn delete(project_id: &str, path: &str, recursive: bool) -> CmdResult<FileOutput
             content: None,
             size: None,
             bytes_written: None,
+            dry_run: false,
+            action_required: None,
             stdout: None,
             stderr: None,
             exit_code: 0,
@@ -622,6 +709,8 @@ fn rename(project_id: &str, old_path: &str, new_path: &str) -> CmdResult<FileOut
             content: None,
             size: None,
             bytes_written: None,
+            dry_run: false,
+            action_required: None,
             stdout: None,
             stderr: None,
             exit_code: 0,

--- a/tests/commands/file_test.rs
+++ b/tests/commands/file_test.rs
@@ -55,3 +55,55 @@ fn file_read_json_includes_size_metadata() {
     assert_eq!(payload.content.as_deref(), Some(content));
     assert_eq!(payload.size, Some(content.len() as i64));
 }
+
+#[test]
+fn file_delete_without_apply_returns_plan_and_preserves_file() {
+    let project_root = tempfile::tempdir().expect("project tempdir");
+    let project_id = "local-file-delete-plan";
+    let file_path = project_root.path().join("sample.txt");
+    std::fs::write(&file_path, "keep me").expect("write sample file");
+
+    let result = with_isolated_home(|home| {
+        let project_dir = home
+            .path()
+            .join(".config")
+            .join("homeboy")
+            .join("projects")
+            .join(project_id);
+        std::fs::create_dir_all(&project_dir).expect("create project config dir");
+        let config = serde_json::json!({
+            "base_path": project_root.path().to_string_lossy(),
+        });
+        std::fs::write(
+            project_dir.join(format!("{project_id}.json")),
+            serde_json::to_vec(&config).expect("serialize project config"),
+        )
+        .expect("write project config");
+
+        run(
+            FileArgs {
+                command: FileCommand::Delete {
+                    project_id: project_id.to_string(),
+                    path: "sample.txt".to_string(),
+                    recursive: false,
+                    apply: false,
+                },
+            },
+            &GlobalArgs {},
+        )
+    });
+
+    let (output, code) = result.expect("run homeboy file delete");
+    let FileCommandOutput::Standard(payload) = output else {
+        panic!("expected standard file output");
+    };
+
+    assert_eq!(code, 0);
+    assert_eq!(payload.command, "file.delete");
+    assert!(payload.dry_run);
+    assert_eq!(
+        payload.action_required.as_deref(),
+        Some("Re-run with --apply to delete the remote path.")
+    );
+    assert!(file_path.exists());
+}


### PR DESCRIPTION
## Summary
- Add explicit --apply guardrails to destructive DB and file commands.
- Default guarded commands to non-mutating plan/dry-run output.
- Update command docs and command safety metadata.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt and diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and tests; Chris remains responsible for review and merge.