### PR TITLE
fix(test): resolve failing test (#5494)

### DIFF
--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -739,7 +739,14 @@ fn source_upgrade_homeboy_path_realignment(
 }
 
 fn source_checkout_build_identity(source_path: &Path) -> Option<String> {
+    // `rev-parse` must produce a commit hash; an empty result means we can't
+    // identify the checkout, so treat it as failure.
     let commit = git_output(source_path, &["rev-parse", "--short=12", "HEAD"])?;
+    if commit.trim().is_empty() {
+        return None;
+    }
+    // `git status --porcelain` returns empty output for a clean tree, which is
+    // the normal, successful case — empty here must NOT be treated as failure.
     let status = git_output(source_path, &["status", "--porcelain"])?;
     let dirty_suffix = if status.trim().is_empty() {
         ""
@@ -750,7 +757,7 @@ fn source_checkout_build_identity(source_path: &Path) -> Option<String> {
     Some(format!(
         "homeboy {}+{}{}",
         current_version(),
-        commit,
+        commit.trim(),
         dirty_suffix
     ))
 }
@@ -766,12 +773,10 @@ fn git_output(source_path: &Path, args: &[&str]) -> Option<String> {
         return None;
     }
 
-    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if value.is_empty() {
-        None
-    } else {
-        Some(value)
-    }
+    // Return the (possibly empty) stdout on success. Empty output is valid for
+    // commands like `git status --porcelain` on a clean tree; callers that
+    // require non-empty output must validate it themselves.
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 fn sync_runner_extensions(


### PR DESCRIPTION
## Summary
Fixes the failing test `core::upgrade::runners::tests::source_runner_upgrade_realigns_to_same_version_source_checkout_identity` (issue #5494).

## Root cause
`source_checkout_build_identity()` builds an identity string from a source checkout by running `git rev-parse` and `git status --porcelain`. Both calls go through `git_output()`, which treated **empty stdout as failure** and returned `None`.

For `git status --porcelain`, empty output is the *normal, successful* result on a clean working tree. So for any clean checkout, `git_output(... "status" ...)` returned `None`, the `?` short-circuited, and `source_checkout_build_identity()` returned `None` — causing the test's `.unwrap()` to panic with `called Option::unwrap() on a None value` at `runners.rs:2430`.

This is a real regression (reproduced deterministically on fresh `origin/main`), not a flake.

## Fix
- `git_output()` now returns `Some("")` on a successful command with empty stdout instead of conflating empty output with command failure. It still returns `None` on non-zero exit / spawn failure.
- `source_checkout_build_identity()` now explicitly validates that `rev-parse` produced a non-empty commit (the one case that genuinely requires output), while allowing the clean-tree empty `status` result through.

## Verification
- `cargo test --lib core::upgrade::runners::tests::source_runner_upgrade_realigns_to_same_version_source_checkout_identity` → 1 passed
- Sibling `source_runner_upgrade*` tests → 2 passed
- `cargo fmt` clean

Closes #5494