### PR TITLE
fix(audit): strengthen vacuous tests to clear test_quality findings (#5423)

### DIFF
--- a/src/commands/agent_task/tests/loop_compile.rs
+++ b/src/commands/agent_task/tests/loop_compile.rs
@@ -251,40 +251,63 @@ fn controller_materialize_projects_policy_results_with_provenance() {
     )
     .expect("write second policy result");
 
-    let (value, status) = controller_materialize(AgentTaskControllerMaterializeArgs {
-        spec: format!("@{}", spec_path.display()),
-        inputs: None,
-        policy_results: vec![
-            format!("@{}", policy_path.display()),
-            format!("@{}", second_policy_path.display()),
-        ],
-    })
-    .expect("materialize spec");
+    let (value, status) =
+        super::support::controller_materialize(AgentTaskControllerMaterializeArgs {
+            spec: format!("@{}", spec_path.display()),
+            inputs: None,
+            policy_results: vec![
+                format!("@{}", policy_path.display()),
+                format!("@{}", second_policy_path.display()),
+            ],
+        })
+        .expect("materialize spec");
 
     assert_eq!(status, 0);
+    assert_eq!(
+        value["schema"],
+        "homeboy/agent-task-loop-spec-materialization/v1"
+    );
     assert_eq!(
         value["spec"]["workflows"][0]["inputs"]["policy_inputs"]["example-policy"]
             ["requested_tier"],
         "foundation"
     );
+    // The second workflow declared no `inputs` block of its own; materialization
+    // must synthesize one and project every policy's results into it.
     assert_eq!(
         value["spec"]["workflows"][1]["inputs"]["policy_results"]["example-policy"]["decision"],
         "hold"
     );
     assert_eq!(
+        value["spec"]["workflows"][1]["inputs"]["policy_results"]["example-policy"]
+            ["selected_tier"],
+        "foundation"
+    );
+    assert_eq!(
         value["spec"]["workflows"][1]["inputs"]["policy_results"]["second-policy"]["enabled"],
         true
     );
+    // Provenance for each policy is recorded under spec metadata keyed by policy id.
     assert_eq!(
         value["spec"]["metadata"]["policy_materialization"]["example-policy"]["provenance"]
             ["source"],
         "fixture"
     );
     assert_eq!(
+        value["spec"]["metadata"]["policy_materialization"]["example-policy"]["provenance"]
+            ["sha256"],
+        "abc123"
+    );
+    assert_eq!(
         value["spec"]["metadata"]["policy_materialization"]["second-policy"]["provenance"]
             ["source"],
         "second-fixture"
     );
+    // Policies without `policy_inputs` must not leak an `example-policy`-style block
+    // onto the first workflow for the second policy id.
+    assert!(value["spec"]["workflows"][0]["inputs"]["policy_inputs"]
+        .get("second-policy")
+        .is_none());
 }
 
 #[test]
@@ -311,7 +334,7 @@ fn controller_materialize_rejects_non_object_policy_result_fields() {
     )
     .expect("write policy result");
 
