### PR TITLE
Fix release workflow input reuse

### DIFF
--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -161,7 +161,7 @@ pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, 
     let options = ReleaseOptions {
         bump_type: bump_type.clone(),
         dry_run: input.dry_run,
-        path_override: input.path_override,
+        path_override: input.path_override.clone(),
         skip_checks: input.skip_checks,
         skip_checks_granular: input.skip_checks_granular.clone(),
         pipeline: input.pipeline.clone(),


### PR DESCRIPTION
## Summary
- Clone the release path override when building release options so the command input can still be inspected later for result phase metadata.

## Verification
- `rustfmt --check src/core/release/workflow.rs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosing the CI compile failure and applying the minimal ownership fix.