### PR TITLE
fix(report): read artifact-backed metrics in browser evidence compare (#4621)

### DIFF
--- a/src/commands/report/browser_evidence_compare.rs
+++ b/src/commands/report/browser_evidence_compare.rs
@@ -405,8 +405,7 @@ mod implementation {
         })?;
         files.sort();
 
-        let mut samples = Vec::new();
-        let mut artifacts = BTreeSet::new();
+        let mut parsed = Vec::new();
         for file in files {
             let raw = match std::fs::read_to_string(&file) {
                 Ok(raw) => raw,
@@ -430,18 +429,35 @@ mod implementation {
                     continue;
                 }
             };
-            let source = artifact_ref(root, &file, include_local_paths, None);
+            parsed.push((file, value));
+        }
+
+        // Files that other trace files declare as artifacts (e.g. artifacts/*-metrics.json) are
+        // ingested into their owning sample below; reading them again as standalone evidence would
+        // double count metrics into a phantom variant, so collect their canonical paths first and
+        // skip them as top-level evidence sources.
+        let declared_artifact_paths = declared_artifact_paths(&parsed, adapters);
+
+        let mut samples = Vec::new();
+        let mut artifacts = BTreeSet::new();
+        for (file, value) in &parsed {
+            if is_declared_artifact_file(file, &declared_artifact_paths) {
+                continue;
+            }
+            let source = artifact_ref(root, file, include_local_paths, None);
+            let source_dir = file.parent().map(Path::to_path_buf);
             let before = samples.len();
             collect_samples(
-                &value,
+                value,
                 &SampleContext::default(),
                 &source,
+                source_dir.as_deref(),
                 &mut samples,
                 &mut artifacts,
                 adapters,
             );
             if samples.len() == before {
-                collect_provenance_artifacts(&value, &source, &mut artifacts, adapters);
+                collect_provenance_artifacts(value, &source, &mut artifacts, adapters);
             }
         }
 
@@ -492,6 +508,62 @@ mod implementation {
         Ok(merged)
     }
 
