### PR TITLE
feat(self): expose authoritative binary/runtime view across controller and runners (#4861)

### DIFF
--- a/docs/commands/self.md
+++ b/docs/commands/self.md
@@ -12,6 +12,7 @@ homeboy self <COMMAND>
 
 - `status` — report the active binary, version, and install/update signals
 - `identity` — report the active binary build identity without external probes
+- `doctor` — report one authoritative binary/runtime view across the controller and every configured runner
 - `cleanup-runtime-tmp` — plan or delete orphaned Homeboy runtime temp entries
 
 ### `status`
@@ -32,6 +33,25 @@ homeboy self identity
 Returns the current binary build identity directly from the running executable.
 Use this when a runner or daemon freshness check needs a cheap local identity
 without probing surrounding install state.
+
+### `doctor`
+
+```sh
+homeboy self doctor
+```
+
+Reports one authoritative runtime view spanning the controller and every
+configured runner so operators never have to manually reason about which
+Homeboy binary is in effect. The controller is the authoritative reference
+point; each runner row reports its configured executable path, the version and
+build identity of its active daemon (when connected), and how that compares to
+the controller.
+
+When every participant agrees with the controller, `agrees` is `true` and the
+command exits `0`. When any runner reports a different version or a stale daemon
+(a daemon started by a different build than the configured runner executable),
+`agrees` is `false`, the disagreement is described in `drift_notes`, and the
+command exits non-zero so cook loops can detect binary-identity drift.
 
 ### `cleanup-runtime-tmp`
 

--- a/src/commands/self_cmd.rs
+++ b/src/commands/self_cmd.rs
@@ -1,7 +1,8 @@
 use clap::{Args, Subcommand};
 use homeboy::core::build_identity;
 use homeboy::core::engine;
-use homeboy::core::self_status;
+use homeboy::core::runners::{self as runner, Runner, RunnerKind, RunnerStatusReport};
+use homeboy::core::self_status::{self, ControllerRuntimeInput, RunnerRuntimeInput};
 use serde_json::Value;
 
 use crate::commands::{CmdResult, GlobalArgs};
@@ -18,6 +19,9 @@ pub enum SelfCommand {
     Status(SelfStatusArgs),
     /// Report the active binary build identity without external probes
     Identity(SelfIdentityArgs),
+    /// Report one authoritative binary/runtime view across the controller and
+    /// every configured runner, including version drift signals
+    Doctor(SelfDoctorArgs),
     /// Plan or delete orphaned Homeboy runtime temp entries
     CleanupRuntimeTmp(SelfCleanupRuntimeTmpArgs),
 }
@@ -27,6 +31,9 @@ pub struct SelfStatusArgs {}
 
 #[derive(Args)]
 pub struct SelfIdentityArgs {}
+
+#[derive(Args)]
+pub struct SelfDoctorArgs {}
 
 #[derive(Args)]
 pub struct SelfCleanupRuntimeTmpArgs {
@@ -57,6 +64,16 @@ pub fn run(args: SelfArgs, _global: &GlobalArgs) -> CmdResult<Value> {
                 .map_err(|e| homeboy::core::Error::internal_json(e.to_string(), None))?;
             Ok((json, 0))
         }
+        SelfCommand::Doctor(_) => {
+            let view = self_status::build_runtime_view(
+                collect_controller_input(),
+                collect_runner_inputs(),
+            );
+            let exit_code = if view.agrees { 0 } else { 1 };
+            let json = serde_json::to_value(view)
+                .map_err(|e| homeboy::core::Error::internal_json(e.to_string(), None))?;
+            Ok((json, exit_code))
+        }
         SelfCommand::CleanupRuntimeTmp(args) => {
             let output = engine::temp::cleanup_runtime_tmp(
                 args.apply,
@@ -68,5 +85,75 @@ pub fn run(args: SelfArgs, _global: &GlobalArgs) -> CmdResult<Value> {
                 .map_err(|e| homeboy::core::Error::internal_json(e.to_string(), None))?;
             Ok((json, 0))
         }
+    }
+}
+
+/// Collect the controller-side authoritative binary facts. Reuses the existing
+/// `self status` collector for install-method detection and source-checkout
+/// probing so the runtime view and `self status` never disagree about the
+/// active binary.
+fn collect_controller_input() -> ControllerRuntimeInput {
+    let status = self_status::collect_status();
+    let binary_path = if status.active_binary == "unknown" {
+        None
+    } else {
+        Some(status.active_binary)
+    };
+    ControllerRuntimeInput {
+        binary_path,
+        version: status.active_version,
+        build_identity: status.active_build_identity,
+        install_method: status.install_method,
+        source_checkout: status.source_checkout,
+    }
+}
+
+/// Collect one runtime input per configured runner. Pairs each runner's
+/// configured executable path with the identity of its active daemon session
+/// (when connected) so the assembler can flag version skew and stale daemons in
+/// a single view. Probes are best-effort: a runner that fails to load or has no
+/// session simply reports `connected: false`.
+fn collect_runner_inputs() -> Vec<RunnerRuntimeInput> {
+    let Ok(runners) = runner::list() else {
+        return Vec::new();
+    };
+    let statuses = runner::statuses().unwrap_or_default();
+
+    runners
+        .into_iter()
+        .map(|runner| {
+            let status = statuses.iter().find(|report| report.runner_id == runner.id);
+            runner_runtime_input(runner, status)
+        })
+        .collect()
+}
+
+fn runner_runtime_input(runner: Runner, status: Option<&RunnerStatusReport>) -> RunnerRuntimeInput {
+    let connected = status.map(|report| report.connected).unwrap_or(false);
+    let session = status
+        .filter(|report| report.connected)
+        .and_then(|report| report.session.as_ref());
+    let daemon_version = session.map(|session| session.homeboy_version.clone());
+    let daemon_build_identity = session.and_then(|session| session.homeboy_build_identity.clone());
+    let daemon_drift = status
+        .map(|report| report.stale_daemon.is_some())
+        .unwrap_or(false);
+
+    RunnerRuntimeInput {
+        runner_id: runner.id,
+        kind: runner_kind_label(&runner.kind).to_string(),
+        server_id: runner.server_id,
+        configured_binary_path: runner.settings.homeboy_path,
+        connected,
+        daemon_version,
+        daemon_build_identity,
+        daemon_drift,
+    }
+}
+
+fn runner_kind_label(kind: &RunnerKind) -> &'static str {
+    match kind {
+        RunnerKind::Local => "local",
+        RunnerKind::Ssh => "ssh",
     }
 }

--- a/src/core/self_status.rs
+++ b/src/core/self_status.rs
@@ -330,6 +330,180 @@ fn non_empty(value: String) -> Option<String> {
     }
 }
 
