### PR TITLE
Fix direct runner artifact downloads

### DIFF
--- a/src/core/runner/evidence.rs
+++ b/src/core/runner/evidence.rs
@@ -2,6 +2,8 @@ use std::fs;
 use std::path::PathBuf;
 
 use base64::Engine;
+use reqwest::blocking::Client;
+use reqwest::header;
 use serde_json::{json, Value};
 
 use crate::core::api_jobs::{Job, JobArtifactMetadata, JobEvent, JobStatus};
@@ -13,7 +15,7 @@ use crate::core::observation::{ArtifactRecord, ObservationStore, RunRecord};
 use crate::core::paths;
 
 use super::execution::{canonical_daemon_body, daemon_api_get, result_event_data};
-use super::{load, Runner};
+use super::{load, status, Runner, RunnerTunnelMode};
 
 pub fn is_remote_runner_artifact_path(path: &str) -> bool {
     EXECUTION_CONTRACT.artifacts.is_runner_artifact_ref(path)
@@ -59,6 +61,10 @@ pub fn download_remote_artifact(
     output: Option<PathBuf>,
 ) -> Result<RemoteArtifactDownload> {
     let token = RemoteArtifactToken::parse(path)?;
+    if let Some(download) = download_direct_runner_artifact(&token, output.clone())? {
+        return Ok(download);
+    }
+
     let data = daemon_api_get(
         &token.runner_id,
         &format!(
@@ -118,6 +124,117 @@ pub fn download_remote_artifact(
             .get("sha256")
             .and_then(Value::as_str)
             .map(str::to_string),
+    })
+}
+
+fn download_direct_runner_artifact(
+    token: &RemoteArtifactToken,
+    output: Option<PathBuf>,
+) -> Result<Option<RemoteArtifactDownload>> {
+    let runner = load(&token.runner_id)?;
+    let connected = status(&token.runner_id)?;
+    let Some(session) = connected.session.filter(|_| connected.connected) else {
+        return Err(Error::validation_invalid_argument(
+            "runner",
+            "runner is not connected to a daemon; run `homeboy runner connect <runner-id>` first",
+            Some(runner.id),
+            Some(vec![
+                "Read/query integrations use the connected daemon so results come from the runner machine.".to_string(),
+            ]),
+        ));
+    };
+
+    if session.mode != RunnerTunnelMode::DirectSsh {
+        return Ok(None);
+    }
+
+    let Some(local_url) = session.local_url.as_deref() else {
+        return Ok(None);
+    };
+
+    let client = Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|err| Error::internal_unexpected(format!("build daemon HTTP client: {err}")))?;
+    let path = format!(
+        "/runs/{}/artifacts/{}/content",
+        encode_uri_component(&token.run_id),
+        encode_uri_component(&token.artifact_id)
+    );
+    let response = client
+        .get(format!("{}{}", local_url.trim_end_matches('/'), path))
+        .send()
+        .map_err(|err| Error::internal_unexpected(format!("query runner daemon: {err}")))?;
+    let status = response.status();
+    let headers = response.headers().clone();
+    if !status.is_success() {
+        let body = response.text().unwrap_or_default();
+        return Err(Error::validation_invalid_argument(
+            "artifact_id",
+            format!(
+                "runner artifact fetch failed with HTTP {}: {}",
+                status.as_u16(),
+                body
+            ),
+            Some(token.artifact_id.clone()),
+            None,
+        ));
+    }
+
+    let bytes = response.bytes().map_err(|err| {
+        Error::internal_unexpected(format!("read runner artifact response: {err}"))
+    })?;
+    let filename = content_disposition_filename(&headers)
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| token.artifact_id.clone());
+    let output_path = output.unwrap_or_else(|| {
+        paths::artifact_root()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join("runner")
+            .join(&token.runner_id)
+            .join(&token.run_id)
+            .join(filename)
+    });
+    if let Some(parent) = output_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some(format!("create {}", parent.display())),
+            )
+        })?;
+    }
+    let size_bytes = i64::try_from(bytes.len()).ok();
+    fs::write(&output_path, bytes).map_err(|err| {
+        Error::internal_io(
+            err.to_string(),
+            Some(format!("write runner artifact {}", output_path.display())),
+        )
+    })?;
+
+    Ok(Some(RemoteArtifactDownload {
+        output_path,
+        content_type: header_string(&headers, header::CONTENT_TYPE.as_str()),
+        size_bytes,
+        sha256: header_string(&headers, "x-homeboy-artifact-sha256"),
+    }))
+}
+
+fn header_string(headers: &header::HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
+}
+
+fn content_disposition_filename(headers: &header::HeaderMap) -> Option<String> {
+    let value = header_string(headers, header::CONTENT_DISPOSITION.as_str())?;
+    value.split(';').find_map(|part| {
+        let part = part.trim();
+        let filename = part.strip_prefix("filename=")?;
+        Some(filename.trim_matches('"').to_string())
     })
 }
 
@@ -839,6 +956,20 @@ mod tests {
         assert_eq!(parsed.runner_id, "runner/a");
         assert_eq!(parsed.run_id, "run b");
         assert_eq!(parsed.artifact_id, "artifact:c");
+    }
+
+    #[test]
+    fn test_content_disposition_filename_parses_quoted_attachment_name() {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::CONTENT_DISPOSITION,
+            header::HeaderValue::from_static("attachment; filename=\"report.json\""),
+        );
+
+        assert_eq!(
+            content_disposition_filename(&headers).as_deref(),
+            Some("report.json")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fetch direct runner artifacts through the daemon byte endpoint instead of the JSON-envelope API client.
- Preserve the existing JSON fallback for non-direct runner sessions.
- Add coverage for parsing daemon artifact filenames from `Content-Disposition`.

## Testing
- `homeboy test --runner homeboy-lab --skip-lint --allow-dirty-lab-workspace -- test_content_disposition_filename_parses_quoted_attachment_name`
- `homeboy lint --runner homeboy-lab --allow-dirty-lab-workspace`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the runner artifact retrieval failure, implementing the direct byte-fetch path, adding targeted coverage, and running verification through `homeboy-lab`.