+    /// Collect the canonical filesystem paths of every JSON file declared as an artifact by any
+    /// parsed trace file. Used to avoid treating artifact-backed metric files as standalone
+    /// evidence samples.
+    fn declared_artifact_paths(
+        parsed: &[(PathBuf, Value)],
+        adapters: &[TraceBrowserEvidenceAdapterConfig],
+    ) -> BTreeSet<PathBuf> {
+        let mut declared = BTreeSet::new();
+        for (file, value) in parsed {
+            let Some(source_dir) = file.parent() else {
+                continue;
+            };
+            let mut refs = BTreeSet::new();
+            collect_artifact_targets(value, &mut refs, adapters);
+            for artifact in refs {
+                if let Some(path) = resolve_local_artifact_path(source_dir, &artifact.target) {
+                    if path.extension().and_then(|ext| ext.to_str()) == Some("json") {
+                        declared.insert(canonical_path(&path));
+                    }
+                }
+            }
+        }
+        declared
+    }
+
+    fn is_declared_artifact_file(file: &Path, declared: &BTreeSet<PathBuf>) -> bool {
+        declared.contains(&canonical_path(file))
+    }
+
+    fn canonical_path(path: &Path) -> PathBuf {
+        std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    }
+
+    /// Recursively collect every declared artifact reference (both `artifacts` arrays and adapter
+    /// artifact maps) from a parsed JSON value.
+    fn collect_artifact_targets(
+        value: &Value,
+        artifacts: &mut BTreeSet<ArtifactRef>,
+        adapters: &[TraceBrowserEvidenceAdapterConfig],
+    ) {
+        match value {
+            Value::Object(object) => {
+                collect_object_artifacts(object, artifacts, adapters);
+                for value in object.values() {
+                    collect_artifact_targets(value, artifacts, adapters);
+                }
+            }
+            Value::Array(values) => {
+                for value in values {
+                    collect_artifact_targets(value, artifacts, adapters);
+                }
+            }
+            _ => {}
+        }
+    }
+
     fn collect_json_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
         for entry in std::fs::read_dir(dir)? {
             let entry = entry?;
@@ -509,17 +581,20 @@ mod implementation {
         value: &Value,
         inherited: &SampleContext,
         source: &ArtifactRef,
+        source_dir: Option<&Path>,
         samples: &mut Vec<BrowserEvidenceSample>,
         artifacts: &mut BTreeSet<ArtifactRef>,
         adapters: &[TraceBrowserEvidenceAdapterConfig],
     ) {
         match value {
-            Value::Object(object) => {
-                collect_object_samples(object, inherited, source, samples, artifacts, adapters)
-            }
+            Value::Object(object) => collect_object_samples(
+                object, inherited, source, source_dir, samples, artifacts, adapters,
+            ),
             Value::Array(array) => {
                 for item in array {
-                    collect_samples(item, inherited, source, samples, artifacts, adapters);
+                    collect_samples(
+                        item, inherited, source, source_dir, samples, artifacts, adapters,
+                    );
                 }
             }
             _ => {}
@@ -530,6 +605,7 @@ mod implementation {
         object: &Map<String, Value>,
         inherited: &SampleContext,
         source: &ArtifactRef,
+        source_dir: Option<&Path>,
         samples: &mut Vec<BrowserEvidenceSample>,
         artifacts: &mut BTreeSet<ArtifactRef>,
         adapters: &[TraceBrowserEvidenceAdapterConfig],
@@ -538,18 +614,24 @@ mod implementation {
         let runs = object.get("runs").and_then(Value::as_array);
 
         if has_browser_signal(object, adapters) && runs.is_none() {
-            samples.push(sample_from_object(object, &context, source, adapters));
+            samples.push(sample_from_object(
+                object, &context, source, source_dir, adapters,
+            ));
         } else if has_provenance_signal(object) {
             collect_object_artifacts(object, artifacts, adapters);
             artifacts.insert(source.clone());
         }
 
         if let Some(data) = object.get("data") {
-            collect_samples(data, &context, source, samples, artifacts, adapters);
+            collect_samples(
+                data, &context, source, source_dir, samples, artifacts, adapters,
+            );
         }
         for key in ["scenarios", "profiles", "variants", "matrix", "results"] {
             if let Some(value) = object.get(key) {
-                collect_samples(value, &context, source, samples, artifacts, adapters);
+                collect_samples(
+                    value, &context, source, source_dir, samples, artifacts, adapters,
+                );
             }
         }
         if let Some(runs) = runs {
@@ -558,7 +640,15 @@ mod implementation {
                 if run_context.profile.is_none() {
                     run_context.profile = Some(format!("repeat-{}", index + 1));
                 }
-                collect_samples(run, &run_context, source, samples, artifacts, adapters);
+                collect_samples(
+                    run,
+                    &run_context,
+                    source,
+                    source_dir,
+                    samples,
+                    artifacts,
+                    adapters,
+                );
             }
         }
     }
@@ -684,6 +774,7 @@ mod implementation {
         object: &Map<String, Value>,
         context: &SampleContext,
         source: &ArtifactRef,
+        source_dir: Option<&Path>,
         adapters: &[TraceBrowserEvidenceAdapterConfig],
     ) -> BrowserEvidenceSample {
         let mut sample = BrowserEvidenceSample {
@@ -745,12 +836,177 @@ mod implementation {
             .or_else(|| error_count(object, &["page_errors", "pageErrors", "errors"]));
         collect_artifacts(object, &mut sample.artifacts);
         collect_declared_artifact_map_adapters(object, &mut sample.artifacts, adapters);
+        ingest_artifact_backed_metrics(&mut sample, source_dir, adapters);
         if sample.browser_metrics.is_empty() && sample.lifecycle_metrics.is_empty() {
             sample
                 .notes
                 .push("timing metrics missing or not numeric".to_string());
         }
         sample
+    }
+
+    /// Pull structured metrics out of declared artifact files (e.g. `artifacts/*-metrics.json`)
+    /// referenced from a trace sample. Trace producers frequently leave request counts and
+    /// browser metrics only in an artifact JSON while the top-level trace.json carries a string
+    /// summary, so without this the reporter would render "No comparable metrics found".
+    ///
+    /// This is intentionally generic: it resolves each declared artifact relative to the trace
+    /// file's directory, parses any readable JSON, and reuses the same field-recognition helpers
+    /// used for inline trace metrics. Values already present from the top-level trace.json take
+    /// precedence; artifact files only fill in what is missing.
+    fn ingest_artifact_backed_metrics(
+        sample: &mut BrowserEvidenceSample,
+        source_dir: Option<&Path>,
+        adapters: &[TraceBrowserEvidenceAdapterConfig],
+    ) {
+        let Some(source_dir) = source_dir else {
+            return;
+        };
+        let targets = sample
+            .artifacts
+            .iter()
+            .map(|artifact| artifact.target.clone())
+            .collect::<Vec<_>>();
+        for target in targets {
+            let Some(path) = resolve_local_artifact_path(source_dir, &target) else {
+                continue;
+            };
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let Ok(raw) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+                continue;
+            };
+            if merge_artifact_metrics(sample, &value, adapters) {
+                sample
+                    .notes
+                    .push(format!("ingested artifact-backed metrics from {}", target));
+            }
+        }
+    }
+
+    /// Resolve a declared artifact reference to a local file path relative to the trace file's
+    /// directory. Rejects parent-directory traversal and remote (URL) targets so only artifacts
+    /// co-located with the trace evidence are read.
+    fn resolve_local_artifact_path(source_dir: &Path, target: &str) -> Option<PathBuf> {
+        if target.is_empty() || target.contains("://") {
+            return None;
+        }
+        let relative = Path::new(target);
+        if relative.is_absolute() {
+            return relative.exists().then(|| relative.to_path_buf());
+        }
+        if relative
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+        {
+            return None;
+        }
+        let candidate = source_dir.join(relative);
+        candidate.exists().then_some(candidate)
+    }
+
+    /// Merge metrics found in an artifact JSON value into the sample, only filling fields that are
+    /// still empty. Returns true if any metric was contributed by the artifact.
+    fn merge_artifact_metrics(
+        sample: &mut BrowserEvidenceSample,
+        value: &Value,
+        adapters: &[TraceBrowserEvidenceAdapterConfig],
+    ) -> bool {
+        let Some(object) = value.as_object() else {
+            return false;
+        };
+        let mut staged = BrowserEvidenceSample::default();
+        collect_requests(object, &mut staged);
+        collect_metric_object(
+            object.get("browser_metrics"),
+            &mut staged.browser_metrics,
+            &browser_metric_names(),
+        );
+        collect_metric_object(
+            object.get("metrics"),
+            &mut staged.browser_metrics,
+            &browser_metric_names(),
+        );
+        collect_metric_object(
+            object
+                .get("summary")
+                .and_then(Value::as_object)
+                .and_then(|summary| summary.get("metrics")),
+            &mut staged.browser_metrics,
+            &browser_metric_names(),
+        );
+        collect_top_level_numbers(object, &mut staged.browser_metrics, &browser_metric_names());
+        collect_metric_object(
+            object.get("lifecycle_metrics"),
+            &mut staged.lifecycle_metrics,
+            &lifecycle_metric_names(),
+        );
+        collect_metric_object(
+            object.get("dom_lifecycle"),
+            &mut staged.lifecycle_metrics,
+            &lifecycle_metric_names(),
+        );
+        collect_top_level_numbers(
+            object,
+            &mut staged.lifecycle_metrics,
+            &lifecycle_metric_names(),
+        );
+        if let Some(summary) = object.get("summary").and_then(Value::as_object) {
+            collect_declared_browser_summary_adapters(summary, &mut staged, adapters);
+        }
+        staged.console_errors = staged
+            .console_errors
+            .or_else(|| error_count(object, &["console_errors", "consoleErrors"]));
+        staged.page_errors = staged
+            .page_errors
+            .or_else(|| error_count(object, &["page_errors", "pageErrors", "errors"]));
+
+        let mut contributed = false;
+        if sample.request_total.is_none() {
+            if let Some(request_total) = staged.request_total {
+                sample.request_total = Some(request_total);
+                contributed = true;
+            }
+        }
+        contributed |=
+            merge_missing_count_map(&mut sample.request_by_host, &staged.request_by_host);
+        contributed |=
+            merge_missing_count_map(&mut sample.request_by_type, &staged.request_by_type);
+        contributed |=
+            merge_missing_count_map(&mut sample.browser_metrics, &staged.browser_metrics);
+        contributed |=
+            merge_missing_count_map(&mut sample.lifecycle_metrics, &staged.lifecycle_metrics);
+        if sample.console_errors.is_none() {
+            if let Some(console_errors) = staged.console_errors {
+                sample.console_errors = Some(console_errors);
+                contributed = true;
+            }
+        }
+        if sample.page_errors.is_none() {
+            if let Some(page_errors) = staged.page_errors {
+                sample.page_errors = Some(page_errors);
+                contributed = true;
+            }
+        }
+        contributed
+    }
+
+    fn merge_missing_count_map(
+        target: &mut BTreeMap<String, f64>,
+        source: &BTreeMap<String, f64>,
+    ) -> bool {
+        let mut contributed = false;
+        for (key, value) in source {
+            if !target.contains_key(key) {
+                target.insert(key.clone(), *value);
+                contributed = true;
+            }
+        }
+        contributed
     }
 
     pub(super) fn compare_variants(

--- a/tests/report_browser_evidence_compare_test.rs
+++ b/tests/report_browser_evidence_compare_test.rs
@@ -546,6 +546,70 @@ process.stdout.write(JSON.stringify({
 }
 
 #[test]
+fn ingests_metrics_from_declared_artifact_files() {
+    // Regression for #4621: per-run trace.json carried only a string summary plus a declared
+    // artifact link, while the request counts and browser metrics lived in
+    // artifacts/<name>-metrics.json. The reporter must read those artifact-backed metrics rather
+    // than printing "No comparable metrics found".
+    let guard = tmp_dir("artifact-backed-metrics");
+    let root = guard.path();
+
+    for (side, network, dom) in [("baseline", 18, 700), ("candidate", 24, 900)] {
+        write_fixture_file(
+            &root.join(side),
+            "trace.json",
+            r#"{
+                "scenario_id":"product-page-waterfall",
+                "profile":"desktop",
+                "summary":"Captured waterfall trace; see artifact for metrics.",
+                "assertions":[{"id":"ready","status":"pass"}],
+                "artifacts":[{"label":"metrics","path":"artifacts/waterfall-metrics.json"}]
+            }"#,
+        );
+        write_fixture_file(
+            &root.join(side).join("artifacts"),
+            "waterfall-metrics.json",
+            &format!(
+                r#"{{
+                    "request_count": {network},
+                    "request_summary": {{
+                        "by_host": {{ "example.test": {network} }},
+                        "by_type": {{ "script": {network} }}
+                    }},
+                    "browser_metrics": {{ "browser_dom_content_loaded_ms": {dom}, "browser_cls": 0 }}
+                }}"#
+            ),
+        );
+    }
+
+    let report = browser_evidence_compare_from_args(&args(root, false)).expect("report renders");
+
+    assert_eq!(report.totals.baseline_samples, 1);
+    assert_eq!(report.totals.candidate_samples, 1);
+    let variant = report.variants.first().expect("variant should exist");
+    assert_eq!(
+        variant.request_totals.baseline.as_ref().unwrap().median,
+        18.0
+    );
+    assert_eq!(
+        variant.request_totals.candidate.as_ref().unwrap().median,
+        24.0
+    );
+    assert_eq!(variant.request_totals.median_delta, Some(6.0));
+    assert!(variant.request_by_host.contains_key("example.test"));
+    assert!(variant.request_by_type.contains_key("script"));
+    assert_eq!(
+        variant.browser_metrics["browser_dom_content_loaded_ms"].median_delta,
+        Some(200.0)
+    );
+    assert!(report.markdown.contains("Request Counts By Host"));
+    assert!(report.markdown.contains("browser_dom_content_loaded_ms"));
+    assert!(report
+        .markdown
+        .contains("ingested artifact-backed metrics from artifacts/waterfall-metrics.json"));
+}
+
+#[test]
 fn keeps_runtime_and_artifact_manifests_out_of_variant_matrix() {
     let guard = tmp_dir("artifact-manifests");
     let root = guard.path();


### PR DESCRIPTION
## Summary
Fixes #4621. The browser evidence comparison report printed `No comparable metrics found` for request counts when a trace producer left structured metrics only in a declared artifact file (e.g. `artifacts/ece-waterfall-metrics.json`) while the top-level `trace.json` carried just a string `summary`, `assertions`, and artifact links.

The reporter now reads metrics out of declared artifact JSON files referenced from a trace sample, surfacing request counts, request-by-host/type maps, browser metrics, lifecycle metrics, and console/page errors.

## Changes
- Thread the trace file's directory through evidence reading so declared artifacts can be resolved on disk.
- After collecting a sample's declared artifacts, resolve each local JSON artifact (relative to the trace file, rejecting URLs and parent-dir traversal), parse it, and merge any metrics it contains. Values already present in the top-level `trace.json` take precedence; artifact files only fill in what is missing. A note records which artifact file contributed metrics (diagnostics requested by the issue).
- Two-pass file reading: files declared as artifacts by other trace files are skipped as standalone evidence sources so artifact-backed metrics aren't double counted into a phantom variant.
- Kept fully generic — reuses existing field-recognition helpers and adapter config; no provider/Stripe-specific logic.

## Tests
- Added `ingests_metrics_from_declared_artifact_files` covering a trace whose request counts and browser metrics live only in a declared `artifacts/*-metrics.json`.
- Full `report_browser_evidence_compare_test` suite passes (8/8). `cargo fmt` + `cargo build --lib` clean.