### PR TITLE
refactor: purge upstream detector literals + dedupe summary commands

### DIFF
--- a/src/commands/agent_task_summary.rs
+++ b/src/commands/agent_task_summary.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 
 use super::agent_task::{AgentTaskArgs, AgentTaskCommand};
+use super::summary_json::{array_len, string_value, u64_value, usize_value, value_at};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AgentTaskSummaryKind {
@@ -204,30 +205,6 @@ fn first_diagnostic_message<'a>(payload: &'a Value, path: &[&str]) -> Option<&'a
         })
 }
 
-fn value_at<'a>(payload: &'a Value, path: &[&str]) -> Option<&'a Value> {
-    let mut current = payload;
-    for segment in path {
-        if let Ok(index) = segment.parse::<usize>() {
-            current = current.as_array()?.get(index)?;
-        } else {
-            current = current.get(*segment)?;
-        }
-    }
-    Some(current)
-}
-
-fn string_value<'a>(payload: &'a Value, path: &[&str]) -> Option<&'a str> {
-    value_at(payload, path)?.as_str()
-}
-
-fn usize_value(payload: &Value, path: &[&str]) -> Option<usize> {
-    value_at(payload, path)?.as_u64()?.try_into().ok()
-}
-
-fn array_len(payload: &Value, path: &[&str]) -> Option<usize> {
-    Some(value_at(payload, path)?.as_array()?.len())
-}
-
 fn aggregate_outcome_count(payload: &Value) -> Option<usize> {
     array_len(payload, &["aggregate", "outcomes"])
 }
@@ -412,10 +389,6 @@ fn metadata_changed_files(artifact: &Value) -> usize {
         .and_then(Value::as_u64)
         .map(|count| count as usize)
         .unwrap_or(0)
-}
-
-fn u64_value(payload: &Value, path: &[&str]) -> Option<u64> {
-    value_at(payload, path)?.as_u64()
 }
 
 /// A run whose lifecycle state is `succeeded` but that produced zero promotion

--- a/src/commands/bench_summary.rs
+++ b/src/commands/bench_summary.rs
@@ -18,6 +18,8 @@
 
 use serde_json::Value;
 
+use super::summary_json::{array_len, string_value, u64_value, usize_value, value_at};
+
 /// Render a compact summary for a serialized `BenchOutput` value. Returns
 /// `None` for variants where the full JSON is the better default (lists,
 /// embedded `runs` observation output, matrix fan-out), so those paths keep
@@ -376,34 +378,6 @@ fn finish(lines: Vec<String>) -> String {
     let mut output = lines.join("\n");
     output.push('\n');
     output
-}
-
-fn value_at<'a>(payload: &'a Value, path: &[&str]) -> Option<&'a Value> {
-    let mut current = payload;
-    for segment in path {
-        if let Ok(index) = segment.parse::<usize>() {
-            current = current.as_array()?.get(index)?;
-        } else {
-            current = current.get(*segment)?;
-        }
-    }
-    Some(current)
-}
-
-fn string_value<'a>(payload: &'a Value, path: &[&str]) -> Option<&'a str> {
-    value_at(payload, path)?.as_str()
-}
-
-fn u64_value(payload: &Value, path: &[&str]) -> Option<u64> {
-    value_at(payload, path)?.as_u64()
-}
-
-fn usize_value(payload: &Value, path: &[&str]) -> Option<usize> {
-    value_at(payload, path)?.as_u64()?.try_into().ok()
-}
-
-fn array_len(payload: &Value, path: &[&str]) -> Option<usize> {
-    Some(value_at(payload, path)?.as_array()?.len())
 }
 
 #[cfg(test)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -239,6 +239,7 @@ pub mod source_command;
 pub mod ssh;
 pub mod stack;
 pub mod status;
+pub(crate) mod summary_json;
 pub mod test;
 pub mod trace;
 pub mod triage;

--- a/src/commands/runs_summary.rs
+++ b/src/commands/runs_summary.rs
@@ -13,6 +13,8 @@
 
 use serde_json::Value;
 
+use super::summary_json::{string_value, value_at};
+
 /// Render a compact summary for a serialized `RunsOutput` value. Returns
 /// `None` for any variant other than `show`, leaving other `runs`
 /// subcommands with their existing full-JSON presentation.
@@ -108,22 +110,6 @@ fn finish(lines: Vec<String>) -> String {
     let mut output = lines.join("\n");
     output.push('\n');
     output
-}
-
-fn value_at<'a>(payload: &'a Value, path: &[&str]) -> Option<&'a Value> {
-    let mut current = payload;
-    for segment in path {
-        if let Ok(index) = segment.parse::<usize>() {
-            current = current.as_array()?.get(index)?;
-        } else {
-            current = current.get(*segment)?;
-        }
-    }
-    Some(current)
-}
-
-fn string_value<'a>(payload: &'a Value, path: &[&str]) -> Option<&'a str> {
-    value_at(payload, path)?.as_str()
 }
 
 #[cfg(test)]

