### PR TITLE
Fix dispatch workspace fallback for stale cwd

### DIFF
--- a/src/core/agent_task_dispatch_plan.rs
+++ b/src/core/agent_task_dispatch_plan.rs
@@ -16,7 +16,7 @@ use crate::core::agent_task_config_materialization::materialize_provider_config_
 use crate::core::agent_task_provider::provider_requires_cwd_git_checkout;
 use crate::core::agent_task_scheduler::{AgentTaskPlan, AgentTaskRetryPolicy};
 use crate::core::agent_task_secrets::validate_secret_env;
-use crate::core::{config, defaults, worktree, Error, Result};
+use crate::core::{config, defaults, git, worktree, Error, Result};
 
 use super::agent_task_dispatch_service::AgentTaskDispatchRequest;
 
@@ -268,6 +268,12 @@ fn resolve_dispatch_workspace(
     if let Some(cwd) = &request.cwd {
         let path = std::path::PathBuf::from(cwd);
         if !path.is_dir() {
+            if let Some(root) = std::env::current_dir()
+                .ok()
+                .and_then(|cwd| git::repo_root(&cwd))
+            {
+                return Ok(Some(DispatchWorkspaceTarget::path(root, "cwd-fallback")));
+            }
             return Err(Error::validation_invalid_argument(
                 "cwd",
                 format!(
@@ -695,6 +701,29 @@ mod tests {
         assert!(!serialized.contains("kimaki"));
         assert!(!serialized.contains("channel"));
         assert!(!serialized.contains("thread"));
+    }
+
+    #[test]
+    fn dispatch_plan_falls_back_to_current_git_root_for_stale_cwd() {
+        let repo = tempfile::tempdir().expect("repo");
+        git(repo.path(), &["init"]);
+        let previous_cwd = std::env::current_dir().expect("current dir");
+        std::env::set_current_dir(repo.path()).expect("enter repo");
+
+        let plan = build_dispatch_plan(&dispatch_request(DispatchRequestOverrides {
+            prompt: Some("Cook inside the materialized workspace.".to_string()),
+            cwd: Some("/path/that/does/not/exist".to_string()),
+            ..DispatchRequestOverrides::default()
+        }));
+
+        std::env::set_current_dir(previous_cwd).expect("restore cwd");
+        let plan = plan.expect("dispatch plan");
+        let expected_root = std::fs::canonicalize(repo.path()).expect("canonical repo path");
+        assert_eq!(
+            plan.tasks[0].workspace.root.as_deref(),
+            Some(expected_root.to_str().expect("repo path utf8"))
+        );
+        assert_eq!(plan.tasks[0].metadata["workspace"]["kind"], "cwd-fallback");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fall back to the current git root when a dispatch request carries a stale cwd path.
- Preserve the existing validation error when no git root fallback is available.
- Add a regression test for stale cwd dispatch planning.

## Verification
- `git diff --check`
- `rustfmt --check src/core/agent_task_dispatch_plan.rs`
- Homeboy Lab focused test: `homeboy test --runner homeboy-lab --allow-dirty-lab-workspace -- dispatch_plan_falls_back_to_current_git_root_for_stale_cwd`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosing the Lab/controller cwd portability failure, drafting the focused fix and regression test, and running verification.