### PR TITLE
feat(deploy): tag output variants

### DIFF
--- a/src/command_contract/public_variants.rs
+++ b/src/command_contract/public_variants.rs
@@ -66,6 +66,20 @@ pub const PUBLIC_OUTPUT_VARIANT_CONTRACTS: &[PublicOutputVariantContract] = &[
         golden_fixture: None,
     },
     PublicOutputVariantContract {
+        command: "deploy",
+        variant: "single",
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("single"),
+        golden_fixture: Some("deploy_contract.json"),
+    },
+    PublicOutputVariantContract {
+        command: "deploy",
+        variant: "multi_project",
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("multi_project"),
+        golden_fixture: Some("deploy_contract.json"),
+    },
+    PublicOutputVariantContract {
         command: "runs",
         variant: "list",
         discriminator_field: Some("variant"),

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -79,6 +79,7 @@ pub struct DeployArgs {
 #[derive(Serialize)]
 pub struct DeployOutput {
     pub command: String,
+    pub variant: &'static str,
     pub project_id: String,
     pub all: bool,
     pub outdated: bool,
@@ -93,6 +94,7 @@ pub struct DeployOutput {
 #[derive(Serialize)]
 pub struct MultiProjectDeployOutput {
     pub command: String,
+    pub variant: &'static str,
     pub component_ids: Vec<String>,
     pub projects: Vec<ProjectDeployResult>,
     pub summary: MultiDeploySummary,
@@ -168,6 +170,7 @@ pub fn run(
     Ok((
         DeployCommandOutput::Single(DeployOutput {
             command: "deploy.run".to_string(),
+            variant: "single",
             project_id,
             all: args.all,
             outdated: args.outdated,
@@ -301,6 +304,7 @@ fn run_multi_output(
     Ok((
         DeployCommandOutput::Multi(MultiProjectDeployOutput {
             command: "deploy.run_multi".to_string(),
+            variant: "multi_project",
             component_ids: result.component_ids,
             projects: result.projects,
             summary: result.summary,

--- a/src/commands/golden_contract_tests.rs
+++ b/src/commands/golden_contract_tests.rs
@@ -230,6 +230,7 @@ fn deploy_command_json_contract_matches_golden_fixture() {
             "scenarios": [
                 scenario("deploy dry-run single", DeployCommandOutput::Single(DeployOutput {
                     command: "deploy.run".to_string(),
+                    variant: "single",
                     project_id: "production".to_string(),
                     all: false,
                     outdated: false,
@@ -242,6 +243,7 @@ fn deploy_command_json_contract_matches_golden_fixture() {
                 })),
                 scenario("deploy dry-run multi-project", DeployCommandOutput::Multi(MultiProjectDeployOutput {
                     command: "deploy.multi".to_string(),
+                    variant: "multi_project",
                     component_ids: vec!["homeboy".to_string()],
                     projects: vec![ProjectDeployResult {
                         project_id: "production".to_string(),

--- a/tests/fixtures/golden_json_contracts/deploy_contract.json
+++ b/tests/fixtures/golden_json_contracts/deploy_contract.json
@@ -7,6 +7,7 @@
           "behind_upstream": false,
           "check": false,
           "command": "deploy.run",
+          "variant": "single",
           "dry_run": true,
           "force": false,
           "outdated": false,
@@ -49,6 +50,7 @@
         "data": {
           "check": false,
           "command": "deploy.multi",
+          "variant": "multi_project",
           "component_ids": [
             "homeboy"
           ],


### PR DESCRIPTION
## Summary
- Add additive deploy output variants for single and multi-project deploy outputs.
- Preserve existing command and payload fields.
- Update public output contracts and deploy golden fixture.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran jq and diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and PR text; Chris remains responsible for review and merge.