### PR TITLE
feat(deploy): add post-deploy front-end smoke check to catch runtime-fataling releases (#5471)

### DIFF
--- a/src/core/deploy/mod.rs
+++ b/src/core/deploy/mod.rs
@@ -10,6 +10,7 @@ mod policy;
 pub(crate) mod provenance;
 pub mod release_download;
 mod safety_and_artifact;
+mod smoke;
 mod transfer;
 mod types;
 mod version_overrides;

--- a/src/core/deploy/orchestration.rs
+++ b/src/core/deploy/orchestration.rs
@@ -246,6 +246,28 @@ pub(super) fn deploy_components(
         restore_branches(&tag_checkouts);
     }
 
+    // Post-deploy front-end smoke check (opt-in, project-scoped). Runs only when
+    // something actually deployed — a runtime-fataling release that returns 500
+    // to fresh visitors should fail the deploy here so it gets rolled back
+    // instead of sitting live. Catches runtime errors that `php -l`/syntax-only
+    // preflight structurally cannot. See homeboy#5471.
+    if succeeded > 0 {
+        if let Some(smoke) = run_post_deploy_smoke(&project, &mut results) {
+            if smoke {
+                // Smoke failed and was not warn-only: flip every just-deployed
+                // component to failed so the overall deploy exit code is non-zero
+                // and the operator/automation treats it as a rollback candidate.
+                for result in results.iter_mut() {
+                    if result.status == "deployed" {
+                        result.status = "failed".to_string();
+                    }
+                }
+                failed += succeeded;
+                succeeded = 0;
+            }
+        }
+    }
+
     Ok(DeployOrchestrationResult {
         results,
         summary: DeploySummary {
@@ -255,6 +277,54 @@ pub(super) fn deploy_components(
             skipped: 0,
         },
     })
+}
+
+/// Run the project's post-deploy smoke check, recording the outcome on the
+/// deploy results.
+///
+/// Returns:
+/// - `None` when no smoke check is configured/enabled,
+/// - `Some(true)` when the smoke FAILED and should fail the deploy,
+/// - `Some(false)` when the smoke passed or only warned.
+///
+/// Warnings/errors are appended to the first deployed component result so they
+/// surface in CLI/JSON output alongside the deploy that triggered them.
+fn run_post_deploy_smoke(project: &Project, results: &mut [ComponentDeployResult]) -> Option<bool> {
+    let config = project.smoke_check.as_ref()?;
+    let outcome = super::smoke::run_smoke_check(config)?;
+
+    if outcome.is_ok() {
+        log_status!(
+            "deploy",
+            "Post-deploy smoke check passed for '{}' ({})",
+            project.id,
+            config.url
+        );
+        return Some(false);
+    }
+
+    let detail = outcome
+        .failure_detail()
+        .unwrap_or("post-deploy smoke check failed")
+        .to_string();
+
+    if config.warn_only {
+        log_status!("deploy", "Warning: {} (warn_only)", detail);
+        if let Some(first) = results.iter_mut().find(|r| r.status == "deployed") {
+            first.warnings.push(format!("{} (warn_only)", detail));
+        }
+        return Some(false);
+    }
+
+    log_status!(
+        "deploy",
+        "{} — failing deploy; roll back the release",
+        detail
+    );
+    if let Some(first) = results.iter_mut().find(|r| r.status == "deployed") {
+        first.error = Some(detail);
+    }
+    Some(true)
 }
 
 fn validate_supported_build_configs(components: &[Component]) -> Result<()> {
@@ -1398,6 +1468,89 @@ mod tests {
                 .contains("missing.zip"),
             "unexpected error: {:?}",
             failures[0].error
+        );
+    }
+
+    fn deployed_result(id: &str) -> ComponentDeployResult {
+        let component = make_component(id, "/tmp/does-not-matter");
+        ComponentDeployResult::new(&component, "/srv/site").with_status("deployed")
+    }
+
+    #[test]
+    fn post_deploy_smoke_is_noop_without_config() {
+        let project = Project {
+            id: "site".to_string(),
+            ..Project::default()
+        };
+        let mut results = vec![deployed_result("plugin")];
+
+        assert_eq!(run_post_deploy_smoke(&project, &mut results), None);
+        assert_eq!(results[0].status, "deployed");
+    }
+
+    #[test]
+    fn post_deploy_smoke_noop_when_disabled() {
+        let project = Project {
+            id: "site".to_string(),
+            smoke_check: Some(crate::core::project::SmokeCheckConfig {
+                enabled: false,
+                url: "https://example.test/".to_string(),
+                ..Default::default()
+            }),
+            ..Project::default()
+        };
+        let mut results = vec![deployed_result("plugin")];
+
+        assert_eq!(run_post_deploy_smoke(&project, &mut results), None);
+    }
+
+    #[test]
+    fn post_deploy_smoke_failure_records_error_and_fails() {
+        // enabled smoke against an unreachable URL fails the deploy and records
+        // the error on the deployed component.
+        let project = Project {
+            id: "site".to_string(),
+            smoke_check: Some(crate::core::project::SmokeCheckConfig {
+                enabled: true,
+                // Reserved TEST-NET address (RFC 5737) so the request fails fast.
+                url: "http://192.0.2.1:9/".to_string(),
+                timeout_secs: 1,
+                ..Default::default()
+            }),
+            ..Project::default()
+        };
+        let mut results = vec![deployed_result("plugin")];
+
+        assert_eq!(run_post_deploy_smoke(&project, &mut results), Some(true));
+        assert!(
+            results[0].error.is_some(),
+            "failed smoke must record an error on the deployed component"
+        );
+    }
+
+    #[test]
+    fn post_deploy_smoke_warn_only_does_not_fail() {
+        let project = Project {
+            id: "site".to_string(),
+            smoke_check: Some(crate::core::project::SmokeCheckConfig {
+                enabled: true,
+                url: "http://192.0.2.1:9/".to_string(),
+                timeout_secs: 1,
+                warn_only: true,
+                ..Default::default()
+            }),
+            ..Project::default()
+        };
+        let mut results = vec![deployed_result("plugin")];
+
+        assert_eq!(run_post_deploy_smoke(&project, &mut results), Some(false));
+        assert_eq!(
+            results[0].status, "deployed",
+            "warn_only smoke must not fail the deploy"
+        );
+        assert!(
+            results[0].warnings.iter().any(|w| w.contains("warn_only")),
+            "warn_only smoke failure should be surfaced as a warning"
         );
     }
 

--- a/src/core/deploy/smoke.rs
+++ b/src/core/deploy/smoke.rs
@@ -1,0 +1,189 @@
+//! Post-deploy front-end smoke check.
+//!
+//! After a successful real deploy, fetch a configured URL as a fresh
+//! (cookie-less) visitor and assert it returns the expected HTTP status and
+//! optional content. A failing smoke check fails the deploy (unless
+//! `warn_only`) so a runtime-fataling release is flagged for rollback instead
+//! of sitting live.
+//!
+//! This is deliberately stack-agnostic: core only knows "fetch a URL, assert a
+//! status/content substring". The concrete front-end URL (e.g. a WordPress
+//! home page) is supplied by the project config, keeping core free of any
+//! WordPress/PHP specifics. See homeboy#5471.
+
+use std::time::Duration;
+
+use crate::core::http_probe::get_status_and_body;
+use crate::core::project::SmokeCheckConfig;
+
+/// Outcome of a post-deploy smoke check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum SmokeOutcome {
+    /// The check passed (status matched and content, if required, was present).
+    Passed { status: u16 },
+    /// The check ran but the assertion failed.
+    Failed { message: String },
+    /// The request itself could not be made (connection error, build error).
+    Errored { message: String },
+}
+
+impl SmokeOutcome {
+    pub(super) fn is_ok(&self) -> bool {
+        matches!(self, SmokeOutcome::Passed { .. })
+    }
+
+    /// Human-readable failure detail, if the smoke did not pass.
+    pub(super) fn failure_detail(&self) -> Option<&str> {
+        match self {
+            SmokeOutcome::Passed { .. } => None,
+            SmokeOutcome::Failed { message } | SmokeOutcome::Errored { message } => Some(message),
+        }
+    }
+}
+
+/// Run the post-deploy smoke check described by `config`.
+///
+/// Returns `None` when the check is disabled (the common, opt-out-by-default
+/// case) so callers can cheaply skip when no smoke is configured.
+pub(super) fn run_smoke_check(config: &SmokeCheckConfig) -> Option<SmokeOutcome> {
+    if !config.enabled {
+        return None;
+    }
+
+    Some(evaluate(config, |url, timeout| {
+        get_status_and_body(url, timeout).map_err(|e| e.message)
+    }))
+}
+
+/// Evaluate the smoke assertion against a fetcher. Split out from
+/// [`run_smoke_check`] so the assertion logic is unit-testable without real
+/// network I/O.
+fn evaluate<F>(config: &SmokeCheckConfig, fetch: F) -> SmokeOutcome
+where
+    F: FnOnce(&str, Duration) -> std::result::Result<(u16, String), String>,
+{
+    let url = config.url.trim();
+    if url.is_empty() {
+        return SmokeOutcome::Errored {
+            message:
+                "smoke_check.enabled is true but smoke_check.url is empty — set the front-end URL to probe"
+                    .to_string(),
+        };
+    }
+
+    let timeout = Duration::from_secs(config.timeout_secs.max(1));
+
+    let (status, body) = match fetch(url, timeout) {
+        Ok(pair) => pair,
+        Err(message) => return SmokeOutcome::Errored { message },
+    };
+
+    if status != config.expected_status {
+        return SmokeOutcome::Failed {
+            message: format!(
+                "post-deploy smoke check: {} returned HTTP {} (expected {})",
+                url, status, config.expected_status
+            ),
+        };
+    }
+
+    if let Some(needle) = config
+        .expect_content
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        if !body.contains(needle) {
+            return SmokeOutcome::Failed {
+                message: format!(
+                    "post-deploy smoke check: {} returned HTTP {} but response body did not contain expected content {:?}",
+                    url, status, needle
+                ),
+            };
+        }
+    }
+
+    SmokeOutcome::Passed { status }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(enabled: bool) -> SmokeCheckConfig {
+        SmokeCheckConfig {
+            enabled,
+            url: "https://example.test/".to_string(),
+            expected_status: 200,
+            expect_content: None,
+            timeout_secs: 5,
+            warn_only: false,
+        }
+    }
+
+    #[test]
+    fn disabled_check_is_skipped() {
+        assert!(run_smoke_check(&config(false)).is_none());
+    }
+
+    #[test]
+    fn passes_when_status_matches() {
+        let outcome = evaluate(&config(true), |_, _| {
+            Ok((200, "<html>ok</html>".to_string()))
+        });
+        assert!(outcome.is_ok());
+        assert_eq!(outcome, SmokeOutcome::Passed { status: 200 });
+    }
+
+    #[test]
+    fn fails_on_unexpected_status() {
+        let outcome = evaluate(&config(true), |_, _| Ok((500, "Fatal error".to_string())));
+        assert!(!outcome.is_ok());
+        let detail = outcome.failure_detail().expect("failure detail");
+        assert!(detail.contains("HTTP 500"));
+        assert!(detail.contains("expected 200"));
+    }
+
+    #[test]
+    fn fails_when_required_content_missing() {
+        let mut cfg = config(true);
+        cfg.expect_content = Some("Welcome".to_string());
+        let outcome = evaluate(&cfg, |_, _| Ok((200, "<html>different</html>".to_string())));
+        assert!(!outcome.is_ok());
+        assert!(outcome
+            .failure_detail()
+            .unwrap()
+            .contains("did not contain expected content"));
+    }
+
+    #[test]
+    fn passes_when_required_content_present() {
+        let mut cfg = config(true);
+        cfg.expect_content = Some("Welcome".to_string());
+        let outcome = evaluate(&cfg, |_, _| {
+            Ok((200, "<html>Welcome home</html>".to_string()))
+        });
+        assert!(outcome.is_ok());
+    }
+
+    #[test]
+    fn errors_on_empty_url() {
+        let mut cfg = config(true);
+        cfg.url = "   ".to_string();
+        let outcome = evaluate(&cfg, |_, _| panic!("fetch must not run for empty url"));
+        assert!(matches!(outcome, SmokeOutcome::Errored { .. }));
+        assert!(outcome.failure_detail().unwrap().contains("url is empty"));
+    }
+
+    #[test]
+    fn errors_surface_fetch_failure() {
+        let outcome = evaluate(&config(true), |_, _| {
+            Err("HTTP GET https://example.test/ failed: connection refused".to_string())
+        });
+        assert!(matches!(outcome, SmokeOutcome::Errored { .. }));
+        assert!(outcome
+            .failure_detail()
+            .unwrap()
+            .contains("connection refused"));
+    }
+}

