### PR TITLE
refactor(audit): resolve structural finding in bench/parsing (#5517)

### DIFF
--- a/src/core/extension/bench/parsing/mod.rs
+++ b/src/core/extension/bench/parsing/mod.rs
@@ -6,6 +6,14 @@
 //! scenario-level keys so extensions can emit extra metadata without
 //! breaking forward compatibility.
 //!
+//! This module is the parse orchestration entry point. The work is split
+//! across cohesive submodules:
+//! - [`normalize`] preprocesses the raw `serde_json::Value` before
+//!   deserialization (envelope key stripping, scenario filtering, sample
+//!   metric folding, diagnostic source hoisting, inline artifact pruning).
+//! - [`validate`] enforces post-deserialization invariants (unique scenario
+//!   ids, variance-aware distributions) and derives scenario span results.
+//!
 //! # Schema
 //!
 //! ```json
@@ -53,32 +61,29 @@
 //! }
 //! ```
 
-use std::collections::BTreeMap;
+mod normalize;
+mod validate;
+
 use std::path::Path;
 
 use crate::core::error::{Error, Result};
-use crate::core::observation::timeline::{reporting_timeline, summarize_spans};
 
 use super::artifact_validation;
 use super::metric_policy_preset::expand_metric_policy_presets;
 use super::phase_events::evaluate_phase_events;
+
+use normalize::{
+    filter_value_scenarios_by_ids, is_bench_provenance_contract,
+    normalize_diagnostic_producer_sources, normalize_extension_sample_metrics,
+    normalize_inline_artifact_payloads,
+};
+use validate::{evaluate_spans, validate_unique_scenario_ids, validate_variance_policies};
 
 pub use super::result_types::{
     BenchMemory, BenchMetricDirection, BenchMetricPhase, BenchMetricPolicy, BenchMetrics,
     BenchProvenance, BenchProvenanceLink, BenchResults, BenchRunExecution, BenchRunMetadata,
     BenchRunSnapshot, BenchRunnerMetadata, BenchScenario, BenchWorkloadMetadata, RegressionTest,
 };
-
-/// Derive scenario span results from the shared observation timeline contract.
-fn evaluate_spans(results: &mut BenchResults) {
-    for scenario in &mut results.scenarios {
-        if scenario.span_definitions.is_empty() {
-            continue;
-        }
-        let timeline = reporting_timeline(&scenario.timeline);
-        scenario.span_results = summarize_spans(&timeline, &scenario.span_definitions);
-    }
-}
 
 /// Read and parse a `$HOMEBOY_BENCH_RESULTS_FILE` written by an extension.
 pub fn parse_bench_results_file(path: &Path) -> Result<BenchResults> {
@@ -162,276 +167,6 @@ fn parse_bench_results_str_with_artifact_context_and_scenarios(
     evaluate_spans(&mut parsed);
     artifact_validation::validate_artifact_paths(&parsed, rig_id)?;
     Ok(parsed)
-}
-
-fn normalize_inline_artifact_payloads(value: &mut serde_json::Value) {
-    let Some(scenarios) = value
-        .get_mut("scenarios")
-        .and_then(serde_json::Value::as_array_mut)
-    else {
-        return;
-    };
-
-    for scenario in scenarios {
-        normalize_artifact_map(scenario.get_mut("artifacts"));
-
-        let Some(runs) = scenario
-            .get_mut("runs")
-            .and_then(serde_json::Value::as_array_mut)
-        else {
-            continue;
-        };
-        for run in runs {
-            normalize_artifact_map(run.get_mut("artifacts"));
-        }
-    }
-}
-
-fn normalize_artifact_map(value: Option<&mut serde_json::Value>) {
-    let Some(artifacts) = value.and_then(serde_json::Value::as_object_mut) else {
-        return;
-    };
-
-    artifacts.retain(|_, artifact| artifact_has_pointer_field(artifact));
-}
-
-fn artifact_has_pointer_field(artifact: &serde_json::Value) -> bool {
-    let Some(object) = artifact.as_object() else {
-        return false;
-    };
-    [
-        "path",
-        "url",
-        "public_url",
-        "preview_url",
-        "viewer_url",
-        "local_url",
-        "observation_artifact_id",
-    ]
-    .iter()
-    .any(|field| object.contains_key(*field))
-}
-
-fn normalize_diagnostic_producer_sources(value: &mut serde_json::Value) {
-    normalize_diagnostic_array(value.get_mut("diagnostics"));
-
-    if let Some(run_metadata) = value.get_mut("run_metadata") {
-        normalize_diagnostic_array(run_metadata.get_mut("diagnostics"));
-    }
-
-    let Some(scenarios) = value
-        .get_mut("scenarios")
-        .and_then(serde_json::Value::as_array_mut)
-    else {
-        return;
-    };
-
-    for scenario in scenarios {
-        normalize_diagnostic_array(scenario.get_mut("diagnostics"));
-        let Some(runs) = scenario
-            .get_mut("runs")
-            .and_then(serde_json::Value::as_array_mut)
-        else {
-            continue;
-        };
-        for run in runs {
-            normalize_diagnostic_array(run.get_mut("diagnostics"));
-        }
-    }
-}
-
-fn normalize_diagnostic_array(value: Option<&mut serde_json::Value>) {
-    let Some(diagnostics) = value.and_then(serde_json::Value::as_array_mut) else {
-        return;
-    };
-
-    for diagnostic in diagnostics {
-        let Some(object) = diagnostic.as_object_mut() else {
-            continue;
-        };
-        let Some(source) = object.remove("source") else {
-            continue;
-        };
-        match source {
-            serde_json::Value::String(source) => {
-                let metadata_key = if object.contains_key("metadata") {
-                    "metadata"
-                } else if object.contains_key("details") {
-                    "details"
-                } else {
-                    "metadata"
-                };
-                let metadata = object
-                    .entry(metadata_key.to_string())
-                    .or_insert_with(|| serde_json::json!({}));
-                if let Some(metadata_object) = metadata.as_object_mut() {
-                    metadata_object.insert(
-                        "producer_source".to_string(),
-                        serde_json::Value::String(source),
-                    );
-                }
-            }
-            other => {
-                object.insert("source".to_string(), other);
-            }
-        }
-    }
-}
-
-fn filter_value_scenarios_by_ids(value: &mut serde_json::Value, scenario_ids: &[String]) {
-    if scenario_ids.is_empty() {
-        return;
-    }
-
-    let Some(scenarios) = value
-        .get_mut("scenarios")
-        .and_then(serde_json::Value::as_array_mut)
-    else {
-        return;
-    };
-
-    scenarios.retain(|scenario| {
-        scenario
-            .get("id")
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|id| scenario_ids.iter().any(|selected| selected == id))
-    });
-}
-
-fn normalize_extension_sample_metrics(value: &mut serde_json::Value) {
-    let Some(scenarios) = value
-        .get_mut("scenarios")
-        .and_then(serde_json::Value::as_array_mut)
-    else {
-        return;
-    };
-
-    for scenario in scenarios {
-        if let Some(object) = scenario.as_object_mut() {
-            if object
-                .get("provenance")
-                .is_some_and(|value| !is_bench_provenance_contract(value))
-            {
-                object.remove("provenance");
-            }
-        }
-        let Some(metrics) = scenario
-            .get_mut("metrics")
-            .and_then(serde_json::Value::as_object_mut)
-        else {
-            continue;
-        };
-
-        let mut normalized = serde_json::Map::new();
-        let mut distributions = serde_json::Map::new();
-        for (name, metric) in std::mem::take(metrics) {
-            if metric.is_number() {
-                normalized.insert(name, metric);
-                continue;
-            }
-
-            let Some(samples) = metric.get("samples").and_then(serde_json::Value::as_object) else {
-                normalized.insert(name, metric);
-                continue;
-            };
-            if let Some(mean) = samples.get("mean").and_then(serde_json::Value::as_f64) {
-                if let Some(number) = serde_json::Number::from_f64(mean) {
-                    normalized.insert(name.clone(), serde_json::Value::Number(number));
-                }
-            }
-            if let Some(values) = samples.get("values").and_then(serde_json::Value::as_array) {
-                distributions.insert(name, serde_json::Value::Array(values.clone()));
-            }
-        }
-
-        if !distributions.is_empty() {
-            normalized.insert(
-                "distributions".to_string(),
-                serde_json::Value::Object(distributions),
-            );
-        }
-        *metrics = normalized;
-    }
-}
-
-fn is_bench_provenance_contract(value: &serde_json::Value) -> bool {
-    value
-        .as_object()
-        .is_some_and(|object| object.contains_key("links") || object.contains_key("labels"))
-}
-
-fn validate_unique_scenario_ids(results: &BenchResults) -> Result<()> {
-    let mut seen: BTreeMap<&str, Option<&str>> = BTreeMap::new();
-
-    for scenario in &results.scenarios {
-        if let Some(first_file) = seen.insert(&scenario.id, scenario.file.as_deref()) {
-            let first = first_file.unwrap_or("<unknown>");
-            let second = scenario.file.as_deref().unwrap_or("<unknown>");
-            return Err(Error::validation_invalid_argument(
-                "scenarios.id",
-                format!(
-                    "duplicate bench scenario id `{}` from `{}` and `{}`; scenario ids must be unique, so dispatchers should derive ids from workload paths relative to the bench root or fail discovery before emitting results",
-                    scenario.id, first, second
-                ),
-                Some(scenario.id.clone()),
-                Some(vec![first.to_string(), second.to_string()]),
-            ));
-        }
-    }
-
-    Ok(())
-}
-
-fn validate_variance_policies(results: &BenchResults) -> Result<()> {
-    for (name, policy) in &results.metric_policies {
-        if !policy.variance_aware {
-            continue;
-        }
-        for scenario in &results.scenarios {
-            if scenario.metrics.get(name).is_none() {
-                continue;
-            }
-            let Some(samples) = scenario.metrics.distribution(name) else {
-                return Err(Error::validation_invalid_argument(
-                    "metrics.distributions",
-                    format!(
-                        "variance-aware metric `{}` in scenario `{}` must emit metrics.distributions.{}",
-                        name, scenario.id, name
-                    ),
-                    None,
-                    None,
-                ));
-            };
-            if samples.iter().any(|value| !value.is_finite()) {
-                return Err(Error::validation_invalid_argument(
-                    "metrics.distributions",
-                    format!(
-                        "variance-aware metric `{}` in scenario `{}` contains a non-finite sample",
-                        name, scenario.id
-                    ),
-                    None,
-                    None,
-                ));
-            }
-            if let Some(min) = policy.min_iterations_for_variance {
-                if samples.len() < min as usize {
-                    return Err(Error::validation_invalid_argument(
-                        "metrics.distributions",
-                        format!(
-                            "variance-aware metric `{}` in scenario `{}` has {} samples; minimum is {}",
-                            name,
-                            scenario.id,
-                            samples.len(),
-                            min
-                        ),
-                        None,
-                        None,
-                    ));
-                }
-            }
-        }
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/core/extension/bench/parsing/normalize.rs
+++ b/src/core/extension/bench/parsing/normalize.rs
@@ -1,0 +1,207 @@
+//! JSON value preprocessing applied before deserializing into `BenchResults`.
+//!
+//! These helpers operate on the raw `serde_json::Value` to keep the strict
+//! `BenchResults` deserializer tolerant of forward-compatible extension output:
+//! they drop non-contract envelope keys, filter scenarios by selection, fold
+//! extension sample metrics into the canonical shape, hoist diagnostic
+//! `source` fields into metadata, and strip inline artifact payloads that lack
+//! a pointer field.
+
+pub(super) fn normalize_inline_artifact_payloads(value: &mut serde_json::Value) {
+    let Some(scenarios) = value
+        .get_mut("scenarios")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+
+    for scenario in scenarios {
+        normalize_artifact_map(scenario.get_mut("artifacts"));
+
+        let Some(runs) = scenario
+            .get_mut("runs")
+            .and_then(serde_json::Value::as_array_mut)
+        else {
+            continue;
+        };
+        for run in runs {
+            normalize_artifact_map(run.get_mut("artifacts"));
+        }
+    }
+}
+
+fn normalize_artifact_map(value: Option<&mut serde_json::Value>) {
+    let Some(artifacts) = value.and_then(serde_json::Value::as_object_mut) else {
+        return;
+    };
+
+    artifacts.retain(|_, artifact| artifact_has_pointer_field(artifact));
+}
+
+fn artifact_has_pointer_field(artifact: &serde_json::Value) -> bool {
+    let Some(object) = artifact.as_object() else {
+        return false;
+    };
+    [
+        "path",
+        "url",
+        "public_url",
+        "preview_url",
+        "viewer_url",
+        "local_url",
+        "observation_artifact_id",
+    ]
+    .iter()
+    .any(|field| object.contains_key(*field))
+}
+
+pub(super) fn normalize_diagnostic_producer_sources(value: &mut serde_json::Value) {
+    normalize_diagnostic_array(value.get_mut("diagnostics"));
+
+    if let Some(run_metadata) = value.get_mut("run_metadata") {
+        normalize_diagnostic_array(run_metadata.get_mut("diagnostics"));
+    }
+
+    let Some(scenarios) = value
+        .get_mut("scenarios")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+
+    for scenario in scenarios {
+        normalize_diagnostic_array(scenario.get_mut("diagnostics"));
+        let Some(runs) = scenario
+            .get_mut("runs")
+            .and_then(serde_json::Value::as_array_mut)
+        else {
+            continue;
+        };
+        for run in runs {
+            normalize_diagnostic_array(run.get_mut("diagnostics"));
+        }
+    }
+}
+
+fn normalize_diagnostic_array(value: Option<&mut serde_json::Value>) {
+    let Some(diagnostics) = value.and_then(serde_json::Value::as_array_mut) else {
+        return;
+    };
+
+    for diagnostic in diagnostics {
+        let Some(object) = diagnostic.as_object_mut() else {
+            continue;
+        };
+        let Some(source) = object.remove("source") else {
+            continue;
+        };
+        match source {
+            serde_json::Value::String(source) => {
+                let metadata_key = if object.contains_key("metadata") {
+                    "metadata"
+                } else if object.contains_key("details") {
+                    "details"
+                } else {
+                    "metadata"
+                };
+                let metadata = object
+                    .entry(metadata_key.to_string())
+                    .or_insert_with(|| serde_json::json!({}));
+                if let Some(metadata_object) = metadata.as_object_mut() {
+                    metadata_object.insert(
+                        "producer_source".to_string(),
+                        serde_json::Value::String(source),
+                    );
+                }
+            }
+            other => {
+                object.insert("source".to_string(), other);
+            }
+        }
+    }
+}
+
+pub(super) fn filter_value_scenarios_by_ids(
+    value: &mut serde_json::Value,
+    scenario_ids: &[String],
+) {
+    if scenario_ids.is_empty() {
+        return;
+    }
+
+    let Some(scenarios) = value
+        .get_mut("scenarios")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+
+    scenarios.retain(|scenario| {
+        scenario
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|id| scenario_ids.iter().any(|selected| selected == id))
+    });
+}
+
+pub(super) fn normalize_extension_sample_metrics(value: &mut serde_json::Value) {
+    let Some(scenarios) = value
+        .get_mut("scenarios")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+
+    for scenario in scenarios {
+        if let Some(object) = scenario.as_object_mut() {
+            if object
+                .get("provenance")
+                .is_some_and(|value| !is_bench_provenance_contract(value))
+            {
+                object.remove("provenance");
+            }
+        }
+        let Some(metrics) = scenario
+            .get_mut("metrics")
+            .and_then(serde_json::Value::as_object_mut)
+        else {
+            continue;
+        };
+
+        let mut normalized = serde_json::Map::new();
+        let mut distributions = serde_json::Map::new();
+        for (name, metric) in std::mem::take(metrics) {
+            if metric.is_number() {
+                normalized.insert(name, metric);
+                continue;
+            }
+
+            let Some(samples) = metric.get("samples").and_then(serde_json::Value::as_object) else {
+                normalized.insert(name, metric);
+                continue;
+            };
+            if let Some(mean) = samples.get("mean").and_then(serde_json::Value::as_f64) {
+                if let Some(number) = serde_json::Number::from_f64(mean) {
+                    normalized.insert(name.clone(), serde_json::Value::Number(number));
+                }
+            }
+            if let Some(values) = samples.get("values").and_then(serde_json::Value::as_array) {
+                distributions.insert(name, serde_json::Value::Array(values.clone()));
+            }
+        }
+
+        if !distributions.is_empty() {
+            normalized.insert(
+                "distributions".to_string(),
+                serde_json::Value::Object(distributions),
+            );
+        }
+        *metrics = normalized;
+    }
+}
+
+pub(super) fn is_bench_provenance_contract(value: &serde_json::Value) -> bool {
+    value
+        .as_object()
+        .is_some_and(|object| object.contains_key("links") || object.contains_key("labels"))
+}

--- a/src/core/extension/bench/parsing/validate.rs
+++ b/src/core/extension/bench/parsing/validate.rs
@@ -1,0 +1,98 @@
+//! Post-deserialization validation and span derivation for `BenchResults`.
+//!
+//! Once the raw envelope is normalized and deserialized, these helpers enforce
+//! the structural contract the deserializer cannot express on its own: unique
+//! scenario ids, well-formed variance-aware metric distributions, and scenario
+//! span results derived from the shared observation timeline contract.
+
+use std::collections::BTreeMap;
+
+use crate::core::error::{Error, Result};
+use crate::core::observation::timeline::{reporting_timeline, summarize_spans};
+
+use super::BenchResults;
+
+/// Derive scenario span results from the shared observation timeline contract.
+pub(super) fn evaluate_spans(results: &mut BenchResults) {
+    for scenario in &mut results.scenarios {
+        if scenario.span_definitions.is_empty() {
+            continue;
+        }
+        let timeline = reporting_timeline(&scenario.timeline);
+        scenario.span_results = summarize_spans(&timeline, &scenario.span_definitions);
+    }
+}
+
+pub(super) fn validate_unique_scenario_ids(results: &BenchResults) -> Result<()> {
+    let mut seen: BTreeMap<&str, Option<&str>> = BTreeMap::new();
+
+    for scenario in &results.scenarios {
+        if let Some(first_file) = seen.insert(&scenario.id, scenario.file.as_deref()) {
+            let first = first_file.unwrap_or("<unknown>");
+            let second = scenario.file.as_deref().unwrap_or("<unknown>");
+            return Err(Error::validation_invalid_argument(
+                "scenarios.id",
+                format!(
+                    "duplicate bench scenario id `{}` from `{}` and `{}`; scenario ids must be unique, so dispatchers should derive ids from workload paths relative to the bench root or fail discovery before emitting results",
+                    scenario.id, first, second
+                ),
+                Some(scenario.id.clone()),
+                Some(vec![first.to_string(), second.to_string()]),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) fn validate_variance_policies(results: &BenchResults) -> Result<()> {
+    for (name, policy) in &results.metric_policies {
+        if !policy.variance_aware {
+            continue;
+        }
+        for scenario in &results.scenarios {
+            if scenario.metrics.get(name).is_none() {
+                continue;
+            }
+            let Some(samples) = scenario.metrics.distribution(name) else {
+                return Err(Error::validation_invalid_argument(
+                    "metrics.distributions",
+                    format!(
+                        "variance-aware metric `{}` in scenario `{}` must emit metrics.distributions.{}",
+                        name, scenario.id, name
+                    ),
+                    None,
+                    None,
+                ));
+            };
+            if samples.iter().any(|value| !value.is_finite()) {
+                return Err(Error::validation_invalid_argument(
+                    "metrics.distributions",
+                    format!(
+                        "variance-aware metric `{}` in scenario `{}` contains a non-finite sample",
+                        name, scenario.id
+                    ),
+                    None,
+                    None,
+                ));
+            }
+            if let Some(min) = policy.min_iterations_for_variance {
+                if samples.len() < min as usize {
+                    return Err(Error::validation_invalid_argument(
+                        "metrics.distributions",
+                        format!(
+                            "variance-aware metric `{}` in scenario `{}` has {} samples; minimum is {}",
+                            name,
+                            scenario.id,
+                            samples.len(),
+                            min
+                        ),
+                        None,
+                        None,
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Resolves the `god_file` structural audit finding on `src/core/extension/bench/parsing.rs` (1627 lines, threshold 1500) reported in #5517.
- Splits the single file into a `parsing/` module with cohesive submodules along natural seams, keeping all public paths stable.

## Changes
- `parsing/mod.rs` — parse orchestration entry points (`parse_bench_results_*`) plus the integration-style test suite that exercises the public API. Re-exports all previously public types from `result_types` unchanged.
- `parsing/normalize.rs` — raw `serde_json::Value` preprocessing applied before deserialization (envelope key stripping, scenario filtering, extension sample-metric folding, diagnostic `source` hoisting, inline artifact pruning, provenance contract check).
- `parsing/validate.rs` — post-deserialization invariants (unique scenario ids, variance-aware metric distributions) and scenario span derivation from the shared observation timeline contract.

## Verification
- `homeboy audit homeboy` no longer reports the `parsing` god_file finding (0 live findings for the path).
- `cargo build --lib` compiles cleanly (module split sound; public re-export paths preserved).
- `cargo fmt` applied.
- Core stays ecosystem-agnostic — no behavioral changes, pure structural refactor.