-    let error = controller_materialize(AgentTaskControllerMaterializeArgs {
+    let error = super::support::controller_materialize(AgentTaskControllerMaterializeArgs {
         spec: format!("@{}", spec_path.display()),
         inputs: None,
         policy_results: vec![format!("@{}", policy_path.display())],
@@ -319,6 +342,11 @@ fn controller_materialize_rejects_non_object_policy_result_fields() {
     .expect_err("policy result fields are validated");
 
     assert!(error.message.contains("policy materialization fields"));
+    // The validation must reject the non-object field as an invalid-argument error
+    // scoped to the `policy_results` field and attribute it to the offending policy id.
+    assert_eq!(error.details["field"], "policy-result.policy_results");
+    assert_eq!(error.details["id"], "example-policy");
+    assert!(error.message.contains("must be JSON objects when present"));
 }
 
 #[test]

--- a/src/commands/trace/rig_tests.rs
+++ b/src/commands/trace/rig_tests.rs
@@ -262,21 +262,30 @@ fn rig_trace_workload_expansion_warns_when_executed_path_differs_from_rig_root()
         rig_config_root: None,
     };
 
-    let warnings = rig_owned_trace_workload_expansion_warnings(
+    let warnings = super::rig_owned_trace_workload_expansion_warnings(
         Some(&context),
         Some(TRACE_FIXTURE_EXTENSION_ID),
     );
 
     assert_eq!(warnings.len(), 1);
-    assert!(warnings[0].contains("wc-stripe-trace"));
-    assert!(warnings[0]
-        .contains("${components.stripe.path}/bench/ece-product-page-waterfall.trace.mjs"));
-    assert!(warnings[0].contains(&format!("Rig source root: `{}`", rig_root.path().display())));
-    assert!(warnings[0].contains(&format!(
+    let warning = &warnings[0];
+    assert!(warning.starts_with("Warning: "));
+    assert!(warning.contains("wc-stripe-trace"));
+    assert!(
+        warning.contains("${components.stripe.path}/bench/ece-product-page-waterfall.trace.mjs")
+    );
+    assert!(warning.contains(&format!("Rig source root: `{}`", rig_root.path().display())));
+    assert!(warning.contains(&format!(
         "Executed extra workload path: `{}`",
         trace_path.display()
     )));
-    assert!(warnings[0].contains("refresh/reinstall the rig package"));
+    // The expanded workload file exists on disk, so the warning must use the
+    // staleness-oriented remediation phrasing rather than the missing-path variant.
+    assert!(warning.contains("If this is stale, refresh/reinstall the rig package"));
+    assert!(!warning.contains("check the expanded path before rerunning"));
+    // The executed path resolves outside the rig source root, which is exactly
+    // why the divergence warning fires.
+    assert!(!trace_path.starts_with(rig_root.path()));
 }
 
 #[test]
@@ -292,14 +301,43 @@ fn rig_trace_workload_expansion_is_quiet_inside_rig_root() {
     ))
     .expect("parse rig");
     let context = TraceRigContext {
-        rig_spec,
+        rig_spec: rig_spec.clone(),
         rig_package_root: Some(rig_root.path().to_path_buf()),
         rig_config_root: None,
     };
 
-    assert!(rig_owned_trace_workload_expansion_warnings(
+    // `${package.root}` resolves to the rig package root itself, so the expanded
+    // workload lives inside the source root and no divergence warning fires.
+    assert!(super::rig_owned_trace_workload_expansion_warnings(
         Some(&context),
         Some(TRACE_FIXTURE_EXTENSION_ID),
+    )
+    .is_empty());
+
+    // Quietness is anchored to the package root: `${package.root}` expansion tracks
+    // `rig_package_root`, so adding an unrelated config root does not change the
+    // containment check and the result stays quiet.
+    let other_root = tempfile::TempDir::new().expect("other root");
+    let config_context = TraceRigContext {
+        rig_spec,
+        rig_package_root: Some(rig_root.path().to_path_buf()),
+        rig_config_root: Some(other_root.path().to_path_buf()),
+    };
+    let warnings = super::rig_owned_trace_workload_expansion_warnings(
+        Some(&config_context),
+        Some(TRACE_FIXTURE_EXTENSION_ID),
+    );
+    assert!(
+        warnings.is_empty(),
+        "package.root expansion tracks rig_package_root regardless of config root: {warnings:?}"
+    );
+
+    // A missing extension id short-circuits to no warnings even with a valid context.
+    assert!(super::rig_owned_trace_workload_expansion_warnings(Some(&context), None).is_empty());
+    // A missing rig context likewise yields no warnings.
+    assert!(super::rig_owned_trace_workload_expansion_warnings(
+        None,
+        Some(TRACE_FIXTURE_EXTENSION_ID)
     )
     .is_empty());
 }


### PR DESCRIPTION
## Summary
Closes #5423. Strengthens the four tests flagged as `test_quality` / `vacuous_test` so they assert meaningful product behavior instead of tripping the heuristic. These were **false-positives** caused by the detector being unable to see product calls reached through glob re-exports (`use super::support::*`) combined with `tempfile`/`std::` fixture markers — but rather than baseline them, the tests are now genuinely tightened and the product call is referenced via an explicit `super::` path so the audit recognizes it.

### Findings addressed
- `loop_compile.rs::controller_materialize_projects_policy_results_with_provenance` — now asserts the materialization schema, that the inputs-less second workflow gets every policy's results projected (incl. `selected_tier`), provenance `sha256`, and that policies without `policy_inputs` don't leak onto workflow 0.
- `loop_compile.rs::controller_materialize_rejects_non_object_policy_result_fields` — now asserts the structured error (`details.field` = `policy-result.policy_results`, `details.id` = offending policy id, message body).
- `rig_tests.rs::rig_trace_workload_expansion_warns_when_executed_path_differs_from_rig_root` — now asserts the `Warning:` prefix, the staleness-specific remediation phrasing (vs the missing-path variant), and that the executed path genuinely resolves outside the rig root.
- `rig_tests.rs::rig_trace_workload_expansion_is_quiet_inside_rig_root` — now also proves quietness is path-driven (config-root independence) and that missing extension-id / missing rig-context short-circuit to empty.

## Verification
- `homeboy audit homeboy --only vacuous_test --ignore-baseline`: all four findings **clear** (stash/pop confirmed they were FLAGGED before the change, clear after).
- `cargo test --lib` for all four tests: **pass**.
- `cargo fmt` clean. `cargo build --lib` clean. No `docs/changelog.md` touched. Core remains agnostic.