### PR TITLE
fix(file): align homeboy file root with deploy plugin paths (#5456)

### DIFF
--- a/src/commands/file.rs
+++ b/src/commands/file.rs
@@ -9,6 +9,13 @@ use homeboy::core::{join_remote_path, project};
 
 use super::CmdResult;
 
+/// Inspect and modify remote project files.
+///
+/// Path resolution mirrors deploy so inspection agrees with the deployed path:
+/// absolute paths are used verbatim; relative paths matching a managed prefix
+/// declared by a linked extension (e.g. `wp-content/...`) resolve through the
+/// project's configured `path_roots` (the same root deploy writes active
+/// components to); everything else joins against the project `base_path`.
 #[derive(Args)]
 pub struct FileArgs {
     #[command(subcommand)]

--- a/src/core/project/files.rs
+++ b/src/core/project/files.rs
@@ -12,7 +12,7 @@ use crate::core::engine::executor::execute_for_project;
 use crate::core::engine::text;
 use crate::core::engine::{command, shell};
 use crate::core::error::{Error, Result};
-use crate::core::paths::{self as base_path, resolve_path_string};
+use crate::core::paths::resolve_path_string;
 use crate::core::project;
 
 use std::path::Path;
@@ -164,11 +164,25 @@ pub fn read_stdin() -> Result<String> {
     Ok(content)
 }
 
+/// Resolve a remote file path against a project, honoring managed path_roots.
+///
+/// Relative paths matching an extension-declared managed prefix (e.g.
+/// `wp-content`) resolve through the project's `path_roots` exactly like
+/// deploy, so file inspection agrees with the deployed path even when the
+/// active component directory lives outside `base_path` (e.g. WP Cloud). (#5456)
+fn resolve_remote_path(
+    project: &project::Project,
+    base_path_value: &str,
+    path: &str,
+) -> Result<String> {
+    super::resolve_project_remote_path(project, base_path_value, path)
+}
+
 /// List directory contents.
 pub fn list(project_id: &str, path: &str) -> Result<ListResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path = resolve_remote_path(&project, &project_base_path, path)?;
     let command = format!("ls -la {}", shell::quote_path(&full_path));
     let output = execute_for_project(&project, &command)?;
     command::require_success(output.success, &output.stderr, "LIST")?;
@@ -186,7 +200,7 @@ pub fn list(project_id: &str, path: &str) -> Result<ListResult> {
 pub fn read(project_id: &str, path: &str) -> Result<ReadResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path = resolve_remote_path(&project, &project_base_path, path)?;
     let command = format!("cat {}", shell::quote_path(&full_path));
     let output = execute_for_project(&project, &command)?;
     command::require_success(output.success, &output.stderr, "READ")?;
@@ -215,7 +229,7 @@ fn generate_unique_delimiter(content: &str) -> String {
 pub fn write(project_id: &str, path: &str, content: &str) -> Result<WriteResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path = resolve_remote_path(&project, &project_base_path, path)?;
     let delimiter = generate_unique_delimiter(content);
     let command = format!(
         "cat > {} << '{}'\n{}\n{}",
@@ -238,7 +252,7 @@ pub fn write(project_id: &str, path: &str, content: &str) -> Result<WriteResult>
 pub fn delete(project_id: &str, path: &str, recursive: bool) -> Result<DeleteResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path = resolve_remote_path(&project, &project_base_path, path)?;
     let flags = if recursive { "-rf" } else { "-f" };
     let command = format!("rm {} {}", flags, shell::quote_path(&full_path));
     let output = execute_for_project(&project, &command)?;
@@ -255,8 +269,8 @@ pub fn delete(project_id: &str, path: &str, recursive: bool) -> Result<DeleteRes
 pub fn rename(project_id: &str, old_path: &str, new_path: &str) -> Result<RenameResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_old = base_path::join_remote_path(Some(&project_base_path), old_path)?;
-    let full_new = base_path::join_remote_path(Some(&project_base_path), new_path)?;
+    let full_old = resolve_remote_path(&project, &project_base_path, old_path)?;
+    let full_new = resolve_remote_path(&project, &project_base_path, new_path)?;
     let command = format!(
         "mv {} {}",
         shell::quote_path(&full_old),
@@ -338,7 +352,7 @@ pub fn find(
 ) -> Result<FindResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path = resolve_remote_path(&project, &project_base_path, path)?;
 
     let mut cmd = format!("find {}", shell::quote_path(&full_path));
 
@@ -391,7 +405,7 @@ pub fn grep(
 ) -> Result<GrepResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path = resolve_remote_path(&project, &project_base_path, path)?;
 
     if pattern.trim().is_empty() {
         return Err(Error::validation_missing_argument(vec![
@@ -479,7 +493,7 @@ pub fn download(
     recursive: bool,
 ) -> Result<DownloadResult> {
     let (ctx, project_base_path) = resolve_project_ssh_with_base_path(project_id)?;
-    let full_remote_path = base_path::join_remote_path(Some(&project_base_path), remote_path)?;
+    let full_remote_path = resolve_remote_path(&ctx.project, &project_base_path, remote_path)?;
 
     // Create local parent directories if needed
     let local = Path::new(local_path);

--- a/src/core/project/files/edit.rs
+++ b/src/core/project/files/edit.rs
@@ -4,7 +4,6 @@ use crate::core::context::require_project_base_path;
 use crate::core::engine::executor::execute_for_project;
 use crate::core::engine::{command, shell};
 use crate::core::error::{Error, Result};
-use crate::core::paths as base_path;
 use crate::core::project;
 
 use super::{read, write};
@@ -36,7 +35,8 @@ pub fn edit_replace_line(
 ) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path =
+        crate::core::project::resolve_project_remote_path(&project, &project_base_path, path)?;
 
     let read_result = read(project_id, path)?;
     let original_lines: Vec<String> = read_result.content.lines().map(String::from).collect();
@@ -88,7 +88,8 @@ pub fn edit_insert_after_line(
 ) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path =
+        crate::core::project::resolve_project_remote_path(&project, &project_base_path, path)?;
 
     let read_result = read(project_id, path)?;
     let original_lines: Vec<String> = read_result.content.lines().map(String::from).collect();
@@ -138,7 +139,8 @@ pub fn edit_insert_before_line(
 ) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path =
+        crate::core::project::resolve_project_remote_path(&project, &project_base_path, path)?;
 
     let read_result = read(project_id, path)?;
     let original_lines: Vec<String> = read_result.content.lines().map(String::from).collect();
@@ -183,7 +185,8 @@ pub fn edit_insert_before_line(
 pub fn edit_delete_line(project_id: &str, path: &str, line_num: usize) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path =
+        crate::core::project::resolve_project_remote_path(&project, &project_base_path, path)?;
 
     let read_result = read(project_id, path)?;
     let original_lines: Vec<String> = read_result.content.lines().map(String::from).collect();
@@ -233,7 +236,8 @@ pub fn edit_delete_lines(
 ) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path =
+        crate::core::project::resolve_project_remote_path(&project, &project_base_path, path)?;
 
     let read_result = read(project_id, path)?;
     let original_lines: Vec<String> = read_result.content.lines().map(String::from).collect();
@@ -296,7 +300,8 @@ pub fn edit_replace_pattern(
 ) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path =
+        crate::core::project::resolve_project_remote_path(&project, &project_base_path, path)?;
 
     let read_result = read(project_id, path)?;
     let original_lines: Vec<String> = read_result.content.lines().map(String::from).collect();
@@ -343,7 +348,8 @@ pub fn edit_replace_pattern(
 pub fn edit_delete_pattern(project_id: &str, path: &str, pattern: &str) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path =
+        crate::core::project::resolve_project_remote_path(&project, &project_base_path, path)?;
 
     let read_result = read(project_id, path)?;
     let original_lines: Vec<String> = read_result.content.lines().map(String::from).collect();
@@ -383,7 +389,8 @@ pub fn edit_delete_pattern(project_id: &str, path: &str, pattern: &str) -> Resul
 pub fn edit_append(project_id: &str, path: &str, content: &str) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path =
+        crate::core::project::resolve_project_remote_path(&project, &project_base_path, path)?;
 
     let read_result = read(project_id, path)?;
     let original_lines: Vec<String> = read_result.content.lines().map(String::from).collect();
@@ -421,7 +428,8 @@ pub fn edit_append(project_id: &str, path: &str, content: &str) -> Result<EditRe
 pub fn edit_prepend(project_id: &str, path: &str, content: &str) -> Result<EditResult> {
     let project = project::load(project_id)?;
     let project_base_path = require_project_base_path(project_id, &project)?;
-    let full_path = base_path::join_remote_path(Some(&project_base_path), path)?;
+    let full_path =
+        crate::core::project::resolve_project_remote_path(&project, &project_base_path, path)?;
 
     let read_result = read(project_id, path)?;
     let original_lines: Vec<String> = read_result.content.lines().map(String::from).collect();

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 pub mod component;
 pub mod files;
 pub mod logs;
+mod path_resolution;
 pub mod pins;
 mod readiness;
 pub mod report;
@@ -28,6 +29,7 @@ pub use component::{
 };
 pub use files::{FileEntry, GrepMatch, LineChange};
 pub use logs::{LogContent, LogEntry, LogSearchResult, PinnedLogsContent};
+pub use path_resolution::resolve_project_remote_path;
 pub use pins::{
     add_pin, list_pins, remove_pin, rename_pin, update_pin, PinUpdateOptions, ProjectPinChange,
     ProjectPinListItem, ProjectPinOutput,

--- a/src/core/project/path_resolution.rs
+++ b/src/core/project/path_resolution.rs
@@ -1,0 +1,154 @@
+//! Project-level remote path resolution for ad-hoc file operations.
+//!
+//! Deploy resolves a component's `remote_path` against project `path_roots`
+//! (e.g. mapping a `wp-content/...` prefix onto an absolute managed root such
+//! as `/srv/htdocs/wp-content`). Ad-hoc `homeboy file` commands historically
+//! joined every relative path against `base_path` alone, so on installs whose
+//! active component directory lives outside `base_path` (e.g. WP Cloud, where
+//! `base_path` is `/htdocs/__wp__` but active plugins are written under
+//! `/srv/htdocs/wp-content/plugins/...`) operators could not inspect the path
+//! deploy actually writes to. (#5456)
+//!
+//! This module applies the *same* managed-prefix resolution deploy uses, but
+//! at the project layer (no component context). It stays agnostic: the managed
+//! prefixes and root names come from extension manifests, not hard-coded here.
+
+use std::collections::HashMap;
+
+use crate::core::component;
+use crate::core::extension::{self, RemotePathRootRule};
+use crate::core::paths as base_path;
+use crate::core::project::Project;
+
+/// Resolve a remote path for an ad-hoc file operation against a project.
+///
+/// Resolution order:
+/// 1. Absolute paths are used verbatim (operators can always target an exact
+///    path such as `/srv/htdocs/wp-content/plugins/foo`).
+/// 2. Relative paths matching an extension-declared managed prefix (e.g.
+///    `wp-content`) resolve through the project's configured `path_roots`,
+///    matching deploy's behavior so the inspectable path agrees with the
+///    deployed path.
+/// 3. Everything else joins against `base_path` (unchanged legacy behavior).
+pub fn resolve_project_remote_path(
+    project: &Project,
+    base_path_value: &str,
+    path: &str,
+) -> crate::core::error::Result<String> {
+    let trimmed = path.trim();
+
+    // Absolute paths win immediately — join_remote_path already returns them
+    // verbatim, but short-circuiting keeps the managed-prefix scan off the hot
+    // path and makes the intent explicit.
+    if trimmed.starts_with('/') {
+        return base_path::join_remote_path(Some(base_path_value), trimmed);
+    }
+
+    if let Some(resolved) = resolve_with_path_roots(project, base_path_value, trimmed)? {
+        return Ok(resolved);
+    }
+
+    base_path::join_remote_path(Some(base_path_value), trimmed)
+}
+
+fn resolve_with_path_roots(
+    project: &Project,
+    base_path_value: &str,
+    path: &str,
+) -> crate::core::error::Result<Option<String>> {
+    for rule in project_remote_path_root_rules(project) {
+        if !path_matches_prefix(path, &rule.path_prefix) {
+            continue;
+        }
+
+        // Only resolve through a root that is actually configured for this
+        // project. Without one we fall back to base_path joining so behavior is
+        // unchanged for projects that never set path_roots.
+        let Some(root) = project.path_roots.get(&rule.root) else {
+            return Ok(None);
+        };
+
+        let child = if rule.strip_prefix {
+            strip_path_prefix(path, &rule.path_prefix)
+        } else {
+            path
+        };
+
+        let resolved_root = base_path::join_remote_path(Some(base_path_value), root)?;
+
+        if child.is_empty() {
+            return Ok(Some(resolved_root));
+        }
+
+        return base_path::join_remote_path(Some(&resolved_root), child).map(Some);
+    }
+
+    Ok(None)
+}
+
+/// Collect every path-root rule declared by extensions attached to the project
+/// (project-level extensions plus any extensions on attached components). Rules
+/// are deduplicated by `(path_prefix, root)` so multiple components linking the
+/// same extension don't produce redundant scans.
+fn project_remote_path_root_rules(project: &Project) -> Vec<RemotePathRootRule> {
+    let mut extension_ids: Vec<String> = Vec::new();
+
+    if let Some(extensions) = &project.extensions {
+        extension_ids.extend(extensions.keys().cloned());
+    }
+
+    // Attached components only carry IDs at the project layer; load each to read
+    // the extensions declared in its repo-owned metadata. Failures are
+    // non-fatal — a missing component must not break file path resolution.
+    for attachment in &project.components {
+        if let Ok(loaded) = component::load(&attachment.id) {
+            if let Some(extensions) = &loaded.extensions {
+                extension_ids.extend(extensions.keys().cloned());
+            }
+        }
+    }
+
+    let mut seen_rules: HashMap<(String, String), ()> = HashMap::new();
+    let mut rules = Vec::new();
+    let mut seen_extensions = HashMap::new();
+
+    for id in extension_ids {
+        if seen_extensions.insert(id.clone(), ()).is_some() {
+            continue;
+        }
+        let Ok(manifest) = extension::load_extension(&id) else {
+            continue;
+        };
+        let Some(deploy) = manifest.deploy else {
+            continue;
+        };
+        for rule in deploy.path_roots {
+            let key = (rule.path_prefix.clone(), rule.root.clone());
+            if seen_rules.insert(key, ()).is_none() {
+                rules.push(rule);
+            }
+        }
+    }
+
+    rules
+}
+
+fn path_matches_prefix(path: &str, prefix: &str) -> bool {
+    let path = path.trim_matches('/');
+    let prefix = prefix.trim_matches('/');
+
+    !prefix.is_empty() && (path == prefix || path.starts_with(&format!("{}/", prefix)))
+}
+
+fn strip_path_prefix<'a>(path: &'a str, prefix: &str) -> &'a str {
+    let path = path.trim_start_matches('/');
+    let prefix = prefix.trim_matches('/');
+
+    path.strip_prefix(prefix)
+        .map(|remaining| remaining.trim_start_matches('/'))
+        .unwrap_or(path)
+}
+
+#[cfg(test)]
+#[path = "../../../tests/core/project/path_resolution_test.rs"]
+mod path_resolution_test;

--- a/tests/core/project/path_resolution_test.rs
+++ b/tests/core/project/path_resolution_test.rs
@@ -1,0 +1,167 @@
+//! Tests for project-level remote path resolution (#5456).
+//!
+//! Included into the lib via `#[path]` from
+//! `src/core/project/path_resolution.rs`, so `super::*` reaches the module
+//! under test and `crate::*` reaches the rest of the crate.
+
+use super::*;
+
+use crate::core::component::ScopedExtensionConfig;
+use crate::core::extension::{DeployCapability, ExtensionManifest};
+use crate::test_support::with_isolated_home;
+use std::collections::HashMap;
+
+fn install_wordpress_extension() {
+    crate::core::extension::save_manifest(&ExtensionManifest {
+        id: "wordpress".to_string(),
+        name: "WordPress".to_string(),
+        version: "1.0.0".to_string(),
+        deploy: Some(DeployCapability {
+            verifications: Vec::new(),
+            overrides: Vec::new(),
+            protected_path_suffixes: Vec::new(),
+            owner_hints: Vec::new(),
+            archive_install: Vec::new(),
+            remote_path_inference: Vec::new(),
+            path_roots: vec![RemotePathRootRule {
+                path_prefix: "wp-content".to_string(),
+                root: "wp_content".to_string(),
+                strip_prefix: true,
+                detect_command: None,
+            }],
+            version_patterns: Vec::new(),
+            since_tag: None,
+        }),
+        ..serde_json::from_value(serde_json::json!({
+            "name": "WordPress",
+            "version": "1.0.0"
+        }))
+        .expect("manifest")
+    })
+    .expect("save extension");
+}
+
+fn wp_project(base_path: &str, wp_content_root: Option<&str>) -> Project {
+    let mut path_roots = HashMap::new();
+    if let Some(root) = wp_content_root {
+        path_roots.insert("wp_content".to_string(), root.to_string());
+    }
+
+    Project {
+        id: "studioweb-runtime".to_string(),
+        base_path: Some(base_path.to_string()),
+        path_roots,
+        extensions: Some(HashMap::from([(
+            "wordpress".to_string(),
+            ScopedExtensionConfig::default(),
+        )])),
+        ..Project::default()
+    }
+}
+
+#[test]
+fn absolute_paths_are_used_verbatim() {
+    with_isolated_home(|_| {
+        install_wordpress_extension();
+        let project = wp_project("/htdocs/__wp__", Some("/srv/htdocs/wp-content"));
+
+        let resolved = resolve_project_remote_path(
+            &project,
+            "/htdocs/__wp__",
+            "/srv/htdocs/wp-content/plugins/studio-web/inc/frontend-chat-integration.php",
+        )
+        .expect("resolve absolute");
+
+        assert_eq!(
+            resolved,
+            "/srv/htdocs/wp-content/plugins/studio-web/inc/frontend-chat-integration.php"
+        );
+    });
+}
+
+#[test]
+fn managed_prefix_resolves_through_configured_root() {
+    // The crux of #5456: a relative `wp-content/...` path must resolve to the
+    // managed wp_content root (where deploy writes active plugins), NOT to
+    // base_path/wp-content under `/htdocs/__wp__`.
+    with_isolated_home(|_| {
+        install_wordpress_extension();
+        let project = wp_project("/htdocs/__wp__", Some("/srv/htdocs/wp-content"));
+
+        let resolved = resolve_project_remote_path(
+            &project,
+            "/htdocs/__wp__",
+            "wp-content/plugins/studio-web",
+        )
+        .expect("resolve managed prefix");
+
+        assert_eq!(resolved, "/srv/htdocs/wp-content/plugins/studio-web");
+    });
+}
+
+#[test]
+fn managed_prefix_without_configured_root_falls_back_to_base_path() {
+    // Projects that never configured a wp_content root keep the legacy
+    // base_path-joined behavior — no surprise breakage.
+    with_isolated_home(|_| {
+        install_wordpress_extension();
+        let project = wp_project("/srv/site", None);
+
+        let resolved = resolve_project_remote_path(&project, "/srv/site", "wp-content/plugins/foo")
+            .expect("resolve fallback");
+
+        assert_eq!(resolved, "/srv/site/wp-content/plugins/foo");
+    });
+}
+
+#[test]
+fn non_managed_relative_paths_join_against_base_path() {
+    with_isolated_home(|_| {
+        install_wordpress_extension();
+        let project = wp_project("/htdocs/__wp__", Some("/srv/htdocs/wp-content"));
+
+        let resolved = resolve_project_remote_path(&project, "/htdocs/__wp__", "wp-config.php")
+            .expect("resolve non-managed");
+
+        assert_eq!(resolved, "/htdocs/__wp__/wp-config.php");
+    });
+}
+
+#[test]
+fn relative_root_is_joined_against_base_path() {
+    // A path_root configured as a relative value resolves under base_path,
+    // mirroring deploy's `resolve_with_project_root` semantics.
+    with_isolated_home(|_| {
+        install_wordpress_extension();
+        let project = wp_project("/srv/site", Some("wp-content"));
+
+        let resolved =
+            resolve_project_remote_path(&project, "/srv/site", "wp-content/themes/theme")
+                .expect("resolve relative root");
+
+        assert_eq!(resolved, "/srv/site/wp-content/themes/theme");
+    });
+}
+
+#[test]
+fn path_matches_prefix_handles_boundaries() {
+    assert!(path_matches_prefix("wp-content", "wp-content"));
+    assert!(path_matches_prefix("wp-content/plugins/foo", "wp-content"));
+    assert!(path_matches_prefix("/wp-content/plugins", "wp-content"));
+    assert!(!path_matches_prefix("wp-content-extra/foo", "wp-content"));
+    assert!(!path_matches_prefix("var/log", "wp-content"));
+    assert!(!path_matches_prefix("anything", ""));
+}
+
+#[test]
+fn strip_path_prefix_removes_managed_prefix() {
+    assert_eq!(
+        strip_path_prefix("wp-content/plugins/foo", "wp-content"),
+        "plugins/foo"
+    );
+    assert_eq!(strip_path_prefix("wp-content", "wp-content"), "");
+    assert_eq!(
+        strip_path_prefix("var/log/app.log", "wp-content"),
+        "var/log/app.log"
+    );
+}


### PR DESCRIPTION
## Summary
Fixes the remaining part of #5456: `homeboy file` was rooted only at the project `base_path` (e.g. `/htdocs/__wp__` on WP Cloud) and could not inspect the path deploy actually writes active plugins to (`/srv/htdocs/wp-content/plugins/...`), producing false-negative `grep`/`read` verification after a successful deploy. (The `deployed_ref` accuracy half was already fixed by #5472.)

`homeboy file` now resolves paths the **same way deploy does**:
- **Absolute paths** are used verbatim (operators can always target an exact path).
- **Relative paths matching an extension-declared managed prefix** (e.g. `wp-content/...`) resolve through the project's configured `path_roots` — the same managed root deploy installs to — so inspection agrees with the deployed path.
- **Everything else** joins against `base_path` (unchanged legacy behavior; projects without `path_roots` see no change).

## Design / agnosticism
- New core module `src/core/project/path_resolution.rs` holds the shared, **WP-agnostic** resolver. Managed prefixes (`wp-content`) and root names (`wp_content`) come from extension manifests' `path_roots` rules, not hard-coded in core — identical to deploy's `resolve_effective_remote_path`.
- All `homeboy file` operations (`list`/`read`/`write`/`delete`/`rename`/`find`/`grep`/`download`/`edit`) route through the new resolver.
- `homeboy file --help` now documents the resolution order so operators understand the rooting (the issue's "or clearly explain" expectation).

## Tests
- Added `tests/core/project/path_resolution_test.rs` (7 cases): absolute passthrough, managed-prefix to configured-root resolution (the WP Cloud crux), fallback to `base_path` when no root configured, non-managed relative paths, relative-root joining, and prefix-boundary/strip helpers. All pass.
- `cargo build --lib` clean; `cargo fmt` applied.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude (claude-code)
- **Used for:** investigation, implementation, tests, and this PR description.