### PR TITLE
feat(cli): guard mutating api requests

### DIFF
--- a/docs/commands/api.md
+++ b/docs/commands/api.md
@@ -23,26 +23,34 @@ homeboy api <project_id> get <endpoint>
 ### `post`
 
 ```sh
-homeboy api <project_id> post <endpoint> [--body <json>] [--form <key=value>]...
+homeboy api <project_id> post <endpoint> --apply [--body <json>] [--form <key=value>]...
 ```
+
+Mutating requests require `--apply`.
 
 ### `put`
 
 ```sh
-homeboy api <project_id> put <endpoint> [--body <json>] [--form <key=value>]...
+homeboy api <project_id> put <endpoint> --apply [--body <json>] [--form <key=value>]...
 ```
+
+Mutating requests require `--apply`.
 
 ### `patch`
 
 ```sh
-homeboy api <project_id> patch <endpoint> [--body <json>] [--form <key=value>]...
+homeboy api <project_id> patch <endpoint> --apply [--body <json>] [--form <key=value>]...
 ```
+
+Mutating requests require `--apply`.
 
 ### `delete`
 
 ```sh
-homeboy api <project_id> delete <endpoint>
+homeboy api <project_id> delete <endpoint> --apply
 ```
+
+Mutating requests require `--apply`.
 
 ## Notes
 
@@ -50,6 +58,7 @@ homeboy api <project_id> delete <endpoint>
 - `--body` is parsed as JSON. If parsing fails, the request is sent with `body: null`.
 - `--form key=value` may be repeated for `post`, `put`, and `patch`; form fields take precedence over `--body`.
 - If `--body` and `--form` are omitted, `body` is `null`.
+- `get` is allowed without `--apply`; `post`, `put`, `patch`, and `delete` require `--apply` before Homeboy sends the request.
 
 ## Output
 

--- a/docs/commands/http.md
+++ b/docs/commands/http.md
@@ -12,8 +12,10 @@ homeboy http get https://logstash.example.com/logstash/... --proxy socks5://127.
 ```
 
 ```sh
