### PR TITLE
Closes #5413

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -119,6 +119,8 @@
     },
     "convention_exception_globs": [
       "src/commands/adapter.rs",
+      "src/commands/agent_task_summary.rs",
+      "src/commands/output_runtime.rs",
       "src/core/code_audit/detectors/test_coverage.rs",
       "src/core/code_audit/detectors/test_vacuity.rs",
       "src/core/code_audit/detectors/upstream_workaround.rs"
@@ -490,10 +492,8 @@
     "audit": {
       "context_id": "homeboy",
       "created_at": "2026-06-19T16:45:00Z",
-      "item_count": 409,
+      "item_count": 407,
       "known_fingerprints": [
-        "Commands::src/commands/agent_task_summary.rs::NamingMismatch",
-        "Commands::src/commands/output_runtime.rs::NamingMismatch",
         "compiler::src/core/deploy/planning.rs::CompilerWarning",
         "compiler::src/core/extension/test/run.rs::CompilerWarning",
         "core_boundary_leak:core-agnostic-source::src/core/code_audit/codebase_map.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `WooCommerce` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",


### PR DESCRIPTION
## Summary
Resolves the 2 **Commands** audit `naming_mismatch` findings (#5413):
- `src/commands/output_runtime.rs` — `JsonCommandRun` does not match the `Args` suffix convention
- `src/commands/agent_task_summary.rs` — `AgentTaskSummaryKind` does not match the `Args` suffix convention

## Why these were flagged
The `Commands` group's detected naming convention suffix is `Args` (most command files declare `*Args` structs). The audit marks a file "helper-like" when *none* of its declared types match that suffix. Both flagged files are genuine output/summary helpers — not CLI argument structs — so forcing an `Args` suffix would be wrong.

## Fix
Both findings were previously carried as stale entries in the audit baseline (`known_fingerprints`). Replaced that with the established structural exemption used for other command helpers (e.g. `src/commands/adapter.rs`):
- Added both files to `convention_exception_globs` in `homeboy.json`, which suppresses convention deviations at the source.
- Removed the two now-redundant baseline `known_fingerprints` rows and decremented `item_count` accordingly.

Pure config change — no command code touched, so `command_contract` / `golden_contract` behavior is unchanged.

Closes #5413