### PR TITLE
refactor(release): introduce execution plan

### DIFF
--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -4,7 +4,8 @@ use serde::Serialize;
 use homeboy::core::component;
 use homeboy::core::deploy::{self, ReleaseStateStatus};
 use homeboy::core::release::{
-    self, BatchReleaseResult, ReleaseCommandInput, ReleaseCommandResult, ReleasePipelineOptions,
+    self, BatchReleaseResult, ReleaseCommandInput, ReleaseCommandResult, ReleaseExecutionPlan,
+    ReleasePhase, ReleasePipelineOptions,
 };
 use homeboy::core::scope::{self, Scope};
 
@@ -128,6 +129,35 @@ impl ReleaseArgs {
         }
     }
 
+    fn execution_plan(&self, skip_checks: bool) -> ReleaseExecutionPlan {
+        let phase = if self.recover {
+            ReleasePhase::Recover
+        } else if self.dry_run_args.dry_run {
+            ReleasePhase::Plan
+        } else if self.deploy {
+            ReleasePhase::Deploy
+        } else if self.skip_publish {
+            ReleasePhase::Prepare
+        } else {
+            ReleasePhase::Publish
+        };
+
+        let apply_risks = [
+            (self.deploy, "--deploy"),
+            (self.recover, "--recover"),
+            (self.retag, "--retag"),
+            (self.head, "--head"),
+            (skip_checks, "bare --skip-checks"),
+        ]
+        .into_iter()
+        .filter_map(|(enabled, flag)| enabled.then_some(flag))
+        .collect::<Vec<_>>();
+
+        let requires_apply = !self.apply && !self.dry_run_args.dry_run && !apply_risks.is_empty();
+
+        ReleaseExecutionPlan::new(phase, requires_apply, apply_risks)
+    }
+
     /// Resolve `--skip-checks` into (skip-all, granular-check-list).
     ///
     /// - Flag absent → `(false, [])`: run every quality gate.
@@ -220,7 +250,8 @@ pub fn run(
     _global: &crate::commands::GlobalArgs,
 ) -> CmdResult<ReleaseCommandOutput> {
     let (skip_checks, skip_checks_granular) = args.resolve_skip_checks()?;
-    validate_apply_boundary(&args, skip_checks)?;
+    let execution = args.execution_plan(skip_checks);
+    validate_apply_boundary(&execution)?;
     let component_ids = resolve_component_ids(&args, &args.components)?;
     let bump_override = args.bump.clone();
 
@@ -240,6 +271,7 @@ pub fn run(
             pipeline: args.pipeline_options(),
             skip_github_release: args.no_github_release,
             git_identity: args.git_identity.clone(),
+            execution: Some(execution.clone()),
         })?;
 
         return Ok((
@@ -303,6 +335,7 @@ pub fn run(
         },
         skip_github_release: args.no_github_release,
         git_identity: args.git_identity.clone(),
+        execution: Some(execution),
     };
 
     let batch_result = release::run_batch(&component_ids, &input_template);
@@ -327,25 +360,12 @@ pub fn run(
     ))
 }
 
