### PR TITLE
feat(runner): add reverse claim reconciliation route

### DIFF
--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -297,10 +297,12 @@ where
         },
         ("POST", "/runner/sessions")
         | ("POST", "/runner/jobs")
+        | ("POST", "/runner/jobs/reconcile")
         | ("POST", "/runner/jobs/claim") => remote_runner::route(method, path, body, job_store),
-        ("GET", "/runner/sessions") | ("GET", "/runner/jobs") | ("GET", "/runner/jobs/claim") => {
-            method_not_allowed()
-        }
+        ("GET", "/runner/sessions")
+        | ("GET", "/runner/jobs")
+        | ("GET", "/runner/jobs/reconcile")
+        | ("GET", "/runner/jobs/claim") => method_not_allowed(),
         ("POST", path) if path.starts_with("/runner/jobs/") => {
             remote_runner::route(method, path, body, job_store)
         }

--- a/src/core/daemon/broker_config.rs
+++ b/src/core/daemon/broker_config.rs
@@ -98,13 +98,15 @@ pub fn render_broker_config(options: BrokerConfigOptions) -> Result<BrokerConfig
             "systemctl status homeboy-broker".to_string(),
             "journalctl -u homeboy-broker -f".to_string(),
             "homeboy daemon status".to_string(),
+            format!("curl -fsS -X POST http://{listen}/runner/jobs/reconcile"),
             format!("curl -fsS http://{listen}/health"),
             "homeboy runner status <runner-id>".to_string(),
         ],
         restart_caveats: vec![
             "The durable job store is reopened from /var/lib/homeboy/.config/homeboy/daemon/jobs.json after restart.".to_string(),
             "Queued remote-runner jobs survive daemon restart; running broker-owned jobs are marked failed as stale.".to_string(),
-            "Active reverse-runner claims remain claim-scoped until their lease expires; runners should reclaim after the lease window.".to_string(),
+            "Run POST /runner/jobs/reconcile before broker maintenance to let the broker fail expired reverse-runner claims explicitly.".to_string(),
+            "Active reverse-runner claims remain claim-scoped until their lease expires; runners should reclaim after the broker reconciliation window.".to_string(),
             "Use systemctl restart homeboy-broker only when runners can tolerate lease expiry or retry.".to_string(),
         ],
         retention_expectations: vec![
@@ -204,6 +206,10 @@ mod tests {
             .contains("ExecStart=/usr/local/bin/homeboy daemon serve --addr 127.0.0.1:7421"));
         assert!(config.systemd_unit.contains("Restart=on-failure"));
         assert!(config.safe_exposure.loopback_only);
+        assert!(config
+            .operational_commands
+            .iter()
+            .any(|command| command.contains("/runner/jobs/reconcile")));
         assert!(config
             .safe_exposure
             .public_reverse_proxy_blocked_by

--- a/src/core/daemon/remote_runner.rs
+++ b/src/core/daemon/remote_runner.rs
@@ -80,6 +80,10 @@ pub(super) fn route(
             Ok(body) => daemon_endpoint_response("runner.jobs.submit", body),
             Err(err) => error_response(400, err),
         },
+        ("POST", "/runner/jobs/reconcile") => match reconcile(job_store) {
+            Ok(body) => daemon_endpoint_response("runner.jobs.reconcile", body),
+            Err(err) => error_response(400, err),
+        },
         ("POST", "/runner/jobs/claim") => match claim(body, job_store) {
             Ok(body) => daemon_endpoint_response("runner.jobs.claim", body),
             Err(err) => error_response(400, err),
@@ -92,13 +96,27 @@ pub(super) fn route(
                 "unknown remote runner broker path",
                 Some(path.to_string()),
                 Some(vec![
-                    "Use /runner/jobs, /runner/jobs/claim, /runner/jobs/<job-id>/events, /runner/jobs/<job-id>/finish, /runner/jobs/<job-id>/heartbeat, or /runner/jobs/<job-id>/cancel."
+                    "Use /runner/jobs, /runner/jobs/reconcile, /runner/jobs/claim, /runner/jobs/<job-id>/events, /runner/jobs/<job-id>/finish, /runner/jobs/<job-id>/heartbeat, or /runner/jobs/<job-id>/cancel."
                         .to_string(),
                     "Use /runner/sessions to register reverse runner sessions.".to_string(),
                 ]),
             ),
         ),
     }
+}
+
+fn reconcile(job_store: &JobStore) -> Result<Value> {
+    let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+    let reconciled = job_store.reconcile_expired_remote_runner_claims(now_ms)?;
+    Ok(json!({
+        "command": "api.runner.jobs.reconcile",
+        "reconciled": reconciled,
+        "reconciled_count": reconciled.len(),
+        "policy": {
+            "owner": "broker",
+            "reason": "expired reverse-runner claims are broker-owned lifecycle state"
+        },
+    }))
 }
 
 fn register_session(body: Option<Value>) -> Result<Value> {

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -511,6 +511,61 @@ fn routes_remote_runner_job_updates_require_live_matching_claim_id() {
 }
 
 #[test]
+fn broker_reconcile_route_owns_expired_reverse_runner_claims() {
+    let store = JobStore::default();
+    let submit = route_with_job_store_and_body(
+        "POST",
+        "/runner/jobs",
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "command": ["homeboy", "test", "sample-plugin"]
+        })),
+        &store,
+    );
+    let job_id = submit.body["body"]["job"]["id"]
+        .as_str()
+        .expect("job id")
+        .to_string();
+
+    let claim = route_with_job_store_and_body(
+        "POST",
+        "/runner/jobs/claim",
+        Some(serde_json::json!({
+            "runner_id": "homeboy-lab",
+            "lease_ms": 1
+        })),
+        &store,
+    );
+    assert_eq!(claim.status_code, 200);
+    std::thread::sleep(std::time::Duration::from_millis(5));
+
+    let reconcile = route_with_job_store_and_body(
+        "POST",
+        "/runner/jobs/reconcile",
+        Some(serde_json::json!({})),
+        &store,
+    );
+
+    assert_eq!(reconcile.status_code, 200);
+    assert_eq!(reconcile.body["endpoint"], "runner.jobs.reconcile");
+    assert_eq!(
+        reconcile.body["body"]["command"],
+        "api.runner.jobs.reconcile"
+    );
+    assert_eq!(reconcile.body["body"]["reconciled_count"], 1);
+    assert_eq!(reconcile.body["body"]["reconciled"][0]["id"], job_id);
+    assert_eq!(reconcile.body["body"]["reconciled"][0]["status"], "failed");
+    assert_eq!(reconcile.body["body"]["policy"]["owner"], "broker");
+
+    let events = store
+        .events(uuid::Uuid::parse_str(&job_id).expect("job uuid"))
+        .expect("events");
+    assert!(events
+        .iter()
+        .any(|event| event.message.as_deref() == Some("remote runner claim expired")));
+}
+
+#[test]
 fn daemon_http_error_envelope_includes_error_payload() {
     let _home = HomeGuard::new();
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");


### PR DESCRIPTION
## Summary
- Add broker-owned POST /runner/jobs/reconcile for expired reverse runner claims.
- Return reconciled jobs, count, and broker ownership metadata.
- Advertise reconcile preflight in broker config.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt and diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and tests; Chris remains responsible for review and merge.