### PR TITLE
test(cli): ratchet safety surfaces

### DIFF
--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -246,6 +246,64 @@ fn command_safety_manifest_docs_paths_match_command_docs() {
 }
 
 #[test]
+fn visible_safety_manifest_entries_advertise_live_command_docs() {
+    let manifest = current_command_safety_manifest();
+
+    for entry in all_safety_entries(&manifest.commands) {
+        if entry.hidden {
+            continue;
+        }
+
+        let path = entry
+            .docs
+            .path
+            .as_deref()
+            .unwrap_or_else(|| panic!("visible command {:?} is missing docs metadata", entry.path));
+        let top_level = entry.path.first().expect("safety path should not be empty");
+        assert_eq!(
+            path,
+            format!("docs/commands/{top_level}.md"),
+            "visible command {:?} should point at its top-level command doc",
+            entry.path
+        );
+        assert!(
+            command_doc_manifest_path(path).is_file(),
+            "visible command {:?} advertises `{path}` in the safety manifest, but that file is missing",
+            entry.path
+        );
+    }
+}
+
+#[test]
+fn mutating_safety_manifest_entries_advertise_apply_or_are_allowlisted() {
+    let manifest = current_command_safety_manifest();
+    let explicit_no_apply_surface = BTreeSet::from([
+        "file mkdir".to_string(),
+        "file rename".to_string(),
+        "triage".to_string(),
+    ]);
+
+    let missing_safety_surface: Vec<_> = all_safety_entries(&manifest.commands)
+        .into_iter()
+        .filter(|entry| entry.mutates)
+        .filter(|entry| {
+            !entry.dry_run.supported
+                && !entry.output.notes.contains("--apply")
+                && !entry.output.notes.contains("--dry-run")
+                && !entry.output.notes.contains("--check")
+                && !entry.dangerous_flags.iter().any(|flag| flag == "--apply")
+                && !explicit_no_apply_surface.contains(&entry.path.join(" "))
+        })
+        .map(|entry| entry.path.join(" "))
+        .collect();
+
+    assert!(
+        missing_safety_surface.is_empty(),
+        "mutating safety-manifest entries must advertise dry-run/apply/check metadata or be explicitly allowlisted: {missing_safety_surface:?}"
+    );
+}
+
+#[test]
 fn command_docs_files_match_command_index_snapshot() {
     let documented = documented_command_index_entries();
     let companion_topics = BTreeSet::from([
@@ -510,6 +568,15 @@ fn documented_command_doc_files() -> BTreeSet<String> {
 
 fn visible_manifest_entry_with_docs_path(entry: &CommandSafetyEntry) -> bool {
     !entry.hidden && entry.docs.path.is_some()
+}
+
+fn all_safety_entries(entries: &[CommandSafetyEntry]) -> Vec<&CommandSafetyEntry> {
+    let mut flattened = Vec::new();
+    for entry in entries {
+        flattened.push(entry);
+        flattened.extend(all_safety_entries(&entry.subcommands));
+    }
+    flattened
 }
 
 fn command_doc_manifest_path(path: &str) -> std::path::PathBuf {

--- a/tests/output_contracts_test.rs
+++ b/tests/output_contracts_test.rs
@@ -1,6 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use homeboy::cli_surface::current_command_surface;
+use homeboy::command_contract::{
+    registered_command_json_family, CommandJsonFamily, PUBLIC_OUTPUT_VARIANT_CONTRACTS,
+};
 use homeboy::commands::bench::BenchOutput;
 use homeboy::commands::extension::{ExtensionDetail, ExtensionOutput};
 use homeboy::commands::rig::RigCommandOutput;
@@ -33,6 +36,7 @@ use serde::Serialize;
 use serde_json::{json, Value};
 
 const REQUIRED_QUALITY_COMMAND_FIXTURES: &[&str] = &["audit", "lint", "review", "test"];
+const REQUIRED_OPS_VARIANT_COMMANDS: &[&str] = &["db", "deploy"];
 
 struct OutputContractScenario {
     command: &'static str,
@@ -62,6 +66,31 @@ fn visible_quality_commands_have_declared_golden_json_contract_fixtures() {
         assert!(
             covered.contains(command),
             "missing golden JSON output contract fixture for visible quality command: {command}"
+        );
+    }
+}
+
+#[test]
+fn public_output_variant_contracts_cover_known_ops_command_families() {
+    let surface = current_command_surface();
+    let covered: BTreeSet<_> = PUBLIC_OUTPUT_VARIANT_CONTRACTS
+        .iter()
+        .map(|contract| contract.command)
+        .collect();
+
+    for command in REQUIRED_OPS_VARIANT_COMMANDS {
+        assert!(
+            surface.contains_path(&[*command]),
+            "required ops output variant command is not visible in the CLI surface: {command}"
+        );
+        assert_eq!(
+            registered_command_json_family(command),
+            Some(CommandJsonFamily::Ops),
+            "required output variant command should stay routed through the ops JSON family: {command}"
+        );
+        assert!(
+            covered.contains(command),
+            "missing public output variant contract for ops command family: {command}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Ratchet visible command docs path coverage through the safety manifest.
- Require mutating safety entries to advertise guard metadata or be allowlisted.
- Ratchet public output variant coverage for known ops families.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and tests; Chris remains responsible for review and merge.