### PR TITLE
Centralize repeated enum dispatch via methods on the enum

### DIFF
--- a/src/commands/agent_task/review.rs
+++ b/src/commands/agent_task/review.rs
@@ -436,17 +436,14 @@ fn review_next_actions(
 }
 
 fn promotion_handoff(report: &AgentTaskPromotionReport, to_worktree: &str) -> Value {
-    let patch_promoted = matches!(
-        report.status,
-        AgentTaskPromotionStatus::Applied | AgentTaskPromotionStatus::GateFailed
-    );
+    let patch_promoted = report.status.patch_promoted();
     let finalize_path = report
         .provenance
         .get("worktree_path")
         .and_then(Value::as_str)
         .unwrap_or(to_worktree);
     let mut next_actions = Vec::new();
-    if report.status == AgentTaskPromotionStatus::GateFailed {
+    if report.status.gate_failed() {
         next_actions.push(
             "patch promoted but deterministic gates failed; use gate feedback before finalizing"
                 .to_string(),
@@ -467,11 +464,7 @@ fn promotion_handoff(report: &AgentTaskPromotionReport, to_worktree: &str) -> Va
             "patch_promoted": patch_promoted,
             "pr_opened": false
         },
-        "boundary": match report.status {
-            AgentTaskPromotionStatus::Applied => "patch_promoted_no_pr",
-            AgentTaskPromotionStatus::GateFailed => "patch_promoted_gates_failed",
-            AgentTaskPromotionStatus::DryRun => "patch_not_promoted_dry_run",
-        },
+        "boundary": report.status.handoff_boundary(),
         "finalize_command": format!(
             "homeboy agent-task finalize-pr --run-id <run-id> --path {finalize_path} --title <title> --commit-message <message>"
         ),

--- a/src/core/agent_task_promotion.rs
+++ b/src/core/agent_task_promotion.rs
@@ -106,6 +106,28 @@ pub enum AgentTaskPromotionStatus {
     GateFailed,
 }
 
+impl AgentTaskPromotionStatus {
+    /// Whether a patch was actually promoted into the target worktree for this
+    /// status (true for both clean applies and gate-failed applies).
+    pub fn patch_promoted(self) -> bool {
+        matches!(self, Self::Applied | Self::GateFailed)
+    }
+
+    /// Whether deterministic gates failed after the patch was promoted.
+    pub fn gate_failed(self) -> bool {
+        matches!(self, Self::GateFailed)
+    }
+
+    /// Stable handoff boundary identifier for this promotion status.
+    pub fn handoff_boundary(self) -> &'static str {
+        match self {
+            Self::Applied => "patch_promoted_no_pr",
+            Self::GateFailed => "patch_promoted_gates_failed",
+            Self::DryRun => "patch_not_promoted_dry_run",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskPromotionSource {
     pub kind: String,

--- a/src/core/rig/capabilities.rs
+++ b/src/core/rig/capabilities.rs
@@ -7,9 +7,7 @@ use serde::Serialize;
 
 use super::expand::expand_vars;
 use super::pipeline::{PipelineOutcome, PipelineStepOutcome};
-use super::spec::{
-    ExecutableRequirementSpec, FilesystemAssertionKind, FilesystemAssertionSpec, RigSpec,
-};
+use super::spec::{ExecutableRequirementSpec, FilesystemAssertionSpec, RigSpec};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RigRequirementCheckPlan {
@@ -159,19 +157,13 @@ fn evaluate_filesystem_assertion(
     }
 
     let resolved = resolve_filesystem_assertion_path(rig, assertion);
-    let exists = match assertion.kind {
-        FilesystemAssertionKind::Path => resolved.exists(),
-        FilesystemAssertionKind::File => resolved.is_file(),
-        FilesystemAssertionKind::Dir => resolved.is_dir(),
-    };
-
-    if exists {
+    if assertion.kind.matches_path(&resolved) {
         return Ok(());
     }
 
     let mut message = format!(
         "{} assertion failed: {} (declared: {})",
-        filesystem_kind_label(assertion.kind),
+        assertion.kind.label(),
         resolved.display(),
         assertion.path
     );
@@ -205,21 +197,10 @@ fn executable_label(requirement: &ExecutableRequirementSpec) -> String {
 }
 
 fn filesystem_label(assertion: &FilesystemAssertionSpec) -> String {
-    assertion.label.clone().unwrap_or_else(|| {
-        format!(
-            "require {} {}",
-            filesystem_kind_label(assertion.kind),
-            assertion.path
-        )
-    })
-}
-
-fn filesystem_kind_label(kind: FilesystemAssertionKind) -> &'static str {
-    match kind {
-        FilesystemAssertionKind::Path => "path",
-        FilesystemAssertionKind::File => "file",
-        FilesystemAssertionKind::Dir => "dir",
-    }
+    assertion
+        .label
+        .clone()
+        .unwrap_or_else(|| format!("require {} {}", assertion.kind.label(), assertion.path))
 }
 
 fn find_executable(candidate: &str) -> Option<PathBuf> {
@@ -258,7 +239,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::core::rig::spec::{RigRequirementsSpec, RigSpec};
+    use crate::core::rig::spec::{FilesystemAssertionKind, RigRequirementsSpec, RigSpec};
 
     #[test]
     fn plans_executable_and_filesystem_requirements() {

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -261,6 +261,24 @@ impl FilesystemAssertionKind {
     pub fn is_path(&self) -> bool {
         matches!(self, Self::Path)
     }
+
+    /// Human-readable label for this assertion kind.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Path => "path",
+            Self::File => "file",
+            Self::Dir => "dir",
+        }
+    }
+
+    /// Whether the given path satisfies this assertion kind.
+    pub fn matches_path(self, path: &std::path::Path) -> bool {
+        match self {
+            Self::Path => path.exists(),
+            Self::File => path.is_file(),
+            Self::Dir => path.is_dir(),
+        }
+    }
 }
 
 /// Desktop launcher settings for a rig.


### PR DESCRIPTION
## Summary
Closes #5418.

Two enums were exhaustively matched in multiple locations with parallel/duplicated body shapes — a maintenance hazard, since adding a variant required updating every scattered match. This consolidates each variant→value mapping into a single source of truth: methods on the enum itself.

### `AgentTaskPromotionStatus` (agent_task review/promotion)
- Added `patch_promoted()`, `gate_failed()`, and `handoff_boundary()` methods on the enum.
- `review.rs::promotion_handoff` now calls those methods instead of re-matching / re-`matches!`-ing over the variants (the `boundary` string map, the `patch_promoted` `matches!`, and the `gate_failed` comparison).
- The variant→notification constructor match in `agent_task_promotion.rs::promotion_notification` legitimately produces distinct constructor bodies and stays put; the duplicated *primitive* mappings are what got centralized.

### `FilesystemAssertionKind` (rig/capabilities.rs)
- Added `label()` and `matches_path()` methods on the enum.
- `evaluate_filesystem_assertion` now uses `kind.matches_path(&resolved)` instead of matching to call `exists()/is_file()/is_dir()`, and `kind.label()` for the message.
- `filesystem_label` uses `kind.label()`; the duplicate `filesystem_kind_label` free function is removed.

Behavior is identical — only the variant dispatch is centralized so adding a variant is a single change.

## Validation
- `cargo build --lib` clean (only the pre-existing unrelated `daemon_api_post` unused-import warning remains).
- `cargo fmt` applied.
- Relying on CI for full build/test (agent_task + rig + command_contract).