### PR TITLE
fix(test): resolve failing test (#5559)

### DIFF
--- a/src/commands/agent_task_dispatch.rs
+++ b/src/commands/agent_task_dispatch.rs
@@ -194,6 +194,8 @@ mod tests {
                 .to_string();
             let patch_path = std::path::Path::new(&workspace).join("changes.patch");
             std::fs::write(&patch_path, "diff --git a/file b/file\n").expect("patch fixture");
+            let transcript_path = std::path::Path::new(&workspace).join("transcript.log");
+            std::fs::write(&transcript_path, "cook transcript\n").expect("transcript fixture");
             let (value, exit_code) = dispatch_service::run_cook_command(
                 dispatch_args(DispatchArgOverrides {
                     prompt: Some("Cook a patch.".to_string()),
@@ -202,7 +204,10 @@ mod tests {
                     ..DispatchArgOverrides::default()
                 })
                 .into(),
-                PatchExecutor { patch_path },
+                PatchExecutor {
+                    patch_path,
+                    transcript_path,
+                },
             )
             .expect("cook run");
 
@@ -249,6 +254,7 @@ mod tests {
                 .into(),
                 PatchExecutor {
                     patch_path: std::path::PathBuf::new(),
+                    transcript_path: std::path::PathBuf::new(),
                 },
             )
             .expect("queued cook");
@@ -358,6 +364,7 @@ mod tests {
 
     struct PatchExecutor {
         patch_path: std::path::PathBuf,
+        transcript_path: std::path::PathBuf,
     }
 
     impl AgentTaskExecutorAdapter for PatchExecutor {
@@ -372,20 +379,36 @@ mod tests {
                 status: AgentTaskOutcomeStatus::Succeeded,
                 summary: Some("patch ready".to_string()),
                 failure_classification: None,
-                artifacts: vec![AgentTaskArtifact {
-                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-                    id: "patch-1".to_string(),
-                    kind: "patch".to_string(),
-                    name: Some("changes.patch".to_string()),
-                    path: Some(self.patch_path.display().to_string()),
-                    url: None,
-                    mime: None,
-                    size_bytes: std::fs::metadata(&self.patch_path)
-                        .ok()
-                        .map(|metadata| metadata.len()),
-                    sha256: None,
-                    metadata: Value::Null,
-                }],
+                artifacts: vec![
+                    AgentTaskArtifact {
+                        schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                        id: "patch-1".to_string(),
+                        kind: "patch".to_string(),
+                        name: Some("changes.patch".to_string()),
+                        path: Some(self.patch_path.display().to_string()),
+                        url: None,
+                        mime: None,
+                        size_bytes: std::fs::metadata(&self.patch_path)
+                            .ok()
+                            .map(|metadata| metadata.len()),
+                        sha256: None,
+                        metadata: Value::Null,
+                    },
+                    AgentTaskArtifact {
+                        schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                        id: "transcript-1".to_string(),
+                        kind: "transcript".to_string(),
+                        name: Some("transcript.log".to_string()),
+                        path: Some(self.transcript_path.display().to_string()),
+                        url: None,
+                        mime: None,
+                        size_bytes: std::fs::metadata(&self.transcript_path)
+                            .ok()
+                            .map(|metadata| metadata.len()),
+                        sha256: None,
+                        metadata: Value::Null,
+                    },
+                ],
                 typed_artifacts: Vec::new(),
                 evidence_refs: Vec::new(),
                 diagnostics: Vec::new(),


### PR DESCRIPTION
## Summary
- Fixes failing test `commands::agent_task_dispatch::tests::cook_output_marks_patch_artifact_handoff_boundary` (issue #5559).
- The test's `PatchExecutor` fixture only emitted a `patch` artifact, but the dispatch plan declares `patch`, `agent_result`, and `transcript` as required expected artifacts. After #5555 added `classify_missing_required_typed_artifacts`, a successful outcome missing the required `transcript` typed artifact is now flipped to `Failed`, yielding `aggregate_exit_code == 1` and breaking `assert_eq!(exit_code, 0)` at agent_task_dispatch.rs:209.
- Updated the fixture to also produce a `transcript` artifact (and write a transcript fixture file), so the cook outcome satisfies the new required-typed-artifact contract while preserving the test's original intent.

## Root cause
- Regression from #5555 (`fix(agent-task): fail missing typed artifact outcomes`, commit `0ac7caad` — the exact SHA of the failing CI run). The new strict classification was not accompanied by a fixture update for this pre-existing dispatch test.

## Verification
- `cargo test --lib commands::agent_task_dispatch::tests` -> 5 passed, 0 failed (previously 1 failed).