-fn validate_apply_boundary(args: &ReleaseArgs, skip_checks: bool) -> homeboy::core::Result<()> {
-    if args.apply
-        || args.dry_run_args.dry_run
-        || (!args.deploy && !args.recover && !args.retag && !args.head && !skip_checks)
-    {
+fn validate_apply_boundary(execution: &ReleaseExecutionPlan) -> homeboy::core::Result<()> {
+    if !execution.requires_apply {
         return Ok(());
     }
 
-    let risky_flags = [
-        (args.deploy, "--deploy"),
-        (args.recover, "--recover"),
-        (args.retag, "--retag"),
-        (args.head, "--head"),
-        (skip_checks, "bare --skip-checks"),
-    ]
-    .into_iter()
-    .filter_map(|(enabled, flag)| enabled.then_some(flag))
-    .collect::<Vec<_>>()
-    .join(" and ");
+    let risky_flags = execution.apply_risks.join(" and ");
 
     Err(homeboy::core::Error::validation_invalid_argument(
         "apply",
@@ -554,7 +574,8 @@ mod tests {
         args.dry_run_args.dry_run = false;
         args.head = true;
 
-        let err = validate_apply_boundary(&args, false).expect_err("--head requires --apply");
+        let execution = args.execution_plan(false);
+        let err = validate_apply_boundary(&execution).expect_err("--head requires --apply");
 
         assert!(err
             .message
@@ -566,7 +587,8 @@ mod tests {
         let mut args = args(&["fixture"]);
         args.head = true;
 
-        validate_apply_boundary(&args, false).expect("dry-run may preview risky mode");
+        let execution = args.execution_plan(false);
+        validate_apply_boundary(&execution).expect("dry-run may preview risky mode");
     }
 
     #[test]
@@ -574,8 +596,9 @@ mod tests {
         let mut args = args(&["fixture"]);
         args.dry_run_args.dry_run = false;
 
+        let execution = args.execution_plan(true);
         let err =
-            validate_apply_boundary(&args, true).expect_err("bare --skip-checks requires --apply");
+            validate_apply_boundary(&execution).expect_err("bare --skip-checks requires --apply");
 
         assert!(err
             .message
@@ -587,7 +610,8 @@ mod tests {
         let mut args = args(&["fixture"]);
         args.dry_run_args.dry_run = false;
 
-        validate_apply_boundary(&args, false).expect("granular skip-checks is not guarded");
+        let execution = args.execution_plan(false);
+        validate_apply_boundary(&execution).expect("granular skip-checks is not guarded");
     }
 
     #[test]
@@ -598,6 +622,19 @@ mod tests {
         args.retag = true;
         args.apply = true;
 
-        validate_apply_boundary(&args, false).expect("--apply confirms risky release mode");
+        let execution = args.execution_plan(false);
+        validate_apply_boundary(&execution).expect("--apply confirms risky release mode");
+    }
+
+    #[test]
+    fn execution_plan_resolves_phase_from_args() {
+        let mut args = args(&["fixture"]);
+        args.dry_run_args.dry_run = false;
+        args.skip_publish = true;
+
+        let execution = args.execution_plan(false);
+
+        assert_eq!(execution.phase, ReleasePhase::Prepare);
+        assert!(!execution.requires_apply);
     }
 }

--- a/src/core/release/mod.rs
+++ b/src/core/release/mod.rs
@@ -27,9 +27,9 @@ pub use planner::plan;
 pub use types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseArtifact,
     ReleaseCommandInput, ReleaseCommandResult, ReleaseDeploymentResult, ReleaseDeploymentSummary,
-    ReleaseOptions, ReleasePhase, ReleasePipelineOptions, ReleasePlan, ReleaseProjectDeployResult,
-    ReleaseRun, ReleaseRunResult, ReleaseRunSummary, ReleaseSemverCommit,
-    ReleaseSemverRecommendation, ReleaseStepResult, ReleaseStepStatus,
+    ReleaseExecutionPlan, ReleaseOptions, ReleasePhase, ReleasePipelineOptions, ReleasePlan,
+    ReleaseProjectDeployResult, ReleaseRun, ReleaseRunResult, ReleaseRunSummary,
+    ReleaseSemverCommit, ReleaseSemverRecommendation, ReleaseStepResult, ReleaseStepStatus,
 };
 pub use utils::{extract_latest_notes, parse_release_artifacts};
 pub use workflow::{run_batch, run_command, SKIPPED_RELEASE_EXIT_CODE};

--- a/src/core/release/types.rs
+++ b/src/core/release/types.rs
@@ -339,6 +339,42 @@ pub struct ReleaseCommandInput {
     /// Git identity for release commits: "bot", "Name <email>", or None (use existing config).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_identity: Option<String>,
+    /// Internal execution contract resolved before the workflow runs.
+    #[serde(skip_serializing)]
+    pub execution: Option<ReleaseExecutionPlan>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseExecutionPlan {
+    pub phase: ReleasePhase,
+    pub requires_apply: bool,
+    pub apply_risks: Vec<&'static str>,
+}
+
+impl ReleaseExecutionPlan {
+    pub fn new(phase: ReleasePhase, requires_apply: bool, apply_risks: Vec<&'static str>) -> Self {
+        Self {
+            phase,
+            requires_apply,
+            apply_risks,
+        }
+    }
+
+    pub fn default_for_command_input(input: &ReleaseCommandInput) -> Self {
+        let phase = if input.recover {
+            ReleasePhase::Recover
+        } else if input.dry_run {
+            ReleasePhase::Plan
+        } else if input.pipeline.deploy {
+            ReleasePhase::Deploy
+        } else if input.pipeline.skip_publish {
+            ReleasePhase::Prepare
+        } else {
+            ReleasePhase::Publish
+        };
+
+        Self::new(phase, false, Vec::new())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -5,7 +5,7 @@ use crate::core::plan::PlanStep;
 use super::context::load_component;
 use super::types::{
     BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseBumpPolicyOptions,
-    ReleaseCommandInput, ReleaseCommandResult, ReleaseOptions, ReleasePhase, ReleasePlan,
+    ReleaseCommandInput, ReleaseCommandResult, ReleaseExecutionPlan, ReleaseOptions, ReleasePlan,
     ReleaseRun, ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus,
 };
 
@@ -19,21 +19,16 @@ use super::types::{
 /// `status: "skipped"` + `skipped_reason` + an actionable force hint (issue #4316).
 pub const SKIPPED_RELEASE_EXIT_CODE: i32 = 5;
 
-fn release_phase(input: &ReleaseCommandInput) -> ReleasePhase {
-    if input.recover {
-        ReleasePhase::Recover
-    } else if input.dry_run {
-        ReleasePhase::Plan
-    } else if input.pipeline.deploy {
-        ReleasePhase::Deploy
-    } else if input.pipeline.skip_publish {
-        ReleasePhase::Prepare
-    } else {
-        ReleasePhase::Publish
-    }
+fn release_execution_plan(input: &ReleaseCommandInput) -> ReleaseExecutionPlan {
+    input
+        .execution
+        .clone()
+        .unwrap_or_else(|| ReleaseExecutionPlan::default_for_command_input(input))
 }
 
 pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32)> {
+    let execution = release_execution_plan(&input);
+
     if input.recover {
         return run_recover(&input);
     }
@@ -183,7 +178,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
             let release_summary = release_summary_from_run(&run);
             return Ok((
                 ReleaseCommandResult {
-                    phase: release_phase(&input),
+                    phase: execution.phase,
                     component_id: input.component_id,
                     status,
                     bump_type,
@@ -216,7 +211,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
 
         return Ok((
             ReleaseCommandResult {
-                phase: release_phase(&input),
+                phase: execution.phase,
                 component_id: input.component_id,
                 status: release_command_status(true, skipped_reason.as_deref(), None),
                 bump_type,
@@ -288,7 +283,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
 
     Ok((
         ReleaseCommandResult {
-            phase: release_phase(&input),
+            phase: execution.phase,
             component_id: input.component_id,
             status: release_command_status(false, skipped_reason.as_deref(), Some(&run_result)),
             bump_type,
@@ -812,7 +807,7 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
             ReleaseCommandResult {
                 component_id: input.component_id.clone(),
                 status: "recovered".to_string(),
-                phase: release_phase(input),
+                phase: release_execution_plan(input).phase,
                 bump_type: "recover".to_string(),
                 dry_run: false,
                 releasable_commits: 0,
@@ -968,7 +963,7 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
             } else {
                 "recovered".to_string()
             },
-            phase: release_phase(input),
+            phase: release_execution_plan(input).phase,
             bump_type: "recover".to_string(),
             dry_run: false,
             releasable_commits: 0,
@@ -1262,6 +1257,7 @@ pub fn run_batch(
             pipeline: input_template.pipeline.clone(),
             skip_github_release: input_template.skip_github_release,
             git_identity: input_template.git_identity.clone(),
+            execution: input_template.execution.clone(),
         };
 
         match run_command(input) {
@@ -1325,6 +1321,7 @@ pub fn run_batch(
 mod tests {
     use super::*;
     use crate::core::plan::{PlanStep, PlanStepStatus, PlanValues};
+    use crate::core::release::types::ReleasePhase;
     use crate::core::release::{ReleaseRunResult, ReleaseStepResult, ReleaseStepStatus};
 
     #[test]
@@ -1724,19 +1721,19 @@ mod tests {
     #[test]
     fn release_phase_maps_current_modes() {
         let mut input = ReleaseCommandInput::default();
-        assert_eq!(release_phase(&input), ReleasePhase::Publish);
+        assert_eq!(release_execution_plan(&input).phase, ReleasePhase::Publish);
 
         input.dry_run = true;
-        assert_eq!(release_phase(&input), ReleasePhase::Plan);
+        assert_eq!(release_execution_plan(&input).phase, ReleasePhase::Plan);
 
         input.dry_run = false;
         input.pipeline.skip_publish = true;
-        assert_eq!(release_phase(&input), ReleasePhase::Prepare);
+        assert_eq!(release_execution_plan(&input).phase, ReleasePhase::Prepare);
 
         input.pipeline.deploy = true;
-        assert_eq!(release_phase(&input), ReleasePhase::Deploy);
+        assert_eq!(release_execution_plan(&input).phase, ReleasePhase::Deploy);
 
         input.recover = true;
-        assert_eq!(release_phase(&input), ReleasePhase::Recover);
+        assert_eq!(release_execution_plan(&input).phase, ReleasePhase::Recover);
     }
 }


### PR DESCRIPTION
## Summary
- Introduce ReleaseExecutionPlan for phase and apply-risk metadata.
- Build the plan once from release args and reuse it in CLI/workflow logic.
- Preserve existing release output and CLI behavior.

## Testing
- Not run locally: cargo/test/benchmarks are intentionally avoided on this machine.
- Ran rustfmt and diff checks in the implementation worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted implementation and PR text; Chris remains responsible for review and merge.