### PR TITLE
fix(audit): remove core agnostic-source boundary leaks (#5504)

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -493,7 +493,7 @@
     "audit": {
       "context_id": "homeboy",
       "created_at": "2026-06-20T15:43:14Z",
-      "item_count": 404,
+      "item_count": 403,
       "known_fingerprints": [
         "compiler::src/core/deploy/planning.rs::CompilerWarning",
         "compiler::src/core/extension/test/run.rs::CompilerWarning",
@@ -667,7 +667,6 @@
         "core_boundary_leak:core-agnostic-source::src/core/runner/lab_capabilities.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `npm` appears at line <line> in behavioral context `lab_runner_capability_contract`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::src/core/runner/lab_capabilities.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `lab_runner_capability_contract`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::src/core/runner/lab_command.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `required_tools_for_command_prefix`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::src/core/runner/lab_workspaces.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `npm` appears at line <line> in behavioral context `bootstrap_source_cli_node_dependencies`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::src/core/runner/lab_workspaces_deps.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `npm` appears at line <line> in behavioral context `bootstrap_source_cli_node_dependencies`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::src/core/runner/lab_workspaces_deps.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `npm` appears at line <line> in behavioral context `source_cli_bootstrap_capability_preflight`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::src/core/runner/lab_workspaces_deps.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `npm` appears at line <line> in behavioral context `source_cli_workspace_has_package_lock`::CoreBoundaryLeak",
@@ -1087,7 +1086,6 @@
               "core_boundary_leak:core-agnostic-source::src/core/runner/lab_capabilities.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `npm` appears at line <line> in behavioral context `lab_runner_capability_contract`::CoreBoundaryLeak",
               "core_boundary_leak:core-agnostic-source::src/core/runner/lab_capabilities.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `lab_runner_capability_contract`::CoreBoundaryLeak",
               "core_boundary_leak:core-agnostic-source::src/core/runner/lab_command.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `required_tools_for_command_prefix`::CoreBoundaryLeak",
-              "core_boundary_leak:core-agnostic-source::src/core/runner/lab_workspaces.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `npm` appears at line <line> in behavioral context `bootstrap_source_cli_node_dependencies`::CoreBoundaryLeak",
               "core_boundary_leak:core-agnostic-source::src/core/runner/lab_workspaces_deps.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `npm` appears at line <line> in behavioral context `bootstrap_source_cli_node_dependencies`::CoreBoundaryLeak",
               "core_boundary_leak:core-agnostic-source::src/core/runner/lab_workspaces_deps.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `npm` appears at line <line> in behavioral context `source_cli_bootstrap_capability_preflight`::CoreBoundaryLeak",
               "core_boundary_leak:core-agnostic-source::src/core/runner/lab_workspaces_deps.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `npm` appears at line <line> in behavioral context `source_cli_workspace_has_package_lock`::CoreBoundaryLeak",


### PR DESCRIPTION
## Summary
- Resolves #5504 (audit: core boundary leak — core-agnostic-source, 2 findings on `src/core/runner/lab_workspaces.rs`).
- The flagged `npm` leaks no longer live in `lab_workspaces.rs`: commit 3fcad116 (#5492/#5505 "split god-files") relocated `bootstrap_source_cli_node_dependencies` / `source_cli_bootstrap_capability_preflight` and the `"npm"` literal into the new `src/core/runner/lab_workspaces_deps.rs`. Those live findings are already baselined under `lab_workspaces_deps.rs`.
- This leaves the two `lab_workspaces.rs` baseline rows pointing at a file that no longer contains the term — stale acknowledged fingerprints that keep the reconcile bot tracking a non-existent leak.

## Changes
- Remove the obsolete `lab_workspaces.rs::...bootstrap_source_cli_node_dependencies` fingerprint from both `baselines.audit.known_fingerprints` and the scoped `core-boundary` debt-baseline `acknowledged` list in `homeboy.json`.
- Decrement `baselines.audit.item_count` 404 -> 403 to reflect the removed item.
- The real `npm` policy coverage is preserved by the existing `lab_workspaces_deps.rs` baseline rows (the file that actually contains the literal).

## Verification
- `homeboy audit homeboy --only core_boundary_leak`: passes, 0 new findings, no `lab_workspaces.rs` agnostic finding reported.
- `cargo fmt`: no Rust files in this change (only `homeboy.json`).
- Only `homeboy.json` modified; `docs/changelog.md` untouched.