### PR TITLE
fix(test): remove domain term from bench fixture

### DIFF
--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -1492,7 +1492,7 @@ mod tests {
                         "query-profile": {
                             "schema": "example/query-profile/v1",
                             "summary": { "query_count": 1 },
-                            "cases": [ { "case_id": "products", "samples": [] } ]
+                            "cases": [ { "case_id": "sample-a", "samples": [] } ]
                         },
                         "diagnostics": {
                             "path": "bench/diagnostics.json",

--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -1505,9 +1505,7 @@ mod tests {
 
         let parsed = parse_bench_results_str(raw).unwrap();
 
-        assert!(!parsed.scenarios[0]
-            .artifacts
-            .contains_key("query-profile"));
+        assert!(!parsed.scenarios[0].artifacts.contains_key("query-profile"));
         assert!(parsed.scenarios[0].artifacts.contains_key("diagnostics"));
     }
 


### PR DESCRIPTION
## Summary
- Replaces a domain-specific bench fixture case ID with a neutral sample value.
- Keeps the generic query-profile fixture clear of language caught by the core boundary detector.

## Testing
- git diff --check
- targeted source search for the removed fixture terms

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosing the post-merge CI fixture leak and drafting the one-line test fixture fix.