### PR TITLE
feat(release): require apply for risky modes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -695,7 +695,7 @@ jobs:
         run: |
           cargo build --release --bin homeboy
           ./target/release/homeboy extension install-for-component --path . --source https://github.com/Extra-Chill/homeboy-extensions
-          ./target/release/homeboy release homeboy --head --from-artifacts artifacts --skip-checks
+          ./target/release/homeboy release homeboy --head --from-artifacts artifacts --skip-checks --apply
 
   publish-homebrew-formula:
     needs:

--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -14,6 +14,7 @@ By default Homeboy auto-detects the bump from commit history. Use `--bump <major
 - `--project <PROJECT>` / `-p <PROJECT>`: Release components from a project
 - `--outdated`: With `--project`, release only components with unreleased commits
 - `--path <PATH>`: Override local path for a single-component release
+- `--apply`: Confirm risky real release modes such as `--deploy`, `--recover`, `--retag`, `--head`, or bare `--skip-checks`
 - `--deploy`: Deploy this component to all projects that use it after release
 - `--recover`: Recover from an interrupted release
 - `--head`: Finish the release pipeline for the version commit and tag already checked out at HEAD
@@ -30,6 +31,8 @@ By default Homeboy auto-detects the bump from commit history. Use `--bump <major
 `homeboy release` executes component releases: detects or applies a version bump, finalizes generated changelog entries, commits, tags, pushes, and optionally publishes release artifacts. Use `--dry-run` to preview the release plan without making changes.
 
 `--head` is for CI jobs where another step already created the release commit and tag, but Homeboy should still own the rest of the release lifecycle. It keeps the safe preflight checks, skips changelog/version/git mutation steps, populates release state from the version and tag at HEAD, then runs `release.package` (unless `--from-artifacts` is provided), `github.release`, `release.publish`, cleanup, and post-release hooks through the normal pipeline.
+
+Risky real release modes require explicit `--apply`: `--deploy`, `--recover`, `--retag`, `--head`, and bare `--skip-checks`. Dry-run previews never require `--apply`, and granular skips such as `--skip-checks=lint` keep the normal release flow because other quality gates remain active.
 
 When `--bump` requests a lower keyword bump than Homeboy detects from releasable commits, release execution requires confirmation in an interactive terminal. Non-interactive runs must pass `--force-lower-bump`; otherwise Homeboy refuses before creating release artifacts, commits, tags, or pushes. Dry-run still returns the plan and semver recommendation for review.
 
@@ -51,7 +54,7 @@ homeboy release <component_id>
 ```sh
 # Build/package artifacts somewhere else, then let Homeboy create/update the
 # GitHub Release and run publish hooks without re-tagging.
-homeboy release <component_id> --head --from-artifacts ./artifacts --skip-checks
+homeboy release <component_id> --head --from-artifacts ./artifacts --skip-checks --apply
 ```
 
 ## Release Pipeline

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -31,6 +31,10 @@ pub struct ReleaseArgs {
     #[command(flatten)]
     dry_run_args: DryRunArgs,
 
+    /// Confirm risky release execution modes.
+    #[arg(long)]
+    apply: bool,
+
     /// Deploy to all projects using this component after release
     #[arg(long)]
     deploy: bool,
@@ -193,6 +197,7 @@ impl ReleaseArgs {
             outdated,
             path,
             dry_run_args: DryRunArgs { dry_run },
+            apply: false,
             deploy,
             recover,
             retag: false,
@@ -212,9 +217,10 @@ pub fn run(
     args: ReleaseArgs,
     _global: &crate::commands::GlobalArgs,
 ) -> CmdResult<ReleaseCommandOutput> {
+    let (skip_checks, skip_checks_granular) = args.resolve_skip_checks()?;
+    validate_apply_boundary(&args, skip_checks)?;
     let component_ids = resolve_component_ids(&args, &args.components)?;
     let bump_override = args.bump.clone();
-    let (skip_checks, skip_checks_granular) = args.resolve_skip_checks()?;
 
     // Single component: use the original single-release flow
     if component_ids.len() == 1 {
@@ -312,6 +318,36 @@ pub fn run(
             result: batch_result,
         }),
         exit_code,
+    ))
+}
+
+fn validate_apply_boundary(args: &ReleaseArgs, skip_checks: bool) -> homeboy::core::Result<()> {
+    if args.apply
+        || args.dry_run_args.dry_run
+        || (!args.deploy && !args.recover && !args.retag && !args.head && !skip_checks)
+    {
+        return Ok(());
+    }
+
+    let risky_flags = [
+        (args.deploy, "--deploy"),
+        (args.recover, "--recover"),
+        (args.retag, "--retag"),
+        (args.head, "--head"),
+        (skip_checks, "bare --skip-checks"),
+    ]
+    .into_iter()
+    .filter_map(|(enabled, flag)| enabled.then_some(flag))
+    .collect::<Vec<_>>()
+    .join(" and ");
+
+    Err(homeboy::core::Error::validation_invalid_argument(
+        "apply",
+        format!(
+            "Real releases with {risky_flags} require explicit --apply. Use --dry-run to preview or re-run with --apply to release."
+        ),
+        None,
+        None,
     ))
 }
 
