### PR TITLE
Fix controller dispatch cwd portability

### DIFF
--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -242,9 +242,14 @@ fn apply_dispatch_defaults_for_root(spec: &mut AgentTaskRepoLoopSpec, root: Path
     let Value::Object(defaults) = defaults else {
         return;
     };
-    defaults
-        .entry("cwd".to_string())
-        .or_insert_with(|| Value::String(root.display().to_string()));
+    let should_set_cwd = defaults
+        .get("cwd")
+        .and_then(Value::as_str)
+        .map(|cwd| !Path::new(cwd).is_dir())
+        .unwrap_or(true);
+    if should_set_cwd {
+        defaults.insert("cwd".to_string(), Value::String(root.display().to_string()));
+    }
     defaults
         .entry("repo".to_string())
         .or_insert_with(|| Value::String(repo));

--- a/src/commands/agent_task/tests/dispatch.rs
+++ b/src/commands/agent_task/tests/dispatch.rs
@@ -144,6 +144,54 @@ fn from_spec_dispatch_defaults_fall_back_to_current_git_checkout() {
 }
 
 #[test]
+fn from_spec_dispatch_defaults_replace_stale_workspace_cwd() {
+    let repo = tempfile::tempdir().expect("repo dir");
+    let git_status = Command::new("git")
+        .arg("-C")
+        .arg(repo.path())
+        .arg("init")
+        .status()
+        .expect("git init runs");
+    assert!(git_status.success());
+    let mut spec = AgentTaskRepoLoopSpec {
+        schema: None,
+        loop_id: "repo-loop-stale-cwd-defaults".to_string(),
+        phase: "init".to_string(),
+        config_version: "v1".to_string(),
+        metadata: json!({
+            "dispatch_defaults": {
+                "cwd": "/path/that/does/not/exist",
+                "repo": "stale-repo"
+            }
+        }),
+        entities: Vec::new(),
+        agents: Vec::new(),
+        tools: Vec::new(),
+        abilities: Vec::new(),
+        workflows: Vec::new(),
+        artifacts: Vec::new(),
+        artifact_graph: Vec::new(),
+        dependencies: Vec::new(),
+        gates: Vec::new(),
+        metrics: Vec::new(),
+        gate_bundles: Vec::new(),
+        policy: None,
+        phases: Vec::new(),
+        actions: Vec::new(),
+        initial_event: None,
+    };
+
+    apply_from_spec_dispatch_defaults_with_cwd(&mut spec, "-", || Some(repo.path().to_path_buf()));
+    let expected_root = std::fs::canonicalize(repo.path()).expect("canonical repo path");
+
+    assert_eq!(
+        spec.metadata["dispatch_defaults"]["cwd"],
+        expected_root.display().to_string()
+    );
+    assert_eq!(spec.metadata["dispatch_defaults"]["repo"], "stale-repo");
+}
+
+#[test]
 fn controller_dispatch_args_preserve_top_level_workspace_context_in_plan() {
     let repo = tempfile::tempdir().expect("repo dir");
     let repo_path = repo.path().display().to_string();

--- a/src/commands/runs/refs.rs
+++ b/src/commands/runs/refs.rs
@@ -163,9 +163,10 @@ pub fn runs_refs(args: RunsRefsArgs) -> CmdResult<RunsOutput> {
 
 fn run_matches_filter(run: &RunRecord, filter: &RunListFilter) -> bool {
     filter.kind.as_deref().is_none_or(|kind| run.kind == kind)
-        && filter.component_id.as_deref().is_none_or(|component| {
-            run.component_id.as_deref() == Some(component)
-        })
+        && filter
+            .component_id
+            .as_deref()
+            .is_none_or(|component| run.component_id.as_deref() == Some(component))
         && filter
             .status
             .as_deref()

--- a/src/core/rig/spec.rs
+++ b/src/core/rig/spec.rs
@@ -253,7 +253,6 @@ pub enum FilesystemAssertionKind {
     Dir,
 }
 
-
 impl FilesystemAssertionKind {
     pub fn is_path(&self) -> bool {
         matches!(self, Self::Path)

--- a/src/core/runner/lab_args/envelope.rs
+++ b/src/core/runner/lab_args/envelope.rs
@@ -183,7 +183,10 @@ fn agent_task_text_flag(arg: &str) -> Option<&'static str> {
 
 fn agent_task_text_inline_arg(arg: &str) -> Option<(&'static str, &str)> {
     for flag in ["--prompt", "--task", "--tasks"] {
-        if let Some(value) = arg.strip_prefix(flag).and_then(|rest| rest.strip_prefix('=')) {
+        if let Some(value) = arg
+            .strip_prefix(flag)
+            .and_then(|rest| rest.strip_prefix('='))
+        {
             return Some((flag, value));
         }
     }
@@ -271,6 +274,9 @@ mod tests {
             ArgValue::InlineText("Fix it".to_string())
         );
         assert_eq!(envelope.inputs.agent_task_text_specs[2].flag, "--tasks");
-        assert_eq!(envelope.inputs.agent_task_text_specs[2].value, ArgValue::Stdin);
+        assert_eq!(
+            envelope.inputs.agent_task_text_specs[2].value,
+            ArgValue::Stdin
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Replace stale/nonexistent from-spec dispatch cwd defaults with the current repo root.
- Add a regression test for specs carrying a stale absolute workspace path.
- Apply rustfmt to current-main drift so the branch is format-clean.

## Verification
- `rustfmt --check $(git ls-files '*.rs')`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosing the Lab offload cwd portability failure and applying the minimal upstream fix.