### PR TITLE
Apply rustfmt to current main

### DIFF
--- a/src/core/extension/runtime_helper/tests.rs
+++ b/src/core/extension/runtime_helper/tests.rs
@@ -695,7 +695,9 @@ if (result.code !== 0) throw new Error(`phase command failed: ${result.code}`);
             .expect("json");
     assert_eq!(value["phase"], "install");
     assert!(value["command_label"].as_str().is_some());
-    assert!(value["samples"].as_array().is_some_and(|samples| !samples.is_empty()));
+    assert!(value["samples"]
+        .as_array()
+        .is_some_and(|samples| !samples.is_empty()));
     assert_eq!(value["samples"][0]["phase"], "install");
 }
 

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -254,11 +254,10 @@ fn visible_safety_manifest_entries_advertise_live_command_docs() {
             continue;
         }
 
-        let path = entry
-            .docs
-            .path
-            .as_deref()
-            .unwrap_or_else(|| panic!("visible command {:?} is missing docs metadata", entry.path));
+        let path =
+            entry.docs.path.as_deref().unwrap_or_else(|| {
+                panic!("visible command {:?} is missing docs metadata", entry.path)
+            });
         let top_level = entry.path.first().expect("safety path should not be empty");
         assert_eq!(
             path,

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -299,7 +299,10 @@ fn routes_registered_artifact_downloads_and_sync_manifest() {
     assert_eq!(sync.body["command"], "api.runs.artifacts.sync");
     assert_eq!(sync.body["artifacts"][0]["id"], artifact.id);
     assert_eq!(sync.body["artifacts"][0]["content_available"], true);
-    assert_eq!(sync.body["artifacts"][0]["retrieval"]["mode"], "direct_download");
+    assert_eq!(
+        sync.body["artifacts"][0]["retrieval"]["mode"],
+        "direct_download"
+    );
     assert_eq!(
         sync.body["artifacts"][0]["download_path"],
         format!("/runs/{}/artifacts/{}", run.id, artifact.id)

--- a/tests/core/deps_test.rs
+++ b/tests/core/deps_test.rs
@@ -27,7 +27,9 @@ fn script_stack_component(
     let script = path.join("deps.sh");
     write_file(
         &script,
-        &format!("#!/bin/sh\nif [ \"$1\" = status ]; then\ncat <<'JSON'\n{status_json}\nJSON\nfi\n"),
+        &format!(
+            "#!/bin/sh\nif [ \"$1\" = status ]; then\ncat <<'JSON'\n{status_json}\nJSON\nfi\n"
+        ),
     );
     let mut component = stack_component(id, &path.display().to_string(), edges);
     component.scripts = Some(ComponentScriptsConfig {
@@ -113,7 +115,10 @@ fn status_reads_composer_direct_constraints_and_lock_details() {
         .unwrap();
     assert_eq!(transitive.manifest_section, None);
     assert_eq!(transitive.constraint, None);
-    assert_eq!(transitive.locked_reference.as_deref(), Some("transitive-ref"));
+    assert_eq!(
+        transitive.locked_reference.as_deref(),
+        Some("transitive-ref")
+    );
 }
 
 #[test]
@@ -132,7 +137,10 @@ fn status_filters_to_one_package() {
             }
         }"#,
     );
-    write_file(&root.join("composer.lock"), r#"{ "packages": [], "packages-dev": [] }"#);
+    write_file(
+        &root.join("composer.lock"),
+        r#"{ "packages": [], "packages-dev": [] }"#,
+    );
 
     let status = deps::status(Some("fixture"), Some(&root_path), Some("fixture/two")).unwrap();
 
@@ -200,7 +208,9 @@ fn stack_plan_walks_declared_downstream_edges_in_order() {
         ),
     ];
 
-    let plan = deps::stack_plan_from_components("example-org/html-to-blocks-converter", &components).unwrap();
+    let plan =
+        deps::stack_plan_from_components("example-org/html-to-blocks-converter", &components)
+            .unwrap();
 
     let steps = plan.planned_steps();
 
@@ -355,7 +365,10 @@ fn stack_plan_keeps_explicit_edge_config_when_provider_edge_matches() {
     let steps = plan.planned_steps();
 
     assert_eq!(plan.step_count(), 1);
-    assert_eq!(steps[0].update_command, "fixture-provider update fixture/upstream");
+    assert_eq!(
+        steps[0].update_command,
+        "fixture-provider update fixture/upstream"
+    );
     assert_eq!(steps[0].post_update, vec!["fixture-provider build"]);
     assert_eq!(steps[0].test, vec!["fixture-provider test"]);
 }
@@ -468,8 +481,14 @@ esac
     assert_eq!(result.requested_constraint.as_deref(), Some("^2.0"));
     assert!(result.install.is_some());
     assert!(result.rebuild.is_some());
-    assert_eq!(fs::read_to_string(root.join("provider-install-marker")).unwrap(), "installed");
-    assert_eq!(fs::read_to_string(root.join("build-marker")).unwrap(), "rebuilt");
+    assert_eq!(
+        fs::read_to_string(root.join("provider-install-marker")).unwrap(),
+        "installed"
+    );
+    assert_eq!(
+        fs::read_to_string(root.join("build-marker")).unwrap(),
+        "rebuilt"
+    );
 }
 
 #[test]
@@ -564,7 +583,10 @@ fn update_with_constraint_changes_manifest_and_lock_for_local_path_package() {
     )
     .unwrap();
 
-    assert_eq!(result.before.unwrap().locked_version.as_deref(), Some("1.0.0"));
+    assert_eq!(
+        result.before.unwrap().locked_version.as_deref(),
+        Some("1.0.0")
+    );
     let after = result.after.unwrap();
     assert_eq!(after.constraint.as_deref(), Some("1.1.0"));
     assert_eq!(after.locked_version.as_deref(), Some("1.1.0"));

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -485,7 +485,10 @@ fn artifact_content_serves_encoded_artifact_store_locator() {
         assert_eq!(response.body["size_bytes"], 12);
         assert_eq!(response.body["content_available"], true);
         assert_eq!(response.body["retrieval"]["mode"], "inline_base64");
-        assert_eq!(response.body["retrieval"]["content_field"], "content_base64");
+        assert_eq!(
+            response.body["retrieval"]["content_field"],
+            "content_base64"
+        );
         assert_eq!(
             response.body["content_base64"].as_str(),
             Some("eyJzdGVwcyI6W119")

--- a/tests/core/refactor/decompose_test.rs
+++ b/tests/core/refactor/decompose_test.rs
@@ -137,14 +137,13 @@ fn test_parse_items() {
     fs::create_dir_all(root.join("src")).expect("create source dir");
     fs::write(root.join("src/example.unknown"), "content\n").expect("write source file");
 
-    let plan = refactor::build_plan("src/example.unknown", &root, "grouped", true)
-        .expect("build plan");
+    let plan =
+        refactor::build_plan("src/example.unknown", &root, "grouped", true).expect("build plan");
     assert_eq!(plan.total_items, 0);
-    assert!(
-        plan.warnings
-            .iter()
-            .any(|warning| warning.contains("No refactor parser available"))
-    );
+    assert!(plan
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("No refactor parser available")));
 
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## Summary
- Apply rustfmt to the current main branch so CI baseline test jobs can run past cargo fmt checks.

## Verification
- `rustfmt --check $(git ls-files '*.rs')`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosing the CI baseline formatting blocker and applying rustfmt-only cleanup.