--- a/src/commands/summary_json.rs
+++ b/src/commands/summary_json.rs
@@ -1,0 +1,46 @@
+//! Shared JSON-path accessors for the compact-summary renderers.
+//!
+//! The `agent_task`, `bench`, and `runs` compact-summary modules all walk a
+//! serialized JSON envelope by dotted segment paths to pull out strings,
+//! counts, and array lengths. These small accessors used to be copy-pasted
+//! into each summary module verbatim, which the audit flagged as duplicate
+//! functions. They live here once so every summary renderer shares a single
+//! implementation.
+
+use serde_json::Value;
+
+/// Walk `payload` following `path`, where each segment is either an object key
+/// or (when it parses as a `usize`) an array index. Returns the addressed value
+/// or `None` if any segment is missing or mistyped.
+pub(crate) fn value_at<'a>(payload: &'a Value, path: &[&str]) -> Option<&'a Value> {
+    let mut current = payload;
+    for segment in path {
+        if let Ok(index) = segment.parse::<usize>() {
+            current = current.as_array()?.get(index)?;
+        } else {
+            current = current.get(*segment)?;
+        }
+    }
+    Some(current)
+}
+
+/// Resolve `path` and return it as a string slice, if present and a string.
+pub(crate) fn string_value<'a>(payload: &'a Value, path: &[&str]) -> Option<&'a str> {
+    value_at(payload, path)?.as_str()
+}
+
+/// Resolve `path` and return it as a `u64`, if present and an unsigned integer.
+pub(crate) fn u64_value(payload: &Value, path: &[&str]) -> Option<u64> {
+    value_at(payload, path)?.as_u64()
+}
+
+/// Resolve `path` and return it as a `usize`, if present and a non-negative
+/// integer that fits.
+pub(crate) fn usize_value(payload: &Value, path: &[&str]) -> Option<usize> {
+    value_at(payload, path)?.as_u64()?.try_into().ok()
+}
+
+/// Resolve `path` and return the length of the array it addresses, if present.
+pub(crate) fn array_len(payload: &Value, path: &[&str]) -> Option<usize> {
+    Some(value_at(payload, path)?.as_array()?.len())
+}

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -1,7 +1,7 @@
 use clap::{CommandFactory, Parser};
 use homeboy::cli_surface::{
-    command_surface_from_with_depth, current_command_safety_manifest, current_command_surface,
-    CommandSafetyEntry, Cli, Commands,
+    command_surface_from_with_depth, current_command_safety_manifest, current_command_surface, Cli,
+    CommandSafetyEntry, Commands,
 };
 use std::collections::BTreeSet;
 use std::fs;

--- a/tests/core/code_audit/run_test.rs
+++ b/tests/core/code_audit/run_test.rs
@@ -505,7 +505,13 @@ fn json_summary_for_targeted_detector_counts_current_and_unbaselined_findings() 
 #[test]
 fn execution_plan_filters_to_requested_detector_family() {
     let cases = [
-        (AuditFinding::GodFile, "structural", "duplication", true, false),
+        (
+            AuditFinding::GodFile,
+            "structural",
+            "duplication",
+            true,
+            false,
+        ),
         (
             AuditFinding::DuplicateFunction,
             "duplication",
@@ -515,13 +521,9 @@ fn execution_plan_filters_to_requested_detector_family() {
         ),
     ];
 
-    for (
-        finding,
-        ready_detector,
-        disabled_detector,
-        structural_enabled,
-        duplication_enabled,
-    ) in cases {
+    for (finding, ready_detector, disabled_detector, structural_enabled, duplication_enabled) in
+        cases
+    {
         let plan = AuditExecutionPlan::from_filters(&[finding], &[]);
 
         assert_eq!(plan.run_structural(), structural_enabled);


### PR DESCRIPTION
## Summary
- **#5417 (duplication):** Extract the JSON-path accessors (`value_at`, `string_value`, `u64_value`, `usize_value`, `array_len`) that were copy-pasted across the `agent_task`, `bench`, and `runs` compact-summary modules into a single shared `commands::summary_json` module. This clears the duplicate-`usize_value` audit finding and also removes the parallel duplicate `value_at`/`string_value`/`array_len` bodies in the same modules (root-cause dedup, not just the flagged function).
- **#5415 (detector-agnostic leak in `upstream_workaround.rs`):** Already resolved on `main` by #5393 (the `fix-5378-upstream-agnostic` work that relocated the tracker-reference regexes and version-guard tokens into the agnostic `conventions.rs` home and dropped the stale baseline rows). After rebasing onto current `main`, no detector changes are needed here — the audit issue is stale and will reconcile closed.

## Validation
- `cargo fmt` clean.
- `cargo build --lib` passes (only pre-existing unrelated warnings).
- Full audit + command_contract validation left to CI.

Closes #5415
Closes #5417