### PR TITLE
Carry controller workflow artifacts forward

### DIFF
--- a/src/core/agent_task_controller_service/actions.rs
+++ b/src/core/agent_task_controller_service/actions.rs
@@ -338,6 +338,8 @@ where
     E: AgentTaskExecutorAdapter + Clone,
     D: ControllerDispatchHook,
 {
+    let request = request_with_required_workflow_artifacts(record, request);
+    let request = &request;
     let mode = request
         .get("mode")
         .and_then(Value::as_str)
@@ -369,12 +371,15 @@ where
             let aggregate_value = serde_json::to_value(&run_result.value)
                 .map_err(|error| Error::internal_json(error.to_string(), None))?;
             Ok((
-                serde_json::json!({
-                    "mode": mode,
-                    "run_id": submitted.run_id,
-                    "submitted": submitted,
-                    "aggregate": aggregate_value,
-                }),
+                execution_with_request_workflow_artifacts(
+                    serde_json::json!({
+                        "mode": mode,
+                        "run_id": submitted.run_id,
+                        "submitted": submitted,
+                        "aggregate": aggregate_value,
+                    }),
+                    request,
+                ),
                 run_result.exit_code,
             ))
         }
@@ -391,11 +396,14 @@ where
                 request,
             )?;
             Ok((
-                serde_json::json!({
-                    "mode": mode,
-                    "run_id": submitted.run_id,
-                    "submitted": submitted,
-                }),
+                execution_with_request_workflow_artifacts(
+                    serde_json::json!({
+                        "mode": mode,
+                        "run_id": submitted.run_id,
+                        "submitted": submitted,
+                    }),
+                    request,
+                ),
                 0,
             ))
         }
@@ -407,7 +415,10 @@ where
             let aggregate_value = serde_json::to_value(&run_result.value)
                 .map_err(|error| Error::internal_json(error.to_string(), None))?;
             Ok((
-                serde_json::json!({ "mode": mode, "run_id": run_id, "aggregate": aggregate_value }),
+                execution_with_request_workflow_artifacts(
+                    serde_json::json!({ "mode": mode, "run_id": run_id, "aggregate": aggregate_value }),
+                    request,
+                ),
                 run_result.exit_code,
             ))
         }
@@ -419,7 +430,10 @@ where
             let aggregate_value = serde_json::to_value(&run_result.value)
                 .map_err(|error| Error::internal_json(error.to_string(), None))?;
             Ok((
-                serde_json::json!({ "mode": mode, "run_id": run_id, "aggregate": aggregate_value }),
+                execution_with_request_workflow_artifacts(
+                    serde_json::json!({ "mode": mode, "run_id": run_id, "aggregate": aggregate_value }),
+                    request,
+                ),
                 run_result.exit_code,
             ))
         }
@@ -434,7 +448,10 @@ where
                 record_controller_spawn(record, action, dedupe_key, entity_id, run_id, request)?;
             }
             Ok((
-                serde_json::json!({ "mode": mode, "result": value }),
+                execution_with_request_workflow_artifacts(
+                    serde_json::json!({ "mode": mode, "result": value }),
+                    request,
+                ),
                 run_result.exit_code,
             ))
         }
@@ -445,7 +462,10 @@ where
                 record_controller_result_evidence(record, entity_id, run_id, &value)?;
             }
             Ok((
-                serde_json::json!({ "mode": mode, "result": value }),
+                execution_with_request_workflow_artifacts(
+                    serde_json::json!({ "mode": mode, "result": value }),
+                    request,
+                ),
                 exit_code,
             ))
         }

--- a/src/core/agent_task_controller_service/artifacts.rs
+++ b/src/core/agent_task_controller_service/artifacts.rs
@@ -168,7 +168,7 @@ pub(super) fn collect_required_artifacts_from_declarations(
         };
         let Some(kind) = first_non_empty_str(
             declaration,
-            &[&["kind"], &["artifact_type"], &["data", "kind"]],
+            &[&["kind"], &["artifact_type"], &["type"], &["data", "kind"]],
         ) else {
             continue;
         };