--- a/src/core/http_probe.rs
+++ b/src/core/http_probe.rs
@@ -32,6 +32,35 @@ pub(crate) fn get_status(url: &str, timeout: Duration) -> std::result::Result<u1
     Ok(response.status().as_u16())
 }
 
+/// Fetch a URL and return both the status code and the response body.
+///
+/// Used by call sites that need to assert on body content as well as status
+/// (e.g. the post-deploy smoke check verifying a real page rendered). The
+/// blocking reqwest client has no cookie store, so each call is a fresh,
+/// cookie-less request — matching a first-time visitor.
+pub(crate) fn get_status_and_body(
+    url: &str,
+    timeout: Duration,
+) -> std::result::Result<(u16, String), HttpProbeError> {
+    let client = blocking_client(timeout).map_err(|e| HttpProbeError {
+        message: Error::internal_unexpected(format!("build http client: {}", e)).message,
+        is_connect: false,
+    })?;
+
+    let response = client.get(url).send().map_err(|e| HttpProbeError {
+        message: format!("HTTP GET {} failed: {}", url, e),
+        is_connect: e.is_connect(),
+    })?;
+
+    let status = response.status().as_u16();
+    let body = response.text().map_err(|e| HttpProbeError {
+        message: format!("reading response body from {} failed: {}", url, e),
+        is_connect: false,
+    })?;
+
+    Ok((status, body))
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::{Read, Write};

--- a/src/core/project/mod.rs
+++ b/src/core/project/mod.rs
@@ -117,6 +117,15 @@ pub struct Project {
     /// These are checked via `systemctl is-active <name>` on the remote server.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub services: Vec<String>,
+
+    /// Post-deploy front-end smoke check (opt-in, config-driven).
+    ///
+    /// When enabled, homeboy fetches the configured URL as a fresh visitor after
+    /// a successful real deploy and fails the deploy if it does not return the
+    /// expected status (and optional content). Catches runtime-fataling releases
+    /// that `php -l`/syntax-only checks structurally cannot. See homeboy#5471.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub smoke_check: Option<SmokeCheckConfig>,
 }
 
 impl ConfigEntity for Project {

--- a/src/core/project/types.rs
+++ b/src/core/project/types.rs
@@ -147,6 +147,66 @@ impl Default for DatabaseConfig {
     }
 }
 
+/// Post-deploy smoke check configuration.
+///
+/// Opt-in, config-driven front-end health check that runs after a successful
+/// real deploy. It fetches a configured URL as a fresh (cookie-less) visitor
+/// and asserts the HTTP status (and optionally a content substring), failing
+/// the deploy when the smoke fails.
+///
+/// This is deliberately generic: core only knows "fetch a URL, assert a
+/// status/content". The concrete front-end URL (e.g. a WordPress site home
+/// page) belongs in the project config, not in core, so the smoke step stays
+/// stack-agnostic. It exists to catch runtime-fataling releases that pass
+/// syntax-only checks (`php -l`) and never get exercised by a real page load
+/// — see homeboy#5471.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SmokeCheckConfig {
+    /// Whether the post-deploy smoke check runs. Defaults to false (opt-in).
+    #[serde(default)]
+    pub enabled: bool,
+    /// URL to fetch after deploy. Required when `enabled` is true.
+    #[serde(default)]
+    pub url: String,
+    /// HTTP status code that counts as healthy. Defaults to 200.
+    #[serde(default = "default_smoke_expected_status")]
+    pub expected_status: u16,
+    /// Optional substring that must appear in the response body. When set, the
+    /// smoke also fetches the body and fails if the substring is absent — a
+    /// cheap way to assert "real page rendered", not just "server answered".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expect_content: Option<String>,
+    /// Request timeout in seconds. Defaults to 15.
+    #[serde(default = "default_smoke_timeout_secs")]
+    pub timeout_secs: u64,
+    /// When true, a failed smoke check only warns instead of failing the deploy.
+    /// Defaults to false: a failing smoke fails the deploy so runtime-fataling
+    /// releases are flagged for rollback rather than left live.
+    #[serde(default)]
+    pub warn_only: bool,
+}
+
+fn default_smoke_expected_status() -> u16 {
+    200
+}
+
+fn default_smoke_timeout_secs() -> u64 {
+    15
+}
+
+impl Default for SmokeCheckConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            url: String::new(),
+            expected_status: default_smoke_expected_status(),
+            expect_content: None,
+            timeout_secs: default_smoke_timeout_secs(),
+            warn_only: false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ApiConfig {
     #[serde(default)]


### PR DESCRIPTION
## Summary

Closes #5471 (the deploy-safety half — detection at deploy time).

On 2026-06-20 a network-activated WP plugin shipped an uncaught PHP `ValueError` on the front-end `template_redirect` path and 500'd the entire network to new visitors for ~3.5h. `php -l` (syntax-only) structurally can't catch a runtime error, and nothing exercised a real page load after deploy — so the bad release sat live.

This adds an **opt-in, config-driven post-deploy front-end smoke check** to `homeboy deploy` that fetches a configured URL as a fresh (cookie-less) visitor after a successful real deploy, asserts HTTP status (and optional content), and **fails the deploy** when the smoke fails — flagging the release for rollback instead of leaving it live. This is the check that would have caught the exact outage in seconds.

## What changed

- **`SmokeCheckConfig`** (project-level config, `src/core/project/types.rs`): `enabled` (opt-in, default off), `url`, `expected_status` (default 200), `expect_content` (optional body substring), `timeout_secs` (default 15), `warn_only` (default false → a failed smoke fails the deploy). The concrete front-end URL lives in **project config**, keeping core stack-agnostic — core only knows "fetch a URL, assert status/content".
- **`Project.smoke_check`** field added.
- **`src/core/deploy/smoke.rs`**: new module evaluating the smoke assertion. Fetch logic is split from assertion logic so the policy is unit-testable without network I/O. The blocking reqwest client has no cookie store, so each probe is a genuine first-time-visitor request.
- **`http_probe::get_status_and_body`**: shared helper returning status + body for content assertions (reuses the existing `#5364` blocking-client helper).
- **`orchestration::deploy_components`**: runs the smoke check once per project after a successful real deploy (`succeeded > 0`); on non-warn-only failure, flips deployed components to `failed` so the exit code is non-zero and automation treats it as a rollback candidate. Skipped entirely in `--check`/`--dry-run`.

## Scope notes

- Generic and opt-in by design — no change to release semantics for projects that don't configure `smoke_check`.
- Issue asks #2 (loud `--skip-checks`) and #3 (preflight runtime smoke) are deliberately left out to keep this surgical; #2 touches release UX and the issue itself frames the prod-side fatal-rate ALARM as complementary/separate (extrachill-analytics#48).

## Tests

Unit tests cover the assertion matrix (status match/mismatch, content present/missing, empty URL, fetch error) and the orchestration gating (noop without config, noop when disabled, failure records error + fails, warn_only warns without failing). Verified with `cargo build --lib` (full `cargo test`/`--tests` skipped locally per VPS OOM constraints; CI gates the suite).