### PR TITLE
fix(runner): remote-exec path-translation + capability preflight (#5422)

### DIFF
--- a/src/core/runner/execution.rs
+++ b/src/core/runner/execution.rs
@@ -41,7 +41,7 @@ pub(crate) const RUNNER_HOSTED_EXEC_ENV: &str = "HOMEBOY_RUNNER_HOSTED_EXEC";
 mod extension_parity;
 mod policy;
 use extension_parity::{required_extensions_for_command, validate_runner_extension_parity};
-use policy::{validate_runner_policy, RunnerPolicyRequest};
+use policy::{remote_execution_preflight, validate_runner_policy, RunnerPolicyRequest};
 
 #[derive(Debug, Clone)]
 pub struct RunnerExecOptions {
@@ -183,12 +183,14 @@ pub fn exec(runner_id: &str, options: RunnerExecOptions) -> Result<(RunnerExecOu
 
     validate_runner_extension_parity(runner_id, &runner, &cwd, &required_extensions)?;
 
+    // Remote capability-parity preflight: derive the contract from the command's
+    // top-level executable when the caller did not supply an explicit one, so
+    // remote dispatch always validates that the runner can satisfy the command
+    // before starting execution instead of failing mid-run (#5093, #5422).
+    let capability_preflight =
+        remote_execution_preflight(&options.command, options.capability_preflight.as_ref());
     let run_capability_preflight = |runner: &Runner| -> Result<()> {
-        preflight_runner_capability_plan(
-            runner,
-            options.capability_preflight.as_ref(),
-            &request_env,
-        )
+        preflight_runner_capability_plan(runner, capability_preflight.as_ref(), &request_env)
     };
 
     if should_force_diagnostic_ssh(&runner, &options) {

--- a/src/core/runner/execution/policy.rs
+++ b/src/core/runner/execution/policy.rs
@@ -2,9 +2,45 @@ use serde_json::json;
 
 use crate::core::error::{Error, ErrorCode, Result};
 
-use crate::core::runner::{Runner, RunnerKind};
+use crate::core::runner::{Runner, RunnerCapabilityPreflight, RunnerKind};
 
 use super::{trim_trailing_slashes, RunnerExecOptions};
+
+/// Derive the remote capability-parity preflight for a runner dispatch.
+///
+/// Remote execution dispatch must validate that the runner can satisfy the
+/// command's top-level executable before starting execution, so a missing tool
+/// fails before remote dispatch instead of mid-run. When the caller has already
+/// supplied an explicit capability preflight (e.g. rig install requiring the
+/// `homeboy` tool), that contract is preserved unchanged; otherwise a contract
+/// is derived from the command's first argv element. `exec` no-ops this gate for
+/// local runners and SSH runners that already advertise the executable, so it is
+/// behavior-preserving on a provisioned runner and fails loudly otherwise
+/// (#5093, #5422).
+pub(super) fn remote_execution_preflight(
+    command: &[String],
+    explicit: Option<&RunnerCapabilityPreflight>,
+) -> Option<RunnerCapabilityPreflight> {
+    if let Some(explicit) = explicit {
+        return Some(explicit.clone());
+    }
+
+    let required_commands: Vec<String> = command
+        .first()
+        .filter(|program| !program.trim().is_empty())
+        .cloned()
+        .into_iter()
+        .collect();
+    if required_commands.is_empty() {
+        return None;
+    }
+
+    Some(RunnerCapabilityPreflight {
+        command: "runner.exec".to_string(),
+        required_commands,
+        ..Default::default()
+    })
+}
 
 pub(super) struct RunnerPolicyRequest<'a> {
     pub(super) project_id: Option<&'a str>,

--- a/src/core/runner/lab_workspaces.rs
+++ b/src/core/runner/lab_workspaces.rs
@@ -8,8 +8,9 @@ use crate::core::component::{self, TargetSpec};
 use crate::core::{Error, Result};
 
 use super::{
-    exec, sync_workspace, workspace::git_output, RunnerExecOptions,
-    RunnerGitDependencyMaterializationOutput, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+    exec, preflight_remote_argv_path_translation, sync_workspace, workspace::git_output,
+    RunnerCapabilityPreflight, RunnerExecOptions, RunnerGitDependencyMaterializationOutput,
+    RunnerRequiredTool, RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
     RunnerWorkspaceSyncOutput,
 };
 
@@ -77,7 +78,11 @@ pub(super) fn sync_extra_lab_workspaces(
         .0;
         let entry = workspace_mapping_entry(&extra.role, &synced);
         if extra.bootstrap_node_dependencies {
-            bootstrap_source_cli_node_dependencies(runner_id, &synced.remote_path)?;
+            bootstrap_source_cli_node_dependencies(
+                runner_id,
+                &synced.local_path,
+                &synced.remote_path,
+            )?;
         }
         workspace_mapping.push(entry.clone());
         synced_entries.push(entry);
@@ -887,25 +892,66 @@ fn source_cli_workspace_has_package_lock(file_path: &Path) -> bool {
         .is_some_and(|workspace| workspace.join("package-lock.json").is_file())
 }
 
-fn bootstrap_source_cli_node_dependencies(runner_id: &str, remote_path: &str) -> Result<()> {
+/// Capability-parity contract for the runner-side source-CLI dependency
+/// bootstrap. The `npm ci` install is executed by the runner's Node toolchain,
+/// so the runner must expose the `node` and `npm` tools. `exec` short-circuits
+/// this preflight for local runners and for SSH runners that already advertise
+/// the tools, so it is behavior-preserving on a provisioned runner and fails
+/// loudly before a remote run that would otherwise error mid-dispatch (#5422).
+fn source_cli_bootstrap_capability_preflight() -> RunnerCapabilityPreflight {
+    RunnerCapabilityPreflight {
+        command: "lab.source_cli_bootstrap".to_string(),
+        required_tools: vec![RunnerRequiredTool::Node, RunnerRequiredTool::Npm],
+        required_commands: Vec::new(),
+        required_components: Vec::new(),
+        required_env: Vec::new(),
+    }
+}
+
+fn bootstrap_source_cli_node_dependencies(
+    runner_id: &str,
+    local_path: &str,
+    remote_path: &str,
+) -> Result<()> {
+    let command = vec![
+        "npm".to_string(),
+        "ci".to_string(),
+        "--omit=dev".to_string(),
+        "--ignore-scripts".to_string(),
+    ];
+
+    // Path-translation preflight: the source-built CLI workspace has already been
+    // synced to a runner-side remote path; the dependency install runs with the
+    // remote workspace as cwd. Assert that no controller-local workspace path
+    // survived un-translated into the dispatched argv before handing it to the
+    // remote runner, so a missed remap fails loudly here instead of installing
+    // against a non-existent local path (#5422).
+    preflight_remote_argv_path_translation(
+        "Lab source-CLI dependency bootstrap",
+        runner_id,
+        &command,
+        Path::new(local_path),
+        remote_path,
+    )?;
+
     let (output, exit_code) = exec(
         runner_id,
         RunnerExecOptions {
             cwd: Some(remote_path.to_string()),
             project_id: None,
             allow_diagnostic_ssh: false,
-            command: vec![
-                "npm".to_string(),
-                "ci".to_string(),
-                "--omit=dev".to_string(),
-                "--ignore-scripts".to_string(),
-            ],
+            command,
             env: HashMap::new(),
             secret_env_names: Vec::new(),
             capture_patch: false,
             raw_exec: true,
             source_snapshot: None,
-            capability_preflight: None,
+            // Validate remote capability parity before dispatch: the bootstrap is
+            // executed by the runner-side `npm`/`node` toolchain, so require those
+            // tools on the runner. `exec` no-ops this gate for local and
+            // already-capable SSH runners, so behavior is unchanged on a correctly
+            // provisioned runner and fails early otherwise (#5422).
+            capability_preflight: Some(source_cli_bootstrap_capability_preflight()),
             required_extensions: Vec::new(),
             require_paths: Vec::new(),
         },


### PR DESCRIPTION
## Summary
Closes #5422.

Adds the missing **path-translation preflight** and **remote-capability-parity validation** before remote execution dispatch at the two flagged sites, mirroring the established preflight pattern from prior waves (`rig_materialization.rs` #5285, `lab/offload.rs` #5071, `route.rs`/`worker.rs` #5093).

## Changes
- **`src/core/runner/execution/policy.rs`** — new `remote_execution_preflight` helper derives a capability-parity `RunnerCapabilityPreflight` from the command's top-level executable when the caller did not supply an explicit one (preserves explicit contracts, e.g. rig install requiring `homeboy`).
- **`src/core/runner/execution.rs`** — `exec` now runs `remote_execution_preflight` so remote dispatch always validates the runner can satisfy the command before starting execution instead of failing mid-run. `exec` already no-ops the gate for local / already-capable SSH runners, so behavior is unchanged on a provisioned runner.
- **`src/core/runner/lab_workspaces.rs`** — `bootstrap_source_cli_node_dependencies` now:
  - runs `preflight_remote_argv_path_translation` against the synced workspace local→remote paths before dispatching the `npm ci`, so a missed path remap fails loudly on the controller.
  - supplies a `capability_preflight` requiring the runner-side `node`/`npm` toolchain via new `source_cli_bootstrap_capability_preflight`.

Scoped to adding the preflights — dispatch behavior is otherwise unchanged. No docs/changelog touched.

## Validation
- `cargo fmt` clean.
- Local `cargo build --lib` currently blocked only by an inherited, pre-existing E0382 in `src/core/release/workflow.rs` (present on base `b969fede`, unrelated to this change). CI runs the full runner + lab test suite.
- The `remote_execution_preflight` audit findings should clear.