### PR TITLE
feat(fleet): require apply for exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,10 +378,13 @@ homeboy logs show production --follow
 homeboy db query production "select 1"
 homeboy file read production /path/to/file
 homeboy file copy production:/path/to/file staging:/path/to/file
+homeboy fleet exec production --check -- wp plugin list
+homeboy fleet exec production --apply -- wp plugin list
 ```
 
 These commands are valuable for configured projects and server fleets. They are
-not required for the local/CI/agent quality loop.
+not required for the local/CI/agent quality loop. `fleet exec` requires
+`--apply` for real SSH fan-out; `--check` keeps the operation in plan mode.
 
 ## Extensions
 

--- a/docs/commands/fleet.md
+++ b/docs/commands/fleet.md
@@ -140,10 +140,11 @@ Summary includes counts for quick overview.
 ### `exec`
 
 ```sh
-homeboy fleet exec <id> -- <command>
+homeboy fleet exec <id> --check -- <command>
+homeboy fleet exec <id> --apply -- <command>
 ```
 
-Runs a command across projects in the fleet via each project's configured SSH connection. `fleet exec` participates in resource-policy warnings because it can create heavy remote work, but it is intentionally local-only for Lab offload: the command depends on local fleet, project, and server configuration before opening those SSH sessions, and runner-side config parity is not guaranteed.
+Plans or runs a command across projects in the fleet via each project's configured SSH connection. Real remote execution requires `--apply`; use `--check` to preview the per-project plan without opening SSH command sessions. `fleet exec` participates in resource-policy warnings because it can create heavy remote work, but it is intentionally local-only for Lab offload: the command depends on local fleet, project, and server configuration before opening those SSH sessions, and runner-side config parity is not guaranteed.
 
 ## Fleet Deployment
 

--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -479,6 +479,8 @@ fn command_safety_metadata(path: &[String]) -> CommandSafetyMetadata {
             metadata.mutates = true;
             metadata.operator = true;
             metadata.dry_run_flag = Some("--check");
+            metadata.output_notes = "default output is blocked for remote execution; pass --check to plan or --apply to execute";
+            metadata.dangerous_flags = vec!["--apply"];
             metadata.lab_notes = "local-only: depends on local fleet/project/server configuration before SSH fan-out";
         }
         ["api", "post"] | ["api", "put"] | ["api", "patch"] | ["api", "delete"] => {
@@ -689,6 +691,8 @@ mod tests {
 
         let fleet_exec = manifest.find_path(&["fleet", "exec"]).unwrap();
         assert_eq!(fleet_exec.dry_run.flag.as_deref(), Some("--check"));
+        assert!(fleet_exec.output.notes.contains("--apply"));
+        assert!(fleet_exec.dangerous_flags.contains(&"--apply".to_string()));
         assert!(fleet_exec.lab.notes.contains("local-only"));
 
         let db_delete_row = manifest.find_path(&["db", "delete-row"]).unwrap();

--- a/src/command_contract/lab.rs
+++ b/src/command_contract/lab.rs
@@ -853,10 +853,10 @@ mod tests {
         ])
         .supports_lab_runner());
         assert!(!parsed_command(&["homeboy", "rig", "up", "studio"]).supports_lab_runner());
-        assert!(
-            !parsed_command(&["homeboy", "fleet", "exec", "prod", "wp", "plugin", "list"])
-                .supports_lab_runner()
-        );
+        assert!(!parsed_command(&[
+            "homeboy", "fleet", "exec", "prod", "--apply", "wp", "plugin", "list",
+        ])
+        .supports_lab_runner());
         assert!(!parsed_command(&["homeboy", "status"]).supports_lab_runner());
         assert!(!parsed_command(&["homeboy", "bench", "list"]).supports_lab_runner());
         assert!(
@@ -1208,9 +1208,11 @@ mod tests {
             LabCommandPortability::LocalOnly(reason) if reason.contains("single-workspace Lab snapshot")
         ));
 
-        let fleet = parsed_command(&["homeboy", "fleet", "exec", "prod", "wp", "plugin", "list"])
-            .lab_contract()
-            .expect("fleet exec contract");
+        let fleet = parsed_command(&[
+            "homeboy", "fleet", "exec", "prod", "--apply", "wp", "plugin", "list",
+        ])
+        .lab_contract()
+        .expect("fleet exec contract");
         assert_eq!(fleet.hot_label, "fleet exec");
         assert!(matches!(
             fleet.portability,
@@ -1323,12 +1325,12 @@ mod tests {
             .lab_runner_unsupported_reason()
             .expect("rig up reason")
             .contains("single-workspace Lab snapshot"));
-        assert!(
-            parsed_command(&["homeboy", "fleet", "exec", "prod", "wp", "plugin", "list"])
-                .lab_runner_unsupported_reason()
-                .expect("fleet exec reason")
-                .contains("config parity")
-        );
+        assert!(parsed_command(&[
+            "homeboy", "fleet", "exec", "prod", "--apply", "wp", "plugin", "list",
+        ])
+        .lab_runner_unsupported_reason()
+        .expect("fleet exec reason")
+        .contains("config parity"));
         assert!(
             parsed_command(&["homeboy", "lint", "--changed-since", "origin/main"])
                 .lab_runner_unsupported_reason()

--- a/src/commands/fleet.rs
+++ b/src/commands/fleet.rs
@@ -26,7 +26,14 @@ impl FleetArgs {
     }
 
     pub fn is_hot_resource_command(&self) -> bool {
-        matches!(self.command, FleetCommand::Exec { check: false, .. })
+        matches!(
+            self.command,
+            FleetCommand::Exec {
+                check: false,
+                apply: true,
+                ..
+            }
+        )
     }
 }
 
@@ -125,6 +132,10 @@ enum FleetCommand {
         #[arg(long)]
         check: bool,
 
+        /// Confirm the command should execute over SSH on every project in the fleet
+        #[arg(long)]
+        apply: bool,
+
         /// Override the SSH user for this execution (instead of each server's configured user)
         #[arg(long)]
         user: Option<String>,
@@ -181,8 +192,9 @@ pub fn run(args: FleetArgs, _global: &super::GlobalArgs) -> CmdResult<FleetOutpu
             id,
             command,
             check,
+            apply,
             user,
-        } => exec(&id, command, check, user),
+        } => exec(&id, command, check, apply, user),
     }
 }
 
@@ -512,9 +524,11 @@ fn exec(
     id: &str,
     command: Vec<String>,
     check: bool,
+    apply: bool,
     user: Option<String>,
 ) -> CmdResult<FleetOutput> {
-    let run = fleet::collect_exec_run(id, command, check, user)?;
+    validate_exec_apply_boundary(id, &command, check, apply)?;
+    let run = fleet::collect_exec_run(id, command, check, apply, user)?;
 
     Ok((
         FleetOutput {
@@ -532,3 +546,31 @@ fn exec(
         run.exit_code,
     ))
 }
+
+fn validate_exec_apply_boundary(
+    id: &str,
+    command: &[String],
+    check: bool,
+    apply: bool,
+) -> homeboy::core::Result<()> {
+    if check || apply || command.is_empty() {
+        return Ok(());
+    }
+
+    Err(homeboy::core::Error::validation_invalid_argument(
+        "apply",
+        format!(
+            "fleet exec sends commands over SSH to every project in the fleet and requires explicit --apply. Use --check to preview or re-run with --apply to execute. Suggested command: homeboy fleet exec {id} --apply -- {}",
+            command.join(" ")
+        ),
+        None,
+        Some(vec![format!(
+            "homeboy fleet exec {id} --apply -- {}",
+            command.join(" ")
+        )]),
+    ))
+}
+
+#[cfg(test)]
+#[path = "../../tests/commands/fleet_test.rs"]
+mod fleet_test;

--- a/src/core/fleet/exec.rs
+++ b/src/core/fleet/exec.rs
@@ -41,9 +41,10 @@ pub fn collect_exec(
     fleet_id: &str,
     command: Vec<String>,
     check: bool,
+    apply: bool,
     user_override: Option<String>,
 ) -> crate::core::Result<(Vec<FleetExecProjectResult>, FleetExecSummary, i32)> {
-    let run = collect_exec_run(fleet_id, command, check, user_override)?;
+    let run = collect_exec_run(fleet_id, command, check, apply, user_override)?;
     Ok((run.results, run.summary, run.exit_code))
 }
 
@@ -51,13 +52,26 @@ pub fn collect_exec_run(
     fleet_id: &str,
     command: Vec<String>,
     check: bool,
+    apply: bool,
     user_override: Option<String>,
 ) -> crate::core::Result<FleetExecRun> {
     if command.is_empty() {
         return Err(
             crate::core::Error::validation_missing_argument(vec!["command".to_string()])
-                .with_hint("Usage: homeboy fleet exec <fleet> -- <command>".to_string()),
+                .with_hint(
+                    "Usage: homeboy fleet exec <fleet> --check -- <command> or homeboy fleet exec <fleet> --apply -- <command>"
+                        .to_string(),
+                ),
         );
+    }
+
+    if !check && !apply {
+        return Err(crate::core::Error::validation_invalid_argument(
+            "apply",
+            "fleet exec sends commands over SSH to every project in the fleet and requires explicit --apply. Use --check to preview or re-run with --apply to execute.",
+            None,
+            Some(vec!["homeboy fleet exec <fleet> --apply -- <command>".to_string()]),
+        ));
     }
 
     let command_string = if command.len() == 1 {
@@ -335,5 +349,19 @@ mod tests {
 
         assert_eq!("fleet.exec.alpha", step.id);
         assert_eq!(ExecutionStatus::Skipped, step.status);
+    }
+
+    #[test]
+    fn real_fleet_exec_requires_apply_before_loading_fleet() {
+        let error = collect_exec_run(
+            "missing-fleet",
+            vec!["wp".to_string(), "plugin".to_string(), "list".to_string()],
+            false,
+            false,
+            None,
+        )
+        .expect_err("real fleet exec should require --apply");
+
+        assert!(error.message.contains("requires explicit --apply"));
     }
 }

--- a/tests/commands/fleet_test.rs
+++ b/tests/commands/fleet_test.rs
@@ -1,0 +1,25 @@
+use super::validate_exec_apply_boundary;
+
+#[test]
+fn fleet_exec_requires_apply_for_real_execution() {
+    let command = vec!["wp".to_string(), "plugin".to_string(), "list".to_string()];
+
+    let err = validate_exec_apply_boundary("production", &command, false, false)
+        .expect_err("real fleet exec should require --apply");
+
+    assert!(err.message.contains("requires explicit --apply"));
+    assert!(err.message.contains("Use --check to preview"));
+    assert!(err
+        .message
+        .contains("homeboy fleet exec production --apply"));
+}
+
+#[test]
+fn fleet_exec_check_and_applied_execution_pass_apply_guard() {
+    let command = vec!["wp".to_string(), "plugin".to_string(), "list".to_string()];
+
+    validate_exec_apply_boundary("production", &command, true, false)
+        .expect("--check should not require --apply");
+    validate_exec_apply_boundary("production", &command, false, true)
+        .expect("--apply should pass guard");
+}


### PR DESCRIPTION
## Summary
- Require --apply for real fleet exec SSH fan-out.
- Keep --check as the read-only planning mode.
- Update docs, safety metadata, Lab contract messaging, and tests.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt and diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and tests; Chris remains responsible for review and merge.