### PR TITLE
fix(trace): handle macOS dark-wake keychain failure in secret resolution (#4162)

### DIFF
--- a/src/core/keychain.rs
+++ b/src/core/keychain.rs
@@ -81,6 +81,28 @@ pub fn remove_many(project_id: &str, variable_names: &[String]) -> Result<usize>
     Ok(removed)
 }
 
+/// Returns true when a keychain error indicates the OS secure storage was
+/// reachable but could not service the request because no interactive UI is
+/// available (for example, macOS "dark wake", a locked login keychain, or a
+/// headless/SSH session). These conditions are recoverable by exporting the
+/// secret as a process environment variable instead of reading the keychain.
+///
+/// Detection is message-based because the underlying `keyring`/Security
+/// framework surfaces these conditions as opaque platform errors rather than a
+/// dedicated error variant. Kept OS-agnostic so callers on any platform get a
+/// consistent escape hatch when secure storage needs UI that isn't available.
+pub fn is_secure_storage_unavailable(error: &Error) -> bool {
+    let haystack = error.message.to_ascii_lowercase();
+    const NEEDLES: [&str; 5] = [
+        "dark wake",
+        "no ui possible",
+        "secure storage failure",
+        "user interaction is not allowed",
+        "interaction not allowed",
+    ];
+    NEEDLES.iter().any(|needle| haystack.contains(needle))
+}
+
 pub fn missing_error(project_id: &str, variable_name: &str) -> Error {
     Error::new(
         ErrorCode::ExtensionNotFound,
@@ -313,6 +335,19 @@ mod tests {
     #[test]
     fn account_key_uses_project_and_variable() {
         assert_eq!(account_key("wpcloud-api", "token"), "wpcloud-api:token");
+    }
+
+    #[test]
+    fn detects_dark_wake_secure_storage_failure() {
+        let boxed: Box<dyn std::error::Error + Send + Sync> = "In dark wake, no UI possible".into();
+        let error = keyring_error(keyring::Error::PlatformFailure(boxed));
+        assert!(is_secure_storage_unavailable(&error));
+    }
+
+    #[test]
+    fn does_not_flag_ordinary_keychain_errors() {
+        let error = missing_error("wpcloud-api", "token");
+        assert!(!is_secure_storage_unavailable(&error));
     }
 
     #[test]

--- a/src/core/trace_secrets.rs
+++ b/src/core/trace_secrets.rs
@@ -35,10 +35,36 @@ pub fn resolve_secret_env(
         }
 
         if let Some(project_id) = project_id {
-            if let Some(value) = keychain::get(project_id, &name)? {
-                resolved.push((name.clone(), value));
-                statuses.push(status(name, true, "project-keychain"));
-                continue;
+            match keychain::get(project_id, &name) {
+                Ok(Some(value)) => {
+                    resolved.push((name.clone(), value));
+                    statuses.push(status(name, true, "project-keychain"));
+                    continue;
+                }
+                Ok(None) => {}
+                Err(error) if keychain::is_secure_storage_unavailable(&error) => {
+                    // The OS keychain is reachable but cannot service the read
+                    // without an interactive UI (macOS dark wake, locked login
+                    // keychain, or headless/SSH session). Surface an actionable
+                    // diagnostic that points at the env-first escape hatch
+                    // instead of failing with an opaque platform error.
+                    return Err(Error::validation_invalid_argument(
+                        "secret-env",
+                        format!(
+                            "could not read trace secret '{name}' from the project keychain: {}",
+                            error.message
+                        ),
+                        None,
+                        Some(vec![
+                            format!(
+                                "Export the value in the controller shell before running trace, for example `export {name}=...`; `--secret-env` prefers process env over the keychain."
+                            ),
+                            "This happens when the OS keychain needs UI that isn't available (macOS dark wake, a locked login keychain, or a headless/SSH session). Rerun from an unlocked, interactive user session, or use exported env values.".to_string(),
+                            "For repeatable headless runs, configure a `source: env` mapping with `homeboy agent-task auth map-env` so trace secrets resolve without keychain access.".to_string(),
+                        ]),
+                    ));
+                }
+                Err(error) => return Err(error),
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #4162. A runner-offloaded trace failed before execution while resolving `--secret-env` from the local project keychain with `Platform secure storage failure: In dark wake, no UI possible`. The opaque platform error was propagated verbatim with no guidance on how to rerun headlessly.

Now `trace_secrets::resolve_secret_env` detects the keychain-unavailable failure mode (macOS dark wake, locked login keychain, or headless/SSH session) and returns a clear, actionable diagnostic that points operators at the env-first escape hatch instead of crashing with a raw platform error.

## Changes

- **`keychain.rs`**: add `is_secure_storage_unavailable(&Error)` helper that detects "no UI possible" / "dark wake" / "secure storage failure" / "interaction not allowed" conditions. Message-based detection because `keyring`/Security framework surfaces these as opaque platform errors with no dedicated variant; kept OS-agnostic so any platform gets a consistent escape hatch.
- **`trace_secrets.rs`**: when the project-keychain read errors with a secure-storage-unavailable condition, return a `validation_invalid_argument` error whose hints explain:
  1. export the value in the controller shell (`--secret-env` prefers process env over keychain),
  2. rerun from an unlocked interactive session, and
  3. configure a `source: env` mapping via `homeboy agent-task auth map-env` for repeatable headless runs.

## Notes

- Existing resolution order (env -> agent-task -> project-keychain) is unchanged; only the keychain-error branch is hardened.
- Non-keychain errors still propagate unchanged.
- Added two unit tests for the detection helper. `cargo fmt` clean; `cargo build --lib` passes. No docs/changelog touched.