### PR TITLE
Closes #5416 — remove/narrow dead code flagged by audit

### DIFF
--- a/src/core/artifact_contract.rs
+++ b/src/core/artifact_contract.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::core::artifact_ref::{ArtifactRef, EvidenceRef};
+use crate::core::artifact_ref::ArtifactRef;
 use crate::core::observation::ArtifactRecord;
 
 pub const ARTIFACT_CONTRACT_SCHEMA: &str = "homeboy/artifact-contract/v1";
@@ -76,7 +76,7 @@ impl ArtifactContract {
             .or(self.path.as_deref())
     }
 
-    pub fn into_evidence_contract(self) -> Option<EvidenceContract> {
+    pub(crate) fn into_evidence_contract(self) -> Option<EvidenceContract> {
         let target = self.target()?.to_string();
         let label = self.label.clone().unwrap_or_else(|| self.kind.clone());
         Some(EvidenceContract {
@@ -167,16 +167,6 @@ impl EvidenceContract {
         let mut evidence: Self = serde_json::from_value(value).map_err(|err| err.to_string())?;
         evidence.normalize()?;
         Ok(evidence)
-    }
-
-    pub fn to_evidence_ref(&self) -> EvidenceRef {
-        EvidenceRef {
-            schema: crate::core::artifact_ref::EVIDENCE_REF_SCHEMA.to_string(),
-            kind: self.kind.clone(),
-            target: self.target.clone(),
-            label: self.label.clone(),
-            artifact: None,
-        }
     }
 
     fn normalize(&mut self) -> Result<(), String> {

--- a/src/core/artifact_manifest.rs
+++ b/src/core/artifact_manifest.rs
@@ -116,7 +116,7 @@ impl ArtifactManifest {
         }
     }
 
-    pub fn artifact_contracts(
+    pub(crate) fn artifact_contracts(
         &self,
     ) -> Result<Vec<crate::core::artifact_contract::ArtifactContract>> {
         if self.schema != ARTIFACT_MANIFEST_SCHEMA {
@@ -252,7 +252,9 @@ impl ArtifactManifest {
 }
 
 impl ArtifactManifestEntry {
-    pub fn to_artifact_contract(&self) -> Result<crate::core::artifact_contract::ArtifactContract> {
+    pub(crate) fn to_artifact_contract(
+        &self,
+    ) -> Result<crate::core::artifact_contract::ArtifactContract> {
         validate_entry_shape(self)?;
         let mut extra = std::collections::BTreeMap::new();
         if let Some(id) = &self.id {

--- a/src/core/artifact_ref.rs
+++ b/src/core/artifact_ref.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::core::execution_contract::{decode_uri_component, encode_uri_component};
+use crate::core::execution_contract::decode_uri_component;
 use crate::core::observation::ArtifactRecord;
 
 pub const ARTIFACT_REF_SCHEMA: &str = "homeboy/artifact-ref/v1";
@@ -50,16 +50,6 @@ impl ArtifactReference {
         }
 
         Self::LocalPath(value)
-    }
-
-    pub fn runner_artifact(runner_id: &str, run_id: &str, artifact_id: &str) -> Self {
-        Self::parse(format!(
-            "{}{}/{}/{}",
-            RUNNER_ARTIFACT_REF_SCHEME,
-            encode_uri_component(runner_id),
-            encode_uri_component(run_id),
-            encode_uri_component(artifact_id)
-        ))
     }
 
     pub fn metadata_only(label: &str) -> Self {
@@ -134,7 +124,7 @@ impl ArtifactRef {
         }
     }
 
-    pub fn public_target(&self) -> Option<String> {
+    pub(crate) fn public_target(&self) -> Option<String> {
         self.public_url
             .clone()
             .or_else(|| self.url.clone())
@@ -167,7 +157,7 @@ impl EvidenceRef {
         }
     }
 
-    pub fn from_artifact(artifact: ArtifactRef) -> Option<Self> {
+    pub(crate) fn from_artifact(artifact: ArtifactRef) -> Option<Self> {
         let target = artifact.public_target()?;
         Some(Self {
             schema: EVIDENCE_REF_SCHEMA.to_string(),

--- a/src/core/change_artifact.rs
+++ b/src/core/change_artifact.rs
@@ -122,7 +122,7 @@ impl ChangeArtifact {
     /// The projection is intentionally lossy: source snapshot, schema, and
     /// digest remain in metadata while the lifecycle artifact carries the
     /// review-facing id/type/files/diff/provenance fields.
-    pub fn to_execution_change_artifact(
+    pub(crate) fn to_execution_change_artifact(
         &self,
         fallback_id: impl Into<String>,
         artifact_type: impl Into<String>,

--- a/src/core/lab_routing.rs
+++ b/src/core/lab_routing.rs
@@ -38,7 +38,9 @@ pub struct LabRoutingRequest<'a> {
     pub active_run_id: Option<&'a str>,
 }
 
-pub fn route_lab_offload(request: LabRoutingRequest<'_>) -> Result<runners::LabOffloadOutcome> {
+pub(crate) fn route_lab_offload(
+    request: LabRoutingRequest<'_>,
+) -> Result<runners::LabOffloadOutcome> {
     if let Some(timeout) = request.timeout {
         return execute_lab_offload_with_timeout(request, timeout);
     }
@@ -249,7 +251,7 @@ fn lab_dispatch_metadata(
 /// Render offloaded stdout, attaching persisted-run retrieval guidance when a
 /// run was recorded. Mirrors the legacy CLI helper but is owned by core so the
 /// transformation is testable without constructing a clap `Cli`.
-pub fn stdout_with_persisted_run_retrieval(
+pub(crate) fn stdout_with_persisted_run_retrieval(
     stdout: &str,
     retrieval: Option<&PersistedRunRetrieval>,
 ) -> String {
@@ -332,7 +334,7 @@ pub fn lab_offload_command_from_contract(
     }
 }
 
-pub fn lab_route_plan_from_contract(
+pub(crate) fn lab_route_plan_from_contract(
     contract: LabCommandContract,
     required_extensions: Vec<String>,
 ) -> LabRoutePlan {

--- a/src/core/preview_client.rs
+++ b/src/core/preview_client.rs
@@ -216,7 +216,7 @@ pub fn diagnose_auth(
     })
 }
 
-pub fn forward_to_local_origin(
+pub(crate) fn forward_to_local_origin(
     client: &Client,
     local_origin: &str,
     request: PreviewIngressRequest,

--- a/src/core/preview_ingress.rs
+++ b/src/core/preview_ingress.rs
@@ -268,7 +268,7 @@ pub fn remove_route(session_id: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn load_route(session_id: &str) -> Result<PreviewIngressRoute> {
+pub(crate) fn load_route(session_id: &str) -> Result<PreviewIngressRoute> {
     let path = paths::preview_ingress_route_file(session_id)?;
     let data = fs::read_to_string(&path)
         .map_err(|e| Error::internal_io(e.to_string(), Some(path.display().to_string())))?;

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -36,7 +36,7 @@ impl ProcessStep {
 /// When a step omits a working directory, the normalized root becomes the
 /// effective working directory. This gives local commands, extensions, and rigs
 /// one reusable path policy without requiring filesystem canonicalization.
-pub fn prepare_contained_process_step(
+pub(crate) fn prepare_contained_process_step(
     root: impl AsRef<Path>,
     step: ProcessStep,
 ) -> Result<ProcessStep> {

--- a/src/core/source_snapshot.rs
+++ b/src/core/source_snapshot.rs
@@ -87,7 +87,7 @@ impl SourceSnapshot {
         Self::collect_local_with_policy(runner_id, path, remote_path, sync_mode, &policy)
     }
 
-    pub fn collect_local_with_policy(
+    pub(crate) fn collect_local_with_policy(
         runner_id: &str,
         path: &Path,
         remote_path: Option<&str>,
@@ -132,7 +132,7 @@ impl SourceSnapshot {
         Self::existing_remote_with_policy(runner_id, remote_path, workspace_root, &policy)
     }
 
-    pub fn existing_remote_with_policy(
+    pub(crate) fn existing_remote_with_policy(
         runner_id: &str,
         remote_path: &str,
         workspace_root: Option<&str>,
@@ -164,7 +164,7 @@ impl SourceSnapshot {
     }
 }
 
-pub fn default_sync_excludes() -> Vec<String> {
+pub(crate) fn default_sync_excludes() -> Vec<String> {
     DEFAULT_SYNC_EXCLUDES
         .iter()
         .map(|value| value.to_string())


### PR DESCRIPTION
## Summary
Resolves the `dead_code` audit category (#5416). Of the 19 findings, 17 are cleared in code and 2 are deliberately kept (documented below).

## Changes
**Removed (genuinely dead — zero callers anywhere, incl. tests):**
- `ArtifactReference::runner_artifact` (`src/core/artifact_ref.rs`) — also dropped the now-unused `encode_uri_component` import.
- `EvidenceContract::to_evidence_ref` (`src/core/artifact_contract.rs`) — also dropped the now-unused `EvidenceRef` import.

**Narrowed `pub` → `pub(crate)` (used only within their own file, so the export was actionable dead code; Rust's `pub(crate)` removes them from the audit's public-API surface):**
- `artifact_contract.rs`: `into_evidence_contract`
- `artifact_manifest.rs`: `artifact_contracts`, `to_artifact_contract`
- `artifact_ref.rs`: `public_target`, `from_artifact`
- `change_artifact.rs`: `to_execution_change_artifact`
- `lab_routing.rs`: `route_lab_offload`, `stdout_with_persisted_run_retrieval`, `lab_route_plan_from_contract`
- `preview_client.rs`: `forward_to_local_origin`
- `preview_ingress.rs`: `load_route`
- `process.rs`: `prepare_contained_process_step`
- `source_snapshot.rs`: `collect_local_with_policy`, `existing_remote_with_policy`, `default_sync_excludes`

Verified none of the narrowed functions are re-exported (`pub use`) or referenced cross-file; the only external references were same-file (production or test) call sites, which still resolve under `pub(crate)`.

## Deliberately kept (2 findings)
The two `dead_code_marker` findings on `tests/core/rig/support.rs` (`attach` line 90, `push_main` line 134) are **left as-is**. The `#[allow(dead_code)]` markers are required and already documented: `support.rs` is `#[path]`-included separately into both `source_test.rs` and `install_test.rs`; `attach`/`push_main` are used by `source_test.rs` but not `install_test.rs`, so they appear unused from one compilation view. Removing the markers would produce real `dead_code` warnings (warnings-as-errors in CI); removing the functions is impossible since they are actively used. This is the correct documented suppression, not dead code.

## Validation
- `cargo fmt` clean on changed files (unrelated fmt churn in untouched test files was reverted to keep the diff surgical).
- `cargo build --lib` exercised all changed `src/core/*` modules with no errors attributable to this change. A pre-existing borrow-after-partial-move error in `src/core/release/workflow.rs:291` exists on `origin/main` itself (inherited merge churn, unrelated to this PR).

Closes #5416