+// ----------------------------------------------------------------------------
+// Authoritative runtime view (#4861)
+// ----------------------------------------------------------------------------
+
+/// One controller-side input describing the binary that is actually executing
+/// the current `homeboy` invocation. Kept free of probes so the assembler is a
+/// pure function over already-collected facts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControllerRuntimeInput {
+    pub binary_path: Option<String>,
+    pub version: String,
+    pub build_identity: BuildIdentity,
+    pub install_method: InstallMethod,
+    /// Optional source checkout backing the active binary (debug builds).
+    pub source_checkout: Option<SourceCheckoutStatus>,
+}
+
+/// One runner-side input describing a configured runner and, when connected,
+/// the binary identity of its active daemon. All fields are pre-resolved facts
+/// so the assembler stays deterministic and unit-testable.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RunnerRuntimeInput {
+    pub runner_id: String,
+    pub kind: String,
+    #[allow(clippy::struct_field_names)]
+    pub server_id: Option<String>,
+    /// Configured runner executable path (`settings.homeboy_path`).
+    pub configured_binary_path: Option<String>,
+    pub connected: bool,
+    /// Version reported by the active daemon session, when connected.
+    pub daemon_version: Option<String>,
+    /// Build identity reported by the active daemon session, when connected.
+    pub daemon_build_identity: Option<String>,
+    /// True when the active daemon was started by a build that differs from the
+    /// configured runner executable (existing stale-daemon drift signal).
+    pub daemon_drift: bool,
+}
+
+/// Authoritative identity of a single runtime participant (controller or
+/// runner) collapsed to the fields operators reason about when deciding which
+/// binary to use.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeParticipant {
+    /// `controller` or `runner`.
+    pub role: String,
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_id: Option<String>,
+    /// Authoritative version string for this participant, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Authoritative build-identity display string, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_identity: Option<String>,
+    /// The binary path operators should treat as authoritative for this
+    /// participant.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub binary_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub install_method: Option<InstallMethod>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_checkout: Option<SourceCheckoutStatus>,
+    pub connected: bool,
+    /// Relation of this participant's version to the controller's version.
+    pub relation_to_controller: VersionRelation,
+    /// True when this participant's active runtime disagrees with its own
+    /// configured/authoritative binary (e.g. a stale daemon).
+    pub internal_drift: bool,
+}
+
+/// One authoritative runtime view spanning the controller and every configured
+/// runner, plus the drift signals an operator needs to decide whether a single
+/// repair is required.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeView {
+    pub command: String,
+    /// The controller is always the authoritative reference point.
+    pub controller: RuntimeParticipant,
+    pub runners: Vec<RuntimeParticipant>,
+    /// True when any participant disagrees with the controller version or has
+    /// internal drift. When false, operators can trust a single binary view.
+    pub agrees: bool,
+    /// Human-facing, deterministic notes describing each disagreement.
+    pub drift_notes: Vec<String>,
+}
+
+/// Pure assembler: collapse already-collected controller and runner inputs into
+/// one authoritative runtime view. Deterministic and side-effect free so it can
+/// be unit tested without touching the registry, SSH, or daemons.
+pub fn build_runtime_view(
+    controller: ControllerRuntimeInput,
+    runners: Vec<RunnerRuntimeInput>,
+) -> RuntimeView {
+    let controller_version = controller.version.clone();
+
+    let controller_participant = RuntimeParticipant {
+        role: "controller".to_string(),
+        id: "controller".to_string(),
+        kind: None,
+        server_id: None,
+        version: Some(controller.version.clone()),
+        build_identity: Some(controller.build_identity.display.clone()),
+        binary_path: controller.binary_path.clone(),
+        install_method: Some(controller.install_method.clone()),
+        source_checkout: controller.source_checkout.clone(),
+        connected: true,
+        relation_to_controller: VersionRelation::Current,
+        internal_drift: false,
+    };
+
+    let mut drift_notes = Vec::new();
+    let mut runner_participants = Vec::with_capacity(runners.len());
+
+    for runner in runners {
+        let relation = match runner.daemon_version.as_deref() {
+            Some(version) => relation_to_latest(version, Some(&controller_version)),
+            None => VersionRelation::Unknown,
+        };
+
+        if runner.connected {
+            if let Some(version) = runner.daemon_version.as_deref() {
+                if relation != VersionRelation::Current {
+                    drift_notes.push(format!(
+                        "runner `{}` active daemon is {version} ({}) but controller is {controller_version}",
+                        runner.runner_id,
+                        relation_label(&relation),
+                    ));
+                }
+            }
+        }
+
+        if runner.daemon_drift {
+            drift_notes.push(format!(
+                "runner `{}` active daemon was started by a different build than its configured executable",
+                runner.runner_id
+            ));
+        }
+
+        runner_participants.push(RuntimeParticipant {
+            role: "runner".to_string(),
+            id: runner.runner_id,
+            kind: Some(runner.kind),
+            server_id: runner.server_id,
+            version: runner.daemon_version,
+            build_identity: runner.daemon_build_identity,
+            binary_path: runner.configured_binary_path,
+            install_method: None,
+            source_checkout: None,
+            connected: runner.connected,
+            relation_to_controller: relation,
+            internal_drift: runner.daemon_drift,
+        });
+    }
+
+    RuntimeView {
+        command: "self doctor".to_string(),
+        controller: controller_participant,
+        runners: runner_participants,
+        agrees: drift_notes.is_empty(),
+        drift_notes,
+    }
+}
+
+fn relation_label(relation: &VersionRelation) -> &'static str {
+    match relation {
+        VersionRelation::Current => "current",
+        VersionRelation::Behind => "behind",
+        VersionRelation::Ahead => "ahead",
+        VersionRelation::Unknown => "unknown",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -469,5 +643,148 @@ mod tests {
         assert_eq!(status.active_version, upgrade::current_version());
         assert_eq!(status.install_method, InstallMethod::Unknown);
         assert_eq!(status.version_relation, VersionRelation::Current);
+    }
+
+    fn identity(version: &str) -> BuildIdentity {
+        BuildIdentity {
+            version: version.to_string(),
+            git_commit: None,
+            git_dirty: None,
+            display: format!("homeboy {version}"),
+        }
+    }
+
+    fn controller_input(version: &str) -> ControllerRuntimeInput {
+        ControllerRuntimeInput {
+            binary_path: Some("/opt/homebrew/bin/homeboy".to_string()),
+            version: version.to_string(),
+            build_identity: identity(version),
+            install_method: InstallMethod::Homebrew,
+            source_checkout: None,
+        }
+    }
+
+    #[test]
+    fn runtime_view_agrees_when_runners_match_controller() {
+        let view = build_runtime_view(
+            controller_input("0.235.0"),
+            vec![RunnerRuntimeInput {
+                runner_id: "lab".to_string(),
+                kind: "ssh".to_string(),
+                server_id: Some("lab-host".to_string()),
+                configured_binary_path: Some("/home/runner/target/release/homeboy".to_string()),
+                connected: true,
+                daemon_version: Some("0.235.0".to_string()),
+                daemon_build_identity: Some("homeboy 0.235.0".to_string()),
+                daemon_drift: false,
+            }],
+        );
+
+        assert_eq!(view.command, "self doctor");
+        assert_eq!(view.controller.role, "controller");
+        assert_eq!(view.controller.version.as_deref(), Some("0.235.0"));
+        assert_eq!(
+            view.controller.relation_to_controller,
+            VersionRelation::Current
+        );
+        assert_eq!(view.runners.len(), 1);
+        let runner = &view.runners[0];
+        assert_eq!(runner.role, "runner");
+        assert_eq!(runner.id, "lab");
+        assert_eq!(runner.relation_to_controller, VersionRelation::Current);
+        assert!(runner.connected);
+        assert!(view.agrees);
+        assert!(view.drift_notes.is_empty());
+    }
+
+    #[test]
+    fn runtime_view_flags_runner_version_skew() {
+        let view = build_runtime_view(
+            controller_input("0.235.0"),
+            vec![RunnerRuntimeInput {
+                runner_id: "lab".to_string(),
+                kind: "ssh".to_string(),
+                server_id: Some("lab-host".to_string()),
+                configured_binary_path: None,
+                connected: true,
+                daemon_version: Some("0.229.11".to_string()),
+                daemon_build_identity: Some("homeboy 0.229.11".to_string()),
+                daemon_drift: false,
+            }],
+        );
+
+        assert!(!view.agrees);
+        assert_eq!(
+            view.runners[0].relation_to_controller,
+            VersionRelation::Behind
+        );
+        assert_eq!(view.drift_notes.len(), 1);
+        assert!(view.drift_notes[0].contains("lab"));
+        assert!(view.drift_notes[0].contains("0.229.11"));
+        assert!(view.drift_notes[0].contains("0.235.0"));
+    }
+
+    #[test]
+    fn runtime_view_reports_internal_daemon_drift() {
+        let view = build_runtime_view(
+            controller_input("0.235.0"),
+            vec![RunnerRuntimeInput {
+                runner_id: "lab".to_string(),
+                kind: "ssh".to_string(),
+                server_id: None,
+                configured_binary_path: Some("/srv/homeboy".to_string()),
+                connected: true,
+                daemon_version: Some("0.235.0".to_string()),
+                daemon_build_identity: Some("homeboy 0.235.0+deadbeef".to_string()),
+                daemon_drift: true,
+            }],
+        );
+
+        assert!(!view.agrees);
+        assert!(view.runners[0].internal_drift);
+        assert_eq!(
+            view.runners[0].relation_to_controller,
+            VersionRelation::Current
+        );
+        assert_eq!(view.drift_notes.len(), 1);
+        assert!(view.drift_notes[0].contains("different build"));
+    }
+
+    #[test]
+    fn runtime_view_disconnected_runner_is_unknown_not_drift() {
+        let view = build_runtime_view(
+            controller_input("0.235.0"),
+            vec![RunnerRuntimeInput {
+                runner_id: "lab".to_string(),
+                kind: "ssh".to_string(),
+                server_id: None,
+                configured_binary_path: Some("/srv/homeboy".to_string()),
+                connected: false,
+                daemon_version: None,
+                daemon_build_identity: None,
+                daemon_drift: false,
+            }],
+        );
+
+        assert!(view.agrees);
+        assert!(view.drift_notes.is_empty());
+        assert!(!view.runners[0].connected);
+        assert_eq!(
+            view.runners[0].relation_to_controller,
+            VersionRelation::Unknown
+        );
+    }
+
+    #[test]
+    fn runtime_view_json_shape_is_stable() {
+        let view = build_runtime_view(controller_input("0.235.0"), Vec::new());
+        let json = serde_json::to_value(view).unwrap();
+
+        assert_eq!(json["command"], "self doctor");
+        assert_eq!(json["controller"]["role"], "controller");
+        assert_eq!(json["controller"]["version"], "0.235.0");
+        assert_eq!(json["controller"]["connected"], true);
+        assert_eq!(json["agrees"], true);
+        assert!(json["runners"].as_array().unwrap().is_empty());
     }
 }

