### PR TITLE
Fix from-spec cwd fallback in snapshot workspaces

### DIFF
--- a/src/commands/agent_task/controller.rs
+++ b/src/commands/agent_task/controller.rs
@@ -210,13 +210,21 @@ fn dispatch_root_for_spec(
     spec_arg: &str,
     current_dir: impl FnOnce() -> Option<PathBuf>,
 ) -> Option<PathBuf> {
+    let current_dir = current_dir();
     let Some(spec_path) = spec_file_path(spec_arg) else {
-        return current_dir().and_then(|path| git_root_for_path(&path));
+        return current_dir.and_then(|path| dispatch_root_for_current_dir(&path));
     };
     if let Some(root) = git_root_for_spec(&spec_path) {
         return Some(root);
     }
-    current_dir().and_then(|path| git_root_for_path(&path))
+    current_dir.and_then(|path| dispatch_root_for_current_dir(&path))
+}
+
+fn dispatch_root_for_current_dir(path: &Path) -> Option<PathBuf> {
+    git_root_for_path(path).or_else(|| {
+        path.is_dir()
+            .then(|| std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()))
+    })
 }
 
 fn apply_dispatch_defaults_for_root(spec: &mut AgentTaskRepoLoopSpec, root: PathBuf) {

--- a/src/commands/agent_task/tests/dispatch.rs
+++ b/src/commands/agent_task/tests/dispatch.rs
@@ -192,6 +192,52 @@ fn from_spec_dispatch_defaults_replace_stale_workspace_cwd() {
 }
 
 #[test]
+fn from_spec_dispatch_defaults_replace_stale_cwd_in_snapshot_workspace() {
+    let workspace = tempfile::tempdir().expect("workspace dir");
+    let mut spec = AgentTaskRepoLoopSpec {
+        schema: None,
+        loop_id: "repo-loop-snapshot-cwd-defaults".to_string(),
+        phase: "init".to_string(),
+        config_version: "v1".to_string(),
+        metadata: json!({
+            "dispatch_defaults": {
+                "cwd": "/path/that/does/not/exist",
+                "repo": "wp-site-generator"
+            }
+        }),
+        entities: Vec::new(),
+        agents: Vec::new(),
+        tools: Vec::new(),
+        abilities: Vec::new(),
+        workflows: Vec::new(),
+        artifacts: Vec::new(),
+        artifact_graph: Vec::new(),
+        dependencies: Vec::new(),
+        gates: Vec::new(),
+        metrics: Vec::new(),
+        gate_bundles: Vec::new(),
+        policy: None,
+        phases: Vec::new(),
+        actions: Vec::new(),
+        initial_event: None,
+    };
+
+    apply_from_spec_dispatch_defaults_with_cwd(&mut spec, "-", || {
+        Some(workspace.path().to_path_buf())
+    });
+    let expected_root = std::fs::canonicalize(workspace.path()).expect("canonical workspace path");
+
+    assert_eq!(
+        spec.metadata["dispatch_defaults"]["cwd"],
+        expected_root.display().to_string()
+    );
+    assert_eq!(
+        spec.metadata["dispatch_defaults"]["repo"],
+        "wp-site-generator"
+    );
+}
+
+#[test]
 fn controller_dispatch_args_preserve_top_level_workspace_context_in_plan() {
     let repo = tempfile::tempdir().expect("repo dir");
     let repo_path = repo.path().display().to_string();


### PR DESCRIPTION
## Summary
- Let `agent-task controller from-spec` use the current runner directory as a dispatch cwd fallback when no git root exists.
- Preserve existing git-root preference for normal checkouts.
- Add a regression for stale embedded `dispatch_defaults.cwd` inside a non-git snapshot workspace.

## Verification
- `git diff --check`
- `rustfmt --check src/commands/agent_task/controller.rs src/commands/agent_task/tests/dispatch.rs`
- `homeboy test --runner homeboy-lab --allow-dirty-lab-workspace -- from_spec_dispatch_defaults_replace_stale_cwd_in_snapshot_workspace`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosing the remaining Lab/controller stale cwd path, drafting the generic fallback and regression test, and running verification.