### PR TITLE
Allow source upgrades from detached checkouts

### DIFF
--- a/assets/defaults/extension-provided-defaults.json
+++ b/assets/defaults/extension-provided-defaults.json
@@ -12,7 +12,7 @@
     },
     "source": {
       "path_patterns": ["/target/release/", "/target/debug/"],
-      "upgrade_command": "set -e\n\ngit pull\n. \"$HOME/.cargo/env\"\ncargo build --release\n\nBIN_PATH=\"$(command -v homeboy)\"\nARTIFACT=\"target/release/homeboy\"\nTMP_BIN=\"$(dirname \"$BIN_PATH\")/.homeboy-upgrade.$$\"\ncleanup() { [ -e \"$TMP_BIN\" ] && rm -f \"$TMP_BIN\"; }\ntrap cleanup EXIT\n\n\"$ARTIFACT\" --version >/dev/null\ninstall -m 0755 \"$ARTIFACT\" \"$TMP_BIN\"\n\"$TMP_BIN\" --version >/dev/null\nmv \"$TMP_BIN\" \"$BIN_PATH\"\ntrap - EXIT\n\"$BIN_PATH\" --version >/dev/null",
+      "upgrade_command": "set -e\n\nif git symbolic-ref -q HEAD >/dev/null && git rev-parse --abbrev-ref --symbolic-full-name @{upstream} >/dev/null 2>&1; then\n  git pull --ff-only\nelse\n  echo \"Skipping git pull for detached or upstream-less source checkout\"\nfi\n. \"$HOME/.cargo/env\"\ncargo build --release\n\nBIN_PATH=\"$(command -v homeboy)\"\nARTIFACT=\"target/release/homeboy\"\nTMP_BIN=\"$(dirname \"$BIN_PATH\")/.homeboy-upgrade.$$\"\ncleanup() { [ -e \"$TMP_BIN\" ] && rm -f \"$TMP_BIN\"; }\ntrap cleanup EXIT\n\n\"$ARTIFACT\" --version >/dev/null\ninstall -m 0755 \"$ARTIFACT\" \"$TMP_BIN\"\n\"$TMP_BIN\" --version >/dev/null\nmv \"$TMP_BIN\" \"$BIN_PATH\"\ntrap - EXIT\n\"$BIN_PATH\" --version >/dev/null",
       "list_command": null
     },
     "binary": {


### PR DESCRIPTION
## Summary
- Make source upgrades pull only when the source checkout is on a branch with an upstream.
- Allow detached or upstream-less source checkouts to build the exact provided ref.
- Use `git pull --ff-only` for branch-based source upgrades.

## Why
Runner workspace sync can materialize an explicit source ref as a detached checkout. The source upgrade default previously ran `git pull` unconditionally, causing upgrades from an explicit synced ref to fail before build with `You are not currently on a branch`.

## Testing
- `jq empty assets/defaults/extension-provided-defaults.json`
- Not run locally: Rust-heavy verification is intentionally left to GitHub Actions in this environment.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Root-cause analysis, implementation, validation, and PR description drafting.
