### PR TITLE
fix: resolve main lint break (rustfmt violation in bench/parsing.rs test)

### DIFF
--- a/src/core/extension/bench/parsing.rs
+++ b/src/core/extension/bench/parsing.rs
@@ -1505,9 +1505,7 @@ mod tests {
 
         let parsed = parse_bench_results_str(raw).unwrap();
 
-        assert!(!parsed.scenarios[0]
-            .artifacts
-            .contains_key("query-profile"));
+        assert!(!parsed.scenarios[0].artifacts.contains_key("query-profile"));
         assert!(parsed.scenarios[0].artifacts.contains_key("diagnostics"));
     }
 


### PR DESCRIPTION
## Summary
- Fixes the main-branch lint gate failure that was failing fast (~40s, "lint phase failed with 0 findings") on **all** open PRs.
- Root cause was a **rustfmt violation** (not a compile error) introduced by #5501 ("Carry controller workflow artifacts forward") in `src/core/extension/bench/parsing.rs`.

## Details
`cargo fmt --check` failed on `src/core/extension/bench/parsing.rs:1505` — a test assertion that was hand-wrapped across 3 lines but is short enough that rustfmt wants it on a single line. Because the failure is a fmt-check failure (which runs before clippy), the gate exited quickly with **zero clippy findings**, matching the reported symptom exactly.

`cargo build --lib --tests` and `cargo clippy --lib --tests` were both already clean — this was never a compile break.

## Fix
Ran `cargo fmt`; single-line the assertion:

```rust
assert!(!parsed.scenarios[0].artifacts.contains_key("query-profile"));
```

## Verification
- `cargo fmt --check` -> clean (exit 0)
- `cargo build --all-targets` -> clean (warnings only, pre-existing dead_code)
- `cargo clippy --lib --tests` -> no errors