### PR TITLE
fix(release): guard against missing committed lockfile shipping stale git deps (#5426)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -183,7 +183,8 @@
           "src/core/runner/tool_registry.rs",
           "src/core/cleanup.rs",
           "src/core/cleanup/self_artifacts.rs",
-          "src/core/runner/lab_args/tests.rs"
+          "src/core/runner/lab_args/tests.rs",
+          "src/core/release/executor/lockfile_guard.rs"
         ],
         "id": "core-agnostic-source",
         "ignore_after_line_equals": [

--- a/src/core/git/mod.rs
+++ b/src/core/git/mod.rs
@@ -64,7 +64,7 @@ pub use primitives::{
     short_head_revision, stage_all, status_porcelain, status_porcelain_bytes, toplevel,
     update_to_remote_default_branch,
 };
-pub(crate) use primitives::{is_git_repo, list_tracked_markdown_files};
+pub(crate) use primitives::{is_git_repo, is_tracked_path, list_tracked_markdown_files};
 
 use std::path::Path;
 use std::process::Command;

--- a/src/core/git/primitives.rs
+++ b/src/core/git/primitives.rs
@@ -318,6 +318,20 @@ pub(crate) fn is_git_repo(path: &str) -> bool {
     command::succeeded_in(path, "git", &["rev-parse", "--git-dir"])
 }
 
+/// Report whether `relative` (a repo-relative path) is committed/tracked in the
+/// git repository rooted at (or containing) `repo_dir`.
+///
+/// Returns `false` when the path is gitignored, untracked, or the directory is
+/// not a git repository. Uses `git ls-files --error-unmatch`, which only
+/// succeeds for paths recorded in the index.
+pub(crate) fn is_tracked_path(repo_dir: &Path, relative: &str) -> bool {
+    command::succeeded_in(
+        &repo_dir.to_string_lossy(),
+        "git",
+        &["ls-files", "--error-unmatch", "--", relative],
+    )
+}
+
 /// Get the git repository root directory from any path within the repo.
 pub fn get_git_root(path: &str) -> Result<String> {
     run_git(

--- a/src/core/release/executor.rs
+++ b/src/core/release/executor.rs
@@ -25,6 +25,7 @@ use super::utils::{extract_latest_notes, parse_release_artifacts};
 pub(crate) mod artifacts;
 pub(crate) mod changelog;
 mod github_release;
+pub(crate) mod lockfile_guard;
 pub(crate) mod package_preflight;
 pub(crate) mod prepare;
 mod publish;

--- a/src/core/release/executor/lockfile_guard.rs
+++ b/src/core/release/executor/lockfile_guard.rs
@@ -1,0 +1,450 @@
+//! Guard against non-deterministic isolated builds caused by a missing
+//! committed lockfile alongside git-pinned dependencies.
+//!
+//! ## The failure this prevents
+//!
+//! Homeboy's release/deploy builds run in an isolated tree that only contains
+//! committed files. When a manifest pins a dependency to a git ref (e.g.
+//! `github:org/pkg#v1.2.3`) but the corresponding lockfile is gitignored or
+//! never committed, the isolated install re-resolves that ref from scratch.
+//! Git refs are mutable and the package manager's git cache can hand back a
+//! *stale* commit for the same tag, producing a different — and sometimes
+//! broken — artifact than the one the developer built locally. The build still
+//! "succeeds", so a partial/incorrect artifact ships with no hard signal.
+//!
+//! The durable fix is to commit the lockfile so the isolated build resolves the
+//! exact same tree every time. This guard detects the dangerous shape — a
+//! manifest with git-pinned deps but no committed lockfile — and fails the
+//! release preflight loudly before any artifact is built or shipped.
+//!
+//! Ecosystem specifics (npm manifest/lockfile names, git-ref dependency syntax)
+//! are intentionally contained in this module rather than leaking into deep
+//! core; the release pipeline simply invokes the guard during preflight.
+
+use std::path::Path;
+
+use crate::core::error::{Error, Result};
+use crate::core::git;
+
+/// Manifest / lockfile pairing for a single package ecosystem. The first
+/// existing-and-committed lockfile in `lockfiles` satisfies the guard.
+struct ManifestSpec {
+    manifest: &'static str,
+    lockfiles: &'static [&'static str],
+}
+
+/// Supported manifest ecosystems. Only npm-family manifests currently express
+/// git-pinned dependencies in the shape this guard inspects; the list is a
+/// table so additional ecosystems can be added without touching the walk.
+const MANIFEST_SPECS: &[ManifestSpec] = &[ManifestSpec {
+    manifest: "package.json",
+    lockfiles: &[
+        "package-lock.json",
+        "npm-shrinkwrap.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+    ],
+}];
+
+/// Directories that never contain source-of-truth manifests for the component
+/// being released, and would make the walk slow or noisy.
+const SKIP_DIRS: &[&str] = &[".git", "node_modules", "vendor", "target", "dist", "build"];
+
+/// A manifest that pins git dependencies but has no committed lockfile.
+struct UnlockedManifest {
+    /// Manifest path relative to the component root (display form).
+    manifest_rel: String,
+    /// Example git-pinned dependency specs (for the operator-facing message).
+    pinned: Vec<String>,
+    /// Lockfile names that would satisfy the guard for this manifest.
+    expected_lockfiles: Vec<String>,
+}
+
+/// Inspect the component tree for manifests that pin git dependencies without a
+/// committed lockfile, and fail loudly when any are found.
+///
+/// `component_root` must be the original component checkout (it has a `.git`
+/// directory) so committed/tracked state can be determined. When the component
+/// is not a git repository the guard cannot reason about committed state and is
+/// skipped (the broader release flow handles non-git components elsewhere).
+pub(crate) fn guard_committed_lockfiles(component_root: &Path) -> Result<()> {
+    let root_str = component_root.to_string_lossy();
+    if !git::is_git_repo(&root_str) {
+        return Ok(());
+    }
+
+    let mut offenders = Vec::new();
+    collect_unlocked_manifests(component_root, component_root, &mut offenders);
+
+    if offenders.is_empty() {
+        return Ok(());
+    }
+
+    Err(missing_lockfile_error(&offenders))
+}
+
+fn collect_unlocked_manifests(
+    component_root: &Path,
+    dir: &Path,
+    offenders: &mut Vec<UnlockedManifest>,
+) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+
+        if file_type.is_dir() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if SKIP_DIRS.contains(&name.as_ref()) {
+                continue;
+            }
+            collect_unlocked_manifests(component_root, &path, offenders);
+            continue;
+        }
+
+        if !file_type.is_file() {
+            continue;
+        }
+
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        let Some(spec) = MANIFEST_SPECS
+            .iter()
+            .find(|spec| spec.manifest == file_name.as_ref())
+        else {
+            continue;
+        };
+
+        if let Some(offender) = inspect_manifest(component_root, &path, spec) {
+            offenders.push(offender);
+        }
+    }
+}
+
+/// Returns `Some` when `manifest_path` pins git dependencies but has no
+/// committed lockfile sibling.
+fn inspect_manifest(
+    component_root: &Path,
+    manifest_path: &Path,
+    spec: &ManifestSpec,
+) -> Option<UnlockedManifest> {
+    let contents = std::fs::read_to_string(manifest_path).ok()?;
+    let pinned = git_pinned_dependencies(&contents);
+    if pinned.is_empty() {
+        return None;
+    }
+
+    let dir = manifest_path.parent().unwrap_or(component_root);
+    let has_committed_lockfile = spec.lockfiles.iter().any(|lockfile| {
+        let lockfile_path = dir.join(lockfile);
+        if !lockfile_path.exists() {
+            return false;
+        }
+        match lockfile_path.strip_prefix(component_root) {
+            Ok(rel) => git::is_tracked_path(component_root, &rel.to_string_lossy()),
+            Err(_) => false,
+        }
+    });
+
+    if has_committed_lockfile {
+        return None;
+    }
+
+    let manifest_rel = manifest_path
+        .strip_prefix(component_root)
+        .map(|rel| rel.to_string_lossy().to_string())
+        .unwrap_or_else(|_| manifest_path.to_string_lossy().to_string());
+
+    Some(UnlockedManifest {
+        manifest_rel,
+        pinned,
+        expected_lockfiles: spec.lockfiles.iter().map(|l| l.to_string()).collect(),
+    })
+}
+
+/// Extract dependency specs that resolve from a mutable git ref. Parses the
+/// manifest's `dependencies`, `devDependencies`, and `optionalDependencies`
+/// maps and returns the `name@spec` pairs whose value points at a git source.
+fn git_pinned_dependencies(manifest_contents: &str) -> Vec<String> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(manifest_contents) else {
+        return Vec::new();
+    };
+
+    let sections = ["dependencies", "devDependencies", "optionalDependencies"];
+
+    let mut pinned = Vec::new();
+    for section in sections {
+        let Some(map) = value.get(section).and_then(serde_json::Value::as_object) else {
+            continue;
+        };
+        for (name, spec) in map {
+            let Some(spec) = spec.as_str() else { continue };
+            if is_git_pinned_spec(spec) {
+                pinned.push(format!("{name}@{spec}"));
+            }
+        }
+    }
+
+    pinned.sort();
+    pinned.dedup();
+    pinned
+}
+
+/// Detect dependency specs that resolve from a git source rather than a content
+/// -addressed registry tarball. These are the specs that re-resolve (and can go
+/// stale) without a committed lockfile.
+fn is_git_pinned_spec(spec: &str) -> bool {
+    let spec = spec.trim();
+
+    // Explicit git protocols / hosting shorthands understood by npm-family
+    // package managers.
+    const GIT_PREFIXES: &[&str] = &[
+        "git+",
+        "git://",
+        "github:",
+        "gitlab:",
+        "bitbucket:",
+        "gist:",
+    ];
+    if GIT_PREFIXES.iter().any(|prefix| spec.starts_with(prefix)) {
+        return true;
+    }
+
+    // `user/repo` or `user/repo#ref` shorthand resolves to GitHub. Exclude
+    // registry ranges and file/link/workspace specs, which never contain a
+    // bare `owner/repo` slug.
+    if spec.contains("://") || spec.starts_with("file:") || spec.starts_with("link:") {
+        return false;
+    }
+    if spec.starts_with("npm:")
+        || spec.starts_with("workspace:")
+        || spec.starts_with('^')
+        || spec.starts_with('~')
+        || spec.starts_with('>')
+        || spec.starts_with('<')
+        || spec.starts_with('=')
+        || spec.starts_with('*')
+    {
+        return false;
+    }
+
+    // `owner/repo` shorthand: exactly one slash, both halves non-empty, and the
+    // value is not a semver-looking string.
+    let slug = spec.split('#').next().unwrap_or(spec);
+    let parts: Vec<&str> = slug.split('/').collect();
+    parts.len() == 2
+        && !parts[0].is_empty()
+        && !parts[1].is_empty()
+        && !parts[0].chars().next().is_some_and(|c| c.is_ascii_digit())
+}
+
+fn missing_lockfile_error(offenders: &[UnlockedManifest]) -> Error {
+    let mut lines = vec![
+        "Release blocked: git-pinned dependencies without a committed lockfile.".to_string(),
+        String::new(),
+        "The isolated release/deploy build only sees committed files. A manifest \
+         that pins a git ref (e.g. github:org/pkg#tag) with no committed lockfile \
+         re-resolves that ref every build and can silently pull a stale cached \
+         commit — shipping a different (possibly broken) artifact than you built \
+         locally."
+            .to_string(),
+        String::new(),
+    ];
+
+    for offender in offenders {
+        lines.push(format!("  {}", offender.manifest_rel));
+        for dep in &offender.pinned {
+            lines.push(format!("    pinned: {dep}"));
+        }
+        lines.push(format!(
+            "    missing committed lockfile (one of: {})",
+            offender.expected_lockfiles.join(", ")
+        ));
+    }
+
+    let hints = vec![
+        "Generate and commit the lockfile (e.g. `npm install` then commit \
+         package-lock.json) so the isolated build resolves the exact same tree."
+            .to_string(),
+        "Ensure the lockfile is not gitignored — `git check-ignore <lockfile>` \
+         should report nothing."
+            .to_string(),
+    ];
+
+    Error::validation_invalid_argument(
+        "release.preflight.lockfile",
+        lines.join("\n"),
+        None,
+        Some(hints),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run_git(dir: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo(dir: &Path) {
+        run_git(dir, &["init", "--quiet"]);
+        run_git(dir, &["config", "user.email", "test@example.com"]);
+        run_git(dir, &["config", "user.name", "Test"]);
+    }
+
+    fn write(dir: &Path, rel: &str, contents: &str) {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent");
+        }
+        std::fs::write(path, contents).expect("write file");
+    }
+
+    const GIT_PINNED_MANIFEST: &str = r#"{
+        "name": "theme",
+        "dependencies": {
+            "@org/tokens": "github:org/tokens#v0.8.1",
+            "lodash": "^4.17.0"
+        }
+    }"#;
+
+    #[test]
+    fn detects_git_shorthand_and_protocol_specs() {
+        assert!(is_git_pinned_spec("github:org/tokens#v0.8.1"));
+        assert!(is_git_pinned_spec("git+https://github.com/org/pkg.git"));
+        assert!(is_git_pinned_spec("git://github.com/org/pkg.git"));
+        assert!(is_git_pinned_spec("gitlab:org/pkg"));
+        assert!(is_git_pinned_spec("org/tokens#v0.8.1"));
+        assert!(is_git_pinned_spec("org/tokens"));
+    }
+
+    #[test]
+    fn ignores_registry_and_local_specs() {
+        assert!(!is_git_pinned_spec("^4.17.0"));
+        assert!(!is_git_pinned_spec("~1.2.3"));
+        assert!(!is_git_pinned_spec("1.2.3"));
+        assert!(!is_git_pinned_spec("*"));
+        assert!(!is_git_pinned_spec(">=2.0.0"));
+        assert!(!is_git_pinned_spec("npm:@scope/pkg@1.0.0"));
+        assert!(!is_git_pinned_spec("file:../local"));
+        assert!(!is_git_pinned_spec("link:../local"));
+        assert!(!is_git_pinned_spec("workspace:*"));
+        assert!(!is_git_pinned_spec("https://example.com/pkg.tgz"));
+    }
+
+    #[test]
+    fn parses_pinned_deps_from_all_sections() {
+        let manifest = r#"{
+            "dependencies": { "a": "github:org/a#v1" },
+            "devDependencies": { "b": "org/b#v2", "c": "^1.0.0" },
+            "optionalDependencies": { "d": "git+https://x/d.git" }
+        }"#;
+        let pinned = git_pinned_dependencies(manifest);
+        assert_eq!(
+            pinned,
+            vec![
+                "a@github:org/a#v1".to_string(),
+                "b@org/b#v2".to_string(),
+                "d@git+https://x/d.git".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn fails_when_git_pinned_dep_has_no_committed_lockfile() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        init_repo(root);
+        write(root, "package.json", GIT_PINNED_MANIFEST);
+        run_git(root, &["add", "package.json"]);
+        run_git(root, &["commit", "--quiet", "-m", "init"]);
+
+        let err = guard_committed_lockfiles(root).expect_err("should block release");
+        assert!(err.message.contains("git-pinned dependencies"));
+        assert!(err.message.contains("package.json"));
+        assert!(err.message.contains("github:org/tokens#v0.8.1"));
+    }
+
+    #[test]
+    fn fails_when_lockfile_present_but_gitignored() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        init_repo(root);
+        write(root, "package.json", GIT_PINNED_MANIFEST);
+        write(root, "package-lock.json", "{}");
+        write(root, ".gitignore", "package-lock.json\n");
+        run_git(root, &["add", "package.json", ".gitignore"]);
+        run_git(root, &["commit", "--quiet", "-m", "init"]);
+
+        let err = guard_committed_lockfiles(root)
+            .expect_err("gitignored lockfile should not satisfy the guard");
+        assert!(err.message.contains("git-pinned dependencies"));
+    }
+
+    #[test]
+    fn passes_when_lockfile_committed() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        init_repo(root);
+        write(root, "package.json", GIT_PINNED_MANIFEST);
+        write(root, "package-lock.json", "{}");
+        run_git(root, &["add", "package.json", "package-lock.json"]);
+        run_git(root, &["commit", "--quiet", "-m", "init"]);
+
+        guard_committed_lockfiles(root).expect("committed lockfile satisfies the guard");
+    }
+
+    #[test]
+    fn passes_when_no_git_pinned_deps() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        init_repo(root);
+        write(
+            root,
+            "package.json",
+            r#"{ "dependencies": { "lodash": "^4.17.0" } }"#,
+        );
+        run_git(root, &["add", "package.json"]);
+        run_git(root, &["commit", "--quiet", "-m", "init"]);
+
+        guard_committed_lockfiles(root).expect("registry-only deps need no lockfile guard");
+    }
+
+    #[test]
+    fn skips_node_modules_and_non_git_trees() {
+        // Non-git tree: guard is a no-op.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        write(root, "package.json", GIT_PINNED_MANIFEST);
+        guard_committed_lockfiles(root).expect("non-git tree is skipped");
+
+        // node_modules manifests are not inspected.
+        let temp2 = tempfile::tempdir().expect("tempdir");
+        let root2 = temp2.path();
+        init_repo(root2);
+        write(root2, "node_modules/dep/package.json", GIT_PINNED_MANIFEST);
+        write(root2, "package.json", r#"{ "name": "root" }"#);
+        run_git(root2, &["add", "."]);
+        run_git(root2, &["commit", "--quiet", "-m", "init"]);
+        guard_committed_lockfiles(root2).expect("node_modules is skipped");
+    }
+}

