### PR TITLE
fix(audit): DRY intra-method duplication to clear findings (#5491)

### DIFF
--- a/src/core/engine/execution_context.rs
+++ b/src/core/engine/execution_context.rs
@@ -306,21 +306,24 @@ fn merge_string_setting_override(
     key: &str,
     value: &str,
 ) {
-    let Some((root, child_path)) = key.split_once('.') else {
+    // Replace any existing top-level entry for `key` with the raw string value.
+    // Used for both the no-dot case and malformed dotted keys (empty segments),
+    // which are treated as opaque flat keys rather than nested paths.
+    let set_flat = |settings: &mut Vec<(String, serde_json::Value)>| {
         settings.retain(|(k, _)| k != key);
         settings.push((
             key.to_string(),
             serde_json::Value::String(value.to_string()),
         ));
+    };
+
+    let Some((root, child_path)) = key.split_once('.') else {
+        set_flat(settings);
         return;
     };
 
     if root.is_empty() || child_path.is_empty() || child_path.split('.').any(str::is_empty) {
-        settings.retain(|(k, _)| k != key);
-        settings.push((
-            key.to_string(),
-            serde_json::Value::String(value.to_string()),
-        ));
+        set_flat(settings);
         return;
     }
 

--- a/src/core/release/executor/github_release.rs
+++ b/src/core/release/executor/github_release.rs
@@ -98,23 +98,24 @@ pub(crate) fn run_github_release(
         .map(|artifact| artifact.path.clone())
         .collect();
     let has_artifacts = !artifact_paths.is_empty();
-    // Repair commands available before the exact body is built/persisted (gh
-    // missing / unauthenticated / upload paths). These regenerate notes since
-    // no persisted exact-body file exists yet. The create path below rebuilds a
-    // persisted-aware closure once the body is written to disk (issue #3508).
-    let repair_commands = |notes_start_tag: Option<&str>| {
+    // Single repair-command builder for every failure path. The persisted
+    // exact-body file only exists after `persist_release_body` runs below, so
+    // early paths (gh missing / unauthenticated / upload) pass `None` and
+    // regenerate notes, while the create path passes the persisted path so the
+    // repair `--notes-file` reproduces the body byte-for-byte (issue #3508).
+    let repair_commands = |notes_start_tag: Option<&str>, persisted_notes: Option<&str>| {
         github_release_repair_commands(
             &tag,
             &github,
             &component.github,
             &artifact_paths,
             notes_start_tag,
-            None,
+            persisted_notes,
         )
     };
 
     if !gh_is_available() {
-        let repair = repair_commands(None);
+        let repair = repair_commands(None, None);
         log_status!(
             "release",
             "✗ `gh` CLI not found on PATH — GitHub Release was NOT created"
@@ -130,7 +131,7 @@ pub(crate) fn run_github_release(
     }
 
     if !gh_is_authenticated(&github, &component.github) {
-        let repair = repair_commands(None);
+        let repair = repair_commands(None, None);
         log_status!(
             "release",
             "✗ `gh` is not authenticated — GitHub Release was NOT created"
@@ -194,7 +195,7 @@ pub(crate) fn run_github_release(
         if !upload_output.status.success() {
             let stderr = String::from_utf8_lossy(&upload_output.stderr).to_string();
             let stdout = String::from_utf8_lossy(&upload_output.stdout).to_string();
-            let repair = repair_commands(None);
+            let repair = repair_commands(None, None);
             log_status!("release", "✗ `gh release upload` failed: {}", stderr.trim());
             log_repair_commands(&repair);
             return Ok(upload_failed_result(
@@ -233,16 +234,6 @@ pub(crate) fn run_github_release(
     // repair `--notes-file` reproduces it byte-for-byte. A failure to write the
     // artifact is non-fatal: fall back to commands that regenerate notes.
     let persisted_notes_path = persist_release_body(component, &tag, &release_notes);
-    let repair_commands = |notes_start_tag: Option<&str>| {
-        github_release_repair_commands(
-            &tag,
-            &github,
-            &component.github,
-            &artifact_paths,
-            notes_start_tag,
-            persisted_notes_path.as_deref(),
-        )
-    };
 
     log_status!(
         "release",
@@ -290,7 +281,7 @@ pub(crate) fn run_github_release(
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let repair = repair_commands(notes_start_tag.as_deref());
+        let repair = repair_commands(notes_start_tag.as_deref(), persisted_notes_path.as_deref());
         // Distinguish the path that brought us here so operators (and tests)
         // can see whether the fallback-after-generated-notes-failure also
         // failed, versus a plain create failure with working notes.

--- a/src/core/release/workflow.rs
+++ b/src/core/release/workflow.rs
@@ -637,6 +637,44 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
     let current_version = &version_info.version;
     let tag_name = format_tag(current_version, monorepo.as_ref());
 
+    // Create the annotated release tag, surfacing `err_label` on failure. Shared
+    // by the retag-to-HEAD and first-time create paths below, which issue the
+    // identical `git tag` and differ only in the error wording.
+    let create_tag = |err_label: &str| -> Result<()> {
+        let tag_result = git::tag(
+            Some(&input.component_id),
+            Some(&tag_name),
+            Some(&format!("Release {}", tag_name)),
+        )?;
+        if !tag_result.success {
+            return Err(Error::git_command_failed(format!(
+                "{}: {}",
+                err_label, tag_result.stderr
+            )));
+        }
+        Ok(())
+    };
+
+    // Push commits and tags to origin, surfacing `err_label` on failure. Shared
+    // by the retag and first-time push paths below, which issue the identical
+    // tags-included push and differ only in the error wording.
+    let push_tags = |err_label: &str| -> Result<()> {
+        let push_result = git::push(
+            Some(&input.component_id),
+            git::PushOptions {
+                tags: true,
+                ..Default::default()
+            },
+        )?;
+        if !push_result.success {
+            return Err(Error::git_command_failed(format!(
+                "{}: {}",
+                err_label, push_result.stderr
+            )));
+        }
+        Ok(())
+    };
+
     // Surface the orphan-tag pattern from issue #2234. When the latest release
     // tag points at a commit whose subject is *not* `release: vX.Y.Z`, the
     // previous release was botched (tag without bump). Recover should warn
@@ -771,31 +809,9 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
             git::delete_remote_tag(&component.local_path, &tag_name)?;
         }
 
-        let tag_result = git::tag(
-            Some(&input.component_id),
-            Some(&tag_name),
-            Some(&format!("Release {}", tag_name)),
-        )?;
-        if !tag_result.success {
-            return Err(Error::git_command_failed(format!(
-                "Failed to re-create tag at HEAD: {}",
-                tag_result.stderr
-            )));
-        }
+        create_tag("Failed to re-create tag at HEAD")?;
 
-        let push_result = git::push(
-            Some(&input.component_id),
-            git::PushOptions {
-                tags: true,
-                ..Default::default()
-            },
-        )?;
-        if !push_result.success {
-            return Err(Error::git_command_failed(format!(
-                "Failed to push retagged {}: {}",
-                tag_name, push_result.stderr
-            )));
-        }
+        push_tags(&format!("Failed to push retagged {}", tag_name))?;
 
         let actions = vec![format!("retagged {} to HEAD", tag_name)];
         log_status!(
@@ -897,36 +913,13 @@ fn run_recover(input: &ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32
 
     if !tag_exists_local {
         log_status!("recover", "Creating tag {}...", tag_name);
-        let tag_result = git::tag(
-            Some(&input.component_id),
-            Some(&tag_name),
-            Some(&format!("Release {}", tag_name)),
-        )?;
-        if !tag_result.success {
-            return Err(Error::git_command_failed(format!(
-                "Failed to create tag: {}",
-                tag_result.stderr
-            )));
-        }
+        create_tag("Failed to create tag")?;
         actions.push(format!("created tag {}", tag_name));
     }
 
     if !tag_exists_remote {
         log_status!("recover", "Pushing to remote...");
-        let push_result = git::push(
-            Some(&input.component_id),
-            git::PushOptions {
-                tags: true,
-                force_with_lease: false,
-                ..Default::default()
-            },
-        )?;
-        if !push_result.success {
-            return Err(Error::git_command_failed(format!(
-                "Failed to push: {}",
-                push_result.stderr
-            )));
-        }
+        push_tags("Failed to push")?;
         actions.push("pushed commits and tags".to_string());
     }
 
@@ -1023,6 +1016,28 @@ fn reconcile_release_branch(
     };
     let head_commit = git::get_head_commit(path)?;
 
+    // Push HEAD to the branch (tags included), surfacing `err_label` on failure.
+    // Shared by the fast-forward and post-rebase paths below, which push the
+    // identical refspec and differ only in the error wording.
+    let push_branch = |err_label: &str| -> Result<()> {
+        let push = git::push_at(
+            Some(component_id),
+            git::PushOptions {
+                tags: true,
+                refspec: Some(format!("HEAD:refs/heads/{branch}")),
+                ..Default::default()
+            },
+            Some(path),
+        )?;
+        if !push.success {
+            return Err(Error::git_command_failed(format!(
+                "Failed to push {} branch {}: {}",
+                err_label, branch, push.stderr
+            )));
+        }
+        Ok(())
+    };
+
     // The release commit is already on the remote branch — nothing to do.
     if git::is_ancestor(path, &head_commit, &remote_commit)? {
         return Ok(None);
@@ -1035,21 +1050,7 @@ fn reconcile_release_branch(
             "Pushing release commit to remote {} (remote did not advance)...",
             branch
         );
-        let push = git::push_at(
-            Some(component_id),
-            git::PushOptions {
-                tags: true,
-                refspec: Some(format!("HEAD:refs/heads/{branch}")),
-                ..Default::default()
-            },
-            Some(path),
-        )?;
-        if !push.success {
-            return Err(Error::git_command_failed(format!(
-                "Failed to push release branch {}: {}",
-                branch, push.stderr
-            )));
-        }
+        push_branch("release")?;
         return Ok(Some(format!("pushed release commit to {}", branch)));
     }
 
@@ -1093,21 +1094,7 @@ fn reconcile_release_branch(
         ));
     }
 
-    let push = git::push_at(
-        Some(component_id),
-        git::PushOptions {
-            tags: true,
-            refspec: Some(format!("HEAD:refs/heads/{branch}")),
-            ..Default::default()
-        },
-        Some(path),
-    )?;
-    if !push.success {
-        return Err(Error::git_command_failed(format!(
-            "Failed to push rebased release branch {}: {}",
-            branch, push.stderr
-        )));
-    }
+    push_branch("rebased release")?;
 
     Ok(Some(format!(
         "rebased release commit onto advanced remote and pushed {}",


### PR DESCRIPTION
## Summary
Clears all 4 `intra_method_duplication` audit findings from #5491 by extracting the repeated within-method blocks into local closures. Behavior is identical — only the duplicated code is consolidated.

## Changes
- **`src/core/engine/execution_context.rs`** — `merge_string_setting_override`: extracted a `set_flat` closure for the repeated "replace top-level entry with raw string" block (no-dot key + malformed dotted key paths).
- **`src/core/release/executor/github_release.rs`** — `run_github_release`: merged the two near-identical `repair_commands` closures (pre-persist vs post-persist) into one that takes the persisted-notes path as a parameter.
- **`src/core/release/workflow.rs`** —
  - `reconcile_release_branch`: extracted a `push_branch(err_label)` closure for the fast-forward and post-rebase push blocks.
  - `run_recover`: extracted `create_tag(err_label)` for the retag/first-time `git tag` blocks and `push_tags(err_label)` for the retag/first-time push blocks (the latter surfaced as a follow-on finding once the tag blocks were DRYed).

## Verification
- `homeboy audit homeboy --changed-since origin/main --only intra_method_duplicate` → `"findings": []`, `"passed": true`.
- `cargo build --lib` clean (pre-existing dead-code warnings only).
- `cargo fmt` applied.

Closes #5491.