-homeboy http request POST https://example.com/api --json '{"ok":true}' --header 'X-Example: value'
+homeboy http request POST --apply https://example.com/api --json '{"ok":true}' --header 'X-Example: value'
 ```
+
+`homeboy http request` allows `GET`, `HEAD`, and `OPTIONS` without `--apply`. Other methods require `--apply` before Homeboy sends the request.
 
 ## Options
 
@@ -22,5 +24,6 @@ homeboy http request POST https://example.com/api --json '{"ok":true}' --header 
 - `--header 'Name: value'` adds a request header.
 - `--json <json>` sends a JSON body.
 - `--form key=value` sends form fields.
+- `--apply` confirms mutating `request` methods other than `GET`, `HEAD`, and `OPTIONS`.
 
 Output is structured JSON with `method`, `url`, `status`, `headers`, and `body`.

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -484,11 +484,15 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
         ["api", "post"] | ["api", "put"] | ["api", "patch"] | ["api", "delete"] => {
             metadata.mutates = true;
             metadata.operator = true;
+            metadata.output_notes = "mutating API requests require --apply";
+            metadata.dangerous_flags = vec!["--apply"];
         }
         ["http", "request"] => {
             metadata.mutates = true;
             metadata.operator = true;
-            metadata.dangerous_flags = vec!["METHOD!=GET", "METHOD!=HEAD", "METHOD!=OPTIONS"];
+            metadata.output_notes = "mutating HTTP methods require --apply; GET, HEAD, and OPTIONS are allowed without it";
+            metadata.dangerous_flags =
+                vec!["--apply", "METHOD!=GET", "METHOD!=HEAD", "METHOD!=OPTIONS"];
         }
         ["bench"] | ["test"] | ["lint"] | ["audit"] | ["trace"] => {
             metadata.lab_supported = true;
@@ -692,6 +696,16 @@ mod tests {
 
         let file_write = manifest.find_path(&["file", "write"]).unwrap();
         assert!(file_write.output.notes.contains("--apply"));
+
+        let api_post = manifest.find_path(&["api", "post"]).unwrap();
+        assert!(api_post.output.notes.contains("--apply"));
+        assert!(api_post.dangerous_flags.contains(&"--apply".to_string()));
+
+        let http_request = manifest.find_path(&["http", "request"]).unwrap();
+        assert!(http_request.output.notes.contains("--apply"));
+        assert!(http_request
+            .dangerous_flags
+            .contains(&"METHOD!=GET".to_string()));
     }
 
     #[test]
@@ -750,6 +764,24 @@ mod tests {
             ["homeboy", "db", "drop-table", "mysite", "--apply", "wp_tmp"].as_slice(),
             ["homeboy", "file", "delete", "mysite", "tmp.txt", "--apply"].as_slice(),
             ["homeboy", "file", "write", "mysite", "tmp.txt", "--apply"].as_slice(),
+            [
+                "homeboy",
+                "api",
+                "mysite",
+                "post",
+                "/wp/v2/posts",
+                "--apply",
+            ]
+            .as_slice(),
+            [
+                "homeboy",
+                "http",
+                "request",
+                "POST",
+                "--apply",
+                "https://example.test/api",
+            ]
+            .as_slice(),
         ] {
             Cli::try_parse_from(args).unwrap_or_else(|error| {
                 panic!("documented command form failed to parse: {args:?}\n{error}")

--- a/src/commands/api.rs
+++ b/src/commands/api.rs
@@ -23,6 +23,9 @@ enum ApiCommand {
     Post {
         /// API endpoint
         endpoint: String,
+        /// Confirm the mutating request should be sent.
+        #[arg(long)]
+        apply: bool,
         /// JSON body
         #[arg(long)]
         body: Option<String>,
@@ -34,6 +37,9 @@ enum ApiCommand {
     Put {
         /// API endpoint
         endpoint: String,
+        /// Confirm the mutating request should be sent.
+        #[arg(long)]
+        apply: bool,
         /// JSON body
         #[arg(long)]
         body: Option<String>,
@@ -45,6 +51,9 @@ enum ApiCommand {
     Patch {
         /// API endpoint
         endpoint: String,
+        /// Confirm the mutating request should be sent.
+        #[arg(long)]
+        apply: bool,
         /// JSON body
         #[arg(long)]
         body: Option<String>,
@@ -56,12 +65,55 @@ enum ApiCommand {
     Delete {
         /// API endpoint
         endpoint: String,
+        /// Confirm the mutating request should be sent.
+        #[arg(long)]
+        apply: bool,
     },
 }
 
 pub fn run(args: ApiArgs, _global: &crate::commands::GlobalArgs) -> CmdResult<api::ApiOutput> {
+    require_apply_for_mutation(&args)?;
     let input = build_api_json(&args);
     api::run(&input)
+}
+
+fn require_apply_for_mutation(args: &ApiArgs) -> homeboy::core::Result<()> {
+    let Some((command, endpoint, apply)) = mutating_command(&args.command) else {
+        return Ok(());
+    };
+
+    if *apply {
+        return Ok(());
+    }
+
+    Err(homeboy::core::Error::validation_invalid_argument(
+        "apply",
+        format!(
+            "homeboy api {command} sends a mutating request and requires explicit --apply. Suggested command: homeboy api {} {command} {} --apply",
+            args.project_id, endpoint
+        ),
+        None,
+        Some(vec![format!(
+            "homeboy api {} {command} {} --apply",
+            args.project_id, endpoint
+        )]),
+    ))
+}
+
+fn mutating_command(command: &ApiCommand) -> Option<(&'static str, &str, &bool)> {
+    match command {
+        ApiCommand::Get { .. } => None,
+        ApiCommand::Post {
+            endpoint, apply, ..
+        } => Some(("post", endpoint, apply)),
+        ApiCommand::Put {
+            endpoint, apply, ..
+        } => Some(("put", endpoint, apply)),
+        ApiCommand::Patch {
+            endpoint, apply, ..
+        } => Some(("patch", endpoint, apply)),
+        ApiCommand::Delete { endpoint, apply } => Some(("delete", endpoint, apply)),
+    }
 }
 
 fn build_api_json(args: &ApiArgs) -> String {
@@ -69,6 +121,7 @@ fn build_api_json(args: &ApiArgs) -> String {
         ApiCommand::Get { endpoint } => ("GET", endpoint.clone(), None, "json"),
         ApiCommand::Post {
             endpoint,
+            apply: _,
             body,
             form,
         } => (
@@ -79,6 +132,7 @@ fn build_api_json(args: &ApiArgs) -> String {
         ),
         ApiCommand::Put {
             endpoint,
+            apply: _,
             body,
             form,
         } => (
@@ -89,6 +143,7 @@ fn build_api_json(args: &ApiArgs) -> String {
         ),
         ApiCommand::Patch {
             endpoint,
+            apply: _,
             body,
             form,
         } => (
@@ -97,7 +152,7 @@ fn build_api_json(args: &ApiArgs) -> String {
             build_body(body, form),
             body_format(form),
         ),
-        ApiCommand::Delete { endpoint } => ("DELETE", endpoint.clone(), None, "json"),
+        ApiCommand::Delete { endpoint, apply: _ } => ("DELETE", endpoint.clone(), None, "json"),
     };
 
     serde_json::json!({
@@ -109,6 +164,10 @@ fn build_api_json(args: &ApiArgs) -> String {
     })
     .to_string()
 }
+
+#[cfg(test)]
+#[path = "../../tests/commands/api_test.rs"]
+mod api_test;
 
 fn build_body(body: &Option<String>, form: &[String]) -> Option<serde_json::Value> {
     if !form.is_empty() {

--- a/src/commands/http.rs
+++ b/src/commands/http.rs
@@ -19,6 +19,10 @@ enum HttpCommand {
         /// HTTP method
         method: String,
 
+        /// Confirm the mutating request should be sent.
+        #[arg(long)]
+        apply: bool,
+
         #[command(flatten)]
         args: RequestArgs,
     },
@@ -53,11 +57,42 @@ struct RequestArgs {
 pub fn run(args: HttpArgs, _global: &GlobalArgs) -> CmdResult<HttpRequestOutput> {
     let input = match args.command {
         HttpCommand::Get(args) => build_input("GET", args),
-        HttpCommand::Request { method, args } => build_input(&method, args),
+        HttpCommand::Request {
+            method,
+            apply,
+            args,
+        } => {
+            require_apply_for_request(&method, apply, &args.url)?;
+            build_input(&method, args)
+        }
     };
 
     let output = http_request::run(input)?;
     Ok((output, 0))
+}
+
+fn require_apply_for_request(method: &str, apply: bool, url: &str) -> homeboy::core::Result<()> {
+    if !is_mutating_method(method) || apply {
+        return Ok(());
+    }
+
+    Err(homeboy::core::Error::validation_invalid_argument(
+        "apply",
+        format!(
+            "homeboy http request {method} sends a mutating request and requires explicit --apply. Suggested command: homeboy http request {method} --apply {url}"
+        ),
+        None,
+        Some(vec![format!(
+            "homeboy http request {method} --apply {url}"
+        )]),
+    ))
+}
+
+fn is_mutating_method(method: &str) -> bool {
+    !matches!(
+        method.to_ascii_uppercase().as_str(),
+        "GET" | "HEAD" | "OPTIONS"
+    )
 }
 
 fn build_input(method: &str, args: RequestArgs) -> HttpRequestInput {
@@ -71,3 +106,7 @@ fn build_input(method: &str, args: RequestArgs) -> HttpRequestInput {
         form_body: args.form,
     }
 }
+
+#[cfg(test)]
+#[path = "../../tests/commands/http_test.rs"]
+mod http_test;

--- a/tests/commands/api_test.rs
+++ b/tests/commands/api_test.rs
@@ -1,0 +1,60 @@
+use super::{require_apply_for_mutation, ApiArgs, ApiCommand};
+
+#[test]
+fn api_mutating_commands_require_apply() {
+    for command in [
+        ApiCommand::Post {
+            endpoint: "/wp/v2/posts".to_string(),
+            apply: false,
+            body: None,
+            form: Vec::new(),
+        },
+        ApiCommand::Put {
+            endpoint: "/wp/v2/posts/1".to_string(),
+            apply: false,
+            body: None,
+            form: Vec::new(),
+        },
+        ApiCommand::Patch {
+            endpoint: "/wp/v2/posts/1".to_string(),
+            apply: false,
+            body: None,
+            form: Vec::new(),
+        },
+        ApiCommand::Delete {
+            endpoint: "/wp/v2/posts/1".to_string(),
+            apply: false,
+        },
+    ] {
+        let err = require_apply_for_mutation(&ApiArgs {
+            project_id: "site".to_string(),
+            command,
+        })
+        .expect_err("mutating API command should require --apply");
+
+        assert!(err.message.contains("requires explicit --apply"));
+        assert!(err.message.contains("Suggested command: homeboy api site"));
+    }
+}
+
+#[test]
+fn api_get_and_applied_mutations_pass_apply_guard() {
+    require_apply_for_mutation(&ApiArgs {
+        project_id: "site".to_string(),
+        command: ApiCommand::Get {
+            endpoint: "/wp/v2/posts".to_string(),
+        },
+    })
+    .expect("GET should not require --apply");
+
+    require_apply_for_mutation(&ApiArgs {
+        project_id: "site".to_string(),
+        command: ApiCommand::Post {
+            endpoint: "/wp/v2/posts".to_string(),
+            apply: true,
+            body: None,
+            form: Vec::new(),
+        },
+    })
+    .expect("applied mutation should pass guard");
+}

--- a/tests/commands/http_test.rs
+++ b/tests/commands/http_test.rs
@@ -1,0 +1,30 @@
+use super::{is_mutating_method, require_apply_for_request};
+
+#[test]
+fn http_request_mutating_methods_require_apply() {
+    for method in ["POST", "put", "PATCH", "DELETE"] {
+        let err = require_apply_for_request(method, false, "https://example.test/api")
+            .expect_err("mutating HTTP method should require --apply");
+
+        assert!(err.message.contains("requires explicit --apply"));
+        assert!(err
+            .message
+            .contains(&format!("homeboy http request {method} --apply")));
+    }
+}
+
+#[test]
+fn http_request_safe_methods_do_not_require_apply() {
+    for method in ["GET", "head", "Options"] {
+        assert!(!is_mutating_method(method));
+        require_apply_for_request(method, false, "https://example.test/api")
+            .expect("safe HTTP method should not require --apply");
+    }
+}
+
+#[test]
+fn http_request_applied_mutation_passes_guard() {
+    assert!(is_mutating_method("POST"));
+    require_apply_for_request("POST", true, "https://example.test/api")
+        .expect("applied mutation should pass guard");
+}


### PR DESCRIPTION
## Summary
- Require --apply for mutating api post/put/patch/delete commands.
- Require --apply for mutating http request methods.
- Leave safe GET, HEAD, OPTIONS, and http get flows unchanged.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt and diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and tests; Chris remains responsible for review and merge.