### PR TITLE
fix(test): resolve failing test (#5536)

### DIFF
--- a/src/core/upgrade/runners.rs
+++ b/src/core/upgrade/runners.rs
@@ -2779,8 +2779,18 @@ mod tests {
             &["config", "user.email", "homeboy@example.test"],
         );
         run_git(dir.path(), &["config", "user.name", "Homeboy Test"]);
+        // Disable commit signing for the throwaway checkout. CI/dev environments
+        // that set `commit.gpgsign = true` globally would otherwise fail the
+        // commit (or leave the tree in a state where `rev-parse`/`status`
+        // misbehave), causing `source_checkout_build_identity` to return `None`
+        // and panic the caller's `.unwrap()`.
+        run_git(dir.path(), &["config", "commit.gpgsign", "false"]);
+        run_git(dir.path(), &["config", "tag.gpgsign", "false"]);
         run_git(dir.path(), &["add", "README.md"]);
-        run_git(dir.path(), &["commit", "-m", "Initial commit"]);
+        run_git(
+            dir.path(),
+            &["commit", "--no-gpg-sign", "-m", "Initial commit"],
+        );
         dir
     }
 
@@ -2788,6 +2798,12 @@ mod tests {
         let output = std::process::Command::new("git")
             .arg("-C")
             .arg(path)
+            // Isolate from ambient global/system git config so the throwaway
+            // checkout behaves deterministically regardless of the host
+            // environment (e.g. dubious-ownership safe.directory checks or
+            // global signing settings).
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
             .args(args)
             .output()
             .expect("run git");


### PR DESCRIPTION
## Summary
Fixes the flaky/environment-sensitive test failure reported in #5536:
`core::upgrade::runners::tests::source_runner_upgrade_realigns_to_same_version_source_checkout_identity`.

In CI the test panicked with `called Option::unwrap() on a None value` at the
`source_checkout_build_identity(source_dir.path()).unwrap()` call. The `git_source_checkout`
test helper builds a throwaway git repo and commits to it, but — unlike every other git
test helper in this codebase (release/executor, operations_tags, workflow, git_push, etc.)
— it did **not** disable commit signing or isolate from ambient global/system git config.
On hosts with `commit.gpgsign = true` globally (or other interfering global config), the
checkout's `git rev-parse`/`git status` reads behaved unexpectedly, so
`source_checkout_build_identity` returned `None` and the caller's `.unwrap()` panicked.

## Fix
- Disable `commit.gpgsign`/`tag.gpgsign` and pass `--no-gpg-sign` on the throwaway commit,
  matching the established convention used by the other git test helpers.
- Run all helper git commands with `GIT_CONFIG_GLOBAL=/dev/null` and
  `GIT_CONFIG_SYSTEM=/dev/null` so the throwaway checkout is deterministic regardless of
  host environment (signing, safe.directory, etc.).

Scope is limited to the test helper; production behavior is unchanged.

## Verification
- `cargo test --lib core::upgrade::runners::tests::source_runner_upgrade_realigns_to_same_version_source_checkout_identity` → ok
- `cargo test --lib core::upgrade::runners::tests::` → 19 passed
- `cargo fmt` clean

Closes #5536