### PR TITLE
fix(runner): remove unused daemon_api_post re-export breaking lint

### DIFF
--- a/src/core/runners.rs
+++ b/src/core/runners.rs
@@ -62,7 +62,7 @@ pub use super::runner::{
 // `pub use runner::*`. Keep them available so existing in-tree callers
 // (currently `commands::runs::remote`) compile, but do not expose them as
 // public API.
-pub(crate) use super::runner::{daemon_api_get, daemon_api_post};
+pub(crate) use super::runner::daemon_api_get;
 
 // ----------------------------------------------------------------------------
 // Explicit API groups


### PR DESCRIPTION
## Summary
- Removed the unused `daemon_api_post` from the `pub(crate)` re-export at `src/core/runners.rs:65`, which was breaking the Lint gate (`clippy -D warnings`) for every PR on main.

## Details
A recent merge removed the last caller of `daemon_api_post`. The only remaining reference to it via this re-export was the export itself, so clippy flagged it as `unused import`. `daemon_api_get` is still used (`commands::runs::remote`) and was kept.

```
-pub(crate) use super::runner::{daemon_api_get, daemon_api_post};
+pub(crate) use super::runner::daemon_api_get;
```

The function definition (`execution.rs`) and the separate `pub use` in `runner/mod.rs` are left intact (public API surface, not flagged).

## Validation
- `cargo clippy --lib` no longer emits the `daemon_api_post` unused-import warning; no clippy errors.
- `cargo fmt` clean (surgical single-line diff).