### PR TITLE
test(config): harden cache invalidation

### DIFF
--- a/src/commands/utils/entity_suggest.rs
+++ b/src/commands/utils/entity_suggest.rs
@@ -2,7 +2,7 @@
 
 use homeboy::core::engine::text::levenshtein;
 use homeboy::core::{component, extension, project, server};
-use std::sync::OnceLock;
+use std::sync::{OnceLock, RwLock};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EntityType {
@@ -36,33 +36,59 @@ struct EntityIdList {
     ids: Vec<String>,
 }
 
-static ENTITY_SUGGESTION_SNAPSHOT: OnceLock<Vec<EntityIdList>> = OnceLock::new();
+static ENTITY_SUGGESTION_SNAPSHOT: OnceLock<RwLock<Option<Vec<EntityIdList>>>> = OnceLock::new();
 
-fn entity_suggestion_snapshot() -> &'static [EntityIdList] {
-    ENTITY_SUGGESTION_SNAPSHOT.get_or_init(|| {
-        vec![
-            EntityIdList {
-                entity_type: EntityType::Component,
-                ids: component::list_ids().unwrap_or_default(),
-            },
-            EntityIdList {
-                entity_type: EntityType::Project,
-                ids: project::list_ids().unwrap_or_default(),
-            },
-            EntityIdList {
-                entity_type: EntityType::Server,
-                ids: server::list()
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|server| server.id)
-                    .collect(),
-            },
-            EntityIdList {
-                entity_type: EntityType::Extension,
-                ids: extension::available_extension_ids(),
-            },
-        ]
-    })
+fn entity_suggestion_cache() -> &'static RwLock<Option<Vec<EntityIdList>>> {
+    ENTITY_SUGGESTION_SNAPSHOT.get_or_init(|| RwLock::new(None))
+}
+
+fn load_entity_suggestion_snapshot() -> Vec<EntityIdList> {
+    vec![
+        EntityIdList {
+            entity_type: EntityType::Component,
+            ids: component::list_ids().unwrap_or_default(),
+        },
+        EntityIdList {
+            entity_type: EntityType::Project,
+            ids: project::list_ids().unwrap_or_default(),
+        },
+        EntityIdList {
+            entity_type: EntityType::Server,
+            ids: server::list()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|server| server.id)
+                .collect(),
+        },
+        EntityIdList {
+            entity_type: EntityType::Extension,
+            ids: extension::available_extension_ids(),
+        },
+    ]
+}
+
+fn entity_suggestion_snapshot() -> Vec<EntityIdList> {
+    if let Some(snapshot) = match entity_suggestion_cache().read() {
+        Ok(slot) => slot.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    } {
+        return snapshot;
+    }
+
+    let snapshot = load_entity_suggestion_snapshot();
+    match entity_suggestion_cache().write() {
+        Ok(mut slot) => *slot = Some(snapshot.clone()),
+        Err(poisoned) => *poisoned.into_inner() = Some(snapshot.clone()),
+    }
+    snapshot
+}
+
+#[cfg(test)]
+pub(crate) fn reset_entity_suggestion_cache_for_test() {
+    match entity_suggestion_cache().write() {
+        Ok(mut slot) => *slot = None,
+        Err(poisoned) => *poisoned.into_inner() = None,
+    }
 }
 
 pub fn find_entity_match(input: &str) -> Option<EntityMatch> {
@@ -155,4 +181,30 @@ pub fn generate_entity_hints(
     }
 
     hints
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::with_isolated_home;
+    use homeboy::core::project::{self, Project};
+
+    #[test]
+    fn isolated_home_guard_resets_entity_suggestion_cache_between_homes() {
+        with_isolated_home(|_| {
+            project::save(&Project {
+                id: "cached-project".to_string(),
+                ..Project::default()
+            })
+            .expect("save project");
+
+            let matched = find_entity_match("cached-project").expect("project match");
+            assert_eq!(matched.entity_type, EntityType::Project);
+            assert_eq!(matched.entity_id, "cached-project");
+        });
+
+        with_isolated_home(|_| {
+            assert!(find_entity_match("cached-project").is_none());
+        });
+    }
 }

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -658,6 +658,67 @@ mod tests {
     }
 
     #[test]
+    fn load_config_cache_refreshes_after_save_config() {
+        with_isolated_home(|_| {
+            let cached_default = load_config();
+            assert!(!cached_default.settings.contains_key("cache_marker"));
+
+            save_config(&HomeboyConfig {
+                settings: HashMap::from([("cache_marker".to_string(), serde_json::json!("saved"))]),
+                ..HomeboyConfig::default()
+            })
+            .expect("save config");
+
+            let loaded = load_config();
+            assert_eq!(loaded.settings["cache_marker"], "saved");
+        });
+    }
+
+    #[test]
+    fn reset_config_clears_cached_config() {
+        with_isolated_home(|_| {
+            save_config(&HomeboyConfig {
+                settings: HashMap::from([(
+                    "cache_marker".to_string(),
+                    serde_json::json!("before-reset"),
+                )]),
+                ..HomeboyConfig::default()
+            })
+            .expect("save config");
+
+            let cached = load_config();
+            assert_eq!(cached.settings["cache_marker"], "before-reset");
+
+            assert!(reset_config().expect("reset config"));
+
+            let loaded = load_config();
+            assert!(!loaded.settings.contains_key("cache_marker"));
+        });
+    }
+
+    #[test]
+    fn isolated_home_guard_resets_config_cache_between_homes() {
+        with_isolated_home(|_| {
+            save_config(&HomeboyConfig {
+                settings: HashMap::from([(
+                    "cache_marker".to_string(),
+                    serde_json::json!("first-home"),
+                )]),
+                ..HomeboyConfig::default()
+            })
+            .expect("save first home config");
+
+            let loaded = load_config();
+            assert_eq!(loaded.settings["cache_marker"], "first-home");
+        });
+
+        with_isolated_home(|_| {
+            let loaded = load_config();
+            assert!(!loaded.settings.contains_key("cache_marker"));
+        });
+    }
+
+    #[test]
     fn homeboy_config_leaves_triage_priority_labels_unset_by_default() {
         let config = HomeboyConfig::default();
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -54,6 +54,7 @@ impl HomeGuard {
     pub(crate) fn new() -> Self {
         let guard = home_lock().lock().unwrap_or_else(|e| e.into_inner());
         crate::core::defaults::reset_config_cache_for_test();
+        crate::commands::utils::entity_suggest::reset_entity_suggestion_cache_for_test();
         let prior = std::env::var("HOME").ok();
         let prior_xdg_data_home = std::env::var("XDG_DATA_HOME").ok();
         let prior_artifact_root = std::env::var("HOMEBOY_ARTIFACT_ROOT").ok();
@@ -139,6 +140,7 @@ impl Drop for HomeGuard {
             ),
         }
         crate::core::defaults::reset_config_cache_for_test();
+        crate::commands::utils::entity_suggest::reset_entity_suggestion_cache_for_test();
     }
 }
 


### PR DESCRIPTION
## Summary
- Add tests for config cache refresh after save and clear after reset.
- Reset config and entity suggestion caches around isolated HOME guards.
- Add a test-only entity suggestion cache reset helper.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt and diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and tests; Chris remains responsible for review and merge.