### PR TITLE
feat(trace): persist trace compare pair artifacts as first-class evidence (#4233)

### DIFF
--- a/src/commands/trace.rs
+++ b/src/commands/trace.rs
@@ -712,10 +712,15 @@ fn execute_trace_run_impl(args: TraceArgs) -> homeboy::core::Result<TraceRunExec
         persist_trace_workflow_result(observation, &run_dir, &workflow, rig_state.as_ref());
     }
 
+    let run_id = observation
+        .as_ref()
+        .map(|observation| observation.run_id.clone());
+
     Ok(TraceRunExecution {
         workflow,
         run_dir,
         rig_state,
+        run_id,
     })
 }
 

--- a/src/commands/trace/compare_targets.rs
+++ b/src/commands/trace/compare_targets.rs
@@ -89,6 +89,8 @@ pub(super) fn run_compare_targets(args: TraceArgs) -> CmdResult<TraceCommandOutp
     )?;
     let baseline_aggregate = proof.baseline;
     let candidate_aggregate = proof.candidate;
+    let baseline_run_ids = proof.baseline_run_ids;
+    let candidate_run_ids = proof.candidate_run_ids;
 
     let baseline_path = output_dir.join("baseline.aggregate.json");
     let candidate_path = output_dir.join("candidate.aggregate.json");
@@ -141,6 +143,38 @@ pub(super) fn run_compare_targets(args: TraceArgs) -> CmdResult<TraceCommandOutp
         || compare.focus_status.as_deref() == Some("fail")
         || compare.guardrail_status.as_deref() == Some("fail")
         || compare.metric_guardrail_status.as_deref() == Some("fail");
+    let compare_status = if failed { "fail" } else { "pass" };
+
+    let pair_artifact = build_compare_pair_artifact(
+        &component_id,
+        &scenario_id,
+        compare_status,
+        &output_dir,
+        &artifact_paths,
+        &compare,
+        ComparePairSideInputs {
+            target: Some(baseline_target.input.clone()),
+            git_sha: compare.before_git_sha.clone(),
+            status: compare.before_status.clone(),
+            run_ids: baseline_run_ids,
+            aggregate: &baseline_aggregate,
+        },
+        ComparePairSideInputs {
+            target: Some(candidate_target.input.clone()),
+            git_sha: compare.after_git_sha.clone(),
+            status: compare.after_status.clone(),
+            run_ids: candidate_run_ids,
+            aggregate: &candidate_aggregate,
+        },
+    );
+    trace_compare::persist_compare_pair_artifact(&artifact_paths.pair, &pair_artifact)?;
+    let pair_json = serde_json::to_value(&pair_artifact).map_err(|err| {
+        homeboy::core::Error::internal_json(
+            err.to_string(),
+            Some("trace.compare.pair.serialize".to_string()),
+        )
+    })?;
+
     finish_compare_observation(
         observation,
         if failed {
@@ -165,13 +199,83 @@ pub(super) fn run_compare_targets(args: TraceArgs) -> CmdResult<TraceCommandOutp
                 "focus_status": compare.focus_status.as_deref(),
                 "guardrail_status": compare.guardrail_status.as_deref(),
                 "metric_guardrail_status": compare.metric_guardrail_status.as_deref(),
-            }
+            },
+            "compare_pair": pair_json,
         }),
     );
     Ok((
         TraceCommandOutput::Compare(compare),
         if failed { 1 } else { 0 },
     ))
