### PR TITLE
feat(cli): expose safety manifest json

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ For exhaustive command docs, see
 [docs/commands/commands-index.md](docs/commands/commands-index.md) or run
 `homeboy docs list`.
 
+Agents can inspect the recursive command safety manifest with `homeboy list --json`.
+The manifest includes command paths, mutation/operator classification, dry-run
+flags, dangerous flags, structured-output notes, Lab routing metadata, and docs
+paths while `homeboy list` continues to print the raw top-level help.
+
 ## Quick Start
 
 ### 1. Add `homeboy.json`

--- a/src/cli_runtime.rs
+++ b/src/cli_runtime.rs
@@ -2,7 +2,7 @@ use clap::{ArgMatches, Command, CommandFactory, FromArgMatches};
 use std::io::IsTerminal;
 use std::sync::OnceLock;
 
-use crate::cli_surface::{Cli, Commands};
+use crate::cli_surface::{current_command_safety_manifest, Cli, Commands};
 use crate::commands;
 use crate::commands::cli;
 use crate::commands::output_runtime;
@@ -190,10 +190,14 @@ impl CliRuntime {
 
         run_startup_update_checks(&cli.command);
 
-        if matches!(cli.command, Commands::List) {
-            let mut cmd = self.build_augmented_command();
-            cmd.print_help().expect("Failed to print help");
-            println!();
+        if let Commands::List { json } = &cli.command {
+            if *json {
+                print_command_safety_manifest_json();
+            } else {
+                let mut cmd = self.build_augmented_command();
+                cmd.print_help().expect("Failed to print help");
+                println!();
+            }
             return std::process::ExitCode::SUCCESS;
         }
 
@@ -231,6 +235,12 @@ impl CliRuntime {
         self.extension_discovery
             .get_or_init(collect_extension_cli_info)
     }
+}
+
+fn print_command_safety_manifest_json() {
+    let manifest = current_command_safety_manifest();
+    let json = serde_json::to_string_pretty(&manifest).expect("command safety manifest serializes");
+    println!("{json}");
 }
 
 fn run_raw_agent_tool_dispatch(command: &Commands) -> Option<i32> {

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -1,4 +1,5 @@
 use clap::{Command, CommandFactory, Parser, Subcommand};
+use serde::Serialize;
 use std::path::PathBuf;
 
 use crate::commands::{
@@ -166,7 +167,11 @@ pub enum Commands {
     Upgrade(upgrade::UpgradeArgs),
     /// List available commands (deprecated alias for --help)
     #[command(hide = true)]
-    List,
+    List {
+        /// Print the recursive command safety manifest as JSON.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -195,7 +200,7 @@ pub struct CommandSurfaceEntry {
     pub subcommands: Vec<CommandSurfaceEntry>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CommandSafetyManifest {
     pub commands: Vec<CommandSafetyEntry>,
 }
@@ -213,7 +218,7 @@ impl CommandSafetyManifest {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CommandSafetyEntry {
     pub name: String,
     pub path: Vec<String>,
@@ -240,25 +245,25 @@ impl CommandSafetyEntry {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CommandDryRunMetadata {
     pub supported: bool,
     pub flag: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CommandOutputMetadata {
     pub structured: bool,
     pub notes: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CommandLabMetadata {
     pub supported: bool,
     pub notes: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CommandDocsMetadata {
     pub path: Option<String>,
 }
@@ -335,7 +340,7 @@ impl Commands {
             Commands::Api(_) => "api",
             Commands::Http(_) => "http",
             Commands::Upgrade(_) => "upgrade",
-            Commands::List => "list",
+            Commands::List { .. } => "list",
         }
     }
 }

--- a/src/command_contract/output.rs
+++ b/src/command_contract/output.rs
@@ -286,7 +286,7 @@ impl Commands {
                 output_file_mode,
                 CommandOutputContractKind::JsonEnvelope,
             ),
-            Commands::List => CommandOutputDescriptor {
+            Commands::List { .. } => CommandOutputDescriptor {
                 response_mode: CommandResponseMode::Raw(CommandRawOutputMode::Markdown),
                 output_file_mode,
                 json_family: CommandJsonFamily::RawOnly,
@@ -453,7 +453,7 @@ mod tests {
             CommandResponseMode::Raw(CommandRawOutputMode::Markdown)
         );
         assert_eq!(
-            Commands::List.response_mode(false),
+            (Commands::List { json: false }).response_mode(false),
             CommandResponseMode::Raw(CommandRawOutputMode::Markdown)
         );
     }
@@ -498,7 +498,7 @@ mod tests {
             CommandOutputContractKind::JsonEnvelope
         );
 
-        let list_descriptor = Commands::List.descriptor(false);
+        let list_descriptor = (Commands::List { json: false }).descriptor(false);
         assert_eq!(
             list_descriptor.output.json_family,
             CommandJsonFamily::RawOnly

--- a/src/commands/adapter.rs
+++ b/src/commands/adapter.rs
@@ -161,6 +161,8 @@ mod tests {
         )
         .is_ok());
 
-        assert!(command_adapter(Commands::List, CommandOutputFileMode::None).is_err());
+        assert!(
+            command_adapter(Commands::List { json: false }, CommandOutputFileMode::None).is_err()
+        );
     }
 }

--- a/src/commands/json_output/mod.rs
+++ b/src/commands/json_output/mod.rs
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     fn list_json_dispatch_reports_raw_output_mode() {
-        let (result, exit_code) = dispatch(Commands::List, &GlobalArgs {});
+        let (result, exit_code) = dispatch(Commands::List { json: false }, &GlobalArgs {});
 
         assert_ne!(exit_code, 0);
         assert!(result
@@ -187,7 +187,7 @@ mod tests {
     #[test]
     fn json_dispatch_family_comes_from_command_registry() {
         assert_eq!(
-            dispatch_family(&Commands::List),
+            dispatch_family(&Commands::List { json: false }),
             CommandDispatchFamily::RawOnly
         );
     }

--- a/src/commands/raw_output/mod.rs
+++ b/src/commands/raw_output/mod.rs
@@ -152,7 +152,7 @@ mod tests {
     #[test]
     fn interactive_passthrough_has_no_raw_text_result() {
         let result = run(
-            Commands::List,
+            Commands::List { json: false },
             &GlobalArgs {},
             CommandRawOutputMode::InteractivePassthrough,
         );
@@ -163,7 +163,7 @@ mod tests {
     #[test]
     fn unsupported_plain_text_command_returns_output_mode_error() {
         let result = run(
-            Commands::List,
+            Commands::List { json: false },
             &GlobalArgs {},
             CommandRawOutputMode::PlainText,
         )

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -1,5 +1,8 @@
 use clap::{CommandFactory, Parser};
-use homeboy::cli_surface::{command_surface_from_with_depth, current_command_surface, Cli};
+use homeboy::cli_surface::{
+    command_surface_from_with_depth, current_command_safety_manifest, current_command_surface, Cli,
+    Commands,
+};
 use std::collections::BTreeSet;
 use std::fs;
 
@@ -122,6 +125,31 @@ fn command_surface_depth_is_configurable() {
 
     assert!(surface.contains_path(&["runner", "job"]));
     assert!(!surface.contains_path(&["runner", "job", "logs"]));
+}
+
+#[test]
+fn hidden_list_json_flag_exposes_recursive_safety_manifest() {
+    let cli = Cli::try_parse_from(["homeboy", "list", "--json"])
+        .expect("hidden list --json should parse");
+    assert!(matches!(cli.command, Commands::List { json: true }));
+
+    let value = serde_json::to_value(current_command_safety_manifest())
+        .expect("safety manifest should serialize");
+    assert_eq!(value["commands"][0]["path"].as_array().unwrap().len(), 1);
+    assert!(value["commands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|entry| entry["subcommands"]
+            .as_array()
+            .is_some_and(|subcommands| !subcommands.is_empty())));
+    assert!(value["commands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|entry| entry.get("mutates").is_some()
+            && entry.get("operator").is_some()
+            && entry.get("dangerous_flags").is_some()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add homeboy list --json to emit the command safety manifest as structured JSON.
- Preserve the existing raw help output for homeboy list without --json.
- Document the new JSON inventory path.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt and diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and PR text; Chris remains responsible for review and merge.