--- a/src/core/release/executor/package_preflight.rs
+++ b/src/core/release/executor/package_preflight.rs
@@ -14,6 +14,12 @@ pub(crate) fn run_package_preflight(
     component_local_path: &str,
     skip_build_validation: bool,
 ) -> Result<ReleaseStepResult> {
+    // Inspect the original component checkout (which still has its `.git`) for
+    // git-pinned dependencies that lack a committed lockfile. The isolated
+    // build copy below excludes `.git`, so this committed-state check must run
+    // against the source tree before we mutate or build anything.
+    super::lockfile_guard::guard_committed_lockfiles(Path::new(component_local_path))?;
+
     let temp = create_release_preflight_tempdir()?;
     let temp_component_path = temp.join("component");
     copy_release_preflight_tree(Path::new(component_local_path), &temp_component_path)?;


### PR DESCRIPTION
## Summary
Closes #5426. Adds a release **preflight guard** that detects the dangerous build shape behind the recent silent broken-theme deploy: a manifest pinning a git-ref dependency (e.g. `github:org/pkg#tag`) with **no committed lockfile**.

Homeboy's isolated release/deploy build only sees committed files. When the lockfile is gitignored/uncommitted, the isolated install re-resolves the git ref each build and can hand back a *stale* cached commit — shipping a different (possibly broken) artifact than the developer built locally, with no hard failure. The theme that lost `theme.json` is exactly this class.

## What it does
- New `src/core/release/executor/lockfile_guard.rs`: walks the component tree (skipping `node_modules`/`vendor`/build dirs), parses manifest `dependencies`/`devDependencies`/`optionalDependencies`, and flags specs that resolve from a mutable git source (git protocols + `owner/repo#ref` shorthand, excluding registry/file/workspace specs).
- For any manifest with git-pinned deps, it requires a **committed** lockfile sibling (one of `package-lock.json` / `npm-shrinkwrap.json` / `pnpm-lock.yaml` / `yarn.lock`). Gitignored-but-present lockfiles do **not** satisfy the guard.
- Fails the existing `preflight.package` step **loudly** with an actionable message + hints (commit the lockfile; confirm it isn't gitignored) before any artifact is built or shipped — so the whole class is caught once for all components.
- Runs against the original checkout (with `.git`) since the preflight build copy strips `.git`; committed state is determined via a new `git::is_tracked_path` helper (`git ls-files --error-unmatch`).

## Boundary / agnosticism
The npm/manifest/lockfile specifics are contained in this single build-path module (the release executor that owns the package step) rather than leaking into deep core, and the file is added to the `core-agnostic-source` audit allowlist — the sanctioned escape hatch the detector itself suggests for intentional ecosystem-aware build code. No `docs/changelog.md` changes.

## Tests
8 unit tests in `lockfile_guard.rs` cover: git shorthand/protocol detection, registry/local spec exclusion, multi-section parsing, missing-lockfile failure, gitignored-lockfile failure, committed-lockfile pass, registry-only pass, and node_modules/non-git skip. All pass. `cargo build --lib` clean.