+}
+
+/// Inputs for one side of the compare pair artifact, assembled from the proof
+/// matrix output and the resolved target.
+struct ComparePairSideInputs<'a> {
+    target: Option<String>,
+    git_sha: Option<String>,
+    status: Option<String>,
+    run_ids: Vec<String>,
+    aggregate: &'a extension_trace::TraceAggregateOutput,
+}
+
+/// Assemble the first-class, provider-agnostic compare pair artifact linking the
+/// compare command, child baseline/candidate run ids, the report path, and the
+/// persisted artifact bundle directories.
+#[allow(clippy::too_many_arguments)]
+fn build_compare_pair_artifact(
+    component_id: &str,
+    scenario_id: &str,
+    status: &str,
+    output_dir: &Path,
+    artifact_paths: &trace_compare::CompareArtifactPaths,
+    compare: &extension_trace::TraceCompareOutput,
+    baseline: ComparePairSideInputs<'_>,
+    candidate: ComparePairSideInputs<'_>,
+) -> trace_compare::ComparePairArtifact {
+    let post_compare_artifacts = compare
+        .browser_proof
+        .as_ref()
+        .map(|proof| {
+            proof
+                .baseline_dirs
+                .iter()
+                .chain(proof.candidate_dirs.iter())
+                .map(|dir| trace_compare::ComparePairLinkedArtifact {
+                    kind: "browser-proof-dir".to_string(),
+                    path: dir.clone(),
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    trace_compare::ComparePairArtifact {
+        kind: "trace-compare-pair",
+        command: "trace.compare".to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        component: component_id.to_string(),
+        scenario_id: scenario_id.to_string(),
+        status: status.to_string(),
+        baseline: compare_pair_side(baseline),
+        candidate: compare_pair_side(candidate),
+        output_dir: output_dir.to_string_lossy().to_string(),
+        compare_json: artifact_paths.compare.to_string_lossy().to_string(),
+        summary_path: artifact_paths.summary.to_string_lossy().to_string(),
+        post_compare_artifacts,
+    }
+}
+
+fn compare_pair_side(inputs: ComparePairSideInputs<'_>) -> trace_compare::ComparePairSide {
+    let artifact_dirs = run_artifact_dirs(inputs.aggregate)
+        .into_iter()
+        .map(|path| path.to_string_lossy().to_string())
+        .collect();
+    trace_compare::ComparePairSide::new(
+        inputs.target,
+        inputs.git_sha,
+        inputs.status,
+        inputs.run_ids,
+        artifact_dirs,
+    )
 }
 
 fn start_compare_observation(
@@ -243,6 +347,8 @@ struct TargetProofMatrix {
     baseline: extension_trace::TraceAggregateOutput,
     candidate: extension_trace::TraceAggregateOutput,
     run_order: Vec<extension_trace::TraceCompareRunOrderOutput>,
+    baseline_run_ids: Vec<String>,
+    candidate_run_ids: Vec<String>,
 }
 
 fn run_target_proof_matrix(
@@ -299,10 +405,14 @@ fn run_target_proof_matrix(
         });
     }
 
+    let baseline_run_ids = baseline.run_ids().to_vec();
+    let candidate_run_ids = candidate.run_ids().to_vec();
     Ok(TargetProofMatrix {
         baseline: baseline.finish(args, span_metadata.clone())?,
         candidate: candidate.finish(args, span_metadata)?,
         run_order: proof_run_order,
+        baseline_run_ids,
+        candidate_run_ids,
     })
 }
 
@@ -350,6 +460,7 @@ struct TargetAggregateBuilder {
     failure_count: usize,
     rig_state: Option<homeboy::core::rig::RigStateSnapshot>,
     overlays: Vec<extension_trace::TraceOverlay>,
+    run_ids: Vec<String>,
 }
 
 impl TargetAggregateBuilder {
@@ -374,7 +485,15 @@ impl TargetAggregateBuilder {
             failure_count: 0,
             rig_state: None,
             overlays: Vec::new(),
+            run_ids: Vec::new(),
         }
+    }
+
+    /// Observation run ids of the child runs recorded for this group, in the
+    /// order they executed. Used to link child baseline/candidate run records
+    /// into the first-class compare pair artifact.
+    fn run_ids(&self) -> &[String] {
+        &self.run_ids
     }
 
     fn record(
@@ -395,6 +514,9 @@ impl TargetAggregateBuilder {
     ) -> RecordedProofRun {
         if self.rig_state.is_none() {
             self.rig_state = execution.rig_state.clone();
+        }
+        if let Some(run_id) = execution.run_id.as_ref() {
+            self.run_ids.push(run_id.clone());
         }
         if self.overlays.is_empty() && !execution.workflow.overlays.is_empty() {
             self.overlays = execution.workflow.overlays.clone();
@@ -1042,6 +1164,67 @@ mod tests {
             assert!(artifact_kinds.contains("trace-compare-candidate-aggregate"));
             assert!(artifact_kinds.contains("trace-compare-json"));
             assert!(artifact_kinds.contains("trace-compare-summary"));
+            assert!(
+                artifact_kinds.contains("trace-compare-pair"),
+                "compare pair artifact recorded as first-class evidence"
+            );
+
+            // The pair artifact is the canonical evidence index: it must link
+            // the child baseline/candidate observation run ids and be addressable
+            // from the compare run metadata so reporting never spelunks temp paths.
+            let pair_artifact = artifacts
+                .iter()
+                .find(|artifact| artifact.kind == "trace-compare-pair")
+                .expect("pair artifact present");
+            let pair_path = std::path::Path::new(&pair_artifact.path);
+            assert!(pair_path.exists(), "pair artifact persisted to disk");
+            let pair: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(pair_path).expect("read pair"))
+                    .expect("parse pair");
+            assert_eq!(pair["kind"], "trace-compare-pair");
+            assert_eq!(pair["command"], "trace.compare");
+            assert_eq!(pair["component"], "studio");
+            assert_eq!(pair["status"], "pass");
+            let baseline_run_ids = pair["baseline"]["run_ids"]
+                .as_array()
+                .expect("baseline run ids array");
+            let candidate_run_ids = pair["candidate"]["run_ids"]
+                .as_array()
+                .expect("candidate run ids array");
+            assert!(
+                !baseline_run_ids.is_empty(),
+                "at least one baseline child run id linked"
+            );
+            assert!(
+                !candidate_run_ids.is_empty(),
+                "at least one candidate child run id linked"
+            );
+            // Linked child run ids must resolve to real persisted run records.
+            for run_id in baseline_run_ids.iter().chain(candidate_run_ids.iter()) {
+                let run_id = run_id.as_str().expect("run id string");
+                assert!(
+                    store.get_run(run_id).expect("lookup child run").is_some(),
+                    "child run {run_id} persisted in observation store"
+                );
+            }
+            assert_eq!(
+                pair["baseline"]["run_evidence"][0]["evidence_command"],
+                format!(
+                    "homeboy runs evidence {}",
+                    baseline_run_ids[0].as_str().unwrap()
+                )
+            );
+
+            // The compare run metadata embeds the same pair index so consumers can
+            // address compare-level evidence directly from the run record.
+            assert_eq!(
+                compare_run.metadata_json["compare_pair"]["kind"],
+                "trace-compare-pair"
+            );
+            assert_eq!(
+                compare_run.metadata_json["compare_pair"]["baseline"]["run_ids"],
+                pair["baseline"]["run_ids"]
+            );
         });
     }
 

--- a/src/commands/trace/run_service.rs
+++ b/src/commands/trace/run_service.rs
@@ -20,6 +20,11 @@ pub(super) struct TraceRunExecution {
     pub(super) workflow: extension_trace::TraceRunWorkflowResult,
     pub(super) run_dir: RunDir,
     pub(super) rig_state: Option<rig::RigStateSnapshot>,
+    /// Observation run id of the child trace run, when an observation store was
+    /// available. Surfaced so compare orchestration can link child run records
+    /// into the first-class compare pair artifact instead of forcing downstream
+    /// reporting to rediscover run ids from artifact directories.
+    pub(super) run_id: Option<String>,
 }
 
 impl TraceRunService {

--- a/src/core/trace_compare.rs
+++ b/src/core/trace_compare.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use crate::core::observation::{NewRunRecord, ObservationStore, RunStatus};
+use crate::core::observation::{NewRunRecord, ObservationStore, RunEvidenceCommands, RunStatus};
 
 /// Resolved on-disk locations of the artifacts a compare run persists.
 pub struct CompareArtifactPaths {
@@ -19,6 +19,106 @@ pub struct CompareArtifactPaths {
     pub candidate: PathBuf,
     pub compare: PathBuf,
     pub summary: PathBuf,
+    pub pair: PathBuf,
+}
+
+/// First-class, provider-agnostic compare pair artifact. It is the canonical
+/// evidence record a `trace compare` invocation produces: a single index that
+/// links the compare command, the child baseline/candidate observation run ids,
+/// the generated report/summary path, and the persisted artifact bundle
+/// directories. Downstream report commands address this record instead of
+/// rediscovering run ids and artifact directories from temp paths.
+///
+/// The shape is intentionally generic — it knows nothing about WordPress,
+/// browsers, screenshots, or any specific extension. Visual diffs and other
+/// post-compare evidence are linked generically through `post_compare_artifacts`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ComparePairArtifact {
+    /// Schema marker so consumers can detect the artifact kind without guessing.
+    pub kind: &'static str,
+    /// The command that produced this compare (e.g. `trace.compare`).
+    pub command: String,
+    /// RFC3339 timestamp of when the pair artifact was assembled.
+    pub timestamp: String,
+    /// Component the compare ran against.
+    pub component: String,
+    /// Scenario identifier the compare exercised.
+    pub scenario_id: String,
+    /// Resolved status of the compare (`pass`/`fail`).
+    pub status: String,
+    /// Baseline side reference (target input, resolved run ids, artifact dirs).
+    pub baseline: ComparePairSide,
+    /// Candidate side reference (target input, resolved run ids, artifact dirs).
+    pub candidate: ComparePairSide,
+    /// Output directory holding the persisted compare artifacts.
+    pub output_dir: String,
+    /// Compare JSON artifact path (the structured comparison result).
+    pub compare_json: String,
+    /// Generated Markdown report/summary path.
+    pub summary_path: String,
+    /// Any post-compare evidence artifacts (e.g. visual diffs) addressed
+    /// generically by kind + path so the model stays extension-agnostic.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub post_compare_artifacts: Vec<ComparePairLinkedArtifact>,
+}
+
+/// One side (baseline or candidate) of a compare pair: the target it ran
+/// against, the child observation run ids it produced, and the run artifact
+/// directories those runs wrote.
+#[derive(Debug, Clone, Serialize)]
+pub struct ComparePairSide {
+    /// The target input (path or git ref) requested for this side.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// Resolved git sha for the side, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_sha: Option<String>,
+    /// Aggregate status reported for the side.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// Child observation run ids, each addressable via `homeboy runs evidence`.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub run_ids: Vec<String>,
+    /// Retrieval commands for the first child run, when present, so an agent can
+    /// pivot to per-run evidence without constructing commands by hand.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub run_evidence: Vec<RunEvidenceCommands>,
+    /// Run artifact directories produced by the side's child runs.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub artifact_dirs: Vec<String>,
+}
+
+/// A generically-addressed post-compare artifact (kind + path) such as a visual
+/// diff bundle. The pair artifact records the address, not the semantics.
+#[derive(Debug, Clone, Serialize)]
+pub struct ComparePairLinkedArtifact {
+    pub kind: String,
+    pub path: String,
+}
+
+impl ComparePairSide {
+    /// Build a side reference, deriving the evidence retrieval commands from the
+    /// child run ids so downstream consumers get ready-to-run addresses.
+    pub fn new(
+        target: Option<String>,
+        git_sha: Option<String>,
+        status: Option<String>,
+        run_ids: Vec<String>,
+        artifact_dirs: Vec<String>,
+    ) -> Self {
+        let run_evidence = run_ids
+            .iter()
+            .map(|run_id| RunEvidenceCommands::for_run_id(run_id))
+            .collect();
+        Self {
+            target,
+            git_sha,
+            status,
+            run_ids,
+            run_evidence,
+            artifact_dirs,
+        }
+    }
 }
 
 /// The data a single compare run persists to its output directory.
@@ -68,6 +168,7 @@ pub fn persist_compare_artifacts<B: Serialize, C: Serialize, M: Serialize>(
         candidate: output_dir.join("candidate.aggregate.json"),
         compare: output_dir.join("compare.json"),
         summary: output_dir.join("summary.md"),
+        pair: output_dir.join("compare.pair.json"),
     };
     write_json_artifact(&paths.baseline, set.baseline_aggregate)?;
     write_json_artifact(&paths.candidate, set.candidate_aggregate)?;
@@ -83,6 +184,16 @@ pub fn persist_compare_artifacts<B: Serialize, C: Serialize, M: Serialize>(
         )
     })?;
     Ok(paths)
+}
+
+/// Persist the first-class compare pair artifact to `path`, returning the
+/// artifact unchanged so the command layer can embed it in observation
+/// metadata. This is the canonical evidence index for a compare run.
+pub fn persist_compare_pair_artifact(
+    path: &Path,
+    pair: &ComparePairArtifact,
+) -> crate::core::Result<()> {
+    write_json_artifact(path, pair)
 }
 
 /// An active observation run bracketing a trace-compare invocation. Owns the
@@ -129,6 +240,9 @@ impl CompareObservation {
         let _ = self
             .store
             .record_artifact(&self.run_id, "trace-compare-summary", &paths.summary);
+        let _ = self
+            .store
+            .record_artifact(&self.run_id, "trace-compare-pair", &paths.pair);
         let _ = self.store.finish_run(&self.run_id, status, Some(metadata));
     }
 }


