### PR TITLE
Expand rig extension settings for bench components

### DIFF
--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -215,33 +215,25 @@ fn expand_rig_extension_settings(
     extensions: &mut HashMap<String, ScopedExtensionConfig>,
 ) {
     for extension in extensions.values_mut() {
-        for (key, value) in extension.settings.iter_mut() {
-            expand_rig_setting_value(spec, Some(key.as_str()), value);
+        for value in extension.settings.values_mut() {
+            expand_rig_setting_value(spec, value);
         }
     }
 }
 
-fn expand_rig_setting_value(spec: &RigSpec, key: Option<&str>, value: &mut serde_json::Value) {
+fn expand_rig_setting_value(spec: &RigSpec, value: &mut serde_json::Value) {
     match value {
         serde_json::Value::String(raw) => {
-            let expanded = rig::expand::expand_vars(spec, raw);
-            *raw = if key == Some("wp_codebox_source_root") {
-                std::fs::canonicalize(&expanded)
-                    .ok()
-                    .map(|path| path.to_string_lossy().into_owned())
-                    .unwrap_or(expanded)
-            } else {
-                expanded
-            };
+            *raw = rig::expand::expand_vars(spec, raw);
         }
         serde_json::Value::Array(values) => {
             for value in values {
-                expand_rig_setting_value(spec, None, value);
+                expand_rig_setting_value(spec, value);
             }
         }
         serde_json::Value::Object(values) => {
-            for (key, value) in values {
-                expand_rig_setting_value(spec, Some(key.as_str()), value);
+            for value in values.values_mut() {
+                expand_rig_setting_value(spec, value);
             }
         }
         _ => {}

--- a/src/commands/bench/matrix.rs
+++ b/src/commands/bench/matrix.rs
@@ -1,8 +1,8 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
 use homeboy::core::ci_profile::{self, CiResolvedJob};
-use homeboy::core::component::Component;
+use homeboy::core::component::{Component, ScopedExtensionConfig};
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::engine::invocation::InvocationRequirements;
 use homeboy::core::engine::run_dir::RunDir;
@@ -197,7 +197,8 @@ pub(super) fn rig_component_path(spec: &RigSpec, component_id: &str) -> Option<S
 
 pub(super) fn rig_component_for_bench(spec: &RigSpec, component_id: &str) -> Option<Component> {
     let rig_component = spec.components.get(component_id)?;
-    let extensions = rig_component.extensions.clone()?;
+    let mut extensions = rig_component.extensions.clone()?;
+    expand_rig_extension_settings(spec, &mut extensions);
     let mut component = Component {
         id: component_id.to_string(),
         local_path: rig::expand::expand_vars(spec, &rig_component.path),
@@ -207,6 +208,44 @@ pub(super) fn rig_component_for_bench(spec: &RigSpec, component_id: &str) -> Opt
     };
     component.resolve_remote_path();
     Some(component)
+}
+
+fn expand_rig_extension_settings(
+    spec: &RigSpec,
+    extensions: &mut HashMap<String, ScopedExtensionConfig>,
+) {
+    for extension in extensions.values_mut() {
+        for (key, value) in extension.settings.iter_mut() {
+            expand_rig_setting_value(spec, Some(key.as_str()), value);
+        }
+    }
+}
+
+fn expand_rig_setting_value(spec: &RigSpec, key: Option<&str>, value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::String(raw) => {
+            let expanded = rig::expand::expand_vars(spec, raw);
+            *raw = if key == Some("wp_codebox_source_root") {
+                std::fs::canonicalize(&expanded)
+                    .ok()
+                    .map(|path| path.to_string_lossy().into_owned())
+                    .unwrap_or(expanded)
+            } else {
+                expanded
+            };
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                expand_rig_setting_value(spec, None, value);
+            }
+        }
+        serde_json::Value::Object(values) => {
+            for (key, value) in values {
+                expand_rig_setting_value(spec, Some(key.as_str()), value);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn component_shared_state(

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -759,16 +759,16 @@ fn rig_bench_component_expands_extension_settings() {
     fs::create_dir_all(&plugin_path).expect("create plugin path");
 
     let spec: RigSpec = serde_json::from_value(serde_json::json!({
-        "id": "woocommerce-performance",
+        "id": "example-performance",
         "components": {
-            "woocommerce": {
+            "example": {
                 "path": plugin_path.to_string_lossy(),
                 "extensions": {
-                    "wordpress": {
-                        "wp_codebox_source_root": "${components.woocommerce.path}/../..",
-                        "wp_codebox_source_subpath": "plugins/woocommerce",
-                        "wp_codebox_file_mounts": [
-                            { "source": "${components.woocommerce.path}/woocommerce.php" }
+                    "example-extension": {
+                        "source_root": "${components.example.path}/../..",
+                        "source_subpath": "plugins/example",
+                        "file_mounts": [
+                            { "source": "${components.example.path}/example.php" }
                         ]
                     }
                 }
@@ -778,27 +778,27 @@ fn rig_bench_component_expands_extension_settings() {
     .expect("parse rig spec");
 
     let component =
-        matrix::rig_component_for_bench(&spec, "woocommerce").expect("resolve rig bench component");
-    let wordpress = component
+        matrix::rig_component_for_bench(&spec, "example").expect("resolve rig bench component");
+    let extension = component
         .extensions
         .as_ref()
-        .and_then(|extensions| extensions.get("wordpress"))
-        .expect("wordpress extension settings");
+        .and_then(|extensions| extensions.get("example-extension"))
+        .expect("example extension settings");
 
     assert_eq!(
-        wordpress.settings.get("wp_codebox_source_root"),
+        extension.settings.get("source_root"),
         Some(&serde_json::Value::String(
-            monorepo.path().to_string_lossy().into_owned()
+            plugin_path.join("../..").to_string_lossy().into_owned()
         ))
     );
     let expected_mount_source = plugin_path
-        .join("woocommerce.php")
+        .join("example.php")
         .to_string_lossy()
         .into_owned();
     assert_eq!(
-        wordpress
+        extension
             .settings
-            .get("wp_codebox_file_mounts")
+            .get("file_mounts")
             .and_then(|value| value.as_array())
             .and_then(|items| items.first())
             .and_then(|item| item.get("source"))

--- a/src/commands/bench/tests.rs
+++ b/src/commands/bench/tests.rs
@@ -753,6 +753,61 @@ fn single_rig_selector_filters_extra_workloads_before_execution() {
 }
 
 #[test]
+fn rig_bench_component_expands_extension_settings() {
+    let monorepo = tempfile::TempDir::new().expect("monorepo dir");
+    let plugin_path = monorepo.path().join("plugins").join("woocommerce");
+    fs::create_dir_all(&plugin_path).expect("create plugin path");
+
+    let spec: RigSpec = serde_json::from_value(serde_json::json!({
+        "id": "woocommerce-performance",
+        "components": {
+            "woocommerce": {
+                "path": plugin_path.to_string_lossy(),
+                "extensions": {
+                    "wordpress": {
+                        "wp_codebox_source_root": "${components.woocommerce.path}/../..",
+                        "wp_codebox_source_subpath": "plugins/woocommerce",
+                        "wp_codebox_file_mounts": [
+                            { "source": "${components.woocommerce.path}/woocommerce.php" }
+                        ]
+                    }
+                }
+            }
+        }
+    }))
+    .expect("parse rig spec");
+
+    let component =
+        matrix::rig_component_for_bench(&spec, "woocommerce").expect("resolve rig bench component");
+    let wordpress = component
+        .extensions
+        .as_ref()
+        .and_then(|extensions| extensions.get("wordpress"))
+        .expect("wordpress extension settings");
+
+    assert_eq!(
+        wordpress.settings.get("wp_codebox_source_root"),
+        Some(&serde_json::Value::String(
+            monorepo.path().to_string_lossy().into_owned()
+        ))
+    );
+    let expected_mount_source = plugin_path
+        .join("woocommerce.php")
+        .to_string_lossy()
+        .into_owned();
+    assert_eq!(
+        wordpress
+            .settings
+            .get("wp_codebox_file_mounts")
+            .and_then(|value| value.as_array())
+            .and_then(|items| items.first())
+            .and_then(|item| item.get("source"))
+            .and_then(|value| value.as_str()),
+        Some(expected_mount_source.as_str())
+    );
+}
+
+#[test]
 fn run_profile_selects_rig_profile_scenarios() {
     with_isolated_home(|home| {
         write_bench_extension(home);


### PR DESCRIPTION
## Summary
- Expand rig-provided extension settings before resolving bench components.
- Reuse rig variable expansion for `${components.<id>.path}`, `${env.*}`, `${package.root}`, and `~` inside extension settings.
- Keep extension setting semantics generic; consumers remain responsible for validating their own settings.

## Testing
- `rustfmt --check src/commands/bench/matrix.rs src/commands/bench/tests.rs`
- `git diff --check -- src/commands/bench/matrix.rs src/commands/bench/tests.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Woo full-surface Lab setup failure and drafted the generic bench component extension-setting expansion fix and focused unit test; Chris directed the workflow and retains review responsibility.
