### PR TITLE
feat(artifacts): expose retrieval capability

### DIFF
--- a/docs/architecture/headless-daemon-api.md
+++ b/docs/architecture/headless-daemon-api.md
@@ -93,6 +93,7 @@ A useful headless UI can be built from this read/query surface:
 - `GET /stacks`, `GET /stacks/:id`, and `POST /stacks/:id/status` for stacked
   branch inspection
 - `GET /runs`, `GET /runs/:id`, `GET /runs/:id/artifacts`,
+  `GET /runs/:id/artifacts/sync`, `GET /runs/:id/artifacts/:artifact_id`,
   `GET /runs/:id/artifacts/:artifact_id/content`, and `GET /runs/:id/findings`
   for persisted evidence
 - `GET /audit/runs` and `GET /bench/runs` for analysis-specific run history
@@ -104,6 +105,15 @@ A useful headless UI can be built from this read/query surface:
 This is enough for a dashboard that lists components, shows selected checkout
 state, displays rigs/stacks, starts analysis jobs, streams progress, and renders
 structured final results.
+
+Artifact evidence is intentionally explicit about byte availability. Artifact
+metadata and sync payloads expose `content_available`, `content_url`,
+`fetch_command`, and `retrieval.mode`. Consumers fetch bytes only when
+`content_available` is `true`; `metadata_only` records are evidence pointers and
+must not trigger guessed runner paths or private filesystem probing. The
+transport-free API handler returns JSON with `retrieval.mode: inline_base64` and
+the bytes in `content_base64`; daemon artifact byte routes stream the file
+response directly when serving artifact responses.
 
 ## Job/Event Contract
 

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -92,6 +92,8 @@ contract and return the same JSON envelope shape as other daemon responses.
 - `GET /runs?kind=bench|audit&component=<id>&rig=<id>&status=<status>&limit=<n>`
 - `GET /runs/:id`
 - `GET /runs/:id/artifacts`
+- `GET /runs/:id/artifacts/sync`
+- `GET /runs/:id/artifacts/:artifact_id`
 - `GET /runs/:id/artifacts/:artifact_id/content`
 - `GET /runs/:id/findings?tool=<tool>&file=<path>&fingerprint=<id>&limit=<n>`
 - `GET /audit/runs?component=<id>&rig=<id>&status=<status>&limit=<n>`
@@ -113,6 +115,15 @@ The run readers expose persisted observation-store evidence from previous
 analysis runs. They do not start audit, lint, test, bench, rig, or stack work.
 Run summaries include `status_note` when a running record appears stale or
 cannot be verified with owner metadata, matching the CLI run-history output.
+
+Artifact list/sync responses include a byte-retrieval contract for each record:
+`content_available`, `content_url`, `fetch_command`, and `retrieval.mode`.
+`retrieval.mode: direct_download` means the daemon route can serve bytes and the
+CLI command can fetch them. `retrieval.mode: metadata_only` means orchestrators
+must treat the record as evidence metadata only; no byte endpoint is expected to
+work for that artifact. Daemon artifact byte routes stream the file response;
+the transport-free API handler reports inline byte payloads as
+`retrieval.mode: inline_base64` with `content_field: content_base64`.
 
 `homeboy runs compare --format=json` remains CLI-only for now. A daemon compare
 endpoint should reuse that implementation rather than duplicating comparison

--- a/docs/operators/controller-runner-reverse-runner.md
+++ b/docs/operators/controller-runner-reverse-runner.md
@@ -248,6 +248,14 @@ The controller broker API wraps every successful response as
 responses without `data.body` as malformed instead of falling back to direct
 `data` payload parsing.
 
+Reverse-broker artifact lookup is metadata-only in the current contract. Broker
+artifact metadata includes `retrieval.mode: metadata_only`,
+`content_available: false`, and no `content_url` or `fetch_command`. When those
+artifacts are mirrored into persisted run evidence, orchestrators should use the
+same fields to avoid guessing runner-local paths. Byte retrieval is available
+only from run artifact routes or CLI outputs that report `content_available` set
+to `true` with `retrieval.mode` set to `direct_download` or `inline_base64`.
+
 ## Troubleshooting
 
 | Symptom | Check | Likely fix |