### PR DESCRIPTION
## Summary
- `trace compare` now persists a first-class, provider-agnostic **compare pair artifact** (`compare.pair.json`) as the canonical evidence index for a compare run, closing #4233.
- The pair artifact links the compare command, child baseline/candidate observation run ids (with ready-to-run `homeboy runs evidence` retrieval commands), resolved git shas, the compare JSON + Markdown report paths, run artifact bundle directories, and any post-compare artifacts (e.g. browser proof dirs) addressed generically by kind + path.
- Recorded as a `trace-compare-pair` artifact on the compare observation run and embedded into the compare run's `metadata_json.compare_pair`, so `homeboy runs evidence/artifacts` and report commands can address compare-level evidence directly instead of rediscovering run ids and dirs from temp paths.

## Details
- Surfaced the child trace run's observation `run_id` via `TraceRunExecution`, captured per-group (baseline/candidate) in the proof matrix, and threaded into the pair artifact.
- New core types in `src/core/trace_compare.rs`: `ComparePairArtifact`, `ComparePairSide`, `ComparePairLinkedArtifact` + `persist_compare_pair_artifact`. Kept fully agnostic — no WordPress / browser / screenshot assumptions; visual diffs are linked generically.
- Coordinated with #4621 (report-reading side): this change is scoped to persistence / the pair-artifact only.

## Tests
- Extended the interleaved-children compare test to assert the `trace-compare-pair` artifact is recorded, persisted to disk, links real persisted baseline/candidate child run ids, exposes evidence retrieval commands, and is mirrored in the compare run metadata.

Closes #4233