--- a/tests/command_surface_test.rs
+++ b/tests/command_surface_test.rs
@@ -333,6 +333,7 @@ fn docs_cover_focused_command_surface_cleanup_targets() {
 
     let self_docs = include_str!("../docs/commands/self.md");
     assert!(self_docs.contains("`identity`"));
+    assert!(self_docs.contains("`doctor`"));
     assert!(self_docs.contains("`cleanup-runtime-tmp`"));
     assert!(self_docs.contains("--older-than-days"));
     assert!(self_docs.contains("--apply"));
@@ -365,6 +366,7 @@ fn docs_cover_focused_command_surface_cleanup_targets() {
         ["homeboy", "auth", "profile", "set-basic", "dev"].as_slice(),
         ["homeboy", "auth", "profile", "set-bearer", "dev"].as_slice(),
         ["homeboy", "self", "identity"].as_slice(),
+        ["homeboy", "self", "doctor"].as_slice(),
         [
             "homeboy",
             "self",


### PR DESCRIPTION
## Summary

Closes #4861. During cook loops it was unclear which Homeboy binary was authoritative (bare controller binary vs source-checkout debug binary vs configured runner executable vs active runner daemon), forcing operators to manually track up to five binary identities.

This adds **`homeboy self doctor`** — one authoritative runtime view spanning the controller and every configured runner, with explicit version-drift signals.

## What it does

- Treats the **controller** as the authoritative reference point (active binary path, version, build identity, install method, source checkout).
- Adds one **runner** row per configured runner: configured executable path, the active daemon's version + build identity (when connected), and how that compares to the controller (`current` / `behind` / `ahead` / `unknown`).
- Surfaces two drift signals in `drift_notes`:
  - runner active daemon version differs from the controller, and
  - runner active daemon was started by a different build than its configured executable (reusing the existing stale-daemon detection).
- `agrees: true` + exit `0` when everything matches the controller; `agrees: false` + non-zero exit when any runner disagrees, so cook loops can detect binary-identity drift programmatically.

## Design

- Core logic lives in `self_status::build_runtime_view`, a **pure, side-effect-free assembler** over already-collected `ControllerRuntimeInput` / `RunnerRuntimeInput` facts — fully unit-testable without registry, SSH, or daemons.
- The command layer (`self doctor`) collects inputs from the existing `self status` collector (controller) and the runner registry + `runner::statuses()` (runners). Probes are best-effort; a runner that fails to load or has no session simply reports `connected: false`.
- Agnostic: no language/framework/ecosystem assumptions; reuses existing version-relation and stale-daemon contracts.

## Tests

- 5 new unit tests in `self_status` covering: agreement, version skew, internal daemon drift, disconnected-runner-is-unknown, and stable JSON shape.
- `command_surface_test` updated to cover the new `doctor` subcommand (docs assertion + CLI parse smoke).
- `cargo build --lib` and `cargo check --bin homeboy` both clean; full suite runs in CI.