### PR TITLE
fix(changelog): eliminate docs/changelog.md multi-PR conflict surface (#4876)

### DIFF
--- a/docs/commands/changelog.md
+++ b/docs/commands/changelog.md
@@ -14,6 +14,8 @@ In JSON output mode, the default `show` output is returned as JSON (with a `cont
 
 > **Note:** Homeboy generates changelog entries automatically from conventional-prefixed commits (`feat:` / `fix:` / etc.) at release time. There is no `changelog add` command — users don't hand-curate changelog bullets. See `homeboy release` and the commits since the last tag.
 
+> **Do not hand-edit the changelog in feature PRs.** The release pipeline rewrites the changelog's next section from commits during `homeboy release`, so per-PR edits are overwritten — and because every PR would touch the same shared file, hand-edits make the changelog a guaranteed multi-PR merge-conflict surface (#4876). `homeboy review` enforces this: when a scoped review changeset (`--changed-since` / `--changed-only`) modifies the component's configured `changelog_target`, review surfaces a steering hint pointing you back to conventional commits. Describe the change in the commit message instead.
+
 ## Subcommands
 
 ### Default

--- a/src/commands/review/mod.rs
+++ b/src/commands/review/mod.rs
@@ -21,6 +21,7 @@ use homeboy::core::extension::test::TestCommandOutput;
 use homeboy::core::git;
 use homeboy::core::plan::PlanStep;
 use homeboy::core::quality::{build_quality_plan, QualityPlanOptions};
+use homeboy::core::release::changelog;
 use homeboy::core::review::{
     self, ReviewArtifactFindings, ReviewCommandOutput, ReviewOutputInput, ReviewService,
     ReviewStage, ReviewStages,
@@ -264,6 +265,21 @@ pub fn run(args: ReviewArgs, global: &GlobalArgs) -> CmdResult<ReviewCommandOutp
     });
 
     let mut top_hints: Vec<String> = Vec::new();
+
+    // Changelog-edit guard (#4876): homeboy regenerates the changelog from
+    // conventional commits at release time, so hand-editing the tracked
+    // changelog in a feature PR is both pointless and a guaranteed multi-PR
+    // merge-conflict surface. Surface a steering hint when the changeset
+    // modifies the component's configured changelog target. Agnostic: keys off
+    // `changelog_target` with no hardcoded filenames, and only runs when we
+    // actually computed a changed-file set (scoped review).
+    if let Some(changed_files) = review_context.precomputed_changed_files() {
+        if let Some(violation) =
+            changelog::detect_changelog_edit(component.changelog_target.as_deref(), changed_files)
+        {
+            top_hints.push(violation.message);
+        }
+    }
 
     let mut audit_stage = None;
     let mut lint_stage = None;

--- a/src/core/release/changelog/guard.rs
+++ b/src/core/release/changelog/guard.rs
@@ -1,0 +1,197 @@
+//! Changelog-edit guard.
+//!
+//! Homeboy owns the changelog completely: entries are generated from
+//! conventional-prefixed commits (`feat:` / `fix:` / ...) at release time and
+//! the release pipeline rewrites the next-section in place. Hand-editing the
+//! tracked changelog file in a feature PR is therefore both pointless (the
+//! release run regenerates it) and actively harmful — a single shared
+//! append-only file is a guaranteed conflict surface when multiple PRs are in
+//! flight against the same branch (#4876).
+//!
+//! This guard detects when a non-release changeset modifies the component's
+//! configured changelog target so callers (`homeboy review`, CI) can steer the
+//! contributor back to conventional commits instead of hand-editing the
+//! changelog. It is intentionally agnostic: it keys off the component's
+//! resolved `changelog_target` and a list of changed paths, with no
+//! hardcoded filenames.
+
+use std::path::{Component as PathComponent, Path, PathBuf};
+
+/// Outcome of checking a changeset against the changelog-edit guard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangelogGuardViolation {
+    /// The changelog path (as it appeared in the changeset) that was modified.
+    pub path: String,
+    /// Human-readable steering message explaining the policy and the fix.
+    pub message: String,
+}
+
+/// Detect whether `changed_files` modifies the configured `changelog_target`.
+///
+/// `changelog_target` is the component's configured changelog path (relative to
+/// the component root, e.g. `docs/changelog.md` or `CHANGELOG.md`). Both the
+/// target and the changed paths are normalized so that equivalent spellings
+/// (`./docs/changelog.md`, `docs/changelog.md`) compare equal and matching is
+/// case-insensitive (changelog filenames are conventionally cased
+/// inconsistently across repos).
+///
+/// Returns `None` when no changed file touches the changelog. When the
+/// changelog was modified it returns a [`ChangelogGuardViolation`] carrying a
+/// steering message. The caller decides whether to treat it as a warning hint
+/// or a hard failure.
+pub fn detect_changelog_edit(
+    changelog_target: Option<&str>,
+    changed_files: &[String],
+) -> Option<ChangelogGuardViolation> {
+    let target = changelog_target?.trim();
+    if target.is_empty() {
+        return None;
+    }
+
+    let normalized_target = normalize_relative_path(target)?;
+
+    let matched = changed_files
+        .iter()
+        .find(|candidate| paths_match(&normalized_target, candidate))?;
+
+    Some(ChangelogGuardViolation {
+        path: matched.clone(),
+        message: steering_message(matched),
+    })
+}
+
+/// Build the steering message shown when a changeset hand-edits the changelog.
+fn steering_message(path: &str) -> String {
+    format!(
+        "Changeset modifies the changelog ({path}). Homeboy generates changelog \
+entries from conventional-prefixed commits (feat:/fix:/...) at release time and \
+rewrites this file during `homeboy release` — hand-editing it is overwritten and \
+makes the changelog a multi-PR merge-conflict surface. Revert the changelog edit \
+and describe the change in the commit message instead."
+    )
+}
+
+/// True when `normalized_target` (a normalized relative changelog path) refers
+/// to the same file as `candidate` (a changed-file path from a git diff).
+fn paths_match(normalized_target: &Path, candidate: &str) -> bool {
+    match normalize_relative_path(candidate) {
+        Some(normalized_candidate) => {
+            paths_eq_ignore_case(normalized_target, &normalized_candidate)
+        }
+        None => false,
+    }
+}
+
+/// Normalize a relative path by dropping `.` components and collapsing
+/// redundant separators, without resolving symlinks or touching the
+/// filesystem. Returns `None` for empty or purely `.`-valued inputs.
+fn normalize_relative_path(raw: &str) -> Option<PathBuf> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in Path::new(trimmed).components() {
+        match component {
+            PathComponent::CurDir => {}
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
+/// Case-insensitive path equality across components. Changelog filenames are
+/// cased inconsistently across repos (`CHANGELOG.md`, `changelog.md`), so the
+/// guard should not miss an edit purely because of casing differences between
+/// the configured target and the changed path.
+fn paths_eq_ignore_case(a: &Path, b: &Path) -> bool {
+    let mut a_components = a.components();
+    let mut b_components = b.components();
+    loop {
+        match (a_components.next(), b_components.next()) {
+            (Some(a_component), Some(b_component)) => {
+                let a_str = a_component.as_os_str().to_string_lossy();
+                let b_str = b_component.as_os_str().to_string_lossy();
+                if !a_str.eq_ignore_ascii_case(&b_str) {
+                    return false;
+                }
+            }
+            (None, None) => return true,
+            _ => return false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn files(paths: &[&str]) -> Vec<String> {
+        paths.iter().map(|p| p.to_string()).collect()
+    }
+
+    #[test]
+    fn detects_direct_changelog_edit() {
+        let violation = detect_changelog_edit(
+            Some("docs/changelog.md"),
+            &files(&["src/main.rs", "docs/changelog.md"]),
+        )
+        .expect("changelog edit should be flagged");
+        assert_eq!(violation.path, "docs/changelog.md");
+        assert!(violation.message.contains("conventional-prefixed commits"));
+    }
+
+    #[test]
+    fn ignores_changesets_without_changelog() {
+        assert!(detect_changelog_edit(
+            Some("docs/changelog.md"),
+            &files(&["src/main.rs", "README.md"]),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn matches_despite_dot_slash_and_casing() {
+        // Configured target lower-cased, changed path with ./ prefix and
+        // different casing — these refer to the same file.
+        let violation =
+            detect_changelog_edit(Some("./docs/changelog.md"), &files(&["docs/CHANGELOG.md"]))
+                .expect("normalized + case-insensitive match should fire");
+        assert_eq!(violation.path, "docs/CHANGELOG.md");
+    }
+
+    #[test]
+    fn matches_root_changelog_target() {
+        let violation = detect_changelog_edit(Some("CHANGELOG.md"), &files(&["CHANGELOG.md"]))
+            .expect("root changelog edit should be flagged");
+        assert_eq!(violation.path, "CHANGELOG.md");
+    }
+
+    #[test]
+    fn does_not_match_similarly_named_unrelated_file() {
+        // A file that merely contains the word "changelog" but is not the
+        // configured target must not be flagged.
+        assert!(detect_changelog_edit(
+            Some("docs/changelog.md"),
+            &files(&["docs/changelog-policy.md", "src/changelog/io.rs"]),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn no_target_is_a_noop() {
+        assert!(detect_changelog_edit(None, &files(&["docs/changelog.md"])).is_none());
+        assert!(detect_changelog_edit(Some("   "), &files(&["docs/changelog.md"])).is_none());
+    }
+
+    #[test]
+    fn empty_changeset_is_a_noop() {
+        assert!(detect_changelog_edit(Some("docs/changelog.md"), &[]).is_none());
+    }
+}

--- a/src/core/release/changelog/mod.rs
+++ b/src/core/release/changelog/mod.rs
@@ -1,9 +1,11 @@
 mod bulk;
+mod guard;
 mod io;
 mod sections;
 mod settings;
 
 pub use bulk::{show, ShowOutput};
+pub use guard::{detect_changelog_edit, ChangelogGuardViolation};
 pub use io::{
     discover_changelog_relative_path, read_component_snapshots, resolve_changelog_path,
     ChangelogSnapshotData, FinalizedReleaseSnapshot, CHANGELOG_CANDIDATES,


### PR DESCRIPTION
## Summary

Closes #4876. `docs/changelog.md` is a single shared append-only file that every PR touched, making it a guaranteed merge-conflict surface (the issue reported 4 manual rebases in one parallel-cook wave purely from changelog collisions). Project policy is that homeboy owns the changelog completely — the release pipeline regenerates the next section from conventional commits at tag time (`finalize_with_generated_entries` builds entries in memory and writes directly to `## [version]`), so per-PR hand-edits are pointless *and* conflict-prone. The papercut was that nothing enforced the policy.

This adds a structural **guard** (the author's preferred option) rather than relying on guidance.

## Changes

- **New `core/release/changelog/guard.rs`** — pure, agnostic `detect_changelog_edit(changelog_target, changed_files)`. Keys off the component's configured `changelog_target` (no hardcoded filenames), normalizes `./`-prefixes and matches changelog paths case-insensitively (`CHANGELOG.md` vs `changelog.md`), and returns a steering message when a changeset modifies the changelog. Fully unit-tested.
- **`homeboy review` wiring** — when a scoped review (`--changed-since` / `--changed-only`) computes a changed-file set that touches the changelog target, review surfaces a non-blocking steering hint pointing the contributor back to conventional commits. Non-blocking so legitimate release PRs (which *do* update the changelog) are never falsely failed.
- **Docs** — `docs/commands/changelog.md` now documents the "do not hand-edit the changelog in feature PRs" policy and the review guard.

## Why a hint, not a hard fail

The issue asks for a check that "fails/warns." A warning is the safe enforcement level here: the same file is legitimately rewritten by `homeboy release`, so a hard block would false-positive on release PRs.

## Testing

- `cargo build --lib` and `cargo check --bin homeboy` (only pre-existing unrelated warnings)
- `cargo fmt --check` passes
- New guard unit tests cover the matching/normalization logic (CI runs the full suite).