### PR TITLE
feat(release): add phase metadata

### DIFF
--- a/src/commands/golden_contract_tests.rs
+++ b/src/commands/golden_contract_tests.rs
@@ -31,7 +31,7 @@ use crate::core::extension::bench::{BenchCommandOutput, BenchListWorkflowResult}
 use crate::core::observation::ArtifactRecord;
 use crate::core::release::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseCommandResult,
-    ReleasePlan, ReleaseSemverCommit, ReleaseSemverRecommendation,
+    ReleasePhase, ReleasePlan, ReleaseSemverCommit, ReleaseSemverRecommendation,
 };
 use crate::core::stack::{
     GitRef, InspectCommit, InspectCommitDetails, InspectOutput, InspectPr, LocalState,
@@ -454,6 +454,11 @@ fn release_result(
     ReleaseCommandResult {
         component_id: component_id.to_string(),
         status: if dry_run { "planned" } else { "released" }.to_string(),
+        phase: if dry_run {
+            ReleasePhase::Plan
+        } else {
+            ReleasePhase::Publish
+        },
         bump_type: bump_type.to_string(),
         dry_run,
         releasable_commits: 1,

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -27,9 +27,9 @@ pub use planner::plan;
 pub use types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseArtifact,
     ReleaseCommandInput, ReleaseCommandResult, ReleaseDeploymentResult, ReleaseDeploymentSummary,
-    ReleaseOptions, ReleasePipelineOptions, ReleasePlan, ReleaseProjectDeployResult, ReleaseRun,
-    ReleaseRunResult, ReleaseRunSummary, ReleaseSemverCommit, ReleaseSemverRecommendation,
-    ReleaseStepResult, ReleaseStepStatus,
+    ReleaseOptions, ReleasePhase, ReleasePipelineOptions, ReleasePlan, ReleaseProjectDeployResult,
+    ReleaseRun, ReleaseRunResult, ReleaseRunSummary, ReleaseSemverCommit,
+    ReleaseSemverRecommendation, ReleaseStepResult, ReleaseStepStatus,
 };
 pub use utils::{extract_latest_notes, parse_release_artifacts};
 pub use workflow::{run_batch, run_command, SKIPPED_RELEASE_EXIT_CODE};

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -353,6 +353,16 @@ pub struct ReleaseDeploymentSummary {
     pub planned: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReleasePhase {
+    Plan,
+    Prepare,
+    Publish,
+    Recover,
+    Deploy,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseProjectDeployResult {
     pub project_id: String,
@@ -373,6 +383,7 @@ pub struct ReleaseDeploymentResult {
 pub struct ReleaseCommandResult {
     pub component_id: String,
     pub status: String,
+    pub phase: ReleasePhase,
     pub bump_type: String,
     pub dry_run: bool,
     pub releasable_commits: usize,

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -5,8 +5,8 @@ use crate::core::plan::PlanStep;
 use super::context::load_component;
 use super::types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseBumpPolicyOptions,
-    ReleaseCommandInput, ReleaseCommandResult, ReleaseOptions, ReleasePlan, ReleaseRun,
-    ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus,
+    ReleaseCommandInput, ReleaseCommandResult, ReleaseOptions, ReleasePhase, ReleasePlan,
+    ReleaseRun, ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus,
 };
 
 /// Process exit code returned when a release is intentionally skipped (no tag,
@@ -18,6 +18,20 @@ use super::types::{
 /// release reports `success: false` while the data payload still carries
 /// `status: "skipped"` + `skipped_reason` + an actionable force hint (issue #4316).
 pub const SKIPPED_RELEASE_EXIT_CODE: i32 = 5;
+
+fn release_phase(input: &ReleaseCommandInput) -> ReleasePhase {
+    if input.recover {
+        ReleasePhase::Recover
+    } else if input.dry_run {
+        ReleasePhase::Plan
+    } else if input.pipeline.deploy {
+        ReleasePhase::Deploy
+    } else if input.pipeline.skip_publish {
+        ReleasePhase::Prepare
+    } else {
+        ReleasePhase::Publish
+    }
+}
 
 pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32)> {
     if input.recover {
@@ -169,6 +183,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
             let release_summary = release_summary_from_run(&run);
             return Ok((
                 ReleaseCommandResult {
+                    phase: release_phase(&input),
                     component_id: input.component_id,
                     status,
                     bump_type,
@@ -201,6 +216,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
 
         return Ok((
             ReleaseCommandResult {
+                phase: release_phase(&input),
                 component_id: input.component_id,
                 status: release_command_status(true, skipped_reason.as_deref(), None),
                 bump_type,
@@ -272,6 +288,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
 
     Ok((
         ReleaseCommandResult {
+            phase: release_phase(&input),
             component_id: input.component_id,
             status: release_command_status(false, skipped_reason.as_deref(), Some(&run_result)),
             bump_type,
@@ -795,6 +812,7 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
             ReleaseCommandResult {
                 component_id: input.component_id.clone(),
                 status: "recovered".to_string(),
+                phase: release_phase(input),
                 bump_type: "recover".to_string(),
                 dry_run: false,
                 releasable_commits: 0,
@@ -950,6 +968,7 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
             } else {
                 "recovered".to_string()
             },
+            phase: release_phase(input),
             bump_type: "recover".to_string(),
             dry_run: false,
             releasable_commits: 0,
@@ -1700,5 +1719,24 @@ mod tests {
         run_in(dir, &["git", "tag", "v0.7.4"]);
 
         assert!(diagnose_orphan_tag(&dir.to_string_lossy(), "v0.7.4").is_none());
+    }
+
+    #[test]
+    fn release_phase_maps_current_modes() {
+        let mut input = ReleaseCommandInput::default();
+        assert_eq!(release_phase(&input), ReleasePhase::Publish);
+
+        input.dry_run = true;
+        assert_eq!(release_phase(&input), ReleasePhase::Plan);
+
+        input.dry_run = false;
+        input.pipeline.skip_publish = true;
+        assert_eq!(release_phase(&input), ReleasePhase::Prepare);
+
+        input.pipeline.deploy = true;
+        assert_eq!(release_phase(&input), ReleasePhase::Deploy);
+
+        input.recover = true;
+        assert_eq!(release_phase(&input), ReleasePhase::Recover);
     }
 }

--- a/tests/fixtures/golden_json_contracts/release_contract.json
+++ b/tests/fixtures/golden_json_contracts/release_contract.json
@@ -10,6 +10,7 @@
             "component_id": "homeboy",
             "dry_run": true,
             "new_version": "0.198.0",
+            "phase": "plan",
             "plan": {
               "component_id": "homeboy",
               "enabled": true,
@@ -92,6 +93,7 @@
                   "component_id": "homeboy",
                   "dry_run": true,
                   "new_version": "0.198.0",
+                  "phase": "plan",
                   "plan": {
                     "component_id": "homeboy",
                     "enabled": true,


### PR DESCRIPTION
## Summary
- Add typed release phase metadata to release command results.
- Map existing flows to plan, prepare, publish, recover, and deploy phases.
- Preserve existing release CLI behavior.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt, jq, and diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and PR text; Chris remains responsible for review and merge.