### PR TITLE
feat(release): tag output variants

### DIFF
--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -141,6 +141,7 @@ With `--dry-run`:
 ```json
 {
   "command": "release",
+  "variant": "single",
   "result": {
     "component_id": "<component_id>",
     "bump_type": "patch",
@@ -201,6 +202,7 @@ Without `--dry-run`:
 ```json
 {
   "command": "release",
+  "variant": "single",
   "result": {
     "component_id": "<component_id>",
     "bump_type": "patch",

--- a/src/command_contract/public_variants.rs
+++ b/src/command_contract/public_variants.rs
@@ -80,6 +80,20 @@ pub const PUBLIC_OUTPUT_VARIANT_CONTRACTS: &[PublicOutputVariantContract] = &[
         golden_fixture: Some("deploy_contract.json"),
     },
     PublicOutputVariantContract {
+        command: "release",
+        variant: "single",
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("single"),
+        golden_fixture: Some("release_contract.json"),
+    },
+    PublicOutputVariantContract {
+        command: "release",
+        variant: "batch",
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("batch"),
+        golden_fixture: Some("release_contract.json"),
+    },
+    PublicOutputVariantContract {
         command: "runs",
         variant: "list",
         discriminator_field: Some("variant"),

--- a/src/commands/golden_contract_tests.rs
+++ b/src/commands/golden_contract_tests.rs
@@ -199,9 +199,11 @@ fn release_command_json_contract_matches_golden_fixture() {
         json!({
             "scenarios": [
                 scenario("release dry-run single", ReleaseCommandOutput::Single(ReleaseOutput {
+                    variant: "single",
                     result: release_result("homeboy", "minor", true, Some(release_plan())),
                 })),
                 scenario("release dry-run batch", ReleaseCommandOutput::Batch(BatchReleaseOutput {
+                    variant: "batch",
                     result: BatchReleaseResult {
                         results: vec![BatchReleaseComponentResult {
                             component_id: "homeboy".to_string(),

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -96,12 +96,14 @@ pub struct ReleaseArgs {
 #[derive(Serialize)]
 #[serde(tag = "command", rename = "release")]
 pub struct ReleaseOutput {
+    pub variant: &'static str,
     pub result: ReleaseCommandResult,
 }
 
 #[derive(Serialize)]
 #[serde(tag = "command", rename = "release.batch")]
 pub struct BatchReleaseOutput {
+    pub variant: &'static str,
     pub result: BatchReleaseResult,
 }
 
@@ -235,7 +237,10 @@ pub fn run(
         })?;
 
         return Ok((
-            ReleaseCommandOutput::Single(ReleaseOutput { result }),
+            ReleaseCommandOutput::Single(ReleaseOutput {
+                variant: "single",
+                result,
+            }),
             exit_code,
         ));
     }
@@ -309,6 +314,7 @@ pub fn run(
 
     Ok((
         ReleaseCommandOutput::Batch(BatchReleaseOutput {
+            variant: "batch",
             result: batch_result,
         }),
         exit_code,

--- a/tests/fixtures/golden_json_contracts/release_contract.json
+++ b/tests/fixtures/golden_json_contracts/release_contract.json
@@ -4,6 +4,7 @@
       "payload": {
         "data": {
           "command": "release",
+          "variant": "single",
           "result": {
             "bump_type": "minor",
             "component_id": "homeboy",
@@ -81,6 +82,7 @@
       "payload": {
         "data": {
           "command": "release.batch",
+          "variant": "batch",
           "result": {
             "results": [
               {


### PR DESCRIPTION
## Summary
- Add additive release output variants for single and batch release outputs.
- Preserve existing command and result payload fields.
- Update public contracts and release golden fixture.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran jq and diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and PR text; Chris remains responsible for review and merge.