@@ -456,6 +492,7 @@ mod tests {
             outdated: false,
             path: None,
             dry_run_args: DryRunArgs { dry_run: true },
+            apply: false,
             deploy: false,
             recover: false,
             retag: false,
@@ -503,5 +540,58 @@ mod tests {
             .expect_err("unknown check rejected");
         assert_eq!(err.code.as_str(), "validation.invalid_argument");
         assert!(err.to_string().contains("Unknown check 'bogus'"));
+    }
+
+    #[test]
+    fn risky_real_release_requires_apply() {
+        let mut args = args(&["fixture"]);
+        args.dry_run_args.dry_run = false;
+        args.head = true;
+
+        let err = validate_apply_boundary(&args, false).expect_err("--head requires --apply");
+
+        assert!(err
+            .message
+            .contains("Real releases with --head require explicit --apply"));
+    }
+
+    #[test]
+    fn risky_dry_run_release_does_not_require_apply() {
+        let mut args = args(&["fixture"]);
+        args.head = true;
+
+        validate_apply_boundary(&args, false).expect("dry-run may preview risky mode");
+    }
+
+    #[test]
+    fn bare_skip_checks_real_release_requires_apply() {
+        let mut args = args(&["fixture"]);
+        args.dry_run_args.dry_run = false;
+
+        let err =
+            validate_apply_boundary(&args, true).expect_err("bare --skip-checks requires --apply");
+
+        assert!(err
+            .message
+            .contains("Real releases with bare --skip-checks require explicit --apply"));
+    }
+
+    #[test]
+    fn granular_skip_checks_real_release_does_not_require_apply() {
+        let mut args = args(&["fixture"]);
+        args.dry_run_args.dry_run = false;
+
+        validate_apply_boundary(&args, false).expect("granular skip-checks is not guarded");
+    }
+
+    #[test]
+    fn apply_confirms_risky_real_release() {
+        let mut args = args(&["fixture"]);
+        args.dry_run_args.dry_run = false;
+        args.recover = true;
+        args.retag = true;
+        args.apply = true;
+
+        validate_apply_boundary(&args, false).expect("--apply confirms risky release mode");
     }
 }

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -124,3 +124,12 @@ fn release_test_gate_exposes_release_blocking_policy_to_rust_tests() {
 
     assert!(gate_test.contains("RELEASE_BLOCKING_COMMANDS: ${{ env.RELEASE_BLOCKING_COMMANDS }}"));
 }
+
+#[test]
+fn release_finish_head_pipeline_confirms_apply_boundary() {
+    let host = job_section(release_workflow(), "host");
+
+    assert!(host.contains(
+        "./target/release/homeboy release homeboy --head --from-artifacts artifacts --skip-checks --apply"
+    ));
+}


### PR DESCRIPTION
## Summary
- Add release --apply.
- Require --apply for risky non-dry-run release modes: --deploy, --recover, --retag, --head, and bare --skip-checks.
- Update release docs and release workflow usage.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt and diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and tests; Chris remains responsible for review and merge.