### PR TITLE
feat(http): tag output variant

### DIFF
--- a/docs/commands/http.md
+++ b/docs/commands/http.md
@@ -26,4 +26,5 @@ homeboy http request POST --apply https://example.com/api --json '{"ok":true}' -
 - `--form key=value` sends form fields.
 - `--apply` confirms mutating `request` methods other than `GET`, `HEAD`, and `OPTIONS`.
 
-Output is structured JSON with `method`, `url`, `status`, `headers`, and `body`.
+Output is structured JSON with `variant`, `method`, `url`, `status`, `headers`, and `body`.
+The `variant` discriminator is currently `response`.

--- a/src/command_contract/public_variants.rs
+++ b/src/command_contract/public_variants.rs
@@ -122,6 +122,13 @@ pub const PUBLIC_OUTPUT_VARIANT_CONTRACTS: &[PublicOutputVariantContract] = &[
         golden_fixture: None,
     },
     PublicOutputVariantContract {
+        command: "http",
+        variant: "response",
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("response"),
+        golden_fixture: None,
+    },
+    PublicOutputVariantContract {
         command: "release",
         variant: "single",
         discriminator_field: Some("variant"),

--- a/src/core/http_request.rs
+++ b/src/core/http_request.rs
@@ -20,6 +20,7 @@ pub struct HttpRequestInput {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HttpRequestOutput {
+    pub variant: String,
     pub method: String,
     pub url: String,
     pub status: u16,
@@ -107,6 +108,7 @@ fn response_output(method: &str, url: &str, response: Response) -> Result<HttpRe
     let body = serde_json::from_str(&text).unwrap_or(Value::String(text));
 
     Ok(HttpRequestOutput {
+        variant: "response".to_string(),
         method: method.to_string(),
         url: url.to_string(),
         status,
@@ -162,6 +164,7 @@ mod tests {
         })
         .unwrap();
 
+        assert_eq!(output.variant, "response");
         assert_eq!(output.status, 200);
         assert_eq!(output.body["ok"], true);
         assert_eq!(output.headers["content-type"], vec!["application/json"]);


### PR DESCRIPTION
## Summary
- Add additive variant metadata to HTTP request output.
- Register the HTTP response variant in public output contracts.
- Update HTTP command docs.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt and diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and PR text; Chris remains responsible for review and merge.