### PR TITLE
fix(audit): add missing profile field to AuditRunWorkflowArgs test initializers (#5396)

### DIFF
--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -225,10 +225,7 @@ pub fn lab_runner_support_summary() -> LabRunnerSupportSummary {
             "--runner is only supported for commands with portable Lab offload support: {}",
             human_join(&supported_labels)
         ),
-        hint: format!(
-            "Current Lab offload support: {}.",
-            human_join(&hint_labels)
-        ),
+        hint: format!("Current Lab offload support: {}.", human_join(&hint_labels)),
         supported_labels,
     }
 }

--- a/src/core/artifact_ref.rs
+++ b/src/core/artifact_ref.rs
@@ -29,11 +29,14 @@ impl ArtifactReference {
         if let Some(rest) = value.strip_prefix(RUNNER_ARTIFACT_REF_SCHEME) {
             let parts = rest.split('/').collect::<Vec<_>>();
             if parts.len() == 3 {
+                let runner_id = decode_uri_component(parts[0]);
+                let run_id = decode_uri_component(parts[1]);
+                let artifact_id = decode_uri_component(parts[2]);
                 return Self::RunnerArtifact {
                     value,
-                    runner_id: decode_uri_component(parts[0]),
-                    run_id: decode_uri_component(parts[1]),
-                    artifact_id: decode_uri_component(parts[2]),
+                    runner_id,
+                    run_id,
+                    artifact_id,
                 };
             }
         }

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -235,7 +235,9 @@ pub fn mirror_reverse_broker_evidence(
     let patch = mirrored_reverse_patch_result(
         &store,
         &run.id,
-        result.get("patch").or_else(|| result.pointer("/data/patch")),
+        result
+            .get("patch")
+            .or_else(|| result.pointer("/data/patch")),
     )?;
     Ok(Some(MirroredDaemonEvidence { run, patch }))
 }
@@ -510,7 +512,9 @@ fn reverse_broker_artifact_record(
         viewer_url: None,
         viewer_links: Vec::new(),
         sha256: artifact.sha256.clone(),
-        size_bytes: artifact.size_bytes.and_then(|size| i64::try_from(size).ok()),
+        size_bytes: artifact
+            .size_bytes
+            .and_then(|size| i64::try_from(size).ok()),
         mime: artifact.mime.clone(),
         metadata_json: json!({
             "runner_id": runner.id.clone(),

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -96,6 +96,7 @@ fn make_args(include_fixability: bool) -> AuditRunWorkflowArgs {
         exclude_kinds: vec![],
         only_labels: vec![],
         exclude_labels: vec![],
+        profile: crate::core::code_audit::AuditProfile::Full,
         extension_overrides: vec![],
         baseline_flags: crate::core::engine::baseline::BaselineFlags {
             baseline: false,


### PR DESCRIPTION
## Summary

P0 — `main` was RED with compile errors breaking the Lint + Test gates, blocking **all** PRs. While fixing the assigned #5396, two additional pre-existing breaks on `main` were found that *also* block every PR. All three are deterministic fixes; all three are needed for a green build.

## Fixes

1. **E0063 (#5396)** — `AuditRunWorkflowArgs` gained `pub profile: AuditProfile`, but the test helper `make_args()` in `tests/core/code_audit/run_test.rs` was not updated. Added `profile: crate::core::code_audit::AuditProfile::Full` (the canonical default used by `audit.rs`, `audit_baseline.rs`, and the execution-plan defaults). `make_changed_since_args()` reuses `make_args()`, so it's covered. Both `src/` initializers (`audit.rs:142`, `audit_baseline.rs:80`) already had the field.

2. **E0505 borrow error** in `src/core/artifact_ref.rs` (introduced by `8e2beb15 refactor(artifacts): normalize artifact refs`) — `parts` borrows `value` while `value` is moved into `RunnerArtifact`. Decode the three parts into owned `String`s *before* moving `value`.

3. **`cargo fmt` drift** in `src/command_contract/lab.rs` and `src/core/runner/evidence.rs` — the Lint gate's `cargo fmt --check` was already failing on `main` independent of the compile errors. Reformatted to satisfy the gate.

## Validation

- `cargo build --lib --tests` → no `E0063` / `E0505` / errors
- `cargo fmt --check` → clean
- (Did **not** run the full test suite — RAM constraints on this host; CI runs the rest.)

Did not touch `docs/changelog.md`.

Closes #5396