### PR TITLE
chore(lint): clear accumulated clippy warnings

### DIFF
--- a/src/cli_surface.rs
+++ b/src/cli_surface.rs
@@ -208,9 +208,7 @@ pub struct CommandSafetyManifest {
 
 impl CommandSafetyManifest {
     pub fn find_path(&self, path: &[&str]) -> Option<&CommandSafetyEntry> {
-        let Some((first, rest)) = path.split_first() else {
-            return None;
-        };
+        let (first, rest) = path.split_first()?;
 
         self.commands
             .iter()

--- a/src/commands/bench/observation.rs
+++ b/src/commands/bench/observation.rs
@@ -518,9 +518,7 @@ fn persist_bench_artifact(
         };
     }
 
-    let Some(original_path) = artifact.path.clone() else {
-        return None;
-    };
+    let original_path = artifact.path.clone()?;
     if bench_artifact_path_is_blocked(&original_path) {
         return Some(bench_artifact_diagnostic(
             scenario_id,
@@ -591,15 +589,11 @@ fn apply_recorded_bench_artifact_links(
     record: &ArtifactRecord,
 ) -> Option<BenchDiagnostic> {
     artifact.observation_artifact_id = Some(record.id.clone());
-    let Some(public_url) = artifact_links::public_artifact_url(record) else {
-        return None;
-    };
+    let public_url = artifact_links::public_artifact_url(record)?;
     artifact.public_url = Some(public_url.clone());
     artifact.viewer_links = artifact_links::cached_validated_viewer_links(record, &public_url);
     artifact.viewer_url = artifact.viewer_links.first().map(|link| link.url.clone());
-    let Some(validation) = record.metadata_json.get("public_url_validation") else {
-        return None;
-    };
+    let validation = record.metadata_json.get("public_url_validation")?;
     let reachable = validation
         .get("reachable")
         .and_then(serde_json::Value::as_bool)

--- a/src/commands/runs/refs.rs
+++ b/src/commands/runs/refs.rs
@@ -163,9 +163,10 @@ pub fn runs_refs(args: RunsRefsArgs) -> CmdResult<RunsOutput> {
 
 fn run_matches_filter(run: &RunRecord, filter: &RunListFilter) -> bool {
     filter.kind.as_deref().is_none_or(|kind| run.kind == kind)
-        && filter.component_id.as_deref().is_none_or(|component| {
-            run.component_id.as_deref() == Some(component)
-        })
+        && filter
+            .component_id
+            .as_deref()
+            .is_none_or(|component| run.component_id.as_deref() == Some(component))
         && filter
             .status
             .as_deref()

--- a/src/commands/trace/observation_lifecycle.rs
+++ b/src/commands/trace/observation_lifecycle.rs
@@ -133,9 +133,7 @@ pub(crate) fn finish_lab_dispatch_observation(
     status: RunStatus,
     metadata: serde_json::Value,
 ) -> Option<PersistedRunRetrieval> {
-    let Some(observation) = observation else {
-        return None;
-    };
+    let observation = observation?;
     let retrieval = PersistedRunRetrieval::for_run(&observation.run_id);
     let _ = observation.store.record_trace_run(
         NewTraceRunRecord::builder(

--- a/src/core/code_audit/core_fingerprint.rs
+++ b/src/core/code_audit/core_fingerprint.rs
@@ -952,6 +952,13 @@ fn is_contract_type_hint(type_hint: &str, grammar: &Grammar) -> bool {
 
 /// Extract dead code suppression markers.
 fn extract_dead_code_markers(symbols: &[Symbol], lines: &[&str]) -> Vec<DeadCodeMarker> {
+    static ITEM_RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(
+            r"(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(?:unsafe\s+)?(?:const\s+)?(?:static\s+)?(?:fn|struct|enum|type|trait|const|static|mod)\s+(\w+)",
+        )
+        .unwrap()
+    });
+
     let mut markers = Vec::new();
 
     // Look for dead_code_marker pattern matches
@@ -968,11 +975,7 @@ fn extract_dead_code_markers(symbols: &[Symbol], lines: &[&str]) -> Vec<DeadCode
                 continue;
             }
             // Try to find a declaration
-            let item_re = regex::Regex::new(
-                r"(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(?:unsafe\s+)?(?:const\s+)?(?:static\s+)?(?:fn|struct|enum|type|trait|const|static|mod)\s+(\w+)",
-            )
-            .unwrap();
-            if let Some(caps) = item_re.captures(line) {
+            if let Some(caps) = ITEM_RE.captures(line) {
                 markers.push(DeadCodeMarker {
                     item: caps[1].to_string(),
                     line: s.line,

--- a/src/core/code_audit/detectors/enum_dispatch_contracts.rs
+++ b/src/core/code_audit/detectors/enum_dispatch_contracts.rs
@@ -264,9 +264,7 @@ impl SourceFile {
             if arm.is_empty() {
                 continue;
             }
-            let Some(arrow) = Self::find_top_level_arrow(arm.as_bytes()) else {
-                return None;
-            };
+            let arrow = Self::find_top_level_arrow(arm.as_bytes())?;
             let pattern = arm[..arrow].trim();
             let expression = arm[arrow + 2..].trim();
             let (arm_enum, variant) = Self::parse_enum_variant_pattern(pattern)?;

--- a/src/core/code_audit/detectors/field_patterns.rs
+++ b/src/core/code_audit/detectors/field_patterns.rs
@@ -498,9 +498,7 @@ fn parse_type_before_name_field(line: &str) -> Option<FieldSignature> {
         content = stripped.trim_start();
     }
 
-    let Some(dollar_pos) = content.find('$') else {
-        return None;
-    };
+    let dollar_pos = content.find('$')?;
 
     let field_type = content[..dollar_pos].trim();
     let after_dollar = &content[dollar_pos + 1..];

--- a/src/core/code_audit/detectors/requested_detectors/config_roundtrip_keys.rs
+++ b/src/core/code_audit/detectors/requested_detectors/config_roundtrip_keys.rs
@@ -152,17 +152,8 @@ fn missing_roundtrip_sides(key: &str, key_sets: &ConfigRoundtripKeySets) -> Vec<
     let copied = key_sets.copied.contains_key(key);
     let mut missing = Vec::new();
 
-    if behavior_bearing {
-        if !exported {
-            missing.push("export");
-        }
-        if !imported {
-            missing.push("import");
-        }
-        if key_sets.copy_enabled && !copied {
-            missing.push("copy");
-        }
-    } else if exported != imported
+    if behavior_bearing
+        || exported != imported
         || (key_sets.copy_enabled && (copied != exported || copied != imported))
     {
         if !exported {

--- a/src/core/code_audit/duplication.rs
+++ b/src/core/code_audit/duplication.rs
@@ -297,9 +297,10 @@ fn count_body_lines(fp: &FileFingerprint, method_name: &str) -> usize {
                 brace_depth += 1;
             } else if ch == '}' {
                 brace_depth -= 1;
-                if open_line.is_some() && brace_depth == 0 {
-                    let open = open_line.unwrap();
-                    return line_idx.saturating_sub(open).saturating_sub(1);
+                if let Some(open) = open_line {
+                    if brace_depth == 0 {
+                        return line_idx.saturating_sub(open).saturating_sub(1);
+                    }
                 }
             }
         }
@@ -1080,6 +1081,7 @@ fn lcs_ratio(a: &[String], b: &[String]) -> f64 {
 /// - Methods with fewer than MIN_CALL_COUNT calls
 /// - Pairs already caught by exact or near-duplicate detection
 /// - Pairs below both similarity thresholds
+///
 /// Detect parallel implementations — methods with similar call patterns across files.
 ///
 /// `convention_methods` contains method names that are expected by discovered conventions.

--- a/src/core/code_audit/execution_plan.rs
+++ b/src/core/code_audit/execution_plan.rs
@@ -476,6 +476,7 @@ impl AuditExecutionPlan {
         Self::from_profile_and_filters(AuditProfile::Full, &[], &[])
     }
 
+    #[cfg(test)]
     pub(crate) fn from_filters(only: &[AuditFinding], exclude: &[AuditFinding]) -> Self {
         Self::from_profile_and_filters(AuditProfile::Full, only, exclude)
     }

--- a/src/core/component/audit.rs
+++ b/src/core/component/audit.rs
@@ -439,8 +439,8 @@ fn default_remote_execution_preflight_convention() -> String {
     "remote_execution_preflight".to_string()
 }
 
-fn is_default_remote_execution_preflight_convention(value: &String) -> bool {
-    value.as_str() == default_remote_execution_preflight_convention()
+fn is_default_remote_execution_preflight_convention(value: &str) -> bool {
+    value == default_remote_execution_preflight_convention()
 }
 
 impl Default for RemoteExecutionSafetyConfig {
@@ -653,8 +653,8 @@ fn default_thin_command_adapter_convention() -> String {
     "thin_command_adapter".to_string()
 }
 
-fn is_default_thin_command_adapter_convention(value: &String) -> bool {
-    value.as_str() == default_thin_command_adapter_convention()
+fn is_default_thin_command_adapter_convention(value: &str) -> bool {
+    value == default_thin_command_adapter_convention()
 }
 
 fn default_thin_command_adapter_threshold() -> u32 {

--- a/src/core/extension/bench/run.rs
+++ b/src/core/extension/bench/run.rs
@@ -558,7 +558,7 @@ fn require_positive(name: &str, value: u64) -> Result<()> {
 /// averaging.
 pub fn run_main_bench_workflow(
     component: &Component,
-    source_path: &PathBuf,
+    source_path: &Path,
     args: BenchRunWorkflowArgs,
     run_dir: &RunDir,
 ) -> Result<BenchRunWorkflowResult> {

--- a/src/core/extension/component_script.rs
+++ b/src/core/extension/component_script.rs
@@ -154,8 +154,7 @@ pub(crate) fn run_component_scripts_with_run_dir(
         &env,
         script_args,
     )?;
-    output.extension_phase_timings =
-        super::runner::read_extension_phase_timings(&run_dir.path().to_path_buf())?;
+    output.extension_phase_timings = super::runner::read_extension_phase_timings(run_dir.path())?;
     Ok(output)
 }
 

--- a/src/core/extension/runner.rs
+++ b/src/core/extension/runner.rs
@@ -256,7 +256,7 @@ impl ExtensionRunner {
             child_resource: output.child_resource,
             extension_phase_timings: self
                 .run_dir_path
-                .as_ref()
+                .as_deref()
                 .map(read_extension_phase_timings)
                 .transpose()?
                 .unwrap_or_default(),
@@ -316,9 +316,9 @@ impl ExtensionRunner {
 }
 
 pub(crate) fn read_extension_phase_timings(
-    run_dir_path: &PathBuf,
+    run_dir_path: &Path,
 ) -> Result<Vec<ExtensionPhaseTiming>> {
-    let run_dir = RunDir::from_existing(run_dir_path.clone())?;
+    let run_dir = RunDir::from_existing(run_dir_path.to_path_buf())?;
     let Some(value) = run_dir.read_step_output(run_dir::files::PHASE_TIMINGS) else {
         return Ok(Vec::new());
     };

--- a/src/core/extension/test/parsing.rs
+++ b/src/core/extension/test/parsing.rs
@@ -268,13 +268,13 @@ fn default_test_result_parse_spec() -> ParseSpec {
     }
 }
 
-pub fn parse_coverage_file(path: &std::path::Path) -> std::result::Result<CoverageOutput, ()> {
-    let content = local_files::read_file(path, "read coverage file").map_err(|_| ())?;
-    let data: serde_json::Value = serde_json::from_str(&content).map_err(|_| ())?;
+pub fn parse_coverage_file(path: &std::path::Path) -> Option<CoverageOutput> {
+    let content = local_files::read_file(path, "read coverage file").ok()?;
+    let data: serde_json::Value = serde_json::from_str(&content).ok()?;
 
-    let totals = data.get("totals").ok_or(())?;
-    let lines = totals.get("lines").ok_or(())?;
-    let methods = totals.get("methods").ok_or(())?;
+    let totals = data.get("totals")?;
+    let lines = totals.get("lines")?;
+    let methods = totals.get("methods")?;
 
     let lines_pct = lines
         .get("pct")
@@ -318,7 +318,7 @@ pub fn parse_coverage_file(path: &std::path::Path) -> std::result::Result<Covera
         })
         .unwrap_or_default();
 
-    Ok(CoverageOutput {
+    Some(CoverageOutput {
         lines_pct,
         lines_total,
         lines_covered,

--- a/src/core/extension/test/run.rs
+++ b/src/core/extension/test/run.rs
@@ -299,9 +299,7 @@ pub fn run_main_test_workflow(
         require_phpunit_tests,
     );
 
-    let coverage = coverage_file
-        .as_ref()
-        .and_then(|file| parse_coverage_file(file).ok());
+    let coverage = coverage_file.as_deref().and_then(parse_coverage_file);
 
     let failure_analysis_input = parse_failures_file(&failures_file);
     let findings = failure_analysis_input

--- a/src/core/extension/trace/generic_runner.rs
+++ b/src/core/extension/trace/generic_runner.rs
@@ -89,7 +89,7 @@ pub(super) fn run_generic_trace_runner(
         stderr: String::from_utf8_lossy(&output.stderr).to_string(),
         child_resource: None,
         extension_phase_timings: super::super::runner::read_extension_phase_timings(
-            &run_dir.path().to_path_buf(),
+            run_dir.path(),
         )?,
     })
 }

--- a/src/core/git/github_comment_sections.rs
+++ b/src/core/git/github_comment_sections.rs
@@ -133,9 +133,7 @@ pub(crate) fn render_comment(
         out.push_str(&format!("<!-- homeboy:section-key={}:end -->", key));
         // Blank line between sections, and between the last section and a
         // footer block. Trailing newline on the last line of the comment.
-        if idx + 1 < ordered.len() {
-            out.push_str("\n\n");
-        } else if has_footer {
+        if idx + 1 < ordered.len() || has_footer {
             out.push_str("\n\n");
         } else {
             out.push('\n');

--- a/src/core/lifecycle_store.rs
+++ b/src/core/lifecycle_store.rs
@@ -75,9 +75,11 @@ pub(super) fn record_exists(run_id: &str) -> Result<bool> {
 
 pub(super) fn read_records() -> Result<Vec<AgentTaskRunRecord>> {
     let store = ObservationStore::open_initialized()?;
-    let mut filter = RunListFilter::default();
-    filter.kind = Some("agent-task".to_string());
-    filter.limit = Some(1000);
+    let filter = RunListFilter {
+        kind: Some("agent-task".to_string()),
+        limit: Some(1000),
+        ..Default::default()
+    };
     let mut records = Vec::new();
     for run in store.list_runs(filter)? {
         match record_from_run(&run) {

--- a/src/core/refactor/transform.rs
+++ b/src/core/refactor/transform.rs
@@ -747,14 +747,7 @@ fn apply_hoist_static_context(
                 .replace("$1", &screaming)
                 .replace("$2", init_expr.as_deref().unwrap_or(""))
                 .split('\n')
-                .enumerate()
-                .map(|(j, part)| {
-                    if j == 0 {
-                        format!("{}{}", indent, part)
-                    } else {
-                        format!("{}{}", indent, part)
-                    }
-                })
+                .map(|part| format!("{}{}", indent, part))
                 .collect::<Vec<_>>()
                 .join("\n");
 

--- a/src/core/rig/capabilities.rs
+++ b/src/core/rig/capabilities.rs
@@ -1,6 +1,5 @@
 //! Generic declarative rig requirements and capability checks.
 
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;

--- a/src/core/rig/runner.rs
+++ b/src/core/rig/runner.rs
@@ -627,9 +627,7 @@ impl RigRunObserver {
         pipeline: Option<&PipelineOutcome>,
         result: &Result<T>,
     ) -> Option<RigRunArtifactIndex> {
-        let Some(observer) = observer else {
-            return None;
-        };
+        let observer = observer?;
         let status = match result {
             Ok(_) if pipeline.is_some_and(PipelineOutcome::is_success) => RunStatus::Pass,
             Ok(_) => RunStatus::Fail,

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -243,16 +243,14 @@ impl Default for FilesystemAssertionSpec {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
-#[derive(Default)]
 pub enum FilesystemAssertionKind {
     #[default]
     Path,
     File,
     Dir,
 }
-
 
 impl FilesystemAssertionKind {
     pub fn is_path(&self) -> bool {

--- a/src/core/runner/connection_daemon.rs
+++ b/src/core/runner/connection_daemon.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 use std::time::Duration;
 
 use reqwest::blocking::Client;
@@ -20,7 +20,7 @@ pub(super) fn connect_remote_daemon(
     expected_version: &str,
     expected_identity: &str,
     runner_id: &str,
-    session_path: &PathBuf,
+    session_path: &Path,
 ) -> std::result::Result<(u16, Option<u32>, String, RemoteDaemon), (RunnerConnectReport, i32)> {
     let failed_after_tunnel = |tunnel_pid: Option<u32>, message: String| {
         if let Some(pid) = tunnel_pid {
@@ -28,7 +28,7 @@ pub(super) fn connect_remote_daemon(
         }
         failed_connect(
             runner_id,
-            session_path.clone(),
+            session_path.to_path_buf(),
             RunnerFailureKind::DaemonStartupFailure,
             message,
         )
@@ -44,7 +44,7 @@ pub(super) fn connect_remote_daemon(
             if let Err(message) = remote_daemon_stop(client, homeboy) {
                 return Err(failed_connect(
                     runner_id,
-                    session_path.clone(),
+                    session_path.to_path_buf(),
                     RunnerFailureKind::DaemonStartupFailure,
                     message,
                 ));
@@ -54,7 +54,7 @@ pub(super) fn connect_remote_daemon(
                 Err(message) => {
                     return Err(failed_connect(
                         runner_id,
-                        session_path.clone(),
+                        session_path.to_path_buf(),
                         RunnerFailureKind::DaemonStartupFailure,
                         message,
                     ));
@@ -86,12 +86,12 @@ fn open_daemon_tunnel(
     server: &Server,
     daemon: &RemoteDaemon,
     runner_id: &str,
-    session_path: &PathBuf,
+    session_path: &Path,
 ) -> std::result::Result<(u16, Option<u32>, String), (RunnerConnectReport, i32)> {
     let Ok(remote_addr) = parse_loopback_daemon_addr(&daemon.address) else {
         return Err(failed_connect(
             runner_id,
-            session_path.clone(),
+            session_path.to_path_buf(),
             RunnerFailureKind::DaemonStartupFailure,
             "remote daemon did not report a loopback address".to_string(),
         ));
@@ -100,7 +100,7 @@ fn open_daemon_tunnel(
     let local_port = reserve_loopback_port().map_err(|err| {
         failed_connect(
             runner_id,
-            session_path.clone(),
+            session_path.to_path_buf(),
             RunnerFailureKind::TunnelFailure,
             err.to_string(),
         )
@@ -114,7 +114,7 @@ fn open_daemon_tunnel(
     if !tunnel.success {
         return Err(failed_connect(
             runner_id,
-            session_path.clone(),
+            session_path.to_path_buf(),
             RunnerFailureKind::TunnelFailure,
             format!("SSH tunnel setup failed: {}", tunnel.stderr.trim()),
         ));
@@ -126,7 +126,7 @@ fn open_daemon_tunnel(
         }
         return Err(failed_connect(
             runner_id,
-            session_path.clone(),
+            session_path.to_path_buf(),
             RunnerFailureKind::TunnelFailure,
             format!(
                 "local tunnel 127.0.0.1:{} did not become reachable",

--- a/src/core/runner/lab/args_util.rs
+++ b/src/core/runner/lab/args_util.rs
@@ -74,7 +74,7 @@ fn subcommand_index_before_passthrough(args: &[String], subcommand: &str) -> Opt
 
 fn option_value<'a>(args: &'a [String], start_index: usize, flag: &str) -> Option<&'a str> {
     let flag_eq = format!("{flag}=");
-    let mut iter = args.iter().enumerate().skip(start_index);
+    let iter = args.iter().enumerate().skip(start_index);
     for (index, arg) in iter {
         if arg == "--" {
             return None;

--- a/src/core/runner/lab_args/envelope.rs
+++ b/src/core/runner/lab_args/envelope.rs
@@ -183,7 +183,10 @@ fn agent_task_text_flag(arg: &str) -> Option<&'static str> {
 
 fn agent_task_text_inline_arg(arg: &str) -> Option<(&'static str, &str)> {
     for flag in ["--prompt", "--task", "--tasks"] {
-        if let Some(value) = arg.strip_prefix(flag).and_then(|rest| rest.strip_prefix('=')) {
+        if let Some(value) = arg
+            .strip_prefix(flag)
+            .and_then(|rest| rest.strip_prefix('='))
+        {
             return Some((flag, value));
         }
     }
@@ -271,6 +274,9 @@ mod tests {
             ArgValue::InlineText("Fix it".to_string())
         );
         assert_eq!(envelope.inputs.agent_task_text_specs[2].flag, "--tasks");
-        assert_eq!(envelope.inputs.agent_task_text_specs[2].value, ArgValue::Stdin);
+        assert_eq!(
+            envelope.inputs.agent_task_text_specs[2].value,
+            ArgValue::Stdin
+        );
     }
 }

--- a/src/core/server/api.rs
+++ b/src/core/server/api.rs
@@ -90,12 +90,6 @@ struct ApiInput {
     body_format: BodyFormat,
 }
 
-impl Default for BodyFormat {
-    fn default() -> Self {
-        Self::Json
-    }
-}
-
 impl<'de> serde::Deserialize<'de> for BodyFormat {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where

--- a/src/core/server/http.rs
+++ b/src/core/server/http.rs
@@ -244,8 +244,9 @@ impl ApiClient {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BodyFormat {
+    #[default]
     Json,
     Form,
 }

--- a/src/core/server/process_cleanup.rs
+++ b/src/core/server/process_cleanup.rs
@@ -65,7 +65,7 @@ impl ProcessGroupCleanupGuard {
 
     #[cfg(unix)]
     pub(crate) fn pgid(&self) -> Option<i32> {
-        self.pgid.map(|pgid| pgid)
+        self.pgid
     }
 
     #[cfg(not(unix))]

--- a/src/core/upgrade/execution.rs
+++ b/src/core/upgrade/execution.rs
@@ -209,9 +209,8 @@ where
             .as_ref()
             .and_then(|info| info.version.as_deref())
             .is_some()
+            || last_seen.is_none()
         {
-            last_seen = active_binary;
-        } else if last_seen.is_none() {
             last_seen = active_binary;
         }
 


### PR DESCRIPTION
## Summary
Proactive cleanup of accumulated clippy lint debt on `main`. Reduces lib clippy warnings from **103 → ~67** (all remaining are structural lints — see below). Also fixes a compile-blocking borrow-after-partial-move that briefly broke `cargo clippy --lib` on main (independently fixed upstream during rebase; resolved by taking theirs).

All changes are **lint-only / no behavior change**:
- Remove dead/unused code (`from_filters` gated to `#[cfg(test)]`, unused `daemon_api_post` re-export).
- Rewrite `let...else { return None }` as the `?` operator (8 sites).
- Collapse `if` branches with identical blocks (5 sites).
- Hoist a `Regex::new` out of a nested loop into a `LazyLock` static.
- Use `&str`/`&Path` over `&String`/`&PathBuf` in fn signatures.
- Convert a `Result<_, ()>` to `Option`.
- `#[derive(Default)]` instead of hand-written `Default` impls.
- Field-init-shorthand for `Default::default()` structs.
- Mechanical `clippy --fix` simplifications (redundant closures, `map_or`→`is_none_or`, `map`→`inspect`, `while let`→`for`, identity-map removal, useless conversions, `is_some()`→`is_none()`).

## Remaining (not in scope here — follow-up)
Left untouched because they are judgment-call **structural** lints that this repo already manages via scoped `#[allow]`, and refactoring them risks behavior changes / merge churn on a fast-moving `main`:
- `large_enum_variant` (~17) + large `Err`-variant (~8)
- `type_complexity` (~12)
- `too_many_arguments` (~20)
- `needless_range_loop` (~10)
- A handful of fresh `dead_code` (`never used`) warnings introduced by parallel merges after this branch was cut.

A focused follow-up can add scoped `#[allow(..., reason = "...")]` (or box/refactor) for these to get the Lint gate fully to zero.

## Verification
- `cargo build --lib` ✅ clean
- `cargo clippy --lib` ✅ compiles; only the structural warnings above remain
- `cargo fmt` ✅ applied