--- a/src/core/daemon/artifact_download.rs
+++ b/src/core/daemon/artifact_download.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use crate::core::artifact_links::{public_artifact_url, viewer_links};
 use crate::core::error::{Error, Result};
-use crate::core::execution_contract::decode_uri_component;
+use crate::core::execution_contract::{decode_uri_component, encode_uri_component};
 use crate::core::observation::{ArtifactRecord, ObservationStore};
 use crate::core::paths;
 use crate::core::runner;
@@ -34,6 +34,9 @@ pub(crate) fn route(path: &str) -> Option<HttpResponse> {
         ["artifacts", artifact_token] => resolve_artifact_download(None, artifact_token),
         ["runs", run_id, "artifacts", "sync"] => artifact_sync_manifest(run_id),
         ["runs", run_id, "artifacts", artifact_token] => {
+            resolve_artifact_download(Some(run_id), artifact_token)
+        }
+        ["runs", run_id, "artifacts", artifact_token, "content"] => {
             resolve_artifact_download(Some(run_id), artifact_token)
         }
         _ => return None,
@@ -308,13 +311,22 @@ fn artifact_sync_manifest(run_id: &str) -> Result<ResolvedArtifactResponse> {
         .map(|artifact| {
             let public_url = public_artifact_url(&artifact);
             let viewer_links = viewer_links(&artifact, public_url.as_deref());
+            let retrieval = artifact_retrieval_contract(&artifact, Some(run_id));
             json!({
                 "id": artifact.id,
                 "path_token": artifact.id,
                 "run_id": artifact.run_id,
                 "kind": artifact.kind,
                 "type": artifact.artifact_type,
-                "download_path": format!("/runs/{}/artifacts/{}", run_id, artifact.id),
+                "content_available": retrieval["content_available"],
+                "content_url": retrieval["content_url"],
+                "fetch_command": retrieval["fetch_command"],
+                "retrieval": retrieval,
+                "download_path": format!(
+                    "/runs/{}/artifacts/{}",
+                    encode_uri_component(run_id),
+                    encode_uri_component(&artifact.id)
+                ),
                 "public_url": public_url,
                 "viewer_links": viewer_links,
                 "sha256": artifact.sha256,
@@ -340,12 +352,70 @@ fn artifact_metadata_body(
         "command": "api.runs.artifact.download",
         "artifact": artifact,
         "path_token": artifact.id,
+        "content_available": true,
+        "content_url": format!(
+            "/runs/{}/artifacts/{}/content",
+            encode_uri_component(&artifact.run_id),
+            encode_uri_component(&artifact.id)
+        ),
+        "fetch_command": format!(
+            "homeboy runs artifact get {} {} -o <path>",
+            shell_token(&artifact.run_id),
+            shell_token(&artifact.id)
+        ),
+        "retrieval": artifact_retrieval_contract(artifact, Some(&artifact.run_id)),
         "content_type": download.map(|download| download.content_type.clone()).or_else(|| artifact.mime.clone()),
         "size_bytes": download
             .and_then(|download| i64::try_from(download.size_bytes).ok())
             .or(artifact.size_bytes),
         "sha256": artifact.sha256,
     })
+}
+
+fn artifact_retrieval_contract(
+    artifact: &ArtifactRecord,
+    route_run_id: Option<&str>,
+) -> serde_json::Value {
+    let content_available = artifact.artifact_type == "file"
+        || artifact.artifact_type == "remote_file"
+        || runner::is_remote_runner_artifact_path(&artifact.path);
+    let run_id = route_run_id.unwrap_or(&artifact.run_id);
+    if content_available {
+        let content_url = format!(
+            "/runs/{}/artifacts/{}/content",
+            encode_uri_component(run_id),
+            encode_uri_component(&artifact.id)
+        );
+        json!({
+            "mode": "direct_download",
+            "content_available": true,
+            "content_url": content_url,
+            "fetch_command": format!(
+                "homeboy runs artifact get {} {} -o <path>",
+                shell_token(run_id),
+                shell_token(&artifact.id)
+            ),
+        })
+    } else {
+        json!({
+            "mode": "metadata_only",
+            "content_available": false,
+            "content_url": null,
+            "fetch_command": null,
+            "hint": "Artifact bytes are not available from this record; use artifact metadata only.",
+        })
+    }
+}
+
+fn shell_token(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':'))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
 }
 
 fn sanitize_header_value(value: &str) -> String {

--- a/src/core/daemon/remote_runner.rs
+++ b/src/core/daemon/remote_runner.rs
@@ -153,6 +153,8 @@ fn lookup_artifact(job_id: Uuid, artifact_id: &str, job_store: &JobStore) -> Res
         "retrieval": {
             "mode": "metadata_only",
             "content_available": false,
+            "content_url": null,
+            "fetch_command": null,
             "metadata_path": format!("/runner/jobs/{job_id}/artifacts/{artifact_id}"),
             "future_content_path": format!("/runner/jobs/{job_id}/artifacts/{artifact_id}/content"),
             "hint": "Reverse broker artifacts currently retain metadata only. Use runner-side artifact commands for bytes until broker content proxying lands."

--- a/src/core/http_api.rs
+++ b/src/core/http_api.rs
@@ -473,6 +473,8 @@ fn artifact_content(run_id: &str, artifact_id: &str) -> Result<Value> {
                 "command": "api.runs.artifact.content",
                 "run_id": run_id,
                 "artifact_id": artifact.id,
+                "content_available": true,
+                "retrieval": inline_content_retrieval(),
                 "filename": filename,
                 "mime": download.content_type.or_else(|| artifact.mime.clone()),
                 "size_bytes": size_bytes,
@@ -505,6 +507,8 @@ fn artifact_content(run_id: &str, artifact_id: &str) -> Result<Value> {
         "command": "api.runs.artifact.content",
         "run_id": run_id,
         "artifact_id": artifact.id,
+        "content_available": true,
+        "retrieval": inline_content_retrieval(),
         "filename": filename,
         "mime": artifact.mime,
         "size_bytes": artifact.size_bytes,
@@ -544,12 +548,23 @@ fn artifact_store_content(
         "command": "api.runs.artifact.content",
         "run_id": run_id,
         "artifact_id": artifact_id,
+        "content_available": true,
+        "retrieval": inline_content_retrieval(),
         "filename": filename,
         "mime": crate::core::artifact_metadata::content_type_from_path(&path),
         "size_bytes": size_bytes,
         "sha256": sha256,
         "content_base64": base64::engine::general_purpose::STANDARD.encode(content),
     }))
+}
+
+fn inline_content_retrieval() -> Value {
+    json!({
+        "mode": "inline_base64",
+        "content_available": true,
+        "content_field": "content_base64",
+        "encoding": "base64",
+    })
 }
 
 fn safe_artifact_store_path(locator: &str) -> Result<std::path::PathBuf> {

--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -528,9 +528,12 @@ fn reverse_broker_artifact_record(
                 job.id,
                 encode_uri_component(&artifact.id)
             ),
+            "content_available": false,
             "broker_artifact_retrieval": {
                 "mode": "metadata_only",
                 "content_available": false,
+                "content_url": null,
+                "fetch_command": null,
                 "hint": "Reverse broker artifact mirroring preserves metadata only; broker byte retrieval is a future content-proxy slice."
             },
             "metadata": artifact.metadata.clone(),

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::core::api_jobs::{JobEventKind, JobStatus, JobStore};
-use crate::core::observation::{NewRunRecord, ObservationStore};
+use crate::core::observation::{ArtifactRecord, NewRunRecord, ObservationStore};
 use crate::test_support::HomeGuard;
 
 const DAEMON_TEST_RESPONSE_LIMIT_BYTES: u64 = 64 * 1024;
@@ -251,6 +251,25 @@ fn routes_registered_artifact_downloads_and_sync_manifest() {
     let artifact = store
         .record_artifact(&run.id, "bench_results", &artifact_path)
         .expect("record artifact");
+    let metadata_only = ArtifactRecord {
+        id: "exported-summary".to_string(),
+        run_id: run.id.clone(),
+        kind: "summary".to_string(),
+        artifact_type: "metadata-only".to_string(),
+        path: "metadata-only:exported-summary".to_string(),
+        url: None,
+        public_url: None,
+        viewer_url: None,
+        viewer_links: Vec::new(),
+        sha256: None,
+        size_bytes: Some(11),
+        mime: Some("application/json".to_string()),
+        metadata_json: serde_json::json!({}),
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    store
+        .import_artifact(&metadata_only)
+        .expect("metadata-only artifact");
 
     let download = route(
         "GET",
@@ -259,17 +278,41 @@ fn routes_registered_artifact_downloads_and_sync_manifest() {
     assert_eq!(download.status_code, 200);
     assert!(download.artifact.is_some());
     assert_eq!(download.body["artifact"]["id"], artifact.id);
+    assert_eq!(download.body["content_available"], true);
+    assert_eq!(download.body["retrieval"]["mode"], "direct_download");
+    assert_eq!(
+        download.body["content_url"],
+        format!("/runs/{}/artifacts/{}/content", run.id, artifact.id)
+    );
     assert_eq!(download.body["size_bytes"], 11);
+
+    let content_alias = route(
+        "GET",
+        &format!("/runs/{}/artifacts/{}/content", run.id, artifact.id),
+    );
+    assert_eq!(content_alias.status_code, 200);
+    assert!(content_alias.artifact.is_some());
 
     let sync = route("GET", &format!("/runs/{}/artifacts/sync", run.id));
     assert_eq!(sync.status_code, 200);
     assert!(sync.artifact.is_none());
     assert_eq!(sync.body["command"], "api.runs.artifacts.sync");
     assert_eq!(sync.body["artifacts"][0]["id"], artifact.id);
+    assert_eq!(sync.body["artifacts"][0]["content_available"], true);
+    assert_eq!(sync.body["artifacts"][0]["retrieval"]["mode"], "direct_download");
     assert_eq!(
         sync.body["artifacts"][0]["download_path"],
         format!("/runs/{}/artifacts/{}", run.id, artifact.id)
     );
+    let metadata_artifact = sync.body["artifacts"]
+        .as_array()
+        .expect("artifact array")
+        .iter()
+        .find(|artifact| artifact["id"] == "exported-summary")
+        .expect("metadata-only artifact");
+    assert_eq!(metadata_artifact["content_available"], false);
+    assert_eq!(metadata_artifact["content_url"], serde_json::Value::Null);
+    assert_eq!(metadata_artifact["retrieval"]["mode"], "metadata_only");
 
     let raw_path = route(
         "GET",

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -483,6 +483,9 @@ fn artifact_content_serves_encoded_artifact_store_locator() {
         assert_eq!(response.body["filename"], "blueprint.after.json");
         assert_eq!(response.body["mime"], "application/json");
         assert_eq!(response.body["size_bytes"], 12);
+        assert_eq!(response.body["content_available"], true);
+        assert_eq!(response.body["retrieval"]["mode"], "inline_base64");
+        assert_eq!(response.body["retrieval"]["content_field"], "content_base64");
         assert_eq!(
             response.body["content_base64"].as_str(),
             Some("eyJzdGVwcyI6W119")
@@ -538,6 +541,8 @@ fn artifact_content_serves_percent_encoded_stored_artifact_ids() {
 
         assert_eq!(response.endpoint, "runs.artifact.content");
         assert_eq!(response.body["artifact_id"], artifact.id);
+        assert_eq!(response.body["content_available"], true);
+        assert_eq!(response.body["retrieval"]["mode"], "inline_base64");
         assert_eq!(response.body["filename"], "summary.json");
     });
 }


### PR DESCRIPTION
## Summary
- Add explicit artifact retrieval capability metadata to daemon and reverse artifact responses.
- Add documented daemon content alias for run artifacts.
- Keep reverse broker artifacts metadata-only while making that contract explicit.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and tests; Chris remains responsible for review and merge.