### PR TITLE
fix(audit): unify parallel implementations to clear findings (#5421)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -492,7 +492,7 @@
     "audit": {
       "context_id": "homeboy",
       "created_at": "2026-06-19T16:45:00Z",
-      "item_count": 407,
+      "item_count": 401,
       "known_fingerprints": [
         "compiler::src/core/deploy/planning.rs::CompilerWarning",
         "compiler::src/core/extension/test/run.rs::CompilerWarning",
@@ -765,7 +765,9 @@
         "output_capture::tests/agent_tool_dispatch.rs::UnboundedOutputCapture",
         "parallel-implementation::src/commands/report/browser_evidence_compare.rs::ParallelImplementation",
         "parallel-implementation::src/core/artifact_links.rs::ParallelImplementation",
+        "parallel-implementation::src/core/component/inventory.rs::ParallelImplementation",
         "parallel-implementation::src/core/extension/trace/run.rs::ParallelImplementation",
+        "parallel-implementation::src/core/release/changelog/guard.rs::ParallelImplementation",
         "parallel-implementation::src/core/release/executor/publish.rs::ParallelImplementation",
         "remote_execution_preflight::src/core/runner/execution/policy.rs::RemoteExecutionPreflight",
         "remote_execution_preflight::src/core/runner/lab_workspaces.rs::RemoteExecutionPreflight",

--- a/src/core/runner/lab_args/agent_task_specs.rs
+++ b/src/core/runner/lab_args/agent_task_specs.rs
@@ -15,51 +15,35 @@ use crate::core::config::read_json_spec_to_string;
 use crate::core::{Error, Result};
 
 use super::envelope::ExecutionEnvelope;
-use super::path_remap::{remap_paths_in_value, LabPathRemap};
+use super::path_remap::{
+    order_mappings_by_specificity, remap_paths_in_value, try_rewrite_flag_value_args, LabPathRemap,
+};
 
 pub(in crate::core::runner) fn remap_agent_task_plan_in_args(
     args: &[String],
     mappings: &[LabPathRemap],
     source_path: &Path,
 ) -> Result<Vec<String>> {
-    let mut ordered: Vec<&LabPathRemap> = mappings.iter().collect();
-    ordered.sort_by_key(|mapping| {
-        (
-            std::cmp::Reverse(mapping.local.len()),
-            std::cmp::Reverse(mapping.remote.len()),
-        )
-    });
+    let ordered = order_mappings_by_specificity(mappings);
 
-    let mut out = Vec::with_capacity(args.len());
-    let mut iter = args.iter().peekable();
-    let mut passthrough = false;
-    while let Some(arg) = iter.next() {
-        if passthrough {
-            out.push(arg.clone());
-            continue;
-        }
-        if arg == "--" {
-            passthrough = true;
-            out.push(arg.clone());
-            continue;
-        }
+    try_rewrite_flag_value_args(args, |arg, iter, out| {
         if arg == "--plan" {
-            out.push(arg.clone());
+            out.push(arg.to_string());
             if let Some(spec) = iter.next() {
                 out.push(remap_agent_task_plan_spec(spec, &ordered, source_path)?);
             }
-            continue;
+            return Ok(());
         }
         if let Some(spec) = arg.strip_prefix("--plan=") {
             out.push(format!(
                 "--plan={}",
                 remap_agent_task_plan_spec(spec, &ordered, source_path)?
             ));
-            continue;
+            return Ok(());
         }
-        out.push(arg.clone());
-    }
-    Ok(out)
+        out.push(arg.to_string());
+        Ok(())
+    })
 }
 
 pub(in crate::core::runner) fn inline_agent_task_prompt_files_in_args(

--- a/src/core/runner/lab_args/envelope.rs
+++ b/src/core/runner/lab_args/envelope.rs
@@ -5,6 +5,8 @@
 //! rewrite helpers can consume the typed refs one path at a time while preserving
 //! the exact argv output they already produced.
 
+use super::path_remap::{rewrite_flag_value_args, try_rewrite_flag_value_args};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::core::runner) struct ExecutionEnvelope {
     argv: Vec<String>,
@@ -87,66 +89,41 @@ impl ExecutionEnvelope {
         &self,
         mut rewrite: impl FnMut(&str) -> String,
     ) -> Vec<String> {
-        let mut out = Vec::with_capacity(self.argv.len());
-        let mut iter = self.argv.iter().peekable();
-        let mut passthrough = false;
-        while let Some(arg) = iter.next() {
-            if passthrough {
-                out.push(arg.clone());
-                continue;
-            }
-            if arg == "--" {
-                passthrough = true;
-                out.push(arg.clone());
-                continue;
-            }
+        rewrite_flag_value_args(&self.argv, |arg, iter, out| {
             if arg == "--provider-config" {
-                out.push(arg.clone());
+                out.push(arg.to_string());
                 if let Some(spec) = iter.next() {
                     out.push(rewrite(spec));
                 }
-                continue;
+                return;
             }
             if let Some(spec) = arg.strip_prefix("--provider-config=") {
                 out.push(format!("--provider-config={}", rewrite(spec)));
-                continue;
+                return;
             }
-            out.push(arg.clone());
-        }
-        out
+            out.push(arg.to_string());
+        })
     }
 
     pub fn rewrite_agent_task_text_values(
         &self,
         mut rewrite: impl FnMut(&str, &str) -> crate::core::Result<String>,
     ) -> crate::core::Result<Vec<String>> {
-        let mut out = Vec::with_capacity(self.argv.len());
-        let mut iter = self.argv.iter().peekable();
-        let mut passthrough = false;
-        while let Some(arg) = iter.next() {
-            if passthrough {
-                out.push(arg.clone());
-                continue;
-            }
-            if arg == "--" {
-                passthrough = true;
-                out.push(arg.clone());
-                continue;
-            }
+        try_rewrite_flag_value_args(&self.argv, |arg, iter, out| {
             if let Some(flag) = agent_task_text_flag(arg) {
-                out.push(arg.clone());
+                out.push(arg.to_string());
                 if let Some(spec) = iter.next() {
                     out.push(rewrite(spec, flag)?);
                 }
-                continue;
+                return Ok(());
             }
             if let Some((flag, spec)) = agent_task_text_inline_arg(arg) {
                 out.push(format!("{}={}", flag, rewrite(spec, flag)?));
-                continue;
+                return Ok(());
             }
-            out.push(arg.clone());
-        }
-        Ok(out)
+            out.push(arg.to_string());
+            Ok(())
+        })
     }
 }
 

--- a/src/core/runner/lab_args/path_remap.rs
+++ b/src/core/runner/lab_args/path_remap.rs
@@ -5,7 +5,9 @@
 //! in CLI arguments and JSON payloads to their synced remote equivalents.
 
 use serde_json::Value;
+use std::iter::Peekable;
 use std::path::Path;
+use std::slice::Iter;
 
 /// A local -> remote path pair produced by Lab workspace sync, used to remap
 /// controller-side absolute paths embedded in a `--provider-config` payload to
@@ -16,14 +18,12 @@ pub(in crate::core::runner) struct LabPathRemap {
     pub remote: String,
 }
 
-pub(in crate::core::runner) fn remap_path_settings_in_args(
-    args: &[String],
-    mappings: &[LabPathRemap],
-) -> Vec<String> {
-    if mappings.is_empty() {
-        return args.to_vec();
-    }
-
+/// Order remap pairs most-specific-first so a longer local prefix wins over a
+/// shorter one it is nested under (and, for equal-length locals, the longer
+/// remote wins). Every Lab arg rewriter must remap against this ordering so the
+/// same controller path always resolves to the same remote path regardless of
+/// which flag carried it.
+pub(super) fn order_mappings_by_specificity(mappings: &[LabPathRemap]) -> Vec<&LabPathRemap> {
     let mut ordered: Vec<&LabPathRemap> = mappings.iter().collect();
     ordered.sort_by_key(|mapping| {
         (
@@ -31,7 +31,21 @@ pub(in crate::core::runner) fn remap_path_settings_in_args(
             std::cmp::Reverse(mapping.remote.len()),
         )
     });
+    ordered
+}
 
+/// Walk `args` honoring the `--` passthrough boundary (everything after `--` is
+/// copied verbatim) and delegate each pre-passthrough argument to `rewrite`.
+///
+/// `rewrite` receives the current argument, a peekable iterator over the
+/// remaining arguments (so it can consume the value of a two-token `--flag
+/// value` pair), and the output buffer it must push its result onto. This is the
+/// single shared scaffold behind every Lab flag-value rewriter; only the
+/// per-flag matching differs between callers.
+pub(super) fn rewrite_flag_value_args<F>(args: &[String], mut rewrite: F) -> Vec<String>
+where
+    F: FnMut(&str, &mut Peekable<Iter<'_, String>>, &mut Vec<String>),
+{
     let mut out = Vec::with_capacity(args.len());
     let mut iter = args.iter().peekable();
     let mut passthrough = false;
@@ -45,37 +59,80 @@ pub(in crate::core::runner) fn remap_path_settings_in_args(
             out.push(arg.clone());
             continue;
         }
-        if arg == "--setting" {
+        rewrite(arg, &mut iter, &mut out);
+    }
+    out
+}
+
+/// Fallible variant of [`rewrite_flag_value_args`] for rewriters whose per-flag
+/// handler can fail (e.g. when materializing an `@file` spec). Short-circuits on
+/// the first error.
+pub(super) fn try_rewrite_flag_value_args<F>(
+    args: &[String],
+    mut rewrite: F,
+) -> crate::core::Result<Vec<String>>
+where
+    F: FnMut(&str, &mut Peekable<Iter<'_, String>>, &mut Vec<String>) -> crate::core::Result<()>,
+{
+    let mut out = Vec::with_capacity(args.len());
+    let mut iter = args.iter().peekable();
+    let mut passthrough = false;
+    while let Some(arg) = iter.next() {
+        if passthrough {
             out.push(arg.clone());
+            continue;
+        }
+        if arg == "--" {
+            passthrough = true;
+            out.push(arg.clone());
+            continue;
+        }
+        rewrite(arg, &mut iter, &mut out)?;
+    }
+    Ok(out)
+}
+
+pub(in crate::core::runner) fn remap_path_settings_in_args(
+    args: &[String],
+    mappings: &[LabPathRemap],
+) -> Vec<String> {
+    if mappings.is_empty() {
+        return args.to_vec();
+    }
+
+    let ordered = order_mappings_by_specificity(mappings);
+
+    rewrite_flag_value_args(args, |arg, iter, out| {
+        if arg == "--setting" {
+            out.push(arg.to_string());
             if let Some(raw) = iter.next() {
                 out.push(remap_path_setting_pair(raw, &ordered));
             }
-            continue;
+            return;
         }
         if arg == "--setting-json" {
-            out.push(arg.clone());
+            out.push(arg.to_string());
             if let Some(raw) = iter.next() {
                 out.push(remap_path_json_setting_pair(raw, &ordered));
             }
-            continue;
+            return;
         }
         if let Some(raw) = arg.strip_prefix("--setting=") {
             out.push(format!(
                 "--setting={}",
                 remap_path_setting_pair(raw, &ordered)
             ));
-            continue;
+            return;
         }
         if let Some(raw) = arg.strip_prefix("--setting-json=") {
             out.push(format!(
                 "--setting-json={}",
                 remap_path_json_setting_pair(raw, &ordered)
             ));
-            continue;
+            return;
         }
-        out.push(arg.clone());
-    }
-    out
+        out.push(arg.to_string());
+    })
 }
 
 pub(super) fn remap_path_setting_pair(raw: &str, mappings: &[&LabPathRemap]) -> String {


### PR DESCRIPTION
## Summary
Resolves the `parallel implementation` audit category for homeboy (#5421).

Two distinct finding pairs were reported (each bidirectional):

### Pair B — real duplication, unified at root cause (DRY)
`remap_path_settings_in_args` (`lab_args/path_remap.rs`) and `remap_agent_task_plan_in_args` (`lab_args/agent_task_specs.rs`) shared an identical structure: a "sort mappings by specificity" preamble and a "walk argv honoring the `--` passthrough boundary, rewrite recognized flag values" loop. The same loop was *also* hand-copied twice more in `ExecutionEnvelope` (`rewrite_provider_config_values`, `rewrite_agent_task_text_values`).

Extracted two shared helpers in `path_remap.rs`:
- `order_mappings_by_specificity` — the single source for most-specific-first remap ordering.
- `rewrite_flag_value_args` / `try_rewrite_flag_value_args` — the passthrough-aware argv-walk scaffold (infallible + fallible variants), parameterized by a per-flag closure.

All **four** previously-parallel rewriters now route through these helpers; only the per-flag matching differs. This collapses ~120 lines of duplicated scaffolding into one place.

### Pair A — genuine false-positive, baselined with justification
`paths_eq_ignore_case` (`release/changelog/guard.rs`) and `stable_root_before_temp_marker` (`component/inventory.rs`) are fundamentally different algorithms — case-insensitive path equality vs. scanning a single path for the prefix before a temp-marker segment. They only share the unavoidable std path-iteration vocabulary (`components`, `as_os_str`, `to_string_lossy`). Unifying them would force artificial coupling between two unrelated modules, so they are baselined in `homeboy.json` (matching the existing `parallel-implementation::<file>::ParallelImplementation` precedent) rather than suppressed in code.

## Verification
- `homeboy audit homeboy` baseline comparison: `new_items: 0` for `parallel_implementation`; the only remaining new items are pre-existing, unrelated baseline drift (god-files, dead-code warnings, etc.) in files this PR does not touch.
- `cargo build --lib` clean (no new warnings in touched files).
- `cargo test --lib lab_args` — 35 passed, behavior preserved.
- `cargo fmt` applied. CI runs the full suite.
- Core stays agnostic (no ecosystem literals introduced).