@@ -192,11 +192,13 @@ pub(super) fn execution_contains_artifact(value: &Value, artifact_id: &str, kind
             let id_matches = object
                 .get("id")
                 .or_else(|| object.get("artifact_id"))
+                .or_else(|| object.get("name"))
                 .and_then(Value::as_str)
                 == Some(artifact_id);
             let kind_matches = object
                 .get("kind")
                 .or_else(|| object.get("artifact_type"))
+                .or_else(|| object.get("type"))
                 .and_then(Value::as_str)
                 == Some(kind);
             (id_matches && kind_matches)
@@ -208,6 +210,86 @@ pub(super) fn execution_contains_artifact(value: &Value, artifact_id: &str, kind
             .iter()
             .any(|value| execution_contains_artifact(value, artifact_id, kind)),
         _ => false,
+    }
+}
+
+pub(super) fn request_with_required_workflow_artifacts(
+    record: &AgentTaskLoopControllerRecord,
+    request: &Value,
+) -> Value {
+    let workflow_artifacts = matching_completed_workflow_artifacts(record, request);
+    if workflow_artifacts.is_empty() {
+        return request.clone();
+    }
+
+    let mut request = request.as_object().cloned().unwrap_or_default();
+    merge_workflow_artifacts(&mut request, &workflow_artifacts);
+    if let Some(dispatch) = request.get_mut("dispatch").and_then(Value::as_object_mut) {
+        merge_workflow_artifacts(dispatch, &workflow_artifacts);
+    }
+    Value::Object(request)
+}
+
+pub(super) fn execution_with_request_workflow_artifacts(
+    execution: Value,
+    request: &Value,
+) -> Value {
+    let Some(workflow_artifacts) = request
+        .get("workflow_artifacts")
+        .and_then(Value::as_array)
+        .filter(|artifacts| !artifacts.is_empty())
+    else {
+        return execution;
+    };
+    let mut execution = execution.as_object().cloned().unwrap_or_default();
+    merge_workflow_artifacts(&mut execution, workflow_artifacts);
+    Value::Object(execution)
+}
+
+fn matching_completed_workflow_artifacts(
+    record: &AgentTaskLoopControllerRecord,
+    request: &Value,
+) -> Vec<Value> {
+    let required = required_workflow_artifacts(request);
+    if required.is_empty() {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+    for lineage in &record.task_lineage {
+        let Some(entries) = lineage.outputs["evidence_index"]["entries"].as_array() else {
+            continue;
+        };
+        for artifact in entries
+            .iter()
+            .flat_map(|entry| entry["typed_artifacts"].as_array().into_iter().flatten())
+        {
+            if required.iter().any(|required| {
+                execution_contains_artifact(artifact, &required.artifact_id, &required.kind)
+            }) && !matches.iter().any(|existing| existing == artifact)
+            {
+                matches.push(artifact.clone());
+            }
+        }
+    }
+    matches
+}
+
+fn merge_workflow_artifacts(
+    object: &mut serde_json::Map<String, Value>,
+    workflow_artifacts: &[Value],
+) {
+    let entry = object
+        .entry("workflow_artifacts".to_string())
+        .or_insert_with(|| serde_json::json!([]));
+    if !entry.is_array() {
+        *entry = serde_json::json!([]);
+    }
+    let target = entry.as_array_mut().expect("workflow artifacts array");
+    for artifact in workflow_artifacts {
+        if !target.iter().any(|existing| existing == artifact) {
+            target.push(artifact.clone());
+        }
     }
 }
 

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -1516,7 +1516,7 @@ fn completed_typed_artifacts_are_carried_to_later_required_workflow_artifacts() 
             .iter()
             .all(|action| action.diagnostics.is_empty()));
         assert_eq!(
-            result.value.results[1].execution["workflow_artifacts"][0]["name"],
+            result.value.results[1]["execution"]["workflow_artifacts"][0]["name"],
             json!("static_site_candidate")
         );
 

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -1511,7 +1511,10 @@ fn completed_typed_artifacts_are_carried_to_later_required_workflow_artifacts() 
             .next_actions
             .iter()
             .all(|action| action.status == AgentTaskLoopActionStatus::Completed));
-        assert!(loaded.next_actions.iter().all(|action| action.diagnostics.is_empty()));
+        assert!(loaded
+            .next_actions
+            .iter()
+            .all(|action| action.diagnostics.is_empty()));
         assert_eq!(
             result.value.results[1].execution["workflow_artifacts"][0]["name"],
             json!("static_site_candidate")

--- a/src/core/agent_task_controller_service/tests.rs
+++ b/src/core/agent_task_controller_service/tests.rs
@@ -32,6 +32,11 @@ struct ArtifactDispatchHook {
 }
 
 #[derive(Clone, Default)]
+struct TypedArtifactHandoffDispatchHook {
+    observed_requests: Arc<Mutex<Vec<Value>>>,
+}
+
+#[derive(Clone, Default)]
 struct EvidenceExecutor;
 
 impl ControllerDispatchHook for CapturingDispatchHook {
@@ -80,6 +85,31 @@ impl ControllerDispatchHook for ArtifactDispatchHook {
             }),
             0,
         ))
+    }
+}
+
+impl ControllerDispatchHook for TypedArtifactHandoffDispatchHook {
+    fn dispatch(&self, request: &Value) -> Result<(Value, i32)> {
+        let mut observed = self
+            .observed_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        observed.push(request.clone());
+        let index = observed.len();
+        drop(observed);
+
+        let mut result = json!({
+            "schema": "homeboy/test-generic-dispatch-result/v1",
+            "run_id": format!("typed-artifact-handoff-{index}"),
+        });
+        if index == 1 {
+            result["typed_artifacts"] = json!([{
+                "name": "static_site_candidate",
+                "type": "static_site",
+                "payload": { "path": "dist/index.html" }
+            }]);
+        }
+        Ok((result, 0))
     }
 }
 
