### PR TITLE
Preserve invalid bench artifact paths for validation

### DIFF
--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -192,10 +192,10 @@ fn normalize_artifact_map(value: Option<&mut serde_json::Value>) {
         return;
     };
 
-    artifacts.retain(|_, artifact| artifact_has_pointer(artifact));
+    artifacts.retain(|_, artifact| artifact_has_pointer_field(artifact));
 }
 
-fn artifact_has_pointer(artifact: &serde_json::Value) -> bool {
+fn artifact_has_pointer_field(artifact: &serde_json::Value) -> bool {
     let Some(object) = artifact.as_object() else {
         return false;
     };
@@ -209,12 +209,7 @@ fn artifact_has_pointer(artifact: &serde_json::Value) -> bool {
         "observation_artifact_id",
     ]
     .iter()
-    .any(|field| {
-        object
-            .get(*field)
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|value| !value.trim().is_empty())
-    })
+    .any(|field| object.contains_key(*field))
 }
 
 fn normalize_diagnostic_producer_sources(value: &mut serde_json::Value) {


### PR DESCRIPTION
## Summary
- keep pointer-shaped bench artifacts during parser normalization even when the pointer value is blank
- continue dropping inline payload-only benchmark artifacts before strict artifact deserialization
- restore existing empty-path validation diagnostics for scenario and iteration artifacts

## Verification
- Not run locally: Rust/Cargo verification is intentionally left to CI per local environment rules.
- Inspected failing CI log from PR #5459: bench parser validation tests failed because normalization removed empty path artifacts before validation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the CI failure, applying the targeted parser fix, and drafting this PR description.
