### PR TITLE
fix(ci): stop lint-autofix from pushing to PR branch mid-review (#3819)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,14 @@ jobs:
           name: homeboy-binary
           path: .homeboy-bin
 
+      - name: Verify homeboy binary present
+        run: |
+          if [ ! -f .homeboy-bin/homeboy ]; then
+            echo "::error::Build artifact missing from upstream Build job: .homeboy-bin/homeboy was not produced/uploaded by gate-build. This is a CI artifact-handoff problem, not a code finding in this change. Re-run the failed Build job or investigate the homeboy-binary upload step." >&2
+            exit 1
+          fi
+          chmod +x .homeboy-bin/homeboy
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -246,6 +254,14 @@ jobs:
           name: homeboy-binary
           path: .homeboy-bin
 
+      - name: Verify homeboy binary present
+        run: |
+          if [ ! -f .homeboy-bin/homeboy ]; then
+            echo "::error::Build artifact missing from upstream Build job: .homeboy-bin/homeboy was not produced/uploaded by gate-build. This is a CI artifact-handoff problem, not a lint finding in this change. Re-run the failed Build job or investigate the homeboy-binary upload step." >&2
+            exit 1
+          fi
+          chmod +x .homeboy-bin/homeboy
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -281,6 +297,14 @@ jobs:
         with:
           name: homeboy-binary
           path: .homeboy-bin
+
+      - name: Verify homeboy binary present
+        run: |
+          if [ ! -f .homeboy-bin/homeboy ]; then
+            echo "::error::Build artifact missing from upstream Build job: .homeboy-bin/homeboy was not produced/uploaded by gate-build. This is a CI artifact-handoff problem, not a test finding in this change. Re-run the failed Build job or investigate the homeboy-binary upload step." >&2
+            exit 1
+          fi
+          chmod +x .homeboy-bin/homeboy
 
       - name: Generate GitHub App token
         id: app-token
@@ -323,8 +347,13 @@ jobs:
           name: homeboy-binary
           path: .homeboy-bin
 
-      - name: Prepare binary
-        run: chmod +x .homeboy-bin/homeboy
+      - name: Verify homeboy binary present
+        run: |
+          if [ ! -f .homeboy-bin/homeboy ]; then
+            echo "::error::Build artifact missing from upstream Build job: .homeboy-bin/homeboy was not produced/uploaded by gate-build. This is a CI artifact-handoff problem, not an autofix finding. Re-run the failed Build job or investigate the homeboy-binary upload step." >&2
+            exit 1
+          fi
+          chmod +x .homeboy-bin/homeboy
 
       # Rust toolchain needed for cargo fmt (called by lint fixer in autofix)
       - name: Install Rust toolchain


### PR DESCRIPTION
## Summary
Addresses the two CI frictions reported in #3819.

**Concern #1 — lint-autofix pushes to PR branch mid-review:** already fixed on `main`.
- PR `ci.yml` sets `autofix: 'false'` explicitly (#4795) and no longer builds/uploads a binary, so no on-failure autofix push can churn an in-flight PR.
- Release-path autofix (`gate-refactor` in `release.yml`) runs only on the release path and uses `autofix-open-pr: 'true'` — it opens a separate PR rather than pushing commits to a branch under review.

**Concern #2 — Lint/Test fail on missing build artifact, masking the real finding:** fixed here.
- Added a `Verify homeboy binary present` preflight step to the release gate jobs (`gate-audit`, `gate-lint`, `gate-test`, `gate-refactor`) after the artifact download.
- When `.homeboy-bin/homeboy` is missing (i.e. the upstream `gate-build` artifact handoff failed), the job now fails with an explicit `::error::Build artifact missing from upstream Build job ...` message instead of the bare `binary-path '.homeboy-bin/homeboy' does not exist`. This makes it obvious it is CI plumbing, not a code finding, so reviewers don't chase a non-existent lint/test issue.

## Notes
- `ci.yml` (PR path) needed no change — concern #1 was already resolved there.
- No `docs/changelog.md` edits.
- Validated both workflow YAML files parse cleanly.

Refs #3819