### PR TITLE
docs: document audit --profile flag to fix cli_surface drift gate

### DIFF
--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -22,6 +22,7 @@ Works with registered components (by ID) or raw filesystem paths.
 - `--extension <ID>`: One-shot extension override for the current invocation; repeat to layer multiple extension hints
 - `--only <kind>`: Restrict findings to one or more finding kinds; repeat for multiple kinds
 - `--exclude <kind>`: Exclude one or more finding kinds; repeat for multiple kinds
+- `--profile <PROFILE>`: Detector profile to run (`full`, `pr`, or `architecture`); defaults to `full`. `full` runs the complete audit, `pr` runs cheap root-level blockers for changed-file review, and `architecture` runs architecture-focused detectors
 - `--baseline`: Save current audit state as baseline for future comparisons
 - `--ignore-baseline`: Skip baseline comparison even if a baseline exists
 - `--ratchet`: Auto-update the baseline when the current run improves on it


### PR DESCRIPTION
## Summary
- The `audit` command exposes a `--profile <full|pr|architecture>` flag (added at `src/commands/audit.rs:48-51`) via live clap help, but `docs/commands/audit.md` never documented it.
- This deterministically fails `cli_surface::tests::docs_cover_high_use_command_surfaces`, which asserts every visible long flag from live `--help` is documented — a real test-gate blocker on `main`.
- Adds the flag to the Options section. No code/behavior change.

## Verification context
Found while doing a local definitive green-check of `main` (HEAD `172ca436`) because parallel fleet merges were cancelling every CI run. On that HEAD:
- `cargo build --lib` — compiles clean (no `error[E...]`)
- `homeboy lint homeboy` — **passed** (clippy warnings are all baselined; gate is green)
- `cargo build --lib --tests` — test targets compile clean (no E0063/E0061)
- `cargo test --lib` — `5250 passed`, with only 3 failures, of which this docs-drift was the sole deterministic, CI-relevant one.

The other 2 remaining failures (`core::extension::lifecycle::...linked_update_switches_clean_worktree...` and `core::refactor::plan::generate::module_surface::build_uses_snapshot_content_for_module_surfaces`) are host-state/integration dependencies of the verification VPS (real git worktree ops + installed-extension `.rs` claiming), not main defects — they pass on a clean CI runner.

After this fix, `cli_surface` module is 11/11 green.