### PR TITLE
fix(extensions): narrow shared scripts lifecycle install after helper migration (#4907)

### DIFF
--- a/src/core/extension/lifecycle/install_sources.rs
+++ b/src/core/extension/lifecycle/install_sources.rs
@@ -191,12 +191,21 @@ pub(crate) fn resolve_cloned_extension(
     )))
 }
 
+/// Shared assets installed from a monorepo extension source root.
+///
+/// Each entry maps a source-relative directory to its install target. The
+/// `scripts/lib` narrowing (#4907) is deliberate: after the extension helper
+/// migration (homeboy-extensions#1466), installed extension layouts only source
+/// the shared library subtree via `../../../scripts/lib/...` for direct
+/// invocation. The rest of the monorepo `scripts/` tree is repo dev/CI tooling
+/// that never participates in the installed layout, so lifecycle no longer
+/// installs it under `~/.config/homeboy/extensions/scripts`.
 fn install_shared_assets_from_root(source_root: &Path, extension_dir: &Path) -> Result<()> {
     let Some(extensions_dir) = extension_dir.parent() else {
         return Ok(());
     };
 
-    for shared_dir in ["scripts", "agent-runtimes", "runtime-agent-ci"] {
+    for shared_dir in ["scripts/lib", "agent-runtimes", "runtime-agent-ci"] {
         let source = source_root.join(shared_dir);
         if !source.is_dir() {
             continue;
@@ -205,8 +214,18 @@ fn install_shared_assets_from_root(source_root: &Path, extension_dir: &Path) -> 
         let target = match shared_dir {
             "agent-runtimes" => paths::agent_runtimes()?,
             "runtime-agent-ci" => paths::homeboy()?.join(shared_dir),
+            // Shared extension libraries install under the extensions root so
+            // installed wrappers can source `../../../scripts/lib/...`.
             _ => extensions_dir.join(shared_dir),
         };
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                Error::internal_io(
+                    e.to_string(),
+                    Some(format!("prepare shared extension {shared_dir}")),
+                )
+            })?;
+        }
         if target.exists() {
             std::fs::remove_dir_all(&target).map_err(|e| {
                 Error::internal_io(


### PR DESCRIPTION
## Summary
Narrows the extension lifecycle's shared-`scripts/` special-case to only install the shared library subtree, following the extension helper migration (homeboy-extensions#1466). Closes #4907.

## Background
`install_shared_assets_from_root` recursively copied the entire monorepo top-level `scripts/` directory into `~/.config/homeboy/extensions/scripts`. That breadth existed so installed extension layouts could source `../../../scripts/lib/...` for direct invocation, including core-helper fallback copies.

After homeboy-extensions#1466, the core-helper fallbacks (`runner-prelude.sh`, `runner-steps.sh`, `command-capture.sh`, `sidecar-writer.sh`, `resolve-context.sh`, `write-test-results.sh`) were removed from `scripts/lib`. What remains under `scripts/lib` are extension-specific shared libraries still sourced at runtime via parent-relative paths in installed extensions:
- `nodejs` bench/trace -> `../../../scripts/lib/browser-result-shapes.mjs`
- `rust` -> `../../scripts/lib/test-result-adapters.sh`
- `wordpress` -> `../../scripts/lib/browser-result-shapes.cjs`

The rest of the monorepo `scripts/` tree (`bootstrap-standard-extensions.sh`, `browser-result-shapes-smoke.sh`) is repo dev/CI tooling referenced only from the repo's own tests/docs -- it never participates in the installed extension layout.

## Change
- Install `scripts/lib` (not the whole `scripts/` tree) into `~/.config/homeboy/extensions/scripts/lib`, so installed wrappers still resolve `../../../scripts/lib/...`.
- Removed the now-unnecessary breadth that installed repo-only dev/CI scripts.
- `agent-runtimes` -> `~/.config/homeboy/agent-runtimes` and `runtime-agent-ci` installs are unchanged.
- Added documentation explaining the narrowing rationale.

## Validation
- `cargo build --lib` clean.
- Existing tests `cloned_monorepo_install_materializes_shared_scripts` and `linked_monorepo_install_materializes_shared_scripts` still assert `extensions/scripts/lib/test-result-adapters.sh` -- preserved by the new target path.
- Heavy `cargo test`/`cargo build --tests` deferred to CI per VPS constraints.