### PR TITLE
feat(deploy): require apply for risky modes

### DIFF
--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -3,7 +3,7 @@
 ## Synopsis
 
 ```sh
-homeboy deploy [<project_id>|<component_id>] [<component_ids...>] [-p|--project <id>] [-c|--component <id>]... [--all] [--outdated|--behind-upstream] [--check] [--dry-run] [--json '<spec>']
+homeboy deploy [<project_id>|<component_id>] [<component_ids...>] [-p|--project <id>] [-c|--component <id>]... [--all] [--outdated|--behind-upstream] [--check] [--dry-run] [--apply] [--json '<spec>']
 # If no component IDs are provided, you must use --all, --outdated, --behind-upstream, or --check.
 
 # Multi-project deployment
@@ -33,6 +33,7 @@ Options:
   - Shows all components for the project with version comparison status.
   - Combines with `--outdated` or component IDs to filter results.
 - `--dry-run`: preview what would be deployed without executing (no build, no upload)
+- `--apply`: confirm real deploys that use dangerous modes such as `--head` or `--force`
 - `--force`: deploy even with uncommitted changes
 - `--json`: JSON input spec for bulk operations (`{"component_ids": ["component-id", ...]}`)
 - `--projects`: deploy to multiple projects (comma-separated). When using this flag, all positional arguments are treated as component IDs. Each project deployment builds independently.
@@ -43,6 +44,8 @@ Options:
 - `--no-pull`: skip the automatic pull before deploy.
 - `--head`: deploy the current branch `HEAD` instead of the latest tag.
 - `--tagged`: force tag-based deploy and ignore reusable build artifacts.
+
+Real deploys with `--head` or `--force` require `--apply`. Preview and status commands (`--dry-run` or `--check`) do not require `--apply`.
 
 Bulk JSON input uses `component_ids` (snake_case):
 

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -44,6 +44,9 @@ pub struct DeployArgs {
     /// Preview what would be deployed without executing
     #[arg(long)]
     pub dry_run: bool,
+    /// Confirm dangerous deploy modes like --head or --force
+    #[arg(long)]
+    pub apply: bool,
     /// Check component status without building or deploying
     #[arg(long, visible_alias = "status")]
     pub check: bool,
@@ -112,6 +115,8 @@ pub fn run(
     mut args: DeployArgs,
     _global: &crate::commands::GlobalArgs,
 ) -> CmdResult<DeployCommandOutput> {
+    validate_apply_boundary(&args)?;
+
     // Fleet deploy
     if let Some(ref fleet_id) = args.fleet {
         let fl = homeboy::core::fleet::load(fleet_id)?;
@@ -183,6 +188,27 @@ pub fn run(
 }
 
 // === Argument resolution helpers ===
+
+fn validate_apply_boundary(args: &DeployArgs) -> homeboy::core::Result<()> {
+    if args.apply || args.dry_run || args.check || (!args.head && !args.force) {
+        return Ok(());
+    }
+
+    let dangerous_flags = [(args.head, "--head"), (args.force, "--force")]
+        .into_iter()
+        .filter_map(|(enabled, flag)| enabled.then_some(flag))
+        .collect::<Vec<_>>()
+        .join(" and ");
+
+    Err(homeboy::core::Error::validation_invalid_argument(
+        "apply",
+        format!(
+            "Real deploys with {dangerous_flags} require explicit --apply. Use --dry-run to preview or re-run with --apply to deploy."
+        ),
+        None,
+        None,
+    ))
+}
 
 fn resolve_shared_component_ids(args: &DeployArgs) -> homeboy::core::Result<Vec<String>> {
     if let Some(ref comps) = args.component {
@@ -311,3 +337,7 @@ fn run_multi_output(
         exit_code,
     ))
 }
+
+#[cfg(test)]
+#[path = "../../tests/commands/deploy_test.rs"]
+mod deploy_test;

--- a/tests/commands/deploy_test.rs
+++ b/tests/commands/deploy_test.rs
@@ -1,14 +1,6 @@
-use homeboy::core::deploy::parse_bulk_component_ids;
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-fn tmp_dir(name: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    std::env::temp_dir().join(format!("homeboy-deploy-{name}-{nanos}"))
-}
+use super::{run, DeployArgs};
+use crate::commands::GlobalArgs;
+use crate::core::deploy::parse_bulk_component_ids;
 
 #[test]
 fn test_parse_bulk_component_ids_supports_json_array() {
@@ -25,4 +17,90 @@ fn test_parse_bulk_component_ids_supports_json_object() {
 #[test]
 fn test_parse_bulk_component_ids_rejects_csv() {
     assert!(parse_bulk_component_ids("api, web").is_err());
+}
+
+#[test]
+fn deploy_head_requires_apply_for_real_deploy() {
+    let result = run(
+        deploy_args(|args| {
+            args.target_id = Some("project-a".to_string());
+            args.component_ids = vec!["component-a".to_string()];
+            args.head = true;
+        }),
+        &GlobalArgs {},
+    );
+
+    let err = match result {
+        Ok(_) => panic!("--head real deploy should require --apply"),
+        Err(err) => err,
+    };
+    assert!(err
+        .message
+        .contains("Real deploys with --head require explicit --apply"));
+}
+
+#[test]
+fn deploy_force_requires_apply_for_real_deploy() {
+    let result = run(
+        deploy_args(|args| {
+            args.target_id = Some("project-a".to_string());
+            args.component_ids = vec!["component-a".to_string()];
+            args.force = true;
+        }),
+        &GlobalArgs {},
+    );
+
+    let err = match result {
+        Ok(_) => panic!("--force real deploy should require --apply"),
+        Err(err) => err,
+    };
+    assert!(err
+        .message
+        .contains("Real deploys with --force require explicit --apply"));
+}
+
+#[test]
+fn deploy_head_dry_run_does_not_require_apply() {
+    let result = run(
+        deploy_args(|args| {
+            args.target_id = Some("missing-project".to_string());
+            args.component_ids = vec!["component-a".to_string()];
+            args.head = true;
+            args.dry_run = true;
+        }),
+        &GlobalArgs {},
+    );
+
+    let err = match result {
+        Ok(_) => panic!("dry-run should pass apply boundary before project lookup"),
+        Err(err) => err,
+    };
+    assert!(!err.message.contains("requires explicit --apply"));
+}
+
+fn deploy_args(mut customize: impl FnMut(&mut DeployArgs)) -> DeployArgs {
+    let mut args = DeployArgs {
+        target_id: None,
+        component_ids: Vec::new(),
+        project: None,
+        component: None,
+        json: None,
+        all: false,
+        outdated: false,
+        behind_upstream: false,
+        dry_run: false,
+        apply: false,
+        check: false,
+        force: false,
+        projects: None,
+        fleet: None,
+        shared: false,
+        keep_deps: false,
+        version: None,
+        no_pull: false,
+        head: false,
+        tagged: false,
+    };
+    customize(&mut args);
+    args
 }


### PR DESCRIPTION
## Summary
- Add deploy --apply.
- Require --apply for real deploys that use --head or --force.
- Keep --dry-run and --check preview/status flows unblocked.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt and diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and tests; Chris remains responsible for review and merge.