### PR TITLE
fix(ci): treat CLEAN-with-zero-checks PR state as not-mergeable (#4872)

### DIFF
--- a/src/core/triage.rs
+++ b/src/core/triage.rs
@@ -916,6 +916,14 @@ fn derive_pr_next_action(pr: &TriagePrItem) -> Option<String> {
     if review == Some("APPROVED") && is_dirty_merge_state(merge) {
         return Some("approved_but_dirty".to_string());
     }
+    // GitHub reports mergeStateStatus=CLEAN with an empty statusCheckRollup during
+    // the force-push/rebase window before CI registers on the new head SHA. A CLEAN
+    // PR whose required checks have not reported yet is NOT mergeable — gating merge
+    // automation on CLEAN alone would merge a commit whose CI has never run (#4872).
+    // Surface this race explicitly so the silent neutral state never reads as ready.
+    if merge == Some("CLEAN") && checks.is_none() {
+        return Some("clean_but_checks_not_reported".to_string());
+    }
     if review == Some("APPROVED") && merge == Some("CLEAN") && checks == Some("PENDING") {
         return Some("approved_but_pending_checks".to_string());
     }
@@ -1115,6 +1123,7 @@ const PR_ACTION_PRIORITY: &[&str] = &[
     "approved_but_dirty",
     "needs_rebase",
     "review_required",
+    "clean_but_checks_not_reported",
     "approved_but_pending_checks",
     "clean_and_ready",
     "stale_pr",
@@ -1123,9 +1132,11 @@ const PR_ACTION_PRIORITY: &[&str] = &[
 fn pr_action_severity(kind: &str) -> &'static str {
     match kind {
         "draft_with_failing_checks" | "checks_failed" | "approved_but_dirty" => "high",
-        "needs_rebase" | "review_required" | "approved_but_pending_checks" | "clean_and_ready" => {
-            "medium"
-        }
+        "needs_rebase"
+        | "review_required"
+        | "clean_but_checks_not_reported"
+        | "approved_but_pending_checks"
+        | "clean_and_ready" => "medium",
         _ => "low",
     }
 }
@@ -1141,6 +1152,11 @@ fn pr_action_label(kind: &str, count: usize) -> String {
         "approved_but_dirty" => pluralize(count, "approved PR is dirty", "approved PRs are dirty"),
         "needs_rebase" => pluralize(count, "PR needs rebase", "PRs need rebase"),
         "review_required" => pluralize(count, "PR needs review", "PRs need review"),
+        "clean_but_checks_not_reported" => pluralize(
+            count,
+            "PR is CLEAN but checks have not reported yet",
+            "PRs are CLEAN but checks have not reported yet",
+        ),
         "approved_but_pending_checks" => pluralize(
             count,
             "approved PR is waiting on checks",

--- a/src/core/triage/tests.rs
+++ b/src/core/triage/tests.rs
@@ -473,6 +473,39 @@ mod pull_requests {
     }
 
     #[test]
+    fn parse_prs_flags_clean_with_zero_checks_as_not_reported() {
+        // Reproduces the #4872 force-push window: GitHub reports mergeStateStatus
+        // CLEAN with an empty statusCheckRollup before CI registers on the new head.
+        // This must surface a distinct "checks not reported" action rather than
+        // silently reading as clean_and_ready (which would let merge automation
+        // merge a commit whose CI has never run).
+        let raw = r#"[
+            {
+              "number": 1,
+              "title": "Just force-pushed",
+              "url": "https://github.com/o/r/pull/1",
+              "state": "OPEN",
+              "isDraft": false,
+              "reviewDecision": "APPROVED",
+              "mergeStateStatus": "CLEAN",
+              "statusCheckRollup": [],
+              "labels": [],
+              "assignees": [],
+              "author": {"login":"example-org"},
+              "updatedAt": "2026-04-26T00:00:00Z"
+            }
+        ]"#;
+
+        let items = parse_prs(raw, None, false).unwrap();
+        assert_eq!(
+            items[0].signals.next_action.as_deref(),
+            Some("clean_but_checks_not_reported")
+        );
+        // The zero-check rollup must never be summarized as a successful state.
+        assert!(items[0].signals.checks.is_none());
+    }
+
+    #[test]
     fn parse_prs_marks_behind_and_dirty_as_needs_rebase() {
         let raw = r#"[
             {

--- a/src/core/triage/watch.rs
+++ b/src/core/triage/watch.rs
@@ -324,6 +324,12 @@ fn watch_until_reached(
         "closed" => matches!(current.state.state.as_str(), "CLOSED" | "MERGED"),
         "green" => current.state.checks.as_deref() == Some("SUCCESS"),
         "green-mergeable" => {
+            // A PR is only mergeable once its checks have reported SUCCESS on the
+            // current head. `checks` is `None` when GitHub returns an empty
+            // statusCheckRollup (e.g. the force-push window where mergeStateStatus
+            // flips to CLEAN before CI registers on the new head SHA). Requiring an
+            // explicit SUCCESS — never a bare CLEAN — keeps that race from merging
+            // untested code (#4872).
             current.item_type == "pull_request"
                 && !current.state.draft
                 && current.state.checks.as_deref() == Some("SUCCESS")
@@ -572,6 +578,30 @@ mod tests {
         assert!(watch_until_reached("green-mergeable", &item, None));
         assert!(watch_until_reached("green", &item, None));
         assert!(!watch_until_reached("merged", &item, None));
+    }
+
+    #[test]
+    fn watch_until_green_mergeable_rejects_clean_with_zero_checks() {
+        // Force-push window: mergeStateStatus flips to CLEAN before CI registers on
+        // the new head, so statusCheckRollup is empty and `checks` is None (#4872).
+        // A bare CLEAN must not satisfy green-mergeable.
+        let item = TriageWatchItem {
+            item_type: "pull_request".to_string(),
+            state: TriageWatchItemState {
+                state: "OPEN".to_string(),
+                title: None,
+                url: None,
+                checks: None,
+                review_decision: Some("APPROVED".to_string()),
+                merge_state: Some("CLEAN".to_string()),
+                head_sha: Some("abc123".to_string()),
+                merged_at: None,
+                draft: false,
+            },
+        };
+
+        assert!(!watch_until_reached("green-mergeable", &item, None));
+        assert!(!watch_until_reached("green", &item, None));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #4872. After a force-push/rebase, `gh pr view --json mergeStateStatus,statusCheckRollup` reports `mergeStateStatus: CLEAN` with an **empty `statusCheckRollup`** for a window while CI is still registering on the new head SHA. Automation (or an operator) gating on `CLEAN` could merge a commit whose CI has never run.

Root cause: homeboy's PR merge-readiness classifier in `src/core/triage.rs` (`derive_pr_next_action`) had no branch for the `CLEAN` + zero-checks case — it fell through to `None`, so the silent neutral state read as "nothing to do" rather than "not ready". The `green-mergeable` watch target already required `checks == SUCCESS`, but the invariant was implicit.

## Changes

- **`derive_pr_next_action`**: when `mergeStateStatus == CLEAN` but `statusCheckRollup` is empty (`checks` is `None`), surface a distinct `clean_but_checks_not_reported` action instead of silently returning `None`. This sits above `clean_and_ready` in priority so a force-push window never reads as mergeable.
- Registered the new action kind in `PR_ACTION_PRIORITY`, `pr_action_severity` (medium), and `pr_action_label`.
- **`green-mergeable` watch target**: added an explicit guard/comment documenting that `checks` must be `SUCCESS` (never a bare `CLEAN`); empty rollup → `checks == None` → not mergeable.

## Tests

- `parse_prs_flags_clean_with_zero_checks_as_not_reported` — CLEAN + empty rollup → `clean_but_checks_not_reported`, and `checks` stays `None`.
- `watch_until_green_mergeable_rejects_clean_with_zero_checks` — CLEAN + no checks does not satisfy `green-mergeable`/`green`.

Core stays language/framework-agnostic. `cargo fmt` clean; `cargo build --lib` passes locally (full suite deferred to CI).