@@ -1414,6 +1444,93 @@ fn resume_fails_required_workflow_artifact_handoff_before_downstream_action() {
                 && event.payload["diagnostics"][0]["code"]
                     == json!("required_workflow_artifacts_missing")
         }));
+    });
+}
+
+#[test]
+fn completed_typed_artifacts_are_carried_to_later_required_workflow_artifacts() {
+    with_isolated_home(|_| {
+        let mut record = init(ControllerInitRequest {
+            loop_id: "loop-service-typed-artifact-handoff".to_string(),
+            phase: "generate".to_string(),
+            config_version: "v1".to_string(),
+        })
+        .expect("controller initialized");
+        let workflow_context = json!({
+            "schema": "homeboy/repo-loop-workflow-context/v1",
+            "workflow_id": "import-static-site",
+            "plan": {
+                "schema": "homeboy/repo-loop-workflow-plan/v1",
+                "artifacts": [{
+                    "id": "static_site_candidate",
+                    "artifact_type": "static_site",
+                    "required": true
+                }]
+            }
+        });
+        record.record_action(
+            AgentTaskLoopPolicyAction::SpawnTask {
+                dedupe_key: "workflow:build-static-site".to_string(),
+                entity_id: None,
+                request: json!({
+                    "mode": "dispatch",
+                    "run_id": "typed-artifact-handoff-producer"
+                }),
+            },
+            "produce static site candidate",
+        );
+        record.record_action(
+            AgentTaskLoopPolicyAction::SpawnTask {
+                dedupe_key: "workflow:import-static-site".to_string(),
+                entity_id: None,
+                request: json!({
+                    "mode": "dispatch",
+                    "run_id": "typed-artifact-handoff-consumer",
+                    "dispatch": {
+                        "client_context": workflow_context.to_string()
+                    }
+                }),
+            },
+            "consume static site candidate",
+        );
+        controller::write_controller(&record).expect("controller written");
+
+        let dispatch = TypedArtifactHandoffDispatchHook::default();
+        let result = resume(
+            "loop-service-typed-artifact-handoff",
+            CapturingExecutor::default(),
+            &dispatch,
+        )
+        .expect("controller resumed");
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.value.results.len(), 2);
+        let loaded = controller::load_controller("loop-service-typed-artifact-handoff")
+            .expect("controller loaded");
+        assert!(loaded
+            .next_actions
+            .iter()
+            .all(|action| action.status == AgentTaskLoopActionStatus::Completed));
+        assert!(loaded.next_actions.iter().all(|action| action.diagnostics.is_empty()));
+        assert_eq!(
+            result.value.results[1].execution["workflow_artifacts"][0]["name"],
+            json!("static_site_candidate")
+        );
+
+        let observed = dispatch
+            .observed_requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        assert_eq!(observed.len(), 2);
+        assert_eq!(
+            observed[1]["workflow_artifacts"][0]["type"],
+            json!("static_site")
+        );
+        assert_eq!(
+            observed[1]["dispatch"]["workflow_artifacts"][0]["name"],
+            json!("static_site_candidate")
+        );
     });
 }
 

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -1485,12 +1485,12 @@ mod tests {
             "iterations": 1,
             "scenarios": [
                 {
-                    "id": "rest-db-query-profile",
+                    "id": "query-profile",
                     "iterations": 1,
                     "metrics": { "duration_ms": 12.0 },
                     "artifacts": {
-                        "rest-db-query-profile": {
-                            "schema": "wp-codebox/wordpress-rest-db-query-profile/v1",
+                        "query-profile": {
+                            "schema": "example/query-profile/v1",
                             "summary": { "query_count": 1 },
                             "cases": [ { "case_id": "products", "samples": [] } ]
                         },
@@ -1507,7 +1507,7 @@ mod tests {
 
         assert!(!parsed.scenarios[0]
             .artifacts
-            .contains_key("rest-db-query-profile"));
+            .contains_key("query-profile"));
         assert!(parsed.scenarios[0].artifacts.contains_key("diagnostics"));
     }
 


### PR DESCRIPTION
## Summary
- carry completed controller typed artifacts into later workflow actions that require them
- include carried workflow artifacts in the execution envelope used by required-artifact validation
- match typed artifact `name`/`type` fields when validating artifact handoffs

## Testing
- `git diff --check`
- Rust tests not run locally per machine policy; added focused coverage in `src/core/agent_task_controller_service/tests.rs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosing the controller artifact handoff bug, drafting the Rust implementation, and adding focused regression coverage.